### PR TITLE
fix(core): Gate large PDF text extraction

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -715,6 +715,36 @@ describe('ReadFileTool', () => {
         return invocation.execute(abortSignal);
       }
 
+      it('returns a short error when a text-only model reads a large PDF without pages', async () => {
+        const pdfPath = path.join(tempRootDir, 'large.pdf');
+        await fsp.writeFile(pdfPath, Buffer.alloc(2 * 1024 * 1024));
+        const textOnlyConfig = {
+          getFileService: () => new FileDiscoveryService(tempRootDir),
+          getFileSystemService: () => new StandardFileSystemService(),
+          getTargetDir: () => tempRootDir,
+          getWorkspaceContext: () => createMockWorkspaceContext(tempRootDir),
+          storage: {
+            getProjectTempDir: () => path.join(tempRootDir, '.temp'),
+            getProjectDir: () => path.join(tempRootDir, '.project'),
+            getUserSkillsDirs: () => [
+              path.join(os.homedir(), '.qwen', 'skills'),
+            ],
+          },
+          getTruncateToolOutputThreshold: () => 2500,
+          getTruncateToolOutputLines: () => 500,
+          getContentGeneratorConfig: () => ({ modalities: {} }),
+          getFileReadCache: () => fileReadCache,
+          getFileReadCacheDisabled: () => false,
+        } as unknown as Config;
+        const textOnlyTool = new ReadFileTool(textOnlyConfig);
+
+        const result = await read({ file_path: pdfPath }, textOnlyTool);
+
+        expect(result.error?.type).toBe(ToolErrorType.FILE_TOO_LARGE);
+        expect(String(result.llmContent).length).toBeLessThan(1000);
+        expect(result.llmContent).toContain("Use the 'pages' parameter");
+      });
+
       it('returns the file_unchanged placeholder on a second full Read of an unchanged text file', async () => {
         const filePath = path.join(tempRootDir, 'note.txt');
         await fsp.writeFile(filePath, 'hello world', 'utf-8');

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -24,6 +24,14 @@ vi.mock('../telemetry/loggers.js', () => ({
   logFileOperation: vi.fn(),
 }));
 
+vi.mock('../utils/pdf.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/pdf.js')>();
+  return {
+    ...actual,
+    isPdftotextAvailable: async () => true,
+  };
+});
+
 describe('ReadFileTool', () => {
   let tempRootDir: string;
   let tool: ReadFileTool;

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -28,6 +28,7 @@ vi.mock('../utils/pdf.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/pdf.js')>();
   return {
     ...actual,
+    getPDFPageCount: async () => 31,
     isPdftotextAvailable: async () => true,
   };
 });
@@ -750,6 +751,7 @@ describe('ReadFileTool', () => {
 
         expect(result.error?.type).toBe(ToolErrorType.FILE_TOO_LARGE);
         expect(String(result.llmContent).length).toBeLessThan(1000);
+        expect(result.llmContent).toContain('has 31 pages');
         expect(result.llmContent).toContain("Use the 'pages' parameter");
       });
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -19,7 +19,7 @@ import {
   getSpecificMimeType,
   isCacheableReadResult,
 } from '../utils/fileUtils.js';
-import { parsePDFPageRange } from '../utils/pdf.js';
+import { parsePDFPageRange, PDF_MAX_PAGES_PER_READ } from '../utils/pdf.js';
 import type { Config } from '../config/config.js';
 import { FileOperation } from '../telemetry/metrics.js';
 import { getProgrammingLanguage } from '../telemetry/telemetry-utils.js';
@@ -54,8 +54,7 @@ export interface ReadFileToolParams {
 
   /**
    * For PDF files, the page range to extract as text (e.g. "1-5", "3", "10-20").
-   * Pages are 1-indexed. Max 20 pages per request. Open-ended ranges like "3-"
-   * are not supported.
+   * Pages are 1-indexed. Open-ended ranges like "3-" are not supported.
    */
   pages?: string;
 }
@@ -394,7 +393,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
     super(
       ReadFileTool.Name,
       ToolDisplayNames.READ_FILE,
-      `Reads and returns the content of a specified file. The file_path argument MUST be an absolute path. Always construct it by combining the project root with the file's relative path (e.g. project root '/path/to/project/' + relative 'foo/bar.txt' = '/path/to/project/foo/bar.txt'). If the user provides a relative path, resolve it against the project root first. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), PDF files, and Jupyter notebooks (.ipynb). For text files, it can read specific line ranges. For PDF files, use the 'pages' parameter to extract specific page ranges as text (e.g. '1-5'). Max 20 pages per request. This tool can read Jupyter notebooks (.ipynb) and returns structured cell content with outputs.`,
+      `Reads and returns the content of a specified file. The file_path argument MUST be an absolute path. Always construct it by combining the project root with the file's relative path (e.g. project root '/path/to/project/' + relative 'foo/bar.txt' = '/path/to/project/foo/bar.txt'). If the user provides a relative path, resolve it against the project root first. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), PDF files, and Jupyter notebooks (.ipynb). For text files, it can read specific line ranges. For PDF files, use the 'pages' parameter to extract specific page ranges as text (e.g. '1-5'). Max ${PDF_MAX_PAGES_PER_READ} pages per request. Large PDFs cannot be read all at once when the model does not support native PDF input; retry with narrower page ranges if the tool reports a PDF is too large. This tool can read Jupyter notebooks (.ipynb) and returns structured cell content with outputs.`,
       Kind.Read,
       {
         properties: {
@@ -415,7 +414,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
           },
           pages: {
             description:
-              "Optional: For PDF files, the page range to extract as text (e.g., '1-5', '3', '10-20'). Pages are 1-indexed. Max 20 pages per request. Open-ended ranges like '3-' are not supported. When provided, PDF content is extracted as text regardless of model capabilities.",
+              `Optional: For PDF files, the page range to extract as text (e.g., '1-5', '3', '10-20'). Pages are 1-indexed. Max ${PDF_MAX_PAGES_PER_READ} pages per request. Open-ended ranges like '3-' are not supported. Use this for large PDFs or when the model does not support native PDF input.`,
             type: 'string',
           },
         },
@@ -471,9 +470,9 @@ export class ReadFileTool extends BaseDeclarativeTool<
         return `Invalid pages parameter: '${params.pages}'. Use formats like '5' or '1-10'.`;
       }
       if (parsed.lastPage === Infinity) {
-        return `Open-ended page ranges (e.g. '3-') are not supported; specify an explicit end page within the 20-page limit (e.g. '3-22').`;
+        return `Open-ended page ranges (e.g. '3-') are not supported; specify an explicit end page within the ${PDF_MAX_PAGES_PER_READ}-page limit (e.g. '3-22').`;
       }
-      const maxPages = 20;
+      const maxPages = PDF_MAX_PAGES_PER_READ;
       if (parsed.lastPage - parsed.firstPage + 1 > maxPages) {
         return `Pages range exceeds maximum of ${maxPages} pages per request.`;
       }

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1306,6 +1306,34 @@ describe('fileUtils', () => {
       expect(mockExecFile.mock.calls[1]![0]).toBe('pdftotext');
     });
 
+    it('rejects compact PDFs when pdfinfo reports too many pages', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.alloc(64 * 1024));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          42\n',
+        stderr: '',
+        code: 0,
+      });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.llmContent).toContain('has 42 pages');
+      expect(result.returnDisplay).toContain('PDF requires page range');
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
+      expect(mockExecFile.mock.calls[1]![0]).toBe('pdftotext');
+    });
+
     it('uses size-heuristic page guidance when pdfinfo is unavailable', async () => {
       actualNodeFs.writeFileSync(
         testPdfFilePath,
@@ -1494,9 +1522,14 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain('too large to return safely');
     });
 
-    it('rejects dense no-pages PDF extraction after skipping the small-file page-count pre-check', async () => {
+    it('rejects dense no-pages PDF extraction after exact page count allows full reads', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          2\n',
+        stderr: '',
+        code: 0,
+      });
       mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
       mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
 
@@ -1515,12 +1548,17 @@ describe('fileUtils', () => {
       expect(String(result.llmContent).length).toBeLessThan(1000);
       expect(
         mockExecFile.mock.calls.some((call) => call[0] === 'pdfinfo'),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('references dense no-pages PDFs for @ attachments', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          2\n',
+        stderr: '',
+        code: 0,
+      });
       mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
       mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
 
@@ -1538,6 +1576,41 @@ describe('fileUtils', () => {
       expect(result.error).toBeUndefined();
       expect(result.returnDisplay).toContain('Referenced large PDF');
       expect(result.llmContent).toContain('too large to return safely');
+    });
+
+    it('allows full PDF text extraction at the full-text size cap', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          2\n',
+        stderr: '',
+        code: 0,
+      });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'full text at cap', stderr: '', code: 0 });
+      const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
+        size: 100 * 1024 * 1024,
+        isDirectory: () => false,
+        isFile: () => true,
+      } as fs.Stats);
+
+      try {
+        const mockConfigNoPdf = {
+          ...mockConfig,
+          getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+        } as unknown as Config;
+
+        const result = await processSingleFileContent(
+          testPdfFilePath,
+          mockConfigNoPdf,
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.llmContent).toBe('full text at cap');
+        expect(mockExecFile).toHaveBeenCalledTimes(3);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
 
     it('rejects huge no-pages PDFs before returning page guidance', async () => {
@@ -1565,6 +1638,7 @@ describe('fileUtils', () => {
         expect(result.returnDisplay).toContain('PDF file too large');
         expect(result.llmContent).toContain("Use the 'pages' parameter");
         expect(result.llmContent).toContain('split the document');
+        expect(result.stats).toBeDefined();
         expect(mockExecFile).not.toHaveBeenCalled();
       } finally {
         statSpy.mockRestore();
@@ -1611,6 +1685,41 @@ describe('fileUtils', () => {
       }
     });
 
+    it('allows explicit page ranges at the paged text-extraction size cap', async () => {
+      const fakePdfData = Buffer.from('fake pdf data');
+      actualNodeFs.writeFileSync(testPdfFilePath, fakePdfData);
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'paged text at cap', stderr: '', code: 0 });
+
+      const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
+        size: 512 * 1024 * 1024,
+        isDirectory: () => false,
+        isFile: () => true,
+      } as fs.Stats);
+
+      try {
+        const mockConfigNoPdf = {
+          ...mockConfig,
+          getContentGeneratorConfig: () => ({
+            modalities: { image: true },
+          }),
+        } as unknown as Config;
+
+        const result = await processSingleFileContent(
+          testPdfFilePath,
+          mockConfigNoPdf,
+          { pages: '1-5' },
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.llmContent).toBe('paged text at cap');
+        expect(mockExecFile).toHaveBeenCalledTimes(2);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+
     it('rejects explicit page ranges above the paged text-extraction size cap', async () => {
       const fakePdfData = Buffer.from('fake pdf data');
       actualNodeFs.writeFileSync(testPdfFilePath, fakePdfData);
@@ -1638,6 +1747,7 @@ describe('fileUtils', () => {
 
         expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
         expect(result.llmContent).toContain('page-range text extraction');
+        expect(result.stats).toBeDefined();
         expect(mockExecFile).not.toHaveBeenCalled();
       } finally {
         statSpy.mockRestore();

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1275,7 +1275,65 @@ describe('fileUtils', () => {
       expect(result.returnDisplay).toContain('Failed to read pdf');
     });
 
-    it('rejects large full-PDF text fallback before running pdftotext', async () => {
+    it('rejects large full-PDF text fallback before extracting text', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          42\n',
+        stderr: '',
+        code: 0,
+      });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.llmContent).toContain("Use the 'pages' parameter");
+      expect(result.returnDisplay).toContain('PDF requires page range');
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
+      expect(mockExecFile.mock.calls[1]![0]).toBe('pdftotext');
+    });
+
+    it('uses size-heuristic page guidance when pdfinfo is unavailable', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdfinfo missing', code: 1 });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.llmContent).toContain('appears to have about 21 pages');
+      expect(result.returnDisplay).toContain('PDF requires page range');
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
+      expect(mockExecFile.mock.calls[1]![0]).toBe('pdftotext');
+    });
+
+    it('surfaces missing pdftotext before page-range guidance', async () => {
       actualNodeFs.writeFileSync(
         testPdfFilePath,
         Buffer.alloc(2 * 1024 * 1024),
@@ -1297,11 +1355,10 @@ describe('fileUtils', () => {
         mockConfigNoPdf,
       );
 
-      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
-      expect(result.llmContent).toContain("Use the 'pages' parameter");
-      expect(result.returnDisplay).toContain('PDF requires page range');
-      expect(mockExecFile).toHaveBeenCalledTimes(1);
-      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
+      expect(result.errorType).toBe(ToolErrorType.READ_CONTENT_FAILURE);
+      expect(result.llmContent).toContain('pdftotext is not installed');
+      expect(result.llmContent).not.toContain("Use the 'pages' parameter");
+      expect(result.returnDisplay).toContain('Failed to read pdf');
     });
 
     it('returns a reference instead of an error for large @-attached PDFs', async () => {
@@ -1315,6 +1372,7 @@ describe('fileUtils', () => {
         stderr: '',
         code: 0,
       });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
 
       const mockConfigNoPdf = {
         ...mockConfig,
@@ -1380,9 +1438,81 @@ describe('fileUtils', () => {
       expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
       expect(String(result.llmContent).length).toBeLessThan(1000);
       expect(result.llmContent).toContain('too large to return safely');
+      expect(result.llmContent).toContain('selected page exceeds');
     });
 
-    it('references huge no-pages PDFs before the text-extraction size cap', async () => {
+    it('rejects dense non-ASCII PDF extraction with a short error', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({
+        stdout: '\u4e00'.repeat(11_000),
+        stderr: '',
+        code: 0,
+      });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { pages: '1' },
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(String(result.llmContent).length).toBeLessThan(1000);
+      expect(result.llmContent).toContain('too large to return safely');
+    });
+
+    it('rejects dense no-pages PDF extraction after a small page-count pre-check', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: 'Pages:          2\n', stderr: '', code: 0 });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.returnDisplay).toContain('PDF text too large');
+      expect(String(result.llmContent).length).toBeLessThan(1000);
+    });
+
+    it('references dense no-pages PDFs for @ attachments', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: 'Pages:          2\n', stderr: '', code: 0 });
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { largePdfBehavior: 'reference' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.returnDisplay).toContain('Referenced large PDF');
+      expect(result.llmContent).toContain('too large to return safely');
+    });
+
+    it('rejects huge no-pages PDFs before returning page guidance', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
       const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
@@ -1403,9 +1533,10 @@ describe('fileUtils', () => {
           { largePdfBehavior: 'reference' },
         );
 
-        expect(result.error).toBeUndefined();
-        expect(result.returnDisplay).toContain('Referenced large PDF');
-        expect(result.llmContent).toContain("Use the 'pages' parameter");
+        expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+        expect(result.returnDisplay).toContain('PDF file too large');
+        expect(result.llmContent).toContain('Split the document');
+        expect(result.llmContent).not.toContain("Use the 'pages' parameter");
         expect(mockExecFile).not.toHaveBeenCalled();
       } finally {
         statSpy.mockRestore();

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1418,6 +1418,33 @@ describe('fileUtils', () => {
       ).toBe(true);
     });
 
+    it.each([
+      ['abc', 'Invalid pages parameter'],
+      ['1-', 'Open-ended page ranges'],
+      ['1-21', 'Pages range exceeds maximum of 20'],
+    ])(
+      'rejects unsafe internal pages value %s before extracting text',
+      async (pages, expectedMessage) => {
+        actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+        mockMimeGetType.mockReturnValue('application/pdf');
+
+        const mockConfigNoPdf = {
+          ...mockConfig,
+          getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+        } as unknown as Config;
+
+        const result = await processSingleFileContent(
+          testPdfFilePath,
+          mockConfigNoPdf,
+          { pages },
+        );
+
+        expect(result.errorType).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+        expect(result.llmContent).toContain(expectedMessage);
+        expect(mockExecFile).not.toHaveBeenCalled();
+      },
+    );
+
     it('rejects overly dense page-range extraction with a short error', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
@@ -1467,10 +1494,9 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain('too large to return safely');
     });
 
-    it('rejects dense no-pages PDF extraction after a small page-count pre-check', async () => {
+    it('rejects dense no-pages PDF extraction after skipping the small-file page-count pre-check', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
-      mockExecResult({ stdout: 'Pages:          2\n', stderr: '', code: 0 });
       mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
       mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
 
@@ -1487,12 +1513,14 @@ describe('fileUtils', () => {
       expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
       expect(result.returnDisplay).toContain('PDF text too large');
       expect(String(result.llmContent).length).toBeLessThan(1000);
+      expect(
+        mockExecFile.mock.calls.some((call) => call[0] === 'pdfinfo'),
+      ).toBe(false);
     });
 
     it('references dense no-pages PDFs for @ attachments', async () => {
       actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
       mockMimeGetType.mockReturnValue('application/pdf');
-      mockExecResult({ stdout: 'Pages:          2\n', stderr: '', code: 0 });
       mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
       mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
 
@@ -1535,8 +1563,8 @@ describe('fileUtils', () => {
 
         expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
         expect(result.returnDisplay).toContain('PDF file too large');
-        expect(result.llmContent).toContain('Split the document');
-        expect(result.llmContent).not.toContain("Use the 'pages' parameter");
+        expect(result.llmContent).toContain("Use the 'pages' parameter");
+        expect(result.llmContent).toContain('split the document');
         expect(mockExecFile).not.toHaveBeenCalled();
       } finally {
         statSpy.mockRestore();
@@ -1578,6 +1606,39 @@ describe('fileUtils', () => {
         // Routed into the pdftotext path — either success or the
         // install-guidance error, never "File size exceeds the 10MB limit".
         expect(result.returnDisplay ?? '').toMatch(/pdf/i);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+
+    it('rejects explicit page ranges above the paged text-extraction size cap', async () => {
+      const fakePdfData = Buffer.from('fake pdf data');
+      actualNodeFs.writeFileSync(testPdfFilePath, fakePdfData);
+      mockMimeGetType.mockReturnValue('application/pdf');
+
+      const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
+        size: 600 * 1024 * 1024,
+        isDirectory: () => false,
+        isFile: () => true,
+      } as fs.Stats);
+
+      try {
+        const mockConfigNoPdf = {
+          ...mockConfig,
+          getContentGeneratorConfig: () => ({
+            modalities: { image: true },
+          }),
+        } as unknown as Config;
+
+        const result = await processSingleFileContent(
+          testPdfFilePath,
+          mockConfigNoPdf,
+          { pages: '1-5' },
+        );
+
+        expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+        expect(result.llmContent).toContain('page-range text extraction');
+        expect(mockExecFile).not.toHaveBeenCalled();
       } finally {
         statSpy.mockRestore();
       }

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1387,6 +1387,7 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain('pdftotext is not installed');
       expect(result.llmContent).not.toContain("Use the 'pages' parameter");
       expect(result.returnDisplay).toContain('Failed to read pdf');
+      expect(result.stats).toBeDefined();
     });
 
     it('returns a reference instead of an error for large @-attached PDFs', async () => {
@@ -1417,6 +1418,37 @@ describe('fileUtils', () => {
       expect(result.llmContent).toContain("Use the 'pages' parameter");
       expect(result.returnDisplay).toContain('Referenced large PDF');
       expect(result.stats).toBeDefined();
+    });
+
+    it('returns a reference for large @-attached PDFs when pdftotext is unavailable', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          42\n',
+        stderr: '',
+        code: 0,
+      });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { largePdfBehavior: 'reference' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain("Use the 'pages' parameter");
+      expect(result.returnDisplay).toContain('Referenced large PDF');
+      expect(result.stats).toBeDefined();
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
     });
 
     it('keeps explicit pages reads on the pdftotext path', async () => {
@@ -1576,6 +1608,29 @@ describe('fileUtils', () => {
       expect(result.error).toBeUndefined();
       expect(result.returnDisplay).toContain('Referenced large PDF');
       expect(result.llmContent).toContain('too large to return safely');
+    });
+
+    it('rejects dense page-range PDF extraction for @ attachments', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { pages: '1-5', largePdfBehavior: 'reference' },
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.returnDisplay).toContain('PDF text too large');
+      expect(String(result.llmContent).length).toBeLessThan(1000);
+      expect(result.stats).toBeDefined();
     });
 
     it('allows full PDF text extraction at the full-text size cap', async () => {

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -1874,14 +1874,13 @@ describe('fileUtils', () => {
       }
     });
 
-    it('should reject PDFs that exceed the text-extraction size cap (100MB)', async () => {
+    it('should allow explicit page ranges above the full-PDF text-extraction size cap', async () => {
       const fakePdfData = Buffer.from('fake pdf data');
       actualNodeFs.writeFileSync(testPdfFilePath, fakePdfData);
       mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'selected page text', stderr: '', code: 0 });
 
-      // 200MB PDF — text-extraction path skips the 10MB gate but still
-      // needs a sane ceiling so pdftotext can't be asked to stream GBs
-      // until the 30s timeout fires.
       const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
         size: 200 * 1024 * 1024,
         isDirectory: () => false,
@@ -1902,9 +1901,9 @@ describe('fileUtils', () => {
           { pages: '1-5' },
         );
 
-        expect(result.error).toMatch(/exceeds extraction size limit/i);
-        expect(result.returnDisplay).toMatch(/PDF file too large/i);
-        expect(result.errorType).toBeDefined();
+        expect(result.error).toBeUndefined();
+        expect(result.llmContent).toBe('selected page text');
+        expect(result.returnDisplay).toContain('Read pdf as text (pages 1-5)');
       } finally {
         statSpy.mockRestore();
       }

--- a/packages/core/src/utils/fileUtils.test.ts
+++ b/packages/core/src/utils/fileUtils.test.ts
@@ -17,6 +17,7 @@ import {
 import * as actualNodeFs from 'node:fs'; // For setup/teardown
 import fs from 'node:fs';
 import fsPromises from 'node:fs/promises';
+import { execFile } from 'node:child_process';
 import path from 'node:path';
 import os from 'node:os';
 import mime from 'mime/lite';
@@ -35,6 +36,8 @@ import {
 } from './fileUtils.js';
 import type { Config } from '../config/config.js';
 import { StandardFileSystemService } from '../services/fileSystemService.js';
+import { ToolErrorType } from '../tools/tool-error.js';
+import { resetPdftotextCache } from './pdf.js';
 
 vi.mock('mime/lite', () => ({
   default: { getType: vi.fn() },
@@ -76,6 +79,34 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 const mockMimeGetType = mime.getType as Mock;
+const mockExecFile = vi.mocked(execFile);
+
+function mockExecResult(result: {
+  stdout: string;
+  stderr: string;
+  code: number;
+}) {
+  mockExecFile.mockImplementationOnce(
+    (_cmd: unknown, _args: unknown, _opts: unknown, cb: unknown) => {
+      const callback = cb as (
+        err: Error | null,
+        stdout: string,
+        stderr: string,
+      ) => void;
+      if (result.code !== 0) {
+        const err = new Error('command failed') as Error & { code: number };
+        err.code = result.code;
+        callback(err, result.stdout, result.stderr);
+      } else {
+        callback(null, result.stdout, result.stderr);
+      }
+      return {
+        kill: vi.fn(),
+        on: vi.fn(),
+      } as unknown as import('node:child_process').ChildProcess;
+    },
+  );
+}
 
 describe('fileUtils', () => {
   let tempRootDir: string;
@@ -103,6 +134,7 @@ describe('fileUtils', () => {
 
   beforeEach(() => {
     vi.resetAllMocks(); // Reset all mocks, including mime.getType
+    resetPdftotextCache();
 
     tempRootDir = actualNodeFs.mkdtempSync(
       path.join(os.tmpdir(), 'fileUtils-test-'),
@@ -1241,6 +1273,143 @@ describe('fileUtils', () => {
       // rather than silently skipping
       expect(result.llmContent).toContain('Cannot extract text from PDF');
       expect(result.returnDisplay).toContain('Failed to read pdf');
+    });
+
+    it('rejects large full-PDF text fallback before running pdftotext', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          42\n',
+        stderr: '',
+        code: 0,
+      });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(result.llmContent).toContain("Use the 'pages' parameter");
+      expect(result.returnDisplay).toContain('PDF requires page range');
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile.mock.calls[0]![0]).toBe('pdfinfo');
+    });
+
+    it('returns a reference instead of an error for large @-attached PDFs', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({
+        stdout: 'Pages:          42\n',
+        stderr: '',
+        code: 0,
+      });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { largePdfBehavior: 'reference' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain("Use the 'pages' parameter");
+      expect(result.returnDisplay).toContain('Referenced large PDF');
+      expect(result.stats).toBeDefined();
+    });
+
+    it('keeps explicit pages reads on the pdftotext path', async () => {
+      actualNodeFs.writeFileSync(
+        testPdfFilePath,
+        Buffer.alloc(2 * 1024 * 1024),
+      );
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'page one text', stderr: '', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { pages: '1' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toBe('page one text');
+      expect(
+        mockExecFile.mock.calls.some((call) => call[0] === 'pdftotext'),
+      ).toBe(true);
+    });
+
+    it('rejects overly dense page-range extraction with a short error', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      mockExecResult({ stdout: '', stderr: 'pdftotext version', code: 0 });
+      mockExecResult({ stdout: 'x'.repeat(80_000), stderr: '', code: 0 });
+
+      const mockConfigNoPdf = {
+        ...mockConfig,
+        getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+      } as unknown as Config;
+
+      const result = await processSingleFileContent(
+        testPdfFilePath,
+        mockConfigNoPdf,
+        { pages: '1' },
+      );
+
+      expect(result.errorType).toBe(ToolErrorType.FILE_TOO_LARGE);
+      expect(String(result.llmContent).length).toBeLessThan(1000);
+      expect(result.llmContent).toContain('too large to return safely');
+    });
+
+    it('references huge no-pages PDFs before the text-extraction size cap', async () => {
+      actualNodeFs.writeFileSync(testPdfFilePath, Buffer.from('%PDF-1.7'));
+      mockMimeGetType.mockReturnValue('application/pdf');
+      const statSpy = vi.spyOn(fs.promises, 'stat').mockResolvedValueOnce({
+        size: 200 * 1024 * 1024,
+        isDirectory: () => false,
+        isFile: () => true,
+      } as fs.Stats);
+
+      try {
+        const mockConfigNoPdf = {
+          ...mockConfig,
+          getContentGeneratorConfig: () => ({ modalities: { image: true } }),
+        } as unknown as Config;
+
+        const result = await processSingleFileContent(
+          testPdfFilePath,
+          mockConfigNoPdf,
+          { largePdfBehavior: 'reference' },
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.returnDisplay).toContain('Referenced large PDF');
+        expect(result.llmContent).toContain("Use the 'pages' parameter");
+        expect(mockExecFile).not.toHaveBeenCalled();
+      } finally {
+        statSpy.mockRestore();
+      }
     });
 
     it('should skip the 10MB size gate when extracting PDF text by pages', async () => {

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1294,7 +1294,6 @@ export async function processSingleFileContent(
           return {
             llmContent: pdfResult.text,
             returnDisplay: `Read pdf as text${pagesLabel}: ${relativePathForDisplay}`,
-            isTruncated: pdfResult.truncated ?? false,
             stats,
           };
         }

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1074,12 +1074,13 @@ export async function processSingleFileContent(
         `PDF full-text fallback gate: file=${relativePathForDisplay}, sizeMB=${fileSizeInMB.toFixed(2)}, pageCount=${pageCount ?? 'unknown'}, required=${requirement.required}, effectivePageCount=${requirement.effectivePageCount}, hadPdfInfo=${requirement.hadPdfInfo}, behavior=${largePdfBehavior}`,
       );
       if (requirement.required) {
-        if (!(await isPdftotextAvailable())) {
+        if (largePdfBehavior === 'error' && !(await isPdftotextAvailable())) {
           return {
             llmContent: `[Cannot extract text from PDF: "${displayName}". ${PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE}]`,
             returnDisplay: `Failed to read pdf: ${relativePathForDisplay}`,
             error: PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE,
             errorType: ToolErrorType.READ_CONTENT_FAILURE,
+            stats,
           };
         }
         const guidance = buildLargePDFGuidance(displayName, requirement);

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1055,6 +1055,7 @@ export async function processSingleFileContent(
         returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_FULL_TEXT_EXTRACTION_MAX_MB}MB).`,
         error: `PDF exceeds extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
         errorType: ToolErrorType.FILE_TOO_LARGE,
+        stats,
       };
     }
     if (pageRange && fileSizeInMB > PDF_PAGED_TEXT_EXTRACTION_MAX_MB) {
@@ -1063,16 +1064,12 @@ export async function processSingleFileContent(
         returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_PAGED_TEXT_EXTRACTION_MAX_MB}MB).`,
         error: `PDF exceeds page-range extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
         errorType: ToolErrorType.FILE_TOO_LARGE,
+        stats,
       };
     }
     if (willExtractPdfText && !pageRange) {
-      const heuristicRequirement = shouldRequirePDFPageRange(null, stats.size);
-      let pageCount: number | null = null;
-      let requirement = heuristicRequirement;
-      if (heuristicRequirement.required) {
-        pageCount = await getPDFPageCount(filePath);
-        requirement = shouldRequirePDFPageRange(pageCount, stats.size);
-      }
+      const pageCount = await getPDFPageCount(filePath);
+      const requirement = shouldRequirePDFPageRange(pageCount, stats.size);
       debugLogger.debug(
         `PDF full-text fallback gate: file=${relativePathForDisplay}, sizeMB=${fileSizeInMB.toFixed(2)}, pageCount=${pageCount ?? 'unknown'}, required=${requirement.required}, effectivePageCount=${requirement.effectivePageCount}, hadPdfInfo=${requirement.hadPdfInfo}, behavior=${largePdfBehavior}`,
       );
@@ -1314,6 +1311,9 @@ export async function processSingleFileContent(
         if (pdfResult.success) {
           const estimatedTokens = estimatePDFTextOutputTokens(pdfResult.text);
           if (estimatedTokens > PDF_TEXT_RESULT_MAX_TOKENS) {
+            debugLogger.debug(
+              `PDF text extraction output exceeds token limit: file=${relativePathForDisplay}, pages=${normalizedPages ?? 'all'}, estimatedTokens=${estimatedTokens}, limit=${PDF_TEXT_RESULT_MAX_TOKENS}`,
+            );
             const guidance = buildPDFTextTooLargeGuidance(
               displayName,
               estimatedTokens,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -1009,11 +1009,11 @@ export async function processSingleFileContent(
     // explicit page reads can bypass the inline-data cap. Full-document text
     // fallback is separately gated by page count or size heuristic below. Use
     // 9.9MB to leave margin for base64 encoding overhead (#1880). A separate
-    // upper bound applies to the extraction path so a multi-GB file can't hang
-    // pdftotext until the 30s timeout.
+    // upper bound applies to full-document extraction so a multi-GB file can't
+    // hang pdftotext until the 30s timeout.
     const willExtractPdfText =
       fileType === 'pdf' && (pages !== undefined || !modalities.pdf);
-    if (willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
+    if (!pages && willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
       return {
         llmContent: `PDF file is too large for text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_EXTRACTION_MAX_MB}MB limit. Split the document into smaller files before retrying.`,
         returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_EXTRACTION_MAX_MB}MB).`,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -29,6 +29,7 @@ import {
   getPDFPageCount,
   isPdftotextAvailable,
   parsePDFPageRange,
+  PDF_MAX_PAGES_PER_READ,
   PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE,
   PDF_TEXT_RESULT_MAX_TOKENS,
   shouldRequirePDFPageRange,
@@ -40,14 +41,13 @@ const debugLogger = createDebugLogger('FILE_UTILS');
 // Default values for encoding and separator format
 export const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
 
-// Upper bound on the on-disk size of a PDF we will hand to the
-// pdftotext text-extraction path. The 10MB inline-data cap is bypassed
-// for this branch (pdftotext streams the file rather than base64-
-// encoding it), so a separate ceiling prevents handing pdftotext an
-// arbitrarily large file it would spend the full 30s timeout chewing
-// on. 100MB is large enough for typical scanned documents and reports
-// while keeping wall-clock and RSS bounded.
-const PDF_EXTRACTION_MAX_MB = 100;
+// Upper bounds on the on-disk size of PDFs we will hand to pdftotext.
+// The 10MB inline-data cap is bypassed for this path, so keep explicit
+// ceilings before spawning poppler. Full reads are tighter because they
+// are the path that triggered context overflows; page-range reads get a
+// larger ceiling so legitimate large documents can still be sampled.
+const PDF_FULL_TEXT_EXTRACTION_MAX_MB = 100;
+const PDF_PAGED_TEXT_EXTRACTION_MAX_MB = 512;
 
 // --- Unicode BOM detection & decoding helpers --------------------------------
 
@@ -1003,27 +1003,76 @@ export async function processSingleFileContent(
       config.getContentGeneratorConfig?.()?.modalities ?? {};
 
     const fileSizeInMB = stats.size / (1024 * 1024);
+    const normalizedPages = pages?.trim();
+    let pageRange:
+      | NonNullable<ReturnType<typeof parsePDFPageRange>>
+      | undefined;
+    if (fileType === 'pdf' && normalizedPages !== undefined) {
+      const invalidPagesDisplay = `Invalid PDF pages parameter: ${relativePathForDisplay}`;
+      const invalidPagesResult = (message: string) => ({
+        llmContent: message,
+        returnDisplay: invalidPagesDisplay,
+        error: message,
+        errorType: ToolErrorType.INVALID_TOOL_PARAMS,
+      });
+      const parsedPageRange = parsePDFPageRange(normalizedPages);
+      if (!parsedPageRange) {
+        return invalidPagesResult(
+          `Invalid pages parameter: '${normalizedPages}'. Use formats like '5' or '1-10'.`,
+        );
+      }
+      if (parsedPageRange.lastPage === Infinity) {
+        return invalidPagesResult(
+          `Open-ended page ranges (e.g. '3-') are not supported; specify an explicit end page within the ${PDF_MAX_PAGES_PER_READ}-page limit (e.g. '3-22').`,
+        );
+      }
+      if (
+        parsedPageRange.lastPage - parsedPageRange.firstPage + 1 >
+        PDF_MAX_PAGES_PER_READ
+      ) {
+        return invalidPagesResult(
+          `Pages range exceeds maximum of ${PDF_MAX_PAGES_PER_READ} pages per request.`,
+        );
+      }
+      pageRange = parsedPageRange;
+    }
+
     // The 10MB cap exists for inline-data paths (base64 images / audio /
     // video / PDFs), where the encoded payload must fit in the model's
     // data-URI budget. PDF text extraction streams through pdftotext, so
-    // explicit page reads can bypass the inline-data cap. Full-document text
-    // fallback is separately gated by page count or size heuristic below. Use
-    // 9.9MB to leave margin for base64 encoding overhead (#1880). A separate
-    // upper bound applies to full-document extraction so a multi-GB file can't
-    // hang pdftotext until the 30s timeout.
+    // explicit page reads can bypass the inline-data cap but not the
+    // pdftotext-specific ceilings above. Use 9.9MB to leave margin for
+    // base64 encoding overhead (#1880).
     const willExtractPdfText =
-      fileType === 'pdf' && (pages !== undefined || !modalities.pdf);
-    if (!pages && willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
+      fileType === 'pdf' && (pageRange !== undefined || !modalities.pdf);
+    if (
+      !pageRange &&
+      willExtractPdfText &&
+      fileSizeInMB > PDF_FULL_TEXT_EXTRACTION_MAX_MB
+    ) {
       return {
-        llmContent: `PDF file is too large for text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_EXTRACTION_MAX_MB}MB limit. Split the document into smaller files before retrying.`,
-        returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_EXTRACTION_MAX_MB}MB).`,
+        llmContent: `PDF file is too large for full text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_FULL_TEXT_EXTRACTION_MAX_MB}MB limit. Use the 'pages' parameter to read a narrower range, or split the document into smaller files before retrying.`,
+        returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_FULL_TEXT_EXTRACTION_MAX_MB}MB).`,
         error: `PDF exceeds extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
         errorType: ToolErrorType.FILE_TOO_LARGE,
       };
     }
-    if (willExtractPdfText && !pages) {
-      const pageCount = await getPDFPageCount(filePath);
-      const requirement = shouldRequirePDFPageRange(pageCount, stats.size);
+    if (pageRange && fileSizeInMB > PDF_PAGED_TEXT_EXTRACTION_MAX_MB) {
+      return {
+        llmContent: `PDF file is too large for page-range text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_PAGED_TEXT_EXTRACTION_MAX_MB}MB limit. Split the document into smaller files before retrying.`,
+        returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_PAGED_TEXT_EXTRACTION_MAX_MB}MB).`,
+        error: `PDF exceeds page-range extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
+        errorType: ToolErrorType.FILE_TOO_LARGE,
+      };
+    }
+    if (willExtractPdfText && !pageRange) {
+      const heuristicRequirement = shouldRequirePDFPageRange(null, stats.size);
+      let pageCount: number | null = null;
+      let requirement = heuristicRequirement;
+      if (heuristicRequirement.required) {
+        pageCount = await getPDFPageCount(filePath);
+        requirement = shouldRequirePDFPageRange(pageCount, stats.size);
+      }
       debugLogger.debug(
         `PDF full-text fallback gate: file=${relativePathForDisplay}, sizeMB=${fileSizeInMB.toFixed(2)}, pageCount=${pageCount ?? 'unknown'}, required=${requirement.required}, effectivePageCount=${requirement.effectivePageCount}, hadPdfInfo=${requirement.hadPdfInfo}, behavior=${largePdfBehavior}`,
       );
@@ -1235,7 +1284,7 @@ export async function processSingleFileContent(
         // When `pages` is provided, always extract text (even if model supports PDF natively).
         // When model supports PDF modality and no pages requested, send as base64.
         // Otherwise, fall back to pdftotext for text extraction.
-        if (!pages && modalities.pdf) {
+        if (!pageRange && modalities.pdf) {
           // Model supports PDF natively — send as base64
           const contentBuffer = await fs.promises.readFile(filePath);
           const base64Data = contentBuffer.toString('base64');
@@ -1261,20 +1310,16 @@ export async function processSingleFileContent(
         }
 
         // Extract text via pdftotext (for pages parameter, or models without PDF support)
-        const pageRange = pages ? parsePDFPageRange(pages) : undefined;
-        const pdfResult = await extractPDFText(
-          filePath,
-          pageRange ?? undefined,
-        );
+        const pdfResult = await extractPDFText(filePath, pageRange);
         if (pdfResult.success) {
           const estimatedTokens = estimatePDFTextOutputTokens(pdfResult.text);
           if (estimatedTokens > PDF_TEXT_RESULT_MAX_TOKENS) {
             const guidance = buildPDFTextTooLargeGuidance(
               displayName,
               estimatedTokens,
-              pages,
+              normalizedPages,
             );
-            if (!pages && largePdfBehavior === 'reference') {
+            if (!pageRange && largePdfBehavior === 'reference') {
               return {
                 llmContent: guidance,
                 returnDisplay: `Referenced large PDF: ${relativePathForDisplay}`,
@@ -1290,7 +1335,9 @@ export async function processSingleFileContent(
             };
           }
 
-          const pagesLabel = pages ? ` (pages ${pages})` : '';
+          const pagesLabel = normalizedPages
+            ? ` (pages ${normalizedPages})`
+            : '';
           return {
             llmContent: pdfResult.text,
             returnDisplay: `Read pdf as text${pagesLabel}: ${relativePathForDisplay}`,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -27,7 +27,9 @@ import {
   estimatePDFTextOutputTokens,
   extractPDFText,
   getPDFPageCount,
+  isPdftotextAvailable,
   parsePDFPageRange,
+  PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE,
   PDF_TEXT_RESULT_MAX_TOKENS,
   shouldRequirePDFPageRange,
 } from './pdf.js';
@@ -1011,13 +1013,29 @@ export async function processSingleFileContent(
     // pdftotext until the 30s timeout.
     const willExtractPdfText =
       fileType === 'pdf' && (pages !== undefined || !modalities.pdf);
+    if (willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
+      return {
+        llmContent: `PDF file is too large for text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_EXTRACTION_MAX_MB}MB limit. Split the document into smaller files before retrying.`,
+        returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_EXTRACTION_MAX_MB}MB).`,
+        error: `PDF exceeds extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
+        errorType: ToolErrorType.FILE_TOO_LARGE,
+      };
+    }
     if (willExtractPdfText && !pages) {
-      const pageCount =
-        fileSizeInMB > PDF_EXTRACTION_MAX_MB
-          ? null
-          : await getPDFPageCount(filePath);
+      const pageCount = await getPDFPageCount(filePath);
       const requirement = shouldRequirePDFPageRange(pageCount, stats.size);
+      debugLogger.debug(
+        `PDF full-text fallback gate: file=${relativePathForDisplay}, sizeMB=${fileSizeInMB.toFixed(2)}, pageCount=${pageCount ?? 'unknown'}, required=${requirement.required}, effectivePageCount=${requirement.effectivePageCount}, hadPdfInfo=${requirement.hadPdfInfo}, behavior=${largePdfBehavior}`,
+      );
       if (requirement.required) {
+        if (!(await isPdftotextAvailable())) {
+          return {
+            llmContent: `[Cannot extract text from PDF: "${displayName}". ${PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE}]`,
+            returnDisplay: `Failed to read pdf: ${relativePathForDisplay}`,
+            error: PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE,
+            errorType: ToolErrorType.READ_CONTENT_FAILURE,
+          };
+        }
         const guidance = buildLargePDFGuidance(displayName, requirement);
         const returnDisplay =
           largePdfBehavior === 'reference'
@@ -1035,14 +1053,6 @@ export async function processSingleFileContent(
           stats,
         };
       }
-    }
-    if (willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
-      return {
-        llmContent: `PDF file is too large for text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_EXTRACTION_MAX_MB}MB limit. Use the 'pages' parameter to read a narrower range, or split the document.`,
-        returnDisplay: `PDF file too large (${fileSizeInMB.toFixed(2)}MB > ${PDF_EXTRACTION_MAX_MB}MB).`,
-        error: `PDF exceeds extraction size limit: ${filePath} (${fileSizeInMB.toFixed(2)}MB)`,
-        errorType: ToolErrorType.FILE_TOO_LARGE,
-      };
     }
     if (fileSizeInMB > 9.9 && !willExtractPdfText) {
       return {
@@ -1262,7 +1272,15 @@ export async function processSingleFileContent(
             const guidance = buildPDFTextTooLargeGuidance(
               displayName,
               estimatedTokens,
+              pages,
             );
+            if (!pages && largePdfBehavior === 'reference') {
+              return {
+                llmContent: guidance,
+                returnDisplay: `Referenced large PDF: ${relativePathForDisplay}`,
+                stats,
+              };
+            }
             return {
               llmContent: guidance,
               returnDisplay: `PDF text too large: ${relativePathForDisplay}`,

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -21,7 +21,16 @@ import { createDebugLogger } from './debugLogger.js';
 import { getErrorMessage, isNodeError } from './errors.js';
 import type { InputModalities } from '../core/contentGenerator.js';
 import { detectEncodingFromBuffer } from './systemEncoding.js';
-import { extractPDFText, parsePDFPageRange } from './pdf.js';
+import {
+  buildLargePDFGuidance,
+  buildPDFTextTooLargeGuidance,
+  estimatePDFTextOutputTokens,
+  extractPDFText,
+  getPDFPageCount,
+  parsePDFPageRange,
+  PDF_TEXT_RESULT_MAX_TOKENS,
+  shouldRequirePDFPageRange,
+} from './pdf.js';
 import { readNotebookWithMetadata } from './notebook.js';
 
 const debugLogger = createDebugLogger('FILE_UTILS');
@@ -856,6 +865,11 @@ export interface ProcessSingleFileContentOptions {
    * sets this after deciding the vision bridge should handle the image.
    */
   preserveUnsupportedImage?: boolean;
+  /**
+   * Large full-PDF text fallback returns a tool error by default. `@`-attached
+   * PDFs use `reference` so the model gets guidance without a failed read.
+   */
+  largePdfBehavior?: 'error' | 'reference';
 }
 
 /**
@@ -924,7 +938,13 @@ export async function processSingleFileContent(
           limit: legacyLimit,
           pages: legacyPages,
         };
-  const { offset, limit, pages, preserveUnsupportedImage = false } = options;
+  const {
+    offset,
+    limit,
+    pages,
+    preserveUnsupportedImage = false,
+    largePdfBehavior = 'error',
+  } = options;
   const rootDirectory = config.getTargetDir();
   try {
     let stats: import('node:fs').Stats;
@@ -983,14 +1003,39 @@ export async function processSingleFileContent(
     const fileSizeInMB = stats.size / (1024 * 1024);
     // The 10MB cap exists for inline-data paths (base64 images / audio /
     // video / PDFs), where the encoded payload must fit in the model's
-    // data-URI budget. PDF text extraction streams through pdftotext and
-    // truncates to MAX_PDF_TEXT_OUTPUT_CHARS, so oversized PDFs should go
-    // through it instead of being rejected up front. Use 9.9MB to leave
-    // margin for base64 encoding overhead (#1880). A separate upper
-    // bound applies to the extraction path so a multi-GB file can't hang
+    // data-URI budget. PDF text extraction streams through pdftotext, so
+    // explicit page reads can bypass the inline-data cap. Full-document text
+    // fallback is separately gated by page count or size heuristic below. Use
+    // 9.9MB to leave margin for base64 encoding overhead (#1880). A separate
+    // upper bound applies to the extraction path so a multi-GB file can't hang
     // pdftotext until the 30s timeout.
     const willExtractPdfText =
       fileType === 'pdf' && (pages !== undefined || !modalities.pdf);
+    if (willExtractPdfText && !pages) {
+      const pageCount =
+        fileSizeInMB > PDF_EXTRACTION_MAX_MB
+          ? null
+          : await getPDFPageCount(filePath);
+      const requirement = shouldRequirePDFPageRange(pageCount, stats.size);
+      if (requirement.required) {
+        const guidance = buildLargePDFGuidance(displayName, requirement);
+        const returnDisplay =
+          largePdfBehavior === 'reference'
+            ? `Referenced large PDF: ${relativePathForDisplay}`
+            : `PDF requires page range: ${relativePathForDisplay}`;
+        return {
+          llmContent: guidance,
+          returnDisplay,
+          ...(largePdfBehavior === 'error'
+            ? {
+                error: guidance,
+                errorType: ToolErrorType.FILE_TOO_LARGE,
+              }
+            : {}),
+          stats,
+        };
+      }
+    }
     if (willExtractPdfText && fileSizeInMB > PDF_EXTRACTION_MAX_MB) {
       return {
         llmContent: `PDF file is too large for text extraction: ${fileSizeInMB.toFixed(2)}MB exceeds the ${PDF_EXTRACTION_MAX_MB}MB limit. Use the 'pages' parameter to read a narrower range, or split the document.`,
@@ -1212,10 +1257,27 @@ export async function processSingleFileContent(
           pageRange ?? undefined,
         );
         if (pdfResult.success) {
+          const estimatedTokens = estimatePDFTextOutputTokens(pdfResult.text);
+          if (estimatedTokens > PDF_TEXT_RESULT_MAX_TOKENS) {
+            const guidance = buildPDFTextTooLargeGuidance(
+              displayName,
+              estimatedTokens,
+            );
+            return {
+              llmContent: guidance,
+              returnDisplay: `PDF text too large: ${relativePathForDisplay}`,
+              error: guidance,
+              errorType: ToolErrorType.FILE_TOO_LARGE,
+              stats,
+            };
+          }
+
           const pagesLabel = pages ? ` (pages ${pages})` : '';
           return {
             llmContent: pdfResult.text,
             returnDisplay: `Read pdf as text${pagesLabel}: ${relativePathForDisplay}`,
+            isTruncated: pdfResult.truncated ?? false,
+            stats,
           };
         }
 

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -13,6 +13,8 @@ import {
   resetPdftotextCache,
   shouldRequirePDFPageRange,
   estimatePDFTextOutputTokens,
+  buildLargePDFGuidance,
+  buildPDFTextTooLargeGuidance,
 } from './pdf.js';
 
 vi.mock('node:child_process', () => ({
@@ -121,8 +123,42 @@ describe('pdf utilities', () => {
       });
     });
 
-    it('estimates dense PDF text output tokens using the same char ratio as prompt estimation', () => {
+    it('estimates dense ASCII PDF text output tokens with wrapper allowance', () => {
       expect(estimatePDFTextOutputTokens('x'.repeat(64_000))).toBe(16_016);
+    });
+
+    it('estimates dense non-ASCII PDF text conservatively', () => {
+      expect(estimatePDFTextOutputTokens('\u4e00'.repeat(45_000))).toBe(49_517);
+    });
+
+    it('builds exact page-range guidance for pdfinfo-backed and heuristic counts', () => {
+      expect(
+        buildLargePDFGuidance('paper.pdf', {
+          required: true,
+          effectivePageCount: 42,
+          hadPdfInfo: true,
+        }),
+      ).toBe(
+        "PDF \"paper.pdf\" has 42 pages, which is too many to read at once. Use the 'pages' parameter to read a specific page range such as '1-5'. Maximum 20 pages per request.",
+      );
+      expect(
+        buildLargePDFGuidance('scan.pdf', {
+          required: true,
+          effectivePageCount: 21,
+          hadPdfInfo: false,
+        }),
+      ).toBe(
+        "PDF \"scan.pdf\" appears to have about 21 pages, which is too many to read at once. Use the 'pages' parameter to read a specific page range such as '1-5'. Maximum 20 pages per request.",
+      );
+    });
+
+    it('builds exact dense-text guidance for range and single-page reads', () => {
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345)).toBe(
+        "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.",
+      );
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1')).toBe(
+        'PDF text extracted from "paper.pdf" is too large to return safely (12345 estimated tokens; limit 12000). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.',
+      );
     });
   });
 

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -392,7 +392,6 @@ describe('pdf utilities', () => {
       expect(result).toEqual({
         success: true,
         text: 'Hello World\nThis is a PDF.',
-        truncated: false,
       });
     });
 
@@ -520,7 +519,6 @@ describe('pdf utilities', () => {
       const result = await extractPDFText('/test.pdf');
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.truncated).toBe(true);
         expect(result.text.length).toBeLessThan(110000);
         expect(result.text).toContain('text truncated');
         expect(result.text).toContain("'pages' parameter");
@@ -545,8 +543,23 @@ describe('pdf utilities', () => {
       const result = await extractPDFText('/test.pdf');
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.truncated).toBe(true);
         expect(result.text.length).toBeLessThan(110000);
+        expect(result.text).toContain('text truncated');
+        expect(result.text).toContain("'pages' parameter");
+      }
+    });
+
+    it('should recover maxBuffer overrun when UTF-8 bytes exceed the threshold', async () => {
+      mockExecResult({
+        stdout: '',
+        stderr: 'pdftotext version 24.02.0',
+        code: 0,
+      });
+      mockMaxBufferExceeded('\u4e00'.repeat(70_000));
+
+      const result = await extractPDFText('/test.pdf');
+      expect(result.success).toBe(true);
+      if (result.success) {
         expect(result.text).toContain('text truncated');
         expect(result.text).toContain("'pages' parameter");
       }

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -153,11 +153,20 @@ describe('pdf utilities', () => {
     });
 
     it('builds exact dense-text guidance for range and single-page reads', () => {
+      const singlePageGuidance =
+        'PDF text extracted from "paper.pdf" is too large to return safely (12345 estimated tokens; limit 12000). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.';
+
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345)).toBe(
         "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.",
       );
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1')).toBe(
-        'PDF text extracted from "paper.pdf" is too large to return safely (12345 estimated tokens; limit 12000). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.',
+        singlePageGuidance,
+      );
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1-1')).toBe(
+        singlePageGuidance,
+      );
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1 - 1')).toBe(
+        singlePageGuidance,
       );
     });
   });

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -153,16 +153,23 @@ describe('pdf utilities', () => {
     });
 
     it('builds exact dense-text guidance for range and single-page reads', () => {
-      const rangeGuidance =
+      const defaultRangeGuidance =
         "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.";
+      const fivePageRangeGuidance =
+        "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with fewer pages, for example '1-3' or a single page.";
+      const twoPageRangeGuidance =
+        "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a single page, for example '1'.";
       const singlePageGuidance =
         'PDF text extracted from "paper.pdf" is too large to return safely (12345 estimated tokens; limit 12000). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.';
 
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345)).toBe(
-        rangeGuidance,
+        defaultRangeGuidance,
+      );
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1-5')).toBe(
+        fivePageRangeGuidance,
       );
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1-2')).toBe(
-        rangeGuidance,
+        twoPageRangeGuidance,
       );
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1')).toBe(
         singlePageGuidance,

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -153,11 +153,16 @@ describe('pdf utilities', () => {
     });
 
     it('builds exact dense-text guidance for range and single-page reads', () => {
+      const rangeGuidance =
+        "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.";
       const singlePageGuidance =
         'PDF text extracted from "paper.pdf" is too large to return safely (12345 estimated tokens; limit 12000). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.';
 
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345)).toBe(
-        "PDF text extracted from \"paper.pdf\" is too large to return safely (12345 estimated tokens; limit 12000). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.",
+        rangeGuidance,
+      );
+      expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1-2')).toBe(
+        rangeGuidance,
       );
       expect(buildPDFTextTooLargeGuidance('paper.pdf', 12_345, '1')).toBe(
         singlePageGuidance,

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -11,6 +11,8 @@ import {
   getPDFPageCount,
   extractPDFText,
   resetPdftotextCache,
+  shouldRequirePDFPageRange,
+  estimatePDFTextOutputTokens,
 } from './pdf.js';
 
 vi.mock('node:child_process', () => ({
@@ -92,6 +94,36 @@ describe('pdf utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetPdftotextCache();
+  });
+
+  describe('PDF budget policy helpers', () => {
+    it('requires pages when pdfinfo reports more than the full-text page limit', () => {
+      expect(shouldRequirePDFPageRange(11, 64 * 1024)).toEqual({
+        required: true,
+        effectivePageCount: 11,
+        hadPdfInfo: true,
+      });
+    });
+
+    it('does not require pages for small PDFs', () => {
+      expect(shouldRequirePDFPageRange(10, 2 * 1024 * 1024)).toEqual({
+        required: false,
+        effectivePageCount: 10,
+        hadPdfInfo: true,
+      });
+    });
+
+    it('falls back to a size heuristic when pdfinfo is unavailable', () => {
+      expect(shouldRequirePDFPageRange(null, 2 * 1024 * 1024)).toEqual({
+        required: true,
+        effectivePageCount: 21,
+        hadPdfInfo: false,
+      });
+    });
+
+    it('estimates dense PDF text output tokens using the same char ratio as prompt estimation', () => {
+      expect(estimatePDFTextOutputTokens('x'.repeat(64_000))).toBe(16_016);
+    });
   });
 
   describe('parsePDFPageRange', () => {
@@ -310,6 +342,7 @@ describe('pdf utilities', () => {
       expect(result).toEqual({
         success: true,
         text: 'Hello World\nThis is a PDF.',
+        truncated: false,
       });
     });
 
@@ -437,6 +470,7 @@ describe('pdf utilities', () => {
       const result = await extractPDFText('/test.pdf');
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.truncated).toBe(true);
         expect(result.text.length).toBeLessThan(110000);
         expect(result.text).toContain('text truncated');
         expect(result.text).toContain("'pages' parameter");
@@ -461,6 +495,7 @@ describe('pdf utilities', () => {
       const result = await extractPDFText('/test.pdf');
       expect(result.success).toBe(true);
       if (result.success) {
+        expect(result.truncated).toBe(true);
         expect(result.text.length).toBeLessThan(110000);
         expect(result.text).toContain('text truncated');
         expect(result.text).toContain("'pages' parameter");

--- a/packages/core/src/utils/pdf.test.ts
+++ b/packages/core/src/utils/pdf.test.ts
@@ -520,7 +520,7 @@ describe('pdf utilities', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.text.length).toBeLessThan(110000);
-        expect(result.text).toContain('text truncated');
+        expect(result.text).toContain('text truncated at 100000 characters');
         expect(result.text).toContain("'pages' parameter");
       }
     });
@@ -561,6 +561,8 @@ describe('pdf utilities', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.text).toContain('text truncated');
+        expect(result.text).toContain('PDF text buffer limit');
+        expect(result.text).not.toContain('100000 characters');
         expect(result.text).toContain("'pages' parameter");
       }
     });

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -265,7 +265,7 @@ export async function getPDFPageCount(
 }
 
 export type PDFTextResult =
-  | { success: true; text: string; truncated?: boolean }
+  | { success: true; text: string; truncated: boolean }
   | { success: false; error: string };
 
 /**

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -8,9 +8,9 @@ import { execFile, type ExecFileOptions } from 'node:child_process';
 import { estimateTextTokens } from './request-tokenizer/textTokenizer.js';
 
 const MAX_PDF_TEXT_OUTPUT_CHARS = 100000;
-export const PDF_FULL_TEXT_PAGE_LIMIT = 10;
+const PDF_FULL_TEXT_PAGE_LIMIT = 10;
 export const PDF_MAX_PAGES_PER_READ = 20;
-export const PDF_PAGE_COUNT_SIZE_HEURISTIC_BYTES = 100 * 1024;
+const PDF_PAGE_COUNT_SIZE_HEURISTIC_BYTES = 100 * 1024;
 export const PDF_TEXT_RESULT_MAX_TOKENS = 12_000;
 const PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS = 64;
 const PDF_TEXT_RESULT_CHARS_PER_TOKEN = 4;
@@ -329,11 +329,18 @@ export async function extractPDFText(
       maxBufferExceeded &&
       Buffer.byteLength(stdout, 'utf8') >= MAX_PDF_TEXT_OUTPUT_CHARS
     ) {
+      const wasCharTruncated = stdout.length > MAX_PDF_TEXT_OUTPUT_CHARS;
+      const text = wasCharTruncated
+        ? stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS)
+        : stdout;
+      const truncationReason = wasCharTruncated
+        ? `at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters`
+        : 'after reaching the PDF text buffer limit';
       return {
         success: true,
         text:
-          stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS) +
-          `\n\n... [text truncated at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters. Use the 'pages' parameter to read specific page ranges.]`,
+          text +
+          `\n\n... [text truncated ${truncationReason}. Use the 'pages' parameter to read specific page ranges.]`,
       };
     }
 

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -266,7 +266,7 @@ export async function getPDFPageCount(
 }
 
 export type PDFTextResult =
-  | { success: true; text: string; truncated: boolean }
+  | { success: true; text: string }
   | { success: false; error: string };
 
 /**
@@ -325,10 +325,12 @@ export async function extractPDFText(
     // the buffer overrun was driven by pathological stderr rather than
     // real text output) and still give the password/corrupt detectors a
     // chance to kick in on the partial stderr.
-    if (maxBufferExceeded && stdout.length >= MAX_PDF_TEXT_OUTPUT_CHARS) {
+    if (
+      maxBufferExceeded &&
+      Buffer.byteLength(stdout, 'utf8') >= MAX_PDF_TEXT_OUTPUT_CHARS
+    ) {
       return {
         success: true,
-        truncated: true,
         text:
           stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS) +
           `\n\n... [text truncated at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters. Use the 'pages' parameter to read specific page ranges.]`,
@@ -366,14 +368,13 @@ export async function extractPDFText(
     if (stdout.length > MAX_PDF_TEXT_OUTPUT_CHARS) {
       return {
         success: true,
-        truncated: true,
         text:
           stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS) +
           `\n\n... [text truncated at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters. Use the 'pages' parameter to read specific page ranges.]`,
       };
     }
 
-    return { success: true, text: stdout, truncated: false };
+    return { success: true, text: stdout };
   } catch (e: unknown) {
     return {
       success: false,

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -63,10 +63,20 @@ export function buildPDFTextTooLargeGuidance(
   pagesUsed?: string,
 ): string {
   const pageRange = pagesUsed ? parsePDFPageRange(pagesUsed) : null;
+  const prefix = `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}).`;
   if (pageRange && pageRange.firstPage === pageRange.lastPage) {
-    return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.`;
+    return `${prefix} The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.`;
   }
-  return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.`;
+  if (pageRange) {
+    const suggestedEnd = Math.floor(
+      (pageRange.firstPage + pageRange.lastPage) / 2,
+    );
+    if (suggestedEnd === pageRange.firstPage) {
+      return `${prefix} Use the 'pages' parameter with a single page, for example '${pageRange.firstPage}'.`;
+    }
+    return `${prefix} Use the 'pages' parameter with fewer pages, for example '${pageRange.firstPage}-${suggestedEnd}' or a single page.`;
+  }
+  return `${prefix} Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.`;
 }
 
 /**

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -62,7 +62,8 @@ export function buildPDFTextTooLargeGuidance(
   estimatedTokens: number,
   pagesUsed?: string,
 ): string {
-  if (pagesUsed && /^\d+$/.test(pagesUsed.trim())) {
+  const pageRange = pagesUsed ? parsePDFPageRange(pagesUsed) : null;
+  if (pageRange && pageRange.firstPage === pageRange.lastPage) {
     return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.`;
   }
   return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.`;

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile, type ExecFileOptions } from 'node:child_process';
+import { estimateTextTokens } from './request-tokenizer/textTokenizer.js';
 
 const MAX_PDF_TEXT_OUTPUT_CHARS = 100000;
 export const PDF_FULL_TEXT_PAGE_LIMIT = 10;
@@ -13,6 +14,8 @@ export const PDF_PAGE_COUNT_SIZE_HEURISTIC_BYTES = 100 * 1024;
 export const PDF_TEXT_RESULT_MAX_TOKENS = 12_000;
 const PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS = 64;
 const PDF_TEXT_RESULT_CHARS_PER_TOKEN = 4;
+export const PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE =
+  'pdftotext is not installed. Install poppler-utils to enable PDF text extraction (e.g. `apt-get install poppler-utils` or `brew install poppler`).';
 // Upper bound on a page number we're willing to forward to pdftotext.
 // Sits well below Number.MAX_SAFE_INTEGER so arithmetic in validation
 // (e.g. lastPage - firstPage + 1) stays exact, and well above any real
@@ -41,8 +44,8 @@ export function shouldRequirePDFPageRange(
 
 export function estimatePDFTextOutputTokens(text: string): number {
   return Math.ceil(
-    (text.length + PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS) /
-      PDF_TEXT_RESULT_CHARS_PER_TOKEN,
+    estimateTextTokens(text) +
+      PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS / PDF_TEXT_RESULT_CHARS_PER_TOKEN,
   );
 }
 
@@ -57,7 +60,11 @@ export function buildLargePDFGuidance(
 export function buildPDFTextTooLargeGuidance(
   displayName: string,
   estimatedTokens: number,
+  pagesUsed?: string,
 ): string {
+  if (pagesUsed && /^\d+$/.test(pagesUsed.trim())) {
+    return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). The selected page exceeds the output limit. Use a native PDF-capable model, split the page content externally, or extract a smaller section with another tool.`;
+  }
   return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.`;
 }
 
@@ -276,8 +283,7 @@ export async function extractPDFText(
   if (!available) {
     return {
       success: false,
-      error:
-        'pdftotext is not installed. Install poppler-utils to enable PDF text extraction (e.g. `apt-get install poppler-utils` or `brew install poppler`).',
+      error: PDF_TEXT_EXTRACTION_UNAVAILABLE_MESSAGE,
     };
   }
 

--- a/packages/core/src/utils/pdf.ts
+++ b/packages/core/src/utils/pdf.ts
@@ -7,11 +7,59 @@
 import { execFile, type ExecFileOptions } from 'node:child_process';
 
 const MAX_PDF_TEXT_OUTPUT_CHARS = 100000;
+export const PDF_FULL_TEXT_PAGE_LIMIT = 10;
+export const PDF_MAX_PAGES_PER_READ = 20;
+export const PDF_PAGE_COUNT_SIZE_HEURISTIC_BYTES = 100 * 1024;
+export const PDF_TEXT_RESULT_MAX_TOKENS = 12_000;
+const PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS = 64;
+const PDF_TEXT_RESULT_CHARS_PER_TOKEN = 4;
 // Upper bound on a page number we're willing to forward to pdftotext.
 // Sits well below Number.MAX_SAFE_INTEGER so arithmetic in validation
 // (e.g. lastPage - firstPage + 1) stays exact, and well above any real
 // PDF (the current world record is roughly 86,000 pages).
 const MAX_PDF_PAGE_NUMBER = 1_000_000;
+
+export interface PDFPageRangeRequirement {
+  required: boolean;
+  effectivePageCount: number;
+  hadPdfInfo: boolean;
+}
+
+export function shouldRequirePDFPageRange(
+  pageCount: number | null,
+  sizeBytes: number,
+): PDFPageRangeRequirement {
+  const hadPdfInfo = pageCount !== null;
+  const effectivePageCount =
+    pageCount ?? Math.ceil(sizeBytes / PDF_PAGE_COUNT_SIZE_HEURISTIC_BYTES);
+  return {
+    required: effectivePageCount > PDF_FULL_TEXT_PAGE_LIMIT,
+    effectivePageCount,
+    hadPdfInfo,
+  };
+}
+
+export function estimatePDFTextOutputTokens(text: string): number {
+  return Math.ceil(
+    (text.length + PDF_TEXT_RESULT_WRAPPER_TOKEN_CHARS) /
+      PDF_TEXT_RESULT_CHARS_PER_TOKEN,
+  );
+}
+
+export function buildLargePDFGuidance(
+  displayName: string,
+  requirement: PDFPageRangeRequirement,
+): string {
+  const source = requirement.hadPdfInfo ? 'has' : 'appears to have about';
+  return `PDF "${displayName}" ${source} ${requirement.effectivePageCount} pages, which is too many to read at once. Use the 'pages' parameter to read a specific page range such as '1-5'. Maximum ${PDF_MAX_PAGES_PER_READ} pages per request.`;
+}
+
+export function buildPDFTextTooLargeGuidance(
+  displayName: string,
+  estimatedTokens: number,
+): string {
+  return `PDF text extracted from "${displayName}" is too large to return safely (${estimatedTokens} estimated tokens; limit ${PDF_TEXT_RESULT_MAX_TOKENS}). Use the 'pages' parameter with a narrower range, for example '1-2' or a single page.`;
+}
 
 /**
  * Lightweight wrapper around execFile that returns { stdout, stderr, code,
@@ -210,7 +258,7 @@ export async function getPDFPageCount(
 }
 
 export type PDFTextResult =
-  | { success: true; text: string }
+  | { success: true; text: string; truncated?: boolean }
   | { success: false; error: string };
 
 /**
@@ -273,6 +321,7 @@ export async function extractPDFText(
     if (maxBufferExceeded && stdout.length >= MAX_PDF_TEXT_OUTPUT_CHARS) {
       return {
         success: true,
+        truncated: true,
         text:
           stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS) +
           `\n\n... [text truncated at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters. Use the 'pages' parameter to read specific page ranges.]`,
@@ -310,13 +359,14 @@ export async function extractPDFText(
     if (stdout.length > MAX_PDF_TEXT_OUTPUT_CHARS) {
       return {
         success: true,
+        truncated: true,
         text:
           stdout.substring(0, MAX_PDF_TEXT_OUTPUT_CHARS) +
           `\n\n... [text truncated at ${MAX_PDF_TEXT_OUTPUT_CHARS} characters. Use the 'pages' parameter to read specific page ranges.]`,
       };
     }
 
-    return { success: true, text: stdout };
+    return { success: true, text: stdout, truncated: false };
   } catch (e: unknown) {
     return {
       success: false,

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -236,7 +236,7 @@ describe('readManyFiles', () => {
       expect(content.length).toBeLessThan(1000);
       expect(mockGetPDFPageCount).toHaveBeenCalledTimes(1);
       expect(mockGetPDFPageCount).toHaveBeenCalledWith(absolutePath);
-      expect(mockIsPdftotextAvailable).toHaveBeenCalledTimes(1);
+      expect(mockIsPdftotextAvailable).not.toHaveBeenCalled();
 
       const status = cache.check(nodeFs.statSync(absolutePath));
       expect(status.state).toBe('fresh');

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import * as nodeFs from 'node:fs';
 import path from 'node:path';
@@ -17,6 +17,17 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { FileReadCache } from '../services/fileReadCache.js';
 import { checkPriorRead } from '../tools/priorReadEnforcement.js';
+import { getPDFPageCount } from './pdf.js';
+
+vi.mock('./pdf.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./pdf.js')>();
+  return {
+    ...actual,
+    getPDFPageCount: vi.fn(),
+  };
+});
+
+const mockGetPDFPageCount = vi.mocked(getPDFPageCount);
 
 /** Helper to convert PartListUnion to string for test assertions */
 function contentToString(parts: PartListUnion): string {
@@ -90,6 +101,8 @@ describe('readManyFiles', () => {
   }
 
   beforeEach(async () => {
+    mockGetPDFPageCount.mockReset();
+    mockGetPDFPageCount.mockResolvedValue(null);
     tempRootDir = nodeFs.realpathSync(
       await fs.mkdtemp(path.join(os.tmpdir(), 'read-many-files-test-')),
     );
@@ -205,6 +218,7 @@ describe('readManyFiles', () => {
       const relativePath = 'paper.pdf';
       const absolutePath = path.join(tempRootDir, relativePath);
       await fs.writeFile(absolutePath, Buffer.alloc(2 * 1024 * 1024));
+      mockGetPDFPageCount.mockResolvedValueOnce(31);
       const cache = new FileReadCache();
       const mockConfig = createMockConfigWithCache(tempRootDir, cache);
 
@@ -216,6 +230,8 @@ describe('readManyFiles', () => {
       expect(result.files[0]!.content).toContain('PDF "paper.pdf"');
       expect(content).toContain("Use the 'pages' parameter");
       expect(content.length).toBeLessThan(1000);
+      expect(mockGetPDFPageCount).toHaveBeenCalledTimes(1);
+      expect(mockGetPDFPageCount).toHaveBeenCalledWith(absolutePath);
 
       const status = cache.check(nodeFs.statSync(absolutePath));
       expect(status.state).toBe('fresh');

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -201,6 +201,29 @@ describe('readManyFiles', () => {
       expect(result.files[0]!.content).toContain('Unsupported image file');
     });
 
+    it('references large PDFs instead of inlining extracted text for @ attachments', async () => {
+      const relativePath = 'paper.pdf';
+      const absolutePath = path.join(tempRootDir, relativePath);
+      await fs.writeFile(absolutePath, Buffer.alloc(2 * 1024 * 1024));
+      const cache = new FileReadCache();
+      const mockConfig = createMockConfigWithCache(tempRootDir, cache);
+
+      const result = await readManyFiles(mockConfig, { paths: [relativePath] });
+      const content = contentToString(result.contentParts);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]!.error).toBeUndefined();
+      expect(result.files[0]!.content).toContain('PDF "paper.pdf"');
+      expect(content).toContain("Use the 'pages' parameter");
+      expect(content.length).toBeLessThan(1000);
+
+      const status = cache.check(nodeFs.statSync(absolutePath));
+      expect(status.state).toBe('fresh');
+      if (status.state === 'fresh') {
+        expect(status.entry.lastReadCacheable).toBe(false);
+      }
+    });
+
     it('should return message when no files found', async () => {
       const mockConfig = createMockConfig(tempRootDir);
 

--- a/packages/core/src/utils/readManyFiles.test.ts
+++ b/packages/core/src/utils/readManyFiles.test.ts
@@ -17,17 +17,19 @@ import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
 import { FileReadCache } from '../services/fileReadCache.js';
 import { checkPriorRead } from '../tools/priorReadEnforcement.js';
-import { getPDFPageCount } from './pdf.js';
+import { getPDFPageCount, isPdftotextAvailable } from './pdf.js';
 
 vi.mock('./pdf.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./pdf.js')>();
   return {
     ...actual,
     getPDFPageCount: vi.fn(),
+    isPdftotextAvailable: vi.fn(),
   };
 });
 
 const mockGetPDFPageCount = vi.mocked(getPDFPageCount);
+const mockIsPdftotextAvailable = vi.mocked(isPdftotextAvailable);
 
 /** Helper to convert PartListUnion to string for test assertions */
 function contentToString(parts: PartListUnion): string {
@@ -103,6 +105,8 @@ describe('readManyFiles', () => {
   beforeEach(async () => {
     mockGetPDFPageCount.mockReset();
     mockGetPDFPageCount.mockResolvedValue(null);
+    mockIsPdftotextAvailable.mockReset();
+    mockIsPdftotextAvailable.mockResolvedValue(true);
     tempRootDir = nodeFs.realpathSync(
       await fs.mkdtemp(path.join(os.tmpdir(), 'read-many-files-test-')),
     );
@@ -232,6 +236,7 @@ describe('readManyFiles', () => {
       expect(content.length).toBeLessThan(1000);
       expect(mockGetPDFPageCount).toHaveBeenCalledTimes(1);
       expect(mockGetPDFPageCount).toHaveBeenCalledWith(absolutePath);
+      expect(mockIsPdftotextAvailable).toHaveBeenCalledTimes(1);
 
       const status = cache.check(nodeFs.statSync(absolutePath));
       expect(status.state).toBe('fresh');

--- a/packages/core/src/utils/readManyFiles.ts
+++ b/packages/core/src/utils/readManyFiles.ts
@@ -194,6 +194,7 @@ async function readFileContent(
   try {
     const fileReadResult = await processSingleFileContent(filePath, config, {
       preserveUnsupportedImage,
+      largePdfBehavior: 'reference',
     });
 
     const prefixText: Part = { text: `\nContent from ${filePath}:\n` };

--- a/packages/core/src/utils/request-tokenizer/textTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.ts
@@ -14,6 +14,27 @@
  * - ASCII characters: 0.25 tokens per char (4 chars = 1 token)
  * - Non-ASCII characters: 1.1 tokens per char (conservative for CJK, emoji, etc.)
  */
+export function estimateTextTokens(text: string): number {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+
+  let asciiChars = 0;
+  let nonAsciiChars = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const charCode = text.charCodeAt(i);
+    if (charCode < 128) {
+      asciiChars++;
+    } else {
+      nonAsciiChars++;
+    }
+  }
+
+  const tokens = asciiChars / 4 + nonAsciiChars * 1.1;
+  return Math.ceil(tokens);
+}
+
 export class TextTokenizer {
   /**
    * Calculate tokens for text content
@@ -36,23 +57,6 @@ export class TextTokenizer {
   }
 
   private calculateTokensSync(text: string): number {
-    if (!text || text.length === 0) {
-      return 0;
-    }
-
-    let asciiChars = 0;
-    let nonAsciiChars = 0;
-
-    for (let i = 0; i < text.length; i++) {
-      const charCode = text.charCodeAt(i);
-      if (charCode < 128) {
-        asciiChars++;
-      } else {
-        nonAsciiChars++;
-      }
-    }
-
-    const tokens = asciiChars / 4 + nonAsciiChars * 1.1;
-    return Math.ceil(tokens);
+    return estimateTextTokens(text);
   }
 }


### PR DESCRIPTION
## What this PR does

This PR adds a PDF read budget policy so text-only PDF handling no longer injects full large-document extraction results into the prompt. Large full-PDF text fallback now returns short guidance to use the `pages` parameter, `@`-attached large PDFs become lightweight references instead of failed reads, and explicit page-range extraction remains supported with an additional token guard for dense pages.

## Why it's needed

A user reported that reading a 100-page PDF with a text-only model produced a context overflow after automatic compression. The root cause was that the PDF fallback extracted roughly 100k characters with `pdftotext`, which could push the next request past the hard prompt safety limit before the model had a chance to recover. Keeping large PDFs as references and requiring explicit page ranges prevents that oversized tool result from entering conversation context.

## Reviewer Test Plan

### How to verify

Run the focused PDF/read tests and confirm they pass. Attach a large PDF on a text-only model and confirm the attachment contributes a short reference that tells the model to call `read_file` with `pages`; call `read_file` on the same PDF without `pages` and confirm it returns a short `file_too_large` error; call `read_file` with a narrow `pages` range and confirm text extraction still works unless the extracted page range exceeds the new output budget.

### Evidence (Before & After)

Before: the reported 100-page PDF produced about 100k characters of extracted text and the next request failed with `Context is too large to send safely after automatic compression`. After: local validation against the same PDF returns a 174-character reference for `@` attachment behavior, a 174-character `file_too_large` guidance for no-pages `read_file`, and still allows `pages: "1"` extraction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.3 on macOS. Validation used `npx vitest run src/utils/pdf.test.ts src/utils/fileUtils.test.ts src/utils/readManyFiles.test.ts src/tools/read-file.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run build && npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: text-only models now require explicit `pages` ranges for PDFs above the full-text page limit, so some previously accepted full-document reads become short guidance responses.
- Not validated / out of scope: OCR, rendering PDF pages as images, changing auto-compaction thresholds, and changing edit authorization semantics for PDF reads are out of scope.
- Breaking changes / migration notes: no API migration is required; native PDF-capable model behavior is preserved, and explicit `pages` reads remain supported with the existing 20-page request limit.

## Linked Issues

Closes #6408

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 增加了 PDF 读取预算策略，避免纯文本 PDF 处理把大型文档的完整提取结果注入 prompt。大型 PDF 的全文文本回退现在会返回简短 guidance，引导使用 `pages` 参数；通过 `@` 附加的大型 PDF 会变成轻量 reference，而不是失败读取；显式 page-range 提取仍然支持，并额外增加了针对高密度页面文本的 token guard。

## Why it's needed

用户反馈在纯文本模型下读取一个 100 页 PDF 后，自动压缩之后仍然出现上下文溢出。根因是 PDF fallback 通过 `pdftotext` 提取了约 100k 字符，导致下一次请求在模型有机会恢复前就超过 hard prompt safety limit。把大型 PDF 保持为 reference，并要求显式页码范围，可以避免这种过大的 tool result 进入对话上下文。

## Reviewer Test Plan

### How to verify

运行聚焦的 PDF/read 测试并确认通过。在纯文本模型下附加大型 PDF，确认附件只贡献一段简短 reference，并提示模型使用带 `pages` 的 `read_file`；对同一 PDF 调用不带 `pages` 的 `read_file`，确认返回简短的 `file_too_large` 错误；再用较窄的 `pages` 范围调用 `read_file`，确认文本提取仍然可用，除非该页码范围的提取文本超过新的输出预算。

### Evidence (Before & After)

Before：反馈中的 100 页 PDF 会产生约 100k 字符的提取文本，下一次请求失败并报 `Context is too large to send safely after automatic compression`。After：对同一个 PDF 的本地验证中，`@` 附件行为返回 174 字符 reference，不带 `pages` 的 `read_file` 返回 174 字符 `file_too_large` guidance，同时 `pages: "1"` 仍然可以进行文本提取。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 上的 Node.js v22.22.3。验证使用了 `npx vitest run src/utils/pdf.test.ts src/utils/fileUtils.test.ts src/utils/readManyFiles.test.ts src/tools/read-file.test.ts`、`npm run lint`、`npm run typecheck`，以及 `npm run build && npm run typecheck`。

## Risk & Scope

- Main risk or tradeoff：纯文本模型现在会要求超过全文页数限制的 PDF 使用显式 `pages` 范围，因此部分过去可接受的全文读取会变成简短 guidance 响应。
- Not validated / out of scope：OCR、将 PDF 页面渲染为图片、修改自动压缩阈值、修改 PDF 读取的编辑授权语义都不在本次范围内。
- Breaking changes / migration notes：不需要 API 迁移；支持原生 PDF 的模型行为保持不变，显式 `pages` 读取仍然支持，并保留现有的每次请求 20 页限制。

## Linked Issues

Closes #6408

</details>
