### PR TITLE
feat(hooks): inject background tasks and cron jobs status into Stop/SubagentStop hook payloads

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2146,6 +2146,22 @@ export class Config {
                   (input['stop_hook_active'] as boolean) || false,
                   (input['last_assistant_message'] as string) || '',
                   contextUsageData,
+                  this.backgroundTaskRegistry.getAll().map(t => ({
+                    id: t.id,
+                    status: t.status,
+                    description: t.description,
+                    subagentType: t.subagentType,
+                  })),
+                  this.isCronEnabled()
+                    ? this.getCronScheduler().list().map(j => ({
+                        id: j.id,
+                        cronExpr: j.cronExpr,
+                        prompt: j.prompt,
+                        recurring: j.recurring,
+                        durable: j.durable || false,
+                        status: 'active',
+                      }))
+                    : undefined,
                   signal,
                 );
                 result = stopResult.finalOutput
@@ -2246,6 +2262,22 @@ export class Config {
                   (input['stop_hook_active'] as boolean) || false,
                   (input['permission_mode'] as PermissionMode) ||
                     PermissionMode.Default,
+                  this.backgroundTaskRegistry.getAll().map(t => ({
+                    id: t.id,
+                    status: t.status,
+                    description: t.description,
+                    subagentType: t.subagentType,
+                  })),
+                  this.isCronEnabled()
+                    ? this.getCronScheduler().list().map(j => ({
+                        id: j.id,
+                        cronExpr: j.cronExpr,
+                        prompt: j.prompt,
+                        recurring: j.recurring,
+                        durable: j.durable || false,
+                        status: 'active',
+                      }))
+                    : undefined,
                   signal,
                 );
                 break;

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -190,6 +190,8 @@ export class HookEventHandler {
     stopHookActive: boolean = false,
     lastAssistantMessage: string = '',
     contextUsage?: ContextUsageData,
+    backgroundTasks?: StopInput['background_tasks'],
+    crons?: StopInput['crons'],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: StopInput = {
@@ -197,6 +199,8 @@ export class HookEventHandler {
       stop_hook_active: stopHookActive,
       last_assistant_message: lastAssistantMessage,
       ...contextUsage,
+      ...(backgroundTasks ? { background_tasks: backgroundTasks } : {}),
+      ...(crons ? { crons } : {}),
     };
 
     return this.executeHooks(HookEventName.Stop, input, undefined, signal);
@@ -536,6 +540,8 @@ export class HookEventHandler {
     lastAssistantMessage: string,
     stopHookActive: boolean,
     permissionMode: PermissionMode,
+    backgroundTasks?: SubagentStopInput['background_tasks'],
+    crons?: SubagentStopInput['crons'],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: SubagentStopInput = {
@@ -546,6 +552,8 @@ export class HookEventHandler {
       agent_type: agentType,
       agent_transcript_path: agentTranscriptPath,
       last_assistant_message: lastAssistantMessage,
+      ...(backgroundTasks ? { background_tasks: backgroundTasks } : {}),
+      ...(crons ? { crons } : {}),
     };
 
     // Pass agentType as context for matcher filtering

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -205,12 +205,16 @@ export class HookSystem {
     stopHookActive: boolean = false,
     lastAssistantMessage: string = '',
     contextUsage?: ContextUsageData,
+    backgroundTasks?: StopInput['background_tasks'],
+    crons?: StopInput['crons'],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     return this.hookEventHandler.fireStopEvent(
       stopHookActive,
       lastAssistantMessage,
       contextUsage,
+      backgroundTasks,
+      crons,
       signal,
     );
   }
@@ -411,6 +415,8 @@ export class HookSystem {
     lastAssistantMessage: string,
     stopHookActive: boolean,
     permissionMode: PermissionMode,
+    backgroundTasks?: SubagentStopInput['background_tasks'],
+    crons?: SubagentStopInput['crons'],
     signal?: AbortSignal,
   ): Promise<DefaultHookOutput | undefined> {
     const result = await this.hookEventHandler.fireSubagentStopEvent(
@@ -420,6 +426,8 @@ export class HookSystem {
       lastAssistantMessage,
       stopHookActive,
       permissionMode,
+      backgroundTasks,
+      crons,
       signal,
     );
     return result.finalOutput

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -929,6 +929,22 @@ export interface ContextUsageData {
 export interface StopInput extends HookInput, Partial<ContextUsageData> {
   stop_hook_active: boolean;
   last_assistant_message: string;
+  /** Snapshot of running background agent tasks at the time the stop event fires. */
+  background_tasks?: Array<{
+    id: string;
+    status: string;
+    description: string;
+    subagentType?: string;
+  }>;
+  /** Snapshot of active cron jobs at the time the stop event fires. */
+  crons?: Array<{
+    id: string;
+    cronExpr: string;
+    prompt: string;
+    recurring: boolean;
+    durable: boolean;
+    status: string;
+  }>;
 }
 
 /**
@@ -1102,6 +1118,22 @@ export interface SubagentStopInput extends HookInput {
   agent_type: AgentType | string;
   agent_transcript_path: string;
   last_assistant_message: string;
+  /** Snapshot of running background agent tasks at the time the subagent stop event fires. */
+  background_tasks?: Array<{
+    id: string;
+    status: string;
+    description: string;
+    subagentType?: string;
+  }>;
+  /** Snapshot of active cron jobs at the time the subagent stop event fires. */
+  crons?: Array<{
+    id: string;
+    cronExpr: string;
+    prompt: string;
+    recurring: boolean;
+    durable: boolean;
+    status: string;
+  }>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #6529 — Injects background tasks and cron jobs status into `Stop` and `SubagentStop` hook event inputs, so hook scripts can be aware of async work in progress when the agent stops.

## Changes

### hooks/types.ts
- Added optional `background_tasks` and `crons` fields to `StopInput`
- Added the same optional fields to `SubagentStopInput`

### hooks/hookEventHandler.ts
- Threaded the new params through `fireStopEvent()` (after `contextUsageData`, before `signal`)
- Threaded the new params through `fireSubagentStopEvent()` (after `permissionMode`, before `signal`)

### hooks/hookSystem.ts
- Passed the new params through to `hookEventHandler`

### config/config.ts
- At both call sites, injected actual data from `BackgroundTaskRegistry.getAll()` and `getCronScheduler().list()`
- Cron injection gated on `isCronEnabled()` to avoid throws when cron is disabled

## Verification

- The infrastructure existed on both sides but was never connected
- No existing callers affected — new params are optional
- Tests continue to pass with the extended interface