### PR TITLE
feat(hooks): inject background tasks and cron jobs status into Stop/SubagentStop hook payloads

### DIFF
--- a/packages/core/src/goals/goalLoop.integration.test.ts
+++ b/packages/core/src/goals/goalLoop.integration.test.ts
@@ -56,6 +56,8 @@ function makeStopInput(lastAssistantText: string): StopInput {
     timestamp: new Date().toISOString(),
     stop_hook_active: true,
     last_assistant_message: lastAssistantText,
+    background_tasks: [],
+    crons: [],
   };
 }
 

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -410,6 +410,125 @@ describe('HookEventHandler', () => {
       expect(result.success).toBe(true);
       expect(result.finalOutput).toBeUndefined();
     });
+
+    it('should inject background_tasks and crons into Stop input', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      const mockRegistry = {
+        getAll: vi.fn().mockReturnValue([
+          {
+            id: 'bg-1',
+            status: 'running',
+            subagentType: 'Explorer',
+            startTime: 1720000000000,
+            description: 'test task',
+          },
+        ]),
+      };
+      const mockScheduler = {
+        list: vi.fn().mockReturnValue([
+          {
+            id: 'cron-1',
+            cronExpr: '0 */2 * * *',
+            prompt: 'check status',
+            recurring: true,
+            fireAtMs: 1720007200000,
+            lastFiredAt: 1720000000000,
+          },
+        ]),
+      };
+      const configWithMocks = mockConfig as unknown as {
+        getBackgroundTaskRegistry: () => typeof mockRegistry;
+        getCronScheduler: () => typeof mockScheduler;
+      };
+      configWithMocks.getBackgroundTaskRegistry = () => mockRegistry;
+      configWithMocks.getCronScheduler = () => mockScheduler;
+
+      // Re-create handler with updated config mocks
+      const handler = new HookEventHandler(
+        mockConfig,
+        mockHookPlanner,
+        mockHookRunner,
+        mockHookAggregator,
+        mockSessionHooksManager,
+      );
+
+      await handler.fireStopEvent(true, 'msg');
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as {
+        background_tasks: Array<{
+          id: string;
+          status: string;
+          agent_type: string;
+        }>;
+        crons: Array<{ id: string; schedule: string; prompt: string }>;
+      };
+
+      expect(input.background_tasks).toHaveLength(1);
+      expect(input.background_tasks[0].id).toBe('bg-1');
+      expect(input.background_tasks[0].status).toBe('running');
+      expect(input.background_tasks[0].agent_type).toBe('Explorer');
+
+      expect(input.crons).toHaveLength(1);
+      expect(input.crons[0].id).toBe('cron-1');
+      expect(input.crons[0].schedule).toBe('0 */2 * * *');
+      expect(input.crons[0].prompt).toBe('check status');
+    });
+
+    it('should return empty arrays when registry/scheduler unavailable', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      // Config without registry/scheduler methods
+      const bareConfig = {
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
+        getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
+        getWorkingDir: vi.fn().mockReturnValue('/test/cwd'),
+      } as unknown as Config;
+
+      const handler = new HookEventHandler(
+        bareConfig,
+        mockHookPlanner,
+        mockHookRunner,
+        mockHookAggregator,
+        mockSessionHooksManager,
+      );
+
+      await handler.fireStopEvent(true, 'msg');
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as {
+        background_tasks: unknown[];
+        crons: unknown[];
+      };
+
+      expect(input.background_tasks).toEqual([]);
+      expect(input.crons).toEqual([]);
+    });
   });
 
   describe('fireSessionStartEvent', () => {

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -52,11 +52,14 @@ import type {
   InstructionsLoadedInput,
   InstructionMemoryType,
   InstructionLoadReason,
+  BackgroundTaskInfo,
+  CronJobInfo,
 } from './types.js';
 import { HookPhase, PermissionMode } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { logHookCall } from '../telemetry/loggers.js';
 import { HookCallEvent } from '../telemetry/types.js';
+import type { CronJob } from '../services/cronScheduler.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
@@ -100,6 +103,50 @@ export class HookEventHandler {
    */
   getMessagesProvider(): MessagesProvider | undefined {
     return this.messagesProvider;
+  }
+
+  /**
+   * Snapshot of current background tasks for hook payloads.
+   * Non-blocking: reads registry state synchronously.
+   */
+  private getBackgroundTaskSnapshot(): BackgroundTaskInfo[] {
+    try {
+      const registry = this.config.getBackgroundTaskRegistry();
+      return registry.getAll().map((task) => ({
+        id: task.id,
+        status: task.status,
+        agent_type: task.subagentType ?? 'unknown',
+        started_at: new Date(task.startTime).toISOString(),
+        description: task.description,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Snapshot of current cron jobs for hook payloads.
+   * Non-blocking: reads scheduler state synchronously.
+   */
+  private getCronJobSnapshot(): CronJobInfo[] {
+    try {
+      const scheduler = this.config.getCronScheduler();
+      return scheduler.list().map((job: CronJob) => ({
+        id: job.id,
+        schedule: job.cronExpr,
+        prompt: job.prompt,
+        recurring: job.recurring,
+        next_run: job.fireAtMs
+          ? new Date(job.fireAtMs).toISOString()
+          : undefined,
+        last_run: job.lastFiredAt
+          ? new Date(job.lastFiredAt).toISOString()
+          : undefined,
+        enabled: true,
+      }));
+    } catch {
+      return [];
+    }
   }
 
   /**
@@ -196,6 +243,8 @@ export class HookEventHandler {
       ...this.createBaseInput(HookEventName.Stop),
       stop_hook_active: stopHookActive,
       last_assistant_message: lastAssistantMessage,
+      background_tasks: this.getBackgroundTaskSnapshot(),
+      crons: this.getCronJobSnapshot(),
       ...contextUsage,
     };
 
@@ -546,6 +595,8 @@ export class HookEventHandler {
       agent_type: agentType,
       agent_transcript_path: agentTranscriptPath,
       last_assistant_message: lastAssistantMessage,
+      background_tasks: this.getBackgroundTaskSnapshot(),
+      crons: this.getCronJobSnapshot(),
     };
 
     // Pass agentType as context for matcher filtering

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -5,6 +5,7 @@
  */
 import type { ChildProcess } from 'child_process';
 import type { ToolArtifact } from '../tools/tools.js';
+import type { TaskStatus } from '../agents/tasks/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
@@ -924,11 +925,37 @@ export interface ContextUsageData {
 }
 
 /**
+ * Background task info for hook payloads
+ */
+export interface BackgroundTaskInfo {
+  id: string;
+  status: TaskStatus;
+  agent_type: string;
+  started_at: string;
+  description?: string;
+}
+
+/**
+ * Cron job info for hook payloads
+ */
+export interface CronJobInfo {
+  id: string;
+  schedule: string;
+  prompt: string;
+  recurring: boolean;
+  next_run?: string;
+  last_run?: string;
+  enabled: boolean;
+}
+
+/**
  * Stop hook input
  */
 export interface StopInput extends HookInput, Partial<ContextUsageData> {
   stop_hook_active: boolean;
   last_assistant_message: string;
+  background_tasks: BackgroundTaskInfo[];
+  crons: CronJobInfo[];
 }
 
 /**
@@ -1102,6 +1129,8 @@ export interface SubagentStopInput extends HookInput {
   agent_type: AgentType | string;
   agent_transcript_path: string;
   last_assistant_message: string;
+  background_tasks: BackgroundTaskInfo[];
+  crons: CronJobInfo[];
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Extends the `StopInput` and `SubagentStopInput` hook interfaces with `background_tasks` and `crons` fields, and wires existing `BackgroundTaskRegistry` and `CronScheduler` snapshots into `fireStopEvent` and `fireSubagentStopEvent`. Hook scripts receiving the Stop/SubagentStop payload can now observe async work state at agent stop time. Two new snapshot methods (`getBackgroundTaskSnapshot` and `getCronJobSnapshot`) read registry state synchronously and return empty arrays on failure, ensuring data collection is non-blocking and never delays the stop hook response. Also updates `goalLoop.integration.test.ts` to satisfy the extended `StopInput` type.

## Why it's needed

Claude Code's Stop/SubagentStop hook payloads include `background_tasks` and `crons` fields, allowing hook scripts to get async work status at agent stop time. This is valuable for status reports, cleanup logic based on running background tasks, logging/monitoring of complete work state snapshots, and decision support based on cron job status. Qwen Code already has `BackgroundTaskRegistry` and `CronCreate/List/Delete` tools — this PR simply connects existing registry queries into hook input construction.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/core && npx vitest run src/hooks/hookEventHandler.test.ts` — confirm 129 tests pass including the two new background_tasks/crons injection tests
2. Run `npm run typecheck` — confirm no type errors
3. Inspect the Stop/SubagentStop hook stdin payload by configuring a command hook on the Stop event and printing the received JSON — verify `background_tasks` and `crons` arrays are present (empty `[]` when no active tasks/crons)

### Evidence (Before & After)

N/A — non-user-visible change, verified by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅    |
| 🪟 Windows |  ⚠️    |
|  🐧 Linux  |  ⚠️    |

## Risk & Scope

- Main risk or tradeoff: Snapshot methods read two registries synchronously; guarded by try/catch so failure returns empty arrays and never blocks the stop hook.
- Not validated / out of scope: Windows and Linux CI runs not yet completed; SessionStart injection (suggested in triage) deferred to a follow-up.
- Breaking changes / migration notes: None — new fields are always-present arrays, existing hook scripts that ignore them are unaffected.

## Linked Issues

Closes #6529

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展了 `StopInput` 和 `SubagentStopInput` hook 接口，新增 `background_tasks` 和 `crons` 字段，并将已有的 `BackgroundTaskRegistry` 和 `CronScheduler` 快照接入 `fireStopEvent` 和 `fireSubagentStopEvent`。接收 Stop/SubagentStop payload 的 hook 脚本现在可以在 agent 停止时观察异步工作状态。两个新的快照方法（`getBackgroundTaskSnapshot` 和 `getCronJobSnapshot`）同步读取注册表状态，失败时返回空数组，确保数据收集是非阻塞的，不会延迟 stop hook 响应。同时更新了 `goalLoop.integration.test.ts` 以满足扩展后的 `StopInput` 类型要求。

## 为什么需要这个 PR

Claude Code 的 Stop/SubagentStop hook payload 包含 `background_tasks` 和 `crons` 字段，允许 hook 脚本在 agent 停止时获取异步工作状态。这对于生成状态报告、根据运行中的后台任务决定清理逻辑、记录完整工作状态快照、以及根据 cron 任务状态做决策支持都有价值。Qwen Code 已经有 `BackgroundTaskRegistry` 和 `CronCreate/List/Delete` 工具——本 PR 只是将已有的注册表查询接入 hook 输入构造。

## Reviewer 测试计划

### 如何验证

1. 运行 `cd packages/core && npx vitest run src/hooks/hookEventHandler.test.ts`——确认 129 个测试全部通过，包括两个新增的 background_tasks/crons 注入测试
2. 运行 `npm run typecheck`——确认无类型错误
3. 通过在 Stop 事件上配置 command hook 并打印收到的 JSON 来检查 Stop/SubagentStop hook stdin payload——验证 `background_tasks` 和 `crons` 数组始终存在（无活动任务/cron 时为空数组 `[]`）

### 证据（Before & After）

N/A——非用户可见变更，由单元测试验证。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

## 风险与范围

- 主要风险或权衡：快照方法同步读取两个注册表；由 try/catch 保护，失败时返回空数组，永远不会阻塞 stop hook
- 未验证/超出范围：Windows 和 Linux CI 运行尚未完成；SessionStart 注入（triage 中建议的）推迟到后续 PR
- 破坏性变更/迁移说明：无——新字段是始终存在的数组，忽略它们的已有 hook 脚本不受影响

## 关联 Issue

Closes #6529

</details>
