### PR TITLE
feat(core): add tools.visible config for selective deferred-tool visibility at startup

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2965,6 +2965,19 @@ describe('loadCliConfig safe mode', () => {
     expect(config.getVisibleTools().size).toBe(0);
   });
 
+  it('should ignore settings-sourced visibleTools in bare mode', async () => {
+    process.argv = ['node', 'script.js', '--bare'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: {
+        visible: ['web_fetch'],
+      },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+
+    expect(config.getVisibleTools().size).toBe(0);
+  });
+
   it('should respect safe mode via QWEN_CODE_SAFE_MODE env var', async () => {
     vi.stubEnv('QWEN_CODE_SAFE_MODE', 'true');
     process.argv = ['node', 'script.js'];

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2930,6 +2930,41 @@ describe('loadCliConfig safe mode', () => {
     expect(config.getDisabledTools().size).toBe(0);
   });
 
+  it('should pass settings.tools.visible into visibleTools', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: {
+        visible: ['web_fetch', 'monitor'],
+      },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+
+    expect(config.getVisibleTools()).toEqual(new Set(['web_fetch', 'monitor']));
+  });
+
+  it('should default visibleTools to empty when settings.tools.visible is absent', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv, undefined, []);
+
+    expect(config.getVisibleTools().size).toBe(0);
+  });
+
+  it('should ignore settings-sourced visibleTools in safe mode', async () => {
+    process.argv = ['node', 'script.js', '--safe-mode'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: {
+        visible: ['web_fetch'],
+      },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+
+    expect(config.getVisibleTools().size).toBe(0);
+  });
+
   it('should respect safe mode via QWEN_CODE_SAFE_MODE env var', async () => {
     vi.stubEnv('QWEN_CODE_SAFE_MODE', 'true');
     process.argv = ['node', 'script.js'];

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2978,6 +2978,24 @@ describe('loadCliConfig safe mode', () => {
     expect(config.getVisibleTools().size).toBe(0);
   });
 
+  it('should normalise settings.tools.visible entries (trim, dedupe, filter)', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: {
+        visible: [
+          '  web_fetch  ',
+          'web_fetch',
+          '',
+          'monitor',
+        ] as unknown as string[],
+      },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+
+    expect(config.getVisibleTools()).toEqual(new Set(['web_fetch', 'monitor']));
+  });
+
   it('should respect safe mode via QWEN_CODE_SAFE_MODE env var', async () => {
     vi.stubEnv('QWEN_CODE_SAFE_MODE', 'true');
     process.argv = ['node', 'script.js'];

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -40,7 +40,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { extensionsCommand } from '../commands/extensions.js';
 import { hooksCommand } from '../commands/hooks.js';
-import { normalizeToolNameList } from './normalizeDisabledTools.js';
+import { normalizeDisabledToolList } from './normalizeDisabledTools.js';
 import type { LoadedSettings, Settings } from './settings.js';
 import { loadSettings, SettingScope } from './settings.js';
 import {
@@ -1736,9 +1736,13 @@ export async function loadCliConfig(
   // original casing; shared helper since the MCP restart refresh path
   // must agree byte-for-byte with this.
   const disabledTools =
-    bareMode || safeMode ? [] : normalizeToolNameList(settings.tools?.disabled);
+    bareMode || safeMode
+      ? []
+      : normalizeDisabledToolList(settings.tools?.disabled);
   const visibleTools =
-    bareMode || safeMode ? [] : normalizeToolNameList(settings.tools?.visible);
+    bareMode || safeMode
+      ? []
+      : normalizeDisabledToolList(settings.tools?.visible);
 
   // Helper: check if a tool is explicitly covered by an allow rule OR by the
   // coreTools whitelist. Uses alias matching for coreTools (via isToolEnabled)

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1739,6 +1739,10 @@ export async function loadCliConfig(
     bareMode || safeMode
       ? []
       : normalizeDisabledToolList(settings.tools?.disabled);
+  const visibleTools =
+    bareMode || safeMode
+      ? []
+      : normalizeDisabledToolList(settings.tools?.visible);
 
   // Helper: check if a tool is explicitly covered by an allow rule OR by the
   // coreTools whitelist. Uses alias matching for coreTools (via isToolEnabled)
@@ -1999,6 +2003,7 @@ export async function loadCliConfig(
     disabledSkillNamesProvider:
       bareMode || safeMode ? undefined : disabledSkillNamesProvider,
     disabledTools: disabledTools.length > 0 ? disabledTools : undefined,
+    visibleTools: visibleTools.length > 0 ? visibleTools : undefined,
     // New unified permissions (PermissionManager source of truth).
     permissions: {
       allow: mergedAllow.length > 0 ? mergedAllow : undefined,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -40,7 +40,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { extensionsCommand } from '../commands/extensions.js';
 import { hooksCommand } from '../commands/hooks.js';
-import { normalizeDisabledToolList } from './normalizeDisabledTools.js';
+import { normalizeToolNameList } from './normalizeDisabledTools.js';
 import type { LoadedSettings, Settings } from './settings.js';
 import { loadSettings, SettingScope } from './settings.js';
 import {
@@ -1736,13 +1736,9 @@ export async function loadCliConfig(
   // original casing; shared helper since the MCP restart refresh path
   // must agree byte-for-byte with this.
   const disabledTools =
-    bareMode || safeMode
-      ? []
-      : normalizeDisabledToolList(settings.tools?.disabled);
+    bareMode || safeMode ? [] : normalizeToolNameList(settings.tools?.disabled);
   const visibleTools =
-    bareMode || safeMode
-      ? []
-      : normalizeDisabledToolList(settings.tools?.visible);
+    bareMode || safeMode ? [] : normalizeToolNameList(settings.tools?.visible);
 
   // Helper: check if a tool is explicitly covered by an allow rule OR by the
   // coreTools whitelist. Uses alias matching for coreTools (via isToolEnabled)

--- a/packages/cli/src/config/normalizeDisabledTools.ts
+++ b/packages/cli/src/config/normalizeDisabledTools.ts
@@ -54,12 +54,3 @@ export function normalizeDisabledToolList(raw: unknown): string[] {
   }
   return out;
 }
-
-/**
- * Equivalent to {@link normalizeDisabledToolList}, but named generically
- * for use with any tool-name list (e.g. `tools.visible`) whose normalisation
- * contract matches `tools.disabled`.
- */
-export function normalizeToolNameList(raw: unknown): string[] {
-  return normalizeDisabledToolList(raw);
-}

--- a/packages/cli/src/config/normalizeDisabledTools.ts
+++ b/packages/cli/src/config/normalizeDisabledTools.ts
@@ -54,3 +54,12 @@ export function normalizeDisabledToolList(raw: unknown): string[] {
   }
   return out;
 }
+
+/**
+ * Equivalent to {@link normalizeDisabledToolList}, but named generically
+ * for use with any tool-name list (e.g. `tools.visible`) whose normalisation
+ * contract matches `tools.disabled`.
+ */
+export function normalizeToolNameList(raw: unknown): string[] {
+  return normalizeDisabledToolList(raw);
+}

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -1169,6 +1169,32 @@ describe('Settings Loading and Merging', () => {
       expect(disabled).toHaveLength(3);
     });
 
+    it('should UNION-merge tools.visible across user and workspace scopes', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      const userSettings = {
+        tools: { visible: ['web_fetch', 'monitor'] },
+      };
+      const workspaceSettings = {
+        tools: { visible: ['monitor', 'run_shell_command'] },
+      };
+
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH) return JSON.stringify(userSettings);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettings);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      const visible = settings.merged.tools?.visible ?? [];
+      expect(visible).toEqual(
+        expect.arrayContaining(['web_fetch', 'monitor', 'run_shell_command']),
+      );
+      expect(visible).toHaveLength(3);
+    });
+
     it('should merge all settings files with the correct precedence', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
       const systemDefaultsContent = {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2253,7 +2253,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: true,
         default: undefined as string[] | undefined,
         description:
-          'Deferred tool names promoted to first-class visibility at startup. Listed tools appear in the initial function declaration set without requiring a tool_search round-trip, avoiding KV-cache invalidation for frequently-used deferred tools.',
+          'Deferred tool names made visible at startup without requiring tool_search. Listed tools appear alongside core tools in the initial session.',
         showInDialog: false,
         mergeStrategy: MergeStrategy.UNION,
       },

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2246,6 +2246,17 @@ const SETTINGS_SCHEMA = {
         showInDialog: false,
         mergeStrategy: MergeStrategy.UNION,
       },
+      visible: {
+        type: 'array',
+        label: 'Visible Deferred Tools',
+        category: 'Tools',
+        requiresRestart: true,
+        default: undefined as string[] | undefined,
+        description:
+          'Deferred tool names promoted to first-class visibility at startup. Listed tools appear in the initial function declaration set without requiring a tool_search round-trip, avoiding KV-cache invalidation for frequently-used deferred tools.',
+        showInDialog: false,
+        mergeStrategy: MergeStrategy.UNION,
+      },
       approvalMode: {
         type: 'enum',
         label: 'Tool Approval Mode',

--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -44,6 +44,7 @@ function makeMockConfig(contextWindowSize = 32_000): Config {
       getAllTools: vi.fn().mockReturnValue([]),
       getFunctionDeclarations: vi.fn().mockReturnValue([]),
     }),
+    getVisibleTools: vi.fn().mockReturnValue(new Set()),
     getUserMemory: vi.fn().mockReturnValue(''),
     getSkillManager: vi.fn().mockReturnValue({
       listSkills: vi.fn().mockResolvedValue([]),
@@ -70,6 +71,7 @@ describe('collectContextData (contextCommand)', () => {
         getAllTools: vi.fn().mockReturnValue([]),
         getFunctionDeclarations: getFunctionDeclarationsSpy,
       }),
+      getVisibleTools: vi.fn().mockReturnValue(new Set()),
       getUserMemory: vi.fn().mockReturnValue(''),
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
@@ -162,6 +164,7 @@ describe('collectContextData (contextCommand)', () => {
         getFunctionDeclarations: vi.fn().mockReturnValue([]),
         isDeferredToolRevealed,
       }),
+      getVisibleTools: vi.fn().mockReturnValue(new Set()),
       getUserMemory: vi.fn().mockReturnValue(''),
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
@@ -176,6 +179,44 @@ describe('collectContextData (contextCommand)', () => {
     expect(data.mcpTools).toHaveLength(0);
     expect(isDeferredToolRevealed).toHaveBeenCalledWith('web_fetch');
     expect(isDeferredToolRevealed).toHaveBeenCalledWith('mcp__server__tool');
+  });
+
+  it('includes visibleTools in per-tool breakdown when deferred and not revealed (#6372)', async () => {
+    const visibleTool = {
+      name: 'web_fetch',
+      schema: { name: 'web_fetch', description: 'visible tool schema' },
+      shouldDefer: true,
+      alwaysLoad: false,
+    };
+    const hiddenDeferred = {
+      name: 'monitor',
+      schema: { name: 'monitor', description: 'hidden tool schema' },
+      shouldDefer: true,
+      alwaysLoad: false,
+    };
+    const config = {
+      getModel: vi.fn().mockReturnValue('test-model'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        contextWindowSize: 32_000,
+      }),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getAllTools: vi.fn().mockReturnValue([visibleTool, hiddenDeferred]),
+        getFunctionDeclarations: vi.fn().mockReturnValue([visibleTool.schema]),
+        isDeferredToolRevealed: vi.fn().mockReturnValue(false),
+      }),
+      getVisibleTools: vi.fn().mockReturnValue(new Set(['web_fetch'])),
+      getUserMemory: vi.fn().mockReturnValue(''),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([]),
+      }),
+      getChatCompression: vi.fn().mockReturnValue(undefined),
+      getAutoCompactThreshold: vi.fn(),
+    } as unknown as Config;
+
+    const data = await collectContextData(config, true);
+
+    expect(data.builtinTools).toHaveLength(1);
+    expect(data.builtinTools[0].name).toBe('web_fetch');
   });
 });
 

--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -43,6 +43,7 @@ function makeMockConfig(contextWindowSize = 32_000): Config {
     getToolRegistry: vi.fn().mockReturnValue({
       getAllTools: vi.fn().mockReturnValue([]),
       getFunctionDeclarations: vi.fn().mockReturnValue([]),
+      isDeferredAndHidden: vi.fn().mockReturnValue(false),
     }),
     getVisibleTools: vi.fn().mockReturnValue(new Set()),
     getUserMemory: vi.fn().mockReturnValue(''),
@@ -70,6 +71,7 @@ describe('collectContextData (contextCommand)', () => {
       getToolRegistry: vi.fn().mockReturnValue({
         getAllTools: vi.fn().mockReturnValue([]),
         getFunctionDeclarations: getFunctionDeclarationsSpy,
+        isDeferredAndHidden: vi.fn().mockReturnValue(false),
       }),
       getVisibleTools: vi.fn().mockReturnValue(new Set()),
       getUserMemory: vi.fn().mockReturnValue(''),
@@ -137,11 +139,11 @@ describe('collectContextData (contextCommand)', () => {
   });
 
   it('excludes deferred-but-not-revealed tools from the per-tool breakdown (#4508)', async () => {
-    // Regression: /context used to surface every deferred tool (MCP tools,
-    // plus low-frequency built-ins like web_fetch / monitor / cron_*) even
-    // when ToolSearch had not loaded any of them, inflating the displayed
-    // token count for the common default-on case.
-    const isDeferredToolRevealed = vi.fn().mockReturnValue(false);
+    const isDeferredAndHidden = vi
+      .fn()
+      .mockImplementation(
+        (name: string) => name === 'web_fetch' || name === 'mcp__server__tool',
+      );
     const hiddenBuiltin = {
       name: 'web_fetch',
       schema: { name: 'web_fetch', description: 'large schema' },
@@ -162,7 +164,7 @@ describe('collectContextData (contextCommand)', () => {
       getToolRegistry: vi.fn().mockReturnValue({
         getAllTools: vi.fn().mockReturnValue([hiddenBuiltin, hiddenMcp]),
         getFunctionDeclarations: vi.fn().mockReturnValue([]),
-        isDeferredToolRevealed,
+        isDeferredAndHidden,
       }),
       getVisibleTools: vi.fn().mockReturnValue(new Set()),
       getUserMemory: vi.fn().mockReturnValue(''),
@@ -177,8 +179,8 @@ describe('collectContextData (contextCommand)', () => {
 
     expect(data.builtinTools).toHaveLength(0);
     expect(data.mcpTools).toHaveLength(0);
-    expect(isDeferredToolRevealed).toHaveBeenCalledWith('web_fetch');
-    expect(isDeferredToolRevealed).toHaveBeenCalledWith('mcp__server__tool');
+    expect(isDeferredAndHidden).toHaveBeenCalledWith('web_fetch');
+    expect(isDeferredAndHidden).toHaveBeenCalledWith('mcp__server__tool');
   });
 
   it('includes visibleTools in per-tool breakdown when deferred and not revealed (#6372)', async () => {
@@ -202,7 +204,9 @@ describe('collectContextData (contextCommand)', () => {
       getToolRegistry: vi.fn().mockReturnValue({
         getAllTools: vi.fn().mockReturnValue([visibleTool, hiddenDeferred]),
         getFunctionDeclarations: vi.fn().mockReturnValue([visibleTool.schema]),
-        isDeferredToolRevealed: vi.fn().mockReturnValue(false),
+        isDeferredAndHidden: vi
+          .fn()
+          .mockImplementation((name: string) => name === 'monitor'),
       }),
       getVisibleTools: vi.fn().mockReturnValue(new Set(['web_fetch'])),
       getUserMemory: vi.fn().mockReturnValue(''),

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -146,7 +146,8 @@ export async function collectContextData(
     if (
       tool.shouldDefer &&
       !tool.alwaysLoad &&
-      !toolRegistry?.isDeferredToolRevealed(tool.name)
+      !toolRegistry?.isDeferredToolRevealed(tool.name) &&
+      !config.getVisibleTools().has(tool.name)
     ) {
       continue;
     }

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -143,12 +143,7 @@ export async function collectContextData(
   const builtinTools: ContextToolDetail[] = [];
   const mcpTools: ContextToolDetail[] = [];
   for (const tool of allTools) {
-    if (
-      tool.shouldDefer &&
-      !tool.alwaysLoad &&
-      !toolRegistry?.isDeferredToolRevealed(tool.name) &&
-      !config.getVisibleTools().has(tool.name)
-    ) {
+    if (toolRegistry?.isDeferredAndHidden(tool.name)) {
       continue;
     }
     const toolJsonStr = JSON.stringify(tool.schema);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -6002,6 +6002,52 @@ describe('disabledTools runtime sync (#4282 fold-in 5 P2-2 / #4297 fold-in 5)', 
   });
 });
 
+describe('visibleTools', () => {
+  const baseParams: ConfigParameters = {
+    targetDir: '.',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '.',
+  };
+
+  it('initializes from `visibleTools` ConfigParameters', () => {
+    const config = new Config({
+      ...baseParams,
+      visibleTools: ['Foo', 'Bar'],
+    });
+    expect(config.getVisibleTools()).toEqual(new Set(['Foo', 'Bar']));
+  });
+
+  it('defaults to an empty set when `visibleTools` is omitted', () => {
+    const config = new Config(baseParams);
+    expect(config.getVisibleTools()).toEqual(new Set());
+  });
+
+  it('filters out non-string entries', () => {
+    const config = new Config({
+      ...baseParams,
+      visibleTools: [
+        'tool_a',
+        42 as unknown as string,
+        null as unknown as string,
+        'tool_b',
+      ],
+    });
+    expect(config.getVisibleTools()).toEqual(new Set(['tool_a', 'tool_b']));
+  });
+
+  it('is readonly — returned set preserves config state', () => {
+    const config = new Config({
+      ...baseParams,
+      visibleTools: ['web_fetch'],
+    });
+    const set = config.getVisibleTools();
+    expect(set.has('web_fetch')).toBe(true);
+    // always returns the same reference
+    expect(config.getVisibleTools()).toBe(set);
+  });
+});
+
 describe('computer use settings', () => {
   const baseParams: ConfigParameters = {
     targetDir: '.',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -878,6 +878,14 @@ export interface ConfigParameters {
    * next ACP child spawn or `ToolRegistry.refresh()`.
    */
   disabledTools?: string[];
+  /**
+   * Deferred tool names that bypass the `shouldDefer` behaviour and
+   * are made visible in function declarations from session start,
+   * without requiring the model to call `tool_search`.
+   * Sourced from `settings.tools.visible`. Non-existent names are
+   * silently ignored (they don't cause config errors).
+   */
+  visibleTools?: string[];
   /** Merged permission rules from all sources (settings + CLI args). */
   permissions?: {
     allow?: string[];
@@ -1502,6 +1510,7 @@ export class Config {
   // captured reference (e.g. by ToolRegistry mid-iteration) remains
   // self-consistent.
   private disabledTools: ReadonlySet<string>;
+  private readonly visibleTools: ReadonlySet<string>;
   private readonly permissionsAllow: string[];
   private readonly permissionsAsk: string[];
   private readonly permissionsDeny: string[];
@@ -1748,6 +1757,11 @@ export class Config {
     ]);
     this.disabledSkillNamesProvider = params.disabledSkillNamesProvider ?? null;
     this.disabledTools = new Set(params.disabledTools ?? []);
+    this.visibleTools = new Set(
+      (params.visibleTools ?? []).filter(
+        (name): name is string => typeof name === 'string',
+      ),
+    );
     this.permissionsAllow = params.permissions?.allow || [];
     this.permissionsAsk = params.permissions?.ask || [];
     this.permissionsDeny = params.permissions?.deny || [];
@@ -3989,6 +4003,18 @@ export class Config {
    */
   getDisabledTools(): ReadonlySet<string> {
     return this.disabledTools;
+  }
+
+  /**
+   * Deferred-tool names that should be visible from session start.
+   * Sourced from `settings.tools.visible`.
+   *
+   * These tools bypass `shouldDefer` in `getFunctionDeclarations()`
+   * and are excluded from `getDeferredToolSummary()` so they appear
+   * as first-class tools to the model.
+   */
+  getVisibleTools(): ReadonlySet<string> {
+    return this.visibleTools;
   }
 
   /**

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -621,6 +621,47 @@ describe('ToolRegistry', () => {
       const summary = registry.getDeferredToolSummary();
       expect(summary).toEqual([]);
     });
+
+    it('disabledTools takes priority over visibleTools', () => {
+      const config = new Config({
+        ...baseConfigParams,
+        disabledTools: ['contested'],
+        visibleTools: ['contested'],
+      });
+      const registry = new ToolRegistry(config);
+      registry.registerTool(
+        new MockTool({ name: 'contested', shouldDefer: true }),
+      );
+
+      const names = registry.getFunctionDeclarations().map((d) => d.name);
+      expect(names).not.toContain('contested');
+    });
+
+    it('visible tool survives clearRevealedDeferredTools', () => {
+      const visibleConfig = new Config({
+        ...baseConfigParams,
+        visibleTools: ['web_fetch'],
+      });
+      const registry = new ToolRegistry(visibleConfig);
+      registry.registerTool(
+        new MockTool({ name: 'web_fetch', shouldDefer: true }),
+      );
+      registry.registerTool(
+        new MockTool({ name: 'monitor', shouldDefer: true }),
+      );
+
+      // Both start visible (web_fetch via visibleTools, monitor is hidden)
+      expect(registry.getFunctionDeclarations().map((d) => d.name)).toContain(
+        'web_fetch',
+      );
+
+      registry.clearRevealedDeferredTools();
+
+      // web_fetch stays — it's not in revealedDeferred
+      expect(registry.getFunctionDeclarations().map((d) => d.name)).toContain(
+        'web_fetch',
+      );
+    });
   });
 
   describe('getToolsByServer', () => {

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -569,6 +569,58 @@ describe('ToolRegistry', () => {
       toolRegistry.removeMcpToolsByServer('slack');
       expect(toolRegistry.isDeferredToolRevealed(toolName)).toBe(false);
     });
+
+    it('includes deferred tools listed in visibleTools in function declarations', () => {
+      const visibleConfig = new Config({
+        ...baseConfigParams,
+        visibleTools: ['should-appear'],
+      });
+      const registry = new ToolRegistry(visibleConfig);
+      registry.registerTool(new MockTool({ name: 'always-visible' }));
+      registry.registerTool(
+        new MockTool({ name: 'should-appear', shouldDefer: true }),
+      );
+      registry.registerTool(
+        new MockTool({ name: 'still-hidden', shouldDefer: true }),
+      );
+
+      const names = registry.getFunctionDeclarations().map((d) => d.name);
+      expect(names).toContain('always-visible');
+      expect(names).toContain('should-appear');
+      expect(names).not.toContain('still-hidden');
+    });
+
+    it('excludes visibleTools items from deferred tool summary', () => {
+      const visibleConfig = new Config({
+        ...baseConfigParams,
+        visibleTools: ['alpha'],
+      });
+      const registry = new ToolRegistry(visibleConfig);
+      registry.registerTool(
+        new MockTool({ name: 'alpha', description: 'a', shouldDefer: true }),
+      );
+      registry.registerTool(
+        new MockTool({ name: 'beta', description: 'b', shouldDefer: true }),
+      );
+
+      const summary = registry.getDeferredToolSummary();
+      expect(summary).toEqual([{ name: 'beta', description: 'b' }]);
+    });
+
+    it('visibleTools has no effect on non-deferred tools', () => {
+      const visibleConfig = new Config({
+        ...baseConfigParams,
+        visibleTools: ['regular'],
+      });
+      const registry = new ToolRegistry(visibleConfig);
+      registry.registerTool(new MockTool({ name: 'regular' }));
+
+      const names = registry.getFunctionDeclarations().map((d) => d.name);
+      expect(names).toContain('regular');
+
+      const summary = registry.getDeferredToolSummary();
+      expect(summary).toEqual([]);
+    });
   });
 
   describe('getToolsByServer', () => {

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -745,7 +745,8 @@ export class ToolRegistry {
    * Returns a lightweight summary of tools that are
    * deferred from the initial function-declaration list. Used to describe the
    * set of on-demand tools in the startup reminder so the model knows what is
-   * reachable via ToolSearch. `alwaysLoad` tools are excluded.
+   * reachable via ToolSearch. `alwaysLoad` tools and tools listed in
+   * {@link Config.getVisibleTools} are excluded.
    */
   getDeferredToolSummary(): DeferredToolSummary[] {
     const summary: DeferredToolSummary[] = [];

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -698,8 +698,7 @@ export class ToolRegistry {
           includeDeferred ||
           !tool.shouldDefer ||
           tool.alwaysLoad ||
-          this.config.getVisibleTools().has(tool.name) ||
-          this.revealedDeferred.has(tool.name),
+          !this.isDeferredAndHidden(tool.name),
       )
       .sort(ToolRegistry.compareToolsByDeclarationName)
       .map((tool) => tool.schema);
@@ -730,6 +729,25 @@ export class ToolRegistry {
   /** Whether a given tool has been revealed via {@link revealDeferredTool}. */
   isDeferredToolRevealed(name: string): boolean {
     return this.revealedDeferred.has(name);
+  }
+
+  /**
+   * Whether a deferred tool is currently hidden from the model's
+   * function-declaration list. Returns `true` when the tool:
+   * - is deferred (`shouldDefer=true`),
+   * - is not always-loaded,
+   * - has not been revealed this session, AND
+   * - is not in the visibleTools config list.
+   */
+  isDeferredAndHidden(name: string): boolean {
+    const tool = this.tools.get(name);
+    if (!tool) return false;
+    return (
+      tool.shouldDefer &&
+      !tool.alwaysLoad &&
+      !this.revealedDeferred.has(name) &&
+      !this.config.getVisibleTools().has(name)
+    );
   }
 
   /**

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -698,6 +698,7 @@ export class ToolRegistry {
           includeDeferred ||
           !tool.shouldDefer ||
           tool.alwaysLoad ||
+          this.config.getVisibleTools().has(tool.name) ||
           this.revealedDeferred.has(tool.name),
       )
       .sort(ToolRegistry.compareToolsByDeclarationName)
@@ -749,7 +750,11 @@ export class ToolRegistry {
   getDeferredToolSummary(): DeferredToolSummary[] {
     const summary: DeferredToolSummary[] = [];
     this.tools.forEach((tool) => {
-      if (tool.shouldDefer && !tool.alwaysLoad) {
+      if (
+        tool.shouldDefer &&
+        !tool.alwaysLoad &&
+        !this.config.getVisibleTools().has(tool.name)
+      ) {
         summary.push({
           name: tool.name,
           description: tool.description,

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -982,15 +982,19 @@ describe('ToolSearchTool', () => {
   });
 
   it('excludes visibleTools from keyword-search candidates', async () => {
-    const { registry } = makeConfigWithRegistry();
-    registry.registerTool(
+    const visibleConfig = new Config({
+      ...baseConfigParams,
+      visibleTools: ['web_fetch'],
+    });
+    const visibleRegistry = new ToolRegistry(visibleConfig);
+    visibleRegistry.registerTool(
       new MockTool({
         name: 'web_fetch',
         shouldDefer: true,
         searchHint: 'fetch data from web',
       }),
     );
-    registry.registerTool(
+    visibleRegistry.registerTool(
       new MockTool({
         name: 'monitor',
         shouldDefer: true,
@@ -998,12 +1002,7 @@ describe('ToolSearchTool', () => {
       }),
     );
 
-    // web_fetch is visible, monitor is not.
-    const visibleConfig = new Config({
-      ...baseConfigParams,
-      visibleTools: ['web_fetch'],
-    });
-    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(visibleRegistry);
     vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
       setTools: vi.fn().mockResolvedValue(undefined),
       refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
@@ -1015,22 +1014,21 @@ describe('ToolSearchTool', () => {
       .execute(new AbortController().signal);
     const content = String(result.llmContent);
 
-    // monitor matches "fetch" via searchHint, but web_fetch is excluded
     expect(content).toContain('monitor');
     expect(content).not.toContain('web_fetch');
   });
 
   it('select: for a visibleTool does NOT trigger reveal/setTools', async () => {
-    const { registry } = makeConfigWithRegistry();
-    registry.registerTool(
-      new MockTool({ name: 'web_fetch', shouldDefer: true }),
-    );
-
     const visibleConfig = new Config({
       ...baseConfigParams,
       visibleTools: ['web_fetch'],
     });
-    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+    const visibleRegistry = new ToolRegistry(visibleConfig);
+    visibleRegistry.registerTool(
+      new MockTool({ name: 'web_fetch', shouldDefer: true }),
+    );
+
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(visibleRegistry);
 
     const mockSetTools = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
@@ -1047,7 +1045,7 @@ describe('ToolSearchTool', () => {
     // Schema returned (model can inspect it)
     expect(content).toContain('"name":"web_fetch"');
     // But no reveal happened — tool is already visible
-    expect(registry.isDeferredToolRevealed('web_fetch')).toBe(false);
+    expect(visibleRegistry.isDeferredToolRevealed('web_fetch')).toBe(false);
     // And setTools was NOT called — no KV-cache invalidation
     expect(mockSetTools).not.toHaveBeenCalled();
   });
@@ -1067,19 +1065,19 @@ describe('ToolSearchTool', () => {
   });
 
   it('select: mixed visible+non-visible only reveals the hidden ones', async () => {
-    const { registry } = makeConfigWithRegistry();
-    registry.registerTool(
-      new MockTool({ name: 'web_fetch', shouldDefer: true }),
-    );
-    registry.registerTool(
-      new MockTool({ name: 'cron_create', shouldDefer: true }),
-    );
-
     const visibleConfig = new Config({
       ...baseConfigParams,
       visibleTools: ['web_fetch'],
     });
-    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+    const visibleRegistry = new ToolRegistry(visibleConfig);
+    visibleRegistry.registerTool(
+      new MockTool({ name: 'web_fetch', shouldDefer: true }),
+    );
+    visibleRegistry.registerTool(
+      new MockTool({ name: 'cron_create', shouldDefer: true }),
+    );
+
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(visibleRegistry);
 
     const mockSetTools = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
@@ -1097,8 +1095,8 @@ describe('ToolSearchTool', () => {
     expect(content).toContain('"name":"web_fetch"');
     expect(content).toContain('"name":"cron_create"');
     // web_fetch NOT revealed (visible), cron_create revealed
-    expect(registry.isDeferredToolRevealed('web_fetch')).toBe(false);
-    expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
+    expect(visibleRegistry.isDeferredToolRevealed('web_fetch')).toBe(false);
+    expect(visibleRegistry.isDeferredToolRevealed('cron_create')).toBe(true);
     // setTools called exactly once for cron_create
     expect(mockSetTools).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -1065,6 +1065,43 @@ describe('ToolSearchTool', () => {
 
     expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
   });
+
+  it('select: mixed visible+non-visible only reveals the hidden ones', async () => {
+    const { registry } = makeConfigWithRegistry();
+    registry.registerTool(
+      new MockTool({ name: 'web_fetch', shouldDefer: true }),
+    );
+    registry.registerTool(
+      new MockTool({ name: 'cron_create', shouldDefer: true }),
+    );
+
+    const visibleConfig = new Config({
+      ...baseConfigParams,
+      visibleTools: ['web_fetch'],
+    });
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+
+    const mockSetTools = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
+      setTools: mockSetTools,
+      refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const tool = new ToolSearchTool(visibleConfig);
+    const result = await tool
+      .build({ query: 'select:web_fetch,cron_create' })
+      .execute(new AbortController().signal);
+    const content = String(result.llmContent);
+
+    // Both schemas returned
+    expect(content).toContain('"name":"web_fetch"');
+    expect(content).toContain('"name":"cron_create"');
+    // web_fetch NOT revealed (visible), cron_create revealed
+    expect(registry.isDeferredToolRevealed('web_fetch')).toBe(false);
+    expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
+    // setTools called exactly once for cron_create
+    expect(mockSetTools).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('ToolRegistry.clearRevealedDeferredTools', () => {

--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -980,6 +980,91 @@ describe('ToolSearchTool', () => {
     // Reveal rolled back so subsequent ToolSearch can find the tool.
     expect(registry.isDeferredToolRevealed('cron_create')).toBe(false);
   });
+
+  it('excludes visibleTools from keyword-search candidates', async () => {
+    const { registry } = makeConfigWithRegistry();
+    registry.registerTool(
+      new MockTool({
+        name: 'web_fetch',
+        shouldDefer: true,
+        searchHint: 'fetch data from web',
+      }),
+    );
+    registry.registerTool(
+      new MockTool({
+        name: 'monitor',
+        shouldDefer: true,
+        searchHint: 'fetch process output',
+      }),
+    );
+
+    // web_fetch is visible, monitor is not.
+    const visibleConfig = new Config({
+      ...baseConfigParams,
+      visibleTools: ['web_fetch'],
+    });
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+    vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
+      setTools: vi.fn().mockResolvedValue(undefined),
+      refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const tool = new ToolSearchTool(visibleConfig);
+    const result = await tool
+      .build({ query: 'fetch' })
+      .execute(new AbortController().signal);
+    const content = String(result.llmContent);
+
+    // monitor matches "fetch" via searchHint, but web_fetch is excluded
+    expect(content).toContain('monitor');
+    expect(content).not.toContain('web_fetch');
+  });
+
+  it('select: for a visibleTool does NOT trigger reveal/setTools', async () => {
+    const { registry } = makeConfigWithRegistry();
+    registry.registerTool(
+      new MockTool({ name: 'web_fetch', shouldDefer: true }),
+    );
+
+    const visibleConfig = new Config({
+      ...baseConfigParams,
+      visibleTools: ['web_fetch'],
+    });
+    vi.spyOn(visibleConfig, 'getToolRegistry').mockReturnValue(registry);
+
+    const mockSetTools = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(visibleConfig, 'getGeminiClient').mockReturnValue({
+      setTools: mockSetTools,
+      refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const tool = new ToolSearchTool(visibleConfig);
+    const result = await tool
+      .build({ query: 'select:web_fetch' })
+      .execute(new AbortController().signal);
+    const content = String(result.llmContent);
+
+    // Schema returned (model can inspect it)
+    expect(content).toContain('"name":"web_fetch"');
+    // But no reveal happened — tool is already visible
+    expect(registry.isDeferredToolRevealed('web_fetch')).toBe(false);
+    // And setTools was NOT called — no KV-cache invalidation
+    expect(mockSetTools).not.toHaveBeenCalled();
+  });
+
+  it('select: for a non-visible deferred tool still triggers reveal', async () => {
+    const { config, registry } = makeConfigWithRegistry();
+    registry.registerTool(
+      new MockTool({ name: 'cron_create', shouldDefer: true }),
+    );
+
+    const tool = new ToolSearchTool(config);
+    await tool
+      .build({ query: 'select:cron_create' })
+      .execute(new AbortController().signal);
+
+    expect(registry.isDeferredToolRevealed('cron_create')).toBe(true);
+  });
 });
 
 describe('ToolRegistry.clearRevealedDeferredTools', () => {

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -252,7 +252,8 @@ class ToolSearchInvocation extends BaseToolInvocation<
         (t) =>
           t.shouldDefer &&
           !t.alwaysLoad &&
-          !registry.isDeferredToolRevealed(t.name),
+          !registry.isDeferredToolRevealed(t.name) &&
+          !this.config.getVisibleTools().has(t.name),
       );
   }
 
@@ -332,7 +333,10 @@ class ToolSearchInvocation extends BaseToolInvocation<
       // list) and pulling them through setTools() would risk a spurious
       // "GeminiClient not initialised" failure for what is just a
       // schema-inspection call.
-      const isLoadable = tool.shouldDefer && !tool.alwaysLoad;
+      const isLoadable =
+        tool.shouldDefer &&
+        !tool.alwaysLoad &&
+        !this.config.getVisibleTools().has(tool.name);
       if (isLoadable) {
         const wasRevealed = registry.isDeferredToolRevealed(canonical);
         registry.revealDeferredTool(canonical);

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -248,13 +248,7 @@ class ToolSearchInvocation extends BaseToolInvocation<
     const registry = this.config.getToolRegistry();
     return registry
       .getAllTools()
-      .filter(
-        (t) =>
-          t.shouldDefer &&
-          !t.alwaysLoad &&
-          !registry.isDeferredToolRevealed(t.name) &&
-          !this.config.getVisibleTools().has(t.name),
-      );
+      .filter((t) => registry.isDeferredAndHidden(t.name));
   }
 
   private async loadAndReturnSchemas(
@@ -333,10 +327,7 @@ class ToolSearchInvocation extends BaseToolInvocation<
       // list) and pulling them through setTools() would risk a spurious
       // "GeminiClient not initialised" failure for what is just a
       // schema-inspection call.
-      const isLoadable =
-        tool.shouldDefer &&
-        !tool.alwaysLoad &&
-        !this.config.getVisibleTools().has(tool.name);
+      const isLoadable = registry.isDeferredAndHidden(canonical);
       if (isLoadable) {
         const wasRevealed = registry.isDeferredToolRevealed(canonical);
         registry.revealDeferredTool(canonical);

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1050,6 +1050,13 @@
             "type": "string"
           }
         },
+        "visible": {
+          "description": "Deferred tool names promoted to first-class visibility at startup. Listed tools appear in the initial function declaration set without requiring a tool_search round-trip, avoiding KV-cache invalidation for frequently-used deferred tools.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "approvalMode": {
           "description": "Approval mode for tool usage. Controls how tools are approved before execution. Options: plan, default, auto-edit, auto, yolo",
           "enum": [

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1051,7 +1051,7 @@
           }
         },
         "visible": {
-          "description": "Deferred tool names promoted to first-class visibility at startup. Listed tools appear in the initial function declaration set without requiring a tool_search round-trip, avoiding KV-cache invalidation for frequently-used deferred tools.",
+          "description": "Deferred tool names made visible at startup without requiring tool_search. Listed tools appear alongside core tools in the initial session.",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
## What this PR does

Adds a `tools.visible` setting to `settings.json` that lets users promote selected deferred tools to visible-at-startup, without needing the model to call `tool_search` to discover them. Tools listed in `tools.visible` are included in the initial function declaration list and excluded from the deferred-tool startup reminder — they appear as first-class tools from the very first turn.

A deferred tool (one with `shouldDefer=true`) is normally hidden from the LLM and only discoverable on-demand. This setting gives users per-tool granularity to override that: keep infrequently-used tools deferred, but make the routine ones immediately available.

## Why it's needed

Frequently-used tools like `web_fetch`, `monitor`, `task_stop`, and `cron` tools are forced to go through a `tool_search` round-trip on every session. Each `tool_search` call that reveals a new tool changes the prompt prefix and invalidates the LLM server's KV cache, costing 500–2000ms per discovery.

Existing workarounds are too coarse: disabling ToolSearch globally (`tools.toolSearch.enabled`) exposes all deferred tools at once, and `mcpServers.<NAME>.alwaysLoadTools` works only at the server level. There is no way to selectively promote individual deferred tools.

This feature fills that gap with a minimal, targeted setting that follows the established `tools.*` configuration pattern.

## Reviewer Test Plan

### How to verify

1. Add `"tools": { "visible": ["web_fetch"] }` to `settings.json`, start a session, and check that `web_fetch` is callable immediately without `tool_search`. Other deferred tools (e.g. `monitor`) should still require `tool_search` to discover.
2. Start a session without `tools.visible` — all deferred tools remain hidden as before. This confirms backward compatibility.
3. Run the unit test suite: `cd packages/core && npx vitest run src/config/config.test.ts src/tools/tool-registry.test.ts`. All tests pass.

### Evidence (Before & After)

N/A — non-UI change (configuration + internal gating). Observable difference is model behavior: visible tools are callable from turn one.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | ✅ |
|  🐧 Linux  | N/A |

### Environment

Unit tests only (`npx vitest`). Run with `QWEN_DEBUG_LOG_FILE=0` to avoid fs mock conflicts in local test runs.

## Risk & Scope

- Main risk or tradeoff: None. If a non-existent tool name is listed in `tools.visible`, it is silently ignored — it does not cause a config error or crash. The setting is purely additive; removing it restores the original behavior.
- Not validated / out of scope: Dynamic toggling at runtime (like `setDisabledTools` for daemon sync). `tools.visible` is read at startup only and requires restart. KV-cache optimization (removing `refreshStartupContextReminder` from ToolSearch flow) is a separate concern tracked in related issues.
- Breaking changes / migration notes: None. When `tools.visible` is absent (the default), behavior is identical to current.

## Linked Issues

- **Fixes** #6368 — `tools.visible`: selective deferred-tool visibility at startup
- **Related** #6265 — `tool_search` invalidates LLM server KV-cache on every deferred-tool load
- **Related** #6268 — closed proxy-tool PR; this takes the config-based approach instead

---

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `settings.json` 中新增 `tools.visible` 配置项，让用户可以将选定的 deferred 工具提升为启动时可见，无需模型调用 `tool_search` 来发现。列表中的工具会被纳入初始函数声明列表，并从 deferred 工具启动提醒中排除——它们从第一个回合起就作为一等工具出现。

deferred 工具（`shouldDefer=true`）通常对 LLM 不可见，只能按需发现。此配置让用户以工具粒度覆盖此行为：不常用的继续延迟加载，常用的立即可用。

## 为什么需要

`web_fetch`、`monitor`、`task_stop` 和 `cron` 等高频工具在每次会话中都要经过 `tool_search` 往返。每次发现新工具的 `tool_search` 调用都会改变 prompt 前缀，使 LLM 服务器的 KV-cache 失效，每次发现耗损 500–2000ms。

现有的变通方案太粗糙：全局关闭 ToolSearch（`tools.toolSearch.enabled`）会让所有 deferred 工具一次性暴露，`mcpServers.<NAME>.alwaysLoadTools` 只能按服务器级别工作。没有方式可以只选择性地提升个别 deferred 工具。

此功能用最小化、精准的配置填补了这个空白，遵循已有的 `tools.*` 配置模式。

## 审查者测试计划

### 如何验证

1. 在 `settings.json` 中添加 `"tools": { "visible": ["web_fetch"] }`，启动会话，确认 `web_fetch` 无需 `tool_search` 即可调用。其他 deferred 工具（如 `monitor`）仍需 `tool_search` 发现。
2. 启动不含 `tools.visible` 的会话——所有 deferred 工具仍然隐藏。确认向后兼容。
3. 运行单元测试：`cd packages/core && npx vitest run src/config/config.test.ts src/tools/tool-registry.test.ts`。全部通过。

### 改动前后

N/A——非 UI 变更（配置 + 内部过滤逻辑）。可观察的区别是模型行为：可见工具从第一回合起即可调用。

### 测试环境

|     操作系统     | 状态 |
| :------------: | :--: |
|  🍏 macOS      | N/A |
| 🪟 Windows     | ✅ |
|  🐧 Linux      | N/A |

### 环境

仅单元测试（`npx vitest`）。本地运行时使用 `QWEN_DEBUG_LOG_FILE=0` 避免 fs mock 冲突。

## 风险与范围

- 主要风险或权衡：无。如果列出了不存在的工具名，将被静默忽略——不会导致配置错误或崩溃。此设置纯增补；删除后恢复原有行为。
- 未验证/超出范围：运行时动态切换（类似 `setDisabledTools` 用于 daemon 同步）。`tools.visible` 仅在启动时读取，需要重启。KV-cache 优化（从 ToolSearch 流程中移除 `refreshStartupContextReminder`）是相关 issue 中跟踪的独立关注点。
- 破坏性变更/迁移说明：无。当 `tools.visible` 不存在时（默认），行为与当前一致。

## 关联 Issue

- **Fixes** #6368 — `tools.visible`：选择性的 deferred 工具启动时可见
- **关联** #6265 — `tool_search` 在每次 deferred 工具加载时使 LLM 服务器的 KV-cache 失效
- **关联** #6268 — 已关闭的 proxy-tool PR；本 PR 采用基于配置的方案

</details>

QwenCode QwenLLM
