### PR TITLE
fix(cli): Keep model picker entries contiguous in short terminals

### DIFF
--- a/packages/cli/src/ui/components/DialogManager.tsx
+++ b/packages/cli/src/ui/components/DialogManager.tsx
@@ -272,6 +272,7 @@ export const DialogManager = ({
         isFastModelMode={uiState.isFastModelMode}
         isVoiceModelMode={uiState.isVoiceModelMode}
         isVisionModelMode={uiState.isVisionModelMode}
+        availableTerminalHeight={listDialogHeight}
       />
     );
   }

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, act } from '@testing-library/react';
 import process from 'node:process';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ModelDialog, encodeAuxModelSelector } from './ModelDialog.js';
@@ -171,6 +171,101 @@ describe('<ModelDialog />', () => {
     const props = mockedSelect.mock.calls[0][0];
     expect(props.items).toHaveLength(12);
     expect(props.maxItemsToShow).toBe(6);
+  });
+
+  it('floors visible model options to 1 when the terminal is very short', () => {
+    renderComponent(
+      { availableTerminalHeight: 5 },
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: '',
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    const props = mockedSelect.mock.calls[0][0];
+    expect(props.maxItemsToShow).toBe(1);
+  });
+
+  it('accounts for the taller two-row option height when descriptions are present', () => {
+    renderComponent(
+      { availableTerminalHeight: 20 },
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: `Description ${i + 1}`,
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    const props = mockedSelect.mock.calls[0][0];
+    expect(props.maxItemsToShow).toBe(3);
+  });
+
+  it('falls back to the default max item count when no terminal height is given', () => {
+    renderComponent(
+      {},
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: '',
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    const props = mockedSelect.mock.calls[0][0];
+    expect(props.maxItemsToShow).toBe(10);
+  });
+
+  it('shrinks visible model options to leave room for a displayed error message', async () => {
+    const switchModel = vi.fn().mockRejectedValue(new Error('network down'));
+
+    renderComponent(
+      { availableTerminalHeight: 20 },
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        switchModel,
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: '',
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    const initialProps = mockedSelect.mock.calls[0][0];
+    expect(initialProps.maxItemsToShow).toBe(6);
+
+    await act(async () => {
+      await initialProps.onSelect(initialProps.items[0].value);
+    });
+
+    const propsAfterError =
+      mockedSelect.mock.calls[mockedSelect.mock.calls.length - 1][0];
+    expect(propsAfterError.maxItemsToShow).toBeLessThan(6);
   });
 
   it('hides discontinued qwen-oauth models for other auth types', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -170,7 +170,8 @@ describe('<ModelDialog />', () => {
 
     const props = mockedSelect.mock.calls[0][0];
     expect(props.items).toHaveLength(12);
-    expect(props.maxItemsToShow).toBe(6);
+    expect(props.maxItemsToShow).toBe(4);
+    expect(props.showScrollArrows).toBe(true);
   });
 
   it('floors visible model options to 1 when the terminal is very short', () => {
@@ -212,7 +213,7 @@ describe('<ModelDialog />', () => {
     );
 
     const props = mockedSelect.mock.calls[0][0];
-    expect(props.maxItemsToShow).toBe(3);
+    expect(props.maxItemsToShow).toBe(2);
   });
 
   it('falls back to the default max item count when no terminal height is given', () => {
@@ -257,7 +258,7 @@ describe('<ModelDialog />', () => {
     );
 
     const initialProps = mockedSelect.mock.calls[0][0];
-    expect(initialProps.maxItemsToShow).toBe(6);
+    expect(initialProps.maxItemsToShow).toBe(4);
 
     await act(async () => {
       await initialProps.onSelect(initialProps.items[0].value);
@@ -267,7 +268,7 @@ describe('<ModelDialog />', () => {
       mockedSelect.mock.calls[mockedSelect.mock.calls.length - 1][0];
     // errorMessage = "Failed to switch model to 'model-1'.\n\nnetwork down"
     // (3 lines) -> errorMessageRows = 2 + 3 = 5 ->
-    // floor((20 - 14 - 5) / 1) = 1.
+    // max(1, floor((20 - 16 - 5) / 1)) = 1.
     expect(propsAfterError.maxItemsToShow).toBe(1);
   });
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -265,7 +265,10 @@ describe('<ModelDialog />', () => {
 
     const propsAfterError =
       mockedSelect.mock.calls[mockedSelect.mock.calls.length - 1][0];
-    expect(propsAfterError.maxItemsToShow).toBeLessThan(6);
+    // errorMessage = "Failed to switch model to 'model-1'.\n\nnetwork down"
+    // (3 lines) -> errorMessageRows = 2 + 3 = 5 ->
+    // floor((20 - 14 - 5) / 1) = 1.
+    expect(propsAfterError.maxItemsToShow).toBe(1);
   });
 
   it('hides discontinued qwen-oauth models for other auth types', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -151,6 +151,28 @@ describe('<ModelDialog />', () => {
     expect(props.showNumbers).toBe(true);
   });
 
+  it('caps visible model options to the available dialog height', () => {
+    renderComponent(
+      { availableTerminalHeight: 20 },
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: '',
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    const props = mockedSelect.mock.calls[0][0];
+    expect(props.items).toHaveLength(12);
+    expect(props.maxItemsToShow).toBe(6);
+  });
+
   it('hides discontinued qwen-oauth models for other auth types', () => {
     renderComponent(
       {},

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -170,8 +170,10 @@ describe('<ModelDialog />', () => {
 
     const props = mockedSelect.mock.calls[0][0];
     expect(props.items).toHaveLength(12);
-    expect(props.maxItemsToShow).toBe(4);
-    expect(props.showScrollArrows).toBe(true);
+    expect(props.maxItemsToShow).toBe(6);
+    // The picker deliberately leaves the ▲/▼ scroll indicators off: they are
+    // two always-rendered chrome rows better spent on two more entries.
+    expect(props.showScrollArrows).toBeUndefined();
   });
 
   it('floors visible model options to 1 when the terminal is very short', () => {
@@ -193,38 +195,6 @@ describe('<ModelDialog />', () => {
 
     const props = mockedSelect.mock.calls[0][0];
     expect(props.maxItemsToShow).toBe(1);
-    expect(props.showScrollArrows).toBe(false);
-  });
-
-  it('drops the scroll arrows when they would crowd out every option row', () => {
-    const contextValue = {
-      getModel: vi.fn(() => 'model-1'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() =>
-        Array.from({ length: 12 }, (_, i) => ({
-          id: `model-${i + 1}`,
-          label: `Model ${i + 1}`,
-          description: '',
-          authType: AuthType.USE_OPENAI,
-        })),
-      ),
-    };
-
-    // height 17: one option row fits alongside the arrows -> keep them.
-    renderComponent({ availableTerminalHeight: 17 }, contextValue);
-    const propsWithArrows = mockedSelect.mock.calls[0][0];
-    expect(propsWithArrows.showScrollArrows).toBe(true);
-    expect(propsWithArrows.maxItemsToShow).toBe(1);
-
-    cleanup();
-    mockedSelect.mockClear();
-
-    // height 16: reserving the two arrow rows would leave no room for any
-    // option row -> drop the arrows and spend those rows on the list.
-    renderComponent({ availableTerminalHeight: 16 }, contextValue);
-    const propsWithoutArrows = mockedSelect.mock.calls[0][0];
-    expect(propsWithoutArrows.showScrollArrows).toBe(false);
-    expect(propsWithoutArrows.maxItemsToShow).toBe(2);
   });
 
   it('accounts for the taller two-row option height when descriptions are present', () => {
@@ -245,7 +215,7 @@ describe('<ModelDialog />', () => {
     );
 
     const props = mockedSelect.mock.calls[0][0];
-    expect(props.maxItemsToShow).toBe(2);
+    expect(props.maxItemsToShow).toBe(3);
   });
 
   it('falls back to the default max item count when no terminal height is given', () => {
@@ -290,8 +260,7 @@ describe('<ModelDialog />', () => {
     );
 
     const initialProps = mockedSelect.mock.calls[0][0];
-    expect(initialProps.maxItemsToShow).toBe(4);
-    expect(initialProps.showScrollArrows).toBe(true);
+    expect(initialProps.maxItemsToShow).toBe(6);
 
     await act(async () => {
       await initialProps.onSelect(initialProps.items[0].value);
@@ -300,11 +269,9 @@ describe('<ModelDialog />', () => {
     const propsAfterError =
       mockedSelect.mock.calls[mockedSelect.mock.calls.length - 1][0];
     // errorMessage = "Failed to switch model to 'model-1'.\n\nnetwork down"
-    // (3 lines) -> errorMessageRows = 2 + 3 = 5. With arrows the budget is
-    // 20 - 16 - 5 < 1, so the arrows are dropped ->
+    // (3 lines) -> errorMessageRows = 2 + 3 = 5 ->
     // max(1, floor((20 - 14 - 5) / 1)) = 1.
     expect(propsAfterError.maxItemsToShow).toBe(1);
-    expect(propsAfterError.showScrollArrows).toBe(false);
   });
 
   it('hides discontinued qwen-oauth models for other auth types', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -239,6 +239,28 @@ describe('<ModelDialog />', () => {
     expect(props.maxItemsToShow).toBe(10);
   });
 
+  it('clamps visible model options to the default max when the terminal is tall', () => {
+    renderComponent(
+      { availableTerminalHeight: 100 },
+      {
+        getModel: vi.fn(() => 'model-1'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() =>
+          Array.from({ length: 12 }, (_, i) => ({
+            id: `model-${i + 1}`,
+            label: `Model ${i + 1}`,
+            description: '',
+            authType: AuthType.USE_OPENAI,
+          })),
+        ),
+      },
+    );
+
+    // floor((100 - 14) / 1) = 86 rows of budget, clamped to the 10-item max.
+    const props = mockedSelect.mock.calls[0][0];
+    expect(props.maxItemsToShow).toBe(10);
+  });
+
   it('shrinks visible model options to leave room for a displayed error message', async () => {
     const switchModel = vi.fn().mockRejectedValue(new Error('network down'));
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -193,6 +193,38 @@ describe('<ModelDialog />', () => {
 
     const props = mockedSelect.mock.calls[0][0];
     expect(props.maxItemsToShow).toBe(1);
+    expect(props.showScrollArrows).toBe(false);
+  });
+
+  it('drops the scroll arrows when they would crowd out every option row', () => {
+    const contextValue = {
+      getModel: vi.fn(() => 'model-1'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() =>
+        Array.from({ length: 12 }, (_, i) => ({
+          id: `model-${i + 1}`,
+          label: `Model ${i + 1}`,
+          description: '',
+          authType: AuthType.USE_OPENAI,
+        })),
+      ),
+    };
+
+    // height 17: one option row fits alongside the arrows -> keep them.
+    renderComponent({ availableTerminalHeight: 17 }, contextValue);
+    const propsWithArrows = mockedSelect.mock.calls[0][0];
+    expect(propsWithArrows.showScrollArrows).toBe(true);
+    expect(propsWithArrows.maxItemsToShow).toBe(1);
+
+    cleanup();
+    mockedSelect.mockClear();
+
+    // height 16: reserving the two arrow rows would leave no room for any
+    // option row -> drop the arrows and spend those rows on the list.
+    renderComponent({ availableTerminalHeight: 16 }, contextValue);
+    const propsWithoutArrows = mockedSelect.mock.calls[0][0];
+    expect(propsWithoutArrows.showScrollArrows).toBe(false);
+    expect(propsWithoutArrows.maxItemsToShow).toBe(2);
   });
 
   it('accounts for the taller two-row option height when descriptions are present', () => {
@@ -259,6 +291,7 @@ describe('<ModelDialog />', () => {
 
     const initialProps = mockedSelect.mock.calls[0][0];
     expect(initialProps.maxItemsToShow).toBe(4);
+    expect(initialProps.showScrollArrows).toBe(true);
 
     await act(async () => {
       await initialProps.onSelect(initialProps.items[0].value);
@@ -267,9 +300,11 @@ describe('<ModelDialog />', () => {
     const propsAfterError =
       mockedSelect.mock.calls[mockedSelect.mock.calls.length - 1][0];
     // errorMessage = "Failed to switch model to 'model-1'.\n\nnetwork down"
-    // (3 lines) -> errorMessageRows = 2 + 3 = 5 ->
-    // max(1, floor((20 - 16 - 5) / 1)) = 1.
+    // (3 lines) -> errorMessageRows = 2 + 3 = 5. With arrows the budget is
+    // 20 - 16 - 5 < 1, so the arrows are dropped ->
+    // max(1, floor((20 - 14 - 5) / 1)) = 1.
     expect(propsAfterError.maxItemsToShow).toBe(1);
+    expect(propsAfterError.showScrollArrows).toBe(false);
   });
 
   it('hides discontinued qwen-oauth models for other auth types', () => {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -126,6 +126,11 @@ const MAX_MODEL_ITEMS_TO_SHOW = 10;
 // hint text (2). Adjust this whenever that surrounding layout changes, and
 // re-verify with an E2E height sweep rather than guessing.
 const MODEL_DIALOG_FIXED_ROWS = 16;
+// The ▲/▼ scroll indicators are two chrome rows that BaseSelectionList
+// renders unconditionally while enabled (it dims rather than hides them).
+// Included in MODEL_DIALOG_FIXED_ROWS; subtracted back out on dialogs too
+// short to afford them.
+const MODEL_DIALOG_SCROLL_ARROW_ROWS = 2;
 const MODEL_OPTION_ROW_HEIGHT = 1;
 const MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION = 2;
 
@@ -405,6 +410,17 @@ export function ModelDialog({
   const errorMessageRows = errorMessage
     ? 2 + errorMessage.split('\n').length
     : 0;
+  // Drop the scroll arrows when reserving their rows would leave no room for
+  // even one option row: on such short dialogs the always-rendered arrows
+  // would push the option rows past the dialog's clipped height, leaving the
+  // picker with arrows but no visible entries.
+  const showScrollArrows =
+    availableTerminalHeight === undefined ||
+    availableTerminalHeight - MODEL_DIALOG_FIXED_ROWS - errorMessageRows >=
+      modelOptionRowHeight;
+  const modelDialogFixedRows = showScrollArrows
+    ? MODEL_DIALOG_FIXED_ROWS
+    : MODEL_DIALOG_FIXED_ROWS - MODEL_DIALOG_SCROLL_ARROW_ROWS;
   const maxModelItemsToShow =
     availableTerminalHeight === undefined
       ? MAX_MODEL_ITEMS_TO_SHOW
@@ -414,7 +430,7 @@ export function ModelDialog({
             MAX_MODEL_ITEMS_TO_SHOW,
             Math.floor(
               (availableTerminalHeight -
-                MODEL_DIALOG_FIXED_ROWS -
+                modelDialogFixedRows -
                 errorMessageRows) /
                 modelOptionRowHeight,
             ),
@@ -843,7 +859,7 @@ export function ModelDialog({
             onHighlight={handleHighlight}
             initialIndex={initialIndex}
             showNumbers={true}
-            showScrollArrows={true}
+            showScrollArrows={showScrollArrows}
             maxItemsToShow={maxModelItemsToShow}
           />
         </Box>

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -393,9 +393,11 @@ export function ModelDialog({
     ? MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION
     : MODEL_OPTION_ROW_HEIGHT;
   // The error box adds its own marginTop plus one row per line (errorPrefix +
-  // blank line from the "\n\n" join + the underlying error's own lines).
+  // blank line from the "\n\n" join + the underlying error's own lines), plus
+  // a buffer since the error Text wraps and long lines can span extra rows on
+  // narrow terminals.
   const errorMessageRows = errorMessage
-    ? 1 + errorMessage.split('\n').length
+    ? 2 + errorMessage.split('\n').length
     : 0;
   const maxModelItemsToShow =
     availableTerminalHeight === undefined

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -392,6 +392,11 @@ export function ModelDialog({
   )
     ? MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION
     : MODEL_OPTION_ROW_HEIGHT;
+  // The error box adds its own marginTop plus one row per line (errorPrefix +
+  // blank line from the "\n\n" join + the underlying error's own lines).
+  const errorMessageRows = errorMessage
+    ? 1 + errorMessage.split('\n').length
+    : 0;
   const maxModelItemsToShow =
     availableTerminalHeight === undefined
       ? MAX_MODEL_ITEMS_TO_SHOW
@@ -400,7 +405,9 @@ export function ModelDialog({
           Math.min(
             MAX_MODEL_ITEMS_TO_SHOW,
             Math.floor(
-              (availableTerminalHeight - MODEL_DIALOG_FIXED_ROWS) /
+              (availableTerminalHeight -
+                MODEL_DIALOG_FIXED_ROWS -
+                errorMessageRows) /
                 modelOptionRowHeight,
             ),
           ),

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -115,7 +115,13 @@ interface ModelDialogProps {
   isFastModelMode?: boolean;
   isVoiceModelMode?: boolean;
   isVisionModelMode?: boolean;
+  availableTerminalHeight?: number;
 }
+
+const MAX_MODEL_ITEMS_TO_SHOW = 10;
+const MODEL_DIALOG_FIXED_ROWS = 14;
+const MODEL_OPTION_ROW_HEIGHT = 1;
+const MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION = 2;
 
 function maskApiKey(apiKey: string | undefined): string {
   if (!apiKey) return `(${t('not set')})`;
@@ -239,6 +245,7 @@ export function ModelDialog({
   isFastModelMode,
   isVoiceModelMode,
   isVisionModelMode,
+  availableTerminalHeight,
 }: ModelDialogProps): React.JSX.Element {
   const config = useContext(ConfigContext);
   const uiState = useContext(UIStateContext);
@@ -379,12 +386,32 @@ export function ModelDialog({
       ),
     [availableModelEntries],
   );
+  const modelOptionRowHeight = MODEL_OPTIONS.some(
+    ({ description }) =>
+      typeof description !== 'string' || description.trim().length > 0,
+  )
+    ? MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION
+    : MODEL_OPTION_ROW_HEIGHT;
+  const maxModelItemsToShow =
+    availableTerminalHeight === undefined
+      ? MAX_MODEL_ITEMS_TO_SHOW
+      : Math.max(
+          1,
+          Math.min(
+            MAX_MODEL_ITEMS_TO_SHOW,
+            Math.floor(
+              (availableTerminalHeight - MODEL_DIALOG_FIXED_ROWS) /
+                modelOptionRowHeight,
+            ),
+          ),
+        );
 
   // In fast model mode, default to the currently configured fast model
   const fastModelSetting = settings?.merged?.fastModel as string | undefined;
   const voiceModelSetting = settings?.merged?.voiceModel as string | undefined;
   const visionModelSetting = settings?.merged?.visionModel as
-    string | undefined;
+    | string
+    | undefined;
   const parsedVisionModelValue = parseVisionModelSetting(visionModelSetting);
   const parsedFastModelSetting = useMemo(() => {
     if (!isFastModelMode) return undefined;
@@ -704,7 +731,8 @@ export function ModelDialog({
         }
 
         after = config.getContentGeneratorConfig?.() as
-          ContentGeneratorConfig | undefined;
+          | ContentGeneratorConfig
+          | undefined;
         effectiveAuthType = after?.authType ?? selectedAuthType ?? authType;
         effectiveModelId = after?.model ?? modelId;
       } catch (e) {
@@ -800,6 +828,7 @@ export function ModelDialog({
             onHighlight={handleHighlight}
             initialIndex={initialIndex}
             showNumbers={true}
+            maxItemsToShow={maxModelItemsToShow}
           />
         </Box>
       )}

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -119,7 +119,13 @@ interface ModelDialogProps {
 }
 
 const MAX_MODEL_ITEMS_TO_SHOW = 10;
-const MODEL_DIALOG_FIXED_ROWS = 14;
+// Non-list dialog chrome to reserve when capping visible model rows: outer
+// round border (2) + outer padding (2) + title (1) + gap before the list (1)
+// + highlighted-entry detail panel (divider + up to 4 detail rows, ~6) +
+// scroll-arrow rows shown above/below a capped list (2) + footer gap and
+// hint text (2). Adjust this whenever that surrounding layout changes, and
+// re-verify with an E2E height sweep rather than guessing.
+const MODEL_DIALOG_FIXED_ROWS = 16;
 const MODEL_OPTION_ROW_HEIGHT = 1;
 const MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION = 2;
 
@@ -837,6 +843,7 @@ export function ModelDialog({
             onHighlight={handleHighlight}
             initialIndex={initialIndex}
             showNumbers={true}
+            showScrollArrows={true}
             maxItemsToShow={maxModelItemsToShow}
           />
         </Box>

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -122,15 +122,13 @@ const MAX_MODEL_ITEMS_TO_SHOW = 10;
 // Non-list dialog chrome to reserve when capping visible model rows: outer
 // round border (2) + outer padding (2) + title (1) + gap before the list (1)
 // + highlighted-entry detail panel (divider + up to 4 detail rows, ~6) +
-// scroll-arrow rows shown above/below a capped list (2) + footer gap and
-// hint text (2). Adjust this whenever that surrounding layout changes, and
+// footer gap and hint text (2). The list intentionally omits the ▲/▼ scroll
+// indicators other list dialogs enable: they are two always-rendered chrome
+// rows, and in a height-capped dialog those rows are better spent on two
+// more entries — the entry numbering already shows where the visible window
+// sits in the list. Adjust this whenever the surrounding layout changes, and
 // re-verify with an E2E height sweep rather than guessing.
-const MODEL_DIALOG_FIXED_ROWS = 16;
-// The ▲/▼ scroll indicators are two chrome rows that BaseSelectionList
-// renders unconditionally while enabled (it dims rather than hides them).
-// Included in MODEL_DIALOG_FIXED_ROWS; subtracted back out on dialogs too
-// short to afford them.
-const MODEL_DIALOG_SCROLL_ARROW_ROWS = 2;
+const MODEL_DIALOG_FIXED_ROWS = 14;
 const MODEL_OPTION_ROW_HEIGHT = 1;
 const MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION = 2;
 
@@ -410,17 +408,6 @@ export function ModelDialog({
   const errorMessageRows = errorMessage
     ? 2 + errorMessage.split('\n').length
     : 0;
-  // Drop the scroll arrows when reserving their rows would leave no room for
-  // even one option row: on such short dialogs the always-rendered arrows
-  // would push the option rows past the dialog's clipped height, leaving the
-  // picker with arrows but no visible entries.
-  const showScrollArrows =
-    availableTerminalHeight === undefined ||
-    availableTerminalHeight - MODEL_DIALOG_FIXED_ROWS - errorMessageRows >=
-      modelOptionRowHeight;
-  const modelDialogFixedRows = showScrollArrows
-    ? MODEL_DIALOG_FIXED_ROWS
-    : MODEL_DIALOG_FIXED_ROWS - MODEL_DIALOG_SCROLL_ARROW_ROWS;
   const maxModelItemsToShow =
     availableTerminalHeight === undefined
       ? MAX_MODEL_ITEMS_TO_SHOW
@@ -430,7 +417,7 @@ export function ModelDialog({
             MAX_MODEL_ITEMS_TO_SHOW,
             Math.floor(
               (availableTerminalHeight -
-                modelDialogFixedRows -
+                MODEL_DIALOG_FIXED_ROWS -
                 errorMessageRows) /
                 modelOptionRowHeight,
             ),
@@ -859,7 +846,6 @@ export function ModelDialog({
             onHighlight={handleHighlight}
             initialIndex={initialIndex}
             showNumbers={true}
-            showScrollArrows={showScrollArrows}
             maxItemsToShow={maxModelItemsToShow}
           />
         </Box>

--- a/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.test.tsx
+++ b/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.test.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Text } from 'ink';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import {
@@ -114,5 +115,20 @@ describe('DescriptiveRadioButtonSelect', () => {
     });
 
     expect(lastFrame()).toBe('› Foo Title\n  Bar Title');
+  });
+
+  it('renders a non-string (ReactNode) description', () => {
+    const { lastFrame } = renderComponent({
+      items: [
+        {
+          title: 'Foo Title',
+          description: <Text>Custom node description</Text>,
+          value: 'foo',
+          key: 'foo',
+        },
+      ],
+    });
+
+    expect(lastFrame()).toBe('› Foo Title\n  Custom node description');
   });
 });

--- a/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.test.tsx
+++ b/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.test.tsx
@@ -94,4 +94,25 @@ describe('DescriptiveRadioButtonSelect', () => {
     });
     expect(lastFrame()).toMatchSnapshot();
   });
+
+  it('does not render empty description rows', () => {
+    const { lastFrame } = renderComponent({
+      items: [
+        {
+          title: 'Foo Title',
+          description: '',
+          value: 'foo',
+          key: 'foo',
+        },
+        {
+          title: 'Bar Title',
+          description: '   ',
+          value: 'bar',
+          key: 'bar',
+        },
+      ],
+    });
+
+    expect(lastFrame()).toBe('› Foo Title\n  Bar Title');
+  });
 });

--- a/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/DescriptiveRadioButtonSelect.tsx
@@ -63,16 +63,24 @@ export function DescriptiveRadioButtonSelect<T>({
       showScrollArrows={showScrollArrows}
       maxItemsToShow={maxItemsToShow}
       itemGap={itemGap}
-      renderItem={(item, { titleColor }) => (
-        <Box flexDirection="column" key={item.key}>
-          <Text color={titleColor}>{item.title}</Text>
-          {typeof item.description === 'string' ? (
-            <Text color={theme.text.secondary}>{item.description}</Text>
-          ) : (
-            item.description
-          )}
-        </Box>
-      )}
+      renderItem={(item, { titleColor }) => {
+        const hasDescription =
+          typeof item.description === 'string'
+            ? item.description.trim().length > 0
+            : item.description != null;
+
+        return (
+          <Box flexDirection="column" key={item.key}>
+            <Text color={titleColor}>{item.title}</Text>
+            {hasDescription &&
+              (typeof item.description === 'string' ? (
+                <Text color={theme.text.secondary}>{item.description}</Text>
+              ) : (
+                item.description
+              ))}
+          </Box>
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## What this PR does

This PR makes the model picker size its visible option window from the available dialog height before rendering, and it avoids rendering blank description rows for options that do not have descriptions. In short terminals, the picker now shows a smaller contiguous window instead of letting the outer terminal-height clamp hide every other row. The row budget also reserves space for the inline error message shown after a failed switch, so the dialog does not overflow again in that state. The picker deliberately omits the ▲/▼ scroll indicators other list dialogs enable: they are two always-rendered chrome rows, and in a height-capped dialog those rows are better spent on two more entries — the entry numbering already shows where the visible window sits in the list.

## Why it's needed

When `/model` was opened in a constrained terminal, the picker could display non-contiguous entries such as `2, 4, 6, 8, 10`, making it look like some models were missing from the selectable list. The issue happened because the list rendered more physical rows than the dialog could display, so overflow clipping removed rows after the list had already chosen which logical items to show.

## Reviewer Test Plan

### How to verify

Open `/model` in a short terminal and confirm that the visible model numbers are contiguous. At very small heights, only a small subset may be visible, but it should be ordered without missing entries; at taller heights, the picker should expand up to the normal ten-entry window. There are no scroll indicators; the entry numbers show where the window sits and the footer hint covers navigation.

### Evidence (Before & After)

Evidence re-captured after the review-round changes, with eight configured models.

Before: with a 24-row terminal, the visible picker entries were `1, 2, 4, 5, 6, 7, 8` — entry `3` was missing — and two rows of the details panel were overlapped into one corrupted line.

After: with the same 24-row terminal, the picker shows a contiguous `1, 2, 3, 4, 5` window with an intact details panel. A height sweep with the bundled CLI at terminal heights `14, 20, 21, 22, 23, 24, 25, 26, 29, 30, 34` showed a contiguous window at every height, growing from one visible entry at `14` to all eight from `29` up.

| Before: skipped entry, corrupted detail row | After: contiguous window |
| :---: | :---: |
| ![Before screenshot showing model picker entries 1,2,4,5,6,7,8 with entry 3 missing](https://raw.githubusercontent.com/QwenLM/qwen-code/1c73f8e3e096d5de000a0d1222a1143308875d31/before-model-picker-rows24.png) | ![After screenshot showing model picker entries 1 through 5 contiguously](https://raw.githubusercontent.com/QwenLM/qwen-code/1c73f8e3e096d5de000a0d1222a1143308875d31/after-model-picker-rows24.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local verification used `node dist/cli.js` in a direct PTY script with constrained terminal row counts.

## Risk & Scope

- Main risk or tradeoff: the model picker can show fewer entries at very small terminal heights, but the visible entries are now contiguous and navigable instead of partially clipped. With the window capped there is no explicit indicator that more entries exist below the window; the entry numbering and the ↑↓ footer hint are the scroll signal.
- Not validated / out of scope: Windows and Linux terminal rendering were not manually verified. On dialogs shorter than the fixed chrome itself (roughly under 20 terminal rows), the details panel can still lose rows to clipping; sizing the chrome itself down at such heights is left as a follow-up.
- Breaking changes / migration notes: none.

## Linked Issues

User-reported issue; no GitHub issue number is attached.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在渲染前根据可用的对话框高度计算模型选择器可显示的选项数量，并且不再为没有描述内容的选项渲染空白描述行。在较矮的终端里，模型选择器现在会显示一个更小但连续的窗口，而不是让外层高度裁剪隐藏掉部分行。行数预算同时为切换失败后显示的内联错误信息预留了空间，避免该状态下对话框再次溢出。选择器有意不启用其他列表对话框使用的 ▲/▼ 滚动指示符：它们是两行始终渲染的装饰行，在高度受限的对话框里这两行更值得用来多显示两个条目——条目编号本身已经能标示可见窗口在列表中的位置。

## Why it's needed

当在受限高度的终端中打开 `/model` 时，模型选择器可能显示不连续的条目，例如 `2, 4, 6, 8, 10`，看起来像是有些模型从可选列表中丢失了。问题的原因是列表渲染出的实际行数超过了对话框可以显示的高度，导致外层溢出裁剪在列表已经选定逻辑条目之后移除了部分物理行。

## Reviewer Test Plan

### How to verify

在较矮的终端中打开 `/model`，确认可见的模型编号是连续的。在非常小的高度下，可能只显示少量条目，但它们应该保持有序且不会缺号；在更高的终端中，选择器应扩展到正常的十个条目窗口。没有滚动指示符；条目编号标示窗口位置，页脚提示覆盖了导航操作。

### Evidence (Before & After)

以下证据是在评审轮次的修改之后重新采集的，配置了八个模型。

修复前：在 24 行终端中，可见的模型条目为 `1, 2, 4, 5, 6, 7, 8`，缺少条目 `3`，且详情面板有两行被挤压重叠成一行乱码。

修复后：在相同的 24 行终端中，选择器显示连续的 `1, 2, 3, 4, 5` 窗口，详情面板完整。使用打包后的 CLI 在终端高度 `14, 20, 21, 22, 23, 24, 25, 26, 29, 30, 34` 下做高度扫描，每个高度都显示连续的可见窗口，从 `14` 行时的一个条目逐步扩展到 `29` 行及以上的全部八个条目。截图见上方英文部分的前后对比表。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

本地验证使用 `node dist/cli.js`，通过直接 PTY 脚本设置受限终端行数。

## Risk & Scope

- Main risk or tradeoff: 在非常小的终端高度下，模型选择器可能显示更少条目，但可见条目现在是连续且可导航的，不再被部分裁剪。窗口被截断时没有显式的"下方还有条目"指示；条目编号和页脚的 ↑↓ 提示承担滚动信号。
- Not validated / out of scope: 未手动验证 Windows 和 Linux 的终端渲染。当对话框高度小于固定装饰行本身（大约 20 行终端以下）时，详情面板仍可能因裁剪丢行；在这类高度下压缩装饰行本身留作后续改进。
- Breaking changes / migration notes: 无。

## Linked Issues

用户报告的问题；目前没有关联的 GitHub issue 编号。

</details>
