### PR TITLE
feat(web-shell): restore the full composer in split-view panes

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -105,6 +105,7 @@ import {
 } from './utils/copyCommand';
 import { isEditableTarget } from './utils/dom';
 import { getModelDisplayName } from './utils/modelDisplay';
+import { isVisibleComposerModel } from './utils/composerModels';
 import { filterModelSwitchMessages } from './utils/modelSwitchMessages';
 import { decideEscapeIntent } from './utils/escapeIntent';
 import type { SkillInfo } from './completions/slashCompletion';
@@ -240,7 +241,6 @@ const MAX_TOASTS = 4;
 const BOUND_RUN_SWITCH_TIMEOUT_MS = 30_000;
 const COMPACT_MODE_SETTING_KEY = 'ui.compactMode';
 const HIDE_TIPS_SETTING_KEY = 'ui.hideTips';
-const HIDDEN_COMPOSER_MODEL_IDS = new Set(['coder-model(qwen-oauth)']);
 
 /** Maps each ModelDialogMode to its i18n title key — single source of truth. */
 const MODE_TITLE_KEY: Record<ModelDialogMode, string> = {
@@ -249,10 +249,6 @@ const MODE_TITLE_KEY: Record<ModelDialogMode, string> = {
   voice: 'model.setVoice',
   vision: 'model.setVision',
 };
-
-function isVisibleComposerModel(model: { id: string }): boolean {
-  return !HIDDEN_COMPOSER_MODEL_IDS.has(model.id);
-}
 
 function normalizeHiddenCommand(command: string): string {
   return command.trim().replace(/^\/+/, '').toLowerCase();

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -93,6 +93,12 @@ vi.mock('./ChatEditor', () => ({
           mode
         </button>
         <button
+          data-testid="pane-pick-badmode"
+          onClick={() => props.onSelectMode?.('totally-bogus')}
+        >
+          badmode
+        </button>
+        <button
           data-testid="pane-pick-model"
           onClick={() => props.onSelectModel?.('gpt-x')}
         >
@@ -477,5 +483,51 @@ describe('ChatPane', () => {
       await Promise.resolve();
     });
     expect(onError).toHaveBeenCalled();
+  });
+
+  it('reports a failed approval mode switch to onError', async () => {
+    const onError = vi.fn();
+    setApprovalMode.mockRejectedValueOnce(new Error('mode switch failed'));
+    render({ onError });
+    await act(async () => {
+      testid('pane-pick-mode')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('rejects an invalid approval mode without calling the daemon', () => {
+    const onError = vi.fn();
+    render({ onError });
+    act(() =>
+      testid('pane-pick-badmode')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(setApprovalMode).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('auto-approves a pending tool call when the pane switches to yolo', async () => {
+    pendingPermission = {
+      id: 'perm-yolo',
+      toolName: 'write_file',
+      toolKind: 'edit',
+      options: [{ id: 'allow-1', label: 'Allow once', kind: 'allow_once' }],
+      rawInput: {},
+    };
+    render();
+    await act(async () => {
+      testid('pane-pick-mode')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(setApprovalMode).toHaveBeenCalledWith('yolo');
+    expect(submitPermission).toHaveBeenCalledWith('perm-yolo', 'allow-1');
   });
 });

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -25,9 +25,18 @@ let sendPromptAdmit: (() => void) | undefined;
 const sendPrompt = vi.fn(async () => ({}) as any);
 const submitPermission = vi.fn(async () => {});
 const cancel = vi.fn(async () => {});
+const setApprovalMode = vi.fn(async (mode: string) => ({ mode }));
+const setModel = vi.fn(async () => ({}) as any);
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
-  useActions: () => ({ sendPrompt, submitPermission, cancel }),
+  DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
+  useActions: () => ({
+    sendPrompt,
+    submitPermission,
+    cancel,
+    setApprovalMode,
+    setModel,
+  }),
   useConnection: () => connectionState,
   useStreamingState: () => streamingStateValue,
   useTranscriptBlocks: () => [],
@@ -77,8 +86,31 @@ vi.mock('./ChatEditor', () => ({
         <button data-testid="pane-cancel" onClick={props.onCancel}>
           cancel
         </button>
+        <button
+          data-testid="pane-pick-mode"
+          onClick={() => props.onSelectMode?.('yolo')}
+        >
+          mode
+        </button>
+        <button
+          data-testid="pane-pick-model"
+          onClick={() => props.onSelectModel?.('gpt-x')}
+        >
+          model
+        </button>
         <span data-testid="pane-running">{String(props.isRunning)}</span>
         <span data-testid="pane-dialogopen">{String(props.dialogOpen)}</span>
+        <span data-testid="pane-toolbar">
+          {JSON.stringify(props.visibleToolbarActions ?? null)}
+        </span>
+        <span data-testid="pane-commands">
+          {String((props.commands ?? []).length)}
+        </span>
+        <span data-testid="pane-mode">{String(props.currentMode)}</span>
+        <span data-testid="pane-model">{String(props.currentModel)}</span>
+        <span data-testid="pane-models">
+          {JSON.stringify(props.availableModels ?? null)}
+        </span>
       </div>
     );
   },
@@ -137,6 +169,8 @@ beforeEach(() => {
   );
   submitPermission.mockClear();
   cancel.mockClear();
+  setApprovalMode.mockClear();
+  setModel.mockClear();
 });
 
 afterEach(() => {
@@ -369,5 +403,79 @@ describe('ChatPane', () => {
     expect(testid('pane-streaming')?.getAttribute('data-started-at')).toBe(
       'none',
     );
+  });
+
+  it('enables the interactive composer controls (approval mode, model, voice)', () => {
+    render();
+    expect(testid('pane-toolbar')?.textContent).toBe(
+      JSON.stringify(['approvalMode', 'model', 'voice']),
+    );
+  });
+
+  it("lists the pane session's own commands in the slash menu", () => {
+    connectionState.commands = [
+      { name: 'clear', description: 'Clear', source: 'builtin-command' },
+      { name: 'compress', description: 'Compress', source: 'builtin-command' },
+    ];
+    render();
+    expect(testid('pane-commands')?.textContent).toBe('2');
+  });
+
+  it('hides internal composer models and labels the rest', () => {
+    connectionState.models = [
+      { id: 'coder-model(qwen-oauth)', label: 'Coder' },
+      { id: 'qwen-max', label: 'qwen-max' },
+    ];
+    render();
+    const models = JSON.parse(testid('pane-models')!.textContent!);
+    expect(models.map((m: { id: string }) => m.id)).toEqual(['qwen-max']);
+  });
+
+  it("drives THIS pane's approval mode when one is picked", () => {
+    render();
+    act(() =>
+      testid('pane-pick-mode')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(setApprovalMode).toHaveBeenCalledWith('yolo');
+  });
+
+  it("switches THIS pane's model when one is picked", () => {
+    render();
+    act(() =>
+      testid('pane-pick-model')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(setModel).toHaveBeenCalledWith('gpt-x');
+  });
+
+  it("reflects the pane session's current mode and model", () => {
+    connectionState.currentMode = 'auto-edit';
+    connectionState.currentModel = 'qwen-max';
+    render();
+    expect(testid('pane-mode')?.textContent).toBe('auto-edit');
+    expect(testid('pane-model')?.textContent).toBe('qwen-max');
+  });
+
+  it('falls back to the default mode and empty model when unset', () => {
+    render();
+    expect(testid('pane-mode')?.textContent).toBe('default');
+    expect(testid('pane-model')?.textContent).toBe('');
+  });
+
+  it('reports a failed model switch to onError', async () => {
+    const onError = vi.fn();
+    setModel.mockRejectedValueOnce(new Error('switch failed'));
+    render({ onError });
+    await act(async () => {
+      testid('pane-pick-model')!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import {
   useActions,
   useConnection,
@@ -77,6 +77,11 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
     pendingApproval && !isAskUser ? pendingApproval : null;
   const pendingAskUserApproval =
     pendingApproval && isAskUser ? pendingApproval : null;
+  // Tracked in a ref so an async approval-mode switch (handleSelectMode) reads
+  // the approval current when setApprovalMode *resolves*, not a stale one
+  // captured at click time — mirrors App's pendingApprovalRef.
+  const pendingToolApprovalRef = useRef(pendingToolApproval);
+  pendingToolApprovalRef.current = pendingToolApproval;
   const approvalActive =
     pendingToolApproval !== null || pendingAskUserApproval !== null;
   const isResponding = streamingState !== 'idle';
@@ -169,6 +174,27 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
       }
       actions
         .setApprovalMode(modeId)
+        .then(() => {
+          // Mirror App's handleSetMode: switching THIS pane to yolo (or
+          // auto-edit for an edit tool) auto-approves a tool call already
+          // awaiting approval in this pane, so the shortcut behaves the same as
+          // in the single-session chat.
+          const approval = pendingToolApprovalRef.current;
+          if (!approval) return;
+          const autoApprove =
+            modeId === 'yolo' ||
+            (modeId === 'auto-edit' && approval.toolKind === 'edit');
+          if (!autoApprove) return;
+          const allowOnce = approval.options.find(
+            (option) => option.kind === 'allow_once',
+          );
+          if (!allowOnce) return;
+          actions
+            .submitPermission(approval.id, allowOnce.id)
+            .catch((error: unknown) =>
+              reportError(error, 'Failed to auto-approve tool call'),
+            );
+        })
         .catch((error: unknown) =>
           reportError(error, 'Failed to set approval mode'),
         );

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -17,15 +17,26 @@ import { extractPendingPermission } from '../adapters/transcriptAdapter';
 import type { PromptImage } from '../adapters/promptTypes';
 import type { ComposerSubmitCommit } from '../hooks/useComposerCore';
 import { isAskUserPermission } from '../utils/askUserPermission';
+import { isDaemonApprovalMode } from '../utils/sessionPreparation';
+import { isVisibleComposerModel } from '../utils/composerModels';
+import { getModelDisplayName } from '../utils/modelDisplay';
+import { localizeBuiltinDescriptions } from '../constants/localCommands';
 import { MessageList } from './MessageList';
 import { StreamingStatus } from './StreamingStatus';
-import { ChatEditor } from './ChatEditor';
+import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
 import { ToolApproval } from './messages/ToolApproval';
 import { AskUserQuestion } from './messages/AskUserQuestion';
 import styles from './ChatPane.module.css';
 
-const EMPTY_COMMANDS: never[] = [];
-const EMPTY_TOOLBAR: never[] = [];
+// Split-view panes get the same interactive composer controls as the main chat,
+// each scoped to the pane's own session: the approval-mode and model pickers,
+// plus voice dictation. The width toggle is omitted (panes size themselves); the
+// slash menu is populated from the session's own command list (see below).
+const PANE_TOOLBAR_ACTIONS: readonly ComposerToolbarAction[] = [
+  'approvalMode',
+  'model',
+  'voice',
+];
 
 export interface ChatPaneProps {
   /** Header label; falls back to the session's own display name / id. */
@@ -128,6 +139,53 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
       );
   }, [actions, reportError]);
 
+  // Composer wiring, all scoped to THIS pane's own DaemonSession context. The
+  // slash menu lists the session's daemon commands — they run server-side when
+  // submitted (via sendPrompt), so e.g. `/clear` clears this pane's session, not
+  // the outer one. The approval-mode and model pickers likewise drive this
+  // session's own actions; the SDK reflects the change back on `connection`.
+  const commands = useMemo(
+    () => localizeBuiltinDescriptions(connection.commands ?? [], t),
+    [connection.commands, t],
+  );
+  const availableModels = useMemo(
+    () =>
+      (connection.models ?? []).filter(isVisibleComposerModel).map((model) => ({
+        id: model.id,
+        label: getModelDisplayName(model.label || model.id),
+      })),
+    [connection.models],
+  );
+  const handleSelectMode = useCallback(
+    (modeId: string) => {
+      // Modes always arrive from the toolbar's own picker, but narrow anyway so
+      // the daemon action gets a well-typed value (mirrors App's handleSetMode).
+      if (!isDaemonApprovalMode(modeId)) {
+        reportError(
+          new Error(`Unsupported approval mode: ${modeId}`),
+          'Failed to set approval mode',
+        );
+        return;
+      }
+      actions
+        .setApprovalMode(modeId)
+        .catch((error: unknown) =>
+          reportError(error, 'Failed to set approval mode'),
+        );
+    },
+    [actions, reportError],
+  );
+  const handleSelectModel = useCallback(
+    (modelId: string) => {
+      actions
+        .setModel(modelId)
+        .catch((error: unknown) =>
+          reportError(error, 'Failed to switch model'),
+        );
+    },
+    [actions, reportError],
+  );
+
   const headerLabel =
     title || connection.displayName || connection.sessionId?.slice(0, 8) || '';
 
@@ -212,8 +270,13 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           isRunning={isResponding}
-          commands={EMPTY_COMMANDS}
-          visibleToolbarActions={EMPTY_TOOLBAR}
+          commands={commands}
+          visibleToolbarActions={PANE_TOOLBAR_ACTIONS}
+          currentMode={connection.currentMode ?? 'default'}
+          currentModel={connection.currentModel ?? ''}
+          availableModels={availableModels}
+          onSelectMode={handleSelectMode}
+          onSelectModel={handleSelectModel}
           dialogOpen={approvalActive}
           placeholderText={t('splitView.composerPlaceholder')}
         />

--- a/packages/web-shell/client/utils/composerModels.ts
+++ b/packages/web-shell/client/utils/composerModels.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Model IDs hidden from the composer's model picker — internal / duplicate
+ * entries that must not be user-selectable. Shared by the main chat composer
+ * (App) and the split-view pane composers (ChatPane) so both hide the same set.
+ */
+export const HIDDEN_COMPOSER_MODEL_IDS = new Set(['coder-model(qwen-oauth)']);
+
+/** Whether a model may appear in the composer's model picker. */
+export function isVisibleComposerModel(model: { id: string }): boolean {
+  return !HIDDEN_COMPOSER_MODEL_IDS.has(model.id);
+}


### PR DESCRIPTION
## What this PR does

The in-window split view rendered each session pane through a deliberately minimal composer: typing "/" opened nothing, and the approval-mode, model, and voice controls were all missing. This PR wires each pane's composer to its own session so all four are back per pane — the slash-command menu, the approval-mode picker, the model picker, and voice dictation. The single-session chat composer is unchanged.

## Why it's needed

Anyone driving sessions from the split view lost the composer controls they rely on in the normal chat. Because a pane targets its own session, restoring the controls there gives them the right per-pane semantics: slash commands are submitted through the pane's session and executed server-side, so `/clear` clears that pane's session rather than the outer chat, and the approval-mode / model pickers change only that pane's session (the SDK reflects the change back on the pane's connection).

## Reviewer Test Plan

### How to verify

1. Open the Web Shell with at least two sessions and enter the in-window Split View (Session Overview → open split, or the sidebar "Split View" entry).
2. In any pane's composer, type `/` — the slash menu now lists that session's commands. Run `/clear` and confirm it clears only that pane's session.
3. Confirm the composer toolbar shows the approval-mode picker and the model picker; change each and confirm only that pane's session is affected.
4. If the daemon advertises voice (`voice_transcribe` capability), the mic button appears and dictates into that pane.

Expected vs observed: before this change the pane composer had none of these (only the send button); after, all four are present and scoped to the pane. `npx vitest run` in `packages/web-shell` stays green (1247 tests, incl. new ChatPane coverage) and `npm run build` succeeds.

### Evidence (Before & After)

The screenshots render the real `ChatEditor` with the exact props a split pane passes it (a component harness stubs only the daemon's voice capability so the mic button is visible without a live model).

Before — the split-pane composer: no slash menu, no toolbar controls:

![before — minimal pane composer](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-pane-composer/shots/before.png)

After — approval-mode, model, and voice restored:

![after — enriched pane composer](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-pane-composer/shots/after.png)

After — the slash menu works in the pane (commands run server-side against the pane's own session):

![after — slash menu open](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/split-pane-composer/shots/after-slash.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `npx vitest run` and `npm run build` in `packages/web-shell`, plus a Vite + Playwright component harness rendering the real composer for the screenshots.

## Risk & Scope

- Main risk or tradeoff: the pane's slash menu lists the daemon's server-executable commands, not the client-only UI commands (`/theme`, `/settings`, …) that are app-global rather than per-session — so every command shown in a pane actually runs there.
- Not validated / out of scope: visual density in very narrow panes (below ~700px the toolbar labels collapse to icons — existing responsive behavior, not introduced here).
- Breaking changes / migration notes: none. The single-session composer is untouched; the shared model-visibility filter (`isVisibleComposerModel` / `HIDDEN_COMPOSER_MODEL_IDS`) moved to `utils/composerModels` with no behavior change.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

窗口内分屏（in-window split view）里，每个会话窗格用的是一个刻意精简的输入框：打 “/” 没有任何反应，审批模式、模型、语音三个控件也都不见了。本 PR 把每个窗格的输入框接到它自己的会话上，让这四样都按窗格恢复——斜杠命令菜单、审批模式选择器、模型选择器、语音听写。单会话聊天的输入框保持不变。

## 为什么需要

在分屏里操作会话的人，丢失了他们在普通聊天里依赖的输入框控件。由于窗格针对的是它自己的会话，在窗格里恢复这些控件能得到正确的“按窗格”语义：斜杠命令通过窗格自己的会话提交并在服务端执行，所以 `/clear` 清的是这个窗格的会话而不是外层聊天；审批模式 / 模型选择器也只改这个窗格的会话（SDK 会把变更写回窗格的 connection）。

## 复核测试计划

### 如何验证

1. 用至少两个会话打开 Web Shell，进入窗口内分屏（会话总览 → 打开分屏，或侧栏“分屏”入口）。
2. 在任意窗格的输入框里打 `/` —— 斜杠菜单会列出该会话的命令。运行 `/clear`，确认只清了该窗格的会话。
3. 确认输入框工具栏显示审批模式选择器和模型选择器；分别切换，确认只影响该窗格的会话。
4. 如果 daemon 广播了语音能力（`voice_transcribe`），麦克风按钮出现并可向该窗格听写。

预期 vs 实际：改动前窗格输入框这些都没有（只有发送键）；改动后四样都在且按窗格隔离。`packages/web-shell` 下 `npx vitest run` 保持全绿（1247 个测试，含新增的 ChatPane 覆盖），`npm run build` 成功。

### 证据（前 / 后）

截图渲染的是真实的 `ChatEditor`，传入的正是分屏窗格所传的 props（组件 harness 仅桩掉 daemon 的语音能力，好让麦克风按钮在没有真实模型时也可见）。

前 —— 分屏窗格输入框：没有斜杠菜单，没有工具栏控件（见上方 before 图）。

后 —— 审批模式、模型、语音恢复（见上方 after 图）。

后 —— 斜杠菜单在窗格里可用，命令在服务端针对窗格自己的会话执行（见上方 after-slash 图）。

### 测试平台

🍏 macOS ✅ · 🪟 Windows ⚠️（未测） · 🐧 Linux ⚠️（未测）

### 运行环境（可选）

本地：`packages/web-shell` 下 `npx vitest run` 与 `npm run build`，外加一个 Vite + Playwright 组件 harness 渲染真实输入框用于截图。

## 风险与范围

- 主要风险 / 取舍：窗格的斜杠菜单列出的是 daemon 可在服务端执行的命令，不含纯客户端的 UI 命令（`/theme`、`/settings` 等，这些是应用级全局而非按会话的）——所以窗格里显示的每个命令都真的能在该窗格生效。
- 未验证 / 范围外：极窄窗格里的视觉密度（宽度低于约 700px 时工具栏文字标签会收缩成图标——这是既有的响应式行为，非本 PR 引入）。
- 破坏性变更 / 迁移说明：无。单会话输入框未改动；共享的模型可见性过滤（`isVisibleComposerModel` / `HIDDEN_COMPOSER_MODEL_IDS`）移到了 `utils/composerModels`，行为不变。

## 关联 Issue

N/A

</details>
