### PR TITLE
fix(memory): don't advance AutoMemory extract cursor when the agent makes zero tool calls

### DIFF
--- a/packages/core/src/memory/extract.test.ts
+++ b/packages/core/src/memory/extract.test.ts
@@ -59,6 +59,7 @@ describe('auto-memory extraction', () => {
       touchedTopics: [],
       touchedProjectScope: false,
       touchedUserScope: false,
+      hasToolActivity: true,
       systemMessage: undefined,
     });
 
@@ -125,6 +126,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
       vi.mocked(rebuildManagedAutoMemoryIndex).mockRejectedValueOnce(
@@ -151,6 +153,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: true,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
       vi.mocked(rebuildManagedAutoMemoryIndex).mockResolvedValueOnce('');
@@ -180,6 +183,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user', 'project'],
         touchedProjectScope: true,
         touchedUserScope: true,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -200,6 +204,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: false,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -227,6 +232,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -284,6 +290,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: [],
         touchedProjectScope: false,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -331,6 +338,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -356,6 +364,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -400,6 +409,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -489,6 +499,7 @@ describe('auto-memory extraction', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: undefined,
       });
 
@@ -531,6 +542,51 @@ describe('auto-memory extraction', () => {
         agentCallsBefore + 1,
       );
       expect(result.cursor.processedOffset).toBe(compressedHistory.length);
+    });
+    it('BUG #6311: should NOT advance cursor when agent makes zero tool calls (hallucination)', async () => {
+      vi.mocked(runAutoMemoryExtractionByAgent).mockResolvedValue({
+        touchedTopics: [],
+        touchedProjectScope: false,
+        touchedUserScope: false,
+        hasToolActivity: false,
+        systemMessage: undefined,
+      });
+
+      const history = [
+        {
+          role: 'user' as const,
+          parts: [{ text: 'Remember that I prefer pnpm over npm.' }],
+        },
+      ];
+
+      const result = await runAutoMemoryExtract({
+        projectRoot,
+        sessionId: 'session-1',
+        config: mockConfig,
+        history: [...history],
+      });
+
+      expect(result.cursor.processedOffset).toBe(0);
+    });
+    it('should advance cursor on legitimate noop (agent checked memory, found nothing new)', async () => {
+      vi.mocked(runAutoMemoryExtractionByAgent).mockResolvedValue({
+        touchedTopics: [],
+        touchedProjectScope: false,
+        touchedUserScope: false,
+        hasToolActivity: true,
+        systemMessage: undefined,
+      });
+
+      const history = [{ role: 'user' as const, parts: [{ text: 'hello' }] }];
+
+      const result = await runAutoMemoryExtract({
+        projectRoot,
+        sessionId: 'session-1',
+        config: mockConfig,
+        history: [...history],
+      });
+
+      expect(result.cursor.processedOffset).toBe(1);
     });
   });
 });

--- a/packages/core/src/memory/extract.ts
+++ b/packages/core/src/memory/extract.ts
@@ -197,9 +197,12 @@ export async function runAutoMemoryExtract(params: {
     await Promise.all([projectRebuild, userRebuild]);
   }
 
+  const madeGenuineProgress =
+    agentResult.touchedTopics.length > 0 || agentResult.hasToolActivity;
+
   const cursor: AutoMemoryExtractCursor = {
     sessionId: params.sessionId,
-    processedOffset: params.history.length,
+    processedOffset: madeGenuineProgress ? params.history.length : startOffset,
     updatedAt: now.toISOString(),
   };
   await writeExtractCursor(params.projectRoot, cursor);

--- a/packages/core/src/memory/extractAgent.test.ts
+++ b/packages/core/src/memory/extractAgent.test.ts
@@ -67,6 +67,7 @@ describe('auto-memory extraction with agent planner', () => {
         touchedTopics: ['user'],
         touchedProjectScope: true,
         touchedUserScope: false,
+        hasToolActivity: true,
         systemMessage: 'Managed auto-memory updated: user.md',
       };
     });

--- a/packages/core/src/memory/extractionAgentPlanner.test.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.test.ts
@@ -76,6 +76,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
       status: 'completed',
       finalText: '',
       filesTouched: ['/tmp/auto-memory/user/prefs.md'],
+      filesWritten: ['/tmp/auto-memory/user/prefs.md'],
     });
 
     const result = await runAutoMemoryExtractionByAgent(mockConfig, '/tmp');
@@ -84,6 +85,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
       touchedTopics: ['user'],
       touchedProjectScope: true,
       touchedUserScope: false,
+      hasToolActivity: true,
       systemMessage: 'Managed auto-memory updated: user.md',
     });
     expect(runForkedAgent).toHaveBeenCalledWith(
@@ -108,6 +110,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
       status: 'completed',
       finalText: '',
       filesTouched: [],
+      filesWritten: [],
     });
 
     const result = await runAutoMemoryExtractionByAgent(mockConfig, '/tmp');
@@ -115,6 +118,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
       touchedTopics: [],
       touchedProjectScope: false,
       touchedUserScope: false,
+      hasToolActivity: false,
       systemMessage: undefined,
     });
   });
@@ -176,6 +180,11 @@ describe('runAutoMemoryExtractionByAgent', () => {
         '/tmp/auto-memory/reference/api.md',
         '/tmp/some/other/file.ts',
       ],
+      filesWritten: [
+        '/tmp/auto-memory/project/arch.md',
+        '/tmp/auto-memory/reference/api.md',
+        '/tmp/some/other/file.ts',
+      ],
     });
 
     const result = await runAutoMemoryExtractionByAgent(mockConfig, '/tmp');
@@ -192,6 +201,10 @@ describe('runAutoMemoryExtractionByAgent', () => {
       status: 'completed',
       finalText: '',
       filesTouched: [
+        '/tmp/user-memory/user/role.md',
+        '/tmp/user-memory/feedback/terse.md',
+      ],
+      filesWritten: [
         '/tmp/user-memory/user/role.md',
         '/tmp/user-memory/feedback/terse.md',
       ],
@@ -230,6 +243,10 @@ describe('runAutoMemoryExtractionByAgent', () => {
         'C:/Users/foo/.qwen/projects/proj/memory/project/release.md',
         'C:/Users/foo/.qwen/memories/user/role.md',
       ],
+      filesWritten: [
+        'C:/Users/foo/.qwen/projects/proj/memory/project/release.md',
+        'C:/Users/foo/.qwen/memories/user/role.md',
+      ],
     });
 
     try {
@@ -253,6 +270,10 @@ describe('runAutoMemoryExtractionByAgent', () => {
       status: 'completed',
       finalText: '',
       filesTouched: [
+        '/tmp/auto-memory\\project\\arch.md',
+        '/tmp/user-memory\\user\\role.md',
+      ],
+      filesWritten: [
         '/tmp/auto-memory\\project\\arch.md',
         '/tmp/user-memory\\user\\role.md',
       ],
@@ -291,6 +312,10 @@ describe('runAutoMemoryExtractionByAgent', () => {
       status: 'completed',
       finalText: '',
       filesTouched: [
+        '/tmp/user-memory/user/role.md',
+        '/tmp/auto-memory/project/release.md',
+      ],
+      filesWritten: [
         '/tmp/user-memory/user/role.md',
         '/tmp/auto-memory/project/release.md',
       ],

--- a/packages/core/src/memory/extractionAgentPlanner.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.ts
@@ -61,6 +61,7 @@ export interface AutoMemoryExtractionExecutionResult {
   /** True when at least one file inside the user-level memory root was written/edited. */
   touchedUserScope: boolean;
   systemMessage?: string;
+  hasToolActivity: boolean;
 }
 
 /**
@@ -291,12 +292,13 @@ export async function runAutoMemoryExtractionByAgent(
   }
 
   const { topics, touchedProjectScope, touchedUserScope } =
-    touchedTopicsFromFilePaths(result.filesTouched, projectRoot);
+    touchedTopicsFromFilePaths(result.filesWritten ?? [], projectRoot);
 
   return {
     touchedTopics: topics,
     touchedProjectScope,
     touchedUserScope,
+    hasToolActivity: result.filesTouched.length > 0,
     systemMessage:
       topics.length > 0
         ? `Managed auto-memory updated: ${topics.map((t) => `${t}.md`).join(', ')}`

--- a/packages/core/src/memory/memoryLifecycle.integration.test.ts
+++ b/packages/core/src/memory/memoryLifecycle.integration.test.ts
@@ -82,6 +82,7 @@ describe('managed auto-memory lifecycle integration', () => {
           touchedTopics: [topic],
           touchedProjectScope: true,
           touchedUserScope: false,
+          hasToolActivity: true,
           systemMessage: undefined,
         };
       },


### PR DESCRIPTION
Fixes #6311

The extract cursor previously advanced unconditionally after the forked extractor agent reported completed, even when it made zero real tool calls, for example a small or local model hallucinating a bash command instead of calling write_file. This silently and permanently skipped those history messages from being reprocessed.

Also fixes extractionAgentPlanner.ts using filesTouched, which is attempted and unconfirmed paths, instead of filesWritten, which is confirmed successful writes, when deriving touchedTopics. This matches the pattern already used in remember.ts.

touchedTopics.length greater than 0 alone is not sufficient to gate the cursor advance. A legitimate nothing durable to save outcome also produces an empty touchedTopics array and would otherwise be treated the same as a hallucinated run. A new hasToolActivity signal, derived from filesTouched which includes read only calls like read_file, distinguishes agent engaged with the task and found nothing new to save, which is a legitimate noop where the cursor still advances, from agent made zero tool calls at all, which is the hallucination case where the cursor is held for retry.

## What this PR does

This PR changes two files in packages/core/src/memory. extract.ts now only advances processedOffset to the full history length when the extractor agent made genuine progress, meaning touchedTopics.length is greater than 0 or hasToolActivity is true. Otherwise it holds the cursor at its previous offset so the same slice of history gets retried on the next extraction pass instead of being silently skipped forever. extractionAgentPlanner.ts adds a new hasToolActivity field to the AutoMemoryExtractionExecutionResult interface, which is true whenever the agent made at least one real tool call, and switches touchedTopics derivation from filesTouched to filesWritten so only confirmed writes count toward topics touched.

## Why it's needed

Issue 6311 shows a local model called liquid slash lfm2 1.2b hallucinating a bash script as plain text instead of calling write_file during managed AutoMemory extraction. The extractor agent still reported status completed, so the cursor advanced past those messages unconditionally. The user's remember this instruction was silently dropped and could never be retried, even in a later session with a stronger model. The triage comment suggested gating the cursor advance on touchedTopics.length greater than 0, but that alone cannot distinguish a legitimate agent checked existing memory and decided there is nothing new to save outcome from the hallucination case, since both produce an empty touchedTopics array. The hasToolActivity signal fixes that ambiguity by checking whether the agent made any tool call at all, including read only ones like read_file, which is the actual signature of a hallucinated run in the issue log.

## Reviewer Test Plan

### How to verify

This is a pure unit test level fix. runAutoMemoryExtractionByAgent is fully mocked in extract.test.ts at packages/core/src/memory/extract.test.ts, so no real LLM calls are needed to reproduce or verify this.

Step one, reproduce the bug before the fix. With only the new test added and the source fix not yet applied, run this single test in isolation.
cd packages/core
npx vitest run src/memory/extract.test.ts -t "BUG #6311"

This produces a failing test with the following output.
FAIL src/memory/extract.test.ts
BUG #6311: should NOT advance cursor when agent makes zero tool calls (hallucination)
AssertionError: expected 1 to be +0
Expected: 0
Received: 1

Received 1 is the bug itself. Even though the agent made zero tool calls, the cursor still advanced past the single unprocessed message, meaning the instruction Remember that I prefer pnpm over npm would never be retried and would be lost forever.

Step two, apply the fix in extract.ts and extractionAgentPlanner.ts. Rerun the same test.
npx vitest run src/memory/extract.test.ts -t "BUG #6311"

This now passes.
PASS src/memory/extract.test.ts
BUG #6311: should NOT advance cursor when agent makes zero tool calls (hallucination)

Step three, confirm no regressions across every file touched by this change.
npx vitest run src/memory/extract.test.ts
Result: 16 passed, 16 total.
npx vitest run src/memory/extractionAgentPlanner.test.ts
Result: 11 passed, 11 total.
npx vitest run src/memory/extractAgent.test.ts
Result: 1 passed, 1 total.
npx vitest run src/memory/memoryLifecycle.integration.test.ts
Result: 1 passed, 1 total.
npx vitest run src/memory/remember.test.ts
Result: 11 passed, 11 total.

A companion regression test named should advance cursor on legitimate noop confirms the fix does not overcorrect. When the agent genuinely checked memory and found nothing new, meaning hasToolActivity is true and touchedTopics is empty, the cursor still advances normally to the full history length.

Step four, confirm lint and typecheck are clean.
npm run lint
Result: no errors.
npm run typecheck --workspace=packages/core
Result: no errors.

### Evidence (Before & After)

This is a non UI, backend only logic fix, so there are no screenshots. The evidence is the exact numeric value of processedOffset before and after the fix, shown through the test assertion output above.

Before the fix, for the hallucination scenario where the agent completes with zero tool calls, processedOffset was 1 when it should have stayed at 0. This is a silent numeric error, not a crash and not a visible error message to the end user, which is exactly why it went unnoticed until someone inspected the cursor file directly, as described in the original issue.
<img width="983" height="547" alt="before" src="https://github.com/user-attachments/assets/2b9c6710-0e78-460f-82ff-0ec5d121644c" />

After the fix, for that same hallucination scenario, processedOffset correctly stays at 0, so the unprocessed message will be retried on the next extraction pass.
<img width="981" height="370" alt="after" src="https://github.com/user-attachments/assets/ab5fd754-0700-487e-89e9-8fb80b97a465" />

For the legitimate noop scenario, where the agent has hasToolActivity true but touchedTopics empty, processedOffset correctly advances to the full history length both before and after the fix, confirming the fix only changes behavior for the true hallucination case and does not regress the normal skip logic.

Summary table.

| Scenario | processedOffset before fix | processedOffset after fix | Correct behavior |
| --- | --- | --- | --- |
| Hallucination, zero tool calls | 1, wrong | 0, correct | Retry on next pass |
| Legitimate noop, has tool activity | full length, correct | full length, correct | No regression |
| Normal write | full length, correct | full length, correct | No regression |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  |  not tested |
| Windows | tested |
|  Linux  |  not tested |

### Environment (optional)

Local run using npx vitest against packages/core on Windows, Node v24.17.0. runAutoMemoryExtractionByAgent is mocked at the unit test layer throughout, so no real model or sandbox environment is involved in this verification.

## Risk & Scope

Main risk or tradeoff: if hasToolActivity is ever computed incorrectly for a legitimate run, for example an agent that only reads memory but genuinely has nothing to save, the cursor could fail to advance and the same history slice would be retried indefinitely. The included legitimate noop regression test guards against this specific case.

Not validated or out of scope: behavior against a real local or small model actually hallucinating, as in the original issue log, was not re verified end to end. This fix targets the exact mechanism described in the issue, meaning zero tool calls on a completed run, at the unit test level. The companion issue 6308 about configurable extractor timeouts is related but not addressed here.

Breaking changes or migration notes: AutoMemoryExtractionExecutionResult gains a new required field hasToolActivity. Any other caller constructing this type, whether in test mocks or elsewhere, will need to supply it. This PR updates all in repo mocks accordingly.

## Linked Issues

Fixes #6311

<details>
<summary>中文说明</summary>

修复 6311 号问题

之前 extract cursor 在 forked extractor agent 报告 completed 状态后会无条件推进，即使 agent 实际上没有做任何真正的工具调用，例如本地或小模型把 bash 命令幻觉成了纯文本，而不是调用 write_file。这会导致这些历史消息被永久性地静默跳过，再也不会被重新处理。

同时修复了 extractionAgentPlanner.ts 中使用 filesTouched，也就是尝试写入但未确认成功的路径，而不是 filesWritten，也就是确认成功写入的路径，来推导 touchedTopics 的问题，使其与 remember.ts 中已有的写法保持一致。

仅凭 touchedTopics.length 大于 0 不足以作为 cursor 推进的判断条件。合法的没有新东西需要保存的结果同样会产生空的 touchedTopics 数组，如果只看这个字段，会和幻觉场景混为一谈。新增的 hasToolActivity 信号，从 filesTouched 派生，包含只读调用如 read_file，能够区分 agent 认真检查过确实没有新东西这种合法 noop，此时 cursor 正常推进，和 agent 完全没有调用任何工具这种幻觉场景，此时 cursor 保持不变以便重试。

## 这个 PR 做了什么

在 packages 下 core 下 src 下 memory 目录中改动了两个文件。extract.ts 现在只有在 extractor agent 确实取得了实质性进展时，也就是 touchedTopics.length 大于 0 或者 hasToolActivity 为 true，才会将 processedOffset 推进到完整的 history 长度。否则 cursor 保持在之前的 offset，让同一段历史消息在下一次提取时被重新处理，而不是被永久跳过。extractionAgentPlanner.ts 在 AutoMemoryExtractionExecutionResult 接口中新增了 hasToolActivity 字段，只要 agent 做过至少一次真正的工具调用就为 true，并将 touchedTopics 的推导来源从 filesTouched 切换为 filesWritten，确保只有确认成功的写入才会被计入涉及的主题。

## 为什么需要这个改动

6311 号问题中展示了一个本地模型在 managed AutoMemory 提取过程中，把一段 bash 脚本当作纯文本吐出来，而不是调用 write_file 工具。extractor agent 依然报告了 completed 状态，导致 cursor 无条件跳过了这些消息，用户记住这件事的指令被静默丢弃，而且永远无法重试，即使之后换成更强的模型也不行。分类评论建议仅凭 touchedTopics.length 大于 0 来判断，但这无法区分 agent 认真检查了现有记忆判断没有新东西需要保存这种合法结果和幻觉场景，两者产生的 touchedTopics 都是空数组。hasToolActivity 信号通过检查 agent 是否做过任何工具调用，包括只读调用如 read_file，解决了这个歧义，这正是问题日志中幻觉场景的真实特征。

## Reviewer 测试方案

这是一个纯单元测试层面的修复，extract.test.ts 中 runAutoMemoryExtractionByAgent 被完全 mock 掉，因此复现和验证都不需要真实的 LLM 调用。

第一步，在修复前复现 bug。只加上新测试但源码还没改的情况下，单独跑这一个测试，命令是进入 packages 下 core 目录，然后跑 npx vitest run，指定 extract.test.ts 文件，参数加上 t 和 BUG 6311。这会产生一个失败的测试，输出显示期望是 0，实际收到的是 1。收到 1 就是 bug 本身，即使 agent 零工具调用，cursor 依然跳过了这条唯一未处理的消息，意味着记住我更喜欢用 pnpm 而不是 npm 这条指令永远不会被重试，会永久丢失。

第二步，应用 extract.ts 和 extractionAgentPlanner.ts 里的修复，重新跑同一个测试，这次测试通过。

第三步，确认所有涉及文件都没有回归。分别跑 extract.test.ts，结果 16 个测试全部通过。跑 extractionAgentPlanner.test.ts，结果 11 个测试全部通过。跑 extractAgent.test.ts，结果 1 个测试通过。跑 memoryLifecycle.integration.test.ts，结果 1 个测试通过。跑 remember.test.ts，结果 11 个测试全部通过。配套新增的回归测试确认这个修复没有矫枉过正，当 agent 确实检查过记忆判断没有新东西时，cursor 依然正常推进。

第四步，确认 lint 和 typecheck 都干净，两者均无报错通过。

## 证据，修复前和修复后

这是一个非 UI、纯后端逻辑修复，所以没有截图。证据就是 processedOffset 这个数值在修复前后的具体变化。

修复前，对于 agent 完成时零工具调用的幻觉场景，processedOffset 是 1，但本应保持为 0。这是一个静默的数值错误，不是崩溃，也不是给最终用户看到的报错提示，这正是为什么这个问题一直没被发现，直到有人直接检查 cursor 文件才发现，正如原始 issue 里描述的那样。

修复后，同样的幻觉场景下，processedOffset 正确地保持为 0，这样未处理的消息会在下一次提取时被重试。

对于合法 noop 场景，也就是 agent 有工具活动但 touchedTopics 为空，修复前后 processedOffset 都正确地推进到完整长度，确认这个修复只改变了真正幻觉场景下的行为，没有破坏正常的跳过逻辑。

## 测试环境

Windows 已测试，macOS 和 Linux 未测试。本地在 Windows 上通过 npx vitest run 针对 packages 下 core 跑测试，Node 版本 v24.17.0。全程 runAutoMemoryExtractionByAgent 都在单元测试层被 mock，不涉及真实模型或沙箱环境。

## 风险与范围

主要风险，如果 hasToolActivity 在某个合法场景下被错误计算，比如 agent 只是读取了记忆但确实没有需要保存的东西却被误判，cursor 可能无法推进，导致同一段历史消息被无限重试。已包含的合法 noop 回归测试专门针对这种情况做了防护。

未验证或超出范围，没有针对真实的本地或小模型实际产生幻觉的场景做端到端复测，本修复在单元测试层面针对 issue 中描述的确切机制进行了修复，也就是 completed 状态下零工具调用。相关的 6308 号问题，关于可配置 extractor 超时，与本修复相关但未在此一并处理。

破坏性改动或迁移说明，AutoMemoryExtractionExecutionResult 新增了一个必填字段 hasToolActivity，任何其他构造该类型的调用方，无论是测试 mock 还是其他地方，都需要补上这个字段，本 PR 已同步更新了仓库内所有相关 mock。

</details>