### PR TITLE
fix(monitor): preserve inherited git pager

### DIFF
--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -191,8 +191,15 @@ describe('MonitorTool', () => {
   let monitorRegistry: MonitorRegistry;
   let mockChild: ReturnType<typeof createMockChild>;
   let mockIsPathWithinWorkspace: ReturnType<typeof vi.fn>;
+  let originalPager: string | undefined;
+  let originalGitPager: string | undefined;
 
   beforeEach(() => {
+    originalPager = process.env['PAGER'];
+    originalGitPager = process.env['GIT_PAGER'];
+    delete process.env['PAGER'];
+    delete process.env['GIT_PAGER'];
+
     vi.clearAllMocks();
     mockOsPlatform.mockReturnValue('linux');
 
@@ -229,6 +236,18 @@ describe('MonitorTool', () => {
 
   afterEach(() => {
     monitorRegistry.abortAll();
+
+    if (originalPager === undefined) {
+      delete process.env['PAGER'];
+    } else {
+      process.env['PAGER'] = originalPager;
+    }
+
+    if (originalGitPager === undefined) {
+      delete process.env['GIT_PAGER'];
+    } else {
+      process.env['GIT_PAGER'] = originalGitPager;
+    }
   });
 
   // Helper to access protected validateToolParamValues
@@ -682,7 +701,33 @@ describe('MonitorTool', () => {
 
       const spawnOptions = mockSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('cat');
-      expect(spawnOptions.env['GIT_PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
+    });
+
+    it('preserves inherited git pager values for spawned processes', async () => {
+      process.env['GIT_PAGER'] = 'delta';
+      const invocation = createInvocation({
+        command: 'git log --oneline',
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      const spawnOptions = mockSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('cat');
+      expect(spawnOptions.env['GIT_PAGER']).toBe('delta');
+    });
+
+    it('does not inject Unix pager defaults into Windows monitor env when unset', async () => {
+      mockOsPlatform.mockReturnValue('win32');
+      const invocation = createInvocation({
+        command: 'tail -f /var/log/app.log',
+      });
+
+      await invocation.execute(new AbortController().signal);
+
+      const spawnOptions = mockSpawn.mock.calls[0][2];
+      expect(spawnOptions.env['PAGER']).toBe('');
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
     });
 
     it('propagates explicit pager configuration to spawned processes', async () => {
@@ -697,7 +742,7 @@ describe('MonitorTool', () => {
 
       const spawnOptions = mockSpawn.mock.calls[0][2];
       expect(spawnOptions.env['PAGER']).toBe('more');
-      expect(spawnOptions.env['GIT_PAGER']).toBe('more');
+      expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
     });
 
     it('does not spawn when the turn signal is already aborted', async () => {

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -369,7 +369,7 @@ class MonitorToolInvocation extends BaseToolInvocation<
           QWEN_CODE: '1',
           TERM: 'dumb', // no color codes for streaming
           ...getShellPagerEnv(this.config.getShellExecutionConfig().pager, {
-            includeGitPager: true,
+            includeGitPager: false,
             platform: os.platform(),
           }),
           ...getShellContextEnvVars(),

--- a/packages/core/src/utils/shell-pager-env.test.ts
+++ b/packages/core/src/utils/shell-pager-env.test.ts
@@ -44,6 +44,28 @@ describe('shellPagerEnv', () => {
     });
   });
 
+  it('omits GIT_PAGER when git pager output is not requested', () => {
+    expect(
+      getShellPagerEnv('less', {
+        includeGitPager: false,
+        platform: 'linux',
+      }),
+    ).toEqual({
+      PAGER: 'less',
+    });
+  });
+
+  it('uses the default pager without GIT_PAGER when git pager output is not requested', () => {
+    expect(
+      getShellPagerEnv(undefined, {
+        includeGitPager: false,
+        platform: 'linux',
+      }),
+    ).toEqual({
+      PAGER: 'cat',
+    });
+  });
+
   it('treats an empty pager as an explicit request to disable pager env values', () => {
     expect(
       getShellPagerEnv('', { includeGitPager: true, platform: 'linux' }),


### PR DESCRIPTION
## What this PR does

This follow-up keeps the monitor tool from injecting `GIT_PAGER` when generating the monitor spawn environment. The monitor path still applies the platform-aware `PAGER` handling from #6390, but it now leaves inherited `GIT_PAGER` values untouched, matching the child_process fallback behavior.

This also adds focused coverage for the Windows monitor pager path and for the `includeGitPager: false` helper behavior.

## Why it's needed

In #6390, the monitor path started passing `includeGitPager: true`, which means non-Windows monitor-spawned processes received `GIT_PAGER=cat` by default. That can override a user's inherited git pager configuration, such as `delta`, `less -R`, or other custom values.

The child_process fallback path intentionally preserves inherited `GIT_PAGER` behavior. This PR aligns monitor with that behavior while keeping the Windows `PAGER=cat` fix intact.

## Reviewer Test Plan

### How to verify

Run the focused monitor and pager helper tests:

```bash
npm run test:ci --workspace=packages/core -- src/tools/monitor.test.ts src/utils/shell-pager-env.test.ts
```

Run core typecheck and focused formatting/lint checks:

```bash
npm run typecheck --workspace=packages/core
npx prettier --check packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/utils/shell-pager-env.test.ts
npx eslint packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/utils/shell-pager-env.test.ts --max-warnings 0
git diff --check
```

Expected: monitor-spawned processes still receive the platform-aware `PAGER` value, but `GIT_PAGER` is not injected by the monitor path. The Windows monitor test verifies that an unset pager produces `PAGER=''` and does not inject `GIT_PAGER`.

### Evidence (Before & After)

N/A for UI screenshots. This is covered by focused unit tests around the generated monitor spawn environment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Windows workspace, Node/npm from the repository.

## Risk & Scope

- Main risk or tradeoff: monitor-spawned git commands now preserve inherited `GIT_PAGER` values instead of forcing `GIT_PAGER=cat`; this matches the child_process fallback behavior and avoids overriding user custom git pager configuration.
- Not validated / out of scope: changing the shell execution PTY path, changing `PAGER` platform defaults, or changing settings schema behavior.
- Breaking changes / migration notes: none expected.

## Linked Issues

Follow-up to #6390

<details>
<summary>中文说明</summary>

## What this PR does

这个 follow-up PR 避免 monitor 工具在生成 spawn 环境时注入 `GIT_PAGER`。monitor 路径仍然保留 #6390 引入的平台感知 `PAGER` 处理，但现在会保留继承来的 `GIT_PAGER`，与 child_process fallback 的行为保持一致。

这个 PR 还补充了 Windows monitor pager 路径，以及 `includeGitPager: false` helper 行为的聚焦测试。

## Why it's needed

在 #6390 中，monitor 路径开始传入 `includeGitPager: true`，这会让非 Windows 的 monitor-spawned process 默认收到 `GIT_PAGER=cat`。这可能覆盖用户继承来的 git pager 配置，例如 `delta`、`less -R` 或其他自定义值。

child_process fallback 路径会保留继承的 `GIT_PAGER` 行为。这个 PR 让 monitor 与该行为对齐，同时保留 Windows 下避免 `PAGER=cat` 的修复。

## Reviewer Test Plan

### How to verify

运行 monitor 和 pager helper 的聚焦测试：

```bash
npm run test:ci --workspace=packages/core -- src/tools/monitor.test.ts src/utils/shell-pager-env.test.ts
```

运行 core typecheck 和聚焦格式 / lint 检查：

```bash
npm run typecheck --workspace=packages/core
npx prettier --check packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/utils/shell-pager-env.test.ts
npx eslint packages/core/src/tools/monitor.ts packages/core/src/tools/monitor.test.ts packages/core/src/utils/shell-pager-env.test.ts --max-warnings 0
git diff --check
```

预期：monitor-spawned process 仍然会收到平台感知的 `PAGER` 值，但 monitor 路径不会注入 `GIT_PAGER`。Windows monitor 测试会验证未配置 pager 时产生 `PAGER=''`，并且不注入 `GIT_PAGER`。

### Evidence (Before & After)

非 UI 变更，不需要截图。行为由生成 monitor spawn 环境的聚焦单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地 Windows workspace，使用仓库内 Node/npm 环境。

## Risk & Scope

- Main risk or tradeoff: monitor-spawned git 命令现在会保留继承的 `GIT_PAGER`，而不是强制设置 `GIT_PAGER=cat`；这与 child_process fallback 行为一致，并避免覆盖用户自定义 git pager 配置。
- Not validated / out of scope: 不改变 shell execution PTY 路径，不改变 `PAGER` 平台默认值，不改变 settings schema 行为。
- Breaking changes / migration notes: 预期没有。

## Linked Issues

Follow-up to #6390

</details>
