### PR TITLE
fix(cli): show file path in compact tool summary for single collapsible tools

### DIFF
--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -227,6 +227,35 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary(tools, false)).toBe('Read 1 file');
   });
 
+  it('falls back to count format when description is JSON (error args)', () => {
+    const tools = [
+      make({
+        callId: 'c1',
+        name: 'ReadFile',
+        description: '{"file_path":"/tmp/test.txt"}',
+      }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Read 1 file');
+  });
+
+  it('falls back to count format when description starts with array bracket', () => {
+    const tools = [
+      make({ callId: 'c1', name: 'Shell', description: '["ls", "-la"]' }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Ran 1 command');
+  });
+
+  it('strips ANSI escape sequences from description', () => {
+    const tools = [
+      make({
+        callId: 'c1',
+        name: 'ReadFile',
+        description: '\x1b[32ma.ts\x1b[0m',
+      }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Read a.ts');
+  });
+
   it('mixed group with count per category', () => {
     const tools = [
       make({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -245,7 +245,7 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary(tools, false)).toBe('Ran 1 command');
   });
 
-  it('strips ANSI escape sequences from description', () => {
+  it('strips ANSI CSI escape sequences from description', () => {
     const tools = [
       make({
         callId: 'c1',
@@ -254,6 +254,24 @@ describe('buildToolSummary', () => {
       }),
     ];
     expect(buildToolSummary(tools, false)).toBe('Read a.ts');
+  });
+
+  it('strips non-CSI ANSI sequences (charset, OSC) from description', () => {
+    const tools = [
+      make({ callId: 'c1', name: 'Shell', description: '\x1b(Bls -la\x1b[0m' }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Ran ls -la');
+  });
+
+  it('replaces embedded newlines with spaces in description', () => {
+    const tools = [
+      make({
+        callId: 'c1',
+        name: 'Shell',
+        description: 'echo hello\nworld',
+      }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Ran echo hello world');
   });
 
   it('mixed group with count per category', () => {

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -123,7 +123,7 @@ describe('<CompactToolGroupDisplay /> — summary label', () => {
     );
     const frame = lastFrame()!;
     // CATEGORY_ORDER: search → read → list → ...
-    expect(frame).toContain('Searched 1 pattern');
+    expect(frame).toContain('Searched search pattern');
     expect(frame).toContain('read 2 files');
   });
 
@@ -145,7 +145,7 @@ describe('<CompactToolGroupDisplay /> — summary label', () => {
     const { lastFrame } = render(
       <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
     );
-    expect(lastFrame()).toContain('Ran 1 command');
+    expect(lastFrame()).toContain('Ran ls -la');
   });
 });
 
@@ -166,12 +166,12 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary([], false)).toBe('');
   });
 
-  it('single tool uses count format', () => {
-    expect(buildToolSummary([make({})], false)).toBe('Read 1 file');
+  it('single tool uses description format', () => {
+    expect(buildToolSummary([make({})], false)).toBe('Read a.ts');
   });
 
   it('single tool uses progressive verb when active', () => {
-    expect(buildToolSummary([make({})], true)).toBe('Reading 1 file');
+    expect(buildToolSummary([make({})], true)).toBe('Reading a.ts');
   });
 
   it('multiple same-type tools use count', () => {
@@ -191,7 +191,7 @@ describe('buildToolSummary', () => {
     ];
     // CATEGORY_ORDER: search → read → list → command → edit
     expect(buildToolSummary(tools, false)).toBe(
-      'Read 1 file, ran 1 command, edited 1 file',
+      'Read a.ts, ran npm test, edited b.ts',
     );
   });
 
@@ -201,14 +201,30 @@ describe('buildToolSummary', () => {
       make({ callId: 'c2', name: 'Shell', description: 'ls' }),
     ];
     const result = buildToolSummary(tools, false);
-    expect(result).toBe('Read 1 file, ran 1 command');
+    expect(result).toBe('Read a.ts, ran ls');
   });
 
   it('unknown tool names fall to other category', () => {
     const tools = [
       make({ callId: 'c1', name: 'UnknownTool', description: 'something' }),
     ];
-    expect(buildToolSummary(tools, false)).toBe('Used 1 tool');
+    expect(buildToolSummary(tools, false)).toBe('Used something');
+  });
+
+  it('falls back to count format when description is empty', () => {
+    const tools = [make({ callId: 'c1', name: 'ReadFile', description: '' })];
+    expect(buildToolSummary(tools, false)).toBe('Read 1 file');
+  });
+
+  it('falls back to count format when description is undefined', () => {
+    const tools = [
+      make({
+        callId: 'c1',
+        name: 'ReadFile',
+        description: undefined as unknown as string,
+      }),
+    ];
+    expect(buildToolSummary(tools, false)).toBe('Read 1 file');
   });
 
   it('mixed group with count per category', () => {
@@ -217,7 +233,7 @@ describe('buildToolSummary', () => {
       make({ callId: 'c2', name: 'ReadFile', description: 'b.ts' }),
       make({ callId: 'c3', name: 'Shell', description: 'npm test' }),
     ];
-    expect(buildToolSummary(tools, false)).toBe('Read 2 files, ran 1 command');
+    expect(buildToolSummary(tools, false)).toBe('Read 2 files, ran npm test');
   });
 
   it('legacy display names map to correct categories', () => {
@@ -226,7 +242,7 @@ describe('buildToolSummary', () => {
       make({ callId: 'c2', name: 'ReadFolder', description: '/src' }),
     ];
     expect(buildToolSummary(tools, false)).toBe(
-      'Searched 1 pattern, listed 1 directory',
+      'Searched pattern, listed /src',
     );
   });
 });

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -204,28 +204,32 @@ export function buildToolSummary(
 ): string {
   if (toolCalls.length === 0) return '';
 
-  // Group by category and count
-  const counts = new Map<ToolCategory, number>();
+  // Group by category to preserve tool references for description access
+  const toolsByCategory = new Map<ToolCategory, IndividualToolCallDisplay[]>();
 
   for (const tool of toolCalls) {
     const cat = getToolCategory(tool.name);
-    counts.set(cat, (counts.get(cat) ?? 0) + 1);
+    const arr = toolsByCategory.get(cat) ?? [];
+    arr.push(tool);
+    toolsByCategory.set(cat, arr);
   }
 
   const parts: string[] = [];
   for (const cat of CATEGORY_ORDER) {
-    const count = counts.get(cat);
-    if (!count) continue;
+    const tools = toolsByCategory.get(cat);
+    if (!tools || tools.length === 0) continue;
 
     const template = CATEGORY_TEMPLATES[cat];
     const verb = isActive ? template.activeVerb : template.pastVerb;
     const lower = parts.length > 0;
     const v = lower ? verb.toLowerCase() : verb;
 
-    if (count === 1) {
+    if (tools.length === 1 && tools[0].description) {
+      parts.push(`${v} ${tools[0].description}`);
+    } else if (tools.length === 1) {
       parts.push(`${v} 1 ${template.singular}`);
     } else {
-      parts.push(`${v} ${count} ${template.plural}`);
+      parts.push(`${v} ${tools.length} ${template.plural}`);
     }
   }
 

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -199,12 +199,15 @@ export function isCollapsibleTool(toolName: string): boolean {
 function safeDescription(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
 
-  // Strip ANSI escape sequences
-  // eslint-disable-next-line no-control-regex
-  const stripped = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-  // Reject control characters (except tab/newline)
-  // eslint-disable-next-line no-control-regex
-  const cleaned = stripped.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  /* eslint-disable no-control-regex */
+  // Strip all common ANSI escape sequences: OSC, charset, CSI, and single-byte ESC
+  const stripped = raw.replace(
+    /\x1b\][^\x07]*\x07|\x1b[()][A-Z0-9]|\x1b\[[0-9;]*[a-zA-Z]|\x1b./g,
+    '',
+  );
+  // Replace all C0 control characters (including \n, \r) with spaces
+  const cleaned = stripped.replace(/[\x00-\x1f\x7f]/g, ' ').trim();
+  /* eslint-enable no-control-regex */
 
   // Reject JSON-looking blobs (error fallback from args)
   if (cleaned.startsWith('{') || cleaned.startsWith('[')) return undefined;

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -190,13 +190,39 @@ export function isCollapsibleTool(toolName: string): boolean {
 }
 
 /**
+ * Strip ANSI control sequences and reject JSON-looking error fallbacks.
+ *
+ * When a tool call errors, `useReactToolScheduler` sets description to
+ * `JSON.stringify(request.args)` which produces `{...}` blobs. Return
+ * `undefined` for those so the caller falls back to count format.
+ */
+function safeDescription(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+
+  // Strip ANSI escape sequences
+  // eslint-disable-next-line no-control-regex
+  const stripped = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+  // Reject control characters (except tab/newline)
+  // eslint-disable-next-line no-control-regex
+  const cleaned = stripped.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+
+  // Reject JSON-looking blobs (error fallback from args)
+  if (cleaned.startsWith('{') || cleaned.startsWith('[')) return undefined;
+
+  return cleaned || undefined;
+}
+
+/**
  * Build a semantic summary line from a batch of tool calls.
  *
- * Single tool  → "Read 1 file" / "Ran 1 command"
- * Multi  same  → "Read 3 files"
- * Multi mixed  → "Read 3 files, edited 2 files, ran 1 command"
+ * Single tool (with description) → "Read a.ts" / "Ran ls -la"
+ * Single tool (no description)   → "Read 1 file" / "Ran 1 command"
+ * Multi  same                    → "Read 3 files"
+ * Multi mixed                    → "Read a.ts, ran npm test, edited b.ts"
  *
  * Uses past tense when all tools are done, present progressive when active.
+ * Falls back to count format when description is empty, contains control
+ * characters, or looks like a JSON blob (e.g. error fallback from args).
  */
 export function buildToolSummary(
   toolCalls: IndividualToolCallDisplay[],
@@ -224,10 +250,13 @@ export function buildToolSummary(
     const lower = parts.length > 0;
     const v = lower ? verb.toLowerCase() : verb;
 
-    if (tools.length === 1 && tools[0].description) {
-      parts.push(`${v} ${tools[0].description}`);
-    } else if (tools.length === 1) {
-      parts.push(`${v} 1 ${template.singular}`);
+    if (tools.length === 1) {
+      const safeDesc = safeDescription(tools[0].description);
+      if (safeDesc !== undefined) {
+        parts.push(`${v} ${safeDesc}`);
+      } else {
+        parts.push(`${v} 1 ${template.singular}`);
+      }
     } else {
       parts.push(`${v} ${tools.length} ${template.plural}`);
     }

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -185,7 +185,7 @@ describe('<ToolGroupMessage />', () => {
       );
       const frame = lastFrame() ?? '';
       // CATEGORY_ORDER: search first (capitalized), then read (lowercased)
-      expect(frame).toContain('Searched 1 pattern');
+      expect(frame).toContain('Searched pattern');
       expect(frame).toContain('read 2 files');
       expect(frame).not.toContain('MockTool');
     });
@@ -204,7 +204,7 @@ describe('<ToolGroupMessage />', () => {
       );
       const frame = lastFrame() ?? '';
       // Collapsible → summary line
-      expect(frame).toContain('Read 1 file');
+      expect(frame).toContain('Read a.ts');
       // Non-collapsible → individual ToolMessage
       expect(frame).toContain('MockTool[s1]');
     });
@@ -226,7 +226,7 @@ describe('<ToolGroupMessage />', () => {
       // All tools render individually — no summary line
       expect(frame).toContain('MockTool[r1]');
       expect(frame).toContain('MockTool[e1]');
-      expect(frame).not.toContain('Read 1 file');
+      expect(frame).not.toContain('Read a.ts');
     });
 
     it('forceExpandAll passes forceShowResult to Success siblings in error group', () => {
@@ -276,7 +276,7 @@ describe('<ToolGroupMessage />', () => {
       );
       const frame = lastFrame() ?? '';
       // Successful ReadFile → summary line
-      expect(frame).toContain('Read 1 file');
+      expect(frame).toContain('Read a.ts');
       // Canceled ReadFile → individual ToolMessage (partial output visible)
       expect(frame).toContain('MockTool[r2]');
     });
@@ -306,7 +306,7 @@ describe('<ToolGroupMessage />', () => {
       const frame = lastFrame() ?? '';
       expect(frame).toContain('Recalled 2 memories');
       // Collapsible tool still summarized
-      expect(frame).toContain('Read 1 file');
+      expect(frame).toContain('Read config.yaml');
       // Non-collapsible tool rendered individually
       expect(frame).toContain('MockTool[s1]');
     });


### PR DESCRIPTION
## What this PR does

Changes the compact tool group summary to display the actual file path or search pattern when a single collapsible tool (read/search/list) is executed, instead of a generic count like "Read 1 file". When multiple tools of the same type are batched together, the count format is preserved. If the tool description is unavailable, it falls back to the count format.

## Why it's needed

Collapsible tools (ReadFile, Grep, Glob, ListFiles) include a `description` field containing the file path or search parameters, but `buildToolSummary()` only used the tool name for categorization and discarded this information. Users executing a read operation would see "Read 1 file" with no indication of which file was read, making it harder to follow agent actions in the TUI.

## Reviewer Test Plan

### How to verify

1. Start the CLI and ask it to read a single file (e.g., "read src/index.ts")
2. Observe the tool summary line shows "Read src/index.ts" instead of "Read 1 file"
3. Ask it to read multiple files at once — summary should show "Read N files" (count format preserved)
4. Run the unit test: `cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx` — all 21 tests pass

### Evidence (Before & After)

| Scenario | Before | After |
|----------|--------|-------|
| Single read_file | `Read 1 file` | `Read src/a.ts` |
| Single grep | `Searched 1 pattern` | `Searched 'foo' in path './'` |
| Multiple reads | `Read 3 files` | `Read 3 files` (unchanged) |
| Mixed (1 read + 1 shell) | `Read 1 file, ran 1 command` | `Read src/a.ts, ran ls` |
| Description empty (fallback) | `Read 1 file` | `Read 1 file` (unchanged) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  ⚠️    |
|  🐧 Linux  |  ⚠️    |

### Environment

`cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx` — 21 tests passed

## Risk & Scope

- Main risk or tradeoff: Display string length may vary more widely with file paths, but `ink`'s `wrap="truncate-end"` handles overflow
- Not validated / out of scope: Non-English locale rendering of file paths
- Breaking changes / migration notes: None — purely a display format change

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

修改了紧凑工具组摘要的显示逻辑：当执行单个可折叠工具（read/search/list）时，显示实际的文件路径或搜索模式，而不是通用的 "Read 1 file" 计数。当多个同类型工具批量执行时，保留计数格式。如果工具描述不可用，则回退到计数格式。

## 为什么需要

可折叠工具（ReadFile、Grep、Glob、ListFiles）包含一个 `description` 字段，记录了文件路径或搜索参数，但 `buildToolSummary()` 只使用工具名称进行分类计数，丢弃了这些信息。用户执行读取操作时只能看到 "Read 1 file"，无法知道读了哪个文件，难以在 TUI 中跟踪 agent 的操作。

## 评审者测试计划

### 如何验证

1. 启动 CLI 并让它读取单个文件（如 "read src/index.ts"）
2. 观察工具摘要行显示 "Read src/index.ts" 而非 "Read 1 file"
3. 让它一次读取多个文件 — 摘要应显示 "Read N files"（保留计数格式）
4. 运行单元测试：`cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx` — 21 个测试全部通过

### 证据（前后对比）

| 场景 | 之前 | 之后 |
|------|------|------|
| 单个 read_file | `Read 1 file` | `Read src/a.ts` |
| 单个 grep | `Searched 1 pattern` | `Searched 'foo' in path './'` |
| 多个 reads | `Read 3 files` | `Read 3 files`（不变） |
| 混合（1 read + 1 shell） | `Read 1 file, ran 1 command` | `Read src/a.ts, ran ls` |
| description 为空（回退） | `Read 1 file` | `Read 1 file`（不变） |

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### 环境

`cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx` — 21 个测试通过

## 风险与范围

- 主要风险或权衡：显示字符串长度会因文件路径而变化较大，但 `ink` 的 `wrap="truncate-end"` 会处理溢出
- 未验证/超出范围：非英文 locale 下文件路径的渲染
- 破坏性变更/迁移说明：无 — 纯显示格式变更

## 关联 Issue

无

</details>
