### PR TITLE
fix(cli): prefer command name match over alias match regardless of recentScore

### DIFF
--- a/packages/cli/src/ui/hooks/useSlashCompletion.integration.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.integration.test.ts
@@ -31,6 +31,10 @@ function useTestHarnessForSlashCompletion(
   query: string | null,
   slashCommands: readonly SlashCommand[],
   commandContext: CommandContext,
+  recentCommands?: ReadonlyMap<
+    string,
+    { name: string; usedAt: number; count: number }
+  >,
 ) {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
@@ -41,6 +45,7 @@ function useTestHarnessForSlashCompletion(
     query,
     slashCommands,
     commandContext,
+    recentCommands,
     setSuggestions,
     setIsLoadingSuggestions,
     setIsPerfectMatch,
@@ -168,5 +173,54 @@ describe('useSlashCompletion integration', () => {
     expect(clearIndex).toBeGreaterThanOrEqual(0);
     expect(resumeIndex).toBeLessThan(clearIndex);
     expect(recapIndex).toBeLessThan(clearIndex);
+  });
+
+  it('prefers command name match over alias match even when alias has recentScore', async () => {
+    // Regression test: recentScore should not shadow nameVsAlias dimension.
+    // Real-world conflict: /re matches `resume` (name) and `reset` (alias of clear).
+    // Even if `clear` was used recently (giving it a recentScore > 0), `resume`
+    // (name match) should still rank first because name-vs-alias is checked before
+    // recentScore in the sort chain.
+    const now = Date.now();
+    const slashCommands = [
+      createTestCommand({
+        name: 'clear',
+        altNames: ['reset', 'new'],
+        description: 'Clear conversation history',
+      }),
+      createTestCommand({
+        name: 'resume',
+        altNames: ['continue'],
+        description: 'Resume a previous session',
+      }),
+    ];
+
+    // Give `clear` a recentScore to simulate it was used recently
+    const recentCommands = new Map([
+      ['clear', { name: 'clear', usedAt: now, count: 1 }],
+    ]);
+
+    const { result } = renderHook(() =>
+      useTestHarnessForSlashCompletion(
+        true,
+        '/re',
+        slashCommands,
+        mockCommandContext,
+        recentCommands,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions.length).toBeGreaterThan(1);
+    });
+
+    // resume is a name match; reset is an alias match.
+    // Even with recentScore boosting `clear`, name match must win.
+    const names = result.current.suggestions.map((s) => s.value);
+    const resumeIndex = names.indexOf('resume');
+    const clearIndex = names.indexOf('clear');
+    expect(resumeIndex).toBeGreaterThanOrEqual(0);
+    expect(clearIndex).toBeGreaterThanOrEqual(0);
+    expect(resumeIndex).toBeLessThan(clearIndex);
   });
 });

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -247,8 +247,8 @@ function compareRankedCommandMatches(
   return (
     right.matchStrength - left.matchStrength ||
     right.completionPriority - left.completionPriority ||
-    right.recentScore - left.recentScore ||
     nameVsAlias ||
+    right.recentScore - left.recentScore ||
     right.score - left.score ||
     left.start - right.start ||
     left.itemLength - right.itemLength ||


### PR DESCRIPTION
## What this PR does

Fixes a sorting issue in slash command completion where recently-used alias matches would incorrectly shadow name matches. The fix swaps the order of `nameVsAlias` and `recentScore` in the `compareRankedCommandMatches` sort chain, ensuring that a command matched by its primary name always ranks above an alias match, with recency acting as a tie-breaker only within the same match-type bucket.

Adds a regression test that verifies name matches outrank alias matches even when the alias has a recentScore boost.

## Why it's needed

When a user types `/re`, both `resume` (name match) and `clear` via its `reset` alias match. Without this fix, if `clear` was used recently, its `recentScore` would cause it to rank above `resume`, even though `resume` is a direct name match. This violates the semantic intent that "a name match should always beat an alias match at the same strength level, regardless of recency."

This was identified in issue #6503 where a maintainer confirmed the fix direction: swap lines 251 and 252 in `compareRankedCommandMatches` so the chain becomes `matchStrength → completionPriority → nameVsAlias → recentScore → score → …`.

## Reviewer Test Plan

### How to verify

1. Run the integration test: `cd packages/cli && npx vitest run src/ui/hooks/useSlashCompletion.integration.test.ts`
2. All 4 tests should pass, including the new regression test that gives `clear` a recentScore and verifies `resume` still ranks first for `/re`
3. Manually test in the CLI: type `/re` and confirm `resume` appears before `clear` even if `clear` was recently used

### Evidence (Before & After)

**Before:** `recentScore` evaluated before `nameVsAlias`, causing alias matches with recent usage to outrank name matches.

**After:** `nameVsAlias` evaluated before `recentScore`, ensuring name matches always outrank alias matches at the same matchStrength level, with recency only breaking ties within the same match type.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: None — this is a one-line sort order swap with a targeted regression test
- Not validated / out of scope: Windows and Linux platforms (tested on macOS only)
- Breaking changes / migration notes: None

## Linked Issues

Fixes #6503

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复了斜杠命令补全中的排序问题：最近使用的别名匹配会错误地覆盖名称匹配。修复方案是在 `compareRankedCommandMatches` 排序链中交换 `nameVsAlias` 和 `recentScore` 的顺序，确保通过主名称匹配的命令始终排在别名匹配之前，近期使用分数仅在同类型匹配内作为打破平局的因素。

添加了回归测试，验证即使别名有 recentScore 提升，名称匹配仍然优先。

## 为什么需要

当用户输入 `/re` 时，`resume`（名称匹配）和 `clear` 的 `reset` 别名都会匹配。修复前，如果 `clear` 最近被使用过，它的 `recentScore` 会导致它排在 `resume` 前面，即使 `resume` 是直接名称匹配。这违反了"名称匹配应始终优于别名匹配"的语义意图。

此问题在 issue #6503 中被维护者确认，修复方向是交换排序链中的两行。

## 验证方法

1. 运行集成测试：`cd packages/cli && npx vitest run src/ui/hooks/useSlashCompletion.integration.test.ts`
2. 所有 4 个测试应通过，包括新的回归测试
3. 在 CLI 中手动测试：输入 `/re` 确认 `resume` 出现在 `clear` 前面

</details>
