### PR TITLE
fix(cli): fixed-width elapsed time below one minute to stop status-line jitter

### DIFF
--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -72,7 +72,7 @@ describe('<LoadingIndicator />', () => {
     const output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Loading...');
-    expect(output).toContain('5s');
+    expect(output).toContain('5.0s');
     expect(output).toContain('esc to cancel');
   });
 
@@ -89,7 +89,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain('10s');
+    expect(output).not.toContain('10.0s');
   });
 
   it('should display the currentLoadingPhrase correctly', () => {
@@ -102,6 +102,22 @@ describe('<LoadingIndicator />', () => {
       StreamingState.Responding,
     );
     expect(lastFrame()).toContain('Processing data...');
+  });
+
+  it('should keep a fixed-width time string across 0.5s ticks below one minute (#6402)', () => {
+    // The timer ticks at 0.5s resolution; without the fixed decimal the
+    // string alternates between "1s" and "1.5s" and the status line jitters.
+    const half = renderWithContext(
+      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={1.5} />,
+      StreamingState.Responding,
+    );
+    expect(half.lastFrame()).toContain('(1.5s · esc to cancel)');
+
+    const whole = renderWithContext(
+      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={2} />,
+      StreamingState.Responding,
+    );
+    expect(whole.lastFrame()).toContain('(2.0s · esc to cancel)');
   });
 
   it('should display the elapsedTime correctly when Responding', () => {
@@ -156,7 +172,7 @@ describe('<LoadingIndicator />', () => {
     let output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Now Responding');
-    expect(output).toContain('(2s · esc to cancel)');
+    expect(output).toContain('(2.0s · esc to cancel)');
 
     // Transition to WaitingForConfirmation
     rerender(
@@ -171,7 +187,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain('15s');
+    expect(output).not.toContain('15.0s');
 
     // Transition back to Idle
     rerender(
@@ -211,7 +227,7 @@ describe('<LoadingIndicator />', () => {
       // Check for single line output
       expect(output?.includes('\n')).toBe(false);
       expect(output).toContain('Loading...');
-      expect(output).toContain('(5s · esc to cancel)');
+      expect(output).toContain('(5.0s · esc to cancel)');
       expect(output).toContain('Right');
     });
 
@@ -233,8 +249,8 @@ describe('<LoadingIndicator />', () => {
       expect(lines).toHaveLength(3);
       if (lines) {
         expect(lines[0]).toContain('Loading...');
-        expect(lines[0]).not.toContain('5s');
-        expect(lines[1]).toContain('5s');
+        expect(lines[0]).not.toContain('5.0s');
+        expect(lines[1]).toContain('5.0s');
         expect(lines[2]).toContain('Right');
       }
     });
@@ -267,7 +283,7 @@ describe('<LoadingIndicator />', () => {
       const output = lastFrame();
       expect(output).toContain('↓ 847 tokens');
       expect(output).not.toContain('↑');
-      expect(output).toContain('5s');
+      expect(output).toContain('5.0s');
       expect(output).toContain('esc to cancel');
     });
 
@@ -320,7 +336,7 @@ describe('<LoadingIndicator />', () => {
         120,
       );
       const output = lastFrame();
-      expect(output).toContain('(5s · ↓ 5.4k tokens · esc to cancel)');
+      expect(output).toContain('(5.0s · ↓ 5.4k tokens · esc to cancel)');
     });
 
     it('should not show response tokens/sec by default', () => {

--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -118,6 +118,13 @@ describe('<LoadingIndicator />', () => {
       StreamingState.Responding,
     );
     expect(whole.lastFrame()).toContain('(2.0s · esc to cancel)');
+
+    // Timer start / reset publishes exactly 0.
+    const zero = renderWithContext(
+      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={0} />,
+      StreamingState.Responding,
+    );
+    expect(zero.lastFrame()).toContain('(0.0s · esc to cancel)');
   });
 
   it('should display the elapsedTime correctly when Responding', () => {

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -90,8 +90,12 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
   const showTokens = !isNarrow && outputTokens > 0;
   const tokenArrow = isReceivingContent ? '↓' : '↑';
 
+  // Fixed one-decimal width below the minute mark so the 0.5s-resolution
+  // ticks ("1s" vs "1.5s") don't shift the rest of the status line (#6402).
   const timeStr =
-    elapsedTime < 60 ? `${elapsedTime}s` : formatDuration(elapsedTime * 1000);
+    elapsedTime < 60
+      ? `${elapsedTime.toFixed(1)}s`
+      : formatDuration(elapsedTime * 1000);
 
   const tokenStr = showTokens
     ? ` · ${tokenArrow} ${formatTokenCount(outputTokens)} tokens`

--- a/packages/cli/src/ui/components/__snapshots__/LoadingIndicator.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/LoadingIndicator.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<LoadingIndicator /> > should truncate long primary text instead of wrapping 1`] = `
-"  MockResponding This is an extremely long loading phrase that should be truncated in (5s · esc to
-  Spinner                                                                            cancel)"
+"  MockResponding This is an extremely long loading phrase that should be truncated i (5.0s · esc to
+  Spinner                                                                           cancel)"
 `;


### PR DESCRIPTION
## What this PR does

Renders the elapsed time in the loading status line with a fixed one-decimal width while it is below one minute (`0.5s`, `1.0s`, `1.5s`, …). The at-or-above-one-minute path (`1m`, `2m 5s`, …) is unchanged.

## Why it's needed

The timer ticks at 0.5s resolution, so the string alternated between forms like `1s` and `1.5s` — the ±2-character width change shifted everything after it (`· esc to cancel`, token counts) twice a second, making the status line distracting and hard to read. This is the first of the two approaches suggested in the issue triage (fixed decimal keeps the sub-second precision; rounding to whole seconds would drop it).

## Reviewer Test Plan

### How to verify

Start any request that takes a few seconds and watch the status line during the first minute: the time should render as `1.0s`, `1.5s`, `2.0s`, … with constant width, so the `· esc to cancel` suffix and token counters no longer jump horizontally. Past one minute the display switches to `1m`, `1m 30s` exactly as before.

### Evidence (Before & After)

Before (main): status line alternates `(1.5s · esc to cancel)` / `(2s · esc to cancel)` — suffix shifts left/right every tick.

After (this branch, captured from a real tmux session against a mock provider at 0.5s intervals):

```
  ... Fiddling with the character creation screen... (1.5s · esc to cancel)
  .   Fiddling with the character creation screen... (2.5s · esc to cancel)
  ... Fiddling with the character creation screen... (4.0s · esc to cancel)
  .   Fiddling with the character creation screen... (4.5s · esc to cancel)
```

All frames render the time at the same width; the suffix stays put.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` (tsx from source) driven in tmux against a local mock OpenAI-compatible server with delayed responses; unit tests via `npx vitest run src/ui/components/LoadingIndicator.test.tsx` (28 pass).

## Risk & Scope

- Main risk or tradeoff: purely cosmetic string-format change in one component; sub-minute display gains a `.0` on whole seconds.
- Not validated / out of scope: web-shell has its own timer rendering and is unaffected; no change to timer resolution or the ≥1m format.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6402
