### PR TITLE
test(core): keep context warning test aligned with default token limit

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -44,6 +44,7 @@ import {
   createContentGeneratorConfig,
   resolveContentGeneratorConfigWithSources,
 } from '../core/contentGenerator.js';
+import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import { GeminiClient } from '../core/client.js';
 import { ShellTool } from '../tools/shell.js';
 import { canUseRipgrep } from '../utils/ripgrepUtils.js';
@@ -3474,14 +3475,17 @@ describe('Server Config (config.ts)', () => {
   });
 
   it('getWarnings should use the model token limit when no contextWindowSize is configured', () => {
+    const warningThresholdTokens = Math.floor(DEFAULT_TOKEN_LIMIT * 0.15);
     const config = new Config({
       ...baseParams,
       model: 'unknown-model-for-context-warning-test',
-      userMemory: 'a'.repeat(100_000),
+      userMemory: 'a'.repeat((warningThresholdTokens + 1) * 4),
     });
 
     expect(config.getWarnings()).toContainEqual(
-      expect.stringContaining("model's 131,072 token context window"),
+      expect.stringContaining(
+        `model's ${DEFAULT_TOKEN_LIMIT.toLocaleString()} token context window`,
+      ),
     );
   });
 


### PR DESCRIPTION
## What this PR does

Updates the context-warning regression test so it derives both the oversized memory fixture and the expected warning text from the current default token limit instead of hard-coding the previous 131,072-token default.

## Why it's needed

Multiple PRs that include the 200,000-token default context-window change can hit the same Ubuntu CI failure. The change that introduced this failure condition is PR #6387 (`fix(core): default context windows to 200k`), specifically commit `17788a2c15bcc6f892034cc9bb5db4764f6e96c4`, which changes the unknown-model fallback `DEFAULT_TOKEN_LIMIT` from 131,072 to 200,000.

The shared test fixture only crossed the 15% warning threshold for the previous 131,072-token default, so once the default window is larger the warning disappears and `config.getWarnings()` returns an empty array. PR #6387 is therefore the introducing PR, but the CI failure shows up across the affected PR stack because they all carry or depend on that default-window change. This keeps the test validating the intended fallback behavior across default-window changes.

## Reviewer Test Plan

### How to verify

Confirm that the context warning test still emits a warning when no explicit contextWindowSize is configured, and that the warning text follows the repository's current default token limit.

### Evidence (Before & After)

N/A, non-UI test-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested via GitHub Actions |

### Environment (optional)

Local: Node v22.22.0, npm 10.9.4. CI: Qwen Code CI run 28786634109.

## Risk & Scope

- Main risk or tradeoff: Low; this only changes a test fixture and assertion to follow the default token-limit constant.
- Not validated / out of scope: macOS and Windows jobs were skipped by the CI profile for this PR.
- Breaking changes / migration notes: None.

## Linked Issues

Introduced by #6387. Related to the CI failures seen across PRs that include or depend on the 200,000-token default context-window change.

<details>
<summary>中文说明</summary>

## What this PR does

更新 context warning 回归测试，让超大 memory fixture 和预期 warning 文案都从当前默认 token limit 推导，而不是写死旧的 131,072 token 默认值。

## Why it's needed

多条包含 200,000 token 默认 context window 变更的 PR 都可能遇到同一个 Ubuntu CI 失败。引入这个失败触发条件的是 #6387（`fix(core): default context windows to 200k`），具体是 commit `17788a2c15bcc6f892034cc9bb5db4764f6e96c4`，它把 unknown model fallback 的 `DEFAULT_TOKEN_LIMIT` 从 131,072 改成 200,000。

共享的旧测试数据只会在之前 131,072 token 默认值下超过 15% warning 阈值；默认窗口变大后，warning 不再出现，`config.getWarnings()` 返回空数组。因此 #6387 是引入该触发条件的 PR，但这个 CI 失败会出现在受影响 PR 栈里的多条 PR 上，因为它们都携带或依赖这个默认窗口变更。这个改动让测试继续验证预期的 fallback 行为，同时不再被默认窗口数值变化打挂。

## Reviewer Test Plan

### How to verify

确认未显式配置 contextWindowSize 时，context warning 测试仍会触发 warning，并且 warning 文案会跟随仓库当前默认 token limit。

### Evidence (Before & After)

N/A，非 UI 的测试修复。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested via GitHub Actions |

### Environment (optional)

本地：Node v22.22.0，npm 10.9.4。CI：Qwen Code CI run 28786634109。

## Risk & Scope

- Main risk or tradeoff: 低；只调整测试 fixture 和断言，使其跟随默认 token-limit 常量。
- Not validated / out of scope: 这个 PR 的 CI profile 跳过了 macOS 和 Windows jobs。
- Breaking changes / migration notes: 无。

## Linked Issues

由 #6387 引入。关联多条包含或依赖 200,000 token 默认 context window 变更的 PR 上看到的 CI 失败。

</details>