### PR TITLE
chore(core): remove stale refreshStartupContextReminder mocks from tool-search tests

### DIFF
--- a/packages/core/src/tools/tool-search.test.ts
+++ b/packages/core/src/tools/tool-search.test.ts
@@ -601,7 +601,6 @@ describe('ToolSearchTool', () => {
     const setToolsSpy = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(config, 'getGeminiClient').mockReturnValue({
       setTools: setToolsSpy,
-      refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
     } as never);
 
     const tool = new ToolSearchTool(config);
@@ -646,7 +645,6 @@ describe('ToolSearchTool', () => {
       const setToolsSpy = vi.fn().mockResolvedValue(undefined);
       vi.spyOn(config, 'getGeminiClient').mockReturnValue({
         setTools: setToolsSpy,
-        refreshStartupContextReminder: vi.fn().mockResolvedValue(undefined),
       } as never);
 
       const tool = new ToolSearchTool(config);


### PR DESCRIPTION
## What this PR does

Removes two stale `refreshStartupContextReminder` mock stubs from `tool-search.test.ts` that were missed when the method was removed from `tool-search.ts` in PR #6420. The `makeConfigWithRegistry()` helper was cleaned up as part of that PR, but two inline mock client stubs at lines 604 and 649 were left behind.

## Why it's needed

Dead mock stubs are noise — they suggest the tested code still depends on `refreshStartupContextReminder` when it doesn't. Removing them keeps the test suite honest and prevents confusion for future readers.

## Reviewer Test Plan

### How to verify

1. Confirm the two removed lines are the only change (1 file, −2 lines)
2. Verify `tool-search.ts` (the module under test) makes no calls to `refreshStartupContextReminder` — it was removed in #6420
3. Run the affected tests: `cd packages/core && npx vitest run src/tools/tool-search.test.ts`

### Evidence (Before & After)

**Before:** Two mock stubs reference a method that no longer exists in the tested module.
**After:** Both stubs removed. Tests pass without them.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: None. Removing dead mock code cannot affect runtime behaviour.
- Not validated / out of scope: N/A.
- Breaking changes / migration notes: None.

## Linked Issues

Reference: #6420 (initiated by wenshao's review comment on the parent PR).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

从 `tool-search.test.ts` 中删除两个陈旧的 `refreshStartupContextReminder` mock 桩，这些桩在 PR #6420 中从 `tool-search.ts` 移除该方法时被遗漏了。`makeConfigWithRegistry()` 辅助函数在 #6420 中已清理，但两处内联 mock 客户端桩（第 604 行和第 649 行）被遗留了下来。

## 为什么需要它

无用的 mock 桩是噪声——它们暗示被测试的代码仍然依赖 `refreshStartupContextReminder`，但实际上并非如此。移除它们可以保持测试套件的诚实性，避免对未来的读者造成困惑。

## 审阅者测试计划

### 如何验证

1. 确认唯一的改动是删除了两行代码（1 个文件，−2 行）
2. 验证 `tool-search.ts`（被测试的模块）不再调用 `refreshStartupContextReminder`——该方法已在 #6420 中移除
3. 运行受影响的测试：`cd packages/core && npx vitest run src/tools/tool-search.test.ts`

### 证据（前后对比）

**之前：** 两个 mock 桩引用了一个在被测试模块中已不存在的方法。
**之后：** 两个桩均已删除。没有它们测试依然通过。

### 已测试

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS        |  ⚠️  |
| 🪟 Windows       |  ✅  |
|  🐧 Linux         |  ⚠️  |

## 风险与范围

- 主要风险或权衡：无。删除无用的 mock 代码不会影响运行时行为。
- 未验证 / 超出范围：不适用。
- 破坏性更改 / 迁移说明：无。

## 关联问题

参考：PR #6420（由 wenshao 在父 PR 上的审查评论发起）。

</details>

QwenCode QwenLLM
