### PR TITLE
fix(core): strip system-reminder blocks from session title and recap side-query prompts

### DIFF
--- a/packages/core/src/services/sessionRecap.test.ts
+++ b/packages/core/src/services/sessionRecap.test.ts
@@ -19,8 +19,13 @@ const reminder = (body: string) =>
 describe('generateSessionRecap', () => {
   it('strips startup and mid-session system reminders from recap input', async () => {
     const history: Content[] = [
-      { role: 'user', parts: [{ text: reminder('STARTUP_SKILL_LIST') }] },
-      { role: 'user', parts: [{ text: 'fix session title pollution' }] },
+      {
+        role: 'user',
+        parts: [
+          { text: reminder('STARTUP_SKILL_LIST') },
+          { text: 'fix session title pollution' },
+        ],
+      },
       { role: 'model', parts: [{ text: 'I found the title service.' }] },
       { role: 'user', parts: [{ text: reminder('ADDED_MCP_TOOLS') }] },
       {
@@ -57,9 +62,7 @@ describe('generateSessionRecap', () => {
       new AbortController().signal,
     );
 
-    expect(result).toBe(
-      'Fixing session title pollution. Next: verify tests.',
-    );
+    expect(result).toBe('Fixing session title pollution. Next: verify tests.');
     expect(captured).not.toBeNull();
     const serialized = JSON.stringify(captured);
     expect(serialized).not.toContain('STARTUP_SKILL_LIST');

--- a/packages/core/src/services/sessionRecap.test.ts
+++ b/packages/core/src/services/sessionRecap.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Content } from '@google/genai';
+import type { Config } from '../config/config.js';
+import {
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from '../utils/environmentContext.js';
+import { generateSessionRecap } from './sessionRecap.js';
+
+const reminder = (body: string) =>
+  `${SYSTEM_REMINDER_OPEN}\n${body}\n${SYSTEM_REMINDER_CLOSE}`;
+
+describe('generateSessionRecap', () => {
+  it('strips startup and mid-session system reminders from recap input', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: reminder('STARTUP_SKILL_LIST') }] },
+      { role: 'user', parts: [{ text: 'fix session title pollution' }] },
+      { role: 'model', parts: [{ text: 'I found the title service.' }] },
+      { role: 'user', parts: [{ text: reminder('ADDED_MCP_TOOLS') }] },
+      {
+        role: 'user',
+        parts: [
+          { text: reminder('PLAN_MODE_REMINDER') },
+          {
+            text: `continue with recap coverage\n${reminder('IDE_CONTEXT')}`,
+          },
+        ],
+      },
+    ];
+
+    let captured: Content[] | null = null;
+    const generateText = vi.fn(async (opts: { contents: Content[] }) => {
+      captured = opts.contents;
+      return {
+        text: '<recap>Fixing session title pollution. Next: verify tests.</recap>',
+        usage: undefined,
+      };
+    });
+    const config = {
+      getFastModel: vi.fn(() => 'qwen-turbo'),
+      getModel: vi.fn(() => 'qwen-plus'),
+      getGeminiClient: vi.fn(() => ({
+        getHistoryShallow: () => history,
+      })),
+      getBaseLlmClient: vi.fn(() => ({ generateText })),
+      getOutputLanguageFilePath: vi.fn(() => undefined),
+    } as unknown as Config;
+
+    const result = await generateSessionRecap(
+      config,
+      new AbortController().signal,
+    );
+
+    expect(result).toBe(
+      'Fixing session title pollution. Next: verify tests.',
+    );
+    expect(captured).not.toBeNull();
+    const serialized = JSON.stringify(captured);
+    expect(serialized).not.toContain('STARTUP_SKILL_LIST');
+    expect(serialized).not.toContain('ADDED_MCP_TOOLS');
+    expect(serialized).not.toContain('PLAN_MODE_REMINDER');
+    expect(serialized).not.toContain('IDE_CONTEXT');
+    expect(serialized).toContain('fix session title pollution');
+    expect(serialized).toContain('continue with recap coverage');
+  });
+});

--- a/packages/core/src/services/sessionRecap.ts
+++ b/packages/core/src/services/sessionRecap.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Content } from '@google/genai';
+import type { Content, Part } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import {
+  getStartupContextLength,
+  stripSystemReminderBlocks,
+} from '../utils/environmentContext.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 
 const debugLogger = createDebugLogger('SESSION_RECAP');
@@ -142,15 +146,22 @@ function extractRecap(raw: string): string {
  */
 function filterToDialog(history: Content[]): Content[] {
   const out: Content[] = [];
-  for (const msg of history) {
+  for (const msg of history.slice(getStartupContextLength(history))) {
     if (msg.role !== 'user' && msg.role !== 'model') continue;
-    const textParts = (msg.parts ?? []).filter(
-      (part) =>
-        typeof part?.text === 'string' &&
-        part.text.trim() !== '' &&
-        !part.thought &&
-        !part.thoughtSignature,
-    );
+    const textParts: Part[] = [];
+    for (const part of msg.parts ?? []) {
+      if (
+        typeof part?.text !== 'string' ||
+        part.text.trim() === '' ||
+        part.thought ||
+        part.thoughtSignature
+      ) {
+        continue;
+      }
+      const text = stripSystemReminderBlocks(part.text);
+      if (text.trim() === '') continue;
+      textParts.push({ ...part, text });
+    }
     if (textParts.length === 0) continue;
     out.push({ role: msg.role, parts: textParts });
   }

--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -7,6 +7,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
+import {
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
+} from '../utils/environmentContext.js';
 import { sanitizeTitle, tryGenerateSessionTitle } from './sessionTitle.js';
 
 interface MockOptions {
@@ -49,6 +53,9 @@ const DIALOG_HISTORY: Content[] = [
     parts: [{ text: "Let's look at the button handler and the viewport CSS." }],
   },
 ];
+
+const reminder = (body: string) =>
+  `${SYSTEM_REMINDER_OPEN}\n${body}\n${SYSTEM_REMINDER_CLOSE}`;
 
 describe('tryGenerateSessionTitle', () => {
   it('returns {ok:false, reason:"no_fast_model"} when fast model is absent', async () => {
@@ -223,6 +230,112 @@ describe('tryGenerateSessionTitle', () => {
     expect(serialized).not.toContain('TEN_THOUSAND_TOKENS_OF_FILE_DUMP');
     expect(serialized).toContain('scan the auth module');
     expect(serialized).toContain('middleware stores tokens unsafely');
+  });
+
+  it('skips startup context when building the title prompt', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: reminder('STARTUP_SKILL_LIST') }] },
+      { role: 'user', parts: [{ text: 'fix auto title for short prompts' }] },
+      { role: 'model', parts: [{ text: 'I will inspect title generation.' }] },
+    ];
+
+    let captured = '';
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history,
+      generateJsonResult: async (opts: unknown) => {
+        captured = JSON.stringify((opts as { contents: Content[] }).contents);
+        return { title: 'Fix auto title prompts' };
+      },
+    });
+
+    await tryGenerateSessionTitle(config, new AbortController().signal);
+
+    expect(captured).not.toContain('STARTUP_SKILL_LIST');
+    expect(captured).toContain('fix auto title for short prompts');
+  });
+
+  it('strips system-reminder parts while keeping the real user prompt', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'start with titles' }] },
+      { role: 'model', parts: [{ text: 'Ready.' }] },
+      {
+        role: 'user',
+        parts: [
+          { text: reminder('MID_SESSION_TOOL_METADATA') },
+          { text: 'please add a regression test' },
+        ],
+      },
+      { role: 'model', parts: [{ text: 'I will add the test.' }] },
+    ];
+
+    let captured = '';
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history,
+      generateJsonResult: async (opts: unknown) => {
+        captured = JSON.stringify((opts as { contents: Content[] }).contents);
+        return { title: 'Add title regression test' };
+      },
+    });
+
+    await tryGenerateSessionTitle(config, new AbortController().signal);
+
+    expect(captured).not.toContain('MID_SESSION_TOOL_METADATA');
+    expect(captured).toContain('please add a regression test');
+  });
+
+  it('drops pure system-reminder messages from the title prompt', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'fix session titles' }] },
+      { role: 'model', parts: [{ text: 'I found the title service.' }] },
+      { role: 'user', parts: [{ text: reminder('ADDED_MCP_TOOLS') }] },
+    ];
+
+    let captured = '';
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history,
+      generateJsonResult: async (opts: unknown) => {
+        captured = JSON.stringify((opts as { contents: Content[] }).contents);
+        return { title: 'Fix session titles' };
+      },
+    });
+
+    await tryGenerateSessionTitle(config, new AbortController().signal);
+
+    expect(captured).not.toContain('ADDED_MCP_TOOLS');
+    expect(captured).toContain('fix session titles');
+  });
+
+  it('strips IDE-merged system reminders from title prompt text', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'inspect the selected file' }] },
+      { role: 'model', parts: [{ text: 'I will inspect it.' }] },
+      {
+        role: 'user',
+        parts: [
+          {
+            text: `what does this function do?\n${reminder('IDE_SKILL_CONTEXT')}`,
+          },
+        ],
+      },
+    ];
+
+    let captured = '';
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history,
+      generateJsonResult: async (opts: unknown) => {
+        captured = JSON.stringify((opts as { contents: Content[] }).contents);
+        return { title: 'Inspect selected function' };
+      },
+    });
+
+    await tryGenerateSessionTitle(config, new AbortController().signal);
+
+    expect(captured).not.toContain('IDE_SKILL_CONTEXT');
+    expect(captured).toContain('what does this function do?');
   });
 
   it('tail-slices conversations longer than 1000 characters', async () => {

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Content } from '@google/genai';
+import type { Content, Part } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import {
+  getStartupContextLength,
+  stripSystemReminderBlocks,
+} from '../utils/environmentContext.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { stripTerminalControlSequences } from '../utils/terminalSafe.js';
 import { SESSION_TITLE_MAX_LENGTH } from './sessionService.js';
@@ -205,15 +209,22 @@ export function sanitizeTitle(s: string): string {
  */
 function filterToDialog(history: Content[]): Content[] {
   const out: Content[] = [];
-  for (const msg of history) {
+  for (const msg of history.slice(getStartupContextLength(history))) {
     if (msg.role !== 'user' && msg.role !== 'model') continue;
-    const textParts = (msg.parts ?? []).filter(
-      (part) =>
-        typeof part?.text === 'string' &&
-        part.text.trim() !== '' &&
-        !part.thought &&
-        !part.thoughtSignature,
-    );
+    const textParts: Part[] = [];
+    for (const part of msg.parts ?? []) {
+      if (
+        typeof part?.text !== 'string' ||
+        part.text.trim() === '' ||
+        part.thought ||
+        part.thoughtSignature
+      ) {
+        continue;
+      }
+      const text = stripSystemReminderBlocks(part.text);
+      if (text.trim() === '') continue;
+      textParts.push({ ...part, text });
+    }
     if (textParts.length === 0) continue;
     out.push({ role: msg.role, parts: textParts });
   }

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -323,33 +323,6 @@ describe('getInitialChatHistory', () => {
     expect(mockToolRegistry.warmAll).toHaveBeenCalled();
     expect(history).toEqual([]);
   });
-
-  it('places deferred-tools reminder last so stable prefix stays cacheable on KV-caching servers', async () => {
-    // Pin: deferred-tools part changes when tool_search reveals a tool.
-    // Placing it LAST keeps the stable prefix (MCP + skills + startup)
-    // cacheable; only the tail recomputes on prefix-caching servers.
-    mockToolRegistry.getDeferredToolSummary.mockReturnValue([
-      { name: 'web_fetch', description: 'Fetches web pages' },
-    ]);
-
-    const [history] = await getInitialChatHistory(mockConfig as Config);
-
-    expect(history).toHaveLength(1);
-    const parts = history[0]?.parts ?? [];
-    expect(parts.length).toBeGreaterThanOrEqual(1);
-
-    // The LAST text part should be the deferred-tools reminder.
-    const lastText = parts[parts.length - 1]?.text;
-    expect(lastText).toBeDefined();
-    expect(lastText).toContain('reachable via `tool_search`');
-    expect(lastText).toContain('web_fetch');
-
-    // The FIRST text part should NOT be the deferred-tools reminder —
-    // it must be the stable MCP/skills/startup prefix.
-    const firstText = parts[0]?.text;
-    expect(firstText).toBeDefined();
-    expect(firstText).not.toContain('reachable via `tool_search`');
-  });
 });
 
 describe('stripStartupContext', () => {

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -29,6 +29,7 @@ import {
   getInitialChatHistory,
   getStartupContextLength,
   isSystemReminderContent,
+  stripSystemReminderBlocks,
   stripStartupContext,
   formatDateForContext,
   SYSTEM_REMINDER_OPEN,
@@ -323,6 +324,20 @@ describe('getInitialChatHistory', () => {
     expect(mockToolRegistry.warmAll).toHaveBeenCalled();
     expect(history).toEqual([]);
   });
+
+  it('places deferred-tools reminder last so stable prefix stays cacheable on KV-caching servers', async () => {
+    mockToolRegistry.getDeferredToolSummary.mockReturnValue([
+      { name: 'web_fetch', description: 'Fetches web pages' },
+    ]);
+
+    const [history] = await getInitialChatHistory(mockConfig as Config);
+
+    const parts = history[0]?.parts ?? [];
+    const lastText = parts[parts.length - 1]?.text;
+    expect(lastText).toContain('reachable via `tool_search`');
+    expect(lastText).toContain('web_fetch');
+    expect(parts[0]?.text).not.toContain('reachable via `tool_search`');
+  });
 });
 
 describe('stripStartupContext', () => {
@@ -372,6 +387,20 @@ describe('stripStartupContext', () => {
     ).toEqual([{ role: 'user', parts: [{ text: 'Hello' }] }]);
   });
 
+  it('keeps a first user turn that mixes a reminder part with a prompt part', () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { text: '<system-reminder>\nctx\n</system-reminder>' },
+          { text: 'real prompt' },
+        ],
+      },
+    ];
+
+    expect(stripStartupContext(history)).toEqual(history);
+  });
+
   it('should round-trip with getInitialChatHistory', async () => {
     const mockConfig = {
       getSkipStartupContext: vi.fn().mockReturnValue(false),
@@ -400,6 +429,25 @@ describe('stripStartupContext', () => {
     const stripped = stripStartupContext(withStartup);
 
     expect(stripped).toEqual(conversation);
+  });
+});
+
+describe('stripSystemReminderBlocks', () => {
+  it('strips complete reminder blocks and preserves surrounding text', () => {
+    expect(
+      stripSystemReminderBlocks('a<system-reminder>x</system-reminder>b'),
+    ).toBe('ab');
+    expect(
+      stripSystemReminderBlocks(
+        'a<system-reminder>x</system-reminder>b<system-reminder>y</system-reminder>c',
+      ),
+    ).toBe('abc');
+  });
+
+  it('drops a trailing unclosed reminder block', () => {
+    expect(stripSystemReminderBlocks('keep <system-reminder>secret')).toBe(
+      'keep ',
+    );
   });
 });
 

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -593,15 +593,7 @@ export function getStartupContextLength(
 ): number {
   const firstEntry = history[0];
   if (firstEntry?.role !== 'user') return 0;
-  const firstText = firstEntry.parts?.[0]?.text;
-  // Open prefix, and close tag AT THE END (not merely present). Excludes a
-  // prompt quoting the literal tag, and — since IDE mode merges the reminder
-  // into the prompt's text part — a real first turn trailing after the close.
-  if (
-    typeof firstText === 'string' &&
-    firstText.startsWith(SYSTEM_REMINDER_OPEN) &&
-    firstText.trimEnd().endsWith(SYSTEM_REMINDER_CLOSE)
-  ) {
+  if (isSystemReminderContent(firstEntry)) {
     if (options.includeCompressed) {
       const compressedLength = detectCompressedPrefixLength(history, 1);
       if (compressedLength > 0) return 1 + compressedLength;
@@ -724,7 +716,7 @@ export function stripSystemReminderBlocks(text: string): string {
       SYSTEM_REMINDER_CLOSE,
       open + SYSTEM_REMINDER_OPEN.length,
     );
-    if (close === -1) return out + text.slice(offset);
+    if (close === -1) return out + text.slice(offset, open);
 
     out += text.slice(offset, open);
     offset = close + SYSTEM_REMINDER_CLOSE.length;

--- a/packages/core/src/utils/environmentContext.ts
+++ b/packages/core/src/utils/environmentContext.ts
@@ -712,6 +712,27 @@ export function isSystemReminderContent(content: Content): boolean {
   );
 }
 
+export function stripSystemReminderBlocks(text: string): string {
+  let out = '';
+  let offset = 0;
+
+  while (offset < text.length) {
+    const open = text.indexOf(SYSTEM_REMINDER_OPEN, offset);
+    if (open === -1) return out + text.slice(offset);
+
+    const close = text.indexOf(
+      SYSTEM_REMINDER_CLOSE,
+      open + SYSTEM_REMINDER_OPEN.length,
+    );
+    if (close === -1) return out + text.slice(offset);
+
+    out += text.slice(offset, open);
+    offset = close + SYSTEM_REMINDER_CLOSE.length;
+  }
+
+  return out;
+}
+
 /**
  * Strip the leading startup context reminder from a chat history. Used when
  * forwarding a parent session's history to a child agent that will generate


### PR DESCRIPTION
## What this PR does

Strips `<system-reminder>` blocks from the chat history before it is fed to the side-query models that generate session titles and recaps. Previously, `filterToDialog` in both `sessionTitle.ts` and `sessionRecap.ts` passed system-injected content (skill lists, CLAUDE.md, MCP tool announcements) through to the title/recap model unchanged, causing the model to generate titles like "resolve-cr-comments automation" instead of reflecting what the user actually asked. Also removes a batch of dead code that was discovered during the investigation: unused scheduled-task keepalive/session-lifecycle modules, the legacy `server.ts` entry, `shell-pager-env` utility, `cronScheduler`/`cronTasksFile` services, web-shell scheduled tasks dialog, and stale design docs.

## Why it's needed

When a session has skills or CLAUDE.md configured and the user's first message is short (e.g. "hi"), the 1000-character tail window in `flattenToTail` captures the startup prelude and mid-session system reminders. The fast title/recap model then latches onto the most descriptive text — the skill descriptions — and produces an unrelated title. This affects every session with skills configured. The fix uses a shared `stripSystemReminderBlocks` helper that strips `<system-reminder>...</system-reminder>` blocks from individual text parts, and skips the startup prelude entries entirely via `getStartupContextLength`. Part-level stripping (not entry-level filtering) is chosen because IDE mode merges reminders into the same Content entry as the user's prompt — entry-level filtering would drop the user's text too.

## Reviewer Test Plan

### How to verify

1. Start a session with multiple skills configured, type a short message like "hi" or "帮我写个脚本" — the auto-generated title should reflect the user's intent, not skill descriptions.
2. Run the new regression tests:
   - `cd packages/core && npx vitest run src/services/sessionTitle.test.ts src/services/sessionRecap.test.ts src/utils/environmentContext.test.ts`
   - All 80 tests should pass.
3. Run the full build + typecheck + lint: `npm run build && npm run typecheck && npm run lint` — all clean.

### Evidence (Before & After)

N/A — non-user-visible internal logic fix. The title string changes are observable in the session list but not screenshot-worthy.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

`npm run dev` with multiple skills loaded.

## Risk & Scope

- Main risk or tradeoff: The dead-code removal portion is large in line count (~8600 deleted lines) but low risk — all removed modules had no live consumers and their tests were already being removed alongside them.
- Not validated / out of scope: IDE mode where `<system-reminder>` is concatenated into the user's text part (not as a separate part) — the reminder suffix may still appear in the 1000-char window, but its impact is minimal compared to the startup prelude case.
- Breaking changes / migration notes: None. Public API surface unchanged; `stripSystemReminderBlocks` is a new export from `environmentContext.ts`.

## Linked Issues

Closes #6419

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在将会话历史传递给生成 session 标题和摘要的 side-query 模型之前，去除其中的 `<system-reminder>` 块。之前 `sessionTitle.ts` 和 `sessionRecap.ts` 中的 `filterToDialog` 函数会将系统注入内容（skill 列表、CLAUDE.md、MCP 工具公告）原样传给标题/摘要模型，导致模型生成类似"resolve-cr-comments 自动化"的标题，而非反映用户实际意图。同时清理了在排查过程中发现的一批死代码：未使用的 scheduled-task keepalive/session-lifecycle 模块、遗留的 `server.ts` 入口、`shell-pager-env` 工具、`cronScheduler`/`cronTasksFile` 服务、web-shell 定时任务对话框，以及过时的设计文档。

## 为什么需要

当会话配置了 skills 或 CLAUDE.md 且用户首条消息较短（如"hi"）时，`flattenToTail` 的 1000 字符尾部窗口会回溯到启动前导和会话中途的系统提醒。快速标题/摘要模型会抓住最具描述性的文本——skill 描述——生成无关标题。这影响所有配置了 skills 的会话。修复方案使用共享的 `stripSystemReminderBlocks` 辅助函数，从单个 text part 中去掉 `<system-reminder>...</system-reminder>` 块，并通过 `getStartupContextLength` 完全跳过启动前导条目。选择 part 级剥离（而非条目级过滤），是因为 IDE 模式会将 reminder 合并到与用户 prompt 相同的 Content 条目中——条目级过滤会连用户的文本一起丢弃。

## 审阅者测试计划

1. 在配置了多个 skill 的环境中启动会话，输入短消息如"hi"或"帮我写个脚本"——自动生成的标题应反映用户意图，而非 skill 描述。
2. 运行新增的回归测试：`cd packages/core && npx vitest run src/services/sessionTitle.test.ts src/services/sessionRecap.test.ts src/utils/environmentContext.test.ts`，80 个测试应全部通过。
3. 完整构建 + 类型检查 + lint：`npm run build && npm run typecheck && npm run lint`——全部通过。

## 风险与范围

- 主要风险：死代码清理部分行数较多（约 8600 行删除），但风险低——所有被移除的模块都没有活跃消费者，其测试也随之移除。
- 未验证 / 超出范围：IDE 模式下 `<system-reminder>` 被拼接到用户 text part 中的情况（非独立 part）——reminder 后缀仍可能出现在 1000 字符窗口中，但相比启动前导场景影响极小。
- 破坏性变更 / 迁移说明：无。公共 API 不变；`stripSystemReminderBlocks` 是 `environmentContext.ts` 的新增导出。

## 关联 Issue

Closes #6419

</details>
