### PR TITLE
fix(cli): ignore current review run in presubmit CI

### DIFF
--- a/packages/cli/src/commands/review/presubmit.test.ts
+++ b/packages/cli/src/commands/review/presubmit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { presubmitCommand } from './presubmit.js';
+
+const {
+  ghMock,
+  ghApiMock,
+  ghApiAllMock,
+  currentUserMock,
+  ensureAuthenticatedMock,
+  readFileSyncMock,
+  writeFileSyncMock,
+  writeStdoutLineMock,
+} = vi.hoisted(() => ({
+  ghMock: vi.fn(),
+  ghApiMock: vi.fn(),
+  ghApiAllMock: vi.fn(),
+  currentUserMock: vi.fn(),
+  ensureAuthenticatedMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+  writeStdoutLineMock: vi.fn(),
+}));
+
+vi.mock('./lib/gh.js', () => ({
+  gh: ghMock,
+  ghApi: ghApiMock,
+  ghApiAll: ghApiAllMock,
+  currentUser: currentUserMock,
+  ensureAuthenticated: ensureAuthenticatedMock,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const mock = {
+    ...actual,
+    readFileSync: readFileSyncMock,
+    writeFileSync: writeFileSyncMock,
+  };
+  return { ...mock, default: mock };
+});
+
+vi.mock('../../utils/stdioHelpers.js', () => ({
+  writeStdoutLine: writeStdoutLineMock,
+}));
+
+describe('presubmitCommand', () => {
+  const baseArgs = {
+    _: [],
+    $0: 'qwen',
+    pr_number: '6387',
+    commit_sha: 'abc123',
+    owner_repo: 'QwenLM/qwen-code',
+    out_path: '/tmp/presubmit.json',
+  };
+
+  const originalGithubRunId = process.env['GITHUB_RUN_ID'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureAuthenticatedMock.mockReturnValue(undefined);
+    currentUserMock.mockReturnValue('qwen-code-ci-bot');
+    ghMock.mockReturnValue('contributor');
+    ghApiAllMock.mockReturnValue([]);
+    readFileSyncMock.mockReturnValue('[]');
+    process.env['GITHUB_RUN_ID'] = '28788268483';
+  });
+
+  afterEach(() => {
+    if (originalGithubRunId === undefined) {
+      delete process.env['GITHUB_RUN_ID'];
+    } else {
+      process.env['GITHUB_RUN_ID'] = originalGithubRunId;
+    }
+  });
+
+  it('ignores the running Qwen PR review check when deciding whether CI is still pending', async () => {
+    ghApiMock.mockImplementation((path: string) => {
+      if (path.endsWith('/check-runs')) {
+        return {
+          check_runs: [
+            {
+              name: 'Test (ubuntu-latest, Node 22.x)',
+              status: 'completed',
+              conclusion: 'success',
+            },
+            {
+              name: 'review-pr',
+              status: 'in_progress',
+              conclusion: null,
+              details_url:
+                'https://github.com/QwenLM/qwen-code/actions/runs/28788268483/job/85362025778',
+            },
+          ],
+        };
+      }
+      if (path.endsWith('/status')) {
+        return { statuses: [] };
+      }
+      return null;
+    });
+
+    const handler = presubmitCommand.handler;
+    if (!handler) throw new Error('presubmit handler missing');
+
+    await handler(baseArgs as Parameters<typeof handler>[0]);
+
+    const [, content] = writeFileSyncMock.mock.calls.find(
+      ([path]) => path === '/tmp/presubmit.json',
+    ) ?? [null, null];
+    const result = JSON.parse(String(content));
+
+    expect(result.ciStatus.class).toBe('all_pass');
+    expect(result.downgradeApprove).toBe(false);
+    expect(result.downgradeReasons).not.toContain('CI still running');
+  });
+});

--- a/packages/cli/src/commands/review/presubmit.ts
+++ b/packages/cli/src/commands/review/presubmit.ts
@@ -47,6 +47,8 @@ interface CheckRun {
   name: string;
   status: string;
   conclusion: string | null;
+  details_url?: string;
+  html_url?: string;
 }
 
 interface CommitStatus {
@@ -63,6 +65,16 @@ const FAIL_CONCLUSIONS = new Set([
 const FAIL_STATUS_STATES = new Set(['failure', 'error']);
 const PENDING_STATES = new Set(['queued', 'in_progress', 'pending']);
 
+function isCurrentActionsRunCheck(run: CheckRun): boolean {
+  const runId = process.env['GITHUB_RUN_ID'];
+  if (!runId) return false;
+
+  const runUrlMarker = `/actions/runs/${runId}/`;
+  return [run.details_url, run.html_url].some(
+    (url) => typeof url === 'string' && url.includes(runUrlMarker),
+  );
+}
+
 interface PresubmitArgs {
   pr_number: string;
   commit_sha: string;
@@ -74,8 +86,11 @@ interface PresubmitArgs {
 function classifyCi(checkRuns: CheckRun[], statuses: CommitStatus[]) {
   const failedCheckNames: string[] = [];
   let hasPending = false;
+  const relevantCheckRuns = checkRuns.filter(
+    (run) => !isCurrentActionsRunCheck(run),
+  );
 
-  for (const run of checkRuns) {
+  for (const run of relevantCheckRuns) {
     if (run.status === 'completed') {
       if (run.conclusion && FAIL_CONCLUSIONS.has(run.conclusion)) {
         failedCheckNames.push(run.name);
@@ -95,7 +110,7 @@ function classifyCi(checkRuns: CheckRun[], statuses: CommitStatus[]) {
   let cls: 'all_pass' | 'any_failure' | 'all_pending' | 'no_checks';
   if (failedCheckNames.length > 0) {
     cls = 'any_failure';
-  } else if (checkRuns.length === 0 && statuses.length === 0) {
+  } else if (relevantCheckRuns.length === 0 && statuses.length === 0) {
     cls = 'no_checks';
   } else if (hasPending) {
     cls = 'all_pending';
@@ -106,7 +121,7 @@ function classifyCi(checkRuns: CheckRun[], statuses: CommitStatus[]) {
   return {
     class: cls,
     failedCheckNames,
-    totalChecks: checkRuns.length + statuses.length,
+    totalChecks: relevantCheckRuns.length + statuses.length,
   };
 }
 


### PR DESCRIPTION
## What this PR does

Updates `/review presubmit` CI classification so the currently running GitHub Actions review run does not count as pending CI for its own approval decision. The filter is intentionally narrow: it only ignores check-runs whose `details_url` or `html_url` belongs to the current `GITHUB_RUN_ID`.

Adds a regression test for the observed failure mode where the real PR CI has already completed successfully but `🧐 Qwen Pull Request Review / review-pr` is still `in_progress`.

## Why it's needed

The automated Qwen Code review flow can otherwise become self-referential. In PR #6387, the bot found no issues and produced an approving verdict, but the published review was downgraded to `COMMENTED` with `CI still running` because the `review-pr` job was still running at the moment it submitted the review.

This prevents a clean bot approval from clearing stale bot review state, even when the only pending check is the review workflow itself. Real PR CI and commit statuses still participate in the pending/failing gate.

such as  https://github.com/QwenLM/qwen-code/pull/6397#issue-4819339885

<img width="1228" height="402" alt="image" src="https://github.com/user-attachments/assets/10af522d-8fd9-47ac-8474-78354c386290" />

## Reviewer Test Plan

### How to verify

Run the focused review command tests and CLI typecheck:

```console
cd packages/cli
npm run test -- src/commands/review.test.ts src/commands/review/presubmit.test.ts src/commands/review/post-suggestions.test.ts src/commands/review/pr-context.test.ts
npm run typecheck
```

The new regression test should show that a pending check-run from the current `GITHUB_RUN_ID` is ignored, while the remaining successful PR CI lets the presubmit report stay `all_pass` without a `CI still running` downgrade reason.

### Evidence (Before & After)

N/A — non-UI CI classification fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local worktree under `/tmp/qwen-review-ci-self-check`; `npm ci` completed before verification.

## Risk & Scope

- Main risk or tradeoff: filtering too broadly could hide real CI. This PR avoids that by matching only the current Actions run URL via `GITHUB_RUN_ID`, not by job name or workflow name.
- Not validated / out of scope: changing local `/review` behavior when no `GITHUB_RUN_ID` is present. Local runs continue to classify remote pending checks the same way as before.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #6396

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 `/review presubmit` 的 CI 分类逻辑，让当前正在运行的 GitHub Actions review run 不再把自己的 check-run 当作 pending CI。过滤范围刻意保持很窄：只忽略 `details_url` 或 `html_url` 属于当前 `GITHUB_RUN_ID` 的 check-run。

新增回归测试覆盖已观察到的问题：真实 PR CI 已经成功完成，但 `🧐 Qwen Pull Request Review / review-pr` 自己仍处于 `in_progress` 时，不应把审批降级成 comment。

## 为什么需要

自动 Qwen Code review 流程之前会形成自引用等待。PR #6387 中，bot 没发现问题并给出 approve verdict，但实际发布的 review 被降级成 `COMMENTED`，原因是 `CI still running`；当时正在 pending 的正是同一个 `review-pr` job 自己。

这会阻止干净的 bot approve 清掉旧的 bot review 状态，即使唯一 pending 的 check 是 review workflow 自己。真实 PR CI 和 commit status 仍然会继续参与 pending/failing gate。

## Reviewer Test Plan

### How to verify

运行聚焦的 review 命令测试和 CLI typecheck：

```console
cd packages/cli
npm run test -- src/commands/review.test.ts src/commands/review/presubmit.test.ts src/commands/review/post-suggestions.test.ts src/commands/review/pr-context.test.ts
npm run typecheck
```

新增回归测试应证明：来自当前 `GITHUB_RUN_ID` 的 pending check-run 会被忽略；其余真实 PR CI 成功时，presubmit report 保持 `all_pass`，并且不会出现 `CI still running` 降级原因。

### Evidence (Before & After)

N/A — 非 UI 的 CI 分类修复。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

本地 worktree：`/tmp/qwen-review-ci-self-check`；验证前已完成 `npm ci`。

## Risk & Scope

- 主要风险或取舍：如果过滤过宽，可能隐藏真实 CI。本 PR 只通过 `GITHUB_RUN_ID` 匹配当前 Actions run URL，不按 job name 或 workflow name 泛化过滤。
- 未验证 / 不在范围内：没有 `GITHUB_RUN_ID` 的本地 `/review` 行为。本地运行仍和之前一样分类远端 pending checks。
- Breaking changes / migration notes：无。

## Linked Issues

Resolves #6396

</details>
