### PR TITLE
docs(channels): add WeCom to channels overview

### DIFF
--- a/docs/users/features/channels/overview.md
+++ b/docs/users/features/channels/overview.md
@@ -1,6 +1,6 @@
 # Channels
 
-Channels let you interact with a Qwen Code agent from messaging platforms like Telegram, WeChat, QQ, DingTalk, or Feishu, instead of the terminal. You send messages from your phone or desktop chat app, and the agent responds just like it would in the CLI.
+Channels let you interact with a Qwen Code agent from messaging platforms like Telegram, WeChat, QQ, DingTalk, WeCom, or Feishu, instead of the terminal. You send messages from your phone or desktop chat app, and the agent responds just like it would in the CLI.
 
 ## How It Works
 
@@ -15,7 +15,7 @@ All channels share one agent process with isolated sessions per user. Each chann
 
 ## Quick Start
 
-1. Set up a bot on your messaging platform (see channel-specific guides: [Telegram](./telegram), [WeChat](./weixin), [QQ Bot](./qqbot), [DingTalk](./dingtalk), [Feishu](./feishu))
+1. Set up a bot on your messaging platform (see channel-specific guides: [Telegram](./telegram), [WeChat](./weixin), [QQ Bot](./qqbot), [DingTalk](./dingtalk), [WeCom](./wecom), [Feishu](./feishu))
 2. Add the channel configuration to `~/.qwen/settings.json`
 3. Run `qwen channel start` to start all channels, or `qwen channel start <name>` for a single channel
 
@@ -49,10 +49,12 @@ Channels are configured under the `channels` key in `settings.json`. Each channe
 
 | Option                   | Required         | Description                                                                                                                                                            |
 | ------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                   | Yes              | Channel type: `telegram`, `weixin`, `qq`, `dingtalk`, `feishu`, or a custom type from an extension (see [Plugins](./plugins))                                          |
-| `token`                  | Telegram         | Bot token. Supports `$ENV_VAR` syntax to read from environment variables. Not needed for WeChat, DingTalk, or Feishu                                                   |
+| `type`                   | Yes              | Channel type: `telegram`, `weixin`, `qq`, `dingtalk`, `wecom`, `feishu`, or a custom type from an extension (see [Plugins](./plugins))                                 |
+| `token`                  | Telegram         | Bot token. Supports `$ENV_VAR` syntax to read from environment variables. Not needed for WeChat, DingTalk, WeCom, or Feishu                                            |
 | `clientId`               | DingTalk, Feishu | DingTalk AppKey or Feishu App ID. Supports `$ENV_VAR` syntax                                                                                                           |
 | `clientSecret`           | DingTalk, Feishu | DingTalk AppSecret or Feishu App Secret. Supports `$ENV_VAR` syntax                                                                                                    |
+| `botId`                  | WeCom            | WeCom intelligent robot Bot ID. Supports `$ENV_VAR` syntax. See [WeCom](./wecom)                                                                                       |
+| `secret`                 | WeCom            | WeCom intelligent robot Secret. Supports `$ENV_VAR` syntax. See [WeCom](./wecom)                                                                                       |
 | `model`                  | No               | Model to use for this channel (e.g., `qwen3.5-plus`). Overrides the default model. Useful for multimodal models that support image input                               |
 | `senderPolicy`           | No               | Who can talk to the bot: `allowlist` (default), `open`, or `pairing`                                                                                                   |
 | `allowedUsers`           | No               | List of user IDs allowed to use the bot (used by `allowlist` and `pairing` policies)                                                                                   |
@@ -273,6 +275,8 @@ Files work with any model — no multimodal support required.
 | Captions | Photo/file captions included as message text | Not applicable                   | Rich text: mixed text + images in one message | Rich text (`post`): text extracted; embedded images ignored |
 
 > QQ Bot does not process incoming media — image and sticker messages are ignored, so it has no media-handling row above.
+>
+> WeCom accepts text, images, mixed text plus images, files, videos, and voice messages (transcribed). Images are passed to the agent as attachments; files and videos are downloaded to temporary local paths. See [WeCom](./wecom#images-and-files) for details.
 
 ## Dispatch Modes
 
@@ -343,7 +347,7 @@ Channels support slash commands. These are handled locally (no agent round-trip)
 
 All other slash commands (e.g., `/compress`, `/summary`) are forwarded to the agent.
 
-These commands work on all channel types (Telegram, WeChat, QQ, DingTalk, Feishu).
+These commands work on all channel types (Telegram, WeChat, QQ, DingTalk, WeCom, Feishu).
 
 ## Running
 


### PR DESCRIPTION
## What this PR does

Adds the WeCom (Enterprise WeChat) intelligent robot channel to the channels overview page (`docs/users/features/channels/overview.md`). WeCom now appears in the intro platform list, the Quick Start channel-specific guide links, the `type` option enumeration and the `token` "not needed for" exclusion, two new `botId`/`secret` rows in the Options table, a media-support note under Platform differences, and the "these commands work on all channel types" list under Slash Commands.

## Why it's needed

The WeCom channel was added in #6436 and shipped with its own guide (`wecom.md`), a `_meta.ts` navigation entry, and a registered adapter (`channelType: 'wecom'`, config keys `botId`/`secret`). However, the channels **overview** page — the first page most users read — was never updated and did not mention WeCom anywhere. A reader browsing the overview would not learn that WeCom is supported, what config keys it needs, or that it handles media. This closes that onboarding gap so the overview matches the shipped feature set and the per-channel guide.

## Reviewer Test Plan

### How to verify

This is a docs-only change. Confirm the overview now lists WeCom consistently with the other channels and the existing `wecom.md` guide:
- WeCom appears in the intro list, Quick Start links, `type`/`token` rows, and the Slash Commands channel list.
- New `botId` and `secret` Options rows match the keys documented in `docs/users/features/channels/wecom.md` (`type: "wecom"`, `botId`, `secret`) and the registered adapter (`packages/channels/wecom/src/index.ts` → `channelType: 'wecom'`).
- The `./wecom` links and the `./wecom#images-and-files` anchor resolve (the `## Images and Files` heading exists in `wecom.md`).
- No new page was added, so no `_meta.ts` change is required (the WeCom entry already exists).

### Evidence (Before & After)

N/A — docs-only change, no user-visible/TUI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — documentation only.

## Risk & Scope

- Main risk or tradeoff: None. Documentation-only edit to a single overview page; no code paths affected.
- Not validated / out of scope: Other `docs/users/` surfaces were audited (auth, model providers, settings, slash commands, `_meta.ts` navigation, and the `qc-helper` doc index) and found in sync — no other drift addressed here.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up documentation for the WeCom channel introduced in #6436.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 channels 概览页面（`docs/users/features/channels/overview.md`）中补充 WeCom（企业微信）智能机器人渠道。WeCom 现在会出现在开头的平台列表、快速开始的渠道专属指南链接、`type` 选项枚举和 `token` "不需要" 的排除说明中，并在选项表中新增了 `botId`/`secret` 两行、在"平台差异"下新增了媒体支持说明，以及在 Slash Commands 的"适用于所有渠道类型"列表中加入 WeCom。

## 为什么需要

WeCom 渠道在 #6436 中加入，并附带了自己的指南（`wecom.md`）、`_meta.ts` 导航条目以及已注册的适配器（`channelType: 'wecom'`，配置项 `botId`/`secret`）。但作为多数用户首先阅读的 channels **概览** 页面从未更新，完全没有提到 WeCom。浏览概览的读者无法得知 WeCom 已受支持、需要哪些配置项、或它支持媒体。本次修改弥补了这一入门空白，使概览与已发布的功能和单渠道指南保持一致。

## 审查测试计划

### 如何验证

这是纯文档改动。确认概览现在与其他渠道以及现有的 `wecom.md` 指南一致地列出 WeCom：
- WeCom 出现在开头列表、快速开始链接、`type`/`token` 行以及 Slash Commands 渠道列表中。
- 新增的 `botId` 和 `secret` 选项行与 `docs/users/features/channels/wecom.md` 中记录的配置项（`type: "wecom"`、`botId`、`secret`）以及已注册的适配器（`packages/channels/wecom/src/index.ts` → `channelType: 'wecom'`）一致。
- `./wecom` 链接及 `./wecom#images-and-files` 锚点可正常解析（`wecom.md` 中存在 `## Images and Files` 标题）。
- 未新增页面，因此无需修改 `_meta.ts`（WeCom 条目已存在）。

### 证据（改动前后）

N/A —— 纯文档改动，无用户可见 / TUI 输出。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

N/A —— 仅文档。

## 风险与范围

- 主要风险或权衡：无。仅对单个概览页面进行文档修改，不影响任何代码路径。
- 未验证 / 超出范围：其它 `docs/users/` 内容（认证、模型提供方、设置、slash 命令、`_meta.ts` 导航以及 `qc-helper` 文档索引）已一并审计并确认与代码同步，本 PR 不涉及其它漂移。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

WeCom 渠道（#6436）的后续文档补充。

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_013n2siz25hmVj8cHptz6h6M)_