### PR TITLE
fix(web-shell): refine tool call summaries

### DIFF
--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { ACPToolCall } from '../../adapters/types';
 import { I18nProvider } from '../../i18n';
+import { WebShellCustomizationProvider } from '../../customization';
 
 vi.mock('../../App', async () => {
   const { createContext } = await import('react');
@@ -56,14 +57,17 @@ function makeTool(overrides: Partial<ACPToolCall> = {}): ACPToolCall {
   };
 }
 
-function renderToolLine(tool: ACPToolCall): HTMLElement {
+function renderToolLine(
+  tool: ACPToolCall,
+  props: Partial<Parameters<typeof ToolLine>[0]> = {},
+): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
     root.render(
       <I18nProvider language="en">
-        <ToolLine tool={tool} />
+        <ToolLine tool={tool} {...props} />
       </I18nProvider>,
     );
   });
@@ -71,14 +75,19 @@ function renderToolLine(tool: ACPToolCall): HTMLElement {
   return container;
 }
 
-function renderToolGroup(tools: ACPToolCall[]): HTMLElement {
+function renderToolGroup(
+  tools: ACPToolCall[],
+  customization = {},
+): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
     root.render(
       <I18nProvider language="en">
-        <ToolGroup tools={tools} />
+        <WebShellCustomizationProvider value={customization}>
+          <ToolGroup tools={tools} />
+        </WebShellCustomizationProvider>
       </I18nProvider>,
     );
   });
@@ -185,16 +194,49 @@ describe('tool group summary logic', () => {
     );
   });
 
-  it('formats a single tool summary from the tool itself', () => {
+  it('formats a single shell summary as only the semantic description', () => {
+    expect(
+      formatSingleToolSummary(
+        makeTool({
+          toolName: 'run_shell_command',
+          args: {
+            command: 'dataworks-infra workspace list',
+            description: '查询用户工作空间列表',
+            timeout: 30000,
+          },
+        }),
+        t,
+      ),
+    ).toBe('查询用户工作空间列表');
+  });
+
+  it('falls back to command text for shell summaries without descriptions', () => {
     expect(
       formatSingleToolSummary(
         makeTool({
           toolName: 'Shell',
-          args: { command: 'npm run build' },
+          args: { command: 'npm run build', timeout: 30000 },
         }),
         t,
       ),
     ).toBe('Shell npm run build');
+  });
+
+  it('uses only skill names in single tool summaries', () => {
+    expect(
+      formatSingleToolSummary(
+        makeTool({
+          toolName: 'skill',
+          title:
+            'Skill: Use skill: "qc-helper" with args: "weather in Hangzhou next 5 days"',
+          args: {
+            skill: 'qc-helper',
+            args: 'weather in Hangzhou next 5 days',
+          },
+        }),
+        t,
+      ),
+    ).toBe('Skill qc-helper');
   });
 
   it('uses action summaries for single todo and ask-user tools', () => {
@@ -232,6 +274,61 @@ describe('tool group summary logic', () => {
     expect(summary.length).toBeLessThan(140);
     expect(summary).toContain('...');
   });
+
+  it('lets custom tool header extras render single-tool chat summaries', () => {
+    const container = renderToolGroup(
+      [
+        makeTool({
+          toolName: 'run_shell_command',
+          args: {
+            command: 'dataworks-infra workspace list',
+            description: '查询用户工作空间列表',
+            timeout: 30000,
+          },
+        }),
+      ],
+      {
+        renderToolHeaderExtra: (info) => (
+          <span data-testid="custom-summary">
+            {info.kind}:{info.description}
+          </span>
+        ),
+      },
+    );
+
+    const summary = container.querySelector('button');
+    expect(summary?.textContent).not.toContain('Shell');
+    expect(summary?.textContent).toContain('shell:查询用户工作空间列表');
+    expect(summary?.textContent).not.toContain('timeout: 30000ms');
+  });
+
+  it('uses action descriptions for shell rows inside grouped summaries', () => {
+    const container = renderToolGroup([
+      makeTool({
+        callId: 'shell',
+        toolName: 'run_shell_command',
+        title:
+          'Shell: dataworks-infra workspace list [timeout: 30000ms] (查询用户工作空间列表)',
+        args: {
+          command: 'dataworks-infra workspace list',
+          description: '查询用户工作空间列表',
+          timeout: 30000,
+        },
+      }),
+      makeTool({
+        callId: 'read',
+        toolName: 'read_file',
+        args: { file_path: 'README.md' },
+      }),
+    ]);
+
+    expect(container.textContent).toContain('Shell');
+    expect(container.textContent).toContain('查询用户工作空间列表');
+    expect(container.textContent).not.toContain(
+      'dataworks-infra workspace list',
+    );
+    expect(container.textContent).not.toContain('timeout: 30000ms');
+  });
 });
 
 describe('tool expandability', () => {
@@ -252,6 +349,31 @@ describe('tool expandability', () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  it('does not expand skill rows that only have the skill name', () => {
+    expect(
+      hasExpandableContent(
+        makeTool({
+          toolName: 'skill',
+          args: { skill: 'review' },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasExpandableContent(
+        makeTool({
+          toolName: 'skill',
+          args: { skill: 'review' },
+          content: [
+            {
+              type: 'content',
+              content: { type: 'text', text: '# Code Review' },
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -362,6 +484,68 @@ describe('tool row rendering', () => {
     act(() => header.click());
     expect(header.textContent).toContain(pattern);
     expect(header.textContent).toContain('packages/web-shell/client');
+  });
+
+  it('uses the shell tool name for expanded cards from action summaries', () => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'run_shell_command',
+        args: {
+          command: 'dataworks-infra workspace list',
+          description: '查询用户工作空间列表',
+          timeout: 30000,
+        },
+        content: [
+          {
+            type: 'content',
+            content: { type: 'text', text: 'failed\nwith details' },
+          },
+        ],
+      }),
+      { summaryOnly: true },
+    );
+    const header = container.querySelector('[role="button"]') as HTMLElement;
+
+    expect(header.textContent).toContain('Shell');
+    expect(header.textContent).toContain('查询用户工作空间列表');
+
+    act(() => header.click());
+
+    const cardTitle = container.querySelector('[class*="expandedCardTitle"]');
+    expect(cardTitle?.textContent).toBe('Shell');
+  });
+
+  it('shows complete skill content in the expanded card body', () => {
+    const container = renderToolLine(
+      makeTool({
+        toolName: 'skill',
+        title: 'Skill: Use skill: "review" with args: "check the current diff"',
+        args: {
+          skill: 'review',
+        },
+        content: [
+          {
+            type: 'content',
+            content: {
+              type: 'text',
+              text: 'Base directory for this skill: /repo\n# Code Review',
+            },
+          },
+        ],
+      }),
+    );
+    const header = container.querySelector('[role="button"]') as HTMLElement;
+
+    expect(header.textContent).toContain('Skill');
+    expect(header.textContent).toContain('review');
+    expect(header.textContent).not.toContain('check the current diff');
+
+    act(() => header.click());
+
+    const output = container.querySelector('pre');
+    expect(output?.textContent).toBe(
+      'Base directory for this skill: /repo\n# Code Review',
+    );
   });
 });
 

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -20,7 +20,6 @@ const {
   extractDiff,
   fencedCodeBlock,
   formatSingleToolSummary,
-  formatRunningSingleToolSummary,
   formatToolGroupSummary,
   getActiveTool,
   getRawFileDiff,
@@ -248,20 +247,6 @@ describe('tool group summary logic', () => {
     ).toBe('Asked user');
   });
 
-  it('keeps running state and command details for a single active tool', () => {
-    expect(
-      formatRunningSingleToolSummary(
-        makeTool({
-          toolName: 'Shell',
-          status: 'in_progress',
-          args: { command: 'npm run build' },
-        }),
-        t,
-        '0:03',
-      ),
-    ).toBe('Running Shell npm run build 0:03');
-  });
-
   it('truncates long single tool descriptions in the chat summary', () => {
     const summary = formatSingleToolSummary(
       makeTool({
@@ -356,6 +341,7 @@ describe('tool expandability', () => {
       hasExpandableContent(
         makeTool({
           toolName: 'skill',
+          title: 'Skill: Use skill: "review"',
           args: { skill: 'review' },
         }),
       ),
@@ -546,6 +532,22 @@ describe('tool row rendering', () => {
     expect(output?.textContent).toBe(
       'Base directory for this skill: /repo\n# Code Review',
     );
+  });
+
+  it('keeps running state for single todo summaries', () => {
+    const container = renderToolGroup([
+      makeTool({
+        toolName: 'todo_write',
+        status: 'in_progress',
+        args: {
+          todos: [{ id: '1', content: 'Check UI', status: 'in_progress' }],
+        },
+      }),
+    ]);
+    const summary = container.querySelector('button');
+
+    expect(summary?.textContent).toContain('Running');
+    expect(summary?.textContent).toContain('Updated task list');
   });
 });
 

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -81,11 +81,7 @@ export function hasExpandableContent(tool: ACPToolCall): boolean {
     return !!text && text.trim().length > 0 && text.split('\n').length > 1;
   }
   if (isSkillToolName(name)) {
-    return (
-      !!getFirstToolContentText(tool) ||
-      !!tool.title ||
-      (typeof tool.args?.args === 'string' && !!tool.args.args.trim())
-    );
+    return !!getFirstToolContentText(tool);
   }
   if (name === 'edit' || name === 'write' || name === 'editfile') {
     return hasEditContent(tool);
@@ -640,18 +636,23 @@ function SingleToolSummary({
   workspaceCwd?: string;
 }) {
   const { t } = useI18n();
+  const runningPrefix =
+    isActiveToolStatus(tool.status) && t('toolGroup.runningPrefix').trim();
 
   if (
     isTodoWriteToolName(tool.toolName) ||
     isAskUserQuestionToolName(tool.toolName)
   ) {
-    return <>{formatSingleToolSummary(tool, t, workspaceCwd)}</>;
+    return (
+      <>
+        {runningPrefix && <span>{runningPrefix} </span>}
+        {formatSingleToolSummary(tool, t, workspaceCwd)}
+        {runningDuration && <span> {runningDuration}</span>}
+      </>
+    );
   }
 
   const info = getSingleToolSummaryInfo(tool, t, workspaceCwd);
-  const runningPrefix =
-    isActiveToolStatus(tool.status) &&
-    t('toolGroup.running', { name: '' }).trim();
 
   return (
     <>
@@ -665,19 +666,6 @@ function SingleToolSummary({
       {runningDuration && <span> {runningDuration}</span>}
     </>
   );
-}
-
-export function formatRunningSingleToolSummary(
-  tool: ACPToolCall,
-  t: ReturnType<typeof useI18n>['t'],
-  duration?: string,
-  workspaceCwd?: string,
-): string {
-  return t('toolGroup.running', {
-    name: formatSingleToolSummary(tool, t, workspaceCwd),
-    count: 1,
-    duration: duration ?? '',
-  });
 }
 
 function formatCompletedToolSummary(

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -42,9 +42,12 @@ import {
   getAgentDisplayStatus,
   getAgentType,
   getTaskExecutionRecord,
+  getShellToolSemanticDescription,
   getToolDescription,
+  getToolSummaryDescription,
   getToolResultSummary,
   isAskUserQuestionToolName,
+  isSkillToolName,
   isShellToolName,
   toolContainsCallId,
 } from './toolFormatting';
@@ -77,6 +80,13 @@ export function hasExpandableContent(tool: ACPToolCall): boolean {
     const text = extractText(tool);
     return !!text && text.trim().length > 0 && text.split('\n').length > 1;
   }
+  if (isSkillToolName(name)) {
+    return (
+      !!getFirstToolContentText(tool) ||
+      !!tool.title ||
+      (typeof tool.args?.args === 'string' && !!tool.args.args.trim())
+    );
+  }
   if (name === 'edit' || name === 'write' || name === 'editfile') {
     return hasEditContent(tool);
   }
@@ -104,6 +114,7 @@ function hasDetailView(tool: ACPToolCall): boolean {
     name === 'read' ||
     name === 'read_file' ||
     name === 'readfile' ||
+    isSkillToolName(name) ||
     isAskUserQuestionToolName(tool.toolName)
   );
 }
@@ -477,6 +488,22 @@ function ExpandedAskUserQuestionOutput({ tool }: { tool: ACPToolCall }) {
   return <pre className={styles.expandedOutput}>{text}</pre>;
 }
 
+function ExpandedSkillOutput({ tool }: { tool: ACPToolCall }) {
+  const content =
+    getFirstToolContentText(tool) ||
+    (typeof tool.args?.args === 'string' && tool.args.args.trim()
+      ? tool.args.args.trim()
+      : (tool.title ?? ''));
+
+  return <pre className={styles.expandedOutput}>{content}</pre>;
+}
+
+function getFirstToolContentText(tool: ACPToolCall): string {
+  const block = tool.content?.[0];
+  if (block?.type !== 'content') return '';
+  return typeof block.content?.text === 'string' ? block.content.text : '';
+}
+
 export function getToolHeaderKind(tool: ACPToolCall): ToolHeaderKind {
   const name = tool.toolName.toLowerCase();
   if (isSubAgentToolCall(tool)) return 'agent';
@@ -575,9 +602,69 @@ export function formatSingleToolSummary(
     return t('toolGroup.summary.askedUser', { count: 1 });
   }
 
+  const { displayName, description, hideDisplayName } =
+    getSingleToolSummaryInfo(tool, t, workspaceCwd);
+  return [hideDisplayName ? '' : displayName, description]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function getSingleToolSummaryInfo(
+  tool: ACPToolCall,
+  t: ReturnType<typeof useI18n>['t'],
+  workspaceCwd?: string,
+): ToolHeaderExtraRenderInfo & { hideDisplayName: boolean } {
   const displayName = localizeToolDisplayName(tool.toolName, t);
-  const description = truncateText(getToolDescription(tool, workspaceCwd), 120);
-  return [displayName, description].filter(Boolean).join(' ');
+  const description = truncateText(
+    getToolSummaryDescription(tool, workspaceCwd),
+    120,
+  );
+  return {
+    kind: getToolHeaderKind(tool),
+    tool,
+    displayName,
+    description,
+    elapsed: '',
+    workspaceCwd,
+    hideDisplayName: !!getShellToolSemanticDescription(tool),
+  };
+}
+
+function SingleToolSummary({
+  tool,
+  runningDuration,
+  workspaceCwd,
+}: {
+  tool: ACPToolCall;
+  runningDuration?: string;
+  workspaceCwd?: string;
+}) {
+  const { t } = useI18n();
+
+  if (
+    isTodoWriteToolName(tool.toolName) ||
+    isAskUserQuestionToolName(tool.toolName)
+  ) {
+    return <>{formatSingleToolSummary(tool, t, workspaceCwd)}</>;
+  }
+
+  const info = getSingleToolSummaryInfo(tool, t, workspaceCwd);
+  const runningPrefix =
+    isActiveToolStatus(tool.status) &&
+    t('toolGroup.running', { name: '' }).trim();
+
+  return (
+    <>
+      {runningPrefix && <span>{runningPrefix} </span>}
+      <span className={styles.chatSummaryInline}>
+        {!info.hideDisplayName && (
+          <span className={styles.lineName}>{info.displayName}</span>
+        )}
+        <ToolHeaderExtra info={info} />
+      </span>
+      {runningDuration && <span> {runningDuration}</span>}
+    </>
+  );
 }
 
 export function formatRunningSingleToolSummary(
@@ -1046,6 +1133,12 @@ export const ToolLine = memo(function ToolLine({
                 workspaceCwd,
               }}
             />
+            <span
+              className={
+                expanded ? styles.lineChevronDown : styles.lineChevronRight
+              }
+              aria-hidden="true"
+            />
           </div>
         )}
         {showExpanded && (
@@ -1061,8 +1154,12 @@ export const ToolLine = memo(function ToolLine({
     );
   }
 
-  const description = getToolDescription(tool, workspaceCwd);
+  const fullDescription = getToolDescription(tool, workspaceCwd);
   const result = getToolResultSummary(tool);
+  const summaryShell = summaryOnly && isShellToolName(tool.toolName);
+  const description = summaryShell
+    ? getToolSummaryDescription(tool, workspaceCwd)
+    : fullDescription;
   const displayName = localizeToolDisplayName(tool.toolName, t);
   const elapsed =
     isShellToolName(tool.toolName) || isWebFetchToolName(tool.toolName)
@@ -1100,7 +1197,7 @@ export const ToolLine = memo(function ToolLine({
   const useMarkdownDetail = isRead;
   const hideDescriptionInHeader =
     showDescriptionInDetail && !isShell && !isSearch && !isRead;
-  const expandedCardDetail = description;
+  const expandedCardDetail = fullDescription;
   const showExpandedSummaryPanel =
     !isTodo && expanded && !detailView && (showDescriptionInDetail || result);
 
@@ -1158,6 +1255,14 @@ export const ToolLine = memo(function ToolLine({
               workspaceCwd,
             }}
           />
+          {expandable && (
+            <span
+              className={
+                expanded ? styles.lineChevronDown : styles.lineChevronRight
+              }
+              aria-hidden="true"
+            />
+          )}
         </div>
       )}
       {(!summaryOnly || expanded) && isTodo && hasTodoList && (
@@ -1222,6 +1327,7 @@ export const ToolLine = memo(function ToolLine({
               {isAskUserQuestionToolName(tool.toolName) && (
                 <ExpandedAskUserQuestionOutput tool={tool} />
               )}
+              {isSkillToolName(name) && <ExpandedSkillOutput tool={tool} />}
             </ToolExpandedCard>
           )}
         </div>
@@ -1292,16 +1398,15 @@ export const ToolGroup = memo(function ToolGroup({
                 : styles.chatSummaryText
             }
           >
-            {singleTool
-              ? hasRunningTool
-                ? formatRunningSingleToolSummary(
-                    singleTool,
-                    t,
-                    runningDuration,
-                    workspaceCwd,
-                  )
-                : formatSingleToolSummary(singleTool, t, workspaceCwd)
-              : formatToolGroupSummary(tools, t, runningDuration)}
+            {singleTool ? (
+              <SingleToolSummary
+                tool={singleTool}
+                runningDuration={hasRunningTool ? runningDuration : undefined}
+                workspaceCwd={workspaceCwd}
+              />
+            ) : (
+              formatToolGroupSummary(tools, t, runningDuration)
+            )}
           </span>
           <span
             className={

--- a/packages/web-shell/client/components/messages/toolFormatting.test.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.test.ts
@@ -5,6 +5,7 @@ import {
   getAgentCurrentToolHint,
   getToolDescription,
   getToolResultSummary,
+  getToolSummaryDescription,
   localizeToolDisplayName,
   TOOL_DISPLAY_NAMES,
 } from './toolFormatting';
@@ -262,6 +263,52 @@ describe('toolFormatting', () => {
         }),
       ),
     ).toBe('cat ~/.qwen/settings.json (查看 ~/.qwen/settings.json 文件内容)');
+  });
+
+  it('uses semantic shell descriptions for summaries', () => {
+    const shellTool = tool({
+      toolName: 'run_shell_command',
+      title:
+        'Shell: dataworks-infra workspace list [timeout: 30000ms] (查询用户工作空间列表)',
+      args: {
+        command: 'dataworks-infra workspace list',
+        description: '查询用户工作空间列表',
+        timeout: 30000,
+      },
+    });
+
+    expect(getToolSummaryDescription(shellTool)).toBe('查询用户工作空间列表');
+    expect(getToolDescription(shellTool)).toBe(
+      'dataworks-infra workspace list [timeout: 30000ms] (查询用户工作空间列表)',
+    );
+  });
+
+  it('falls back to shell commands in summaries without timeout metadata', () => {
+    expect(
+      getToolSummaryDescription(
+        tool({
+          toolName: 'run_shell_command',
+          args: {
+            command: 'npm test',
+            timeout: 1000,
+          },
+        }),
+      ),
+    ).toBe('npm test');
+  });
+
+  it('describes skill calls from raw input', () => {
+    expect(
+      getToolDescription(
+        tool({
+          toolName: 'skill',
+          args: {
+            skill: 'qc-helper',
+            args: 'weather in Hangzhou next 5 days',
+          },
+        }),
+      ),
+    ).toBe('qc-helper');
   });
 
   it('summarizes read_file rawOutput by line count', () => {

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -292,10 +292,6 @@ function getDescriptionFromArgs(
     }
     return description;
   }
-  if (isSkillToolName(name)) {
-    const skillName = getStringArg(args, 'skill');
-    if (skillName) return skillName;
-  }
   if (args.file_path) {
     if (args.description) return String(args.description);
     return pathForDisplay(String(args.file_path), workspaceCwd);

--- a/packages/web-shell/client/components/messages/toolFormatting.ts
+++ b/packages/web-shell/client/components/messages/toolFormatting.ts
@@ -100,11 +100,38 @@ export function getToolDescription(
   tool: ACPToolCall,
   workspaceCwd?: string,
 ): string {
+  if (isSkillToolName(tool.toolName)) {
+    const skillName = getStringArg(tool.args, 'skill');
+    if (skillName) return truncateText(skillName, MAX_DESCRIPTION_LENGTH);
+  }
   const fromTitle = getDescriptionFromTitle(tool, workspaceCwd);
   if (fromTitle) return truncateText(fromTitle, MAX_DESCRIPTION_LENGTH);
   const fromArgs = getDescriptionFromArgs(tool, workspaceCwd);
   if (fromArgs) return truncateText(fromArgs, MAX_DESCRIPTION_LENGTH);
   return '';
+}
+
+export function getToolSummaryDescription(
+  tool: ACPToolCall,
+  workspaceCwd?: string,
+): string {
+  if (!isShellToolName(tool.toolName)) {
+    return getToolDescription(tool, workspaceCwd);
+  }
+
+  const description = getStringArg(tool.args, 'description');
+  if (description) return truncateText(description, MAX_DESCRIPTION_LENGTH);
+
+  const fromArgs = getDescriptionFromArgs(tool, workspaceCwd, {
+    includeTimeout: false,
+  });
+  if (fromArgs) return truncateText(fromArgs, MAX_DESCRIPTION_LENGTH);
+  return '';
+}
+
+export function getShellToolSemanticDescription(tool: ACPToolCall): string {
+  if (!isShellToolName(tool.toolName)) return '';
+  return getStringArg(tool.args, 'description');
 }
 
 export function extractText(tool: ACPToolCall): string | null {
@@ -223,9 +250,11 @@ function parseGrepSummary(text: string): string | null {
 function getDescriptionFromArgs(
   tool: ACPToolCall,
   workspaceCwd?: string,
+  options: { includeTimeout?: boolean } = {},
 ): string {
   const args = tool.args || {};
   const name = tool.toolName.toLowerCase();
+  const includeTimeout = options.includeTimeout ?? true;
 
   if (args.command) {
     let description = String(args.command);
@@ -234,11 +263,12 @@ function getDescriptionFromArgs(
     }
     if (args.is_background) {
       description += ' [background]';
-    } else if (args.timeout) {
+    } else if (includeTimeout && args.timeout) {
       description += ` [timeout: ${String(args.timeout)}ms]`;
     }
-    if (args.description) {
-      description += ` (${String(args.description).replace(/\n/g, ' ')})`;
+    const argDescription = getStringArg(args, 'description');
+    if (argDescription) {
+      description += ` (${argDescription})`;
     }
     return truncateText(description, MAX_DESCRIPTION_LENGTH);
   }
@@ -261,6 +291,10 @@ function getDescriptionFromArgs(
       description += ` in path '${String(args.path)}'`;
     }
     return description;
+  }
+  if (isSkillToolName(name)) {
+    const skillName = getStringArg(args, 'skill');
+    if (skillName) return skillName;
   }
   if (args.file_path) {
     if (args.description) return String(args.description);
@@ -285,6 +319,14 @@ function getDescriptionFromArgs(
   return '';
 }
 
+function getStringArg(
+  args: Record<string, unknown> | undefined,
+  key: string,
+): string {
+  const value = args?.[key];
+  return typeof value === 'string' ? value.trim().replace(/\n/g, ' ') : '';
+}
+
 export function isShellToolName(name: string): boolean {
   const normalized = name.toLowerCase();
   return (
@@ -293,6 +335,10 @@ export function isShellToolName(name: string): boolean {
     normalized === 'shell' ||
     normalized === 'execute_command'
   );
+}
+
+export function isSkillToolName(name: string): boolean {
+  return name.toLowerCase() === 'skill';
 }
 
 export function toolContainsCallId(

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -82,6 +82,16 @@
   font-weight: 400;
 }
 
+.chatSummaryInline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 100%;
+  color: inherit;
+  vertical-align: bottom;
+}
+
 .chatSummaryTextActive {
   color: var(--muted-foreground);
   background-image: linear-gradient(
@@ -193,12 +203,12 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-}
-
-.icon {
   color: var(--muted-foreground);
   font-size: 13px;
   font-weight: 400;
+}
+
+.icon {
   flex-shrink: 0;
   white-space: nowrap;
 }
@@ -208,15 +218,10 @@
 }
 
 .lineName {
-  font-weight: 400;
-  color: var(--muted-foreground);
-  font-size: 13px;
   flex-shrink: 0;
 }
 
 .lineArg {
-  color: var(--muted-foreground);
-  font-size: 13px;
   min-width: 0;
   flex: 1;
   overflow: hidden;
@@ -226,7 +231,6 @@
 
 .lineElapsed {
   margin-left: auto;
-  color: var(--muted-foreground);
   font-size: 12px;
   flex-shrink: 0;
 }
@@ -242,10 +246,51 @@
   cursor: pointer;
 }
 
-.lineExpandable:hover .lineName,
-.lineExpandable:hover .lineArg,
-.lineExpandable:hover .lineElapsed {
+.lineExpandable .lineArg {
+  flex: 0 1 auto;
+}
+
+.lineExpandable:hover,
+.lineExpandable:focus-visible {
   color: var(--foreground);
+}
+
+.lineChevronRight,
+.lineChevronDown {
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.lineChevronRight::before,
+.lineChevronDown::before {
+  content: '';
+  display: block;
+  width: 5px;
+  height: 5px;
+  border-right: 1.25px solid currentColor;
+  border-bottom: 1.25px solid currentColor;
+  border-radius: 0.5px;
+  margin: 3px 0 0 2px;
+}
+
+.lineChevronRight::before {
+  transform: rotate(-45deg);
+}
+
+.lineChevronDown::before {
+  margin: 2px 0 0 3px;
+  transform: rotate(45deg);
+}
+
+.lineExpandable:hover .lineChevronRight,
+.lineExpandable:hover .lineChevronDown,
+.lineExpandable:focus-visible .lineChevronRight,
+.lineExpandable:focus-visible .lineChevronDown {
+  opacity: 1;
 }
 
 .lineOutput {

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -431,6 +431,9 @@
   align-items: baseline;
   gap: 8px;
   min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  font-weight: 400;
 }
 
 .compactCount {

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1641,7 +1641,7 @@ const ZH: Messages = {
   'toolName.todo_write': '任务清单',
   'toolName.save_memory': '保存记忆',
   'toolName.agent': 'Agent',
-  'toolName.skill': '技能',
+  'toolName.skill': '查看技能',
   'toolName.enter_plan_mode': '进入计划模式',
   'toolName.exit_plan_mode': '退出计划模式',
   'toolName.web_fetch': '网络搜索',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1550,6 +1550,7 @@ const EN: Messages = {
     `Running ${v?.name ?? 'tool'}${v?.duration ? ` ${v.duration}` : ''}${
       Number(v?.count ?? 0) > 1 ? ` · ${v?.count ?? 0} tools` : ''
     }`,
+  'toolGroup.runningPrefix': 'Running',
   'thinking.expand': 'Expand thinking',
   'thinking.collapse': 'Collapse thinking',
   'thinking.running': (v) => `Thinking${v?.duration ? ` ${v.duration}` : ''}`,
@@ -3115,6 +3116,7 @@ const ZH: Messages = {
     `正在执行 ${v?.name ?? '工具'}${v?.duration ? ` ${v.duration}` : ''}${
       Number(v?.count ?? 0) > 1 ? ` · 共 ${v?.count ?? 0} 个工具` : ''
     }`,
+  'toolGroup.runningPrefix': '正在执行',
   'thinking.expand': '展开思考',
   'thinking.collapse': '收起思考',
   'thinking.running': (v) => `正在思考${v?.duration ? ` ${v.duration}` : ''}`,


### PR DESCRIPTION
## What this PR does

This PR refines how web-shell renders tool-call summaries and expanded tool details. Shell calls now use semantic descriptions in compact summaries, omit timeout metadata from collapsed summaries, and keep full command details available inside expanded cards. Single shell calls with a semantic description show only that description so the transcript reads like the action that was performed, while grouped shell rows still keep the tool label for scanability. Skill calls now show the skill name in summaries and expose the loaded skill content in the expanded card.

It also polishes expandable tool rows by adding inline chevrons after the row content, lets parent row styling control tool line text color/weight, and updates the Chinese skill tool label from “技能” to “查看技能”.

## Why it's needed

The previous shell summary text surfaced implementation details such as command strings and timeout values in places where users primarily need a semantic description. That made transcripts noisier and less helpful at a glance. Skill calls also collapsed to a generic label and did not reliably expose the useful content returned by the skill call. These changes make the common transcript path easier to scan while preserving the full details behind expansion.

## Reviewer Test Plan

### How to verify

Open a web-shell session with shell and skill tool calls. Confirm a single shell call with a description displays only the description in the collapsed chat summary, while a shell call without a description still falls back to the command. Confirm grouped shell rows display the shell label plus the description, without timeout metadata, and that expanding a shell row still shows the complete command details. Confirm a skill call summary displays the skill name and that expanding it shows the returned skill content. Confirm expandable rows show an inline chevron on hover or focus.

Run `cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx client/components/messages/toolFormatting.test.ts`. Expected result: all tests pass.

Run `cd packages/web-shell && npm run build`. Expected result: the build succeeds. The existing Vite large chunk warning may still be printed.

### Evidence (Before & After)

Before: Shell summaries could include command strings and timeout metadata, single shell summaries repeated the tool label even when a semantic description existed, skill summaries were generic, and skill details could be truncated or incomplete.

After: Shell summaries prioritize semantic descriptions, single described shell calls display only the description, grouped shell rows remain labeled, expanded shell cards keep full command details, skill summaries show the skill name, and expanded skill cards show the returned skill content.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local package checks from `packages/web-shell`: targeted Vitest files and production build.

## Risk & Scope

- Main risk or tradeoff: This changes compact transcript copy for shell and skill tool calls, so users who relied on seeing command strings in collapsed summaries will now need to expand rows when a semantic description is available.
- Not validated / out of scope: Browser screenshot verification across themes and platforms was not performed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 优化了 web-shell 对工具调用摘要和展开详情的展示方式。Shell 调用现在会在紧凑摘要中优先展示语义化描述，折叠态摘要不再带 timeout 元信息，同时展开卡片中仍保留完整命令详情。带语义化描述的单个 shell 调用只展示描述本身，让会话记录读起来更像实际执行的操作；多个工具分组里的 shell 行仍保留工具标签，方便快速扫读。Skill 调用现在会在摘要中展示 skill 名称，并在展开卡片里展示 skill 返回的内容。

同时，这个 PR 还给可展开工具行补充了跟随内容的内联箭头，让父级行样式统一控制工具行文本颜色和字重，并将中文 skill 工具标签从“技能”调整为“查看技能”。

## 为什么需要

之前的 shell 摘要会在用户只需要语义描述的位置暴露命令字符串和 timeout 等实现细节，使会话记录更嘈杂，也不利于快速理解。Skill 调用也会折叠成比较泛的标签，并且展开时不一定能可靠展示有用的返回内容。这些调整让常见会话路径更易读，同时仍然可以通过展开查看完整详情。

## Reviewer Test Plan

### 如何验证

打开一个包含 shell 和 skill 工具调用的 web-shell 会话。确认带描述的单个 shell 调用在折叠的聊天摘要中只展示描述；没有描述的 shell 调用仍 fallback 展示命令。确认多个工具分组中的 shell 行展示 shell 标签加描述，不展示 timeout 元信息，并且展开 shell 行后仍能看到完整命令详情。确认 skill 调用摘要展示 skill 名称，展开后展示返回的 skill 内容。确认可展开行在 hover 或 focus 时显示跟随内容的内联箭头。

运行 `cd packages/web-shell && npx vitest run client/components/messages/ToolGroup.test.tsx client/components/messages/toolFormatting.test.ts`。预期结果：所有测试通过。

运行 `cd packages/web-shell && npm run build`。预期结果：构建成功。已有的 Vite 大 chunk warning 可能仍会打印。

### 证据（Before & After）

Before：Shell 摘要可能包含命令字符串和 timeout 元信息；即使有语义描述，单个 shell 摘要也会重复工具标签；skill 摘要比较泛；skill 详情可能被截断或不完整。

After：Shell 摘要优先展示语义化描述；带描述的单个 shell 调用只展示描述；分组中的 shell 行仍保留标签；shell 展开卡片保留完整命令详情；skill 摘要展示 skill 名称；skill 展开卡片展示返回的 skill 内容。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ⚠️ 未测试   |

### 环境（可选）

在 `packages/web-shell` 中运行了定向 Vitest 测试和生产构建。

## 风险与范围

- 主要风险或取舍：这会改变 shell 和 skill 工具调用在紧凑会话记录中的文案；如果用户之前依赖折叠态摘要查看命令字符串，那么在存在语义描述时现在需要展开行查看。
- 未验证 / 不在范围内：没有做跨主题和跨平台的浏览器截图验证。
- Breaking changes / 迁移说明：无。

## 关联 Issue

N/A

</details>
