### PR TITLE
fix(cli): allow approval-mode changes without bearer token

### DIFF
--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1706,7 +1706,7 @@ export function registerSessionRoutes(
 
   app.post(
     '/session/:id/approval-mode',
-    mutate({ strict: true }),
+    mutate(),
     withMutableSession(
       'POST /session/:id/approval-mode',
       async (req, res, sessionId) => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -8181,24 +8181,24 @@ describe('createServeApp', () => {
   });
 
   describe('POST /session/:id/approval-mode (#4175 Wave 4 PR 17)', () => {
-    // Strict-gated route: refuses on no-token loopback defaults. All
-    // tests configure a token and forward `Authorization: Bearer …`.
+    // Non-strict route: works on no-token loopback defaults (matches
+    // POST /session/:id/model). Token-configured tests still forward
+    // `Authorization: Bearer …`.
     const tokenOpts: ServeOptions = { ...baseOpts, token: 'secret' };
     const auth = (req: request.Test): request.Test =>
       req
         .set('Host', `127.0.0.1:${tokenOpts.port}`)
         .set('Authorization', 'Bearer secret');
 
-    it('401 on no-token daemon: strict gate refuses without bearer auth', async () => {
+    it('200 on no-token daemon without bearer auth', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(baseOpts, undefined, { bridge });
       const res = await request(app)
         .post('/session/session-A/approval-mode')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ mode: 'yolo' });
-      expect(res.status).toBe(401);
-      expect(res.body.code).toBe('token_required');
-      expect(bridge.setApprovalModeCalls).toHaveLength(0);
+      expect(res.status).toBe(200);
+      expect(bridge.setApprovalModeCalls).toHaveLength(1);
     });
 
     it('200 with the typed result on success and persist defaults to false', async () => {


### PR DESCRIPTION
## Summary

`POST /session/:id/approval-mode` was gated with `mutate({ strict: true })`, requiring a bearer token. But similar session-scoped routes (`POST /session/:id/model`, `POST /session/:id/language`) use `mutate()` (non-strict). This inconsistency prevented the Web Shell from setting YOLO approval mode on daemons without a configured token, showing a confusing toast error on every new YOLO session:

> Set approval mode failed: POST /session/:id/approval-mode: This route requires the daemon to be configured with a bearer token.

## Changes

Relax the approval-mode route from `mutate({ strict: true })` to `mutate()`, matching the model route and the session create/load/resume lifecycle paths that are also non-strict.

## Reviewer Test Plan

**How to verify:**
1. Start a daemon **without** `QWEN_SERVER_TOKEN` configured
2. Open Web Shell and create a new session with YOLO approval mode
3. **Before:** Toast error appears; approval mode stays on default
4. **After:** No toast; session correctly switches to YOLO mode
5. With `QWEN_SERVER_TOKEN` set + bearer auth: route still works as before

---

<details>
<summary>🇨🇳 中文说明</summary>

## 问题

`POST /session/:id/approval-mode` 路由使用了 `mutate({ strict: true })`，要求必须配置 bearer token。但类似的会话级路由（`/session/:id/model`、`/session/:id/language`）都是 `mutate()`（非严格模式）。这种不一致导致在没有配置 token 的 daemon 上，Web Shell 无法设置 YOLO 审批模式，每次新建 YOLO 会话都会弹出一条令人困惑的错误提示。

## 改动

将 approval-mode 路由从 `mutate({ strict: true })` 放宽为 `mutate()`，与 model 路由保持一致，也与 session 的 create/load/resume 生命周期路径保持统一。

## 验证方式

1. 启动 daemon 时**不配置** `QWEN_SERVER_TOKEN`
2. 打开 Web Shell，新建 YOLO 审批模式的会话
3. **修复前：** 弹出错误提示，审批模式停留在 default
4. **修复后：** 无提示，会话正确切换到 YOLO 模式
5. 配置 `QWEN_SERVER_TOKEN` 并使用 bearer auth 时：路由行为不变

</details>