### PR TITLE
Guard main assistant protocol tag leakage

### DIFF
--- a/docs/plans/2026-07-09-protocol-leak-retry.md
+++ b/docs/plans/2026-07-09-protocol-leak-retry.md
@@ -1,0 +1,50 @@
+# Protocol Leak Retry Guard
+
+Status: WIP
+
+Issue: #6595
+
+## Problem
+
+Some long-context `qwen3.7-max` sessions can emit internal protocol-style tags
+such as `<analysis>` and `<summary>` in a normal main assistant response. When
+that response is treated as ordinary assistant text, it can be recorded into
+JSONL, pushed into chat history, and replayed into later prompts.
+
+The primary risk is context contamination. Once the bad response enters history,
+future turns and compaction can preserve or amplify the wrong summary-style
+mode.
+
+## Proposed Direction
+
+Treat visible protocol tags in normal main assistant text as invalid model
+output, not as content to sanitize in place.
+
+The first implementation should:
+
+1. Detect protocol-tag leakage on the main assistant response path before the
+   response is recorded or pushed into history.
+2. Discard the entire abnormal assistant response when the detector fires.
+3. Retry once from the original history before the bad response.
+4. Keep any corrective instruction request-only so it does not persist into the
+   conversation.
+5. Scope the initial guard to pure-text assistant responses to avoid replaying
+   tool calls after side-effecting tools may have executed.
+6. Leave expected compression side-query behavior unchanged, since compaction
+   can intentionally use `<analysis>` as internal scratchpad text.
+
+Compact fallback can be considered after a failed retry, but compaction should
+not be the first response because it can lose useful context.
+
+## Validation Plan
+
+- Unit-test protocol leak detection for `<analysis>`, `<summary>`, and related
+  internal tags.
+- Cover false positives such as fenced code blocks and valid HTML
+  `<details><summary>...</summary></details>`.
+- Add a stream/retry test where the first response leaks tags and the retry
+  succeeds.
+- Assert the rejected response is not recorded to JSONL and is not present in
+  chat history.
+- Assert compression side-query responses are not blocked by the main-turn
+  guard.


### PR DESCRIPTION
## What this PR does

Adds a WIP design note for guarding normal main assistant turns against visible protocol-tag leakage such as `<analysis>` and `<summary>`. This PR intentionally does not implement the runtime guard yet; it records the proposed scope and validation plan before code changes.

## Why it's needed

Issue #6595 describes cases where `qwen3.7-max` may emit internal analysis or summary tags in a normal assistant response. If that response is recorded into history, it can contaminate future prompts, replay, and compaction. The planned fix is to discard the abnormal assistant response and retry from the clean pre-response history instead of letting the leaked tags enter context.

## Reviewer Test Plan

### How to verify

Review the plan and confirm it scopes the first implementation to pure-text main assistant responses, excludes expected compression side-query scratchpad output, and requires tests proving rejected responses do not enter history or JSONL.

### Evidence (Before & After)

N/A. This is a planning-only draft PR with no runtime behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A.

## Risk & Scope

- Main risk or tradeoff: none for runtime behavior in this PR; the future implementation must avoid false positives for code fences, valid HTML `<summary>`, and expected compression side-query output.
- Not validated / out of scope: runtime detection, retry behavior, UI rollback for already-committed stream chunks, and compact fallback are not implemented in this PR.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #6595.

<details>
<summary>中文说明</summary>

## What this PR does

新增一份 WIP 设计说明，用来规划如何防止普通主对话 assistant turn 泄漏 `<analysis>`、`<summary>` 等内部协议标签。本 PR 暂不实现运行时代码，只先记录方案范围和验证计划。

## Why it's needed

#6595 描述了 `qwen3.7-max` 在部分场景下可能把内部分析或摘要标签输出到普通 assistant response 中的问题。如果这类 response 被写入 history，会污染后续 prompt、replay 和 compact。计划中的修复方向是丢弃异常 assistant response，并从异常 response 之前的干净 history 自动 retry，而不是让泄漏标签进入上下文。

## Reviewer Test Plan

### How to verify

阅读计划文档，确认第一版实现范围限定在纯文本主 assistant response；不会拦截预期的 compression side-query scratchpad 输出；并且要求测试证明被拒绝的 response 不会进入 history 或 JSONL。

### Evidence (Before & After)

N/A。本 PR 仅包含计划文档，没有运行时行为变化。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A。

## Risk & Scope

- Main risk or tradeoff: 本 PR 对运行时无影响；后续实现需要避免误伤代码块、合法 HTML `<summary>` 和预期的 compression side-query 输出。
- Not validated / out of scope: 本 PR 不包含运行时检测、retry 行为、UI 已提交流式片段回滚、compact fallback。
- Breaking changes / migration notes: 无。

## Linked Issues

关联 #6595。

</details>