### PR TITLE
feat(cli): Show permission mode badge in footer for DEFAULT mode

### DIFF
--- a/packages/cli/src/ui/components/AutoAcceptIndicator.test.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'vitest';
+import { AutoAcceptIndicator } from './AutoAcceptIndicator.js';
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
+
+describe('<AutoAcceptIndicator />', () => {
+  it('renders DEFAULT mode with pause badge and Ask permissions text', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.DEFAULT} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('⏸');
+    expect(frame).toContain('Ask permissions');
+  });
+
+  it('renders PLAN mode indicator', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.PLAN} />,
+    );
+    expect(lastFrame()).toContain('plan mode');
+  });
+
+  it('renders AUTO_EDIT mode indicator', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.AUTO_EDIT} />,
+    );
+    expect(lastFrame()).toContain('auto-accept edits');
+  });
+
+  it('renders AUTO mode indicator', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.AUTO} />,
+    );
+    expect(lastFrame()).toContain('auto mode (classifier-evaluated)');
+  });
+
+  it('renders YOLO mode indicator', () => {
+    const { lastFrame } = render(
+      <AutoAcceptIndicator approvalMode={ApprovalMode.YOLO} />,
+    );
+    expect(lastFrame()).toContain('YOLO mode');
+  });
+});

--- a/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
+++ b/packages/cli/src/ui/components/AutoAcceptIndicator.tsx
@@ -45,6 +45,9 @@ export const AutoAcceptIndicator: React.FC<AutoAcceptIndicatorProps> = ({
       subText = cycleText;
       break;
     case ApprovalMode.DEFAULT:
+      textContent = `⏸ ${t('Ask permissions')}`;
+      subText = cycleText;
+      break;
     default:
       break;
   }

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -8,6 +8,7 @@ import { render } from 'ink-testing-library';
 import { act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Footer } from './Footer.js';
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
 import * as useStatusLineModule from '../hooks/useStatusLine.js';
 import { type UIState, UIStateContext } from '../contexts/UIStateContext.js';
@@ -231,6 +232,19 @@ describe('<Footer />', () => {
       unmount?.();
       vi.useRealTimers();
     }
+  });
+
+  it('shows the default approval mode badge when in DEFAULT mode', () => {
+    const { lastFrame } = renderWithWidth(
+      120,
+      createMockUIState({
+        showAutoAcceptIndicator: ApprovalMode.DEFAULT,
+      }),
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('⏸');
+    expect(frame).toContain('Ask permissions');
+    expect(frame).not.toContain('? for shortcuts');
   });
 
   it('does not display the working directory or branch name', () => {

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -21,7 +21,6 @@ import { useUIState } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useVimModeState } from '../contexts/VimModeContext.js';
-import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import { GeminiSpinner } from './GeminiRespondingSpinner.js';
 import { GoalPill, useFooterGoalState } from './GoalPill.js';
 import { CronPill, useFooterCronTaskCount } from './CronPill.js';
@@ -107,8 +106,7 @@ export const Footer: React.FC = () => {
         message: uiState.startupIdeConnectionStatus.message,
       })}
     </Text>
-  ) : showAutoAcceptIndicator !== undefined &&
-    showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
+  ) : showAutoAcceptIndicator !== undefined ? (
     <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
   ) : suppressHint ? null : (
     <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>

--- a/packages/cli/src/ui/components/agent-view/AgentFooter.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentFooter.tsx
@@ -12,7 +12,7 @@
 
 import type React from 'react';
 import { Box, Text } from 'ink';
-import { ApprovalMode } from '@qwen-code/qwen-code-core';
+import type { ApprovalMode } from '@qwen-code/qwen-code-core';
 import { AutoAcceptIndicator } from '../AutoAcceptIndicator.js';
 import { ContextUsageDisplay } from '../ContextUsageDisplay.js';
 import { theme } from '../../semantic-colors.js';
@@ -30,8 +30,7 @@ export const AgentFooter: React.FC<AgentFooterProps> = ({
   contextWindowSize,
   terminalWidth,
 }) => {
-  const showApproval =
-    approvalMode !== undefined && approvalMode !== ApprovalMode.DEFAULT;
+  const showApproval = approvalMode !== undefined;
   const showContext = promptTokenCount > 0 && contextWindowSize !== undefined;
 
   if (!showApproval && !showContext) {

--- a/packages/cli/src/ui/components/approvalModeVisuals.ts
+++ b/packages/cli/src/ui/components/approvalModeVisuals.ts
@@ -20,6 +20,7 @@ export function getApprovalModeIndicatorColor(
     case ApprovalMode.YOLO:
       return theme.status.error;
     case ApprovalMode.DEFAULT:
+      return theme.text.secondary;
     default:
       return undefined;
   }


### PR DESCRIPTION
## What this PR does

Always display the current permission/approval mode in the footer, including when in the default ("Ask permissions") mode. Previously, non-default modes (PLAN, AUTO_EDIT, AUTO, YOLO) showed colored indicators but the default mode showed nothing, creating visual ambiguity. Now DEFAULT mode renders a subtle grey ⏸ badge with "Ask permissions" text in both the main Footer and AgentFooter, making the active permission mode always visible at a glance.

## Why it's needed

When in DEFAULT mode (the most common mode), users have no visual confirmation of which mode they are in. New users cannot tell if they need to switch modes, and users switching between modes cannot confirm they are back in DEFAULT. There is no visual anchor — the footer only tells you something when you are NOT in the default state. This change aligns with Claude Code v2.1.203 which added a similar grey ⏸ badge for manual permission mode.

## Reviewer Test Plan

### How to verify

1. Launch qwen-code in DEFAULT approval mode (no flags). The footer should show a grey `⏸ Ask permissions` badge instead of `? for shortcuts`.
2. Switch to PLAN mode via Shift+Tab — the badge should change to green `plan mode`.
3. Switch back to DEFAULT — the grey `⏸ Ask permissions` badge should reappear.
4. Cycle through AUTO_EDIT, AUTO, YOLO and back to DEFAULT — each mode should show its respective indicator, and DEFAULT should always show the grey badge.
5. Open an agent tab — the AgentFooter should also show the DEFAULT badge.
6. Run unit tests: `cd packages/cli && npx vitest run src/ui/components/AutoAcceptIndicator.test.tsx src/ui/components/Footer.test.tsx`

### Evidence (Before & After)

**Before:** DEFAULT mode footer shows `? for shortcuts` or empty space — no indication of current permission mode.
<img width="806" height="310" alt="截屏2026-07-08 11 12 56" src="https://github.com/user-attachments/assets/24462054-bace-49e6-9e3c-ad0ac2bfec66" />

**After:** DEFAULT mode footer shows grey `⏸ Ask permissions (shift + tab to cycle)` badge, consistent with other mode indicators.
<img width="796" height="293" alt="截屏2026-07-08 11 12 19" src="https://github.com/user-attachments/assets/014d8593-4d8f-4a3b-a8cf-2b42ab931b63" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Unit tests only (`npx vitest run`). No sandbox or Docker required.

## Risk & Scope

- Main risk or tradeoff: Minimal — purely additive UI change. The `? for shortcuts` hint is replaced by the mode badge in DEFAULT mode; users can still discover shortcuts via the badge's cycle hint.
- Not validated / out of scope: E2E interactive testing on Windows/Linux. Snapshot tests may need updating if golden snapshots capture the footer text.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #6496

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

始终在 footer 中显示当前的权限/审批模式，包括默认的"询问权限"模式。此前，非默认模式（PLAN、AUTO_EDIT、AUTO、YOLO）会显示彩色指示器，但默认模式不显示任何内容，造成视觉上的歧义。现在 DEFAULT 模式会在主 Footer 和 AgentFooter 中渲染一个灰色 ⏸ 徽章及"Ask permissions"文本，使当前权限模式始终一目了然。

## 为什么需要这个改动

在 DEFAULT 模式（最常用的模式）下，用户无法直观确认自己处于哪种模式。新用户不知道是否需要切换模式，切换模式的用户也无法确认已回到 DEFAULT。没有视觉锚点——footer 只在非默认状态下才提供信息。此改动与 Claude Code v2.1.203 一致，该版本也为手动权限模式添加了类似的灰色 ⏸ 徽章。

## 审查者测试计划

### 如何验证

1. 以 DEFAULT 审批模式启动 qwen-code（不带任何标志）。Footer 应显示灰色的 `⏸ Ask permissions` 徽章，而非 `? for shortcuts`。
2. 通过 Shift+Tab 切换到 PLAN 模式——徽章应变为绿色的 `plan mode`。
3. 切回 DEFAULT——灰色 `⏸ Ask permissions` 徽章应重新出现。
4. 依次切换到 AUTO_EDIT、AUTO、YOLO 再回到 DEFAULT——每种模式应显示各自的指示器，DEFAULT 始终显示灰色徽章。
5. 打开 agent 标签页——AgentFooter 也应显示 DEFAULT 徽章。
6. 运行单元测试：`cd packages/cli && npx vitest run src/ui/components/AutoAcceptIndicator.test.tsx src/ui/components/Footer.test.tsx`

### 证据（前后对比）

**修改前：** DEFAULT 模式 footer 显示 `? for shortcuts` 或空白——无当前权限模式指示。
**修改后：** DEFAULT 模式 footer 显示灰色 `⏸ Ask permissions (shift + tab to cycle)` 徽章，与其他模式指示器风格一致。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

仅单元测试（`npx vitest run`）。无需沙箱或 Docker。

## 风险与范围

- 主要风险或权衡：极小——纯增量 UI 变更。DEFAULT 模式下 `? for shortcuts` 提示被模式徽章替代；用户仍可通过徽章的循环提示发现快捷方式。
- 未验证/超出范围：Windows/Linux 上的 E2E 交互测试。如果黄金快照捕获了 footer 文本，快照测试可能需要更新。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Closes #6496

</details>