### PR TITLE
docs: standardize GitHub Actions capitalization

### DIFF
--- a/docs/developers/roadmap.md
+++ b/docs/developers/roadmap.md
@@ -28,7 +28,7 @@
 | Concurrent Runner       | `V0.6.0`  | Batch CLI execution with Git integration                | Coding Workflow                 | 2     |
 | Multimodal Input        | `V0.6.0`  | Image, PDF, audio, video input support                  | User Experience                 | 2     |
 | Skill                   | `V0.6.0`  | Extensible custom AI skills (experimental)              | Coding Workflow                 | 2     |
-| Github Actions          | `V0.5.0`  | qwen-code-action and automation                         | Integrating Community Ecosystem | 1     |
+| GitHub Actions          | `V0.5.0`  | qwen-code-action and automation                         | Integrating Community Ecosystem | 1     |
 | VSCode Plugin           | `V0.5.0`  | VSCode extension plugin                                 | Integrating Community Ecosystem | 1     |
 | QwenCode SDK            | `V0.4.0`  | Open SDK for third-party integration                    | Building Open Capabilities      | 1     |
 | Session                 | `V0.4.0`  | Enhanced session management                             | User Experience                 | 1     |

--- a/docs/users/integration-github-action.md
+++ b/docs/users/integration-github-action.md
@@ -1,4 +1,4 @@
-# Github Actions：qwen-code-action
+# GitHub Actions：qwen-code-action
 
 ## Overview
 


### PR DESCRIPTION
## What this PR does

Standardizes the capitalization of GitHub Actions in the documentation.

## Why it's needed

This keeps the GitHub Actions product name consistent with GitHub's brand spelling and removes a small documentation mismatch.

## Reviewer Test Plan

### How to verify

Confirm the affected documentation uses `GitHub Actions` consistently. I verified the docs formatting and project checks locally.

```bash
npx prettier --check docs/developers/roadmap.md docs/users/integration-github-action.md
npm run build
npm run typecheck
```

### Evidence (Before & After)

N/A - docs-only capitalization fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Local npm workspace with dependencies installed via `npm install`.

## Risk & Scope

- Main risk or tradeoff: Very low; this changes documentation text only.
- Not validated / out of scope: I did not run a docs-site visual preview.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #6366

<details>
<summary>中文说明</summary>

## What this PR does

统一文档中 `GitHub Actions` 的大小写写法。

## Why it's needed

这能让 GitHub Actions 产品名和 GitHub 的品牌写法保持一致，并消除一个很小的文档不一致问题。

## Reviewer Test Plan

### How to verify

确认相关文档统一使用 `GitHub Actions`。我已在本地验证文档格式和项目检查。

```bash
npx prettier --check docs/developers/roadmap.md docs/users/integration-github-action.md
npm run build
npm run typecheck
```

### Evidence (Before & After)

N/A - 仅文档大小写修正。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

本地 npm workspace，依赖通过 `npm install` 安装。

## Risk & Scope

- Main risk or tradeoff: 风险很低，仅修改文档文本。
- Not validated / out of scope: 未运行 docs-site 可视化预览。
- Breaking changes / migration notes: 无。

## Linked Issues

Closes #6366

</details>