### PR TITLE
fix(shell): avoid self-kill from pgrep selectors

### DIFF
--- a/packages/core/src/tools/__snapshots__/shell.test.ts.snap
+++ b/packages/core/src/tools/__snapshots__/shell.test.ts.snap
@@ -52,6 +52,7 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
   - Any command expected to run indefinitely until manually stopped
 
   - Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
+  - To stop a background command started by this tool, use \`task_stop\` when a task id is available. Do not use broad process-name kills such as \`kill $(pgrep node)\`, \`pkill node\`, or \`killall node\`; use a specific PID or process group id where supported.
 - Use foreground execution (is_background: false) for:
   - One-time commands: \`ls\`, \`cat\`, \`grep\`
   - Build commands: \`npm run build\`, \`make\`
@@ -106,6 +107,7 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
   - Web servers: \`python -m http.server\`, \`php -S localhost:8000\`
   - Any command expected to run indefinitely until manually stopped
 
+  - To stop a background command started by this tool, use \`task_stop\` when a task id is available. Do not use broad process-name kills such as \`kill $(pgrep node)\`, \`pkill node\`, or \`killall node\`; use a specific PID or process group id where supported.
 - Use foreground execution (is_background: false) for:
   - One-time commands: \`ls\`, \`cat\`, \`grep\`
   - Build commands: \`npm run build\`, \`make\`

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -4740,6 +4740,8 @@ function getShellToolDescription(): string {
   const processGroupNote = isWindows
     ? ''
     : '\n  - Command is executed as a subprocess that leads its own process group. Command process group can be terminated as `kill -- -PGID` or signaled as `kill -s SIGNAL -- -PGID`.';
+  const processStopNote =
+    '\n  - To stop a background command started by this tool, use `task_stop` when a task id is available. Do not use broad process-name kills such as `kill $(pgrep node)`, `pkill node`, or `killall node`; use a specific PID or process group id where supported.';
 
   return `Executes a given shell command (as \`${executionWrapper}\`) in a subprocess with optional timeout, ensuring proper handling and security measures.
 
@@ -4775,7 +4777,7 @@ ${getShellCommandSequencingGuidance(shellConfiguration)}
   - Database servers: \`mongod\`, \`mysql\`, \`redis-server\`
   - Web servers: \`python -m http.server\`, \`php -S localhost:8000\`
   - Any command expected to run indefinitely until manually stopped
-${processGroupNote}
+${processGroupNote}${processStopNote}
 - Use foreground execution (is_background: false) for:
   - One-time commands: \`ls\`, \`cat\`, \`grep\`
   - Build commands: \`npm run build\`, \`make\`

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -606,6 +606,12 @@ describe('detectSelfKillCommand', () => {
     expect(detectSelfKillCommand('command -p killall node')).toBe(true);
   });
 
+  it('detects kill commands using pgrep selectors for qwen-code hosts', () => {
+    expect(detectSelfKillCommand('kill -9 $(pgrep node)')).toBe(true);
+    expect(detectSelfKillCommand('kill $(pgrep -f node)')).toBe(true);
+    expect(detectSelfKillCommand('pgrep node | xargs kill')).toBe(true);
+  });
+
   it('detects taskkill inline and dash-prefixed image options', () => {
     expect(detectSelfKillCommand('taskkill /IM:node.exe /F')).toBe(true);
     expect(
@@ -648,6 +654,10 @@ describe('detectSelfKillCommand', () => {
     expect(detectSelfKillCommand('pkill -f vite')).toBe(false);
     expect(detectSelfKillCommand('pkill -f "node server.js"')).toBe(false);
     expect(detectSelfKillCommand('pkill -9f "node server.js"')).toBe(false);
+    expect(detectSelfKillCommand('kill -9 $(pgrep vite)')).toBe(false);
+    expect(detectSelfKillCommand('kill -9 $(pgrep -f "node server.js")')).toBe(
+      false,
+    );
     expect(detectSelfKillCommand('pkill -F qwen-code.pid vite')).toBe(false);
     expect(detectSelfKillCommand('taskkill /IM notepad.exe')).toBe(false);
   });

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -609,7 +609,13 @@ describe('detectSelfKillCommand', () => {
   it('detects kill commands using pgrep selectors for qwen-code hosts', () => {
     expect(detectSelfKillCommand('kill -9 $(pgrep node)')).toBe(true);
     expect(detectSelfKillCommand('kill $(pgrep -f node)')).toBe(true);
+    expect(detectSelfKillCommand('kill -9 $(pgrep node | head -1)')).toBe(true);
+    expect(detectSelfKillCommand('kill -9 `pgrep node | head -1`')).toBe(true);
     expect(detectSelfKillCommand('pgrep node | xargs kill')).toBe(true);
+    expect(detectSelfKillCommand('pgrep node | xargs sudo kill')).toBe(true);
+    expect(detectSelfKillCommand('pgrep node | xargs -I {} kill -9 {}')).toBe(
+      true,
+    );
   });
 
   it('detects taskkill inline and dash-prefixed image options', () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -208,6 +208,8 @@ export function splitCommands(command: string): string[] {
   let currentCommand = '';
   let inSingleQuotes = false;
   let inDoubleQuotes = false;
+  let inBackticks = false;
+  let substitutionDepth = 0;
   let i = 0;
 
   const previousNonWhitespaceChar = (index: number): string | undefined => {
@@ -235,13 +237,42 @@ export function splitCommands(command: string): string[] {
       continue;
     }
 
-    if (char === "'" && !inDoubleQuotes) {
+    if (!inSingleQuotes && char === '`') {
+      inBackticks = !inBackticks;
+    } else if (
+      !inSingleQuotes &&
+      !inBackticks &&
+      char === '$' &&
+      nextChar === '('
+    ) {
+      substitutionDepth++;
+      currentCommand += '$(';
+      i += 2;
+      continue;
+    } else if (!inBackticks && substitutionDepth > 0 && char === ')') {
+      substitutionDepth--;
+    } else if (
+      !inBackticks &&
+      substitutionDepth === 0 &&
+      char === "'" &&
+      !inDoubleQuotes
+    ) {
       inSingleQuotes = !inSingleQuotes;
-    } else if (char === '"' && !inSingleQuotes) {
+    } else if (
+      !inBackticks &&
+      substitutionDepth === 0 &&
+      char === '"' &&
+      !inSingleQuotes
+    ) {
       inDoubleQuotes = !inDoubleQuotes;
     }
 
-    if (!inSingleQuotes && !inDoubleQuotes) {
+    if (
+      !inSingleQuotes &&
+      !inDoubleQuotes &&
+      !inBackticks &&
+      substitutionDepth === 0
+    ) {
       if (
         (char === '&' && nextChar === '&') ||
         (char === '|' && (nextChar === '|' || nextChar === '&'))
@@ -458,6 +489,28 @@ const PKILL_OPTIONS_WITH_VALUES = new Set([
   '--uid',
   '-u',
   '--euid',
+]);
+
+const XARGS_OPTIONS_WITH_VALUES = new Set([
+  '-I',
+  '-n',
+  '-P',
+  '-s',
+  '-E',
+  '-d',
+  '-L',
+  '-l',
+  '-a',
+  '-J',
+  '-R',
+  '--replace',
+  '--max-args',
+  '--max-procs',
+  '--max-chars',
+  '--eof',
+  '--delimiter',
+  '--max-lines',
+  '--arg-file',
 ]);
 
 export const SHELL_SELF_KILL_REJECTION =
@@ -773,6 +826,34 @@ function pgrepSubstitutionArgs(segment: string): string[] {
       continue;
     }
 
+    if (char === '`') {
+      let end = index + 1;
+      let innerEscaped = false;
+      for (; end < segment.length; end++) {
+        const innerChar = segment[end]!;
+        if (innerEscaped) {
+          innerEscaped = false;
+          continue;
+        }
+        if (innerChar === '\\') {
+          innerEscaped = true;
+          continue;
+        }
+        if (innerChar === '`') break;
+      }
+      if (end >= segment.length) {
+        break;
+      }
+
+      const inner = segment.slice(index + 1, end).trim();
+      const match = inner.match(/^pgrep\b(.*)$/i);
+      if (match) {
+        args.push(match[1] ?? '');
+      }
+      index = end;
+      continue;
+    }
+
     if (char !== '$' || segment[index + 1] !== '(') {
       continue;
     }
@@ -813,7 +894,10 @@ function xargsInvokesKill(segment: string | undefined): boolean {
     return false;
   }
 
-  const command = tokens.slice(1).find((token) => !isOptionToken(token));
+  const commandTokens = unwrapExecutionPrefixes(
+    commandArguments(tokens, XARGS_OPTIONS_WITH_VALUES),
+  );
+  const command = commandTokens.find((token) => !isOptionToken(token));
   return normalizeExecutableName(command ?? '') === 'kill';
 }
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -736,13 +736,95 @@ function pkillTargetsSelf(tokens: string[]): boolean {
   return args.some((arg) => matchesSelfProcessPattern(arg));
 }
 
+function pgrepTargetsSelf(tokens: string[]): boolean {
+  return pkillTargetsSelf(['pkill', ...tokens.slice(1)]);
+}
+
+function pgrepSubstitutionArgs(segment: string): string[] {
+  let quote: '"' | "'" | '' = '';
+  let escaped = false;
+  const args: string[] = [];
+
+  for (let index = 0; index < segment.length; index++) {
+    const char = segment[index]!;
+
+    if (quote === "'") {
+      if (char === "'") quote = '';
+      continue;
+    }
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      quote = quote === '"' ? '' : '"';
+      continue;
+    }
+
+    if (char === "'" && quote === '') {
+      quote = "'";
+      continue;
+    }
+
+    if (char !== '$' || segment[index + 1] !== '(') {
+      continue;
+    }
+
+    const end = segment.indexOf(')', index + 2);
+    if (end === -1) {
+      break;
+    }
+
+    const inner = segment.slice(index + 2, end).trim();
+    const match = inner.match(/^pgrep\b(.*)$/i);
+    if (match) {
+      args.push(match[1] ?? '');
+    }
+    index = end;
+  }
+
+  return args;
+}
+
+function killCommandTargetsSelf(segment: string): boolean {
+  return pgrepSubstitutionArgs(segment).some((args) => {
+    const parsed = parseShellSegment(`pgrep ${args}`);
+    return parsed !== null && pgrepTargetsSelf(parsed);
+  });
+}
+
+function xargsInvokesKill(segment: string | undefined): boolean {
+  if (!segment) {
+    return false;
+  }
+  const parsed = parseShellSegment(segment);
+  if (!parsed) {
+    return false;
+  }
+  const tokens = unwrapExecutionPrefixes(parsed);
+  if (normalizeExecutableName(tokens[0] ?? '') !== 'xargs') {
+    return false;
+  }
+
+  const command = tokens.slice(1).find((token) => !isOptionToken(token));
+  return normalizeExecutableName(command ?? '') === 'kill';
+}
+
 export function detectSelfKillCommand(command: string): boolean {
   if (!/kill/i.test(command)) {
     return false;
   }
 
   const segments = getCommandSegments(command);
-  for (const segment of segments) {
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]!;
     const parsed = parseShellSegment(segment);
     if (!parsed) {
       continue;
@@ -762,6 +844,16 @@ export function detectSelfKillCommand(command: string): boolean {
     }
     if (root === 'pkill' && pkillTargetsSelf(tokens)) {
       return true;
+    }
+    if (root === 'kill' && killCommandTargetsSelf(segment)) {
+      return true;
+    }
+    if (root === 'pgrep' && pgrepTargetsSelf(tokens)) {
+      for (let j = index + 1; j < segments.length; j++) {
+        if (xargsInvokesKill(segments[j])) {
+          return true;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What this PR does

This PR prevents broad `pgrep`-based process selectors from slipping through the shell self-kill guard when they are used to feed `kill`. It also updates the shell tool guidance so the model is steered toward `task_stop`, a specific PID, or the managed process group instead of process-name-wide Node kills.

## Why it's needed

When Qwen Code starts a user backend server and later tries to stop it, commands such as `kill -9 $(pgrep node)` or `pgrep node | xargs kill` can terminate every Node process on the machine, including the running Qwen Code process itself. The existing guard already blocks `pkill`, `killall`, and `taskkill` broad self-targets; this closes the narrow `pgrep` selector gap without introducing a general shell parser.

## Reviewer Test Plan

### How to verify

Reviewers can confirm that broad `pgrep` selectors targeting `node` or Qwen process names are rejected when routed into `kill`, while targeted PID kills and non-self process selectors remain allowed. The relevant unit tests cover `kill -9 $(pgrep node)`, `kill $(pgrep -f node)`, `pgrep node | xargs kill`, `kill -9 $(pgrep vite)`, and `kill -9 $(pgrep -f "node server.js")`.

### Evidence (Before & After)

Before: the new unit test failed on current `main` because `detectSelfKillCommand("kill -9 $(pgrep node)")` returned `false`. After: `src/utils/shell-utils.test.ts` passes with the new cases and `ShellTool` description snapshots include the safer process-stop guidance.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace on macOS. Verification run from the issue worktree.

## Risk & Scope

- Main risk or tradeoff: This intentionally covers a narrow set of high-confidence `pgrep` self-kill paths instead of trying to parse all shell dataflow patterns.
- Not validated / out of scope: General shell analysis for wrappers such as `parallel`, `strace`, `mapfile`, nested substitutions, aliases, variables, or arbitrary command pipelines is out of scope for this fix.
- Breaking changes / migration notes: No migration required. Some broad process-name kill commands that could terminate Qwen Code are now rejected with the existing shell self-kill message.

## Linked Issues

Resolves #6246
Supersedes #6377

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 阻止宽泛的 `pgrep` 进程选择器在传给 `kill` 时绕过 shell 自杀防护。同时更新 shell 工具说明，引导模型优先使用 `task_stop`、具体 PID，或托管进程组，而不是按进程名杀掉所有 Node 进程。

## Why it's needed

当 Qwen Code 启动用户的后端服务后再尝试停止它时，`kill -9 $(pgrep node)` 或 `pgrep node | xargs kill` 这类命令会杀掉机器上的所有 Node 进程，包括正在运行的 Qwen Code 自身。已有防护已经拦截 `pkill`、`killall`、`taskkill` 的宽泛 self-target；这个 PR 只补上窄范围的 `pgrep` selector 缺口，不引入通用 shell parser。

## Reviewer Test Plan

### How to verify

Reviewer 可以确认：当 `pgrep` 宽泛选择 `node` 或 Qwen 进程名并传给 `kill` 时会被拒绝；具体 PID kill 和非 self 进程选择器仍然允许。相关单测覆盖 `kill -9 $(pgrep node)`、`kill $(pgrep -f node)`、`pgrep node | xargs kill`、`kill -9 $(pgrep vite)` 和 `kill -9 $(pgrep -f "node server.js")`。

### Evidence (Before & After)

Before：新增单测在当前 `main` 上失败，因为 `detectSelfKillCommand("kill -9 $(pgrep node)")` 返回 `false`。After：`src/utils/shell-utils.test.ts` 包含新增 case 后通过，`ShellTool` description snapshot 也包含更安全的停止进程指导。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 本地 Node.js workspace，在 issue 专用 worktree 中验证。

## Risk & Scope

- Main risk or tradeoff: 这个修复刻意只覆盖高置信的 `pgrep` self-kill 路径，不尝试解析所有 shell dataflow 模式。
- Not validated / out of scope: `parallel`、`strace`、`mapfile`、嵌套 substitution、alias、变量或任意 pipeline 的通用 shell 分析不在本次范围内。
- Breaking changes / migration notes: 不需要迁移。可能终止 Qwen Code 的宽泛进程名 kill 命令现在会被已有 shell self-kill message 拒绝。

## Linked Issues

Resolves #6246
Supersedes #6377

</details>
