### PR TITLE
fix(web-shell): keep split-view session list fresh and preserve panes across view switches

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -352,10 +352,30 @@ mockComponent('./components/SessionOverviewPanel', 'SessionOverviewPanel');
 vi.doMock('./components/SplitView', async () => {
   const React = await import('react');
   return {
-    SplitView: (props: { onExit?: () => void }) =>
+    SplitView: (props: {
+      onExit?: () => void;
+      initialSessionIds?: string[];
+      onPanesChange?: (ids: string[]) => void;
+    }) =>
       React.createElement(
         'div',
         { 'data-testid': 'split-view-mock' },
+        // Surface the seed so a test can assert the App preserved / restored it.
+        React.createElement(
+          'span',
+          { 'data-testid': 'split-initial' },
+          (props.initialSessionIds ?? []).join(','),
+        ),
+        // Simulate the real SplitView reporting its live pane set up to the App.
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'split-report-panes',
+            type: 'button',
+            onClick: () => props.onPanesChange?.(['s1', 's2', 's3']),
+          },
+          'report',
+        ),
         React.createElement(
           'button',
           { 'data-testid': 'split-back', type: 'button', onClick: props.onExit },
@@ -1030,6 +1050,47 @@ describe('App session callbacks', () => {
     const panel = container.querySelector('[data-testid="inline-panel"]');
     expect(panel).not.toBeNull();
     expect(panel?.getAttribute('aria-label')).toBe('Session Overview');
+  });
+
+  it('preserves the pane set when leaving the split view and reopening it', async () => {
+    const { container } = renderApp();
+    await flush();
+
+    // Open the split, then let SplitView report a live pane set (s1,s2,s3) back
+    // to the App — the same way real add/remove mirrors up via onPanesChange.
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="split-report-panes"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    // Leave the split (back to the overview)…
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="split-back"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="split-view-page"]')).toBeNull();
+
+    // …and reopen it from the toolbar. The reported panes must be restored, not
+    // reset to empty / the current session (the regression this guards).
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-split-view"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="split-initial"]')?.textContent,
+    ).toBe('s1,s2,s3');
   });
 
   it('enters the split view from a ?split= URL and consumes the param', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1108,6 +1108,22 @@ describe('App session callbacks', () => {
     }
   });
 
+  it('seeds the split from a ?split= URL, deduping and capping the explicit selection', async () => {
+    // Duplicates and more than MAX_SPLIT_PANES (6) ids drive the explicit-
+    // selection branch of openSplitView (dedupe + cap + replace), distinct from
+    // the no-selection restore branch covered above.
+    window.history.pushState({}, '', '/?split=s1,s1,s2,s3,s4,s5,s6,s7');
+    try {
+      const { container } = renderApp();
+      await flush();
+      expect(
+        container.querySelector('[data-testid="split-initial"]')?.textContent,
+      ).toBe('s1,s2,s3,s4,s5,s6');
+    } finally {
+      window.history.pushState({}, '', '/');
+    }
+  });
+
   it('keeps the split view open when an approval becomes pending (unlike the scheduled-tasks page)', async () => {
     // Each split pane owns its own session's approval, so an approval on the
     // outer main session must NOT yank the user out of the split.

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -68,7 +68,7 @@ import { DaemonStatusDialog } from './components/dialogs/DaemonStatusDialog';
 import { SessionOverviewPanel } from './components/SessionOverviewPanel';
 import { SplitView } from './components/SplitView';
 import { useIsLargeScreen } from './hooks/useIsLargeScreen';
-import { parseSplitSessionIds } from './utils/splitUrl';
+import { MAX_SPLIT_PANES, parseSplitSessionIds } from './utils/splitUrl';
 import { ScheduledTasksDialog } from './components/dialogs/ScheduledTasksDialog';
 import { ExtensionsDialog } from './components/dialogs/ExtensionsDialog';
 import { SettingsMessage } from './components/messages/SettingsMessage';
@@ -1237,14 +1237,29 @@ export function App({
     setActivePanel(null);
     setMainView('scheduledTasks');
   }, []);
-  // Open the in-window split view showing 2+ sessions side by side. Seeds with
-  // the given sessions (e.g. the overview selection); SplitView falls back to
-  // the current session when the list is empty.
-  const openSplitView = useCallback((sessionIds?: string[]) => {
-    setActivePanel(null);
-    setSplitSessionIds(sessionIds ?? []);
-    setMainView('split');
-  }, []);
+  // Open the in-window split view showing 2+ sessions side by side. `splitSessionIds`
+  // is the live pane set — SplitView mirrors add/remove back into it via
+  // onPanesChange — so it must be preserved across entries, not blindly reset.
+  const openSplitView = useCallback(
+    (sessionIds?: string[]) => {
+      setActivePanel(null);
+      setSplitSessionIds((prev) => {
+        // An explicit selection (the overview, or a `?split=` URL) replaces the
+        // split with exactly those sessions.
+        const requested = Array.from(
+          new Set((sessionIds ?? []).filter(Boolean)),
+        ).slice(0, MAX_SPLIT_PANES);
+        if (requested.length > 0) return requested;
+        // No selection (the toolbar "Open Split View" button): restore the split
+        // the user already had so switching away and back doesn't clear it; fall
+        // back to the current session when there is nothing to restore.
+        if (prev.length > 0) return prev;
+        return connection.sessionId ? [connection.sessionId] : [];
+      });
+      setMainView('split');
+    },
+    [connection.sessionId],
+  );
   // Stable so SplitView's onExit-dependent effect (auto-exit on last pane
   // close) doesn't re-fire on every App re-render. Back from the split returns
   // to the Session Overview — the hub the split is launched from.
@@ -4577,6 +4592,14 @@ export function App({
                     <CompactModeContext.Provider value={compactMode}>
                       <SplitView
                         initialSessionIds={splitSessionIds}
+                        // Mirror live pane add/remove back up so switching away
+                        // and re-entering restores the same panes. Pass the
+                        // setter directly — a fresh arrow each render would loop
+                        // SplitView's reporting effect.
+                        onPanesChange={setSplitSessionIds}
+                        // Refresh the "add pane" picker when the session list
+                        // changes elsewhere, matching the sidebar.
+                        sessionListReloadToken={sessionListReloadToken}
                         // Back returns to the Session Overview (the hub the split
                         // is launched from), not the single-session chat.
                         onExit={handleSplitExit}

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider } from '../i18n';
@@ -26,7 +27,18 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     </div>
   ),
   useConnection: () => connectionState,
-  useSessions: () => ({ sessions: sessionsState, reload: reloadMock }),
+  // Stateful, like the real hook: reload() re-renders with the CURRENT module
+  // store. This lets a test prove the picker renders sessions that appeared
+  // only after the reload — not merely that reload() was called.
+  useSessions: () => {
+    const [sessions, setSessions] = React.useState<any[]>(() => sessionsState);
+    const reload = React.useCallback(async () => {
+      reloadMock();
+      setSessions([...sessionsState]);
+      return sessionsState;
+    }, []);
+    return { sessions, reload };
+  },
 }));
 
 vi.mock('./ChatPane', () => ({
@@ -63,7 +75,7 @@ beforeEach(() => {
     { sessionId: 's3', workspaceCwd: '/w', displayName: 'Three' },
     { sessionId: 's4', workspaceCwd: '/w', displayName: 'Four' },
   ];
-  reloadMock = vi.fn(async () => sessionsState);
+  reloadMock = vi.fn();
 });
 
 afterEach(() => {
@@ -92,6 +104,19 @@ function panes(): HTMLElement[] {
 function titles(): string[] {
   return Array.from(container!.querySelectorAll('[data-testid="pane-title"]')).map(
     (el) => el.textContent ?? '',
+  );
+}
+function pickerOptions(): string[] {
+  return Array.from(
+    container!.querySelectorAll('[role="option"] button'),
+  ).map((el) => (el.textContent ?? '').trim());
+}
+function openPicker(): void {
+  const addButton = container!.querySelector(
+    'button[aria-haspopup="listbox"]',
+  ) as HTMLButtonElement;
+  act(() =>
+    addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })),
   );
 }
 
@@ -259,6 +284,27 @@ describe('SplitView', () => {
       addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })),
     );
     expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the refreshed session list on reopen — not the entry snapshot', () => {
+    render({ initialSessionIds: ['s1'] });
+    // First open: the picker offers the sessions present at entry.
+    openPicker();
+    expect(pickerOptions()).toEqual(['Two', 'Three', 'Four']);
+    // A session is created elsewhere after the split was entered…
+    sessionsState = [
+      ...sessionsState,
+      { sessionId: 's5', workspaceCwd: '/w', displayName: 'Five' },
+    ];
+    // …reopening the picker reloads and the new session now appears. Without the
+    // reload-on-open the list would be frozen at the entry snapshot (no 'Five').
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      ),
+    );
+    openPicker();
+    expect(pickerOptions()).toEqual(['Two', 'Three', 'Four', 'Five']);
   });
 
   it('reloads the picker list when the parent bumps the reload token', () => {

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -15,6 +15,9 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 /* eslint-disable @typescript-eslint/no-explicit-any */
 let connectionState: any;
 let sessionsState: any[];
+// Stable across renders (assigned once per test) so SplitView's reload effects,
+// which depend on `reload`'s identity, don't re-fire on every render.
+let reloadMock: ReturnType<typeof vi.fn>;
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   DaemonSessionProvider: (props: any) => (
@@ -23,7 +26,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     </div>
   ),
   useConnection: () => connectionState,
-  useSessions: () => ({ sessions: sessionsState }),
+  useSessions: () => ({ sessions: sessionsState, reload: reloadMock }),
 }));
 
 vi.mock('./ChatPane', () => ({
@@ -60,6 +63,7 @@ beforeEach(() => {
     { sessionId: 's3', workspaceCwd: '/w', displayName: 'Three' },
     { sessionId: 's4', workspaceCwd: '/w', displayName: 'Four' },
   ];
+  reloadMock = vi.fn(async () => sessionsState);
 });
 
 afterEach(() => {
@@ -242,5 +246,61 @@ describe('SplitView', () => {
     expect(container!.textContent).toContain('This session pane hit an error');
     expect(panes()).toHaveLength(1);
     expect(titles()).toEqual(['Two']);
+  });
+
+  it('reloads the session list when the picker opens (never a stale list)', () => {
+    render({ initialSessionIds: ['s1'] });
+    // `useSessions` only fetches on mount; nothing reloads until the user acts.
+    expect(reloadMock).not.toHaveBeenCalled();
+    const addButton = container!.querySelector(
+      'button[aria-haspopup="listbox"]',
+    ) as HTMLButtonElement;
+    act(() =>
+      addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads the picker list when the parent bumps the reload token', () => {
+    render({ initialSessionIds: ['s1'], sessionListReloadToken: 0 });
+    // The initial token is not a change, so it does not trigger a reload.
+    expect(reloadMock).not.toHaveBeenCalled();
+    act(() =>
+      root!.render(
+        <I18nProvider language="en">
+          <SplitView
+            onExit={() => {}}
+            initialSessionIds={['s1']}
+            sessionListReloadToken={1}
+          />
+        </I18nProvider>,
+      ),
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors the live pane set up to the parent as panes change', () => {
+    const onPanesChange = vi.fn();
+    render({ initialSessionIds: ['s1'], onPanesChange });
+    // Reported on mount so the parent's seed reflects the actual panes…
+    expect(onPanesChange).toHaveBeenLastCalledWith(['s1']);
+    // …and after every add (so switching away and back restores it).
+    const addButton = container!.querySelector(
+      'button[aria-haspopup="listbox"]',
+    ) as HTMLButtonElement;
+    act(() =>
+      addButton.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    const options = container!.querySelectorAll('[role="option"] button');
+    act(() =>
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(onPanesChange).toHaveBeenLastCalledWith(['s1', 's2']);
+    // …and after every remove.
+    const close = container!.querySelector('[data-testid="pane-close"]');
+    act(() =>
+      close!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(onPanesChange).toHaveBeenLastCalledWith(['s2']);
   });
 });

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -119,23 +119,23 @@ export function SplitView({
   // Also refresh when the parent signals the list changed elsewhere (a session
   // created / deleted / renamed in the sidebar or another tab), so an open
   // picker — or the next open — reflects it without re-entering the split.
-  // Skip while a reload is already in flight: a burst of session changes (bulk
-  // create/delete) bumps the token repeatedly, and we don't want a redundant
-  // concurrent round-trip per bump. `useDaemonResource` already discards stale
-  // responses via its sequence counter; this just avoids the wasted requests.
-  const reloadInFlightRef = useRef(false);
+  // Reload on every distinct token bump. `useDaemonResource` serializes
+  // responses via its sequence counter (last write wins), so overlapping reloads
+  // are safe; and the token is bumped only on discrete session-change events
+  // (App fires an immediate bump plus one delayed follow-up per change), not as a
+  // high-frequency stream. Deliberately *not* skipping while a reload is in
+  // flight: doing so would drop a bump that lands mid-reload — the effect has
+  // already run for that value and clearing an in-flight flag wouldn't re-run it,
+  // so the picker could stay stale after a burst. An occasional redundant fetch
+  // is far cheaper than a lost refresh, and the split has no polling fallback.
   const prevReloadTokenRef = useRef(sessionListReloadToken);
   useEffect(() => {
     if (
       sessionListReloadToken !== undefined &&
-      sessionListReloadToken !== prevReloadTokenRef.current &&
-      !reloadInFlightRef.current
+      sessionListReloadToken !== prevReloadTokenRef.current
     ) {
       prevReloadTokenRef.current = sessionListReloadToken;
-      reloadInFlightRef.current = true;
-      void Promise.resolve(reload()).finally(() => {
-        reloadInFlightRef.current = false;
-      });
+      void reload();
     }
   }, [sessionListReloadToken, reload]);
 

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -119,14 +119,23 @@ export function SplitView({
   // Also refresh when the parent signals the list changed elsewhere (a session
   // created / deleted / renamed in the sidebar or another tab), so an open
   // picker — or the next open — reflects it without re-entering the split.
+  // Skip while a reload is already in flight: a burst of session changes (bulk
+  // create/delete) bumps the token repeatedly, and we don't want a redundant
+  // concurrent round-trip per bump. `useDaemonResource` already discards stale
+  // responses via its sequence counter; this just avoids the wasted requests.
+  const reloadInFlightRef = useRef(false);
   const prevReloadTokenRef = useRef(sessionListReloadToken);
   useEffect(() => {
     if (
       sessionListReloadToken !== undefined &&
-      sessionListReloadToken !== prevReloadTokenRef.current
+      sessionListReloadToken !== prevReloadTokenRef.current &&
+      !reloadInFlightRef.current
     ) {
       prevReloadTokenRef.current = sessionListReloadToken;
-      void reload();
+      reloadInFlightRef.current = true;
+      void Promise.resolve(reload()).finally(() => {
+        reloadInFlightRef.current = false;
+      });
     }
   }, [sessionListReloadToken, reload]);
 

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -25,9 +25,23 @@ const MAX_PANES = MAX_SPLIT_PANES;
 export interface SplitViewProps {
   /** Sessions to open initially (e.g. the selection from the overview). */
   initialSessionIds?: string[];
+  /**
+   * Report the live pane set (after every add / remove) up to the parent so it
+   * survives this view unmounting. Switching away from the split and back must
+   * restore exactly the panes the user had, not reseed from a stale selection.
+   * Must be referentially stable (e.g. a `useState` setter) — a fresh callback
+   * each render would re-fire the reporting effect and loop.
+   */
+  onPanesChange?: (sessionIds: string[]) => void;
   /** Leave the split view (back to the single-session chat). */
   onExit: () => void;
   onError?: (error: unknown, fallback: string) => void;
+  /**
+   * Bumped by the parent whenever the session list changes elsewhere (create /
+   * delete / rename). The "add pane" picker reloads on a change so it never
+   * offers a session that has since been removed or misses one just created.
+   */
+  sessionListReloadToken?: number;
 }
 
 /**
@@ -39,8 +53,10 @@ export interface SplitViewProps {
  */
 export function SplitView({
   initialSessionIds,
+  onPanesChange,
   onExit,
   onError,
+  sessionListReloadToken,
 }: SplitViewProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -49,7 +65,7 @@ export function SplitView({
     connection.capabilities?.features?.includes(
       SESSION_ORGANIZATION_FEATURE,
     ) ?? false;
-  const { sessions } = useSessions({
+  const { sessions, reload } = useSessions({
     autoLoad: true,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
@@ -93,6 +109,27 @@ export function SplitView({
     };
   }, [pickerOpen]);
 
+  // Refresh the list the moment the picker opens — `useSessions` only fetches on
+  // mount, so without this the picker would offer whatever was current when the
+  // split was first entered, missing sessions created since.
+  useEffect(() => {
+    if (pickerOpen) void reload();
+  }, [pickerOpen, reload]);
+
+  // Also refresh when the parent signals the list changed elsewhere (a session
+  // created / deleted / renamed in the sidebar or another tab), so an open
+  // picker — or the next open — reflects it without re-entering the split.
+  const prevReloadTokenRef = useRef(sessionListReloadToken);
+  useEffect(() => {
+    if (
+      sessionListReloadToken !== undefined &&
+      sessionListReloadToken !== prevReloadTokenRef.current
+    ) {
+      prevReloadTokenRef.current = sessionListReloadToken;
+      void reload();
+    }
+  }, [sessionListReloadToken, reload]);
+
   const titleById = useMemo(() => {
     const map = new Map<string, string>();
     for (const session of sessions) {
@@ -124,6 +161,13 @@ export function SplitView({
       onExit();
     }
   }, [paneIds, onExit]);
+
+  // Mirror the live pane set up to the parent so it outlives this component
+  // unmounting when the user switches views. On re-entry the parent reseeds
+  // `initialSessionIds` from it, restoring the exact panes instead of clearing.
+  useEffect(() => {
+    onPanesChange?.(paneIds);
+  }, [paneIds, onPanesChange]);
 
   const removePane = useCallback((sessionId: string) => {
     setPaneIds((prev) => prev.filter((id) => id !== sessionId));


### PR DESCRIPTION
## What this PR does

Fixes two rough edges in the in-window split view (the side-by-side multi-session surface reached from the Session Overview or the "Open Split View" toolbar button): the **"Add session" picker now stays fresh**, and the **split now survives leaving it and coming back**.

- The picker reloads its session list when it opens (and when the app's session list changes elsewhere), so it always offers the current sessions — never a snapshot frozen at the moment you entered the split.
- The set of open panes is now mirrored up to the app, so switching to chat / a panel / the scheduled-tasks page and returning restores exactly the panes you had, and the no-arg "Open Split View" button restores an in-progress split instead of clearing it.

## Why it's needed

`useSessions` only fetches on mount. The split view read that snapshot once and never refreshed, so a session created after you entered the split never appeared in the "Add session" picker, and a session deleted elsewhere was still offered. Meanwhile the live pane set lived in `SplitView`'s local state, which is destroyed when the split unmounts (it is conditionally rendered on `mainView === 'split'`). The seed it re-mounted from was never updated with panes you added, and the toolbar "Open Split View" button reset that seed to empty — so switching away from the split and back collapsed it down to just the current session. Both are things a user hits quickly once they actually work in the split for a while.

## Reviewer Test Plan

### How to verify

1. Open the web shell on a large screen, create a few sessions, and open the split view (Session Overview → select 2+ → open split, or the "Open Split View" toolbar button).
2. **Picker freshness:** create another session (e.g. from the sidebar), then open the split's "+ Add session" picker — the new session is listed. Before this change it was absent until you left and re-entered the split.
3. **Pane preservation:** with 2–3 panes open, switch to the chat / Settings / Scheduled Tasks view, then click "Open Split View" again — the same panes are restored. Before this change the split collapsed to a single pane.

Automated coverage (run in `packages/web-shell`): `npx vitest run client/components/SplitView.test.tsx client/App.test.tsx` — 54 pass, including three new SplitView tests (`reloads the session list when the picker opens`, `reloads the picker list when the parent bumps the reload token`, `mirrors the live pane set up to the parent as panes change`). The four split-related suites (SplitView, App, SessionOverviewPanel, WebShellSidebar) total 110 passing.

The screenshots below are from a small harness that mounts the **real** `SplitView` (real CSS module + i18n) driven in real Chrome via Playwright, with only the chat-pane body and the daemon session list stubbed — so it exercises the exact component and picker/pane wiring this PR changes. The "before" image is the same harness with the pre-fix app wiring (`?mode=old`).

### Evidence (Before & After)

The split view — each pane is an independent session (own transcript, approvals, streaming):

![split view — three independent panes](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/01-split-panes.png)

**Fix 1 — "Add session" picker stays fresh.** A session is created elsewhere; reopening the picker reloads and now offers it (before the fix the list was frozen at entry and it would be missing):

| Picker open — current sessions | After a new session is created elsewhere → reopen |
| --- | --- |
| ![picker before](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/02-picker-before.png) | ![picker after refresh](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/03-picker-after-refresh.png) |

**Fix 2 — panes survive a view switch.** Switch away from the split and reopen it:

| Before — collapses to the current session | After — the split is restored |
| --- | --- |
| ![before fix — one pane](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/05-restored-before-fix.png) | ![after fix — three panes restored](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/04-split-restored.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests + a Vite/Playwright screenshot harness (real Chrome, `channel:'chrome'`). Not run against a live daemon on Windows/Linux — covered by CI.

## Risk & Scope

- Main risk or tradeoff: `SplitView` now reports its pane set up via `onPanesChange`. To avoid a render loop the parent must pass a referentially stable setter (it passes `setSplitSessionIds` directly); this is documented on the prop and covered by the tests.
- Not validated / out of scope: a session created in a *different browser tab* still won't live-update an open split picker — that path never bumps the app's session-list token. This matches the sidebar; only the Session Overview polls. The picker refreshes on open and on the app's own session-change events, which covers the common cases.
- Breaking changes / migration notes: none. `onPanesChange` and `sessionListReloadToken` are optional props; existing behavior is unchanged when they are omitted.

## Linked Issues

N/A — found during manual testing of the split view.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复窗口内分屏视图（从「会话总览」或工具栏「打开分屏」按钮进入的多会话并排界面）的两个问题：**「添加会话」选择器现在保持最新**，且**分屏在切走再切回后不再丢失**。

- 选择器在打开时（以及应用内会话列表在别处变化时）重新拉取会话列表，因此始终列出当前的会话——不再是进入分屏那一刻冻结的快照。
- 打开的面板集合现在会上报给应用，因此切换到聊天 / 某个面板 / 定时任务页再返回时，会精确还原原有面板；无参的「打开分屏」按钮也会恢复进行中的分屏，而不是清空。

## 为什么需要

`useSessions` 只在挂载时抓取一次。分屏读到这份快照后再不刷新，所以进入分屏后新建的会话不会出现在「添加会话」选择器里，别处删除的会话却仍被列出。同时，实时的面板集合存在 `SplitView` 的本地 state 中，而分屏是按 `mainView === 'split'` 条件渲染的，切走即卸载、state 丢失；它重新挂载所依据的种子既不反映用户新加的面板，工具栏「打开分屏」按钮还会把该种子重置为空——于是切走再切回时分屏塌缩到只剩当前会话。用户真正在分屏里工作一会儿后很容易撞到这两点。

## 审阅者验证步骤

### 如何验证

1. 在大屏打开 web shell，建几个会话，进入分屏（会话总览 → 选 2 个以上 → 打开分屏，或工具栏「打开分屏」按钮）。
2. **选择器新鲜度：** 再新建一个会话（例如从侧栏），然后打开分屏的「+ 添加会话」选择器——新会话已列出。改动前它要等你离开并重新进入分屏才出现。
3. **面板保留：** 开着 2–3 个面板时，切到聊天 / 设置 / 定时任务页，再点「打开分屏」——原有面板被还原。改动前分屏会塌缩为单个面板。

自动化覆盖（在 `packages/web-shell` 下运行）：`npx vitest run client/components/SplitView.test.tsx client/App.test.tsx`——54 项通过，含 3 个新增 SplitView 用例（选择器打开时 reload、父级 reload token 变化时 reload、面板增减上报给父级）。四个分屏相关套件（SplitView、App、SessionOverviewPanel、WebShellSidebar）共 110 项通过。

下方截图来自一个小型 harness：它挂载**真实**的 `SplitView`（真实 CSS module + i18n），用 Playwright 在真实 Chrome 中驱动，仅将聊天面板正文与 daemon 会话列表打桩——因此运行的正是本 PR 改动的组件与选择器/面板接线逻辑。「修复前」那张是同一 harness 套用修复前的应用接线（`?mode=old`）。

### 证据（前后对比）

分屏视图——每个面板都是独立会话（各自的 transcript、审批、流式输出）：

![分屏——三个独立面板](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/01-split-panes.png)

**修复 1 —— 「添加会话」选择器保持最新。** 别处新建了一个会话，重新打开选择器时会 reload 并把它列出（修复前列表冻结在进入时，会缺这一项）：

| 选择器打开——当前会话 | 别处新建会话后 → 重新打开 |
| --- | --- |
| ![选择器 before](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/02-picker-before.png) | ![选择器刷新后](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/03-picker-after-refresh.png) |

**修复 2 —— 面板在切换视图后仍在。** 切走再重新打开分屏：

| 修复前——塌缩到当前会话 | 修复后——分屏被还原 |
| --- | --- |
| ![修复前——1 个面板](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/05-restored-before-fix.png) | ![修复后——3 个面板还原](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-view-session-list/pr-assets/split-view/04-split-restored.png) |

### 风险与范围

- 主要风险：`SplitView` 现在通过 `onPanesChange` 上报面板集合。为避免渲染循环，父级必须传入引用稳定的 setter（现直接传 `setSplitSessionIds`）；该约束已写在 prop 注释里并有测试覆盖。
- 未验证 / 范围外：在**另一个浏览器标签页**新建的会话仍不会实时刷新已打开的分屏选择器——该路径不会触发应用的会话列表 token（与侧栏一致，只有会话总览做轮询）。选择器在打开时以及应用自身的会话变更事件上刷新，已覆盖常见场景。
- 破坏性变更 / 迁移说明：无。`onPanesChange` 与 `sessionListReloadToken` 均为可选 prop，省略时行为不变。

</details>
