### PR TITLE
feat(sdk): add allowed_mcp_server_names option to both SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -227,6 +227,9 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     if options.allowed_tools:
         args.extend(["--allowed-tools", ",".join(options.allowed_tools)])
 
+    if options.allowed_mcp_server_names:
+        args.extend(["--allowed-mcp-server-names", ",".join(options.allowed_mcp_server_names)])
+
     if options.auth_type:
         args.extend(["--auth-type", options.auth_type])
 

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -114,6 +114,7 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    allowed_mcp_server_names: list[str]
 
 
 @dataclass
@@ -139,6 +140,7 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    allowed_mcp_server_names: list[str] | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -182,6 +184,9 @@ class QueryOptions:
             stderr=cast(
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
+            ),
+            allowed_mcp_server_names=_as_optional_str_list(
+                data, "allowed_mcp_server_names"
             ),
         )
 

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -66,6 +66,7 @@ export function query({
     coreTools: options.coreTools,
     excludeTools: options.excludeTools,
     allowedTools: options.allowedTools,
+    allowedMcpServerNames: options.allowedMcpServerNames,
     authType: options.authType,
     includePartialMessages: options.includePartialMessages,
     resume: options.resume,

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -317,6 +317,16 @@ export class ProcessTransport implements Transport {
       args.push('--allowed-tools', this.options.allowedTools.join(','));
     }
 
+    if (
+      this.options.allowedMcpServerNames &&
+      this.options.allowedMcpServerNames.length > 0
+    ) {
+      args.push(
+        '--allowed-mcp-server-names',
+        this.options.allowedMcpServerNames.join(','),
+      );
+    }
+
     if (this.options.authType) {
       args.push('--auth-type', this.options.authType);
     }

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -182,5 +182,6 @@ export const QueryOptionsSchema = z
     resume: z.string().optional(),
     sessionId: z.string().optional(),
     timeout: TimeoutConfigSchema.optional(),
+    allowedMcpServerNames: z.array(z.string()).optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,11 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  /**
+   * Allowed MCP server names. When provided, only these MCP servers
+   * will be available. Equivalent to CLI's `--allowed-mcp-server-names`.
+   */
+  allowedMcpServerNames?: string[];
 };
 
 export interface QuerySystemPromptPreset {
@@ -503,4 +508,10 @@ export interface QueryOptions {
      */
     streamClose?: number;
   };
+
+  /**
+   * Allowed MCP server names. When provided, only these MCP servers
+   * will be available. Equivalent to CLI's `--allowed-mcp-server-names`.
+   */
+  allowedMcpServerNames?: string[];
 }


### PR DESCRIPTION
## Summary

Add `allowed_mcp_server_names` (Python) / `allowedMcpServerNames` (TS) option that maps to CLI's `--allowed-mcp-server-names` flag, allowing users to whitelist which MCP servers are available for a session.

Note: `strict_mcp_config` was not implemented as the CLI does not have this flag.

## Test plan

- [x] Python SDK tests pass (`pytest` — 58 passed)
- [x] TypeScript SDK typecheck passes (`tsc --noEmit`)
- [x] TypeScript SDK tests pass (`vitest run` — 1163 passed)