### PR TITLE
fix(daemon): preserve user message source metadata

### DIFF
--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -113,6 +113,7 @@ export class HistoryReplayer {
               await this.messageEmitter.emitUserMessage(
                 displayText,
                 record.timestamp,
+                record.subtype === 'cron' ? { source: 'cron' } : undefined,
               );
             }
             break;

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
@@ -53,6 +53,21 @@ describe('MessageEmitter', () => {
         content: { type: 'text', text: multilineText },
       });
     });
+
+    it('should include source metadata when provided', async () => {
+      await emitter.emitUserMessage('scheduled prompt', 1_700_000_000_000, {
+        source: 'cron',
+      });
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'scheduled prompt' },
+        _meta: {
+          timestamp: 1_700_000_000_000,
+          source: 'cron',
+        },
+      });
+    });
   });
 
   describe('emitAgentMessage', () => {

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -90,12 +90,17 @@ export class MessageEmitter extends BaseEmitter {
   async emitUserMessage(
     text: string,
     timestamp?: string | number,
+    options: { source?: string } = {},
   ): Promise<void> {
     const epochMs = BaseEmitter.toEpochMs(timestamp);
+    const _meta = {
+      ...(epochMs != null ? { timestamp: epochMs } : {}),
+      ...(options.source ? { source: options.source } : {}),
+    };
     await this.sendUpdate({
       sessionUpdate: 'user_message_chunk',
       content: { type: 'text', text },
-      ...(epochMs != null && { _meta: { timestamp: epochMs } }),
+      ...(Object.keys(_meta).length > 0 ? { _meta } : {}),
     });
   }
 

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -531,6 +531,7 @@ function normalizeSessionUpdate(
       ) {
         return [];
       }
+      const meta = extractUpdateMeta(update);
       const content = update['content'];
       const part = extractContentPart(content);
       if (part) {
@@ -555,13 +556,29 @@ function normalizeSessionUpdate(
         }
         if (part.kind === 'text') {
           return part.text
-            ? [{ ...base, type: 'user.text.delta', text: part.text }]
+            ? [
+                {
+                  ...base,
+                  type: 'user.text.delta',
+                  text: part.text,
+                  ...(meta ? { meta } : {}),
+                },
+              ]
             : [];
         }
         return [];
       }
       const text = getTextContent(content);
-      return text ? [{ ...base, type: 'user.text.delta', text }] : [];
+      return text
+        ? [
+            {
+              ...base,
+              type: 'user.text.delta',
+              text,
+              ...(meta ? { meta } : {}),
+            },
+          ]
+        : [];
     }
     case 'agent_message_chunk': {
       const text = getTextContent(update['content']);

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -522,6 +522,39 @@ describe('daemon UI normalizer and transcript reducer', () => {
     ).toMatchObject([{ type: 'user.text.delta', text: 'hello' }]);
   });
 
+  it('preserves user message metadata on transcript blocks', () => {
+    const events = normalizeDaemonEvent({
+      id: 23,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text: 'scheduled prompt' },
+          _meta: { source: 'cron' },
+        },
+      },
+    } as const);
+
+    expect(events).toMatchObject([
+      {
+        type: 'user.text.delta',
+        text: 'scheduled prompt',
+        meta: { source: 'cron' },
+      },
+    ]);
+
+    const state = reduceDaemonTranscriptEvents(
+      createDaemonTranscriptState({ now: 1 }),
+      events,
+    );
+    expect(state.blocks[0]).toMatchObject({
+      kind: 'user',
+      text: 'scheduled prompt',
+      meta: { source: 'cron' },
+    });
+  });
+
   it('carries user shell command metadata into user shell transcript blocks', () => {
     let state = createDaemonTranscriptState({ now: 1 });
     const commandEvents = normalizeDaemonEvent({

--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -79,6 +79,7 @@ export interface DaemonUserMessage extends DaemonMessageMeta {
   role: 'user';
   content: string;
   images?: Array<{ data: string; mimeType: string }>;
+  source?: string;
 }
 
 export interface DaemonAssistantMessage extends DaemonMessageMeta {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -125,6 +125,21 @@ function toolBlock(
 }
 
 describe('transcriptBlocksToDaemonMessages', () => {
+  it('preserves user source metadata', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('user-1', 'user', 'scheduled prompt', 1, false, {
+        meta: { source: 'cron' },
+      }),
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      id: 'user-1',
+      role: 'user',
+      content: 'scheduled prompt',
+      source: 'cron',
+    });
+  });
+
   it('hides background task notifications by metadata', () => {
     const messages = transcriptBlocksToDaemonMessages([
       textBlock(

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -195,11 +195,16 @@ export function transcriptBlocksToDaemonMessages(
         currentThinkingIdx = null;
         needsNewContentMessage = false;
         const textBlock = block as DaemonTextTranscriptBlock;
+        const meta = getRecord(
+          (textBlock as ExtendedDaemonTextTranscriptBlock).meta,
+        );
+        const source = getString(meta, 'source');
         const msg: DaemonUserMessage = {
           id: block.id,
           role: 'user',
           content: textBlock.text,
           timestamp: blockTime,
+          ...(source ? { source } : {}),
         };
         // Attach images if present
         if (textBlock.images && textBlock.images.length > 0) {


### PR DESCRIPTION
## What this PR does

This PR preserves source metadata on user-message transcript events end to end. Cron and loop prompts already emit `_meta.source`, and this change keeps that metadata through SDK normalization, transcript blocks, web-shell message adaptation, and history replay.

## Why it's needed

The session timeline needs to know when a user-message turn came from a scheduled task before it can render scheduled-task-specific UI. The daemon was already marking cron-fired user chunks, but the user-message normalizer dropped `_meta`, so the web shell could not distinguish cron turns from ordinary user prompts.

## Reviewer Test Plan

### How to verify

Create or replay a session with a cron-fired prompt and confirm the corresponding user transcript block carries `source: "cron"` through the SDK and web-shell adapter. The downstream timeline UI can then identify the turn as scheduled-task-originated.

### Evidence (Before & After)

Before: `user_message_chunk._meta.source` was not copied onto user text delta events, so web-shell user messages had no `source` field.

After: user text delta events and transcript blocks preserve `_meta.source`, and replayed cron prompts can emit the same source metadata.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace on macOS. Verified with `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts`, `cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts`, `cd packages/cli && npx vitest run src/acp-integration/session/emitters/MessageEmitter.test.ts`, and `npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: User-message metadata that was previously dropped now reaches transcript consumers, so callers that read raw block metadata may see additional keys.
- Not validated / out of scope: The timeline clock/icon rendering is intentionally left for a follow-up UI PR.
- Breaking changes / migration notes: None expected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 端到端保留 user message 的 source metadata。cron 和 loop prompt 已经会发出 `_meta.source`，这里把这个 metadata 继续保留到 SDK normalize、transcript block、web-shell message adapter，以及历史回放路径。

## 为什么需要

左侧会话时间轴需要知道一个 user turn 是否来自定时任务，后续才能渲染定时任务专属 UI。daemon 已经给 cron 触发的 user chunk 打了标记，但 user-message normalizer 会丢掉 `_meta`，导致 web shell 无法区分 cron turn 和普通用户输入。

## Reviewer Test Plan

### 如何验证

创建或回放一个 cron 触发的 prompt，确认对应 user transcript block 会保留 `source: "cron"`，并能通过 SDK 和 web-shell adapter 传递。下游时间轴 UI 就可以据此识别该 turn 来自定时任务。

### 证据（Before & After）

Before：`user_message_chunk._meta.source` 没有被复制到 user text delta event 上，所以 web-shell user message 没有 `source` 字段。

After：user text delta event 和 transcript block 都会保留 `_meta.source`，历史回放的 cron prompt 也可以发出同样的 source metadata。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

macOS 本地 Node.js workspace。已用 `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts`、`cd packages/web-shell && npx vitest run client/adapters/transcriptToMessages.test.ts`、`cd packages/cli && npx vitest run src/acp-integration/session/emitters/MessageEmitter.test.ts` 和 `npm run typecheck` 验证。

## 风险和范围

- 主要风险或取舍：之前被丢弃的 user-message metadata 现在会到达 transcript 消费方，因此读取 raw block metadata 的调用方可能看到额外字段。
- 未验证 / 不在范围内：时间轴时钟图标和具体 UI 渲染留给后续 UI PR。
- 破坏性变更 / 迁移说明：预期没有。

## 关联 Issue

N/A
</details>