### PR TITLE
feat(web-shell): add Qwen logo beside the sidebar new-chat button

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -140,6 +140,44 @@
   stroke-width: 1.5;
 }
 
+.topRow {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.topRow .newChatButton {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
+.brandLogo {
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.brandLogo svg {
+  width: 26px;
+  height: 26px;
+  display: block;
+}
+
+.collapsed .topRow {
+  width: 100%;
+  justify-content: center;
+}
+
+.collapsed .topRow .newChatButton {
+  flex: 0 0 auto;
+}
+
 .body {
   flex: 1 1 auto;
   min-height: 0;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
@@ -225,6 +225,24 @@ describe('WebShellSidebar — version footer', () => {
   });
 });
 
+describe('WebShellSidebar — brand logo', () => {
+  it('renders the Qwen brand mark beside the new-chat button when expanded', () => {
+    const { container } = renderSidebar(false);
+    // Filled brand mark (shared with the favicon), not a stroked nav icon.
+    const mark = container.querySelector('svg path[fill="#6D44E8"]');
+    expect(mark).not.toBeNull();
+    // The mark and the new-chat button share the same top row.
+    const topRow = mark!.closest('div');
+    expect(topRow?.querySelector('[aria-label="New chat"]')).not.toBeNull();
+  });
+
+  it('hides the brand mark when collapsed (only the new-chat button remains)', () => {
+    const { container } = renderSidebar(true);
+    expect(container.querySelector('svg path[fill="#6D44E8"]')).toBeNull();
+    expect(container.querySelector('[aria-label="New chat"]')).not.toBeNull();
+  });
+});
+
 describe('WebShellSidebar — daemon status entry', () => {
   it('invokes onOpenDaemonStatus when the footer button is clicked', () => {
     const onOpenDaemonStatus = vi.fn();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -202,6 +202,25 @@ function IconNewChat() {
   );
 }
 
+/**
+ * Qwen brand mark. Same artwork as the browser-tab favicon in index.html and
+ * the QwenLM GitHub avatar; inlined as an SVG rather than hot-linked because
+ * the Web Shell CSP is `img-src 'self' data: blob:` (see web-shell-static.ts),
+ * which blocks remote images. The purple #6D44E8 fill is legible on both the
+ * light and dark sidebar backgrounds. Filled (not stroked) so it opts out of
+ * the shared `.navIcon svg` stroke styling.
+ */
+function IconQwenLogo() {
+  return (
+    <svg viewBox="0 0 141.38 140" aria-hidden="true">
+      <path
+        fill="#6D44E8"
+        d="m140.93 85-16.35-28.33-1.93-3.34 8.66-15a3.323 3.323 0 0 0 0-3.34l-9.62-16.67c-.3-.51-.72-.93-1.22-1.22s-1.07-.45-1.67-.45H82.23l-8.66-15a3.33 3.33 0 0 0-2.89-1.67H51.43c-.59 0-1.17.16-1.66.45-.5.29-.92.71-1.22 1.22L32.19 29.98l-1.92 3.33H12.96c-.59 0-1.17.16-1.66.45-.5.29-.93.71-1.22 1.22L.45 51.66a3.323 3.323 0 0 0 0 3.34l18.28 31.67-8.66 15a3.32 3.32 0 0 0 0 3.34l9.62 16.67c.3.51.72.93 1.22 1.22s1.07.45 1.67.45h36.56l8.66 15a3.35 3.35 0 0 0 2.89 1.67h19.25a3.34 3.34 0 0 0 2.89-1.67l18.28-31.67h17.32c.6 0 1.17-.16 1.67-.45s.92-.71 1.22-1.22l9.62-16.67a3.323 3.323 0 0 0 0-3.34ZM51.44 3.33 61.07 20l-9.63 16.66h76.98l-9.62 16.66H45.67l-11.54-20zM57.21 120H22.58l9.63-16.67h19.25l-38.5-66.67h19.25l9.62 16.67L68.78 100l-11.55 20Zm61.59-33.34-9.62-16.67-38.49 66.67-9.63-16.67 9.63-16.66 26.94-46.67h23.1l17.32 30z"
+      />
+    </svg>
+  );
+}
+
 function IconFolder({ expanded }: { expanded: boolean }) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -2355,19 +2374,26 @@ export function WebShellSidebar({
           </div>
         </DialogShell>
       )}
-      <button
-        className={styles.newChatButton}
-        type="button"
-        title={t('sidebar.newChat')}
-        aria-label={t('sidebar.newChat')}
-        disabled={newSessionDisabled}
-        onClick={handleNewSession}
-      >
-        <span className={styles.navIcon}>
-          <IconNewChat />
-        </span>
-        {!collapsed && <span>{t('sidebar.newChat')}</span>}
-      </button>
+      <div className={styles.topRow}>
+        {!collapsed && (
+          <span className={styles.brandLogo} aria-hidden="true">
+            <IconQwenLogo />
+          </span>
+        )}
+        <button
+          className={styles.newChatButton}
+          type="button"
+          title={t('sidebar.newChat')}
+          aria-label={t('sidebar.newChat')}
+          disabled={newSessionDisabled}
+          onClick={handleNewSession}
+        >
+          <span className={styles.navIcon}>
+            <IconNewChat />
+          </span>
+          {!collapsed && <span>{t('sidebar.newChat')}</span>}
+        </button>
+      </div>
 
       <div className={styles.body}>
         {!collapsed && (


### PR DESCRIPTION
## What this PR does

Adds the Qwen brand mark to the top of the Web Shell sidebar, placed to the left of the **New chat** button on the same row (not on a separate row). The artwork is the same SVG already used for the browser-tab favicon and the QwenLM GitHub avatar. When the sidebar is collapsed there is no room beside the compact button, so the mark is hidden and only the New chat button remains.

## Why it's needed

The Web Shell sidebar had no product branding at the top, so the surface was not immediately recognizable as Qwen Code. A small inline logo next to the New chat button adds that identity without spending a dedicated row. The logo is inlined as an SVG rather than hot-linked from a remote URL because the Web Shell CSP is `img-src 'self' data: blob:` (see `packages/cli/src/serve/web-shell-static.ts`), which blocks external images; reusing the local favicon artwork keeps it CSP-safe, offline, and legible on both light and dark themes.

## Reviewer Test Plan

### How to verify

1. `cd packages/web-shell && npm run dev` (or run `qwen serve --web`) and open the Web Shell.
2. Expected: the purple Qwen mark appears at the top-left of the sidebar, immediately to the left of the New chat button, on the same row.
3. Collapse the sidebar (chevron in the footer): the mark is hidden and the compact "+" New chat button remains centered.
4. Toggle light/dark theme: the mark stays legible in both.
5. Unit tests: `cd packages/web-shell && npx vitest run` — 1154 passing, including 2 new sidebar tests covering the expanded (mark beside the button) and collapsed (mark hidden) behavior.

### Evidence (Before & After)

**Before:** the sidebar started directly with the New chat button — no branding at the top.

**After** (left→right: dark · expanded, dark · collapsed, light · expanded) — the Qwen mark sits to the left of the New chat button, and is hidden when collapsed:

![Web Shell sidebar logo — dark expanded, dark collapsed, light expanded](https://raw.githubusercontent.com/wenshao/qwen-code/pr-shot-web-shell-logo/docs/pr-assets/web-shell-sidebar-logo.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- Pure client-side CSS/TSX; verified on macOS via a real-browser (Chrome/Playwright) render of the sidebar plus vitest. Cross-platform behavior is identical. -->

### Environment (optional)

Verified by rendering the real `WebShellSidebar` in Chrome via a Vite dev server (Playwright screenshot, the image above) and by `vitest`.

## Risk & Scope

- Main risk or tradeoff: purely presentational sidebar change. The one subtlety is that the filled brand SVG must not inherit the sidebar's shared `.navIcon svg { fill: none; stroke: currentColor }` rule — handled by giving the logo a dedicated `.brandLogo` class plus an inline `fill`.
- Not validated / out of scope: no branding shown in collapsed mode beyond hiding the mark (there is no horizontal room beside the 32px button).
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 Web Shell 侧栏顶部加上 Qwen 品牌标志，放在 **New chat（新会话）** 按钮的左侧、同一行（不单独占一行）。图形与浏览器标签页 favicon、以及 QwenLM 的 GitHub 头像是同一份 SVG。侧栏收起时，紧凑按钮旁边没有空间，因此隐藏标志、只保留 New chat 按钮。

## 为什么需要

Web Shell 侧栏顶部原本没有任何产品标识，界面不能一眼认出是 Qwen Code。在 New chat 按钮旁加一个小的内联 Logo 就能补上这个标识，且不额外占一整行。这里用内联 SVG 而不是外链远程 URL，是因为 Web Shell 的 CSP 是 `img-src 'self' data: blob:`（见 `packages/cli/src/serve/web-shell-static.ts`），会拦截外部图片；复用本地 favicon 图形可保证 CSP 安全、离线可用、且在明暗主题下都清晰。

## 复核测试计划

### 如何验证

1. `cd packages/web-shell && npm run dev`（或运行 `qwen serve --web`）打开 Web Shell。
2. 预期：紫色 Qwen 标志出现在侧栏左上角，紧挨在 New chat 按钮左侧、同一行。
3. 收起侧栏（页脚的箭头）：标志隐藏，紧凑的 "+" New chat 按钮居中保留。
4. 切换明暗主题：标志在两种主题下都清晰。
5. 单元测试：`cd packages/web-shell && npx vitest run` —— 1154 个通过，含 2 个新增侧栏测试，分别覆盖展开（标志在按钮左侧）与收起（标志隐藏）两种行为。

### 证据（前后对比）

**之前：** 侧栏顶部直接是 New chat 按钮，没有任何品牌标识。

**之后**（从左到右：暗色·展开、暗色·收起、亮色·展开）—— Qwen 标志位于 New chat 按钮左侧，收起时隐藏：见上方英文部分的截图。

### 测试平台

仅在 macOS 上验证（纯客户端 CSS/TSX，跨平台行为一致）：通过真实浏览器（Chrome/Playwright）渲染侧栏截图 + vitest。

## 风险与范围

- 主要风险/取舍：纯展示性改动。唯一微妙点是填充的品牌 SVG 不能继承侧栏共享的 `.navIcon svg { fill: none; stroke }` 规则——通过给 Logo 单独的 `.brandLogo` class + 内联 `fill` 解决。
- 未验证/范围外：收起模式下除隐藏标志外不显示其他品牌元素（32px 按钮旁无横向空间）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A

</details>
