### PR TITLE
fix(web-shell): count daemon sessions in Daemon Status usage dashboard

### DIFF
--- a/packages/cli/src/serve/routes/usage-stats.ts
+++ b/packages/cli/src/serve/routes/usage-stats.ts
@@ -8,16 +8,17 @@
  * Read-only usage-dashboard surface behind the Web Shell Daemon Status
  * "统计 / Usage" tab. Serves the selected range's (`today`/`week`/`month`)
  * flattened token totals plus a trailing per-day heatmap, computed by core's
- * `buildUsageDashboard` from the durable local usage history (global `~/.qwen`,
- * cross-project) — the same source the TUI `/stats` command reads. The history
- * load runs read-only (`persistRebuild: false`), so serving a GET never writes
- * to `~/.qwen`, even when the persisted file is missing and the loader falls
- * back to transcript replay.
+ * `buildUsageDashboard` from the local usage history (global `~/.qwen`,
+ * cross-project). Uses `loadUsageHistoryWithLive`, which unions the durable
+ * `usage_record.jsonl` (written only by the TUI `/clear` path) with a replay of
+ * recent transcripts — so daemon / Web Shell sessions and any in-progress
+ * session are counted here, unlike the TUI `/stats` view. The load is
+ * read-only (never writes `~/.qwen`).
  *
  * Open GET (no `mutate` gate), consistent with `GET /daemon/status` and
  * `GET /scheduled-tasks`: it exposes only aggregate local usage counts.
  *
- * The heavy step — `loadUsageHistory` can replay every project's transcripts —
+ * The heavy step — `loadUsageHistoryWithLive` can replay recent transcripts —
  * is cached once (range-independent), so toggling Today/7D/30D re-aggregates
  * cheaply from a single disk read instead of re-loading per range, and
  * concurrent requests coalesce onto the in-flight load.
@@ -26,7 +27,7 @@
 import type { Application } from 'express';
 import {
   buildUsageDashboard,
-  loadUsageHistory,
+  loadUsageHistoryWithLive,
   type UsageSummaryRecord,
 } from '@qwen-code/qwen-code-core';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
@@ -67,9 +68,7 @@ export function registerUsageStatsRoutes(
   app: Application,
   deps: RegisterUsageStatsRoutesDeps = {},
 ): void {
-  const loadHistory =
-    deps.loadHistory ??
-    (() => loadUsageHistory(undefined, { persistRebuild: false }));
+  const loadHistory = deps.loadHistory ?? (() => loadUsageHistoryWithLive());
   const ttlMs = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
 
   // Closure-scoped, range-independent history cache (one daemon per process).

--- a/packages/core/src/services/usage-dashboard-service.test.ts
+++ b/packages/core/src/services/usage-dashboard-service.test.ts
@@ -98,6 +98,89 @@ describe('loadUsageDashboard', () => {
     );
   }
 
+  /**
+   * Plant a transcript-only (never-persisted, e.g. daemon / Web Shell) session
+   * timestamped now, so it lands in the `today` window when replayed.
+   */
+  function plantTranscript(sessionId: string, totalTokens: number): void {
+    const cwd = '/daemon/project';
+    const ts = new Date().toISOString();
+    const chatsDir = path.join(
+      process.env['QWEN_HOME']!,
+      'projects',
+      'daemon-project',
+      'chats',
+    );
+    fs.mkdirSync(chatsDir, { recursive: true });
+    const records = [
+      {
+        sessionId,
+        cwd,
+        uuid: 'u1',
+        parentUuid: null,
+        timestamp: ts,
+        type: 'user',
+        message: { role: 'user', content: 'hi' },
+      },
+      {
+        sessionId,
+        cwd,
+        uuid: 'u2',
+        parentUuid: 'u1',
+        timestamp: ts,
+        type: 'system',
+        subtype: 'ui_telemetry',
+        systemPayload: {
+          uiEvent: {
+            'event.name': 'qwen-code.api_response',
+            'event.timestamp': ts,
+            response_id: 'r1',
+            model: 'qwen-max',
+            duration_ms: 1200,
+            input_token_count: totalTokens * 0.6,
+            output_token_count: totalTokens * 0.4,
+            cached_content_token_count: 0,
+            thoughts_token_count: 0,
+            total_token_count: totalTokens,
+            prompt_id: 'p1',
+          },
+        },
+      },
+      {
+        sessionId,
+        cwd,
+        uuid: 'u3',
+        parentUuid: 'u2',
+        timestamp: ts,
+        type: 'assistant',
+        message: { role: 'assistant', content: 'ok' },
+      },
+    ];
+    fs.writeFileSync(
+      path.join(chatsDir, `${sessionId}.jsonl`),
+      records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+  }
+
+  it('today totals include a daemon / Web Shell transcript session, not just the persisted file', async () => {
+    // Guards the wiring: loadUsageDashboard must read the live-merging loader,
+    // so a session that only lives in a transcript (never persisted by /clear)
+    // still counts. A revert to the persisted-only loader would drop it.
+    seed([
+      rec({
+        sessionId: 'persisted',
+        timestamp: Date.now(),
+        model: { totalTokens: 1000, inputTokens: 1000 },
+      }),
+    ]);
+    plantTranscript('daemon-live', 1600);
+
+    const dash = await loadUsageDashboard({ range: 'today' });
+
+    expect(dash.summary.sessions).toBe(2);
+    expect(dash.summary.totalTokens).toBe(2600);
+  });
+
   it('flattens today totals across all sessions active today', async () => {
     const now = Date.now();
     seed([

--- a/packages/core/src/services/usage-dashboard-service.ts
+++ b/packages/core/src/services/usage-dashboard-service.ts
@@ -7,7 +7,7 @@
 import {
   aggregateUsage,
   getTimeRangeBounds,
-  loadUsageHistory,
+  loadUsageHistoryWithLive,
   type TimeRange,
   type UsageSummaryRecord,
 } from './usageHistoryService.js';
@@ -275,14 +275,15 @@ export function buildUsageDashboard(
 
 /**
  * Read-only snapshot of local token usage for the daemon usage-dashboard API.
- * Loads the global cross-project history (`~/.qwen`) via {@link loadUsageHistory}
- * (persisted `usage_record.jsonl`, falling back to transcript replay) and builds
- * the dashboard — consistent with the TUI `/stats` view. The load can be I/O
- * heavy on large histories, so callers should cache (the daemon route caches the
- * loaded records and re-runs {@link buildUsageDashboard} per range).
+ * Loads the global cross-project history (`~/.qwen`) via
+ * {@link loadUsageHistoryWithLive} — the persisted `usage_record.jsonl` unioned
+ * with a replay of recent transcripts — so the totals include daemon / Web Shell
+ * and in-progress sessions that the persisted file never captures. The load can
+ * be I/O heavy on large histories, so callers should cache (the daemon route
+ * caches the loaded records and re-runs {@link buildUsageDashboard} per range).
  */
 export async function loadUsageDashboard(
   options: LoadUsageDashboardOptions = {},
 ): Promise<UsageDashboard> {
-  return buildUsageDashboard(await loadUsageHistory(), options);
+  return buildUsageDashboard(await loadUsageHistoryWithLive(), options);
 }

--- a/packages/core/src/services/usageHistoryService.test.ts
+++ b/packages/core/src/services/usageHistoryService.test.ts
@@ -12,6 +12,7 @@ import {
   metricsToUsageRecord,
   aggregateUsage,
   loadUsageHistory,
+  loadUsageHistoryWithLive,
   persistSessionUsage,
 } from './usageHistoryService.js';
 import { ToolCallDecision } from '../telemetry/tool-call-decision.js';
@@ -625,6 +626,131 @@ describe('loadUsageHistory + persistSessionUsage (issue #4994 regression)', () =
     let totalTokens = 0;
     for (const m of Object.values(report.models)) totalTokens += m.totalTokens;
     expect(totalTokens).toBe(1600);
+  });
+
+  // loadUsageHistoryWithLive: the daemon usage-dashboard loader. Unlike
+  // loadUsageHistory (persisted file verbatim when non-empty), it unions the
+  // persisted history with a replay of recent transcripts so daemon / Web Shell
+  // and in-progress sessions — which only the TUI /clear path ever persists —
+  // are counted. See issue: Web Shell "today" undercounted ~20x.
+  function planted(sessionId: string): string {
+    return path.join(
+      process.env['QWEN_HOME']!,
+      'projects',
+      'repro-project',
+      'chats',
+      `${sessionId}.jsonl`,
+    );
+  }
+  function seedPersisted(records: UsageSummaryRecord[]) {
+    fs.writeFileSync(
+      path.join(process.env['QWEN_HOME']!, 'usage_record.jsonl'),
+      records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+  }
+  function persistedRec(sessionId: string, totalTokens: number) {
+    return {
+      version: 1 as const,
+      sessionId,
+      timestamp: Date.now(),
+      startTime: Date.now() - 60000,
+      project: '/p',
+      durationMs: 60000,
+      totalLatencyMs: 1200,
+      models: {
+        'qwen-max': {
+          requests: 1,
+          inputTokens: totalTokens,
+          outputTokens: 0,
+          cachedTokens: 0,
+          thoughtsTokens: 0,
+          totalTokens,
+        },
+      },
+      tools: { totalCalls: 0, totalSuccess: 0, totalFail: 0, byName: {} },
+      files: { linesAdded: 0, linesRemoved: 0 },
+    };
+  }
+
+  it('withLive: unions a never-persisted (daemon) session with the persisted history', async () => {
+    // Persisted: a finalized TUI session. Transcript-only: a daemon / Web Shell
+    // session that /clear never wrote to usage_record.jsonl.
+    seedPersisted([persistedRec('sess-persisted', 1000)]);
+    plantChatJsonl('sess-daemon', 1600);
+
+    const merged = await loadUsageHistoryWithLive();
+    const ids = merged.map((r) => r.sessionId).sort();
+    expect(ids).toEqual(['sess-daemon', 'sess-persisted']);
+
+    const report = aggregateUsage(merged, 'all');
+    let totalTokens = 0;
+    for (const m of Object.values(report.models)) totalTokens += m.totalTokens;
+    // 1000 persisted + 1600 replayed from the daemon transcript.
+    expect(totalTokens).toBe(2600);
+
+    // Read-only: the persisted file must still hold only the original record.
+    const lines = fs
+      .readFileSync(
+        path.join(process.env['QWEN_HOME']!, 'usage_record.jsonl'),
+        'utf8',
+      )
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('withLive: a persisted session with a live transcript is not double-counted (persisted wins)', async () => {
+    // Same sessionId in both the persisted file (authoritative 1000) and the
+    // transcript (1600). Must appear exactly once, keeping the persisted value.
+    seedPersisted([persistedRec('sess-both', 1000)]);
+    plantChatJsonl('sess-both', 1600);
+
+    const merged = await loadUsageHistoryWithLive();
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.sessionId).toBe('sess-both');
+    expect(merged[0]!.models['qwen-max']!.totalTokens).toBe(1000);
+  });
+
+  it('withLive: with a persisted base, the trailing window excludes stale transcripts (sinceMs:0 includes them)', async () => {
+    // A persisted base means the window engages (old days come from the file).
+    seedPersisted([persistedRec('sess-persisted', 500)]);
+    plantChatJsonl('sess-old', 1600);
+    // Age the never-persisted transcript well past the default trailing window.
+    const stale = Date.now() - 100 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(planted('sess-old'), stale / 1000, stale / 1000);
+
+    // Default window: the stale, never-persisted transcript is not replayed.
+    const windowed = await loadUsageHistoryWithLive();
+    expect(windowed.map((r) => r.sessionId)).toEqual(['sess-persisted']);
+    // An unbounded window picks it back up alongside the persisted record.
+    const all = await loadUsageHistoryWithLive({ sinceMs: 0 });
+    expect(all.map((r) => r.sessionId).sort()).toEqual([
+      'sess-old',
+      'sess-persisted',
+    ]);
+  });
+
+  it('withLive: with no persisted base, replays full history (no silent trailing-window truncation)', async () => {
+    // No usage_record.jsonl: nothing else covers old history, so an old
+    // transcript must still be replayed rather than truncated by the window.
+    plantChatJsonl('sess-old', 1600);
+    const stale = Date.now() - 100 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(planted('sess-old'), stale / 1000, stale / 1000);
+
+    const merged = await loadUsageHistoryWithLive();
+    expect(merged.map((r) => r.sessionId)).toEqual(['sess-old']);
+  });
+
+  it('withLive: read-only rebuild — never writes usage_record.jsonl', async () => {
+    plantChatJsonl('sess-daemon-only', 1600);
+    const usagePath = path.join(
+      process.env['QWEN_HOME']!,
+      'usage_record.jsonl',
+    );
+
+    const merged = await loadUsageHistoryWithLive();
+    expect(merged.map((r) => r.sessionId)).toEqual(['sess-daemon-only']);
+    expect(fs.existsSync(usagePath)).toBe(false);
   });
 });
 

--- a/packages/core/src/services/usageHistoryService.test.ts
+++ b/packages/core/src/services/usageHistoryService.test.ts
@@ -752,6 +752,29 @@ describe('loadUsageHistory + persistSessionUsage (issue #4994 regression)', () =
     expect(merged.map((r) => r.sessionId)).toEqual(['sess-daemon-only']);
     expect(fs.existsSync(usagePath)).toBe(false);
   });
+
+  it('withLive: all sessions persisted (empty rebuild) returns the persisted records as-is', async () => {
+    // Common case: no live transcripts at all, only the persisted file.
+    seedPersisted([persistedRec('sess-only', 500)]);
+
+    const merged = await loadUsageHistoryWithLive();
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.sessionId).toBe('sess-only');
+    expect(merged[0]!.models['qwen-max']!.totalTokens).toBe(500);
+  });
+
+  it('withLive: a corrupt usage_record.jsonl falls back to a full transcript replay', async () => {
+    // No usable persisted base (garbage file) — the loader must still surface
+    // the daemon transcript rather than returning nothing.
+    fs.writeFileSync(
+      path.join(process.env['QWEN_HOME']!, 'usage_record.jsonl'),
+      '{ this is not valid json\nalso broken}\n',
+    );
+    plantChatJsonl('sess-daemon', 1600);
+
+    const merged = await loadUsageHistoryWithLive();
+    expect(merged.map((r) => r.sessionId)).toEqual(['sess-daemon']);
+  });
 });
 
 describe('aggregateUsage — skills', () => {

--- a/packages/core/src/services/usageHistoryService.ts
+++ b/packages/core/src/services/usageHistoryService.ts
@@ -239,8 +239,8 @@ interface RebuildFromSessionJsonlOptions {
   sinceMs?: number;
   /**
    * Session ids already covered by the persisted history. Their transcripts are
-   * skipped after a cheap first-line `sessionId` read, avoiding a full replay of
-   * sessions the persisted file already records authoritatively.
+   * skipped by filename (`{sessionId}.jsonl`) with no file read, avoiding a full
+   * replay of sessions the persisted file already records authoritatively.
    */
   skipSessionIds?: ReadonlySet<string>;
 }
@@ -305,13 +305,13 @@ async function rebuildFromSessionJsonl(
           if (mtimeMs < sinceMs) continue;
         }
 
-        // Skip sessions the persisted history already records, reading only the
-        // transcript's first line (which carries the sessionId) rather than
-        // replaying the whole file.
+        // Skip sessions the persisted history already records, before any file
+        // read: the transcript filename is `{sessionId}.jsonl`
+        // (chatRecordingService.ts), so the sessionId — the same value the
+        // full-read path below derives from the first record — needs no I/O.
         if (skipSessionIds && skipSessionIds.size > 0) {
-          const head = await jsonl.readLines<ChatRecord>(filePath, 1);
-          const headSessionId = head[0]?.sessionId;
-          if (headSessionId && skipSessionIds.has(headSessionId)) continue;
+          const fileSessionId = path.basename(file, '.jsonl');
+          if (skipSessionIds.has(fileSessionId)) continue;
         }
 
         const records = await jsonl.read<ChatRecord>(filePath);

--- a/packages/core/src/services/usageHistoryService.ts
+++ b/packages/core/src/services/usageHistoryService.ts
@@ -16,6 +16,24 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('USAGE_HISTORY');
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/**
+ * Trailing window used by {@link loadUsageHistoryWithLive} when merging
+ * non-persisted (daemon / Web Shell / in-progress) sessions into the history.
+ *
+ * Sized to cover the largest summary/daily range the usage-dashboard exposes
+ * (month = 30 days) plus margin, so the hero totals, breakdown tiles, and the
+ * per-day line/bar charts are exact. Crucially it is NOT sized for the full
+ * heatmap span (~12 months): persisted `usage_record.jsonl` records of any age
+ * are always unioned in, so the heatmap keeps its full history, but a *never-
+ * persisted* daemon session older than this window is not replayed — that cell
+ * undercounts slightly. That cosmetic gap is a deliberate trade for load
+ * latency: replaying a full year of transcripts costs ~13s here vs. ~1.7s for
+ * this window (heavy Web Shell users accumulate thousands of unpersisted
+ * transcripts). Widen only alongside a cheaper scan.
+ */
+const LIVE_REBUILD_WINDOW_DAYS = 35;
+
 export interface UsageSummaryRecord {
   version: 1;
   sessionId: string;
@@ -204,10 +222,38 @@ export function metricsToUsageRecord(
   };
 }
 
+interface RebuildFromSessionJsonlOptions {
+  /**
+   * Session to exclude from the one-time persistence migration (the caller's
+   * in-progress session — {@link persistSessionUsage} writes its authoritative
+   * record on `/clear` or exit). It is still returned in the rebuilt records.
+   */
+  skipSessionInRebuild?: string;
+  /** Persist rebuilt records as a migration. Read-only callers pass `false`. */
+  persist?: boolean;
+  /**
+   * Only replay transcripts whose file mtime is at/after this epoch-ms. Bounds
+   * the scan when merging recent live sessions into an already-persisted
+   * history (see {@link loadUsageHistoryWithLive}); undefined replays all.
+   */
+  sinceMs?: number;
+  /**
+   * Session ids already covered by the persisted history. Their transcripts are
+   * skipped after a cheap first-line `sessionId` read, avoiding a full replay of
+   * sessions the persisted file already records authoritatively.
+   */
+  skipSessionIds?: ReadonlySet<string>;
+}
+
 async function rebuildFromSessionJsonl(
-  skipSessionInRebuild?: string,
-  persist = true,
+  options: RebuildFromSessionJsonlOptions = {},
 ): Promise<UsageSummaryRecord[]> {
+  const {
+    skipSessionInRebuild,
+    persist = true,
+    sinceMs,
+    skipSessionIds,
+  } = options;
   const projectsDir = path.join(Storage.getGlobalQwenDir(), 'projects');
   try {
     if (!fs.existsSync(projectsDir)) return [];
@@ -243,6 +289,31 @@ async function rebuildFromSessionJsonl(
     for (const file of files) {
       try {
         const filePath = path.join(chatsDir, file);
+
+        // Bound the scan when merging live sessions into a persisted history:
+        // skip transcripts untouched before `sinceMs`.
+        if (sinceMs !== undefined) {
+          let mtimeMs: number;
+          try {
+            mtimeMs = fs.statSync(filePath).mtimeMs;
+          } catch (e) {
+            debugLogger.debug(
+              `rebuildFromSessionJsonl: cannot stat ${filePath}: ${e}`,
+            );
+            continue;
+          }
+          if (mtimeMs < sinceMs) continue;
+        }
+
+        // Skip sessions the persisted history already records, reading only the
+        // transcript's first line (which carries the sessionId) rather than
+        // replaying the whole file.
+        if (skipSessionIds && skipSessionIds.size > 0) {
+          const head = await jsonl.readLines<ChatRecord>(filePath, 1);
+          const headSessionId = head[0]?.sessionId;
+          if (headSessionId && skipSessionIds.has(headSessionId)) continue;
+        }
+
         const records = await jsonl.read<ChatRecord>(filePath);
         if (records.length === 0) continue;
 
@@ -337,11 +408,71 @@ export async function loadUsageHistory(
   }
 
   return dedupBySessionId(
-    await rebuildFromSessionJsonl(
+    await rebuildFromSessionJsonl({
       skipSessionInRebuild,
-      options?.persistRebuild ?? true,
-    ),
+      persist: options?.persistRebuild ?? true,
+    }),
   );
+}
+
+/**
+ * Load the durable usage history **and** merge in sessions that were never
+ * written to `usage_record.jsonl` — notably daemon / Web Shell sessions (only
+ * the TUI `/clear` path persists usage) and any still-in-progress session.
+ *
+ * Unlike {@link loadUsageHistory}, which returns the persisted file verbatim
+ * whenever it is non-empty (and so silently omits everything not yet
+ * persisted), this replays recent transcripts for sessions the persisted file
+ * does not already cover and unions the two. Persisted records win on any
+ * sessionId conflict — they are the authoritative final snapshot. This is what
+ * the daemon usage-dashboard reads so its totals reflect live Web Shell
+ * activity. Read-only: never writes `usage_record.jsonl`.
+ *
+ * The transcript scan is bounded to a trailing window (mtime-based) so an
+ * established history does not pay a full cross-project replay on every load.
+ */
+export async function loadUsageHistoryWithLive(options?: {
+  /**
+   * Only replay transcripts touched at/after this epoch-ms. Defaults to a
+   * {@link LIVE_REBUILD_WINDOW_DAYS}-day trailing window (covers the dashboard's
+   * summary + daily charts; see the constant for the heatmap trade-off).
+   */
+  sinceMs?: number;
+}): Promise<UsageSummaryRecord[]> {
+  let persisted: UsageSummaryRecord[] = [];
+  try {
+    const records = await jsonl.read<UsageSummaryRecord>(getUsageHistoryPath());
+    persisted = records.filter((r) => r.version === 1);
+  } catch (e) {
+    debugLogger.debug(
+      `loadUsageHistoryWithLive: failed to read usage file: ${e}`,
+    );
+  }
+
+  const persistedIds = new Set(persisted.map((r) => r.sessionId));
+
+  // The trailing window bounds an *incremental* live merge on top of persisted
+  // history: old days come from the persisted file, so only recent transcripts
+  // need replaying. When there is no persisted base (fresh machine, or a user
+  // who only ever ran Web Shell so `/clear` never persisted), nothing else
+  // covers older history — replay it all (unbounded) rather than silently
+  // truncating the dashboard, matching the pre-existing empty-file behavior.
+  const sinceMs =
+    options?.sinceMs ??
+    (persistedIds.size > 0
+      ? Date.now() - LIVE_REBUILD_WINDOW_DAYS * MS_PER_DAY
+      : undefined);
+
+  const rebuilt = await rebuildFromSessionJsonl({
+    persist: false,
+    sinceMs,
+    skipSessionIds: persistedIds,
+  });
+
+  // Persisted records are the authoritative final snapshot, so they win on any
+  // sessionId conflict — place them last (dedupBySessionId is last-wins). The
+  // rebuilt set only adds sessions the persisted file never captured.
+  return dedupBySessionId([...rebuilt, ...persisted]);
 }
 
 export function getTimeRangeBounds(range: TimeRange): {


### PR DESCRIPTION
## What this PR does

Makes the Web Shell **Daemon Status → Usage** dashboard count sessions that run through the daemon (Web Shell) and any session that has not been `/clear`-ed yet. Previously the dashboard read the persisted `usage_record.jsonl` file exclusively, so those sessions — whose usage lives only in the per-session transcripts — were invisible in the totals, heatmap, and per-day charts.

The fix adds a core loader `loadUsageHistoryWithLive()` that unions the durable persisted history with a bounded replay of recent transcripts, deduped by `sessionId` (persisted records win, since they are the authoritative final snapshot). `rebuildFromSessionJsonl` gains an mtime window and a skip-set (the `sessionId` is read cheaply from each transcript's first line) so the merge is incremental rather than a full cross-project replay. The daemon `GET /usage/dashboard` route and core `loadUsageDashboard` now use this loader. TUI `/stats` is intentionally left unchanged.

## Why it's needed

`persistSessionUsage()` is only called from the TUI `/clear` command, so `qwen serve` (Web Shell / daemon) never writes `usage_record.jsonl`. And `loadUsageHistory()` returns that file verbatim whenever it is non-empty, never replaying transcripts. The combination means every daemon session, plus any still-in-progress session, is silently dropped from the dashboard. Measured against a real `~/.qwen` (1110 persisted records), "today" showed **79,125** tokens / 1 session while the true figure was **1,590,066** tokens / 3 sessions — a ~20x undercount — because two active sessions (1.38M and 130K tokens) lived only in transcripts.

## Reviewer Test Plan

### How to verify

Unit tests:

```
npx vitest run \
  packages/core/src/services/usageHistoryService.test.ts \
  packages/core/src/services/usage-dashboard-service.test.ts \
  packages/cli/src/serve/routes/usage-stats.test.ts
# 39 passed (core usageHistory 24 incl. 5 new, dashboard 8, route 7)
```

End-to-end against a real history (no model needed — the route reads local usage off disk):

```
npx tsx packages/cli/src/cli.ts serve --web --port 8811 &
curl -s 'http://127.0.0.1:8811/usage/dashboard?range=today' | jq .summary
```

Expected: `summary.totalTokens` now includes daemon / un-cleared sessions active today (previously only sessions finalized via TUI `/clear` were counted).

### Evidence (Before & After)

Same `~/.qwen`, `GET /usage/dashboard?range=today` → `summary`:

| | totalTokens | sessions | requests |
| :-- | --: | --: | --: |
| **Before** (persisted-only) | 79,125 | 1 | — |
| **After** (persisted ∪ live transcripts) | **1,590,066** | 3 | 37 |

The After figure matches an independent manual sum of today's transcripts (79,125 + 1,380,448 + 130,493 = 1,590,066). The two previously-missing sessions were daemon / un-cleared sessions present in `projects/*/chats/*.jsonl` but absent from `usage_record.jsonl`.

Load-latency trade-off (measured, heavy history): 7d window 191ms · 31d 1.7s · 92d 13.5s · 400d 13.9s. The default 35-day window keeps the summary and daily charts exact (the dashboard's largest range is month = 30d) at ~1.7s; older heatmap cells fall back to persisted data. With no persisted base the loader replays the full history so nothing is silently truncated.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx tsx packages/cli/src/cli.ts serve --web` against a real local `~/.qwen`; vitest for unit tests.

## Risk & Scope

- **Main risk or tradeoff:** Opening the dashboard now replays recent transcripts (bounded by a 35-day mtime window and cached 60s in the route), so the first load on a heavy history costs ~1.7s instead of a pure file read. Heatmap cells older than the window only reflect persisted (`usage_record.jsonl`) data for never-persisted daemon days.
- **Not validated / out of scope:** TUI `/stats` is unchanged — it still omits the current in-progress session (pre-existing). A durable follow-up would persist daemon session usage on session end so the heatmap is accurate at all ages without any transcript replay.
- **Breaking changes / migration notes:** None. Read-only — serving the dashboard never writes `~/.qwen`. No schema or API shape changes.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Web Shell 的 **Daemon Status → 用量（Usage）** 仪表盘把通过 daemon（Web Shell）运行的会话、以及任何尚未 `/clear` 的会话也统计进去。此前仪表盘只读持久化的 `usage_record.jsonl`，而这些会话的用量只存在于各自的 transcript 里，因此在总量、热力图和每日图表中完全不可见。

修复新增 core 加载器 `loadUsageHistoryWithLive()`：把持久化历史与近期 transcript 的回放做并集，按 `sessionId` 去重（持久化记录优先，因为它是权威终态快照）。`rebuildFromSessionJsonl` 增加了 mtime 窗口和跳过集合（`sessionId` 从每个 transcript 首行便宜地读出），使合并是增量的、而非全量跨项目回放。daemon 的 `GET /usage/dashboard` 路由与 core `loadUsageDashboard` 改用该加载器。TUI `/stats` 刻意保持不变。

## 为什么需要

`persistSessionUsage()` 只在 TUI 的 `/clear` 命令里调用，所以 `qwen serve`（Web Shell / daemon）从不写 `usage_record.jsonl`；而 `loadUsageHistory()` 只要该文件非空就原样返回、永不回放 transcript。两者叠加导致所有 daemon 会话、以及任何进行中的会话都被静默丢弃。在真实 `~/.qwen`（1110 条持久化记录）上实测：「今日」只显示 **79,125** tokens / 1 会话，而真值是 **1,590,066** tokens / 3 会话——少算约 20 倍——因为两个活跃会话（1.38M 与 130K tokens）只存在于 transcript 中。

## 审阅测试计划

**如何验证**：见上方单测命令（39 passed）；以及用 `npx tsx packages/cli/src/cli.ts serve --web` 起真实 daemon、`curl /usage/dashboard?range=today` 读取本地用量（无需模型）。

**前后对比**：同一 `~/.qwen`，`range=today` 的 `summary`：Before（仅持久化）= 79,125 tokens / 1 会话；After（持久化 ∪ live transcript）= **1,590,066** tokens / 3 会话 / 37 请求。After 与手工核算今日 transcript 之和一致（79,125 + 1,380,448 + 130,493）。

**成本权衡**（重度历史实测）：7d 窗口 191ms · 31d 1.7s · 92d 13.5s · 400d 13.9s。默认 35 天窗口让 summary 与每日图表精确（仪表盘最大区间为 month=30d），约 1.7s；更老的热力图格子回退到持久化数据。无持久化底座时回放全量历史，不会静默截断。

## 风险与范围

- **主要风险/权衡**：打开仪表盘现在会回放近期 transcript（受 35 天 mtime 窗口界定，路由层缓存 60s），重度历史首次加载约 1.7s 而非纯文件读取。窗口之外的热力图老格子对「从未持久化的 daemon 天数」只反映持久化数据。
- **未验证/范围外**：TUI `/stats` 未改——仍不含当前进行中的会话（既有行为）。后续可让 daemon 在会话结束时持久化用量，使热力图在所有年龄都精确、无需任何 transcript 回放。
- **破坏性变更**：无。只读——服务仪表盘从不写 `~/.qwen`，无 schema / API 形状变化。

</details>
