### PR TITLE
ci: bump qwen-code-action pin to pick up stderr visibility fix

### DIFF
--- a/.github/workflows/qwen-automated-issue-triage.yml
+++ b/.github/workflows/qwen-automated-issue-triage.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Run Qwen Issue Analysis'
-        uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
+        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
         id: 'qwen_issue_analysis'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1037,7 +1037,7 @@ jobs:
       - name: 'Resolve conflicts'
         if: "steps.prepare.outputs.decision == 'run'"
         id: 'resolve_conflicts'
-        uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
+        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
         env:
           PR_NUMBER: '${{ steps.resolve.outputs.pr_number }}'
           BASE_REF: '${{ steps.prepare.outputs.base_ref }}'

--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -292,7 +292,7 @@ jobs:
           echo "Issue follow-up state: event=${EVENT_NAME} dispatch_dry=${DISPATCH_DRY_RUN} issues_dry=${ISSUE_OPENED_DRY_RUN} schedule_dry=${SCHEDULE_DRY_RUN} resolved_dry_run=${dry_run} scheduled_limit=${SCHEDULED_LIMIT_INPUT}"
 
       - name: 'Run Qwen issue follow-up'
-        uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
+        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
         env:
           GITHUB_TOKEN: '${{ env.BOT_GITHUB_TOKEN }}'
           GH_TOKEN: '${{ env.BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/qwen-scheduled-issue-triage.yml
+++ b/.github/workflows/qwen-scheduled-issue-triage.yml
@@ -54,7 +54,7 @@ jobs:
       - name: 'Run Qwen Issue Triage'
         if: |-
           ${{ steps.find_issues.outputs.issues_to_triage != '[]' }}
-        uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
+        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           ISSUES_TO_TRIAGE: '${{ steps.find_issues.outputs.issues_to_triage }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -260,7 +260,7 @@ jobs:
           fi
 
       - name: 'Run Qwen Triage'
-        uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
+        uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'
         env:
           GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'


### PR DESCRIPTION
## What this PR does

Bumps the `qwen-code-action` pin from `5fd6818d` to `6d08e91` across all 5 workflows that consume the action, picking up the stderr visibility fix merged in QwenLM/qwen-code-action#12.

## Why it's needed

The action previously captured stderr to a temp file but only printed it when the CLI exited non-zero. When the agent failed silently (exit 0 with empty output), stderr was discarded — the step reported success with no diagnostics. The fix (already merged in qwen-code-action) makes stderr always visible and adds a warning on empty responses. This PR updates the pin so all 5 workflows get the fix.

## Reviewer Test Plan

### How to verify

Confirm all 5 workflow files now reference `QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f` instead of the old pin `5fd6818d04d64e87d255ee4d5f77995e32fbf4c2`. The new commit is the merge commit of QwenLM/qwen-code-action#12.

### Evidence (Before & After)

N/A — CI pin bump, not user-visible.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

## Risk & Scope

- Main risk or tradeoff: None — the only change is the action commit hash. The action's behavior change (always emitting stderr) is additive and does not alter the action's outputs or exit codes.
- Not validated / out of scope: Did not run the workflows end-to-end (requires CI secrets).
- Breaking changes / migration notes: None.

## Linked Issues

Ref #6553