### PR TITLE
fix(cli): keep status line on session model

### DIFF
--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -69,6 +69,10 @@ const mockConfig = {
   getTargetDir: vi.fn(() => '/test/dir'),
   getModel: vi.fn(() => 'test-model'),
   getModelDisplayName: vi.fn(() => 'Test Model'),
+  getModelsConfig: vi.fn(() => ({
+    getModelDisplayName: (model: string) =>
+      model === 'main-model' ? 'Main Model' : 'Test Model',
+  })),
   getCliVersion: vi.fn(() => '1.0.0'),
   getContentGeneratorConfig: vi.fn(getMockContentGeneratorConfig),
 };
@@ -191,6 +195,7 @@ describe('useStatusLine', () => {
     mockUIState.sessionStats.metrics.files.totalLinesRemoved = 0;
     mockVimMode.vimEnabled = false;
     mockVimMode.vimMode = 'INSERT';
+    mockConfig.getModelDisplayName.mockReturnValue('Test Model');
     mockConfig.getContentGeneratorConfig.mockReturnValue({
       contextWindowSize: 131072,
     });
@@ -212,6 +217,17 @@ describe('useStatusLine', () => {
       expect(child_process.exec).not.toHaveBeenCalled();
       expect(result.current.lines).toEqual([
         '\u279c dir \u00b7 git:(main) \u00b7 Test Model \u00b7 131.1k Context 0.1% used',
+      ]);
+    });
+
+    it('renders the session model when config is scoped to a fast subagent', () => {
+      mockUIState.currentModel = 'main-model';
+      mockConfig.getModelDisplayName.mockReturnValue('Fast Model');
+
+      const { result } = renderHook(() => useStatusLine());
+
+      expect(result.current.lines).toEqual([
+        '\u279c dir \u00b7 git:(main) \u00b7 Main Model \u00b7 131.1k Context 0.1% used',
       ]);
     });
 
@@ -714,6 +730,17 @@ describe('useStatusLine', () => {
 
       const input = JSON.parse(stdinWrittenData);
       expect(input.model.display_name).toBe('Test Model');
+    });
+
+    it('sends the session model when config is scoped to a fast subagent', () => {
+      mockUIState.currentModel = 'main-model';
+      mockConfig.getModelDisplayName.mockReturnValue('Fast Model');
+      setStatusLineConfig({ type: 'command', command: 'cat' });
+
+      renderHook(() => useStatusLine());
+
+      const input = JSON.parse(stdinWrittenData);
+      expect(input.model.display_name).toBe('Main Model');
     });
   });
 

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -220,6 +220,16 @@ describe('useStatusLine', () => {
       ]);
     });
 
+    it('falls back to config model display name when the preset current model is empty', () => {
+      mockUIState.currentModel = '';
+
+      const { result } = renderHook(() => useStatusLine());
+
+      expect(result.current.lines).toEqual([
+        '\u279c dir \u00b7 git:(main) \u00b7 Test Model \u00b7 131.1k Context 0.1% used',
+      ]);
+    });
+
     it('renders the session model when config is scoped to a fast subagent', () => {
       mockUIState.currentModel = 'main-model';
       mockConfig.getModelDisplayName.mockReturnValue('Fast Model');

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -389,6 +389,24 @@ export function useStatusLine(): {
 
   const doUpdate = useCallback(() => {
     const preset = statusLinePresetRef.current;
+    const cmd = statusLineCommandRef.current;
+    if (!preset && !cmd) {
+      clearPullRequestLookup();
+      setOutput([]);
+      return;
+    }
+
+    const ui = uiStateRef.current;
+    const cfg = configRef.current;
+    const stats = ui.sessionStats;
+    const m = stats.metrics;
+    const contentGeneratorConfig = cfg.getContentGeneratorConfig();
+    const contextWindowSize = contentGeneratorConfig?.contextWindowSize || 0;
+    const modelDisplayName = ui.currentModel
+      ? cfg.getModelsConfig().getModelDisplayName(ui.currentModel)
+      : cfg.getModelDisplayName();
+    const { totalInputTokens, totalOutputTokens } = aggregateModelTokens(m);
+
     if (preset) {
       if (activeChildRef.current) {
         activeChildRef.current.kill();
@@ -396,21 +414,13 @@ export function useStatusLine(): {
         generationRef.current++;
       }
 
-      const ui = uiStateRef.current;
-      const cfg = configRef.current;
-      const stats = ui.sessionStats;
-      const m = stats.metrics;
       const currentDir = cfg.getTargetDir();
       ensurePullRequestNumber(preset, currentDir, ui.branchName);
 
-      const { totalInputTokens, totalOutputTokens } = aggregateModelTokens(m);
-
-      const contentGeneratorConfig = cfg.getContentGeneratorConfig();
-      const contextWindowSize = contentGeneratorConfig?.contextWindowSize || 0;
       const data = buildStatusLinePresetData({
         sessionId: stats.sessionId,
         version: cfg.getCliVersion(),
-        modelDisplayName: cfg.getModelDisplayName(),
+        modelDisplayName,
         reasoning: contentGeneratorConfig?.reasoning,
         currentDir,
         branch: ui.branchName,
@@ -429,19 +439,6 @@ export function useStatusLine(): {
 
     clearPullRequestLookup();
 
-    const cmd = statusLineCommandRef.current;
-    if (!cmd) {
-      setOutput([]);
-      return;
-    }
-
-    const ui = uiStateRef.current;
-    const cfg = configRef.current;
-    const stats = ui.sessionStats;
-    const m = stats.metrics;
-
-    const contextWindowSize =
-      cfg.getContentGeneratorConfig()?.contextWindowSize || 0;
     const usedPercentage =
       contextWindowSize > 0
         ? Math.min(
@@ -455,13 +452,11 @@ export function useStatusLine(): {
           )
         : 0;
 
-    const { totalInputTokens, totalOutputTokens } = aggregateModelTokens(m);
-
     const input: StatusLineCommandInput = {
       session_id: stats.sessionId,
       version: cfg.getCliVersion() || 'unknown',
       model: {
-        display_name: cfg.getModelDisplayName(),
+        display_name: modelDisplayName,
       },
       context_window: {
         context_window_size: contextWindowSize,
@@ -511,7 +506,7 @@ export function useStatusLine(): {
     let child: ChildProcess;
     try {
       child = exec(
-        cmd,
+        cmd!,
         { cwd: cfg.getTargetDir(), timeout: 5000, maxBuffer: 1024 * 10 },
         (error, stdout) => {
           if (gen !== generationRef.current) return; // stale


### PR DESCRIPTION
## What this PR does

Keeps the status-line model display tied to the active UI session model instead of reading the model display name from the current config runtime view. The same resolved display name is used for the built-in preset status line and for the `model.display_name` field passed to custom status line commands. If the UI state does not have a current model, the previous config-level fallback is preserved.

## Why it's needed

Background `Explore` agents run on the configured fast model. When those agents complete or update the UI, the status line can be recomputed while config model lookup is scoped to the fast-model runtime, causing the parent footer/status line to show `qwen3-coder-flash` even though the main interactive session is still on `qwen3.7-max`.

The status line describes the main UI session, so it should resolve the display name from `ui.currentModel`.

## Reviewer Test Plan

### How to verify

Configure an OpenAI-compatible provider with separate main and fast models, for example `qwen3.7-max` as the main model and `qwen3-coder-flash` as the fast model. Start the interactive CLI with the default preset status line enabled. Have the main model launch two background `Explore` agents using the `agent` tool with `subagent_type: "Explore"` and `run_in_background: true`. The desired behavior is that request logs still show fast-model traffic from the background agents, while the parent footer/status line continues to show the main session model.

For custom status line commands, configure `ui.statusLine` as a command such as `cat` and confirm the JSON stdin contains the main session model in `model.display_name`.

### Evidence

Confirmed PTY E2E with a local fake OpenAI-compatible server:

- Before parent commit `5d2bfbd21b6eda886b744a22d95a6c88364c9d24`: background `Explore` agents trigger fast-model traffic and the parent status line incorrectly shows `qwen3-coder-flash`.
- After this PR: the same background `Explore` agent scenario still triggers fast-model traffic, but the parent status line stays on `qwen3.7-max`.

Screenshot and detailed E2E report: https://github.com/QwenLM/qwen-code/pull/6514#issuecomment-4911978618

Focused tests also cover the scoped-config condition by making `config.getModelDisplayName()` return `Fast Model` while `ui.currentModel` remains `main-model`; the status line and command payload now resolve to `Main Model`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  |   focused tests + source build + confirmed PTY E2E   |
| Windows |   not tested   |
|  Linux  |   not tested   |

### Environment

Local source build on macOS with Node.js 22.22.0. Verification used the repository bundle, focused Vitest tests, and a local fake OpenAI-compatible server for interactive PTY tests.

## Risk & Scope

- Main risk or tradeoff: low; the fix is limited to status-line display data and does not change model selection or request routing.
- Not validated / out of scope: full cross-platform interactive TUI testing on Windows and Linux.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6512.
