### PR TITLE
fix(memory): give each linked git worktree its own auto-memory root

### DIFF
--- a/docs/users/features/memory.md
+++ b/docs/users/features/memory.md
@@ -91,7 +91,7 @@ Qwen doesn't save everything — only things that would actually be useful next 
 
 ### Where it's stored
 
-Auto-memory files live at `~/.qwen/projects/<project>/memory/`. All branches and worktrees of the same repository share the same memory folder, so what Qwen learns in one branch is available in others.
+Auto-memory files live at `~/.qwen/projects/<project>/memory/`. All branches of the same checkout share the same memory folder, so what Qwen learns in one branch is available in others. Each linked git worktree gets its own memory folder, matching the per-worktree isolation of chats and other session state — repository-wide conventions you want in every worktree belong in [team memory](#team-memory-shared-with-collaborators).
 
 Everything saved is plain markdown — you can open, edit, or delete any file at any time.
 

--- a/packages/core/src/memory/paths.ts
+++ b/packages/core/src/memory/paths.ts
@@ -47,52 +47,6 @@ function findGitRoot(startPath: string): string | null {
   }
 }
 
-function findCanonicalGitRoot(startPath: string): string | null {
-  const gitRoot = findGitRoot(startPath);
-  if (!gitRoot) {
-    return null;
-  }
-
-  try {
-    const gitContent = fs
-      .readFileSync(path.join(gitRoot, '.git'), 'utf-8')
-      .trim();
-    if (!gitContent.startsWith('gitdir:')) {
-      return gitRoot;
-    }
-
-    const worktreeGitDir = path.resolve(
-      gitRoot,
-      gitContent.slice('gitdir:'.length).trim(),
-    );
-    const commonDir = path.resolve(
-      worktreeGitDir,
-      fs.readFileSync(path.join(worktreeGitDir, 'commondir'), 'utf-8').trim(),
-    );
-
-    if (
-      path.resolve(path.dirname(worktreeGitDir)) !==
-      path.join(commonDir, 'worktrees')
-    ) {
-      return gitRoot;
-    }
-
-    const backlink = fs.realpathSync(
-      fs.readFileSync(path.join(worktreeGitDir, 'gitdir'), 'utf-8').trim(),
-    );
-    if (backlink !== path.join(fs.realpathSync(gitRoot), '.git')) {
-      return gitRoot;
-    }
-
-    if (path.basename(commonDir) !== '.git') {
-      return commonDir.normalize('NFC');
-    }
-    return path.dirname(commonDir).normalize('NFC');
-  } catch {
-    return gitRoot;
-  }
-}
-
 /**
  * Returns the base directory for all auto-memory storage.
  * Defaults to the runtime output dir (`runtimeOutputDir`, `QWEN_RUNTIME_DIR`,
@@ -125,12 +79,15 @@ export function getAutoMemoryRoot(projectRoot: string): string {
   if (useLocalMemory) {
     result = path.join(projectRoot, QWEN_DIR, AUTO_MEMORY_DIRNAME);
   } else {
-    const canonicalRoot =
-      findCanonicalGitRoot(projectRoot) ?? path.resolve(projectRoot);
+    // Anchor at the nearest git root WITHOUT resolving linked worktrees back
+    // to their canonical repository root: each worktree gets its own memory,
+    // consistent with the per-worktree isolation of chats/, workflows/, and
+    // team memory (getTeamAutoMemoryRoot). See #6449.
+    const gitRoot = findGitRoot(projectRoot) ?? path.resolve(projectRoot);
     result = path.join(
       memoryBaseDir,
       'projects',
-      sanitizeCwd(canonicalRoot),
+      sanitizeCwd(gitRoot),
       AUTO_MEMORY_DIRNAME,
     );
   }

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -121,6 +121,33 @@ describe('auto-memory storage scaffold', () => {
     );
   });
 
+  it('gives a linked git worktree its own memory root, separate from the main checkout', async () => {
+    delete process.env['QWEN_CODE_MEMORY_LOCAL'];
+    const runtimeDir = path.join(tempDir, 'runtime-output');
+    Storage.setRuntimeBaseDir(runtimeDir);
+    clearAutoMemoryRootCache();
+
+    const main = path.join(tempDir, 'main-repo');
+    const worktree = path.join(tempDir, 'wt');
+    const worktreeGitDir = path.join(main, '.git', 'worktrees', 'wt');
+    await fs.mkdir(worktreeGitDir, { recursive: true });
+    await fs.mkdir(worktree, { recursive: true });
+    await fs.writeFile(
+      path.join(worktree, '.git'),
+      `gitdir: ${worktreeGitDir}`,
+    );
+    await fs.writeFile(path.join(worktreeGitDir, 'commondir'), '../..');
+    await fs.writeFile(
+      path.join(worktreeGitDir, 'gitdir'),
+      path.join(worktree, '.git'),
+    );
+
+    expect(getAutoMemoryRoot(worktree)).toBe(
+      path.join(runtimeDir, 'projects', sanitizeCwd(worktree), 'memory'),
+    );
+    expect(getAutoMemoryRoot(worktree)).not.toBe(getAutoMemoryRoot(main));
+  });
+
   it('uses QWEN_RUNTIME_DIR for managed auto-memory', () => {
     delete process.env['QWEN_CODE_MEMORY_LOCAL'];
     const envRuntimeDir = path.join(tempDir, 'env-runtime-output');


### PR DESCRIPTION
## What this PR does

Gives each linked git worktree its own project auto-memory root instead of resolving back to the canonical repository root. Project memory now anchors at the nearest git root — the same resolution team memory already uses — so parallel worktree sessions no longer write into one shared `MEMORY.md` index. The main checkout resolves to the same path as before, so existing memory is untouched and no migration is needed.

The docs sentence describing the old cross-worktree sharing is updated accordingly, pointing users who want repository-wide conventions in every worktree at the git-tracked team memory tier (which is inherently present in each worktree).

## Why it's needed

A worktree created for a focused task (a bugfix, a PR) shared its project memory with every other worktree of the repository. The index accumulated entries from unrelated parallel work, filling the ~200-line budget and evicting relevant entries. Worktree isolation already covers `chats/`, `workflows/`, temp files, and team memory — project memory was the only shared exception, exactly as the triage analysis on the issue confirmed.

**One thing reviewers should weigh:** the old behavior was documented ("All branches and worktrees of the same repository share the same memory folder"), so this is a deliberate behavior change, not just a code fix — it follows the fix direction in the issue's triage (use `findGitRoot()`, matching `getTeamAutoMemoryRoot()`). Existing worktree users will start with fresh (empty) memory in their worktrees; nothing is deleted — previously shared entries remain with the main checkout's memory. Per the simplicity-first guideline this PR does not add a shared project-level layer alongside per-worktree memory; team memory already serves that role for durable repo-wide conventions.

## Reviewer Test Plan

### How to verify

1. In a repo's main checkout, save a memory (e.g. `/remember ...`) and note `~/.qwen/projects/<sanitized-main-path>/memory/` gets the entry.
2. Create a linked worktree (`git worktree add ../wt`) and start a session there: memory reads/writes should go to `~/.qwen/projects/<sanitized-worktree-path>/memory/`, and the main checkout's index should not pick up worktree entries.
3. Confirm main-checkout resolution is unchanged (same memory path before and after this change).
4. Unit tests: `cd packages/core && npx vitest run src/memory/` (346 tests pass, including a new regression test that builds a linked-worktree fixture and asserts the worktree gets its own root).

### Evidence (Before & After)

Before: `getAutoMemoryRoot(<worktree>)` → `~/.qwen/projects/<sanitized-canonical-root>/memory` (shared). After: `~/.qwen/projects/<sanitized-worktree-path>/memory` (isolated). Covered by the new unit test in the store path suite.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests (`npx vitest run src/memory/`), `npm run build && npm run typecheck`.

## Risk & Scope

- Main risk or tradeoff: behavior change for users who relied on worktrees sharing memory — their worktrees start fresh (old entries stay with the main checkout; nothing is lost). Team memory is the supported way to share conventions across worktrees.
- Not validated / out of scope: no automatic migration/copy of existing memory into worktrees; the issue's secondary concern (push-based memory injection instead of LLM self-management) is a separate architectural topic.
- Breaking changes / migration notes: worktree sessions previously reading the canonical repo's memory will no longer see it; the main checkout is unaffected.

## Linked Issues

Fixes #6449
