### PR TITLE
perf(core): add pure-ASCII fast path to text token estimation

### DIFF
--- a/packages/core/src/utils/request-tokenizer/textTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.test.ts
@@ -262,6 +262,37 @@ describe('TextTokenizer', () => {
     });
   });
 
+  describe('ASCII/non-ASCII boundary', () => {
+    it('should treat DEL (U+007F) as ASCII and U+0080 as non-ASCII', async () => {
+      // '\x7F' = 1 ASCII char: 1 / 4 = 0.25 -> ceil = 1
+      expect(await tokenizer.calculateTokens('\x7F')).toBe(1);
+      // '\u0080' = 1 non-ASCII char: 1 * 1.1 = 1.1 -> ceil = 2
+      expect(await tokenizer.calculateTokens('\u0080')).toBe(2);
+    });
+
+    it('should count pure-ASCII text of any length as ceil(length / 4)', async () => {
+      for (const len of [1, 3, 4, 5, 4096, 4097]) {
+        const text = 'a'.repeat(len);
+        expect(await tokenizer.calculateTokens(text)).toBe(Math.ceil(len / 4));
+      }
+    });
+
+    it('should stay consistent when a single non-ASCII char joins long ASCII text', async () => {
+      const ascii = 'x'.repeat(1000);
+      // 1000 / 4 = 250
+      expect(await tokenizer.calculateTokens(ascii)).toBe(250);
+      // 1000 / 4 + 1 * 1.1 = 251.1 -> ceil = 252, wherever the char sits
+      expect(await tokenizer.calculateTokens(ascii + '中')).toBe(252);
+      expect(await tokenizer.calculateTokens('中' + ascii)).toBe(252);
+    });
+
+    it('should count surrogate pairs as two non-ASCII units within mixed text', async () => {
+      const text = 'abcd🚀'; // 4 ASCII + 2 UTF-16 units
+      // 4 / 4 + 2 * 1.1 = 3.2 -> ceil = 4
+      expect(await tokenizer.calculateTokens(text)).toBe(4);
+    });
+  });
+
   describe('large inputs', () => {
     it('should handle very long text', async () => {
       const longText = 'a'.repeat(200000); // 200k characters

--- a/packages/core/src/utils/request-tokenizer/textTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const NON_ASCII_RE = /[\u0080-\uffff]/;
+
 /**
  * Text tokenizer for calculating text tokens using character-based estimation.
  *
@@ -19,17 +21,19 @@ export function estimateTextTokens(text: string): number {
     return 0;
   }
 
-  let asciiChars = 0;
-  let nonAsciiChars = 0;
+  // Fast path: pure-ASCII text (code, English prose). A single regex scan
+  // uses V8's optimized string search instead of a per-character JS loop.
+  if (!NON_ASCII_RE.test(text)) {
+    return Math.ceil(text.length / 4);
+  }
 
+  let nonAsciiChars = 0;
   for (let i = 0; i < text.length; i++) {
-    const charCode = text.charCodeAt(i);
-    if (charCode < 128) {
-      asciiChars++;
-    } else {
+    if (text.charCodeAt(i) >= 128) {
       nonAsciiChars++;
     }
   }
+  const asciiChars = text.length - nonAsciiChars;
 
   const tokens = asciiChars / 4 + nonAsciiChars * 1.1;
   return Math.ceil(tokens);


### PR DESCRIPTION
## What this PR does

Speeds up the character-based token estimator by 1.61× (median 51.9 ms → 32.2 ms on a deterministic fixture set, −38%). Pure-ASCII text — the common case for code and English prose — is now classified with a single regex scan that uses the engine's optimized string search instead of a per-character loop, and mixed text counts only non-ASCII code units, deriving the ASCII count from the string length. The estimation formula itself is untouched, so every input produces exactly the same token count as before: this was verified exhaustively over all 65,536 single UTF-16 code units and 20,000 randomized mixed strings compared against the previous implementation, plus a pinned sha256 hash over the benchmark outputs and the existing unit suite.

## Why it's needed

Token estimation runs on every text part of a request when tokens are counted for the OpenAI- and Anthropic-compatible generators, so its cost is paid per turn and grows with conversation history; the same estimate also backs guardrails such as `sessionTokenLimit` and the gating of large extracted documents. Performance of these hot paths is an active concern in this repo — #311 reports general CLI slowness, #4748 tracks fast-path latency work, #6506 optimizes large-paste handling, and #4502 / #3735 added guardrail and auto-compaction features that lean on token estimates. The old loop's per-character `charCodeAt` classification is O(n) in JS bytecode with a branch per character; the fast path keeps the same O(n) but moves the scan into the engine's native string search, which is substantially cheaper per character.

## Measured impact

| Metric | Before | After | Change |
|---|---|---|---|
| `tokenizer_ms` (10-fixture set × 2000 iterations) | 51.9 ms | 32.2 ms | 1.61× / −38% |

- Benchmark: `tsx` harness calling `calculateTokens` over a deterministic 10-fixture set (ASCII code snippet, CJK-only, emoji/Greek mixed, 5,000-char ASCII, 3,000-char EN/CJK mix, 1,000-char prompt fragment, empty/1-char edge cases, 2,000-char Greek) for 2,000 iterations after 200 warmup rounds; each quoted number is the median of 6 runs measured solo on an otherwise idle machine (Node 22, Linux).
- Behavior verified identical: sha256 hash over all fixture outputs is bit-identical before/after (`69e5191a…`), an exhaustive check of all 65,536 single code units plus 20,000 seeded random mixed strings found zero mismatches, and the full `request-tokenizer` unit suite passes (64 tests).

<details>
<summary>Benchmark harness (reproducible)</summary>

```js
// bench.mjs — run with: npx tsx bench.mjs (from packages/core)
import { performance } from 'node:perf_hooks';
import { TextTokenizer } from './src/utils/request-tokenizer/textTokenizer.js';

const FIXTURES = [
  'function calculateTokens(text) {\n  let count = 0;\n  for (let i = 0; i < text.length; i++) {\n    count++;\n  }\n  return count;\n}\n',
  '这是一段中文文字，用于测试非ASCII字符的tokenization性能。这个测试包含了各种中文标点符号和汉字，以确保我们的实现能够正确处理。',
  'Hello 🌍 World! This is a test with emoji 🚀 and some unicode: αβγδεζηθικλμνξοπρστυφχψω mixed with ASCII text.',
  'a'.repeat(2500) + 'b'.repeat(2500),
  ('Hello World ').repeat(150) + ('你好世界 ').repeat(60),
  'You are a helpful AI assistant. Your goal is to assist users with their queries in a clear and concise manner. Always provide accurate information and cite sources when possible. Be respectful and professional in all interactions. If you are unsure about something, say so rather than making up information.',
  '', 'x', '中',
  ('αβγδεζηθ').repeat(250),
];

const tokenizer = new TextTokenizer();
for (let w = 0; w < 200; w++) for (const f of FIXTURES) await tokenizer.calculateTokens(f);
const t0 = performance.now();
for (let i = 0; i < 2000; i++) for (const f of FIXTURES) await tokenizer.calculateTokens(f);
console.log(`tokenizer_ms: ${(performance.now() - t0).toFixed(4)}`);
```

</details>

## How this was found

This hotspot was found and optimized with [Weco](https://weco.ai), an evaluation-driven code-optimization agent. The full optimization run (every candidate tried, its measured metric, and the winning diff) is public here:

**Weco run: https://dashboard.weco.ai/share/NsmgRvFRbY-d7sFQXn4g2v_fOG12ySZc**

The submitted patch is a hand-cleaned re-implementation of the winning candidate: the search's integer-arithmetic and lookup-table variants were dropped because they either alter IEEE-754 rounding on some inputs or add a 64 KB table for ~1% extra gain — the version here keeps the original arithmetic bit-for-bit and takes only the scan-strategy improvement.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/utils/request-tokenizer/` → 3 files, 64 tests pass. This includes four new regression tests pinning the classification boundary (U+007F is ASCII, U+0080 is not), pure-ASCII results at lengths around the fast path (1…4097 chars), consistency when a single non-ASCII character joins long ASCII text (result identical wherever the character sits), and surrogate-pair counting inside mixed text.
- `npx eslint` and `npx prettier --check` on both touched files are clean; `tsc --noEmit -p packages/core` passes.
- Optional: run the benchmark harness above on this branch vs `main` to reproduce the timing delta.

### Evidence (Before & After)

N/A (no user-visible change; timing numbers are in Measured impact above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests via vitest; benchmark via `npx tsx` (Node 22, no sandbox).

## Risk & Scope

- Main risk or tradeoff: classification drift between the regex fast path and the counting loop. Mitigated by the exhaustive single-code-unit equivalence check (surrogate halves fall inside `\u0080`–`\uffff`, so lone or paired surrogates classify identically) and the new boundary regression tests.
- Not validated / out of scope: no changes to any consumer of the estimator; the estimation formula and its calibration are deliberately untouched.
- Breaking changes / migration notes: none — internal perf change with byte-identical outputs.

## Linked Issues

Related (no auto-close): #311, #4748, #6506.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将基于字符的 token 估算器提速 1.61×（确定性基准集上中位数 51.9 ms → 32.2 ms，−38%）。纯 ASCII 文本（代码和英文文本的常见情形）现在用一次正则扫描来分类，利用引擎优化过的字符串搜索代替逐字符循环；混合文本只统计非 ASCII 码元，ASCII 数量由字符串长度推导。估算公式本身未改动，因此所有输入的 token 数与之前完全一致：已对全部 65,536 个单个 UTF-16 码元及 20,000 条随机混合字符串与旧实现做了穷举比对，并通过基准输出的 sha256 哈希固定值和现有单元测试套件验证。

## 为什么需要

在为 OpenAI 和 Anthropic 兼容生成器统计 token 时，估算器会作用于请求中的每个文本部分，成本每轮都要支付并随会话历史增长；同样的估算还支撑 `sessionTokenLimit` 等护栏以及大型提取文档的门控。这些热路径的性能是本仓库的活跃议题——#311 报告 CLI 整体变慢，#4748 跟踪快路径延迟优化，#6506 优化大段粘贴处理，#4502 / #3735 增加的护栏与自动压缩功能都依赖 token 估算。旧实现逐字符调用 `charCodeAt` 并对每个字符分支；快路径保持同样的 O(n)，但把扫描移入引擎原生的字符串搜索，单字符成本显著更低。

## 实测影响

见上文表格：`tokenizer_ms` 51.9 ms → 32.2 ms（1.61× / −38%），10 个固定样本 × 2000 次迭代、200 轮预热，每个数字为独占机器上 6 次运行的中位数（Node 22，Linux）。行为一致性通过输出 sha256 哈希、穷举码元比对（零不一致）及 64 个单元测试验证。

## 发现方式

该热点由评估驱动的代码优化代理 [Weco](https://weco.ai) 发现并优化，完整运行记录公开于：https://dashboard.weco.ai/share/NsmgRvFRbY-d7sFQXn4g2v_fOG12ySZc 。提交的补丁是对获胜候选的人工净化重写：搜索得到的整数运算与查找表变体被舍弃，因为前者会在部分输入上改变 IEEE-754 舍入行为，后者为约 1% 的额外收益引入 64 KB 表；本版本逐位保留原有算术，只采纳扫描策略上的改进。

## 审阅者测试计划

- `cd packages/core && npx vitest run src/utils/request-tokenizer/` → 3 个文件、64 个测试全部通过，其中包含 4 个新增回归测试：固定分类边界（U+007F 属 ASCII、U+0080 不属）、快路径附近各长度的纯 ASCII 结果、单个非 ASCII 字符加入长 ASCII 文本时结果与位置无关、混合文本中代理对按两个码元计数。
- 两个改动文件的 `npx eslint`、`npx prettier --check` 均通过；`tsc --noEmit -p packages/core` 通过。
- 可选：在本分支与 `main` 上分别运行上文基准脚本以复现时延差异。

## 风险与范围

- 主要风险：正则快路径与计数循环之间的分类漂移。已通过单码元穷举比对（代理项半区落在 `\u0080`–`\uffff` 内，孤立或成对代理项分类一致）及新增边界回归测试缓解。
- 未验证/超出范围：未改动估算器的任何调用方；估算公式及其标定刻意保持不变。
- 破坏性变更/迁移说明：无——内部性能改动，输出逐字节一致。

## 关联 Issue

相关（不自动关闭）：#311、#4748、#6506。

</details>
