### PR TITLE
fix(core): Include request IDs in OpenAI error logs

### DIFF
--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -344,6 +344,45 @@ describe('OpenAILogger', () => {
       expect(logContent.response).toBeNull();
     });
 
+    it('should log request id from OpenAI API errors', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const error = Object.assign(new Error('Server error'), {
+        requestID: 'req-server-123',
+      });
+
+      const logPath = await logger.logInteraction(
+        { model: 'gpt-4' },
+        undefined,
+        error,
+      );
+      const logContent = JSON.parse(await fs.readFile(logPath, 'utf-8'));
+
+      expect(logContent.error).toMatchObject({
+        message: 'Server error',
+        requestId: 'req-server-123',
+      });
+    });
+
+    it('should log request id from provider error payloads', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const error = new Error(
+        'event:error\n:HTTP_STATUS/429\ndata:{"request_id":"req-provider-456","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}',
+      );
+
+      const logPath = await logger.logInteraction(
+        { model: 'qwen-plus' },
+        undefined,
+        error,
+      );
+      const logContent = JSON.parse(await fs.readFile(logPath, 'utf-8'));
+
+      expect(logContent.error.requestId).toBe('req-provider-456');
+    });
+
     it('should use custom directory when provided', async () => {
       const customDir = path.join(testTempDir, 'custom-logs');
       const logger = new OpenAILogger(customDir);

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as os from 'os';
 import { createDebugLogger } from './debugLogger.js';
 import { isInternalPromptId } from './internalPromptIds.js';
+import { getRateLimitErrorDetails } from './rateLimit.js';
 
 const debugLogger = createDebugLogger('OPENAI_LOGGER');
 const MAIN_SESSION_PROMPT_ID_DELIMITER = '########';
@@ -111,6 +112,39 @@ function contextForPromptId(
   };
 }
 
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function getErrorRequestId(error: Error): string | undefined {
+  const source = error as {
+    requestID?: unknown;
+    request_id?: unknown;
+    requestId?: unknown;
+    response_id?: unknown;
+  };
+  return (
+    getString(source.requestID) ??
+    getString(source.request_id) ??
+    getString(source.requestId) ??
+    getString(source.response_id) ??
+    getRateLimitErrorDetails(error).requestId
+  );
+}
+
+function serializeError(error: Error): {
+  message: string;
+  stack?: string;
+  requestId?: string;
+} {
+  const requestId = getErrorRequestId(error);
+  return {
+    message: error.message,
+    stack: error.stack,
+    ...(requestId ? { requestId } : {}),
+  };
+}
+
 /**
  * Logger specifically for OpenAI API requests and responses
  */
@@ -175,12 +209,7 @@ export class OpenAILogger {
       timestamp: new Date().toISOString(),
       request,
       response: response || null,
-      error: error
-        ? {
-            message: error.message,
-            stack: error.stack,
-          }
-        : null,
+      error: error ? serializeError(error) : null,
       context: contextForPromptId(promptId),
       system: {
         hostname: os.hostname(),


### PR DESCRIPTION
## What this PR does

This PR adds the upstream request correlation id to OpenAI-compatible interaction logs when a chat-completions call fails. The log still records the same request, response, error message, and stack fields as before, but now also includes `error.requestId` when the provider or SDK exposes one.

## Why it's needed

When DashScope or other OpenAI-compatible providers return server-side errors, support and incident debugging depend on the provider request id rather than the successful completion id. Successful calls may have a `chatcmpl-...` response id, but failed calls often only expose a header or body request id. Without this field in `--openai-logging` output, users have to reproduce the failure with lower-level tooling or inspect SDK internals to give provider support a useful correlation id.

## Reviewer Test Plan

### How to verify

Run `--openai-logging` against an OpenAI-compatible endpoint that returns an error and confirm the generated interaction log includes `error.requestId`. I verified this with two real provider scenarios and no mock server: a standard DashScope 401 error and a Token Plan `glm-5.2` 429 quota error.

Scenario 1, real DashScope 401 before/after: I used an intentionally invalid key against the real DashScope OpenAI-compatible endpoint. The before run used the globally installed `qwen 0.19.6`; the after run used the local bundled CLI.

Scenario 2, real Token Plan `glm-5.2` 429: I used the real Token Plan provider with `glm-5.2` and `TOKEN_PLAN_API_KEY`, which returned the expected quota-exhausted 429 error.

### Evidence (Before & After)

Scenario 1 before, with globally installed `qwen 0.19.6` against real DashScope using an intentionally invalid API key:

```json
{
  "response": null,
  "errorKeys": ["message", "stack"],
  "errorRequestId": null
}
```

Scenario 1 after, with the local bundled CLI against the same real DashScope endpoint:

```json
{
  "response": null,
  "errorKeys": ["message", "stack", "requestId"],
  "errorRequestId": "92aee7f0-2624-922d-90e0-5dc7fd5b5a6f"
}
```

Scenario 2 after, with real Token Plan `glm-5.2` and a quota-exhausted `TOKEN_PLAN_API_KEY`:

```json
{
  "request": {
    "model": "glm-5.2"
  },
  "response": null,
  "error": {
    "message": "429 Your token-plan quota has been exhausted.",
    "requestId": "b539561e-6183-4cd1-b906-cd1460ccaf05"
  }
}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node.js v22.12.0 on macOS. E2E used real DashScope and Token Plan OpenAI-compatible endpoints with `--openai-logging` and temporary runtime/log directories; no mock server was used.

## Risk & Scope

- Main risk or tradeoff: The error object in OpenAI interaction logs gains one optional field when available; existing consumers that tolerate additional JSON fields should be unaffected.
- Not validated / out of scope: Windows and Linux local verification were not run. This does not change retry behavior or provider error classification.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在 OpenAI 兼容接口的聊天补全调用失败时，把上游请求关联 ID 写入交互日志。日志仍然保留原有的请求、响应、错误消息和堆栈字段，但当 provider 或 SDK 暴露请求 ID 时，现在会额外包含 `error.requestId`。

## Why it's needed

当 DashScope 或其他 OpenAI 兼容 provider 返回服务端错误时，排查和联系支持通常需要 provider 请求 ID，而不是成功响应里的 completion id。成功调用可能有 `chatcmpl-...` 响应 ID，但失败调用通常只暴露 header 或 body 中的请求 ID。之前 `--openai-logging` 输出里没有这个字段，用户需要用更底层的工具复现问题或检查 SDK 内部状态，才能拿到可用于 provider 排查的关联 ID。

## Reviewer Test Plan

### How to verify

对会返回错误的 OpenAI 兼容 endpoint 运行 `--openai-logging`，确认生成的交互日志包含 `error.requestId`。我用两个真实 provider 场景做了验证，没有使用 mock server：标准 DashScope 401 错误，以及 Token Plan `glm-5.2` 的 429 配额错误。

场景 1，真实 DashScope 401 before/after：我用故意无效的 key 访问真实 DashScope OpenAI 兼容 endpoint。before 使用全局安装的 `qwen 0.19.6`；after 使用本地 bundled CLI。

场景 2，真实 Token Plan `glm-5.2` 429：我使用真实 Token Plan provider、`glm-5.2` 和 `TOKEN_PLAN_API_KEY`，该 key 返回了预期的配额耗尽 429 错误。

### Evidence (Before & After)

场景 1 before，使用全局安装的 `qwen 0.19.6` 和故意无效的 API key 访问真实 DashScope：

```json
{
  "response": null,
  "errorKeys": ["message", "stack"],
  "errorRequestId": null
}
```

场景 1 after，使用本地 bundled CLI 访问同一个真实 DashScope endpoint：

```json
{
  "response": null,
  "errorKeys": ["message", "stack", "requestId"],
  "errorRequestId": "92aee7f0-2624-922d-90e0-5dc7fd5b5a6f"
}
```

场景 2 after，使用真实 Token Plan `glm-5.2` 和配额耗尽的 `TOKEN_PLAN_API_KEY`：

```json
{
  "request": {
    "model": "glm-5.2"
  },
  "response": null,
  "error": {
    "message": "429 Your token-plan quota has been exhausted.",
    "requestId": "b539561e-6183-4cd1-b906-cd1460ccaf05"
  }
}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS 上的 Node.js v22.12.0。E2E 使用真实 DashScope 和 Token Plan OpenAI 兼容 endpoint、`--openai-logging` 和临时 runtime/log 目录；未使用 mock server。

## Risk & Scope

- Main risk or tradeoff: 当请求 ID 可用时，OpenAI 交互日志中的错误对象会多一个可选字段；能容忍额外 JSON 字段的现有消费者不应受到影响。
- Not validated / out of scope: 未在 Windows 和 Linux 本地验证。这个 PR 不改变 retry 行为或 provider 错误分类。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>