### PR TITLE
feat(sdk): add include_directories option to both SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -227,6 +227,9 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     if options.allowed_tools:
         args.extend(["--allowed-tools", ",".join(options.allowed_tools)])
 
+    if options.include_directories:
+        args.extend(["--include-directories", ",".join(options.include_directories)])
+
     if options.auth_type:
         args.extend(["--auth-type", options.auth_type])
 

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -114,6 +114,7 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    include_directories: list[str]
 
 
 @dataclass
@@ -139,6 +140,7 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    include_directories: list[str] | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -183,6 +185,7 @@ class QueryOptions:
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
             ),
+            include_directories=_as_optional_str_list(data, "include_directories"),
         )
 
 

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -67,6 +67,7 @@ export function query({
     excludeTools: options.excludeTools,
     allowedTools: options.allowedTools,
     authType: options.authType,
+    includeDirectories: options.includeDirectories,
     includePartialMessages: options.includePartialMessages,
     resume: options.resume,
     sessionId,

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -317,6 +317,16 @@ export class ProcessTransport implements Transport {
       args.push('--allowed-tools', this.options.allowedTools.join(','));
     }
 
+    if (
+      this.options.includeDirectories &&
+      this.options.includeDirectories.length > 0
+    ) {
+      args.push(
+        '--include-directories',
+        this.options.includeDirectories.join(','),
+      );
+    }
+
     if (this.options.authType) {
       args.push('--auth-type', this.options.authType);
     }

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -182,5 +182,6 @@ export const QueryOptionsSchema = z
     resume: z.string().optional(),
     sessionId: z.string().optional(),
     timeout: TimeoutConfigSchema.optional(),
+    includeDirectories: z.array(z.string()).optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,11 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  /**
+   * Additional directories to include in the workspace context.
+   * Equivalent to CLI's `--include-directories` flag.
+   */
+  includeDirectories?: string[];
 };
 
 export interface QuerySystemPromptPreset {
@@ -503,4 +508,10 @@ export interface QueryOptions {
      */
     streamClose?: number;
   };
+
+  /**
+   * Additional directories to include in the workspace context.
+   * Equivalent to CLI's `--include-directories` flag.
+   */
+  includeDirectories?: string[];
 }


### PR DESCRIPTION
## Summary

Add `include_directories` (Python) / `includeDirectories` (TypeScript) option that maps to CLI's `--include-directories` flag, allowing users to add extra directories to the workspace context.

- **Python SDK**: `include_directories: list[str] | None` in `QueryOptions`, mapped to `--include-directories` (comma-separated)
- **TypeScript SDK**: `includeDirectories?: string[]` in `TransportOptions` and `QueryOptions`, with Zod schema validation

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)
- [x] TypeScript SDK typecheck passes (`tsc --noEmit`)
- [x] TypeScript SDK tests pass (`vitest run` — 1163 passed)