### PR TITLE
fix(cli): forward user input to MCP prompts with no declared arguments

### DIFF
--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -204,6 +204,21 @@ describe('McpPromptLoader', () => {
       const result = loader.parseArgs('--key="value" some text', undefined);
       expect(result).toEqual({ key: 'value', input: 'some text' });
     });
+
+    it('should strip quotes from positional input when promptArgs is undefined', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('"hello world"', undefined);
+      expect(result).toEqual({ input: 'hello world' });
+    });
+
+    it('should not overwrite a named "input" arg with positional text', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs(
+        '--input="named value" some text',
+        undefined,
+      );
+      expect(result).toEqual({ input: 'named value' });
+    });
   });
 
   describe('loadCommands', () => {

--- a/packages/cli/src/services/McpPromptLoader.test.ts
+++ b/packages/cli/src/services/McpPromptLoader.test.ts
@@ -174,6 +174,36 @@ describe('McpPromptLoader', () => {
         pos3: 'p3 "with quotes"',
       });
     });
+
+    it('should forward positional input as "input" when promptArgs is undefined', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('hello world', undefined);
+      expect(result).toEqual({ input: 'hello world' });
+    });
+
+    it('should forward positional input as "input" when promptArgs is empty', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('hello world', []);
+      expect(result).toEqual({ input: 'hello world' });
+    });
+
+    it('should return empty object when promptArgs is undefined and no input', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('', undefined);
+      expect(result).toEqual({});
+    });
+
+    it('should forward named args when promptArgs is undefined', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('--key="value"', undefined);
+      expect(result).toEqual({ key: 'value' });
+    });
+
+    it('should forward both named and positional args when promptArgs is undefined', () => {
+      const loader = new McpPromptLoader(mockConfig);
+      const result = loader.parseArgs('--key="value" some text', undefined);
+      expect(result).toEqual({ key: 'value', input: 'some text' });
+    });
   });
 
   describe('loadCommands', () => {
@@ -219,6 +249,24 @@ describe('McpPromptLoader', () => {
         type: 'message',
         messageType: 'error',
         content: 'Missing required argument(s): --age, --species',
+      });
+    });
+
+    it('should forward user input when prompt has no declared arguments', async () => {
+      vi.spyOn(cliCore, 'getMCPServerPrompts').mockReturnValue([
+        { ...mockPrompt, arguments: undefined },
+      ]);
+      const loader = new McpPromptLoader(mockConfigWithPrompts);
+      const commands = await loader.loadCommands(new AbortController().signal);
+      const action = commands[0].action!;
+      const context = {} as CommandContext;
+      const result = await action(context, 'some user input');
+      expect(mockPrompt.invoke).toHaveBeenCalledWith({
+        input: 'some user input',
+      });
+      expect(result).toEqual({
+        type: 'submit_prompt',
+        content: JSON.stringify('Hello, world!'),
       });
     });
 

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -63,7 +63,7 @@ export class McpPromptLoader implements ICommandLoader {
                   return {
                     type: 'message',
                     messageType: 'info',
-                    content: `Prompt "${prompt.name}" has no arguments.`,
+                    content: `Prompt "${prompt.name}" has no declared arguments. Any text you provide will be forwarded as-is (e.g., /${prompt.name} some text sends { input: "some text" }).`,
                   };
                 }
 

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -275,8 +275,13 @@ export class McpPromptLoader implements ICommandLoader {
 
     if (!promptArgs || promptArgs.length === 0) {
       Object.assign(promptInputs, argValues);
-      if (positionalArgsString) {
-        promptInputs['input'] = positionalArgsString;
+      // Forward positional text as a default "input" argument when the prompt
+      // declares no arguments, matching Claude Code's behavior. This key is a
+      // client-side convention, not part of the MCP spec. A user-provided
+      // --input named arg takes precedence over positional text.
+      const positionalInput = positionalArgs.join(' ');
+      if (positionalInput && !Object.hasOwn(argValues, 'input')) {
+        promptInputs['input'] = positionalInput;
       }
       return promptInputs;
     }

--- a/packages/cli/src/services/McpPromptLoader.ts
+++ b/packages/cli/src/services/McpPromptLoader.ts
@@ -273,7 +273,11 @@ export class McpPromptLoader implements ICommandLoader {
       positionalArgs.push((match[1] ?? match[2]).replace(/\\(.)/g, '$1'));
     }
 
-    if (!promptArgs) {
+    if (!promptArgs || promptArgs.length === 0) {
+      Object.assign(promptInputs, argValues);
+      if (positionalArgsString) {
+        promptInputs['input'] = positionalArgsString;
+      }
       return promptInputs;
     }
     for (const arg of promptArgs) {


### PR DESCRIPTION
## What this PR does

When an MCP server prompt declares no `arguments` field, the slash-command handler silently discarded everything the user typed after the prompt name. The `parseArgs()` method parsed the input into named and positional parts, then hit an early `return {}` that threw all of it away before it ever reached `prompt.invoke()`.

This PR changes that early return so that, when the prompt declares no arguments (either `undefined` or an empty array), the parsed input is still forwarded to the MCP server:

- Named arguments (`--key="value"`) are passed through as-is.
- Positional/free-form text is forwarded under the `input` key (e.g. `{ input: "abc" }`).

This matches Claude Code's behavior of forwarding user text unconditionally regardless of whether the prompt declares arguments.

## Why it's needed

Silent data loss is the core problem. A user typing `/my_prompt some important context` reasonably expects that text to reach the MCP server, but it was silently dropped with no error and no feedback. The MCP server received an empty `{}` arguments object, making the prompt appear broken for no discernible reason.

Fixes #6563.

## Reviewer Test Plan

### How to verify

1. Unit tests cover the new behavior — run `cd packages/cli && npx vitest run src/services/McpPromptLoader.test.ts` and confirm all 33 tests pass.
2. To verify end-to-end, configure an MCP server whose prompt declares no `arguments` field, then run `/prompt_name some text`. Before this fix the server receives `arguments: {}`; after the fix it receives `arguments: { input: "some text" }`.

### Evidence (Before & After)

N/A — no user-visible TUI change; behavior is in MCP argument forwarding.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A — only unit tests.

## Risk & Scope

- Main risk or tradeoff: MCP servers that explicitly declare zero arguments and do not expect an `input` key will receive one. The MCP spec allows servers to ignore unknown arguments, so this should be safe. A server that strictly validates argument keys could surface a new error, but that error would be more informative than the previous silent drop.
- Not validated / out of scope: No-argument prompts that receive only named arguments (e.g. `--key="value"`) — the named args are forwarded as-is, which is the expected behavior but not the primary scenario reported in the issue.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6563

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 MCP server 的 prompt 未声明 `arguments` 字段时，斜杠命令处理器会静默丢弃用户在 prompt 名称后输入的所有内容。`parseArgs()` 方法将输入解析为命名参数和位置参数后，遇到一个提前的 `return {}`，将所有内容丢弃，从未传递到 `prompt.invoke()`。

本 PR 修改了这个提前返回逻辑，使得当 prompt 未声明参数（`undefined` 或空数组）时，解析后的输入仍然会转发给 MCP server：

- 命名参数（`--key="value"`）原样传递。
- 位置参数/自由文本通过 `input` 键转发（例如 `{ input: "abc" }`）。

这与 Claude Code 无条件转发用户文本的行为一致。

## 为什么需要

静默数据丢失是核心问题。用户输入 `/my_prompt some important context` 时，合理预期是文本会到达 MCP server，但它被静默丢弃，没有错误也没有反馈。MCP server 收到空的 `{}` 参数对象，使 prompt 看起来莫名其妙地坏了。

修复 #6563。

## 审阅者测试计划

### 如何验证

1. 单元测试覆盖了新行为 — 运行 `cd packages/cli && npx vitest run src/services/McpPromptLoader.test.ts`，确认全部 33 个测试通过。
2. 端到端验证：配置一个 prompt 未声明 `arguments` 字段的 MCP server，运行 `/prompt_name some text`。修复前 server 收到 `arguments: {}`；修复后收到 `arguments: { input: "some text" }`。

### 证据（前后对比）

N/A — 无用户可见的 TUI 变化；行为在 MCP 参数转发层面。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

N/A — 仅单元测试。

## 风险与范围

- 主要风险/权衡：显式声明零个参数且不期望 `input` 键的 MCP server 会收到一个。MCP 规范允许 server 忽略未知参数，因此应该安全。严格验证参数键的 server 可能会出现新错误，但该错误比之前的静默丢弃更有信息量。
- 未验证/超出范围：仅收到命名参数（例如 `--key="value"`）的无参数 prompt — 命名参数原样转发，这是预期行为但不是 issue 中报告的主要场景。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #6563

</details>
