### PR TITLE
fix(core): resolve symlinks when matching conditional rules and skills

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -222,7 +222,6 @@ const TOOL_FAILURE_KIND_BACKGROUND_AGENT_DENIED = 'background_agent_denied';
 
 const TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED = 'Tool execution blocked by hook';
 
-
 const TOOL_SPAN_STATUS_POST_HOOK_STOPPED = 'Tool execution stopped by hook';
 const TOOL_SPAN_STATUS_PERMISSION_DENIED = 'Permission denied for tool';
 const TOOL_SPAN_STATUS_PERMISSION_HOOK_DENIED =
@@ -3737,7 +3736,8 @@ export class CoreToolScheduler {
           for (const candidatePath of candidatePaths) {
             // Inject conditional rules at most once per session per rule
             // file. The registry tracks dedup internally.
-            const rulesCtx = rulesRegistry?.matchAndConsume(candidatePath);
+            const rulesCtx =
+              await rulesRegistry?.matchAndConsume(candidatePath);
             if (rulesCtx) reminderBlocks.push(rulesCtx);
           }
 

--- a/packages/core/src/skills/skill-activation.test.ts
+++ b/packages/core/src/skills/skill-activation.test.ts
@@ -25,21 +25,21 @@ function makeSkill(overrides: Partial<SkillConfig>): SkillConfig {
 }
 
 describe('splitConditionalSkills', () => {
-  it('treats skills without paths as unconditional', () => {
+  it('treats skills without paths as unconditional', async () => {
     const skills = [makeSkill({ name: 'a' })];
     const { unconditional, conditional } = splitConditionalSkills(skills);
     expect(unconditional).toHaveLength(1);
     expect(conditional).toHaveLength(0);
   });
 
-  it('treats empty paths array as unconditional', () => {
+  it('treats empty paths array as unconditional', async () => {
     const skills = [makeSkill({ name: 'a', paths: [] })];
     const { unconditional, conditional } = splitConditionalSkills(skills);
     expect(unconditional).toHaveLength(1);
     expect(conditional).toHaveLength(0);
   });
 
-  it('classifies skills with non-empty paths as conditional', () => {
+  it('classifies skills with non-empty paths as conditional', async () => {
     const skills = [
       makeSkill({ name: 'a' }),
       makeSkill({ name: 'b', paths: ['src/**/*.tsx'] }),
@@ -53,43 +53,45 @@ describe('splitConditionalSkills', () => {
 describe('SkillActivationRegistry', () => {
   const projectRoot = '/project';
 
-  it('returns empty when no conditional skills are registered', () => {
+  it('returns empty when no conditional skills are registered', async () => {
     const reg = new SkillActivationRegistry([], projectRoot);
-    expect(reg.matchAndConsume('/project/src/App.tsx')).toEqual([]);
+    expect(await reg.matchAndConsume('/project/src/App.tsx')).toEqual([]);
     expect(reg.totalCount).toBe(0);
   });
 
-  it('activates a conditional skill when a matching path is touched', () => {
+  it('activates a conditional skill when a matching path is touched', async () => {
     const reg = new SkillActivationRegistry(
       [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
       projectRoot,
     );
-    const newly = reg.matchAndConsume('/project/src/App.tsx');
+    const newly = await reg.matchAndConsume('/project/src/App.tsx');
     expect(newly).toEqual(['tsx-helper']);
     expect(reg.isActivated('tsx-helper')).toBe(true);
     expect(reg.activatedCount).toBe(1);
   });
 
-  it('does not re-activate an already-active skill on subsequent matches', () => {
+  it('does not re-activate an already-active skill on subsequent matches', async () => {
     const reg = new SkillActivationRegistry(
       [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
       projectRoot,
     );
-    expect(reg.matchAndConsume('/project/src/A.tsx')).toEqual(['tsx-helper']);
+    expect(await reg.matchAndConsume('/project/src/A.tsx')).toEqual([
+      'tsx-helper',
+    ]);
     // Second touch of the same pattern returns nothing new.
-    expect(reg.matchAndConsume('/project/src/B.tsx')).toEqual([]);
+    expect(await reg.matchAndConsume('/project/src/B.tsx')).toEqual([]);
     expect(reg.activatedCount).toBe(1);
   });
 
-  it('returns empty for paths that do not match any skill', () => {
+  it('returns empty for paths that do not match any skill', async () => {
     const reg = new SkillActivationRegistry(
       [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
       projectRoot,
     );
-    expect(reg.matchAndConsume('/project/lib/utils.py')).toEqual([]);
+    expect(await reg.matchAndConsume('/project/lib/utils.py')).toEqual([]);
   });
 
-  it('activates multiple skills whose globs overlap on a single file', () => {
+  it('activates multiple skills whose globs overlap on a single file', async () => {
     const reg = new SkillActivationRegistry(
       [
         makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] }),
@@ -97,28 +99,28 @@ describe('SkillActivationRegistry', () => {
       ],
       projectRoot,
     );
-    const newly = reg.matchAndConsume('/project/src/App.tsx');
+    const newly = await reg.matchAndConsume('/project/src/App.tsx');
     expect(newly.sort()).toEqual(['app-helper', 'tsx-helper']);
   });
 
-  it('accepts relative file paths by resolving against the project root', () => {
+  it('accepts relative file paths by resolving against the project root', async () => {
     const reg = new SkillActivationRegistry(
       [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
       projectRoot,
     );
-    expect(reg.matchAndConsume('src/App.tsx')).toEqual(['tsx-helper']);
+    expect(await reg.matchAndConsume('src/App.tsx')).toEqual(['tsx-helper']);
   });
 
-  it('ignores paths outside the project root', () => {
+  it('ignores paths outside the project root', async () => {
     const reg = new SkillActivationRegistry(
       [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
       projectRoot,
     );
-    expect(reg.matchAndConsume('/other/project/src/App.tsx')).toEqual([]);
+    expect(await reg.matchAndConsume('/other/project/src/App.tsx')).toEqual([]);
     expect(reg.activatedCount).toBe(0);
   });
 
-  it('supports multiple glob patterns per skill (OR semantics)', () => {
+  it('supports multiple glob patterns per skill (OR semantics)', async () => {
     const reg = new SkillActivationRegistry(
       [
         makeSkill({
@@ -129,11 +131,13 @@ describe('SkillActivationRegistry', () => {
       projectRoot,
     );
     // Both patterns should activate the same skill, but only once total.
-    expect(reg.matchAndConsume('/project/test/foo.ts')).toEqual(['multi']);
-    expect(reg.matchAndConsume('/project/src/Bar.tsx')).toEqual([]);
+    expect(await reg.matchAndConsume('/project/test/foo.ts')).toEqual([
+      'multi',
+    ]);
+    expect(await reg.matchAndConsume('/project/src/Bar.tsx')).toEqual([]);
   });
 
-  it('activates broad globs on dotfiles too (dot: true semantics)', () => {
+  it('activates broad globs on dotfiles too (dot: true semantics)', async () => {
     // Regression: picomatch `dot: false` would silently exclude
     // `.eslintrc.js`, `.env`, `.github/*.yml`, etc. from broad globs.
     // Skill activation is "did the model touch a file matching this
@@ -143,12 +147,12 @@ describe('SkillActivationRegistry', () => {
       [makeSkill({ name: 'lint-helper', paths: ['**/*.js'] })],
       projectRoot,
     );
-    expect(reg.matchAndConsume('/project/.eslintrc.js')).toEqual([
+    expect(await reg.matchAndConsume('/project/.eslintrc.js')).toEqual([
       'lint-helper',
     ]);
   });
 
-  it('survives an invalid picomatch pattern (drops it, keeps the rest)', () => {
+  it('survives an invalid picomatch pattern (drops it, keeps the rest)', async () => {
     // Regression: picomatch can throw on pathological patterns
     // (oversized strings, broken extglob nesting). The constructor
     // previously let that throw escape and abort skill loading
@@ -169,10 +173,10 @@ describe('SkillActivationRegistry', () => {
     );
     expect(reg.totalCount).toBe(1);
     // The good pattern still works.
-    expect(reg.matchAndConsume('/project/src/App.ts')).toEqual(['mixed']);
+    expect(await reg.matchAndConsume('/project/src/App.ts')).toEqual(['mixed']);
   });
 
-  it('rejects an absolute relative path (Windows cross-drive case)', () => {
+  it('rejects an absolute relative path (Windows cross-drive case)', async () => {
     // Regression: on Windows, `path.relative('C:\\project', 'D:\\other')`
     // returns an absolute path like `D:\\other`. After normalizing
     // backslashes to forward slashes, broad globs like `**/*.ts` would
@@ -188,7 +192,9 @@ describe('SkillActivationRegistry', () => {
     // as the existing `..` guard; on Windows the new isAbsolute branch
     // catches it. Either way the registry must return [] for paths outside
     // the project root regardless of platform.
-    expect(reg.matchAndConsume('/totally/other/place/file.ts')).toEqual([]);
+    expect(await reg.matchAndConsume('/totally/other/place/file.ts')).toEqual(
+      [],
+    );
     expect(reg.activatedCount).toBe(0);
   });
 });
@@ -198,7 +204,7 @@ describe('resolveProjectRelativePath', () => {
   // branch is testable on POSIX CI runners. On a real POSIX host
   // `path.win32` always behaves like Windows path semantics regardless
   // of the host OS.
-  it('returns the forward-slash-normalized relative path for in-project files (POSIX)', () => {
+  it('returns the forward-slash-normalized relative path for in-project files (POSIX)', async () => {
     expect(
       resolveProjectRelativePath(
         '/project/src/App.tsx',
@@ -208,13 +214,13 @@ describe('resolveProjectRelativePath', () => {
     ).toBe('src/App.tsx');
   });
 
-  it('returns null for paths outside the project root (POSIX, `..` prefix)', () => {
+  it('returns null for paths outside the project root (POSIX, `..` prefix)', async () => {
     expect(
       resolveProjectRelativePath('/elsewhere/foo.ts', '/project', path.posix),
     ).toBeNull();
   });
 
-  it('returns null for Windows cross-drive paths (different drive letter)', () => {
+  it('returns null for Windows cross-drive paths (different drive letter)', async () => {
     // Direct exercise of the new `path.isAbsolute(rawRelativePath)`
     // branch. `path.win32.relative('C:\\project', 'D:\\other\\file.ts')`
     // returns an absolute string like `D:\\other\\file.ts` — without the
@@ -230,7 +236,7 @@ describe('resolveProjectRelativePath', () => {
     ).toBeNull();
   });
 
-  it('normalizes backslashes for in-project Windows paths', () => {
+  it('normalizes backslashes for in-project Windows paths', async () => {
     expect(
       resolveProjectRelativePath(
         'C:\\project\\src\\App.tsx',
@@ -267,7 +273,7 @@ describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
     // collect the union.
     const activated = new Set<string>();
     for (const c of candidates) {
-      for (const n of reg.matchAndConsume(c)) activated.add(n);
+      for (const n of await reg.matchAndConsume(c)) activated.add(n);
     }
     expect(Array.from(activated)).toEqual(['tsx-helper']);
   }, 30_000);
@@ -286,8 +292,75 @@ describe('extractToolFilePaths → SkillActivationRegistry integration', () => {
     );
     const activated = new Set<string>();
     for (const c of candidates) {
-      for (const n of reg.matchAndConsume(c)) activated.add(n);
+      for (const n of await reg.matchAndConsume(c)) activated.add(n);
     }
     expect(activated.size).toBe(0);
   }, 30_000);
+
+  it.skipIf(process.platform === 'win32')(
+    'activates skills when file is reached via symlinked directory',
+    async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+      const testRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'symlink-test-'),
+      );
+      const projectRoot = path.join(testRoot, 'project');
+      const srcDir = path.join(projectRoot, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      const symlinkDir = path.join(projectRoot, 'symlink-to-src');
+      await fs.symlink(srcDir, symlinkDir);
+
+      // Create the actual file so realpath can resolve it
+      const realFile = path.join(srcDir, 'App.tsx');
+      await fs.writeFile(realFile, '// test');
+
+      const reg = new SkillActivationRegistry(
+        [makeSkill({ name: 'tsx-helper', paths: ['src/**/*.tsx'] })],
+        projectRoot,
+      );
+
+      // Access file via symlinked path
+      const symlinkedFile = path.join(symlinkDir, 'App.tsx');
+      const result = await reg.matchAndConsume(symlinkedFile);
+      expect(result).toEqual(['tsx-helper']);
+
+      await fs.rm(testRoot, { recursive: true, force: true });
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'activates skills when project root itself is a symlink',
+    async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const os = await import('node:os');
+      const testRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'symlink-test-'),
+      );
+      const realProject = path.join(testRoot, 'real-project');
+      await fs.mkdir(realProject, { recursive: true });
+      const srcDir = path.join(realProject, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      const symlinkProject = path.join(testRoot, 'symlink-project');
+      await fs.symlink(realProject, symlinkProject);
+
+      // Create the actual file so realpath can resolve it
+      const realFile = path.join(srcDir, 'foo.ts');
+      await fs.writeFile(realFile, '// test');
+
+      const reg = new SkillActivationRegistry(
+        [makeSkill({ name: 'ts-helper', paths: ['src/**/*.ts'] })],
+        symlinkProject,
+      );
+
+      const result = await reg.matchAndConsume(
+        path.join(symlinkProject, 'src', 'foo.ts'),
+      );
+      expect(result).toEqual(['ts-helper']);
+
+      await fs.rm(testRoot, { recursive: true, force: true });
+    },
+  );
 });

--- a/packages/core/src/skills/skill-activation.ts
+++ b/packages/core/src/skills/skill-activation.ts
@@ -18,7 +18,7 @@
 import picomatch from 'picomatch';
 import type { SkillConfig } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { resolveProjectRelativePath } from '../utils/projectPath.js';
+import { resolveSymlinkAwareRelativePaths } from '../utils/projectPath.js';
 
 // Re-export so existing consumers (skill-activation.test.ts) keep
 // working through the old import path. The canonical home is now
@@ -124,31 +124,34 @@ export class SkillActivationRegistry {
    * Activate any conditional skills whose `paths` globs match `filePath`.
    * Returns the names of skills newly activated by this call (empty when
    * either no skill matched, or every match was already active).
+   *
+   * Handles symlinked paths by checking both the original path and the
+   * realpath-resolved path, so skills work correctly in git worktrees and
+   * monorepos with symlinked directories.
    */
-  matchAndConsume(filePath: string): string[] {
+  async matchAndConsume(filePath: string): Promise<string[]> {
     if (this.compiled.length === 0) return [];
 
-    // Skip files outside the project root — conditional skills are scoped
-    // to the project, matching ConditionalRulesRegistry's behavior. The
-    // helper handles the Windows cross-drive case (where `path.relative`
-    // returns an absolute string).
-    const relativePath = resolveProjectRelativePath(filePath, this.projectRoot);
-    if (relativePath === null) {
+    // Resolve symlinks and check both original and realpath-resolved paths
+    const relativePaths = await resolveSymlinkAwareRelativePaths(
+      filePath,
+      this.projectRoot,
+    );
+    if (relativePaths.length === 0) {
       debugLogger.debug(
         `Skipping ${filePath}: outside project root or cross-drive`,
       );
       return [];
     }
-    debugLogger.debug(`matchAndConsume ${filePath} → relative=${relativePath}`);
 
     const newlyActivated: string[] = [];
     for (const { skill, matchers } of this.compiled) {
       if (this.activated.has(skill.name)) continue;
-      if (matchers.some((m) => m(relativePath))) {
+      if (relativePaths.some((relPath) => matchers.some((m) => m(relPath)))) {
         this.activated.add(skill.name);
         newlyActivated.push(skill.name);
         debugLogger.info(
-          `Activated skill "${skill.name}" via path "${relativePath}"`,
+          `Activated skill "${skill.name}" via path "${relativePaths.join(' or ')}"`,
         );
       }
     }

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -541,7 +541,7 @@ export class SkillManager {
     if (!registry || filePaths.length === 0) return [];
     const newlyAcrossPaths = new Set<string>();
     for (const filePath of filePaths) {
-      for (const name of registry.matchAndConsume(filePath)) {
+      for (const name of await registry.matchAndConsume(filePath)) {
         newlyAcrossPaths.add(name);
       }
     }

--- a/packages/core/src/utils/projectPath.test.ts
+++ b/packages/core/src/utils/projectPath.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveProjectRelativePath,
+  resolveSymlinkAwareRelativePaths,
+} from './projectPath.js';
+
+describe('resolveProjectRelativePath', () => {
+  it('returns a forward-slash relative path for an absolute input', () => {
+    const result = resolveProjectRelativePath(
+      '/project/src/foo.ts',
+      '/project',
+    );
+    expect(result).toBe('src/foo.ts');
+  });
+
+  it('returns null for paths outside the project root', () => {
+    expect(resolveProjectRelativePath('/other/foo.ts', '/project')).toBeNull();
+  });
+
+  it('resolves relative paths against projectRoot', () => {
+    const result = resolveProjectRelativePath('src/foo.ts', '/project');
+    expect(result).toBe('src/foo.ts');
+  });
+
+  it('rejects the exact `..` relative path', () => {
+    expect(resolveProjectRelativePath('/', '/project')).toBeNull();
+  });
+});
+
+describe('resolveSymlinkAwareRelativePaths', () => {
+  it('returns the original relative path when realpath is not provided', async () => {
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/src/foo.ts',
+      '/project',
+    );
+    expect(result).toEqual(['src/foo.ts']);
+  });
+
+  it('returns both original and realpath-resolved paths when they differ', async () => {
+    const mockRealpath = vi
+      .fn()
+      .mockResolvedValueOnce('/project/lib/foo.ts') // realpath(file)
+      .mockResolvedValueOnce('/project'); // realpath(projectRoot)
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/src/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    expect(result).toEqual(['src/foo.ts', 'lib/foo.ts']);
+  });
+
+  it('returns only the original path when realpath equals the input', async () => {
+    const mockRealpath = vi.fn().mockResolvedValue('/project/src/foo.ts');
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/src/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    expect(result).toEqual(['src/foo.ts']);
+  });
+
+  it('returns empty array when original path is outside project root', async () => {
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/other/foo.ts',
+      '/project',
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to original path when realpath fails', async () => {
+    const mockRealpath = vi.fn().mockRejectedValue(new Error('ENOENT'));
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/src/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    expect(result).toEqual(['src/foo.ts']);
+  });
+
+  it('filters out realpath result when it is also outside project root', async () => {
+    const mockRealpath = vi
+      .fn()
+      .mockResolvedValueOnce('/other/foo.ts') // realpath(file)
+      .mockResolvedValueOnce('/project'); // realpath(projectRoot)
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/src/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    // realpath resolved to outside project root, so only original is returned
+    expect(result).toEqual(['src/foo.ts']);
+  });
+
+  it('handles symlinked directories correctly', async () => {
+    // Simulate /project/symlink-to-src → /project/src
+    const mockRealpath = vi
+      .fn()
+      .mockResolvedValueOnce('/project/src/nested/foo.ts') // realpath(file)
+      .mockResolvedValueOnce('/project'); // realpath(projectRoot)
+    const result = await resolveSymlinkAwareRelativePaths(
+      '/project/symlink-to-src/nested/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    expect(result).toEqual([
+      'symlink-to-src/nested/foo.ts',
+      'src/nested/foo.ts',
+    ]);
+  });
+
+  it('works with relative input paths', async () => {
+    const mockRealpath = vi
+      .fn()
+      .mockResolvedValueOnce('/project/lib/foo.ts') // realpath(file)
+      .mockResolvedValueOnce('/project'); // realpath(projectRoot)
+    const result = await resolveSymlinkAwareRelativePaths(
+      'src/foo.ts',
+      '/project',
+      mockRealpath,
+    );
+    expect(result).toEqual(['src/foo.ts', 'lib/foo.ts']);
+  });
+});

--- a/packages/core/src/utils/projectPath.ts
+++ b/packages/core/src/utils/projectPath.ts
@@ -5,6 +5,7 @@
  */
 
 import * as path from 'node:path';
+import * as fsPromises from 'node:fs/promises';
 
 /**
  * Compute a project-relative, forward-slash-normalized path for matching
@@ -38,4 +39,68 @@ export function resolveProjectRelativePath(
     return null;
   }
   return rawRelativePath.replace(/\\/g, '/');
+}
+
+/**
+ * Resolve project-relative paths with symlink awareness.
+ *
+ * When a file is accessed via a symlinked path (e.g., in a git worktree or
+ * monorepo with symlinked directories), this function returns both the
+ * original relative path and the realpath-resolved relative path, so that
+ * glob patterns like `src/ **\/*.ts` can match either form.
+ *
+ * Falls back gracefully if `realpath` fails (e.g., ENOENT for non-existent
+ * files or permission errors).
+ *
+ * @param filePath - Absolute or relative path to the file being accessed.
+ * @param projectRoot - Absolute path to the project root.
+ * @param realpath - Async realpath function (defaults to `fsPromises.realpath`).
+ * @param pathModule - Path module (defaults to `path`, parameterized for testing).
+ * @returns Array of unique project-relative paths (1 or 2 elements).
+ */
+export async function resolveSymlinkAwareRelativePaths(
+  filePath: string,
+  projectRoot: string,
+  realpath: (path: string) => Promise<string> = fsPromises.realpath,
+  pathModule: typeof path = path,
+): Promise<string[]> {
+  const originalRelative = resolveProjectRelativePath(
+    filePath,
+    projectRoot,
+    pathModule,
+  );
+
+  // If original path is outside project root, return empty
+  if (originalRelative === null) {
+    return [];
+  }
+
+  const results = [originalRelative];
+
+  // Try to resolve symlinks
+  try {
+    const absolutePath = pathModule.isAbsolute(filePath)
+      ? filePath
+      : pathModule.resolve(projectRoot, filePath);
+    const realFilePath = await realpath(absolutePath);
+
+    if (realFilePath !== absolutePath) {
+      // Resolve projectRoot too — on macOS, os.tmpdir() returns /tmp/...
+      // but realpath resolves it to /private/tmp/..., so both sides must
+      // use the same canonical prefix for path.relative to work.
+      const realProjectRoot = await realpath(projectRoot);
+      const realRelative = resolveProjectRelativePath(
+        realFilePath,
+        realProjectRoot,
+        pathModule,
+      );
+      if (realRelative !== null && realRelative !== originalRelative) {
+        results.push(realRelative);
+      }
+    }
+  } catch {
+    // realpath failed (ENOENT, permission error, etc.) — use original only
+  }
+
+  return results;
 }

--- a/packages/core/src/utils/rulesDiscovery.test.ts
+++ b/packages/core/src/utils/rulesDiscovery.test.ts
@@ -65,7 +65,7 @@ describe('rulesDiscovery', () => {
   // ─────────────────────────────────────────────────────────────────────────
 
   describe('parseRuleFile', () => {
-    it('parses a rule with paths frontmatter', () => {
+    it('parses a rule with paths frontmatter', async () => {
       const content = `---
 description: Frontend rules
 paths:
@@ -81,7 +81,7 @@ Use React functional components.
       expect(rule!.content).toBe('Use React functional components.');
     });
 
-    it('parses a baseline rule without paths', () => {
+    it('parses a baseline rule without paths', async () => {
       const content = `---
 description: General coding standards
 ---
@@ -92,13 +92,13 @@ Always write tests.
       expect(rule!.content).toBe('Always write tests.');
     });
 
-    it('parses a rule without any frontmatter as baseline', () => {
+    it('parses a rule without any frontmatter as baseline', async () => {
       const rule = parseRuleFile('Plain rules.\n\nParagraph.', '/test/r.md');
       expect(rule!.paths).toBeUndefined();
       expect(rule!.content).toBe('Plain rules.\n\nParagraph.');
     });
 
-    it('strips HTML comments', () => {
+    it('strips HTML comments', async () => {
       const content = `---
 description: Test
 ---
@@ -112,7 +112,7 @@ Also visible.
       expect(rule!.content).toContain('Also visible.');
     });
 
-    it('strips adjacent and residual HTML comment markers', () => {
+    it('strips adjacent and residual HTML comment markers', async () => {
       // Defensive cases that previously left residual <!-- in the output,
       // flagged by CodeQL as incomplete multi-character sanitization.
       const content = `---
@@ -126,7 +126,7 @@ A<!-- one --><!-- two -->B<!--unclosed
       expect(rule!.content).toContain('B');
     });
 
-    it('returns null for empty body after stripping', () => {
+    it('returns null for empty body after stripping', async () => {
       const content = `---
 paths:
   - "*.ts"
@@ -136,7 +136,7 @@ paths:
       expect(parseRuleFile(content, '/test/rule.md')).toBeNull();
     });
 
-    it('handles empty paths array as baseline', () => {
+    it('handles empty paths array as baseline', async () => {
       const content = `---
 paths:
 ---
@@ -145,7 +145,7 @@ Some content.
       expect(parseRuleFile(content, '/t.md')!.paths).toBeUndefined();
     });
 
-    it('handles paths as a single string', () => {
+    it('handles paths as a single string', async () => {
       const content = `---
 paths: "src/**/*.ts"
 ---
@@ -154,14 +154,14 @@ Rule.
       expect(parseRuleFile(content, '/t.md')!.paths).toEqual(['src/**/*.ts']);
     });
 
-    it('handles BOM and CRLF', () => {
+    it('handles BOM and CRLF', async () => {
       const content = '\uFEFF---\r\ndescription: BOM\r\n---\r\nContent.\r\n';
       const rule = parseRuleFile(content, '/t.md');
       expect(rule!.description).toBe('BOM');
       expect(rule!.content).toBe('Content.');
     });
 
-    it('treats non-array/non-string paths as baseline', () => {
+    it('treats non-array/non-string paths as baseline', async () => {
       const content = `---
 paths: 42
 ---
@@ -367,33 +367,35 @@ Use hooks.`,
       content: body,
     });
 
-    it('matches a file and returns formatted content', () => {
+    it('matches a file and returns formatted content', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/fe.md', ['src/**/*.tsx'], 'Use hooks.')],
         '/project',
       );
-      const result = reg.matchAndConsume('/project/src/App.tsx');
+      const result = await reg.matchAndConsume('/project/src/App.tsx');
       expect(result).toContain('Use hooks.');
     });
 
-    it('returns undefined when no patterns match', () => {
+    it('returns undefined when no patterns match', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/fe.md', ['src/**/*.tsx'], 'Use hooks.')],
         '/project',
       );
-      expect(reg.matchAndConsume('/project/lib/utils.py')).toBeUndefined();
+      expect(
+        await reg.matchAndConsume('/project/lib/utils.py'),
+      ).toBeUndefined();
     });
 
-    it('injects each rule at most once', () => {
+    it('injects each rule at most once', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/fe.md', ['src/**/*.tsx'], 'Use hooks.')],
         '/project',
       );
-      expect(reg.matchAndConsume('/project/src/A.tsx')).toBeDefined();
-      expect(reg.matchAndConsume('/project/src/B.tsx')).toBeUndefined();
+      expect(await reg.matchAndConsume('/project/src/A.tsx')).toBeDefined();
+      expect(await reg.matchAndConsume('/project/src/B.tsx')).toBeUndefined();
     });
 
-    it('matches multiple rules for one file', () => {
+    it('matches multiple rules for one file', async () => {
       const reg = new ConditionalRulesRegistry(
         [
           rule('/r/ts.md', ['**/*.tsx'], 'Strict.'),
@@ -401,59 +403,59 @@ Use hooks.`,
         ],
         '/project',
       );
-      const result = reg.matchAndConsume('/project/src/App.tsx');
+      const result = await reg.matchAndConsume('/project/src/App.tsx');
       expect(result).toContain('Strict.');
       expect(result).toContain('Hooks.');
       expect(reg.injectedCount).toBe(2);
     });
 
-    it('tracks totalCount and injectedCount', () => {
+    it('tracks totalCount and injectedCount', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/a.md', ['**/*.ts'], 'A'), rule('/r/b.md', ['**/*.py'], 'B')],
         '/project',
       );
       expect(reg.totalCount).toBe(2);
       expect(reg.injectedCount).toBe(0);
-      reg.matchAndConsume('/project/foo.ts');
+      await reg.matchAndConsume('/project/foo.ts');
       expect(reg.injectedCount).toBe(1);
     });
 
-    it('returns undefined when registry is empty', () => {
+    it('returns undefined when registry is empty', async () => {
       const reg = new ConditionalRulesRegistry([], '/project');
-      expect(reg.matchAndConsume('/project/foo.ts')).toBeUndefined();
+      expect(await reg.matchAndConsume('/project/foo.ts')).toBeUndefined();
     });
 
-    it('does not match files outside the project root', () => {
+    it('does not match files outside the project root', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/ts.md', ['**/*.ts'], 'Strict.')],
         '/project',
       );
-      expect(reg.matchAndConsume('/etc/passwd')).toBeUndefined();
-      expect(reg.matchAndConsume('/other/foo.ts')).toBeUndefined();
+      expect(await reg.matchAndConsume('/etc/passwd')).toBeUndefined();
+      expect(await reg.matchAndConsume('/other/foo.ts')).toBeUndefined();
     });
 
-    it('rejects the exact `..` relative path (parent of projectRoot)', () => {
+    it('rejects the exact `..` relative path (parent of projectRoot)', async () => {
       // Pattern matches literal '..' — pathological but defensive
       const reg = new ConditionalRulesRegistry(
         [rule('/r/dot.md', ['..'], 'Parent rule.')],
         '/project',
       );
       // Exact parent directory (unlikely but possible input)
-      expect(reg.matchAndConsume('/')).toBeUndefined();
+      expect(await reg.matchAndConsume('/')).toBeUndefined();
     });
 
-    it('resolves relative paths against projectRoot', () => {
+    it('resolves relative paths against projectRoot', async () => {
       const reg = new ConditionalRulesRegistry(
         [rule('/r/ts.md', ['src/**/*.ts'], 'Strict.')],
         '/project',
       );
       // A relative file_path should be resolved against the project root
       // so "src/foo.ts" matches "src/**/*.ts".
-      const result = reg.matchAndConsume('src/foo.ts');
+      const result = await reg.matchAndConsume('src/foo.ts');
       expect(result).toContain('Strict.');
     });
 
-    it('activates on dotfiles when glob covers them (dot: true semantics)', () => {
+    it('activates on dotfiles when glob covers them (dot: true semantics)', async () => {
       // **/*.yml must match .github/workflows/ci.yml, .prettierrc.yml, etc.
       // Regression: previously picomatch used { dot: false } so hidden paths
       // were silently excluded.
@@ -462,11 +464,11 @@ Use hooks.`,
         '/project',
       );
       expect(
-        reg.matchAndConsume('/project/.github/workflows/ci.yml'),
+        await reg.matchAndConsume('/project/.github/workflows/ci.yml'),
       ).toContain('YAML rule.');
     });
 
-    it('rejects Windows cross-drive paths (shared cross-drive guard)', () => {
+    it('rejects Windows cross-drive paths (shared cross-drive guard)', async () => {
       // Regression: ConditionalRulesRegistry historically only checked
       // `..` / `../` and accepted the absolute string that
       // `path.win32.relative('C:\\proj', 'D:\\elsewhere')` produces. The
@@ -483,13 +485,13 @@ Use hooks.`,
         '/project',
       );
       expect(
-        reg.matchAndConsume('/totally/other/place/file.ts'),
+        await reg.matchAndConsume('/totally/other/place/file.ts'),
       ).toBeUndefined();
     });
 
     it.skipIf(process.platform === 'win32')(
       'should match shell-escaped file paths after unescaping',
-      () => {
+      async () => {
         // On Windows, unescapePath is a no-op (backslash is a path
         // separator, not a shell escape character).
         const reg = new ConditionalRulesRegistry(
@@ -499,10 +501,62 @@ Use hooks.`,
         const escapedPath = 'src/App\\ file.tsx';
         const normalizedPath = unescapePath(escapedPath.trim());
         expect(normalizedPath).toBe('src/App file.tsx');
-        const result = reg.matchAndConsume(
+        const result = await reg.matchAndConsume(
           path.resolve('/project', normalizedPath),
         );
         expect(result).toContain('Use hooks.');
+      },
+    );
+
+    it.skipIf(process.platform === 'win32')(
+      'activates rules when file is reached via symlinked directory',
+      async () => {
+        // Create a real src/ directory and a symlink to it
+        const srcDir = path.join(projectRoot, 'src');
+        await fsPromises.mkdir(srcDir, { recursive: true });
+        const symlinkDir = path.join(projectRoot, 'symlink-to-src');
+        await fsPromises.symlink(srcDir, symlinkDir);
+
+        // Create the actual file so realpath can resolve it
+        const realFile = path.join(srcDir, 'foo.ts');
+        await fsPromises.writeFile(realFile, '// test');
+
+        const reg = new ConditionalRulesRegistry(
+          [rule('/r/ts.md', ['src/**/*.ts'], 'Strict.')],
+          projectRoot,
+        );
+
+        // Access file via symlinked path
+        const symlinkedFile = path.join(symlinkDir, 'foo.ts');
+        const result = await reg.matchAndConsume(symlinkedFile);
+        expect(result).toContain('Strict.');
+      },
+    );
+
+    it.skipIf(process.platform === 'win32')(
+      'activates rules when project root itself is a symlink',
+      async () => {
+        // Create a real project directory and a symlink to it
+        const realProject = path.join(testRootDir, 'real-project');
+        await fsPromises.mkdir(realProject, { recursive: true });
+        const srcDir = path.join(realProject, 'src');
+        await fsPromises.mkdir(srcDir, { recursive: true });
+        const symlinkProject = path.join(testRootDir, 'symlink-project');
+        await fsPromises.symlink(realProject, symlinkProject);
+
+        // Create the actual file so realpath can resolve it
+        const realFile = path.join(srcDir, 'foo.ts');
+        await fsPromises.writeFile(realFile, '// test');
+
+        const reg = new ConditionalRulesRegistry(
+          [rule('/r/ts.md', ['src/**/*.ts'], 'Strict.')],
+          symlinkProject,
+        );
+
+        const result = await reg.matchAndConsume(
+          path.join(symlinkProject, 'src', 'foo.ts'),
+        );
+        expect(result).toContain('Strict.');
       },
     );
   });

--- a/packages/core/src/utils/rulesDiscovery.ts
+++ b/packages/core/src/utils/rulesDiscovery.ts
@@ -22,7 +22,7 @@ import { normalizeContent } from './textUtils.js';
 import { QWEN_DIR } from './paths.js';
 import { Storage } from '../config/storage.js';
 import { createDebugLogger } from './debugLogger.js';
-import { resolveProjectRelativePath } from './projectPath.js';
+import { resolveSymlinkAwareRelativePaths } from './projectPath.js';
 
 const logger = createDebugLogger('RULES_DISCOVERY');
 
@@ -254,23 +254,21 @@ export class ConditionalRulesRegistry {
    * @param filePath - Absolute path of the file being accessed.
    * @returns Formatted rule content, or undefined if no new rules match.
    */
-  matchAndConsume(filePath: string): string | undefined {
+  async matchAndConsume(filePath: string): Promise<string | undefined> {
     if (this.compiledRules.length === 0) return undefined;
 
-    // Shared helper handles `..` outside-root, plus the Windows
-    // cross-drive case (where `path.relative('C:\\proj', 'D:\\else')`
-    // returns an absolute path that would otherwise normalize to
-    // forward slashes and false-match a broad glob like `**/*.ts`).
-    // Without this guard the rules registry diverged from
-    // SkillActivationRegistry, which had been hardened earlier.
-    const relativePath = resolveProjectRelativePath(filePath, this.projectRoot);
-    if (relativePath === null) {
+    // Resolve symlinks and check both original and realpath-resolved paths
+    const relativePaths = await resolveSymlinkAwareRelativePaths(
+      filePath,
+      this.projectRoot,
+    );
+    if (relativePaths.length === 0) {
       return undefined;
     }
 
     const newMatches = this.compiledRules.filter(({ rule, matchers }) => {
       if (this.injected.has(rule.filePath)) return false;
-      return matchers.some((m) => m(relativePath));
+      return relativePaths.some((relPath) => matchers.some((m) => m(relPath)));
     });
 
     if (newMatches.length === 0) return undefined;


### PR DESCRIPTION
## What this PR does

When a file is accessed via a symlinked path (common in git worktrees and monorepos with symlinked directories), conditional rules and conditional skills keyed on the real path failed to activate. This PR adds symlink-aware path resolution so that glob patterns like `src/**/*.ts` match both the original symlinked path and the realpath-resolved path.

## Why it's needed

Developers working in git worktrees or monorepos often have symlinked directories. When a tool touches a file via the symlink path (e.g., `symlink-to-src/foo.ts`), the `paths:` glob `src/**/*.ts` wouldn't match because the relative path was computed from the symlink, not the real directory. This made conditional rules and skills silently fail to activate in these setups.

## Reviewer Test Plan

### How to verify

1. Create a project with a `src/` directory and a symlink pointing to it: `ln -s src symlink-to-src`
2. Add a conditional rule in `.qwen/rules/fe.md` with `paths: ["src/**/*.ts"]`
3. Have the agent touch a file via the symlink path: `symlink-to-src/foo.ts`
4. The rule should activate (previously it would not)

Run tests:

```bash
cd packages/core && npx vitest run src/utils/projectPath.test.ts src/utils/rulesDiscovery.test.ts src/skills/skill-activation.test.ts
```

All 70 tests should pass.

### Evidence (Before & After)

N/A — non-user-visible change (internal path resolution logic)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local dev environment, Node.js 22, vitest

## Risk & Scope

- Main risk or tradeoff: Adds one async `realpath` call per file touch during tool scheduling — negligible I/O overhead
- Not validated / out of scope: Windows symlink behavior (skipped via `it.skipIf(process.platform === 'win32')`)
- Breaking changes / migration notes: `matchAndConsume()` is now async — any external consumers must `await` it

## Linked Issues

Fixes #6356

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

当文件通过符号链接路径访问时（在 git worktree 或使用符号链接目录的 monorepo 中很常见），基于真实路径配置的条件规则和条件技能无法激活。此 PR 添加了符号链接感知的路径解析，使 `src/**/*.ts` 等 glob 模式同时匹配原始符号链接路径和 realpath 解析后的路径。

## 为什么需要

在 git worktree 或 monorepo 中工作的开发者经常使用符号链接目录。当工具通过符号链接路径（如 `symlink-to-src/foo.ts`）访问文件时，`paths:` glob `src/**/*.ts` 无法匹配，因为相对路径是基于符号链接而非真实目录计算的。这导致条件规则和条件技能在这些场景中静默失效。

## 审阅者测试计划

### 如何验证

1. 创建一个包含 `src/` 目录的项目和一个指向它的符号链接：`ln -s src symlink-to-src`
2. 在 `.qwen/rules/fe.md` 中添加条件规则，配置 `paths: ["src/**/*.ts"]`
3. 让 agent 通过符号链接路径访问文件：`symlink-to-src/foo.ts`
4. 规则应该激活（之前不会激活）

运行测试：

```bash
cd packages/core && npx vitest run src/utils/projectPath.test.ts src/utils/rulesDiscovery.test.ts src/skills/skill-activation.test.ts
```

所有 70 个测试应通过。

### 证据（修改前 & 修改后）

N/A — 非用户可见的变更（内部路径解析逻辑）

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地开发环境，Node.js 22，vitest

## 风险 & 范围

- 主要风险或权衡：在工具调度期间每个文件访问增加一次异步 `realpath` 调用 — I/O 开销可忽略不计
- 未验证 / 超出范围：Windows 符号链接行为（通过 `it.skipIf(process.platform === 'win32')` 跳过）
- 破坏性变更 / 迁移说明：`matchAndConsume()` 现在是异步的 — 任何外部调用者必须 `await` 它

## 关联 Issue

Fixes #6356

</details>
