### PR TITLE
fix(cli): Keep CDP MCP env reads at serve boundaries

### DIFF
--- a/packages/cli/src/serve/acp-http/index.ts
+++ b/packages/cli/src/serve/acp-http/index.ts
@@ -102,7 +102,7 @@ function buildChromeDevToolsMcpRuntimeConfig(
   ) {
     return undefined;
   }
-  const command = resolveCdpMcpCommand();
+  const command = resolveCdpMcpCommand(process.env);
   if (!command) {
     writeStderrLine(
       `qwen serve: set ${QWEN_CDP_MCP_COMMAND_ENV} to enable browser automation MCP (no adapter is bundled)`,

--- a/packages/cli/src/serve/cdp-mcp-command.ts
+++ b/packages/cli/src/serve/cdp-mcp-command.ts
@@ -6,22 +6,26 @@
 
 /** Stdio MCP adapter command used by the optional CDP browser automation bridge. */
 export const QWEN_CDP_MCP_COMMAND_ENV = 'QWEN_CDP_MCP_COMMAND';
+const QWEN_SERVE_ACP_HTTP_ENV = 'QWEN_SERVE_ACP_HTTP';
 
 export function resolveCdpMcpCommand(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Readonly<NodeJS.ProcessEnv>,
 ): string | undefined {
   const command = env[QWEN_CDP_MCP_COMMAND_ENV]?.trim();
   return command ? command : undefined;
 }
 
-export function isBrowserAutomationMcpAvailable(opts: {
-  cdpTunnelOverWs?: boolean;
-  token?: string;
-}): boolean {
+export function isBrowserAutomationMcpAvailable(
+  opts: {
+    cdpTunnelOverWs?: boolean;
+    token?: string;
+  },
+  env: Readonly<NodeJS.ProcessEnv>,
+): boolean {
   return (
     opts.cdpTunnelOverWs === true &&
     !opts.token &&
-    process.env['QWEN_SERVE_ACP_HTTP'] !== '0' &&
-    resolveCdpMcpCommand() !== undefined
+    env[QWEN_SERVE_ACP_HTTP_ENV] !== '0' &&
+    resolveCdpMcpCommand(env) !== undefined
   );
 }

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1516,10 +1516,13 @@ describe('runQwenServe runtime startup failures', () => {
 
   it('does not enable browser automation MCP on bearer-protected endpoints', () => {
     expect(
-      isBrowserAutomationMcpAvailable({
-        cdpTunnelOverWs: true,
-        token: 'secret-token',
-      }),
+      isBrowserAutomationMcpAvailable(
+        {
+          cdpTunnelOverWs: true,
+          token: 'secret-token',
+        },
+        process.env,
+      ),
     ).toBe(false);
   });
 

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -854,7 +854,10 @@ function currentServeFeaturesForRunQwenServe(
     // so the bootstrap `/capabilities` window doesn't briefly under-report them.
     clientMcpOverWsEnabled: opts.clientMcpOverWs === true,
     cdpTunnelOverWsEnabled: opts.cdpTunnelOverWs === true,
-    browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(opts),
+    browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(
+      opts,
+      process.env,
+    ),
   });
 }
 

--- a/packages/cli/src/serve/server/serve-features.ts
+++ b/packages/cli/src/serve/server/serve-features.ts
@@ -95,7 +95,10 @@ export function createServeFeatures(
         multiWorkspaceSessionsEnabled,
         clientMcpOverWsEnabled: opts.clientMcpOverWs === true,
         cdpTunnelOverWsEnabled: opts.cdpTunnelOverWs === true,
-        browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(opts),
+        browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(
+          opts,
+          process.env,
+        ),
         voiceTranscriptionAvailable: getCachedVoiceTranscriptionAvailable(),
         // Advertised whenever the `/voice/stream` WS endpoint exists (ACP HTTP
         // on). A configured token no longer suppresses it — the browser carries


### PR DESCRIPTION
## What this PR does

Keeps the optional browser automation MCP environment lookup behind the existing serve process boundaries. The CDP MCP helper now requires callers to pass the environment explicitly, while the bootstrap capabilities path, runtime capabilities path, and ACP WebSocket registration path pass `process.env` from files that are already treated as environment boundaries.

## Why it's needed

PR #6559 failed CI because `packages/cli/src/serve/process-env-guard.test.ts` caught `packages/cli/src/serve/cdp-mcp-command.ts` as a new direct `process.env` reader. That helper was introduced by #6472 for the optional external CDP MCP adapter, but it lives under the workspace-scoped serve tree scanned by the guard. The guard is intentional: serve and acp-bridge code should not grow ad hoc global environment reads outside the approved boundary files, because that makes workspace-scoped runtime behavior harder to isolate and test. This fixes the CI failure by preserving the guard and moving the environment dependency back to the existing serve boundary callers, rather than expanding the allowlist.

## Reviewer Test Plan

### How to verify

Run `npm -w packages/cli exec -- vitest run src/serve/process-env-guard.test.ts`; before this change the guard reports `packages/cli/src/serve/cdp-mcp-command.ts` as an offender, and after this change it passes. For behavior, verify that browser automation MCP is still advertised only when the CDP tunnel and external adapter command are enabled, remains hidden for token-protected endpoints or disabled ACP HTTP, and still dynamically registers the Chrome DevTools runtime MCP server from `QWEN_CDP_MCP_COMMAND`.

### Evidence (Before & After)

N/A, non-UI CI guard fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node 22 workspace. Loopback-dependent tests were run outside the filesystem/network sandbox because the sandbox rejects localhost listeners with `EPERM`.

## Risk & Scope

- Main risk or tradeoff: A caller could miss the newly explicit environment parameter, but TypeScript typecheck covers the API change and the CDP MCP capability/registration paths were tested.
- Not validated / out of scope: Full all-workspaces `npm run test:ci`; this PR used the focused failing guard plus related behavior tests, CLI typecheck, CLI lint, and whitespace checks.
- Breaking changes / migration notes: None.

## Linked Issues

References #6559 and #6472.
