### PR TITLE
feat(sdk): add extensions option to both SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -227,6 +227,9 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     if options.allowed_tools:
         args.extend(["--allowed-tools", ",".join(options.allowed_tools)])
 
+    if options.extensions:
+        args.extend(["--extensions", ",".join(options.extensions)])
+
     if options.auth_type:
         args.extend(["--auth-type", options.auth_type])
 

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -114,6 +114,7 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    extensions: list[str]
 
 
 @dataclass
@@ -139,6 +140,7 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    extensions: list[str] | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -183,6 +185,7 @@ class QueryOptions:
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
             ),
+            extensions=_as_optional_str_list(data, "extensions"),
         )
 
 

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -67,6 +67,7 @@ export function query({
     excludeTools: options.excludeTools,
     allowedTools: options.allowedTools,
     authType: options.authType,
+    extensions: options.extensions,
     includePartialMessages: options.includePartialMessages,
     resume: options.resume,
     sessionId,

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -317,6 +317,10 @@ export class ProcessTransport implements Transport {
       args.push('--allowed-tools', this.options.allowedTools.join(','));
     }
 
+    if (this.options.extensions && this.options.extensions.length > 0) {
+      args.push('--extensions', this.options.extensions.join(','));
+    }
+
     if (this.options.authType) {
       args.push('--auth-type', this.options.authType);
     }

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -182,5 +182,6 @@ export const QueryOptionsSchema = z
     resume: z.string().optional(),
     sessionId: z.string().optional(),
     timeout: TimeoutConfigSchema.optional(),
+    extensions: z.array(z.string()).optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,11 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  /**
+   * List of extensions to use. If not provided, all extensions are used.
+   * Equivalent to CLI's `--extensions` (`-e`) flag.
+   */
+  extensions?: string[];
 };
 
 export interface QuerySystemPromptPreset {
@@ -503,4 +508,10 @@ export interface QueryOptions {
      */
     streamClose?: number;
   };
+
+  /**
+   * List of extensions to use. If not provided, all extensions are used.
+   * Equivalent to CLI's `--extensions` (`-e`) flag.
+   */
+  extensions?: string[];
 }


### PR DESCRIPTION
## Summary

Add `extensions` option that maps to CLI's `--extensions` (`-e`) flag, allowing users to specify which extensions to load for a session. If not provided, all extensions are used.

- **Python SDK**: `extensions: list[str] | None` in `QueryOptions`, mapped to `--extensions` (comma-separated)
- **TypeScript SDK**: `extensions?: string[]` in `TransportOptions` and `QueryOptions`, with Zod schema validation

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)
- [x] TypeScript SDK typecheck passes (`tsc --noEmit`)
- [x] TypeScript SDK tests pass (`vitest run` — 1163 passed)