### PR TITLE
fix(shell): avoid Unix pager default on Windows

### DIFF
--- a/docs/developers/tools/shell.md
+++ b/docs/developers/tools/shell.md
@@ -146,7 +146,7 @@ To show color in the shell output, you need to set the `tools.shell.showColor` s
 
 ### Setting the Pager
 
-You can set a custom pager for the shell output by setting the `tools.shell.pager` setting. The default pager is `cat` on non-Windows platforms. No default is set on Windows. **Note: This setting only applies when `tools.shell.enableInteractiveShell` is enabled.**
+You can set a custom pager for the shell output by setting the `tools.shell.pager` setting. The default pager is `cat` on non-Windows platforms. No default is set on Windows. Set `tools.shell.pager` to an empty string to disable pager environment variables. **Note: This setting only applies when `tools.shell.enableInteractiveShell` is enabled.**
 
 **Example `settings.json`:**
 

--- a/docs/developers/tools/shell.md
+++ b/docs/developers/tools/shell.md
@@ -146,7 +146,7 @@ To show color in the shell output, you need to set the `tools.shell.showColor` s
 
 ### Setting the Pager
 
-You can set a custom pager for the shell output by setting the `tools.shell.pager` setting. The default pager is `cat`. **Note: This setting only applies when `tools.shell.enableInteractiveShell` is enabled.**
+You can set a custom pager for the shell output by setting the `tools.shell.pager` setting. The default pager is `cat` on non-Windows platforms. No default is set on Windows. **Note: This setting only applies when `tools.shell.enableInteractiveShell` is enabled.**
 
 **Example `settings.json`:**
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2189,9 +2189,9 @@ const SETTINGS_SCHEMA = {
             label: 'Pager',
             category: 'Tools',
             requiresRestart: false,
-            default: 'cat' as string | undefined,
+            default: undefined as string | undefined,
             description:
-              'The pager command to use for shell output. Defaults to `cat`.',
+              'The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows.',
             showInDialog: false,
           },
           showColor: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2191,7 +2191,7 @@ const SETTINGS_SCHEMA = {
             requiresRestart: false,
             default: undefined as string | undefined,
             description:
-              'The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows.',
+              'The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows. Set to an empty string to disable pager environment variables.',
             showInDialog: false,
           },
           showColor: {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -511,6 +511,16 @@ describe('Server Config (config.ts)', () => {
       config.setShellExecutionConfig({ pager: undefined });
       expect(config.getShellExecutionConfig().pager).toBeUndefined();
     });
+
+    it('preserves the existing pager when an update omits the pager key', () => {
+      const config = new Config(baseParams);
+
+      config.setShellExecutionConfig({ pager: 'less' });
+      expect(config.getShellExecutionConfig().pager).toBe('less');
+
+      config.setShellExecutionConfig({ terminalWidth: 120 });
+      expect(config.getShellExecutionConfig().pager).toBe('less');
+    });
   });
 
   describe('getMaxSubagentDepth', () => {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -501,6 +501,18 @@ describe('Server Config (config.ts)', () => {
     );
   });
 
+  describe('shell execution config', () => {
+    it('allows explicitly clearing the configured pager', () => {
+      const config = new Config(baseParams);
+
+      config.setShellExecutionConfig({ pager: 'less' });
+      expect(config.getShellExecutionConfig().pager).toBe('less');
+
+      config.setShellExecutionConfig({ pager: undefined });
+      expect(config.getShellExecutionConfig().pager).toBeUndefined();
+    });
+  });
+
   describe('getMaxSubagentDepth', () => {
     it('defaults to 5 when unset', () => {
       expect(new Config(baseParams).getMaxSubagentDepth()).toBe(5);

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -5674,6 +5674,7 @@ export class Config {
       terminalHeight:
         config.terminalHeight ?? this.shellExecutionConfig.terminalHeight,
       showColor: config.showColor ?? this.shellExecutionConfig.showColor,
+      // pager: undefined is a valid explicit clear; ?? would preserve the old value.
       pager: Object.prototype.hasOwnProperty.call(config, 'pager')
         ? config.pager
         : this.shellExecutionConfig.pager,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -53,6 +53,7 @@ import {
 } from '../services/fileSystemService.js';
 import { GitWorktreeService } from '../services/gitWorktreeService.js';
 import { cleanupStaleAgentWorktrees } from '../services/worktreeCleanup.js';
+import { getDefaultShellPager } from '../utils/shell-pager-env.js';
 import {
   CronScheduler,
   DEFAULT_RECURRING_MAX_AGE_DAYS,
@@ -1907,7 +1908,7 @@ export class Config {
       terminalWidth: params.shellExecutionConfig?.terminalWidth ?? 80,
       terminalHeight: params.shellExecutionConfig?.terminalHeight ?? 24,
       showColor: params.shellExecutionConfig?.showColor ?? false,
-      pager: params.shellExecutionConfig?.pager ?? 'cat',
+      pager: params.shellExecutionConfig?.pager ?? getDefaultShellPager(),
       maxBufferedOutputBytes:
         params.shellExecutionConfig?.maxBufferedOutputBytes,
     };

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -53,7 +53,6 @@ import {
 } from '../services/fileSystemService.js';
 import { GitWorktreeService } from '../services/gitWorktreeService.js';
 import { cleanupStaleAgentWorktrees } from '../services/worktreeCleanup.js';
-import { getDefaultShellPager } from '../utils/shell-pager-env.js';
 import {
   CronScheduler,
   DEFAULT_RECURRING_MAX_AGE_DAYS,
@@ -1908,7 +1907,7 @@ export class Config {
       terminalWidth: params.shellExecutionConfig?.terminalWidth ?? 80,
       terminalHeight: params.shellExecutionConfig?.terminalHeight ?? 24,
       showColor: params.shellExecutionConfig?.showColor ?? false,
-      pager: params.shellExecutionConfig?.pager ?? getDefaultShellPager(),
+      pager: params.shellExecutionConfig?.pager,
       maxBufferedOutputBytes:
         params.shellExecutionConfig?.maxBufferedOutputBytes,
     };
@@ -5675,7 +5674,9 @@ export class Config {
       terminalHeight:
         config.terminalHeight ?? this.shellExecutionConfig.terminalHeight,
       showColor: config.showColor ?? this.shellExecutionConfig.showColor,
-      pager: config.pager ?? this.shellExecutionConfig.pager,
+      pager: Object.prototype.hasOwnProperty.call(config, 'pager')
+        ? config.pager
+        : this.shellExecutionConfig.pager,
       maxBufferedOutputBytes:
         config.maxBufferedOutputBytes ??
         this.shellExecutionConfig.maxBufferedOutputBytes,

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -3232,7 +3232,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('');
-      expect(spawnOptions.env['GIT_PAGER']).toBe('');
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],
@@ -3252,7 +3252,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('cat');
-      expect(spawnOptions.env['GIT_PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -147,6 +147,20 @@ const EXPECTED_MERGED_WINDOWS_PATH =
 
 let originalProcessEnv: NodeJS.ProcessEnv;
 
+async function withoutGitPagerEnv(run: () => Promise<unknown>): Promise<void> {
+  const originalGitPager = process.env['GIT_PAGER'];
+  delete process.env['GIT_PAGER'];
+  try {
+    await run();
+  } finally {
+    if (originalGitPager === undefined) {
+      delete process.env['GIT_PAGER'];
+    } else {
+      process.env['GIT_PAGER'] = originalGitPager;
+    }
+  }
+}
+
 const createExpectedAnsiOutput = (text: string | string[]): AnsiOutput => {
   const lines = Array.isArray(text) ? text : text.split('\n');
   const expected: AnsiOutput = Array.from(
@@ -3224,10 +3238,12 @@ describe('ShellExecutionService child_process fallback', () => {
         shell: 'cmd',
       });
 
-      await simulateExecutionWithConfig(
-        'echo hello',
-        (cp) => cp.emit('exit', 0, null),
-        shellExecutionConfigWithoutPager,
+      await withoutGitPagerEnv(() =>
+        simulateExecutionWithConfig(
+          'echo hello',
+          (cp) => cp.emit('exit', 0, null),
+          shellExecutionConfigWithoutPager,
+        ),
       );
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
@@ -3248,7 +3264,9 @@ describe('ShellExecutionService child_process fallback', () => {
         shell: 'cmd',
       });
 
-      await simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null));
+      await withoutGitPagerEnv(() =>
+        simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null)),
+      );
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('cat');

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1918,8 +1918,8 @@ describe('ShellExecutionService', () => {
       );
 
       const spawnOptions = mockPtySpawn.mock.calls[0][2];
-      expect(spawnOptions.env['PAGER']).toBeUndefined();
-      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
+      expect(spawnOptions.env['PAGER']).toBe('');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],
@@ -3231,7 +3231,8 @@ describe('ShellExecutionService child_process fallback', () => {
       );
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
-      expect(spawnOptions.env['PAGER']).toBeUndefined();
+      expect(spawnOptions.env['PAGER']).toBe('');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],
@@ -3251,6 +3252,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('cat');
       mockGetShellConfiguration.mockReturnValue({
         executable: 'bash',
         argsPrefix: ['-c'],

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -133,6 +133,13 @@ const shellExecutionConfig = {
   disableDynamicLineTrimming: true,
 } satisfies ShellExecutionConfig;
 
+const shellExecutionConfigWithoutPager = {
+  terminalWidth: 80,
+  terminalHeight: 24,
+  showColor: false,
+  disableDynamicLineTrimming: true,
+} satisfies ShellExecutionConfig;
+
 const WINDOWS_SYSTEM_PATH = 'C:\\Windows\\System32;C:\\Shared\\Tools';
 const WINDOWS_USER_PATH = 'C:\\Users\\tester\\bin;C:\\Shared\\Tools';
 const EXPECTED_MERGED_WINDOWS_PATH =
@@ -1896,6 +1903,52 @@ describe('ShellExecutionService', () => {
       });
     });
 
+    it('does not inject Unix pager defaults into Windows pty env when unset', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
+      });
+
+      await simulateExecution(
+        'echo hello',
+        (pty) => pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
+        shellExecutionConfigWithoutPager,
+      );
+
+      const spawnOptions = mockPtySpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBeUndefined();
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+    });
+
+    it('preserves explicit pager configuration in Windows pty env', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
+      });
+
+      await simulateExecution('echo hello', (pty) =>
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null }),
+      );
+
+      const spawnOptions = mockPtySpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('cat');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+    });
+
     it('should use bash on Linux', async () => {
       mockPlatform.mockReturnValue('linux');
       await simulateExecution('ls "foo bar"', (pty) =>
@@ -3161,6 +3214,48 @@ describe('ShellExecutionService child_process fallback', () => {
 
       const spawnOptions = mockCpSpawn.mock.calls[0][2];
       expectNormalizedWindowsPathEnv(spawnOptions.env);
+    });
+
+    it('does not inject Unix pager defaults into Windows child_process env when unset', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
+      });
+
+      await simulateExecutionWithConfig(
+        'echo hello',
+        (cp) => cp.emit('exit', 0, null),
+        shellExecutionConfigWithoutPager,
+      );
+
+      const spawnOptions = mockCpSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBeUndefined();
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
+    });
+
+    it('preserves explicit pager configuration in Windows child_process env', async () => {
+      mockPlatform.mockReturnValue('win32');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'cmd.exe',
+        argsPrefix: ['/d', '/s', '/c'],
+        shell: 'cmd',
+      });
+
+      await simulateExecution('echo hello', (cp) => cp.emit('exit', 0, null));
+
+      const spawnOptions = mockCpSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('cat');
+      mockGetShellConfiguration.mockReturnValue({
+        executable: 'bash',
+        argsPrefix: ['-c'],
+        shell: 'bash',
+      });
     });
 
     it('should use bash and detached process group on Linux', async () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -722,7 +722,10 @@ export class ShellExecutionService {
           ...normalizePathEnvForWindows(process.env),
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
-          ...getShellPagerEnv(pager, { platform: os.platform() }),
+          ...getShellPagerEnv(pager, {
+            includeGitPager: true,
+            platform: os.platform(),
+          }),
           ...getShellContextEnvVars(),
         },
       });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -723,7 +723,7 @@ export class ShellExecutionService {
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
           ...getShellPagerEnv(pager, {
-            includeGitPager: true,
+            includeGitPager: false,
             platform: os.platform(),
           }),
           ...getShellContextEnvVars(),

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -24,6 +24,7 @@ import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import { getShellContextEnvVars } from '../utils/shellContextEnv.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { getShellPagerEnv } from '../utils/shell-pager-env.js';
 const { Terminal } = pkg;
 
 const debugLogger = createDebugLogger('SHELL_EXECUTION');
@@ -683,6 +684,7 @@ export class ShellExecutionService {
       abortSignal,
       options.streamStdout ?? false,
       getMaxBufferedOutputBytes(shellExecutionConfig),
+      shellExecutionConfig.pager,
       options.postPromote,
     );
   }
@@ -694,6 +696,7 @@ export class ShellExecutionService {
     abortSignal: AbortSignal,
     streamStdout: boolean,
     maxBufferedOutputBytes: number,
+    pager: string | undefined,
     postPromote?: ShellPostPromoteHandlers,
   ): ShellExecutionHandle {
     try {
@@ -719,7 +722,7 @@ export class ShellExecutionService {
           ...normalizePathEnvForWindows(process.env),
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
-          PAGER: 'cat',
+          ...getShellPagerEnv(pager, { platform: os.platform() }),
           ...getShellContextEnvVars(),
         },
       });
@@ -1419,8 +1422,10 @@ export class ShellExecutionService {
           ...normalizePathEnvForWindows(process.env),
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
-          PAGER: shellExecutionConfig.pager ?? 'cat',
-          GIT_PAGER: shellExecutionConfig.pager ?? 'cat',
+          ...getShellPagerEnv(shellExecutionConfig.pager, {
+            includeGitPager: true,
+            platform: os.platform(),
+          }),
           ...getShellContextEnvVars(),
         },
         handleFlowControl: true,

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -9,6 +9,22 @@ import { EventEmitter } from 'node:events';
 import type { Readable } from 'node:stream';
 import type { ChildProcess } from 'node:child_process';
 
+const mockOsPlatform = vi.hoisted(() =>
+  vi.fn<() => NodeJS.Platform>(() => 'linux'),
+);
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      platform: mockOsPlatform,
+    },
+    platform: mockOsPlatform,
+  };
+});
+
 // Mock child_process.spawn
 const mockSpawn = vi.hoisted(() => vi.fn());
 vi.mock('node:child_process', async (importOriginal) => {
@@ -178,6 +194,7 @@ describe('MonitorTool', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockOsPlatform.mockReturnValue('linux');
 
     monitorRegistry = new MonitorRegistry();
     mockIsPathWithinWorkspace = vi.fn().mockReturnValue(true);
@@ -631,6 +648,18 @@ describe('MonitorTool', () => {
       expect(result.llmContent).toContain('Monitor started');
       expect(result.llmContent).toContain('mon_');
       expect(result.returnDisplay).toContain('watch app logs');
+    });
+
+    it('uses default pager env for spawned processes when pager is unset', async () => {
+      const invocation = createInvocation({
+        command: 'tail -f /var/log/app.log',
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      const spawnOptions = mockSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('cat');
     });
 
     it('propagates explicit pager configuration to spawned processes', async () => {

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -195,6 +195,7 @@ describe('MonitorTool', () => {
         isPathWithinWorkspace: mockIsPathWithinWorkspace,
       }),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
+      getShellExecutionConfig: vi.fn().mockReturnValue({}),
       storage: {
         getUserSkillsDirs: vi
           .fn()
@@ -630,6 +631,21 @@ describe('MonitorTool', () => {
       expect(result.llmContent).toContain('Monitor started');
       expect(result.llmContent).toContain('mon_');
       expect(result.returnDisplay).toContain('watch app logs');
+    });
+
+    it('propagates explicit pager configuration to spawned processes', async () => {
+      vi.mocked(mockConfig.getShellExecutionConfig).mockReturnValue({
+        pager: 'more',
+      });
+      const invocation = createInvocation({
+        command: 'tail -f /var/log/app.log',
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      const spawnOptions = mockSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('more');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('more');
     });
 
     it('does not spawn when the turn signal is already aborted', async () => {

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -17,6 +17,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import stripAnsi from 'strip-ansi';
@@ -367,7 +368,10 @@ class MonitorToolInvocation extends BaseToolInvocation<
           ...process.env,
           QWEN_CODE: '1',
           TERM: 'dumb', // no color codes for streaming
-          ...getShellPagerEnv(undefined),
+          ...getShellPagerEnv(this.config.getShellExecutionConfig().pager, {
+            includeGitPager: true,
+            platform: os.platform(),
+          }),
           ...getShellContextEnvVars(),
         },
       });

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -54,6 +54,7 @@ import {
 } from '../utils/shellAstParser.js';
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { getShellContextEnvVars } from '../utils/shellContextEnv.js';
+import { getShellPagerEnv } from '../utils/shell-pager-env.js';
 
 const debugLogger = createDebugLogger('MONITOR');
 
@@ -366,7 +367,7 @@ class MonitorToolInvocation extends BaseToolInvocation<
           ...process.env,
           QWEN_CODE: '1',
           TERM: 'dumb', // no color codes for streaming
-          PAGER: 'cat',
+          ...getShellPagerEnv(undefined),
           ...getShellContextEnvVars(),
         },
       });

--- a/packages/core/src/utils/shell-pager-env.test.ts
+++ b/packages/core/src/utils/shell-pager-env.test.ts
@@ -15,7 +15,21 @@ describe('shellPagerEnv', () => {
 
   it('does not default to Unix-only cat on Windows', () => {
     expect(getDefaultShellPager('win32')).toBeUndefined();
-    expect(getShellPagerEnv(undefined, { platform: 'win32' })).toEqual({});
+    expect(getShellPagerEnv(undefined, { platform: 'win32' })).toEqual({
+      PAGER: undefined,
+    });
+  });
+
+  it('clears inherited git pager values when requested without an effective pager', () => {
+    expect(
+      getShellPagerEnv(undefined, {
+        includeGitPager: true,
+        platform: 'win32',
+      }),
+    ).toEqual({
+      PAGER: undefined,
+      GIT_PAGER: undefined,
+    });
   });
 
   it('preserves explicit pager configuration on Windows', () => {

--- a/packages/core/src/utils/shell-pager-env.test.ts
+++ b/packages/core/src/utils/shell-pager-env.test.ts
@@ -44,6 +44,15 @@ describe('shellPagerEnv', () => {
     });
   });
 
+  it('treats an empty pager as an explicit request to disable pager env values', () => {
+    expect(
+      getShellPagerEnv('', { includeGitPager: true, platform: 'linux' }),
+    ).toEqual({
+      PAGER: '',
+      GIT_PAGER: '',
+    });
+  });
+
   it('preserves explicit pager configuration on Windows', () => {
     expect(
       getShellPagerEnv('more', { includeGitPager: true, platform: 'win32' }),

--- a/packages/core/src/utils/shell-pager-env.test.ts
+++ b/packages/core/src/utils/shell-pager-env.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getDefaultShellPager, getShellPagerEnv } from './shell-pager-env.js';
+
+describe('shellPagerEnv', () => {
+  it('defaults to cat on non-Windows platforms', () => {
+    expect(getDefaultShellPager('linux')).toBe('cat');
+    expect(getDefaultShellPager('darwin')).toBe('cat');
+  });
+
+  it('does not default to Unix-only cat on Windows', () => {
+    expect(getDefaultShellPager('win32')).toBeUndefined();
+    expect(getShellPagerEnv(undefined, { platform: 'win32' })).toEqual({});
+  });
+
+  it('preserves explicit pager configuration on Windows', () => {
+    expect(
+      getShellPagerEnv('more', { includeGitPager: true, platform: 'win32' }),
+    ).toEqual({
+      PAGER: 'more',
+      GIT_PAGER: 'more',
+    });
+  });
+});

--- a/packages/core/src/utils/shell-pager-env.test.ts
+++ b/packages/core/src/utils/shell-pager-env.test.ts
@@ -16,7 +16,7 @@ describe('shellPagerEnv', () => {
   it('does not default to Unix-only cat on Windows', () => {
     expect(getDefaultShellPager('win32')).toBeUndefined();
     expect(getShellPagerEnv(undefined, { platform: 'win32' })).toEqual({
-      PAGER: undefined,
+      PAGER: '',
     });
   });
 
@@ -27,8 +27,20 @@ describe('shellPagerEnv', () => {
         platform: 'win32',
       }),
     ).toEqual({
-      PAGER: undefined,
-      GIT_PAGER: undefined,
+      PAGER: '',
+      GIT_PAGER: '',
+    });
+  });
+
+  it('sets both PAGER and GIT_PAGER to cat on non-Windows when pager is unset', () => {
+    expect(
+      getShellPagerEnv(undefined, {
+        includeGitPager: true,
+        platform: 'linux',
+      }),
+    ).toEqual({
+      PAGER: 'cat',
+      GIT_PAGER: 'cat',
     });
   });
 

--- a/packages/core/src/utils/shell-pager-env.ts
+++ b/packages/core/src/utils/shell-pager-env.ts
@@ -18,7 +18,12 @@ export function getShellPagerEnv(
   } = {},
 ): NodeJS.ProcessEnv {
   const effectivePager = pager ?? getDefaultShellPager(options.platform);
-  if (!effectivePager) return {};
+  if (!effectivePager) {
+    return {
+      PAGER: undefined,
+      ...(options.includeGitPager ? { GIT_PAGER: undefined } : {}),
+    };
+  }
 
   return {
     PAGER: effectivePager,

--- a/packages/core/src/utils/shell-pager-env.ts
+++ b/packages/core/src/utils/shell-pager-env.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function getDefaultShellPager(
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  return platform === 'win32' ? undefined : 'cat';
+}
+
+export function getShellPagerEnv(
+  pager: string | undefined,
+  options: {
+    includeGitPager?: boolean;
+    platform?: NodeJS.Platform;
+  } = {},
+): NodeJS.ProcessEnv {
+  const effectivePager = pager ?? getDefaultShellPager(options.platform);
+  if (!effectivePager) return {};
+
+  return {
+    PAGER: effectivePager,
+    ...(options.includeGitPager ? { GIT_PAGER: effectivePager } : {}),
+  };
+}

--- a/packages/core/src/utils/shell-pager-env.ts
+++ b/packages/core/src/utils/shell-pager-env.ts
@@ -20,8 +20,8 @@ export function getShellPagerEnv(
   const effectivePager = pager ?? getDefaultShellPager(options.platform);
   if (!effectivePager) {
     return {
-      PAGER: undefined,
-      ...(options.includeGitPager ? { GIT_PAGER: undefined } : {}),
+      PAGER: '',
+      ...(options.includeGitPager ? { GIT_PAGER: '' } : {}),
     };
   }
 

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1011,7 +1011,7 @@
               "default": true
             },
             "pager": {
-              "description": "The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows.",
+              "description": "The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows. Set to an empty string to disable pager environment variables.",
               "type": "string"
             },
             "showColor": {

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1011,9 +1011,8 @@
               "default": true
             },
             "pager": {
-              "description": "The pager command to use for shell output. Defaults to `cat`.",
-              "type": "string",
-              "default": "cat"
+              "description": "The pager command to use for shell output. Defaults to `cat` on non-Windows platforms and unset on Windows.",
+              "type": "string"
             },
             "showColor": {
               "description": "Show color in shell output.",


### PR DESCRIPTION
## What this PR does

This PR stops Qwen Code from injecting the Unix-only `cat` pager by default into Windows shell execution environments. The shell pager default is now platform-aware: non-Windows platforms still default to `cat`, while Windows leaves `PAGER` unset unless the user explicitly configures `tools.shell.pager`.

The same pager environment helper is used for the foreground shell execution paths and the monitor tool path, and explicit pager settings continue to be preserved.

## Why it's needed

On Windows `cmd.exe`, `cat` is not available by default. Some commands and CLIs honor `PAGER` / `GIT_PAGER`, so injecting `PAGER=cat` can cause otherwise valid stdout-producing commands to fail with `'cat' is not recognized as an internal or external command`.

This fixes #6298 without changing the shell command execution flow, PTY handling, encoding prefix logic, or non-Windows default behavior.

## Reviewer Test Plan

### How to verify

Run the focused core tests for pager environment behavior and shell execution:

```bash
npm run test:ci --workspace=packages/core -- src/utils/shell-pager-env.test.ts src/services/shellExecutionService.test.ts
npm run test:ci --workspace=packages/core -- src/tools/monitor.test.ts
npm run typecheck --workspace=packages/core
```

Run the focused CLI settings-schema tests and formatting/lint checks:

```bash
npm run test:ci --workspace=packages/cli -- src/config/settingsSchema.test.ts src/utils/settingsUtils.test.ts
npx prettier --check packages/core/src/utils/shell-pager-env.ts packages/core/src/utils/shell-pager-env.test.ts packages/core/src/services/shellExecutionService.ts packages/core/src/services/shellExecutionService.test.ts packages/core/src/config/config.ts packages/core/src/tools/monitor.ts packages/cli/src/config/settingsSchema.ts
npx eslint packages/core/src/utils/shell-pager-env.ts packages/core/src/utils/shell-pager-env.test.ts packages/core/src/services/shellExecutionService.ts packages/core/src/services/shellExecutionService.test.ts packages/core/src/config/config.ts packages/core/src/tools/monitor.ts packages/cli/src/config/settingsSchema.ts --max-warnings 0
git diff --check
```

Expected: Windows shell envs no longer include the default `PAGER=cat` / `GIT_PAGER=cat` when no pager is configured, while explicit pager configuration is still propagated. Non-Windows defaults still produce `PAGER=cat`.

### Evidence (Before & After)

N/A for UI screenshots. This is covered by focused unit tests around the generated shell environment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Windows workspace, Node/npm from the repository.

## Risk & Scope

- Main risk or tradeoff: Windows users who implicitly relied on Qwen Code injecting `PAGER=cat` will no longer get that default, but `cat` is not available in the default Windows `cmd.exe` environment. Explicit `tools.shell.pager` values are still respected.
- Not validated / out of scope: changing pager behavior for user-configured values, changing shell execution routing, encoding/codepage handling, PTY data handling, or command output decoding.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #6298

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 停止在 Windows shell 执行环境中默认注入 Unix-only 的 `cat` pager。shell pager 的默认值现在按平台区分：非 Windows 平台仍默认使用 `cat`，Windows 平台在用户没有显式配置 `tools.shell.pager` 时不设置 `PAGER`。

前台 shell 执行路径和 monitor 工具路径共用同一个 pager 环境生成 helper；用户显式配置的 pager 仍然会被保留。

## Why it's needed

Windows `cmd.exe` 默认没有 `cat`。一些命令和 CLI 会读取 `PAGER` / `GIT_PAGER`，因此注入 `PAGER=cat` 会让原本正常输出 stdout 的命令失败，并报 `'cat' is not recognized as an internal or external command`。

这个修复解决 #6298，同时不改变 shell 命令执行流程、PTY 处理、编码前缀逻辑或非 Windows 默认行为。

## Reviewer Test Plan

### How to verify

运行 pager 环境和 shell 执行的聚焦 core 测试：

```bash
npm run test:ci --workspace=packages/core -- src/utils/shell-pager-env.test.ts src/services/shellExecutionService.test.ts
npm run test:ci --workspace=packages/core -- src/tools/monitor.test.ts
npm run typecheck --workspace=packages/core
```

运行 CLI settings schema 的聚焦测试和格式 / lint 检查：

```bash
npm run test:ci --workspace=packages/cli -- src/config/settingsSchema.test.ts src/utils/settingsUtils.test.ts
npx prettier --check packages/core/src/utils/shell-pager-env.ts packages/core/src/utils/shell-pager-env.test.ts packages/core/src/services/shellExecutionService.ts packages/core/src/services/shellExecutionService.test.ts packages/core/src/config/config.ts packages/core/src/tools/monitor.ts packages/cli/src/config/settingsSchema.ts
npx eslint packages/core/src/utils/shell-pager-env.ts packages/core/src/utils/shell-pager-env.test.ts packages/core/src/services/shellExecutionService.ts packages/core/src/services/shellExecutionService.test.ts packages/core/src/config/config.ts packages/core/src/tools/monitor.ts packages/cli/src/config/settingsSchema.ts --max-warnings 0
git diff --check
```

预期：Windows shell 环境在未配置 pager 时不再包含默认的 `PAGER=cat` / `GIT_PAGER=cat`，但显式配置的 pager 仍然会传递。非 Windows 默认仍会产生 `PAGER=cat`。

### Evidence (Before & After)

非 UI 变更，不需要截图。行为由生成 shell 环境的聚焦单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Windows workspace，使用仓库内 Node/npm 环境。

## Risk & Scope

- Main risk or tradeoff: 如果 Windows 用户隐式依赖 Qwen Code 注入 `PAGER=cat`，现在不会再得到这个默认值；但默认 Windows `cmd.exe` 环境本来就没有 `cat`。显式 `tools.shell.pager` 配置仍然被尊重。
- Not validated / out of scope: 不改变用户显式配置的 pager 行为，不改变 shell 执行路由、编码/codepage 处理、PTY 数据处理或命令输出解码。
- Breaking changes / migration notes: 预期没有。

## Linked Issues

Fixes #6298

</details>