### PR TITLE
feat(autofix): extend review loop to all dev-bot PRs, add real-time triggers

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -8,10 +8,12 @@ name: 'Qwen Autofix'
 # The lifecycle is asynchronous — a PR is opened in one run and its review is
 # addressed in a later run once a reviewer has weighed in — so each scheduled
 # tick runs only the phase(s) that make sense, decided by the `route` job:
-#   • every 4h             → review phase (sweep the bot's open PRs)
-#   • every 12h (00/12 UTC) → also the issue phase (locate + fix one new bug)
-#   • issues:labeled        → issue phase when ready label, state, and sender match
-#   • workflow_dispatch     → force a phase, an issue, or a PR
+#   • every 4h                   → review phase (sweep the bot's open PRs)
+#   • every 12h (00/12 UTC)      → also the issue phase (locate + fix one new bug)
+#   • issues:labeled             → issue phase when ready label, state, and sender match
+#   • pull_request_review        → review phase (real-time feedback loop for bot PRs)
+#   • pull_request_review_comment → review phase (real-time inline feedback loop)
+#   • workflow_dispatch          → force a phase, an issue, or a PR
 #
 # Every GitHub write (issue/PR comments, labels, branch push, PR create) goes
 # through CI_DEV_BOT_PAT so the bot acts as a single identity, qwen-code-dev-bot.
@@ -21,6 +23,12 @@ on:
   issues:
     types:
       - 'labeled'
+  pull_request_review:
+    types:
+      - 'submitted'
+  pull_request_review_comment:
+    types:
+      - 'created'
   schedule:
     - cron: '0 0,12 * * *' # Issue + review every 12h; must match route SCHEDULE check
     - cron: '0 4,8,16,20 * * *' # Review only between issue runs
@@ -41,7 +49,7 @@ on:
         required: false
         type: 'string'
       pr_number:
-        description: 'Force a specific autofix PR number (implies the review phase)'
+        description: 'Force a specific bot PR number (implies the review phase)'
         required: false
         type: 'string'
       dry_run:
@@ -58,8 +66,8 @@ permissions:
   contents: 'read'
 
 env:
-  # Identity of the autofix bot and the branches it owns. Only its own in-repo
-  # PRs are ever eligible for the review phase — never a fork or another branch.
+  # Identity of the autofix bot. All open in-repo PRs authored by this bot are
+  # eligible for the review phase — not limited to autofix/issue-* branches.
   AUTOFIX_BOT: 'qwen-code-dev-bot'
   BRANCH_PREFIX: 'autofix/issue-'
   # The automated Qwen PR reviewer posts as this account; its review counts as
@@ -110,6 +118,8 @@ jobs:
           REPO: '${{ github.repository }}'
           SENDER_LOGIN: '${{ github.event.sender.login }}'
           SCHEDULE: '${{ github.event.schedule }}'
+          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
+          PR_NUMBER_EVENT: '${{ github.event.pull_request.number }}'
         run: |-
           DO_ISSUE=false
           DO_REVIEW=false
@@ -140,6 +150,18 @@ jobs:
               # Must match the issue-phase cron string on the schedule trigger.
               if [[ "${EVENT_NAME}" == 'schedule' && "${SCHEDULE}" == '0 0,12 * * *' ]]; then
                 DO_ISSUE=true
+              fi
+              # Real-time review triggers: only process PRs authored by the
+              # dev-bot so arbitrary PR reviews do not kick off expensive runs.
+              if [[ "${EVENT_NAME}" == 'pull_request_review' || "${EVENT_NAME}" == 'pull_request_review_comment' ]]; then
+                DO_ISSUE=false
+                if [[ "${PR_AUTHOR}" == "${AUTOFIX_BOT}" ]]; then
+                  DO_REVIEW=true
+                  ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"
+                  echo "🧭 review event on bot PR #${PR_NUMBER_EVENT} → review phase"
+                else
+                  echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"
+                fi
               fi
               if [[ "${EVENT_NAME}" == 'issues' ]]; then
                 DO_REVIEW=false
@@ -190,7 +212,7 @@ jobs:
           echo "dry_run=${DRY_RUN}" >> "${GITHUB_OUTPUT}"
           echo "issue_number=${ROUTE_ISSUE}" >> "${GITHUB_OUTPUT}"
           echo "pr_number=${ROUTE_PR}" >> "${GITHUB_OUTPUT}"
-          echo "🧭 phase='${PHASE:-auto}' event='${EVENT_NAME}' issue='#${ISSUE_NUMBER:-n/a}' schedule='${SCHEDULE:-n/a}' dry_run=${DRY_RUN} → issue=${DO_ISSUE} review=${DO_REVIEW}"
+          echo "🧭 phase='${PHASE:-auto}' event='${EVENT_NAME}' issue='#${ISSUE_NUMBER:-n/a}' pr='#${PR_NUMBER_EVENT:-n/a}' schedule='${SCHEDULE:-n/a}' dry_run=${DRY_RUN} → issue=${DO_ISSUE} review=${DO_REVIEW}"
 
   # ===========================================================================
   # ISSUE PHASE — locate one maintainer-ready issue, fix it, open a PR.
@@ -215,7 +237,7 @@ jobs:
       AUTOFIX_ISSUE_EXCLUDES: 'no:assignee -linked:pr -label:autofix/skip -label:autofix/in-progress -label:status/need-information -label:status/need-retesting sort:created-desc'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -872,17 +894,16 @@ jobs:
         run: |-
           WORKDIR="$(mktemp -d)"
 
-          # Candidate PRs: open, authored by the autofix bot, on autofix/issue-*.
+          # Candidate PRs: all open, in-repo PRs authored by the dev-bot.
           # A forced PR must still pass these checks.
           if [[ -n "${FORCED_PR}" ]]; then
             META="$(gh pr view "${FORCED_PR}" --repo "${REPO}" \
               --json number,state,author,headRefName 2> /dev/null || echo '{}')"
-            OK="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg p "${BRANCH_PREFIX}" \
+            OK="$(jq -r --arg ab "${AUTOFIX_BOT}" \
               '(((.state // "") == "OPEN")
-                 and ((.author.login // "") == $ab)
-                 and ((.headRefName // "") | startswith($p)))' <<< "${META}")"
+                 and ((.author.login // "") == $ab))' <<< "${META}")"
             if [[ "${OK}" != "true" ]]; then
-              echo "❌ #${FORCED_PR} is not an open autofix PR owned by ${AUTOFIX_BOT}"
+              echo "❌ #${FORCED_PR} is not an open PR owned by ${AUTOFIX_BOT}"
               echo "has_targets=false" >> "${GITHUB_OUTPUT}"
               exit 0
             fi
@@ -890,15 +911,18 @@ jobs:
           else
             gh pr list --repo "${REPO}" --state open --author "${AUTOFIX_BOT}" \
               --limit 100 --json number,headRefName > "${WORKDIR}/bot-prs.json"
-            CANDIDATES="$(jq -r --arg p "${BRANCH_PREFIX}" \
-              '.[] | select(.headRefName | startswith($p)) | .number' \
-              "${WORKDIR}/bot-prs.json")"
+            CANDIDATES="$(jq -r '.[] | .number' "${WORKDIR}/bot-prs.json")"
           fi
 
           TARGETS='[]'
           for PR in ${CANDIDATES}; do
             BRANCH="$(gh pr view "${PR}" --repo "${REPO}" --json headRefName --jq '.headRefName')"
-            ISSUE="${BRANCH#"${BRANCH_PREFIX}"}"
+            # Extract issue number: autofix/issue-<N> → N; otherwise use PR number.
+            if [[ "${BRANCH}" == "${BRANCH_PREFIX}"* ]]; then
+              ISSUE="${BRANCH#"${BRANCH_PREFIX}"}"
+            else
+              ISSUE="${PR}"
+            fi
             HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')"
 
             # Push watermark: the PR's last push. Feedback older than this was in
@@ -997,7 +1021,7 @@ jobs:
       WATERMARK: '${{ matrix.target.watermark }}'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -1121,7 +1145,9 @@ jobs:
 
           # Render the actionable feedback into one prompt-ready file.
           {
-            echo "# Review feedback to triage on PR #${PR} (issue #${ISSUE})"
+            ISSUE_REF=""
+            [[ "${ISSUE}" != "${PR}" ]] && ISSUE_REF=" (issue #${ISSUE})"
+            echo "# Review feedback to triage on PR #${PR}${ISSUE_REF}"
             echo
             echo "Only feedback newer than the last evaluation (${WATERMARK}) from"
             echo "trusted maintainers or the automated reviewer is listed."
@@ -1364,7 +1390,9 @@ jobs:
           gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md"
 
           {
-            echo "### PR #${PR} (issue #${ISSUE}) — ${STATUS}"
+            ISSUE_REF=""
+            [[ "${ISSUE}" != "${PR}" ]] && ISSUE_REF=" (issue #${ISSUE})"
+            echo "### PR #${PR}${ISSUE_REF} — ${STATUS}"
             echo "- Base conflict: ${CONFLICT}"
             echo
             if [[ "${OUTCOME}" == "fixed" ]]; then
@@ -1388,7 +1416,9 @@ jobs:
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
           {
-            echo "### PR #${PR} (issue #${ISSUE}) — outcome=${OUTCOME:-unknown}${SUFFIX}"
+            ISSUE_REF=""
+            [[ "${ISSUE}" != "${PR}" ]] && ISSUE_REF=" (issue #${ISSUE})"
+            echo "### PR #${PR}${ISSUE_REF} — outcome=${OUTCOME:-unknown}${SUFFIX}"
             echo "- Base conflict: ${CONFLICT:-unknown}"
             echo
             for f in address-summary.md no-action.md failure.md handoff.md; do

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -69,6 +69,8 @@ env:
   # Identity of the autofix bot. All open in-repo PRs authored by this bot are
   # eligible for the review phase — not limited to autofix/issue-* branches.
   AUTOFIX_BOT: 'qwen-code-dev-bot'
+  # Branch-name prefix used by the issue phase when creating PRs. Also used
+  # for duplicate-PR detection and issue-number extraction from branch names.
   BRANCH_PREFIX: 'autofix/issue-'
   # The automated Qwen PR reviewer posts as this account; its review counts as
   # actionable feedback even though it is not a human collaborator.
@@ -172,13 +174,17 @@ jobs:
                   if [[ "${SENDER_LOGIN}" == "${REVIEW_BOT}" ]]; then
                     sender_is_trusted=true
                   elif [[ -n "${SENDER_LOGIN}" ]]; then
-                    if sender_permission="$(gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission" --jq '.permission // ""' 2>&1)"; then
+                    api_error_file="$(mktemp)"
+                    if sender_permission="$(gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission" --jq '.permission // ""' 2>"${api_error_file}")"; then
                       case "${sender_permission}" in
                         admin|maintain|write) sender_is_trusted=true ;;
                       esac
                     else
+                      api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+                      echo "::warning::Permission API call failed for ${SENDER_LOGIN}: ${api_error:-unknown error}"
                       sender_permission=''
                     fi
+                    rm -f "${api_error_file}"
                   fi
                   if [[ "${sender_is_trusted}" == "true" ]]; then
                     DO_REVIEW=true
@@ -999,13 +1005,16 @@ jobs:
               "${WORKDIR}/rc.json")"
             # Issue-level PR comments (e.g. /review suggestion summaries) are
             # also actionable feedback. Exclude the bot's own eval markers.
+            # Exclude known non-actionable bot comments (triage stages,
+            # coverage reports, suggestion summaries, force-push reminders).
+            BOT_COMMENT_FILTER='<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) '
             N_ISSUE_COMMENTS="$(jq --arg wm "${EFF_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
-              --argjson trust "${TRUSTED_ASSOC}" '
+              --argjson trust "${TRUSTED_ASSOC}" --arg bf "${BOT_COMMENT_FILTER}" '
               [ .[]
                 | select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
                 | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-                | select((.body // "") | test("<!-- autofix-eval ") | not) ] | length' \
+                | select((.body // "") | test($bf) | not) ] | length' \
               "${WORKDIR}/ic.json")"
 
             # mergeable: GitHub may report UNKNOWN until it recomputes; treat only
@@ -1192,7 +1201,7 @@ jobs:
             + (.[2] | map(select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-              | select((.body // "") | test("<!-- autofix-eval ") | not) | .created_at))
+              | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not) | .created_at))
             | max // ""' "${WORKDIR}/rv.json" "${WORKDIR}/rc.json" "${WORKDIR}/ic.json")"
           [[ -z "${NEWEST}" ]] && NEWEST="${WATERMARK}"
           echo "newest=${NEWEST}" >> "${GITHUB_OUTPUT}"
@@ -1234,7 +1243,7 @@ jobs:
               | select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-              | select((.body // "") | test("<!-- autofix-eval ") | not)
+              | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
               | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/ic.json"
           } > "${WORKDIR}/feedback.md"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -12,7 +12,6 @@ name: 'Qwen Autofix'
 #   • every 12h (00/12 UTC)      → also the issue phase (locate + fix one new bug)
 #   • issues:labeled             → issue phase when ready label, state, and sender match
 #   • pull_request_review        → review phase (real-time feedback loop for bot PRs)
-#   • pull_request_review_comment → review phase (real-time inline feedback loop)
 #   • workflow_dispatch          → force a phase, an issue, or a PR
 #
 # Every GitHub write (issue/PR comments, labels, branch push, PR create) goes
@@ -26,9 +25,6 @@ on:
   pull_request_review:
     types:
       - 'submitted'
-  pull_request_review_comment:
-    types:
-      - 'created'
   schedule:
     - cron: '0 0,12 * * *' # Issue + review every 12h; must match route SCHEDULE check
     - cron: '0 4,8,16,20 * * *' # Review only between issue runs
@@ -156,10 +152,12 @@ jobs:
                 DO_ISSUE=true
               fi
               # Real-time review triggers: only process in-repo bot PRs with
-              # reviews/comments from trusted senders (collaborators or the
-              # review bot). This prevents arbitrary commenters from forcing
-              # expensive review-scan runs.
-              if [[ "${EVENT_NAME}" == 'pull_request_review' || "${EVENT_NAME}" == 'pull_request_review_comment' ]]; then
+              # reviews from trusted senders (collaborators or the review bot).
+              # This prevents arbitrary commenters from forcing expensive
+              # review-scan runs. Only pull_request_review:submitted triggers
+              # (not per-comment events) to avoid redundant runs on multi-comment
+              # reviews.
+              if [[ "${EVENT_NAME}" == 'pull_request_review' ]]; then
                 DO_ISSUE=false
                 if [[ "${PR_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then
                   echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -120,6 +120,8 @@ jobs:
           SCHEDULE: '${{ github.event.schedule }}'
           PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
           PR_NUMBER_EVENT: '${{ github.event.pull_request.number }}'
+          PR_HEAD_REPO: '${{ github.event.pull_request.head.repo.full_name }}'
+          PR_BASE_REF: '${{ github.event.pull_request.base.ref }}'
         run: |-
           DO_ISSUE=false
           DO_REVIEW=false
@@ -151,16 +153,40 @@ jobs:
               if [[ "${EVENT_NAME}" == 'schedule' && "${SCHEDULE}" == '0 0,12 * * *' ]]; then
                 DO_ISSUE=true
               fi
-              # Real-time review triggers: only process PRs authored by the
-              # dev-bot so arbitrary PR reviews do not kick off expensive runs.
+              # Real-time review triggers: only process in-repo bot PRs with
+              # reviews/comments from trusted senders (collaborators or the
+              # review bot). This prevents arbitrary commenters from forcing
+              # expensive review-scan runs.
               if [[ "${EVENT_NAME}" == 'pull_request_review' || "${EVENT_NAME}" == 'pull_request_review_comment' ]]; then
                 DO_ISSUE=false
-                if [[ "${PR_AUTHOR}" == "${AUTOFIX_BOT}" ]]; then
-                  DO_REVIEW=true
-                  ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"
-                  echo "🧭 review event on bot PR #${PR_NUMBER_EVENT} → review phase"
-                else
+                if [[ "${PR_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then
                   echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"
+                elif [[ "${PR_HEAD_REPO}" != "${REPO}" ]]; then
+                  echo "🧭 review event ignored: PR is a fork (${PR_HEAD_REPO} != ${REPO})"
+                elif [[ "${PR_BASE_REF}" != "main" ]]; then
+                  echo "🧭 review event ignored: PR targets '${PR_BASE_REF}' not 'main'"
+                else
+                  # Verify the reviewer/commenter is trusted (prompt-injection gate).
+                  sender_permission=''
+                  sender_is_trusted=false
+                  if [[ "${SENDER_LOGIN}" == "${REVIEW_BOT}" ]]; then
+                    sender_is_trusted=true
+                  elif [[ -n "${SENDER_LOGIN}" ]]; then
+                    if sender_permission="$(gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission" --jq '.permission // ""' 2>&1)"; then
+                      case "${sender_permission}" in
+                        admin|maintain|write) sender_is_trusted=true ;;
+                      esac
+                    else
+                      sender_permission=''
+                    fi
+                  fi
+                  if [[ "${sender_is_trusted}" == "true" ]]; then
+                    DO_REVIEW=true
+                    ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"
+                    echo "🧭 review event on bot PR #${PR_NUMBER_EVENT} by ${SENDER_LOGIN} (${sender_permission:-review-bot}) → review phase"
+                  else
+                    echo "🧭 review event ignored: sender '${SENDER_LOGIN}' permission='${sender_permission:-none}' is not trusted"
+                  fi
                 fi
               fi
               if [[ "${EVENT_NAME}" == 'issues' ]]; then
@@ -894,23 +920,28 @@ jobs:
         run: |-
           WORKDIR="$(mktemp -d)"
 
-          # Candidate PRs: all open, in-repo PRs authored by the dev-bot.
-          # A forced PR must still pass these checks.
+          # Candidate PRs: open, same-repo, targeting main, authored by the
+          # dev-bot. A forced PR must still pass all these checks.
           if [[ -n "${FORCED_PR}" ]]; then
             META="$(gh pr view "${FORCED_PR}" --repo "${REPO}" \
-              --json number,state,author,headRefName 2> /dev/null || echo '{}')"
+              --json number,state,author,headRefName,isCrossRepository,baseRefName 2> /dev/null || echo '{}')"
             OK="$(jq -r --arg ab "${AUTOFIX_BOT}" \
               '(((.state // "") == "OPEN")
-                 and ((.author.login // "") == $ab))' <<< "${META}")"
+                 and ((.author.login // "") == $ab)
+                 and ((.isCrossRepository // true) | not)
+                 and ((.baseRefName // "") == "main"))' <<< "${META}")"
             if [[ "${OK}" != "true" ]]; then
-              echo "❌ #${FORCED_PR} is not an open PR owned by ${AUTOFIX_BOT}"
+              echo "❌ #${FORCED_PR} is not an open in-repo main-targeting PR owned by ${AUTOFIX_BOT}"
               echo "has_targets=false" >> "${GITHUB_OUTPUT}"
               exit 0
             fi
             CANDIDATES="${FORCED_PR}"
           else
             gh pr list --repo "${REPO}" --state open --author "${AUTOFIX_BOT}" \
+              --base main \
               --limit 100 --json number,headRefName > "${WORKDIR}/bot-prs.json"
+            # gh pr list with --author on the same repo only returns in-repo PRs,
+            # and --base main limits to main-targeting PRs.
             CANDIDATES="$(jq -r '.[] | .number' "${WORKDIR}/bot-prs.json")"
           fi
 
@@ -966,6 +997,16 @@ jobs:
                 | select((.user.login // "") != $ab)
                 | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb) ] | length' \
               "${WORKDIR}/rc.json")"
+            # Issue-level PR comments (e.g. /review suggestion summaries) are
+            # also actionable feedback. Exclude the bot's own eval markers.
+            N_ISSUE_COMMENTS="$(jq --arg wm "${EFF_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
+              --argjson trust "${TRUSTED_ASSOC}" '
+              [ .[]
+                | select((.created_at // "") > $wm)
+                | select((.user.login // "") != $ab)
+                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.body // "") | test("<!-- autofix-eval ") | not) ] | length' \
+              "${WORKDIR}/ic.json")"
 
             # mergeable: GitHub may report UNKNOWN until it recomputes; treat only
             # an explicit CONFLICTING as a conflict so we never block on UNKNOWN.
@@ -973,12 +1014,12 @@ jobs:
             HAS_CONFLICT='false'
             if [[ "${MERGEABLE}" == "CONFLICTING" ]]; then HAS_CONFLICT='true'; fi
 
-            if [[ "${N_REVIEWS}" -eq 0 && "${N_COMMENTS}" -eq 0 && "${HAS_CONFLICT}" != "true" ]]; then
+            if [[ "${N_REVIEWS}" -eq 0 && "${N_COMMENTS}" -eq 0 && "${N_ISSUE_COMMENTS}" -eq 0 && "${HAS_CONFLICT}" != "true" ]]; then
               echo "✅ #${PR}: nothing new since ${EFF_WM} (conflict=${HAS_CONFLICT})"
               continue
             fi
 
-            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} comment(s) new, conflict=${HAS_CONFLICT}, round=${ROUND}"
+            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} issue comment(s) new, conflict=${HAS_CONFLICT}, round=${ROUND}"
             TARGETS="$(jq -c \
               --arg pr "${PR}" --arg branch "${BRANCH}" --arg issue "${ISSUE}" \
               --arg round "${ROUND}" --arg wm "${EFF_WM}" \
@@ -1020,9 +1061,15 @@ jobs:
       ROUND: '${{ matrix.target.round }}'
       WATERMARK: '${{ matrix.target.watermark }}'
     steps:
-      - name: 'Checkout'
+      # SECURITY: checkout trusted base code first. The PR branch is checked
+      # out later in "Prepare branch and feedback" after the trusted CLI bundle
+      # is built from this base. Without this pin, pull_request_review events
+      # would check out the PR merge ref by default, letting PR-controlled
+      # code influence the secret-bearing address run.
+      - name: 'Checkout trusted base'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
+          ref: '${{ github.event.repository.default_branch }}'
           fetch-depth: 0
           persist-credentials: false
 
@@ -1126,9 +1173,12 @@ jobs:
 
           gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate > "${WORKDIR}/rv.json"
           gh api "repos/${REPO}/pulls/${PR}/comments" --paginate > "${WORKDIR}/rc.json"
+          gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"
 
           # Newest actionable feedback timestamp — stamped into the eval marker so
           # the next scan knows everything up to here has been considered.
+          # Includes reviews, inline review comments, and issue-level PR comments
+          # (excluding the bot's own eval markers).
           NEWEST="$(jq -rs \
             --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
             --argjson trust "${TRUSTED_ASSOC}" '
@@ -1139,7 +1189,11 @@ jobs:
             + (.[1] | map(select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb) | .created_at))
-            | max // ""' "${WORKDIR}/rv.json" "${WORKDIR}/rc.json")"
+            + (.[2] | map(select((.created_at // "") > $wm)
+              | select((.user.login // "") != $ab)
+              | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+              | select((.body // "") | test("<!-- autofix-eval ") | not) | .created_at))
+            | max // ""' "${WORKDIR}/rv.json" "${WORKDIR}/rc.json" "${WORKDIR}/ic.json")"
           [[ -z "${NEWEST}" ]] && NEWEST="${WATERMARK}"
           echo "newest=${NEWEST}" >> "${GITHUB_OUTPUT}"
 
@@ -1172,6 +1226,17 @@ jobs:
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
               | "- \(.path // "?"):\(.line // "?") @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/rc.json"
+            echo
+            echo "## Issue-level comments"
+            jq -r --arg wm "${WATERMARK}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
+              --argjson trust "${TRUSTED_ASSOC}" '
+              .[]
+              | select((.created_at // "") > $wm)
+              | select((.user.login // "") != $ab)
+              | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+              | select((.body // "") | test("<!-- autofix-eval ") | not)
+              | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
+              "${WORKDIR}/ic.json"
           } > "${WORKDIR}/feedback.md"
           echo '--- feedback.md ---'
           cat "${WORKDIR}/feedback.md"

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -98,7 +98,7 @@ blocked, write `<workdir>/failure.md` and do not commit.
 
 Inputs: `--pr`, `--issue`, `<workdir>/feedback.md`, `--conflict`, and `--base`.
 
-The workflow already checked out `autofix/issue-<issue>`. Stay on that branch.
+The workflow already checked out the PR's head branch. Stay on it.
 Read `git diff origin/<base>...HEAD` first, then `<workdir>/feedback.md`.
 
 Classify every feedback point:

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -271,9 +271,11 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).not.toContain(
       "issue_comment:\n    types:\n      - 'created'",
     );
-    // pull_request_review and pull_request_review_comment triggers ARE allowed
-    // (real-time review loop for bot PRs), but the workflow must not accept
-    // arbitrary slash commands from comment bodies.
+    // pull_request_review_comment triggers are NOT used to avoid redundant
+    // runs on multi-comment reviews; only pull_request_review:submitted.
+    expect(workflow).not.toContain(
+      "pull_request_review_comment:\n    types:\n      - 'created'",
+    );
     expect(workflow).not.toContain(
       "COMMENT_BODY: '${{ github.event.comment.body }}'",
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -316,6 +316,33 @@ describe('qwen-autofix workflow', () => {
     );
   });
 
+  it('includes issue-level comments in review feedback scanning', () => {
+    const reviewScanStep =
+      workflow.match(
+        /- name: 'Scan for PRs with new feedback'[\s\S]*?(?=\n[ ]{6}- name: )/,
+      )?.[0] ?? '';
+    // Must count issue-level comments separately from inline review comments.
+    expect(reviewScanStep).toContain('N_ISSUE_COMMENTS=');
+    // Must fetch issue comments for the count (already fetched for markers).
+    expect(reviewScanStep).toContain('ic.json');
+    // Must exclude known non-actionable bot comments.
+    expect(reviewScanStep).toContain('qwen-triage');
+    expect(reviewScanStep).toContain('qwen-review-suggestion-summary');
+    // The "nothing new" gate must check all three feedback sources.
+    expect(reviewScanStep).toContain('"${N_ISSUE_COMMENTS}" -eq 0');
+    // review-address must also fetch ic.json and render issue-level comments.
+    expect(workflow).toContain(
+      'repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"',
+    );
+    expect(workflow).toContain('## Issue-level comments');
+    // NEWEST watermark must consider issue-level comment timestamps.
+    expect(workflow).toContain('.[2] | map(select((.created_at // "")');
+    // Permission API failures in the review-trigger path must be logged.
+    expect(routeStep).toContain(
+      '::warning::Permission API call failed for ${SENDER_LOGIN}',
+    );
+  });
+
   it('keeps forced issue routing bounded to open issues', () => {
     expect(workflow).toContain(
       '--json number,title,body,labels,createdAt,url,state',

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -271,12 +271,9 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).not.toContain(
       "issue_comment:\n    types:\n      - 'created'",
     );
-    expect(workflow).not.toContain(
-      "pull_request_review_comment:\n    types:\n      - 'created'",
-    );
-    expect(workflow).not.toContain(
-      "pull_request_review:\n    types:\n      - 'submitted'",
-    );
+    // pull_request_review and pull_request_review_comment triggers ARE allowed
+    // (real-time review loop for bot PRs), but the workflow must not accept
+    // arbitrary slash commands from comment bodies.
     expect(workflow).not.toContain(
       "COMMENT_BODY: '${{ github.event.comment.body }}'",
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -286,6 +286,36 @@ describe('qwen-autofix workflow', () => {
     expect(routeStep).not.toContain('ROUTE_ISSUE="${ISSUE_NUMBER}"');
   });
 
+  it('gates real-time review triggers on bot author, trusted sender, and in-repo PR', () => {
+    // Route step must check PR author against AUTOFIX_BOT for review events.
+    expect(routeStep).toContain('"${PR_AUTHOR}" != "${AUTOFIX_BOT}"');
+    // Must verify sender is trusted (collaborator or review bot).
+    expect(routeStep).toContain('"${SENDER_LOGIN}" == "${REVIEW_BOT}"');
+    expect(routeStep).toContain(
+      'gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission"',
+    );
+    // Must reject fork PRs and non-main targets.
+    expect(routeStep).toContain('"${PR_HEAD_REPO}" != "${REPO}"');
+    expect(routeStep).toContain('"${PR_BASE_REF}" != "main"');
+    // Must set ROUTE_PR from the event payload.
+    expect(routeStep).toContain(
+      'ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"',
+    );
+    // Review-scan must also verify in-repo and base-ref for forced PRs.
+    const reviewScanStep =
+      workflow.match(
+        /- name: 'Scan for PRs with new feedback'[\s\S]*?(?=\n[ ]{6}- name: )/,
+      )?.[0] ?? '';
+    expect(reviewScanStep).toContain('isCrossRepository');
+    expect(reviewScanStep).toContain('(.baseRefName // "") == "main"');
+    expect(reviewScanStep).toContain('--base main');
+    // review-address must check out trusted base, not PR merge ref.
+    expect(workflow).toContain("'Checkout trusted base'");
+    expect(workflow).toContain(
+      "ref: '${{ github.event.repository.default_branch }}'",
+    );
+  });
+
   it('keeps forced issue routing bounded to open issues', () => {
     expect(workflow).toContain(
       '--json number,title,body,labels,createdAt,url,state',


### PR DESCRIPTION
## What this PR does

Extends the autofix review loop so that every open PR authored by `qwen-code-dev-bot` — not just those on `autofix/issue-*` branches — is automatically scanned for reviewer feedback and patched by the bot. It also adds a real-time `pull_request_review` trigger so the bot responds within minutes instead of waiting up to 4 hours for the next scheduled sweep.

## Why it's needed

PR #6520 is a concrete example: the bot opened a fix PR on a `fix/*` branch, a maintainer left `CHANGES_REQUESTED` with inline comments, but nothing happened. The old `review-scan` job filtered candidates by `startswith("autofix/issue-")`, so any bot PR created on a different branch name was invisible to the feedback loop. The 4-hour-only schedule added further latency even for PRs that were in scope.

## Reviewer Test Plan

### How to verify

1. Inspect the `review-scan` job in `.github/workflows/qwen-autofix.yml` — the candidate query uses `gh pr list --author "${AUTOFIX_BOT}" --base main` with no branch-prefix filter.
2. Inspect the `route` job — `pull_request_review` events are gated on `PR_AUTHOR == AUTOFIX_BOT`, `PR_HEAD_REPO == REPO`, `PR_BASE_REF == main`, and sender write+ permission.
3. Inspect the `review-address` job — the first checkout pins `ref: github.event.repository.default_branch` (trusted base), and the PR branch is only checked out after the trusted CLI bundle is built.
4. Run `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 45 tests pass, including new assertions for the routing contract and issue-level comment scanning.

### Evidence (Before & After)

N/A — this is a GitHub Actions workflow change with no TUI surface. The workflow structural tests (`scripts/tests/qwen-autofix-workflow.test.js`) are the primary verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  ⚠️    |
|  🐧 Linux  |   ✅    |

### Environment (optional)

N/A — workflow YAML and test assertions only.

## Risk & Scope

- Main risk or tradeoff: the real-time trigger runs the full review-address agent on every `pull_request_review` event from a trusted sender on a bot PR. The existing per-PR concurrency group (`cancel-in-progress: false`) serializes bursts, and the MAX_ROUNDS=3 cap prevents infinite loops. The `pull_request_review_comment` trigger was intentionally dropped to avoid redundant runs on multi-comment reviews.
- Not validated / out of scope: the stale-watermark race (multiple queued address runs using scan-time watermarks) was flagged in review but left as-is — changing to `cancel-in-progress: true` risks cancelling a push mid-flight.
- Breaking changes / migration notes: none. Existing `autofix/issue-*` PRs continue to work identically; issue-number extraction from branch names is preserved for those PRs.

## Linked Issues

#6520

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展 autofix review 闭环，使所有由 `qwen-code-dev-bot` 提交的 open PR（不仅限于 `autofix/issue-*` 分支）都能被自动扫描 review 反馈并由 bot 修补。同时添加 `pull_request_review` 实时触发器，使 bot 在几分钟内响应，而不是等待最多 4 小时的下一次定时扫描。

## 为什么需要

PR #6520 是一个具体例子：bot 在 `fix/*` 分支上提了一个修复 PR，维护者留下了 `CHANGES_REQUESTED` 和 inline 评论，但什么也没发生。旧的 `review-scan` 用 `startswith("autofix/issue-")` 过滤候选 PR，所以任何非该前缀分支上的 bot PR 对反馈闭环不可见。4 小时定时扫描即使对在范围内的 PR 也增加了额外延迟。

## 审查者测试计划

### 如何验证

1. 检查 `review-scan` — 候选查询使用 `gh pr list --author "${AUTOFIX_BOT}" --base main`，无分支前缀过滤。
2. 检查 `route` — `pull_request_review` 事件门控检查 `PR_AUTHOR == AUTOFIX_BOT`、`PR_HEAD_REPO == REPO`、`PR_BASE_REF == main` 和 sender write+ 权限。
3. 检查 `review-address` — 第一次 checkout 固定 `ref: github.event.repository.default_branch`（可信基础），PR 分支仅在可信 CLI bundle 构建后才切出。
4. 运行 `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 45 个测试通过，包括路由契约和 issue 级评论扫描的新断言。

### 证据（Before & After）

N/A — 这是一个 GitHub Actions 工作流变更，无 TUI 界面。工作流结构测试是主要验证手段。

### 测试平台

|     OS     | 状态  |
| :--------: | :---: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

N/A — 仅工作流 YAML 和测试断言。

## 风险与范围

- 主要风险/权衡：实时触发器会在每次来自可信 sender 对 bot PR 的 `pull_request_review` 事件上运行完整的 review-address agent。现有的 per-PR 并发组（`cancel-in-progress: false`）串行化突发请求，MAX_ROUNDS=3 上限防止无限循环。`pull_request_review_comment` 触发器被有意移除以避免多评论 review 的冗余运行。
- 未验证/超出范围：stale-watermark 竞态（多个排队的 address 运行使用扫描时水位线）在 review 中被标记但保持现状 — 改为 `cancel-in-progress: true` 有在推送中途取消的风险。
- 破坏性变更/迁移说明：无。现有 `autofix/issue-*` PR 继续完全相同地工作；分支名 issue 号提取对这些 PR 仍然保留。

## 关联 Issue

#6520

</details>
