### PR TITLE
fix(core): prevent KV-cache invalidation on tool_search by reordering reminderParts

### DIFF
--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -40,11 +40,10 @@ function makeConfigWithRegistry(): {
   const config = new Config(baseConfigParams);
   const registry = new ToolRegistry(config);
   vi.spyOn(config, 'getToolRegistry').mockReturnValue(registry);
-  // Stub out the chat client reference ToolSearch tries to refresh; we don't
-  // need end-to-end chat behaviour, just to confirm the call is tolerated.
+  // Stub out the chat client reference so ToolSearch can sync newly
+  // revealed tools via setTools() without a real GeminiClient.
   vi.spyOn(config, 'getGeminiClient').mockReturnValue({
     setTools: vi.fn().mockResolvedValue(undefined),
-    refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
   } as never);
   return { config, registry };
 }
@@ -848,17 +847,12 @@ describe('ToolSearchTool', () => {
     // First search uses keyword path (which calls loadAndReturnSchemas →
     // revealDeferredTool); confirm registry agrees.
     expect(registry.isDeferredToolRevealed('slack_send_message')).toBe(true);
-    const geminiClient = config.getGeminiClient() as unknown as {
-      refreshStartupContextReminder: ReturnType<typeof vi.fn>;
-    };
-    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(1);
 
     // Second: same keyword search now finds nothing (tool excluded).
     const second = await tool
       .build({ query: 'slack' })
       .execute(new AbortController().signal);
     expect(String(second.llmContent)).toContain('No tools found matching');
-    expect(geminiClient.refreshStartupContextReminder).toHaveBeenCalledTimes(1);
   });
 
   it('returns an error result when setTools() throws — model must NOT see schemas as ready', async () => {

--- a/packages/core/src/tools/tool-search.ts
+++ b/packages/core/src/tools/tool-search.ts
@@ -376,22 +376,6 @@ class ToolSearchInvocation extends BaseToolInvocation<
             `[ToolSearch] setTools() failed while revealing deferred tools: ${setToolsError}\n`,
           );
         }
-
-        if (!setToolsError) {
-          try {
-            await geminiClient.refreshStartupContextReminder();
-          } catch (err) {
-            const refreshError =
-              err instanceof Error ? err.message : String(err);
-            debugLogger.warn(
-              'refreshStartupContextReminder() failed after revealing deferred tools:',
-              err,
-            );
-            process.stderr.write(
-              `[ToolSearch] refreshStartupContextReminder() failed after revealing deferred tools: ${refreshError}\n`,
-            );
-          }
-        }
       }
 
       if (setToolsError) {

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -323,6 +323,33 @@ describe('getInitialChatHistory', () => {
     expect(mockToolRegistry.warmAll).toHaveBeenCalled();
     expect(history).toEqual([]);
   });
+
+  it('places deferred-tools reminder last so stable prefix stays cacheable on KV-caching servers', async () => {
+    // Pin: deferred-tools part changes when tool_search reveals a tool.
+    // Placing it LAST keeps the stable prefix (MCP + skills + startup)
+    // cacheable; only the tail recomputes on prefix-caching servers.
+    mockToolRegistry.getDeferredToolSummary.mockReturnValue([
+      { name: 'web_fetch', description: 'Fetches web pages' },
+    ]);
+
+    const [history] = await getInitialChatHistory(mockConfig as Config);
+
+    expect(history).toHaveLength(1);
+    const parts = history[0]?.parts ?? [];
+    expect(parts.length).toBeGreaterThanOrEqual(1);
+
+    // The LAST text part should be the deferred-tools reminder.
+    const lastText = parts[parts.length - 1]?.text;
+    expect(lastText).toBeDefined();
+    expect(lastText).toContain('reachable via `tool_search`');
+    expect(lastText).toContain('web_fetch');
+
+    // The FIRST text part should NOT be the deferred-tools reminder —
+    // it must be the stable MCP/skills/startup prefix.
+    const firstText = parts[0]?.text;
+    expect(firstText).toBeDefined();
+    expect(firstText).not.toContain('reachable via `tool_search`');
+  });
 });
 
 describe('stripStartupContext', () => {

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -543,13 +543,16 @@ export async function getInitialChatHistory(
     ? await buildAvailableSkillsReminder(config)
     : null;
 
+  // Stable parts first (MCP, skills, startup) so prefix-caching servers
+  // retain the KV-cache for the shared prefix. Deferred-tools is last
+  // because tool_search revelations change it — only the tail recomputes.
   const reminderParts = [
-    includeDeferredToolsReminder
-      ? buildDeferredToolsReminder(toolRegistry)
-      : null,
     buildMcpServerInstructionsReminder(toolRegistry),
     skillsResult?.reminder ?? null,
     startupReminder,
+    includeDeferredToolsReminder
+      ? buildDeferredToolsReminder(toolRegistry)
+      : null,
   ]
     .filter((text): text is string => text !== null)
     .map((text) => ({ text }));


### PR DESCRIPTION
## What this PR does

On prefix-caching LLM servers (llama.cpp, vLLM, Ollama), every `tool_search` call that reveals a deferred tool invalidates the entire startup system-reminder KV-cache. This PR fixes that by reordering the `reminderParts` array so the stable parts (MCP instructions, skills snapshot, startup context) come first, with the volatile deferred-tools reminder placed last. It also removes the post-discovery `refreshStartupContextReminder()` call in `tool-search.ts`, which was triggering a full system-reminder rebuild that is cosmetic — tools are already registered via `setTools()` and fully functional.

## Why it's needed

Currently, `getInitialChatHistory()` assembles `reminderParts` with deferred-tools at index 0. When `tool_search` reveals a tool, `buildDeferredToolsReminder()` returns a different list, changing the very first part of the cached prefix. Prefix-caching servers see this as a prefix mismatch from token 1 and discard the entire KV-cache, forcing a full recomputation on every subsequent request.

Additionally, `tool-search.ts` calls `refreshStartupContextReminder()` after revealing tools, which rebuilds the entire startup reminder. This is purely cosmetic — the tool is already registered and callable via `setTools()` — but it guarantees cache invalidation on every reveal.

## Reviewer Test Plan

### How to verify

1. Start a session with MCP servers configured (so deferred tools exist)
2. Observe the startup system-reminder: deferred-tools section should appear in the **last** part of `history[0]`, not the first
3. Call `tool_search` to reveal a deferred tool
4. Confirm the tool is immediately callable in the next turn
5. Confirm that `getInitialChatHistory()` no longer calls `refreshStartupContextReminder` after tool reveal
6. Run unit tests: `cd packages/core && npx vitest run src/utils/environmentContext.test.ts src/tools/tool-search.test.ts`

### Evidence (Before & After)

**Before:** `reminderParts` order: `[deferredTools, MCP, skills, startup]` — deferred-tools at index 0, first part changes on every tool reveal, busting entire KV-cache prefix.

**After:** `reminderParts` order: `[MCP, skills, startup, deferredTools]` — stable prefix cacheable, only the tail recomputes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local: `npm run build && npm run typecheck`, vitest with `QWEN_DEBUG_LOG_FILE=0`.

## Risk & Scope

- Main risk or tradeoff: The deferred-tools section in the startup reminder becomes cosmetically stale after tool reveal — it still lists revealed tools as "reachable via `tool_search`". This is an accepted trade-off (confirmed by maintainer @doudouOUC in [#6265](https://github.com/QwenLM/qwen-code/issues/6265#issuecomment-4899609594)) because tool functionality is unaffected: tools are registered via `setTools()` and the model can call them immediately. The stale listing is informational only.
- Not validated / out of scope: Dispatch tool redesign (separate effort). The `refreshStartupContextReminder` method remains in `client.ts` for other legitimate callers.
- Breaking changes / migration notes: None. Only the order of parts within `history[0]` changes; content is identical.

## Linked Issues

Fixes #6265

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在使用前缀缓存的 LLM 服务器（llama.cpp、vLLM、Ollama）上，每次 `tool_search` 揭示一个延迟工具时，都会使整个启动 system-reminder 的 KV 缓存失效。这个 PR 通过重新排列 `reminderParts` 数组来修复此问题：将稳定的部分（MCP 指令、技能快照、启动上下文）放在前面，将易变的延迟工具提醒放在最后。同时移除了 `tool-search.ts` 中揭示后调用的 `refreshStartupContextReminder()`，该调用会触发完整的 system-reminder 重建，但这纯粹是装饰性的——工具已经通过 `setTools()` 注册并完全可用。

## 为什么需要

目前 `getInitialChatHistory()` 将延迟工具放在 `reminderParts` 的索引 0 位置。当 `tool_search` 揭示一个工具时，`buildDeferredToolsReminder()` 返回不同的列表，改变了缓存前缀的第一个部分。前缀缓存服务器从第一个 token 就检测到前缀不匹配，丢弃整个 KV 缓存，迫使每次后续请求都完全重新计算。

此外，`tool-search.ts` 在揭示工具后调用 `refreshStartupContextReminder()`，重建整个启动提醒。这纯粹是装饰性的——工具已经注册并可调用——但它确保了每次揭示都会使缓存失效。

## 审阅者测试计划

### 验证方法

1. 启动配置了 MCP 服务器的会话（确保存在延迟工具）
2. 观察启动 system-reminder：延迟工具部分应出现在 `history[0]` 的**最后**一个 part 中，而非第一个
3. 调用 `tool_search` 揭示一个延迟工具
4. 确认该工具在下一轮中立即可调用
5. 确认 `getInitialChatHistory()` 在工具揭示后不再调用 `refreshStartupContextReminder`
6. 运行单元测试：`cd packages/core && npx vitest run src/utils/environmentContext.test.ts src/tools/tool-search.test.ts`

### 证据（前后对比）

**之前：** `reminderParts` 顺序：`[deferredTools, MCP, skills, startup]` — 延迟工具在索引 0，每次工具揭示都会改变第一个部分，使整个 KV 缓存前缀失效。

**之后：** `reminderParts` 顺序：`[MCP, skills, startup, deferredTools]` — 稳定前缀可缓存，仅尾部重新计算。

## 风险与范围

- 主要风险或权衡：启动提醒中的延迟工具部分在工具揭示后会变得装饰性过时——它仍然将已揭示的工具列为"可通过 `tool_search` 访问"。这是已接受的权衡（由维护者 @doudouOUC 在 [#6265](https://github.com/QwenLM/qwen-code/issues/6265#issuecomment-4899609594) 中确认），因为工具功能不受影响：工具通过 `setTools()` 注册，模型可以立即调用。过时的列表仅是信息性的。
- 未验证 / 超出范围：Dispatch 工具重新设计（独立工作）。`refreshStartupContextReminder` 方法保留在 `client.ts` 中供其他合法调用者使用。
- 破坏性变更 / 迁移说明：无。仅 `history[0]` 中部分的顺序发生变化；内容相同。

## 关联 Issues

Fixes #6265

</details>

QwenCode QwenLLM
