### PR TITLE
fix(core): require integer ReadFile pagination params

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -146,19 +146,51 @@ describe('ReadFileTool', () => {
         offset: -1,
       };
       expect(() => tool.build(params)).toThrow(
-        'Offset must be a non-negative number',
+        'Offset must be a non-negative integer',
       );
     });
 
-    it('should throw error if limit is zero or negative', () => {
+    it('should throw error if offset is fractional', () => {
       const params: ReadFileToolParams = {
         file_path: path.join(tempRootDir, 'test.txt'),
-        limit: 0,
+        offset: 1.5,
       };
-      expect(() => tool.build(params)).toThrow(
-        'Limit must be a positive number',
-      );
+      expect(() => tool.build(params)).toThrow('params/offset must be integer');
     });
+
+    it('should allow zero offset', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        offset: 0,
+      };
+      expect(tool.build(params)).toBeDefined();
+    });
+
+    it.each([0, -1])(
+      'should throw error if limit is not positive (%s)',
+      (limit) => {
+        const params: ReadFileToolParams = {
+          file_path: path.join(tempRootDir, 'test.txt'),
+          limit,
+        };
+        expect(() => tool.build(params)).toThrow(
+          'Limit must be a positive integer',
+        );
+      },
+    );
+
+    it.each([0.5, 1.5])(
+      'should throw error if limit is fractional (%s)',
+      (limit) => {
+        const params: ReadFileToolParams = {
+          file_path: path.join(tempRootDir, 'test.txt'),
+          limit,
+        };
+        expect(() => tool.build(params)).toThrow(
+          'params/limit must be integer',
+        );
+      },
+    );
 
     it('should reject offset or limit for notebook files', () => {
       const params: ReadFileToolParams = {

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -406,12 +406,12 @@ export class ReadFileTool extends BaseDeclarativeTool<
           offset: {
             description:
               "Optional: For text files, the 0-based line number to start reading from. Requires 'limit' to be set. Use for paginating through large files.",
-            type: 'number',
+            type: 'integer',
           },
           limit: {
             description:
               "Optional: For text files, maximum number of lines to read. Use with 'offset' to paginate through large files. If omitted, reads the entire file (if feasible, up to a default limit).",
-            type: 'number',
+            type: 'integer',
           },
           pages: {
             description:
@@ -441,11 +441,17 @@ export class ReadFileTool extends BaseDeclarativeTool<
       return `File path must be absolute, but was relative: ${filePath}. You must provide an absolute path.`;
     }
 
-    if (params.offset !== undefined && params.offset < 0) {
-      return 'Offset must be a non-negative number';
+    if (
+      params.offset !== undefined &&
+      (!Number.isInteger(params.offset) || params.offset < 0)
+    ) {
+      return 'Offset must be a non-negative integer';
     }
-    if (params.limit !== undefined && params.limit <= 0) {
-      return 'Limit must be a positive number';
+    if (
+      params.limit !== undefined &&
+      (!Number.isInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'Limit must be a positive integer';
     }
 
     if (params.pages !== undefined) {


### PR DESCRIPTION
﻿## What this PR does

This PR tightens `ReadFileTool` pagination parameters so `offset` and `limit` are treated as integer line controls instead of arbitrary numbers.

It changes the tool schema for both fields from `number` to `integer`, adds runtime integer validation in `ReadFileTool.validateToolParamValues()`, and adds regression tests for fractional pagination inputs.

## Why it's needed

`ReadFileTool` describes `offset` as a 0-based line number and `limit` as the number of lines to read. Both values are discrete line controls, so they should be integers.

Before this change, the schema exposed both fields as `number`, and runtime validation only rejected negative `offset` values and non-positive `limit` values. Fractional inputs such as:

```json
{
  "file_path": "/tmp/example.txt",
  "offset": 1.5,
  "limit": 1.5
}
```

could pass the ReadFile-specific validation path. That leaves downstream file-reading code and display text with ambiguous pagination semantics: JavaScript array slicing coerces fractional indexes, while user-facing descriptions can still compute fractional ranges such as `lines 2.5-3.5`.

This PR rejects those malformed pagination requests at the tool boundary instead of letting fractional line numbers reach the file-read pipeline.

## Reviewer Test Plan

### How to verify

Reviewers can confirm that:

- `offset` and `limit` are now declared as `integer` in the ReadFile tool schema.
- fractional `offset` values such as `1.5` are rejected.
- fractional `limit` values such as `0.5` and `1.5` are rejected.
- existing valid pagination behavior still works, including `offset: 0` and positive integer limits.

### Evidence (Before & After)

Before this change, the tool schema advertised:

```ts
offset: { type: 'number' }
limit: { type: 'number' }
```

and ReadFile-specific validation only checked:

```ts
params.offset < 0
params.limit <= 0
```

After this change, both schema and runtime validation require integer semantics:

```ts
offset: { type: 'integer' }
limit: { type: 'integer' }
```

and:

```ts
!Number.isInteger(params.offset) || params.offset < 0
!Number.isInteger(params.limit) || params.limit <= 0
```

The new tests cover the malformed fractional inputs directly.

### Tested on

|     OS     | Status |
| :--------: | :----: |
| 🍎 macOS   | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
| 🐧 Linux   | ✅ tested |

### Environment (optional)

Windows local validation with Node.js from `D:\ZXY\Dev\nodejs`.

Commands run on Windows and WSL/Linux:

```powershell
npm ci --no-audit --no-fund
npm run test --workspace=packages/core -- read-file.test.ts
npm run typecheck --workspace=packages/core
git diff --check
```

Windows results:

```text
read-file.test.ts: 68 passed, 2 skipped
typecheck: passed
git diff --check: passed
```

WSL/Linux results with temporary native Node.js v22.13.1:

```text
read-file.test.ts: 70 passed
typecheck: passed
git diff --check: passed
```

## Risk & Scope

- Main risk or tradeoff: this is a small input-contract tightening. Any caller that was accidentally sending fractional line offsets or limits will now receive validation errors instead of ambiguous reads.
- Not validated / out of scope: full repository test suite and macOS local validation were not run.
- Breaking changes / migration notes: no intended breaking change for valid callers; integer pagination inputs continue to work.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 收紧了 `ReadFileTool` 的分页参数校验，让 `offset` 和 `limit` 按“整数行号 / 整数行数”处理，而不是任意数字。

具体改动包括：将工具 schema 中的 `offset` / `limit` 从 `number` 改为 `integer`，在 `ReadFileTool.validateToolParamValues()` 中增加运行时整数校验，并补充小数分页参数的回归测试。

## 为什么需要它

`ReadFileTool` 中 `offset` 表示 0-based 起始行号，`limit` 表示读取多少行。行号和行数都是离散概念，因此语义上应当是整数。

在本次修复之前，schema 将这两个字段声明为 `number`，运行时只拒绝负数 `offset` 和非正数 `limit`。因此类似下面的小数输入可能绕过 ReadFile 自身的校验：

```json
{
  "file_path": "/tmp/example.txt",
  "offset": 1.5,
  "limit": 1.5
}
```

这会让下游文件读取逻辑和展示文案出现含混语义：JavaScript array slicing 会对小数索引做隐式整数化处理，而用户可见描述仍可能计算出 `lines 2.5-3.5` 这类没有实际意义的行号范围。

这个 PR 在工具边界直接拒绝小数分页参数，避免小数行号进入文件读取管线。

## Reviewer 测试计划

Reviewers 可以确认：

- ReadFile 工具 schema 中 `offset` 和 `limit` 已声明为 `integer`。
- `offset: 1.5` 会被拒绝。
- `limit: 0.5` 和 `limit: 1.5` 会被拒绝。
- 合法分页行为仍然可用，例如 `offset: 0` 和正整数 `limit`。

## 证据

修复前 schema 使用：

```ts
offset: { type: 'number' }
limit: { type: 'number' }
```

并且 ReadFile 自身校验只检查：

```ts
params.offset < 0
params.limit <= 0
```

修复后 schema 和运行时校验都明确使用整数语义：

```ts
offset: { type: 'integer' }
limit: { type: 'integer' }
```

并且增加：

```ts
!Number.isInteger(params.offset) || params.offset < 0
!Number.isInteger(params.limit) || params.limit <= 0
```

新增测试直接覆盖了这些小数输入。

## 风险与范围

主要风险是输入契约被收紧：如果某些调用方之前意外传入小数分页参数，现在会得到校验错误。但这符合 `offset` / `limit` 作为行号和行数的实际语义。

本 PR 不改变 PDF pages、notebook 读取、文件内容读取、缓存逻辑或正常整数分页行为。

</details>
