### PR TITLE
fix(web-shell): hide rotating loading phrase in split-view pane status

### DIFF
--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -56,6 +56,7 @@ vi.mock('./StreamingStatus', () => ({
     <div
       data-testid="pane-streaming"
       data-started-at={props.startedAt === undefined ? 'none' : String(props.startedAt)}
+      data-show-phrase={String(props.showPhrase)}
     />
   ),
 }));
@@ -161,6 +162,13 @@ describe('ChatPane', () => {
     render({ title: 'Refactor core' });
     expect(testid('pane-messages')?.textContent).toBe('1');
     expect(container!.textContent).toContain('Refactor core');
+  });
+
+  it('suppresses the rotating loading phrase in its compact status', () => {
+    render();
+    expect(testid('pane-streaming')?.getAttribute('data-show-phrase')).toBe(
+      'false',
+    );
   });
 
   it('sends a prompt to its own session on submit', () => {

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -206,7 +206,9 @@ export function ChatPane({ title, isCurrent, onClose, onError }: ChatPaneProps) 
             />
           </div>
         )}
-        <StreamingStatus startedAt={activeTurnStartedAt} />
+        {/* Panes keep the composer status compact: spinner + elapsed time +
+            token count + cancel hint, but no rotating "witty" loading phrase. */}
+        <StreamingStatus startedAt={activeTurnStartedAt} showPhrase={false} />
         <ChatEditor
           onSubmit={handleSubmit}
           onCancel={handleCancel}

--- a/packages/web-shell/client/components/StreamingStatus.test.tsx
+++ b/packages/web-shell/client/components/StreamingStatus.test.tsx
@@ -35,7 +35,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function render(customization: WebShellCustomization = {}): HTMLElement {
+function render(
+  customization: WebShellCustomization = {},
+  props: { showPhrase?: boolean } = {},
+): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -43,7 +46,7 @@ function render(customization: WebShellCustomization = {}): HTMLElement {
     root.render(
       <I18nProvider language="en">
         <WebShellCustomizationProvider value={customization}>
-          <StreamingStatus />
+          <StreamingStatus {...props} />
         </WebShellCustomizationProvider>
       </I18nProvider>,
     );
@@ -88,6 +91,23 @@ describe('StreamingStatus loading phrases', () => {
     expect(container.firstElementChild?.querySelectorAll('span').length).toBe(
       2,
     );
+  });
+
+  it('hides the phrase but keeps the dynamic status when showPhrase is false', () => {
+    pinPhraseSelection();
+    // A resolver that would otherwise supply a phrase must still be suppressed.
+    const container = render({ loadingPhrases: () => ['should not appear'] }, {
+      showPhrase: false,
+    });
+    // The witty phrase (the "废话文学") is gone: no label span.
+    expect(labelText(container)).toBeUndefined();
+    expect(container.textContent).not.toContain('should not appear');
+    // But the dynamic status stays: spinner + meta (elapsed time + cancel hint).
+    const spans = container.firstElementChild?.querySelectorAll('span') ?? [];
+    expect(spans.length).toBe(2);
+    expect(spans[0]?.textContent).not.toBe(''); // spinner frame
+    expect(container.textContent).toContain('esc to cancel'); // meta/cancel hint
+    expect(container.textContent).toMatch(/\ds/); // elapsed time, e.g. "0s"
   });
 
   it('falls back to the built-in defaults when the resolver returns undefined', () => {

--- a/packages/web-shell/client/components/StreamingStatus.tsx
+++ b/packages/web-shell/client/components/StreamingStatus.tsx
@@ -12,11 +12,21 @@ import styles from './StreamingStatus.module.css';
 
 interface StreamingStatusProps {
   startedAt?: number;
+  /**
+   * When false, hide the rotating "witty" loading phrase and skip its rotation
+   * timer entirely — the spinner, elapsed time, token count, and cancel hint
+   * still render. Split-view panes pass false to keep each pane's composer
+   * status compact. Defaults to true (the main chat shows the phrase).
+   */
+  showPhrase?: boolean;
 }
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-export function StreamingStatus({ startedAt }: StreamingStatusProps) {
+export function StreamingStatus({
+  startedAt,
+  showPhrase = true,
+}: StreamingStatusProps) {
   const streamingState = useStreamingState();
   const { estimatedOutputTokens, isReceivingContent } =
     useStreamingLoadingMetrics();
@@ -71,6 +81,10 @@ export function StreamingStatus({ startedAt }: StreamingStatusProps) {
   }, [isActive, startedAt]);
 
   useEffect(() => {
+    // Callers that hide the phrase (e.g. split-view panes) don't need the
+    // rotation timer at all — bail before arming it so panes don't each run a
+    // needless interval and re-render on every tick.
+    if (!showPhrase) return;
     if (streamingState === 'idle') {
       setLoadingPhrase(resolvePhrases(language)[0] ?? '');
       return;
@@ -90,7 +104,7 @@ export function StreamingStatus({ startedAt }: StreamingStatusProps) {
     pickPhrase();
     const interval = setInterval(pickPhrase, PHRASE_CHANGE_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [language, streamingState, resolvePhrases]);
+  }, [language, streamingState, resolvePhrases, showPhrase]);
 
   useEffect(() => {
     if (streamingState === 'idle') return;
@@ -113,7 +127,9 @@ export function StreamingStatus({ startedAt }: StreamingStatusProps) {
   return (
     <div className={styles.status}>
       <span className={styles.spinner}>{spinnerChar}</span>
-      {loadingPhrase && <span className={styles.label}>{loadingPhrase}</span>}
+      {showPhrase && loadingPhrase && (
+        <span className={styles.label}>{loadingPhrase}</span>
+      )}
       <span className={styles.meta}>
         ({timeStr}
         {tokenStr} · {t('stream.cancel')})


### PR DESCRIPTION
## What this PR does

In the in-window split view, each pane's streaming status line no longer shows the rotating "witty" loading phrase (the corporate-jargon filler such as "正在赋能全链路，寻找关键抓手…"). The spinner, elapsed time, token count, and cancel hint all stay. `StreamingStatus` gains a `showPhrase` prop (default `true`), and the split-view `ChatPane` passes `showPhrase={false}`. When the phrase is hidden the 15s phrase-rotation timer is skipped entirely, so each pane avoids a needless interval and re-render.

## Why it's needed

A split view can show several panes side by side, each with its own streaming status. The rotating loading phrases add visual noise and eat horizontal space in the narrow panes without conveying anything actionable — the useful signal (elapsed time, token count, cancel hint) is the compact meta that follows. The main single-session chat is unchanged: it still shows the phrase because the prop defaults to `true`.

## Reviewer Test Plan

### How to verify

- Unit (from `packages/web-shell`): `npx vitest run client/components/StreamingStatus.test.tsx client/components/ChatPane.test.tsx` — 27 tests pass. New cases assert (a) `showPhrase={false}` hides the phrase even when a resolver supplies one, while the spinner + elapsed time + `esc to cancel` remain, and (b) `ChatPane` passes `showPhrase={false}`.
- Manual: open a split view with a pane mid-turn. Expected: the pane status line reads `⠸ (Ns · ↑ N tokens · esc to cancel)` with no phrase, above the composer; the main chat still shows the phrase.

Expected vs observed: in split panes the phrase is gone and the dynamic info is retained; the main view is unchanged. Observed matches expected.

### Evidence (Before & After)

① Main view (`showPhrase` default) keeps the phrase. ② / ③ Split panes (`showPhrase={false}`) drop only the phrase, keeping the spinner / elapsed time / cancel hint above the composer.

![before and after](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets-split-pane/docs/verify-split-pane.png)

Rendered status text captured from a real Chromium run of the actual `StreamingStatus` / `ChatPane` components:

- Before / main: `⠸ 正在给产品经理画饼，请稍等… (4s · esc 取消)`
- After / split pane: `⠸ (4s · esc 取消)`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Vitest (jsdom) unit tests, plus a real-Chromium component harness rendering the actual `StreamingStatus` and `ChatPane` under a stubbed daemon SDK forced into the streaming state.

## Risk & Scope

- Main risk or tradeoff: minimal — a new opt-in prop that defaults to today's behavior; only the split-view `ChatPane` opts out.
- Not validated / out of scope: no change to the main chat composer; the pane token count still comes from the existing streaming metrics.
- Breaking changes / migration notes: none.

## Linked Issues

<!-- none -->

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在窗口内分屏视图里，每个 pane 的流式状态行不再显示那句每 15 秒轮换的"废话文学"加载短语(诸如"正在赋能全链路，寻找关键抓手…"这类互联网黑话)。转圈图标、耗时、token 数、取消提示全部保留。`StreamingStatus` 新增 `showPhrase` 属性(默认 `true`),分屏用的 `ChatPane` 传 `showPhrase={false}`。短语隐藏时会完全跳过那个 15 秒的轮换定时器,因此每个 pane 不会各自空跑一个定时器和重渲染。

## 为什么需要

分屏可以同时并排显示多个 pane,每个都有自己的流式状态。这些轮换短语在狭窄的 pane 里增加视觉噪音、占用横向空间,却不传递任何可操作信息——有用的信号(耗时、token 数、取消提示)是后面那段紧凑的 meta。主视图(单会话聊天)保持不变:因为属性默认 `true`,仍然显示短语。

## 如何验证

- 单元测试(在 `packages/web-shell` 下):`npx vitest run client/components/StreamingStatus.test.tsx client/components/ChatPane.test.tsx`,27 项通过。新增用例断言:(a) `showPhrase={false}` 即使 resolver 提供了短语也会隐藏它,同时转圈图标 + 耗时 + `esc to cancel` 仍在;(b) `ChatPane` 确实传了 `showPhrase={false}`。
- 手动:打开分屏,让某个 pane 处于回答中。预期:pane 状态行显示 `⠸ (Ns · ↑ N tokens · esc 取消)`,无短语,位于输入框上方;主视图仍显示短语。

## 证据(改动前后)

①主视图(`showPhrase` 默认)保留短语。②/③分屏 pane(`showPhrase={false}`)只删短语,保留转圈图标 / 耗时 / 取消提示,位于输入框上方。截图见上方英文部分。

真实 Chromium 渲染真实 `StreamingStatus` / `ChatPane` 组件后抓取的状态文本:

- 改动前 / 主视图:`⠸ 正在给产品经理画饼，请稍等… (4s · esc 取消)`
- 改动后 / 分屏 pane:`⠸ (4s · esc 取消)`

## 风险与范围

- 主要风险/权衡:极小——新增一个可选属性,默认等同现状;只有分屏 `ChatPane` 主动关闭短语。
- 未验证/范围外:主视图 composer 无改动;pane 的 token 数仍来自既有流式指标。
- 破坏性改动/迁移:无。

</details>
