### PR TITLE
docs: document PreToolUse hook permissionDecision "ask" behavior

### DIFF
--- a/docs/users/features/hooks.md
+++ b/docs/users/features/hooks.md
@@ -396,6 +396,12 @@ Hook output supports three categories of fields:
 - `hookSpecificOutput.updatedInput`: modified tool input parameters to use instead of original
 - `hookSpecificOutput.additionalContext`: additional context information
 
+The `permissionDecision` value controls whether the tool runs:
+
+- `"allow"` — run the tool without the usual approval prompt.
+- `"deny"` — block the tool; it does not execute and an error is returned to the model.
+- `"ask"` — pause and ask the user to confirm the tool call in the TUI before it runs. Confirming runs the tool once; declining cancels it. In contexts that cannot prompt for confirmation — headless (`--prompt`) runs and background subagents — `"ask"` falls back to `"deny"`.
+
 **Note**: While standard hook output fields like `decision` and `reason` are technically supported by the underlying class, the official interface expects the `hookSpecificOutput` with `permissionDecision` and `permissionDecisionReason`.
 
 **Example Output**:


### PR DESCRIPTION
## What this PR does

Documents what each `permissionDecision` value does for a `PreToolUse` hook in `docs/users/features/hooks.md`. The doc already lists `"allow"`, `"deny"`, and `"ask"` as the allowed values but never explained their behavior — most importantly `"ask"`, which now pauses the tool and surfaces a TUI confirmation before the tool runs, and falls back to `"deny"` in contexts that cannot prompt (headless `--prompt` runs and background subagents).

## Why it's needed

A `PreToolUse` hook returning `permissionDecision: "ask"` recently changed from behaving like `"deny"` to actually prompting the user for confirmation. A hook author reading the docs had no way to know what `"ask"` does or that it degrades to `"deny"` in non-interactive contexts, so a security-conscious hook could not choose between `"deny"` and `"ask"` intentionally. The added description makes the three values' semantics explicit, matching the current runtime behavior.

## Reviewer Test Plan

### How to verify

Cross-check the added description against the source of truth:
- `"ask"` bounces the tool from execution back to awaiting-approval and builds a synthetic confirmation — see `bounceToAwaitingApprovalForAsk` in `packages/core/src/core/coreToolScheduler.ts` (ProceedOnce re-executes, Cancel cancels).
- The non-interactive fallback to deny — see `canPromptForAskBounce` in the same file: a non-interactive CLI (unless `STREAM_JSON`), background agents, and suppressed permission prompts return `false`, so `"ask"` becomes deny there.

Docs-only change — no runtime behavior is affected. No pages were added, moved, or renamed, so navigation (`_meta.ts`) and the `qc-helper` doc index are unchanged.

### Evidence (Before & After)

N/A — documentation-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: None beyond documentation accuracy; no code paths change.
- Not validated / out of scope: Only the `PreToolUse` `permissionDecision` semantics are documented; the `decision`/`"ask"` fields on other hook events were not expanded.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在 `docs/users/features/hooks.md` 中补充说明 `PreToolUse` 钩子的 `permissionDecision` 各取值的行为。文档此前已列出 `"allow"`、`"deny"`、`"ask"` 三个允许值，但从未说明其行为——尤其是 `"ask"`：它现在会暂停工具调用并在 TUI 中弹出确认，在无法弹出确认的场景（headless `--prompt` 运行与后台子代理）中回退为 `"deny"`。

## 为什么需要

`PreToolUse` 钩子返回 `permissionDecision: "ask"` 的行为近期从“等同 `"deny"`”变为“真正提示用户确认”。文档读者无法得知 `"ask"` 的作用，也不知道它在非交互场景会退化为 `"deny"`，因此安全敏感的钩子无法有意识地在 `"deny"` 与 `"ask"` 之间选择。新增的说明使三个取值的语义明确，并与当前运行时行为一致。

## 复核测试计划

仅文档改动，不影响运行时行为。未新增、移动或重命名任何页面，因此导航（`_meta.ts`）与 `qc-helper` 文档索引无需改动。对照 `packages/core/src/core/coreToolScheduler.ts` 中的 `bounceToAwaitingApprovalForAsk` 与 `canPromptForAskBounce` 即可核对。

### 证据（前后对比）

N/A —— 纯文档改动。

## 风险与范围

- 主要风险：无，除文档准确性外不涉及任何代码路径。
- 未覆盖 / 超出范围：仅记录了 `PreToolUse` 的 `permissionDecision` 语义，未扩展其他钩子事件上的 `decision`/`"ask"` 字段。
- 破坏性变更 / 迁移说明：无。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaAuWXeZsnLnxm7Q3S8kLQ)_