### PR TITLE
Avoid refreshing session activity on load

### DIFF
--- a/packages/core/src/services/chatRecordingService.autoTitle.test.ts
+++ b/packages/core/src/services/chatRecordingService.autoTitle.test.ts
@@ -364,16 +364,14 @@ describe('ChatRecordingService - auto-title trigger', () => {
     expect(svc.getCurrentCustomTitle()).toBe('Auto-generated title');
     expect(svc.getCurrentTitleSource()).toBe('auto');
 
-    // finalize() was called by the constructor — drain the queued async
-    // write before inspecting the mock.
+    await svc.flush();
+    expect(findCustomTitleRecord()).toBeUndefined();
+
+    svc.recordUserMessage([{ text: 'resume work' }]);
     await svc.flush();
 
-    // The re-appended record must carry titleSource: 'auto', not 'manual'.
-    const finalizeRecord = vi
-      .mocked(jsonl.writeLine)
-      .mock.calls.map((c) => c[1] as ChatRecord)
-      .find((r) => r.type === 'system' && r.subtype === 'custom_title');
-    expect(finalizeRecord?.systemPayload).toEqual({
+    const reanchoredRecord = findCustomTitleRecord();
+    expect(reanchoredRecord?.systemPayload).toEqual({
       customTitle: 'Auto-generated title',
       titleSource: 'auto',
     });
@@ -404,12 +402,13 @@ describe('ChatRecordingService - auto-title trigger', () => {
     expect(svc.getCurrentCustomTitle()).toBe('User chose this');
     expect(svc.getCurrentTitleSource()).toBe('manual');
     await svc.flush();
+    expect(findCustomTitleRecord()).toBeUndefined();
 
-    const finalizeRecord = vi
-      .mocked(jsonl.writeLine)
-      .mock.calls.map((c) => c[1] as ChatRecord)
-      .find((r) => r.type === 'system' && r.subtype === 'custom_title');
-    expect(finalizeRecord?.systemPayload).toEqual({
+    svc.recordUserMessage([{ text: 'resume work' }]);
+    await svc.flush();
+
+    const reanchoredRecord = findCustomTitleRecord();
+    expect(reanchoredRecord?.systemPayload).toEqual({
       customTitle: 'User chose this',
       titleSource: 'manual',
     });
@@ -438,13 +437,14 @@ describe('ChatRecordingService - auto-title trigger', () => {
     // `titleSource: 'manual'` we can't actually verify.
     expect(svc.getCurrentTitleSource()).toBeUndefined();
     await svc.flush();
+    expect(findCustomTitleRecord()).toBeUndefined();
 
-    const finalizeRecord = vi
-      .mocked(jsonl.writeLine)
-      .mock.calls.map((c) => c[1] as ChatRecord)
-      .find((r) => r.type === 'system' && r.subtype === 'custom_title');
+    svc.recordUserMessage([{ text: 'resume work' }]);
+    await svc.flush();
+
+    const reanchoredRecord = findCustomTitleRecord();
     // Payload must NOT contain a titleSource field when source is unknown.
-    expect(finalizeRecord?.systemPayload).toEqual({
+    expect(reanchoredRecord?.systemPayload).toEqual({
       customTitle: 'Legacy title',
     });
   });

--- a/packages/core/src/services/chatRecordingService.customTitle.test.ts
+++ b/packages/core/src/services/chatRecordingService.customTitle.test.ts
@@ -135,8 +135,9 @@ describe('ChatRecordingService - recordCustomTitle', () => {
   });
 
   describe('finalize', () => {
-    it('should re-append cached custom title to EOF', async () => {
+    it('should re-append cached custom title to EOF after new content', async () => {
       chatRecordingService.recordCustomTitle('my-feature');
+      chatRecordingService.recordUserMessage([{ text: 'new work' }]);
       await chatRecordingService.flush();
       vi.mocked(jsonl.writeLine).mockClear();
 
@@ -153,6 +154,17 @@ describe('ChatRecordingService - recordCustomTitle', () => {
       });
     });
 
+    it('should not write anything when the title is already the latest record', async () => {
+      chatRecordingService.recordCustomTitle('my-feature');
+      await chatRecordingService.flush();
+      vi.mocked(jsonl.writeLine).mockClear();
+
+      chatRecordingService.finalize();
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
     it('should not write anything when no custom title was set', async () => {
       chatRecordingService.finalize();
       await chatRecordingService.flush();
@@ -160,9 +172,33 @@ describe('ChatRecordingService - recordCustomTitle', () => {
       expect(jsonl.writeLine).not.toHaveBeenCalled();
     });
 
+    it('should not re-append a resumed title without new content', async () => {
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        lastCompletedUuid: null,
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+      const getSessionTitleInfo = vi.fn().mockReturnValue({
+        title: 'resumed-title',
+        source: 'manual',
+      });
+      (
+        mockConfig as unknown as {
+          getSessionService: () => {
+            getSessionTitleInfo: typeof getSessionTitleInfo;
+          };
+        }
+      ).getSessionService = () => ({ getSessionTitleInfo });
+
+      const svc = new ChatRecordingService(mockConfig);
+      svc.finalize();
+      await svc.flush();
+
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
     it('should re-append the latest title after multiple renames', async () => {
       chatRecordingService.recordCustomTitle('first-name');
       chatRecordingService.recordCustomTitle('second-name');
+      chatRecordingService.recordUserMessage([{ text: 'new work' }]);
       await chatRecordingService.flush();
       vi.mocked(jsonl.writeLine).mockClear();
 
@@ -288,10 +324,8 @@ describe('ChatRecordingService - recordCustomTitle', () => {
       ).getSessionService = () => ({ getSessionTitleInfo });
 
       const svc = new ChatRecordingService(mockConfig);
-      // Constructor's finalize re-appends a custom_title record on resume
-      // — clear it out so we can isolate the threshold-triggered re-anchor.
       await svc.flush();
-      vi.mocked(jsonl.writeLine).mockClear();
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
 
       const bulkText = 'x'.repeat(2000);
       for (let i = 0; i < 20; i++) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -588,6 +588,7 @@ export class ChatRecordingService {
         this.currentCustomTitle = info.title;
         this.currentTitleSource = info.source;
         if (info.title) {
+          // Prime the threshold so the first real content write re-anchors.
           this.bytesSinceTitleAnchor = TITLE_REANCHOR_BYTES;
         }
       } catch {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -564,6 +564,7 @@ export class ChatRecordingService {
    * returning undefined if the title is beyond both windows).
    */
   private bytesSinceTitleAnchor = 0;
+  private hasNonTitleContentSinceTitleAnchor = false;
 
   constructor(config: Config) {
     this.config = config;
@@ -577,16 +578,18 @@ export class ChatRecordingService {
     // resumed. Legacy records (no `titleSource` field) stay `undefined` —
     // treated as manual for safety without rewriting the JSONL.
     //
-    // We then re-append a custom_title record to EOF so the title stays
-    // within the tail window that readers scan (guarding against a crash
-    // before the next finalize).
+    // Do not re-append during construction: loading/resuming a session is a
+    // read operation from the user's perspective, and touching the JSONL mtime
+    // would make session lists treat it as fresh activity.
     if (config.getResumedSessionData()) {
       try {
         const sessionService = config.getSessionService();
         const info = sessionService.getSessionTitleInfo(config.getSessionId());
         this.currentCustomTitle = info.title;
         this.currentTitleSource = info.source;
-        this.finalize();
+        if (info.title) {
+          this.bytesSinceTitleAnchor = TITLE_REANCHOR_BYTES;
+        }
       } catch {
         // Best-effort — don't block construction
       }
@@ -793,9 +796,11 @@ export class ChatRecordingService {
   private updateTitleAnchorTracking(record: ChatRecord): void {
     if (record.type === 'system' && record.subtype === 'custom_title') {
       this.bytesSinceTitleAnchor = 0;
+      this.hasNonTitleContentSinceTitleAnchor = false;
       return;
     }
     if (!this.currentCustomTitle) return;
+    this.hasNonTitleContentSinceTitleAnchor = true;
     // +1 for the trailing newline jsonl.writeLine appends.
     this.bytesSinceTitleAnchor +=
       Buffer.byteLength(JSON.stringify(record), 'utf8') + 1;
@@ -1319,13 +1324,10 @@ export class ChatRecordingService {
   }
 
   /**
-   * Finalizes the current session by re-appending cached metadata to EOF.
-   *
-   * Call this whenever leaving the current session — whether switching to
-   * another session, shutting down the process, or any other transition.
-   * This single entry point replaces scattered re-append calls and ensures
-   * the custom_title record stays within the last 64KB tail window that
-   * readSessionTitleFromFile() scans.
+   * Finalizes the current session by re-appending cached metadata to EOF, but
+   * only after this recorder has appended non-title content since the last
+   * title anchor. Pure load/resume must remain read-only so session lists do
+   * not treat restored sessions as newly active.
    *
    * Best-effort: errors are logged but never thrown.
    */
@@ -1342,6 +1344,9 @@ export class ChatRecordingService {
       }
     }
     if (!this.currentCustomTitle) {
+      return;
+    }
+    if (!this.hasNonTitleContentSinceTitleAnchor) {
       return;
     }
     try {


### PR DESCRIPTION
## What this PR does

This PR keeps daemon session load/resume from rewriting the session JSONL just to refresh the cached session title anchor. Resumed sessions still load their persisted title into memory, and the title is re-anchored after the next real session write so long-running sessions keep cheap title lookup behavior.

## Why it's needed

The daemon session list uses the session file `mtime` as `updatedAt` / activity time. Loading a named session used to append a duplicate `custom_title` record during recorder construction, which changed the file `mtime` and made a pure refresh/open look like recent activity. That caused idle sessions to jump to the top of the list even when the user had not continued the conversation.

## Reviewer Test Plan

### How to verify

Reproduce the issue by creating two named daemon sessions, closing both, and then loading the older one without sending a prompt. Before this change, the older session's `updatedAt` changes and it moves above the newer session. After this change, load/resume construction is read-only; the session should only move when new content is actually appended.

Run the targeted recorder tests and core typecheck to verify the title re-anchor behavior: `cd packages/core && npx vitest run src/services/chatRecordingService.customTitle.test.ts` and `cd packages/core && npm run typecheck`.

### Evidence (Before & After)

Before: local daemon reproduction showed `Alpha.updatedAt` changing from `2026-07-07T07:27:19.948Z` to `2026-07-07T07:27:35.071Z` immediately after `POST /session/:id/load`, and the JSONL gained a second `custom_title` record without any new prompt.

After: real daemon verification on macOS created five named sessions (`Alpha`, `Beta`, `Gamma`, `Delta`, `Epsilon`), then loaded three older sessions (`Alpha`, `Gamma`, `Beta`) without sending prompts. The list stayed `Epsilon > Delta > Gamma > Beta > Alpha` across all four list calls; `Alpha`, `Gamma`, and `Beta` kept the same `updatedAt` values and each still had exactly one `custom_title` record.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local macOS development checkout. Verified with `npx vitest run src/services/chatRecordingService.customTitle.test.ts` and `npm run typecheck` from `packages/core`. Also verified with a real `tmux` daemon run on port `4286` using isolated `QWEN_RUNTIME_DIR`.

## Risk & Scope

- Main risk or tradeoff: Resumed sessions no longer immediately re-anchor a title on load, so legacy sessions with very stale title placement rely on the next real appended record to refresh the tail anchor. The implementation marks resumed titles so that the next content write triggers re-anchor.
- Not validated / out of scope: Windows and Linux daemon runs were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Resolves #6438

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 避免 daemon 在 load/resume session 时仅为了刷新标题锚点就改写 session JSONL。恢复 session 时仍会把持久化标题读入内存；当后续真的发生 session 写入时，再把标题重新锚到文件尾部，保留长会话的低成本标题读取能力。

## 为什么需要

daemon session list 使用 session 文件的 `mtime` 作为 `updatedAt` / activity time。之前加载一个已命名 session 时，recorder 构造阶段会追加一条重复的 `custom_title` 记录，导致文件 `mtime` 变化，让纯刷新/打开看起来像最近活跃。结果就是没有继续对话的 idle session 也会跳到列表顶部。

## Reviewer Test Plan

### 如何验证

可以创建两个已命名 daemon session，关闭后只 load 较旧的那个，不发送 prompt。修复前，较旧 session 的 `updatedAt` 会变化并上浮；修复后，load/resume 构造阶段保持只读，只有真正追加新内容时 session 才应该上浮。

运行 targeted recorder 测试和 core typecheck 验证标题重锚语义：`cd packages/core && npx vitest run src/services/chatRecordingService.customTitle.test.ts` 和 `cd packages/core && npm run typecheck`。

### Evidence (Before & After)

修复前：本地 daemon 复现显示 `POST /session/:id/load` 后，`Alpha.updatedAt` 从 `2026-07-07T07:27:19.948Z` 变成 `2026-07-07T07:27:35.071Z`，并且 JSONL 在没有新 prompt 的情况下多了一条 `custom_title` 记录。

修复后：真实 macOS daemon 验证创建了五个命名 session（`Alpha`、`Beta`、`Gamma`、`Delta`、`Epsilon`），然后只 load 三个较旧 session（`Alpha`、`Gamma`、`Beta`），不发送 prompt。四次 list 结果始终保持 `Epsilon > Delta > Gamma > Beta > Alpha`；`Alpha`、`Gamma`、`Beta` 的 `updatedAt` 都没有变化，并且每个仍然只有一条 `custom_title` 记录。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment

本地 macOS development checkout。在 `packages/core` 下验证了 `npx vitest run src/services/chatRecordingService.customTitle.test.ts` 和 `npm run typecheck`。同时用隔离 `QWEN_RUNTIME_DIR` 在 `tmux` 中启动真实 daemon，端口 `4286`，完成了 5-session load/list 回归验证。

## 风险和范围

- 主要风险或取舍：resumed session 不再在 load 时立即把 title 重锚到尾部，因此极老的 title 位置需要等下一次真实内容写入时刷新尾部锚点。实现里已经把 resumed title 标记为下次内容写入后需要 re-anchor。
- 未验证 / 范围外：本地没有验证 Windows 和 Linux daemon。
- Breaking changes / migration notes：无。

## Linked Issues

Resolves #6438

</details>
