### PR TITLE
fix(web-shell): refine tool detail presentation

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -27,7 +27,7 @@
   padding-right: env(safe-area-inset-right);
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;
   overflow: hidden;
@@ -519,6 +519,11 @@
   left: 20px;
   z-index: 6;
   pointer-events: auto;
+}
+
+.approvalOverlay:focus,
+.approvalOverlay:focus-visible {
+  outline: none;
 }
 
 .scrollToBottomLayer {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -68,7 +68,6 @@ import { DaemonStatusDialog } from './components/dialogs/DaemonStatusDialog';
 import { ScheduledTasksDialog } from './components/dialogs/ScheduledTasksDialog';
 import { ExtensionsDialog } from './components/dialogs/ExtensionsDialog';
 import { SettingsMessage } from './components/messages/SettingsMessage';
-import { resolveShellOutputMaxLines } from './components/messages/ToolGroup';
 import { isAskUserQuestionToolName } from './components/messages/toolFormatting';
 import { ToolApproval } from './components/messages/ToolApproval';
 import { AskUserQuestion } from './components/messages/AskUserQuestion';
@@ -1976,7 +1975,6 @@ export function App({
     )?.values.effective;
     return typeof value === 'string' && value.trim() ? value.trim() : undefined;
   })();
-  const shellOutputMaxLines = resolveShellOutputMaxLines(workspaceSettings);
   const [compactMode, setCompactMode] = useState(false);
   const compactModeRef = useRef(compactMode);
   compactModeRef.current = compactMode;
@@ -4364,7 +4362,10 @@ export function App({
                 </section>
               )}
               {mainView === 'scheduledTasks' && (
-                <div className={styles.fullPage} data-testid="scheduled-tasks-page">
+                <div
+                  className={styles.fullPage}
+                  data-testid="scheduled-tasks-page"
+                >
                   <div className={styles.fullPageHeader}>
                     <button
                       type="button"
@@ -4461,7 +4462,6 @@ export function App({
                           isResponding={streamingState !== 'idle'}
                           activeTurnStartedAt={activeTurnStartedAt}
                           workspaceCwd={connection.workspaceCwd || ''}
-                          shellOutputMaxLines={shellOutputMaxLines}
                           hideSessionTimeline={
                             effectiveChatWidthMode === 'wide'
                           }

--- a/packages/web-shell/client/components/MessageItem.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageItem.dom.test.tsx
@@ -84,7 +84,7 @@ const assistantMsg = (id: string, content: string): Message =>
   ({ id, role: 'assistant', content, timestamp: 0 }) as Message;
 
 function item(message: Message) {
-  return <MessageItem message={message} shellOutputMaxLines={50} />;
+  return <MessageItem message={message} />;
 }
 
 describe('MessageItem error isolation', () => {

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -30,7 +30,6 @@ interface MessageItemProps {
   onBranchSession?: () => void;
   showAssistantActions?: boolean;
   showAssistantBranch?: boolean;
-  shellOutputMaxLines: number;
 }
 
 export const MessageItem = memo(function MessageItem({
@@ -44,7 +43,6 @@ export const MessageItem = memo(function MessageItem({
   onBranchSession,
   showAssistantActions = false,
   showAssistantBranch = false,
-  shellOutputMaxLines,
 }: MessageItemProps) {
   const body = ((): ReactElement | null => {
     switch (message.role) {
@@ -77,7 +75,6 @@ export const MessageItem = memo(function MessageItem({
             tools={message.tools}
             pendingApproval={pendingApproval}
             workspaceCwd={workspaceCwd}
-            shellOutputMaxLines={shellOutputMaxLines}
           />
         );
       case 'plan':
@@ -239,7 +236,6 @@ function areMessageItemPropsEqual(
   if (prev.onBranchSession !== next.onBranchSession) return false;
   if (prev.showAssistantActions !== next.showAssistantActions) return false;
   if (prev.showAssistantBranch !== next.showAssistantBranch) return false;
-  if (prev.shellOutputMaxLines !== next.shellOutputMaxLines) return false;
   return areMessagesEqual(prev.message, next.message);
 }
 

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -174,7 +174,6 @@ function mount(
           loadingTranscript={opts.loadingTranscript}
           catchingUp={opts.catchingUp}
           isResponding={opts.isResponding}
-          shellOutputMaxLines={50}
           onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
         />
       </I18nProvider>,
@@ -205,7 +204,6 @@ function renderInto(
           loadingTranscript={opts.loadingTranscript}
           catchingUp={opts.catchingUp}
           isResponding={opts.isResponding}
-          shellOutputMaxLines={50}
           onCanScrollToBottomChange={opts.onCanScrollToBottomChange}
         />
       </I18nProvider>,

--- a/packages/web-shell/client/components/MessageList.module.css
+++ b/packages/web-shell/client/components/MessageList.module.css
@@ -156,6 +156,9 @@
 .turnAnswerRow {
   max-width: 100%;
 }
+.turnStatusRow {
+  margin-bottom: 4px;
+}
 
 .turnAnswerRow {
   margin-top: 10px;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -48,7 +48,6 @@ interface MessageListProps {
   tailContent?: ReactNode;
   tailKey?: string;
   virtualScrollThreshold?: number;
-  shellOutputMaxLines: number;
   activeTurnStartedAt?: number;
   /**
    * When true, scroll the tail content into view the moment it first appears
@@ -1712,7 +1711,6 @@ export const MessageList = memo(
       tailContent,
       tailKey = 'tail',
       virtualScrollThreshold = VIRTUAL_SCROLL_THRESHOLD,
-      shellOutputMaxLines,
       autoScrollTailIntoView = false,
       hideSessionTimeline = false,
       showRetryHint = false,
@@ -2646,7 +2644,6 @@ export const MessageList = memo(
                 displayItem.message.role === 'assistant' &&
                 displayItem.message.id === lastCompletedAssistantId
               }
-              shellOutputMaxLines={shellOutputMaxLines}
             />
           );
         };
@@ -2681,7 +2678,6 @@ export const MessageList = memo(
         showRetryHint,
         onRetryClick,
         onBranchSession,
-        shellOutputMaxLines,
         handleToggleCollapse,
       ],
     );

--- a/packages/web-shell/client/components/messages/AssistantMessage.module.css
+++ b/packages/web-shell/client/components/messages/AssistantMessage.module.css
@@ -188,13 +188,24 @@
 
 .thinkingChevronRight,
 .thinkingChevronDown {
-  width: 7px;
-  height: 7px;
-  border-right: 1px solid currentColor;
-  border-bottom: 1px solid currentColor;
+  width: 14px;
+  height: 14px;
+  position: relative;
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 120ms ease;
+}
+
+.thinkingChevronRight::before,
+.thinkingChevronRight::after,
+.thinkingChevronDown::before,
+.thinkingChevronDown::after {
+  content: '';
+  position: absolute;
+  width: 6px;
+  height: 1px;
+  background: currentColor;
+  border-radius: 1px;
 }
 
 .thinkingSummary:hover .thinkingChevronRight,
@@ -205,13 +216,36 @@
 }
 
 .thinkingChevronRight {
+  transform: none;
+}
+
+.thinkingChevronRight::before {
+  top: calc(50% - 2px);
+  left: calc(50% - 3px);
+  transform: rotate(45deg);
+}
+
+.thinkingChevronRight::after {
+  top: calc(50% + 2px);
+  left: calc(50% - 3px);
   transform: rotate(-45deg);
 }
 
 .thinkingChevronDown {
-  transform: rotate(45deg);
-  margin-top: -3px;
+  transform: none;
   opacity: 1;
+}
+
+.thinkingChevronDown::before {
+  top: 50%;
+  left: calc(50% - 5px);
+  transform: rotate(45deg);
+}
+
+.thinkingChevronDown::after {
+  top: 50%;
+  left: calc(50% - 1px);
+  transform: rotate(-45deg);
 }
 
 .thinkingExpandedWrap {

--- a/packages/web-shell/client/components/messages/Markdown.module.css
+++ b/packages/web-shell/client/components/messages/Markdown.module.css
@@ -199,8 +199,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 12px;
-  background: var(--subtle-bg);
-  border-bottom: 0.5px solid var(--border);
+  background: var(--secondary);
 }
 
 .codeBlockLang {
@@ -238,6 +237,7 @@
   font-size: 13px;
   line-height: 1.5;
   background: var(--secondary);
+  margin-top: 0;
 }
 
 .codeBlockContent pre {

--- a/packages/web-shell/client/components/messages/TasksStatusMessage.module.css
+++ b/packages/web-shell/client/components/messages/TasksStatusMessage.module.css
@@ -198,14 +198,20 @@
 }
 
 .embeddedPanel .inlineDetail {
-  padding: 0;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  margin: 5px 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .embeddedPanel .detail {
-  margin: 8px;
-  border-radius: 6px;
-  background: var(--background);
-  padding: 8px;
+  margin: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 .embeddedPanel .nameCell {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { DaemonSettingDescriptor } from '@qwen-code/webui/daemon-react-sdk';
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import type { ACPToolCall } from '../../adapters/types';
+import { I18nProvider } from '../../i18n';
 
 vi.mock('../../App', async () => {
   const { createContext } = await import('react');
@@ -14,16 +17,35 @@ vi.mock('../../App', async () => {
 const {
   buildUnifiedDiff,
   extractDiff,
+  fencedCodeBlock,
+  formatSingleToolSummary,
+  formatRunningSingleToolSummary,
   formatToolGroupSummary,
   getActiveTool,
   getRawFileDiff,
   getToolHeaderKind,
   hasActiveTool,
+  hasExpandableContent,
   isActiveToolStatus,
   isWebFetchToolName,
-  resolveShellOutputMaxLines,
+  languageForPath,
   shouldAutoExpand,
+  ToolGroup,
+  ToolLine,
 } = await import('./ToolGroup');
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
 
 function makeTool(overrides: Partial<ACPToolCall> = {}): ACPToolCall {
   return {
@@ -34,14 +56,65 @@ function makeTool(overrides: Partial<ACPToolCall> = {}): ACPToolCall {
   };
 }
 
+function renderToolLine(tool: ACPToolCall): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <ToolLine tool={tool} />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+function renderToolGroup(tools: ACPToolCall[]): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <ToolGroup tools={tools} />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
 const t = (key: string, values?: Record<string, string | number>): string => {
   if (key === 'toolGroup.running') {
-    return `Running ${values?.name ?? 'tool'}${
+    return `Running ${values?.name ?? 'tool'}${values?.duration ? ` ${values.duration}` : ''}${
       Number(values?.count ?? 0) > 1 ? ` · ${values?.count ?? 0} tools` : ''
     }`;
   }
   if (key === 'toolGroup.summary') {
     return `Ran ${values?.count ?? 0} tool${values?.count === 1 ? '' : 's'}`;
+  }
+  if (key === 'toolGroup.summary.editedFiles') {
+    return `Edited ${values?.count ?? 0} files`;
+  }
+  if (key === 'toolGroup.summary.ranCommands') {
+    return `Ran ${values?.count ?? 0} commands`;
+  }
+  if (key === 'toolGroup.summary.readFiles') {
+    return `Read ${values?.count ?? 0} files`;
+  }
+  if (key === 'toolGroup.summary.searched') {
+    return `Searched ${values?.count ?? 0} times`;
+  }
+  if (key === 'toolGroup.summary.updatedTodos') {
+    return `Updated todos ${values?.count ?? 0} times`;
+  }
+  if (key === 'toolGroup.summary.askedUser') {
+    return 'Asked user';
+  }
+  if (key === 'toolGroup.summary.otherTools') {
+    return `Called ${values?.count ?? 0} other tools`;
   }
   return key;
 };
@@ -50,18 +123,6 @@ const zhT = (key: string, values?: Record<string, string | number>): string => {
   if (key === 'toolName.readfile') return '读取文件';
   return t(key, values);
 };
-
-function setting(value: unknown): DaemonSettingDescriptor {
-  return {
-    key: 'ui.shellOutputMaxLines',
-    type: 'number',
-    label: 'Shell output max lines',
-    category: 'ui',
-    requiresRestart: false,
-    default: 5,
-    values: { effective: value },
-  };
-}
 
 describe('tool group summary logic', () => {
   it('detects active tool statuses', () => {
@@ -99,15 +160,98 @@ describe('tool group summary logic', () => {
     expect(formatToolGroupSummary(tools, zhT)).toBe('Running 读取文件');
   });
 
-  it('falls back to a completed summary without tool names', () => {
+  it('summarizes completed tool groups by common action type', () => {
     const tools = [
       makeTool({ callId: 'shell', status: 'completed' }),
       makeTool({ callId: 'read', toolName: 'ReadFile', status: 'completed' }),
+      makeTool({ callId: 'edit', toolName: 'edit', status: 'completed' }),
+      makeTool({ callId: 'grep', toolName: 'grep', status: 'completed' }),
+      makeTool({
+        callId: 'todo',
+        toolName: 'todo_write',
+        status: 'completed',
+      }),
+      makeTool({
+        callId: 'ask',
+        toolName: 'ask_user_question',
+        status: 'completed',
+      }),
     ];
 
     expect(hasActiveTool(tools)).toBe(false);
-    expect(getActiveTool(tools).callId).toBe('read');
-    expect(formatToolGroupSummary(tools, t)).toBe('Ran 2 tools');
+    expect(getActiveTool(tools).callId).toBe('ask');
+    expect(formatToolGroupSummary(tools, t)).toBe(
+      'Edited 1 files Ran 1 commands Read 1 files Searched 1 times Updated todos 1 times Asked user',
+    );
+  });
+
+  it('formats a single tool summary from the tool itself', () => {
+    expect(
+      formatSingleToolSummary(
+        makeTool({
+          toolName: 'Shell',
+          args: { command: 'npm run build' },
+        }),
+        t,
+      ),
+    ).toBe('Shell npm run build');
+  });
+
+  it('uses action summaries for single todo and ask-user tools', () => {
+    expect(
+      formatSingleToolSummary(makeTool({ toolName: 'todo_write' }), t),
+    ).toBe('Updated todos 1 times');
+    expect(
+      formatSingleToolSummary(makeTool({ toolName: 'ask_user_question' }), t),
+    ).toBe('Asked user');
+  });
+
+  it('keeps running state and command details for a single active tool', () => {
+    expect(
+      formatRunningSingleToolSummary(
+        makeTool({
+          toolName: 'Shell',
+          status: 'in_progress',
+          args: { command: 'npm run build' },
+        }),
+        t,
+        '0:03',
+      ),
+    ).toBe('Running Shell npm run build 0:03');
+  });
+
+  it('truncates long single tool descriptions in the chat summary', () => {
+    const summary = formatSingleToolSummary(
+      makeTool({
+        toolName: 'Shell',
+        args: { command: 'x'.repeat(200) },
+      }),
+      t,
+    );
+
+    expect(summary.length).toBeLessThan(140);
+    expect(summary).toContain('...');
+  });
+});
+
+describe('tool expandability', () => {
+  it('only marks tools with actual detail views as expandable by output', () => {
+    expect(
+      hasExpandableContent(
+        makeTool({
+          toolName: 'Shell',
+          content: [{ type: 'content', content: { text: 'first\nsecond' } }],
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      hasExpandableContent(
+        makeTool({
+          toolName: 'list_directory',
+          rawOutput: 'a\nb',
+        }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -124,6 +268,9 @@ describe('tool kind logic', () => {
     );
     expect(getToolHeaderKind(makeTool({ toolName: 'todo_write' }))).toBe(
       'todo',
+    );
+    expect(getToolHeaderKind(makeTool({ toolName: 'ask_user_question' }))).toBe(
+      'ask',
     );
   });
 
@@ -150,13 +297,82 @@ describe('tool kind logic', () => {
   });
 });
 
+describe('tool row rendering', () => {
+  it('renders ANSI shell output as styled spans instead of escape text', () => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'Shell',
+        status: 'failed',
+        content: [
+          {
+            type: 'content',
+            content: { text: '\u001b[31mfailed\u001b[0m\nplain' },
+          },
+        ],
+      }),
+    );
+
+    expect(container.textContent).toContain('failed');
+    expect(container.textContent).not.toContain('\u001b[31m');
+    expect(container.querySelector('pre span[style*="color"]')).not.toBeNull();
+  });
+
+  it('wraps a single expanded agent body in a headerless card', () => {
+    const container = renderToolGroup([
+      makeTool({
+        toolName: 'Task',
+        status: 'in_progress',
+        args: { description: 'Investigate build failure' },
+        subContent: 'working through the issue',
+      }),
+    ]);
+    const summary = container.querySelector('button') as HTMLButtonElement;
+
+    act(() => summary.click());
+
+    const card = container.querySelector('[class*="expandedAgentCard"]');
+    expect(card).not.toBeNull();
+    expect(card?.textContent).toContain('working through the issue');
+    expect(container.querySelector('[class*="expandedCardHeader"]')).toBeNull();
+  });
+
+  it('keeps glob details visible in the header after expanding', () => {
+    const pattern =
+      '**/very-long-component-pattern-that-crosses-the-expand-threshold-*.tsx';
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'glob',
+        args: {
+          pattern,
+          path: 'packages/web-shell/client',
+        },
+        content: [
+          {
+            type: 'content',
+            content: {
+              text: 'packages/web-shell/client/App.tsx',
+            },
+          },
+        ],
+      }),
+    );
+    const header = container.querySelector('[role="button"]') as HTMLElement;
+
+    expect(header.textContent).toContain(pattern);
+    act(() => header.click());
+    expect(header.textContent).toContain(pattern);
+    expect(header.textContent).toContain('packages/web-shell/client');
+  });
+});
+
 describe('tool output logic', () => {
-  it('resolves shell output max lines from settings', () => {
-    expect(resolveShellOutputMaxLines([])).toBe(5);
-    expect(resolveShellOutputMaxLines([setting(12)])).toBe(12);
-    expect(resolveShellOutputMaxLines([setting(2.8)])).toBe(2);
-    expect(resolveShellOutputMaxLines([setting(-1)])).toBe(0);
-    expect(resolveShellOutputMaxLines([setting('bad')])).toBe(5);
+  it('sanitizes read-file languages before building markdown fences', () => {
+    expect(languageForPath('src/App.tsx')).toBe('tsx');
+    expect(languageForPath('diagram.mermaid')).toBe('text');
+    expect(languageForPath('bad.weird\nlang')).toBe('text');
+    expect(fencedCodeBlock('tsx', 'const fence = "~~~";')).toBe(
+      '~~~~tsx\nconst fence = "~~~";\n~~~~',
+    );
   });
 
   it('suppresses truncated session diffs from raw output', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1,5 +1,12 @@
-import { memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import type { DaemonSettingDescriptor } from '@qwen-code/webui/daemon-react-sdk';
+import {
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import type {
   ACPToolCall,
   PermissionRequest,
@@ -18,6 +25,7 @@ import {
 } from '../../utils/todos';
 import { useSharedNow } from '../../hooks/useSharedNow';
 import { TodoEventSummary, TodoFullList } from './TodoView';
+import { Markdown } from './Markdown';
 import {
   formatDurationMs,
   formatElapsed,
@@ -53,12 +61,9 @@ interface ToolGroupProps {
   tools: ACPToolCall[];
   pendingApproval?: PermissionRequest | null;
   workspaceCwd?: string;
-  shellOutputMaxLines?: number;
 }
 
-const DEFAULT_SHELL_OUTPUT_MAX_LINES = 5;
-
-function hasExpandableContent(tool: ACPToolCall): boolean {
+export function hasExpandableContent(tool: ACPToolCall): boolean {
   const name = tool.toolName.toLowerCase();
   if (isAskUserQuestionToolName(tool.toolName)) return !!extractText(tool);
   // write_file shows content from args even before completion
@@ -186,61 +191,33 @@ export function buildUnifiedDiff(oldText: string, newText: string): string {
   return result.reverse().join('\n');
 }
 
-const MAX_BASH_LINE_CHARS = 150;
-const MAX_READ_LINES = 25;
-
 // A description longer than this is likely ellipsised on a normal-width row, so
 // the row becomes expandable to re-flow the full text into a wrapped block.
 const DESCRIPTION_EXPAND_THRESHOLD = 60;
+const MAX_MARKDOWN_READ_CHARS = 200_000;
+const MAX_MARKDOWN_READ_LINES = 1000;
+const READ_LANGUAGE_ALIASES: Record<string, string> = {
+  cjs: 'javascript',
+  cts: 'typescript',
+  h: 'c',
+  hpp: 'cpp',
+  js: 'javascript',
+  jsx: 'jsx',
+  mjs: 'javascript',
+  mts: 'typescript',
+  py: 'python',
+  rb: 'ruby',
+  sh: 'bash',
+  ts: 'typescript',
+  tsx: 'tsx',
+  yml: 'yaml',
+};
 
-export function resolveShellOutputMaxLines(
-  settings: readonly DaemonSettingDescriptor[],
-): number {
-  const setting = settings.find((s) => s.key === 'ui.shellOutputMaxLines');
-  const value = setting?.values.effective;
-  const raw =
-    typeof value === 'number' ? value : DEFAULT_SHELL_OUTPUT_MAX_LINES;
-  return Math.max(0, Math.floor(raw || 0));
-}
-
-function truncateLine(line: string, max: number): string {
-  if (line.length <= max) return line;
-  return line.slice(0, max) + ' …';
-}
-
-function ExpandedBashOutput({
-  tool,
-  maxLines,
-}: {
-  tool: ACPToolCall;
-  maxLines: number;
-}) {
-  const { t } = useI18n();
-  const [showAll, setShowAll] = useState(false);
+function ExpandedBashOutput({ tool }: { tool: ACPToolCall }) {
   const output = useMemo(() => extractText(tool) || '', [tool]);
-  const lines = useMemo(() => output.split('\n'), [output]);
-  const isLong = maxLines > 0 && lines.length > maxLines;
-  const hiddenLinesCount = Math.max(0, lines.length - maxLines);
-  const hasTruncatedLine = useMemo(
-    () => lines.some((l) => l.length > MAX_BASH_LINE_CHARS),
-    [lines],
-  );
-  const expandable = isLong || hasTruncatedLine;
-  const displayText = useMemo(() => {
-    if (showAll) return output;
-    if (isLong) {
-      return [
-        `... first ${hiddenLinesCount} lines hidden ...`,
-        ...lines
-          .slice(-maxLines)
-          .map((l) => truncateLine(l, MAX_BASH_LINE_CHARS)),
-      ].join('\n');
-    }
-    return lines.map((l) => truncateLine(l, MAX_BASH_LINE_CHARS)).join('\n');
-  }, [hiddenLinesCount, isLong, lines, maxLines, output, showAll]);
   const ansiSegments = useMemo(
-    () => (hasAnsi(displayText) ? parseAnsi(displayText) : null),
-    [displayText],
+    () => (hasAnsi(output) ? parseAnsi(output) : null),
+    [output],
   );
 
   return (
@@ -259,53 +236,59 @@ function ExpandedBashOutput({
                 {seg.text}
               </span>
             ))
-          : displayText}
+          : output}
       </pre>
-      {expandable && (
-        <button
-          className={styles.expandBtn}
-          onClick={() => setShowAll(!showAll)}
-          aria-expanded={showAll}
-        >
-          {showAll
-            ? t('tool.showLess')
-            : isLong
-              ? t('tool.showAll', { count: lines.length })
-              : t('tool.showFullLines')}
-        </button>
-      )}
     </div>
   );
 }
 
 function ExpandedReadContent({ tool }: { tool: ACPToolCall }) {
-  const { t } = useI18n();
-  const [showAll, setShowAll] = useState(false);
   const content = useMemo(() => extractText(tool) || '', [tool]);
-  const lines = useMemo(() => content.split('\n'), [content]);
-  const isLong = lines.length > MAX_READ_LINES;
-  const displayText = useMemo(
-    () =>
-      isLong && !showAll ? lines.slice(0, MAX_READ_LINES).join('\n') : content,
-    [content, isLong, lines, showAll],
-  );
+  const language = languageForPath(getReadFilePath(tool));
+  const plainText =
+    language === 'text' ||
+    content.length > MAX_MARKDOWN_READ_CHARS ||
+    exceedsLineLimit(content, MAX_MARKDOWN_READ_LINES);
 
   return (
     <div className={styles.expandedRead}>
-      <pre className={styles.expandedOutput}>{displayText}</pre>
-      {isLong && (
-        <button
-          className={styles.expandBtn}
-          onClick={() => setShowAll(!showAll)}
-          aria-expanded={showAll}
-        >
-          {showAll
-            ? t('tool.showLess')
-            : t('tool.linesTotal', { count: lines.length })}
-        </button>
+      {plainText ? (
+        <pre className={styles.expandedOutput}>{content}</pre>
+      ) : (
+        <Markdown content={fencedCodeBlock(language, content)} />
       )}
     </div>
   );
+}
+
+function getReadFilePath(tool: ACPToolCall): string {
+  const filePath = tool.args?.file_path ?? tool.args?.path;
+  return typeof filePath === 'string' ? filePath : '';
+}
+
+function exceedsLineLimit(text: string, maxLines: number): boolean {
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10 && ++lines > maxLines) return true;
+  }
+  return false;
+}
+
+export function languageForPath(filePath: string): string {
+  const ext = filePath.split(/[?#]/, 1)[0]?.split('.').pop()?.toLowerCase();
+  if (!ext || ext === filePath.toLowerCase()) return 'text';
+  if (ext === 'mermaid' || ext === 'mmd') return 'text';
+  const language = READ_LANGUAGE_ALIASES[ext] ?? ext;
+  return /^[\w+.#-]+$/.test(language) ? language : 'text';
+}
+
+export function fencedCodeBlock(language: string, code: string): string {
+  const longestFence =
+    code
+      .match(/~{3,}/g)
+      ?.reduce((max, fence) => Math.max(max, fence.length), 0) ?? 0;
+  const fence = '~'.repeat(Math.max(3, longestFence + 1));
+  return `${fence}${language}\n${code}\n${fence}`;
 }
 
 function ExpandedEditContent({ tool }: { tool: ACPToolCall }) {
@@ -319,6 +302,26 @@ function ExpandedEditContent({ tool }: { tool: ACPToolCall }) {
       ) : (
         <pre className={styles.expandedOutput}>{text}</pre>
       )}
+    </div>
+  );
+}
+
+function ToolExpandedCard({
+  title,
+  detail,
+  children,
+}: {
+  title: string;
+  detail?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className={styles.expandedCard}>
+      <div className={styles.expandedCardHeader}>
+        <span className={styles.expandedCardTitle}>{title}</span>
+        {detail && <span className={styles.expandedCardDetail}>{detail}</span>}
+      </div>
+      {children && <div className={styles.expandedCardBody}>{children}</div>}
     </div>
   );
 }
@@ -345,20 +348,24 @@ function TodoToolBody({
   tool,
   todos,
   expanded,
+  title,
 }: {
   tool: ACPToolCall;
   todos: TodoItem[];
   expanded: boolean;
+  title: string;
 }) {
   const timeline = useContext(TodoTimelineContext);
   const events = timeline.get(tool.callId)?.events ?? [];
-  return (
-    <div className={styles.todoBody}>
-      {expanded ? (
+  return expanded ? (
+    <ToolExpandedCard title={title}>
+      <div className={styles.todoBody}>
         <TodoFullList todos={todos} />
-      ) : (
-        <TodoEventSummary todos={todos} events={events} />
-      )}
+      </div>
+    </ToolExpandedCard>
+  ) : (
+    <div className={styles.todoBody}>
+      <TodoEventSummary todos={todos} events={events} />
     </div>
   );
 }
@@ -367,8 +374,11 @@ interface ToolLineProps {
   tool: ACPToolCall;
   approval?: PermissionRequest | null;
   workspaceCwd?: string;
-  shellOutputMaxLines?: number;
   summaryOnly?: boolean;
+  forceExpanded?: boolean;
+  forceExpandable?: boolean;
+  hideHeader?: boolean;
+  hideCollapsedOutput?: boolean;
 }
 
 function getAgentDisplayInfo(
@@ -468,6 +478,7 @@ function ExpandedAskUserQuestionOutput({ tool }: { tool: ACPToolCall }) {
 export function getToolHeaderKind(tool: ACPToolCall): ToolHeaderKind {
   const name = tool.toolName.toLowerCase();
   if (isSubAgentToolCall(tool)) return 'agent';
+  if (isAskUserQuestionToolName(tool.toolName)) return 'ask';
   if (isShellToolName(name)) return 'shell';
   if (isWebFetchToolName(name)) return 'fetch';
   if (isTodoWriteToolName(name)) return 'todo';
@@ -542,9 +553,99 @@ export function formatToolGroupSummary(
     });
   }
 
+  const summary = formatCompletedToolSummary(tools, t);
+  if (summary) return summary;
+
   return t('toolGroup.summary', {
     count: tools.length,
   });
+}
+
+export function formatSingleToolSummary(
+  tool: ACPToolCall,
+  t: ReturnType<typeof useI18n>['t'],
+  workspaceCwd?: string,
+): string {
+  if (isTodoWriteToolName(tool.toolName)) {
+    return t('toolGroup.summary.updatedTodos', { count: 1 });
+  }
+  if (isAskUserQuestionToolName(tool.toolName)) {
+    return t('toolGroup.summary.askedUser', { count: 1 });
+  }
+
+  const displayName = localizeToolDisplayName(tool.toolName, t);
+  const description = truncateText(getToolDescription(tool, workspaceCwd), 120);
+  return [displayName, description].filter(Boolean).join(' ');
+}
+
+export function formatRunningSingleToolSummary(
+  tool: ACPToolCall,
+  t: ReturnType<typeof useI18n>['t'],
+  duration?: string,
+  workspaceCwd?: string,
+): string {
+  return t('toolGroup.running', {
+    name: formatSingleToolSummary(tool, t, workspaceCwd),
+    count: 1,
+    duration: duration ?? '',
+  });
+}
+
+function formatCompletedToolSummary(
+  tools: ACPToolCall[],
+  t: ReturnType<typeof useI18n>['t'],
+): string {
+  let edited = 0;
+  let commands = 0;
+  let read = 0;
+  let searched = 0;
+  let todos = 0;
+  let asked = 0;
+  let other = 0;
+
+  for (const tool of tools) {
+    const name = tool.toolName.toLowerCase();
+    if (isShellToolName(name)) {
+      commands++;
+    } else if (
+      name === 'edit' ||
+      name === 'editfile' ||
+      name === 'write' ||
+      name === 'write_file' ||
+      name === 'writefile'
+    ) {
+      edited++;
+    } else if (name === 'read' || name === 'read_file' || name === 'readfile') {
+      read++;
+    } else if (
+      name === 'grep' ||
+      name === 'grep_search' ||
+      name === 'search' ||
+      name === 'glob' ||
+      name === 'web_search' ||
+      name === 'websearch'
+    ) {
+      searched++;
+    } else if (isTodoWriteToolName(name)) {
+      todos++;
+    } else if (isAskUserQuestionToolName(name)) {
+      asked++;
+    } else {
+      other++;
+    }
+  }
+
+  const parts = [
+    edited ? t('toolGroup.summary.editedFiles', { count: edited }) : '',
+    commands ? t('toolGroup.summary.ranCommands', { count: commands }) : '',
+    read ? t('toolGroup.summary.readFiles', { count: read }) : '',
+    searched ? t('toolGroup.summary.searched', { count: searched }) : '',
+    todos ? t('toolGroup.summary.updatedTodos', { count: todos }) : '',
+    asked ? t('toolGroup.summary.askedUser') : '',
+    other ? t('toolGroup.summary.otherTools', { count: other }) : '',
+  ].filter(Boolean);
+
+  return parts.join(' ');
 }
 
 export function hasActiveTool(tools: ACPToolCall[]): boolean {
@@ -679,6 +780,27 @@ function TodoIcon() {
   );
 }
 
+function AskUserIcon() {
+  return (
+    <svg
+      className={styles.chatSummaryToolIcon}
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M3.4 3.2h7.2c.7 0 1.25.55 1.25 1.25v3.4c0 .7-.55 1.25-1.25 1.25H7.5L4.5 11V9.1H3.4c-.7 0-1.25-.55-1.25-1.25v-3.4c0-.7.55-1.25 1.25-1.25Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 function AgentIcon() {
   return (
     <svg
@@ -702,6 +824,7 @@ function AgentIcon() {
 function ToolSummaryIcon({ tool }: { tool: ACPToolCall }) {
   const kind = getToolHeaderKind(tool);
   if (kind === 'agent') return <AgentIcon />;
+  if (kind === 'ask') return <AskUserIcon />;
   if (kind === 'edit' || kind === 'write') return <PencilIcon />;
   if (kind === 'fetch') return <WebFetchIcon />;
   if (kind === 'read') return <FileIcon />;
@@ -767,8 +890,11 @@ function areToolLinePropsEqual(
 ): boolean {
   if (prev.approval?.id !== next.approval?.id) return false;
   if (prev.workspaceCwd !== next.workspaceCwd) return false;
-  if (prev.shellOutputMaxLines !== next.shellOutputMaxLines) return false;
   if (prev.summaryOnly !== next.summaryOnly) return false;
+  if (prev.forceExpanded !== next.forceExpanded) return false;
+  if (prev.forceExpandable !== next.forceExpandable) return false;
+  if (prev.hideHeader !== next.hideHeader) return false;
+  if (prev.hideCollapsedOutput !== next.hideCollapsedOutput) return false;
   const a = prev.tool;
   const b = next.tool;
   return (
@@ -816,13 +942,16 @@ export const ToolLine = memo(function ToolLine({
   tool,
   approval,
   workspaceCwd,
-  shellOutputMaxLines = DEFAULT_SHELL_OUTPUT_MAX_LINES,
   summaryOnly = false,
+  forceExpanded = false,
+  forceExpandable = false,
+  hideHeader = false,
+  hideCollapsedOutput = false,
 }: ToolLineProps) {
   const { t } = useI18n();
   const compactMode = useContext(CompactModeContext);
   const [expanded, setExpanded] = useState(
-    () => !compactMode && shouldAutoExpand(tool),
+    () => forceExpanded || (!compactMode && shouldAutoExpand(tool)),
   );
   // Set once the user explicitly toggles this row, so auto-collapse-on-
   // completion never silently overrides their choice.
@@ -830,12 +959,14 @@ export const ToolLine = memo(function ToolLine({
 
   useEffect(
     () => {
-      setExpanded(compactMode ? false : shouldAutoExpand(tool));
+      setExpanded(
+        forceExpanded || (compactMode ? false : shouldAutoExpand(tool)),
+      );
       // A new tool identity (or compact-mode toggle) resets the manual latch.
       userToggledRef.current = false;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [compactMode, tool.callId, tool.toolName],
+    [compactMode, forceExpanded, tool.callId, tool.toolName],
   );
   const isAgent = isSubAgentToolCall(tool);
   const hasApproval = approval && approval.toolCallId === tool.callId;
@@ -853,10 +984,15 @@ export const ToolLine = memo(function ToolLine({
   // user chose, driven from their own panel) and failures stay open so the
   // error output remains visible.
   useEffect(() => {
-    if (!isAgent && tool.status === 'completed' && !userToggledRef.current) {
+    if (
+      !forceExpanded &&
+      !isAgent &&
+      tool.status === 'completed' &&
+      !userToggledRef.current
+    ) {
       setExpanded(false);
     }
-  }, [isAgent, tool.status]);
+  }, [forceExpanded, isAgent, tool.status]);
 
   if (isAgent) {
     const info = getAgentDisplayInfo(tool, now);
@@ -876,31 +1012,41 @@ export const ToolLine = memo(function ToolLine({
     ]
       .filter(Boolean)
       .join(' · ');
-    const showExpanded = expanded || !!hasApproval || !!hasSubToolApproval;
+    const showExpanded =
+      forceExpanded || expanded || !!hasApproval || !!hasSubToolApproval;
+    const panel = (
+      <SubAgentPanel tool={tool} hideHeader defaultExpanded inline />
+    );
     return (
       <div className={styles.line}>
-        <div
-          className={`${styles.lineMain} ${styles.lineExpandable}`}
-          onClick={() => setExpanded(!expanded)}
-        >
-          <StatusIcon status={isComplete ? info.status : tool.status} />
-          <span className={styles.lineName}>{displayName}</span>
-          <ToolHeaderExtra
-            info={{
-              kind: 'agent',
-              tool,
-              displayName,
-              description: info.description
-                ? truncateText(info.description, 60)
-                : '',
-              elapsed: isComplete ? completeMeta : runningMeta,
-              workspaceCwd,
-            }}
-          />
-        </div>
+        {!hideHeader && (
+          <div
+            className={`${styles.lineMain} ${styles.lineExpandable}`}
+            onClick={() => setExpanded(!expanded)}
+          >
+            <StatusIcon status={isComplete ? info.status : tool.status} />
+            <span className={styles.lineName}>{displayName}</span>
+            <ToolHeaderExtra
+              info={{
+                kind: 'agent',
+                tool,
+                displayName,
+                description: info.description
+                  ? truncateText(info.description, 60)
+                  : '',
+                elapsed: isComplete ? completeMeta : runningMeta,
+                workspaceCwd,
+              }}
+            />
+          </div>
+        )}
         {showExpanded && (
           <div className={styles.lineDetail}>
-            <SubAgentPanel tool={tool} hideHeader defaultExpanded inline />
+            {hideHeader ? (
+              <div className={styles.expandedAgentCard}>{panel}</div>
+            ) : (
+              panel
+            )}
           </div>
         )}
       </div>
@@ -922,107 +1068,153 @@ export const ToolLine = memo(function ToolLine({
   const todoCompleted = todoItems
     ? todoItems.filter((td) => td.status === 'completed').length
     : 0;
+  const isShell = isShellToolName(name);
+  const isSearch =
+    name === 'grep' ||
+    name === 'grep_search' ||
+    name === 'search' ||
+    name === 'glob';
+  const isRead = name === 'read' || name === 'read_file' || name === 'readfile';
   // A row expands when it has a todo list to reveal, detail output
   // (bash/diff/read content), or a description long enough to be ellipsised.
   // When a long description is expanded we move it out of the header into a
   // wrapped block below, so the header drops its single-line copy.
   const descExpandable = !isTodo && isDescriptionExpandable(description);
-  const expandable = isTodo
-    ? hasTodoList
-    : hasExpandableContent(tool) || descExpandable;
-  const relocateDescription = expanded && descExpandable;
+  const expandable =
+    !forceExpanded &&
+    (forceExpandable ||
+      (isTodo ? hasTodoList : hasExpandableContent(tool) || descExpandable));
   // Whether the expanded row renders a kind-specific detail view. When it does
   // not (e.g. grep/glob/web_fetch with a long description), keep the result
   // summary visible instead of replacing it with an empty detail area.
   const detailView = hasDetailView(tool);
+  const showDescriptionInDetail = expanded && descExpandable;
+  const useMarkdownDetail = isRead;
+  const hideDescriptionInHeader =
+    showDescriptionInDetail && !isShell && !isSearch && !isRead;
+  const expandedCardDetail = description;
+  const showExpandedSummaryPanel =
+    !isTodo && expanded && !detailView && (showDescriptionInDetail || result);
 
   return (
     <div className={styles.line}>
-      <div
-        className={`${styles.lineMain} ${expandable ? styles.lineExpandable : ''}`}
-        title={
-          expandable
-            ? expanded
-              ? t('tool.collapseHint')
-              : t('tool.expand')
-            : undefined
-        }
-        aria-expanded={expandable ? expanded : undefined}
-        role={expandable ? 'button' : undefined}
-        tabIndex={expandable ? 0 : undefined}
-        onClick={
-          expandable
-            ? () => {
-                userToggledRef.current = true;
-                setExpanded((value) => !value);
-              }
-            : undefined
-        }
-        onKeyDown={
-          expandable
-            ? (event) => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                userToggledRef.current = true;
-                setExpanded((value) => !value);
-              }
-            : undefined
-        }
-      >
-        <StatusIcon status={tool.status} />
-        <span className={styles.lineName}>{displayName}</span>
-        {isTodo && hasTodoList && (
-          <span className={styles.todoProgress}>
-            {todoCompleted}/{todoItems!.length}
-          </span>
-        )}
-        <ToolHeaderExtra
-          info={{
-            kind: getToolHeaderKind(tool),
-            tool,
-            displayName,
-            // A todo row carries its checklist in the body below; a redundant
-            // "Update Todos" description and the instant write duration would
-            // only clutter the header next to the progress count.
-            description: isTodo || relocateDescription ? '' : description,
-            elapsed: isTodo ? '' : elapsed,
-            workspaceCwd,
-          }}
-        />
-      </div>
+      {!hideHeader && (
+        <div
+          className={`${styles.lineMain} ${expandable ? styles.lineExpandable : ''}`}
+          title={
+            expandable
+              ? expanded
+                ? t('tool.collapseHint')
+                : t('tool.expand')
+              : undefined
+          }
+          aria-expanded={expandable ? expanded : undefined}
+          role={expandable ? 'button' : undefined}
+          tabIndex={expandable ? 0 : undefined}
+          onClick={
+            expandable
+              ? () => {
+                  userToggledRef.current = true;
+                  setExpanded((value) => !value);
+                }
+              : undefined
+          }
+          onKeyDown={
+            expandable
+              ? (event) => {
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  event.preventDefault();
+                  userToggledRef.current = true;
+                  setExpanded((value) => !value);
+                }
+              : undefined
+          }
+        >
+          <StatusIcon status={tool.status} />
+          <span className={styles.lineName}>{displayName}</span>
+          {isTodo && hasTodoList && (
+            <span className={styles.todoProgress}>
+              {todoCompleted}/{todoItems!.length}
+            </span>
+          )}
+          <ToolHeaderExtra
+            info={{
+              kind: getToolHeaderKind(tool),
+              tool,
+              displayName,
+              // A todo row carries its checklist in the body below; a redundant
+              // "Update Todos" description and the instant write duration would
+              // only clutter the header next to the progress count.
+              description: isTodo || hideDescriptionInHeader ? '' : description,
+              elapsed: isTodo ? '' : elapsed,
+              workspaceCwd,
+            }}
+          />
+        </div>
+      )}
       {(!summaryOnly || expanded) && isTodo && hasTodoList && (
-        <TodoToolBody tool={tool} todos={todoItems!} expanded={expanded} />
+        <TodoToolBody
+          tool={tool}
+          todos={todoItems!}
+          expanded={expanded}
+          title={displayName}
+        />
       )}
       {/* Todo tool whose payload couldn't be parsed (e.g. malformed args):
           fall back to the raw result summary so the row isn't blank. */}
       {(!summaryOnly || expanded) && isTodo && !hasTodoList && result && (
         <div className={styles.lineOutput}>{result}</div>
       )}
-      {relocateDescription && (
-        <div className={styles.lineFullArg}>{description}</div>
+      {showExpandedSummaryPanel && (
+        <ToolExpandedCard title={displayName} detail={expandedCardDetail}>
+          {result && (
+            <div
+              className={`${styles.lineOutput} ${styles.expandedLineOutput}`}
+            >
+              {result}
+            </div>
+          )}
+        </ToolExpandedCard>
       )}
       {!isTodo &&
+        !hideCollapsedOutput &&
         result &&
+        !showExpandedSummaryPanel &&
         (!expanded || !detailView) &&
         (!summaryOnly || expanded) && (
-          <div className={styles.lineOutput}>{result}</div>
+          <div
+            className={
+              expanded
+                ? `${styles.lineOutput} ${styles.expandedLineOutput}`
+                : styles.lineOutput
+            }
+          >
+            {result}
+          </div>
         )}
       {!isTodo && expanded && detailView && (
-        <div className={styles.lineDetail}>
-          {isShellToolName(name) && (
-            <ExpandedBashOutput tool={tool} maxLines={shellOutputMaxLines} />
-          )}
-          {(name === 'write_file' || name === 'writefile') && (
-            <ExpandedEditContent tool={tool} />
-          )}
-          {(name === 'edit' || name === 'write' || name === 'editfile') && (
-            <ExpandedEditContent tool={tool} />
-          )}
-          {(name === 'read' || name === 'read_file' || name === 'readfile') && (
+        <div
+          className={
+            useMarkdownDetail
+              ? `${styles.lineDetail} ${styles.markdownLineDetail}`
+              : styles.lineDetail
+          }
+        >
+          {isRead ? (
             <ExpandedReadContent tool={tool} />
-          )}
-          {isAskUserQuestionToolName(tool.toolName) && (
-            <ExpandedAskUserQuestionOutput tool={tool} />
+          ) : (
+            <ToolExpandedCard title={displayName} detail={expandedCardDetail}>
+              {isShellToolName(name) && <ExpandedBashOutput tool={tool} />}
+              {(name === 'write_file' || name === 'writefile') && (
+                <ExpandedEditContent tool={tool} />
+              )}
+              {(name === 'edit' || name === 'write' || name === 'editfile') && (
+                <ExpandedEditContent tool={tool} />
+              )}
+              {isAskUserQuestionToolName(tool.toolName) && (
+                <ExpandedAskUserQuestionOutput tool={tool} />
+              )}
+            </ToolExpandedCard>
           )}
         </div>
       )}
@@ -1034,13 +1226,13 @@ export const ToolGroup = memo(function ToolGroup({
   tools,
   pendingApproval,
   workspaceCwd,
-  shellOutputMaxLines,
 }: ToolGroupProps) {
   const { t } = useI18n();
   const compactMode = useContext(CompactModeContext);
   const [chatExpanded, setChatExpanded] = useState(false);
   const hasRunningTool = hasActiveTool(tools);
   const activeTool = tools.length > 0 ? getActiveTool(tools) : undefined;
+  const singleTool = tools.length === 1 ? tools[0] : undefined;
   const summaryIconTool = tools[0] ?? activeTool;
   const liveStartedAtRef = useRef(Date.now());
   const summaryNow = useSharedNow(hasRunningTool);
@@ -1085,7 +1277,16 @@ export const ToolGroup = memo(function ToolGroup({
                 : styles.chatSummaryText
             }
           >
-            {formatToolGroupSummary(tools, t, runningDuration)}
+            {singleTool
+              ? hasRunningTool
+                ? formatRunningSingleToolSummary(
+                    singleTool,
+                    t,
+                    runningDuration,
+                    workspaceCwd,
+                  )
+                : formatSingleToolSummary(singleTool, t, workspaceCwd)
+              : formatToolGroupSummary(tools, t, runningDuration)}
           </span>
           <span
             className={
@@ -1109,8 +1310,9 @@ export const ToolGroup = memo(function ToolGroup({
                   tool={tool}
                   approval={pendingApproval}
                   workspaceCwd={workspaceCwd}
-                  shellOutputMaxLines={shellOutputMaxLines}
-                  summaryOnly
+                  summaryOnly={!singleTool}
+                  forceExpanded={!!singleTool}
+                  hideHeader={!!singleTool}
                 />
               ))}
             </div>
@@ -1128,7 +1330,6 @@ export const ToolGroup = memo(function ToolGroup({
           tool={tool}
           approval={pendingApproval}
           workspaceCwd={workspaceCwd}
-          shellOutputMaxLines={shellOutputMaxLines}
         />
       ))}
     </div>

--- a/packages/web-shell/client/components/messages/toolFormatting.test.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.test.ts
@@ -305,9 +305,15 @@ describe('toolFormatting', () => {
     it('keeps proper tool names / acronyms in English', () => {
       const t = getTranslator('zh-CN');
       expect(localizeToolDisplayName('agent', t)).toBe('Agent');
-      expect(localizeToolDisplayName('grep_search', t)).toBe('Grep');
       expect(localizeToolDisplayName('glob', t)).toBe('Glob');
       expect(localizeToolDisplayName('lsp', t)).toBe('LSP');
+    });
+
+    it('localizes grep tool aliases in Chinese', () => {
+      const t = getTranslator('zh-CN');
+      expect(localizeToolDisplayName('grep', t)).toBe('搜索内容');
+      expect(localizeToolDisplayName('grep_search', t)).toBe('搜索内容');
+      expect(localizeToolDisplayName('search', t)).toBe('搜索内容');
     });
 
     it('falls back to the English display name when the locale has no entry', () => {
@@ -325,7 +331,7 @@ describe('toolFormatting', () => {
     it('has a zh translation for every tool in the display-name map', () => {
       const tZh = getTranslator('zh-CN');
       // Tools intentionally shown in English (proper names / acronyms).
-      const keepEnglish = new Set(['agent', 'grep_search', 'glob', 'search']);
+      const keepEnglish = new Set(['agent', 'glob']);
       const untranslated = Object.keys(TOOL_DISPLAY_NAMES).filter(
         (wire) =>
           !keepEnglish.has(wire) &&

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -4,6 +4,7 @@ export const TOOL_DISPLAY_NAMES: Record<string, string> = {
   edit: 'Edit',
   write_file: 'WriteFile',
   read_file: 'ReadFile',
+  grep: 'Grep',
   grep_search: 'Grep',
   glob: 'Glob',
   run_shell_command: 'Shell',

--- a/packages/web-shell/client/components/messages/tools/DiffView.module.css
+++ b/packages/web-shell/client/components/messages/tools/DiffView.module.css
@@ -1,8 +1,6 @@
 .view {
-  margin-top: 6px;
-  border-radius: 4px;
+  margin: 0;
   overflow: hidden;
-  border: 1px solid var(--border);
   font-size: 12px;
 }
 

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
@@ -52,8 +52,8 @@
 }
 
 .summaryToolIcon {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
   display: block;
 }
 
@@ -99,13 +99,24 @@
 
 .chevronRight,
 .chevronDown {
-  width: 7px;
-  height: 7px;
-  border-right: 1px solid currentColor;
-  border-bottom: 1px solid currentColor;
+  width: 14px;
+  height: 14px;
+  position: relative;
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 120ms ease;
+}
+
+.chevronRight::before,
+.chevronRight::after,
+.chevronDown::before,
+.chevronDown::after {
+  content: '';
+  position: absolute;
+  width: 6px;
+  height: 1px;
+  background: currentColor;
+  border-radius: 1px;
 }
 
 .summary:hover .chevronRight,
@@ -116,17 +127,40 @@
 }
 
 .chevronRight {
+  transform: none;
+}
+
+.chevronRight::before {
+  top: calc(50% - 2px);
+  left: calc(50% - 3px);
+  transform: rotate(45deg);
+}
+
+.chevronRight::after {
+  top: calc(50% + 2px);
+  left: calc(50% - 3px);
   transform: rotate(-45deg);
 }
 
 .chevronDown {
+  transform: none;
+}
+
+.chevronDown::before {
+  top: 50%;
+  left: calc(50% - 5px);
   transform: rotate(45deg);
-  margin-top: -3px;
+}
+
+.chevronDown::after {
+  top: 50%;
+  left: calc(50% - 1px);
+  transform: rotate(-45deg);
 }
 
 .group {
-  background: var(--muted);
-  border: 1px solid var(--border);
+  background: var(--secondary);
+  border: 0.5px solid var(--border);
   border-radius: var(--radius);
   padding: 8px 12px;
   margin: 5px 0;
@@ -157,8 +191,6 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  /* border-left: 2px solid var(--border); */
-  padding-left: 10px;
 }
 
 .row {
@@ -199,6 +231,4 @@
 
 .detail {
   margin-top: 4px;
-  padding: 6px 0 2px;
-  border-top: 1px solid var(--border);
 }

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
@@ -1,8 +1,7 @@
 .panel {
-  background: var(--muted);
-  border: 1px solid var(--border);
+  background: var(--secondary);
+  border: 0.5px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px 12px;
   width: 100%;
   min-width: 0;
   max-width: 100%;

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
@@ -99,4 +99,50 @@ describe('SubAgentPanel sub-tool timestamps', () => {
     );
     expect(container.textContent).not.toContain(formatTimestamp(reference));
   });
+
+  it('keeps sub-tools expandable while hiding their collapsed output summary', () => {
+    const container = renderPanel(
+      makeAgentWithSubTool({
+        callId: 'sub-1',
+        toolName: 'Shell',
+        status: 'completed',
+        args: { command: 'npm test' },
+        content: [
+          {
+            type: 'content',
+            content: { text: 'first line\nsecond line' },
+          },
+        ],
+      }),
+    );
+    const row = Array.from(container.querySelectorAll('[role="button"]')).find(
+      (el) => el.textContent?.includes('Shell'),
+    ) as HTMLElement | undefined;
+
+    expect(row).toBeDefined();
+    expect(row!.textContent).toContain('npm test');
+    expect(container.textContent).not.toContain('first line');
+    act(() => row!.click());
+    expect(container.textContent).toContain('first line');
+    expect(container.textContent).toContain('second line');
+  });
+
+  it('hides non-standard sub-tool summaries until the row is expanded', () => {
+    const container = renderPanel(
+      makeAgentWithSubTool({
+        callId: 'sub-1',
+        toolName: 'list_directory',
+        status: 'completed',
+        rawOutput: 'src\npackage.json',
+      }),
+    );
+    const row = Array.from(container.querySelectorAll('[role="button"]')).find(
+      (el) => el.textContent?.includes('ListFiles'),
+    ) as HTMLElement | undefined;
+
+    expect(row).toBeDefined();
+    expect(container.textContent).not.toContain('2 item(s)');
+    act(() => row!.click());
+    expect(container.textContent).toContain('2 item(s)');
+  });
 });

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
@@ -104,14 +104,13 @@ const SubToolLine = memo(function SubToolLine({ tool }: { tool: ACPToolCall }) {
     tool.subTools || tool.subContent ? (
       <SubAgentPanel tool={tool} />
     ) : (
-      <ToolLine tool={tool} />
+      <ToolLine tool={tool} forceExpandable hideCollapsedOutput />
     );
   return <SubToolTime timestamp={tool.startTime}>{body}</SubToolTime>;
 });
 
 function TaskToolCallLine({ tc }: { tc: TaskToolCall }) {
   const { t } = useI18n();
-  const desc = tc.description || '';
   return (
     <div className={chromeStyles.line}>
       <div className={chromeStyles.lineMain}>
@@ -119,9 +118,6 @@ function TaskToolCallLine({ tc }: { tc: TaskToolCall }) {
         <span className={chromeStyles.lineName}>
           {localizeToolDisplayName(tc.name, t)}
         </span>
-        {desc && (
-          <span className={chromeStyles.lineArg}>{truncateText(desc, 70)}</span>
-        )}
       </div>
     </div>
   );

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -67,8 +67,8 @@
 }
 
 .chatSummaryToolIcon {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
   display: block;
 }
 
@@ -111,13 +111,24 @@
 
 .chatChevronRight,
 .chatChevronDown {
-  width: 7px;
-  height: 7px;
-  border-right: 1px solid currentColor;
-  border-bottom: 1px solid currentColor;
+  width: 14px;
+  height: 14px;
+  position: relative;
   flex-shrink: 0;
   opacity: 0;
   transition: opacity 120ms ease;
+}
+
+.chatChevronRight::before,
+.chatChevronRight::after,
+.chatChevronDown::before,
+.chatChevronDown::after {
+  content: '';
+  position: absolute;
+  width: 6px;
+  height: 1px;
+  background: currentColor;
+  border-radius: 1px;
 }
 
 .chatSummary:hover .chatChevronRight,
@@ -128,13 +139,36 @@
 }
 
 .chatChevronRight {
+  transform: none;
+}
+
+.chatChevronRight::before {
+  top: calc(50% - 2px);
+  left: calc(50% - 3px);
+  transform: rotate(45deg);
+}
+
+.chatChevronRight::after {
+  top: calc(50% + 2px);
+  left: calc(50% - 3px);
   transform: rotate(-45deg);
 }
 
 .chatChevronDown {
-  transform: rotate(45deg);
-  margin-top: -3px;
+  transform: none;
   opacity: 1;
+}
+
+.chatChevronDown::before {
+  top: 50%;
+  left: calc(50% - 5px);
+  transform: rotate(45deg);
+}
+
+.chatChevronDown::after {
+  top: 50%;
+  left: calc(50% - 1px);
+  transform: rotate(-45deg);
 }
 
 .chatSummaryContentClip {
@@ -208,7 +242,9 @@
   cursor: pointer;
 }
 
-.lineExpandable:hover .lineName {
+.lineExpandable:hover .lineName,
+.lineExpandable:hover .lineArg,
+.lineExpandable:hover .lineElapsed {
   color: var(--foreground);
 }
 
@@ -221,22 +257,73 @@
   line-height: 1.4;
 }
 
-/* Full, wrapped tool argument shown below the header when the row is expanded
-   (the header drops its single-line ellipsised copy). Aligns with the expanded
-   output block below it. */
-.lineFullArg {
-  margin-left: 16px;
-  margin-top: 2px;
+.expandedCard {
+  margin: 5px 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  border: 0.5px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--secondary);
+}
+
+.expandedCardHeader {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  align-items: stretch;
+  gap: 3px;
+  padding: 8px 12px 8px;
+}
+
+.expandedCardTitle {
+  flex-shrink: 0;
+  color: var(--foreground);
   font-size: 12px;
-  line-height: 1.4;
+  font-weight: 500;
+}
+
+.expandedCardDetail {
+  min-width: 0;
   color: var(--muted-foreground);
   font-family: var(--font-mono);
-  white-space: pre-wrap;
-  word-break: break-word;
+  font-size: 12px;
+  line-height: 1.4;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.expandedCardBody {
+  padding: 6px 12px 8px;
+  min-width: 0;
+}
+
+.expandedAgentCard {
+  background: var(--secondary);
+  border: 0.5px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  margin: 5px 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.expandedLineOutput {
+  margin-left: 0;
 }
 
 .lineDetail {
+  margin: 5px 0;
+  min-width: 0;
+  overflow: visible;
+}
+
+.markdownLineDetail {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  overflow: visible;
 }
 
 .expandedBash,
@@ -245,20 +332,21 @@
 }
 
 .expandedOutput {
-  padding: 0px 0px 0 16px;
+  margin: 0;
+  padding: 0;
   font-size: 12px;
   line-height: 1.5;
   color: var(--muted-foreground);
+  font-family: var(--font-mono);
   white-space: pre-wrap;
   word-break: break-word;
   overflow-x: auto;
   max-height: 400px;
   overflow-y: auto;
-  margin-bottom: 0;
 }
 
 .expandedEdit {
-  margin-top: 2px;
+  margin: 0;
 }
 
 .expandedWrite {
@@ -271,25 +359,6 @@
   color: var(--success-color);
 }
 
-.expandBtn {
-  display: block;
-  width: 100%;
-  padding: 3px 10px;
-  margin-top: 10px;
-  font-size: 11px;
-  font-family: var(--font-mono);
-  background: var(--subtle-bg);
-  border: none;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  text-align: left;
-}
-
-.expandBtn:hover {
-  color: var(--agent-blue-500);
-  background: var(--agent-blue-100);
-}
-
 .todoProgress {
   color: var(--muted-foreground);
   font-size: 12px;
@@ -299,6 +368,10 @@
 
 .todoBody {
   padding: 4px 0 2px 14px;
+}
+
+.expandedCardBody .todoBody {
+  padding: 0;
 }
 
 .compactGroup {

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -65,6 +65,7 @@ export type MarkdownTableMode = 'basic' | 'advanced';
 
 export type ToolHeaderKind =
   | 'agent'
+  | 'ask'
   | 'edit'
   | 'fetch'
   | 'read'

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1460,13 +1460,22 @@ const EN: Messages = {
   'tool.expand': 'Expand',
   'tool.collapseHint': 'Collapse',
   'tool.status.failed': 'Failed',
-  'tool.showAll': (v) => `▼ Show all (${v?.count ?? 0} lines)`,
-  'tool.showLess': '▲ Show less',
-  'tool.showFullLines': '▼ Show full lines',
-  'tool.linesTotal': (v) => `▼ ${v?.count ?? 0} lines total`,
   'toolGroup.moreKinds': (v) => ` +${v?.count ?? 0}`,
   'toolGroup.summary': (v) =>
     `Ran ${v?.count ?? 0} tool${v?.count === 1 ? '' : 's'}`,
+  'toolGroup.summary.editedFiles': (v) =>
+    `Edited ${v?.count ?? 0} file${v?.count === 1 ? '' : 's'}`,
+  'toolGroup.summary.ranCommands': (v) =>
+    `Ran ${v?.count ?? 0} command${v?.count === 1 ? '' : 's'}`,
+  'toolGroup.summary.readFiles': (v) =>
+    `Read ${v?.count ?? 0} file${v?.count === 1 ? '' : 's'}`,
+  'toolGroup.summary.searched': (v) =>
+    `Searched ${v?.count ?? 0} time${v?.count === 1 ? '' : 's'}`,
+  'toolGroup.summary.updatedTodos': (v) =>
+    `Updated task list${v?.count === 1 ? '' : ` ${v?.count ?? 0} times`}`,
+  'toolGroup.summary.askedUser': 'Asked user',
+  'toolGroup.summary.otherTools': (v) =>
+    `Called ${v?.count ?? 0} other tool${v?.count === 1 ? '' : 's'}`,
   'toolGroup.running': (v) =>
     `Running ${v?.name ?? 'tool'}${v?.duration ? ` ${v.duration}` : ''}${
       Number(v?.count ?? 0) > 1 ? ` · ${v?.count ?? 0} tools` : ''
@@ -1521,7 +1530,8 @@ const ZH: Messages = {
   'toolName.edit': '编辑',
   'toolName.write_file': '写入文件',
   'toolName.read_file': '读取文件',
-  'toolName.grep_search': 'Grep',
+  'toolName.grep': '搜索内容',
+  'toolName.grep_search': '搜索内容',
   'toolName.glob': 'Glob',
   'toolName.run_shell_command': '运行命令',
   'toolName.todo_write': '任务清单',
@@ -1561,7 +1571,7 @@ const ZH: Messages = {
   'toolName.readfile': '读取文件',
   'toolName.write': '写入文件',
   'toolName.writefile': '写入文件',
-  'toolName.search': 'Grep',
+  'toolName.search': '搜索内容',
   'toolName.todowrite': '任务清单',
   'toolName.savememory': '保存记忆',
   'toolName.askuserquestion': '询问用户',
@@ -2915,12 +2925,18 @@ const ZH: Messages = {
   'tool.expand': '展开',
   'tool.collapseHint': '收起',
   'tool.status.failed': '执行失败',
-  'tool.showAll': (v) => `▼ 显示全部（${v?.count ?? 0} 行）`,
-  'tool.showLess': '▲ 显示更少',
-  'tool.showFullLines': '▼ 显示完整行',
-  'tool.linesTotal': (v) => `▼ 共 ${v?.count ?? 0} 行`,
   'toolGroup.moreKinds': (v) => ` +${v?.count ?? 0}`,
   'toolGroup.summary': (v) => `调用了 ${v?.count ?? 0} 个工具`,
+  'toolGroup.summary.editedFiles': (v) => `已编辑 ${v?.count ?? 0} 个文件`,
+  'toolGroup.summary.ranCommands': (v) => `已运行 ${v?.count ?? 0} 条命令`,
+  'toolGroup.summary.readFiles': (v) => `已读取 ${v?.count ?? 0} 个文件`,
+  'toolGroup.summary.searched': (v) => `已搜索 ${v?.count ?? 0} 次`,
+  'toolGroup.summary.updatedTodos': (v) =>
+    Number(v?.count ?? 0) > 1
+      ? `已更新任务清单 ${v?.count ?? 0} 次`
+      : '已更新任务清单',
+  'toolGroup.summary.askedUser': '已询问用户',
+  'toolGroup.summary.otherTools': (v) => `调用了 ${v?.count ?? 0} 个工具`,
   'toolGroup.running': (v) =>
     `正在执行 ${v?.name ?? '工具'}${v?.duration ? ` ${v.duration}` : ''}${
       Number(v?.count ?? 0) > 1 ? ` · 共 ${v?.count ?? 0} 个工具` : ''


### PR DESCRIPTION
## What this PR does

This PR updates the web-shell tool presentation as a product-design change. Completed tool groups now summarize the actual kinds of work that happened, such as edited files, ran commands, read files, searched, updated task lists, asked the user, and other tools, instead of only saying that a number of tools were called.

When there is only one tool call, the outer summary now shows that tool directly, such as the command or file action, instead of adding an extra "called 1 tool" layer. A single running tool keeps the running state and elapsed time visible while still showing the tool detail in the summary.

Tool detail views were restyled to use a consistent compact card treatment for command output, grep/search results, task-list updates, ask-user output, edits, writes, and agent details. Read-file details continue to render as syntax-highlighted Markdown code blocks when appropriate, while very large reads and Mermaid files fall back to plain preformatted text. Shell details intentionally show the full output in a scrollable area to match the product expectation that web-shell users can scroll freely.

Sub-agent tool rows now keep the collapsed state concise and require expansion to view details, including non-standard tools. This preserves the compact agent panel while still making every sub-tool result reachable.

## Why it's needed

The previous tool summary and detail layout emphasized the number of tool calls more than the work that was performed. That made transcripts harder to scan, especially in web-shell where users expect richer visual grouping and direct access to the most relevant action.

These changes align the web experience with the intended product design: summaries should describe the work, single-tool interactions should avoid unnecessary nesting, and expanded details should share a consistent visual language without hiding important output. Shell output is not truncated by design; the web surface should keep the full command output available when the user chooses to expand it.

## Reviewer Test Plan

### How to verify

Open a web-shell conversation with multiple completed tools and confirm the outer summary names the performed work by category rather than only showing a raw tool count. Try a single command tool and confirm the outer summary shows the command directly; while it is running, confirm the summary still shows the running state and elapsed time. Expand command, grep/search, task-list, ask-user, edit/write, read-file, and agent details and confirm they use the updated card treatment. In a sub-agent details panel, confirm sub-tools stay compact until expanded and that both standard tools and non-standard tools can be expanded to reveal their details. Expand a shell command with output and confirm the full output is available inside the scrollable detail area rather than being truncated.

### Evidence (Before & After)

Before: tool groups primarily showed a generic count such as "called N tools", a single tool still required an extra summary layer, several expanded details used inconsistent or nested card treatments, and sub-agent tool rows could either expose extra collapsed summaries or fail to reveal non-standard tool results cleanly.

After: tool groups summarize work by category, a single tool appears directly in the outer summary, expanded details use a consistent compact card style, read-file content uses syntax-aware rendering with safe plain-text fallbacks, shell details keep full scrollable output, and sub-agent tools remain concise until expanded.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Validated locally with targeted web-shell unit tests and TypeScript checking: 
 RUN  v3.2.4 /Users/ytahdn/Documents/Codes/qwen/qwen-code/packages/web-shell/client

 ✓ components/messages/ToolGroup.test.tsx (19 tests) 34ms
 ✓ components/messages/tools/SubAgentPanel.test.tsx (5 tests) 32ms

 Test Files  2 passed (2)
      Tests  24 passed (24)
   Start at  21:37:49
   Duration  1.58s (transform 236ms, setup 0ms, collect 713ms, tests 66ms, environment 772ms, prepare 86ms); .

## Risk & Scope

- Main risk or tradeoff: Shell details intentionally render full command output when expanded. This matches the requested web-shell product behavior, but extremely large command output can still be expensive for the browser after the user opens the detail view.
- Not validated / out of scope: Full cross-browser visual QA and Windows/Linux manual verification were not performed locally.
- Breaking changes / migration notes: None expected; this is a web-shell presentation change.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 调整 web-shell 的工具展示方式，属于产品设计层面的展示行为改动。工具组完成后，现在会按实际发生的工作类型汇总，例如已编辑文件、已运行命令、已读取文件、已搜索、已更新任务清单、已询问用户以及其他工具，而不是只展示调用了几个工具。

当只有一个工具调用时，最外层 summary 会直接展示当前工具，例如命令或文件动作，不再额外展示一层“调用了 1 个工具”。单个工具正在运行时，summary 仍然保留运行状态和耗时，同时展示工具本身的信息。

工具详情视图统一调整为更紧凑一致的卡片样式，覆盖命令输出、grep/search 结果、任务清单更新、询问用户、编辑、写入和 agent 详情等场景。读取文件详情在适合时继续按文件后缀使用 Markdown 代码块高亮；超大读取内容和 Mermaid 文件会回退为纯 pre 文本展示。Shell 详情按照产品预期保留完整输出，并在详情区域内滚动查看，不做截断。

Sub-agent 内部的工具行现在保持折叠态简洁，需要展开后查看详情，包括非标准工具也可以展开查看结果。这样 agent 面板保持紧凑，同时不会丢失任何子工具结果。

## Why it's needed

之前的工具 summary 更强调调用了多少个工具，而不是实际完成了什么工作。这让 transcript 不够容易扫读，尤其在 web-shell 中，用户更期待清晰的视觉分组和直接看到最相关的动作。

这些改动让 web 体验符合预期的产品设计：summary 应该描述实际工作，单工具交互不需要多一层嵌套，展开详情应该有一致的视觉语言，同时不能隐藏重要输出。Shell 输出按设计不截断；在 web 场景中，用户主动展开后应能通过滚动查看完整命令输出。

## Reviewer Test Plan

### How to verify

打开一个包含多个已完成工具的 web-shell 会话，确认最外层 summary 按工具类型展示完成的工作，而不是只展示工具数量。尝试单个命令工具，确认最外层 summary 直接展示该命令；运行中时确认仍展示运行状态和耗时。展开命令、grep/search、任务清单、询问用户、编辑/写入、读取文件和 agent 详情，确认使用新的统一卡片样式。在 sub-agent 详情面板中，确认子工具折叠态保持简洁，标准工具和非标准工具都能展开查看详情。展开带输出的 shell 命令，确认完整输出保留在可滚动详情区域中，而不是被截断。

### Evidence (Before & After)

Before：工具组主要展示类似“调用了 N 个工具”的泛化数量；单个工具仍然需要额外 summary 层；部分展开详情样式不统一或出现嵌套卡片；sub-agent 工具行可能在折叠态暴露多余摘要，或无法清晰展示非标准工具结果。

After：工具组按工作类型汇总；单个工具直接展示在最外层 summary；展开详情使用一致的紧凑卡片样式；读取文件具备按后缀渲染和安全纯文本回退；shell 详情保留完整可滚动输出；sub-agent 工具保持折叠态简洁，展开后查看详情。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

本地通过 web-shell 定向单测和 TypeScript 检查验证：
 RUN  v3.2.4 /Users/ytahdn/Documents/Codes/qwen/qwen-code/packages/web-shell/client

 ✓ components/messages/ToolGroup.test.tsx (19 tests) 33ms
 ✓ components/messages/tools/SubAgentPanel.test.tsx (5 tests) 32ms

 Test Files  2 passed (2)
      Tests  24 passed (24)
   Start at  21:37:59
   Duration  1.24s (transform 203ms, setup 0ms, collect 524ms, tests 65ms, environment 438ms, prepare 67ms)；。

## Risk & Scope

- Main risk or tradeoff: Shell 详情在用户展开后会按产品预期渲染完整命令输出。这符合当前 web-shell 的设计要求，但如果命令输出极大，用户展开详情时浏览器仍可能有渲染成本。
- Not validated / out of scope: 本地没有做完整跨浏览器视觉 QA，也没有手动验证 Windows/Linux。
- Breaking changes / migration notes: 无预期 breaking change；这是 web-shell 展示层改动。

## Linked Issues

N/A

</details>