### PR TITLE
fix(core): prevent re-invoking loaded skill from appending duplicate content

### DIFF
--- a/packages/core/src/tools/skill.test.ts
+++ b/packages/core/src/tools/skill.test.ts
@@ -920,6 +920,118 @@ describe('SkillTool', () => {
         }),
       );
     });
+
+    it('returns full content on first invocation and short message on re-invocation', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(
+        mockRuntimeConfig,
+      );
+
+      const invocation1 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result1 = await invocation1.execute();
+      const llmText1 = partToString(result1.llmContent);
+      expect(llmText1).toContain('Review code for quality and best practices.');
+      expect(llmText1).toContain('Base directory for this skill:');
+      expect(result1.returnDisplay).toBe(
+        'Specialized skill for reviewing code quality',
+      );
+
+      const invocation2 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result2 = await invocation2.execute();
+      const llmText2 = partToString(result2.llmContent);
+      expect(llmText2).toBe(
+        'Skill "code-review" is already loaded in context.',
+      );
+      expect(result2.returnDisplay).toBe(
+        'Skill "code-review" is already loaded in context.',
+      );
+    });
+
+    it('still allows loading a different skill after one is already loaded', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime)
+        .mockResolvedValueOnce(mockSkills[0])
+        .mockResolvedValueOnce(mockSkills[1]);
+
+      const inv1 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      await inv1.execute();
+
+      const inv2 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'testing' });
+      const result2 = await inv2.execute();
+      const llmText2 = partToString(result2.llmContent);
+      expect(llmText2).toContain('Help write comprehensive tests.');
+    });
+
+    it('does not skip dedup for skills that failed to load on first attempt', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockRuntimeConfig);
+
+      const inv1 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      await inv1.execute();
+
+      const inv2 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result2 = await inv2.execute();
+      const llmText2 = partToString(result2.llmContent);
+      expect(llmText2).toContain('Review code for quality and best practices.');
+    });
+
+    it('clearLoadedSkills resets dedup state so the next invocation returns full content', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(
+        mockRuntimeConfig,
+      );
+
+      const inv1 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      await inv1.execute();
+
+      skillTool.clearLoadedSkills();
+
+      const inv2 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result2 = await inv2.execute();
+      const llmText2 = partToString(result2.llmContent);
+      expect(llmText2).toContain('Review code for quality and best practices.');
+    });
+
+    it('re-invocation still logs telemetry and calls onSkillLoaded', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(
+        mockRuntimeConfig,
+      );
+
+      const inv1 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      await inv1.execute();
+
+      vi.mocked(logSkillLaunch).mockClear();
+      vi.mocked(recordSkillInvocation).mockClear();
+
+      const inv2 = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      await inv2.execute();
+
+      expect(logSkillLaunch).toHaveBeenCalledWith(
+        config,
+        expect.objectContaining({
+          skill_name: 'code-review',
+          success: true,
+        }),
+      );
+    });
   });
 
   describe('modelInvocableCommands integration', () => {

--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -251,6 +251,7 @@ export class SkillTool extends BaseDeclarativeTool<SkillParams, ToolResult> {
       params,
       (name: string) => this.loadedSkillNames.add(name),
       this.config.getModelInvocableCommandsExecutor(),
+      (name: string) => this.loadedSkillNames.has(name),
     );
   }
 
@@ -312,6 +313,7 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
           args?: string,
         ) => Promise<ModelInvocableCommandExecutorResult | null>)
       | null = null,
+    private readonly isSkillLoaded: (name: string) => boolean = () => false,
   ) {
     super(params);
   }
@@ -484,6 +486,22 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
         this.config,
         new SkillLaunchEvent(this.params.skill, true, this.promptId),
       );
+
+      // Prevent re-invoking an already-loaded skill from appending
+      // duplicate instructions to context. The first invocation
+      // returns the full skill body; subsequent invocations return a
+      // short confirmation so the model knows the skill is active
+      // without wasting context tokens. Check BEFORE calling
+      // onSkillLoaded, which adds the name to the loaded set.
+      if (this.isSkillLoaded(this.params.skill)) {
+        this.onSkillLoaded(this.params.skill);
+        const msg = `Skill "${this.params.skill}" is already loaded in context.`;
+        return {
+          llmContent: msg,
+          returnDisplay: msg,
+        };
+      }
+
       this.onSkillLoaded(this.params.skill);
 
       // Auto-approve the skill's declared allowedTools for the rest of the session.


### PR DESCRIPTION
## What this PR does

When a skill is invoked multiple times in the same session (e.g., calling `/review` twice, or invoking the `skill` tool with the same skill name), each invocation previously appended the full SKILL.md body content to the conversation history as a new tool result. This wasted context tokens — skill bodies can be hundreds of lines, and re-invocation silently doubled or tripled the overhead.

This PR adds deduplication: the first invocation returns the full skill body as before; subsequent invocations of the same skill return a short confirmation message (`"Skill 'xyz' is already loaded in context."`) instead of the full body.

## Why it's needed

**User problem:** Re-invoking a skill is a natural thing to do — the model might want to "refresh" or re-read instructions. Without dedup, each re-invocation silently wastes hundreds of tokens with duplicate content that's already in the conversation history.

**Current workaround:** None. The user has no way to know that re-invoking wastes tokens, and there's no mechanism to prevent it.

**Who benefits:** All users who invoke skills, especially in long sessions where context budget matters.

## Reviewer Test Plan

### How to verify

1. Invoke any skill (e.g., `/review` or `skill("code-review")`) — full content should be returned as before
2. Invoke the same skill again — a short message `"Skill 'code-review' is already loaded in context."` should be returned instead of the full body
3. Invoke a different skill — full content should be returned (dedup is per-skill, not global)
4. Run `/clear` — the dedup state is reset, so the next invocation of any skill returns full content again

Run tests:

```bash
cd packages/core && npx vitest run src/tools/skill.test.ts
```

All 78 tests should pass, including 5 new dedup tests.

### Evidence (Before & After)

N/A — non-user-visible change (internal dedup logic, model sees shorter tool results)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local dev environment, Node.js 22, vitest

## Risk & Scope

- Main risk or tradeoff: The model receives a shorter message on re-invocation — it must rely on the earlier full content already in the conversation history. This is the intended behavior (the content is still there, just not duplicated).
- Not validated / out of scope: The `<system-reminder>` skill availability reminders and `SkillActivationRegistry` already have their own dedup — this PR only affects the Skill tool execution path.
- Breaking changes: None — `isSkillLoaded` is a new optional constructor parameter with a default of `() => false`, so existing callers are unaffected.

## Linked Issues

Fixes #6427

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

当在同一会话中多次调用同一个技能时（例如两次调用 `/review`，或用 `skill` 工具调用相同技能名），每次调用之前都会将完整的 SKILL.md 内容作为新的工具结果追加到对话历史中，浪费了上下文 token。

此 PR 添加了去重逻辑：第一次调用返回完整技能内容；后续调用返回简短确认消息（`"Skill 'xyz' is already loaded in context."`），而不是完整内容。

## 为什么需要

重新调用技能是很自然的操作——模型可能想"刷新"或重新阅读指令。没有去重的话，每次重新调用都会静默地浪费数百个 token，重复已经在对话历史中的内容。

## 审阅者测试计划

### 如何验证

1. 调用任何技能（如 `/review`）——应返回完整内容
2. 再次调用同一技能——应返回简短消息 `"Skill 'code-review' is already loaded in context."`
3. 调用不同技能——应返回完整内容（去重是按技能的，不是全局的）
4. 运行 `/clear`——去重状态重置，下次调用任何技能都返回完整内容

运行测试：

```bash
cd packages/core && npx vitest run src/tools/skill.test.ts
```

所有 78 个测试应通过，包括 5 个新的去重测试。

### 证据（修改前 & 修改后）

N/A — 非用户可见的变更（内部去重逻辑，模型看到更短的工具结果）

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

本地开发环境，Node.js 22，vitest

## 风险 & 范围

- 主要风险或权衡：模型在重新调用时收到更短的消息——它需要依赖对话历史中已有的早期完整内容。这是预期行为（内容还在，只是不重复了）。
- 未验证 / 超出范围：`<system-reminder>` 技能可用性提醒和 `SkillActivationRegistry` 已有自己的去重——此 PR 仅影响 Skill 工具执行路径。
- 破坏性变更：无——`isSkillLoaded` 是新的可选构造函数参数，默认值为 `() => false`，现有调用者不受影响。

## 关联 Issue

Fixes #6427

</details>
