### PR TITLE
fix(daemon): Handle settings reload events outside transcript

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -267,6 +267,9 @@ export function normalizeDaemonEvent(
     case 'settings_changed':
       return normalizeSettingsChanged(event, base);
 
+    case 'settings_reloaded':
+      return normalizeSettingsReloaded(event, base);
+
     case 'trust_change_requested':
       return normalizeTrustChangeRequested(event, base);
 
@@ -1220,6 +1223,24 @@ function normalizeSettingsChanged(
       key,
       scope: scope ?? 'workspace',
       value: isRecord(event.data) ? event.data['value'] : undefined,
+    },
+  ];
+}
+
+function normalizeSettingsReloaded(
+  event: DaemonEvent,
+  base: NormalizedEventBase,
+): DaemonUiEvent[] {
+  if (!isRecord(event.data)) {
+    return fallbackDebug(event, base, 'malformed settings_reloaded payload');
+  }
+  return [
+    {
+      ...base,
+      type: 'workspace.settings.changed',
+      key: 'settings_reloaded',
+      scope: 'workspace',
+      value: event.data,
     },
   ];
 }

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -2255,6 +2255,33 @@ describe('daemon UI normalizer — Wave 3/4 event coverage (PR-A)', () => {
     ]);
   });
 
+  it('normalizes settings_reloaded as a settings refresh signal', () => {
+    const events = normalizeDaemonEvent(
+      envelopeOf('settings_reloaded', {
+        env: { updatedKeys: ['OPENAI_API_KEY'], removedKeys: [] },
+        changedKeys: ['env', 'hooks'],
+        childReloaded: true,
+        sessionsRefreshed: ['session-1'],
+        sessionsSkipped: [],
+      }),
+    );
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'workspace.settings.changed',
+        key: 'settings_reloaded',
+        scope: 'workspace',
+        value: expect.objectContaining({
+          childReloaded: true,
+          sessionsRefreshed: ['session-1'],
+        }) as unknown,
+      }),
+    ]);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: 'debug' }),
+    );
+  });
+
   it('normalizes workspace_initialized actions', () => {
     const events = normalizeDaemonEvent(
       envelopeOf('workspace_initialized', { path: '/w', action: 'created' }),

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -2064,6 +2064,61 @@ describe('DaemonSessionProvider', () => {
     });
   });
 
+  it('logs settings reloads without inserting daemon debug blocks', async () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const session = createMockSession({
+      events: async function* settingsReloadEvents() {
+        yield {
+          id: 31,
+          v: 1,
+          type: 'settings_reloaded',
+          data: {
+            env: { updatedKeys: ['OPENAI_API_KEY'], removedKeys: [] },
+            changedKeys: ['env', 'hooks'],
+            childReloaded: true,
+            sessionsRefreshed: ['session-1'],
+            sessionsSkipped: [],
+          },
+        };
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let signals: DaemonWorkspaceEventSignals | undefined;
+    let blocks: readonly DaemonTranscriptBlock[] | undefined;
+
+    function Harness() {
+      signals = useDaemonWorkspaceEventSignals();
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(signals?.settingsVersion).toBe(1);
+    expect(blocks).not.toContainEqual(
+      expect.objectContaining({
+        kind: 'debug',
+        text: expect.stringContaining(
+          'settings_reloaded (unrecognized daemon event)',
+        ) as string,
+      }),
+    );
+    expect(debug).toHaveBeenCalledWith(
+      '[DaemonSessionProvider] settings reloaded:',
+      expect.objectContaining({
+        childReloaded: true,
+        changedKeys: ['env', 'hooks'],
+        env: { updatedKeys: ['OPENAI_API_KEY'], removedKeys: [] },
+        sessionsRefreshed: ['session-1'],
+        sessionsSkipped: [],
+      }),
+    );
+    debug.mockRestore();
+  });
+
   it('treats prompt abort during cancel as cancellation and keeps busy until cancel completes', async () => {
     const cancel = createDeferred<void>();
     const assistantChunk = createDeferred<void>();

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1608,6 +1608,7 @@ function normalizeAndFilterEvent(
   setConnection: Dispatch<SetStateAction<DaemonConnectionState>>,
   behavior: { updateConnection?: boolean } = {},
 ): DaemonUiEvent[] {
+  logSettingsReloadEvent(event);
   if (behavior.updateConnection !== false) {
     updateConnectionFromDaemonEvent(event, setConnection);
   }
@@ -1621,6 +1622,53 @@ function normalizeAndFilterEvent(
     return goalStatusEvent ? [goalStatusEvent] : [];
   }
   return goalStatusEvent ? [...normalized, goalStatusEvent] : normalized;
+}
+
+function logSettingsReloadEvent(event: DaemonEvent): void {
+  if (event.type !== 'settings_reloaded') return;
+  console.debug(
+    '[DaemonSessionProvider] settings reloaded:',
+    getSettingsReloadLogData(event),
+  );
+}
+
+function getSettingsReloadLogData(event: DaemonEvent): Record<string, unknown> {
+  const log: Record<string, unknown> = {};
+  if (event.id !== undefined) log['eventId'] = event.id;
+  if (!isRecord(event.data)) {
+    log['payload'] = 'non-object';
+    return log;
+  }
+
+  const env = getSettingsReloadEnvLog(event.data['env']);
+  const changedKeys = getStringArray(event.data['changedKeys']);
+  const sessionsRefreshed = getStringArray(event.data['sessionsRefreshed']);
+  const sessionsSkipped = getStringArray(event.data['sessionsSkipped']);
+  const childReloaded = event.data['childReloaded'];
+  const childError = getString(event.data, 'childError');
+
+  if (env) log['env'] = env;
+  if (changedKeys) log['changedKeys'] = changedKeys;
+  if (typeof childReloaded === 'boolean') log['childReloaded'] = childReloaded;
+  if (sessionsRefreshed) log['sessionsRefreshed'] = sessionsRefreshed;
+  if (sessionsSkipped) log['sessionsSkipped'] = sessionsSkipped;
+  if (childError) log['childError'] = childError;
+  return log;
+}
+
+function getSettingsReloadEnvLog(
+  value: unknown,
+): { updatedKeys: string[]; removedKeys: string[] } | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    updatedKeys: getStringArray(value['updatedKeys']) ?? [],
+    removedKeys: getStringArray(value['removedKeys']) ?? [],
+  };
+}
+
+function getStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
 }
 
 function filterDaemonUiEventsForTranscript(


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR treats daemon settings reload notifications as structured workspace settings refresh signals instead of unknown debug transcript entries, so reload metadata no longer appears as a chat message in web shell sessions. It also emits a concise debug log for reload diagnostics with the changed settings keys, environment key names, child reload status, refreshed or skipped sessions, and reload errors when present.

## Why it's needed

When daemon reloads were broadcast to active sessions, the UI layer did not recognize the reload event and rendered the raw event payload into the conversation transcript. That made operational reload noise visible to users and still did not give developers a clean log line for troubleshooting reload behavior.

## Reviewer Test Plan

### How to verify

Trigger a daemon settings reload while a web shell session is open. The transcript should not show a `settings_reloaded (unrecognized daemon event)` system/debug message, settings-dependent UI state should refresh through the workspace settings signal, and browser DevTools should show a `[DaemonSessionProvider] settings reloaded:` debug entry containing only diagnostic key names and session status fields.

Run `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts --testNamePattern "settings_reloaded"` and expect one focused test to pass. Run `cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx --testNamePattern "logs settings reloads"` and expect one focused test to pass. Run `npm run build` and `npm run typecheck` from the repository root and expect both commands to exit successfully.

### Evidence (Before & After)

Before: a daemon settings reload could appear in the web shell transcript as `settings_reloaded (unrecognized daemon event)` with the reload payload. After: the same reload is normalized as a workspace settings refresh signal, is omitted from the transcript, and is available as a concise debug log for troubleshooting.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Node.js v22.22.3, npm 10.9.8, local repository build and unit test commands.

## Risk & Scope

- Main risk or tradeoff: Reload diagnostics now go to browser debug logging rather than the chat transcript, so operators need DevTools or collected console logs to inspect them.
- Not validated / out of scope: Manual browser reload testing on Windows and Linux was not performed locally.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将 daemon settings reload 通知处理为结构化的 workspace settings refresh signal，而不是未知 debug transcript 条目，因此 reload 元数据不再作为 web shell 会话中的聊天消息展示。同时，它会为 reload 排障输出一条简洁的 debug log，包含变更的 settings key、环境变量 key 名、child reload 状态、刷新或跳过的 session，以及存在时的 reload 错误。

## Why it's needed

daemon reload 广播到活跃 session 后，UI 层之前没有识别 reload 事件，于是会把原始事件 payload 渲染进会话 transcript。这会让用户看到运维 reload 噪声，同时也没有给开发者提供一条清晰的日志来排查 reload 行为。

## Reviewer Test Plan

### How to verify

在 web shell session 打开时触发 daemon settings reload。transcript 中不应该再出现 `settings_reloaded (unrecognized daemon event)` system/debug 消息，依赖 settings 的 UI 状态应该通过 workspace settings signal 刷新，并且浏览器 DevTools 中应该出现 `[DaemonSessionProvider] settings reloaded:` debug 记录，其中只包含诊断用的 key 名和 session 状态字段。

运行 `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts --testNamePattern "settings_reloaded"`，预期一个 focused test 通过。运行 `cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx --testNamePattern "logs settings reloads"`，预期一个 focused test 通过。从仓库根目录运行 `npm run build` 和 `npm run typecheck`，预期两个命令都成功退出。

### Evidence (Before & After)

Before：daemon settings reload 可能作为 `settings_reloaded (unrecognized daemon event)` 连同 reload payload 一起出现在 web shell transcript 中。After：同一个 reload 会被归一化为 workspace settings refresh signal，不再进入 transcript，并且会作为简洁 debug log 供排障使用。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Node.js v22.22.3，npm 10.9.8，本地仓库 build 和 unit test 命令。

## Risk & Scope

- Main risk or tradeoff：reload 诊断信息现在输出到浏览器 debug log，而不是聊天 transcript，因此运维人员需要通过 DevTools 或采集到的 console log 查看。
- Not validated / out of scope：没有在本地手动验证 Windows 和 Linux 浏览器场景。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>
