### PR TITLE
feat(sdk): add reasoning effort option to CLI and both SDKs

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -14,7 +14,7 @@
  * which wraps these controllers with a stable programmatic API.
  *
  * Controllers:
- * - SystemController: initialize, interrupt, set_model, supported_commands, get_context_usage
+ * - SystemController: initialize, interrupt, set_model, set_effort, supported_commands, get_context_usage
  * - PermissionController: can_use_tool, set_permission_mode
  * - SdkMcpController: mcp_server_status (mcp_message handled via callback)
  *
@@ -375,6 +375,7 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       case 'interrupt':
       case 'continue_last_turn':
       case 'set_model':
+      case 'set_effort':
       case 'supported_commands':
       case 'get_context_usage':
         return this.systemController;

--- a/packages/cli/src/nonInteractive/control/controllers/systemController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/systemController.ts
@@ -18,6 +18,7 @@ import type {
   ControlRequestPayload,
   CLIControlInitializeRequest,
   CLIControlSetModelRequest,
+  CLIControlSetEffortRequest,
   CLIMcpServerConfig,
   CLIControlGetContextUsageRequest,
 } from '../../types.js';
@@ -67,6 +68,12 @@ export class SystemController extends BaseController {
       case 'set_model':
         return this.handleSetModel(
           payload as CLIControlSetModelRequest,
+          signal,
+        );
+
+      case 'set_effort':
+        return this.handleSetEffort(
+          payload as CLIControlSetEffortRequest,
           signal,
         );
 
@@ -253,6 +260,23 @@ export class SystemController extends BaseController {
       }
     }
 
+    // Apply initial effort if provided
+    if (payload.effort) {
+      try {
+        this.context.config.setReasoningEffort(
+          payload.effort as 'low' | 'medium' | 'high' | 'xhigh' | 'max',
+        );
+        debugLogger.info(
+          `[SystemController] Initial effort set to: ${payload.effort}`,
+        );
+      } catch (error) {
+        debugLogger.error(
+          `[SystemController] Failed to set initial effort ${payload.effort}:`,
+          error,
+        );
+      }
+    }
+
     // Build capabilities for response
     const capabilities = this.buildControlCapabilities();
 
@@ -281,6 +305,8 @@ export class SystemController extends BaseController {
       can_set_permission_mode:
         typeof this.context.config.setApprovalMode === 'function',
       can_set_model: typeof this.context.config.setModel === 'function',
+      can_set_effort:
+        typeof this.context.config.setReasoningEffort === 'function',
       can_get_context_usage: true,
       // SDK MCP servers are supported - messages routed through control plane
       can_handle_mcp_message: true,
@@ -451,6 +477,36 @@ export class SystemController extends BaseController {
         error,
       );
 
+      throw new Error(errorMessage);
+    }
+  }
+
+  private async handleSetEffort(
+    payload: CLIControlSetEffortRequest,
+    signal: AbortSignal,
+  ): Promise<Record<string, unknown>> {
+    if (signal.aborted) {
+      throw new Error('Request aborted');
+    }
+
+    const effort = payload.effort;
+    if (typeof effort !== 'string' || effort.trim() === '') {
+      throw new Error('Invalid effort specified for set_effort request');
+    }
+
+    try {
+      this.context.config.setReasoningEffort(
+        effort as 'low' | 'medium' | 'high' | 'xhigh' | 'max',
+      );
+      debugLogger.info(`[SystemController] Effort set to: ${effort}`);
+      return { subtype: 'set_effort', effort };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to set effort';
+      debugLogger.error(
+        `[SystemController] Failed to set effort ${effort}:`,
+        error,
+      );
       throw new Error(errorMessage);
     }
   }

--- a/packages/cli/src/nonInteractive/types.ts
+++ b/packages/cli/src/nonInteractive/types.ts
@@ -388,6 +388,7 @@ export interface CLIControlInitializeRequest {
    */
   mcpServers?: Record<string, CLIMcpServerConfig>;
   agents?: SubagentConfig[];
+  effort?: string;
 }
 
 export interface CLIControlSetPermissionModeRequest {
@@ -418,6 +419,11 @@ export interface CLIControlSetModelRequest {
   model: string;
 }
 
+export interface CLIControlSetEffortRequest {
+  subtype: 'set_effort';
+  effort: string;
+}
+
 export interface CLIControlMcpStatusRequest {
   subtype: 'mcp_server_status';
 }
@@ -440,6 +446,7 @@ export type ControlRequestPayload =
   | CLIHookCallbackRequest
   | CLIControlMcpMessageRequest
   | CLIControlSetModelRequest
+  | CLIControlSetEffortRequest
   | CLIControlMcpStatusRequest
   | CLIControlSupportedCommandsRequest
   | CLIControlGetContextUsageRequest;

--- a/packages/sdk-python/src/qwen_code_sdk/protocol.py
+++ b/packages/sdk-python/src/qwen_code_sdk/protocol.py
@@ -218,6 +218,7 @@ class CLIControlInitializeRequest(TypedDict):
     subtype: Literal["initialize"]
     hooks: NotRequired[Any]
     mcpServers: NotRequired[dict[str, dict[str, Any]]]
+    effort: NotRequired[str]
 
 
 class CLIControlSetPermissionModeRequest(TypedDict):
@@ -228,6 +229,11 @@ class CLIControlSetPermissionModeRequest(TypedDict):
 class CLIControlSetModelRequest(TypedDict):
     subtype: Literal["set_model"]
     model: str
+
+
+class CLIControlSetEffortRequest(TypedDict):
+    subtype: Literal["set_effort"]
+    effort: str
 
 
 class CLIControlMcpStatusRequest(TypedDict):
@@ -244,6 +250,7 @@ ControlRequestPayload: TypeAlias = (
     | CLIControlInitializeRequest
     | CLIControlSetPermissionModeRequest
     | CLIControlSetModelRequest
+    | CLIControlSetEffortRequest
     | CLIControlMcpStatusRequest
     | CLIControlSupportedCommandsRequest
     | dict[str, Any]

--- a/packages/sdk-python/src/qwen_code_sdk/query.py
+++ b/packages/sdk-python/src/qwen_code_sdk/query.py
@@ -110,6 +110,8 @@ class Query:
     async def _initialize(self) -> None:
         try:
             payload: dict[str, Any] = {"hooks": None}
+            if self._options.effort:
+                payload["effort"] = self._options.effort
             await self._send_control_request("initialize", payload)
         except Exception as exc:
             await self._finish_with_error(exc)
@@ -473,6 +475,10 @@ class Query:
     async def set_model(self, model: str) -> None:
         await self._ensure_started()
         await self._send_control_request("set_model", {"model": model})
+
+    async def set_effort(self, effort: str) -> None:
+        await self._ensure_started()
+        await self._send_control_request("set_effort", {"effort": effort})
 
     async def supported_commands(self) -> dict[str, Any] | None:
         await self._ensure_started()

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -23,6 +23,7 @@ AuthType: TypeAlias = Literal[
     "gemini",
     "vertex-ai",
 ]
+Effort: TypeAlias = Literal["low", "medium", "high", "xhigh", "max"]
 
 
 class PermissionSuggestion(TypedDict):
@@ -114,6 +115,7 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    effort: Effort
 
 
 @dataclass
@@ -139,6 +141,7 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    effort: Effort | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -182,6 +185,10 @@ class QueryOptions:
             stderr=cast(
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
+            ),
+            effort=cast(
+                Effort | None,
+                _as_optional_str(data, "effort"),
             ),
         )
 

--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -14,6 +14,7 @@ from .types import (
 
 _VALID_PERMISSION_MODES = {"default", "plan", "auto-edit", "yolo"}
 _VALID_AUTH_TYPES = {"openai", "anthropic", "qwen-oauth", "gemini", "vertex-ai"}
+_VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 
 
 def validate_query_options(options: QueryOptions) -> None:
@@ -30,6 +31,12 @@ def validate_query_options(options: QueryOptions) -> None:
         raise ValidationError(
             f"Invalid auth_type: {options.auth_type!r}. "
             "Expected one of: openai, anthropic, qwen-oauth, gemini, vertex-ai."
+        )
+
+    if options.effort and options.effort not in _VALID_EFFORTS:
+        raise ValidationError(
+            f"Invalid effort: {options.effort!r}. "
+            "Expected one of: low, medium, high, xhigh, max."
         )
 
     _validate_optional_callable(options.can_use_tool, _validate_can_use_tool_callable)

--- a/packages/sdk-typescript/src/query/Query.ts
+++ b/packages/sdk-typescript/src/query/Query.ts
@@ -306,6 +306,7 @@ export class Query implements AsyncIterable<SDKMessage> {
             ? mcpServersForCli
             : undefined,
         agents: this.options.agents,
+        effort: this.options.effort,
       });
       logger.info('Query initialized successfully');
     } catch (error) {
@@ -966,6 +967,18 @@ export class Query implements AsyncIterable<SDKMessage> {
 
   async setModel(model: string): Promise<void> {
     await this.sendControlRequest(ControlRequestType.SET_MODEL, { model });
+  }
+
+  /**
+   * Change the reasoning effort level at runtime.
+   *
+   * @param effort - One of: 'low', 'medium', 'high', 'xhigh', 'max'
+   * @throws Error if query is closed or effort is invalid
+   */
+  async setEffort(
+    effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max',
+  ): Promise<void> {
+    await this.sendControlRequest(ControlRequestType.SET_EFFORT, { effort });
   }
 
   /**

--- a/packages/sdk-typescript/src/types/protocol.ts
+++ b/packages/sdk-typescript/src/types/protocol.ts
@@ -357,6 +357,7 @@ export interface CLIControlInitializeRequest {
    */
   mcpServers?: Record<string, MCPServerConfig>;
   agents?: SubagentConfig[];
+  effort?: string;
 }
 
 export interface CLIControlSetPermissionModeRequest {
@@ -387,6 +388,11 @@ export interface CLIControlSetModelRequest {
   model: string;
 }
 
+export interface CLIControlSetEffortRequest {
+  subtype: 'set_effort';
+  effort: string;
+}
+
 export interface CLIControlMcpStatusRequest {
   subtype: 'mcp_server_status';
 }
@@ -409,6 +415,7 @@ export type ControlRequestPayload =
   | CLIHookCallbackRequest
   | CLIControlMcpMessageRequest
   | CLIControlSetModelRequest
+  | CLIControlSetEffortRequest
   | CLIControlMcpStatusRequest
   | CLIControlSupportedCommandsRequest
   | CLIControlGetContextUsageRequest;
@@ -604,6 +611,7 @@ export enum ControlRequestType {
   INTERRUPT = 'interrupt',
   CONTINUE_LAST_TURN = 'continue_last_turn',
   SET_MODEL = 'set_model',
+  SET_EFFORT = 'set_effort',
   SUPPORTED_COMMANDS = 'supported_commands',
   GET_CONTEXT_USAGE = 'get_context_usage',
 

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -182,5 +182,6 @@ export const QueryOptionsSchema = z
     resume: z.string().optional(),
     sessionId: z.string().optional(),
     timeout: TimeoutConfigSchema.optional(),
+    effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,16 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  /**
+   * Reasoning effort level for the model.
+   * Controls how much reasoning/thinking the model does before responding.
+   * - 'low': Minimal reasoning, faster responses
+   * - 'medium': Balanced reasoning (default)
+   * - 'high': More thorough reasoning
+   * - 'xhigh': Extended reasoning
+   * - 'max': Maximum reasoning, slowest but most thorough
+   */
+  effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 };
 
 export interface QuerySystemPromptPreset {
@@ -503,4 +513,17 @@ export interface QueryOptions {
      */
     streamClose?: number;
   };
+
+  /**
+   * Reasoning effort level for the model.
+   * Controls how much reasoning/thinking the model does before responding.
+   * Sent to CLI via the initialize control request.
+   * Can be changed at runtime via `query.setEffort()`.
+   * - 'low': Minimal reasoning, faster responses
+   * - 'medium': Balanced reasoning (default)
+   * - 'high': More thorough reasoning
+   * - 'xhigh': Extended reasoning
+   * - 'max': Maximum reasoning, slowest but most thorough
+   */
+  effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 }


### PR DESCRIPTION
## Summary

- Add `set_effort` control request to CLI's `SystemController`, with routing in `ControlDispatcher`
- Accept `effort` in the `initialize` payload so it can be set at startup
- Report `can_set_effort` capability in the initialize response
- **Python SDK**: `effort` field in `QueryOptions` (with validation), `Effort` type alias, `set_effort()` runtime method, `CLIControlSetEffortRequest` protocol type
- **TypeScript SDK**: `effort` field in `QueryOptions`/`TransportOptions` (with Zod schema), `setEffort()` runtime method, `SET_EFFORT` in `ControlRequestType` enum, `CLIControlSetEffortRequest` protocol interface

Valid effort values: `low`, `medium`, `high`, `xhigh`, `max`.

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)
- [x] TypeScript SDK typecheck passes (`tsc --noEmit`)
- [x] TypeScript SDK tests pass (`vitest run` — 1163 passed)
- [ ] Manual: verify `effort` is applied when set via `QueryOptions`
- [ ] Manual: verify `set_effort()` / `setEffort()` changes effort at runtime