### PR TITLE
fix(web-shell): hide sidebar settings text when width is insufficient

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -945,6 +945,13 @@
 
 .footerButton {
   flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.footerButtonLabel {
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .collapseButton {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -2517,7 +2517,11 @@ export function WebShellSidebar({
           <span className={`${styles.navIcon} ${styles.settingsIcon}`}>
             <IconSettings />
           </span>
-          {!collapsed && <span>{t('sidebar.settings')}</span>}
+          {!collapsed && (
+            <span className={styles.footerButtonLabel}>
+              {t('sidebar.settings')}
+            </span>
+          )}
         </button>
         {!collapsed && versionLabel && (
           <span className={styles.version} title={`Qwen Code ${versionLabel}`}>


### PR DESCRIPTION
## Summary

Prevent the "Settings" (设置) label in the web shell sidebar from wrapping to a new line when the sidebar is narrow. Instead, the text is clipped via `overflow: hidden` and only the gear icon remains visible.

## Changes

- Added `min-width: 0; overflow: hidden` to `.footerButton` so it can shrink below its content's natural width
- Added `.footerButtonLabel` class with `white-space: nowrap; overflow: hidden` to clip the text gracefully
- Applied the new class to the settings text `<span>` in `WebShellSidebar.tsx`

## Before / After

| Before | After |
|---|---|
| "设置" text wraps to a second line | Text is hidden, only the gear icon shows |

## Reviewer Test Plan

1. Open the web shell sidebar
2. Drag the sidebar resize handle to make it narrower
3. Verify the "Settings" text does not wrap — it should disappear smoothly as space runs out, leaving only the gear icon
4. Verify the collapse/expand toggle still works correctly
