### PR TITLE
fix(autofix): report review handoff failures

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1409,7 +1409,7 @@ jobs:
               echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
               echo
               echo "**Failure:**"
-              head -c 1500 "${WORKDIR}/failure.md"
+              head -c 1500 "${WORKDIR}/failure.md" | sed 's/<!--[^>]*-->//g'
               echo
               echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} -->"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1281,7 +1281,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               cat "${WORKDIR}/${f}"
@@ -1391,7 +1391,7 @@ jobs:
             echo "### PR #${PR} (issue #${ISSUE}) — outcome=${OUTCOME:-unknown}${SUFFIX}"
             echo "- Base conflict: ${CONFLICT:-unknown}"
             echo
-            for f in address-summary.md no-action.md failure.md; do
+            for f in address-summary.md no-action.md failure.md handoff.md; do
               if [[ -s "${WORKDIR}/${f}" ]]; then
                 echo "**${f}:**"
                 cat "${WORKDIR}/${f}"
@@ -1400,7 +1400,7 @@ jobs:
             done
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          if [[ "${DRY_RUN}" != "true" && "${OUTCOME:-unknown}" == "failed" && -n "${NEWEST:-}" && -n "${GITHUB_TOKEN:-}" && -s "${WORKDIR}/failure.md" ]]; then
+          if [[ "${DRY_RUN}" != "true" && "${OUTCOME:-unknown}" == "failed" && -n "${NEWEST:-}" && -n "${GITHUB_TOKEN:-}" && -s "${WORKDIR}/handoff.md" ]]; then
             {
               echo "🤖 Could not address the latest review feedback automatically."
               echo

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1382,6 +1382,8 @@ jobs:
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
+          GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+          NEWEST: '${{ steps.prepare.outputs.newest }}'
         run: |-
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
@@ -1397,3 +1399,20 @@ jobs:
               fi
             done
           } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${DRY_RUN}" != "true" && "${OUTCOME:-unknown}" == "failed" && -n "${NEWEST:-}" && -n "${GITHUB_TOKEN:-}" && -s "${WORKDIR}/failure.md" ]]; then
+            {
+              echo "🤖 Could not address the latest review feedback automatically."
+              echo
+              echo "The feedback was evaluated, but AutoFix failed before producing a verified commit. A human should take over this PR."
+              echo
+              echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo
+              echo "**Failure:**"
+              head -c 1500 "${WORKDIR}/failure.md"
+              echo
+              echo
+              echo "<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} -->"
+            } > "${WORKDIR}/report.md"
+            gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || true
+          fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1401,6 +1401,19 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
           if [[ "${DRY_RUN}" != "true" && "${OUTCOME:-unknown}" == "failed" && -n "${NEWEST:-}" && -n "${GITHUB_TOKEN:-}" && -s "${WORKDIR}/handoff.md" ]]; then
+            api_error_file="$(mktemp)"
+            if ! bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2>"${api_error_file}")"; then
+              api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+              rm -f "${api_error_file}"
+              echo "::error::Failed to verify CI_DEV_BOT_PAT identity with gh api user: ${api_error:-unknown error}."
+              exit 1
+            fi
+            rm -f "${api_error_file}"
+            echo "CI_DEV_BOT_PAT authenticates as ${bot_actor}"
+            if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
+              echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
+              exit 1
+            fi
             {
               echo "🤖 Could not address the latest review feedback automatically."
               echo
@@ -1414,5 +1427,5 @@ jobs:
               echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} -->"
             } > "${WORKDIR}/report.md"
-            gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || true
+            gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || echo "::warning::Failed to post handoff comment on PR #${PR}"
           fi

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import {
+  createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -66,6 +67,67 @@ function writeFailure(workdir, message) {
   );
 }
 
+function writeHandoff(workdir, message) {
+  mkdirSync(workdir, { recursive: true });
+  writeFileSync(file(workdir, 'handoff.md'), `${message}\n`);
+}
+
+function isLoopGuardOutput(output) {
+  return (
+    output.includes('turn_tool_call_cap') ||
+    output.includes('Loop detection halted the run')
+  );
+}
+
+function runQwen(options, prompt) {
+  mkdirSync(options.workdir, { recursive: true });
+  const log = createWriteStream(file(options.workdir, 'agent.log'), {
+    flags: 'w',
+  });
+  let outputTail = '';
+  let settled = false;
+  let timedOut = false;
+  let timer;
+
+  return new Promise((resolve) => {
+    const child = spawn(options.qwenBin, ['--yolo', '--prompt', prompt], {
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      log.end(() => {
+        resolve({
+          ...result,
+          timedOut,
+          loopDetected: isLoopGuardOutput(outputTail),
+        });
+      });
+    };
+
+    const record = (chunk, stream) => {
+      const text = chunk.toString('utf8');
+      outputTail = (outputTail + text).slice(-20_000);
+      log.write(chunk);
+      stream.write(chunk);
+    };
+
+    child.stdout.on('data', (chunk) => record(chunk, process.stdout));
+    child.stderr.on('data', (chunk) => record(chunk, process.stderr));
+    child.on('error', (error) => finish({ error, status: null, signal: null }));
+    child.on('close', (status, signal) =>
+      finish({ error: null, status, signal }),
+    );
+
+    timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, QWEN_TIMEOUT_MS);
+  });
+}
+
 function promptFor(options, spec) {
   const skill = readFileSync(skillPath, 'utf8')
     .replace(/\r\n/g, '\n')
@@ -123,22 +185,36 @@ if (missingInputs.length > 0) {
   );
 }
 
-const result = spawnSync(options.qwenBin, ['--yolo', '--prompt', prompt], {
-  stdio: 'inherit',
-  timeout: QWEN_TIMEOUT_MS,
-});
+const result = await runQwen(options, prompt);
 if (result.error || result.signal || result.status !== 0) {
   const detail = result.error
     ? result.error.message
-    : result.signal
-      ? `signal ${result.signal}`
-      : `status ${String(result.status)}`;
+    : result.timedOut
+      ? `timeout (${QWEN_TIMEOUT_MS}ms)`
+      : result.signal
+        ? `signal ${result.signal}`
+        : `status ${String(result.status)}`;
   if (!existsSync(file(options.workdir, 'failure.md'))) {
-    writeFailure(
-      options.workdir,
-      `Qwen failed during ${options.mode}: ${detail}.`,
-    );
+    if (result.loopDetected) {
+      writeFailure(
+        options.workdir,
+        `Qwen hit the tool-call loop guard during ${options.mode}: turn_tool_call_cap. A human should take over this feedback batch.`,
+      );
+      writeHandoff(
+        options.workdir,
+        'Qwen hit the tool-call loop guard; a human should take over this feedback batch.',
+      );
+    } else {
+      writeFailure(
+        options.workdir,
+        `Qwen failed during ${options.mode}: ${detail}.`,
+      );
+    }
   } else {
+    writeHandoff(
+      options.workdir,
+      'The agent wrote failure.md before qwen exited; a human should take over this feedback batch.',
+    );
     console.error(
       `Qwen failed during ${options.mode}: ${detail}; preserving agent-written failure.md.`,
     );
@@ -148,6 +224,10 @@ if (result.error || result.signal || result.status !== 0) {
 
 if (existsSync(file(options.workdir, 'failure.md'))) {
   const content = readFileSync(file(options.workdir, 'failure.md'), 'utf8');
+  writeHandoff(
+    options.workdir,
+    'The agent wrote failure.md; a human should take over this feedback batch.',
+  );
   console.error(`Autofix agent wrote failure.md:\n${content}`);
   process.exit(0);
 }

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -18,7 +18,7 @@ const skillPath = resolve(
   '..',
   'SKILL.md',
 );
-const QWEN_TIMEOUT_MS = 50 * 60 * 1000;
+const QWEN_TIMEOUT_MS = Number(process.env.QWEN_TIMEOUT_MS) || 50 * 60 * 1000;
 const specs = {
   'assess-candidates': {
     inputs: ['candidates.json'],
@@ -79,6 +79,14 @@ function isLoopGuardOutput(output) {
   );
 }
 
+function killQwen(child, signal) {
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    child.kill(signal);
+  }
+}
+
 function runQwen(options, prompt) {
   mkdirSync(options.workdir, { recursive: true });
   const log = createWriteStream(file(options.workdir, 'agent.log'), {
@@ -95,6 +103,7 @@ function runQwen(options, prompt) {
   return new Promise((resolve) => {
     const child = spawn(options.qwenBin, ['--yolo', '--prompt', prompt], {
       stdio: ['inherit', 'pipe', 'pipe'],
+      detached: true,
     });
 
     const finish = (result) => {
@@ -131,9 +140,9 @@ function runQwen(options, prompt) {
 
     timer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
+      killQwen(child, 'SIGTERM');
       killTimer = setTimeout(() => {
-        if (!settled) child.kill('SIGKILL');
+        if (!settled) killQwen(child, 'SIGKILL');
       }, 10_000);
     }, QWEN_TIMEOUT_MS);
   });

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -90,6 +90,7 @@ function runQwen(options, prompt) {
   let settled = false;
   let timedOut = false;
   let timer;
+  let killTimer;
 
   return new Promise((resolve) => {
     const child = spawn(options.qwenBin, ['--yolo', '--prompt', prompt], {
@@ -100,6 +101,7 @@ function runQwen(options, prompt) {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      clearTimeout(killTimer);
       const payload = {
         ...result,
         timedOut,
@@ -130,6 +132,9 @@ function runQwen(options, prompt) {
     timer = setTimeout(() => {
       timedOut = true;
       child.kill('SIGTERM');
+      killTimer = setTimeout(() => {
+        if (!settled) child.kill('SIGKILL');
+      }, 10_000);
     }, QWEN_TIMEOUT_MS);
   });
 }
@@ -204,7 +209,7 @@ if (result.error || result.signal || result.status !== 0) {
     if (result.loopDetected) {
       writeFailure(
         options.workdir,
-        `Qwen hit the tool-call loop guard during ${options.mode}: turn_tool_call_cap. A human should take over this feedback batch.`,
+        `Qwen hit the tool-call loop guard during ${options.mode}. A human should take over this feedback batch.`,
       );
       writeHandoff(
         options.workdir,

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -100,13 +100,16 @@ function runQwen(options, prompt) {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      log.end(() => {
-        resolve({
-          ...result,
-          timedOut,
-          loopDetected: loopDetected || isLoopGuardOutput(outputTail),
-        });
-      });
+      const payload = {
+        ...result,
+        timedOut,
+        loopDetected: loopDetected || isLoopGuardOutput(outputTail),
+      };
+      if (log.destroyed) {
+        resolve(payload);
+      } else {
+        log.end(() => resolve(payload));
+      }
     };
 
     const record = (chunk, stream) => {

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -116,8 +116,8 @@ function runQwen(options, prompt) {
 
     const record = (chunk, stream) => {
       const text = chunk.toString('utf8');
-      if (!loopDetected && isLoopGuardOutput(text)) loopDetected = true;
       outputTail = (outputTail + text).slice(-20_000);
+      if (!loopDetected && isLoopGuardOutput(outputTail)) loopDetected = true;
       log.write(chunk);
       stream.write(chunk);
     };

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -84,7 +84,9 @@ function runQwen(options, prompt) {
   const log = createWriteStream(file(options.workdir, 'agent.log'), {
     flags: 'w',
   });
+  log.on('error', () => {});
   let outputTail = '';
+  let loopDetected = false;
   let settled = false;
   let timedOut = false;
   let timer;
@@ -102,13 +104,14 @@ function runQwen(options, prompt) {
         resolve({
           ...result,
           timedOut,
-          loopDetected: isLoopGuardOutput(outputTail),
+          loopDetected: loopDetected || isLoopGuardOutput(outputTail),
         });
       });
     };
 
     const record = (chunk, stream) => {
       const text = chunk.toString('utf8');
+      if (!loopDetected && isLoopGuardOutput(text)) loopDetected = true;
       outputTail = (outputTail + text).slice(-20_000);
       log.write(chunk);
       stream.write(chunk);

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -7,6 +7,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -895,7 +896,7 @@ describe('qwen-autofix workflow', () => {
     );
   });
 
-  it('posts a human-handoff marker when review addressing fails', () => {
+  it('posts a human-handoff marker when review addressing reaches a terminal handoff', () => {
     expect(reviewAddressReportStep).toContain(
       "GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'",
     );
@@ -903,7 +904,7 @@ describe('qwen-autofix workflow', () => {
       "NEWEST: '${{ steps.prepare.outputs.newest }}'",
     );
     expect(reviewAddressReportStep).toContain('"${DRY_RUN}" != "true"');
-    expect(reviewAddressReportStep).toContain('-s "${WORKDIR}/failure.md"');
+    expect(reviewAddressReportStep).toContain('-s "${WORKDIR}/handoff.md"');
     expect(reviewAddressReportStep).toContain(
       '<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} -->',
     );
@@ -912,6 +913,50 @@ describe('qwen-autofix workflow', () => {
     );
     expect(reviewAddressReportStep).toContain('gh pr comment "${PR}"');
     expect(reviewAddressReportStep).toContain('human should take over');
+  });
+
+  it('writes agent output to a log and marks loop guard failures for handoff', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeQwenStub(dir, [
+        "process.stderr.write('Loop detection halted the run (turn_tool_call_cap: too many tool calls)\\n');",
+        'process.exit(1);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(join(dir, 'agent.log'), 'utf8')).toContain(
+        'turn_tool_call_cap',
+      );
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'turn_tool_call_cap',
+      );
+      expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
+        'human should take over',
+      );
+    });
+  });
+
+  it('does not mark generic qwen subprocess failures for handoff', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeQwenStub(dir, [
+        "process.stderr.write('temporary upstream error\\n');",
+        'process.exit(1);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(join(dir, 'agent.log'), 'utf8')).toContain(
+        'temporary upstream error',
+      );
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'Qwen failed during address-review',
+      );
+      expect(existsSync(join(dir, 'handoff.md'))).toBe(false);
+    });
   });
 
   it('preserves agent-written failure details when the qwen subprocess fails', () => {
@@ -935,7 +980,8 @@ describe('qwen-autofix workflow', () => {
     const runner = readFileSync(autofixRunnerScriptPath, 'utf8');
 
     expect(runner).toContain('const QWEN_TIMEOUT_MS = 50 * 60 * 1000');
-    expect(runner).toContain('timeout: QWEN_TIMEOUT_MS');
+    expect(runner).toContain('setTimeout(() =>');
+    expect(runner).toContain('}, QWEN_TIMEOUT_MS)');
   });
 
   it('reports external qwen subprocess signals without calling them timeouts', () => {
@@ -994,6 +1040,9 @@ describe('qwen-autofix workflow', () => {
       expect(result.stderr).toContain('cannot proceed');
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         'cannot proceed',
+      );
+      expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
+        'human should take over',
       );
     });
   });

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1001,6 +1001,9 @@ describe('qwen-autofix workflow', () => {
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         'agent detail',
       );
+      expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
+        'human should take over',
+      );
     });
   });
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -913,13 +913,14 @@ describe('qwen-autofix workflow', () => {
     );
     expect(reviewAddressReportStep).toContain('gh pr comment "${PR}"');
     expect(reviewAddressReportStep).toContain('human should take over');
+    expect(reviewAddressReportStep).toContain("sed 's/<!--[^>]*-->//g'");
   });
 
   it('writes agent output to a log and marks loop guard failures for handoff', () => {
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
       const stub = writeQwenStub(dir, [
-        "process.stderr.write('Loop detection halted the run (turn_tool_call_cap: too many tool calls)\\n');",
+        "process.stderr.write('turn_tool_call_cap: too many tool calls\\n');",
         'process.exit(1);',
       ]);
 
@@ -929,6 +930,33 @@ describe('qwen-autofix workflow', () => {
       expect(readFileSync(join(dir, 'agent.log'), 'utf8')).toContain(
         'turn_tool_call_cap',
       );
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'turn_tool_call_cap',
+      );
+      expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
+        'human should take over',
+      );
+    });
+  });
+
+  it('handles agent log stream errors without crashing immediately', () => {
+    expect(readFileSync(autofixRunnerScriptPath, 'utf8')).toContain(
+      "log.on('error', () => {});",
+    );
+  });
+
+  it('detects loop guard output before it falls out of the log tail', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeQwenStub(dir, [
+        "process.stderr.write('Loop detection halted the run\\n');",
+        "process.stdout.write('x'.repeat(21_000));",
+        'process.exit(1);',
+      ]);
+
+      const result = runAddressReview(dir, stub);
+
+      expect(result.status).not.toBe(0);
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         'turn_tool_call_cap',
       );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1022,10 +1022,51 @@ describe('qwen-autofix workflow', () => {
   it('bounds qwen subprocess runtime', () => {
     const runner = readFileSync(autofixRunnerScriptPath, 'utf8');
 
-    expect(runner).toContain('const QWEN_TIMEOUT_MS = 50 * 60 * 1000');
+    expect(runner).toContain('50 * 60 * 1000');
     expect(runner).toContain('setTimeout(() =>');
-    expect(runner).toContain("child.kill('SIGKILL')");
+    expect(runner).toContain("killQwen(child, 'SIGKILL')");
     expect(runner).toContain('}, QWEN_TIMEOUT_MS)');
+  });
+
+  it('kills qwen subprocess descendants on timeout', () => {
+    withRunnerDir((dir) => {
+      writeFileSync(join(dir, 'feedback.md'), 'feedback\n');
+      const stub = writeQwenStub(dir, [
+        "import { spawn } from 'node:child_process';",
+        "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 3000)'], {",
+        "  stdio: ['ignore', 'inherit', 'inherit'],",
+        '});',
+        'setTimeout(() => process.exit(0), 3000);',
+      ]);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          autofixRunnerScriptPath,
+          '--mode',
+          'address-review',
+          '--pr',
+          '5678',
+          '--issue',
+          '1234',
+          '--workdir',
+          dir,
+          '--qwen-bin',
+          stub,
+        ],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, QWEN_TIMEOUT_MS: '100' },
+          timeout: 2000,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
+        'timeout (100ms)',
+      );
+    });
   });
 
   it('reports external qwen subprocess signals without calling them timeouts', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -895,6 +895,25 @@ describe('qwen-autofix workflow', () => {
     );
   });
 
+  it('posts a human-handoff marker when review addressing fails', () => {
+    expect(reviewAddressReportStep).toContain(
+      "GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'",
+    );
+    expect(reviewAddressReportStep).toContain(
+      "NEWEST: '${{ steps.prepare.outputs.newest }}'",
+    );
+    expect(reviewAddressReportStep).toContain('"${DRY_RUN}" != "true"');
+    expect(reviewAddressReportStep).toContain('-s "${WORKDIR}/failure.md"');
+    expect(reviewAddressReportStep).toContain(
+      '<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} -->',
+    );
+    expect(reviewAddressReportStep).toContain(
+      'Could not address the latest review feedback automatically',
+    );
+    expect(reviewAddressReportStep).toContain('gh pr comment "${PR}"');
+    expect(reviewAddressReportStep).toContain('human should take over');
+  });
+
   it('preserves agent-written failure details when the qwen subprocess fails', () => {
     withRunnerDir((dir) => {
       writeFileSync(join(dir, 'candidates.json'), '[]\n');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -943,6 +943,9 @@ describe('qwen-autofix workflow', () => {
     expect(readFileSync(autofixRunnerScriptPath, 'utf8')).toContain(
       "log.on('error', () => {});",
     );
+    expect(readFileSync(autofixRunnerScriptPath, 'utf8')).toContain(
+      'if (log.destroyed)',
+    );
   });
 
   it('detects loop guard output before it falls out of the log tail', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -912,6 +912,15 @@ describe('qwen-autofix workflow', () => {
       'Could not address the latest review feedback automatically',
     );
     expect(reviewAddressReportStep).toContain('gh pr comment "${PR}"');
+    expect(reviewAddressReportStep).toContain(
+      'GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq \'.login\'',
+    );
+    expect(reviewAddressReportStep).toContain(
+      'CI_DEV_BOT_PAT authenticates as ${bot_actor}',
+    );
+    expect(reviewAddressReportStep).toContain(
+      '::warning::Failed to post handoff comment on PR #${PR}',
+    );
     expect(reviewAddressReportStep).toContain('human should take over');
     expect(reviewAddressReportStep).toContain("sed 's/<!--[^>]*-->//g'");
   });
@@ -931,7 +940,7 @@ describe('qwen-autofix workflow', () => {
         'turn_tool_call_cap',
       );
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
-        'turn_tool_call_cap',
+        'Qwen hit the tool-call loop guard',
       );
       expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
         'human should take over',
@@ -961,7 +970,7 @@ describe('qwen-autofix workflow', () => {
 
       expect(result.status).not.toBe(0);
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
-        'turn_tool_call_cap',
+        'Qwen hit the tool-call loop guard',
       );
       expect(readFileSync(join(dir, 'handoff.md'), 'utf8')).toContain(
         'human should take over',
@@ -1015,6 +1024,7 @@ describe('qwen-autofix workflow', () => {
 
     expect(runner).toContain('const QWEN_TIMEOUT_MS = 50 * 60 * 1000');
     expect(runner).toContain('setTimeout(() =>');
+    expect(runner).toContain("child.kill('SIGKILL')");
     expect(runner).toContain('}, QWEN_TIMEOUT_MS)');
   });
 


### PR DESCRIPTION
## What this PR does

AutoFix review-address failures now distinguish diagnostic failures from terminal human-handoff failures. The runner writes model/tool output to agent.log, keeps failure.md as failure detail, and writes handoff.md only when the agent explicitly failed the feedback batch or when qwen hits the tool-call loop guard. The workflow posts the PR handoff comment and acted=false autofix marker only when handoff.md exists.

## Why it's needed

The observed #6377 failure hit the model loop/tool-call guard. That case should be visible on the PR and should not be retried forever on every scheduled sweep. A generic qwen subprocess failure, however, can be transient; this PR avoids marking those as handled, so a later scheduled run can retry the same feedback.

## Reviewer Test Plan

### How to verify

Review the review-address reporting path: terminal handoff failures produce handoff.md, post a PR comment, and advance the autofix marker; generic qwen subprocess failures still write failure.md and agent.log but do not post the handoff marker.

### Evidence (Before & After)

N/A — workflow reporting behavior only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Validated with: npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js; npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js .qwen/skills/autofix/scripts/run-agent.mjs; actionlint -ignore 'SC2129' .github/workflows/qwen-autofix.yml; git diff --check. The ignored SC2129 warning is pre-existing on main.

## Risk & Scope

- Main risk or tradeoff: loop-guard and explicit agent failure handoffs advance the review watermark for that feedback, so a human needs to take over instead of expecting another automatic retry.
- Not validated / out of scope: changing the agent prompt, raising tool-call limits, or fixing PR #6377 itself.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up for AutoFix review failures observed on #6377.

<details>
<summary>中文说明</summary>

## What this PR does

AutoFix 的 review-address 失败现在会区分“诊断失败”和“需要人工接手的终止性失败”。runner 会把模型和工具输出写到 agent.log，failure.md 只保留失败细节；只有 agent 明确写出失败，或者 qwen 命中 tool-call loop guard 时，才会额外写 handoff.md。workflow 只有在 handoff.md 存在时，才会发 PR 交接评论并写 acted=false 的 autofix marker。

## Why it's needed

#6377 暴露的问题是模型命中了 loop/tool-call guard。这个场景应该在 PR 上可见，也不应该每次定时扫描都无限重试。但普通 qwen 子进程失败可能只是临时问题；这个 PR 不会把这类失败标记成已处理，因此后续定时任务仍然可以重试同一批反馈。

## Reviewer Test Plan

### How to verify

检查 review-address reporting 路径：终止性交接失败会生成 handoff.md、发布 PR 评论并推进 autofix marker；普通 qwen 子进程失败仍会写 failure.md 和 agent.log，但不会发布 handoff marker。

### Evidence (Before & After)

N/A — 仅 workflow reporting 行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

已验证：npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js；npx prettier --check .github/workflows/qwen-autofix.yml scripts/tests/qwen-autofix-workflow.test.js .qwen/skills/autofix/scripts/run-agent.mjs；actionlint -ignore 'SC2129' .github/workflows/qwen-autofix.yml；git diff --check。忽略的 SC2129 是 main 上已有告警。

## Risk & Scope

- Main risk or tradeoff: loop guard 和 agent 明确失败的 handoff 会推进该批 feedback 的 watermark，因此后续需要人工接手，而不是期待再次自动重试。
- Not validated / out of scope: 不改 agent prompt、不提高 tool-call limit、不修 #6377 本身。
- Breaking changes / migration notes: 无。

## Linked Issues

跟进 #6377 暴露出来的 AutoFix review failure 问题。

</details>