### PR TITLE
fix(core): align monitor limit parameter schemas

### DIFF
--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -238,6 +238,17 @@ describe('MonitorTool', () => {
       }
     ).createInvocation(params);
 
+  describe('schema', () => {
+    it('declares monitor limits as integers', () => {
+      const schema = monitorTool.schema.parametersJsonSchema as {
+        properties?: Record<string, { type?: string }>;
+      };
+
+      expect(schema.properties?.['max_events']?.type).toBe('integer');
+      expect(schema.properties?.['idle_timeout_ms']?.type).toBe('integer');
+    });
+  });
+
   describe('confirmation details', () => {
     it('includes command-scoped permission rules for monitor commands', async () => {
       const invocation = createInvocation({

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -510,6 +510,12 @@ describe('MonitorTool', () => {
       );
     });
 
+    it('rejects fractional max_events', () => {
+      expect(validate({ command: 'tail -f log', max_events: 1.5 })).toBe(
+        'max_events must be a positive integer.',
+      );
+    });
+
     it('rejects max_events over limit', () => {
       expect(validate({ command: 'tail -f log', max_events: 20000 })).toBe(
         'max_events cannot exceed 10000.',
@@ -518,6 +524,12 @@ describe('MonitorTool', () => {
 
     it('rejects invalid idle_timeout_ms', () => {
       expect(validate({ command: 'tail -f log', idle_timeout_ms: -100 })).toBe(
+        'idle_timeout_ms must be a positive integer.',
+      );
+    });
+
+    it('rejects fractional idle_timeout_ms', () => {
+      expect(validate({ command: 'tail -f log', idle_timeout_ms: 500.5 })).toBe(
         'idle_timeout_ms must be a positive integer.',
       );
     });

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -696,12 +696,12 @@ export class MonitorTool extends BaseDeclarativeTool<
               'Brief description of what this monitor watches (e.g., "webpack build output"). Truncated to 80 characters in display.',
           },
           max_events: {
-            type: 'number',
+            type: 'integer',
             description:
               'Stop the monitor after this many events. Default 1000. Max 10000.',
           },
           idle_timeout_ms: {
-            type: 'number',
+            type: 'integer',
             description:
               'Stop the monitor if no output for this many milliseconds. Default 300000 (5 min). Max 600000.',
           },

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -734,6 +734,8 @@ export class MonitorTool extends BaseDeclarativeTool<
     if (hasUnsafeMonitorBackgroundOperator(params.command)) {
       return 'Monitor commands must not contain non-final top-level background operators. Remove "&" and let the monitor manage process lifetime.';
     }
+    // AJV enforces type: 'integer' from the schema. This method adds
+    // range checks (min/max) that the schema does not express.
     if (params.max_events !== undefined) {
       if (
         typeof params.max_events !== 'number' ||


### PR DESCRIPTION
﻿This is mostly a schema-alignment PR rather than a runtime bug fix. The monitor runtime validator already rejects fractional values for these fields, so maintainers should feel free to accept this as a small consistency improvement or close it if the current runtime-only guard is considered sufficient.

## What this PR does

This PR changes the monitor tool schema for `max_events` and `idle_timeout_ms` from `number` to `integer`, matching the validation behavior that already requires both values to be positive integers. It also adds a focused schema assertion so the declaration stays aligned with the runtime validation contract.

## Why it's needed

`max_events` and `idle_timeout_ms` are discrete limits: one is an event count, and the other is a millisecond timeout value. The monitor validator already treats them that way by rejecting non-integer values with `max_events must be a positive integer.` and `idle_timeout_ms must be a positive integer.`

Before this change, the public tool schema still exposed both fields as `number`. That could make tool callers believe fractional values were schema-valid even though the monitor tool would reject them at runtime. This PR makes the schema describe the same contract that the validator already enforces.

This does not expand monitor behavior or change process lifetime handling. It only tightens the declared parameter shape for values that were already invalid at the tool boundary.

## Reviewer Test Plan

### How to verify

A reviewer can confirm that the monitor schema now declares `max_events` and `idle_timeout_ms` as `integer`, while the existing runtime validation still rejects invalid fractional or non-positive values. The new unit test covers the schema contract directly, and the existing monitor validation tests continue to cover the runtime guard.

### Evidence (Before & After)

Before:

```ts
max_events: {
  type: 'number',
}
idle_timeout_ms: {
  type: 'number',
}
```

After:

```ts
max_events: {
  type: 'integer',
}
idle_timeout_ms: {
  type: 'integer',
}
```

Runtime behavior was already protected by `Number.isInteger(...)`, so the visible behavior for invalid fractional values is unchanged: they remain rejected.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍎 macOS  | ⚪ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Windows local validation used Node.js `v24.15.0` / npm `11.12.1`. WSL validation used Ubuntu-22.04 with Node.js `v24.15.0` / npm `11.12.1`.

Commands run on Windows:

```text
cd packages/core && npx vitest run src/tools/monitor.test.ts
npm run build --workspace=packages/core
git diff --check
```

Results on Windows:

```text
src/tools/monitor.test.ts: 74 tests passed
packages/core build: passed
git diff --check: passed
```

Commands run on WSL Ubuntu-22.04:

```text
cd packages/core && npx vitest run src/tools/monitor.test.ts --pool forks --poolOptions.forks.singleFork=true
npm run build --workspace=packages/core
```

Results on WSL Ubuntu-22.04:

```text
src/tools/monitor.test.ts: 74 tests passed
packages/core build: passed
```

## Risk & Scope

- Main risk or tradeoff: Very low. This only aligns schema metadata with existing validation, but it may make fractional tool calls fail earlier during schema-aware generation/validation instead of reaching the monitor validator.
- Not validated / out of scope: macOS local runs were not performed. No TUI/media evidence is included because this is a schema metadata alignment with no UI behavior change.
- Breaking changes / migration notes: No supported integer usage changes. Fractional values were already rejected by runtime validation.

## Linked Issues

N/A — no linked issue. This is a small consistency cleanup discovered during local tool-schema review.

<details>
<summary>中文说明</summary>

这更多是一个 schema 对齐 PR，而不是运行时 bug 修复。monitor 的运行时校验已经会拒绝小数，所以 maintainer 如果认为当前运行时保护已经足够，也完全可以不接受这个 PR。

## What this PR does

这个 PR 将 monitor 工具的 `max_events` 和 `idle_timeout_ms` schema 从 `number` 改成 `integer`，使它们和已有运行时校验保持一致。PR 也补了一个聚焦的 schema 断言，防止后续声明再次和校验语义分离。

## Why it's needed

`max_events` 和 `idle_timeout_ms` 都是离散限制：一个是事件数量，另一个是毫秒超时时间。monitor validator 当前已经通过 `Number.isInteger(...)` 要求它们必须是正整数，并会返回 `max_events must be a positive integer.` / `idle_timeout_ms must be a positive integer.`。

修改前，公开 tool schema 仍然把这两个字段声明为 `number`。这会让 schema-aware 的调用方误以为小数是合法输入，但运行时又会拒绝它们。这个 PR 只是让 schema 描述和 validator 已经执行的契约一致。

这不会扩展 monitor 行为，也不会改变后台进程生命周期管理。它只收紧两个本来就不合法的参数声明。

## Reviewer Test Plan

### How to verify

Reviewer 可以确认 monitor schema 现在将 `max_events` 和 `idle_timeout_ms` 声明为 `integer`，同时现有运行时校验仍然拒绝非法小数或非正数。新增测试直接覆盖 schema 契约，已有 monitor validation 测试继续覆盖运行时保护。

### Evidence (Before & After)

修改前：两个字段声明为 `number`。修改后：两个字段声明为 `integer`。运行时行为本来就由 `Number.isInteger(...)` 保护，因此非法小数的可见行为不变，仍然会被拒绝。

### Tested on

Windows 和 WSL Ubuntu-22.04 已测试；macOS 未本地测试。Windows 验证命令为 `cd packages/core && npx vitest run src/tools/monitor.test.ts`、`npm run build --workspace=packages/core`、`git diff --check`，结果均通过。WSL Ubuntu-22.04 验证命令为 `cd packages/core && npx vitest run src/tools/monitor.test.ts --pool forks --poolOptions.forks.singleFork=true`、`npm run build --workspace=packages/core`，结果均通过。

## Risk & Scope

主要风险很低：这只让 schema metadata 和已有 validation 对齐。唯一变化是 schema-aware 的调用链可能更早识别小数输入非法，而不是等到 monitor validator 再拒绝。没有支持的整数用法会改变，小数值此前也已经不是有效输入。

## Linked Issues

N/A — 这是本地 tool-schema review 中发现的小一致性修复，没有关联 issue。

</details>