### PR TITLE
fix(cli): clean up IDE client after deferred timeout

### DIFF
--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -24,6 +24,10 @@ const mockRecordStartupEvent = vi.hoisted(() => vi.fn());
 const mockCheckForUpdates = vi.hoisted(() => vi.fn());
 const mockHandleAutoUpdate = vi.hoisted(() => vi.fn());
 const mockConnectIdeForStartup = vi.hoisted(() => vi.fn());
+const mockDisconnectIde = vi.hoisted(() => vi.fn());
+const mockGetIdeClientInstance = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ disconnect: mockDisconnectIde }),
+);
 const mockInitializeTelemetry = vi.hoisted(() => vi.fn());
 const mockStartBackgroundHousekeeping = vi.hoisted(() => vi.fn());
 
@@ -32,6 +36,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
     debug: mockDebug,
     warn: mockWarn,
   }),
+  IdeClient: { getInstance: () => mockGetIdeClientInstance() },
   initializeTelemetry: (...args: unknown[]) => mockInitializeTelemetry(...args),
 }));
 
@@ -91,6 +96,10 @@ describe('startupPrefetch', () => {
     vi.useRealTimers();
     mockCheckForUpdates.mockResolvedValue(null);
     mockConnectIdeForStartup.mockResolvedValue(undefined);
+    mockDisconnectIde.mockResolvedValue(undefined);
+    mockGetIdeClientInstance.mockResolvedValue({
+      disconnect: mockDisconnectIde,
+    });
   });
 
   afterEach(() => {
@@ -270,13 +279,13 @@ describe('startupPrefetch', () => {
       startPostRenderPrefetches(config, makeSettings(), { connectIde: true });
 
       await vi.dynamicImportSettled();
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(15_000);
 
       expect(statuses).toEqual([
         { state: 'connecting' },
         {
           state: 'failed',
-          message: 'ide_connect timed out after 10000ms',
+          message: 'ide_connect timed out after 15000ms',
         },
       ]);
       expect(mockRecordStartupEvent).toHaveBeenCalledWith(
@@ -286,9 +295,65 @@ describe('startupPrefetch', () => {
       expect(mockWarn).toHaveBeenCalledWith(
         'ide_connect failed:',
         expect.objectContaining({
-          message: 'ide_connect timed out after 10000ms',
+          message: 'ide_connect timed out after 15000ms',
         }),
       );
+      expect(mockDisconnectIde).toHaveBeenCalledTimes(1);
+    } finally {
+      stop();
+    }
+  });
+
+  it('disconnects IDE again if startup connect succeeds after timeout', async () => {
+    vi.useFakeTimers();
+    const config = makeConfig();
+    let resolveConnect!: () => void;
+    const delayedSuccess = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+    mockConnectIdeForStartup.mockReturnValue(delayedSuccess);
+
+    startPostRenderPrefetches(config, makeSettings(), { connectIde: true });
+
+    await vi.dynamicImportSettled();
+    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.dynamicImportSettled();
+
+    expect(mockDisconnectIde).toHaveBeenCalledTimes(1);
+
+    resolveConnect();
+    await vi.dynamicImportSettled();
+
+    expect(mockDisconnectIde).toHaveBeenCalledTimes(2);
+    expect(mockWarn).toHaveBeenCalledWith(
+      'ide_connect failed:',
+      expect.objectContaining({
+        message: 'ide_connect timed out after 15000ms',
+      }),
+    );
+  });
+
+  it('fails deferred IDE connection when the startup connect rejects quickly', async () => {
+    const config = makeConfig();
+    const error = new Error('connection refused');
+    mockConnectIdeForStartup.mockRejectedValue(error);
+    const { statuses, stop } = captureIdeConnectionStatuses();
+
+    try {
+      startPostRenderPrefetches(config, makeSettings(), { connectIde: true });
+
+      await vi.dynamicImportSettled();
+
+      expect(statuses).toEqual([
+        { state: 'connecting' },
+        { state: 'failed', message: 'connection refused' },
+      ]);
+      expect(mockRecordStartupEvent).toHaveBeenCalledWith(
+        'startup_prefetch_failed',
+        { name: 'ide_connect' },
+      );
+      expect(mockWarn).toHaveBeenCalledWith('ide_connect failed:', error);
+      expect(mockDisconnectIde).not.toHaveBeenCalled();
     } finally {
       stop();
     }
@@ -306,7 +371,7 @@ describe('startupPrefetch', () => {
     startPostRenderPrefetches(config, makeSettings(), { connectIde: true });
 
     await vi.dynamicImportSettled();
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(15_000);
 
     const underlyingError = new Error('socket closed');
     rejectConnect(underlyingError);
@@ -315,7 +380,7 @@ describe('startupPrefetch', () => {
     expect(mockWarn).toHaveBeenCalledWith(
       'ide_connect failed:',
       expect.objectContaining({
-        message: 'ide_connect timed out after 10000ms',
+        message: 'ide_connect timed out after 15000ms',
       }),
     );
     expect(mockDebug).toHaveBeenCalledWith(

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -6,6 +6,7 @@
 
 import {
   createDebugLogger,
+  IdeClient,
   initializeTelemetry,
   type Config,
 } from '@qwen-code/qwen-code-core';
@@ -16,31 +17,56 @@ import { recordStartupEvent } from '../utils/startupProfiler.js';
 
 const debugLogger = createDebugLogger('STARTUP_PREFETCH');
 
-const DEFERRED_IDE_CONNECT_TIMEOUT_MS = 10_000;
+const DEFERRED_IDE_CONNECT_TIMEOUT_MS = 15_000;
 
 const earlyStarted = new WeakSet<Config>();
 const postRenderStarted = new WeakSet<Config>();
 
+/**
+ * Bounds optional startup work without cancelling the underlying promise.
+ *
+ * The original promise can still complete after the timeout branch wins the
+ * race. We keep observing that late result so a late IDE success can be cleaned
+ * up and a late rejection does not become an unhandled rejection.
+ */
 function withTimeout<T>(
   promise: Promise<T>,
   name: string,
   timeoutMs: number,
+  onTimeout: () => Promise<void> | void = () => {},
 ): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
+  const runTimeoutCleanup = () => {
+    void Promise.resolve()
+      .then(onTimeout)
+      .catch((err) => {
+        debugLogger.debug(`${name} timeout cleanup failed:`, err);
+      });
+  };
   const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
       timedOut = true;
+      runTimeoutCleanup();
       reject(new Error(`${name} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     timeoutId.unref?.();
   });
 
-  promise.catch((err) => {
-    if (timedOut) {
-      debugLogger.debug(`${name} underlying error after timeout:`, err);
-    }
-  });
+  // This rejection handler intentionally mirrors `catch()`: it handles the
+  // underlying promise if it rejects after the timeout has already been reported.
+  void promise.then(
+    () => {
+      if (timedOut) {
+        runTimeoutCleanup();
+      }
+    },
+    (err) => {
+      if (timedOut) {
+        debugLogger.debug(`${name} underlying error after timeout:`, err);
+      }
+    },
+  );
 
   return Promise.race([promise, timeout]).finally(() => {
     if (timeoutId) {
@@ -65,6 +91,19 @@ function runDeferredTask(name: string, task: () => Promise<void> | void): void {
       recordStartupEvent('startup_prefetch_failed', { name });
       debugLogger.warn(`${name} failed:`, err);
     });
+}
+
+/**
+ * Keeps deferred IDE timeout semantics consistent with the visible failure UI.
+ *
+ * A deferred IDE connection cannot be aborted directly, so on timeout we close
+ * the singleton client. If the original connect later succeeds, `withTimeout`
+ * invokes this cleanup again to avoid leaving an active IDE connection behind a
+ * stale startup failure state.
+ */
+async function disconnectIdeAfterDeferredTimeout(): Promise<void> {
+  const ideClient = await IdeClient.getInstance();
+  await ideClient.disconnect();
 }
 
 /**
@@ -129,6 +168,7 @@ export function startPostRenderPrefetches(
           connectIdeForStartup(config),
           'ide_connect',
           DEFERRED_IDE_CONNECT_TIMEOUT_MS,
+          disconnectIdeAfterDeferredTimeout,
         );
         appEvents.emit(AppEvent.StartupIdeConnectionStatusChanged, {
           state: 'connected',


### PR DESCRIPTION
...(#6507)

## What this PR does

- Extends deferred startup timeout handling with an optional cleanup callback.
- Disconnects the IDE client when deferred IDE startup times out.
- Re-runs the timeout cleanup if the original IDE connection later succeeds after the timeout.
- Keeps late rejection handling for the original IDE connection so timeout paths do not produce unhandled promise rejections.
- Increases the deferred IDE startup timeout to 15 seconds.
- Adds unit tests for timeout cleanup, late success cleanup, quick rejection, and late rejection diagnostics.

## Why it's needed

Deferred IDE startup can time out while the underlying IDE connection promise continues running. If that original connection later succeeds, the CLI can keep an active IDE client internally while the startup UI/status still shows a timeout failure.

This PR keeps the timeout failure semantics consistent with internal IDE state by disconnecting the IDE client after a deferred timeout, including the late-success case.

## Reviewer Test Plan
### How to verify
Confirm that deferred IDE startup timeout cleanup behaves consistently:

- When deferred IDE connection hangs past the timeout, startup records an IDE connection failure and disconnects the IDE client.
- When the original IDE connection succeeds after the timeout has already been reported, the IDE client is disconnected again so the process does not keep an active IDE connection behind stale failure UI.
- When deferred IDE connection rejects quickly before timeout, the original error is reported and no timeout cleanup is run.
- When the original IDE connection rejects after timeout, the underlying error is logged for diagnostics without producing an unhandled promise rejection.

### Evidence (Before & After)

Before: when the deferred IDE connection timed out, startup reported `ide_connect timed out` and showed the IDE startup state as failed, but the underlying connection promise could still complete later. If that late completion succeeded, the process could keep an active IDE client internally while the visible startup state remained failed.

After: when the deferred IDE connection times out, startup still reports the timeout failure, but it also disconnects the IDE client. If the original connection later succeeds after the timeout, cleanup runs again so the internal IDE connection state remains aligned with the visible failure state. Quick connection failures before timeout still report the original error directly.


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅    |
| 🪟 Windows |  ⚠️      |
|  🐧 Linux  |   ⚠️     |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)
Local unit tests on macOS via:

`cd packages/cli && npx vitest run src/startup/startup-prefetch.test.ts`

## Risk & Scope

- Main risk or tradeoff: timeout cleanup now actively disconnects the singleton IDE client after deferred IDE startup times out. This is intentional for deferred startup because the UI has already reported IDE startup as failed.
- Not validated / out of scope: manual IDE extension end-to-end behavior on Windows and Linux was not locally validated.
- Breaking changes / migration notes: none expected.

## Linked Issues

Close (#6507)

<details>
<summary>中文说明</summary>

## What this PR does

- 为 deferred startup timeout 处理增加可选的 cleanup 回调。
- 当 deferred IDE startup 超时时，主动断开 IDE client。
- 如果原始 IDE 连接在 timeout 已经发生后又成功完成，再次执行 timeout cleanup。
- 保留对原始 IDE 连接 late rejection 的处理，避免 timeout 路径产生 unhandled promise rejection。
- 将 deferred IDE startup timeout 增加到 15 秒。
- 增加单元测试，覆盖 timeout cleanup、late success cleanup、quick rejection 和 late rejection diagnostics。

## Why it's needed

Deferred IDE startup 可能已经超时，但底层 IDE connection promise 仍在继续运行。如果这个原始连接之后成功完成，CLI 内部可能会保留一个 active IDE client，而 startup UI/status 仍然显示连接失败。

这个 PR 通过在 deferred timeout 后断开 IDE client，让 timeout failure 语义和内部 IDE 状态保持一致，包括原始连接在 timeout 后才成功的 late-success 场景。

## Reviewer Test Plan

### How to verify

确认 deferred IDE startup timeout cleanup 的行为保持一致：

- 当 deferred IDE connection 挂起并超过 timeout 后，startup 会记录 IDE connection failure，并断开 IDE client。
- 当原始 IDE connection 在 timeout 已经上报后才成功完成，IDE client 会再次被断开，因此进程不会在 stale failure UI 背后保留 active IDE connection。
- 当 deferred IDE connection 在 timeout 前快速 reject，会直接上报原始错误，并且不会执行 timeout cleanup。
- 当原始 IDE connection 在 timeout 后才 reject，会记录底层错误用于诊断，并且不会产生 unhandled promise rejection。

### Evidence (Before & After)

Before: 当 deferred IDE connection 超时时，startup 会上报 `ide_connect timed out`，并把 IDE startup 状态显示为 failed，但底层 connection promise 仍可能在之后完成。如果这个 late completion 成功，进程内部可能会保留 active IDE client，而可见的 startup 状态仍然是 failed。

After: 当 deferred IDE connection 超时时，startup 仍然会上报 timeout failure，但同时会断开 IDE client。如果原始 connection 在 timeout 后才成功完成，cleanup 会再次执行，确保内部 IDE connection 状态和可见的 failure 状态保持一致。timeout 前快速失败的 connection 仍然会直接上报原始错误。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅    |
| 🪟 Windows |  ⚠️      |
|  🐧 Linux  |   ⚠️     |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS 本地单元测试：

`cd packages/cli && npx vitest run src/startup/startup-prefetch.test.ts`

## Risk & Scope

- Main risk or tradeoff: timeout cleanup 现在会在 deferred IDE startup 超时后主动断开 singleton IDE client。对于 deferred startup 来说这是有意行为，因为 UI 已经将 IDE startup 上报为 failed。
- Not validated / out of scope: 未在 Windows 和 Linux 上进行手动 IDE extension 端到端验证。
- Breaking changes / migration notes: 预期没有 breaking changes。

</details>
