### PR TITLE
fix(web-shell): Improve user tags and mobile menu layout

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -225,6 +225,13 @@
   .hamburgerButton {
     display: flex;
   }
+
+  .hamburgerButtonFloating {
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + 12px);
+    left: calc(env(safe-area-inset-left) + 12px);
+    z-index: 10;
+  }
 }
 
 .appChatEmpty.appWithSidebar {
@@ -235,14 +242,6 @@
 .appChatEmpty .chatPane {
   justify-content: center;
   overflow-y: auto;
-}
-
-@media (max-width: 760px) {
-  .appChatEmpty .hamburgerButton {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-  }
 }
 
 .app,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -172,6 +172,7 @@ import {
   type WebShellComposerInput,
   type WebShellMarkdownCustomization,
   type ToolHeaderExtraRenderer,
+  type UserMessageContentRenderer,
   type WelcomeHeaderRenderer,
   type WelcomeFooterRenderer,
   type ComposerToolbarStartRenderer,
@@ -401,6 +402,8 @@ export interface WebShellProps {
   renderWelcomeHeader?: WelcomeHeaderRenderer;
   /** Custom renderer shown below the chat composer in the empty welcome state. */
   renderWelcomeFooter?: WelcomeFooterRenderer;
+  /** Custom renderer for the inside of user chat bubbles. Defaults to plain text. */
+  renderUserMessageContent?: UserMessageContentRenderer;
   /** Custom renderer inserted before the built-in chat composer toolbar controls. */
   renderComposerToolbarStart?: ComposerToolbarStartRenderer;
   /** Custom renderer inserted after the built-in composer toolbar controls. */
@@ -792,6 +795,7 @@ export function App({
   renderToolHeaderExtra,
   renderWelcomeHeader,
   renderWelcomeFooter,
+  renderUserMessageContent,
   renderComposerToolbarStart,
   renderComposerToolbarEnd,
   renderComposerToolbarRight,
@@ -903,6 +907,7 @@ export function App({
       renderToolHeaderExtra,
       renderWelcomeHeader,
       renderWelcomeFooter,
+      renderUserMessageContent,
       renderComposerToolbarStart,
       renderComposerToolbarEnd,
       renderComposerToolbarRight,
@@ -917,6 +922,7 @@ export function App({
       renderToolHeaderExtra,
       renderWelcomeHeader,
       renderWelcomeFooter,
+      renderUserMessageContent,
       renderComposerToolbarStart,
       renderComposerToolbarEnd,
       renderComposerToolbarRight,
@@ -4537,29 +4543,38 @@ export function App({
                   : styles.chatPane
               }
             >
-              {sidebarOptions.enabled && (
-                <button
-                  type="button"
-                  className={styles.hamburgerButton}
-                  onClick={() => setMobileDrawerOpen((open) => !open)}
-                  aria-label={t('sidebar.toggleMenu')}
-                  aria-expanded={mobileDrawerOpen}
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
+              {sidebarOptions.enabled &&
+                !activePanel &&
+                mainView === 'chat' && (
+                  <button
+                    type="button"
+                    className={[
+                      styles.hamburgerButton,
+                      isChatEmptyState
+                        ? styles.hamburgerButtonFloating
+                        : undefined,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    onClick={() => setMobileDrawerOpen((open) => !open)}
+                    aria-label={t('sidebar.toggleMenu')}
+                    aria-expanded={mobileDrawerOpen}
                   >
-                    <line x1="3" y1="6" x2="21" y2="6" />
-                    <line x1="3" y1="12" x2="21" y2="12" />
-                    <line x1="3" y1="18" x2="21" y2="18" />
-                  </svg>
-                </button>
-              )}
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <line x1="3" y1="6" x2="21" y2="6" />
+                      <line x1="3" y1="12" x2="21" y2="12" />
+                      <line x1="3" y1="18" x2="21" y2="18" />
+                    </svg>
+                  </button>
+                )}
               {activePanel && (
                 <section
                   className={styles.panelHost}

--- a/packages/web-shell/client/components/messages/UserMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { WebShellCustomizationProvider } from '../../customization';
 import { UserMessage } from './UserMessage';
 
 (
@@ -45,5 +46,22 @@ describe('UserMessage', () => {
     const img = container.querySelector('img');
     expect(img).not.toBeNull();
     expect(img!.getAttribute('src')).toBe('data:image/png;base64,abc');
+  });
+
+  it('uses a custom content renderer when provided', () => {
+    const container = render(
+      <WebShellCustomizationProvider
+        value={{
+          renderUserMessageContent: ({ content }) => (
+            <span data-testid="tag-chip">{content.slice(1)}</span>
+          ),
+        }}
+      >
+        <UserMessage content="@.husky/_/husky.sh xuyao" />
+      </WebShellCustomizationProvider>,
+    );
+
+    expect(container.querySelector('[data-testid="tag-chip"]')).not.toBeNull();
+    expect(container.textContent).toContain('.husky/_/husky.sh xuyao');
   });
 });

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -1,5 +1,6 @@
 import {
   memo,
+  useMemo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -7,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { isSafeImageSrc } from './Markdown';
+import { useWebShellCustomization } from '../../customization';
 import { useI18n } from '../../i18n';
 import flashStyles from '../MessageLocateFlash.module.css';
 import styles from './UserMessage.module.css';
@@ -28,14 +30,19 @@ export const UserMessage = memo(function UserMessage({
   isLocateFlashing = false,
 }: UserMessageProps) {
   const { t } = useI18n();
+  const { renderUserMessageContent } = useWebShellCustomization();
   const contentRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(false);
-  const [overflowing, setOverflowing] = useState(false);
+  const [heightOverflowing, setHeightOverflowing] = useState(false);
+  const renderedContent = useMemo(
+    () => renderUserMessageContent?.({ content, images }) ?? content,
+    [content, images, renderUserMessageContent],
+  );
 
   const measureOverflow = useCallback(() => {
     const el = contentRef.current;
     if (!el) return;
-    setOverflowing(el.scrollHeight > 400);
+    setHeightOverflowing(el.scrollHeight > 400);
   }, []);
 
   useLayoutEffect(() => {
@@ -61,7 +68,7 @@ export const UserMessage = memo(function UserMessage({
         <div
           ref={contentRef}
           className={`${styles.chatContent} ${
-            overflowing && !expanded ? styles.chatContentCollapsed : ''
+            heightOverflowing && !expanded ? styles.chatContentCollapsed : ''
           }`}
         >
           {images && images.length > 0 && (
@@ -83,9 +90,9 @@ export const UserMessage = memo(function UserMessage({
               })}
             </div>
           )}
-          {content}
+          {renderedContent}
         </div>
-        {overflowing && (
+        {heightOverflowing && (
           <button
             type="button"
             className={styles.toggleButton}

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -90,6 +90,15 @@ export type ToolHeaderExtraRenderer = (
 export type WelcomeHeaderRenderer = (props: WelcomeHeaderProps) => ReactNode;
 export type WelcomeFooterRenderer = (props: WelcomeHeaderProps) => ReactNode;
 
+export interface UserMessageContentRenderInfo {
+  content: string;
+  images?: readonly { data: string; mimeType: string }[];
+}
+
+export type UserMessageContentRenderer = (
+  info: UserMessageContentRenderInfo,
+) => ReactNode;
+
 export type WebShellBuiltinComposerTagKind =
   | 'extension'
   | 'mcp'
@@ -277,6 +286,7 @@ export interface WebShellCustomization {
   renderToolHeaderExtra?: ToolHeaderExtraRenderer;
   renderWelcomeHeader?: WelcomeHeaderRenderer;
   renderWelcomeFooter?: WelcomeFooterRenderer;
+  renderUserMessageContent?: UserMessageContentRenderer;
   renderComposerToolbarStart?: ComposerToolbarStartRenderer;
   renderComposerToolbarEnd?: ComposerToolbarEndRenderer;
   renderComposerToolbarRight?: ComposerToolbarRightRenderer;

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -12,6 +12,8 @@ export type {
   ToolHeaderExtraRenderer,
   ToolHeaderExtraRenderInfo,
   ToolHeaderKind,
+  UserMessageContentRenderer,
+  UserMessageContentRenderInfo,
   ComposerToolbarStartRenderer,
   ComposerToolbarRightRenderer,
   WelcomeFooterRenderer,

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -115,6 +115,8 @@ export type {
   ToolHeaderExtraRenderer,
   ToolHeaderExtraRenderInfo,
   ToolHeaderKind,
+  UserMessageContentRenderer,
+  UserMessageContentRenderInfo,
   ComposerToolbarStartRenderer,
   ComposerToolbarRightRenderer,
   WebShellComposerToolbarRenderInfo,


### PR DESCRIPTION
## What this PR does

Adds an optional user-message content renderer to Web Shell so embedders can display submitted tag references as chips or other structured UI while the default transcript rendering remains plain text. It also adjusts the mobile sidebar menu button so it stays in the top-left corner on the empty welcome screen, does not overlap settings or other full-page views, and does not float over existing conversation content.

## Why it's needed

Tag references can be shown as chips in the composer but appear as plain prompt text after submission. Embedders need a focused hook to render those user bubbles consistently without replacing the rest of the message chrome, timestamp, copying, image display, or height-based expand/collapse behavior. The mobile menu positioning also needed tightening so the welcome screen affordance is visible without creating overlap on settings or existing sessions.

## Reviewer Test Plan

### How to verify

Open Web Shell on a mobile-width viewport with the sidebar enabled. On the empty welcome screen, confirm the menu button appears in the top-left safe area. Open Settings, Scheduled Tasks, or Split View and confirm the menu button is not shown over those views. Load an existing chat and confirm the menu button no longer floats over transcript content. For the user-message renderer, pass `renderUserMessageContent` from a host integration and confirm only the user bubble body changes while default rendering remains unchanged when the prop is omitted.

### Evidence (Before & After)

Before: tag references submitted from the composer appeared as plain prompt text, the welcome screen menu could sit in the centered content flow, and making it fixed caused overlap in settings or existing sessions. After: hosts can render submitted tag references with custom UI, the welcome menu sits at top-left, and the menu is hidden or non-floating in panel/full-page/existing-chat states.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local package checks under `packages/web-shell`: `vitest run client/components/messages/UserMessage.test.tsx`, `tsc -p tsconfig.lib.json --noEmit`, and Prettier checks for the touched files all passed. Root `npm run build`, `npm run typecheck`, and the Husky pre-commit hook could not run in this local Codex runtime because `npm` is not available on PATH; `scripts/build.js` also shells out to `npm run generate` and failed for the same reason.

## Risk & Scope

- Main risk or tradeoff: Custom user-message renderers can change bubble layout if host code returns wide or poorly wrapping content, though default rendering is unchanged.
- Not validated / out of scope: Full root preflight and cross-platform manual UI validation.
- Breaking changes / migration notes: None; the new renderer is optional.

## Linked Issues

N/A — no issue id for this change.

<details>
<summary>中文说明</summary>

## What this PR does

为 Web Shell 增加可选的用户消息内容渲染入口，嵌入方可以把已提交的 tag 引用显示成 chip 或其他结构化 UI，同时默认 transcript 仍然保持普通文本展示。这个 PR 也调整了移动端侧边栏菜单按钮：空 welcome 页面时按钮固定在左上角，进入设置或其他整页视图时不再重叠，已有会话内容里也不会浮在消息上方。

## Why it's needed

tag 引用在输入框里可以显示为 chip，但提交后会变成普通 prompt 文本。嵌入方需要一个聚焦的 hook 来一致地渲染用户气泡内容，同时不替换消息外层、时间戳、复制、图片展示或按高度展开/收起这些已有行为。移动端菜单按钮的位置也需要收紧，既要让 welcome 页可见，又不能在设置页或已有会话中产生重叠。

## Reviewer Test Plan

### How to verify

在移动端宽度 viewport 打开启用 sidebar 的 Web Shell。空 welcome 页应看到菜单按钮在左上安全区。打开设置、计划任务或分屏视图，确认菜单按钮不会覆盖这些页面。加载已有会话，确认菜单按钮不会浮在 transcript 内容上。对于用户消息 renderer，从宿主集成传入 `renderUserMessageContent`，确认只有用户气泡正文变化；不传该 prop 时默认展示保持不变。

### Evidence (Before & After)

Before：从 composer 提交的 tag 引用在消息里显示为普通 prompt 文本；welcome 页菜单按钮可能跟随居中内容流；将其改为 fixed 后又会覆盖设置页或已有会话。After：宿主可以自定义已提交 tag 引用的展示；welcome 页菜单位于左上角；panel、整页视图和已有会话状态下不会显示或浮动覆盖菜单按钮。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

已在 `packages/web-shell` 下通过相关包级检查：`vitest run client/components/messages/UserMessage.test.tsx`、`tsc -p tsconfig.lib.json --noEmit`，以及 touched files 的 Prettier 检查。当前本地 Codex runtime 的 PATH 中没有 `npm`，所以无法运行 root `npm run build`、`npm run typecheck` 和 Husky pre-commit；`scripts/build.js` 内部也会调用 `npm run generate`，因此同样因缺少 npm 失败。

## Risk & Scope

- Main risk or tradeoff：宿主自定义用户消息 renderer 如果返回过宽或换行不佳的内容，可能影响气泡布局；默认展示不受影响。
- Not validated / out of scope：完整 root preflight 和跨平台手动 UI 验证。
- Breaking changes / migration notes：无；新的 renderer 是可选能力。

## Linked Issues

N/A — 这次变更没有 issue id。
</details>


## Pictures
<img width="1412" height="1830" alt="image" src="https://github.com/user-attachments/assets/ee487000-e601-4ff1-add8-63eb0a4f1bfe" />
<img width="1000" height="1368" alt="image" src="https://github.com/user-attachments/assets/631cce62-715e-4a1c-9df1-af91eb662dae" />
<img width="2318" height="758" alt="image" src="https://github.com/user-attachments/assets/70d03509-5b26-42f2-8c77-789adf7ae972" />
