### PR TITLE
feat(sdk-python): add get_context_usage() method

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/protocol.py
+++ b/packages/sdk-python/src/qwen_code_sdk/protocol.py
@@ -238,6 +238,11 @@ class CLIControlSupportedCommandsRequest(TypedDict):
     subtype: Literal["supported_commands"]
 
 
+class CLIControlGetContextUsageRequest(TypedDict):
+    subtype: Literal["get_context_usage"]
+    show_details: NotRequired[bool]
+
+
 ControlRequestPayload: TypeAlias = (
     CLIControlInterruptRequest
     | CLIControlPermissionRequest
@@ -246,6 +251,7 @@ ControlRequestPayload: TypeAlias = (
     | CLIControlSetModelRequest
     | CLIControlMcpStatusRequest
     | CLIControlSupportedCommandsRequest
+    | CLIControlGetContextUsageRequest
     | dict[str, Any]
 )
 

--- a/packages/sdk-python/src/qwen_code_sdk/query.py
+++ b/packages/sdk-python/src/qwen_code_sdk/query.py
@@ -482,6 +482,14 @@ class Query:
         await self._ensure_started()
         return await self._send_control_request("mcp_server_status")
 
+    async def get_context_usage(
+        self, show_details: bool = False
+    ) -> dict[str, Any] | None:
+        await self._ensure_started()
+        return await self._send_control_request(
+            "get_context_usage", {"show_details": show_details}
+        )
+
     @property
     def control_request_timeout(self) -> float:
         return self._options.timeout.control_request


### PR DESCRIPTION
## Summary

Add `get_context_usage(show_details=False)` method to the Python SDK's `Query` class, which sends the `get_context_usage` control request to the CLI. Also adds the `CLIControlGetContextUsageRequest` protocol type.

The TS SDK already has `getContextUsage()`, and the CLI already handles the `get_context_usage` control request in `SystemController`.

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)