### PR TITLE
fix(daemon): surface workspace memory task error details

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3681,6 +3681,64 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
+  it('suppresses details for timed out workspace memory remember unavailable errors', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    const controller = new AbortController();
+    controller.abort();
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(controller.signal);
+
+    try {
+      const error = await agent
+        .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+          content: 'Remember me.',
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        code: -32009,
+        message: 'Managed memory is unavailable for this daemon workspace',
+        data: { errorKind: 'managed_memory_unavailable' },
+      });
+      expect(
+        (error as { data?: Record<string, unknown> }).data,
+      ).not.toHaveProperty('details');
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory remember timed out:',
+        expect.objectContaining({
+          code: 'managed_memory_unavailable',
+          details: 'memory service stopped',
+        }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
   it('omits details for workspace memory failures without a detail source', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
@@ -3862,6 +3920,61 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('rejects workspace memory forget when the bridge reports managed memory unavailable', async () => {
+    const forget = vi.fn().mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+      getMemoryManager: vi.fn().mockReturnValue({ forget }),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordUiTelemetryEvent: vi.fn(),
+      }),
+      getTranscriptPath: vi.fn().mockReturnValue('/tmp/transcript.jsonl'),
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const error = await agent
+      .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryForget, {
+        query: 'old preference',
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: -32009,
+      message: 'Managed memory is unavailable for this daemon workspace',
+      data: { errorKind: 'managed_memory_unavailable' },
+    });
+    expect(
+      (error as { data?: Record<string, unknown> }).data,
+    ).not.toHaveProperty('details');
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory forget failed:',
+      expect.objectContaining({
+        code: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('uses forget-specific error codes for workspace memory forget timeouts', async () => {
     const forget = vi.fn().mockRejectedValue(new Error('late abort'));
     Object.assign(mockConfig, {
@@ -4005,6 +4118,58 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         code: 'dream_failed',
         details: 'boom',
         stack: expect.stringContaining('boom'),
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('rejects workspace memory dream when the bridge reports managed memory unavailable', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordUiTelemetryEvent: vi.fn(),
+      }),
+      getTranscriptPath: vi.fn().mockReturnValue('/tmp/transcript.jsonl'),
+    });
+    mockRunManagedAutoMemoryDream.mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const error = await agent
+      .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryDream, {})
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: -32009,
+      message: 'Managed memory is unavailable for this daemon workspace',
+      data: { errorKind: 'managed_memory_unavailable' },
+    });
+    expect(
+      (error as { data?: Record<string, unknown> }).data,
+    ).not.toHaveProperty('details');
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory dream failed:',
+      expect.objectContaining({
+        code: 'managed_memory_unavailable',
+        details: 'memory service stopped',
       }),
     );
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3434,6 +3434,59 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('rejects workspace memory remember when the bridge reports managed memory unavailable', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    let rejection: unknown;
+    try {
+      await agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+        content: 'Remember me.',
+      });
+    } catch (err) {
+      rejection = err;
+    }
+
+    expect(rejection).toMatchObject({
+      code: -32009,
+      message: 'Managed memory is unavailable for this daemon workspace',
+      data: { errorKind: 'managed_memory_unavailable' },
+    });
+    expect(
+      (rejection as { data: Record<string, unknown> }).data,
+    ).not.toHaveProperty('details');
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember failed:',
+      expect.objectContaining({
+        code: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('includes details for workspace memory remember failures', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3681,7 +3681,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
-  it('suppresses details for timed out workspace memory remember unavailable errors', async () => {
+  it('preserves timeout codes for timed out workspace memory remember unavailable errors', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
       getProjectRoot: vi.fn().mockReturnValue('/workspace'),
@@ -3718,17 +3718,17 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         .catch((caught: unknown) => caught);
 
       expect(error).toMatchObject({
-        code: -32009,
-        message: 'Managed memory is unavailable for this daemon workspace',
-        data: { errorKind: 'managed_memory_unavailable' },
+        code: -32099,
+        message: 'Workspace memory remember timed out',
+        data: {
+          errorKind: 'remember_timeout',
+          details: 'memory service stopped',
+        },
       });
-      expect(
-        (error as { data?: Record<string, unknown> }).data,
-      ).not.toHaveProperty('details');
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
-        'Workspace memory remember unavailable during timeout:',
+        'Workspace memory remember timed out:',
         expect.objectContaining({
-          code: 'managed_memory_unavailable',
+          code: 'remember_timeout',
           details: 'memory service stopped',
         }),
       );
@@ -4029,7 +4029,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
-  it('suppresses details for timed out workspace memory forget unavailable errors', async () => {
+  it('preserves timeout codes for timed out workspace memory forget unavailable errors', async () => {
     const forget = vi.fn().mockRejectedValue({
       data: {
         errorKind: 'managed_memory_unavailable',
@@ -4071,17 +4071,17 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         .catch((caught: unknown) => caught);
 
       expect(error).toMatchObject({
-        code: -32009,
-        message: 'Managed memory is unavailable for this daemon workspace',
-        data: { errorKind: 'managed_memory_unavailable' },
+        code: -32099,
+        message: 'Workspace memory forget timed out',
+        data: {
+          errorKind: 'forget_timeout',
+          details: 'memory service stopped',
+        },
       });
-      expect(
-        (error as { data?: Record<string, unknown> }).data,
-      ).not.toHaveProperty('details');
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
-        'Workspace memory forget unavailable during timeout:',
+        'Workspace memory forget timed out:',
         expect.objectContaining({
-          code: 'managed_memory_unavailable',
+          code: 'forget_timeout',
           details: 'memory service stopped',
         }),
       );
@@ -4291,7 +4291,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
-  it('suppresses details for timed out workspace memory dream unavailable errors', async () => {
+  it('preserves timeout codes for timed out workspace memory dream unavailable errors', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
       getProjectRoot: vi.fn().mockReturnValue('/workspace'),
@@ -4330,17 +4330,17 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         .catch((caught: unknown) => caught);
 
       expect(error).toMatchObject({
-        code: -32009,
-        message: 'Managed memory is unavailable for this daemon workspace',
-        data: { errorKind: 'managed_memory_unavailable' },
+        code: -32099,
+        message: 'Workspace memory dream timed out',
+        data: {
+          errorKind: 'dream_timeout',
+          details: 'memory service stopped',
+        },
       });
-      expect(
-        (error as { data?: Record<string, unknown> }).data,
-      ).not.toHaveProperty('details');
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
-        'Workspace memory dream unavailable during timeout:',
+        'Workspace memory dream timed out:',
         expect.objectContaining({
-          code: 'managed_memory_unavailable',
+          code: 'dream_timeout',
           details: 'memory service stopped',
         }),
       );

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3685,6 +3685,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       message: 'Workspace memory forget failed',
       data: { errorKind: 'forget_failed', details: 'boom' },
     });
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory forget failed:',
+      {
+        code: 'forget_failed',
+        details: 'boom',
+      },
+    );
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -3826,6 +3833,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       message: 'Workspace memory dream failed',
       data: { errorKind: 'dream_failed', details: 'boom' },
     });
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory dream failed:',
+      {
+        code: 'dream_failed',
+        details: 'boom',
+      },
+    );
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -3867,6 +3881,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         message: 'Workspace memory dream timed out',
         data: { errorKind: 'dream_timeout' },
       });
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory dream timed out:',
+        {
+          code: 'dream_timeout',
+          details: 'late abort',
+        },
+      );
     } finally {
       timeoutSpy.mockRestore();
       mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3575,6 +3575,63 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('falls back when workspace memory error code extraction throws', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('code getter failed');
+        },
+      },
+    );
+    mockRunManagedRememberByAgent.mockRejectedValue(err);
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const error = await agent
+      .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+        content: 'Remember me.',
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: -32099,
+      message: 'Workspace memory remember failed',
+      data: { errorKind: 'remember_failed' },
+    });
+    expect(
+      (error as { data?: Record<string, unknown> }).data,
+    ).not.toHaveProperty('details');
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      'Failed to extract workspace memory error code:',
+      { extractionError: 'code getter failed' },
+    );
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember failed:',
+      expect.objectContaining({
+        code: 'remember_failed',
+        details: '<details unavailable>',
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('uses remember-specific error codes for workspace memory remember timeouts', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3726,7 +3726,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         (error as { data?: Record<string, unknown> }).data,
       ).not.toHaveProperty('details');
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
-        'Workspace memory remember timed out:',
+        'Workspace memory remember unavailable during timeout:',
         expect.objectContaining({
           code: 'managed_memory_unavailable',
           details: 'memory service stopped',
@@ -4029,6 +4029,69 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
+  it('suppresses details for timed out workspace memory forget unavailable errors', async () => {
+    const forget = vi.fn().mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+      getMemoryManager: vi.fn().mockReturnValue({ forget }),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordUiTelemetryEvent: vi.fn(),
+      }),
+      getTranscriptPath: vi.fn().mockReturnValue('/tmp/transcript.jsonl'),
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    const controller = new AbortController();
+    controller.abort();
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(controller.signal);
+
+    try {
+      const error = await agent
+        .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryForget, {
+          query: 'old preference',
+        })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        code: -32009,
+        message: 'Managed memory is unavailable for this daemon workspace',
+        data: { errorKind: 'managed_memory_unavailable' },
+      });
+      expect(
+        (error as { data?: Record<string, unknown> }).data,
+      ).not.toHaveProperty('details');
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory forget unavailable during timeout:',
+        expect.objectContaining({
+          code: 'managed_memory_unavailable',
+          details: 'memory service stopped',
+        }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
   it('runs workspace memory dream without requiring a session', async () => {
     Object.assign(mockConfig, {
       isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
@@ -4219,6 +4282,66 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           code: 'dream_timeout',
           details: 'late abort',
           stack: expect.stringContaining('late abort'),
+        }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('suppresses details for timed out workspace memory dream unavailable errors', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordUiTelemetryEvent: vi.fn(),
+      }),
+      getTranscriptPath: vi.fn().mockReturnValue('/tmp/transcript.jsonl'),
+    });
+    mockRunManagedAutoMemoryDream.mockRejectedValue({
+      data: {
+        errorKind: 'managed_memory_unavailable',
+        details: 'memory service stopped',
+      },
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    const controller = new AbortController();
+    controller.abort();
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(controller.signal);
+
+    try {
+      const error = await agent
+        .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryDream, {})
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        code: -32009,
+        message: 'Managed memory is unavailable for this daemon workspace',
+        data: { errorKind: 'managed_memory_unavailable' },
+      });
+      expect(
+        (error as { data?: Record<string, unknown> }).data,
+      ).not.toHaveProperty('details');
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory dream unavailable during timeout:',
+        expect.objectContaining({
+          code: 'managed_memory_unavailable',
+          details: 'memory service stopped',
         }),
       );
     } finally {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3508,10 +3508,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     expect(mockDebugLogger.error).toHaveBeenCalledWith(
       'Workspace memory remember failed:',
-      {
+      expect.objectContaining({
         code: 'remember_failed',
         details: 'Authorization: <redacted>',
-      },
+        stack: expect.stringContaining('Authorization: <redacted>'),
+      }),
     );
     expect(JSON.stringify(mockDebugLogger.error.mock.calls)).not.toContain(
       'secret-token-value',
@@ -3519,6 +3520,55 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     mockConnectionState.resolve();
     await agentPromise;
+  });
+
+  it('uses remember-specific error codes for workspace memory remember timeouts', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue(new Error('late abort'));
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    const controller = new AbortController();
+    controller.abort();
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(controller.signal);
+
+    try {
+      await expect(
+        agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+          content: 'Remember me.',
+        }),
+      ).rejects.toMatchObject({
+        code: -32099,
+        message: 'Workspace memory remember timed out',
+        data: { errorKind: 'remember_timeout' },
+      });
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory remember timed out:',
+        expect.objectContaining({
+          code: 'remember_timeout',
+          details: 'late abort',
+          stack: expect.stringContaining('late abort'),
+        }),
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
   });
 
   it('omits details for workspace memory failures without a detail source', async () => {
@@ -3687,10 +3737,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(mockDebugLogger.error).toHaveBeenCalledWith(
       'Workspace memory forget failed:',
-      {
+      expect.objectContaining({
         code: 'forget_failed',
         details: 'boom',
-      },
+        stack: expect.stringContaining('boom'),
+      }),
     );
 
     mockConnectionState.resolve();
@@ -3738,10 +3789,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       });
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
         'Workspace memory forget timed out:',
-        {
+        expect.objectContaining({
           code: 'forget_timeout',
           details: 'late abort',
-        },
+          stack: expect.stringContaining('late abort'),
+        }),
       );
     } finally {
       timeoutSpy.mockRestore();
@@ -3835,10 +3887,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(mockDebugLogger.error).toHaveBeenCalledWith(
       'Workspace memory dream failed:',
-      {
+      expect.objectContaining({
         code: 'dream_failed',
         details: 'boom',
-      },
+        stack: expect.stringContaining('boom'),
+      }),
     );
 
     mockConnectionState.resolve();
@@ -3883,10 +3936,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       });
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
         'Workspace memory dream timed out:',
-        {
+        expect.objectContaining({
           code: 'dream_timeout',
           details: 'late abort',
-        },
+          stack: expect.stringContaining('late abort'),
+        }),
       );
     } finally {
       timeoutSpy.mockRestore();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3430,6 +3430,44 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('includes details for workspace memory remember failures', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue(
+      new Error('remember agent stopped early'),
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+        content: 'Remember me.',
+      }),
+    ).rejects.toMatchObject({
+      code: -32099,
+      message: 'Workspace memory remember failed',
+      data: {
+        errorKind: 'remember_failed',
+        details: 'remember agent stopped early',
+      },
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('runs workspace memory forget without requiring a session', async () => {
     const forget = vi.fn().mockResolvedValue({
       systemMessage: 'Forgot 1 entry.',
@@ -3553,7 +3591,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     ).rejects.toMatchObject({
       code: -32099,
       message: 'Workspace memory forget failed',
-      data: { errorKind: 'forget_failed' },
+      data: { errorKind: 'forget_failed', details: 'boom' },
     });
 
     mockConnectionState.resolve();
@@ -3687,7 +3725,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     ).rejects.toMatchObject({
       code: -32099,
       message: 'Workspace memory dream failed',
-      data: { errorKind: 'dream_failed' },
+      data: { errorKind: 'dream_failed', details: 'boom' },
     });
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3607,7 +3607,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ).rejects.toMatchObject({
         code: -32099,
         message: 'Workspace memory remember timed out',
-        data: { errorKind: 'remember_timeout' },
+        data: { errorKind: 'remember_timeout', details: 'late abort' },
       });
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
         'Workspace memory remember timed out:',
@@ -3658,6 +3658,10 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(
       (error as { data?: Record<string, unknown> }).data,
     ).not.toHaveProperty('details');
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember failed:',
+      expect.objectContaining({ details: '<details unavailable>' }),
+    );
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -3838,7 +3842,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ).rejects.toMatchObject({
         code: -32099,
         message: 'Workspace memory forget timed out',
-        data: { errorKind: 'forget_timeout' },
+        data: { errorKind: 'forget_timeout', details: 'late abort' },
       });
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
         'Workspace memory forget timed out:',
@@ -3985,7 +3989,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ).rejects.toMatchObject({
         code: -32099,
         message: 'Workspace memory dream timed out',
-        data: { errorKind: 'dream_timeout' },
+        data: { errorKind: 'dream_timeout', details: 'late abort' },
       });
       expect(mockDebugLogger.error).toHaveBeenCalledWith(
         'Workspace memory dream timed out:',

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3468,6 +3468,45 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('omits details for workspace memory failures without a detail source', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue({
+      code: 'remember_failed',
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const error = await agent
+      .extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+        content: 'Remember me.',
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: -32099,
+      data: { errorKind: 'remember_failed' },
+    });
+    expect(
+      (error as { data?: Record<string, unknown> }).data,
+    ).not.toHaveProperty('details');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('runs workspace memory forget without requiring a session', async () => {
     const forget = vi.fn().mockResolvedValue({
       systemMessage: 'Forgot 1 entry.',

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -54,6 +54,15 @@ const { mockRunManagedAutoMemoryDream, mockRunManagedRememberByAgent } =
     mockRunManagedRememberByAgent: vi.fn(),
   }));
 
+const { mockDebugLogger } = vi.hoisted(() => ({
+  mockDebugLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
 vi.mock('@agentclientprotocol/sdk', () => ({
   AgentSideConnection: vi.fn().mockImplementation(() => ({
     get closed() {
@@ -119,12 +128,7 @@ vi.mock('node:stream', async (importOriginal) => {
 
 // Mock core dependencies
 vi.mock('@qwen-code/qwen-code-core', () => ({
-  createDebugLogger: () => ({
-    debug: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-  }),
+  createDebugLogger: () => mockDebugLogger,
   registerAcpEventLoopLagGauge: vi.fn(),
   startEventLoopLagMonitor: vi.fn(() => ({
     snapshot: vi.fn(() => ({
@@ -3463,6 +3467,52 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         details: 'remember agent stopped early',
       },
     });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('logs sanitized details for workspace memory failures', async () => {
+    Object.assign(mockConfig, {
+      isManagedMemoryAvailable: vi.fn().mockReturnValue(true),
+      getProjectRoot: vi.fn().mockReturnValue('/workspace'),
+    });
+    mockRunManagedRememberByAgent.mockRejectedValue(
+      new Error('Authorization: Bearer secret-token-value'),
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMemoryRemember, {
+        content: 'Remember me.',
+      }),
+    ).rejects.toMatchObject({
+      code: -32099,
+      message: 'Workspace memory remember failed',
+      data: {
+        errorKind: 'remember_failed',
+        details: 'Authorization: <redacted>',
+      },
+    });
+
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember failed:',
+      'Authorization: <redacted>',
+    );
+    expect(JSON.stringify(mockDebugLogger.error.mock.calls)).not.toContain(
+      'secret-token-value',
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3508,7 +3508,10 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     expect(mockDebugLogger.error).toHaveBeenCalledWith(
       'Workspace memory remember failed:',
-      'Authorization: <redacted>',
+      {
+        code: 'remember_failed',
+        details: 'Authorization: <redacted>',
+      },
     );
     expect(JSON.stringify(mockDebugLogger.error.mock.calls)).not.toContain(
       'secret-token-value',
@@ -3726,6 +3729,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         message: 'Workspace memory forget timed out',
         data: { errorKind: 'forget_timeout' },
       });
+      expect(mockDebugLogger.error).toHaveBeenCalledWith(
+        'Workspace memory forget timed out:',
+        {
+          code: 'forget_timeout',
+          details: 'late abort',
+        },
+      );
     } finally {
       timeoutSpy.mockRestore();
       mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -289,6 +289,14 @@ function workspaceMemoryErrorData(
   }
 }
 
+function workspaceMemoryDebugDetails(err: unknown): string {
+  try {
+    return extractRememberErrorDetails(err) ?? '<details unavailable>';
+  } catch {
+    return '<details unavailable>';
+  }
+}
+
 function parseAcpLocalReadRootsEnv(
   raw = process.env[QWEN_ACP_LOCAL_READ_ROOTS_ENV],
 ): string[] {
@@ -5839,7 +5847,10 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error('Workspace memory remember failed:', err);
+          debugLogger.error(
+            'Workspace memory remember failed:',
+            workspaceMemoryDebugDetails(err),
+          );
           if (childSignal.aborted) {
             throw new RequestError(
               -32099,
@@ -5910,7 +5921,10 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error('Workspace memory forget failed:', err);
+          debugLogger.error(
+            'Workspace memory forget failed:',
+            workspaceMemoryDebugDetails(err),
+          );
           if (childSignal.aborted) {
             throw new RequestError(
               -32099,
@@ -5968,7 +5982,10 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error('Workspace memory dream failed:', err);
+          debugLogger.error(
+            'Workspace memory dream failed:',
+            workspaceMemoryDebugDetails(err),
+          );
           if (childSignal.aborted) {
             throw new RequestError(-32099, 'Workspace memory dream timed out', {
               errorKind: 'dream_timeout',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -168,8 +168,8 @@ import {
   loadCliConfig,
 } from '../config/config.js';
 import {
-  extractRememberErrorCode,
   shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureCode,
   workspaceMemoryFailureDiagnostics,
 } from '../serve/workspace-remember-errors.js';
 import { formatWorkspaceMemoryForgetSummary } from '../serve/workspace-memory-summaries.js';
@@ -5860,7 +5860,11 @@ class QwenAgent implements Agent {
               workspaceMemoryErrorData('remember_timeout', diagnostics),
             );
           }
-          const code = extractRememberErrorCode(err);
+          const code = workspaceMemoryFailureCode(
+            err,
+            'remember_failed',
+            logWorkspaceMemoryExtractionError,
+          );
           debugLogger.error('Workspace memory remember failed:', {
             projectRoot,
             code,
@@ -5947,7 +5951,11 @@ class QwenAgent implements Agent {
               workspaceMemoryErrorData('forget_timeout', diagnostics),
             );
           }
-          const code = extractRememberErrorCode(err, 'forget_failed');
+          const code = workspaceMemoryFailureCode(
+            err,
+            'forget_failed',
+            logWorkspaceMemoryExtractionError,
+          );
           debugLogger.error('Workspace memory forget failed:', {
             projectRoot,
             code,
@@ -6020,7 +6028,11 @@ class QwenAgent implements Agent {
               workspaceMemoryErrorData('dream_timeout', diagnostics),
             );
           }
-          const code = extractRememberErrorCode(err, 'dream_failed');
+          const code = workspaceMemoryFailureCode(
+            err,
+            'dream_failed',
+            logWorkspaceMemoryExtractionError,
+          );
           debugLogger.error('Workspace memory dream failed:', {
             projectRoot,
             code,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5922,9 +5922,11 @@ class QwenAgent implements Agent {
               { errorKind: 'managed_memory_unavailable' },
             );
           }
-          throw new RequestError(-32099, 'Workspace memory forget failed', {
-            ...workspaceMemoryErrorData(code, err),
-          });
+          throw new RequestError(
+            -32099,
+            'Workspace memory forget failed',
+            workspaceMemoryErrorData(code, err),
+          );
         }
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceMemoryDream: {
@@ -5973,9 +5975,11 @@ class QwenAgent implements Agent {
               { errorKind: 'managed_memory_unavailable' },
             );
           }
-          throw new RequestError(-32099, 'Workspace memory dream failed', {
-            ...workspaceMemoryErrorData(code, err),
-          });
+          throw new RequestError(
+            -32099,
+            'Workspace memory dream failed',
+            workspaceMemoryErrorData(code, err),
+          );
         }
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceMcpRestart: {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5847,11 +5847,12 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error(
-            'Workspace memory remember failed:',
-            workspaceMemoryDebugDetails(err),
-          );
+          const details = workspaceMemoryDebugDetails(err);
           if (childSignal.aborted) {
+            debugLogger.error('Workspace memory remember timed out:', {
+              code: 'remember_timeout',
+              details,
+            });
             throw new RequestError(
               -32099,
               'Workspace memory remember timed out',
@@ -5859,6 +5860,10 @@ class QwenAgent implements Agent {
             );
           }
           const code = extractRememberErrorCode(err);
+          debugLogger.error('Workspace memory remember failed:', {
+            code,
+            details,
+          });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
               -32009,
@@ -5921,11 +5926,12 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error(
-            'Workspace memory forget failed:',
-            workspaceMemoryDebugDetails(err),
-          );
+          const details = workspaceMemoryDebugDetails(err);
           if (childSignal.aborted) {
+            debugLogger.error('Workspace memory forget timed out:', {
+              code: 'forget_timeout',
+              details,
+            });
             throw new RequestError(
               -32099,
               'Workspace memory forget timed out',
@@ -5935,6 +5941,10 @@ class QwenAgent implements Agent {
             );
           }
           const code = extractRememberErrorCode(err, 'forget_failed');
+          debugLogger.error('Workspace memory forget failed:', {
+            code,
+            details,
+          });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
               -32009,
@@ -5982,16 +5992,21 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          debugLogger.error(
-            'Workspace memory dream failed:',
-            workspaceMemoryDebugDetails(err),
-          );
+          const details = workspaceMemoryDebugDetails(err);
           if (childSignal.aborted) {
+            debugLogger.error('Workspace memory dream timed out:', {
+              code: 'dream_timeout',
+              details,
+            });
             throw new RequestError(-32099, 'Workspace memory dream timed out', {
               errorKind: 'dream_timeout',
             });
           }
           const code = extractRememberErrorCode(err, 'dream_failed');
+          debugLogger.error('Workspace memory dream failed:', {
+            code,
+            details,
+          });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
               -32009,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -167,7 +167,10 @@ import {
   buildDisabledSkillNamesProvider,
   loadCliConfig,
 } from '../config/config.js';
-import { extractRememberErrorCode } from '../serve/workspace-remember-errors.js';
+import {
+  extractRememberErrorCode,
+  extractRememberErrorDetails,
+} from '../serve/workspace-remember-errors.js';
 import { formatWorkspaceMemoryForgetSummary } from '../serve/workspace-memory-summaries.js';
 import { mapSkillConfigToStatus } from '../serve/workspace-skills-mapping.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
@@ -270,6 +273,17 @@ const POSIX_TMP_LOCAL_READ_ROOT = '/tmp';
 const BTW_CHILD_TIMEOUT_MS = 55_000;
 // Must be less than WORKSPACE_MEMORY_REMEMBER_TIMEOUT_MS (300s) in bridge.ts.
 const WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS = 295_000;
+
+function workspaceMemoryErrorData(
+  code: string,
+  err: unknown,
+): { errorKind: string; details?: string } {
+  const details = extractRememberErrorDetails(err);
+  return {
+    errorKind: code,
+    ...(details ? { details } : {}),
+  };
+}
 
 function parseAcpLocalReadRootsEnv(
   raw = process.env[QWEN_ACP_LOCAL_READ_ROOTS_ENV],
@@ -5833,17 +5847,13 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              { errorKind: 'managed_memory_unavailable' },
+              workspaceMemoryErrorData('managed_memory_unavailable', err),
             );
           }
           throw new RequestError(
             -32099,
-            err instanceof Error && err.message
-              ? err.message
-              : 'Workspace memory remember failed',
-            {
-              errorKind: code,
-            },
+            'Workspace memory remember failed',
+            workspaceMemoryErrorData(code, err),
           );
         }
       }
@@ -5909,11 +5919,11 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              { errorKind: 'managed_memory_unavailable' },
+              workspaceMemoryErrorData('managed_memory_unavailable', err),
             );
           }
           throw new RequestError(-32099, 'Workspace memory forget failed', {
-            errorKind: code,
+            ...workspaceMemoryErrorData(code, err),
           });
         }
       }
@@ -5960,11 +5970,11 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              { errorKind: 'managed_memory_unavailable' },
+              workspaceMemoryErrorData('managed_memory_unavailable', err),
             );
           }
           throw new RequestError(-32099, 'Workspace memory dream failed', {
-            errorKind: code,
+            ...workspaceMemoryErrorData(code, err),
           });
         }
       }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -278,11 +278,15 @@ function workspaceMemoryErrorData(
   code: string,
   err: unknown,
 ): { errorKind: string; details?: string } {
-  const details = extractRememberErrorDetails(err);
-  return {
-    errorKind: code,
-    ...(details ? { details } : {}),
-  };
+  try {
+    const details = extractRememberErrorDetails(err);
+    return {
+      errorKind: code,
+      ...(details ? { details } : {}),
+    };
+  } catch {
+    return { errorKind: code };
+  }
 }
 
 function parseAcpLocalReadRootsEnv(
@@ -5835,6 +5839,7 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
+          debugLogger.error('Workspace memory remember failed:', err);
           if (childSignal.aborted) {
             throw new RequestError(
               -32099,
@@ -5905,6 +5910,7 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
+          debugLogger.error('Workspace memory forget failed:', err);
           if (childSignal.aborted) {
             throw new RequestError(
               -32099,
@@ -5962,6 +5968,7 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
+          debugLogger.error('Workspace memory dream failed:', err);
           if (childSignal.aborted) {
             throw new RequestError(-32099, 'Workspace memory dream timed out', {
               errorKind: 'dream_timeout',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5852,22 +5852,6 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'remember_timeout';
-            if (shouldSuppressRememberErrorDetails(code)) {
-              debugLogger.error(
-                'Workspace memory remember unavailable during timeout:',
-                {
-                  projectRoot,
-                  code,
-                  details: diagnostics.debugDetails,
-                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-                },
-              );
-              throw new RequestError(
-                -32009,
-                'Managed memory is unavailable for this daemon workspace',
-                { errorKind: 'managed_memory_unavailable' },
-              );
-            }
             debugLogger.error('Workspace memory remember timed out:', {
               projectRoot,
               code: timeoutCode,
@@ -5960,22 +5944,6 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'forget_timeout';
-            if (shouldSuppressRememberErrorDetails(code)) {
-              debugLogger.error(
-                'Workspace memory forget unavailable during timeout:',
-                {
-                  projectRoot,
-                  code,
-                  details: diagnostics.debugDetails,
-                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-                },
-              );
-              throw new RequestError(
-                -32009,
-                'Managed memory is unavailable for this daemon workspace',
-                { errorKind: 'managed_memory_unavailable' },
-              );
-            }
             debugLogger.error('Workspace memory forget timed out:', {
               projectRoot,
               code: timeoutCode,
@@ -6054,22 +6022,6 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'dream_timeout';
-            if (shouldSuppressRememberErrorDetails(code)) {
-              debugLogger.error(
-                'Workspace memory dream unavailable during timeout:',
-                {
-                  projectRoot,
-                  code,
-                  details: diagnostics.debugDetails,
-                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-                },
-              );
-              throw new RequestError(
-                -32009,
-                'Managed memory is unavailable for this daemon workspace',
-                { errorKind: 'managed_memory_unavailable' },
-              );
-            }
             debugLogger.error('Workspace memory dream timed out:', {
               projectRoot,
               code: timeoutCode,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -168,6 +168,7 @@ import {
   loadCliConfig,
 } from '../config/config.js';
 import {
+  createWorkspaceMemoryExtractionErrorLogger,
   shouldSuppressRememberErrorDetails,
   workspaceMemoryFailureCode,
   workspaceMemoryFailureDiagnostics,
@@ -285,11 +286,8 @@ function workspaceMemoryErrorData(
   };
 }
 
-function logWorkspaceMemoryExtractionError(target: string, err: unknown): void {
-  debugLogger.warn(`Failed to extract workspace memory error ${target}:`, {
-    extractionError: err instanceof Error ? err.message : String(err),
-  });
-}
+const logWorkspaceMemoryExtractionError =
+  createWorkspaceMemoryExtractionErrorLogger(debugLogger);
 
 function parseAcpLocalReadRootsEnv(
   raw = process.env[QWEN_ACP_LOCAL_READ_ROOTS_ENV],

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5845,24 +5845,34 @@ class QwenAgent implements Agent {
             err,
             logWorkspaceMemoryExtractionError,
           );
-          if (childSignal.aborted) {
-            debugLogger.error('Workspace memory remember timed out:', {
-              projectRoot,
-              code: 'remember_timeout',
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
-            throw new RequestError(
-              -32099,
-              'Workspace memory remember timed out',
-              workspaceMemoryErrorData('remember_timeout', diagnostics),
-            );
-          }
           const code = workspaceMemoryFailureCode(
             err,
             'remember_failed',
             logWorkspaceMemoryExtractionError,
           );
+          if (childSignal.aborted) {
+            const timeoutCode = 'remember_timeout';
+            debugLogger.error('Workspace memory remember timed out:', {
+              projectRoot,
+              code: shouldSuppressRememberErrorDetails(code)
+                ? code
+                : timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
+            if (shouldSuppressRememberErrorDetails(code)) {
+              throw new RequestError(
+                -32009,
+                'Managed memory is unavailable for this daemon workspace',
+                { errorKind: 'managed_memory_unavailable' },
+              );
+            }
+            throw new RequestError(
+              -32099,
+              'Workspace memory remember timed out',
+              workspaceMemoryErrorData(timeoutCode, diagnostics),
+            );
+          }
           debugLogger.error('Workspace memory remember failed:', {
             projectRoot,
             code,
@@ -5936,24 +5946,34 @@ class QwenAgent implements Agent {
             err,
             logWorkspaceMemoryExtractionError,
           );
-          if (childSignal.aborted) {
-            debugLogger.error('Workspace memory forget timed out:', {
-              projectRoot,
-              code: 'forget_timeout',
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
-            throw new RequestError(
-              -32099,
-              'Workspace memory forget timed out',
-              workspaceMemoryErrorData('forget_timeout', diagnostics),
-            );
-          }
           const code = workspaceMemoryFailureCode(
             err,
             'forget_failed',
             logWorkspaceMemoryExtractionError,
           );
+          if (childSignal.aborted) {
+            const timeoutCode = 'forget_timeout';
+            debugLogger.error('Workspace memory forget timed out:', {
+              projectRoot,
+              code: shouldSuppressRememberErrorDetails(code)
+                ? code
+                : timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
+            if (shouldSuppressRememberErrorDetails(code)) {
+              throw new RequestError(
+                -32009,
+                'Managed memory is unavailable for this daemon workspace',
+                { errorKind: 'managed_memory_unavailable' },
+              );
+            }
+            throw new RequestError(
+              -32099,
+              'Workspace memory forget timed out',
+              workspaceMemoryErrorData(timeoutCode, diagnostics),
+            );
+          }
           debugLogger.error('Workspace memory forget failed:', {
             projectRoot,
             code,
@@ -6013,24 +6033,34 @@ class QwenAgent implements Agent {
             err,
             logWorkspaceMemoryExtractionError,
           );
-          if (childSignal.aborted) {
-            debugLogger.error('Workspace memory dream timed out:', {
-              projectRoot,
-              code: 'dream_timeout',
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
-            throw new RequestError(
-              -32099,
-              'Workspace memory dream timed out',
-              workspaceMemoryErrorData('dream_timeout', diagnostics),
-            );
-          }
           const code = workspaceMemoryFailureCode(
             err,
             'dream_failed',
             logWorkspaceMemoryExtractionError,
           );
+          if (childSignal.aborted) {
+            const timeoutCode = 'dream_timeout';
+            debugLogger.error('Workspace memory dream timed out:', {
+              projectRoot,
+              code: shouldSuppressRememberErrorDetails(code)
+                ? code
+                : timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
+            if (shouldSuppressRememberErrorDetails(code)) {
+              throw new RequestError(
+                -32009,
+                'Managed memory is unavailable for this daemon workspace',
+                { errorKind: 'managed_memory_unavailable' },
+              );
+            }
+            throw new RequestError(
+              -32099,
+              'Workspace memory dream timed out',
+              workspaceMemoryErrorData(timeoutCode, diagnostics),
+            );
+          }
           debugLogger.error('Workspace memory dream failed:', {
             projectRoot,
             code,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -169,8 +169,8 @@ import {
 } from '../config/config.js';
 import {
   extractRememberErrorCode,
-  extractRememberErrorDetails,
-  extractRememberErrorStack,
+  shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureDiagnostics,
 } from '../serve/workspace-remember-errors.js';
 import { formatWorkspaceMemoryForgetSummary } from '../serve/workspace-memory-summaries.js';
 import { mapSkillConfigToStatus } from '../serve/workspace-skills-mapping.js';
@@ -275,30 +275,6 @@ const BTW_CHILD_TIMEOUT_MS = 55_000;
 // Must be less than WORKSPACE_MEMORY_REMEMBER_TIMEOUT_MS (300s) in bridge.ts.
 const WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS = 295_000;
 
-function workspaceMemoryFailureDiagnostics(err: unknown): {
-  details?: string;
-  debugDetails: string;
-  stack?: string;
-} {
-  let details: string | undefined;
-  let stack: string | undefined;
-  try {
-    details = extractRememberErrorDetails(err);
-  } catch {
-    details = undefined;
-  }
-  try {
-    stack = extractRememberErrorStack(err);
-  } catch {
-    stack = undefined;
-  }
-  return {
-    ...(details ? { details } : {}),
-    debugDetails: details ?? '<details unavailable>',
-    ...(stack ? { stack } : {}),
-  };
-}
-
 function workspaceMemoryErrorData(
   code: string,
   diagnostics: { details?: string },
@@ -307,6 +283,12 @@ function workspaceMemoryErrorData(
     errorKind: code,
     ...(diagnostics.details ? { details: diagnostics.details } : {}),
   };
+}
+
+function logWorkspaceMemoryExtractionError(target: string, err: unknown): void {
+  debugLogger.warn(`Failed to extract workspace memory error ${target}:`, {
+    extractionError: err instanceof Error ? err.message : String(err),
+  });
 }
 
 function parseAcpLocalReadRootsEnv(
@@ -5846,10 +5828,12 @@ class QwenAgent implements Agent {
         const childSignal = AbortSignal.timeout(
           WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS,
         );
+        let projectRoot = '<unknown>';
         try {
+          projectRoot = this.config.getProjectRoot();
           const result = await runManagedRememberByAgent({
             config: this.config,
-            projectRoot: this.config.getProjectRoot(),
+            projectRoot,
             content: content.trim(),
             contextMode,
             abortSignal: childSignal,
@@ -5859,9 +5843,13 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const diagnostics = workspaceMemoryFailureDiagnostics(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(
+            err,
+            logWorkspaceMemoryExtractionError,
+          );
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory remember timed out:', {
+              projectRoot,
               code: 'remember_timeout',
               details: diagnostics.debugDetails,
               ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
@@ -5869,16 +5857,17 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32099,
               'Workspace memory remember timed out',
-              { errorKind: 'remember_timeout' },
+              workspaceMemoryErrorData('remember_timeout', diagnostics),
             );
           }
           const code = extractRememberErrorCode(err);
           debugLogger.error('Workspace memory remember failed:', {
+            projectRoot,
             code,
             details: diagnostics.debugDetails,
             ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
-          if (code === 'managed_memory_unavailable') {
+          if (shouldSuppressRememberErrorDetails(code)) {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
@@ -5920,8 +5909,9 @@ class QwenAgent implements Agent {
         const childSignal = AbortSignal.timeout(
           WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS,
         );
+        let projectRoot = '<unknown>';
         try {
-          const projectRoot = this.config.getProjectRoot();
+          projectRoot = this.config.getProjectRoot();
           const hiddenConfig = createHiddenWorkspaceMemoryConfig(this.config);
           const result = await this.config
             .getMemoryManager()
@@ -5940,9 +5930,13 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const diagnostics = workspaceMemoryFailureDiagnostics(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(
+            err,
+            logWorkspaceMemoryExtractionError,
+          );
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory forget timed out:', {
+              projectRoot,
               code: 'forget_timeout',
               details: diagnostics.debugDetails,
               ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
@@ -5950,18 +5944,17 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32099,
               'Workspace memory forget timed out',
-              {
-                errorKind: 'forget_timeout',
-              },
+              workspaceMemoryErrorData('forget_timeout', diagnostics),
             );
           }
           const code = extractRememberErrorCode(err, 'forget_failed');
           debugLogger.error('Workspace memory forget failed:', {
+            projectRoot,
             code,
             details: diagnostics.debugDetails,
             ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
-          if (code === 'managed_memory_unavailable') {
+          if (shouldSuppressRememberErrorDetails(code)) {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
@@ -5987,9 +5980,11 @@ class QwenAgent implements Agent {
         const childSignal = AbortSignal.timeout(
           WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS,
         );
+        let projectRoot = '<unknown>';
         try {
+          projectRoot = this.config.getProjectRoot();
           const result = await runManagedAutoMemoryDream(
-            this.config.getProjectRoot(),
+            projectRoot,
             new Date(),
             createHiddenWorkspaceMemoryConfig(this.config),
             childSignal,
@@ -6008,24 +6003,31 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const diagnostics = workspaceMemoryFailureDiagnostics(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(
+            err,
+            logWorkspaceMemoryExtractionError,
+          );
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory dream timed out:', {
+              projectRoot,
               code: 'dream_timeout',
               details: diagnostics.debugDetails,
               ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
             });
-            throw new RequestError(-32099, 'Workspace memory dream timed out', {
-              errorKind: 'dream_timeout',
-            });
+            throw new RequestError(
+              -32099,
+              'Workspace memory dream timed out',
+              workspaceMemoryErrorData('dream_timeout', diagnostics),
+            );
           }
           const code = extractRememberErrorCode(err, 'dream_failed');
           debugLogger.error('Workspace memory dream failed:', {
+            projectRoot,
             code,
             details: diagnostics.debugDetails,
             ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
-          if (code === 'managed_memory_unavailable') {
+          if (shouldSuppressRememberErrorDetails(code)) {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -170,6 +170,7 @@ import {
 import {
   extractRememberErrorCode,
   extractRememberErrorDetails,
+  extractRememberErrorStack,
 } from '../serve/workspace-remember-errors.js';
 import { formatWorkspaceMemoryForgetSummary } from '../serve/workspace-memory-summaries.js';
 import { mapSkillConfigToStatus } from '../serve/workspace-skills-mapping.js';
@@ -274,27 +275,38 @@ const BTW_CHILD_TIMEOUT_MS = 55_000;
 // Must be less than WORKSPACE_MEMORY_REMEMBER_TIMEOUT_MS (300s) in bridge.ts.
 const WORKSPACE_MEMORY_REMEMBER_CHILD_TIMEOUT_MS = 295_000;
 
-function workspaceMemoryErrorData(
-  code: string,
-  err: unknown,
-): { errorKind: string; details?: string } {
+function workspaceMemoryFailureDiagnostics(err: unknown): {
+  details?: string;
+  debugDetails: string;
+  stack?: string;
+} {
+  let details: string | undefined;
+  let stack: string | undefined;
   try {
-    const details = extractRememberErrorDetails(err);
-    return {
-      errorKind: code,
-      ...(details ? { details } : {}),
-    };
+    details = extractRememberErrorDetails(err);
   } catch {
-    return { errorKind: code };
+    details = undefined;
   }
+  try {
+    stack = extractRememberErrorStack(err);
+  } catch {
+    stack = undefined;
+  }
+  return {
+    ...(details ? { details } : {}),
+    debugDetails: details ?? '<details unavailable>',
+    ...(stack ? { stack } : {}),
+  };
 }
 
-function workspaceMemoryDebugDetails(err: unknown): string {
-  try {
-    return extractRememberErrorDetails(err) ?? '<details unavailable>';
-  } catch {
-    return '<details unavailable>';
-  }
+function workspaceMemoryErrorData(
+  code: string,
+  diagnostics: { details?: string },
+): { errorKind: string; details?: string } {
+  return {
+    errorKind: code,
+    ...(diagnostics.details ? { details: diagnostics.details } : {}),
+  };
 }
 
 function parseAcpLocalReadRootsEnv(
@@ -5847,11 +5859,12 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const details = workspaceMemoryDebugDetails(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(err);
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory remember timed out:', {
               code: 'remember_timeout',
-              details,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
             });
             throw new RequestError(
               -32099,
@@ -5862,7 +5875,8 @@ class QwenAgent implements Agent {
           const code = extractRememberErrorCode(err);
           debugLogger.error('Workspace memory remember failed:', {
             code,
-            details,
+            details: diagnostics.debugDetails,
+            ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
@@ -5874,7 +5888,7 @@ class QwenAgent implements Agent {
           throw new RequestError(
             -32099,
             'Workspace memory remember failed',
-            workspaceMemoryErrorData(code, err),
+            workspaceMemoryErrorData(code, diagnostics),
           );
         }
       }
@@ -5926,11 +5940,12 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const details = workspaceMemoryDebugDetails(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(err);
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory forget timed out:', {
               code: 'forget_timeout',
-              details,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
             });
             throw new RequestError(
               -32099,
@@ -5943,7 +5958,8 @@ class QwenAgent implements Agent {
           const code = extractRememberErrorCode(err, 'forget_failed');
           debugLogger.error('Workspace memory forget failed:', {
             code,
-            details,
+            details: diagnostics.debugDetails,
+            ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
@@ -5955,7 +5971,7 @@ class QwenAgent implements Agent {
           throw new RequestError(
             -32099,
             'Workspace memory forget failed',
-            workspaceMemoryErrorData(code, err),
+            workspaceMemoryErrorData(code, diagnostics),
           );
         }
       }
@@ -5992,11 +6008,12 @@ class QwenAgent implements Agent {
           if (err instanceof RequestError) {
             throw err;
           }
-          const details = workspaceMemoryDebugDetails(err);
+          const diagnostics = workspaceMemoryFailureDiagnostics(err);
           if (childSignal.aborted) {
             debugLogger.error('Workspace memory dream timed out:', {
               code: 'dream_timeout',
-              details,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
             });
             throw new RequestError(-32099, 'Workspace memory dream timed out', {
               errorKind: 'dream_timeout',
@@ -6005,7 +6022,8 @@ class QwenAgent implements Agent {
           const code = extractRememberErrorCode(err, 'dream_failed');
           debugLogger.error('Workspace memory dream failed:', {
             code,
-            details,
+            details: diagnostics.debugDetails,
+            ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
           });
           if (code === 'managed_memory_unavailable') {
             throw new RequestError(
@@ -6017,7 +6035,7 @@ class QwenAgent implements Agent {
           throw new RequestError(
             -32099,
             'Workspace memory dream failed',
-            workspaceMemoryErrorData(code, err),
+            workspaceMemoryErrorData(code, diagnostics),
           );
         }
       }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5847,7 +5847,7 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              workspaceMemoryErrorData('managed_memory_unavailable', err),
+              { errorKind: 'managed_memory_unavailable' },
             );
           }
           throw new RequestError(
@@ -5919,7 +5919,7 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              workspaceMemoryErrorData('managed_memory_unavailable', err),
+              { errorKind: 'managed_memory_unavailable' },
             );
           }
           throw new RequestError(-32099, 'Workspace memory forget failed', {
@@ -5970,7 +5970,7 @@ class QwenAgent implements Agent {
             throw new RequestError(
               -32009,
               'Managed memory is unavailable for this daemon workspace',
-              workspaceMemoryErrorData('managed_memory_unavailable', err),
+              { errorKind: 'managed_memory_unavailable' },
             );
           }
           throw new RequestError(-32099, 'Workspace memory dream failed', {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5852,21 +5852,28 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'remember_timeout';
-            debugLogger.error('Workspace memory remember timed out:', {
-              projectRoot,
-              code: shouldSuppressRememberErrorDetails(code)
-                ? code
-                : timeoutCode,
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
             if (shouldSuppressRememberErrorDetails(code)) {
+              debugLogger.error(
+                'Workspace memory remember unavailable during timeout:',
+                {
+                  projectRoot,
+                  code,
+                  details: diagnostics.debugDetails,
+                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+                },
+              );
               throw new RequestError(
                 -32009,
                 'Managed memory is unavailable for this daemon workspace',
                 { errorKind: 'managed_memory_unavailable' },
               );
             }
+            debugLogger.error('Workspace memory remember timed out:', {
+              projectRoot,
+              code: timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
             throw new RequestError(
               -32099,
               'Workspace memory remember timed out',
@@ -5953,21 +5960,28 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'forget_timeout';
-            debugLogger.error('Workspace memory forget timed out:', {
-              projectRoot,
-              code: shouldSuppressRememberErrorDetails(code)
-                ? code
-                : timeoutCode,
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
             if (shouldSuppressRememberErrorDetails(code)) {
+              debugLogger.error(
+                'Workspace memory forget unavailable during timeout:',
+                {
+                  projectRoot,
+                  code,
+                  details: diagnostics.debugDetails,
+                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+                },
+              );
               throw new RequestError(
                 -32009,
                 'Managed memory is unavailable for this daemon workspace',
                 { errorKind: 'managed_memory_unavailable' },
               );
             }
+            debugLogger.error('Workspace memory forget timed out:', {
+              projectRoot,
+              code: timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
             throw new RequestError(
               -32099,
               'Workspace memory forget timed out',
@@ -6040,21 +6054,28 @@ class QwenAgent implements Agent {
           );
           if (childSignal.aborted) {
             const timeoutCode = 'dream_timeout';
-            debugLogger.error('Workspace memory dream timed out:', {
-              projectRoot,
-              code: shouldSuppressRememberErrorDetails(code)
-                ? code
-                : timeoutCode,
-              details: diagnostics.debugDetails,
-              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
-            });
             if (shouldSuppressRememberErrorDetails(code)) {
+              debugLogger.error(
+                'Workspace memory dream unavailable during timeout:',
+                {
+                  projectRoot,
+                  code,
+                  details: diagnostics.debugDetails,
+                  ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+                },
+              );
               throw new RequestError(
                 -32009,
                 'Managed memory is unavailable for this daemon workspace',
                 { errorKind: 'managed_memory_unavailable' },
               );
             }
+            debugLogger.error('Workspace memory dream timed out:', {
+              projectRoot,
+              code: timeoutCode,
+              details: diagnostics.debugDetails,
+              ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
+            });
             throw new RequestError(
               -32099,
               'Workspace memory dream timed out',

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -262,6 +262,40 @@ describe('extractRememberErrorDetails', () => {
     expect(details).not.toContain('BBBBBBBBBBBBBBB');
   });
 
+  it('redacts AWS access keys split by credential separators', () => {
+    for (const separator of ['\x01', '\u00a0', '\u200b']) {
+      const details = extractRememberErrorDetails(
+        new Error(`AWS key AKIA12345678${separator}90123456`),
+      );
+
+      expect(details).toBe('AWS key <redacted>');
+      expect(details).not.toContain('12345678');
+      expect(details).not.toContain('90123456');
+    }
+  });
+
+  it('redacts secret assignments split by credential separators', () => {
+    for (const separator of ['\x01', '\u00a0', '\u200b']) {
+      const details = extractRememberErrorDetails(
+        new Error(`token=aaaaaaaaaa${separator}bbbbbbbb`),
+      );
+
+      expect(details).toBe('token=<redacted>');
+      expect(details).not.toContain('aaaaaaaaaa');
+      expect(details).not.toContain('bbbbbbbb');
+    }
+  });
+
+  it('redacts env secret assignments split by credential separators', () => {
+    const details = extractRememberErrorDetails(
+      new Error('QWEN_DAEMON_TOKEN=AAAAAAAAAA\u00a0BBBBBBBB'),
+    );
+
+    expect(details).toBe('QWEN_DAEMON_TOKEN=<redacted>');
+    expect(details).not.toContain('AAAAAAAAAA');
+    expect(details).not.toContain('BBBBBBBB');
+  });
+
   it('redacts bare bearer tokens separated by invisible characters', () => {
     const details = extractRememberErrorDetails(
       new Error('Bearer\u200BeyJhbGciOiABCDEFGHIJKLMN'),

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -48,6 +48,12 @@ describe('extractRememberErrorDetails', () => {
     );
     expect(
       extractRememberErrorDetails({
+        data: 'ERR_BRIDGE_INTERNAL',
+        message: 'Connection to memory service refused',
+      }),
+    ).toBe('Connection to memory service refused');
+    expect(
+      extractRememberErrorDetails({
         data: { message: 'provider rejected the request' },
       }),
     ).toBe('provider rejected the request');
@@ -56,6 +62,9 @@ describe('extractRememberErrorDetails', () => {
         cause: new Error('nested failure reason'),
       }),
     ).toBe('nested failure reason');
+    expect(extractRememberErrorDetails({ cause: 'string cause reason' })).toBe(
+      'string cause reason',
+    );
     expect(extractRememberErrorDetails('raw string error')).toBe(
       'raw string error',
     );
@@ -71,12 +80,14 @@ describe('extractRememberErrorDetails', () => {
   });
 
   it('normalizes hidden separators before redacting credentials', () => {
-    const details = extractRememberErrorDetails(
-      new Error('Authorization: Bearer\u200bsecret-token-value'),
-    );
+    for (const separator of ['\u200b', '\u2060', '\u2064']) {
+      const details = extractRememberErrorDetails(
+        new Error(`Authorization: Bearer${separator}secret-token-value`),
+      );
 
-    expect(details).toBe('Authorization: <redacted>');
-    expect(details).not.toContain('secret-token-value');
+      expect(details).toBe('Authorization: <redacted>');
+      expect(details).not.toContain('secret-token-value');
+    }
   });
 
   it('normalizes line separators before redacting credentials', () => {
@@ -101,6 +112,19 @@ describe('extractRememberErrorDetails', () => {
     cyclic['cause'] = cyclic;
 
     expect(extractRememberErrorDetails(cyclic)).toBeUndefined();
+  });
+
+  it('limits cause traversal depth', () => {
+    const root: Record<string, unknown> = {};
+    let current = root;
+    for (let index = 0; index < 60; index += 1) {
+      const next: Record<string, unknown> = {};
+      current['cause'] = next;
+      current = next;
+    }
+    current['message'] = 'too deep';
+
+    expect(extractRememberErrorDetails(root)).toBeUndefined();
   });
 
   it('caps long details', () => {

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -203,6 +203,14 @@ describe('extractRememberErrorDetails', () => {
     }
   });
 
+  it('normalizes unicode space separators without collapsing words', () => {
+    const details = extractRememberErrorDetails(
+      new Error('missing column\u00a0name'),
+    );
+
+    expect(details).toBe('missing column name');
+  });
+
   it('redacts bare tokens split by invisible characters', () => {
     const details = extractRememberErrorDetails(
       new Error('OpenAI key sk-AAAAAAAAAA\u2062BBBBBBBBBBBBBBB'),
@@ -338,6 +346,18 @@ describe('extractRememberErrorStack', () => {
     const stack = extractRememberErrorStack(err);
 
     expect(stack).toBe('Error: boom\r\n\tat handler (/workspace/file.ts:1:1)');
+  });
+
+  it('normalizes unicode space separators in stacks without collapsing words', () => {
+    const err = new Error('boom');
+    err.stack =
+      'Error: missing column\u202fname\n\tat handler (/workspace/file.ts:1:1)';
+
+    const stack = extractRememberErrorStack(err);
+
+    expect(stack).toBe(
+      'Error: missing column name\n\tat handler (/workspace/file.ts:1:1)',
+    );
   });
 });
 

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractRememberErrorCode,
   extractRememberErrorDetails,
+  extractRememberErrorStack,
 } from './workspace-remember-errors.js';
 
 describe('extractRememberErrorCode', () => {
@@ -202,5 +203,18 @@ describe('extractRememberErrorDetails', () => {
 
     expect(details).toBe(`${'x'.repeat(984)}... [truncated]`);
     expect(details).toHaveLength(999);
+  });
+});
+
+describe('extractRememberErrorStack', () => {
+  it('redacts and caps error stacks before logging', () => {
+    const err = new Error('Authorization: Bearer secret-token-value');
+    err.stack = `${err.stack}\n${'x'.repeat(1100)}`;
+
+    const stack = extractRememberErrorStack(err);
+
+    expect(stack).toContain('Authorization: <redacted>');
+    expect(stack).not.toContain('secret-token-value');
+    expect(stack).toHaveLength(1000);
   });
 });

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -79,6 +79,23 @@ describe('extractRememberErrorCode', () => {
       { target: 'code', message: 'code getter failed' },
     ]);
   });
+
+  it('keeps fallback behavior when code extraction logging throws', () => {
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('code getter failed');
+        },
+      },
+    );
+
+    expect(
+      workspaceMemoryFailureCode(err, 'dream_failed', () => {
+        throw new Error('logger failed');
+      }),
+    ).toBe('dream_failed');
+  });
 });
 
 describe('extractRememberErrorDetails', () => {
@@ -296,6 +313,21 @@ describe('extractRememberErrorDetails', () => {
     expect(details).not.toContain('BBBBBBBB');
   });
 
+  it('redacts URL credentials split by credential separators', () => {
+    for (const separator of ['\x01', '\u00a0', '\u200b']) {
+      const details = extractRememberErrorDetails(
+        new Error(
+          `postgresql://admin:S3cret${separator}P4ssw0rd@db.internal:5432/mydb`,
+        ),
+      );
+
+      expect(details).toBe('postgresql://<redacted>@db.internal:5432/mydb');
+      expect(details).not.toContain('admin');
+      expect(details).not.toContain('S3cret');
+      expect(details).not.toContain('P4ssw0rd');
+    }
+  });
+
   it('redacts bare bearer tokens separated by invisible characters', () => {
     const details = extractRememberErrorDetails(
       new Error('Bearer\u200BeyJhbGciOiABCDEFGHIJKLMN'),
@@ -475,6 +507,23 @@ describe('workspaceMemoryFailureDiagnostics', () => {
     ]);
   });
 
+  it('keeps fallback diagnostics when detail extraction logging throws', () => {
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('detail getter failed');
+        },
+      },
+    );
+
+    const diagnostics = workspaceMemoryFailureDiagnostics(err, () => {
+      throw new Error('logger failed');
+    });
+
+    expect(diagnostics).toEqual({ debugDetails: '<details unavailable>' });
+  });
+
   it('falls back when stack extraction throws', () => {
     const extractionErrors: Array<{ target: string; message: string }> = [];
     const err = new Proxy(new Error('boom'), {
@@ -502,6 +551,26 @@ describe('workspaceMemoryFailureDiagnostics', () => {
     expect(extractionErrors).toEqual([
       { target: 'stack', message: 'stack getter failed' },
     ]);
+  });
+
+  it('keeps fallback diagnostics when stack extraction logging throws', () => {
+    const err = new Proxy(new Error('boom'), {
+      get(target, property, receiver) {
+        if (property === 'stack') {
+          throw new Error('stack getter failed');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const diagnostics = workspaceMemoryFailureDiagnostics(err, () => {
+      throw new Error('logger failed');
+    });
+
+    expect(diagnostics).toEqual({
+      details: 'boom',
+      debugDetails: 'boom',
+    });
   });
 });
 

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -226,6 +226,15 @@ describe('extractRememberErrorDetails', () => {
     expect(details).toBe(`${'x'.repeat(984)}... [truncated]`);
     expect(details).toHaveLength(999);
   });
+
+  it('keeps the full prefix when the cut point falls before a surrogate pair', () => {
+    const details = extractRememberErrorDetails(
+      new Error(`${'x'.repeat(985)}${'😀'.repeat(100)}`),
+    );
+
+    expect(details).toBe(`${'x'.repeat(985)}... [truncated]`);
+    expect(details).toHaveLength(1000);
+  });
 });
 
 describe('extractRememberErrorStack', () => {

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -79,6 +79,17 @@ describe('extractRememberErrorDetails', () => {
     expect(details).not.toContain('secret-token-value');
   });
 
+  it('normalizes line separators before redacting credentials', () => {
+    for (const separator of ['\u2028', '\u2029']) {
+      const details = extractRememberErrorDetails(
+        new Error(`Authorization: Bearer${separator}secret-token-value`),
+      );
+
+      expect(details).toBe('Authorization: <redacted>');
+      expect(details).not.toContain('secret-token-value');
+    }
+  });
+
   it('sanitizes control characters', () => {
     expect(extractRememberErrorDetails(new Error('line1\nline2\ttab'))).toBe(
       'line1 line2 tab',

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -10,6 +10,7 @@ import {
   extractRememberErrorDetails,
   extractRememberErrorStack,
   shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureCode,
   workspaceMemoryFailureDiagnostics,
 } from './workspace-remember-errors.js';
 
@@ -53,6 +54,30 @@ describe('extractRememberErrorCode', () => {
     current['code'] = 'too_deep';
 
     expect(extractRememberErrorCode(root)).toBe('remember_failed');
+  });
+
+  it('falls back when code extraction throws', () => {
+    const extractionErrors: Array<{ target: string; message: string }> = [];
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('code getter failed');
+        },
+      },
+    );
+
+    expect(
+      workspaceMemoryFailureCode(err, 'dream_failed', (target, cause) =>
+        extractionErrors.push({
+          target,
+          message: cause instanceof Error ? cause.message : String(cause),
+        }),
+      ),
+    ).toBe('dream_failed');
+    expect(extractionErrors).toEqual([
+      { target: 'code', message: 'code getter failed' },
+    ]);
   });
 });
 

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -43,6 +43,9 @@ describe('extractRememberErrorDetails', () => {
         data: { details: 'agent stopped because max turns exceeded' },
       }),
     ).toBe('agent stopped because max turns exceeded');
+    expect(extractRememberErrorDetails({ data: 'raw data detail' })).toBe(
+      'raw data detail',
+    );
     expect(
       extractRememberErrorDetails({
         data: { message: 'provider rejected the request' },
@@ -53,6 +56,9 @@ describe('extractRememberErrorDetails', () => {
         cause: new Error('nested failure reason'),
       }),
     ).toBe('nested failure reason');
+    expect(extractRememberErrorDetails('raw string error')).toBe(
+      'raw string error',
+    );
   });
 
   it('redacts credentials before exposing details', () => {
@@ -62,6 +68,28 @@ describe('extractRememberErrorDetails', () => {
 
     expect(details).toBe('Authorization: <redacted>');
     expect(details).not.toContain('secret-token-value');
+  });
+
+  it('normalizes hidden separators before redacting credentials', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Authorization: Bearer\u200bsecret-token-value'),
+    );
+
+    expect(details).toBe('Authorization: <redacted>');
+    expect(details).not.toContain('secret-token-value');
+  });
+
+  it('sanitizes control characters', () => {
+    expect(extractRememberErrorDetails(new Error('line1\nline2\ttab'))).toBe(
+      'line1 line2 tab',
+    );
+  });
+
+  it('guards against circular causes', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic['cause'] = cyclic;
+
+    expect(extractRememberErrorDetails(cyclic)).toBeUndefined();
   });
 
   it('caps long details', () => {

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -28,6 +28,11 @@ describe('extractRememberErrorCode', () => {
         cause: { code: 'remember_timeout' },
       }),
     ).toBe('remember_timeout');
+    expect(
+      extractRememberErrorCode({
+        cause: { cause: { code: 'remember_path_escape' } },
+      }),
+    ).toBe('remember_path_escape');
     expect(extractRememberErrorCode(new Error('boom'))).toBe('remember_failed');
     expect(extractRememberErrorCode(new Error('boom'), 'forget_failed')).toBe(
       'forget_failed',
@@ -90,6 +95,18 @@ describe('extractRememberErrorDetails', () => {
     }
   });
 
+  it('redacts credentials with hidden separators inside token values', () => {
+    for (const separator of ['\u200b', '\u2060', '\u2064']) {
+      const details = extractRememberErrorDetails(
+        new Error(`Authorization: Bearer secret${separator}token-value`),
+      );
+
+      expect(details).toBe('Authorization: <redacted>');
+      expect(details).not.toContain('secret');
+      expect(details).not.toContain('token-value');
+    }
+  });
+
   it('normalizes line separators before redacting credentials', () => {
     for (const separator of ['\u2028', '\u2029']) {
       const details = extractRememberErrorDetails(
@@ -99,6 +116,26 @@ describe('extractRememberErrorDetails', () => {
       expect(details).toBe('Authorization: <redacted>');
       expect(details).not.toContain('secret-token-value');
     }
+  });
+
+  it('normalizes bidi isolation characters before redacting credentials', () => {
+    for (const separator of ['\u2066', '\u2067', '\u2068', '\u2069']) {
+      const details = extractRememberErrorDetails(
+        new Error(`Authorization: Bearer${separator}secret-token-value`),
+      );
+
+      expect(details).toBe('Authorization: <redacted>');
+      expect(details).not.toContain('secret-token-value');
+    }
+  });
+
+  it('normalizes BOM before redacting credentials', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Authorization: Bearer\ufeffsecret-token-value'),
+    );
+
+    expect(details).toBe('Authorization: <redacted>');
+    expect(details).not.toContain('secret-token-value');
   });
 
   it('sanitizes control characters', () => {
@@ -132,5 +169,14 @@ describe('extractRememberErrorDetails', () => {
 
     expect(details).toMatch(/^x+\.{3} \[truncated\]$/);
     expect(details).toHaveLength(1000);
+  });
+
+  it('does not split surrogate pairs when capping long details', () => {
+    const details = extractRememberErrorDetails(
+      new Error(`${'x'.repeat(984)}${'😀'.repeat(100)}`),
+    );
+
+    expect(details).toBe(`${'x'.repeat(984)}... [truncated]`);
+    expect(details).toHaveLength(999);
   });
 });

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { extractRememberErrorCode } from './workspace-remember-errors.js';
+import {
+  extractRememberErrorCode,
+  extractRememberErrorDetails,
+} from './workspace-remember-errors.js';
 
 describe('extractRememberErrorCode', () => {
   it('extracts remember error codes from common error shapes', () => {
@@ -29,5 +32,42 @@ describe('extractRememberErrorCode', () => {
     expect(extractRememberErrorCode(new Error('boom'), 'forget_failed')).toBe(
       'forget_failed',
     );
+  });
+});
+
+describe('extractRememberErrorDetails', () => {
+  it('extracts details from common error shapes', () => {
+    expect(extractRememberErrorDetails(new Error('boom'))).toBe('boom');
+    expect(
+      extractRememberErrorDetails({
+        data: { details: 'agent stopped because max turns exceeded' },
+      }),
+    ).toBe('agent stopped because max turns exceeded');
+    expect(
+      extractRememberErrorDetails({
+        data: { message: 'provider rejected the request' },
+      }),
+    ).toBe('provider rejected the request');
+    expect(
+      extractRememberErrorDetails({
+        cause: new Error('nested failure reason'),
+      }),
+    ).toBe('nested failure reason');
+  });
+
+  it('redacts credentials before exposing details', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Authorization: Bearer secret-token-value'),
+    );
+
+    expect(details).toBe('Authorization: <redacted>');
+    expect(details).not.toContain('secret-token-value');
+  });
+
+  it('caps long details', () => {
+    const details = extractRememberErrorDetails(new Error('x'.repeat(1100)));
+
+    expect(details).toMatch(/^x+\.{3} \[truncated\]$/);
+    expect(details).toHaveLength(1000);
   });
 });

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -121,6 +121,16 @@ describe('extractRememberErrorDetails', () => {
     }
   });
 
+  it('redacts bare tokens split by invisible characters', () => {
+    const details = extractRememberErrorDetails(
+      new Error('OpenAI key sk-AAAAAAAAAA\u2062BBBBBBBBBBBBBBB'),
+    );
+
+    expect(details).toBe('OpenAI key sk-<redacted>');
+    expect(details).not.toContain('AAAAAAAAAA');
+    expect(details).not.toContain('BBBBBBBBBBBBBBB');
+  });
+
   it('normalizes line separators before redacting credentials', () => {
     for (const separator of ['\u2028', '\u2029']) {
       const details = extractRememberErrorDetails(

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -39,6 +39,19 @@ describe('extractRememberErrorCode', () => {
       'forget_failed',
     );
   });
+
+  it('limits cause traversal depth', () => {
+    const root: Record<string, unknown> = {};
+    let current = root;
+    for (let index = 0; index < 60; index += 1) {
+      const next: Record<string, unknown> = {};
+      current['cause'] = next;
+      current = next;
+    }
+    current['code'] = 'too_deep';
+
+    expect(extractRememberErrorCode(root)).toBe('remember_failed');
+  });
 });
 
 describe('extractRememberErrorDetails', () => {
@@ -130,6 +143,15 @@ describe('extractRememberErrorDetails', () => {
     expect(details).toBe('OpenAI key sk-<redacted>');
     expect(details).not.toContain('AAAAAAAAAA');
     expect(details).not.toContain('BBBBBBBBBBBBBBB');
+  });
+
+  it('redacts bare bearer tokens separated by invisible characters', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Bearer\u200BeyJhbGciOiABCDEFGHIJKLMN'),
+    );
+
+    expect(details).toBe('Bearer <redacted>');
+    expect(details).not.toContain('eyJhbGciOiABCDEFGHIJKLMN');
   });
 
   it('normalizes line separators before redacting credentials', () => {

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -240,11 +240,12 @@ describe('extractRememberErrorDetails', () => {
 describe('extractRememberErrorStack', () => {
   it('redacts and caps error stacks before logging', () => {
     const err = new Error('Authorization: Bearer secret-token-value');
-    err.stack = `${err.stack}\n${'x'.repeat(1100)}`;
+    err.stack = `Error: Authorization: Bearer secret-token-value\n\tat handler (/workspace/file.ts:1:1)\n${'x'.repeat(1100)}`;
 
     const stack = extractRememberErrorStack(err);
 
     expect(stack).toContain('Authorization: <redacted>');
+    expect(stack).toContain('\n\tat handler');
     expect(stack).not.toContain('secret-token-value');
     expect(stack).toHaveLength(1000);
   });

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -9,6 +9,8 @@ import {
   extractRememberErrorCode,
   extractRememberErrorDetails,
   extractRememberErrorStack,
+  shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureDiagnostics,
 } from './workspace-remember-errors.js';
 
 describe('extractRememberErrorCode', () => {
@@ -89,6 +91,15 @@ describe('extractRememberErrorDetails', () => {
     );
   });
 
+  it('prefers bridge details over generic messages', () => {
+    expect(
+      extractRememberErrorDetails({
+        data: { details: 'specific bridge reason' },
+        message: 'generic message',
+      }),
+    ).toBe('specific bridge reason');
+  });
+
   it('redacts credentials before exposing details', () => {
     const details = extractRememberErrorDetails(
       new Error('Authorization: Bearer secret-token-value'),
@@ -132,6 +143,38 @@ describe('extractRememberErrorDetails', () => {
       expect(details).toBe('Authorization: <redacted>');
       expect(details).not.toContain('secret');
       expect(details).not.toContain('token-value');
+    }
+  });
+
+  it('redacts bearer tokens split by unicode space separators', () => {
+    for (const separator of [
+      '\u00a0',
+      '\u1680',
+      '\u2000',
+      '\u2009',
+      '\u200a',
+      '\u202f',
+      '\u205f',
+      '\u3000',
+    ]) {
+      const details = extractRememberErrorDetails(
+        new Error(`Bearer sk-AAAAAAAAAA${separator}BBBBBBBBBBBBBBB`),
+      );
+
+      expect(details).toBe('Bearer <redacted>');
+      expect(details).not.toContain('AAAAAAAAAA');
+      expect(details).not.toContain('BBBBBBBBBBBBBBB');
+    }
+  });
+
+  it('redacts bearer tokens after unicode space separators', () => {
+    for (const separator of ['\u00a0', '\u2009', '\u202f']) {
+      const details = extractRememberErrorDetails(
+        new Error(`Bearer${separator}secret-token-value`),
+      );
+
+      expect(details).toBe('Bearer <redacted>');
+      expect(details).not.toContain('secret-token-value');
     }
   });
 
@@ -191,6 +234,10 @@ describe('extractRememberErrorDetails', () => {
     );
   });
 
+  it('omits empty details after sanitization', () => {
+    expect(extractRememberErrorDetails(new Error('\u200b'))).toBeUndefined();
+  });
+
   it('guards against circular causes', () => {
     const cyclic: Record<string, unknown> = {};
     cyclic['cause'] = cyclic;
@@ -248,5 +295,71 @@ describe('extractRememberErrorStack', () => {
     expect(stack).toContain('\n\tat handler');
     expect(stack).not.toContain('secret-token-value');
     expect(stack).toHaveLength(1000);
+  });
+});
+
+describe('workspaceMemoryFailureDiagnostics', () => {
+  it('falls back when detail extraction throws', () => {
+    const extractionErrors: Array<{ target: string; message: string }> = [];
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('detail getter failed');
+        },
+      },
+    );
+
+    const diagnostics = workspaceMemoryFailureDiagnostics(
+      err,
+      (target, cause) =>
+        extractionErrors.push({
+          target,
+          message: cause instanceof Error ? cause.message : String(cause),
+        }),
+    );
+
+    expect(diagnostics).toEqual({ debugDetails: '<details unavailable>' });
+    expect(extractionErrors).toEqual([
+      { target: 'details', message: 'detail getter failed' },
+    ]);
+  });
+
+  it('falls back when stack extraction throws', () => {
+    const extractionErrors: Array<{ target: string; message: string }> = [];
+    const err = new Proxy(new Error('boom'), {
+      get(target, property, receiver) {
+        if (property === 'stack') {
+          throw new Error('stack getter failed');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const diagnostics = workspaceMemoryFailureDiagnostics(
+      err,
+      (target, cause) =>
+        extractionErrors.push({
+          target,
+          message: cause instanceof Error ? cause.message : String(cause),
+        }),
+    );
+
+    expect(diagnostics).toEqual({
+      details: 'boom',
+      debugDetails: 'boom',
+    });
+    expect(extractionErrors).toEqual([
+      { target: 'stack', message: 'stack getter failed' },
+    ]);
+  });
+});
+
+describe('shouldSuppressRememberErrorDetails', () => {
+  it('suppresses details only for configured public errors', () => {
+    expect(
+      shouldSuppressRememberErrorDetails('managed_memory_unavailable'),
+    ).toBe(true);
+    expect(shouldSuppressRememberErrorDetails('remember_failed')).toBe(false);
   });
 });

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -85,7 +85,14 @@ describe('extractRememberErrorDetails', () => {
   });
 
   it('normalizes hidden separators before redacting credentials', () => {
-    for (const separator of ['\u200b', '\u2060', '\u2064']) {
+    for (const separator of [
+      '\u00ad',
+      '\u061c',
+      '\u180e',
+      '\u200b',
+      '\u2060',
+      '\u2064',
+    ]) {
       const details = extractRememberErrorDetails(
         new Error(`Authorization: Bearer${separator}secret-token-value`),
       );
@@ -96,7 +103,14 @@ describe('extractRememberErrorDetails', () => {
   });
 
   it('redacts credentials with hidden separators inside token values', () => {
-    for (const separator of ['\u200b', '\u2060', '\u2064']) {
+    for (const separator of [
+      '\u00ad',
+      '\u061c',
+      '\u180e',
+      '\u200b',
+      '\u2060',
+      '\u2064',
+    ]) {
       const details = extractRememberErrorDetails(
         new Error(`Authorization: Bearer secret${separator}token-value`),
       );

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -171,6 +171,16 @@ describe('extractRememberErrorDetails', () => {
     }
   });
 
+  it('redacts bearer tokens split by control characters', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Authorization: Bearer secret\x01token-value'),
+    );
+
+    expect(details).toBe('Authorization: <redacted>');
+    expect(details).not.toContain('secret');
+    expect(details).not.toContain('token-value');
+  });
+
   it('redacts bearer tokens split by unicode space separators', () => {
     for (const separator of [
       '\u00a0',
@@ -358,6 +368,18 @@ describe('extractRememberErrorStack', () => {
     expect(stack).toBe(
       'Error: missing column name\n\tat handler (/workspace/file.ts:1:1)',
     );
+  });
+
+  it('redacts stack bearer tokens split by control characters', () => {
+    const err = new Error('Authorization: Bearer secret\x01token-value');
+    err.stack =
+      'Error: Authorization: Bearer secret\x01token-value\n\tat handler (/workspace/file.ts:1:1)';
+
+    const stack = extractRememberErrorStack(err);
+
+    expect(stack).toContain('Authorization: <redacted>');
+    expect(stack).not.toContain('secret');
+    expect(stack).not.toContain('token-value');
   });
 });
 

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -222,6 +222,15 @@ describe('extractRememberErrorDetails', () => {
     expect(details).not.toContain('eyJhbGciOiABCDEFGHIJKLMN');
   });
 
+  it('redacts QQBot tokens separated by invisible characters', () => {
+    const details = extractRememberErrorDetails(
+      new Error('QQBot\u200Bsecret-token-value'),
+    );
+
+    expect(details).toBe('QQBot <redacted>');
+    expect(details).not.toContain('secret-token-value');
+  });
+
   it('normalizes line separators before redacting credentials', () => {
     for (const separator of ['\u2028', '\u2029']) {
       const details = extractRememberErrorDetails(
@@ -320,6 +329,15 @@ describe('extractRememberErrorStack', () => {
     expect(stack).toContain('\n\tat handler');
     expect(stack).not.toContain('secret-token-value');
     expect(stack).toHaveLength(1000);
+  });
+
+  it('preserves CRLF stack line endings before logging', () => {
+    const err = new Error('boom');
+    err.stack = 'Error: boom\r\n\tat handler (/workspace/file.ts:1:1)';
+
+    const stack = extractRememberErrorStack(err);
+
+    expect(stack).toBe('Error: boom\r\n\tat handler (/workspace/file.ts:1:1)');
   });
 });
 

--- a/packages/cli/src/serve/workspace-remember-errors.test.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.test.ts
@@ -231,6 +231,37 @@ describe('extractRememberErrorDetails', () => {
     expect(details).not.toContain('BBBBBBBBBBBBBBB');
   });
 
+  it('redacts platform tokens split by invisible characters', () => {
+    for (const prefix of [
+      'ghp_',
+      'gho_',
+      'ghs_',
+      'ghu_',
+      'github_pat_',
+      'glpat-',
+      'xoxb-',
+      'xoxp-',
+    ]) {
+      const details = extractRememberErrorDetails(
+        new Error(`Platform token ${prefix}AAAAAAAAAA\u200bBBBBBBBBBBBBBBB`),
+      );
+
+      expect(details).toBe('Platform token <redacted>');
+      expect(details).not.toContain('AAAAAAAAAA');
+      expect(details).not.toContain('BBBBBBBBBBBBBBB');
+    }
+  });
+
+  it('redacts platform tokens split by unicode space separators', () => {
+    const details = extractRememberErrorDetails(
+      new Error('Platform token ghp_AAAAAAAAAA\u00a0BBBBBBBBBBBBBBB'),
+    );
+
+    expect(details).toBe('Platform token <redacted>');
+    expect(details).not.toContain('AAAAAAAAAA');
+    expect(details).not.toContain('BBBBBBBBBBBBBBB');
+  });
+
   it('redacts bare bearer tokens separated by invisible characters', () => {
     const details = extractRememberErrorDetails(
       new Error('Bearer\u200BeyJhbGciOiABCDEFGHIJKLMN'),

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -8,12 +8,23 @@ import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
 
 const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
 const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
-const REMEMBER_ERROR_INVISIBLE_RE =
-  /[\p{Cf}\u2028\u2029]|\p{Variation_Selector}/gu;
+const REMEMBER_ERROR_SEPARATOR_RE =
+  /[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector}/gu;
 const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
-  /\b(Bearer|QQBot)(?:[\p{Cf}\u2028\u2029]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
+  /\b(Bearer|QQBot)(?:[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
 // eslint-disable-next-line no-control-regex
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
+const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([
+  'managed_memory_unavailable',
+]);
+
+export interface WorkspaceMemoryFailureDiagnostics {
+  details?: string;
+  debugDetails: string;
+  stack?: string;
+}
+
+type RememberErrorExtractionTarget = 'details' | 'stack';
 
 function errorCodeFromRecord(
   record: Record<string, unknown>,
@@ -104,14 +115,14 @@ function rawRememberErrorDetails(
 function replaceControlChars(details: string): string {
   return details
     .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
-    .replace(REMEMBER_ERROR_INVISIBLE_RE, '')
+    .replace(REMEMBER_ERROR_SEPARATOR_RE, '')
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 
 function replaceStackControlChars(stack: string): string {
   return stack
     .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
-    .replace(REMEMBER_ERROR_INVISIBLE_RE, '')
+    .replace(REMEMBER_ERROR_SEPARATOR_RE, '')
     .replace(REMEMBER_ERROR_CONTROL_RE, (char) =>
       char === '\n' || char === '\t' ? char : ' ',
     );
@@ -170,4 +181,36 @@ export function extractRememberErrorDetails(err: unknown): string | undefined {
 export function extractRememberErrorStack(err: unknown): string | undefined {
   if (!(err instanceof Error) || !err.stack) return undefined;
   return sanitizeRememberErrorStack(err.stack);
+}
+
+export function shouldSuppressRememberErrorDetails(code: string): boolean {
+  return DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES.has(code);
+}
+
+export function workspaceMemoryFailureDiagnostics(
+  err: unknown,
+  onExtractionError?: (
+    target: RememberErrorExtractionTarget,
+    err: unknown,
+  ) => void,
+): WorkspaceMemoryFailureDiagnostics {
+  let details: string | undefined;
+  let stack: string | undefined;
+  try {
+    details = extractRememberErrorDetails(err);
+  } catch (extractionErr) {
+    onExtractionError?.('details', extractionErr);
+    details = undefined;
+  }
+  try {
+    stack = extractRememberErrorStack(err);
+  } catch (extractionErr) {
+    onExtractionError?.('stack', extractionErr);
+    stack = undefined;
+  }
+  return {
+    ...(details ? { details } : {}),
+    debugDetails: details ?? '<details unavailable>',
+    ...(stack ? { stack } : {}),
+  };
 }

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -24,21 +24,33 @@ function errorCodeFromRecord(
   return undefined;
 }
 
+function rawRememberErrorCode(
+  err: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+): string | undefined {
+  if (depth > MAX_REMEMBER_ERROR_CAUSE_DEPTH) return undefined;
+  if (!err || typeof err !== 'object') return undefined;
+  if (seen.has(err)) return undefined;
+  seen.add(err);
+
+  const record = err as Record<string, unknown>;
+  const direct = errorCodeFromRecord(record);
+  if (direct) return direct;
+
+  const cause = record['cause'];
+  if (cause != null) {
+    return rawRememberErrorCode(cause, seen, depth + 1);
+  }
+
+  return undefined;
+}
+
 export function extractRememberErrorCode(
   err: unknown,
   fallback = 'remember_failed',
 ): string {
-  if (err && typeof err === 'object') {
-    const record = err as Record<string, unknown>;
-    const direct = errorCodeFromRecord(record);
-    if (direct) return direct;
-    const cause = record['cause'];
-    if (cause && typeof cause === 'object') {
-      const causedBy = errorCodeFromRecord(cause as Record<string, unknown>);
-      if (causedBy) return causedBy;
-    }
-  }
-  return fallback;
+  return rawRememberErrorCode(err, new WeakSet<object>(), 0) ?? fallback;
 }
 
 function detailFromRecord(
@@ -112,16 +124,19 @@ function replaceControlChars(details: string): string {
 }
 
 function sanitizeRememberErrorDetails(details: string): string | undefined {
-  const normalized = redactLogCredentials(replaceControlChars(details)).trim();
+  const redacted = redactLogCredentials(details);
+  const normalized = redactLogCredentials(replaceControlChars(redacted)).trim();
   if (!normalized) return undefined;
   if (normalized.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
     return normalized;
   }
   const truncationSuffix = '... [truncated]';
-  return `${normalized.slice(
-    0,
-    MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length,
-  )}${truncationSuffix}`;
+  let cutPoint = MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length;
+  const codeUnit = normalized.charCodeAt(cutPoint - 1);
+  if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+    cutPoint -= 1;
+  }
+  return `${normalized.slice(0, cutPoint)}${truncationSuffix}`;
 }
 
 export function extractRememberErrorDetails(err: unknown): string | undefined {

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -83,7 +83,7 @@ function shouldReplaceControlChar(code: number): boolean {
     code <= 31 ||
     (code >= 127 && code <= 159) ||
     (code >= 0x200b && code <= 0x200f) ||
-    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2028 && code <= 0x202e) ||
     (code >= 0x2066 && code <= 0x2069) ||
     code === 0xfeff
   );

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -101,7 +101,7 @@ function rawRememberErrorDetails(
 
 function replaceControlChars(details: string): string {
   return details
-    .replace(REMEMBER_ERROR_INVISIBLE_RE, ' ')
+    .replace(REMEMBER_ERROR_INVISIBLE_RE, '')
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -126,3 +126,8 @@ export function extractRememberErrorDetails(err: unknown): string | undefined {
   if (!raw) return undefined;
   return sanitizeRememberErrorDetails(raw);
 }
+
+export function extractRememberErrorStack(err: unknown): string | undefined {
+  if (!(err instanceof Error) || !err.stack) return undefined;
+  return sanitizeRememberErrorDetails(err.stack);
+}

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -44,6 +44,8 @@ function detailFromRecord(
   record: Record<string, unknown>,
   seen: WeakSet<object>,
 ): string | undefined {
+  // Bridge errors carry the best failure reason in `data`; top-level
+  // `message` and `cause` are generic fallbacks.
   const data = record['data'];
   if (typeof data === 'string' && data.length > 0) return data;
   if (data && typeof data === 'object') {
@@ -76,15 +78,35 @@ function rawRememberErrorDetails(
   return detailFromRecord(err as Record<string, unknown>, seen);
 }
 
+function shouldReplaceControlChar(code: number): boolean {
+  return (
+    code <= 31 ||
+    (code >= 127 && code <= 159) ||
+    (code >= 0x200b && code <= 0x200f) ||
+    (code >= 0x202a && code <= 0x202e) ||
+    (code >= 0x2066 && code <= 0x2069) ||
+    code === 0xfeff
+  );
+}
+
 function replaceControlChars(details: string): string {
-  return Array.from(details, (char) => {
-    const code = char.charCodeAt(0);
-    return code <= 31 || (code >= 127 && code <= 159) ? ' ' : char;
-  }).join('');
+  let normalized = '';
+  let last = 0;
+  for (let index = 0; index < details.length; ) {
+    const code = details.codePointAt(index);
+    if (code === undefined) break;
+    const width = code > 0xffff ? 2 : 1;
+    if (shouldReplaceControlChar(code)) {
+      normalized += details.slice(last, index) + ' ';
+      last = index + width;
+    }
+    index += width;
+  }
+  return last === 0 ? details : normalized + details.slice(last);
 }
 
 function sanitizeRememberErrorDetails(details: string): string | undefined {
-  const normalized = replaceControlChars(redactLogCredentials(details)).trim();
+  const normalized = redactLogCredentials(replaceControlChars(details)).trim();
   if (!normalized) return undefined;
   if (normalized.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
     return normalized;

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -108,20 +108,39 @@ function replaceControlChars(details: string): string {
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function truncateBeforeDanglingSurrogate(
+  details: string,
+  cutPoint: number,
+): number {
+  const beforeCut = details.charCodeAt(cutPoint - 1);
+  const atCut = details.charCodeAt(cutPoint);
+  if (isHighSurrogate(beforeCut) && isLowSurrogate(atCut)) {
+    return cutPoint - 1;
+  }
+  return cutPoint;
+}
+
 function sanitizeRememberErrorDetails(details: string): string | undefined {
-  const redacted = redactLogCredentials(details);
-  const normalized = redactLogCredentials(replaceControlChars(redacted)).trim();
-  if (!normalized) return undefined;
-  if (normalized.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
-    return normalized;
+  const normalized = replaceControlChars(details);
+  const redacted = redactLogCredentials(normalized).trim();
+  if (!redacted) return undefined;
+  if (redacted.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
+    return redacted;
   }
   const truncationSuffix = '... [truncated]';
-  let cutPoint = MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length;
-  const codeUnit = normalized.charCodeAt(cutPoint - 1);
-  if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-    cutPoint -= 1;
-  }
-  return `${normalized.slice(0, cutPoint)}${truncationSuffix}`;
+  const cutPoint = truncateBeforeDanglingSurrogate(
+    redacted,
+    MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length,
+  );
+  return `${redacted.slice(0, cutPoint)}${truncationSuffix}`;
 }
 
 export function extractRememberErrorDetails(err: unknown): string | undefined {

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -7,6 +7,7 @@
 import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
 
 const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
+const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
 
 function errorCodeFromRecord(
   record: Record<string, unknown>,
@@ -43,11 +44,11 @@ export function extractRememberErrorCode(
 function detailFromRecord(
   record: Record<string, unknown>,
   seen: WeakSet<object>,
+  depth: number,
 ): string | undefined {
   // Bridge errors carry the best failure reason in `data`; top-level
   // `message` and `cause` are generic fallbacks.
   const data = record['data'];
-  if (typeof data === 'string' && data.length > 0) return data;
   if (data && typeof data === 'object') {
     const dataRecord = data as Record<string, unknown>;
     const details = dataRecord['details'];
@@ -59,9 +60,11 @@ function detailFromRecord(
   const message = record['message'];
   if (typeof message === 'string' && message.length > 0) return message;
 
+  if (typeof data === 'string' && data.length > 0) return data;
+
   const cause = record['cause'];
-  if (cause && typeof cause === 'object') {
-    return rawRememberErrorDetails(cause, seen);
+  if (cause != null) {
+    return rawRememberErrorDetails(cause, seen, depth + 1);
   }
 
   return undefined;
@@ -70,12 +73,14 @@ function detailFromRecord(
 function rawRememberErrorDetails(
   err: unknown,
   seen: WeakSet<object>,
+  depth: number,
 ): string | undefined {
+  if (depth > MAX_REMEMBER_ERROR_CAUSE_DEPTH) return undefined;
   if (typeof err === 'string' && err.length > 0) return err;
   if (!err || typeof err !== 'object') return undefined;
   if (seen.has(err)) return undefined;
   seen.add(err);
-  return detailFromRecord(err as Record<string, unknown>, seen);
+  return detailFromRecord(err as Record<string, unknown>, seen, depth);
 }
 
 function shouldReplaceControlChar(code: number): boolean {
@@ -84,6 +89,7 @@ function shouldReplaceControlChar(code: number): boolean {
     (code >= 127 && code <= 159) ||
     (code >= 0x200b && code <= 0x200f) ||
     (code >= 0x2028 && code <= 0x202e) ||
+    (code >= 0x2060 && code <= 0x2064) ||
     (code >= 0x2066 && code <= 0x2069) ||
     code === 0xfeff
   );
@@ -119,7 +125,7 @@ function sanitizeRememberErrorDetails(details: string): string | undefined {
 }
 
 export function extractRememberErrorDetails(err: unknown): string | undefined {
-  const raw = rawRememberErrorDetails(err, new WeakSet<object>());
+  const raw = rawRememberErrorDetails(err, new WeakSet<object>(), 0);
   if (!raw) return undefined;
   return sanitizeRememberErrorDetails(raw);
 }

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -108,6 +108,15 @@ function replaceControlChars(details: string): string {
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 
+function replaceStackControlChars(stack: string): string {
+  return stack
+    .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
+    .replace(REMEMBER_ERROR_INVISIBLE_RE, '')
+    .replace(REMEMBER_ERROR_CONTROL_RE, (char) =>
+      char === '\n' || char === '\t' ? char : ' ',
+    );
+}
+
 function isHighSurrogate(codeUnit: number): boolean {
   return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
 }
@@ -128,19 +137,28 @@ function truncateBeforeDanglingSurrogate(
   return cutPoint;
 }
 
-function sanitizeRememberErrorDetails(details: string): string | undefined {
-  const normalized = replaceControlChars(details);
-  const redacted = redactLogCredentials(normalized).trim();
-  if (!redacted) return undefined;
-  if (redacted.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
-    return redacted;
-  }
+function capRememberErrorText(redacted: string): string {
+  if (redacted.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) return redacted;
   const truncationSuffix = '... [truncated]';
   const cutPoint = truncateBeforeDanglingSurrogate(
     redacted,
     MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length,
   );
   return `${redacted.slice(0, cutPoint)}${truncationSuffix}`;
+}
+
+function redactAndCapRememberErrorText(normalized: string): string | undefined {
+  const redacted = redactLogCredentials(normalized).trim();
+  if (!redacted) return undefined;
+  return capRememberErrorText(redacted);
+}
+
+function sanitizeRememberErrorDetails(details: string): string | undefined {
+  return redactAndCapRememberErrorText(replaceControlChars(details));
+}
+
+function sanitizeRememberErrorStack(stack: string): string | undefined {
+  return redactAndCapRememberErrorText(replaceStackControlChars(stack));
 }
 
 export function extractRememberErrorDetails(err: unknown): string | undefined {
@@ -151,5 +169,5 @@ export function extractRememberErrorDetails(err: unknown): string | undefined {
 
 export function extractRememberErrorStack(err: unknown): string | undefined {
   if (!(err instanceof Error) || !err.stack) return undefined;
-  return sanitizeRememberErrorDetails(err.stack);
+  return sanitizeRememberErrorStack(err.stack);
 }

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -8,6 +8,10 @@ import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
 
 const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
 const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
+const REMEMBER_ERROR_INVISIBLE_RE =
+  /[\p{Cf}\u2028\u2029]|\p{Variation_Selector}/gu;
+// eslint-disable-next-line no-control-regex
+const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 
 function errorCodeFromRecord(
   record: Record<string, unknown>,
@@ -95,32 +99,10 @@ function rawRememberErrorDetails(
   return detailFromRecord(err as Record<string, unknown>, seen, depth);
 }
 
-function shouldReplaceControlChar(code: number): boolean {
-  return (
-    code <= 31 ||
-    (code >= 127 && code <= 159) ||
-    (code >= 0x200b && code <= 0x200f) ||
-    (code >= 0x2028 && code <= 0x202e) ||
-    (code >= 0x2060 && code <= 0x2064) ||
-    (code >= 0x2066 && code <= 0x2069) ||
-    code === 0xfeff
-  );
-}
-
 function replaceControlChars(details: string): string {
-  let normalized = '';
-  let last = 0;
-  for (let index = 0; index < details.length; ) {
-    const code = details.codePointAt(index);
-    if (code === undefined) break;
-    const width = code > 0xffff ? 2 : 1;
-    if (shouldReplaceControlChar(code)) {
-      normalized += details.slice(last, index) + ' ';
-      last = index + width;
-    }
-    index += width;
-  }
-  return last === 0 ? details : normalized + details.slice(last);
+  return details
+    .replace(REMEMBER_ERROR_INVISIBLE_RE, ' ')
+    .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 
 function sanitizeRememberErrorDetails(details: string): string | undefined {

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -19,7 +19,7 @@ const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
 const REMEMBER_ERROR_AUTH_TOKEN_WITH_SEPARATORS_RE =
   /\b(Bearer|QQBot)(?:\s|[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+((?:[A-Za-z0-9._~+/=-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9._~+/=-]+)/giu;
 const REMEMBER_ERROR_BARE_TOKEN_WITH_SEPARATORS_RE =
-  /\bsk-(?:[A-Za-z0-9-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9-]+/gu;
+  /\b(?:sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xox[b]-|xox[p]-)(?:[A-Za-z0-9_-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9_-]+/gu;
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 /* eslint-enable no-control-regex */
 const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -153,7 +153,7 @@ function replaceStackControlChars(stack: string): string {
     .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
     .replace(REMEMBER_ERROR_SEPARATOR_RE, '')
     .replace(REMEMBER_ERROR_CONTROL_RE, (char) =>
-      char === '\n' || char === '\t' ? char : ' ',
+      char === '\n' || char === '\r' || char === '\t' ? char : ' ',
     );
 }
 

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -25,6 +25,19 @@ export interface WorkspaceMemoryFailureDiagnostics {
 }
 
 type RememberErrorExtractionTarget = 'code' | 'details' | 'stack';
+type WorkspaceMemoryExtractionLogger = {
+  warn(message: string, context: { extractionError: string }): void;
+};
+
+export function createWorkspaceMemoryExtractionErrorLogger(
+  logger: WorkspaceMemoryExtractionLogger,
+): (target: RememberErrorExtractionTarget, err: unknown) => void {
+  return (target, err) => {
+    logger.warn(`Failed to extract workspace memory error ${target}:`, {
+      extractionError: err instanceof Error ? err.message : String(err),
+    });
+  };
+}
 
 function errorCodeFromRecord(
   record: Record<string, unknown>,

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
+
+const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
+
 function errorCodeFromRecord(
   record: Record<string, unknown>,
 ): string | undefined {
@@ -34,4 +38,66 @@ export function extractRememberErrorCode(
     }
   }
   return fallback;
+}
+
+function detailFromRecord(
+  record: Record<string, unknown>,
+  seen: WeakSet<object>,
+): string | undefined {
+  const data = record['data'];
+  if (typeof data === 'string' && data.length > 0) return data;
+  if (data && typeof data === 'object') {
+    const dataRecord = data as Record<string, unknown>;
+    const details = dataRecord['details'];
+    if (typeof details === 'string' && details.length > 0) return details;
+    const message = dataRecord['message'];
+    if (typeof message === 'string' && message.length > 0) return message;
+  }
+
+  const message = record['message'];
+  if (typeof message === 'string' && message.length > 0) return message;
+
+  const cause = record['cause'];
+  if (cause && typeof cause === 'object') {
+    return rawRememberErrorDetails(cause, seen);
+  }
+
+  return undefined;
+}
+
+function rawRememberErrorDetails(
+  err: unknown,
+  seen: WeakSet<object>,
+): string | undefined {
+  if (typeof err === 'string' && err.length > 0) return err;
+  if (!err || typeof err !== 'object') return undefined;
+  if (seen.has(err)) return undefined;
+  seen.add(err);
+  return detailFromRecord(err as Record<string, unknown>, seen);
+}
+
+function replaceControlChars(details: string): string {
+  return Array.from(details, (char) => {
+    const code = char.charCodeAt(0);
+    return code <= 31 || (code >= 127 && code <= 159) ? ' ' : char;
+  }).join('');
+}
+
+function sanitizeRememberErrorDetails(details: string): string | undefined {
+  const normalized = replaceControlChars(redactLogCredentials(details)).trim();
+  if (!normalized) return undefined;
+  if (normalized.length <= MAX_REMEMBER_ERROR_DETAILS_CHARS) {
+    return normalized;
+  }
+  const truncationSuffix = '... [truncated]';
+  return `${normalized.slice(
+    0,
+    MAX_REMEMBER_ERROR_DETAILS_CHARS - truncationSuffix.length,
+  )}${truncationSuffix}`;
+}
+
+export function extractRememberErrorDetails(err: unknown): string | undefined {
+  const raw = rawRememberErrorDetails(err, new WeakSet<object>());
+  if (!raw) return undefined;
+  return sanitizeRememberErrorDetails(raw);
 }

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -11,12 +11,17 @@ const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
 const REMEMBER_ERROR_FORMAT_RE = /[\p{Cf}]|\p{Variation_Selector}/gu;
 const REMEMBER_ERROR_SPACE_SEPARATOR_RE =
   /[\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/gu;
-const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
-  /\b(Bearer|QQBot)(?:[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
+/* eslint-disable no-control-regex */
 const REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE =
-  /(\b(?:Bearer|QQBot)\s+[A-Za-z0-9._~+/=-]*|\bsk-[A-Za-z0-9-]*)(?:[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
-// eslint-disable-next-line no-control-regex
+  /[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector}/gu;
+const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
+  /\b(Bearer|QQBot)(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
+const REMEMBER_ERROR_AUTH_TOKEN_WITH_SEPARATORS_RE =
+  /\b(Bearer|QQBot)(?:\s|[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+((?:[A-Za-z0-9._~+/=-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9._~+/=-]+)/giu;
+const REMEMBER_ERROR_BARE_TOKEN_WITH_SEPARATORS_RE =
+  /\bsk-(?:[A-Za-z0-9-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9-]+/gu;
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
+/* eslint-enable no-control-regex */
 const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([
   'managed_memory_unavailable',
 ]);
@@ -162,16 +167,27 @@ function replaceStackControlChars(stack: string): string {
     );
 }
 
-function collapseCredentialSeparators(details: string): string {
-  let normalized = details;
-  while (true) {
-    const next = normalized.replace(
-      REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE,
-      '$1',
+function collapseCredentialSeparators(text: string): string {
+  return text
+    .replace(
+      REMEMBER_ERROR_AUTH_TOKEN_WITH_SEPARATORS_RE,
+      (_match, scheme: string, token: string) =>
+        `${scheme} ${token.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, '')}`,
+    )
+    .replace(REMEMBER_ERROR_BARE_TOKEN_WITH_SEPARATORS_RE, (token) =>
+      token.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, ''),
     );
-    if (next === normalized) return normalized;
-    normalized = next;
-  }
+}
+
+function collapseCredentialSeparatorsByStackLine(stack: string): string {
+  return stack
+    .split(/(\r\n|\n|\r)/)
+    .map((part) =>
+      part === '\r\n' || part === '\n' || part === '\r'
+        ? part
+        : collapseCredentialSeparators(part),
+    )
+    .join('');
 }
 
 function isHighSurrogate(codeUnit: number): boolean {
@@ -220,7 +236,7 @@ function sanitizeRememberErrorDetails(details: string): string | undefined {
 
 function sanitizeRememberErrorStack(stack: string): string | undefined {
   return redactAndCapRememberErrorText(
-    replaceStackControlChars(collapseCredentialSeparators(stack)),
+    replaceStackControlChars(collapseCredentialSeparatorsByStackLine(stack)),
   );
 }
 

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -24,7 +24,7 @@ export interface WorkspaceMemoryFailureDiagnostics {
   stack?: string;
 }
 
-type RememberErrorExtractionTarget = 'details' | 'stack';
+type RememberErrorExtractionTarget = 'code' | 'details' | 'stack';
 
 function errorCodeFromRecord(
   record: Record<string, unknown>,
@@ -68,6 +68,22 @@ export function extractRememberErrorCode(
   fallback = 'remember_failed',
 ): string {
   return rawRememberErrorCode(err, new WeakSet<object>(), 0) ?? fallback;
+}
+
+export function workspaceMemoryFailureCode(
+  err: unknown,
+  fallback = 'remember_failed',
+  onExtractionError?: (
+    target: RememberErrorExtractionTarget,
+    err: unknown,
+  ) => void,
+): string {
+  try {
+    return extractRememberErrorCode(err, fallback);
+  } catch (extractionErr) {
+    onExtractionError?.('code', extractionErr);
+    return fallback;
+  }
 }
 
 function detailFromRecord(

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -26,6 +26,8 @@ const REMEMBER_ERROR_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE =
   /((?:api[_-]?key|token|secret|password|pwd)[_-]?[=:]\s*)((?:\S+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*\S+)/giu;
 const REMEMBER_ERROR_ENV_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE =
   /([A-Z][A-Z0-9]{0,50}(?:_[A-Z0-9]{1,50}){0,10}_(?:KEY|TOKEN|SECRET|PASSWORD)\s*[=:]\s*)((?:\S+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*\S+)/gu;
+const REMEMBER_ERROR_URL_CREDENTIALS_WITH_SEPARATORS_RE =
+  /(\b[a-z][a-z0-9+.-]{0,31}:\/\/)([^/@\s]*(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+[^/@\s]*)@/giu;
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 /* eslint-enable no-control-regex */
 const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([
@@ -51,6 +53,20 @@ export function createWorkspaceMemoryExtractionErrorLogger(
       extractionError: err instanceof Error ? err.message : String(err),
     });
   };
+}
+
+function reportRememberErrorExtractionFailure(
+  onExtractionError:
+    | ((target: RememberErrorExtractionTarget, err: unknown) => void)
+    | undefined,
+  target: RememberErrorExtractionTarget,
+  err: unknown,
+): void {
+  try {
+    onExtractionError?.(target, err);
+  } catch {
+    // Preserve fallback behavior if extraction logging fails.
+  }
 }
 
 function errorCodeFromRecord(
@@ -108,7 +124,11 @@ export function workspaceMemoryFailureCode(
   try {
     return extractRememberErrorCode(err, fallback);
   } catch (extractionErr) {
-    onExtractionError?.('code', extractionErr);
+    reportRememberErrorExtractionFailure(
+      onExtractionError,
+      'code',
+      extractionErr,
+    );
     return fallback;
   }
 }
@@ -175,6 +195,11 @@ function replaceStackControlChars(stack: string): string {
 
 function collapseCredentialSeparators(text: string): string {
   return text
+    .replace(
+      REMEMBER_ERROR_URL_CREDENTIALS_WITH_SEPARATORS_RE,
+      (_match, scheme: string, userinfo: string) =>
+        `${scheme}${userinfo.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, '')}@`,
+    )
     .replace(
       REMEMBER_ERROR_AUTH_TOKEN_WITH_SEPARATORS_RE,
       (_match, scheme: string, token: string) =>
@@ -286,13 +311,21 @@ export function workspaceMemoryFailureDiagnostics(
   try {
     details = extractRememberErrorDetails(err);
   } catch (extractionErr) {
-    onExtractionError?.('details', extractionErr);
+    reportRememberErrorExtractionFailure(
+      onExtractionError,
+      'details',
+      extractionErr,
+    );
     details = undefined;
   }
   try {
     stack = extractRememberErrorStack(err);
   } catch (extractionErr) {
-    onExtractionError?.('stack', extractionErr);
+    reportRememberErrorExtractionFailure(
+      onExtractionError,
+      'stack',
+      extractionErr,
+    );
     stack = undefined;
   }
   return {

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -194,6 +194,8 @@ function redactAndCapRememberErrorText(normalized: string): string | undefined {
 }
 
 function sanitizeRememberErrorDetails(details: string): string | undefined {
+  // Keep separator normalization before credential redaction: auth schemes like
+  // `Bearer` and `QQBot` may otherwise be split by invisible characters.
   return redactAndCapRememberErrorText(replaceControlChars(details));
 }
 

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -20,6 +20,12 @@ const REMEMBER_ERROR_AUTH_TOKEN_WITH_SEPARATORS_RE =
   /\b(Bearer|QQBot)(?:\s|[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+((?:[A-Za-z0-9._~+/=-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9._~+/=-]+)/giu;
 const REMEMBER_ERROR_BARE_TOKEN_WITH_SEPARATORS_RE =
   /\b(?:sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xox[b]-|xox[p]-)(?:[A-Za-z0-9_-]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Za-z0-9_-]+/gu;
+const REMEMBER_ERROR_AWS_KEY_WITH_SEPARATORS_RE =
+  /\b(?:AKIA|ASIA)(?:[A-Z0-9]+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*[A-Z0-9]+/gu;
+const REMEMBER_ERROR_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE =
+  /((?:api[_-]?key|token|secret|password|pwd)[_-]?[=:]\s*)((?:\S+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*\S+)/giu;
+const REMEMBER_ERROR_ENV_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE =
+  /([A-Z][A-Z0-9]{0,50}(?:_[A-Z0-9]{1,50}){0,10}_(?:KEY|TOKEN|SECRET|PASSWORD)\s*[=:]\s*)((?:\S+(?:[\x00-\x1f\x7f-\x9f\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+)*\S+)/gu;
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 /* eslint-enable no-control-regex */
 const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([
@@ -176,6 +182,19 @@ function collapseCredentialSeparators(text: string): string {
     )
     .replace(REMEMBER_ERROR_BARE_TOKEN_WITH_SEPARATORS_RE, (token) =>
       token.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, ''),
+    )
+    .replace(REMEMBER_ERROR_AWS_KEY_WITH_SEPARATORS_RE, (token) =>
+      token.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, ''),
+    )
+    .replace(
+      REMEMBER_ERROR_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE,
+      (_match, prefix: string, value: string) =>
+        `${prefix}${value.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, '')}`,
+    )
+    .replace(
+      REMEMBER_ERROR_ENV_SECRET_ASSIGNMENT_WITH_SEPARATORS_RE,
+      (_match, prefix: string, value: string) =>
+        `${prefix}${value.replace(REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE, '')}`,
     );
 }
 

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -10,6 +10,8 @@ const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
 const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
 const REMEMBER_ERROR_INVISIBLE_RE =
   /[\p{Cf}\u2028\u2029]|\p{Variation_Selector}/gu;
+const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
+  /\b(Bearer|QQBot)(?:[\p{Cf}\u2028\u2029]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
 // eslint-disable-next-line no-control-regex
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 
@@ -101,6 +103,7 @@ function rawRememberErrorDetails(
 
 function replaceControlChars(details: string): string {
   return details
+    .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
     .replace(REMEMBER_ERROR_INVISIBLE_RE, '')
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }

--- a/packages/cli/src/serve/workspace-remember-errors.ts
+++ b/packages/cli/src/serve/workspace-remember-errors.ts
@@ -8,10 +8,13 @@ import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
 
 const MAX_REMEMBER_ERROR_DETAILS_CHARS = 1000;
 const MAX_REMEMBER_ERROR_CAUSE_DEPTH = 50;
-const REMEMBER_ERROR_SEPARATOR_RE =
-  /[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector}/gu;
+const REMEMBER_ERROR_FORMAT_RE = /[\p{Cf}]|\p{Variation_Selector}/gu;
+const REMEMBER_ERROR_SPACE_SEPARATOR_RE =
+  /[\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/gu;
 const REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE =
   /\b(Bearer|QQBot)(?:[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
+const REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE =
+  /(\b(?:Bearer|QQBot)\s+[A-Za-z0-9._~+/=-]*|\bsk-[A-Za-z0-9-]*)(?:[\p{Cf}\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]|\p{Variation_Selector})+(?=[A-Za-z0-9._~+/=-])/giu;
 // eslint-disable-next-line no-control-regex
 const REMEMBER_ERROR_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
 const DETAIL_SUPPRESSED_REMEMBER_ERROR_CODES = new Set([
@@ -144,17 +147,31 @@ function rawRememberErrorDetails(
 function replaceControlChars(details: string): string {
   return details
     .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
-    .replace(REMEMBER_ERROR_SEPARATOR_RE, '')
+    .replace(REMEMBER_ERROR_FORMAT_RE, '')
+    .replace(REMEMBER_ERROR_SPACE_SEPARATOR_RE, ' ')
     .replace(REMEMBER_ERROR_CONTROL_RE, ' ');
 }
 
 function replaceStackControlChars(stack: string): string {
   return stack
     .replace(REMEMBER_ERROR_AUTH_SCHEME_INVISIBLE_RE, '$1 ')
-    .replace(REMEMBER_ERROR_SEPARATOR_RE, '')
+    .replace(REMEMBER_ERROR_FORMAT_RE, '')
+    .replace(REMEMBER_ERROR_SPACE_SEPARATOR_RE, ' ')
     .replace(REMEMBER_ERROR_CONTROL_RE, (char) =>
       char === '\n' || char === '\r' || char === '\t' ? char : ' ',
     );
+}
+
+function collapseCredentialSeparators(details: string): string {
+  let normalized = details;
+  while (true) {
+    const next = normalized.replace(
+      REMEMBER_ERROR_CREDENTIAL_SEPARATOR_RE,
+      '$1',
+    );
+    if (next === normalized) return normalized;
+    normalized = next;
+  }
 }
 
 function isHighSurrogate(codeUnit: number): boolean {
@@ -194,13 +211,17 @@ function redactAndCapRememberErrorText(normalized: string): string | undefined {
 }
 
 function sanitizeRememberErrorDetails(details: string): string | undefined {
-  // Keep separator normalization before credential redaction: auth schemes like
-  // `Bearer` and `QQBot` may otherwise be split by invisible characters.
-  return redactAndCapRememberErrorText(replaceControlChars(details));
+  // Keep credential normalization before redaction; auth schemes and token
+  // values may otherwise be split by invisible characters.
+  return redactAndCapRememberErrorText(
+    replaceControlChars(collapseCredentialSeparators(details)),
+  );
 }
 
 function sanitizeRememberErrorStack(stack: string): string | undefined {
-  return redactAndCapRememberErrorText(replaceStackControlChars(stack));
+  return redactAndCapRememberErrorText(
+    replaceStackControlChars(collapseCredentialSeparators(stack)),
+  );
 }
 
 export function extractRememberErrorDetails(err: unknown): string | undefined {

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -223,12 +223,13 @@ function buildApp(
     tokenConfigured: true,
     requireAuth: false,
   },
+  lane = new WorkspaceRememberTaskLane(bridge),
 ) {
   const app = express();
   app.use(express.json({ limit: '1mb' }));
   mountWorkspaceMemoryRememberRoutes(app, {
     bridge,
-    lane: new WorkspaceRememberTaskLane(bridge),
+    lane,
     mutate: createMutationGate(auth),
     parseClientId: (req, res) => {
       const raw = req.get('x-qwen-client-id');
@@ -865,6 +866,66 @@ describe('workspace memory remember routes', () => {
     expect(bridge.rememberCalls).toHaveLength(0);
     expect(bridge.forgetCalls).toHaveLength(0);
     expect(bridge.dreamCalls).toBe(0);
+  });
+
+  it('falls back to kind-specific codes when enqueue code extraction throws', async () => {
+    mockDebugLogger.warn.mockClear();
+    const bridge = buildBridgeStub({});
+    const lane = new WorkspaceRememberTaskLane(bridge);
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('code getter failed');
+        },
+      },
+    );
+    vi.spyOn(lane, 'enqueue').mockImplementation(() => {
+      throw err;
+    });
+    vi.spyOn(lane, 'enqueueForget').mockImplementation(() => {
+      throw err;
+    });
+    vi.spyOn(lane, 'enqueueDream').mockImplementation(() => {
+      throw err;
+    });
+    const app = buildApp(bridge, undefined, lane);
+
+    await request(app)
+      .post('/workspace/memory/remember')
+      .send({ content: 'remember me' })
+      .expect(500)
+      .expect((res) => {
+        expect(res.body).toEqual({
+          error: 'Workspace memory remember failed.',
+          code: 'remember_failed',
+        });
+      });
+    await request(app)
+      .post('/workspace/memory/forget')
+      .send({ query: 'old preference' })
+      .expect(500)
+      .expect((res) => {
+        expect(res.body).toEqual({
+          error: 'Workspace memory forget failed.',
+          code: 'forget_failed',
+        });
+      });
+    await request(app)
+      .post('/workspace/memory/dream')
+      .send({})
+      .expect(500)
+      .expect((res) => {
+        expect(res.body).toEqual({
+          error: 'Workspace memory dream failed.',
+          code: 'dream_failed',
+        });
+      });
+    expect(mockDebugLogger.warn).toHaveBeenCalledTimes(3);
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      'Failed to extract workspace memory error code:',
+      { extractionError: 'code getter failed' },
+    );
   });
 
   it('records bridge failures with stable public error codes', async () => {

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -978,6 +978,52 @@ describe('workspace memory remember routes', () => {
     );
   });
 
+  it('falls back when task-lane error code extraction throws', async () => {
+    mockDebugLogger.error.mockClear();
+    mockDebugLogger.warn.mockClear();
+    const err = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('code getter failed');
+        },
+      },
+    );
+    const bridge = buildBridgeStub({
+      rememberImpl: vi.fn().mockRejectedValue(err),
+    });
+    const app = buildApp(bridge);
+
+    const post = await request(app)
+      .post('/workspace/memory/remember')
+      .send({ content: 'proxy failure' })
+      .expect(202);
+    await waitFor(() => bridge.rememberCalls.length === 1);
+    await request(app)
+      .get(`/workspace/memory/remember/${post.body.taskId}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.status).toBe('failed');
+        expect(res.body.error).toEqual({
+          code: 'remember_failed',
+          message: 'Workspace memory remember failed.',
+        });
+      });
+
+    expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+      'Failed to extract workspace memory error code:',
+      { extractionError: 'code getter failed' },
+    );
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember task failed:',
+      expect.objectContaining({
+        taskId: post.body.taskId,
+        code: 'remember_failed',
+        details: '<details unavailable>',
+      }),
+    );
+  });
+
   it('records forget and dream failures with kind-specific error codes', async () => {
     mockDebugLogger.error.mockClear();
     const bridge = buildBridgeStub({

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -23,6 +23,19 @@ import {
 } from './workspace-remember.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from './workspace-memory-remember-constants.js';
 
+const { mockDebugLogger } = vi.hoisted(() => ({
+  mockDebugLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@qwen-code/qwen-code-core', () => ({
+  createDebugLogger: () => mockDebugLogger,
+}));
+
 type RecordedEvent = Omit<BridgeEvent, 'id' | 'v'>;
 
 interface Deferred<T> {
@@ -921,6 +934,47 @@ describe('workspace memory remember routes', () => {
           message: 'Workspace memory remember timed out.',
         });
       });
+  });
+
+  it('logs sanitized details for task-lane failures', async () => {
+    mockDebugLogger.error.mockClear();
+    const bridge = buildBridgeStub({
+      rememberImpl: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('Authorization: Bearer secret-token-value'),
+        ),
+    });
+    const app = buildApp(bridge);
+
+    const post = await request(app)
+      .post('/workspace/memory/remember')
+      .send({ content: 'secret' })
+      .expect(202);
+    await waitFor(() => bridge.rememberCalls.length === 1);
+    await request(app)
+      .get(`/workspace/memory/remember/${post.body.taskId}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.status).toBe('failed');
+        expect(res.body.error).toEqual({
+          code: 'remember_failed',
+          message: 'Workspace memory remember failed.',
+          details: 'Authorization: <redacted>',
+        });
+      });
+
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory remember task failed:',
+      {
+        taskId: post.body.taskId,
+        code: 'remember_failed',
+        details: 'Authorization: <redacted>',
+      },
+    );
+    expect(JSON.stringify(mockDebugLogger.error.mock.calls)).not.toContain(
+      'secret-token-value',
+    );
   });
 
   it('records forget and dream failures with kind-specific error codes', async () => {

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -858,7 +858,11 @@ describe('workspace memory remember routes', () => {
     const bridge = buildBridgeStub({
       rememberImpl: vi
         .fn()
-        .mockRejectedValueOnce({ code: 'remember_path_escape' })
+        .mockRejectedValueOnce(
+          Object.assign(new Error('agent wrote /tmp/outside'), {
+            code: 'remember_path_escape',
+          }),
+        )
         .mockRejectedValueOnce({
           data: { errorKind: 'managed_memory_unavailable' },
         })
@@ -881,6 +885,7 @@ describe('workspace memory remember routes', () => {
         expect(res.body.error).toEqual({
           code: 'remember_path_escape',
           message: 'Remember agent touched a path outside managed memory.',
+          details: 'agent wrote /tmp/outside',
         });
       });
 
@@ -937,6 +942,7 @@ describe('workspace memory remember routes', () => {
         expect(res.body.error).toEqual({
           code: 'forget_failed',
           message: 'Workspace memory forget failed.',
+          details: 'forget failed',
         });
       });
 
@@ -953,6 +959,7 @@ describe('workspace memory remember routes', () => {
         expect(res.body.error).toEqual({
           code: 'dream_failed',
           message: 'Workspace memory dream failed.',
+          details: 'dream failed',
         });
       });
   });

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -966,11 +966,12 @@ describe('workspace memory remember routes', () => {
 
     expect(mockDebugLogger.error).toHaveBeenCalledWith(
       'Workspace memory remember task failed:',
-      {
+      expect.objectContaining({
         taskId: post.body.taskId,
         code: 'remember_failed',
         details: 'Authorization: <redacted>',
-      },
+        stack: expect.stringContaining('Authorization: <redacted>'),
+      }),
     );
     expect(JSON.stringify(mockDebugLogger.error.mock.calls)).not.toContain(
       'secret-token-value',
@@ -978,6 +979,7 @@ describe('workspace memory remember routes', () => {
   });
 
   it('records forget and dream failures with kind-specific error codes', async () => {
+    mockDebugLogger.error.mockClear();
     const bridge = buildBridgeStub({
       forgetImpl: vi.fn().mockRejectedValue(new Error('forget failed')),
       dreamImpl: vi.fn().mockRejectedValue(new Error('dream failed')),
@@ -1000,6 +1002,15 @@ describe('workspace memory remember routes', () => {
           details: 'forget failed',
         });
       });
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory forget task failed:',
+      expect.objectContaining({
+        taskId: forgetPost.body.taskId,
+        code: 'forget_failed',
+        details: 'forget failed',
+        stack: expect.stringContaining('forget failed'),
+      }),
+    );
 
     const dreamPost = await request(app)
       .post('/workspace/memory/dream')
@@ -1017,5 +1028,14 @@ describe('workspace memory remember routes', () => {
           details: 'dream failed',
         });
       });
+    expect(mockDebugLogger.error).toHaveBeenCalledWith(
+      'Workspace memory dream task failed:',
+      expect.objectContaining({
+        taskId: dreamPost.body.taskId,
+        code: 'dream_failed',
+        details: 'dream failed',
+        stack: expect.stringContaining('dream failed'),
+      }),
+    );
   });
 });

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -865,6 +865,7 @@ describe('workspace memory remember routes', () => {
         )
         .mockRejectedValueOnce({
           data: { errorKind: 'managed_memory_unavailable' },
+          message: 'internal managed memory config path',
         })
         .mockRejectedValueOnce({
           data: { errorKind: 'remember_timeout' },

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -18,6 +18,7 @@ import type {
 import {
   extractRememberErrorCode,
   extractRememberErrorDetails,
+  extractRememberErrorStack,
 } from './workspace-remember-errors.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from './workspace-memory-remember-constants.js';
 import {
@@ -211,6 +212,14 @@ function workspaceMemoryDebugDetails(err: unknown): string {
   }
 }
 
+function workspaceMemoryDebugStack(err: unknown): string | undefined {
+  try {
+    return extractRememberErrorStack(err);
+  } catch {
+    return undefined;
+  }
+}
+
 export class WorkspaceRememberTaskLane {
   private static readonly MAX_TASKS = 1000;
   private static readonly TERMINAL_TASK_TTL_MS = 5 * 60_000;
@@ -364,10 +373,12 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err);
+        const stack = workspaceMemoryDebugStack(err);
         debugLogger.error('Workspace memory remember task failed:', {
           taskId: task.taskId,
           code,
           details: workspaceMemoryDebugDetails(err),
+          ...(stack ? { stack } : {}),
         });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);
@@ -426,10 +437,12 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'forget_failed');
+        const stack = workspaceMemoryDebugStack(err);
         debugLogger.error('Workspace memory forget task failed:', {
           taskId: task.taskId,
           code,
           details: workspaceMemoryDebugDetails(err),
+          ...(stack ? { stack } : {}),
         });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);
@@ -485,10 +498,12 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'dream_failed');
+        const stack = workspaceMemoryDebugStack(err);
         debugLogger.error('Workspace memory dream task failed:', {
           taskId: task.taskId,
           code,
           details: workspaceMemoryDebugDetails(err),
+          ...(stack ? { stack } : {}),
         });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -16,6 +16,7 @@ import type {
   BridgeWorkspaceMemoryRememberResult,
 } from './acp-session-bridge.js';
 import {
+  createWorkspaceMemoryExtractionErrorLogger,
   extractRememberErrorCode,
   shouldSuppressRememberErrorDetails,
   workspaceMemoryFailureCode,
@@ -200,11 +201,8 @@ function createTaskError(
   };
 }
 
-function logWorkspaceMemoryExtractionError(target: string, err: unknown): void {
-  debugLogger.warn(`Failed to extract workspace memory error ${target}:`, {
-    extractionError: err instanceof Error ? err.message : String(err),
-  });
-}
+const logWorkspaceMemoryExtractionError =
+  createWorkspaceMemoryExtractionErrorLogger(debugLogger);
 
 export class WorkspaceRememberTaskLane {
   private static readonly MAX_TASKS = 1000;

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -18,6 +18,7 @@ import type {
 import {
   extractRememberErrorCode,
   shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureCode,
   workspaceMemoryFailureDiagnostics,
 } from './workspace-remember-errors.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from './workspace-memory-remember-constants.js';
@@ -357,7 +358,11 @@ export class WorkspaceRememberTaskLane {
         };
         task.updatedAt = nowIso();
       } catch (err) {
-        const code = extractRememberErrorCode(err);
+        const code = workspaceMemoryFailureCode(
+          err,
+          'remember_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         const diagnostics = workspaceMemoryFailureDiagnostics(
           err,
           logWorkspaceMemoryExtractionError,
@@ -424,7 +429,11 @@ export class WorkspaceRememberTaskLane {
         };
         task.updatedAt = nowIso();
       } catch (err) {
-        const code = extractRememberErrorCode(err, 'forget_failed');
+        const code = workspaceMemoryFailureCode(
+          err,
+          'forget_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         const diagnostics = workspaceMemoryFailureDiagnostics(
           err,
           logWorkspaceMemoryExtractionError,
@@ -488,7 +497,11 @@ export class WorkspaceRememberTaskLane {
         };
         task.updatedAt = nowIso();
       } catch (err) {
-        const code = extractRememberErrorCode(err, 'dream_failed');
+        const code = workspaceMemoryFailureCode(
+          err,
+          'dream_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         const diagnostics = workspaceMemoryFailureDiagnostics(
           err,
           logWorkspaceMemoryExtractionError,

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -186,38 +186,41 @@ export function publicErrorStatus(code: string): number {
 function createTaskError(
   code: string,
   kind: WorkspaceMemoryTaskKind,
-  err: unknown,
+  details?: string,
 ): WorkspaceMemoryTaskBaseSnapshot['error'] {
   const error: WorkspaceMemoryTaskBaseSnapshot['error'] = {
     code,
     message: publicErrorMessage(code, kind),
   };
   if (code === 'managed_memory_unavailable') return error;
-  try {
-    const details = extractRememberErrorDetails(err);
-    return {
-      ...error,
-      ...(details ? { details } : {}),
-    };
-  } catch {
-    return error;
-  }
+  return {
+    ...error,
+    ...(details ? { details } : {}),
+  };
 }
 
-function workspaceMemoryDebugDetails(err: unknown): string {
+function workspaceMemoryFailureDiagnostics(err: unknown): {
+  details?: string;
+  debugDetails: string;
+  stack?: string;
+} {
+  let details: string | undefined;
+  let stack: string | undefined;
   try {
-    return extractRememberErrorDetails(err) ?? '<details unavailable>';
+    details = extractRememberErrorDetails(err);
   } catch {
-    return '<details unavailable>';
+    details = undefined;
   }
-}
-
-function workspaceMemoryDebugStack(err: unknown): string | undefined {
   try {
-    return extractRememberErrorStack(err);
+    stack = extractRememberErrorStack(err);
   } catch {
-    return undefined;
+    stack = undefined;
   }
+  return {
+    ...(details ? { details } : {}),
+    debugDetails: details ?? '<details unavailable>',
+    ...(stack ? { stack } : {}),
+  };
 }
 
 export class WorkspaceRememberTaskLane {
@@ -373,15 +376,15 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err);
-        const stack = workspaceMemoryDebugStack(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(err);
         debugLogger.error('Workspace memory remember task failed:', {
           taskId: task.taskId,
           code,
-          details: workspaceMemoryDebugDetails(err),
-          ...(stack ? { stack } : {}),
+          details: diagnostics.debugDetails,
+          ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
         });
         task.status = 'failed';
-        task.error = createTaskError(code, task.kind, err);
+        task.error = createTaskError(code, task.kind, diagnostics.details);
         task.updatedAt = nowIso();
       }
       try {
@@ -437,15 +440,15 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'forget_failed');
-        const stack = workspaceMemoryDebugStack(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(err);
         debugLogger.error('Workspace memory forget task failed:', {
           taskId: task.taskId,
           code,
-          details: workspaceMemoryDebugDetails(err),
-          ...(stack ? { stack } : {}),
+          details: diagnostics.debugDetails,
+          ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
         });
         task.status = 'failed';
-        task.error = createTaskError(code, task.kind, err);
+        task.error = createTaskError(code, task.kind, diagnostics.details);
         task.updatedAt = nowIso();
       }
       try {
@@ -498,15 +501,15 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'dream_failed');
-        const stack = workspaceMemoryDebugStack(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(err);
         debugLogger.error('Workspace memory dream task failed:', {
           taskId: task.taskId,
           code,
-          details: workspaceMemoryDebugDetails(err),
-          ...(stack ? { stack } : {}),
+          details: diagnostics.debugDetails,
+          ...(diagnostics.stack ? { stack: diagnostics.stack } : {}),
         });
         task.status = 'failed';
-        task.error = createTaskError(code, task.kind, err);
+        task.error = createTaskError(code, task.kind, diagnostics.details);
         task.updatedAt = nowIso();
       }
       try {

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -17,7 +17,6 @@ import type {
 } from './acp-session-bridge.js';
 import {
   createWorkspaceMemoryExtractionErrorLogger,
-  extractRememberErrorCode,
   shouldSuppressRememberErrorDetails,
   workspaceMemoryFailureCode,
   workspaceMemoryFailureDiagnostics,
@@ -652,7 +651,11 @@ export function mountWorkspaceMemoryRememberRoutes(
           ...(originatorClientId ? { originatorClientId } : {}),
         });
       } catch (err) {
-        const code = extractRememberErrorCode(err);
+        const code = workspaceMemoryFailureCode(
+          err,
+          'remember_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         res.status(publicErrorStatus(code)).json({
           error: publicErrorMessage(code, 'remember'),
           code,
@@ -720,7 +723,11 @@ export function mountWorkspaceMemoryRememberRoutes(
         });
         res.status(202).json(task);
       } catch (err) {
-        const code = extractRememberErrorCode(err, 'forget_failed');
+        const code = workspaceMemoryFailureCode(
+          err,
+          'forget_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         res.status(publicErrorStatus(code)).json({
           error: publicErrorMessage(code, 'forget'),
           code,
@@ -765,7 +772,11 @@ export function mountWorkspaceMemoryRememberRoutes(
         });
         res.status(202).json(task);
       } catch (err) {
-        const code = extractRememberErrorCode(err, 'dream_failed');
+        const code = workspaceMemoryFailureCode(
+          err,
+          'dream_failed',
+          logWorkspaceMemoryExtractionError,
+        );
         res.status(publicErrorStatus(code)).json({
           error: publicErrorMessage(code, 'dream'),
           code,

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -15,7 +15,10 @@ import type {
   BridgeWorkspaceMemoryRememberContextMode,
   BridgeWorkspaceMemoryRememberResult,
 } from './acp-session-bridge.js';
-import { extractRememberErrorCode } from './workspace-remember-errors.js';
+import {
+  extractRememberErrorCode,
+  extractRememberErrorDetails,
+} from './workspace-remember-errors.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from './workspace-memory-remember-constants.js';
 import {
   formatWorkspaceMemoryDreamSummary,
@@ -43,6 +46,7 @@ interface WorkspaceMemoryTaskBaseSnapshot {
   error?: {
     code: string;
     message: string;
+    details?: string;
   };
 }
 
@@ -176,6 +180,19 @@ export function publicErrorStatus(code: string): number {
   if (code === 'remember_queue_full') return 429;
   if (code === 'managed_memory_unavailable') return 409;
   return 500;
+}
+
+function createTaskError(
+  code: string,
+  kind: WorkspaceMemoryTaskKind,
+  err: unknown,
+): WorkspaceMemoryTaskBaseSnapshot['error'] {
+  const details = extractRememberErrorDetails(err);
+  return {
+    code,
+    message: publicErrorMessage(code, kind),
+    ...(details ? { details } : {}),
+  };
 }
 
 export class WorkspaceRememberTaskLane {
@@ -337,10 +354,7 @@ export class WorkspaceRememberTaskLane {
           err,
         );
         task.status = 'failed';
-        task.error = {
-          code,
-          message: publicErrorMessage(code, task.kind),
-        };
+        task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();
       }
       try {
@@ -402,10 +416,7 @@ export class WorkspaceRememberTaskLane {
           err,
         );
         task.status = 'failed';
-        task.error = {
-          code,
-          message: publicErrorMessage(code, task.kind),
-        };
+        task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();
       }
       try {
@@ -464,10 +475,7 @@ export class WorkspaceRememberTaskLane {
           err,
         );
         task.status = 'failed';
-        task.error = {
-          code,
-          message: publicErrorMessage(code, task.kind),
-        };
+        task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();
       }
       try {

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -203,6 +203,14 @@ function createTaskError(
   }
 }
 
+function workspaceMemoryDebugDetails(err: unknown): string {
+  try {
+    return extractRememberErrorDetails(err) ?? '<details unavailable>';
+  } catch {
+    return '<details unavailable>';
+  }
+}
+
 export class WorkspaceRememberTaskLane {
   private static readonly MAX_TASKS = 1000;
   private static readonly TERMINAL_TASK_TTL_MS = 5 * 60_000;
@@ -356,11 +364,11 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err);
-        debugLogger.error(
-          'Workspace memory remember task failed:',
-          { taskId: task.taskId },
-          err,
-        );
+        debugLogger.error('Workspace memory remember task failed:', {
+          taskId: task.taskId,
+          code,
+          details: workspaceMemoryDebugDetails(err),
+        });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();
@@ -418,11 +426,11 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'forget_failed');
-        debugLogger.error(
-          'Workspace memory forget task failed:',
-          { taskId: task.taskId },
-          err,
-        );
+        debugLogger.error('Workspace memory forget task failed:', {
+          taskId: task.taskId,
+          code,
+          details: workspaceMemoryDebugDetails(err),
+        });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();
@@ -477,11 +485,11 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'dream_failed');
-        debugLogger.error(
-          'Workspace memory dream task failed:',
-          { taskId: task.taskId },
-          err,
-        );
+        debugLogger.error('Workspace memory dream task failed:', {
+          taskId: task.taskId,
+          code,
+          details: workspaceMemoryDebugDetails(err),
+        });
         task.status = 'failed';
         task.error = createTaskError(code, task.kind, err);
         task.updatedAt = nowIso();

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -17,8 +17,8 @@ import type {
 } from './acp-session-bridge.js';
 import {
   extractRememberErrorCode,
-  extractRememberErrorDetails,
-  extractRememberErrorStack,
+  shouldSuppressRememberErrorDetails,
+  workspaceMemoryFailureDiagnostics,
 } from './workspace-remember-errors.js';
 import { MAX_REMEMBER_CONTENT_BYTES } from './workspace-memory-remember-constants.js';
 import {
@@ -192,35 +192,17 @@ function createTaskError(
     code,
     message: publicErrorMessage(code, kind),
   };
-  if (code === 'managed_memory_unavailable') return error;
+  if (shouldSuppressRememberErrorDetails(code)) return error;
   return {
     ...error,
     ...(details ? { details } : {}),
   };
 }
 
-function workspaceMemoryFailureDiagnostics(err: unknown): {
-  details?: string;
-  debugDetails: string;
-  stack?: string;
-} {
-  let details: string | undefined;
-  let stack: string | undefined;
-  try {
-    details = extractRememberErrorDetails(err);
-  } catch {
-    details = undefined;
-  }
-  try {
-    stack = extractRememberErrorStack(err);
-  } catch {
-    stack = undefined;
-  }
-  return {
-    ...(details ? { details } : {}),
-    debugDetails: details ?? '<details unavailable>',
-    ...(stack ? { stack } : {}),
-  };
+function logWorkspaceMemoryExtractionError(target: string, err: unknown): void {
+  debugLogger.warn(`Failed to extract workspace memory error ${target}:`, {
+    extractionError: err instanceof Error ? err.message : String(err),
+  });
 }
 
 export class WorkspaceRememberTaskLane {
@@ -376,7 +358,10 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err);
-        const diagnostics = workspaceMemoryFailureDiagnostics(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(
+          err,
+          logWorkspaceMemoryExtractionError,
+        );
         debugLogger.error('Workspace memory remember task failed:', {
           taskId: task.taskId,
           code,
@@ -440,7 +425,10 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'forget_failed');
-        const diagnostics = workspaceMemoryFailureDiagnostics(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(
+          err,
+          logWorkspaceMemoryExtractionError,
+        );
         debugLogger.error('Workspace memory forget task failed:', {
           taskId: task.taskId,
           code,
@@ -501,7 +489,10 @@ export class WorkspaceRememberTaskLane {
         task.updatedAt = nowIso();
       } catch (err) {
         const code = extractRememberErrorCode(err, 'dream_failed');
-        const diagnostics = workspaceMemoryFailureDiagnostics(err);
+        const diagnostics = workspaceMemoryFailureDiagnostics(
+          err,
+          logWorkspaceMemoryExtractionError,
+        );
         debugLogger.error('Workspace memory dream task failed:', {
           taskId: task.taskId,
           code,

--- a/packages/cli/src/serve/workspace-remember.ts
+++ b/packages/cli/src/serve/workspace-remember.ts
@@ -187,12 +187,20 @@ function createTaskError(
   kind: WorkspaceMemoryTaskKind,
   err: unknown,
 ): WorkspaceMemoryTaskBaseSnapshot['error'] {
-  const details = extractRememberErrorDetails(err);
-  return {
+  const error: WorkspaceMemoryTaskBaseSnapshot['error'] = {
     code,
     message: publicErrorMessage(code, kind),
-    ...(details ? { details } : {}),
   };
+  if (code === 'managed_memory_unavailable') return error;
+  try {
+    const details = extractRememberErrorDetails(err);
+    return {
+      ...error,
+      ...(details ? { details } : {}),
+    };
+  } catch {
+    return error;
+  }
 }
 
 export class WorkspaceRememberTaskLane {

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1065,6 +1065,7 @@ export interface DaemonWorkspaceMemoryRememberTask {
   error?: {
     code: string;
     message: string;
+    details?: string;
   };
 }
 
@@ -1094,6 +1095,7 @@ export interface DaemonWorkspaceMemoryForgetTask {
   error?: {
     code: string;
     message: string;
+    details?: string;
   };
 }
 
@@ -1116,6 +1118,7 @@ export interface DaemonWorkspaceMemoryDreamTask {
   error?: {
     code: string;
     message: string;
+    details?: string;
   };
 }
 


### PR DESCRIPTION
## What this PR does

This adds an optional `error.details` field to failed async workspace memory task snapshots while keeping `error.message` as the stable public fallback. The details value carries the more specific failure reason from plain errors, JSON-RPC error data, or nested causes, and it is redacted, normalized, and capped before being returned.

The ACP bridge path now includes the same optional details in request error data for workspace memory remember, forget, and dream failures, so clients outside the daemon can distinguish and display better failure context without changing the public message contract.

For the remember JSON-RPC failure path, the public `RequestError.message` is intentionally stabilized to `Workspace memory remember failed`; clients that need the lower-level reason should read `data.details`. The managed-memory-unavailable path keeps static error data and does not expose details because it is a capability/config condition rather than a runtime task failure.

The SDK daemon task types now model the optional details field. This is additive and does not require a new config flag or protocol capability.

## Why it's needed

Workspace memory clients need more than `dream_failed` or another stable public fallback to decide what to show users. A separate details field lets outer UI layers route or explain failures using richer context while preserving the existing public message and error code behavior.

## Reviewer Test Plan

### How to verify

Review that failed async remember, forget, and dream task snapshots still expose the existing stable error code and public message, and now include a redacted optional details string when a lower-level failure reason is available.

Review that ACP workspace memory failures carry the same redacted optional details in JSON-RPC error data, while timeout handling and unavailable-memory handling keep their existing public message and status-code semantics.

Review that synchronous POST failures are unchanged.

### Evidence (Before & After)

N/A for UI screenshots; this is daemon/API plumbing.

Local verification passed: `cd /Users/ethan/Projects/qwen-code-worktree-error-details/packages/cli && npx vitest run src/serve/workspace-remember-errors.test.ts src/serve/workspace-remember.test.ts src/acp-integration/acpAgent.test.ts` produced 3 passed files and 220 passed tests.

Local verification passed: `cd /Users/ethan/Projects/qwen-code-worktree-error-details && npm run build && npm run typecheck` exited 0.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  macOS     |   ✅ tested    |
| Windows    | ⚠️ not tested  |
| Linux      | ⚠️ not tested  |

### Environment (optional)

Local package Vitest plus full repository build and typecheck from the worktree.

## Risk & Scope

- Main risk or tradeoff: More specific failure context is now available to clients, so the implementation redacts obvious credentials, removes control and hidden format characters before redaction, and caps the final details string.
- Not validated / out of scope: Cross-platform manual daemon runs; CI should cover platform build and test differences.
- Breaking changes / migration notes: No schema-breaking migration. The new field is optional and additive; existing `code` and task snapshot `message` behavior remains the stable fallback. The remember JSON-RPC `RequestError.message` is now stable, with raw lower-level detail moved to `data.details`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 给异步 workspace memory task 的失败快照增加了可选的 `error.details` 字段，同时保留 `error.message` 作为稳定的公开 fallback。details 会从普通错误、JSON-RPC error data 或嵌套 cause 中提取更具体的失败原因，并在返回前做凭证脱敏、控制字符归一化和长度上限处理。

ACP bridge 路径现在也会在 workspace memory remember、forget、dream 失败时把相同的可选 details 放进 request error data，这样 daemon 外层客户端可以在不改变公开 message contract 的前提下识别并展示更合适的失败上下文。

对于 remember JSON-RPC 失败路径，公开的 `RequestError.message` 会刻意稳定为 `Workspace memory remember failed`；需要底层原因的客户端应该读取 `data.details`。managed-memory-unavailable 路径保持静态 error data，不暴露 details，因为这是能力/配置条件，不是运行时 task failure。

SDK daemon task 类型也补充了可选 details 字段。这是纯 additive 变更，不需要新增配置开关或协议 capability。

## Why it's needed

Workspace memory 客户端需要比 `dream_failed` 这类稳定 public fallback 更具体的信息，才能决定应该向用户展示什么。单独的 details 字段让外层 UI 可以使用更丰富的上下文进行路由或解释，同时保留现有 public message 和 error code 行为。

## Reviewer Test Plan

### How to verify

检查异步 remember、forget、dream task 失败快照仍然暴露现有稳定 error code 和 public message，并且当底层失败原因可用时会额外带上脱敏后的可选 details 字符串。

检查 ACP workspace memory 失败会在 JSON-RPC error data 中携带相同的脱敏可选 details，同时 timeout 和 managed memory unavailable 分支保持现有 public message 与状态码语义。

检查同步 POST 失败行为没有变化。

### Evidence (Before & After)

非 UI 变更，不适用截图。

本地验证通过：`cd /Users/ethan/Projects/qwen-code-worktree-error-details/packages/cli && npx vitest run src/serve/workspace-remember-errors.test.ts src/serve/workspace-remember.test.ts src/acp-integration/acpAgent.test.ts` 输出 3 个测试文件通过、220 个测试通过。

本地验证通过：`cd /Users/ethan/Projects/qwen-code-worktree-error-details && npm run build && npm run typecheck` 退出码为 0。

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  macOS     |   ✅ tested    |
| Windows    | ⚠️ not tested  |
| Linux      | ⚠️ not tested  |

### Environment (optional)

在 worktree 中运行 package-local Vitest，以及仓库完整 build 和 typecheck。

## Risk & Scope

- Main risk or tradeoff: 现在客户端可以拿到更具体的失败上下文，因此实现会在脱敏前移除控制字符和隐藏 format 字符、对 obvious credentials 脱敏，并对最终 details 字符串加长度上限。
- Not validated / out of scope: 未做跨平台手动 daemon 运行；平台构建和测试差异交给 CI 覆盖。
- Breaking changes / migration notes: 无 schema-breaking migration。新字段是可选 additive 字段，现有 `code` 和 task snapshot `message` 行为仍然是稳定 fallback。remember JSON-RPC `RequestError.message` 现在稳定，底层原始细节移到 `data.details`。

## Linked Issues

N/A

</details>
