### PR TITLE
fix(web-shell): constrain virtual scroll rows

### DIFF
--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -4,6 +4,7 @@ import { act, createRef, type RefObject } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { Message } from '../adapters/types';
 import { I18nProvider } from '../i18n';
+import styles from './MessageList.module.css';
 
 // Mock the App context and the heavy row children so this test exercises only
 // MessageList's own collapse + deferred-scroll logic, not the whole render tree.
@@ -41,6 +42,31 @@ vi.mock('./messages/tools/ParallelAgentsGroup', () => ({
 }));
 vi.mock('./messages/ToolApproval', () => ({ ToolApproval: () => null }));
 vi.mock('./messages/AskUserQuestion', () => ({ AskUserQuestion: () => null }));
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({
+    count,
+    enabled,
+    getItemKey,
+  }: {
+    count: number;
+    enabled: boolean;
+    getItemKey: (index: number) => string | number;
+  }) => {
+    const virtualItems = enabled
+      ? Array.from({ length: Math.min(count, 5) }, (_, index) => ({
+          key: getItemKey(index),
+          index,
+          start: index * 80,
+        }))
+      : [];
+    return {
+      getVirtualItems: () => virtualItems,
+      getTotalSize: () => (enabled ? count * 80 : 0),
+      measureElement: () => {},
+      scrollToIndex: () => {},
+    };
+  },
+}));
 
 const { MessageList } = await import('./MessageList');
 type MessageListHandle = import('./MessageList').MessageListHandle;
@@ -310,6 +336,15 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
     click(toggle(c, 'u1'));
     expect(isCollapsed(c, 'g1')).toBe(true);
+  });
+
+  it('renders virtual scroll rows with sizer and row width classes', () => {
+    const c = mount(simpleTurns(110));
+
+    expect(c.querySelector(`.${styles.virtualSizer}`)).not.toBeNull();
+    expect(c.querySelectorAll(`.${styles.virtualRow}`).length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renders the session timeline in the left gutter without expanding turns', async () => {

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -30,6 +30,25 @@
   transition: width 320ms ease;
 }
 
+.virtualSizer {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  margin-right: 0;
+  margin-left: 0;
+  transition: none;
+}
+
+.virtualRow {
+  width: min(
+    100%,
+    var(--chat-content-width, var(--chat-regular-content-width, 1000px))
+  );
+  margin-right: auto;
+  margin-left: auto;
+  transition: width 320ms ease;
+}
+
 .loadingSkeleton {
   display: flex;
   flex-direction: column;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -2741,10 +2741,9 @@ export const MessageList = memo(
         />
         {useVirtualScroll ? (
           <div
+            className={styles.virtualSizer}
             style={{
               height: totalVirtualSize,
-              width: '100%',
-              position: 'relative',
             }}
           >
             {virtualItems.map((virtualRow) => (
@@ -2752,15 +2751,18 @@ export const MessageList = memo(
                 key={virtualRow.key}
                 data-index={virtualRow.index}
                 ref={virtualizer.measureElement}
-                className={getRowClassName(
-                  String(virtualRow.key),
-                  visibleItems[virtualRow.index - headerOffset],
+                className={joinClassNames(
+                  styles.virtualRow,
+                  getRowClassName(
+                    String(virtualRow.key),
+                    visibleItems[virtualRow.index - headerOffset],
+                  ),
                 )}
                 style={{
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  width: '100%',
+                  right: 0,
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >


### PR DESCRIPTION
## What this PR does

Constrain web-shell virtualized transcript rows to the same centered chat content width used by the non-virtualized transcript. The virtualizer's full-width measurement layer remains full width, while each rendered row now carries the chat content width cap.

## Why it's needed

When long web-shell sessions crossed the virtual scrolling threshold, the transcript rows expanded across the whole pane instead of respecting the configured chat maximum width. This made the page look full-width only after virtualization kicked in.

## Reviewer Test Plan

### How to verify

Open a web-shell session with enough transcript rows to enable virtual scrolling. Confirm messages remain centered and capped to the normal chat content width before and after virtual scrolling is active. Locally, I verified the existing MessageList DOM behavior with `cd packages/web-shell && npx vitest run client/components/MessageList.dom.test.tsx`.

### Evidence (Before & After)

Before: virtualized transcript rows filled the available page width once the virtual scroller activated. After: virtualized transcript rows stay centered and constrained to the normal chat content width while the virtualizer measurement layer remains full width.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local vitest run in `packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: Low. The change is limited to the web-shell virtualized transcript layout and keeps the measurement container full width.
- Not validated / out of scope: Manual browser verification on Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

让 web-shell 虚拟化后的 transcript 行继续使用非虚拟列表相同的居中聊天内容宽度。虚拟滚动器的测量层仍保持全宽，每个实际渲染的行重新套用聊天内容最大宽度。

## Why it's needed

长会话超过虚拟滚动阈值后，transcript 行会展开到整个面板宽度，不再遵守配置的聊天最大宽度。这样页面会在虚拟滚动触发后才突然变成满宽。

## Reviewer Test Plan

### How to verify

打开一个足够长、能够触发虚拟滚动的 web-shell 会话。确认虚拟滚动启用前后，消息仍保持居中并限制在正常聊天内容宽度内。本地已通过 `cd packages/web-shell && npx vitest run client/components/MessageList.dom.test.tsx` 验证现有 MessageList DOM 行为。

### Evidence (Before & After)

Before: 虚拟滚动启用后，transcript 行会填满可用页面宽度。After: 虚拟滚动启用后，transcript 行仍保持居中并限制在正常聊天内容宽度内，同时虚拟滚动器测量层继续保持全宽。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

在 `packages/web-shell` 中运行本地 vitest。

## Risk & Scope

- Main risk or tradeoff: 风险较低。改动仅限 web-shell 虚拟化 transcript 布局，并保留测量容器全宽。
- Not validated / out of scope: 未在 Windows 和 Linux 上做手动浏览器验证。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
