### PR TITLE
Stop repeated subagent tool-call loops

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -34,9 +34,12 @@ import {
 import {
   createDuplicateProviderToolCallResponse,
   findRepeatedDuplicateProviderToolCall,
+  GeminiEventType,
   markDuplicateProviderToolCallResponseSent,
+  type ServerGeminiStreamEvent,
   type ToolCallRequestInfo,
 } from '../../core/turn.js';
+import { LoopDetectionService } from '../../services/loopDetectionService.js';
 import {
   CoreToolScheduler,
   type ToolCall,
@@ -88,6 +91,8 @@ import { matchesMcpPattern } from '../../permissions/rule-parser.js';
 import { ToolNames } from '../../tools/tool-names.js';
 import { DEFAULT_QWEN_MODEL } from '../../config/models.js';
 import { type ContextState, templateString } from './agent-headless.js';
+import { getResponseText } from '../../utils/partUtils.js';
+import { getThoughtSummary } from '../../utils/thoughtUtils.js';
 import {
   isTeammate,
   getTeammateContext,
@@ -758,6 +763,19 @@ export class AgentCore {
     // provider id would keep deterministic providers in a tool-result loop.
     const duplicateProviderToolCallResponseIds = new Set<string>();
     let stickyMaxOutputTokens: number | undefined;
+    const loopDetector = new LoopDetectionService(this.runtimeContext);
+    loopDetector.reset(
+      `${this.runtimeContext.getSessionId()}#${this.subagentId}`,
+    );
+    const checkSubagentLoop = (event: ServerGeminiStreamEvent): boolean => {
+      if (loopDetector.checkAlwaysOnSafeties(event)) {
+        return true;
+      }
+      return (
+        !this.runtimeContext.getSkipLoopDetection() &&
+        loopDetector.addAndCheckHeuristicLoops(event)
+      );
+    };
 
     while (true) {
       // Check abort before starting a new round — prevents unnecessary API
@@ -821,6 +839,7 @@ export class AgentCore {
           undefined;
         let currentResponseId: string | undefined = undefined;
         let wasOutputTruncated = false;
+        let loopDetectedInStream = false;
 
         for await (const streamEvent of responseStream) {
           if (roundAbortController.signal.aborted) {
@@ -835,6 +854,11 @@ export class AgentCore {
           // retry does not inherit stale data (e.g. wasOutputTruncated) from a
           // previous attempt that may have hit MAX_TOKENS.
           if (streamEvent.type === 'retry') {
+            if (checkSubagentLoop({ type: GeminiEventType.Retry })) {
+              terminateMode = AgentTerminateMode.LOOP_DETECTED;
+              loopDetectedInStream = true;
+              break;
+            }
             if (streamEvent.maxOutputTokensEscalated !== undefined) {
               stickyMaxOutputTokens = streamEvent.maxOutputTokensEscalated;
             }
@@ -866,7 +890,8 @@ export class AgentCore {
             if (resp.responseId) {
               currentResponseId = resp.responseId;
             }
-            if (resp.functionCalls) functionCalls.push(...resp.functionCalls);
+            const chunkFunctionCalls = resp.functionCalls ?? [];
+            functionCalls.push(...chunkFunctionCalls);
             if (
               resp.candidates?.[0]?.finishReason === FinishReason.MAX_TOKENS
             ) {
@@ -889,7 +914,79 @@ export class AgentCore {
                 });
             }
             if (resp.usageMetadata) lastUsage = resp.usageMetadata;
+
+            const thoughtSummary = getThoughtSummary(resp);
+            if (
+              thoughtSummary &&
+              checkSubagentLoop({
+                type: GeminiEventType.Thought,
+                value: thoughtSummary,
+              })
+            ) {
+              terminateMode = AgentTerminateMode.LOOP_DETECTED;
+              loopDetectedInStream = true;
+              break;
+            }
+
+            const responseText = getResponseText(resp);
+            if (
+              responseText &&
+              checkSubagentLoop({
+                type: GeminiEventType.Content,
+                value: responseText,
+              })
+            ) {
+              terminateMode = AgentTerminateMode.LOOP_DETECTED;
+              loopDetectedInStream = true;
+              break;
+            }
+
+            for (const fc of chunkFunctionCalls) {
+              const toolName = String(fc.name);
+              if (
+                checkSubagentLoop({
+                  type: GeminiEventType.ToolCallRequest,
+                  value: {
+                    callId: fc.id ?? `${toolName}-${Date.now()}`,
+                    providerCallId: getProviderToolCallId(fc),
+                    name: toolName,
+                    args: (fc.args ?? {}) as Record<string, unknown>,
+                    isClientInitiated: false,
+                    prompt_id: promptId,
+                    response_id: currentResponseId,
+                    wasOutputTruncated,
+                  },
+                })
+              ) {
+                terminateMode = AgentTerminateMode.LOOP_DETECTED;
+                loopDetectedInStream = true;
+                break;
+              }
+            }
+            if (loopDetectedInStream) {
+              break;
+            }
+
+            const finishReason = resp.candidates?.[0]?.finishReason;
+            if (
+              finishReason &&
+              checkSubagentLoop({
+                type: GeminiEventType.Finished,
+                value: {
+                  reason: finishReason,
+                  usageMetadata: resp.usageMetadata,
+                },
+              })
+            ) {
+              terminateMode = AgentTerminateMode.LOOP_DETECTED;
+              loopDetectedInStream = true;
+              break;
+            }
           }
+        }
+
+        if (loopDetectedInStream) {
+          break;
         }
 
         if (roundText || roundThoughtText) {

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1288,6 +1288,79 @@ describe('subagent.ts', () => {
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.LOOP_DETECTED);
       });
 
+      it('should stop consecutive identical tool calls with fresh ids', async () => {
+        const listDirectoryToolDef: FunctionDeclaration = {
+          name: 'list_directory',
+          description: 'Lists a directory',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([listDirectoryToolDef]),
+          getTool: vi.fn().mockReturnValue(undefined),
+        });
+        const toolConfig: ToolConfig = { tools: ['list_directory'] };
+        const missingPath = '/workspace/project/missing-directory';
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([
+            ...Array.from({ length: 5 }, (_, index) => [
+              {
+                id: `call_${index + 1}`,
+                name: 'list_directory',
+                args: { path: missingPath },
+              },
+            ]),
+            'stop',
+          ]),
+        );
+
+        const listDirectoryInvocation = {
+          params: { path: missingPath },
+          getDescription: vi.fn().mockReturnValue('List directory'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          execute: vi.fn().mockResolvedValue({
+            llmContent:
+              'Error: ENOENT: no such file or directory, scandir ' +
+              missingPath,
+            returnDisplay: 'Directory not found',
+          }),
+        };
+        const listDirectoryTool = {
+          name: 'list_directory',
+          displayName: 'List Directory',
+          description: 'List directory contents',
+          kind: 'READ' as const,
+          schema: listDirectoryToolDef,
+          build: vi.fn().mockImplementation(() => listDirectoryInvocation),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        } as unknown as AnyDeclarativeTool;
+        vi.mocked(
+          (config.getToolRegistry() as unknown as ToolRegistry).getTool,
+        ).mockImplementation((name: string) =>
+          name === 'list_directory' ? listDirectoryTool : undefined,
+        );
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(5);
+        expect(listDirectoryInvocation.execute).toHaveBeenCalledTimes(4);
+        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.LOOP_DETECTED);
+      });
+
       it('should ignore duplicate provider tool-call ids already present in chat history', async () => {
         const listFilesToolDef: FunctionDeclaration = {
           name: 'list_files',


### PR DESCRIPTION
## What this PR does

This PR wires subagent reasoning loops into the same loop-detection pipeline used by the main agent. Subagents now feed retry, thought, content, tool-call request, and finish events from the model stream into `LoopDetectionService`, and stop with `LOOP_DETECTED` before executing another repeated tool batch once a loop is detected.

It also adds a regression test for the case where the model keeps requesting the same `list_directory` arguments while changing the tool call ID every turn.

## Why it's needed

Previously, subagents executed through `AgentTool.execute()` → `AgentHeadless.execute()` → `AgentCore.runReasoningLoop()` without the main agent's `LoopDetectionService` integration. The only relevant guard in that path was duplicate provider tool-call ID detection, which does not catch semantically identical calls with fresh IDs.

That allowed built-in subagents such as Explore to repeatedly execute the same failing read-only tool call, consuming time and tokens until another limit interrupted the session. This change gives subagents the same always-on and heuristic loop-detection semantics as the main agent.

## Reviewer Test Plan

### How to verify

Verify a subagent repeatedly receiving the same read-only tool call while the model changes the tool call ID each turn. The expected behavior is that the subagent stops with `LOOP_DETECTED` after the repeated calls reach the loop-detection threshold, and does not keep executing the same failing tool call indefinitely.

Validated locally with:

```bash
git diff --check
npx prettier --check packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts
cd packages/core && npx vitest run src/agents/runtime/agent-headless.test.ts -t "should stop consecutive identical tool calls with fresh ids"
npm run build
npm run typecheck
npm run lint
```

### Evidence (Before & After)

tmux E2E reproduced the reported pattern using a real interactive CLI session and a mock OpenAI-compatible server:

- parent model calls `agent`
- Explore subagent repeatedly receives the same `list_directory` params
- each repeated request uses a fresh tool call ID
- the updated bundle stops the subagent with `LOOP_DETECTED` after 5 Explore model calls

![tmux loop detected](https://raw.githubusercontent.com/yiliang114/img-host/main/qwen-code/issue-6505/tmux-loop-detected-20260708.png)

![mock OpenAI loop count](https://raw.githubusercontent.com/yiliang114/img-host/main/qwen-code/issue-6505/mock-openai-loop-count-20260708.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js v22.22.0, local `npm run bundle`, tmux real-user test harness, mock OpenAI-compatible server.

## Risk & Scope

- Main risk or tradeoff: loop detection can now stop a subagent earlier when it repeats identical tool calls. This is intentional and matches the main agent safety behavior.
- Not validated / out of scope: manual tmux validation was only run on macOS. A separate daemon/ACP end-to-end run was not performed, but the fix is in the shared subagent `AgentCore` path.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6505

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 将子智能体推理循环接入与主智能体一致的 loop detection 机制。子智能体现在会把模型流中的 retry、thought、content、tool-call request 和 finish 事件送入 `LoopDetectionService`，一旦检测到重复工具调用等循环模式，会以 `LOOP_DETECTED` 停止，而不是继续执行下一批重复工具调用。

同时新增了一个回归测试，覆盖模型每次使用不同 tool call ID，但持续请求同一个 `list_directory` 参数的场景。

## Why it's needed

此前子智能体路径会经过 `AgentTool.execute()` → `AgentHeadless.execute()` → `AgentCore.runReasoningLoop()`，但这条路径没有接入主 agent 使用的 `LoopDetectionService`。因此模型只要每次换一个 fresh tool call ID，就能绕过 provider duplicate ID 检测，持续执行语义相同的失败工具调用。

这个问题会导致 Explore 等内置子智能体在缺少 `maxTurns` 的情况下无限循环，持续消耗 token 和时间。修复后，子智能体会复用主 agent 的 always-on 和 heuristic loop detection 语义。

## Reviewer Test Plan

### How to verify

可以验证一个子智能体持续收到同一个 read-only tool call，但 tool call ID 每次不同的场景。预期行为是子智能体在重复调用达到 loop detection 阈值后停止，并向父 agent 返回 `LOOP_DETECTED`，不会继续执行无限工具调用。

本地已运行：

```bash
git diff --check
npx prettier --check packages/core/src/agents/runtime/agent-core.ts packages/core/src/agents/runtime/agent-headless.test.ts
cd packages/core && npx vitest run src/agents/runtime/agent-headless.test.ts -t "should stop consecutive identical tool calls with fresh ids"
npm run build
npm run typecheck
npm run lint
```

### Evidence (Before & After)

tmux E2E 使用真实交互式 CLI 和 mock OpenAI-compatible server 复现了 reported pattern：

- parent model 调用 `agent`
- Explore subagent 反复收到相同的 `list_directory` 参数
- 每次重复请求都使用 fresh tool call ID
- 更新后的 bundle 在 5 次 Explore model calls 后以 `LOOP_DETECTED` 停止

### Tested on

macOS 已验证；Windows 和 Linux 未手动验证。

### Environment (optional)

macOS, Node.js v22.22.0, local `npm run bundle`, tmux real-user test harness, mock OpenAI-compatible server.

## Risk & Scope

- 主要风险或取舍：子智能体现在会在重复相同工具调用时更早停止。这是预期行为，并与主 agent safety behavior 对齐。
- 未验证 / 范围外：tmux 手动验证仅在 macOS 运行；未单独跑 daemon/ACP 端到端验证，但修复位于共享的 subagent `AgentCore` 路径。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Fixes #6505

</details>
