### PR TITLE
fix(core): default context windows to 200k

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3477,11 +3477,12 @@ describe('Server Config (config.ts)', () => {
     const config = new Config({
       ...baseParams,
       model: 'unknown-model-for-context-warning-test',
-      userMemory: 'a'.repeat(100_000),
+      // ~40K estimated tokens — above 15% of the 200K default window.
+      userMemory: 'a'.repeat(160_000),
     });
 
     expect(config.getWarnings()).toContainEqual(
-      expect.stringContaining("model's 131,072 token context window"),
+      expect.stringContaining("model's 200,000 token context window"),
     );
   });
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -2188,7 +2188,7 @@ describe('GeminiChat', async () => {
       //   cheap-gate (real estimate via getHistory + userMessage) →
       //   splitter (real) → runSideQuery (mocked at baseLlmClient) →
       //   persistence.
-      const largeChars = 'x'.repeat(400_000); // ~100K estimated tokens
+      const largeChars = 'x'.repeat(520_000); // ~130K estimated tokens
       const inheritedHistory: Content[] = [
         { role: 'user', parts: [{ text: largeChars }] },
         { role: 'model', parts: [{ text: 'ack' }] },
@@ -2198,8 +2198,9 @@ describe('GeminiChat', async () => {
       chat.setHistory(inheritedHistory);
       expect(chat.getLastPromptTokenCount()).toBe(0);
 
-      // Default DEFAULT_TOKEN_LIMIT = 128K → auto ≈ 95K. 100K estimate
-      // crosses, so cheap-gate must let compaction proceed.
+      // Default DEFAULT_TOKEN_LIMIT = 200K minus the 64K output reservation
+      // leaves a 136K effective window; 130K crosses the auto threshold, so
+      // cheap-gate must let compaction proceed.
       const generateText = vi.fn().mockResolvedValue({
         text: '<state_snapshot>compressed</state_snapshot>',
         usage: {

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -94,6 +94,10 @@ describe('normalize', () => {
 });
 
 describe('tokenLimit', () => {
+  it('uses 200K as the global default context window', () => {
+    expect(DEFAULT_TOKEN_LIMIT).toBe(200_000);
+  });
+
   describe('Google Gemini', () => {
     it('should return 1M for Gemini 3.x (latest)', () => {
       expect(tokenLimit('gemini-3-pro-preview')).toBe(1000000);

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -8,7 +8,7 @@ type TokenCount = number;
  */
 export type TokenLimitType = 'input' | 'output';
 
-export const DEFAULT_TOKEN_LIMIT: TokenCount = 131_072; // 128K (power-of-two)
+export const DEFAULT_TOKEN_LIMIT: TokenCount = 200_000; // 200K tokens
 export const DEFAULT_OUTPUT_TOKEN_LIMIT: TokenCount = 32_000; // 32K tokens
 
 export const ESCALATED_MAX_TOKENS: TokenCount = 64_000;

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -959,4 +959,23 @@ describe('modelConfigResolver', () => {
       expect(result.sources['modalities'].kind).toBe('settings');
     });
   });
+
+  describe('[Regression] env-var-only path must apply model context defaults', () => {
+    it('env-var-only path: contextWindowSize auto-detected for claude-opus-4-6', () => {
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'claude-opus-4-6',
+        },
+      });
+
+      expect(result.config.model).toBe('claude-opus-4-6');
+      expect(result.config.contextWindowSize).toBe(200_000);
+      expect(result.sources['contextWindowSize'].kind).toBe('computed');
+    });
+  });
 });

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -977,5 +977,65 @@ describe('modelConfigResolver', () => {
       expect(result.config.contextWindowSize).toBe(200_000);
       expect(result.sources['contextWindowSize'].kind).toBe('computed');
     });
+
+    it('env-var-only path: contextWindowSize auto-detected for a model whose limit differs from the global default', () => {
+      // gpt-4o resolves to 131,072 ≠ DEFAULT_TOKEN_LIMIT (200,000), so this
+      // assertion fails if the fallback applies the generic default instead
+      // of the model-specific limit.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'gpt-4o',
+        },
+      });
+
+      expect(result.config.model).toBe('gpt-4o');
+      expect(result.config.contextWindowSize).toBe(131_072);
+      expect(result.sources['contextWindowSize'].kind).toBe('computed');
+    });
+
+    it('env-var-only path: unknown model keeps contextWindowSize undefined', () => {
+      // Unknown models must not be stamped with an explicit window and an
+      // 'auto-detected' source — downstream `?? DEFAULT_TOKEN_LIMIT`
+      // consumers apply the generic default instead.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'totally-unknown-model-xyz',
+        },
+      });
+
+      expect(result.config.model).toBe('totally-unknown-model-xyz');
+      expect(result.config.contextWindowSize).toBeUndefined();
+      expect(result.sources['contextWindowSize']).toBeUndefined();
+    });
+
+    it('env-var-only path: explicit settings contextWindowSize is not overridden by fallback', () => {
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {
+          generationConfig: {
+            contextWindowSize: 32_000,
+          },
+        },
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'claude-opus-4-6',
+        },
+      });
+
+      expect(result.config.contextWindowSize).toBe(32_000);
+      expect(result.sources['contextWindowSize'].kind).toBe('settings');
+    });
   });
 });

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -22,6 +22,7 @@ import { AuthType } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
+import { tokenLimit } from '../core/tokenLimits.js';
 import {
   resolveField,
   resolveOptionalField,
@@ -398,6 +399,11 @@ function resolveGenerationConfig(
       (result as any)[field] = settingsConfig[field];
       sources[field] = settingsSource(`model.generationConfig.${field}`);
     }
+  }
+
+  if (result.contextWindowSize === undefined && modelId) {
+    result.contextWindowSize = tokenLimit(modelId, 'input');
+    sources['contextWindowSize'] = computedSource('auto-detected from model');
   }
 
   // modalities fallback: auto-detect from model when neither modelProvider nor

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -22,7 +22,7 @@ import { AuthType } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
-import { tokenLimit } from '../core/tokenLimits.js';
+import { knownTokenLimit } from '../core/tokenLimits.js';
 import {
   resolveField,
   resolveOptionalField,
@@ -401,9 +401,17 @@ function resolveGenerationConfig(
     }
   }
 
+  // contextWindowSize fallback: auto-detect from model when neither
+  // modelProvider nor settings supplied it. Only known models are stamped —
+  // unknown models keep `undefined` so downstream `?? DEFAULT_TOKEN_LIMIT`
+  // consumers apply the generic default without a misleading
+  // 'auto-detected' source label.
   if (result.contextWindowSize === undefined && modelId) {
-    result.contextWindowSize = tokenLimit(modelId, 'input');
-    sources['contextWindowSize'] = computedSource('auto-detected from model');
+    const knownLimit = knownTokenLimit(modelId, 'input');
+    if (knownLimit !== undefined) {
+      result.contextWindowSize = knownLimit;
+      sources['contextWindowSize'] = computedSource('auto-detected from model');
+    }
   }
 
   // modalities fallback: auto-detect from model when neither modelProvider nor

--- a/packages/vscode-ide-companion/src/utils/tokenLimits.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.ts
@@ -22,8 +22,8 @@ type TokenCount = number;
 // Public constants
 // ---------------------------------------------------------------------------
 
-/** Default input context window size: 128 K tokens (power-of-two). */
-export const DEFAULT_TOKEN_LIMIT: TokenCount = 131_072;
+/** Default input context window size: 200 K tokens. */
+export const DEFAULT_TOKEN_LIMIT: TokenCount = 200_000;
 
 // ---------------------------------------------------------------------------
 // Token limit types


### PR DESCRIPTION
## What this PR does

This PR changes Qwen Code's global fallback context window from 128K to 200K and makes env-var-only model selection apply the same model-derived context-window defaults as provider-backed model selection. A model supplied through `OPENAI_MODEL` now resolves `contextWindowSize` from the existing token limit patterns when the user did not configure an explicit context window.

## Why it's needed

Provider-backed models already get model-derived context defaults, so Claude-family models resolve to their 200K input window when selected through `modelProviders`. The env-var-only path resolved the model id but left `contextWindowSize` unset, which made later compression logic fall back to the old generic 128K default. That inconsistency meant the same model could get different context-window assumptions depending only on whether it was selected through env vars or provider config.

This is related to #6384, but it is not the same fix. #6384 is primarily about how much output budget Qwen Code should reserve by default and how to design that policy for models with large maximum output tokens. This PR addresses the input-context side: the generic fallback should be 200K, and env-var model resolution should respect the same token-limit patterns as provider-backed models. It does not attempt to settle the default output-token reservation tradeoff from #6384, though changing the fallback window naturally affects code paths that cap an output reservation against the fallback context window when no more specific window is available.

## Reviewer Test Plan

### How to verify

Run the focused resolver/token/compression tests and confirm `OPENAI_MODEL=claude-opus-4-6` resolves a 200,000-token context window without requiring a `modelProviders` entry. For the bundled CLI sanity check, run with a dummy key and invalid OpenAI-compatible base URL; the command should reach the fake endpoint and report a connection error, not fail locally with `hard limit: 0`.

### Evidence (Before & After)

Before: env-var-only Claude model selection left `contextWindowSize` undefined, so compression fell back to the generic 128K context window while output-token lookup still used Claude's model-specific output limit.

After: env-var-only Claude model selection resolves `contextWindowSize` to 200,000 through the same token-limit patterns used for provider-backed model defaults, and the global fallback context window is 200,000 for unknown models.

Commands run locally:

```bash
cd packages/core && npx vitest run src/core/tokenLimits.test.ts src/models/modelConfigResolver.test.ts src/core/geminiChat.test.ts
npm run build && npm run typecheck && npm run bundle
```

Bundled CLI sanity check result: `hasHardLimitZero: false`, `hasConnectionError: true` when using `OPENAI_MODEL=claude-opus-4-6`, dummy API key, and `OPENAI_BASE_URL=http://127.0.0.1:9/v1`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/npm workspace, bundled CLI via `node dist/cli.js` with clean `QWEN_HOME` and `QWEN_RUNTIME_DIR`.

## Risk & Scope

- Main risk or tradeoff: raising the global fallback context window makes unknown models less conservative; providers with smaller actual context windows may rely on reactive context-overflow handling unless users configure `contextWindowSize` explicitly.
- Not validated / out of scope: this PR does not redesign default output-token reservation policy; that remains the separate design issue discussed in #6384.
- Breaking changes / migration notes: none expected.

## Linked Issues

Related to #6384.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将 Qwen Code 的全局兜底上下文窗口从 128K 调整为 200K，并让仅通过环境变量选择模型的路径使用与 `modelProviders` 路径一致的模型派生上下文窗口默认值。当用户通过 `OPENAI_MODEL` 指定模型且没有显式配置上下文窗口时，现在会根据已有的 token limit patterns 自动解析 `contextWindowSize`。

## Why it's needed

通过 `modelProviders` 选择模型时，模型已经会获得派生出的上下文默认值，因此 Claude 系列模型会解析到 200K input window。但仅通过环境变量选择模型时，代码只解析了 model id，没有填充 `contextWindowSize`，后续压缩逻辑就会回退到旧的通用 128K 默认值。这会导致同一个模型仅因为选择方式不同，就得到不同的上下文窗口假设。

这个 PR 与 #6384 相关，但不是同一个修复。#6384 主要讨论默认应该预留多少输出 token，以及对于最大输出 token 很大的模型应该如何设计这套策略。这个 PR 处理的是 input context 侧的问题：通用兜底值应该是 200K，并且环境变量模型解析应该尊重与 provider-backed 模型相同的 token-limit patterns。这个 PR 不试图解决 #6384 中默认输出 token 预留策略的设计取舍；不过当没有更具体的上下文窗口可用时，兜底窗口变为 200K 会自然影响那些用兜底上下文窗口来限制输出预留上限的路径。

## Reviewer Test Plan

### How to verify

运行聚焦的 resolver/token/compression 测试，并确认 `OPENAI_MODEL=claude-opus-4-6` 在没有 `modelProviders` 配置的情况下也会解析到 200,000 token 的上下文窗口。对于 bundled CLI sanity check，使用 dummy key 和无效的 OpenAI-compatible base URL；命令应该到达假的 endpoint 并报告 connection error，而不是在本地因为 `hard limit: 0` 失败。

### Evidence (Before & After)

Before: 仅通过环境变量选择 Claude 模型时，`contextWindowSize` 保持 undefined，因此压缩逻辑回退到通用 128K 上下文窗口；与此同时，输出 token lookup 又会使用 Claude 的模型特定输出上限。

After: 仅通过环境变量选择 Claude 模型时，会通过与 provider-backed 模型默认值相同的 token-limit patterns 将 `contextWindowSize` 解析为 200,000；未知模型的全局兜底上下文窗口也变为 200,000。

本地运行的命令：

```bash
cd packages/core && npx vitest run src/core/tokenLimits.test.ts src/models/modelConfigResolver.test.ts src/core/geminiChat.test.ts
npm run build && npm run typecheck && npm run bundle
```

Bundled CLI sanity check 结果：使用 `OPENAI_MODEL=claude-opus-4-6`、dummy API key 和 `OPENAI_BASE_URL=http://127.0.0.1:9/v1` 时，结果为 `hasHardLimitZero: false`，`hasConnectionError: true`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Node/npm workspace，使用 clean `QWEN_HOME` 和 `QWEN_RUNTIME_DIR` 运行 bundled CLI：`node dist/cli.js`。

## Risk & Scope

- Main risk or tradeoff: 将全局兜底上下文窗口提高到 200K 会让未知模型的假设不再那么保守；如果某些 provider 的真实上下文窗口更小，除非用户显式配置 `contextWindowSize`，否则可能依赖 reactive context-overflow handling。
- Not validated / out of scope: 这个 PR 不重新设计默认输出 token 预留策略；该问题仍属于 #6384 中讨论的独立设计议题。
- Breaking changes / migration notes: 预期没有。

## Linked Issues

Related to #6384.

</details>