### PR TITLE
fix(core): reject fractional LSP limit inputs

### DIFF
--- a/packages/core/src/tools/lsp.test.ts
+++ b/packages/core/src/tools/lsp.test.ts
@@ -247,7 +247,16 @@ describe('LspTool', () => {
           filePath: 'src/app.ts',
           limit: 0,
         } as LspToolParams);
-        expect(result).toBe('limit must be a positive number.');
+        expect(result).toBe('limit must be a positive integer.');
+      });
+
+      it('rejects fractional limit', () => {
+        const result = tool.validateToolParams({
+          operation: 'documentSymbol',
+          filePath: 'src/app.ts',
+          limit: 1.5,
+        } as LspToolParams);
+        expect(result).toBe('params/limit must be integer');
       });
     });
 
@@ -1050,6 +1059,16 @@ describe('LspTool', () => {
       };
       expect(schema.properties?.line?.type).toBe('number');
       expect(schema.properties?.character?.type).toBe('number');
+    });
+
+    it('limit extension property has integer type', () => {
+      const tool = createTool();
+      const schema = tool.schema.parametersJsonSchema as {
+        properties?: {
+          limit?: { type?: string };
+        };
+      };
+      expect(schema.properties?.limit?.type).toBe('integer');
     });
 
     it('includeDeclaration property has correct type', () => {

--- a/packages/core/src/tools/lsp.test.ts
+++ b/packages/core/src/tools/lsp.test.ts
@@ -247,7 +247,16 @@ describe('LspTool', () => {
           filePath: 'src/app.ts',
           limit: 0,
         } as LspToolParams);
-        expect(result).toBe('limit must be a positive integer.');
+        expect(result).toBe('params/limit must be >= 1');
+      });
+
+      it('rejects negative integer limit', () => {
+        const result = tool.validateToolParams({
+          operation: 'documentSymbol',
+          filePath: 'src/app.ts',
+          limit: -1,
+        } as LspToolParams);
+        expect(result).toBe('params/limit must be >= 1');
       });
 
       it('rejects fractional limit', () => {
@@ -1065,10 +1074,11 @@ describe('LspTool', () => {
       const tool = createTool();
       const schema = tool.schema.parametersJsonSchema as {
         properties?: {
-          limit?: { type?: string };
+          limit?: { type?: string; minimum?: number };
         };
       };
       expect(schema.properties?.limit?.type).toBe('integer');
+      expect(schema.properties?.limit?.minimum).toBe(1);
     });
 
     it('includeDeclaration property has correct type', () => {

--- a/packages/core/src/tools/lsp.ts
+++ b/packages/core/src/tools/lsp.ts
@@ -1082,6 +1082,7 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
           },
           limit: {
             type: 'integer',
+            minimum: 1,
             description: 'Optional maximum number of results to return.',
           },
           diagnostics: {
@@ -1212,13 +1213,6 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
     if (params.endCharacter !== undefined && params.endCharacter < 1) {
       return 'endCharacter must be a positive number.';
     }
-    if (
-      params.limit !== undefined &&
-      (!Number.isInteger(params.limit) || params.limit <= 0)
-    ) {
-      return 'limit must be a positive integer.';
-    }
-
     return null;
   }
 

--- a/packages/core/src/tools/lsp.ts
+++ b/packages/core/src/tools/lsp.ts
@@ -1081,7 +1081,7 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
             description: 'Optional LSP server name to target.',
           },
           limit: {
-            type: 'number',
+            type: 'integer',
             description: 'Optional maximum number of results to return.',
           },
           diagnostics: {
@@ -1212,8 +1212,11 @@ export class LspTool extends BaseDeclarativeTool<LspToolParams, ToolResult> {
     if (params.endCharacter !== undefined && params.endCharacter < 1) {
       return 'endCharacter must be a positive number.';
     }
-    if (params.limit !== undefined && params.limit <= 0) {
-      return 'limit must be a positive number.';
+    if (
+      params.limit !== undefined &&
+      (!Number.isInteger(params.limit) || params.limit <= 0)
+    ) {
+      return 'limit must be a positive integer.';
     }
 
     return null;


### PR DESCRIPTION
## What this PR does

This PR tightens the LSP tool's `limit` parameter so it only accepts positive integer result counts.

The change is intentionally narrow: it only affects Qwen's LSP result-limit extension. It does not change the Claude-compatible core LSP fields such as `line` or `character`, and it does not change the existing default result limits.

## Why it's needed

### What Problem This Solves

`limit` controls how many LSP results may be returned for operations such as definitions, implementations, references, workspace symbols, call hierarchy, diagnostics, and code actions.

Before this change, the schema exposed `limit` as `number`, and runtime validation only rejected non-positive values. A fractional value such as:

```json
{
  "operation": "documentSymbol",
  "filePath": "src/app.ts",
  "limit": 1.5
}
```

could pass the LSP tool's positive-number validation path even though a fractional result count has no meaningful semantics. In other words, `limit` is a discrete count, not a continuous numeric measurement: returning `1`, `2`, or `50` results is meaningful, but returning `1.5` results is not.

### Changes

This PR narrows only the Qwen LSP `limit` extension from `number` to `integer` in the tool schema and adds a runtime integer guard for the same field.

It intentionally leaves `line` and `character` unchanged because those fields are part of the existing Claude-compatible LSP core surface in this repository's tests. The PR also leaves default limits, LSP client behavior, result formatting, and other tools with `limit` parameters unchanged.

### Evidence

The malformed input is small and deterministic:

```json
{
  "operation": "documentSymbol",
  "filePath": "src/app.ts",
  "limit": 1.5
}
```

Before this change, the custom validation only checked `limit <= 0`, so a positive fractional value could pass that validation path. After this change, the schema declares `limit` as `integer`, so fractional `limit` inputs are rejected by schema validation before they reach execution; the runtime guard also rejects non-integer values if it is reached outside the normal schema-first path.

Focused validation now covers both sides of the contract: `limit: 1.5` is rejected, `limit: 0` remains rejected, `limit: 5` continues to be passed to LSP client methods, and `line` / `character` remain schema-compatible as `number`.

### Possible call chain / impact

A possible path for the bad input is:

```text
LspTool.validateToolParams(...)
  -> schema validation / validateToolParamValues(...)
  -> operation-specific LSP execution
  -> result slicing such as slice(0, limit)
  -> LSP client calls that receive limit as a result cap
```

The user-visible impact is small but real: an invalid fractional result cap could previously flow into result slicing or client calls, leaving behavior to JavaScript/index coercion or downstream client handling. This PR moves that rejection to the tool boundary, where the contract is clearest.

This PR does not change source-position coordinates, Claude-compatible `line` / `character` behavior, default result caps, or LSP server interaction semantics for valid integer limits.

## Reviewer Test Plan

### How to verify

A reviewer can confirm that fractional `limit` values are rejected while existing positive integer limits continue to work.

Expected behavior after this change:

- `limit: 5` remains valid and is still passed through to LSP client methods.
- `limit: 0` remains invalid.
- `limit: 1.5` is now invalid because LSP result limits are discrete counts.
- Omitted `limit` values keep the existing defaults, such as `20` or `50` depending on the operation.
- `line` and `character` schema compatibility is intentionally unchanged in this PR.

### Evidence (Before & After)

N/A — non-UI validation via focused unit tests.

Focused validation passed locally on Windows:

```bash
npm run test --workspace=packages/core -- src/tools/lsp.test.ts
npm run typecheck --workspace=packages/core
git diff --check
```

Focused validation also passed in WSL / Ubuntu-22.04:

```bash
wsl -d Ubuntu-22.04 -- bash -lc 'cd /mnt/d/ZXY/Github/qwen-code-lsp-integer && npm run test --workspace=packages/core -- src/tools/lsp.test.ts'
wsl -d Ubuntu-22.04 -- bash -lc 'cd /mnt/d/ZXY/Github/qwen-code-lsp-integer && npm run typecheck --workspace=packages/core'
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested via WSL Ubuntu-22.04 |

### Environment (optional)

Windows local validation used Node.js `v24.15.0` and npm `11.12.1` in the clean worktree. Linux validation used WSL Ubuntu-22.04 with Node.js `v24.15.0` and npm `11.12.1`; `npm install` was run in WSL first so Linux optional dependencies such as Rollup's native package were available.

## Risk & Scope

- Main risk or tradeoff: This tightens validation for Qwen's LSP-only `limit` extension, so invalid fractional values such as `1.5` are rejected instead of being accepted and passed into result slicing or client calls.
- Not validated / out of scope: This PR does not change Claude-compatible core LSP properties such as `line` or `character`, source-position coordinates, default result limits, LSP client behavior, or other tools with `limit` parameters.
- Breaking changes / migration notes: Invalid fractional `limit` inputs now fail validation. Existing positive integer limits and omitted limits keep the same behavior.

## Linked Issues

N/A — independent narrowly scoped validation fix; no existing issue found.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 收紧 LSP 工具的 `limit` 参数校验，让它只接受正整数结果数量。

改动范围刻意保持很小：这里只处理 Qwen 自己扩展的 LSP 结果数量上限，不修改 `line` / `character` 这类已有 Claude Code compatibility 断言覆盖的核心字段，也不修改现有默认返回数量。

## 为什么需要它

### What Problem This Solves

`limit` 表示 LSP 操作最多返回多少条结果，例如 definitions、implementations、references、workspace symbols、call hierarchy、diagnostics 和 code actions。

在修改前，schema 把 `limit` 暴露为 `number`，运行时校验只拒绝非正数。因此下面这种小数值可能通过正数校验：

```json
{
  "operation": "documentSymbol",
  "filePath": "src/app.ts",
  "limit": 1.5
}
```

但“返回 1.5 条结果”没有明确语义。`limit` 是离散计数，不是连续数值；返回 `1`、`2` 或 `50` 条结果是有意义的，返回 `1.5` 条结果没有明确语义。

### Changes

这个 PR 只把 Qwen LSP 扩展字段 `limit` 的 schema 从 `number` 收窄为 `integer`，并为同一个字段增加运行时整数校验。

本 PR 刻意不修改 `line` 和 `character`，因为它们属于当前测试中已有的 Claude-compatible LSP core surface。本 PR 也不修改默认 `limit`、LSP client 行为、结果格式化逻辑，或其他工具里的 `limit` 参数。

### Evidence

触发输入很小且确定：

```json
{
  "operation": "documentSymbol",
  "filePath": "src/app.ts",
  "limit": 1.5
}
```

修改前，自定义校验只检查 `limit <= 0`，所以正小数可能通过这一路校验。修改后，schema 将 `limit` 声明为 `integer`，小数 `limit` 会在进入执行前被 schema 校验拒绝；如果绕过正常 schema-first 路径，运行时 guard 也会拒绝非整数。

聚焦测试现在同时覆盖了这个契约的两边：`limit: 1.5` 会被拒绝，`limit: 0` 仍然会被拒绝，`limit: 5` 继续传给 LSP client，`line` / `character` 仍保持 `number` schema 兼容行为。

### Possible call chain / impact

潜在调用链如下：

```text
LspTool.validateToolParams(...)
  -> schema validation / validateToolParamValues(...)
  -> operation-specific LSP execution
  -> result slicing such as slice(0, limit)
  -> LSP client calls that receive limit as a result cap
```

用户可见影响很小但真实存在：非法的小数结果上限过去可能进入结果截断或 client 调用，让行为依赖 JavaScript/index coercion 或下游 client 的处理。这个 PR 把拒绝动作前移到工具边界，也就是契约最清楚的位置。

本 PR 不修改源码位置坐标、不修改 Claude-compatible `line` / `character` 行为、不修改默认结果数量，也不修改合法整数 `limit` 下的 LSP server 交互语义。

## Reviewer 测试计划

### 如何验证

Reviewer 可以确认小数 `limit` 会被拒绝，同时已有正整数 `limit` 继续可用。

预期行为：

- `limit: 5` 仍然合法，并继续传给 LSP client。
- `limit: 0` 仍然非法。
- `limit: 1.5` 现在会被拒绝，因为 LSP 结果数量上限是离散计数。
- 不传 `limit` 时仍然使用现有默认值，例如不同操作下的 `20` 或 `50`。
- 本 PR 不修改 `line` / `character` 的 schema compatibility 行为。

### Evidence（修改前后）

N/A — 这是非 UI 改动，通过聚焦单测验证。

Windows 本地聚焦验证已通过：

```bash
npm run test --workspace=packages/core -- src/tools/lsp.test.ts
npm run typecheck --workspace=packages/core
git diff --check
```

WSL / Ubuntu-22.04 聚焦验证也已通过：

```bash
wsl -d Ubuntu-22.04 -- bash -lc 'cd /mnt/d/ZXY/Github/qwen-code-lsp-integer && npm run test --workspace=packages/core -- src/tools/lsp.test.ts'
wsl -d Ubuntu-22.04 -- bash -lc 'cd /mnt/d/ZXY/Github/qwen-code-lsp-integer && npm run typecheck --workspace=packages/core'
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 本地未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ✅ 已通过 WSL Ubuntu-22.04 测试 |

### Environment（可选）

Windows 本地验证使用 Node.js `v24.15.0` 和 npm `11.12.1`，在干净 worktree 中执行。Linux 验证使用 WSL Ubuntu-22.04，Node.js `v24.15.0`，npm `11.12.1`；测试前先在 WSL 中运行 `npm install`，以补齐 Rollup 等 Linux optional dependencies。

## 风险和范围

- 主要风险或取舍：这个 PR 会更严格地拒绝以前被模糊接受的小数 `limit`，例如 `1.5`，避免它继续进入结果截断或 LSP client 调用。
- 未验证 / 不在范围内：本 PR 不修改 `line` / `character` 等 Claude-compatible core LSP 字段，不修改源码坐标字段，不修改默认结果数量，不修改 LSP client 行为，也不修改其他工具里的 `limit` 参数。
- Breaking changes / migration notes：非法的小数 `limit` 现在会校验失败。已有正整数 `limit` 和省略 `limit` 的调用保持原行为。

## Linked Issues

N/A — 独立的小范围校验修复；暂未找到已有 issue。

</details>