### PR TITLE
feat(sdk): expose fork_session option in Python and TypeScript SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -240,4 +240,7 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     elif options.session_id:
         args.extend(["--session-id", options.session_id])
 
+    if options.fork_session:
+        args.append("--fork-session")
+
     return args

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -110,6 +110,7 @@ class QueryOptionsDict(TypedDict, total=False):
     include_partial_messages: bool
     resume: str
     continue_session: bool
+    fork_session: bool
     session_id: str
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
@@ -135,6 +136,7 @@ class QueryOptions:
     include_partial_messages: bool = False
     resume: str | None = None
     continue_session: bool = False
+    fork_session: bool = False
     session_id: str | None = None
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
@@ -176,6 +178,7 @@ class QueryOptions:
             or False,
             resume=_as_optional_str(data, "resume"),
             continue_session=_as_optional_bool(data, "continue_session") or False,
+            fork_session=_as_optional_bool(data, "fork_session") or False,
             session_id=_as_optional_str(data, "session_id"),
             timeout=timeout,
             mcp_servers=_as_optional_nested_dict(data, "mcp_servers"),

--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -49,6 +49,13 @@ def validate_query_options(options: QueryOptions) -> None:
             "resume/continue_session restore existing sessions."
         )
 
+    if options.fork_session and not (options.resume or options.continue_session):
+        raise ValidationError(
+            "fork_session requires resume or continue_session. "
+            "Use resume to fork a specific session "
+            "or continue_session to fork the latest session."
+        )
+
     if options.session_id:
         validate_session_id(options.session_id, "session_id")
 

--- a/packages/sdk-python/tests/unit/test_transport.py
+++ b/packages/sdk-python/tests/unit/test_transport.py
@@ -82,6 +82,23 @@ def test_cli_argument_precedence_prefers_resume_then_continue_then_session_id() 
     assert "--session-id" not in args
 
 
+def test_fork_session_adds_flag_after_resume() -> None:
+    args = build_cli_arguments(
+        QueryOptions(resume=VALID_UUID, fork_session=True)
+    )
+
+    assert "--fork-session" in args
+    resume_idx = args.index("--resume")
+    fork_idx = args.index("--fork-session")
+    assert fork_idx > resume_idx
+
+
+def test_fork_session_not_added_by_default() -> None:
+    args = build_cli_arguments(QueryOptions(session_id=VALID_UUID))
+
+    assert "--fork-session" not in args
+
+
 def test_prepare_spawn_info_uses_runtime_for_python_scripts(tmp_path: Path) -> None:
     script_path = tmp_path / "fake-qwen.py"
     script_path.write_text("print('ok')\n", encoding="utf-8")

--- a/packages/sdk-python/tests/unit/test_validation.py
+++ b/packages/sdk-python/tests/unit/test_validation.py
@@ -172,3 +172,16 @@ def test_rejects_mcp_servers() -> None:
         validate_query_options(
             QueryOptions(mcp_servers={"my-server": {"command": "node", "args": []}})
         )
+
+
+def test_rejects_fork_session_without_resume_or_continue() -> None:
+    with pytest.raises(ValidationError, match="fork_session requires resume"):
+        validate_query_options(QueryOptions(fork_session=True))
+
+
+def test_fork_session_with_resume_is_valid() -> None:
+    validate_query_options(QueryOptions(fork_session=True, resume=VALID_UUID))
+
+
+def test_fork_session_with_continue_is_valid() -> None:
+    validate_query_options(QueryOptions(fork_session=True, continue_session=True))

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -68,8 +68,10 @@ export function query({
     allowedTools: options.allowedTools,
     authType: options.authType,
     includePartialMessages: options.includePartialMessages,
+    continue: options.continue,
     resume: options.resume,
     sessionId,
+    forkSession: options.forkSession,
   });
 
   const queryOptions: QueryOptions = {
@@ -149,6 +151,13 @@ function validateOptions(options: QueryOptions): SpawnInfo | undefined {
   // Validate resume format if provided
   if (options.resume) {
     validateSessionId(options.resume, 'resume');
+  }
+
+  // Validate forkSession requires resume or continue
+  if (options.forkSession && !options.resume && !options.continue) {
+    throw new Error(
+      'forkSession requires resume or continue. Use resume to fork a specific session or continue to fork the latest session.',
+    );
   }
 
   try {

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -335,6 +335,10 @@ export class ProcessTransport implements Transport {
       args.push('--session-id', this.options.sessionId);
     }
 
+    if (this.options.forkSession) {
+      args.push('--fork-session');
+    }
+
     return args;
   }
 

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -179,8 +179,10 @@ export const QueryOptionsSchema = z
       )
       .optional(),
     includePartialMessages: z.boolean().optional(),
+    continue: z.boolean().optional(),
     resume: z.string().optional(),
     sessionId: z.string().optional(),
+    forkSession: z.boolean().optional(),
     timeout: TimeoutConfigSchema.optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,13 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  /**
+   * Create a new forked session from the resumed or continued session.
+   * Equivalent to CLI's --fork-session flag.
+   * Must be used with `resume` or `continue`.
+   * @default false
+   */
+  forkSession?: boolean;
 };
 
 export interface QuerySystemPromptPreset {
@@ -451,6 +458,13 @@ export interface QueryOptions {
   includePartialMessages?: boolean;
 
   /**
+   * Resume the most recent session for the current project.
+   * Equivalent to CLI's `--continue` flag.
+   * @default false
+   */
+  continue?: boolean;
+
+  /**
    * Resume a previous session by providing its session ID.
    * This is equivalent to using the `--resume` flag in the Qwen CLI.
    * @example '123e4567-e89b-12d3-a456-426614174000'
@@ -464,6 +478,14 @@ export interface QueryOptions {
    * @example '123e4567-e89b-12d3-a456-426614174000'
    */
   sessionId?: string;
+
+  /**
+   * Create a new forked session from the resumed or continued session.
+   * Equivalent to CLI's `--fork-session` flag.
+   * Must be used with `resume` or `continue`.
+   * @default false
+   */
+  forkSession?: boolean;
 
   /**
    * Timeout configuration for various SDK operations.

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -352,6 +352,30 @@ describe('ProcessTransport', () => {
       );
     });
 
+    it('should include --fork-session argument when forkSession is true', () => {
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const options: TransportOptions = {
+        pathToQwenExecutable: 'qwen',
+        resume: '123e4567-e89b-12d3-a456-426614174000',
+        forkSession: true,
+      };
+
+      new ProcessTransport(options);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'qwen',
+        expect.arrayContaining(['--fork-session']),
+        expect.any(Object),
+      );
+    });
+
     it('should throw if aborted before initialization', () => {
       mockPrepareSpawnInfo.mockReturnValue({
         command: 'qwen',

--- a/packages/sdk-typescript/test/unit/createQuery.test.ts
+++ b/packages/sdk-typescript/test/unit/createQuery.test.ts
@@ -94,4 +94,35 @@ describe('query()', () => {
       }),
     ).toThrow(/systemPrompt/);
   });
+
+  it('passes forkSession to ProcessTransport', async () => {
+    const { query } = await import('../../src/query/createQuery.js');
+
+    query({
+      prompt: 'hello',
+      options: {
+        resume: '123e4567-e89b-12d3-a456-426614174000',
+        forkSession: true,
+      } satisfies QueryOptions,
+    });
+
+    expect(mockProcessTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        forkSession: true,
+      }),
+    );
+  });
+
+  it('rejects forkSession without resume or continue', async () => {
+    const { query } = await import('../../src/query/createQuery.js');
+
+    expect(() =>
+      query({
+        prompt: 'hello',
+        options: {
+          forkSession: true,
+        } satisfies QueryOptions,
+      }),
+    ).toThrow(/forkSession requires resume or continue/);
+  });
 });


### PR DESCRIPTION
## What this PR does

Exposes the `fork_session` (Python) / `forkSession` (TypeScript) option in both SDKs, mapping to the CLI's existing `--fork-session` flag. When set to `true` alongside `resume` or `continue`, the CLI creates a new forked session from the source session instead of resuming it in-place — the forked copy gets a fresh UUID and the original is left untouched.

This PR also exposes the `continue` option on the TypeScript SDK's public `QueryOptions` interface and Zod schema. It was already present on `TransportOptions` and handled by `ProcessTransport.buildCliArguments()`, but wasn't accessible through `QueryOptions` or validated by the schema. This gap meant TypeScript SDK users had no way to use `--continue` (and therefore no way to use `forkSession` with `--continue`).

### Changes by package

**Python SDK** (`packages/sdk-python`):
- `types.py` — added `fork_session: bool` to `QueryOptions` and `QueryOptionsDict`, plus `from_mapping` parsing
- `validation.py` — validates that `fork_session` requires `resume` or `continue_session`
- `transport.py` — passes `--fork-session` to the CLI when `fork_session` is `True`

**TypeScript SDK** (`packages/sdk-typescript`):
- `types.ts` — added `forkSession?: boolean` to `TransportOptions` and `QueryOptions`; added `continue?: boolean` to `QueryOptions`
- `queryOptionsSchema.ts` — added `forkSession` and `continue` to the Zod `QueryOptionsSchema`
- `ProcessTransport.ts` — passes `--fork-session` to the CLI when `forkSession` is `true`
- `createQuery.ts` — passes `forkSession` and `continue` to `ProcessTransport`; validates that `forkSession` requires `resume` or `continue`

## Why it's needed

Session forking is a core CLI feature (implemented since `--fork-session` was added), but neither SDK exposed it. Users who wanted to branch a conversation — e.g., to try a different approach without losing the original session — had no SDK-level way to do so. The TypeScript SDK also had a latent gap where `continue` was wired up internally but not reachable through the public API, which blocked `forkSession` from working with `--continue`.

## Reviewer Test Plan

### How to verify

**Python SDK:**
1. `cd packages/sdk-python && PYTHONPATH=src python3 -m pytest tests/unit/test_validation.py tests/unit/test_transport.py -v` — 39 tests pass, including 5 new fork_session tests
2. Confirm `build_cli_arguments(QueryOptions(resume=UUID, fork_session=True))` includes `--fork-session` after `--resume`
3. Confirm `validate_query_options(QueryOptions(fork_session=True))` raises `ValidationError` with message containing "fork_session requires resume"

**TypeScript SDK:**
1. `cd packages/sdk-typescript && npx vitest run test/unit/createQuery.test.ts test/unit/ProcessTransport.test.ts` — 77 tests pass, including 3 new forkSession tests
2. Confirm `query({ prompt: 'hello', options: { resume: '...', forkSession: true } })` passes `forkSession: true` to `ProcessTransport`, which includes `--fork-session` in CLI args
3. Confirm `query({ prompt: 'hello', options: { forkSession: true } })` throws "forkSession requires resume or continue"

### Evidence (Before & After)

N/A — SDK option mapping, no user-visible TUI change

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment

Unit tests only: Python 3.11 with pytest 9.1, Node.js 22 with vitest 1.6

## Risk & Scope

- Main risk or tradeoff: The TypeScript SDK now accepts `continue` in `QueryOptions`, which was previously rejected by the `.strict()` Zod schema. Any code that relied on the schema rejecting `continue` would need to update — but since the field was already supported on `TransportOptions` and by the CLI, this is a bug fix rather than a behavior change.
- Not validated / out of scope: End-to-end test with a real CLI process (requires qwen CLI installed and auth configured). The CLI's `--fork-session` behavior itself is unchanged — this PR only adds SDK-level option passing.
- Breaking changes / migration notes: None. All new fields are optional with `false`/`undefined` defaults.

## Linked Issues

Related to #4158

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Python 和 TypeScript 两个 SDK 中暴露 `fork_session` / `forkSession` 选项，对应 CLI 已有的 `--fork-session` 标志。当与 `resume` 或 `continue` 配合使用且设为 `true` 时，CLI 会从源会话创建一个新的分叉会话，新会话获得新的 UUID，原会话保持不变。

同时补全了 TypeScript SDK 公共 `QueryOptions` 接口和 Zod schema 中缺失的 `continue` 字段。该字段此前已存在于 `TransportOptions` 中并被 `ProcessTransport.buildCliArguments()` 处理，但未通过 `QueryOptions` 暴露，也未通过 schema 校验。这导致 TypeScript SDK 用户无法使用 `--continue`（进而无法将 `forkSession` 与 `--continue` 配合使用）。

## 为什么需要

会话分叉是 CLI 的核心功能，但两个 SDK 均未暴露。需要在会话中尝试不同方向而不丢失原始会话的用户，无法通过 SDK 实现分叉。TypeScript SDK 还存在 `continue` 选项只在内部可用、公共 API 不可达的问题，阻碍了 `forkSession` 与 `--continue` 的配合使用。

## 风险与范围

- 主要风险：TypeScript SDK 的 `QueryOptions` 现在接受 `continue` 字段，此前 `.strict()` 模式的 Zod schema 会拒绝该字段。但该字段本就被 `TransportOptions` 和 CLI 支持，此处属于补全而非行为变更。
- 未验证：未进行真实 CLI 进程的端到端测试（需安装 qwen CLI 并配置认证）。CLI 的 `--fork-session` 行为本身未改动，本 PR 仅添加 SDK 层的选项传递。
- 破坏性变更：无。所有新字段均为可选，默认值为 `false` / `undefined`。
</details>