### PR TITLE
feat(sdk): add fallback_model and proxy options to Python and TS SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -240,4 +240,10 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     elif options.session_id:
         args.extend(["--session-id", options.session_id])
 
+    if options.fallback_model:
+        args.extend(["--fallback-model", ",".join(options.fallback_model)])
+
+    if options.proxy:
+        args.extend(["--proxy", options.proxy])
+
     return args

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -114,6 +114,8 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    fallback_model: list[str]
+    proxy: str
 
 
 @dataclass
@@ -139,6 +141,8 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    fallback_model: list[str] | None = None
+    proxy: str | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -183,6 +187,8 @@ class QueryOptions:
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
             ),
+            fallback_model=_as_optional_str_list(data, "fallback_model"),
+            proxy=_as_optional_str(data, "proxy"),
         )
 
 

--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -70,6 +70,15 @@ def validate_query_options(options: QueryOptions) -> None:
             "Remove the mcp_servers option or use the TypeScript SDK."
         )
 
+    if options.fallback_model and len(options.fallback_model) > 3:
+        raise ValidationError(
+            "fallback_model supports a maximum of 3 models. "
+            f"Got {len(options.fallback_model)}."
+        )
+
+    if options.proxy is not None and not options.proxy.strip():
+        raise ValidationError("proxy cannot be empty")
+
 
 def _validate_optional_callable(
     value: object,

--- a/packages/sdk-python/tests/unit/test_transport.py
+++ b/packages/sdk-python/tests/unit/test_transport.py
@@ -68,6 +68,23 @@ def test_build_cli_arguments_maps_supported_options() -> None:
     ]
 
 
+def test_build_cli_arguments_includes_fallback_model_and_proxy() -> None:
+    args = build_cli_arguments(
+        QueryOptions(
+            fallback_model=["qwen-plus", "qwen-turbo"],
+            proxy="http://user:pass@proxy.example.com:8080",
+        )
+    )
+
+    assert "--fallback-model" in args
+    assert args[args.index("--fallback-model") + 1] == "qwen-plus,qwen-turbo"
+    assert "--proxy" in args
+    assert (
+        args[args.index("--proxy") + 1]
+        == "http://user:pass@proxy.example.com:8080"
+    )
+
+
 def test_cli_argument_precedence_prefers_resume_then_continue_then_session_id() -> None:
     args = build_cli_arguments(
         QueryOptions(

--- a/packages/sdk-python/tests/unit/test_validation.py
+++ b/packages/sdk-python/tests/unit/test_validation.py
@@ -172,3 +172,15 @@ def test_rejects_mcp_servers() -> None:
         validate_query_options(
             QueryOptions(mcp_servers={"my-server": {"command": "node", "args": []}})
         )
+
+
+def test_rejects_fallback_model_exceeding_max() -> None:
+    with pytest.raises(ValidationError, match="fallback_model supports a maximum of 3"):
+        validate_query_options(
+            QueryOptions(fallback_model=["a", "b", "c", "d"])
+        )
+
+
+def test_rejects_empty_proxy() -> None:
+    with pytest.raises(ValidationError, match="proxy cannot be empty"):
+        validate_query_options(QueryOptions(proxy="   "))

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -70,6 +70,8 @@ export function query({
     includePartialMessages: options.includePartialMessages,
     resume: options.resume,
     sessionId,
+    fallbackModel: options.fallbackModel,
+    proxy: options.proxy,
   });
 
   const queryOptions: QueryOptions = {

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -335,6 +335,14 @@ export class ProcessTransport implements Transport {
       args.push('--session-id', this.options.sessionId);
     }
 
+    if (this.options.fallbackModel && this.options.fallbackModel.length > 0) {
+      args.push('--fallback-model', this.options.fallbackModel.join(','));
+    }
+
+    if (this.options.proxy) {
+      args.push('--proxy', this.options.proxy);
+    }
+
     return args;
   }
 

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -181,6 +181,11 @@ export const QueryOptionsSchema = z
     includePartialMessages: z.boolean().optional(),
     resume: z.string().optional(),
     sessionId: z.string().optional(),
+    fallbackModel: z
+      .array(z.string())
+      .max(3, 'fallbackModel supports a maximum of 3 models')
+      .optional(),
+    proxy: z.string().min(1, 'proxy cannot be empty').optional(),
     timeout: TimeoutConfigSchema.optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,8 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  fallbackModel?: string[];
+  proxy?: string;
 };
 
 export interface QuerySystemPromptPreset {
@@ -464,6 +466,21 @@ export interface QueryOptions {
    * @example '123e4567-e89b-12d3-a456-426614174000'
    */
   sessionId?: string;
+
+  /**
+   * Fallback model(s) for capacity errors (429/503/529).
+   * Up to 3 models, tried in order when the primary model is unavailable.
+   * @example ['qwen-plus', 'qwen-turbo']
+   */
+  fallbackModel?: string[];
+
+  /**
+   * Proxy URL for the Qwen CLI process.
+   * Format: `schema://user:password@host:port`
+   * @example 'http://user:pass@proxy.example.com:8080'
+   * @deprecated Use the "proxy" setting in settings.json instead.
+   */
+  proxy?: string;
 
   /**
    * Timeout configuration for various SDK operations.

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -352,6 +352,55 @@ describe('ProcessTransport', () => {
       );
     });
 
+    it('should include --fallback-model argument when provided', () => {
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const options: TransportOptions = {
+        pathToQwenExecutable: 'qwen',
+        fallbackModel: ['qwen-plus', 'qwen-turbo'],
+      };
+
+      new ProcessTransport(options);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'qwen',
+        expect.arrayContaining(['--fallback-model', 'qwen-plus,qwen-turbo']),
+        expect.any(Object),
+      );
+    });
+
+    it('should include --proxy argument when provided', () => {
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const options: TransportOptions = {
+        pathToQwenExecutable: 'qwen',
+        proxy: 'http://user:pass@proxy.example.com:8080',
+      };
+
+      new ProcessTransport(options);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'qwen',
+        expect.arrayContaining([
+          '--proxy',
+          'http://user:pass@proxy.example.com:8080',
+        ]),
+        expect.any(Object),
+      );
+    });
+
     it('should throw if aborted before initialization', () => {
       mockPrepareSpawnInfo.mockReturnValue({
         command: 'qwen',

--- a/packages/sdk-typescript/test/unit/createQuery.test.ts
+++ b/packages/sdk-typescript/test/unit/createQuery.test.ts
@@ -94,4 +94,51 @@ describe('query()', () => {
       }),
     ).toThrow(/systemPrompt/);
   });
+
+  it('passes fallbackModel to ProcessTransport', async () => {
+    const { query } = await import('../../src/query/createQuery.js');
+
+    query({
+      prompt: 'hello',
+      options: {
+        fallbackModel: ['qwen-plus', 'qwen-turbo'],
+      } satisfies QueryOptions,
+    });
+
+    expect(mockProcessTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackModel: ['qwen-plus', 'qwen-turbo'],
+      }),
+    );
+  });
+
+  it('passes proxy to ProcessTransport', async () => {
+    const { query } = await import('../../src/query/createQuery.js');
+
+    query({
+      prompt: 'hello',
+      options: {
+        proxy: 'http://user:pass@proxy.example.com:8080',
+      } satisfies QueryOptions,
+    });
+
+    expect(mockProcessTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: 'http://user:pass@proxy.example.com:8080',
+      }),
+    );
+  });
+
+  it('rejects more than 3 fallbackModel entries', async () => {
+    const { query } = await import('../../src/query/createQuery.js');
+
+    expect(() =>
+      query({
+        prompt: 'hello',
+        options: {
+          fallbackModel: ['a', 'b', 'c', 'd'],
+        } satisfies QueryOptions,
+      }),
+    ).toThrow(/fallbackModel/);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `fallback_model` (Python) / `fallbackModel` (TS) option mapping to CLI's `--fallback-model` flag (max 3 models, comma-separated)
- Add `proxy` option mapping to CLI's `--proxy` flag (deprecated, but still functional)
- Both options implemented in Python SDK (types, validation, transport) and TS SDK (types, schema, transport, createQuery)
- Unit tests added for both SDKs covering CLI argument building, validation, and pass-through

## Test plan
- [x] Python SDK unit tests pass (37 tests)
- [x] TS SDK unit tests pass (79 tests)
- [x] `fallbackModel` rejects >3 entries via Zod schema
- [x] `fallback_model` rejects >3 entries via Python validation
- [x] Empty `proxy` string rejected by both SDKs