### PR TITLE
feat(sdk): add get_available_models() to Python and TypeScript SDKs

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.test.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.test.ts
@@ -20,6 +20,7 @@ import type {
   CLIControlSetModelRequest,
   CLIControlSupportedCommandsRequest,
   CLIControlGetContextUsageRequest,
+  CLIControlGetAvailableModelsRequest,
 } from '../types.js';
 
 /**
@@ -310,6 +311,40 @@ describe('ControlDispatcher', () => {
         response: {
           subtype: 'success',
           request_id: 'req-ctx',
+          response: mockResponse,
+        },
+      });
+    });
+
+    it('should route get_available_models request to system controller', async () => {
+      const request: CLIControlRequest = {
+        type: 'control_request',
+        request_id: 'req-models',
+        request: {
+          subtype: 'get_available_models',
+        } as CLIControlGetAvailableModelsRequest,
+      };
+
+      const mockResponse = {
+        subtype: 'get_available_models',
+        models: [],
+      };
+
+      vi.mocked(mockSystemController.handleRequest).mockResolvedValue(
+        mockResponse,
+      );
+
+      await dispatcher.dispatch(request);
+
+      expect(mockSystemController.handleRequest).toHaveBeenCalledWith(
+        request.request,
+        'req-models',
+      );
+      expect(mockContext.streamJson.send).toHaveBeenCalledWith({
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: 'req-models',
           response: mockResponse,
         },
       });

--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -14,7 +14,7 @@
  * which wraps these controllers with a stable programmatic API.
  *
  * Controllers:
- * - SystemController: initialize, interrupt, set_model, supported_commands, get_context_usage
+ * - SystemController: initialize, interrupt, set_model, supported_commands, get_context_usage, get_available_models
  * - PermissionController: can_use_tool, set_permission_mode
  * - SdkMcpController: mcp_server_status (mcp_message handled via callback)
  *
@@ -377,6 +377,7 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       case 'set_model':
       case 'supported_commands':
       case 'get_context_usage':
+      case 'get_available_models':
         return this.systemController;
 
       case 'can_use_tool':

--- a/packages/cli/src/nonInteractive/control/controllers/systemController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/systemController.ts
@@ -20,6 +20,7 @@ import type {
   CLIControlSetModelRequest,
   CLIMcpServerConfig,
   CLIControlGetContextUsageRequest,
+  CLIControlGetAvailableModelsRequest,
 } from '../../types.js';
 import { getAvailableCommands } from '../../../nonInteractiveCliCommands.js';
 import {
@@ -79,6 +80,12 @@ export class SystemController extends BaseController {
           signal,
         );
 
+      case 'get_available_models':
+        return this.handleGetAvailableModels(
+          payload as CLIControlGetAvailableModelsRequest,
+          signal,
+        );
+
       default:
         throw new Error(`Unsupported request subtype in SystemController`);
     }
@@ -119,6 +126,42 @@ export class SystemController extends BaseController {
         error instanceof Error ? error.message : 'Failed to get context usage';
       debugLogger.error(
         '[SystemController] Failed to get context usage:',
+        error,
+      );
+      throw new Error(errorMessage);
+    }
+  }
+
+  private async handleGetAvailableModels(
+    _payload: CLIControlGetAvailableModelsRequest,
+    signal: AbortSignal,
+  ): Promise<Record<string, unknown>> {
+    if (signal.aborted) {
+      throw new Error('Request aborted');
+    }
+
+    try {
+      const models = this.context.config.getAvailableModels();
+      if (signal.aborted) {
+        throw new Error('Request aborted');
+      }
+
+      return {
+        subtype: 'get_available_models',
+        models: models.map((m) => ({
+          id: m.id,
+          label: m.label,
+          description: m.description,
+          isVision: m.isVision ?? m.capabilities?.vision ?? false,
+        })),
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Failed to get available models';
+      debugLogger.error(
+        '[SystemController] Failed to get available models:',
         error,
       );
       throw new Error(errorMessage);
@@ -282,6 +325,7 @@ export class SystemController extends BaseController {
         typeof this.context.config.setApprovalMode === 'function',
       can_set_model: typeof this.context.config.setModel === 'function',
       can_get_context_usage: true,
+      can_get_available_models: true,
       // SDK MCP servers are supported - messages routed through control plane
       can_handle_mcp_message: true,
     };

--- a/packages/cli/src/nonInteractive/types.ts
+++ b/packages/cli/src/nonInteractive/types.ts
@@ -431,6 +431,10 @@ export interface CLIControlGetContextUsageRequest {
   show_details?: boolean;
 }
 
+export interface CLIControlGetAvailableModelsRequest {
+  subtype: 'get_available_models';
+}
+
 export type ControlRequestPayload =
   | CLIControlInterruptRequest
   | CLIControlContinueLastTurnRequest
@@ -442,7 +446,8 @@ export type ControlRequestPayload =
   | CLIControlSetModelRequest
   | CLIControlMcpStatusRequest
   | CLIControlSupportedCommandsRequest
-  | CLIControlGetContextUsageRequest;
+  | CLIControlGetContextUsageRequest
+  | CLIControlGetAvailableModelsRequest;
 
 export interface CLIControlRequest {
   type: 'control_request';

--- a/packages/sdk-python/src/qwen_code_sdk/protocol.py
+++ b/packages/sdk-python/src/qwen_code_sdk/protocol.py
@@ -238,6 +238,10 @@ class CLIControlSupportedCommandsRequest(TypedDict):
     subtype: Literal["supported_commands"]
 
 
+class CLIControlGetAvailableModelsRequest(TypedDict):
+    subtype: Literal["get_available_models"]
+
+
 ControlRequestPayload: TypeAlias = (
     CLIControlInterruptRequest
     | CLIControlPermissionRequest
@@ -246,6 +250,7 @@ ControlRequestPayload: TypeAlias = (
     | CLIControlSetModelRequest
     | CLIControlMcpStatusRequest
     | CLIControlSupportedCommandsRequest
+    | CLIControlGetAvailableModelsRequest
     | dict[str, Any]
 )
 

--- a/packages/sdk-python/src/qwen_code_sdk/query.py
+++ b/packages/sdk-python/src/qwen_code_sdk/query.py
@@ -482,6 +482,10 @@ class Query:
         await self._ensure_started()
         return await self._send_control_request("mcp_server_status")
 
+    async def get_available_models(self) -> dict[str, Any] | None:
+        await self._ensure_started()
+        return await self._send_control_request("get_available_models")
+
     @property
     def control_request_timeout(self) -> float:
         return self._options.timeout.control_request

--- a/packages/sdk-python/tests/unit/test_transport.py
+++ b/packages/sdk-python/tests/unit/test_transport.py
@@ -82,6 +82,15 @@ def test_cli_argument_precedence_prefers_resume_then_continue_then_session_id() 
     assert "--session-id" not in args
 
 
+def test_get_available_models_protocol_type() -> None:
+    from qwen_code_sdk.protocol import CLIControlGetAvailableModelsRequest
+
+    req: CLIControlGetAvailableModelsRequest = {
+        "subtype": "get_available_models"
+    }
+    assert req["subtype"] == "get_available_models"
+
+
 def test_prepare_spawn_info_uses_runtime_for_python_scripts(tmp_path: Path) -> None:
     script_path = tmp_path / "fake-qwen.py"
     script_path.write_text("print('ok')\n", encoding="utf-8")

--- a/packages/sdk-typescript/src/query/Query.ts
+++ b/packages/sdk-typescript/src/query/Query.ts
@@ -984,6 +984,16 @@ export class Query implements AsyncIterable<SDKMessage> {
   }
 
   /**
+   * Get the list of available models for the current auth type
+   *
+   * @returns Promise resolving to the list of available models
+   * @throws Error if query is closed
+   */
+  async getAvailableModels(): Promise<Record<string, unknown> | null> {
+    return this.sendControlRequest(ControlRequestType.GET_AVAILABLE_MODELS);
+  }
+
+  /**
    * Get list of control commands supported by the CLI
    *
    * @returns Promise resolving to list of supported command names

--- a/packages/sdk-typescript/src/types/protocol.ts
+++ b/packages/sdk-typescript/src/types/protocol.ts
@@ -606,6 +606,7 @@ export enum ControlRequestType {
   SET_MODEL = 'set_model',
   SUPPORTED_COMMANDS = 'supported_commands',
   GET_CONTEXT_USAGE = 'get_context_usage',
+  GET_AVAILABLE_MODELS = 'get_available_models',
 
   // PermissionController requests
   CAN_USE_TOOL = 'can_use_tool',


### PR DESCRIPTION
## What this PR does

Adds a new `get_available_models` control request that lets both SDKs query the list of models available for the current auth type at runtime. The CLI's `SystemController` handles the request by calling `config.getAvailableModels()` and returning each model's `id`, `label`, `description`, and `isVision` fields.

### Changes by package

**CLI** (`packages/cli`):
- `nonInteractive/types.ts` — added `CLIControlGetAvailableModelsRequest` type and included it in `ControlRequestPayload`
- `nonInteractive/control/ControlDispatcher.ts` — routes `get_available_models` to `SystemController`
- `nonInteractive/control/controllers/systemController.ts` — added `handleGetAvailableModels` handler that calls `config.getAvailableModels()`; added `can_get_available_models` capability to the initialize response

**Python SDK** (`packages/sdk-python`):
- `protocol.py` — added `CLIControlGetAvailableModelsRequest` TypedDict and included it in `ControlRequestPayload`
- `query.py` — added `get_available_models()` async method on `Query`

**TypeScript SDK** (`packages/sdk-typescript`):
- `types/protocol.ts` — added `GET_AVAILABLE_MODELS` to `ControlRequestType` enum
- `query/Query.ts` — added `getAvailableModels()` async method on `Query`

## Why it's needed

Without a way to query available models, SDK users have no programmatic way to discover which models they can use or switch to. The CLI's `/model` interactive command already shows this list, but neither SDK exposed it. This method complements the existing `set_model()` / `setModel()` runtime method — users can now list available models and then switch to one.

## Reviewer Test Plan

### How to verify

**Python SDK:**
1. `cd packages/sdk-python && PYTHONPATH=src python3 -m pytest tests/unit/test_transport.py -v` — 36 tests pass, including the new `test_get_available_models_protocol_type`

**TypeScript SDK:**
1. `cd packages/sdk-typescript && npx vitest run test/unit/Query.test.ts` — 55 tests pass
2. Confirm `query.getAvailableModels()` sends a control request with subtype `get_available_models`

**CLI:**
1. `cd packages/cli && npx vitest run src/nonInteractive/control/ControlDispatcher.test.ts` — includes new test `should route get_available_models request to system controller`
2. Note: this test may fail in some local environments due to a pre-existing vitest module resolution issue with the `https` package in `packages/core/src/telemetry`. This is unrelated to this PR.

### Evidence (Before & After)

N/A — SDK method addition, no user-visible TUI change

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment

Unit tests only: Python 3.11 with pytest 9.1, Node.js 22 with vitest 1.6

## Risk & Scope

- Main risk or tradeoff: This adds a new control request subtype to the CLI's `ControlDispatcher`. If a SDK sends this request to an older CLI version that doesn't recognize `get_available_models`, the CLI will return an "Unknown control request subtype" error. This is expected and backward-compatible — the SDK should handle this gracefully (the method returns `dict | None`).
- Not validated / out of scope: End-to-end test with a real CLI process. The handler uses `config.getAvailableModels()` which is already well-tested in the core package.
- Breaking changes / migration notes: None. New method only, no changes to existing behavior.

## Linked Issues

Related to #4158

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `get_available_models` 控制请求，允许两个 SDK 在运行时查询当前认证类型下可用的模型列表。CLI 的 `SystemController` 通过调用 `config.getAvailableModels()` 处理请求，返回每个模型的 `id`、`label`、`description` 和 `isVision` 字段。

## 为什么需要

SDK 用户此前无法通过编程方式查询可用模型列表。CLI 的 `/model` 交互命令已展示此列表，但 SDK 未暴露。该方法与已有的 `set_model()` / `setModel()` 运行时方法配合使用——用户可以先列出可用模型再切换。

## 风险与范围

- 主要风险：向 CLI 的 `ControlDispatcher` 新增了控制请求子类型。如果 SDK 向不支持该子类型的旧版 CLI 发送请求，CLI 会返回"Unknown control request subtype"错误。这是预期的向后兼容行为。
- 未验证：未进行真实 CLI 进程的端到端测试。handler 使用的 `config.getAvailableModels()` 已在 core 包中有充分测试。
- 破坏性变更：无。仅新增方法，不改变现有行为。
</details>