### PR TITLE
feat(channels): add webhook server for DingTalk event subscriptions

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
 import type { DWClientDownStream } from 'dingtalk-stream-sdk-nodejs';
 import type {
   ChannelTaskLifecycleEvent,
@@ -76,7 +77,9 @@ vi.mock('@qwen-code/channel-base', async () => {
 const { DingtalkChannel } = await import('./DingtalkAdapter.js');
 type DingtalkChannelInstance = InstanceType<typeof DingtalkChannel>;
 
-function createChannel(): DingtalkChannelInstance {
+function createChannel(
+  overrides: Record<string, unknown> = {},
+): DingtalkChannelInstance {
   return new DingtalkChannel(
     'test-dingtalk',
     {
@@ -90,6 +93,7 @@ function createChannel(): DingtalkChannelInstance {
       cwd: '/tmp',
       groupPolicy: 'open',
       groups: {},
+      ...overrides,
     },
     {} as never,
   );
@@ -1233,5 +1237,153 @@ describe('DingtalkChannel proactive send', () => {
     await channel.pushProactive(groupTarget, '   \n ');
 
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('DingtalkChannel webhook events', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function webhook(channel: DingtalkChannelInstance) {
+    return channel as unknown as {
+      verifySignature(timestamp: string, sign: string, secret: string): boolean;
+      onDocChange(data: Record<string, unknown>, eventId?: string): void;
+      sendGroupMessage(text: string): Promise<void>;
+      disconnect(): void;
+      startWebhookServer(): void;
+      webhookPort: number;
+      webhookServer: {
+        address(): { port: number } | string | null;
+        once(event: 'listening', listener: () => void): void;
+      };
+    };
+  }
+
+  function validSign(timestamp: string, secret = 'client-secret'): string {
+    return createHmac('sha256', secret)
+      .update(`${timestamp}\n${secret}`)
+      .digest('base64');
+  }
+
+  async function startWebhook(channel: ReturnType<typeof webhook>) {
+    channel.webhookPort = 0;
+    channel.startWebhookServer();
+    await new Promise<void>((resolve) => {
+      channel.webhookServer.once('listening', resolve);
+    });
+    const address = channel.webhookServer.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Webhook server did not expose a TCP port');
+    }
+    return address.port;
+  }
+
+  it('rejects stale webhook signatures', () => {
+    const channel = webhook(createChannel());
+    const timestamp = String(Date.now() - 10 * 60 * 1000);
+
+    expect(
+      channel.verifySignature(timestamp, validSign(timestamp), 'client-secret'),
+    ).toBe(false);
+  });
+
+  it('compares webhook signatures without accepting prefixes', () => {
+    const channel = webhook(createChannel());
+    const timestamp = String(Date.now());
+    const sign = validSign(timestamp);
+
+    expect(
+      channel.verifySignature(timestamp, sign.slice(0, -2), 'client-secret'),
+    ).toBe(false);
+    expect(channel.verifySignature(timestamp, sign, 'client-secret')).toBe(
+      true,
+    );
+  });
+
+  it('rejects webhook requests with missing signature headers', async () => {
+    const channel = webhook(
+      createChannel({ openConversationId: 'cid-webhook' }),
+    );
+    const sendGroupMessage = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { sendGroupMessage: typeof sendGroupMessage }
+    ).sendGroupMessage = sendGroupMessage;
+    const port = await startWebhook(channel);
+
+    try {
+      const resp = await fetch(`http://127.0.0.1:${port}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          EventType: 'doc_change',
+          data: { dentryName: 'Roadmap' },
+        }),
+      });
+
+      expect(resp.status).toBe(401);
+      expect(sendGroupMessage).not.toHaveBeenCalled();
+    } finally {
+      channel.disconnect();
+    }
+  });
+
+  it('deduplicates doc_change webhook events by EventId', () => {
+    const channel = webhook(
+      createChannel({ openConversationId: 'cid-webhook' }),
+    );
+    const sendGroupMessage = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { sendGroupMessage: typeof sendGroupMessage }
+    ).sendGroupMessage = sendGroupMessage;
+
+    channel.onDocChange({ dentryName: 'Roadmap' }, 'event-1');
+    channel.onDocChange({ dentryName: 'Roadmap' }, 'event-1');
+
+    expect(sendGroupMessage).toHaveBeenCalledOnce();
+  });
+
+  it('escapes markdown fields and blocks unsafe doc URLs', () => {
+    const channel = webhook(
+      createChannel({ openConversationId: 'cid-webhook' }),
+    );
+    const sendGroupMessage = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { sendGroupMessage: typeof sendGroupMessage }
+    ).sendGroupMessage = sendGroupMessage;
+
+    channel.onDocChange({
+      dentryName: '[Release](https://evil.example)',
+      url: 'javascript:alert(1)',
+      operatorName: 'Mallory_(ops)',
+      operateType: 'update',
+    });
+
+    const text = sendGroupMessage.mock.calls[0]![0] as string;
+    expect(text).toContain('\\[Release\\]\\(https://evil.example\\)');
+    expect(text).not.toContain('javascript:alert');
+    expect(text).toContain('Mallory\\_\\(ops\\)');
+  });
+
+  it('sends webhook notifications through the proactive path', async () => {
+    const channel = webhook(
+      createChannel({ openConversationId: 'cid-webhook' }),
+    );
+    const pushProactive = vi.fn().mockResolvedValue(undefined);
+    (
+      channel as unknown as { pushProactive: typeof pushProactive }
+    ).pushProactive = pushProactive;
+
+    await channel.sendGroupMessage('# Doc changed');
+
+    expect(pushProactive).toHaveBeenCalledWith(
+      {
+        channelName: 'test-dingtalk',
+        senderId: 'dingtalk-webhook',
+        chatId: 'cid-webhook',
+        isGroup: true,
+      },
+      '# Doc changed',
+    );
   });
 });

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { createHmac, randomUUID } from 'node:crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
@@ -97,6 +97,8 @@ const GROUP_MSG_API = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send';
 const GROUP_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text} markdown template key
 const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
 const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
+const WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
+const WEBHOOK_SIGNATURE_TOLERANCE_MS = 5 * 60 * 1000;
 
 interface DingTalkTokenResponse {
   errcode?: number;
@@ -297,6 +299,7 @@ export class DingtalkChannel extends ChannelBase {
     await this.client.connect();
 
     if (this.webhookPort) {
+      this.closeWebhookServer();
       this.startWebhookServer();
     }
 
@@ -502,57 +505,57 @@ export class DingtalkChannel extends ChannelBase {
       return;
     }
 
-    const token = await this.getProactiveToken();
-    const robotCode = this.config.clientId;
-    if (!token || !robotCode) {
-      process.stderr.write(
-        `[DingTalk:${this.name}] Cannot send group message: missing token or robotCode.\n`,
-      );
-      return;
-    }
-
-    const title = extractTitle(text);
-    const resp = await fetch(GROUP_MSG_API, {
-      method: 'POST',
-      headers: {
-        'x-acs-dingtalk-access-token': token,
-        'Content-Type': 'application/json',
+    await this.pushProactive(
+      {
+        channelName: this.name,
+        senderId: 'dingtalk-webhook',
+        chatId: this.openConversationId,
+        isGroup: true,
       },
-      body: JSON.stringify({
-        robotCode,
-        openConversationId: this.openConversationId,
-        msgKey: GROUP_MSG_KEY,
-        msgParam: JSON.stringify({ title, text }),
-      }),
-    });
-
-    if (!resp.ok) {
-      const detail = await resp.text().catch(() => '');
-      process.stderr.write(
-        `[DingTalk:${this.name}] sendGroupMessage failed: HTTP ${resp.status} ${detail}\n`,
-      );
-    }
+      text,
+    );
   }
 
   private startWebhookServer(): void {
+    this.closeWebhookServer();
     const port = this.webhookPort!;
     const appSecret = this.config.clientSecret!;
 
     this.webhookServer = createServer((req, res) => {
       const chunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      let bodyBytes = 0;
+      let bodyTooLarge = false;
+
+      req.on('data', (chunk: Buffer) => {
+        if (bodyTooLarge) return;
+        bodyBytes += chunk.length;
+        if (bodyBytes > WEBHOOK_MAX_BODY_BYTES) {
+          bodyTooLarge = true;
+          chunks.length = 0;
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'payload too large' }));
+          req.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on('end', () => {
+        if (bodyTooLarge || res.writableEnded) return;
         try {
           const body = Buffer.concat(chunks).toString('utf-8');
           const payload: DingTalkEventPayload = body ? JSON.parse(body) : {};
 
-          const timestamp = req.headers['timestamp'] as string | undefined;
-          const sign = req.headers['sign'] as string | undefined;
-          if (
-            timestamp &&
-            sign &&
-            !this.verifySignature(timestamp, sign, appSecret)
-          ) {
+          const timestamp = this.firstHeader(req.headers['timestamp']);
+          const sign = this.firstHeader(req.headers['sign']);
+          if (!timestamp || !sign) {
+            process.stderr.write(
+              `[DingTalk:${this.name}] Webhook missing signature headers.\n`,
+            );
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'missing signature' }));
+            return;
+          }
+          if (!this.verifySignature(timestamp, sign, appSecret)) {
             process.stderr.write(
               `[DingTalk:${this.name}] Webhook signature verification failed.\n`,
             );
@@ -576,7 +579,7 @@ export class DingtalkChannel extends ChannelBase {
           }
 
           if (eventType === 'doc_change') {
-            this.onDocChange(payload.data || {});
+            this.onDocChange(payload.data || {}, payload.EventId);
           }
 
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -585,10 +588,18 @@ export class DingtalkChannel extends ChannelBase {
           process.stderr.write(
             `[DingTalk:${this.name}] Webhook error: ${err}\n`,
           );
-          res.writeHead(500, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'internal error' }));
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'internal error' }));
+          }
         }
       });
+    });
+
+    this.webhookServer.on('error', (err) => {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Webhook server error: ${err}\n`,
+      );
     });
 
     this.webhookServer.listen(port, () => {
@@ -603,17 +614,37 @@ export class DingtalkChannel extends ChannelBase {
     sign: string,
     appSecret: string,
   ): boolean {
+    const timestampMs = Number(timestamp);
+    if (
+      !Number.isFinite(timestampMs) ||
+      Math.abs(Date.now() - timestampMs) > WEBHOOK_SIGNATURE_TOLERANCE_MS
+    ) {
+      return false;
+    }
     const expected = createHmac('sha256', appSecret)
       .update(`${timestamp}\n${appSecret}`)
       .digest('base64');
-    return sign === expected;
+    const signBuf = Buffer.from(sign);
+    const expectedBuf = Buffer.from(expected);
+    if (signBuf.length !== expectedBuf.length) return false;
+    return timingSafeEqual(signBuf, expectedBuf);
   }
 
-  private onDocChange(data: Record<string, unknown>): void {
-    const docName = (data['dentryName'] as string) || '未知文档';
-    const docUrl = (data['url'] as string) || '';
-    const operator = (data['operatorName'] as string) || '未知用户';
-    const operateType = (data['operateType'] as string) || '变更';
+  private onDocChange(data: Record<string, unknown>, eventId?: string): void {
+    if (eventId) {
+      const dedupKey = `webhook:${eventId}`;
+      if (this.seenMessages.has(dedupKey)) return;
+      this.seenMessages.set(dedupKey, Date.now());
+    }
+
+    const docName = this.escapeMarkdown(
+      this.stringField(data['dentryName']) || '未知文档',
+    );
+    const docUrl = this.safeDingTalkDocUrl(this.stringField(data['url']));
+    const operator = this.escapeMarkdown(
+      this.stringField(data['operatorName']) || '未知用户',
+    );
+    const operateType = this.stringField(data['operateType']) || '变更';
 
     const operateLabel: Record<string, string> = {
       add: '新建',
@@ -625,7 +656,9 @@ export class DingtalkChannel extends ChannelBase {
       edit: '编辑',
     };
 
-    const action = operateLabel[operateType] || operateType;
+    const action = this.escapeMarkdown(
+      operateLabel[operateType] || operateType,
+    );
 
     const text = [
       `### 📄 文档变更通知`,
@@ -645,6 +678,50 @@ export class DingtalkChannel extends ChannelBase {
     process.stderr.write(
       `[DingTalk:${this.name}] doc_change: ${action} "${docName}" by ${operator}\n`,
     );
+  }
+
+  private firstHeader(
+    value: string | string[] | undefined,
+  ): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+  }
+
+  private stringField(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+  }
+
+  private safeDingTalkDocUrl(value: string): string {
+    if (!value) return '';
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return '';
+    }
+    if (url.protocol !== 'https:' || url.username || url.password) {
+      return '';
+    }
+    const hostname = url.hostname.toLowerCase();
+    if (
+      hostname !== 'dingtalk.com' &&
+      !hostname.endsWith('.dingtalk.com') &&
+      hostname !== 'dingtalkapps.com' &&
+      !hostname.endsWith('.dingtalkapps.com')
+    ) {
+      return '';
+    }
+    return url.toString();
+  }
+
+  private escapeMarkdown(value: string): string {
+    return value.replace(/[\\[\]()_*`<>]/g, '\\$&');
+  }
+
+  private closeWebhookServer(): void {
+    if (!this.webhookServer) return;
+    this.webhookServer.closeAllConnections();
+    this.webhookServer.close();
+    this.webhookServer = undefined;
   }
 
   private getAccessToken(): string | undefined {
@@ -714,9 +791,7 @@ export class DingtalkChannel extends ChannelBase {
     }
     this.activeReactionKeys.clear();
     this.sessionReactionKeys.clear();
-    if (this.webhookServer) {
-      this.webhookServer.close();
-    }
+    this.closeWebhookServer();
     this.client.disconnect();
     process.stderr.write(`[DingTalk:${this.name}] Disconnected.\n`);
   }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -1,8 +1,10 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
 import { DWClient, TOPIC_ROBOT, EventAck } from 'dingtalk-stream-sdk-nodejs';
 import type { DWClientDownStream } from 'dingtalk-stream-sdk-nodejs';
 import {
@@ -76,6 +78,14 @@ interface DingTalkMessageData {
   };
 }
 
+interface DingTalkEventPayload {
+  EventId?: string;
+  EventType?: string;
+  CreateAt?: string;
+  CorpId?: string;
+  data?: Record<string, unknown>;
+}
+
 /** Track seen msgIds to deduplicate retried callbacks. */
 const DEDUP_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -126,6 +136,9 @@ export class DingtalkChannel extends ChannelBase {
    * on (re)connect, so a long-lived socket serves a stale one after ~2h.
    */
   private proactiveToken?: { token: string; expiresAt: number };
+  private openConversationId?: string;
+  private webhookServer?: Server;
+  private webhookPort?: number;
 
   constructor(
     name: string,
@@ -146,6 +159,13 @@ export class DingtalkChannel extends ChannelBase {
       clientSecret: config.clientSecret,
     });
     this.installStructuredDownstreamHandler();
+
+    this.openConversationId = (config as unknown as Record<string, unknown>)[
+      'openConversationId'
+    ] as string | undefined;
+    this.webhookPort = (config as unknown as Record<string, unknown>)[
+      'webhookPort'
+    ] as number | undefined;
   }
 
   private installStructuredDownstreamHandler(): void {
@@ -275,6 +295,10 @@ export class DingtalkChannel extends ChannelBase {
     );
 
     await this.client.connect();
+
+    if (this.webhookPort) {
+      this.startWebhookServer();
+    }
 
     // Periodically clean up dedup map
     this.dedupTimer = setInterval(() => {
@@ -470,6 +494,159 @@ export class DingtalkChannel extends ChannelBase {
     }
   }
 
+  private async sendGroupMessage(text: string): Promise<void> {
+    if (!this.openConversationId) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] No openConversationId configured, cannot push to group.\n`,
+      );
+      return;
+    }
+
+    const token = await this.getProactiveToken();
+    const robotCode = this.config.clientId;
+    if (!token || !robotCode) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Cannot send group message: missing token or robotCode.\n`,
+      );
+      return;
+    }
+
+    const title = extractTitle(text);
+    const resp = await fetch(GROUP_MSG_API, {
+      method: 'POST',
+      headers: {
+        'x-acs-dingtalk-access-token': token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        robotCode,
+        openConversationId: this.openConversationId,
+        msgKey: GROUP_MSG_KEY,
+        msgParam: JSON.stringify({ title, text }),
+      }),
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '');
+      process.stderr.write(
+        `[DingTalk:${this.name}] sendGroupMessage failed: HTTP ${resp.status} ${detail}\n`,
+      );
+    }
+  }
+
+  private startWebhookServer(): void {
+    const port = this.webhookPort!;
+    const appSecret = this.config.clientSecret!;
+
+    this.webhookServer = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          const payload: DingTalkEventPayload = body ? JSON.parse(body) : {};
+
+          const timestamp = req.headers['timestamp'] as string | undefined;
+          const sign = req.headers['sign'] as string | undefined;
+          if (
+            timestamp &&
+            sign &&
+            !this.verifySignature(timestamp, sign, appSecret)
+          ) {
+            process.stderr.write(
+              `[DingTalk:${this.name}] Webhook signature verification failed.\n`,
+            );
+            res.writeHead(403, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'invalid signature' }));
+            return;
+          }
+
+          const eventType = payload.EventType;
+          process.stderr.write(
+            `[DingTalk:${this.name}] Webhook received: EventType=${eventType}\n`,
+          );
+
+          if (eventType === 'check_url') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ msgtype: 'check_url' }));
+            process.stderr.write(
+              `[DingTalk:${this.name}] check_url verified OK.\n`,
+            );
+            return;
+          }
+
+          if (eventType === 'doc_change') {
+            this.onDocChange(payload.data || {});
+          }
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        } catch (err) {
+          process.stderr.write(
+            `[DingTalk:${this.name}] Webhook error: ${err}\n`,
+          );
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal error' }));
+        }
+      });
+    });
+
+    this.webhookServer.listen(port, () => {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Webhook server listening on port ${port}.\n`,
+      );
+    });
+  }
+
+  private verifySignature(
+    timestamp: string,
+    sign: string,
+    appSecret: string,
+  ): boolean {
+    const expected = createHmac('sha256', appSecret)
+      .update(`${timestamp}\n${appSecret}`)
+      .digest('base64');
+    return sign === expected;
+  }
+
+  private onDocChange(data: Record<string, unknown>): void {
+    const docName = (data['dentryName'] as string) || '未知文档';
+    const docUrl = (data['url'] as string) || '';
+    const operator = (data['operatorName'] as string) || '未知用户';
+    const operateType = (data['operateType'] as string) || '变更';
+
+    const operateLabel: Record<string, string> = {
+      add: '新建',
+      update: '更新',
+      delete: '删除',
+      rename: '重命名',
+      move: '移动',
+      copy: '复制',
+      edit: '编辑',
+    };
+
+    const action = operateLabel[operateType] || operateType;
+
+    const text = [
+      `### 📄 文档变更通知`,
+      ``,
+      `- **文档**: ${docUrl ? `[${docName}](${docUrl})` : docName}`,
+      `- **操作**: ${action}`,
+      `- **操作人**: ${operator}`,
+      `- **时间**: ${new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })}`,
+    ].join('\n');
+
+    this.sendGroupMessage(text).catch((err) => {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Error sending doc_change notification: ${err}\n`,
+      );
+    });
+
+    process.stderr.write(
+      `[DingTalk:${this.name}] doc_change: ${action} "${docName}" by ${operator}\n`,
+    );
+  }
+
   private getAccessToken(): string | undefined {
     return this.client.getConfig().access_token;
   }
@@ -537,6 +714,9 @@ export class DingtalkChannel extends ChannelBase {
     }
     this.activeReactionKeys.clear();
     this.sessionReactionKeys.clear();
+    if (this.webhookServer) {
+      this.webhookServer.close();
+    }
     this.client.disconnect();
     process.stderr.write(`[DingTalk:${this.name}] Disconnected.\n`);
   }


### PR DESCRIPTION
## What this PR does

Adds DingTalk event webhook support alongside the existing stream-based robot message connection. A DingTalk channel can now start a local HTTP webhook listener, validate DingTalk callback signatures, answer subscription `check_url` probes, and convert `doc_change` events into group notifications through the proactive group message API.

## Why it's needed

DingTalk document event subscriptions are delivered through HTTP callbacks, not the existing stream message path. Without a webhook listener, a configured DingTalk robot cannot receive document-change events and notify the target group when shared documents are created, edited, renamed, moved, or deleted.

## Reviewer Test Plan

### How to verify

Configure a DingTalk channel with `webhookPort` and `openConversationId`, register the callback URL in DingTalk event subscriptions, and confirm `check_url` succeeds only when DingTalk signature headers are present and valid. Send or replay a signed `doc_change` callback and verify the configured group receives one sanitized markdown notification. Replaying the same `EventId` should not send a duplicate notification. Invalid signatures, missing signature headers, stale timestamps, oversized bodies, and unsafe document URLs should be rejected or neutralized without sending a group message.

### Evidence (Before & After)

Before: DingTalk channels only consumed stream robot messages, so DingTalk document event callbacks had no local endpoint and could not trigger group notifications.

After: The channel can listen for signed DingTalk webhook callbacks, respond to subscription probes, and send sanitized `doc_change` notifications through the existing proactive message path.

Local regression evidence:

```text
cd packages/channels/dingtalk && npx vitest run src/DingtalkAdapter.test.ts --coverage.enabled=false
✓ src/DingtalkAdapter.test.ts (47 tests)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local isolated Codex worktree on macOS with Node.js 22-compatible project dependencies. Live DingTalk tenant callback validation still needs a reviewer with DingTalk event-subscription access.

## Risk & Scope

- Main risk or tradeoff: enabling an HTTP listener increases the channel's local attack surface, so this PR verifies DingTalk signatures, rejects missing or stale signatures, caps request bodies, deduplicates event retries, closes prior webhook servers before restart, and sanitizes notification markdown and URLs.
- Not validated / out of scope: live DingTalk enterprise tenant E2E and network exposure/proxy setup are not validated locally; reviewers with DingTalk admin access should verify the subscription callback flow.
- Breaking changes / migration notes: none expected; webhook behavior is opt-in via configuration.

## Linked Issues

Related to DingTalk channel event webhook support.

<details>
<summary>中文说明</summary>

## What this PR does

在现有基于 stream 的钉钉机器人消息连接之外，增加钉钉事件 webhook 支持。钉钉 channel 现在可以启动本地 HTTP webhook 监听器，校验钉钉回调签名，响应订阅配置时的 `check_url` 探测，并把 `doc_change` 事件通过主动群消息 API 转成群通知。

## Why it's needed

钉钉文档事件订阅通过 HTTP 回调投递，不走现有的 stream 消息路径。如果没有 webhook 监听器，已配置的钉钉机器人无法接收文档变更事件，也无法在共享文档被创建、编辑、重命名、移动或删除时通知目标群。

## Reviewer Test Plan

### How to verify

配置带有 `webhookPort` 和 `openConversationId` 的钉钉 channel，在钉钉事件订阅中登记回调 URL，并确认只有带有有效钉钉签名头的 `check_url` 才会成功。发送或重放一个已签名的 `doc_change` 回调，确认配置的群只收到一条经过清洗的 markdown 通知。重放相同 `EventId` 不应重复发送通知。无效签名、缺失签名头、过期时间戳、超大请求体和不安全文档 URL 应被拒绝或中和，且不会发送群消息。

### Evidence (Before & After)

Before：钉钉 channel 只消费 stream 机器人消息，因此钉钉文档事件回调没有本地入口，也无法触发群通知。

After：channel 可以监听已签名的钉钉 webhook 回调，响应订阅探测，并通过现有主动消息路径发送经过清洗的 `doc_change` 通知。

本地回归证据：

```text
cd packages/channels/dingtalk && npx vitest run src/DingtalkAdapter.test.ts --coverage.enabled=false
✓ src/DingtalkAdapter.test.ts (47 tests)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 上的本地隔离 Codex worktree，使用兼容 Node.js 22 的项目依赖。真实钉钉租户回调验证仍需要有钉钉事件订阅权限的 reviewer 执行。

## Risk & Scope

- Main risk or tradeoff：启用 HTTP 监听器会增加 channel 的本地攻击面，所以本 PR 校验钉钉签名，拒绝缺失或过期签名，限制请求体大小，对事件重试做去重，在重启前关闭旧 webhook server，并清洗通知 markdown 和 URL。
- Not validated / out of scope：本地未验证真实钉钉企业租户 E2E 和网络暴露/代理配置；需要有钉钉管理员权限的 reviewer 验证订阅回调流程。
- Breaking changes / migration notes：无预期破坏性变更；webhook 行为通过配置显式启用。

## Linked Issues

关联钉钉 channel 事件 webhook 支持。

</details>
