### PR TITLE
fix(web-shell): prevent sidebar footer overflow

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -950,8 +950,35 @@
 }
 
 .footerButtonLabel {
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.footerCompact,
+.footerTight {
+  gap: 4px;
+}
+
+.footerCompact .footerButton,
+.footerTight .footerButton {
+  width: 26px;
+  height: 28px;
+  flex: 0 0 26px;
+  justify-content: center;
+  padding: 0;
+}
+
+.footerCompact .footerButtonLabel,
+.footerTight .footerButtonLabel {
+  display: none;
+}
+
+.footerCompact .collapseButton,
+.footerTight .collapseButton {
+  width: 26px;
+  height: 28px;
 }
 
 .collapseButton {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.test.tsx
@@ -105,6 +105,15 @@ const { WebShellSidebar } = await import('./WebShellSidebar');
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
 
 const noop = () => {};
+const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
+
+function setStoredSidebarWidth(width: number): void {
+  window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(width));
+}
+
+function pointerEvent(type: string, clientX: number): MouseEvent {
+  return new MouseEvent(type, { bubbles: true, clientX });
+}
 
 function renderSidebar(
   collapsed: boolean,
@@ -116,6 +125,7 @@ function renderSidebar(
     canOpenSessionsOverview: boolean;
     onOpenSplitView: () => void;
     canOpenSplitView: boolean;
+    onCollapsedChange: (collapsed: boolean) => void;
     onNewSession: () => Promise<boolean> | boolean;
     onLoadSession: (sessionId: string) => Promise<void> | void;
     onError: (error: unknown, message: string) => void;
@@ -153,6 +163,7 @@ function renderSidebar(
 
 beforeEach(() => {
   mockUseSessions.mockClear();
+  window.localStorage.clear();
   mockConnection.sessionId = null;
   mockConnection.capabilities = { qwenCodeVersion: '1.2.3', features: [] };
   for (const store of [mockActive, mockArchived]) {
@@ -196,11 +207,59 @@ afterEach(() => {
 });
 
 describe('WebShellSidebar — version footer', () => {
+  it('shows the settings label and qwen-code version at full footer width', () => {
+    setStoredSidebarWidth(360);
+    const { container } = renderSidebar(false, {
+      canOpenSessionsOverview: true,
+      canOpenSplitView: true,
+    });
+    const settingsButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Settings"]',
+    );
+    const badge = container.querySelector('[title="Qwen Code v1.2.3"]');
+    expect(settingsButton).not.toBeNull();
+    expect(settingsButton?.textContent).toContain('Settings');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('v1.2.3');
+  });
+
   it('shows the qwen-code version in the footer when expanded', () => {
     const { container } = renderSidebar(false);
     const badge = container.querySelector('[title="Qwen Code v1.2.3"]');
     expect(badge).not.toBeNull();
     expect(badge?.textContent).toBe('v1.2.3');
+  });
+
+  it('hides the settings label first while keeping the settings button accessible', () => {
+    setStoredSidebarWidth(260);
+    const { container } = renderSidebar(false, {
+      canOpenSessionsOverview: true,
+      canOpenSplitView: true,
+    });
+    const settingsButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Settings"]',
+    );
+    const badge = container.querySelector('[title="Qwen Code v1.2.3"]');
+    expect(settingsButton).not.toBeNull();
+    expect(settingsButton?.title).toBe('Settings');
+    expect(settingsButton?.textContent).not.toContain('Settings');
+    expect(settingsButton?.querySelector('svg')).not.toBeNull();
+    expect(badge).not.toBeNull();
+  });
+
+  it('hides the version at tight footer width', () => {
+    setStoredSidebarWidth(220);
+    const { container } = renderSidebar(false, {
+      canOpenSessionsOverview: true,
+      canOpenSplitView: true,
+    });
+    const settingsButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Settings"]',
+    );
+    expect(settingsButton).not.toBeNull();
+    expect(settingsButton?.textContent).not.toContain('Settings');
+    expect(container.querySelector('[title="Qwen Code v1.2.3"]')).toBeNull();
+    expect(container.textContent ?? '').not.toContain('v1.2.3');
   });
 
   it('renders a non-semver fallback (e.g. "unknown") without a bogus "v" prefix', () => {
@@ -328,6 +387,42 @@ describe('WebShellSidebar — split view entry', () => {
       button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onOpenSplitView).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebShellSidebar — resize behavior', () => {
+  it('persists normal drag widths without collapsing', () => {
+    setStoredSidebarWidth(260);
+    const onCollapsedChange = vi.fn();
+    const { container } = renderSidebar(false, { onCollapsedChange });
+    const handle = container.querySelector<HTMLElement>('[role="separator"]');
+    expect(handle).not.toBeNull();
+
+    act(() => {
+      handle!.dispatchEvent(pointerEvent('pointerdown', 260));
+      window.dispatchEvent(pointerEvent('pointermove', 230));
+      window.dispatchEvent(pointerEvent('pointerup', 230));
+    });
+
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe('230');
+  });
+
+  it('collapses when dragged past the compact threshold and restores the expanded width', () => {
+    setStoredSidebarWidth(260);
+    const onCollapsedChange = vi.fn();
+    const { container } = renderSidebar(false, { onCollapsedChange });
+    const handle = container.querySelector<HTMLElement>('[role="separator"]');
+    expect(handle).not.toBeNull();
+
+    act(() => {
+      handle!.dispatchEvent(pointerEvent('pointerdown', 260));
+      window.dispatchEvent(pointerEvent('pointermove', 130));
+    });
+
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+    expect(onCollapsedChange).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe('260');
   });
 });
 

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -35,6 +35,12 @@ const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
 const SIDEBAR_DEFAULT_WIDTH = 260;
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 420;
+const SIDEBAR_FOOTER_COMPACT_WIDTH = 344;
+const SIDEBAR_FOOTER_TIGHT_WIDTH = 250;
+const SIDEBAR_DRAG_VISUAL_MIN_WIDTH = 200;
+const SIDEBAR_COLLAPSE_DRAG_THRESHOLD = 56;
+const SIDEBAR_COLLAPSE_DRAG_WIDTH =
+  SIDEBAR_DRAG_VISUAL_MIN_WIDTH - SIDEBAR_COLLAPSE_DRAG_THRESHOLD;
 const ACTIVE_SESSION_POLL_INTERVAL_MS = 2000;
 const IDLE_SESSION_POLL_INTERVAL_MS = 30_000;
 const DIALOG_SESSION_LABEL_MAX_LENGTH = 96;
@@ -168,6 +174,13 @@ function getGroupColorClass(color: DaemonSessionGroupColor): string {
 
 function clampSidebarWidth(width: number): number {
   return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+}
+
+function clampSidebarVisualWidth(width: number): number {
+  return Math.min(
+    SIDEBAR_MAX_WIDTH,
+    Math.max(SIDEBAR_DRAG_VISUAL_MIN_WIDTH, width),
+  );
 }
 
 function readSidebarWidth(): number {
@@ -600,6 +613,9 @@ export function WebShellSidebar({
       ? `v${qwenCodeVersion}`
       : qwenCodeVersion
     : '';
+  const footerCompact =
+    !collapsed && sidebarWidth < SIDEBAR_FOOTER_COMPACT_WIDTH;
+  const footerTight = !collapsed && sidebarWidth < SIDEBAR_FOOTER_TIGHT_WIDTH;
   const sidebarStyle = {
     '--web-shell-sidebar-width': `${sidebarWidth}px`,
   } as CSSProperties;
@@ -1479,6 +1495,8 @@ export function WebShellSidebar({
       const startWidth = sidebarWidth;
       const previousCursor = document.body.style.cursor;
       const previousUserSelect = document.body.style.userSelect;
+      let collapsedByDrag = false;
+      let teardown: (updateState: boolean) => void = () => undefined;
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
       try {
@@ -1486,13 +1504,30 @@ export function WebShellSidebar({
       } catch {
         // Pointer capture is best-effort; window listeners still handle drag.
       }
-      const handlePointerMove = (moveEvent: PointerEvent) => {
-        const nextWidth = clampSidebarWidth(
-          startWidth + moveEvent.clientX - startX,
-        );
-        setSidebarWidth(nextWidth);
-      };
-      const teardown = (updateState: boolean) => {
+      function getRawWidth(clientX: number) {
+        return startWidth + clientX - startX;
+      }
+      function restoreExpandedWidth() {
+        const restoredWidth = clampSidebarWidth(startWidth);
+        setSidebarWidth(restoredWidth);
+        writeSidebarWidth(restoredWidth);
+      }
+      function collapseFromDrag() {
+        if (collapsedByDrag) return;
+        collapsedByDrag = true;
+        restoreExpandedWidth();
+        teardown(true);
+        onCollapsedChange(true);
+      }
+      function handlePointerMove(moveEvent: PointerEvent) {
+        const rawWidth = getRawWidth(moveEvent.clientX);
+        if (rawWidth <= SIDEBAR_COLLAPSE_DRAG_WIDTH) {
+          collapseFromDrag();
+          return;
+        }
+        setSidebarWidth(clampSidebarVisualWidth(rawWidth));
+      }
+      teardown = function resizeTeardown(updateState: boolean) {
         document.body.style.cursor = previousCursor;
         document.body.style.userSelect = previousUserSelect;
         window.removeEventListener('pointermove', handlePointerMove);
@@ -1503,17 +1538,20 @@ export function WebShellSidebar({
           setIsResizing(false);
         }
       };
-      const handlePointerUp = (upEvent: PointerEvent) => {
-        const nextWidth = clampSidebarWidth(
-          startWidth + upEvent.clientX - startX,
-        );
+      function handlePointerUp(upEvent: PointerEvent) {
+        const rawWidth = getRawWidth(upEvent.clientX);
+        if (rawWidth <= SIDEBAR_COLLAPSE_DRAG_WIDTH) {
+          collapseFromDrag();
+          return;
+        }
+        const nextWidth = clampSidebarWidth(rawWidth);
         setSidebarWidth(nextWidth);
         writeSidebarWidth(nextWidth);
         teardown(true);
-      };
-      const handlePointerCancel = () => {
+      }
+      function handlePointerCancel() {
         teardown(true);
-      };
+      }
       resizeTeardownRef.current = teardown;
       window.addEventListener('pointermove', handlePointerMove);
       window.addEventListener('pointerup', handlePointerUp, { once: true });
@@ -1521,7 +1559,7 @@ export function WebShellSidebar({
         once: true,
       });
     },
-    [collapsed, sidebarWidth],
+    [collapsed, onCollapsedChange, sidebarWidth],
   );
 
   const deleteCandidateLabel = deleteCandidate
@@ -2506,7 +2544,13 @@ export function WebShellSidebar({
         </div>
       </div>
 
-      <div className={styles.footer}>
+      <div
+        className={cx(
+          styles.footer,
+          footerCompact && styles.footerCompact,
+          footerTight && styles.footerTight,
+        )}
+      >
         <button
           className={styles.footerButton}
           type="button"
@@ -2517,13 +2561,13 @@ export function WebShellSidebar({
           <span className={`${styles.navIcon} ${styles.settingsIcon}`}>
             <IconSettings />
           </span>
-          {!collapsed && (
+          {!collapsed && !footerCompact && (
             <span className={styles.footerButtonLabel}>
               {t('sidebar.settings')}
             </span>
           )}
         </button>
-        {!collapsed && versionLabel && (
+        {!collapsed && !footerTight && versionLabel && (
           <span className={styles.version} title={`Qwen Code ${versionLabel}`}>
             {versionLabel}
           </span>


### PR DESCRIPTION
## What this PR does

This PR makes the web shell sidebar footer respond to constrained widths in stages: the settings entry becomes icon-only first, the version badge is removed at tighter widths, and dragging past the compact threshold collapses the sidebar to the rail while preserving a sane expanded width for the next open.

## Why it's needed

When launching the web shell locally, I found that the sidebar footer did not have enough width: the "Settings" label was covered, only half of the settings gear was visible, and while shrinking the sidebar the buttons that should remain available in the collapsed/compact footer could become invisible. The staged fallback keeps the controls accessible and avoids clipped footer actions without changing daemon/session behavior.

## Reviewer Test Plan

### How to verify

Open the web shell with the sidebar enabled, make the viewport large enough to show the session overview and split-view footer actions, then drag the sidebar narrower. Confirm the settings label disappears before the version badge, the remaining icons do not overlap at tight widths, and dragging farther left collapses the sidebar to the rail. Expand it again and confirm it restores to a normal supported width rather than the sub-threshold drag width.

### Evidence (Before & After)

Before: local startup showed an overcrowded sidebar footer where the "Settings" text was obscured, the settings gear was only partly visible, and footer buttons could disappear while the sidebar was being narrowed. After: local browser smoke measured no footer overlaps at 260px and 220px sidebar widths, confirmed drag collapse to the 56px rail, and confirmed expanding restored 220px.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested     |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

### Environment (optional)

Local verification used `cd packages/web-shell && npx vitest run client/components/sidebar/WebShellSidebar.test.tsx`, `cd packages/web-shell && npm run build`, and a local Vite web-shell smoke against the running daemon.

## Risk & Scope

- Main risk or tradeoff: the compact thresholds intentionally make the default 260px footer icon-only when every footer action is present, favoring non-overlap over keeping the settings label visible.
- Not validated / out of scope: automatic collapse on window resize is intentionally out of scope; the local daemon did not advertise a qwen-code version during browser smoke, so version badge behavior is covered by unit tests.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 Web Shell 侧边栏底部在宽度受限时按阶段降级：先把设置入口变成纯图标，再在更窄时隐藏版本号，继续向左拖过紧凑阈值后把侧边栏折叠成 rail，并保留一个正常的展开宽度供下次展开使用。

## 为什么需要

我在本地启动 Web Shell 时发现侧边栏底部宽度不够：“设置”两个字被遮挡，设置图标只展示了一半；继续缩小侧边栏时，原本应该保留可操作的收起/紧凑态按钮也会变得不可见。这个分阶段降级方案能保持按钮可访问，避免底部操作被裁切，同时不改变 daemon 或 session 行为。

## Reviewer Test Plan

### 如何验证

打开启用侧边栏的 Web Shell，把视口调到足够显示会话总览和分屏这两个底部入口，然后把侧边栏向窄处拖动。确认“设置”文字会先消失，版本号随后在更窄宽度下消失，剩余图标在紧凑宽度下不重叠；继续向左拖动时侧边栏会折叠为 rail。再次展开后确认宽度恢复到正常支持的宽度，而不是拖拽过程中的阈值以下宽度。

### 证据（Before & After）

Before：本地启动后可以看到侧边栏底部过于拥挤，“设置”文字被遮挡，设置齿轮只显示一半，并且缩小侧边栏时底部按钮可能直接不可见。After：本地浏览器 smoke 在 260px 和 220px 侧边栏宽度下测得底部无重叠，确认拖过阈值会折叠到 56px rail，并确认再次展开会恢复到 220px。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested     |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

### 环境（可选）

本地验证使用了 `cd packages/web-shell && npx vitest run client/components/sidebar/WebShellSidebar.test.tsx`、`cd packages/web-shell && npm run build`，以及连接本地运行 daemon 的 Vite Web Shell 浏览器 smoke。

## 风险与范围

- 主要风险或取舍：当所有底部操作入口都展示时，紧凑阈值会让默认 260px 底部变成纯图标，优先保证不重叠，而不是保留“设置”文字。
- 未验证 / 范围外：窗口尺寸变化时自动折叠本次明确不做；本地 daemon 在浏览器 smoke 时没有返回 qwen-code 版本号，所以版本号展示/隐藏由单测覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
