### PR TITLE
fix(channel): Relay ACP permission requests

### DIFF
--- a/docs/design/2026-07-07-daemon-a2a-v1-design.md
+++ b/docs/design/2026-07-07-daemon-a2a-v1-design.md
@@ -1,0 +1,301 @@
+# Daemon A2A v1 Design
+
+## Summary
+
+A2A v1 lets one `qwen serve` daemon ask another daemon to work in its own
+workspace. The first version is intentionally narrow:
+
+- local daemons are discovered automatically;
+- remote daemons are added through explicit configuration;
+- discovered peers are candidates only and cannot be called until explicitly
+  trusted;
+- the local agent sees a single `ask_peer_daemon` tool through a daemon-hosted
+  runtime MCP server;
+- peer calls send the current user request plus a bounded recent-session
+  summary, not the full transcript, files, attachments, environment, or secrets;
+- the peer daemon keeps its own permission mediation and does not inherit the
+  caller daemon's local permissions.
+
+The implementation should stay at the daemon HTTP boundary. The ACP child should
+see a normal MCP tool call; discovery, trust, peer tokens, and HTTP calls remain
+owned by the parent daemon process.
+
+## Goals
+
+- Let an agent in workspace A delegate a bounded task to a trusted daemon bound
+  to workspace B.
+- Reuse the existing daemon REST/SSE protocol and runtime MCP mutation path.
+- Keep peer discovery separate from peer authorization.
+- Preserve the existing "one daemon = one workspace" model.
+- Keep the first user-facing tool simple enough to audit and test.
+
+## Non-goals
+
+- No LAN broadcast or mDNS discovery in v1.
+- No automatic trust for discovered local daemons.
+- No direct ACP-child-to-ACP-child transport.
+- No transparent passthrough of every remote tool into the local tool registry.
+- No full transcript, file, attachment, or secret propagation.
+- No multi-hop peer calls; v1 caps A2A depth at one.
+
+## Architecture
+
+```text
+qwen serve A
+  A2aRegistry        discovers local peers and reads explicit remote peers
+  A2aTrustStore     records which peer identities are allowed to be called
+  A2aMcpServer      exposes ask_peer_daemon as an SDK-type runtime MCP server
+  A2aPeerClient     calls trusted peer daemon REST/SSE endpoints
+  A2aContextBuilder builds the bounded context sent to peers
+
+agent in daemon A
+  -> ask_peer_daemon(peer, task)
+  -> parent daemon A
+  -> daemon B REST/SSE
+  -> result returns as the MCP tool result
+```
+
+### `A2aRegistry`
+
+`A2aRegistry` owns the candidate peer list. It merges two sources:
+
+- local auto-discovery entries written by running daemons under the user's Qwen
+  state directory;
+- explicit remote peer entries from settings.
+
+Local entries should include daemon id, workspace cwd, URL, PID, start time,
+last heartbeat/update time, and a capabilities hash. Reads must prune stale
+entries by checking age, PID when available, and `/health` reachability. The
+registry must not store bearer tokens.
+
+### `A2aTrustStore`
+
+`A2aTrustStore` records trusted peer identities. Trust should key off a stable
+peer id plus URL/workspace evidence, not just a mutable display name. A peer can
+be visible in `/workspace/a2a/peers` while still not callable.
+
+The v1 design only requires a storage shape and daemon API boundary; UX for
+trusting peers can be CLI, Web Shell, or direct settings mutation in later work.
+
+### `A2aMcpServer`
+
+The parent daemon registers an SDK-type runtime MCP server, for example
+`qwen-a2a`, using the existing `addRuntimeMcpServer` path. The ACP child then
+discovers a normal MCP tool while tool execution routes back to the parent
+daemon through the existing SDK MCP reverse channel.
+
+This avoids a new stdio shim process and prevents peer tokens from entering the
+ACP child. If there is no live ACP channel yet, registration is delayed until
+preheat or the first session creates a channel.
+
+### `A2aPeerClient`
+
+`A2aPeerClient` calls peers through the existing daemon surface:
+
+1. `GET /capabilities` to verify protocol and A2A-compatible feature tags.
+2. `POST /session` to create a per-call A2A session on the peer.
+3. `POST /session/:id/prompt` to submit the delegated task.
+4. `GET /session/:id/events` to observe completion and collect the final answer.
+5. `DELETE /session/:id`, best-effort, once the peer answer is collected.
+
+The client should carry a dedicated A2A client id, for example
+`daemon-a2a:<caller-daemon-id>`, and attach metadata such as `origin: 'a2a'`,
+`callerDaemonId`, `callerWorkspace`, and `a2aDepth`.
+
+### `A2aContextBuilder`
+
+The context builder emits only:
+
+- the current user request;
+- a recent-session summary capped at 4,000 characters;
+- caller workspace identity and daemon id;
+- the explicit `task` string supplied by the local agent.
+
+It must not automatically include the full transcript, files, attachments,
+environment variables, API keys, bearer tokens, or MCP/tool outputs. If the
+local agent wants to share file content, it must place that content explicitly
+in the task.
+
+## Tool Contract
+
+The v1 MCP server exposes one tool:
+
+```ts
+ask_peer_daemon({
+  peer: string,
+  task: string,
+});
+```
+
+The result should be a structured tool result with either:
+
+- a peer answer, including peer id, workspace label, session id, and a concise
+  final response; or
+- a typed A2A error that the local agent can explain to the user.
+
+The `peer` parameter accepts a trusted peer id or display alias. Ambiguous aliases
+must fail with a typed error rather than choosing arbitrarily.
+
+## Discovery and Trust Flow
+
+1. A daemon starts and writes or refreshes its local registry entry.
+2. Other daemons read the registry and show the entry as `discovered`.
+3. Explicit remote peers are loaded from settings and shown as `configured`.
+4. A peer remains `callable: false` until `A2aTrustStore` marks it trusted.
+5. Trusted peers become visible to `ask_peer_daemon`.
+
+Discovery should be best-effort. Failure to write the registry must not prevent
+the daemon from serving normal local clients.
+
+## Call Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant AgentA as Agent in Daemon A
+    participant MCP as qwen-a2a MCP server
+    participant ParentA as Parent Daemon A
+    participant PeerB as Daemon B
+
+    AgentA->>MCP: ask_peer_daemon(peer, task)
+    MCP->>ParentA: SDK MCP reverse call
+    ParentA->>ParentA: resolve peer and verify trust
+    ParentA->>ParentA: build bounded A2A context
+    ParentA->>PeerB: GET /capabilities
+    ParentA->>PeerB: POST /session { origin: "a2a" }
+    ParentA->>PeerB: POST /session/:id/prompt
+    ParentA->>PeerB: GET /session/:id/events
+    PeerB-->>ParentA: final answer or error
+    ParentA->>PeerB: DELETE /session/:id
+    ParentA-->>MCP: structured tool result
+    MCP-->>AgentA: peer answer
+```
+
+The peer's permission mediation is unchanged. If daemon B needs human approval
+for a tool call, daemon B asks its own clients according to its policy. Daemon A
+does not vote on daemon B's permission requests unless daemon B has explicitly
+configured such a client relationship in later work.
+
+## Capabilities and Configuration
+
+Add daemon capability tags:
+
+- `daemon_a2a_discovery`
+- `daemon_a2a_peer_call`
+- `daemon_a2a_mcp_tool`
+
+Add settings under an `a2a` namespace:
+
+```json
+{
+  "a2a": {
+    "enabled": true,
+    "explicitPeers": [
+      {
+        "id": "peer-id",
+        "url": "http://127.0.0.1:4171",
+        "tokenRef": "env:QWEN_A2A_PEER_PEER_ID_TOKEN"
+      }
+    ],
+    "trustedPeers": {
+      "peer-id": {
+        "url": "http://127.0.0.1:4171",
+        "tokenRef": "env:QWEN_A2A_PEER_PEER_ID_TOKEN"
+      }
+    }
+  }
+}
+```
+
+`tokenRef` supports `env:<NAME>` in v1. The daemon resolves the referenced
+environment variable at call time. The local auto-discovery registry must never
+contain the resolved token.
+
+## Security Invariants
+
+- Discovery never grants call permission.
+- Trust is explicit and revocable.
+- Peer calls require the peer daemon's bearer token when the peer requires auth.
+- Peer tokens stay in the parent daemon process and are never included in
+  prompts, summaries, logs, tool output, or ACP child state.
+- A2A calls use bounded context by default.
+- A peer daemon enforces its own auth, CORS, host checks, rate limits, and
+  permission mediation.
+- `a2aDepth` is capped at one in v1. A prompt received with depth one must not be
+  allowed to initiate another peer call.
+- Tool results and logs must sanitize peer-provided error messages before
+  writing to stderr or structured daemon logs.
+
+## Failure Semantics
+
+`ask_peer_daemon` returns structured errors for expected failures:
+
+| Code                       | Meaning                                                                    |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `peer_not_found`           | No discovered or configured peer matches the requested id or alias.        |
+| `peer_not_trusted`         | The peer exists but is not trusted for agent calls.                        |
+| `peer_unreachable`         | The peer URL cannot be reached or fails health/capability checks.          |
+| `peer_auth_failed`         | The peer rejects the configured token.                                     |
+| `peer_capability_mismatch` | The peer does not advertise required daemon protocol support.              |
+| `peer_permission_timeout`  | The peer is waiting for local permission and times out.                    |
+| `peer_prompt_failed`       | The peer prompt returns a daemon or agent failure.                         |
+| `peer_response_timeout`    | The peer accepted the prompt but did not complete within the A2A deadline. |
+| `a2a_depth_exceeded`       | A peer call attempts to call another peer in v1.                           |
+| `peer_alias_ambiguous`     | The supplied peer alias maps to more than one candidate.                   |
+
+Unexpected errors should be mapped to `peer_prompt_failed` with a sanitized
+message and an internal log entry containing the detailed cause.
+
+## Observability
+
+Daemon logs should include:
+
+- registry refresh result and stale-entry pruning counts;
+- trust changes;
+- runtime MCP registration success/failure;
+- peer call start/finish with peer id, caller daemon id, duration, status code,
+  and error code;
+- A2A depth rejection.
+
+Do not log prompt content, summaries, bearer tokens, or peer responses by
+default.
+
+## Implementation Notes
+
+- `createServeApp` already owns `ClientMcpSenderRegistry` and runtime MCP wiring
+  for SDK-type servers. A2A should reuse the same pattern rather than adding a
+  new child transport.
+- `bridge.addRuntimeMcpServer` requires a live ACP channel. Register the
+  `qwen-a2a` MCP server after preheat succeeds or after the first
+  `spawnOrAttach`; retry idempotently when a channel is recreated.
+- Use `RUNTIME_MCP_IF_ABSENT_CONFIG_FLAG`-style conflict behavior so A2A does
+  not shadow a user-configured MCP server name.
+- Keep all new REST routes under `/workspace/a2a/*`. Do not overload
+  `/capabilities` beyond additive feature tags and optional metadata.
+- Avoid adding peer config to `POST /session`; daemon-wide A2A should remain
+  settings/runtime driven like daemon-wide MCP.
+
+## Testing Plan
+
+- Registry unit tests: local registration, refresh, stale pruning, duplicate
+  daemon id update, and health-check pruning.
+- Trust unit tests: discovered-but-untrusted peers are listed but not callable;
+  trust revocation disables calls.
+- MCP server unit tests: `ask_peer_daemon` parameter validation, alias ambiguity,
+  and error mapping.
+- Peer client unit tests: capabilities preflight, session creation, prompt
+  submission, SSE completion, auth failure, timeout, and malformed peer events.
+- Serve integration tests: two fake daemons where A discovers B, trust is added,
+  and A's agent can call B through the A2A MCP tool.
+- Security regression tests: no token in registry or logs, untrusted peers
+  refused, wrong token refused, and `a2aDepth > 1` refused.
+- Lifecycle tests: A2A MCP registration after preheat, after first session when
+  preheat fails, and after ACP channel restart.
+
+## Open Follow-ups
+
+- Design the CLI/Web Shell UX for trusting, untrusting, and naming peers.
+- Consider keychain-backed token references after the `env:` reference path
+  proves useful.
+- Consider LAN discovery only after the local/explicit model is stable and the
+  trust UX is proven.

--- a/docs/plans/2026-07-07-daemon-a2a-v1.md
+++ b/docs/plans/2026-07-07-daemon-a2a-v1.md
@@ -1,0 +1,1813 @@
+# Daemon A2A v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build daemon-to-daemon A2A peer calls where a trusted peer daemon is exposed to the local agent as one `ask_peer_daemon` MCP tool.
+
+**Architecture:** Keep A2A in the parent `qwen serve` process. The ACP child sees a normal SDK-type runtime MCP server named `qwen-a2a`; discovery, trust, peer tokens, bounded context, and peer HTTP/SSE calls stay in the daemon HTTP layer.
+
+**Tech Stack:** TypeScript, Express, Vitest, daemon REST/SSE, MCP SDK JSON-RPC messages, existing `ClientMcpSenderRegistry`, existing `bridge.addRuntimeMcpServer`.
+
+---
+
+## File Structure
+
+- Create `packages/cli/src/serve/a2a/types.ts`: shared A2A wire/domain types, constants, and typed error helpers.
+- Create `packages/cli/src/serve/a2a/settings.ts`: normalize `settings.merged.a2a` into trusted and explicit peer records; resolve `env:<NAME>` token refs.
+- Create `packages/cli/src/serve/a2a/registry.ts`: local daemon registry file read/write/prune helpers.
+- Create `packages/cli/src/serve/a2a/context.ts`: build bounded peer prompt context from the calling session id and bridge recap.
+- Create `packages/cli/src/serve/a2a/peer-client.ts`: call peer daemon `/capabilities`, `/session`, `/session/:id/prompt`, `/session/:id/events`, and `DELETE /session/:id`.
+- Create `packages/cli/src/serve/a2a/mcp-server.ts`: parent-hosted MCP JSON-RPC responder for `initialize`, `tools/list`, and `tools/call`.
+- Create `packages/cli/src/serve/a2a/service.ts`: orchestrates peer resolution, trust checks, context building, and peer client invocation.
+- Create `packages/cli/src/serve/a2a/routes.ts`: read-only peer listing route under `/workspace/a2a/peers`.
+- Create `packages/cli/src/serve/a2a/index.ts`: export A2A public helpers used by `server.ts` and `run-qwen-serve.ts`.
+- Modify `packages/acp-bridge/src/bridgeOptions.ts`: pass optional session context into parent-hosted SDK MCP senders.
+- Modify `packages/acp-bridge/src/bridgeClient.ts`: forward child-provided `sessionId` to the sender lookup.
+- Modify `packages/acp-bridge/src/bridgeTypes.ts`: add a parent-hosted SDK MCP runtime marker that preserves `type: 'sdk'`.
+- Modify `packages/cli/src/acp-integration/acpAgent.ts`: preserve `type: 'sdk'` for either existing client-MCP-over-WS marker or new parent-hosted marker.
+- Modify `packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts`: accept the optional sender context while preserving existing WS behavior.
+- Modify `packages/cli/src/serve/capabilities.ts`: add A2A feature tags and conditional toggles.
+- Modify `packages/cli/src/serve/server/serve-features.ts`: advertise A2A features when enabled.
+- Modify `packages/cli/src/serve/types.ts`: add `a2aEnabled?: boolean`.
+- Modify `packages/cli/src/serve/server.ts`: construct A2A service, register routes, register `qwen-a2a` runtime MCP after a live bridge exists.
+- Modify `packages/cli/src/serve/run-qwen-serve.ts`: start and stop local A2A registry advertisement after the daemon URL is known.
+- Modify `packages/cli/src/config/settingsSchema.ts`: add `a2a` schema.
+- Add focused tests next to the new modules and touch existing tests for changed contracts.
+
+## Task 1: Pass Session Context Through SDK MCP Reverse Senders
+
+**Files:**
+
+- Modify: `packages/acp-bridge/src/bridgeOptions.ts`
+- Modify: `packages/acp-bridge/src/bridgeClient.ts`
+- Modify: `packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts`
+- Test: `packages/acp-bridge/src/bridgeClient.test.ts`
+- Test: `packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts`
+
+- [ ] **Step 1: Write failing acp-bridge test for session-aware sender lookup**
+
+Add a test near the existing `client_mcp/message` tests in `packages/acp-bridge/src/bridgeClient.test.ts`:
+
+```ts
+it('passes the child sessionId to clientMcpSender lookup', async () => {
+  const seen: Array<{ serverName: string; sessionId?: string }> = [];
+  const outbound: ClientMcpFrame[] = [];
+  const registrar = new ClientMcpRegistrar({
+    sendFrame: (frame) => {
+      outbound.push(frame);
+    },
+  });
+  registrar.registerServer('qwen-a2a');
+
+  const client = makeClientWithRegistrar(registrar, (serverName, context) => {
+    seen.push({ serverName, sessionId: context?.sessionId });
+  });
+
+  const payload = { jsonrpc: '2.0', id: 1, method: 'tools/list' as const };
+
+  const callP = client.extMethod(SERVE_CONTROL_EXT_METHODS.clientMcpMessage, {
+    server: 'qwen-a2a',
+    sessionId: 'session-123',
+    payload,
+  });
+  registrar.handleClientMessage({
+    id: outbound[0]!.id,
+    server: 'qwen-a2a',
+    payload,
+  });
+  await callP;
+
+  expect(seen).toEqual([{ serverName: 'qwen-a2a', sessionId: 'session-123' }]);
+});
+```
+
+Extend the existing local helper in that describe block to accept an optional `onLookup` callback:
+
+```ts
+function makeClientWithRegistrar(
+  registrar: ClientMcpRegistrar,
+  onLookup?: (serverName: string, context?: ClientMcpSenderContext) => void,
+): BridgeClient {
+  const sender: ClientMcpMessageSender = (serverName, context) => {
+    onLookup?.(serverName, context);
+    return registrar.hasServer(serverName)
+      ? (payload: unknown) =>
+          registrar.sendSdkMcpMessage(serverName, payload as JSONRPCMessage)
+      : undefined;
+  };
+  return new BridgeClient(
+    (() => undefined) as never,
+    (() => undefined) as never,
+    { request: thrower } as never,
+    0,
+    Infinity,
+    undefined,
+    undefined,
+    undefined,
+    sender,
+  );
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts
+```
+
+Expected: the new test fails because `ClientMcpMessageSender` accepts only `serverName` and `BridgeClient` does not forward `sessionId`.
+
+- [ ] **Step 3: Extend the sender type**
+
+Change `packages/acp-bridge/src/bridgeOptions.ts`:
+
+```ts
+export interface ClientMcpSenderContext {
+  sessionId?: string;
+}
+
+export type ClientMcpMessageSender = (
+  serverName: string,
+  context?: ClientMcpSenderContext,
+) => ((payload: unknown) => Promise<unknown>) | undefined;
+```
+
+Keep the second parameter optional so existing callers compile unchanged.
+
+- [ ] **Step 4: Forward `sessionId` from bridge client**
+
+In `packages/acp-bridge/src/bridgeClient.ts`, inside `handleClientMcpMessage`, read the optional `sessionId`:
+
+```ts
+const sessionId = params['sessionId'];
+if (sessionId !== undefined && typeof sessionId !== 'string') {
+  throw RequestError.invalidParams(
+    undefined,
+    '`sessionId` must be a string when provided',
+  );
+}
+const send = this.clientMcpSender(server, {
+  ...(typeof sessionId === 'string' ? { sessionId } : {}),
+});
+```
+
+- [ ] **Step 5: Preserve existing sender registry behavior**
+
+In `packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts`, update `lookup` to accept but ignore context:
+
+```ts
+readonly lookup: ClientMcpMessageSender = (serverName) => {
+  const entry = this.senders.get(serverName);
+  if (!entry) return undefined;
+  return (payload: unknown) =>
+    entry.sender(serverName, payload as JSONRPCMessage) as Promise<unknown>;
+};
+```
+
+The function body stays the same; only the imported type now permits callers to pass context.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts
+cd packages/cli && npx vitest run src/serve/acp-http/client-mcp-sender-registry.test.ts
+```
+
+Expected: both pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/acp-bridge/src/bridgeOptions.ts packages/acp-bridge/src/bridgeClient.ts packages/acp-bridge/src/bridgeClient.test.ts packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
+git commit -m "feat(daemon): pass session context to sdk mcp senders"
+```
+
+## Task 2: Add Parent-Hosted SDK MCP Runtime Marker
+
+**Files:**
+
+- Modify: `packages/acp-bridge/src/bridgeTypes.ts`
+- Modify: `packages/cli/src/acp-integration/acpAgent.ts`
+- Test: `packages/cli/src/acp-integration/acpAgent.test.ts`
+
+- [ ] **Step 1: Write failing test for parent-hosted marker**
+
+Add a test near existing runtime MCP add tests in `packages/cli/src/acp-integration/acpAgent.test.ts`:
+
+```ts
+it('keeps sdk type for parent-hosted runtime MCP servers', async () => {
+  const manager = createRuntimeMcpManagerSpy();
+  const agent = createAcpAgentWithRuntimeMcpManager(manager);
+
+  await agent.handleExtMethod(
+    SERVE_CONTROL_EXT_METHODS.workspaceMcpRuntimeAdd,
+    {
+      name: 'qwen-a2a',
+      originatorClientId: 'daemon-a2a:test',
+      config: {
+        type: 'sdk',
+        __parentHostedMcp: true,
+      },
+    },
+  );
+
+  expect(manager.addRuntimeMcpServer).toHaveBeenCalledWith(
+    'qwen-a2a',
+    expect.objectContaining({ type: 'sdk' }),
+    'daemon-a2a:test',
+  );
+});
+```
+
+Use the existing helpers in the file for `workspaceMcpRuntimeAdd`; do not introduce a new fake ACP stack if a helper already exists.
+
+- [ ] **Step 2: Run failing test**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
+```
+
+Expected: the new test fails because the current sanitize path strips `type` unless `__clientMcpOverWs` is true.
+
+- [ ] **Step 3: Add marker constant**
+
+In `packages/acp-bridge/src/bridgeTypes.ts`, near `CLIENT_MCP_OVER_WS_CONFIG_FLAG`, add:
+
+```ts
+export const PARENT_HOSTED_MCP_CONFIG_FLAG = '__parentHostedMcp' as const;
+
+export type ParentHostedMcpRuntimeConfig = Record<string, unknown> & {
+  type: 'sdk';
+  [PARENT_HOSTED_MCP_CONFIG_FLAG]: true;
+};
+```
+
+- [ ] **Step 4: Preserve sdk type for either marker**
+
+In `packages/cli/src/acp-integration/acpAgent.ts`, import the new constant and include it in config destructuring:
+
+```ts
+const {
+  trust: _trust,
+  authProviderType: _auth,
+  includeTools: _inc,
+  excludeTools: _exc,
+  cwd: _cwd,
+  env: _env,
+  oauth: _oauth,
+  headers: _headers,
+  type: _type,
+  [CLIENT_MCP_OVER_WS_CONFIG_FLAG]: clientMcpOverWs,
+  [PARENT_HOSTED_MCP_CONFIG_FLAG]: parentHostedMcp,
+  ...safeConfig
+} = config as ClientMcpOverWsRuntimeConfig & ParentHostedMcpRuntimeConfig;
+
+if (clientMcpOverWs === true || parentHostedMcp === true) {
+  (safeConfig as Record<string, unknown>)['type'] = 'sdk';
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts
+```
+
+Expected: the new test and existing runtime MCP tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/acp-bridge/src/bridgeTypes.ts packages/cli/src/acp-integration/acpAgent.ts packages/cli/src/acp-integration/acpAgent.test.ts
+git commit -m "feat(daemon): support parent-hosted sdk mcp servers"
+```
+
+## Task 3: Add A2A Types, Settings Normalization, and Capabilities
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/types.ts`
+- Create: `packages/cli/src/serve/a2a/settings.ts`
+- Create: `packages/cli/src/serve/a2a/settings.test.ts`
+- Create: `packages/cli/src/serve/a2a/index.ts`
+- Modify: `packages/cli/src/config/settingsSchema.ts`
+- Modify: `packages/cli/src/config/settingsSchema.test.ts`
+- Modify: `packages/cli/src/serve/capabilities.ts`
+- Modify: `packages/cli/src/serve/server/serve-features.ts`
+- Modify: `packages/cli/src/serve/types.ts`
+- Test: `packages/cli/src/serve/server/serve-features.test.ts` if present; otherwise add assertions to `packages/cli/src/serve/server.test.ts`.
+
+- [ ] **Step 1: Write failing settings tests**
+
+Create `packages/cli/src/serve/a2a/settings.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeA2aSettings, resolveA2aTokenRef } from './settings.js';
+
+describe('normalizeA2aSettings', () => {
+  it('normalizes explicit and trusted peers', () => {
+    const result = normalizeA2aSettings({
+      enabled: true,
+      explicitPeers: [
+        {
+          id: 'peer-1',
+          alias: 'api',
+          url: 'http://127.0.0.1:4171',
+          tokenRef: 'env:QWEN_A2A_PEER_1_TOKEN',
+        },
+      ],
+      trustedPeers: {
+        'peer-1': {
+          url: 'http://127.0.0.1:4171',
+          tokenRef: 'env:QWEN_A2A_PEER_1_TOKEN',
+        },
+      },
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.explicitPeers).toEqual([
+      {
+        id: 'peer-1',
+        alias: 'api',
+        url: 'http://127.0.0.1:4171',
+        tokenRef: 'env:QWEN_A2A_PEER_1_TOKEN',
+      },
+    ]);
+    expect(result.trustedPeers.get('peer-1')?.url).toBe(
+      'http://127.0.0.1:4171',
+    );
+  });
+
+  it('defaults to disabled for missing or invalid input', () => {
+    expect(normalizeA2aSettings(undefined).enabled).toBe(false);
+    expect(normalizeA2aSettings({ enabled: 'yes' }).enabled).toBe(false);
+  });
+});
+
+describe('resolveA2aTokenRef', () => {
+  it('resolves env token references at call time', () => {
+    vi.stubEnv('QWEN_A2A_TEST_TOKEN', 'secret-token');
+    expect(resolveA2aTokenRef('env:QWEN_A2A_TEST_TOKEN')).toBe('secret-token');
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects non-env token references in v1', () => {
+    expect(() => resolveA2aTokenRef('file:/tmp/token')).toThrow(
+      'Unsupported A2A tokenRef',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/settings.test.ts
+```
+
+Expected: fails because files do not exist.
+
+- [ ] **Step 3: Add A2A shared types**
+
+Create `packages/cli/src/serve/a2a/types.ts`:
+
+```ts
+export const A2A_MCP_SERVER_NAME = 'qwen-a2a' as const;
+export const A2A_MCP_ORIGINATOR_CLIENT_ID = 'daemon-a2a:local' as const;
+export const A2A_CONTEXT_SUMMARY_MAX_CHARS = 4000;
+export const A2A_MAX_DEPTH = 1;
+
+export type A2aPeerSource = 'local' | 'explicit';
+
+export interface A2aPeerConfig {
+  id: string;
+  alias?: string;
+  url: string;
+  tokenRef?: string;
+}
+
+export interface A2aSettings {
+  enabled: boolean;
+  explicitPeers: A2aPeerConfig[];
+  trustedPeers: Map<string, A2aPeerConfig>;
+}
+
+export interface A2aPeerCandidate extends A2aPeerConfig {
+  source: A2aPeerSource;
+  workspaceCwd?: string;
+  daemonId?: string;
+  pid?: number;
+  startedAt?: string;
+  lastSeenAt?: string;
+  trusted: boolean;
+  callable: boolean;
+}
+
+export type A2aErrorCode =
+  | 'peer_not_found'
+  | 'peer_not_trusted'
+  | 'peer_unreachable'
+  | 'peer_auth_failed'
+  | 'peer_capability_mismatch'
+  | 'peer_permission_timeout'
+  | 'peer_prompt_failed'
+  | 'peer_response_timeout'
+  | 'a2a_depth_exceeded'
+  | 'peer_alias_ambiguous';
+
+export class A2aError extends Error {
+  constructor(
+    readonly code: A2aErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'A2aError';
+  }
+}
+```
+
+- [ ] **Step 4: Add settings normalizer**
+
+Create `packages/cli/src/serve/a2a/settings.ts` with strict shape checks:
+
+```ts
+import type { A2aPeerConfig, A2aSettings } from './types.js';
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizePeer(value: unknown): A2aPeerConfig | undefined {
+  const obj = asObject(value);
+  if (!obj) return undefined;
+  const id = obj['id'];
+  const alias = obj['alias'];
+  const url = obj['url'];
+  const tokenRef = obj['tokenRef'];
+  if (typeof id !== 'string' || id.length === 0) return undefined;
+  if (typeof url !== 'string' || url.length === 0) return undefined;
+  return {
+    id,
+    ...(typeof alias === 'string' && alias.length > 0 ? { alias } : {}),
+    url,
+    ...(typeof tokenRef === 'string' && tokenRef.length > 0
+      ? { tokenRef }
+      : {}),
+  };
+}
+
+export function normalizeA2aSettings(value: unknown): A2aSettings {
+  const obj = asObject(value);
+  if (!obj || obj['enabled'] !== true) {
+    return { enabled: false, explicitPeers: [], trustedPeers: new Map() };
+  }
+
+  const explicitPeers = Array.isArray(obj['explicitPeers'])
+    ? obj['explicitPeers'].flatMap((entry) => {
+        const peer = normalizePeer(entry);
+        return peer ? [peer] : [];
+      })
+    : [];
+
+  const trustedPeers = new Map<string, A2aPeerConfig>();
+  const rawTrusted = asObject(obj['trustedPeers']);
+  if (rawTrusted) {
+    for (const [id, rawPeer] of Object.entries(rawTrusted)) {
+      const peer = normalizePeer({ id, ...(asObject(rawPeer) ?? {}) });
+      if (peer) trustedPeers.set(id, peer);
+    }
+  }
+
+  return { enabled: true, explicitPeers, trustedPeers };
+}
+
+export function resolveA2aTokenRef(
+  tokenRef: string | undefined,
+): string | undefined {
+  if (tokenRef === undefined) return undefined;
+  if (!tokenRef.startsWith('env:')) {
+    throw new Error(`Unsupported A2A tokenRef '${tokenRef}'`);
+  }
+  const envName = tokenRef.slice('env:'.length);
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envName)) {
+    throw new Error(`Invalid A2A env tokenRef '${tokenRef}'`);
+  }
+  return process.env[envName];
+}
+```
+
+- [ ] **Step 5: Add settings schema**
+
+In `packages/cli/src/config/settingsSchema.ts`, add top-level `a2a` schema with `showInDialog: false`, `requiresRestart: true`, `type: 'object'`, and properties for `enabled`, `explicitPeers`, and `trustedPeers`. Add a test in `settingsSchema.test.ts`:
+
+```ts
+it('defines the a2a settings namespace as advanced hidden config', () => {
+  const a2a = getSettingsSchema().a2a;
+  expect(a2a.type).toBe('object');
+  expect(a2a.requiresRestart).toBe(true);
+  expect(a2a.showInDialog).toBe(false);
+});
+```
+
+- [ ] **Step 6: Add capability tags and option**
+
+In `packages/cli/src/serve/types.ts`, add:
+
+```ts
+a2aEnabled?: boolean;
+```
+
+In `packages/cli/src/serve/capabilities.ts`, add registry entries:
+
+```ts
+daemon_a2a_discovery: { since: 'v1' },
+daemon_a2a_peer_call: { since: 'v1' },
+daemon_a2a_mcp_tool: { since: 'v1' },
+```
+
+Add `a2aEnabled?: boolean` to `AdvertiseFeatureToggles`, and add predicates for the three tags:
+
+```ts
+['daemon_a2a_discovery', (toggles) => toggles.a2aEnabled === true],
+['daemon_a2a_peer_call', (toggles) => toggles.a2aEnabled === true],
+['daemon_a2a_mcp_tool', (toggles) => toggles.a2aEnabled === true],
+```
+
+In `packages/cli/src/serve/server/serve-features.ts`, pass `a2aEnabled: opts.a2aEnabled === true`.
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/settings.test.ts src/config/settingsSchema.test.ts src/serve/server.test.ts
+```
+
+Expected: passes, including existing conditional feature tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/types.ts packages/cli/src/serve/a2a/settings.ts packages/cli/src/serve/a2a/settings.test.ts packages/cli/src/serve/a2a/index.ts packages/cli/src/config/settingsSchema.ts packages/cli/src/config/settingsSchema.test.ts packages/cli/src/serve/capabilities.ts packages/cli/src/serve/server/serve-features.ts packages/cli/src/serve/types.ts packages/cli/src/serve/server.test.ts
+git commit -m "feat(daemon): add a2a settings and capabilities"
+```
+
+## Task 4: Implement Local A2A Registry
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/registry.ts`
+- Create: `packages/cli/src/serve/a2a/registry.test.ts`
+- Modify: `packages/cli/src/serve/a2a/index.ts`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Create `packages/cli/src/serve/a2a/registry.test.ts`:
+
+```ts
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  readA2aRegistry,
+  upsertA2aRegistryEntry,
+  pruneA2aRegistryEntries,
+} from './registry.js';
+
+describe('A2A local registry', () => {
+  it('upserts a daemon entry without storing tokens', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-a2a-'));
+    const file = path.join(dir, 'daemon-registry.json');
+
+    upsertA2aRegistryEntry(file, {
+      daemonId: 'daemon-1',
+      workspaceCwd: '/repo/a',
+      url: 'http://127.0.0.1:4170',
+      pid: 123,
+      startedAt: '2026-07-07T00:00:00.000Z',
+      lastSeenAt: '2026-07-07T00:00:01.000Z',
+      capabilitiesHash: 'abc',
+    });
+
+    const text = fs.readFileSync(file, 'utf8');
+    expect(text).not.toContain('token');
+    expect(readA2aRegistry(file)).toHaveLength(1);
+  });
+
+  it('prunes stale entries by lastSeenAt', () => {
+    const entries = pruneA2aRegistryEntries(
+      [
+        {
+          daemonId: 'fresh',
+          workspaceCwd: '/repo/fresh',
+          url: 'http://127.0.0.1:4170',
+          pid: 1,
+          startedAt: '2026-07-07T00:00:00.000Z',
+          lastSeenAt: '2026-07-07T00:00:10.000Z',
+          capabilitiesHash: 'fresh',
+        },
+        {
+          daemonId: 'stale',
+          workspaceCwd: '/repo/stale',
+          url: 'http://127.0.0.1:4171',
+          pid: 2,
+          startedAt: '2026-07-07T00:00:00.000Z',
+          lastSeenAt: '2026-07-07T00:00:00.000Z',
+          capabilitiesHash: 'stale',
+        },
+      ],
+      Date.parse('2026-07-07T00:01:00.000Z'),
+      55_000,
+    );
+
+    expect(entries.map((entry) => entry.daemonId)).toEqual(['fresh']);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/registry.test.ts
+```
+
+Expected: fails because registry module does not exist.
+
+- [ ] **Step 3: Implement registry helpers**
+
+Create `packages/cli/src/serve/a2a/registry.ts`:
+
+```ts
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface A2aRegistryEntry {
+  daemonId: string;
+  workspaceCwd: string;
+  url: string;
+  pid: number;
+  startedAt: string;
+  lastSeenAt: string;
+  capabilitiesHash: string;
+}
+
+export interface A2aRegistryFile {
+  v: 1;
+  entries: A2aRegistryEntry[];
+}
+
+function isEntry(value: unknown): value is A2aRegistryEntry {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['daemonId'] === 'string' &&
+    typeof obj['workspaceCwd'] === 'string' &&
+    typeof obj['url'] === 'string' &&
+    typeof obj['pid'] === 'number' &&
+    typeof obj['startedAt'] === 'string' &&
+    typeof obj['lastSeenAt'] === 'string' &&
+    typeof obj['capabilitiesHash'] === 'string'
+  );
+}
+
+export function readA2aRegistry(filePath: string): A2aRegistryEntry[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return [];
+    }
+    const entries = (parsed as { entries?: unknown }).entries;
+    return Array.isArray(entries) ? entries.filter(isEntry) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function pruneA2aRegistryEntries(
+  entries: A2aRegistryEntry[],
+  nowMs: number,
+  maxAgeMs: number,
+): A2aRegistryEntry[] {
+  return entries.filter((entry) => {
+    const lastSeen = Date.parse(entry.lastSeenAt);
+    return Number.isFinite(lastSeen) && nowMs - lastSeen <= maxAgeMs;
+  });
+}
+
+export function writeA2aRegistry(
+  filePath: string,
+  entries: A2aRegistryEntry[],
+): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ v: 1, entries } satisfies A2aRegistryFile, null, 2),
+  );
+}
+
+export function upsertA2aRegistryEntry(
+  filePath: string,
+  entry: A2aRegistryEntry,
+): void {
+  const next = readA2aRegistry(filePath).filter(
+    (candidate) => candidate.daemonId !== entry.daemonId,
+  );
+  next.push(entry);
+  writeA2aRegistry(filePath, next);
+}
+```
+
+- [ ] **Step 4: Export registry helpers**
+
+In `packages/cli/src/serve/a2a/index.ts`:
+
+```ts
+export * from './registry.js';
+export * from './settings.js';
+export * from './types.js';
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/registry.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/registry.ts packages/cli/src/serve/a2a/registry.test.ts packages/cli/src/serve/a2a/index.ts
+git commit -m "feat(daemon): add local a2a registry"
+```
+
+## Task 5: Implement A2A Peer Client and Context Builder
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/context.ts`
+- Create: `packages/cli/src/serve/a2a/context.test.ts`
+- Create: `packages/cli/src/serve/a2a/peer-client.ts`
+- Create: `packages/cli/src/serve/a2a/peer-client.test.ts`
+- Modify: `packages/cli/src/serve/a2a/index.ts`
+
+- [ ] **Step 1: Write context builder tests**
+
+Create `packages/cli/src/serve/a2a/context.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { buildA2aPromptBlocks } from './context.js';
+
+describe('buildA2aPromptBlocks', () => {
+  it('includes task, user request, bounded recap, and caller identity', async () => {
+    const bridge = {
+      generateSessionRecap: vi.fn().mockResolvedValue({
+        sessionId: 's1',
+        recap: 'x'.repeat(5000),
+      }),
+    };
+
+    const blocks = await buildA2aPromptBlocks({
+      bridge,
+      sessionId: 's1',
+      callerDaemonId: 'daemon-a',
+      callerWorkspace: '/repo/a',
+      task: 'Inspect the API tests',
+      currentUserRequest: 'Please ask repo B to inspect tests',
+    });
+
+    const text = blocks[0]!.text;
+    expect(text).toContain('Inspect the API tests');
+    expect(text).toContain('Please ask repo B to inspect tests');
+    expect(text).toContain('/repo/a');
+    expect(text.length).toBeLessThan(4600);
+  });
+});
+```
+
+- [ ] **Step 2: Implement context builder**
+
+Create `packages/cli/src/serve/a2a/context.ts`:
+
+```ts
+import type { AcpSessionBridge } from '../acp-session-bridge.js';
+import { A2A_CONTEXT_SUMMARY_MAX_CHARS } from './types.js';
+
+export interface BuildA2aPromptBlocksOptions {
+  bridge: Pick<AcpSessionBridge, 'generateSessionRecap'>;
+  sessionId?: string;
+  callerDaemonId: string;
+  callerWorkspace: string;
+  task: string;
+  currentUserRequest?: string;
+}
+
+export interface A2aTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export async function buildA2aPromptBlocks(
+  opts: BuildA2aPromptBlocksOptions,
+): Promise<A2aTextBlock[]> {
+  const recap =
+    opts.sessionId !== undefined
+      ? (
+          await opts.bridge.generateSessionRecap(opts.sessionId).catch(() => ({
+            sessionId: opts.sessionId!,
+            recap: null,
+          }))
+        ).recap
+      : null;
+  const boundedRecap =
+    recap !== null ? recap.slice(0, A2A_CONTEXT_SUMMARY_MAX_CHARS) : '';
+  const text = [
+    'You are receiving an A2A delegated task from another qwen daemon.',
+    `Caller daemon: ${opts.callerDaemonId}`,
+    `Caller workspace: ${opts.callerWorkspace}`,
+    opts.currentUserRequest
+      ? `Current user request: ${opts.currentUserRequest}`
+      : 'Current user request: not provided',
+    boundedRecap
+      ? `Recent caller session summary: ${boundedRecap}`
+      : 'Recent caller session summary: unavailable',
+    `Delegated task: ${opts.task}`,
+    'Work only inside your own daemon workspace and follow your local permission policy.',
+  ].join('\n\n');
+  return [{ type: 'text', text }];
+}
+```
+
+- [ ] **Step 3: Write peer client tests**
+
+Create `packages/cli/src/serve/a2a/peer-client.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { A2aPeerClient } from './peer-client.js';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('A2aPeerClient', () => {
+  it('maps auth failure to peer_auth_failed', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, 401));
+    const client = new A2aPeerClient({ fetch: fetchImpl });
+
+    await expect(
+      client.askPeer({
+        peer: { id: 'p', url: 'http://127.0.0.1:4171', token: 'bad' },
+        prompt: [{ type: 'text', text: 'hello' }],
+        clientId: 'daemon-a2a:test',
+        timeoutMs: 1000,
+      }),
+    ).rejects.toMatchObject({ code: 'peer_auth_failed' });
+  });
+
+  it('submits prompt and closes the peer session', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          features: [
+            'capabilities',
+            'session_create',
+            'session_prompt',
+            'session_events',
+            'session_close',
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ sessionId: 'peer-session' }))
+      .mockResolvedValueOnce(jsonResponse({ promptId: 'prompt-1' }, 202))
+      .mockResolvedValueOnce(
+        new Response(
+          [
+            'event: session_update',
+            'data: {"type":"session_update","data":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}}',
+            '',
+            'event: turn_complete',
+            'data: {"type":"turn_complete","data":{"stopReason":"end_turn"}}',
+            '',
+          ].join('\n'),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const client = new A2aPeerClient({ fetch: fetchImpl });
+    const result = await client.askPeer({
+      peer: { id: 'p', url: 'http://127.0.0.1:4171' },
+      prompt: [{ type: 'text', text: 'hello' }],
+      clientId: 'daemon-a2a:test',
+      timeoutMs: 1000,
+    });
+
+    expect(result.text).toBe('done');
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      'http://127.0.0.1:4171/session/peer-session',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 4: Implement peer client**
+
+Create `packages/cli/src/serve/a2a/peer-client.ts` with these public shapes:
+
+```ts
+import { A2aError, type A2aPeerConfig } from './types.js';
+import type { A2aTextBlock } from './context.js';
+
+export interface ResolvedA2aPeer extends A2aPeerConfig {
+  token?: string;
+}
+
+export interface AskPeerOptions {
+  peer: ResolvedA2aPeer;
+  prompt: A2aTextBlock[];
+  clientId: string;
+  timeoutMs: number;
+}
+
+export interface AskPeerResult {
+  peerId: string;
+  sessionId: string;
+  text: string;
+}
+
+export class A2aPeerClient {
+  constructor(
+    private readonly deps: {
+      fetch?: typeof fetch;
+    } = {},
+  ) {}
+
+  async askPeer(opts: AskPeerOptions): Promise<AskPeerResult> {
+    const fetchImpl = this.deps.fetch ?? fetch;
+    const baseUrl = opts.peer.url.replace(/\/+$/, '');
+    const headers = this.headers(opts.peer.token, opts.clientId);
+
+    await this.checkCapabilities(fetchImpl, baseUrl, headers);
+    const sessionId = await this.createSession(fetchImpl, baseUrl, headers);
+    try {
+      await this.submitPrompt(
+        fetchImpl,
+        baseUrl,
+        sessionId,
+        headers,
+        opts.prompt,
+      );
+      const text = await this.readFinalText(
+        fetchImpl,
+        baseUrl,
+        sessionId,
+        headers,
+      );
+      return { peerId: opts.peer.id, sessionId, text };
+    } finally {
+      await fetchImpl(`${baseUrl}/session/${encodeURIComponent(sessionId)}`, {
+        method: 'DELETE',
+        headers,
+      }).catch(() => undefined);
+    }
+  }
+
+  private headers(token: string | undefined, clientId: string): HeadersInit {
+    return {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      'X-Qwen-Client-Id': clientId,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async checkCapabilities(
+    fetchImpl: typeof fetch,
+    baseUrl: string,
+    headers: HeadersInit,
+  ): Promise<void> {
+    const res = await fetchImpl(`${baseUrl}/capabilities`, { headers });
+    if (res.status === 401)
+      throw new A2aError('peer_auth_failed', 'Peer rejected A2A token');
+    if (!res.ok)
+      throw new A2aError(
+        'peer_unreachable',
+        `Peer capabilities failed with ${res.status}`,
+      );
+    const body = (await res.json()) as { features?: unknown };
+    const features = Array.isArray(body.features) ? body.features : [];
+    for (const feature of [
+      'session_create',
+      'session_prompt',
+      'session_events',
+      'session_close',
+    ]) {
+      if (!features.includes(feature)) {
+        throw new A2aError('peer_capability_mismatch', `Peer lacks ${feature}`);
+      }
+    }
+  }
+}
+```
+
+Add private methods for `createSession`, `submitPrompt`, and `readFinalText` in the same file. `readFinalText` should parse SSE `data:` lines, append `agent_message_chunk` text content, and resolve on `turn_complete`; throw `peer_response_timeout` if the stream ends without a terminal turn.
+
+- [ ] **Step 5: Export context and peer client**
+
+In `packages/cli/src/serve/a2a/index.ts`:
+
+```ts
+export * from './context.js';
+export * from './peer-client.js';
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/context.test.ts src/serve/a2a/peer-client.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/context.ts packages/cli/src/serve/a2a/context.test.ts packages/cli/src/serve/a2a/peer-client.ts packages/cli/src/serve/a2a/peer-client.test.ts packages/cli/src/serve/a2a/index.ts
+git commit -m "feat(daemon): add a2a peer client"
+```
+
+## Task 6: Implement A2A Service and MCP Responder
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/service.ts`
+- Create: `packages/cli/src/serve/a2a/service.test.ts`
+- Create: `packages/cli/src/serve/a2a/mcp-server.ts`
+- Create: `packages/cli/src/serve/a2a/mcp-server.test.ts`
+- Modify: `packages/cli/src/serve/a2a/index.ts`
+
+- [ ] **Step 1: Write service tests for trust and ambiguity**
+
+Create `packages/cli/src/serve/a2a/service.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { A2aService } from './service.js';
+
+describe('A2aService', () => {
+  it('rejects untrusted peers', async () => {
+    const service = new A2aService({
+      settings: {
+        enabled: true,
+        explicitPeers: [{ id: 'peer-1', alias: 'api', url: 'http://x' }],
+        trustedPeers: new Map(),
+      },
+      localPeers: [],
+      bridge: { generateSessionRecap: vi.fn() },
+      peerClient: { askPeer: vi.fn() },
+      callerDaemonId: 'daemon-a',
+      callerWorkspace: '/repo/a',
+    });
+
+    await expect(
+      service.askPeer({
+        peer: 'api',
+        task: 'inspect',
+        sessionId: 's1',
+      }),
+    ).rejects.toMatchObject({ code: 'peer_not_trusted' });
+  });
+});
+```
+
+- [ ] **Step 2: Implement service**
+
+Create `packages/cli/src/serve/a2a/service.ts`:
+
+```ts
+import type { AcpSessionBridge } from '../acp-session-bridge.js';
+import { buildA2aPromptBlocks } from './context.js';
+import { A2aPeerClient, type AskPeerResult } from './peer-client.js';
+import {
+  A2A_MAX_DEPTH,
+  A2aError,
+  type A2aPeerCandidate,
+  type A2aSettings,
+} from './types.js';
+import { resolveA2aTokenRef } from './settings.js';
+
+export interface A2aServiceDeps {
+  settings: A2aSettings;
+  localPeers: A2aPeerCandidate[];
+  bridge: Pick<AcpSessionBridge, 'generateSessionRecap'>;
+  peerClient?: Pick<A2aPeerClient, 'askPeer'>;
+  callerDaemonId: string;
+  callerWorkspace: string;
+}
+
+export interface A2aAskRequest {
+  peer: string;
+  task: string;
+  sessionId?: string;
+  currentUserRequest?: string;
+  depth?: number;
+}
+
+export class A2aService {
+  private readonly peerClient: Pick<A2aPeerClient, 'askPeer'>;
+
+  constructor(private readonly deps: A2aServiceDeps) {
+    this.peerClient = deps.peerClient ?? new A2aPeerClient();
+  }
+
+  listPeers(): A2aPeerCandidate[] {
+    return [
+      ...this.deps.localPeers,
+      ...this.deps.settings.explicitPeers.map((peer) => {
+        const trusted = this.deps.settings.trustedPeers.has(peer.id);
+        return {
+          ...peer,
+          source: 'explicit' as const,
+          trusted,
+          callable: trusted,
+        };
+      }),
+    ];
+  }
+
+  async askPeer(req: A2aAskRequest): Promise<AskPeerResult> {
+    if ((req.depth ?? 0) >= A2A_MAX_DEPTH) {
+      throw new A2aError('a2a_depth_exceeded', 'A2A depth exceeded');
+    }
+    const peer = this.resolvePeer(req.peer);
+    const trusted = this.deps.settings.trustedPeers.get(peer.id);
+    if (!trusted) {
+      throw new A2aError(
+        'peer_not_trusted',
+        `Peer '${req.peer}' is not trusted`,
+      );
+    }
+    const token = resolveA2aTokenRef(trusted.tokenRef);
+    const prompt = await buildA2aPromptBlocks({
+      bridge: this.deps.bridge,
+      sessionId: req.sessionId,
+      callerDaemonId: this.deps.callerDaemonId,
+      callerWorkspace: this.deps.callerWorkspace,
+      task: req.task,
+      currentUserRequest: req.currentUserRequest,
+    });
+    return this.peerClient.askPeer({
+      peer: { ...trusted, token },
+      prompt,
+      clientId: `daemon-a2a:${this.deps.callerDaemonId}`,
+      timeoutMs: 120_000,
+    });
+  }
+
+  private resolvePeer(peerRef: string): A2aPeerCandidate {
+    const matches = this.listPeers().filter(
+      (peer) => peer.id === peerRef || peer.alias === peerRef,
+    );
+    if (matches.length === 0) {
+      throw new A2aError('peer_not_found', `Peer '${peerRef}' was not found`);
+    }
+    if (matches.length > 1) {
+      throw new A2aError(
+        'peer_alias_ambiguous',
+        `Peer '${peerRef}' is ambiguous`,
+      );
+    }
+    return matches[0]!;
+  }
+}
+```
+
+- [ ] **Step 3: Write MCP responder tests**
+
+Create `packages/cli/src/serve/a2a/mcp-server.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { createA2aMcpSender } from './mcp-server.js';
+
+describe('createA2aMcpSender', () => {
+  it('lists ask_peer_daemon', async () => {
+    const send = createA2aMcpSender({ askPeer: vi.fn() });
+    const response = await send('qwen-a2a', {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    });
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        tools: [expect.objectContaining({ name: 'ask_peer_daemon' })],
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Implement MCP responder**
+
+Create `packages/cli/src/serve/a2a/mcp-server.ts`:
+
+```ts
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import type { ClientMcpSenderContext } from '@qwen-code/acp-bridge/bridgeOptions';
+import type { A2aService } from './service.js';
+
+function response(id: unknown, result: unknown): JSONRPCMessage {
+  return { jsonrpc: '2.0', id, result } as JSONRPCMessage;
+}
+
+function errorResponse(
+  id: unknown,
+  code: number,
+  message: string,
+): JSONRPCMessage {
+  return { jsonrpc: '2.0', id, error: { code, message } } as JSONRPCMessage;
+}
+
+export function createA2aMcpSender(service: Pick<A2aService, 'askPeer'>) {
+  return async (
+    _serverName: string,
+    message: JSONRPCMessage,
+    context?: ClientMcpSenderContext,
+  ): Promise<JSONRPCMessage> => {
+    const request = message as {
+      id?: unknown;
+      method?: unknown;
+      params?: unknown;
+    };
+    if (request.id === undefined) return response(0, {});
+    if (request.method === 'initialize') {
+      return response(request.id, {
+        protocolVersion: '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'qwen-a2a', version: '1.0.0' },
+      });
+    }
+    if (request.method === 'tools/list') {
+      return response(request.id, {
+        tools: [
+          {
+            name: 'ask_peer_daemon',
+            description:
+              'Ask a trusted qwen daemon peer to work in its own workspace.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                peer: { type: 'string' },
+                task: { type: 'string' },
+              },
+              required: ['peer', 'task'],
+            },
+          },
+        ],
+      });
+    }
+    if (request.method === 'tools/call') {
+      const params = request.params as { name?: unknown; arguments?: unknown };
+      if (params.name !== 'ask_peer_daemon') {
+        return errorResponse(request.id, -32601, 'Unknown A2A tool');
+      }
+      const args = params.arguments as { peer?: unknown; task?: unknown };
+      if (typeof args.peer !== 'string' || typeof args.task !== 'string') {
+        return errorResponse(
+          request.id,
+          -32602,
+          '`peer` and `task` must be strings',
+        );
+      }
+      const result = await service.askPeer({
+        peer: args.peer,
+        task: args.task,
+        sessionId: context?.sessionId,
+      });
+      return response(request.id, {
+        content: [{ type: 'text', text: result.text }],
+      });
+    }
+    return errorResponse(
+      request.id,
+      -32601,
+      `Unsupported method ${String(request.method)}`,
+    );
+  };
+}
+```
+
+- [ ] **Step 5: Update sender registry to pass context to A2A sender**
+
+In `packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts`, split the internal sender type so WS senders and parent-hosted senders share one context-aware map:
+
+```ts
+type RegistrySender = (
+  serverName: string,
+  payload: unknown,
+  context?: ClientMcpSenderContext,
+) => Promise<unknown>;
+
+private readonly senders = new Map<
+  string,
+  { sender: RegistrySender; owner: string }
+>();
+```
+
+Keep the existing `set` method signature for browser-hosted WS MCP servers and adapt it into the generic map:
+
+```ts
+set(serverName: string, sender: WsClientMcpSender, owner: string): void {
+  this.senders.set(serverName, {
+    owner,
+    sender: (name, payload) =>
+      sender(name, payload as JSONRPCMessage) as Promise<unknown>,
+  });
+}
+```
+
+Add a parent-hosted setter for A2A:
+
+```ts
+setParentHosted(
+  serverName: string,
+  sender: RegistrySender,
+  owner: string,
+): void {
+  this.senders.set(serverName, { sender, owner });
+}
+```
+
+Update `lookup` so A2A can receive the calling session id:
+
+```ts
+readonly lookup: ClientMcpMessageSender = (serverName, context) => {
+  const entry = this.senders.get(serverName);
+  if (!entry) return undefined;
+  return (payload: unknown) => entry.sender(serverName, payload, context);
+};
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/service.test.ts src/serve/a2a/mcp-server.test.ts src/serve/acp-http/client-mcp-sender-registry.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/service.ts packages/cli/src/serve/a2a/service.test.ts packages/cli/src/serve/a2a/mcp-server.ts packages/cli/src/serve/a2a/mcp-server.test.ts packages/cli/src/serve/a2a/index.ts packages/cli/src/serve/acp-http/client-mcp-sender-registry.ts packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
+git commit -m "feat(daemon): add a2a mcp responder"
+```
+
+## Task 7: Wire A2A Into Serve Routes and Runtime MCP Registration
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/routes.ts`
+- Create: `packages/cli/src/serve/a2a/routes.test.ts`
+- Modify: `packages/cli/src/serve/server.ts`
+- Modify: `packages/cli/src/serve/server.test.ts`
+
+- [ ] **Step 1: Write route tests**
+
+Create `packages/cli/src/serve/a2a/routes.test.ts`:
+
+```ts
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { registerA2aRoutes } from './routes.js';
+
+describe('registerA2aRoutes', () => {
+  it('lists discovered peers without tokens', async () => {
+    const app = express();
+    registerA2aRoutes(app, {
+      service: {
+        listPeers: () => [
+          {
+            id: 'peer-1',
+            alias: 'api',
+            url: 'http://127.0.0.1:4171',
+            source: 'explicit',
+            trusted: true,
+            callable: true,
+            tokenRef: 'env:SECRET',
+          },
+        ],
+      },
+    });
+
+    const res = await request(app).get('/workspace/a2a/peers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.peers[0]).toMatchObject({
+      id: 'peer-1',
+      alias: 'api',
+      callable: true,
+    });
+    expect(JSON.stringify(res.body)).not.toContain('SECRET');
+    expect(JSON.stringify(res.body)).not.toContain('tokenRef');
+  });
+});
+```
+
+- [ ] **Step 2: Implement route**
+
+Create `packages/cli/src/serve/a2a/routes.ts`:
+
+```ts
+import type { Application } from 'express';
+import type { A2aService } from './service.js';
+
+export function registerA2aRoutes(
+  app: Application,
+  deps: { service: Pick<A2aService, 'listPeers'> },
+): void {
+  app.get('/workspace/a2a/peers', (_req, res) => {
+    res.status(200).json({
+      v: 1,
+      peers: deps.service.listPeers().map((peer) => ({
+        id: peer.id,
+        ...(peer.alias ? { alias: peer.alias } : {}),
+        url: peer.url,
+        source: peer.source,
+        trusted: peer.trusted,
+        callable: peer.callable,
+        ...(peer.workspaceCwd ? { workspaceCwd: peer.workspaceCwd } : {}),
+        ...(peer.daemonId ? { daemonId: peer.daemonId } : {}),
+        ...(peer.lastSeenAt ? { lastSeenAt: peer.lastSeenAt } : {}),
+      })),
+    });
+  });
+}
+```
+
+- [ ] **Step 3: Add serve app wiring**
+
+In `packages/cli/src/serve/server.ts`:
+
+1. Import A2A service, MCP sender, settings normalizer, and route registration.
+2. Normalize `opts.a2aEnabled` and `loadedSettings.merged.a2a` through injected settings.
+3. Construct `A2aService`.
+4. Register `/workspace/a2a/peers`.
+5. Register the `qwen-a2a` sender in `clientMcpSenderRegistry`.
+6. After bridge creation, expose a helper that registers `qwen-a2a` with `bridge.addRuntimeMcpServer`.
+
+The registration helper should be idempotent:
+
+```ts
+async function ensureA2aRuntimeMcpRegistered(): Promise<void> {
+  if (!a2aEnabled) return;
+  clientMcpSenderRegistry.setParentHosted(
+    A2A_MCP_SERVER_NAME,
+    createA2aMcpSender(a2aService),
+    A2A_MCP_ORIGINATOR_CLIENT_ID,
+  );
+  await primaryBridge.addRuntimeMcpServer(
+    A2A_MCP_SERVER_NAME,
+    { type: 'sdk', [PARENT_HOSTED_MCP_CONFIG_FLAG]: true },
+    A2A_MCP_ORIGINATOR_CLIENT_ID,
+  );
+}
+```
+
+Call it from a place where the bridge is live. If `createServeApp` cannot know live channel state, attach it to `app.locals.ensureA2aRuntimeMcpRegistered` and call it from `run-qwen-serve.ts` after preheat and after first session spawn in the next task.
+
+- [ ] **Step 4: Run route and server tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/routes.test.ts src/serve/server.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/routes.ts packages/cli/src/serve/a2a/routes.test.ts packages/cli/src/serve/server.ts packages/cli/src/serve/server.test.ts
+git commit -m "feat(daemon): wire a2a into serve app"
+```
+
+## Task 8: Start Local Advertisement in `runQwenServe`
+
+**Files:**
+
+- Modify: `packages/cli/src/serve/run-qwen-serve.ts`
+- Modify: `packages/cli/src/serve/run-qwen-serve.test.ts`
+- Modify: `packages/cli/src/serve/a2a/registry.ts`
+- Test: `packages/cli/src/serve/run-qwen-serve.test.ts`
+
+- [ ] **Step 1: Write failing lifecycle test**
+
+Add a test in `packages/cli/src/serve/run-qwen-serve.test.ts`:
+
+```ts
+it('writes and cleans up local A2A registry entry when enabled', async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'qws-a2a-'));
+  const registryFile = path.join(workspace, 'daemon-registry.json');
+
+  const handle = await runQwenServe(
+    {
+      hostname: '127.0.0.1',
+      port: 0,
+      mode: 'http-bridge',
+      workspace,
+      a2aEnabled: true,
+    },
+    {
+      preheatBridge: false,
+      a2aRegistryFile: registryFile,
+    },
+  );
+
+  try {
+    const entries = readA2aRegistry(registryFile);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.workspaceCwd).toBe(workspace);
+    expect(entries[0]!.url).toBe(handle.url);
+  } finally {
+    await handle.close();
+  }
+
+  expect(readA2aRegistry(registryFile)).toHaveLength(0);
+});
+```
+
+Add `a2aRegistryFile` as a test-only dependency in `RunQwenServeDeps` rather than hardcoding user state paths in tests.
+
+- [ ] **Step 2: Implement advertisement handle**
+
+In `packages/cli/src/serve/a2a/registry.ts`, add:
+
+```ts
+export interface A2aAdvertisementHandle {
+  refresh(): void;
+  dispose(): void;
+}
+
+export function startA2aAdvertisement(options: {
+  filePath: string;
+  entry: A2aRegistryEntry;
+  intervalMs?: number;
+}): A2aAdvertisementHandle {
+  let disposed = false;
+  const refresh = () => {
+    if (!disposed) {
+      upsertA2aRegistryEntry(options.filePath, {
+        ...options.entry,
+        lastSeenAt: new Date().toISOString(),
+      });
+    }
+  };
+  refresh();
+  const timer = setInterval(refresh, options.intervalMs ?? 15_000);
+  timer.unref?.();
+  return {
+    refresh,
+    dispose() {
+      disposed = true;
+      clearInterval(timer);
+      const remaining = readA2aRegistry(options.filePath).filter(
+        (entry) => entry.daemonId !== options.entry.daemonId,
+      );
+      writeA2aRegistry(options.filePath, remaining);
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Wire run handle close**
+
+In `packages/cli/src/serve/run-qwen-serve.ts`:
+
+1. Add optional dependency `a2aRegistryFile?: string`.
+2. After `server.listen` resolves the actual URL, call `startA2aAdvertisement` when `opts.a2aEnabled === true`.
+3. Store the handle next to other disposables.
+4. Call `advertisement.dispose()` inside `RunHandle.close` and signal shutdown paths.
+
+Use a daemon id such as `serve-${process.pid}-${startup.processStartedAt}`. Hash or sanitize if the id is used as a filename; it is only JSON data in v1.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts src/serve/a2a/registry.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/serve/run-qwen-serve.ts packages/cli/src/serve/run-qwen-serve.test.ts packages/cli/src/serve/a2a/registry.ts packages/cli/src/serve/a2a/registry.test.ts
+git commit -m "feat(daemon): advertise local a2a peers"
+```
+
+## Task 9: End-to-End Serve Integration Test
+
+**Files:**
+
+- Create: `packages/cli/src/serve/a2a/integration.test.ts`
+- Modify: any A2A modules needed by failures
+
+- [ ] **Step 1: Write integration test with fake peer daemon**
+
+Create `packages/cli/src/serve/a2a/integration.test.ts`:
+
+```ts
+import express from 'express';
+import http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { A2aPeerClient } from './peer-client.js';
+
+describe('A2A peer client integration', () => {
+  const servers: http.Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+    );
+    servers.length = 0;
+  });
+
+  it('calls a peer daemon over real HTTP and SSE', async () => {
+    const app = express();
+    app.use(express.json());
+    app.get('/capabilities', (_req, res) =>
+      res.json({
+        features: [
+          'session_create',
+          'session_prompt',
+          'session_events',
+          'session_close',
+        ],
+      }),
+    );
+    app.post('/session', (_req, res) => res.json({ sessionId: 's-peer' }));
+    app.post('/session/s-peer/prompt', (_req, res) =>
+      res.status(202).json({ promptId: 'p-peer', lastEventId: 0 }),
+    );
+    app.get('/session/s-peer/events', (_req, res) => {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.write(
+        'event: session_update\\ndata: {"type":"session_update","data":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"peer answer"}}}\\n\\n',
+      );
+      res.write(
+        'event: turn_complete\\ndata: {"type":"turn_complete","data":{"stopReason":"end_turn"}}\\n\\n',
+      );
+      res.end();
+    });
+    app.delete('/session/s-peer', (_req, res) => res.status(204).end());
+
+    const server = app.listen(0);
+    servers.push(server);
+    const address = server.address();
+    if (typeof address !== 'object' || address === null) {
+      throw new Error('expected TCP address');
+    }
+
+    const client = new A2aPeerClient();
+    const result = await client.askPeer({
+      peer: {
+        id: 'peer',
+        url: `http://127.0.0.1:${address.port}`,
+      },
+      prompt: [{ type: 'text', text: 'hello' }],
+      clientId: 'daemon-a2a:test',
+      timeoutMs: 5000,
+    });
+
+    expect(result.text).toBe('peer answer');
+  });
+});
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run:
+
+```bash
+cd packages/cli && npx vitest run src/serve/a2a/integration.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/serve/a2a/integration.test.ts packages/cli/src/serve/a2a
+git commit -m "test(daemon): cover a2a peer call flow"
+```
+
+## Task 10: Documentation and Final Verification
+
+**Files:**
+
+- Modify: `docs/developers/daemon/11-capabilities-versioning.md`
+- Modify: `docs/developers/daemon/17-configuration.md`
+- Modify: `docs/developers/qwen-serve-protocol.md`
+- Modify: `docs/design/2026-07-07-daemon-a2a-v1-design.md` if implementation changed a contract
+
+- [ ] **Step 1: Update daemon docs**
+
+Document:
+
+- A2A capability tags.
+- `a2a.enabled`, `a2a.explicitPeers`, and `a2a.trustedPeers`.
+- `tokenRef` supports `env:<NAME>` only in v1.
+- `/workspace/a2a/peers` response excludes token refs.
+- `qwen-a2a` exposes `ask_peer_daemon` only for trusted peers.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd packages/acp-bridge && npx vitest run src/bridgeClient.test.ts
+cd packages/cli && npx vitest run src/serve/a2a/settings.test.ts src/serve/a2a/registry.test.ts src/serve/a2a/context.test.ts src/serve/a2a/peer-client.test.ts src/serve/a2a/service.test.ts src/serve/a2a/mcp-server.test.ts src/serve/a2a/routes.test.ts src/serve/a2a/integration.test.ts src/serve/server.test.ts src/serve/run-qwen-serve.test.ts src/acp-integration/acpAgent.test.ts src/config/settingsSchema.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run build and typecheck**
+
+Run:
+
+```bash
+npm run build && npm run typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Commit docs and final fixes**
+
+```bash
+git add docs/developers/daemon/11-capabilities-versioning.md docs/developers/daemon/17-configuration.md docs/developers/qwen-serve-protocol.md docs/design/2026-07-07-daemon-a2a-v1-design.md
+git commit -m "docs: document daemon a2a"
+```
+
+If final fixes changed source files, include those exact files in the same commit only when the change is directly required for verification.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Local discovery is covered by Tasks 4 and 8.
+  - Explicit remote peers and trust are covered by Task 3 and Task 6.
+  - Parent-hosted SDK MCP tool is covered by Tasks 1, 2, 6, and 7.
+  - Bounded context is covered by Task 5.
+  - Peer REST/SSE call flow is covered by Task 5 and Task 9.
+  - Capability/config docs are covered by Task 3 and Task 10.
+  - A2A depth rejection is covered by Task 6.
+- Placeholder scan: no task uses open-ended implementation language; every task lists concrete files, commands, and expected results.
+- Type consistency:
+  - `A2aService.askPeer` receives `sessionId` from `ClientMcpSenderContext`.
+  - `PARENT_HOSTED_MCP_CONFIG_FLAG` preserves `type: 'sdk'`.
+  - `A2aPeerClient.askPeer` returns `{ peerId, sessionId, text }`.
+  - `/workspace/a2a/peers` never serializes `tokenRef`.

--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -54,6 +54,7 @@ import type { ClientMcpMessageSender } from './bridgeOptions.js';
 import { CancelSentinelCollisionError } from './bridgeErrors.js';
 import { CANCEL_VOTE_SENTINEL } from './permissionMediator.js';
 import { SessionArtifactStore } from './sessionArtifacts.js';
+import { SERVE_CONTROL_EXT_METHODS } from './status.js';
 
 /**
  * Minimal-stub constructor for a `BridgeClient` whose only purpose is
@@ -1829,12 +1830,15 @@ describe('BridgeClient — reverse tool channel (qwen/control/client_mcp/message
    */
   function makeClientWithRegistrar(
     registrar: ClientMcpRegistrar,
+    onLookup?: (serverName: string, context: unknown) => void,
   ): BridgeClient {
-    const sender: ClientMcpMessageSender = (serverName: string) =>
-      registrar.hasServer(serverName)
+    const sender: ClientMcpMessageSender = (serverName, context) => {
+      onLookup?.(serverName, context);
+      return registrar.hasServer(serverName)
         ? (payload: unknown) =>
             registrar.sendSdkMcpMessage(serverName, payload as JSONRPCMessage)
         : undefined;
+    };
     return new BridgeClient(
       (() => undefined) as never, // resolveEntry: client_mcp/message is sessionless
       (() => undefined) as never, // resolvePendingRestoreEvents
@@ -1905,6 +1909,59 @@ describe('BridgeClient — reverse tool channel (qwen/control/client_mcp/message
     });
     expect(outbound).toHaveLength(1);
     expect((result as { payload?: unknown }).payload).toBeDefined();
+  });
+
+  it('passes sessionId context to the client MCP sender lookup', async () => {
+    const outbound: ClientMcpFrame[] = [];
+    const lookups: Array<{ serverName: string; context: unknown }> = [];
+    const registrar = new ClientMcpRegistrar({
+      sendFrame: (frame) => {
+        outbound.push(frame);
+      },
+    });
+    registrar.registerServer('qwen-a2a');
+    const client = makeClientWithRegistrar(registrar, (serverName, context) => {
+      lookups.push({ serverName, context });
+    });
+
+    const callP = client.extMethod(SERVE_CONTROL_EXT_METHODS.clientMcpMessage, {
+      server: 'qwen-a2a',
+      sessionId: 'session-123',
+      payload: { jsonrpc: '2.0', id: 7, method: 'tools/list' },
+    });
+
+    await vi.waitFor(() => expect(outbound).toHaveLength(1));
+    registrar.resolveMessage(outbound[0].id, {
+      jsonrpc: '2.0',
+      id: 7,
+      result: { tools: [] },
+    } as JSONRPCMessage);
+
+    await callP;
+    expect(lookups).toEqual([
+      {
+        serverName: 'qwen-a2a',
+        context: { sessionId: 'session-123' },
+      },
+    ]);
+  });
+
+  it('rejects (invalidParams) when sessionId is not a string', async () => {
+    const registrar = new ClientMcpRegistrar({ sendFrame: () => {} });
+    registrar.registerServer('qwen-a2a');
+    const client = makeClientWithRegistrar(registrar);
+    const err = await client
+      .extMethod(SERVE_CONTROL_EXT_METHODS.clientMcpMessage, {
+        server: 'qwen-a2a',
+        sessionId: 123,
+        payload: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RequestError);
+    expect((err as RequestError).code).toBe(-32602);
+    expect((err as RequestError).message).toContain(
+      '`sessionId` must be a string when provided',
+    );
   });
 
   it('rejects (invalidParams) when the named server is not connected', async () => {

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -930,7 +930,14 @@ export class BridgeClient implements Client {
         '`payload` must be a JSON-RPC message object',
       );
     }
-    const send = this.clientMcpSender(server);
+    const sessionId = params['sessionId'];
+    if (sessionId !== undefined && typeof sessionId !== 'string') {
+      throw RequestError.invalidParams(
+        undefined,
+        '`sessionId` must be a string when provided',
+      );
+    }
+    const send = this.clientMcpSender(server, { sessionId });
     if (!send) {
       // The client that hosted this server is gone (WS closed / unregistered).
       throw RequestError.invalidParams(

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -388,6 +388,10 @@ export interface BridgeOptions {
   clientMcpSender?: ClientMcpMessageSender;
 }
 
+export interface ClientMcpSenderContext {
+  sessionId?: string;
+}
+
 /**
  * Looks up the JSON-RPC sender for a client-hosted MCP server by name. Returns
  * `undefined` when no client currently advertises `serverName`. The returned
@@ -398,6 +402,5 @@ export interface BridgeOptions {
  */
 export type ClientMcpMessageSender = (
   serverName: string,
-) =>
-  | ((payload: unknown) => Promise<unknown>)
-  | undefined;
+  context?: ClientMcpSenderContext,
+) => ((payload: unknown) => Promise<unknown>) | undefined;

--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RequestPermissionResponse } from '@agentclientprotocol/sdk';
 import { ACP_EVENT_LOOP_STALL_RESTART_MS, AcpBridge } from './AcpBridge.js';
 import { CHANNEL_LOOP_MCP_SERVER_NAME } from './ChannelLoopTools.js';
 import type { ChannelLoopToolHandler } from './ChannelAgentBridge.js';
@@ -44,6 +45,13 @@ const child = vi.hoisted(() => {
 
   return {
     instances: [] as MockChild[],
+    clients: [] as Array<{
+      requestPermission: (params: unknown) => Promise<unknown>;
+    }>,
+    connections: [] as Array<{
+      initialize: ReturnType<typeof vi.fn>;
+      cancel: ReturnType<typeof vi.fn>;
+    }>,
     MockChild,
     spawn: vi.fn(() => {
       const instance = new MockChild();
@@ -65,9 +73,16 @@ vi.mock('node:stream', () => ({
 vi.mock('@agentclientprotocol/sdk', () => ({
   PROTOCOL_VERSION: 1,
   ndJsonStream: vi.fn(() => ({})),
-  ClientSideConnection: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-  })),
+  ClientSideConnection: vi.fn().mockImplementation((createClient) => {
+    const client = createClient();
+    const connection = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    };
+    child.clients.push(client);
+    child.connections.push(connection);
+    return connection;
+  }),
 }));
 
 type TestableAcpBridge = AcpBridge & {
@@ -91,6 +106,8 @@ type TestableAcpBridge = AcpBridge & {
 describe('AcpBridge', () => {
   beforeEach(() => {
     child.instances.length = 0;
+    child.clients.length = 0;
+    child.connections.length = 0;
     child.spawn.mockClear();
   });
 
@@ -349,5 +366,238 @@ describe('AcpBridge', () => {
     );
 
     expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it('relays ACP permission requests instead of auto-approving them', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+    const permissionRequest = vi.fn();
+    const permissionResolved = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+    bridge.on('permissionResolved', permissionResolved);
+
+    await bridge.start();
+    const request = {
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [
+        { optionId: 'proceed_once', name: 'Allow' },
+        { optionId: 'cancel', name: 'Deny' },
+      ],
+    };
+
+    const pending = child.clients[0]!.requestPermission(request);
+    await Promise.resolve();
+
+    expect(permissionRequest).toHaveBeenCalledTimes(1);
+    const event = permissionRequest.mock.calls[0]![0];
+    expect(event).toMatchObject({
+      sessionId: 'session-1',
+      request,
+    });
+    expect(event.requestId).toMatch(/^acp-permission-/);
+
+    const response = { outcome: { outcome: 'selected', optionId: 'cancel' } };
+    await expect(
+      (
+        bridge as unknown as TestableAcpBridge & {
+          respondToPermission(
+            requestId: string,
+            response: typeof response,
+          ): Promise<boolean>;
+        }
+      ).respondToPermission(event.requestId, response),
+    ).resolves.toBe(true);
+    await expect(pending).resolves.toEqual(response);
+    expect(permissionResolved).toHaveBeenCalledWith({
+      requestId: event.requestId,
+      outcome: response.outcome,
+    });
+    await expect(
+      (
+        bridge as unknown as TestableAcpBridge & {
+          respondToPermission(
+            requestId: string,
+            response: typeof response,
+          ): Promise<boolean>;
+        }
+      ).respondToPermission(event.requestId, response),
+    ).resolves.toBe(false);
+  });
+
+  it('allows permission request listeners to respond synchronously', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+    const response: RequestPermissionResponse = {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    };
+    bridge.on('permissionRequest', (event) => {
+      void bridge.respondToPermission(event.requestId, response);
+    });
+
+    await bridge.start();
+    const pending = child.clients[0]!.requestPermission({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'proceed_once', name: 'Allow' }],
+    });
+
+    await expect(pending).resolves.toEqual(response);
+  });
+
+  it('falls back to the tool call id for permission requests without a session id', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+    const permissionRequest = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+
+    await bridge.start();
+    const pending = child.clients[0]!.requestPermission({
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'cancel', name: 'Deny' }],
+    });
+    await Promise.resolve();
+
+    const event = permissionRequest.mock.calls[0]![0];
+    expect(event.sessionId).toBe('tool-1');
+    await bridge.respondToPermission(event.requestId, {
+      outcome: { outcome: 'cancelled' },
+    });
+    await expect(pending).resolves.toEqual({
+      outcome: { outcome: 'cancelled' },
+    });
+  });
+
+  it('resolves matching pending permissions as cancelled when a session is cancelled', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+    const permissionRequest = vi.fn();
+    const permissionResolved = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+    bridge.on('permissionResolved', permissionResolved);
+
+    await bridge.start();
+    const first = child.clients[0]!.requestPermission({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'cancel', name: 'Deny' }],
+    });
+    const second = child.clients[0]!.requestPermission({
+      sessionId: 'session-2',
+      toolCall: {
+        toolCallId: 'tool-2',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'cancel', name: 'Deny' }],
+    });
+    await Promise.resolve();
+
+    const firstEvent = permissionRequest.mock.calls[0]![0];
+    const secondEvent = permissionRequest.mock.calls[1]![0];
+    await bridge.cancelSession('session-1');
+
+    expect(child.connections[0]!.cancel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+    });
+    await expect(first).resolves.toEqual({
+      outcome: { outcome: 'cancelled' },
+    });
+    expect(permissionResolved).toHaveBeenCalledWith({
+      requestId: firstEvent.requestId,
+      outcome: { outcome: 'cancelled' },
+    });
+    expect(permissionResolved).not.toHaveBeenCalledWith({
+      requestId: secondEvent.requestId,
+      outcome: { outcome: 'cancelled' },
+    });
+
+    const response: RequestPermissionResponse = {
+      outcome: { outcome: 'selected', optionId: 'cancel' },
+    };
+    await expect(
+      bridge.respondToPermission(secondEvent.requestId, response),
+    ).resolves.toBe(true);
+    await expect(second).resolves.toEqual(response);
+  });
+
+  it('resolves pending permissions as cancelled when the ACP child exits', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+    const permissionResolved = vi.fn();
+    bridge.on('permissionResolved', permissionResolved);
+
+    await bridge.start();
+    const pending = child.clients[0]!.requestPermission({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'cancel', name: 'Deny' }],
+    });
+    await Promise.resolve();
+
+    child.instances[0]!.emit('exit', 1, null);
+
+    await expect(pending).resolves.toEqual({
+      outcome: { outcome: 'cancelled' },
+    });
+    expect(permissionResolved).toHaveBeenCalledWith({
+      requestId: 'acp-permission-1',
+      outcome: { outcome: 'cancelled' },
+    });
+  });
+
+  it('resolves pending permissions as cancelled on stop', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    });
+
+    await bridge.start();
+    const pending = child.clients[0]!.requestPermission({
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'shell',
+        title: 'Run command',
+      },
+      options: [{ optionId: 'cancel', name: 'Deny' }],
+    });
+    await Promise.resolve();
+
+    bridge.stop();
+
+    await expect(pending).resolves.toEqual({
+      outcome: { outcome: 'cancelled' },
+    });
   });
 });

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -77,6 +77,14 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
   private readonly channelLoopToolHandlers: ChannelLoopToolHandler[] = [];
   private channelLoopMcpRegistered = false;
   private channelLoopMcpRegistration: Promise<void> | null = null;
+  private permissionCounter = 0;
+  private readonly pendingPermissions = new Map<
+    string,
+    {
+      sessionId: string;
+      resolve: (response: RequestPermissionResponse) => void;
+    }
+  >();
 
   constructor(options: AcpBridgeOptions) {
     super();
@@ -109,7 +117,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
     this.child.stderr?.on('data', (data: Buffer) => {
       const msg = data.toString().trim();
       if (msg) {
-        process.stderr.write(`[AcpBridge] ${msg}\n`);
+        process.stderr.write(`[AcpBridge] ${sanitizeLogText(msg, 4096)}\n`);
         this.maybeKillOnEventLoopStall(msg);
       }
     });
@@ -120,6 +128,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       );
       // Do not emit sessionDied here: a full ACP process exit is handled by
       // channel start crash recovery, which reloads the persisted sessions.
+      this.resolvePendingPermissions();
       this.connection = null;
       this.child = null;
       this.emit('disconnected', code, signal);
@@ -147,15 +156,7 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
 
         requestPermission: async (
           params: RequestPermissionRequest,
-        ): Promise<RequestPermissionResponse> => {
-          // Auto-approve for now; Phase 5 will add interactive approval
-          const options = Array.isArray(params.options) ? params.options : [];
-          const optionId =
-            options.find((o) => o.optionId === 'proceed_once')?.optionId ||
-            options[0]?.optionId ||
-            'proceed_once';
-          return { outcome: { outcome: 'selected', optionId } };
-        },
+        ): Promise<RequestPermissionResponse> => this.requestPermission(params),
 
         extMethod: async (
           method: string,
@@ -245,10 +246,32 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
 
   async cancelSession(sessionId: string): Promise<void> {
     const conn = this.ensureConnection();
-    await conn.cancel({ sessionId });
+    try {
+      await conn.cancel({ sessionId });
+    } finally {
+      this.resolvePendingPermissions(sessionId);
+    }
+  }
+
+  async respondToPermission(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean> {
+    const pending = this.pendingPermissions.get(requestId);
+    if (!pending) {
+      return false;
+    }
+    this.pendingPermissions.delete(requestId);
+    pending.resolve(response);
+    this.emit('permissionResolved', {
+      requestId,
+      outcome: response.outcome,
+    });
+    return true;
   }
 
   stop(): void {
+    this.resolvePendingPermissions();
     if (this.child) {
       this.child.kill();
       this.child = null;
@@ -317,6 +340,42 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       throw new Error('Not connected to ACP agent');
     }
     return this.connection;
+  }
+
+  private requestPermission(
+    request: RequestPermissionRequest,
+  ): Promise<RequestPermissionResponse> {
+    const requestId = `acp-permission-${++this.permissionCounter}`;
+    const sessionId =
+      typeof request.sessionId === 'string' && request.sessionId.length > 0
+        ? request.sessionId
+        : request.toolCall.toolCallId;
+
+    return new Promise<RequestPermissionResponse>((resolve) => {
+      this.pendingPermissions.set(requestId, { sessionId, resolve });
+      this.emit('permissionRequest', {
+        requestId,
+        sessionId,
+        request,
+      });
+    });
+  }
+
+  private resolvePendingPermissions(sessionId?: string): void {
+    const response: RequestPermissionResponse = {
+      outcome: { outcome: 'cancelled' },
+    };
+    for (const [requestId, pending] of this.pendingPermissions) {
+      if (sessionId !== undefined && pending.sessionId !== sessionId) {
+        continue;
+      }
+      this.pendingPermissions.delete(requestId);
+      pending.resolve(response);
+      this.emit('permissionResolved', {
+        requestId,
+        outcome: response.outcome,
+      });
+    }
   }
 
   private maybeKillOnEventLoopStall(stderr: string): void {

--- a/packages/channels/base/src/ChannelAgentBridge.ts
+++ b/packages/channels/base/src/ChannelAgentBridge.ts
@@ -1,3 +1,8 @@
+import type {
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+
 export interface AvailableCommand {
   name: string;
   description: string;
@@ -47,10 +52,23 @@ export interface SessionDiedEvent {
   reason?: string;
 }
 
+export interface PermissionRequestEvent {
+  requestId: string;
+  sessionId: string;
+  request: RequestPermissionRequest;
+}
+
+export interface PermissionResolvedEvent {
+  requestId: string;
+  outcome?: RequestPermissionResponse['outcome'];
+}
+
 interface ChannelAgentBridgeEventMap {
   sessionDied: [SessionDiedEvent];
   textChunk: [sessionId: string, chunk: string];
   toolCall: [ToolCallEvent];
+  permissionRequest: [PermissionRequestEvent];
+  permissionResolved: [PermissionResolvedEvent];
 }
 
 export interface BridgeSessionInfo {
@@ -78,6 +96,10 @@ export interface ChannelAgentBridge {
     options?: { imageBase64?: string; imageMimeType?: string },
   ): Promise<string>;
   cancelSession(sessionId: string): Promise<void>;
+  respondToPermission?(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean>;
   shellCommand?(
     sessionId: string,
     command: string,

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -23,6 +23,7 @@ class TestChannel extends ChannelBase {
   proactive: Array<{ chatId: string; text: string }> = [];
   proactiveSupported = false;
   proactiveTargetSupported: boolean | undefined;
+  sendMessageError?: Error;
   connected = false;
   toolCalls: Array<{ chatId: string; event: unknown }> = [];
   taskEvents: ChannelTaskLifecycleEvent[] = [];
@@ -43,6 +44,9 @@ class TestChannel extends ChannelBase {
     this.connected = true;
   }
   async sendMessage(chatId: string, text: string) {
+    if (this.sendMessageError) {
+      throw this.sendMessageError;
+    }
     this.sent.push({ chatId, text });
   }
   disconnect() {
@@ -133,6 +137,7 @@ function createBridge(): ChannelAgentBridge {
     isConnected: true,
     availableCommands: [],
     setBridge: vi.fn(),
+    respondToPermission: vi.fn().mockResolvedValue(true),
     registerChannelLoopToolHandler: vi.fn((handler: ChannelLoopToolHandler) => {
       channelLoopToolHandler = handler;
     }),
@@ -225,6 +230,258 @@ describe('ChannelBase', () => {
       });
       await ch.handleInbound(envelope());
       expect(bridge.prompt).toHaveBeenCalled();
+    });
+  });
+
+  describe('permission relay', () => {
+    function respondToPermissionMock(): ReturnType<typeof vi.fn> {
+      return (
+        bridge as unknown as {
+          respondToPermission: ReturnType<typeof vi.fn>;
+        }
+      ).respondToPermission;
+    }
+
+    function emitPermission(
+      sessionId: string,
+      requestId: string,
+      options = [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow once' },
+        { optionId: 'cancel', kind: 'reject_once', name: 'Deny' },
+      ],
+    ): void {
+      (bridge as unknown as EventEmitter).emit('permissionRequest', {
+        requestId,
+        sessionId,
+        request: {
+          toolCall: {
+            toolCallId: `tool-${requestId}`,
+            kind: 'shell',
+            title: `Run ${requestId}`,
+            rawInput: { command: 'echo secret-token' },
+          },
+          options,
+        },
+      });
+    }
+
+    async function startSession(
+      ch: TestChannel,
+      env: Partial<Envelope> = {},
+    ): Promise<string> {
+      await ch.handleInbound(envelope({ text: 'run tests', ...env }));
+      const results = (bridge.newSession as ReturnType<typeof vi.fn>).mock
+        .results;
+      return results[results.length - 1]!.value as string;
+    }
+
+    it('sends permission requests to the owning chat and approves with /approve', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1');
+
+      expect(ch.sent.at(-1)?.chatId).toBe('chat1');
+      expect(ch.sent.at(-1)?.text).toContain('Permission requested');
+      expect(ch.sent.at(-1)?.text).toContain('/approve req-1');
+      expect(ch.sent.at(-1)?.text).toContain('/deny req-1');
+      expect(ch.sent.at(-1)?.text).not.toContain('secret-token');
+
+      await ch.handleInbound(envelope({ text: '/approve' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      });
+      expect(ch.sent.at(-1)?.text).toBe('Permission approved.');
+    });
+
+    it('requires an explicit request id when multiple permissions are pending', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1');
+      emitPermission(sessionId, 'req-2');
+
+      await ch.handleInbound(envelope({ text: '/approve' }));
+
+      expect(ch.sent.at(-1)?.text).toContain(
+        'Multiple permission requests are pending',
+      );
+      expect(ch.sent.at(-1)?.text).toContain('req-1');
+      expect(ch.sent.at(-1)?.text).toContain('req-2');
+      expect(respondToPermissionMock()).not.toHaveBeenCalled();
+
+      await ch.handleInbound(envelope({ text: '/approve req-1' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledTimes(1);
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      });
+    });
+
+    it('does not fall back to another pending request when an explicit id is wrong', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1');
+      emitPermission(sessionId, 'req-2');
+
+      await ch.handleInbound(envelope({ text: '/approve missing-request' }));
+
+      expect(respondToPermissionMock()).not.toHaveBeenCalled();
+      expect(ch.sent.at(-1)?.text).toBe(
+        'No pending permission request with that id for this chat.',
+      );
+    });
+
+    it('does not answer permission requests from another chat', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch, { chatId: 'chat2' });
+      emitPermission(sessionId, 'req-chat2');
+
+      await ch.handleInbound(
+        envelope({ chatId: 'chat1', text: '/approve req-chat2' }),
+      );
+
+      expect(ch.sent.at(-1)?.chatId).toBe('chat1');
+      expect(ch.sent.at(-1)?.text).toBe(
+        'No pending permission request with that id for this chat.',
+      );
+      expect(respondToPermissionMock()).not.toHaveBeenCalled();
+    });
+
+    it('gates shared-session permission responses to authorized senders', async () => {
+      const ch = createChannel({
+        allowedUsers: ['boss'],
+        groupPolicy: 'open',
+        sessionScope: 'thread',
+      });
+      const sessionId = await startSession(ch, {
+        chatId: 'group1',
+        isGroup: true,
+        isMentioned: true,
+        senderId: 'boss',
+        threadId: 'thread-1',
+      });
+      emitPermission(sessionId, 'req-1');
+
+      await ch.handleInbound(
+        envelope({
+          chatId: 'group1',
+          isGroup: true,
+          isMentioned: true,
+          senderId: 'rando',
+          text: '/approve req-1',
+          threadId: 'thread-1',
+        }),
+      );
+
+      expect(respondToPermissionMock()).not.toHaveBeenCalled();
+      expect(ch.sent.at(-1)?.text).toContain('Only authorized members');
+
+      await ch.handleInbound(
+        envelope({
+          chatId: 'group1',
+          isGroup: true,
+          isMentioned: true,
+          senderId: 'boss',
+          text: '/approve req-1',
+          threadId: 'thread-1',
+        }),
+      );
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      });
+    });
+
+    it('uses ACP option kinds for approval and denial', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1', [
+        { optionId: 'always', kind: 'allow_always', name: 'Allow always' },
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+        { optionId: 'never', kind: 'reject_always', name: 'Deny always' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Deny once' },
+      ]);
+
+      await ch.handleInbound(envelope({ text: '/approve req-1' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'once' },
+      });
+
+      emitPermission(sessionId, 'req-2', [
+        { optionId: 'always', kind: 'allow_always', name: 'Allow always' },
+        { optionId: 'never', kind: 'reject_always', name: 'Deny always' },
+      ]);
+
+      await ch.handleInbound(envelope({ text: '/deny req-2' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-2', {
+        outcome: { outcome: 'cancelled' },
+      });
+    });
+
+    it('supports explicit approve-always for persistent permission grants', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1', [
+        { optionId: 'always', kind: 'allow_always', name: 'Allow always' },
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+      ]);
+
+      await ch.handleInbound(envelope({ text: '/approve-always req-1' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'always' },
+      });
+    });
+
+    it('allows approve-always without a request id when one request is pending', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1', [
+        { optionId: 'always', kind: 'allow_always', name: 'Allow always' },
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+      ]);
+
+      await ch.handleInbound(envelope({ text: '/approve-always' }));
+
+      expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'selected', optionId: 'always' },
+      });
+    });
+
+    it('clears pending permission requests when the session is cleared', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      emitPermission(sessionId, 'req-1');
+
+      await ch.handleInbound(envelope({ text: '/clear' }));
+      await ch.handleInbound(envelope({ text: '/approve req-1' }));
+
+      expect(respondToPermissionMock()).not.toHaveBeenCalled();
+      expect(ch.sent.at(-1)?.text).toBe(
+        'No pending permission request with that id for this chat.',
+      );
+    });
+
+    it('cancels the permission request when the relay message cannot be sent', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      ch.sendMessageError = new Error('send failed');
+
+      emitPermission(sessionId, 'req-1');
+      await vi.waitFor(() =>
+        expect(respondToPermissionMock()).toHaveBeenCalledWith('req-1', {
+          outcome: { outcome: 'cancelled' },
+        }),
+      );
+      ch.sendMessageError = undefined;
+
+      await ch.handleInbound(envelope({ text: '/approve req-1' }));
+
+      expect(ch.sent.at(-1)?.text).toBe(
+        'No pending permission request with that id for this chat.',
+      );
     });
   });
 

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -33,6 +33,8 @@ import type {
   ChannelAgentBridge,
   ChannelLoopToolCreateInput,
   ChannelLoopToolResult,
+  PermissionRequestEvent,
+  PermissionResolvedEvent,
   SessionDiedEvent,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';
@@ -92,6 +94,16 @@ export interface ChannelLoopPromptOptions {
 
 /** Handler for a slash command. Return true if handled, false to forward to agent. */
 type CommandHandler = (envelope: Envelope, args: string) => Promise<boolean>;
+type PendingPermission = {
+  requestId: string;
+  sessionId: string;
+  target: SessionTarget;
+  request: PermissionRequestEvent['request'];
+};
+type PendingPermissionLookup =
+  | { kind: 'found'; pending: PendingPermission }
+  | { kind: 'none'; explicit: boolean }
+  | { kind: 'ambiguous'; requestIds: string[] };
 type ActivePrompt = {
   cancelled: boolean;
   cancelPending?: boolean;
@@ -204,6 +216,22 @@ export abstract class ChannelBase {
   ): void => {
     this.onSessionDied(event.sessionId);
   };
+  private readonly bridgePermissionRequestListener = (
+    event: PermissionRequestEvent,
+  ): void => {
+    void this.dispatchPermissionRequest(event).catch((err: unknown) => {
+      process.stderr.write(
+        `[${this.name}] permission relay failed for request ${sanitizeLogText(event.requestId, 128)}: ${this.lifecycleError(err)}\n`,
+      );
+    });
+  };
+  private readonly bridgePermissionResolvedListener = (
+    event: PermissionResolvedEvent,
+  ): void => {
+    this.dispatchPermissionResolved(event);
+  };
+  private readonly pendingPermissions = new Map<string, PendingPermission>();
+  private readonly pendingPermissionsByChat = new Map<string, string[]>();
   private readonly channelLoopToolHandler = {
     canHandle: (sessionId: string) =>
       this.router.getTarget(sessionId)?.channelName === this.name,
@@ -238,6 +266,49 @@ export abstract class ChannelBase {
       });
     }
     this.onToolCall(chatId, event);
+  }
+
+  async dispatchPermissionRequest(
+    event: PermissionRequestEvent,
+  ): Promise<void> {
+    const target = this.router.getTarget(event.sessionId);
+    if (!target || target.channelName !== this.name) {
+      return;
+    }
+    this.removePendingPermission(event.requestId);
+    const pending: PendingPermission = {
+      requestId: event.requestId,
+      sessionId: event.sessionId,
+      target,
+      request: event.request,
+    };
+    this.pendingPermissions.set(event.requestId, pending);
+    const chatKey = this.permissionChatKey(target);
+    const requestIds = this.pendingPermissionsByChat.get(chatKey) ?? [];
+    requestIds.push(event.requestId);
+    this.pendingPermissionsByChat.set(chatKey, requestIds);
+    try {
+      await this.sendMessage(
+        target.chatId,
+        this.formatPermissionRequest(pending),
+      );
+    } catch (err) {
+      this.removePendingPermission(event.requestId);
+      try {
+        await this.bridge.respondToPermission?.(event.requestId, {
+          outcome: { outcome: 'cancelled' },
+        });
+      } catch (respondErr) {
+        process.stderr.write(
+          `[${this.name}] permission cancellation failed for request ${sanitizeLogText(event.requestId, 128)}: ${this.lifecycleError(respondErr)}\n`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  dispatchPermissionResolved(event: PermissionResolvedEvent): void {
+    this.removePendingPermission(event.requestId);
   }
 
   constructor(
@@ -924,16 +995,21 @@ export abstract class ChannelBase {
   onSessionDied(sessionId: string): void {
     this.router.removeSessionId(sessionId);
     this.instructedSessions.delete(sessionId);
+    this.removePendingPermissionsForSession(sessionId);
   }
 
   private attachBridgeEvents(bridge: ChannelAgentBridge): void {
     bridge.on('toolCall', this.bridgeToolCallListener);
     bridge.on('sessionDied', this.bridgeSessionDiedListener);
+    bridge.on('permissionRequest', this.bridgePermissionRequestListener);
+    bridge.on('permissionResolved', this.bridgePermissionResolvedListener);
   }
 
   private detachBridgeEvents(bridge: ChannelAgentBridge): void {
     bridge.off('toolCall', this.bridgeToolCallListener);
     bridge.off('sessionDied', this.bridgeSessionDiedListener);
+    bridge.off('permissionRequest', this.bridgePermissionRequestListener);
+    bridge.off('permissionResolved', this.bridgePermissionResolvedListener);
   }
 
   /**
@@ -1036,6 +1112,241 @@ export abstract class ChannelBase {
     });
   }
 
+  private permissionChatKey(
+    target: Pick<SessionTarget, 'chatId' | 'threadId'>,
+  ) {
+    return `${target.chatId}\0${target.threadId ?? ''}`;
+  }
+
+  private pendingPermissionIdsForChatKey(chatKey: string): string[] {
+    const requestIds = this.pendingPermissionsByChat.get(chatKey);
+    if (!requestIds) {
+      return [];
+    }
+    const live = requestIds.filter((id) => this.pendingPermissions.has(id));
+    if (live.length === 0) {
+      this.pendingPermissionsByChat.delete(chatKey);
+    } else if (live.length !== requestIds.length) {
+      this.pendingPermissionsByChat.set(chatKey, live);
+    }
+    return live;
+  }
+
+  private removePendingPermission(requestId: string): void {
+    const pending = this.pendingPermissions.get(requestId);
+    if (!pending) {
+      return;
+    }
+    this.pendingPermissions.delete(requestId);
+    const chatKey = this.permissionChatKey(pending.target);
+    const requestIds = this.pendingPermissionsByChat.get(chatKey);
+    if (!requestIds) {
+      return;
+    }
+    const remaining = requestIds.filter((id) => id !== requestId);
+    if (remaining.length === 0) {
+      this.pendingPermissionsByChat.delete(chatKey);
+    } else {
+      this.pendingPermissionsByChat.set(chatKey, remaining);
+    }
+  }
+
+  private removePendingPermissionsForSession(sessionId: string): void {
+    const requestIds = Array.from(this.pendingPermissions)
+      .filter(([, pending]) => pending.sessionId === sessionId)
+      .map(([requestId]) => requestId);
+    for (const requestId of requestIds) {
+      this.removePendingPermission(requestId);
+    }
+  }
+
+  private pendingPermissionForEnvelope(
+    envelope: Envelope,
+    args: string,
+  ): PendingPermissionLookup {
+    const trimmed = args.trim();
+    if (trimmed) {
+      const explicit = this.pendingPermissions.get(trimmed);
+      if (
+        explicit &&
+        explicit.target.chatId === envelope.chatId &&
+        explicit.target.threadId === envelope.threadId
+      ) {
+        return { kind: 'found', pending: explicit };
+      }
+      return { kind: 'none', explicit: true };
+    }
+    const requestIds = this.pendingPermissionIdsForChatKey(
+      this.permissionChatKey(envelope),
+    );
+    if (requestIds.length === 0) {
+      return { kind: 'none', explicit: false };
+    }
+    if (requestIds.length > 1) {
+      return { kind: 'ambiguous', requestIds };
+    }
+    const pending = this.pendingPermissions.get(requestIds[0]!);
+    return pending
+      ? { kind: 'found', pending }
+      : { kind: 'none', explicit: false };
+  }
+
+  private formatPermissionRequest(pending: PendingPermission): string {
+    const { toolCall, options } = pending.request;
+    const title = sanitizeQuotedText(toolCall.title || 'Tool use', 160);
+    const kind = sanitizeQuotedText(toolCall.kind || 'tool', 40);
+    const lines = [
+      'Permission requested',
+      `Request: ${sanitizeQuotedText(pending.requestId, 128)}`,
+      `Tool: ${title} (${kind})`,
+      '',
+      `Reply /approve ${sanitizeQuotedText(pending.requestId, 128)} to allow once, /approve-always ${sanitizeQuotedText(pending.requestId, 128)} to always allow, or /deny ${sanitizeQuotedText(pending.requestId, 128)} to reject.`,
+    ];
+    if (options.length > 0) {
+      lines.push('', 'Options:');
+      for (const option of options.slice(0, 6)) {
+        lines.push(
+          `- ${sanitizeQuotedText(option.optionId, 80)}: ${sanitizeQuotedText(option.name ?? option.optionId, 120)}`,
+        );
+      }
+    }
+    return lines.join('\n');
+  }
+
+  private approvalOptionId(pending: PendingPermission): string | undefined {
+    const options = pending.request.options;
+    return (
+      options.find((option) => option.kind === 'allow_once')?.optionId ??
+      options.find(
+        (option) =>
+          option.optionId === 'proceed_once' &&
+          (option as { kind?: string }).kind === undefined,
+      )?.optionId
+    );
+  }
+
+  private approvalAlwaysOptionId(
+    pending: PendingPermission,
+  ): string | undefined {
+    return pending.request.options.find(
+      (option) => option.kind === 'allow_always',
+    )?.optionId;
+  }
+
+  private denialResponse(pending: PendingPermission): {
+    outcome:
+      | { outcome: 'selected'; optionId: string }
+      | { outcome: 'cancelled' };
+  } {
+    const option =
+      pending.request.options.find(
+        (candidate) => candidate.kind === 'reject_once',
+      ) ??
+      pending.request.options.find(
+        (candidate) =>
+          candidate.optionId === 'cancel' &&
+          (candidate as { kind?: string }).kind === undefined,
+      );
+    if (option) {
+      return { outcome: { outcome: 'selected', optionId: option.optionId } };
+    }
+    return { outcome: { outcome: 'cancelled' } };
+  }
+
+  private async handlePermissionResponseCommand(
+    envelope: Envelope,
+    args: string,
+    decision: 'approve' | 'approve-always' | 'deny',
+  ): Promise<boolean> {
+    if (!this.isAuthorizedForSharedSession(envelope)) {
+      await this.sendMessage(
+        envelope.chatId,
+        'Only authorized members can answer permission requests in this shared session.',
+      );
+      return true;
+    }
+    const lookup = this.pendingPermissionForEnvelope(envelope, args);
+    if (lookup.kind === 'ambiguous') {
+      const requestList = lookup.requestIds
+        .slice(0, 6)
+        .map((id) => `- ${sanitizeQuotedText(id, 128)}`)
+        .join('\n');
+      await this.sendMessage(
+        envelope.chatId,
+        `Multiple permission requests are pending for this chat. Reply with /${decision} <request-id>.\n${requestList}`,
+      );
+      return true;
+    }
+    if (lookup.kind === 'none') {
+      await this.sendMessage(
+        envelope.chatId,
+        lookup.explicit
+          ? 'No pending permission request with that id for this chat.'
+          : 'No pending permission request for this chat.',
+      );
+      return true;
+    }
+    if (!this.bridge.respondToPermission) {
+      await this.sendMessage(
+        envelope.chatId,
+        'Permission relay is not available for this session.',
+      );
+      return true;
+    }
+
+    const { pending } = lookup;
+    const response = (() => {
+      if (decision === 'deny') {
+        return this.denialResponse(pending);
+      }
+      const optionId =
+        decision === 'approve'
+          ? this.approvalOptionId(pending)
+          : this.approvalAlwaysOptionId(pending);
+      return optionId
+        ? { outcome: { outcome: 'selected' as const, optionId } }
+        : undefined;
+    })();
+    if (!response) {
+      await this.sendMessage(
+        envelope.chatId,
+        decision === 'approve-always'
+          ? 'This permission request has no always-allow option.'
+          : 'This permission request has no approvable option.',
+      );
+      return true;
+    }
+
+    let accepted: boolean;
+    try {
+      accepted = await this.bridge.respondToPermission(
+        pending.requestId,
+        response,
+      );
+    } catch (err) {
+      process.stderr.write(
+        `[${this.name}] permission response failed for request ${sanitizeLogText(pending.requestId, 128)}: ${this.lifecycleError(err)}\n`,
+      );
+      await this.sendMessage(
+        envelope.chatId,
+        'Failed to answer the permission request.',
+      );
+      return true;
+    }
+    this.removePendingPermission(pending.requestId);
+    await this.sendMessage(
+      envelope.chatId,
+      accepted
+        ? decision === 'approve'
+          ? 'Permission approved.'
+          : decision === 'approve-always'
+            ? 'Permission approved always.'
+            : 'Permission denied.'
+        : 'Permission request is no longer pending.',
+    );
+    return true;
+  }
+
   /** Register shared slash commands. Called from constructor. */
   private registerSharedCommands(): void {
     const doClear = async (envelope: Envelope): Promise<void> => {
@@ -1067,6 +1378,7 @@ export abstract class ChannelBase {
             id,
             (this.sessionGenerations.get(id) ?? 0) + 1,
           );
+          this.removePendingPermissionsForSession(id);
           // Cancel an in-flight turn (and drop its buffered follow-ups) before
           // purging, so a running prompt can't deliver a stale response into —
           // or resurrect via collect-drain — the just-cleared session.
@@ -1183,6 +1495,15 @@ export abstract class ChannelBase {
     this.registerCommand('clear', clearHandler);
     this.registerCommand('reset', clearHandler);
     this.registerCommand('new', clearHandler);
+    this.registerCommand('approve', (envelope, args) =>
+      this.handlePermissionResponseCommand(envelope, args, 'approve'),
+    );
+    this.registerCommand('approve-always', (envelope, args) =>
+      this.handlePermissionResponseCommand(envelope, args, 'approve-always'),
+    );
+    this.registerCommand('deny', (envelope, args) =>
+      this.handlePermissionResponseCommand(envelope, args, 'deny'),
+    );
 
     // Read-only: report the current (possibly group-shared) session and workspace.
     // For a shared session, gate it to authorized senders like /clear — /who
@@ -1367,6 +1688,9 @@ export abstract class ChannelBase {
           : '/clear — Clear your session (aliases: /reset, /new)',
         '/who — Show current session & workspace',
         '/status — Show session info',
+        '/approve [request-id] — Approve a pending permission request',
+        '/approve-always <request-id> — Always approve a pending permission request',
+        '/deny [request-id] — Deny a pending permission request',
         '/remember-channel <text> — Save memory for this chat',
         '/channel-memory — Show memory for this chat',
         '/forget-channel confirm — Clear memory for this chat',
@@ -1378,6 +1702,9 @@ export abstract class ChannelBase {
         'clear',
         'reset',
         'new',
+        'approve',
+        'approve-always',
+        'deny',
         'who',
         'status',
         'remember-channel',

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -7,6 +7,8 @@ export type {
   ChannelLoopToolCreateInput,
   ChannelLoopToolHandler,
   ChannelLoopToolResult,
+  PermissionRequestEvent,
+  PermissionResolvedEvent,
   SessionDiedEvent,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -1,8 +1,10 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
 import { DWClient, TOPIC_ROBOT, EventAck } from 'dingtalk-stream-sdk-nodejs';
 import type { DWClientDownStream } from 'dingtalk-stream-sdk-nodejs';
 import {
@@ -76,6 +78,14 @@ interface DingTalkMessageData {
   };
 }
 
+interface DingTalkEventPayload {
+  EventId?: string;
+  EventType?: string;
+  CreateAt?: string;
+  CorpId?: string;
+  data?: Record<string, unknown>;
+}
+
 /** Track seen msgIds to deduplicate retried callbacks. */
 const DEDUP_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -126,6 +136,9 @@ export class DingtalkChannel extends ChannelBase {
    * on (re)connect, so a long-lived socket serves a stale one after ~2h.
    */
   private proactiveToken?: { token: string; expiresAt: number };
+  private openConversationId?: string;
+  private webhookServer?: Server;
+  private webhookPort?: number;
 
   constructor(
     name: string,
@@ -146,6 +159,13 @@ export class DingtalkChannel extends ChannelBase {
       clientSecret: config.clientSecret,
     });
     this.installStructuredDownstreamHandler();
+
+    this.openConversationId = (config as unknown as Record<string, unknown>)[
+      'openConversationId'
+    ] as string | undefined;
+    this.webhookPort = (config as unknown as Record<string, unknown>)[
+      'webhookPort'
+    ] as number | undefined;
   }
 
   private installStructuredDownstreamHandler(): void {
@@ -275,6 +295,10 @@ export class DingtalkChannel extends ChannelBase {
     );
 
     await this.client.connect();
+
+    if (this.webhookPort) {
+      this.startWebhookServer();
+    }
 
     // Periodically clean up dedup map
     this.dedupTimer = setInterval(() => {
@@ -470,6 +494,159 @@ export class DingtalkChannel extends ChannelBase {
     }
   }
 
+  private async sendGroupMessage(text: string): Promise<void> {
+    if (!this.openConversationId) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] No openConversationId configured, cannot push to group.\n`,
+      );
+      return;
+    }
+
+    const token = await this.getProactiveToken();
+    const robotCode = this.config.clientId;
+    if (!token || !robotCode) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Cannot send group message: missing token or robotCode.\n`,
+      );
+      return;
+    }
+
+    const title = extractTitle(text);
+    const resp = await fetch(GROUP_MSG_API, {
+      method: 'POST',
+      headers: {
+        'x-acs-dingtalk-access-token': token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        robotCode,
+        openConversationId: this.openConversationId,
+        msgKey: GROUP_MSG_KEY,
+        msgParam: JSON.stringify({ title, text }),
+      }),
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '');
+      process.stderr.write(
+        `[DingTalk:${this.name}] sendGroupMessage failed: HTTP ${resp.status} ${detail}\n`,
+      );
+    }
+  }
+
+  private startWebhookServer(): void {
+    const port = this.webhookPort!;
+    const appSecret = this.config.clientSecret!;
+
+    this.webhookServer = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          const payload: DingTalkEventPayload = body ? JSON.parse(body) : {};
+
+          const timestamp = req.headers['timestamp'] as string | undefined;
+          const sign = req.headers['sign'] as string | undefined;
+          if (
+            timestamp &&
+            sign &&
+            !this.verifySignature(timestamp, sign, appSecret)
+          ) {
+            process.stderr.write(
+              `[DingTalk:${this.name}] Webhook signature verification failed.\n`,
+            );
+            res.writeHead(403, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'invalid signature' }));
+            return;
+          }
+
+          const eventType = payload.EventType;
+          process.stderr.write(
+            `[DingTalk:${this.name}] Webhook received: EventType=${eventType}\n`,
+          );
+
+          if (eventType === 'check_url') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ msgtype: 'check_url' }));
+            process.stderr.write(
+              `[DingTalk:${this.name}] check_url verified OK.\n`,
+            );
+            return;
+          }
+
+          if (eventType === 'doc_change') {
+            this.onDocChange(payload.data || {});
+          }
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        } catch (err) {
+          process.stderr.write(
+            `[DingTalk:${this.name}] Webhook error: ${err}\n`,
+          );
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'internal error' }));
+        }
+      });
+    });
+
+    this.webhookServer.listen(port, () => {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Webhook server listening on port ${port}.\n`,
+      );
+    });
+  }
+
+  private verifySignature(
+    timestamp: string,
+    sign: string,
+    appSecret: string,
+  ): boolean {
+    const expected = createHmac('sha256', appSecret)
+      .update(`${timestamp}\n${appSecret}`)
+      .digest('base64');
+    return sign === expected;
+  }
+
+  private onDocChange(data: Record<string, unknown>): void {
+    const docName = (data['dentryName'] as string) || '未知文档';
+    const docUrl = (data['url'] as string) || '';
+    const operator = (data['operatorName'] as string) || '未知用户';
+    const operateType = (data['operateType'] as string) || '变更';
+
+    const operateLabel: Record<string, string> = {
+      add: '新建',
+      update: '更新',
+      delete: '删除',
+      rename: '重命名',
+      move: '移动',
+      copy: '复制',
+      edit: '编辑',
+    };
+
+    const action = operateLabel[operateType] || operateType;
+
+    const text = [
+      `### 📄 文档变更通知`,
+      ``,
+      `- **文档**: ${docUrl ? `[${docName}](${docUrl})` : docName}`,
+      `- **操作**: ${action}`,
+      `- **操作人**: ${operator}`,
+      `- **时间**: ${new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })}`,
+    ].join('\n');
+
+    this.sendGroupMessage(text).catch((err) => {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Error sending doc_change notification: ${err}\n`,
+      );
+    });
+
+    process.stderr.write(
+      `[DingTalk:${this.name}] doc_change: ${action} "${docName}" by ${operator}\n`,
+    );
+  }
+
   private getAccessToken(): string | undefined {
     return this.client.getConfig().access_token;
   }
@@ -537,6 +714,9 @@ export class DingtalkChannel extends ChannelBase {
     }
     this.activeReactionKeys.clear();
     this.sessionReactionKeys.clear();
+    if (this.webhookServer) {
+      this.webhookServer.close();
+    }
     this.client.disconnect();
     process.stderr.write(`[DingTalk:${this.name}] Disconnected.\n`);
   }

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -6,6 +6,7 @@ const mockLoadChannelsFromExtensions = vi.hoisted(() => vi.fn());
 const mockParseConfiguredChannels = vi.hoisted(() => vi.fn());
 const mockCreateChannel = vi.hoisted(() => vi.fn());
 const mockRegisterToolCallDispatch = vi.hoisted(() => vi.fn());
+const mockRegisterPermissionRelay = vi.hoisted(() => vi.fn());
 const mockRegisterSessionCleanup = vi.hoisted(() => vi.fn());
 const mockSessionsPath = vi.hoisted(() => vi.fn(() => '/tmp/sessions.json'));
 const mockLoadSettings = vi.hoisted(() =>
@@ -71,6 +72,7 @@ const mockBridgeNewSession = vi.hoisted(() => vi.fn());
 const mockBridgeLoadSession = vi.hoisted(() => vi.fn());
 const mockBridgePrompt = vi.hoisted(() => vi.fn());
 const mockBridgeCancelSession = vi.hoisted(() => vi.fn());
+const mockBridgeRespondToPermission = vi.hoisted(() => vi.fn());
 const mockBridgeShellCommand = vi.hoisted(() => vi.fn());
 const mockBridgeGetAvailableCommands = vi.hoisted(() => vi.fn(() => []));
 const mockDaemonChannelBridge = vi.hoisted(() =>
@@ -85,6 +87,7 @@ const mockDaemonChannelBridge = vi.hoisted(() =>
     loadSession: mockBridgeLoadSession,
     prompt: mockBridgePrompt,
     cancelSession: mockBridgeCancelSession,
+    respondToPermission: mockBridgeRespondToPermission,
     shellCommand: mockBridgeShellCommand,
     start: mockBridgeStart,
     stop: mockBridgeStop,
@@ -128,6 +131,7 @@ vi.mock('./runtime.js', () => ({
   loadChannelsConfig: mockLoadChannelsConfig,
   loadChannelsFromExtensions: mockLoadChannelsFromExtensions,
   parseConfiguredChannels: mockParseConfiguredChannels,
+  registerPermissionRelay: mockRegisterPermissionRelay,
   registerSessionCleanup: mockRegisterSessionCleanup,
   registerToolCallDispatch: mockRegisterToolCallDispatch,
   selectFirstModel: mockSelectFirstModel,
@@ -402,6 +406,48 @@ describe('createDaemonChannelBridgeFacade', () => {
     expect(listSessions).toHaveBeenCalled();
   });
 
+  it('forwards permission responses when present on bridge', async () => {
+    const respondToPermission = vi.fn().mockResolvedValue(true);
+    const bridge = {
+      availableCommands: [],
+      on: mockBridgeOn,
+      off: mockBridgeOff,
+      newSession: mockBridgeNewSession,
+      loadSession: mockBridgeLoadSession,
+      prompt: mockBridgePrompt,
+      cancelSession: mockBridgeCancelSession,
+      respondToPermission,
+    };
+
+    const facade = createDaemonChannelBridgeFacade(bridge, {
+      exposeShellCommand: false,
+    });
+
+    const response = { outcome: { outcome: 'cancelled' as const } };
+    await expect(facade.respondToPermission?.('req-1', response)).resolves.toBe(
+      true,
+    );
+    expect(respondToPermission).toHaveBeenCalledWith('req-1', response);
+  });
+
+  it('omits permission responses when absent on bridge', () => {
+    const bridge = {
+      availableCommands: [],
+      on: mockBridgeOn,
+      off: mockBridgeOff,
+      newSession: mockBridgeNewSession,
+      loadSession: mockBridgeLoadSession,
+      prompt: mockBridgePrompt,
+      cancelSession: mockBridgeCancelSession,
+    };
+
+    const facade = createDaemonChannelBridgeFacade(bridge, {
+      exposeShellCommand: false,
+    });
+
+    expect('respondToPermission' in facade).toBe(false);
+  });
+
   it('omits listSessions when absent on bridge', () => {
     const bridge = {
       availableCommands: [],
@@ -484,6 +530,11 @@ describe('runChannelDaemonWorker', () => {
         proxy: 'http://settings-proxy:8080',
         router: mockSessionRouter.mock.results[0]!.value,
       }),
+    );
+    expect(mockRegisterPermissionRelay).toHaveBeenCalledWith(
+      bridgeFacade,
+      mockSessionRouter.mock.results[0]!.value,
+      expect.any(Map),
     );
     expect(mockResolveProxyUrl).toHaveBeenCalledWith(
       undefined,

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -31,6 +31,7 @@ import {
   loadChannelsConfig,
   loadChannelsFromExtensions,
   parseConfiguredChannels,
+  registerPermissionRelay,
   registerSessionCleanup,
   registerToolCallDispatch,
   selectFirstModel,
@@ -150,6 +151,10 @@ export function createDaemonChannelBridgeFacade(
     prompt: bridge.prompt.bind(bridge),
     cancelSession: bridge.cancelSession.bind(bridge),
   };
+
+  if (bridge.respondToPermission) {
+    facade.respondToPermission = bridge.respondToPermission.bind(bridge);
+  }
 
   if (bridge.getAvailableCommands) {
     facade.getAvailableCommands = bridge.getAvailableCommands.bind(bridge);
@@ -343,6 +348,7 @@ export async function runChannelDaemonWorker(
       );
     }
     registerToolCallDispatch(bridgeFacade, createdRouter, channels);
+    registerPermissionRelay(bridgeFacade, createdRouter, channels);
     registerSessionCleanup(bridgeFacade, createdRouter, channels);
 
     for (const [name, channel] of channels) {

--- a/packages/cli/src/commands/channel/runtime.test.ts
+++ b/packages/cli/src/commands/channel/runtime.test.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
-import { parseConfiguredChannels } from './runtime.js';
+import { parseConfiguredChannels, registerPermissionRelay } from './runtime.js';
 
 vi.mock('./channel-registry.js', () => ({
   getPlugin: async (type: string) =>
@@ -40,5 +41,81 @@ describe('parseConfiguredChannels', () => {
         }),
       }),
     ]);
+  });
+});
+
+describe('registerPermissionRelay', () => {
+  function createBridge() {
+    const emitter = new EventEmitter();
+    return Object.assign(emitter, {
+      availableCommands: [],
+      newSession: vi.fn(),
+      loadSession: vi.fn(),
+      prompt: vi.fn(),
+      cancelSession: vi.fn(),
+      respondToPermission: vi.fn().mockResolvedValue(true),
+    });
+  }
+
+  it('cancels permission requests when no route exists', async () => {
+    const bridge = createBridge();
+    const router = { getTarget: vi.fn() };
+
+    registerPermissionRelay(bridge, router as never, new Map());
+    bridge.emit('permissionRequest', {
+      requestId: 'req-1',
+      sessionId: 'missing-session',
+      request: {
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'shell',
+          title: 'Run command',
+        },
+        options: [],
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(bridge.respondToPermission).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'cancelled' },
+      }),
+    );
+  });
+
+  it('cancels permission requests when channel dispatch fails', async () => {
+    const bridge = createBridge();
+    const router = {
+      getTarget: vi.fn(() => ({ channelName: 'telegram', chatId: 'chat1' })),
+    };
+    const channel = {
+      dispatchPermissionRequest: vi
+        .fn()
+        .mockRejectedValue(new Error('send failed')),
+      dispatchPermissionResolved: vi.fn(),
+    };
+
+    registerPermissionRelay(
+      bridge,
+      router as never,
+      new Map([['telegram', channel as never]]),
+    );
+    bridge.emit('permissionRequest', {
+      requestId: 'req-1',
+      sessionId: 'session-1',
+      request: {
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'shell',
+          title: 'Run command',
+        },
+        options: [],
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(bridge.respondToPermission).toHaveBeenCalledWith('req-1', {
+        outcome: { outcome: 'cancelled' },
+      }),
+    );
   });
 });

--- a/packages/cli/src/commands/channel/runtime.ts
+++ b/packages/cli/src/commands/channel/runtime.ts
@@ -7,6 +7,8 @@ import type {
   ChannelBase,
   ChannelBaseOptions,
   ChannelPlugin,
+  PermissionRequestEvent,
+  PermissionResolvedEvent,
   ToolCallEvent,
 } from '@qwen-code/channel-base';
 import { sanitizeLogText } from '@qwen-code/channel-base';
@@ -160,6 +162,50 @@ export function registerToolCallDispatch(
       if (channel) {
         channel.dispatchToolCall(event);
       }
+    }
+  });
+}
+
+function cancelPermissionRequest(
+  bridge: ChannelAgentBridge,
+  requestId: string,
+): void {
+  void bridge
+    .respondToPermission?.(requestId, { outcome: { outcome: 'cancelled' } })
+    .catch((err: unknown) => {
+      writeStderrLine(
+        `[Channel] Permission cancellation failed for ${sanitizeLogText(requestId, 128)}: ${err instanceof Error ? sanitizeLogText(err.message, 512) : sanitizeLogText(String(err), 512)}`,
+      );
+    });
+}
+
+export function registerPermissionRelay(
+  bridge: ChannelAgentBridge,
+  router: SessionRouter,
+  channels: Map<string, ChannelBase>,
+): void {
+  bridge.on('permissionRequest', (event: PermissionRequestEvent) => {
+    const target = router.getTarget(event.sessionId);
+    if (!target) {
+      cancelPermissionRequest(bridge, event.requestId);
+      return;
+    }
+    const channel = channels.get(target.channelName);
+    if (!channel) {
+      cancelPermissionRequest(bridge, event.requestId);
+      return;
+    }
+    channel.dispatchPermissionRequest(event).catch((err: unknown) => {
+      writeStderrLine(
+        `[Channel] Permission relay failed for ${sanitizeLogText(event.requestId, 128)}: ${err instanceof Error ? sanitizeLogText(err.message, 512) : sanitizeLogText(String(err), 512)}`,
+      );
+      cancelPermissionRequest(bridge, event.requestId);
+    });
+  });
+
+  bridge.on('permissionResolved', (event: PermissionResolvedEvent) => {
+    for (const channel of channels.values()) {
+      channel.dispatchPermissionResolved(event);
     }
   });
 }

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -32,6 +32,7 @@ import {
   loadChannelsConfig,
   loadChannelsFromExtensions,
   parseConfiguredChannels,
+  registerPermissionRelay,
   registerSessionCleanup,
   registerToolCallDispatch,
   selectFirstModel,
@@ -213,6 +214,7 @@ async function startSingle(
       })
     : undefined;
   registerToolCallDispatch(bridge, router, channels);
+  registerPermissionRelay(bridge, router, channels);
   registerSessionCleanup(bridge, router, channels);
 
   try {
@@ -266,6 +268,7 @@ async function startSingle(
         channel.disconnect();
         await channel.connect();
         registerToolCallDispatch(bridge, router, channels);
+        registerPermissionRelay(bridge, router, channels);
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 
@@ -374,6 +377,7 @@ async function startAll(
     );
   }
   registerToolCallDispatch(bridge, router, channels);
+  registerPermissionRelay(bridge, router, channels);
   registerSessionCleanup(bridge, router, channels);
 
   // Connect all channels
@@ -472,6 +476,7 @@ async function startAll(
           process.exit(1);
         }
         registerToolCallDispatch(bridge, router, channels);
+        registerPermissionRelay(bridge, router, channels);
         registerSessionCleanup(bridge, router, channels);
         attachDisconnectHandler(bridge);
 


### PR DESCRIPTION
## What this PR does

Routes ACP permission requests through channel chat instead of auto-approving them. Channel users can approve once, approve always when the ACP option is available, or deny the request from the owning chat or thread. Failed delivery, missing routes, session cancellation, process exit, and bridge stop now resolve pending permission requests as cancelled so agent turns do not hang.

## Why it is needed

Channel standalone previously auto-approved ACP permission requests, which bypassed the user consent flow. Replacing that behavior with a relay keeps tool authorization explicit while preserving safe cleanup paths when the channel cannot deliver the prompt.

## Reviewer Test Plan

### How to verify

Run the focused channel tests and confirm permission requests are emitted, relayed, approved, denied, cancelled on failure, and cleaned up across session and process lifecycle paths.

### Evidence (Before & After)

N/A for screenshots. Before this change ACP channel permission requests were auto-approved. After this change the channel sends a permission prompt and waits for /approve, /approve-always, or /deny.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

### Environment (optional)

Local Node workspace.

## Risk & Scope

- Main risk or tradeoff: channel users must now respond to permission prompts, so unattended channel sessions may pause instead of silently approving tools.
- Not validated / out of scope: platform-specific interactive buttons or cards; this PR uses text commands.
- Breaking changes / migration notes: no config migration required.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

把 ACP 权限请求通过 channel 聊天转发，不再自动批准。channel 用户可以在归属 chat 或 thread 中选择单次批准、在 ACP 提供对应选项时永久批准，或拒绝请求。发送失败、路由缺失、会话取消、进程退出和 bridge 停止时，pending permission 会被 resolve 为 cancelled，避免 agent turn 卡住。

## Why it is needed

channel standalone 之前会自动批准 ACP 权限请求，绕过用户授权流程。改为 permission relay 后，工具授权变成显式用户操作，同时在 channel 无法投递提示时仍保持安全清理。

## Reviewer Test Plan

### How to verify

运行聚焦的 channel 测试，确认 permission request 会被发出、转发、批准、拒绝、失败时取消，并在 session 和 process 生命周期中被清理。

### Evidence (Before & After)

无截图。变更前 ACP channel 权限请求会自动批准。变更后 channel 会发送权限提示，并等待 /approve、/approve-always 或 /deny。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | tested |
| Windows | not tested |
|  Linux  | not tested |

### Environment (optional)

本地 Node workspace。

## Risk & Scope

- Main risk or tradeoff: channel 用户现在必须响应权限提示，因此无人值守的 channel session 可能会暂停，而不是静默批准工具。
- Not validated / out of scope: 平台专用交互按钮或卡片；本 PR 使用文本命令。
- Breaking changes / migration notes: 不需要配置迁移。

## Linked Issues

N/A

</details>