### PR TITLE
fix(web-shell): make dialog backdrop z-index configurable

### DIFF
--- a/packages/web-shell/client/components/dialogs/DialogShell.module.css
+++ b/packages/web-shell/client/components/dialogs/DialogShell.module.css
@@ -47,7 +47,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--web-shell-dialog-backdrop-z-index, 1000);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## What this PR does

Makes the Web Shell dialog backdrop z-index configurable through a CSS custom property, `--web-shell-dialog-backdrop-z-index`, while preserving the existing default stacking behavior.

## Why it's needed

Web Shell already exposes z-index customization for tooltip and popover layers through `--web-shell-tooltip-z-index` and `--web-shell-popover-z-index`. Dialog backdrops still used a hard-coded z-index, which made embedded hosts coordinate modal layering less consistently. This change brings the dialog backdrop in line with the existing customization pattern without changing the default value.

## Reviewer Test Plan

### How to verify

Set `--web-shell-dialog-backdrop-z-index` on `:root` or `body`, open any Web Shell dialog, and confirm the backdrop uses the configured stacking level. With no custom property set, dialogs should continue to use the previous effective z-index of 1000.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Ran `npm run build --workspace @qwen-code/web-shell`.

## Risk & Scope

- Main risk or tradeoff: Very low; the fallback keeps the previous z-index.
- Not validated / out of scope: Visual verification across Windows and Linux browsers.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 通过 CSS 自定义属性 `--web-shell-dialog-backdrop-z-index` 让 Web Shell 的 dialog backdrop z-index 可配置，同时保留现有默认层级行为。

## 为什么需要

Web Shell 目前已经通过 `--web-shell-tooltip-z-index` 和 `--web-shell-popover-z-index` 支持 tooltip 和 popover 层级的自定义。Dialog backdrop 仍然使用硬编码 z-index，嵌入式宿主在协调自己的 modal、overlay 或 shell 容器层级时不够一致。这个改动让 dialog backdrop 与已有的 z-index 自定义模式保持一致，同时不改变默认值。

## Reviewer Test Plan

### 如何验证

在 `:root` 或 `body` 上设置 `--web-shell-dialog-backdrop-z-index`，打开任意 Web Shell dialog，确认 backdrop 使用配置后的层级。未设置该自定义属性时，dialog 应继续使用之前等效的 z-index 1000。

### 证据（Before & After）

N/A

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

执行了 `npm run build --workspace @qwen-code/web-shell`。

## 风险与范围

- 主要风险或取舍：风险很低；fallback 保留了之前的 z-index。
- 未验证 / 不在范围内：未在 Windows 和 Linux 浏览器上做视觉验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>