### PR TITLE
docs(web-shell): document chart renderer integration

### DIFF
--- a/docs/design/skill-required-capabilities.md
+++ b/docs/design/skill-required-capabilities.md
@@ -281,6 +281,11 @@ import {
 />;
 ```
 
+In this renderer configuration, `loadEcharts` lets the host provide the
+approved ECharts runtime, either as a static import or a lazy-loaded module.
+`resolveDataRef` is only used for `data.kind="ref"` chart blocks; it is the
+host-owned bridge from a model-visible data reference to a trusted dataset.
+
 The skill file should be installed or injected only by hosts that perform this
 registration. A simple file-based integration can copy:
 
@@ -304,6 +309,62 @@ For `data.kind="ref"` envelopes, the renderer must use a host-controlled
 arbitrary URLs or evaluate model-provided JavaScript; it should parse the block
 as JSON, resolve only trusted `artifact://` or `session-file://` references, and
 inject the resolved dataset into the ECharts option before rendering.
+
+A daemon-backed host can treat the workspace file API as one artifact backend.
+For example, the host can persist chart artifacts under a controlled workspace
+directory such as `.qwen/artifacts/`, expose model-facing references like
+`artifact://chart-data/orders.csv`, and resolve them through daemon
+`GET /file?path=.qwen/artifacts/chart-data/orders.csv`. This keeps
+`artifact://` as the public chart contract while allowing the first
+implementation to reuse daemon workspace files.
+
+The resolver must still enforce the artifact root before calling the daemon:
+
+```tsx
+const ARTIFACT_ROOT = '.qwen/artifacts/';
+const MAX_CHART_DATA_BYTES = 256 * 1024;
+
+async function resolveDataRef(
+  ref: string,
+  meta: { format?: string; dimensions?: string[] },
+) {
+  const artifactPrefix = 'artifact://';
+  if (!ref.startsWith(artifactPrefix)) {
+    throw new Error(`Unsupported chart data ref: ${ref}`);
+  }
+
+  const artifactPath = ref.slice(artifactPrefix.length);
+  if (
+    artifactPath.length === 0 ||
+    artifactPath.startsWith('/') ||
+    artifactPath.includes('\\') ||
+    artifactPath.split('/').includes('..')
+  ) {
+    throw new Error(`Invalid chart data ref: ${ref}`);
+  }
+
+  const url = new URL('/file', daemonBaseUrl);
+  url.searchParams.set('path', `${ARTIFACT_ROOT}${artifactPath}`);
+  url.searchParams.set('maxBytes', String(MAX_CHART_DATA_BYTES));
+
+  const response = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to read chart data: ${response.status}`);
+  }
+
+  const file = (await response.json()) as { content: string };
+  return meta.format === 'csv'
+    ? parseCsvAsArrayRows(file.content, meta.dimensions)
+    : JSON.parse(file.content);
+}
+```
+
+This example intentionally maps only normalized `artifact://` paths under
+`.qwen/artifacts/`. If a host later moves artifacts to object storage or a
+session-scoped artifact service, only `resolveDataRef` needs to change; the
+model-facing `echarts-fulldata` block can keep using the same ref shape.
 
 ### Pros
 

--- a/docs/design/skill-required-capabilities.md
+++ b/docs/design/skill-required-capabilities.md
@@ -285,6 +285,10 @@ In this renderer configuration, `loadEcharts` lets the host provide the
 approved ECharts runtime, either as a static import or a lazy-loaded module.
 `resolveDataRef` is only used for `data.kind="ref"` chart blocks; it is the
 host-owned bridge from a model-visible data reference to a trusted dataset.
+The model-facing envelope format is described by the optional skill template in
+`packages/web-shell/docs/examples/qwencode-viz/SKILL.md`; the renderer-side
+validation lives in
+`packages/web-shell/client/components/messages/EchartsFullDataBlock.tsx`.
 
 The skill file should be installed or injected only by hosts that perform this
 registration. A simple file-based integration can copy:
@@ -304,11 +308,14 @@ file as the canonical source content and expose it through that layer. In both
 cases, core does not auto-load the skill; the host owns enabling it because the
 host owns the renderer.
 
-For `data.kind="ref"` envelopes, the renderer must use a host-controlled
-`resolveDataRef(ref, meta)` implementation. The renderer should not fetch
-arbitrary URLs or evaluate model-provided JavaScript; it should parse the block
-as JSON, resolve only trusted `artifact://` or `session-file://` references, and
-inject the resolved dataset into the ECharts option before rendering.
+For `data.kind="ref"` envelopes, the built-in renderer validates that `data.ref`
+uses a normalized `artifact://` or `session-file://` reference before it calls
+the host-controlled `resolveDataRef(ref, meta)` implementation. The renderer
+also parses the block as JSON and sanitizes the ECharts option before rendering;
+it does not evaluate model-provided JavaScript, fetch arbitrary URLs, or read
+local files by itself. A custom renderer should preserve the same split:
+renderer-level JSON/ref/option validation first, host-owned artifact resolution
+second.
 
 A daemon-backed host can treat the workspace file API as one artifact backend.
 For example, the host can persist chart artifacts under a controlled workspace

--- a/docs/design/skill-required-capabilities.md
+++ b/docs/design/skill-required-capabilities.md
@@ -249,6 +249,62 @@ Possible distribution models:
 In this model, the skill is available only because the rendering client chose to
 provide it.
 
+### Web Shell Host Integration
+
+A Web Shell host that wants chart output should opt in to both halves of the
+contract:
+
+1. Register an `echarts-fulldata` Markdown code block renderer.
+2. Provide the matching chart skill from
+   `packages/web-shell/docs/examples/qwencode-viz/SKILL.md`.
+
+For example:
+
+```tsx
+import * as echarts from 'echarts';
+import {
+  WebShellWithProviders,
+  createEchartsFullDataRenderer,
+} from '@qwen-code/web-shell';
+
+<WebShellWithProviders
+  baseUrl="http://127.0.0.1:4170"
+  token={token}
+  sessionId={sessionId}
+  markdown={{
+    renderCodeBlock: createEchartsFullDataRenderer({
+      loadEcharts: () => echarts,
+      resolveDataRef: async (ref, meta) =>
+        loadControlledChartDataset(ref, meta),
+    }),
+  }}
+/>;
+```
+
+The skill file should be installed or injected only by hosts that perform this
+registration. A simple file-based integration can copy:
+
+```text
+packages/web-shell/docs/examples/qwencode-viz/SKILL.md
+```
+
+to the workspace or user skill directory, for example:
+
+```text
+.qwen/skills/qwencode-viz/SKILL.md
+```
+
+An integration with its own skill distribution layer can instead load the same
+file as the canonical source content and expose it through that layer. In both
+cases, core does not auto-load the skill; the host owns enabling it because the
+host owns the renderer.
+
+For `data.kind="ref"` envelopes, the renderer must use a host-controlled
+`resolveDataRef(ref, meta)` implementation. The renderer should not fetch
+arbitrary URLs or evaluate model-provided JavaScript; it should parse the block
+as JSON, resolve only trusted `artifact://` or `session-file://` references, and
+inject the resolved dataset into the ECharts option before rendering.
+
 ### Pros
 
 - Minimal core change.


### PR DESCRIPTION
## What this PR does

Documents how a Web Shell host can enable `echarts-fulldata` chart rendering without adding a generic `required-capabilities` skill gate in core.

It describes the host-owned integration path: register the ECharts Markdown code block renderer, provide the optional `qwencode-viz` skill template from `packages/web-shell/docs/examples/qwencode-viz/SKILL.md`, and keep large chart data behind a trusted `artifact://` or `session-file://` resolver instead of embedding arbitrary fetch or JavaScript behavior in model output.

## Why it's needed

The chart renderer is client-specific: CLI and other clients may not be able to render `echarts-fulldata` blocks. This document gives maintainers an explicit design choice for keeping chart instructions opt-in at the Web Shell host layer while leaving room for a future generic capability-gated skill design.

## Reviewer Test Plan

### How to verify

Read the design doc and confirm that Option B says the Web Shell host owns both renderer registration and skill installation or injection. Confirm that the daemon-backed artifact example treats `artifact://` as the public chart contract while mapping it to daemon `GET /file` only inside the host-controlled `resolveDataRef` implementation.

### Evidence (Before & After)

N/A. This is a documentation-only PR.

### Tested on

|     OS     |       Status       |
| :--------: | :----------------: |
|  🍏 macOS  |      ✅ tested      |
| 🪟 Windows | ⚠️ not tested / N/A |
|  🐧 Linux  | ⚠️ not tested / N/A |

### Environment (optional)

Local documentation check on macOS. No runtime environment is required because this PR changes only Markdown documentation.

## Risk & Scope

- Main risk or tradeoff: This documents an opt-in Web Shell integration pattern rather than adding a new core `required-capabilities` skill metadata contract in this PR.
- Not validated / out of scope: No automated renderer tests are added here; existing renderer behavior and skill loading behavior are not changed.
- Breaking changes / migration notes: None. No code or public runtime behavior changes.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

说明 Web Shell 宿主如何启用 `echarts-fulldata` 图表渲染，同时不在 core 里新增通用的 `required-capabilities` skill gate。

文档描述了宿主负责的接入方式：注册 ECharts Markdown code block renderer，提供 `packages/web-shell/docs/examples/qwencode-viz/SKILL.md` 里的可选 `qwencode-viz` skill 模板，并把大数据量图表数据放在可信的 `artifact://` 或 `session-file://` resolver 后面，而不是让模型输出任意 fetch 或 JavaScript 行为。

## 为什么需要

图表 renderer 是 client-specific 的能力：CLI 和其他 client 不一定能渲染 `echarts-fulldata` block。这个文档给维护者一个明确的设计选择：先把图表输出指令作为 Web Shell 宿主层的 opt-in，同时保留未来讨论通用 capability-gated skill 设计的空间。

## Reviewer Test Plan

### How to verify

阅读设计文档，确认 Option B 表达的是 Web Shell 宿主同时拥有 renderer 注册和 skill 安装或注入。确认 daemon-backed artifact 示例把 `artifact://` 作为公开图表契约，而只在宿主受控的 `resolveDataRef` 实现里映射到 daemon `GET /file`。

### Evidence (Before & After)

N/A。这个 PR 只改文档。

### Tested on

|     OS     |       Status       |
| :--------: | :----------------: |
|  🍏 macOS  |      ✅ tested      |
| 🪟 Windows | ⚠️ not tested / N/A |
|  🐧 Linux  | ⚠️ not tested / N/A |

### Environment (optional)

在 macOS 上做了本地文档检查。这个 PR 只修改 Markdown 文档，不需要运行时环境。

## Risk & Scope

- Main risk or tradeoff：本 PR 记录的是 Web Shell opt-in 接入模式，而不是在 core 里新增 `required-capabilities` skill 元数据契约。
- Not validated / out of scope：这里不新增 renderer 自动化测试；不改变现有 renderer 行为和 skill 加载行为。
- Breaking changes / migration notes：无。不改变代码或公开运行时行为。

## Linked Issues

N/A。

</details>
