### PR TITLE
fix(serve): stop cdp-mcp-command reading process.env directly

### DIFF
--- a/packages/cli/src/serve/acp-http/index.ts
+++ b/packages/cli/src/serve/acp-http/index.ts
@@ -102,7 +102,7 @@ function buildChromeDevToolsMcpRuntimeConfig(
   ) {
     return undefined;
   }
-  const command = resolveCdpMcpCommand();
+  const command = resolveCdpMcpCommand(process.env);
   if (!command) {
     writeStderrLine(
       `qwen serve: set ${QWEN_CDP_MCP_COMMAND_ENV} to enable browser automation MCP (no adapter is bundled)`,

--- a/packages/cli/src/serve/cdp-mcp-command.ts
+++ b/packages/cli/src/serve/cdp-mcp-command.ts
@@ -8,20 +8,23 @@
 export const QWEN_CDP_MCP_COMMAND_ENV = 'QWEN_CDP_MCP_COMMAND';
 
 export function resolveCdpMcpCommand(
-  env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv,
 ): string | undefined {
   const command = env[QWEN_CDP_MCP_COMMAND_ENV]?.trim();
   return command ? command : undefined;
 }
 
-export function isBrowserAutomationMcpAvailable(opts: {
-  cdpTunnelOverWs?: boolean;
-  token?: string;
-}): boolean {
+export function isBrowserAutomationMcpAvailable(
+  opts: {
+    cdpTunnelOverWs?: boolean;
+    token?: string;
+  },
+  env: NodeJS.ProcessEnv,
+): boolean {
   return (
     opts.cdpTunnelOverWs === true &&
     !opts.token &&
-    process.env['QWEN_SERVE_ACP_HTTP'] !== '0' &&
-    resolveCdpMcpCommand() !== undefined
+    env['QWEN_SERVE_ACP_HTTP'] !== '0' &&
+    resolveCdpMcpCommand(env) !== undefined
   );
 }

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1516,10 +1516,13 @@ describe('runQwenServe runtime startup failures', () => {
 
   it('does not enable browser automation MCP on bearer-protected endpoints', () => {
     expect(
-      isBrowserAutomationMcpAvailable({
-        cdpTunnelOverWs: true,
-        token: 'secret-token',
-      }),
+      isBrowserAutomationMcpAvailable(
+        {
+          cdpTunnelOverWs: true,
+          token: 'secret-token',
+        },
+        {},
+      ),
     ).toBe(false);
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -854,7 +854,10 @@ function currentServeFeaturesForRunQwenServe(
     // so the bootstrap `/capabilities` window doesn't briefly under-report them.
     clientMcpOverWsEnabled: opts.clientMcpOverWs === true,
     cdpTunnelOverWsEnabled: opts.cdpTunnelOverWs === true,
-    browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(opts),
+    browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(
+      opts,
+      process.env,
+    ),
   });
 }
 

--- a/packages/cli/src/serve/server/serve-features.ts
+++ b/packages/cli/src/serve/server/serve-features.ts
@@ -95,7 +95,10 @@ export function createServeFeatures(
         multiWorkspaceSessionsEnabled,
         clientMcpOverWsEnabled: opts.clientMcpOverWs === true,
         cdpTunnelOverWsEnabled: opts.cdpTunnelOverWs === true,
-        browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(opts),
+        browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(
+          opts,
+          process.env,
+        ),
         voiceTranscriptionAvailable: getCachedVoiceTranscriptionAvailable(),
         // Advertised whenever the `/voice/stream` WS endpoint exists (ACP HTTP
         // on). A configured token no longer suppresses it — the browser carries


### PR DESCRIPTION
## Problem

`packages/cli/src/serve/process-env-guard.test.ts` is currently **failing on `main`**. The guard asserts that workspace-scoped `serve`/`acp-bridge` code never reads `process.env` directly (outside an explicit allowlist of boundary files). `packages/cli/src/serve/cdp-mcp-command.ts` — added in #6472 — reads `process.env` directly in two spots and was never added to the allowlist, so the guard flags it:

```
AssertionError: expected [ 'packages/cli/src/serve/cdp-mcp-command.ts' ] to deeply equal []
```

This turns the `Test` CI check red for **every** PR branched off current `main`.

## Fix

Finish the dependency-injection the file was already set up for, so it reads no `process.env` at all:

- `resolveCdpMcpCommand(env)` — drop the `= process.env` default; take `env` explicitly.
- `isBrowserAutomationMcpAvailable(opts, env)` — take `env` explicitly and use it for both the `QWEN_SERVE_ACP_HTTP` check and the `resolveCdpMcpCommand` call.

`env` is supplied by the three callers, all of which are **already in the guard's allowlist** and legitimately hold `process.env`:

- `acp-http/index.ts`
- `serve/run-qwen-serve.ts`
- `serve/server/serve-features.ts`

## Behavior

Unchanged — every `process.env` lookup resolves to exactly the same value as before; it's just threaded through a parameter. No allowlist entry needed, because `cdp-mcp-command.ts` no longer touches `process.env`.

## Related issue

Fixes #6554.