### PR TITLE
feat(sdk): add disabled_slash_commands option to Python and TS SDKs

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -240,4 +240,9 @@ def build_cli_arguments(options: QueryOptions) -> list[str]:
     elif options.session_id:
         args.extend(["--session-id", options.session_id])
 
+    if options.disabled_slash_commands:
+        args.extend(
+            ["--disabled-slash-commands", ",".join(options.disabled_slash_commands)]
+        )
+
     return args

--- a/packages/sdk-python/src/qwen_code_sdk/types.py
+++ b/packages/sdk-python/src/qwen_code_sdk/types.py
@@ -114,6 +114,7 @@ class QueryOptionsDict(TypedDict, total=False):
     timeout: TimeoutOptionsDict
     mcp_servers: dict[str, dict[str, Any]]
     stderr: Callable[[str], None]
+    disabled_slash_commands: list[str]
 
 
 @dataclass
@@ -139,6 +140,7 @@ class QueryOptions:
     timeout: TimeoutOptions = TimeoutOptions()
     mcp_servers: dict[str, dict[str, Any]] | None = None
     stderr: Callable[[str], None] | None = None
+    disabled_slash_commands: list[str] | None = None
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any] | None) -> QueryOptions:
@@ -183,6 +185,7 @@ class QueryOptions:
                 Callable[[str], None] | None,
                 _as_optional_callable(data, "stderr"),
             ),
+            disabled_slash_commands=_as_optional_str_list(data, "disabled_slash_commands"),
         )
 
 

--- a/packages/sdk-python/tests/unit/test_transport.py
+++ b/packages/sdk-python/tests/unit/test_transport.py
@@ -82,6 +82,16 @@ def test_cli_argument_precedence_prefers_resume_then_continue_then_session_id() 
     assert "--session-id" not in args
 
 
+def test_build_cli_arguments_includes_disabled_slash_commands() -> None:
+    args = build_cli_arguments(
+        QueryOptions(disabled_slash_commands=["/init", "/vim"])
+    )
+
+    assert "--disabled-slash-commands" in args
+    idx = args.index("--disabled-slash-commands")
+    assert args[idx + 1] == "/init,/vim"
+
+
 def test_prepare_spawn_info_uses_runtime_for_python_scripts(tmp_path: Path) -> None:
     script_path = tmp_path / "fake-qwen.py"
     script_path.write_text("print('ok')\n", encoding="utf-8")

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -70,6 +70,7 @@ export function query({
     includePartialMessages: options.includePartialMessages,
     resume: options.resume,
     sessionId,
+    disabledSlashCommands: options.disabledSlashCommands,
   });
 
   const queryOptions: QueryOptions = {

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -335,6 +335,16 @@ export class ProcessTransport implements Transport {
       args.push('--session-id', this.options.sessionId);
     }
 
+    if (
+      this.options.disabledSlashCommands &&
+      this.options.disabledSlashCommands.length > 0
+    ) {
+      args.push(
+        '--disabled-slash-commands',
+        this.options.disabledSlashCommands.join(','),
+      );
+    }
+
     return args;
   }
 

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -181,6 +181,7 @@ export const QueryOptionsSchema = z
     includePartialMessages: z.boolean().optional(),
     resume: z.string().optional(),
     sessionId: z.string().optional(),
+    disabledSlashCommands: z.array(z.string()).optional(),
     timeout: TimeoutConfigSchema.optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -46,6 +46,7 @@ export type TransportOptions = {
    * When resume is provided, this should match the resume ID.
    */
   sessionId?: string;
+  disabledSlashCommands?: string[];
 };
 
 export interface QuerySystemPromptPreset {
@@ -464,6 +465,14 @@ export interface QueryOptions {
    * @example '123e4567-e89b-12d3-a456-426614174000'
    */
   sessionId?: string;
+
+  /**
+   * Slash command names to hide/disable.
+   * Equivalent to CLI's `--disabled-slash-commands` flag.
+   * Matched case-insensitively against the final command name.
+   * @example ['/init', '/vim']
+   */
+  disabledSlashCommands?: string[];
 
   /**
    * Timeout configuration for various SDK operations.

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -352,6 +352,29 @@ describe('ProcessTransport', () => {
       );
     });
 
+    it('should include --disabled-slash-commands when provided', () => {
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const options: TransportOptions = {
+        pathToQwenExecutable: 'qwen',
+        disabledSlashCommands: ['/init', '/vim'],
+      };
+
+      new ProcessTransport(options);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'qwen',
+        expect.arrayContaining(['--disabled-slash-commands', '/init,/vim']),
+        expect.any(Object),
+      );
+    });
+
     it('should throw if aborted before initialization', () => {
       mockPrepareSpawnInfo.mockReturnValue({
         command: 'qwen',


### PR DESCRIPTION
## Summary
- Add `disabled_slash_commands` (Python) / `disabledSlashCommands` (TS) option mapping to CLI's `--disabled-slash-commands` flag
- Slash command names to hide/disable, matched case-insensitively against the final command name
- Implemented in both Python SDK (types, transport) and TS SDK (types, schema, transport, createQuery)
- Unit tests added for both SDKs

## Test plan
- [x] Python SDK unit tests pass (35 tests)
- [x] TS SDK unit tests pass (75 tests)
- [x] `--disabled-slash-commands` flag present in CLI args with comma-separated values