### PR TITLE
fix(web-shell): split-view pane fixes (remove "current" badge, clear composer on send)

### DIFF
--- a/packages/web-shell/client/components/ChatPane.module.css
+++ b/packages/web-shell/client/components/ChatPane.module.css
@@ -10,10 +10,6 @@
   overflow: hidden;
 }
 
-.paneCurrent {
-  border-color: color-mix(in srgb, var(--primary) 60%, var(--border));
-}
-
 .header {
   display: flex;
   align-items: center;
@@ -50,16 +46,6 @@
   font-size: 13px;
   font-weight: 600;
   color: var(--foreground);
-}
-
-.currentBadge {
-  flex: 0 0 auto;
-  padding: 1px 7px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
 }
 
 .closeButton {

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -21,6 +21,7 @@ let latestOnSubmit:
   | undefined;
 let sendPromptResolve: (() => void) | undefined;
 let sendPromptReject: ((e: unknown) => void) | undefined;
+let sendPromptAdmit: (() => void) | undefined;
 const sendPrompt = vi.fn(async () => ({}) as any);
 const submitPermission = vi.fn(async () => {});
 const cancel = vi.fn(async () => {});
@@ -55,7 +56,9 @@ vi.mock('./StreamingStatus', () => ({
   StreamingStatus: (props: any) => (
     <div
       data-testid="pane-streaming"
-      data-started-at={props.startedAt === undefined ? 'none' : String(props.startedAt)}
+      data-started-at={
+        props.startedAt === undefined ? 'none' : String(props.startedAt)
+      }
       data-show-phrase={String(props.showPhrase)}
     />
   ),
@@ -121,10 +124,13 @@ beforeEach(() => {
   latestOnSubmit = undefined;
   sendPrompt.mockReset();
   // Each sendPrompt returns a promise the test controls, so we can assert the
-  // draft is committed only after the prompt is accepted.
+  // draft is committed on admission (onAdmitted) rather than on turn completion
+  // (promise resolution). `sendPromptAdmit` captures the options.onAdmitted hook.
+  sendPromptAdmit = undefined;
   sendPrompt.mockImplementation(
-    () =>
+    (_text?: string, options?: { onAdmitted?: () => void }) =>
       new Promise<unknown>((resolve, reject) => {
+        sendPromptAdmit = options?.onAdmitted;
         sendPromptResolve = () => resolve({});
         sendPromptReject = (e) => reject(e);
       }),
@@ -182,16 +188,26 @@ describe('ChatPane', () => {
     expect((sendPrompt.mock.calls[0] as unknown[])[0]).toBe('hello there');
   });
 
-  it('commits the draft only after the prompt is accepted', async () => {
+  it('commits the draft on admission, without waiting for the turn to finish', async () => {
     render();
     const commit = vi.fn();
     let returned: boolean | undefined;
     act(() => {
       returned = latestOnSubmit!('hi', undefined, commit);
     });
-    // Returns false (keep the draft) and does NOT commit before acceptance.
+    // Returns false (keep the draft) and does NOT commit before admission.
     expect(returned).toBe(false);
     expect(commit).not.toHaveBeenCalled();
+    // The daemon admits the prompt (onAdmitted). The draft clears now, even
+    // though the turn promise is still pending — a long response must not strand
+    // the sent text in the composer until the turn ends.
+    await act(async () => {
+      sendPromptAdmit!();
+      await Promise.resolve();
+    });
+    expect(commit).toHaveBeenCalledTimes(1);
+    // The turn finishing later must NOT commit again — guards against regressing
+    // to committing on promise resolution (turn end) instead of admission.
     await act(async () => {
       sendPromptResolve!();
       await Promise.resolve();
@@ -237,7 +253,11 @@ describe('ChatPane', () => {
         new MouseEvent('click', { bubbles: true }),
       ),
     );
-    expect(submitPermission).toHaveBeenCalledWith('perm-1', 'proceed', undefined);
+    expect(submitPermission).toHaveBeenCalledWith(
+      'perm-1',
+      'proceed',
+      undefined,
+    );
   });
 
   it('routes an AskUserQuestion permission to the AskUserQuestion overlay', () => {

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -228,6 +228,29 @@ describe('ChatPane', () => {
     expect(commit).not.toHaveBeenCalled();
   });
 
+  it('keeps the draft cleared and still reports the error when the turn fails after admission', async () => {
+    const onError = vi.fn();
+    render({ onError });
+    const commit = vi.fn();
+    act(() => {
+      latestOnSubmit!('hi', undefined, commit);
+    });
+    // Admission clears the draft.
+    await act(async () => {
+      sendPromptAdmit!();
+      await Promise.resolve();
+    });
+    expect(commit).toHaveBeenCalledTimes(1);
+    // The turn then fails mid-flight: the draft stays cleared (no second commit)
+    // and the failure is still surfaced to onError.
+    await act(async () => {
+      sendPromptReject!(new Error('turn crashed'));
+      await Promise.resolve();
+    });
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it('keeps pane approvals click-only (no global keyboard shortcuts)', () => {
     pendingPermission = { id: 'perm-1', toolName: 'write_file', rawInput: {} };
     render();

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -90,13 +90,19 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
     ): boolean => {
       const trimmed = text.trim();
       if (!trimmed) return false;
-      // Keep the draft (return false) until the prompt is actually accepted:
-      // sendPrompt can reject (transcript still loading, session disconnected,
-      // or a turn already active), and committing first would silently drop the
-      // user's text. Commit only once it resolves.
+      // Keep the draft (return false) and clear it only once the daemon ADMITS
+      // the prompt. `onAdmitted` fires at acceptance; the sendPrompt promise
+      // itself resolves only when the whole (possibly long) turn finishes, so
+      // committing on resolution would strand the sent text in the composer for
+      // the entire response. If the prompt is rejected before admission
+      // (transcript still loading, session disconnected, or a turn already
+      // active) onAdmitted never fires, so the draft is preserved and the error
+      // is surfaced.
       actions
-        .sendPrompt(trimmed, images && images.length ? { images } : undefined)
-        .then(() => commitAccepted?.())
+        .sendPrompt(trimmed, {
+          ...(images && images.length ? { images } : {}),
+          onAdmitted: () => commitAccepted?.(),
+        })
         .catch((error: unknown) => reportError(error, 'Failed to send prompt'));
       return false;
     },

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -30,8 +30,6 @@ const EMPTY_TOOLBAR: never[] = [];
 export interface ChatPaneProps {
   /** Header label; falls back to the session's own display name / id. */
   title?: string;
-  /** Marks the pane bound to the window's primary (sidebar-selected) session. */
-  isCurrent?: boolean;
   onClose?: () => void;
   onError?: (error: unknown, fallback: string) => void;
 }
@@ -43,7 +41,7 @@ export interface ChatPaneProps {
  * state, approvals, and composer, and the browser scopes keyboard focus to the
  * pane the user clicks into — so there is no cross-pane approval arbitration.
  */
-export function ChatPane({ title, isCurrent, onClose, onError }: ChatPaneProps) {
+export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   const { t } = useI18n();
   const connection = useConnection();
   const actions = useActions();
@@ -119,7 +117,9 @@ export function ChatPane({ title, isCurrent, onClose, onError }: ChatPaneProps) 
   const handleCancel = useCallback(() => {
     actions
       .cancel()
-      .catch((error: unknown) => reportError(error, 'Failed to cancel request'));
+      .catch((error: unknown) =>
+        reportError(error, 'Failed to cancel request'),
+      );
   }, [actions, reportError]);
 
   const headerLabel =
@@ -127,9 +127,7 @@ export function ChatPane({ title, isCurrent, onClose, onError }: ChatPaneProps) 
 
   return (
     <section
-      className={[styles.pane, isCurrent ? styles.paneCurrent : '']
-        .filter(Boolean)
-        .join(' ')}
+      className={styles.pane}
       data-testid="chat-pane"
       aria-label={headerLabel}
     >
@@ -137,11 +135,6 @@ export function ChatPane({ title, isCurrent, onClose, onError }: ChatPaneProps) 
         <span className={styles.title} title={headerLabel}>
           {headerLabel}
         </span>
-        {isCurrent && (
-          <span className={styles.currentBadge}>
-            {t('sessionsOverview.current')}
-          </span>
-        )}
         {onClose && (
           <button
             type="button"

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -101,7 +101,7 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
       actions
         .sendPrompt(trimmed, {
           ...(images && images.length ? { images } : {}),
-          onAdmitted: () => commitAccepted?.(),
+          onAdmitted: commitAccepted,
         })
         .catch((error: unknown) => reportError(error, 'Failed to send prompt'));
       return false;

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -46,7 +46,7 @@ vi.mock('./ChatPane', () => ({
     // Let a test force a render crash to exercise the per-pane ErrorBoundary.
     if (props.title === 'BOOM') throw new Error('pane exploded');
     return (
-      <div data-testid="chat-pane" data-current={props.isCurrent ? 'yes' : 'no'}>
+      <div data-testid="chat-pane">
         <span data-testid="pane-title">{props.title}</span>
         {props.onClose && (
           <button data-testid="pane-close" onClick={props.onClose}>
@@ -102,14 +102,14 @@ function panes(): HTMLElement[] {
   return Array.from(container!.querySelectorAll('[data-testid="chat-pane"]'));
 }
 function titles(): string[] {
-  return Array.from(container!.querySelectorAll('[data-testid="pane-title"]')).map(
-    (el) => el.textContent ?? '',
-  );
+  return Array.from(
+    container!.querySelectorAll('[data-testid="pane-title"]'),
+  ).map((el) => el.textContent ?? '');
 }
 function pickerOptions(): string[] {
-  return Array.from(
-    container!.querySelectorAll('[role="option"] button'),
-  ).map((el) => (el.textContent ?? '').trim());
+  return Array.from(container!.querySelectorAll('[role="option"] button')).map(
+    (el) => (el.textContent ?? '').trim(),
+  );
 }
 function openPicker(): void {
   const addButton = container!.querySelector(
@@ -140,7 +140,6 @@ describe('SplitView', () => {
   it('seeds with the current session when no initial sessions are given', () => {
     render({ initialSessionIds: [] });
     expect(titles()).toEqual(['Three']);
-    expect(panes()[0].getAttribute('data-current')).toBe('yes');
   });
 
   it('dedupes initial sessions', () => {
@@ -235,9 +234,7 @@ describe('SplitView', () => {
     render({ initialSessionIds: ['s1'], onExit });
     expect(onExit).not.toHaveBeenCalled();
     const close = container!.querySelector('[data-testid="pane-close"]');
-    act(() =>
-      close!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
-    );
+    act(() => close!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
@@ -344,9 +341,7 @@ describe('SplitView', () => {
     expect(onPanesChange).toHaveBeenLastCalledWith(['s1', 's2']);
     // …and after every remove.
     const close = container!.querySelector('[data-testid="pane-close"]');
-    act(() =>
-      close!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
-    );
+    act(() => close!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(onPanesChange).toHaveBeenLastCalledWith(['s2']);
   });
 });

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -62,9 +62,8 @@ export function SplitView({
   const connection = useConnection();
   const currentSessionId = connection.sessionId;
   const organizationEnabled =
-    connection.capabilities?.features?.includes(
-      SESSION_ORGANIZATION_FEATURE,
-    ) ?? false;
+    connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE) ??
+    false;
   const { sessions, reload } = useSessions({
     autoLoad: true,
     pageSize: SESSION_LIST_PAGE_SIZE,
@@ -282,7 +281,6 @@ export function SplitView({
                 >
                   <ChatPane
                     title={titleById.get(sessionId)}
-                    isCurrent={sessionId === currentSessionId}
                     onClose={() => removePane(sessionId)}
                     onError={onError}
                   />


### PR DESCRIPTION
## What this PR does

Two small fixes to the in-window split view, both in the split-pane `ChatPane`:

1. **Remove the "current" badge.** Panes no longer show a rounded "当前 / current" pill (or the matching accent-colored border) on the one pane that happens to be the workspace's active session. The `isCurrent` prop, the badge, and the border-highlight branch are removed from `ChatPane`, and `SplitView` no longer passes `isCurrent`. The session sidebar and the session-overview grid keep their own "current" indicators — those are unchanged.

2. **Clear the composer on send, not at turn end.** After sending a message from a split pane, the text stayed in the composer for the entire response. `handleSubmit` committed (cleared) the draft on the `sendPrompt` promise resolving, but that promise resolves only when the whole turn finishes (`waitForAcceptedPromptCompletion`), not when the prompt is accepted. It now clears via the `onAdmitted` hook, which fires at admission — matching the main view. A prompt rejected before admission still preserves the draft and surfaces the error.

## Why it's needed

1. Inside the split view every pane is an equal, independently interactive session — its own `DaemonSessionProvider`, SSE stream, transcript, and approvals, with keyboard focus scoped per pane by the browser. The "current" pane had no special behavior; the marker only surfaced a single-view singleton concept (`connection.sessionId`) into a layout of equal peers, where it conveyed nothing actionable and reliably prompted "what does this do?" questions. Panes are already identified by their titles. The sidebar and overview keep their indicators on purpose, because there they are genuine "you are here" navigation.

2. Committing the draft only on turn completion meant the just-sent text sat in the composer for the whole (possibly long) response — confusing, and easy to accidentally resend. Clearing at admission is prompt and still safe: if the daemon rejects the prompt before admission (transcript still loading, session disconnected, or a turn already active), `onAdmitted` never fires, so the draft is preserved.

## Reviewer Test Plan

### How to verify

- Unit (from `packages/web-shell`): `npx vitest run client/components/ChatPane.test.tsx client/components/SplitView.test.tsx` — 33 tests pass. New/updated cases: the composer commits the draft on admission and NOT again on turn completion (guarding against regressing to the turn-end behavior); `SplitView`'s "seeds with the current session" test keeps its seed assertion, dropping only the assertion on the removed `data-current` marker.
- Type check: `npx tsc --noEmit -p packages/web-shell/tsconfig.lib.json` (the build's typecheck) is clean. The broader `packages/web-shell/tsconfig.json` reports the same pre-existing errors in unrelated test fixtures before and after this change — zero new errors.
- Manual: open a split view with two or more panes, one of which is the active session. (a) No pane shows a "当前 / current" pill or accent border, and the sidebar still highlights the active session. (b) Type in a pane and press Enter — the composer clears immediately (at admission), not only after the model finishes responding.

### Evidence (Before & After)

- Badge: before, the active-session pane rendered a rounded "当前" pill plus an accent-colored (`--primary`) border; after, neither — panes render identically apart from their titles.
- Composer: before, the sent text stayed in the split-pane composer until the turn finished; after, it clears as soon as the prompt is admitted.

Both are behavior/markup changes exercised by the unit tests above; the badge removal is a pure element removal (the `.currentBadge` span and `.paneCurrent` border class), so there is no new UI to screenshot.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Vitest (jsdom) unit tests plus a local `tsc` type check, run on macOS.

## Risk & Scope

- Main risk or tradeoff: low. The badge removal is a pure visual removal with no behavior, data, or API change. The composer fix moves the clear from turn-end to admission via the existing `onAdmitted` hook, preserving the "don't drop the draft if the prompt is rejected before admission" property.
- Not validated / out of scope: the sidebar and session-overview "current" indicators are intentionally kept and unchanged; no change to the main-view composer.
- Breaking changes / migration notes: none. `ChatPane`'s `isCurrent` prop is removed and its only caller (`SplitView`) is updated in the same change; `currentSessionId` is retained purely to seed the initial pane.

## Linked Issues

<!-- none -->

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对窗口内分屏视图的两处小修复,都在分屏窗格 `ChatPane` 里:

1. **移除「当前」徽标。** 窗格不再对「恰好是工作区活动会话」的那一个窗格显示圆角的「当前 / current」药丸(以及配套的高亮色边框)。`ChatPane` 中的 `isCurrent` 属性、徽标、边框高亮分支都被移除,`SplitView` 也不再传 `isCurrent`。会话侧栏和会话总览网格各自的「当前」标识保持不变。

2. **发送时清空输入框,而不是等整轮结束。** 从分屏窗格发送消息后,文本会在整个回复期间一直留在输入框里。`handleSubmit` 原本是在 `sendPrompt` 的 Promise resolve 时才清空草稿,但那个 Promise 要等整轮结束(`waitForAcceptedPromptCompletion`)才 resolve,而不是在 prompt 被受理时。现改为通过 `onAdmitted` 钩子清空——它在受理时触发,和主界面一致。若 prompt 在受理前被拒绝,草稿仍会保留并弹出错误。

## 为什么需要

1. 在分屏视图内部,每个窗格都是完全对等、可独立交互的会话——各自拥有 `DaemonSessionProvider`、SSE 流、转录和审批,键盘焦点由浏览器按窗格隔离。「当前」那个窗格没有任何特殊行为;这个标记只是把一个单视图的单例概念(`connection.sessionId`)暴露进对等窗格并排的布局,在那里它传达不了任何可操作的信息,反而稳定地引发「这是干嘛的?」这类疑问。窗格本来就靠标题区分。侧栏和总览之所以保留标识,是因为在那些场景里它们是真正的「你在这里」导航。

2. 只在整轮完成时才清空草稿,意味着刚发出的文本会在整段(可能很长的)回复期间一直留在输入框里——既令人困惑,又容易误重发。改为在受理时清空既及时又安全:若 daemon 在受理前拒绝了 prompt(转录仍在加载、会话断连,或已有一轮在进行),`onAdmitted` 不会触发,草稿因此得以保留。

## 复核测试计划

### 如何验证

- 单元测试(在 `packages/web-shell` 下):`npx vitest run client/components/ChatPane.test.tsx client/components/SplitView.test.tsx` —— 33 个测试通过。新增/更新用例:输入框在受理时提交草稿,并且在整轮完成时不再二次提交(防止回退到旧的「轮末清空」行为);`SplitView` 的 "seeds with the current session" 测试保留 seed 断言,只删掉针对已移除的 `data-current` 标记的那条断言。
- 类型检查:`npx tsc --noEmit -p packages/web-shell/tsconfig.lib.json`(构建所用的类型检查)干净通过。更宽的 `packages/web-shell/tsconfig.json` 在改动前后都报同样的既有错误(都在无关的测试夹具里)——零新增。
- 手动:打开一个有两个及以上窗格的分屏,其中一个是活动会话。(a) 没有窗格显示「当前 / current」药丸或高亮边框,侧栏仍高亮活动会话。(b) 在某个窗格里输入并回车——输入框立即(在受理时)清空,而不是等模型回复完才清空。

### 证据(改动前后)

- 徽标:改动前,活动会话的那个窗格会渲染一颗圆角「当前」药丸外加高亮色(`--primary`)边框;改动后两者都没有——除各自标题外所有窗格渲染一致。
- 输入框:改动前,发出的文本会留在分屏窗格的输入框里直到整轮结束;改动后,prompt 一被受理就清空。

两者都由上面的单元测试覆盖;徽标移除是纯粹的元素删除(`.currentBadge` span 和 `.paneCurrent` 边框类),因此没有新的 UI 可供截图。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

Vitest(jsdom)单元测试,外加本地 `tsc` 类型检查,在 macOS 上运行。

## 风险与范围

- 主要风险或权衡:低。徽标移除是纯视觉删除,不涉及行为、数据或 API 变化。输入框修复通过既有的 `onAdmitted` 钩子把清空时机从轮末挪到受理,保留了「受理前被拒则不丢草稿」的性质。
- 未验证 / 范围之外:侧栏和会话总览的「当前」标识有意保留、保持不变;主界面 composer 不变。
- 破坏性变更 / 迁移说明:无。`ChatPane` 的 `isCurrent` 属性被移除,其唯一调用方(`SplitView`)在同一改动中一并更新;`currentSessionId` 仅保留用于 seed 初始窗格。

</details>
