### PR TITLE
fix(cli): Allow ACP local fallback reads from /tmp

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1230,6 +1230,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   let stdoutDestroySpy: MockInstance<typeof process.stdout.destroy>;
 
   const mockArgv = {} as CliArgs;
+  const acpLocalReadRootsEnv = 'QWEN_ACP_LOCAL_READ_ROOTS';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1327,75 +1328,39 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
   });
 
   it('configures ACP file system fallback roots for read_file allowed local roots', async () => {
-    const fsCapabilities = { readTextFile: true, writeTextFile: true };
-    const fallbackFileSystem = {};
-    const innerConfig = {
-      ...makeInnerConfig(),
-      getTargetDir: vi.fn().mockReturnValue('/project'),
-      getSessionId: vi.fn().mockReturnValue('session-with-fs'),
-      getFileSystemService: vi.fn().mockReturnValue(fallbackFileSystem),
-      setFileSystemService: vi.fn(),
-      storage: {
-        getProjectTempDir: vi.fn().mockReturnValue('/project/.qwen/tmp'),
-        getProjectDir: vi.fn().mockReturnValue('/project'),
-        getUserSkillsDirs: vi.fn().mockReturnValue(['/home/test/.qwen/skills']),
-      },
-    };
-    vi.mocked(loadSettings).mockReturnValue(makeSessionSettings());
-    vi.mocked(loadCliConfig).mockResolvedValue(
-      innerConfig as unknown as Config,
-    );
-    vi.mocked(Session).mockImplementation(
-      () =>
-        ({
-          getId: vi.fn().mockReturnValue('session-with-fs'),
-          getConfig: vi.fn().mockReturnValue(innerConfig),
-          sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
-          replayHistory: vi.fn().mockResolvedValue(undefined),
-          installRewriter: vi.fn(),
-          startCronScheduler: vi.fn(),
-          dispose: vi.fn(),
-        }) as unknown as InstanceType<typeof Session>,
-    );
+    const previousRoots = process.env[acpLocalReadRootsEnv];
+    delete process.env[acpLocalReadRootsEnv];
 
-    const agentPromise = runAcpAgent(
-      mockConfig,
-      makeSessionSettings(),
-      mockArgv,
-    );
-    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    try {
+      await expectAcpLocalReadRoots(
+        'session-with-fs',
+        expectedDefaultAcpLocalReadRoots(),
+      );
+    } finally {
+      restoreOptionalEnv(acpLocalReadRootsEnv, previousRoots);
+    }
+  });
 
-    const fakeConn = {
-      get closed() {
-        return mockConnectionState.promise;
-      },
-    } as AgentSideConnectionLike;
-    const agent = capturedAgentFactory!(fakeConn) as AgentLike;
+  it('appends QWEN_ACP_LOCAL_READ_ROOTS absolute entries to ACP file system fallback roots', async () => {
+    const previousRoots = process.env[acpLocalReadRootsEnv];
+    const envRootA = path.resolve('/custom/acp-a');
+    const envRootB = path.resolve('/custom/acp-b');
+    process.env[acpLocalReadRootsEnv] = [
+      '',
+      ` ${envRootA} `,
+      'relative-acp-root',
+      envRootB,
+      '   ',
+    ].join(path.delimiter);
 
-    await agent.initialize({ clientCapabilities: { fs: fsCapabilities } });
-    await agent.newSession({ cwd: '/project', mcpServers: [] });
-
-    expect(AcpFileSystemService).toHaveBeenCalledWith(
-      fakeConn,
-      'session-with-fs',
-      fsCapabilities,
-      fallbackFileSystem,
-      {
-        localReadRoots: [
-          '/project/.qwen/tmp',
-          path.join('/project', 'subagents'),
-          '/tmp/qwen-global-temp',
-          '/project/.qwen/memory',
-          '/tmp/user-memory',
-          '/home/test/.qwen/skills',
-          '/tmp/qwen-extensions',
-        ],
-      },
-    );
-    expect(innerConfig.setFileSystemService).toHaveBeenCalled();
-
-    mockConnectionState.resolve();
-    await agentPromise;
+    try {
+      await expectAcpLocalReadRoots(
+        'session-with-fs-env',
+        [...expectedDefaultAcpLocalReadRoots(), envRootA, envRootB],
+      );
+    } finally {
+      restoreOptionalEnv(acpLocalReadRootsEnv, previousRoots);
+    }
   });
 
   it('passes each concurrent newSession its own workspace settings instance', async () => {
@@ -1606,6 +1571,96 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getDisableAllHooks: vi.fn().mockReturnValue(true),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
     };
+  }
+
+  function expectedDefaultAcpLocalReadRoots(): string[] {
+    return [
+      '/project/.qwen/tmp',
+      path.join('/project', 'subagents'),
+      '/tmp/qwen-global-temp',
+      '/project/.qwen/memory',
+      '/tmp/user-memory',
+      '/home/test/.qwen/skills',
+      '/tmp/qwen-extensions',
+      ...(process.platform === 'win32' ? [] : ['/tmp']),
+    ];
+  }
+
+  function restoreOptionalEnv(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  async function expectAcpLocalReadRoots(
+    sessionId: string,
+    expectedLocalReadRoots: string[],
+  ): Promise<void> {
+    const fsCapabilities = { readTextFile: true, writeTextFile: true };
+    const fallbackFileSystem: Record<string, never> = {};
+    const innerConfig = {
+      ...makeInnerConfig(),
+      getTargetDir: vi.fn().mockReturnValue('/project'),
+      getSessionId: vi.fn().mockReturnValue(sessionId),
+      getFileSystemService: vi.fn().mockReturnValue(fallbackFileSystem),
+      setFileSystemService: vi.fn(),
+      storage: {
+        getProjectTempDir: vi.fn().mockReturnValue('/project/.qwen/tmp'),
+        getProjectDir: vi.fn().mockReturnValue('/project'),
+        getUserSkillsDirs: vi.fn().mockReturnValue(['/home/test/.qwen/skills']),
+      },
+    };
+    vi.mocked(loadSettings).mockReturnValue(makeSessionSettings());
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      innerConfig as unknown as Config,
+    );
+    vi.mocked(Session).mockImplementation(
+      () =>
+        ({
+          getId: vi.fn().mockReturnValue(sessionId),
+          getConfig: vi.fn().mockReturnValue(innerConfig),
+          sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
+          replayHistory: vi.fn().mockResolvedValue(undefined),
+          installRewriter: vi.fn(),
+          startCronScheduler: vi.fn(),
+          dispose: vi.fn(),
+        }) as unknown as InstanceType<typeof Session>,
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+    try {
+      const fakeConn = {
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      } as AgentSideConnectionLike;
+      const agent = capturedAgentFactory!(fakeConn) as AgentLike;
+
+      await agent.initialize({ clientCapabilities: { fs: fsCapabilities } });
+      await agent.newSession({ cwd: '/project', mcpServers: [] });
+
+      expect(AcpFileSystemService).toHaveBeenCalledWith(
+        fakeConn,
+        sessionId,
+        fsCapabilities,
+        fallbackFileSystem,
+        {
+          localReadRoots: expectedLocalReadRoots,
+        },
+      );
+      expect(innerConfig.setFileSystemService).toHaveBeenCalled();
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
   }
 
   function makeSessionSettings() {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -263,11 +263,45 @@ import {
 import type { HistoryItemContextUsage } from '../ui/types.js';
 
 const debugLogger = createDebugLogger('ACP_AGENT');
+const QWEN_ACP_LOCAL_READ_ROOTS_ENV = 'QWEN_ACP_LOCAL_READ_ROOTS';
+const POSIX_TMP_LOCAL_READ_ROOT = '/tmp';
 // Must be less than SESSION_BTW_TIMEOUT_MS (60s) in bridge.ts so the child
 // aborts before the bridge's backstop timer fires.
 const BTW_CHILD_TIMEOUT_MS = 55_000;
 // Must be less than WORKSPACE_MEMORY_REMEMBER_TIMEOUT_MS (300s) in bridge.ts.
 const WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS = 295_000;
+
+function parseAcpLocalReadRootsEnv(
+  raw = process.env[QWEN_ACP_LOCAL_READ_ROOTS_ENV],
+): string[] {
+  if (!raw) return [];
+
+  return raw
+    .split(path.delimiter)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && path.isAbsolute(entry));
+}
+
+function defaultAcpOnlyLocalReadRoots(): string[] {
+  return process.platform === 'win32' ? [] : [POSIX_TMP_LOCAL_READ_ROOT];
+}
+
+function buildAcpLocalReadRoots(config: Config): string[] {
+  return [
+    // SYNC: The first group mirrors ReadFileTool's default allowed local roots,
+    // including auto-memory roots. The ACP-only additions below expand only
+    // local read fallback, not read_file's default permission.
+    config.storage.getProjectTempDir(),
+    path.join(config.storage.getProjectDir(), 'subagents'),
+    Storage.getGlobalTempDir(),
+    getAutoMemoryRoot(config.getTargetDir()),
+    getUserAutoMemoryRoot(),
+    ...config.storage.getUserSkillsDirs(),
+    Storage.getUserExtensionsDir(),
+    ...defaultAcpOnlyLocalReadRoots(),
+    ...parseAcpLocalReadRootsEnv(),
+  ];
+}
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -8162,17 +8196,7 @@ class QwenAgent implements Agent {
       this.clientCapabilities.fs,
       config.getFileSystemService(),
       {
-        // SYNC: Mirrors ReadFileTool's default allowed local roots, including
-        // auto-memory roots, so ACP-local read fallback follows the same policy.
-        localReadRoots: [
-          config.storage.getProjectTempDir(),
-          path.join(config.storage.getProjectDir(), 'subagents'),
-          Storage.getGlobalTempDir(),
-          getAutoMemoryRoot(config.getTargetDir()),
-          getUserAutoMemoryRoot(),
-          ...config.storage.getUserSkillsDirs(),
-          Storage.getUserExtensionsDir(),
-        ],
+        localReadRoots: buildAcpLocalReadRoots(config),
       },
     );
     config.setFileSystemService(acpFileSystemService);

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -106,8 +106,9 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     const filePath = path.resolve(this.params.file_path);
     const workspaceContext = this.config.getWorkspaceContext();
 
-    // SYNC: Keep these roots and the auto-memory check below aligned with
-    // AcpAgent.setupFileSystem's localReadRoots.
+    // SYNC: Keep these base roots and the auto-memory check below aligned with
+    // AcpAgent.buildAcpLocalReadRoots' mirrored ReadFileTool group. ACP may
+    // append fallback-only roots after that group.
     const allowedRoots = [
       this.config.storage.getProjectTempDir(),
       // Background subagent transcripts live under <projectDir>/subagents/ and


### PR DESCRIPTION
## What this PR does

This PR expands only ACP local read fallback roots so ACP sessions can recover from client-side workspace-boundary rejections for POSIX `/tmp` paths. It keeps the existing read-file default permission policy unchanged, adds an append-only `QWEN_ACP_LOCAL_READ_ROOTS` escape hatch for extra absolute fallback roots, and keeps fallback path safety delegated to the existing realpath/subpath checks.

## Why it's needed

ACP clients can reject generated local files under paths such as `/tmp/datastudio_cli_extract/...` as outside the workspace, even though the daemon process can read them locally. The change lets ACP fallback handle that narrow case without turning `/tmp` into a general auto-allowed `read_file` location for every mode.

## Reviewer Test Plan

Reviewers should confirm that ACP sessions include `/tmp` in local fallback roots on POSIX platforms, that `QWEN_ACP_LOCAL_READ_ROOTS` appends only absolute entries after defaults, and that regular `read_file` default permissions still ask for external `/tmp` reads.

### How to verify

Run `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts src/acp-integration/service/filesystem.test.ts` and expect both ACP agent root configuration tests and filesystem fallback safety tests to pass. Run `npx eslint packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts packages/core/src/tools/read-file.ts` and expect no lint findings. Run `npm run build && npm run typecheck` from the repository root and expect build plus workspace typecheck to complete successfully.

### Evidence (Before & After)

N/A — non-UI ACP fallback behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS local workspace with Node.js v22.22.3, npm 10.9.8, and qwen 0.19.6 available.

## Risk & Scope

- Main risk or tradeoff: POSIX ACP sessions can now locally fallback-read files under `/tmp` after specific ACP boundary errors, so this intentionally broadens only that fallback surface while preserving realpath/subpath validation.
- Not validated / out of scope: Windows runtime behavior was not tested locally; Windows also does not receive a default `/tmp` root and must use explicit absolute env roots.
- Breaking changes / migration notes: No breaking changes or migration required; `QWEN_ACP_LOCAL_READ_ROOTS` is additive and optional.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 只扩大 ACP 本地读取 fallback roots，让 ACP 会话在客户端因 workspace 边界拒绝 POSIX `/tmp` 路径时，可以由 daemon 本地 fallback 读取。它保持现有 `read_file` 默认权限策略不变，新增追加式 `QWEN_ACP_LOCAL_READ_ROOTS` 作为额外绝对 fallback root 的低层开关，并继续复用现有 realpath/subpath 校验保证路径安全。

## Why it's needed

ACP 客户端可能会把 `/tmp/datastudio_cli_extract/...` 这类生成文件判定为 workspace 外路径并拒绝读取，即使 daemon 进程本地有能力读取。该改动让 ACP fallback 覆盖这个窄场景，同时避免把 `/tmp` 变成所有模式下通用自动允许的 `read_file` 位置。

## Reviewer Test Plan

评审者应确认 POSIX 平台的 ACP 会话会把 `/tmp` 放入本地 fallback roots，`QWEN_ACP_LOCAL_READ_ROOTS` 只会在默认 roots 后追加绝对路径，并且普通 `read_file` 对外部 `/tmp` 路径的默认权限仍然是 ask。

### How to verify

运行 `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts src/acp-integration/service/filesystem.test.ts`，应看到 ACP agent roots 配置测试和 filesystem fallback 安全测试都通过。运行 `npx eslint packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts packages/core/src/tools/read-file.ts`，应无 lint 问题。最后在仓库根目录运行 `npm run build && npm run typecheck`，应成功完成构建和 workspace typecheck。

### Evidence (Before & After)

N/A — 非 UI 的 ACP fallback 行为改动。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地工作区，Node.js v22.22.3、npm 10.9.8、qwen 0.19.6 可用。

## Risk & Scope

- Main risk or tradeoff: POSIX ACP 会话在特定 ACP 边界错误后，现在可以本地 fallback 读取 `/tmp` 下文件；这有意只扩大 fallback 面，同时保留 realpath/subpath 校验。
- Not validated / out of scope: 未在本地验证 Windows 运行时行为；Windows 默认也不会获得 `/tmp` root，需要通过环境变量显式配置绝对路径。
- Breaking changes / migration notes: 无破坏性变更，也不需要迁移；`QWEN_ACP_LOCAL_READ_ROOTS` 是可选的追加配置。

## Linked Issues

N/A

</details>