### PR TITLE
fix(core): reject Windows-style workspace artifact paths

### DIFF
--- a/packages/core/src/tools/record-artifact.test.ts
+++ b/packages/core/src/tools/record-artifact.test.ts
@@ -93,15 +93,58 @@ describe('RecordArtifactTool', () => {
     ).toThrow(/exactly one/);
   });
 
-  it('rejects workspace traversal and unsafe urls before reporting success', () => {
+  it('rejects workspace paths that escape the workspace', () => {
     const tool = new RecordArtifactTool();
 
-    expect(() =>
-      tool.build({
-        title: 'Escape',
-        workspacePath: '../secret.txt',
-      }),
-    ).toThrow(/workspacePath/);
+    for (const workspacePath of [
+      '../secret.txt',
+      '..\\secret.txt',
+      '..\\..\\secret.txt',
+      'reports\\..\\..\\secret.txt',
+      'reports/..\\..\\secret.txt',
+      'C:\\tmp\\report.html',
+      'C:/tmp/report.html',
+      'C:tmp\\report.html',
+      '\\\\server\\share\\report.html',
+      '\\tmp\\report.html',
+    ]) {
+      expect(() =>
+        tool.build({
+          title: 'Escape',
+          workspacePath,
+        }),
+      ).toThrow(/workspacePath/);
+    }
+  });
+
+  it('accepts safe workspace-relative artifact paths', async () => {
+    const tool = new RecordArtifactTool();
+
+    await expect(
+      tool
+        .build({
+          title: 'Safe report',
+          workspacePath: 'reports/summary.html',
+        })
+        .execute(signal),
+    ).resolves.toMatchObject({
+      artifacts: [{ workspacePath: 'reports/summary.html' }],
+    });
+
+    await expect(
+      tool
+        .build({
+          title: 'Windows-style relative report',
+          workspacePath: 'reports\\summary.html',
+        })
+        .execute(signal),
+    ).resolves.toMatchObject({
+      artifacts: [{ workspacePath: 'reports\\summary.html' }],
+    });
+  });
+
+  it('rejects unsafe urls before reporting success', () => {
+    const tool = new RecordArtifactTool();
 
     expect(() =>
       tool.build({

--- a/packages/core/src/tools/record-artifact.ts
+++ b/packages/core/src/tools/record-artifact.ts
@@ -360,14 +360,18 @@ function validateWorkspacePath(value: string): string | null {
   if (stringError) {
     return stringError;
   }
-  if (path.isAbsolute(trimmed)) {
+  if (
+    path.isAbsolute(trimmed) ||
+    path.win32.isAbsolute(trimmed) ||
+    /^[A-Za-z]:/.test(trimmed)
+  ) {
     return '"workspacePath" must be relative to the workspace';
   }
-  const normalized = path.normalize(trimmed);
+  const portableNormalized = path.posix.normalize(trimmed.replace(/\\/g, '/'));
   if (
-    normalized === '..' ||
-    normalized.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(normalized)
+    portableNormalized === '..' ||
+    portableNormalized.startsWith('../') ||
+    path.posix.isAbsolute(portableNormalized)
   ) {
     return '"workspacePath" must stay inside the workspace';
   }


### PR DESCRIPTION
﻿## What this PR does

Tightens `record_artifact` workspacePath validation so Windows-style absolute paths and backslash traversal are rejected consistently, including when Qwen Code is running on POSIX/Linux.

## Why it's needed

### What Problem This Solves

`record_artifact` accepts `workspacePath` as a workspace-relative metadata locator. The tool already rejected native absolute paths and POSIX-style parent-directory traversal, but its validation relied partly on the host platform's path semantics.

On POSIX/Linux, backslash is not a path separator. That meant Windows-style path strings such as `..\secret.txt`, `reports\..\..\secret.txt`, `C:\tmp\report.html`, or UNC-like paths could be treated as ordinary relative strings at the `record_artifact` boundary, even though they do not match the intended workspace-relative contract.

This change makes the validation portable: path strings carrying Windows absolute, drive-relative, UNC-like, or backslash traversal semantics are rejected consistently before `record_artifact` reports success.

### Changes

- Adds Windows-aware absolute path checks with `path.win32.isAbsolute(...)`.
- Rejects drive-prefixed paths such as `C:\tmp\report.html`, `C:/tmp/report.html`, and `C:tmp\report.html`.
- Normalizes backslashes to POSIX separators before checking whether the path escapes the workspace.
- Keeps ordinary workspace-relative artifact paths valid, including `reports/summary.html` and `reports\summary.html`.
- Leaves `record_artifact` scoped to metadata only; it still does not read, write, upload, publish, or verify the referenced resource.

### Evidence

The PR changes only `packages/core/src/tools/record-artifact.ts` and `packages/core/src/tools/record-artifact.test.ts`.

The implementation now checks native absolute paths, Windows absolute paths, drive-prefixed paths, and portable parent-directory traversal before accepting `workspacePath`.

Regression coverage was expanded to reject:

- `../secret.txt`
- `..\secret.txt`
- `..\..\secret.txt`
- `reports\..\..\secret.txt`
- `reports/..\..\secret.txt`
- `C:\tmp\report.html`
- `C:/tmp/report.html`
- `C:tmp\report.html`
- `\\server\share\report.html`
- `\tmp\report.html`

The tests also confirm that normal workspace-relative paths still resolve successfully for both slash and backslash examples.

### Possible call chain / impact

A caller provides `workspacePath` to `record_artifact`, `RecordArtifactTool.build(...)` validates the locator, and `execute(...)` returns artifact metadata only after validation succeeds.

Before this change, some Windows-style escape or absolute-path strings could pass validation when the tool was running on POSIX/Linux because backslashes were treated as plain characters. After this change, those strings are rejected at build-time, so clients receive a validation error instead of a successful artifact metadata result.

The expected impact is limited to invalid `workspacePath` inputs. Valid workspace-relative artifact paths should continue to work unchanged.
## Reviewer Test Plan

### How to verify

Confirm `record_artifact` still accepts normal workspace-relative paths such as `reports/summary.html` and `reports\summary.html`, and rejects `../secret.txt`, `..\secret.txt`, `..\..\secret.txt`, `reports\..\..\secret.txt`, `reports/..\..\secret.txt`, `C:\tmp\report.html`, `C:/tmp/report.html`, `C:tmp\report.html`, `\\server\share\report.html`, and `\tmp\report.html` before reporting success.

### Evidence (Before & After)

N/A - non-UI validation change. Regression coverage is in `packages/core/src/tools/record-artifact.test.ts`.

Focused validation run on Windows:

```txt
> npm run test --workspace=packages/core -- src/tools/record-artifact.test.ts
✓ src/tools/record-artifact.test.ts (15 tests)
Test Files  1 passed (1)
Tests       15 passed (15)
```

Additional local validation:

```txt
> npm run typecheck --workspace=packages/core
exit 0

> npm run lint --workspace=packages/core
exit 0

> git diff --check
exit 0
```

Linux/WSL validation:

```txt
> npm run test --workspace=packages/core -- src/tools/record-artifact.test.ts
✓ src/tools/record-artifact.test.ts (15 tests)
Test Files  1 passed (1)
Tests       15 passed (15)
```

Note: this checkout shares `node_modules` between Windows and WSL. Running the focused test on WSL required installing Rollup's Linux optional package; restoring the Windows optional package afterward kept the Windows focused test/typecheck/lint path green. No package files were changed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍎 macOS  | not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested via WSL Ubuntu-22.04 |

### Environment (optional)

Windows: Node.js `v24.15.0`, npm `11.12.1`. Linux: WSL Ubuntu-22.04 with Node.js `v24.15.0`.

## Risk & Scope

- Main risk or tradeoff: Low; this rejects cross-platform path strings that violate the existing workspace-relative artifact locator contract, while preserving ordinary relative paths.
- Not validated / out of scope: This is not a broad daemon artifact-store rewrite and does not claim a high-severity path traversal exploit. The downstream artifact store keeps its own containment checks.
- Breaking changes / migration notes: None expected for valid workspace-relative artifact paths.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

收紧 `record_artifact` 的 `workspacePath` 校验，让 Windows 风格的绝对路径和反斜杠父目录跳转在 POSIX/Linux 环境下也会被一致拒绝。

## 为什么需要

`workspacePath` 是一个指向当前 workspace 内产物文件的 metadata locator。之前的校验能拒绝本机绝对路径和 POSIX 风格的 `../...`，但依赖当前运行平台的 `node:path` 分隔符语义。

在 POSIX/Linux 上，反斜杠不会被当作路径分隔符，因此 `..\secret.txt`、`reports\..\..\secret.txt`、`C:\tmp\report.html` 这类 Windows 风格路径可能在工具入口处看起来像普通相对字符串。这会让 `record_artifact` 的工具层校验弱于它声明的 workspace-relative 语义。

本 PR 保持范围很窄：`record_artifact` 仍然只记录 artifact metadata，不读取、不写入、不上传、也不验证引用资源；这里只是在返回成功 artifact 结果前拒绝带有 Windows 绝对路径、盘符相对路径、UNC 风格路径或反斜杠 traversal 语义的字符串。

## Reviewer Test Plan

验证 `record_artifact` 仍接受 `reports/summary.html` 和 `reports\summary.html` 这类正常 workspace 相对路径，同时拒绝 `../secret.txt`、`..\secret.txt`、`..\..\secret.txt`、`reports\..\..\secret.txt`、`reports/..\..\secret.txt`、`C:\tmp\report.html`、`C:/tmp/report.html`、`C:tmp\report.html`、`\\server\share\report.html` 和 `\tmp\report.html`。

本地已在 Windows 和 WSL Ubuntu-22.04 上跑过 focused test。Windows 上还跑过 core typecheck、core lint 和 `git diff --check`。

## 风险与范围

风险较低；该修改只拒绝违反现有 workspace-relative contract 的跨平台路径字符串，不改 artifact 读取、写入、上传或 daemon store 行为。它不应被表述为高危 path traversal 漏洞。

</details>

