### PR TITLE
fix(mobile-mcp): strip bounds from UI hierarchy dump

### DIFF
--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -1247,7 +1247,8 @@ export const createMcpServer = (): McpServer => {
     { readOnlyHint: true },
     async ({ device, compressed, output_path }) => {
       const robot = getAndroidRobotFromDevice(device, 'mobile_ui_dump');
-      const xml = await robot.dumpUiHierarchy(compressed ?? false);
+      let xml = await robot.dumpUiHierarchy(compressed ?? false);
+      xml = xml.replace(/ bounds="\[[0-9,]+\]\[[0-9,]+\]"/g, '');
       if (output_path) {
         validateOutputPath(output_path);
         fs.writeFileSync(output_path, xml, 'utf-8');


### PR DESCRIPTION
## Summary

- Strip `bounds` attributes from `mobile_ui_dump` XML output to reduce token consumption for LLM consumers

The bounds coordinates (e.g. `bounds="[126,159][288,222]"`) are not useful for LLMs and significantly inflate the XML payload size.

## Test plan

- [ ] Run `mobile_ui_dump` tool against an Android device and verify XML no longer contains `bounds="..."` attributes