### PR TITLE
feat(sdk): add get_usage_info() control request to CLI and both SDKs

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -377,6 +377,7 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       case 'set_model':
       case 'supported_commands':
       case 'get_context_usage':
+      case 'get_usage_info':
         return this.systemController;
 
       case 'can_use_tool':

--- a/packages/cli/src/nonInteractive/control/controllers/systemController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/systemController.ts
@@ -20,6 +20,7 @@ import type {
   CLIControlSetModelRequest,
   CLIMcpServerConfig,
   CLIControlGetContextUsageRequest,
+  CLIControlGetUsageInfoRequest,
 } from '../../types.js';
 import { getAvailableCommands } from '../../../nonInteractiveCliCommands.js';
 import {
@@ -79,6 +80,12 @@ export class SystemController extends BaseController {
           signal,
         );
 
+      case 'get_usage_info':
+        return this.handleGetUsageInfo(
+          payload as CLIControlGetUsageInfoRequest,
+          signal,
+        );
+
       default:
         throw new Error(`Unsupported request subtype in SystemController`);
     }
@@ -121,6 +128,38 @@ export class SystemController extends BaseController {
         '[SystemController] Failed to get context usage:',
         error,
       );
+      throw new Error(errorMessage);
+    }
+  }
+
+  private async handleGetUsageInfo(
+    payload: CLIControlGetUsageInfoRequest,
+    signal: AbortSignal,
+  ): Promise<Record<string, unknown>> {
+    if (signal.aborted) {
+      throw new Error('Request aborted');
+    }
+
+    try {
+      const { loadUsageDashboard } = await import('@qwen-code/qwen-code-core');
+      if (signal.aborted) {
+        throw new Error('Request aborted');
+      }
+
+      const range = payload.range ?? 'today';
+      const dashboard = await loadUsageDashboard({ range });
+      if (signal.aborted) {
+        throw new Error('Request aborted');
+      }
+
+      return {
+        subtype: 'get_usage_info',
+        ...dashboard,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to get usage info';
+      debugLogger.error('[SystemController] Failed to get usage info:', error);
       throw new Error(errorMessage);
     }
   }

--- a/packages/cli/src/nonInteractive/types.ts
+++ b/packages/cli/src/nonInteractive/types.ts
@@ -431,6 +431,11 @@ export interface CLIControlGetContextUsageRequest {
   show_details?: boolean;
 }
 
+export interface CLIControlGetUsageInfoRequest {
+  subtype: 'get_usage_info';
+  range?: 'today' | 'week' | 'month' | 'all';
+}
+
 export type ControlRequestPayload =
   | CLIControlInterruptRequest
   | CLIControlContinueLastTurnRequest
@@ -442,7 +447,8 @@ export type ControlRequestPayload =
   | CLIControlSetModelRequest
   | CLIControlMcpStatusRequest
   | CLIControlSupportedCommandsRequest
-  | CLIControlGetContextUsageRequest;
+  | CLIControlGetContextUsageRequest
+  | CLIControlGetUsageInfoRequest;
 
 export interface CLIControlRequest {
   type: 'control_request';

--- a/packages/sdk-python/src/qwen_code_sdk/protocol.py
+++ b/packages/sdk-python/src/qwen_code_sdk/protocol.py
@@ -238,6 +238,11 @@ class CLIControlSupportedCommandsRequest(TypedDict):
     subtype: Literal["supported_commands"]
 
 
+class CLIControlGetUsageInfoRequest(TypedDict):
+    subtype: Literal["get_usage_info"]
+    range: NotRequired[str]
+
+
 ControlRequestPayload: TypeAlias = (
     CLIControlInterruptRequest
     | CLIControlPermissionRequest
@@ -246,6 +251,7 @@ ControlRequestPayload: TypeAlias = (
     | CLIControlSetModelRequest
     | CLIControlMcpStatusRequest
     | CLIControlSupportedCommandsRequest
+    | CLIControlGetUsageInfoRequest
     | dict[str, Any]
 )
 

--- a/packages/sdk-python/src/qwen_code_sdk/query.py
+++ b/packages/sdk-python/src/qwen_code_sdk/query.py
@@ -482,6 +482,14 @@ class Query:
         await self._ensure_started()
         return await self._send_control_request("mcp_server_status")
 
+    async def get_usage_info(
+        self, range: str = "today"
+    ) -> dict[str, Any] | None:
+        await self._ensure_started()
+        return await self._send_control_request(
+            "get_usage_info", {"range": range}
+        )
+
     @property
     def control_request_timeout(self) -> float:
         return self._options.timeout.control_request

--- a/packages/sdk-typescript/src/query/Query.ts
+++ b/packages/sdk-typescript/src/query/Query.ts
@@ -984,6 +984,21 @@ export class Query implements AsyncIterable<SDKMessage> {
   }
 
   /**
+   * Get local usage statistics from the CLI
+   *
+   * @param range Time range: 'today', 'week', 'month', or 'all'
+   * @returns Promise resolving to usage dashboard data
+   * @throws Error if query is closed
+   */
+  async getUsageInfo(
+    range: 'today' | 'week' | 'month' | 'all' = 'today',
+  ): Promise<Record<string, unknown> | null> {
+    return this.sendControlRequest(ControlRequestType.GET_USAGE_INFO, {
+      range,
+    });
+  }
+
+  /**
    * Get list of control commands supported by the CLI
    *
    * @returns Promise resolving to list of supported command names

--- a/packages/sdk-typescript/src/types/protocol.ts
+++ b/packages/sdk-typescript/src/types/protocol.ts
@@ -400,6 +400,11 @@ export interface CLIControlGetContextUsageRequest {
   show_details?: boolean;
 }
 
+export interface CLIControlGetUsageInfoRequest {
+  subtype: 'get_usage_info';
+  range?: 'today' | 'week' | 'month' | 'all';
+}
+
 export type ControlRequestPayload =
   | CLIControlInterruptRequest
   | CLIControlContinueLastTurnRequest
@@ -411,7 +416,8 @@ export type ControlRequestPayload =
   | CLIControlSetModelRequest
   | CLIControlMcpStatusRequest
   | CLIControlSupportedCommandsRequest
-  | CLIControlGetContextUsageRequest;
+  | CLIControlGetContextUsageRequest
+  | CLIControlGetUsageInfoRequest;
 
 export interface CLIControlRequest {
   type: 'control_request';
@@ -606,6 +612,7 @@ export enum ControlRequestType {
   SET_MODEL = 'set_model',
   SUPPORTED_COMMANDS = 'supported_commands',
   GET_CONTEXT_USAGE = 'get_context_usage',
+  GET_USAGE_INFO = 'get_usage_info',
 
   // PermissionController requests
   CAN_USE_TOOL = 'can_use_tool',


### PR DESCRIPTION
## Summary

Add a new `get_usage_info` control request that returns local usage statistics from the CLI's usage history service. Data includes token totals, per-model breakdown, daily trends, and heatmap data — the same data the `/stats` interactive command shows.

**CLI:**
- Route `get_usage_info` to `SystemController` in `ControlDispatcher`
- `handleGetUsageInfo` in `SystemController` calls `loadUsageDashboard()` from core
- `CLIControlGetUsageInfoRequest` type with optional `range` field

**Python SDK:** `get_usage_info(range="today")` method on `Query` + `CLIControlGetUsageInfoRequest` protocol type

**TypeScript SDK:** `getUsageInfo(range)` method on `Query` + `GET_USAGE_INFO` in `ControlRequestType` enum + `CLIControlGetUsageInfoRequest` interface

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)
- [x] TypeScript SDK typecheck passes (`tsc --noEmit`)
- [x] TypeScript SDK tests pass (`vitest run` — 1163 passed)