### PR TITLE
fix(desktop): preserve MCP URL query suffixes

### DIFF
--- a/packages/desktop/packages/shared/src/sources/__tests__/server-builder-url.test.ts
+++ b/packages/desktop/packages/shared/src/sources/__tests__/server-builder-url.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { normalizeMcpUrl } from '../server-builder.ts';
+
+describe('normalizeMcpUrl', () => {
+  test('removes trailing slashes from the URL pathname', () => {
+    expect(normalizeMcpUrl('https://api.example.com/mcp/')).toBe(
+      'https://api.example.com/mcp',
+    );
+    expect(normalizeMcpUrl('https://api.example.com/mcp///')).toBe(
+      'https://api.example.com/mcp',
+    );
+  });
+
+  test('preserves trailing slashes inside query parameters', () => {
+    expect(normalizeMcpUrl('https://api.example.com/mcp?key=/')).toBe(
+      'https://api.example.com/mcp?key=/',
+    );
+    expect(normalizeMcpUrl('https://api.example.com/mcp/?key=value/')).toBe(
+      'https://api.example.com/mcp?key=value/',
+    );
+  });
+
+  test('preserves trailing slashes inside URL fragments', () => {
+    expect(normalizeMcpUrl('https://api.example.com/mcp#/')).toBe(
+      'https://api.example.com/mcp#/',
+    );
+    expect(normalizeMcpUrl('https://api.example.com/mcp/#/route/')).toBe(
+      'https://api.example.com/mcp#/route/',
+    );
+  });
+
+  test('keeps legacy fallback behavior for non-parseable URLs', () => {
+    expect(normalizeMcpUrl('not a url///')).toBe('not a url');
+  });
+});

--- a/packages/desktop/packages/shared/src/sources/server-builder.ts
+++ b/packages/desktop/packages/shared/src/sources/server-builder.ts
@@ -338,7 +338,14 @@ export class SourceServerBuilder {
  * - Preserves the user-configured path as-is (no /mcp suffix appended)
  */
 export function normalizeMcpUrl(url: string): string {
-  return url.replace(/\/+$/, '');
+  const suffixIndex = url.search(/[?#]/);
+  if (suffixIndex === -1) {
+    return url.replace(/\/+$/, '');
+  }
+
+  return (
+    url.slice(0, suffixIndex).replace(/\/+$/, '') + url.slice(suffixIndex)
+  );
 }
 
 // Singleton instance

--- a/packages/desktop/packages/shared/src/sources/server-builder.ts
+++ b/packages/desktop/packages/shared/src/sources/server-builder.ts
@@ -334,7 +334,8 @@ export class SourceServerBuilder {
 
 /**
  * Normalize MCP URL to standard format
- * - Removes trailing slashes
+ * - Removes trailing slashes from the path portion only
+ * - Preserves query strings and fragments unchanged
  * - Preserves the user-configured path as-is (no /mcp suffix appended)
  */
 export function normalizeMcpUrl(url: string): string {


### PR DESCRIPTION
## What this PR does

This PR narrows MCP source URL normalization so trailing slash cleanup only applies before the query string or fragment. Remote MCP URLs still have trailing slashes removed from the path portion, but query values and hash fragments are preserved exactly as configured.

## Why it's needed

### What Problem This Solves

The previous implementation normalized MCP URLs with a string-level trailing slash trim:

```ts
url.replace(/\/+$, '')
```

That treats the entire URL as one flat string. URLs are structured values: the path, query string, and fragment each carry different routing or authentication semantics. For a URL such as `https://api.example.com/mcp?key=/`, the trailing slash belongs to the query parameter value, not the path. Removing it changes the configured endpoint semantics from `?key=/` to `?key=`.

That distinction matters for remote MCP sources because the configured `mcp.url` is passed into the runtime connection path. Query values can carry tokens, tenant identifiers, signed request material, compatibility flags, or provider-specific routing parameters. Fragments can also be used by some integrations as client-side routing or endpoint metadata. A normalizer that trims the whole string can therefore corrupt a valid remote MCP URL before the client attempts to connect.

### Changes

This PR keeps the existing path cleanup behavior, but narrows where it applies. Instead of trimming trailing slashes from the entire URL string, `normalizeMcpUrl()` now finds the first query or fragment boundary and trims only the path prefix before that boundary.

```diff
 export function normalizeMcpUrl(url: string): string {
-  return url.replace(/\/+$, '');
+  const suffixIndex = url.search(/[?#]/);
+  if (suffixIndex === -1) {
+    return url.replace(/\/+$/, '');
+  }
+
+  return (
+    url.slice(0, suffixIndex).replace(/\/+$, '') + url.slice(suffixIndex)
+  );
 }
```

The intentionally unchanged behavior is the existing path suffix normalization: `https://api.example.com/mcp/` still becomes `https://api.example.com/mcp`. The changed behavior is limited to preserving `search` and `hash` content exactly as configured.

### Evidence

The failure can be reproduced with the old string-level normalizer:

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=
https://api.example.com/mcp#/      -> https://api.example.com/mcp#
```

After this change, only the path portion is trimmed:

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=/
https://api.example.com/mcp#/      -> https://api.example.com/mcp#/
```

The added focused test covers the key URL shapes:

```bash
cd packages/desktop
bun test packages/shared/src/sources/__tests__/server-builder-url.test.ts
```

It verifies path trailing slash cleanup, query values ending in `/`, fragments ending in `/`, and the legacy fallback behavior for non-parseable strings.

### Possible call chain / impact

```text
source config mcp.url
  -> SourceServerBuilder.buildMcpServer(...)
  -> normalizeMcpUrl(mcp.url)
  -> McpServerConfig.url
  -> remote MCP client connection
```

The same helper is also reused by MCP connection validation, so preserving URL structure benefits both runtime source setup and validation-time connection checks.

This PR does not change OAuth discovery, credential headers, stdio MCP sources, API sources, or the behavior that removes trailing slashes from the path itself. It only prevents query strings and fragments from being treated as part of the path cleanup target.
## Reviewer Test Plan

### How to verify

Run the focused Bun test for MCP URL normalization:

```bash
cd packages/desktop
bun test packages/shared/src/sources/__tests__/server-builder-url.test.ts
```

The test covers path trailing slash cleanup plus query and fragment values that legitimately end with `/`.

### Evidence (Before & After)

N/A for screenshots; this is non-UI URL normalization behavior.

Before this change, string-level normalization produced:

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=
https://api.example.com/mcp#/      -> https://api.example.com/mcp#
```

After this change, only the path portion is trimmed:

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=/
https://api.example.com/mcp#/      -> https://api.example.com/mcp#/
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍎 macOS  | ⚪ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Windows: Bun 1.3.14 installed at `D:\ZXY\Dev\bun\bin`. Linux: WSL Ubuntu 22.04 with Bun 1.3.14 installed at `/mnt/d/ZXY/Dev/bun-linux/bin`.

Validation run:

```bash
cd packages/desktop
bun test packages/shared/src/sources/__tests__/server-builder-url.test.ts
bun run typecheck:shared
```

## Risk & Scope

- Main risk or tradeoff: very low; this changes URL normalization for remote MCP source URLs only and keeps the existing path trailing-slash cleanup behavior.
- Not validated / out of scope: macOS local validation, live remote MCP server calls, OAuth discovery, credential headers, stdio MCP sources, and API sources.
- Breaking changes / migration notes: none expected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 收窄 MCP source URL 的归一化逻辑：只在 query string 或 fragment 之前清理 path 的尾部斜杠。远程 MCP URL 的 path 仍会去掉尾斜杠，但 query 参数和 hash fragment 会按用户配置原样保留。

## 为什么需要它

之前的实现用整串字符串做尾部斜杠删除：

```ts
url.replace(/\/+$, '')
```

这会把 URL 当成一整段普通字符串处理。对于 `https://api.example.com/mcp?key=/` 这样的 URL，最后的 `/` 属于 query 参数值，而不是 path。删除它会把配置语义从 `?key=/` 改成 `?key=`，可能破坏依赖 query token、签名参数或 fragment routing 的远程 MCP server。

这是一个很小的 URL 结构保真修复：只规范化 path 后缀，不改写 `search` 或 `hash` 组件。

## Reviewer 测试计划

运行 focused Bun test：

```bash
cd packages/desktop
bun test packages/shared/src/sources/__tests__/server-builder-url.test.ts
```

该测试覆盖 path 尾斜杠清理，以及 query / fragment 里合法保留尾部 `/` 的情况。

## 证据（Before & After）

非 UI 改动，无截图。

修复前，字符串级归一化会产生：

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=
https://api.example.com/mcp#/      -> https://api.example.com/mcp#
```

修复后，只清理 path 部分：

```text
https://api.example.com/mcp/       -> https://api.example.com/mcp
https://api.example.com/mcp?key=/  -> https://api.example.com/mcp?key=/
https://api.example.com/mcp#/      -> https://api.example.com/mcp#/
```

## 测试环境

Windows：Bun 1.3.14，安装在 `D:\ZXY\Dev\bun\bin`。Linux：WSL Ubuntu 22.04，Bun 1.3.14，安装在 `/mnt/d/ZXY/Dev/bun-linux/bin`。

执行过的验证：

```bash
cd packages/desktop
bun test packages/shared/src/sources/__tests__/server-builder-url.test.ts
bun run typecheck:shared
```

## 风险与范围

主要风险很低；本 PR 只影响远程 MCP source URL 的归一化，并保留原有 path 尾斜杠清理行为。不包含 macOS 本地验证、真实远程 MCP server 调用、OAuth discovery、credential headers、stdio MCP sources 或 API sources。预计无 breaking changes。

## 关联 Issue

N/A

</details>