### PR TITLE
fix(cli): unblock /clear after task cancellation and surface the blocked reason

### DIFF
--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -65,7 +65,7 @@ describe('clearCommand', () => {
               resetChat: mockResetChat,
             }) as unknown as GeminiClient,
           getBackgroundTaskRegistry: vi.fn().mockReturnValue({
-            hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+            hasRunningTasks: vi.fn().mockReturnValue(false),
             reset: mockResetBackgroundTasks,
             abortAll: mockAbortBackgroundTasks,
           }),
@@ -324,7 +324,7 @@ describe('clearCommand', () => {
           config: {
             getHookSystem: mockGetHookSystem,
             getBackgroundTaskRegistry: vi.fn().mockReturnValue({
-              hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+              hasRunningTasks: vi.fn().mockReturnValue(false),
               reset: mockResetBackgroundTasks,
               abortAll: mockAbortBackgroundTasks,
             }),
@@ -404,7 +404,65 @@ describe('clearCommand', () => {
         services: {
           config: {
             getBackgroundTaskRegistry: vi.fn().mockReturnValue({
-              hasUnfinalizedTasks: vi.fn().mockReturnValue(true),
+              hasRunningTasks: vi.fn().mockReturnValue(true),
+              reset: vi.fn(),
+            }),
+            getBackgroundShellRegistry: vi.fn().mockReturnValue({
+              getAll: vi.fn().mockReturnValue([]),
+              hasRunningEntries: vi.fn().mockReturnValue(false),
+              reset: vi.fn(),
+            }),
+            getMonitorRegistry: vi.fn().mockReturnValue({
+              getRunning: vi.fn().mockReturnValue([]),
+              reset: vi.fn(),
+            }),
+            getWorkflowRunRegistry: vi.fn().mockReturnValue({
+              hasRunningEntries: vi.fn().mockReturnValue(false),
+              reset: vi.fn(),
+              abortAll: vi.fn(),
+            }),
+            getHookSystem: mockGetHookSystem,
+            startNewSession: mockStartNewSession,
+            getGeminiClient: vi.fn().mockReturnValue({
+              resetChat: mockResetChat,
+            } as unknown as GeminiClient),
+            getModel: vi.fn().mockReturnValue('test-model'),
+            getApprovalMode: vi.fn().mockReturnValue('default'),
+            getToolRegistry: vi.fn().mockReturnValue({
+              getAllTools: vi.fn().mockReturnValue([]),
+            }),
+            getDebugLogger: vi.fn().mockReturnValue({ warn: vi.fn() }),
+          },
+        },
+        session: {
+          startNewSession: vi.fn(),
+        },
+      });
+
+      const result = await clearCommand.action(blockedContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          "Stop the current session's running background tasks before starting a new session.",
+      });
+      expect(mockStartNewSession).not.toHaveBeenCalled();
+      expect(mockResetChat).not.toHaveBeenCalled();
+    });
+
+    it('returns a visible error when blocked in interactive mode (#5949)', async () => {
+      // Interactive mode used to bail with only a transient debug line,
+      // so a blocked /new looked like the command silently did nothing.
+      if (!clearCommand.action)
+        throw new Error('clearCommand must have an action.');
+
+      const blockedContext = createMockCommandContext({
+        executionMode: 'interactive',
+        services: {
+          config: {
+            getBackgroundTaskRegistry: vi.fn().mockReturnValue({
+              hasRunningTasks: vi.fn().mockReturnValue(true),
               reset: vi.fn(),
             }),
             getBackgroundShellRegistry: vi.fn().mockReturnValue({
@@ -460,7 +518,7 @@ describe('clearCommand', () => {
         services: {
           config: {
             getBackgroundTaskRegistry: vi.fn().mockReturnValue({
-              hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+              hasRunningTasks: vi.fn().mockReturnValue(false),
               reset: vi.fn(),
             }),
             getBackgroundShellRegistry: vi.fn().mockReturnValue({
@@ -516,7 +574,7 @@ describe('clearCommand', () => {
         services: {
           config: {
             getBackgroundTaskRegistry: vi.fn().mockReturnValue({
-              hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+              hasRunningTasks: vi.fn().mockReturnValue(false),
               reset: vi.fn(),
             }),
             getBackgroundShellRegistry: vi.fn().mockReturnValue({

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -47,14 +47,14 @@ export const clearCommand: SlashCommand = {
         const content =
           "Stop the current session's running background tasks before starting a new session.";
         context.ui.setDebugMessage(content);
-        if (context.executionMode !== 'interactive') {
-          return {
-            type: 'message' as const,
-            messageType: 'error' as const,
-            content,
-          };
-        }
-        return;
+        // Return the error in every mode. Interactive mode used to bail
+        // with only the transient debug line above, so a blocked /clear
+        // looked like the command silently did nothing (issue #5949).
+        return {
+          type: 'message' as const,
+          messageType: 'error' as const,
+          content,
+        };
       }
 
       // Fire SessionEnd event (non-blocking to avoid UI lag)

--- a/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -235,7 +235,7 @@ describe('useResumeCommand', () => {
       getGeminiClient: () => geminiClient,
       startNewSession: vi.fn(),
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+        hasRunningTasks: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({
@@ -331,7 +331,7 @@ describe('useResumeCommand', () => {
       getGeminiClient: () => geminiClient,
       startNewSession: vi.fn(),
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+        hasRunningTasks: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({
@@ -424,7 +424,7 @@ describe('useResumeCommand', () => {
       getGeminiClient: () => geminiClient,
       startNewSession: vi.fn(),
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+        hasRunningTasks: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({
@@ -489,7 +489,7 @@ describe('useResumeCommand', () => {
 
     const config = {
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(true),
+        hasRunningTasks: vi.fn().mockReturnValue(true),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({
@@ -554,7 +554,7 @@ describe('useResumeCommand', () => {
 
     const config = {
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+        hasRunningTasks: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({
@@ -629,7 +629,7 @@ describe('useResumeCommand', () => {
       getGeminiClient: () => geminiClient,
       startNewSession: vi.fn(),
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: vi.fn().mockReturnValue(false),
+        hasRunningTasks: vi.fn().mockReturnValue(false),
         reset: vi.fn(),
       }),
       getBackgroundShellRegistry: () => ({

--- a/packages/cli/src/ui/utils/backgroundWorkUtils.test.ts
+++ b/packages/cli/src/ui/utils/backgroundWorkUtils.test.ts
@@ -12,14 +12,14 @@ import {
 } from './backgroundWorkUtils.js';
 
 function createMockConfig(overrides?: {
-  hasUnfinalizedTasks?: boolean;
+  hasRunningTasks?: boolean;
   runningMonitors?: unknown[];
   hasRunningEntries?: boolean;
   hasRunningWorkflows?: boolean;
 }): Config {
   return {
     getBackgroundTaskRegistry: () => ({
-      hasUnfinalizedTasks: () => overrides?.hasUnfinalizedTasks ?? false,
+      hasRunningTasks: () => overrides?.hasRunningTasks ?? false,
       reset: vi.fn(),
     }),
     getMonitorRegistry: () => ({
@@ -42,11 +42,13 @@ describe('hasBlockingBackgroundWork', () => {
     expect(hasBlockingBackgroundWork(createMockConfig())).toBe(false);
   });
 
-  it('returns true when background tasks are unfinalized', () => {
+  // #5949: the gate keys off hasRunningTasks(), NOT hasUnfinalizedTasks()
+  // — a cancelled task whose finalize callback hasn't fired yet must not
+  // block /clear or session resume (both abort-and-reset right after the
+  // gate, suppressing the pending notification anyway).
+  it('returns true when background tasks are still running', () => {
     expect(
-      hasBlockingBackgroundWork(
-        createMockConfig({ hasUnfinalizedTasks: true }),
-      ),
+      hasBlockingBackgroundWork(createMockConfig({ hasRunningTasks: true })),
     ).toBe(true);
   });
 
@@ -75,10 +77,10 @@ describe('hasBlockingBackgroundWork', () => {
     ).toBe(true);
   });
 
-  it('short-circuits: does not check monitors or shells when tasks are unfinalized', () => {
+  it('short-circuits: does not check monitors or shells when tasks are running', () => {
     const config = {
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: () => true,
+        hasRunningTasks: () => true,
         reset: vi.fn(),
       }),
       getMonitorRegistry: () => {
@@ -95,7 +97,7 @@ describe('hasBlockingBackgroundWork', () => {
   it('short-circuits: does not check shells when monitors are running', () => {
     const config = {
       getBackgroundTaskRegistry: () => ({
-        hasUnfinalizedTasks: () => false,
+        hasRunningTasks: () => false,
         reset: vi.fn(),
       }),
       getMonitorRegistry: () => ({

--- a/packages/cli/src/ui/utils/backgroundWorkUtils.ts
+++ b/packages/cli/src/ui/utils/backgroundWorkUtils.ts
@@ -8,7 +8,13 @@ import type { Config } from '@qwen-code/qwen-code-core';
 
 export function hasBlockingBackgroundWork(config: Config): boolean {
   return (
-    config.getBackgroundTaskRegistry().hasUnfinalizedTasks() ||
+    // hasRunningTasks, not hasUnfinalizedTasks: a cancelled task whose
+    // finalize callback hasn't fired yet must not block /clear or
+    // session resume — both abort-and-reset the registry right after
+    // this gate, suppressing the pending notification anyway. Gating on
+    // the unfinalized set made /new silently no-op when typed in the
+    // window between cancel and finalize (issue #5949).
+    config.getBackgroundTaskRegistry().hasRunningTasks() ||
     config.getMonitorRegistry().getRunning().length > 0 ||
     config.getBackgroundShellRegistry().hasRunningEntries() ||
     // R7 (wenshao): the WorkflowRunRegistry is a 4th sibling that the

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -873,6 +873,44 @@ describe('BackgroundTaskRegistry', () => {
     expect(registry.hasUnfinalizedTasks()).toBe(false);
   });
 
+  it('hasRunningTasks ignores cancelled-but-not-notified entries (#5949)', () => {
+    // Session-switch gates (/clear, /resume) key off hasRunningTasks so a
+    // task the user just cancelled — aborted, only its terminal
+    // notification outstanding — cannot make the switch silently no-op.
+    // hasUnfinalizedTasks must still report it for the headless holdback.
+    registry.register({
+      agentId: 'test-1',
+      description: 'test agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      isBackgrounded: true,
+      outputFile: '/tmp/test.jsonl',
+    });
+    expect(registry.hasRunningTasks()).toBe(true);
+
+    registry.cancel('test-1');
+    expect(registry.get('test-1')!.status).toBe('cancelled');
+    expect(registry.hasRunningTasks()).toBe(false);
+    expect(registry.hasUnfinalizedTasks()).toBe(true);
+
+    registry.finalizeCancelled('test-1', '');
+    expect(registry.hasRunningTasks()).toBe(false);
+  });
+
+  it('hasRunningTasks ignores foreground entries', () => {
+    registry.register({
+      agentId: 'fg-1',
+      description: 'foreground agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      isBackgrounded: false,
+      outputFile: '/tmp/test.jsonl',
+    });
+    expect(registry.hasRunningTasks()).toBe(false);
+  });
+
   it('hasUnfinalizedTasks clears once every entry has been notified', () => {
     registry.register({
       agentId: 'a',

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -1009,6 +1009,26 @@ export class BackgroundTaskRegistry {
   }
 
   /**
+   * True while any background entry is still actually executing. Unlike
+   * `hasUnfinalizedTasks()`, a `cancelled`-but-not-yet-finalized entry
+   * does NOT count: its work has already been aborted and only the
+   * terminal task-notification is outstanding. Session-switch gates
+   * (/clear, /resume) key off this instead — they abort-and-reset the
+   * registry right after passing the gate, which suppresses that very
+   * notification, so blocking on it made the command silently no-op
+   * when the user cleared immediately after cancelling (issue #5949).
+   * Headless holdback loops must keep using `hasUnfinalizedTasks()` so
+   * every task_started still pairs with a task_notification.
+   */
+  hasRunningTasks(): boolean {
+    for (const entry of this.agents.values()) {
+      if (!entry.isBackgrounded) continue;
+      if (entry.status === 'running') return true;
+    }
+    return false;
+  }
+
+  /**
    * Drops every in-memory entry without touching sidecar state.
    *
    * Used only when switching to a different session after the caller has


### PR DESCRIPTION
## What this PR does

Fixes #5949 — `/new` (alias of `/clear`) silently did nothing when typed right after cancelling a request. Two stacked causes, both addressed:

1. **Over-strict gate.** `hasBlockingBackgroundWork()` keyed off `BackgroundTaskRegistry.hasUnfinalizedTasks()`, which also counts `cancelled`-but-not-yet-finalized entries. That clause exists for the headless holdback loop (every `task_started` must pair with a `task_notification`), but `/clear` and session resume abort-and-reset the registry immediately after passing the gate — with `notify: false`, suppressing that very notification. Blocking on it only made the switch fail in the window between `cancel()` and `finalizeCancelled()`. The gate now uses a new `BackgroundTaskRegistry.hasRunningTasks()` that counts only entries still actually executing. The headless holdback (`nonInteractiveCli.ts`) keeps using `hasUnfinalizedTasks()` unchanged.

2. **Invisible failure.** When genuinely blocked, interactive mode only called `context.ui.setDebugMessage(...)` — a transient line most users never see — while non-interactive mode returned a proper error. Interactive mode now returns the same visible error message, so a blocked `/clear` shows up in history instead of looking like a no-op.

This matches fix directions (a) and (c) suggested in the issue triage.

## Why the gate change is safe

- Both gate callers (`clearCommand.ts`, `useResumeCommand.ts`) proceed to `abortAll({ notify: false })` + `reset()` after passing the gate, so a cancelled entry awaiting finalization is exactly the state they are about to sweep anyway.
- A `finalizeCancelled()` firing after the sweep is a no-op (`if (!entry) return`).
- `hasUnfinalizedTasks()` is untouched, so the headless SDK contract (task_started/task_notification pairing) is unaffected.

## Reviewer Test Plan

- `cd packages/core && npx vitest run src/agents/background-tasks.test.ts` — 102 passed, including new coverage: `hasRunningTasks` ignores cancelled-but-not-notified entries (while `hasUnfinalizedTasks` still reports them) and ignores foreground entries.
- `cd packages/cli && npx vitest run src/ui/commands/clearCommand.test.ts src/ui/utils/backgroundWorkUtils.test.ts src/ui/hooks/useResumeCommand.test.ts src/ui/hooks/slashCommandProcessor.test.ts` — 112 passed, including a new regression test that a blocked `/clear` in interactive mode returns a visible error message.
- Manual: start a background task, cancel it, immediately run `/new` — the session now clears instead of silently doing nothing; with a genuinely running task, `/new` now prints the blocked-reason error in interactive mode.

Note: the original race (typing `/new` inside the cancel→finalize window) is timing-dependent and not practically reproducible in an automated e2e; the unit tests pin both halves of the fix at the seam where the race manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)