### PR TITLE
feat(sdk-python): enable mcp_servers support via initialize control request

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/query.py
+++ b/packages/sdk-python/src/qwen_code_sdk/query.py
@@ -110,6 +110,8 @@ class Query:
     async def _initialize(self) -> None:
         try:
             payload: dict[str, Any] = {"hooks": None}
+            if self._options.mcp_servers:
+                payload["mcpServers"] = self._options.mcp_servers
             await self._send_control_request("initialize", payload)
         except Exception as exc:
             await self._finish_with_error(exc)

--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -64,12 +64,6 @@ def validate_query_options(options: QueryOptions) -> None:
     ):
         raise ValidationError("path_to_qwen_executable cannot be empty")
 
-    if options.mcp_servers:
-        raise ValidationError(
-            "mcp_servers is not supported in Python SDK v1. "
-            "Remove the mcp_servers option or use the TypeScript SDK."
-        )
-
 
 def _validate_optional_callable(
     value: object,

--- a/packages/sdk-python/tests/unit/test_validation.py
+++ b/packages/sdk-python/tests/unit/test_validation.py
@@ -167,8 +167,7 @@ def test_timeout_rejects_boolean_value() -> None:
         TimeoutOptions.from_mapping({"stream_close": True})
 
 
-def test_rejects_mcp_servers() -> None:
-    with pytest.raises(ValidationError, match="mcp_servers is not supported"):
-        validate_query_options(
-            QueryOptions(mcp_servers={"my-server": {"command": "node", "args": []}})
-        )
+def test_accepts_mcp_servers() -> None:
+    validate_query_options(
+        QueryOptions(mcp_servers={"my-server": {"command": "node", "args": []}})
+    )


### PR DESCRIPTION
## What this PR does

Removes the validation that explicitly rejected `mcp_servers` in the Python SDK. CLI MCP server configs are now sent to the CLI during the `initialize` control request, matching the TypeScript SDK's pattern.

The Python SDK already had `mcp_servers: dict[str, dict[str, Any]]` in `QueryOptions` and `QueryOptionsDict`, and `from_mapping` already parsed it correctly. The only blocker was:
1. `validation.py` raised a `ValidationError` when `mcp_servers` was set
2. `query.py`'s `_initialize()` method did not include `mcpServers` in the initialize payload

Both are now fixed. The CLI's `SystemController.handleInitialize()` already handles external MCP server configs received through the `mcpServers` field in the initialize request.

### What's supported

CLI MCP servers (external servers managed by the CLI process): stdio, SSE, streamable HTTP, WebSocket. These are the same configs the TypeScript SDK supports via `CLIMcpServerConfigSchema`.

### What's not supported

In-process SDK MCP servers (`type: 'sdk'` with a server instance). The TypeScript SDK supports these via `SdkMcpServerConfig`, but this requires a Python MCP server runtime that doesn't exist yet. This is tracked separately in #4889.

### Changes

**Python SDK** (`packages/sdk-python`):
- `validation.py` — removed the `mcp_servers` rejection block
- `query.py` — `_initialize()` now includes `mcpServers` in the initialize payload when configured
- `test_validation.py` — replaced `test_rejects_mcp_servers` with `test_accepts_mcp_servers`

## Why it's needed

The Python SDK is the primary SDK for programmatic access to qwen-code, but it couldn't configure MCP servers — a core feature for extending the CLI with custom tools. Users had to use the TypeScript SDK or configure MCP servers in settings files instead of programmatically. This unblocks the most common use case: defining MCP servers in code when creating a query.

## Reviewer Test Plan

### How to verify

1. `cd packages/sdk-python && PYTHONPATH=src python3 -m pytest tests/unit/test_validation.py tests/unit/test_transport.py -v` — 34 tests pass, including `test_accepts_mcp_servers`

### Evidence (Before & After)

N/A — SDK option change, no user-visible TUI change

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment

Unit tests only: Python 3.11 with pytest 9.1

## Risk & Scope

- Main risk or tradeoff: This removes a hard error, so code that previously caught `ValidationError` for `mcp_servers` will no longer trigger. This is the intended behavior change.
- Not validated / out of scope: End-to-end test with a real MCP server and CLI process. In-process SDK MCP servers (Python) are out of scope (#4889).
- Breaking changes / migration notes: None for normal usage. Code that relied on the `mcp_servers` rejection should update to handle the new behavior.

## Linked Issues

Closes #4889 (partially — CLI MCP servers only, not in-process SDK MCP servers)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除了 Python SDK 中明确拒绝 `mcp_servers` 的验证逻辑。CLI MCP 服务器配置现在通过 `initialize` 控制请求发送给 CLI，与 TypeScript SDK 的模式一致。

Python SDK 此前已有 `mcp_servers` 字段在 `QueryOptions` 和 `QueryOptionsDict` 中，`from_mapping` 也能正确解析。唯一的阻塞点是：
1. `validation.py` 在设置 `mcp_servers` 时抛出 `ValidationError`
2. `query.py` 的 `_initialize()` 方法未在初始化载荷中包含 `mcpServers`

两者均已修复。CLI 的 `SystemController.handleInitialize()` 已经能处理通过 `mcpServers` 字段接收的外部 MCP 服务器配置。

### 支持范围

CLI MCP 服务器（由 CLI 进程管理的外部服务器）：stdio、SSE、streamable HTTP、WebSocket。

### 不支持

进程内 SDK MCP 服务器（`type: 'sdk'` 带服务器实例），需要 Python MCP 服务器运行时，跟踪于 #4889。

## 风险与范围

- 主要风险：移除了硬错误，此前捕获 `mcp_servers` `ValidationError` 的代码不再触发。这是预期的行为变更。
- 破坏性变更：无（正常使用下）。依赖 `mcp_servers` 被拒绝的代码需更新以处理新行为。
</details>