### PR TITLE
ci(autofix): per-issue concurrency, route cancel-in-progress, assigned trigger

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -21,6 +21,7 @@ on:
   issues:
     types:
       - 'labeled'
+      - 'assigned'
   pull_request_review:
     types:
       - 'submitted'
@@ -88,6 +89,9 @@ jobs:
       ${{ github.repository == 'QwenLM/qwen-code' }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
+    concurrency:
+      group: 'qwen-autofix-route'
+      cancel-in-progress: true
     permissions:
       contents: 'read'
     outputs:
@@ -115,6 +119,7 @@ jobs:
           AUTOFIX_APPROVED_LABEL: 'autofix/approved'
           REPO: '${{ github.repository }}'
           SENDER_LOGIN: '${{ github.event.sender.login }}'
+          ASSIGNEE_LOGIN: '${{ github.event.assignee.login }}'
           SCHEDULE: '${{ github.event.schedule }}'
           PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
           PR_NUMBER_EVENT: '${{ github.event.pull_request.number }}'
@@ -196,8 +201,15 @@ jobs:
               fi
               if [[ "${EVENT_NAME}" == 'issues' ]]; then
                 DO_REVIEW=false
-                label_is_trigger=false
-                [[ "${ISSUE_LABEL}" == "${READY_FOR_AGENT_LABEL}" || "${ISSUE_LABEL}" == "${BUG_LABEL}" || "${ISSUE_LABEL}" == "${AUTOFIX_APPROVED_LABEL}" ]] && label_is_trigger=true
+                # Assigned to the autofix bot → issue phase directly (bypasses
+                # label gates; the assignee itself is the trust signal).
+                if [[ "${ASSIGNEE_LOGIN}" == "${AUTOFIX_BOT}" && "${ISSUE_STATE}" == 'open' ]]; then
+                  DO_ISSUE=true
+                  ROUTE_ISSUE="${ISSUE_NUMBER}"
+                  echo "🧭 issue #${ISSUE_NUMBER} assigned to ${AUTOFIX_BOT} → issue phase"
+                else
+                  label_is_trigger=false
+                  [[ "${ISSUE_LABEL}" == "${READY_FOR_AGENT_LABEL}" || "${ISSUE_LABEL}" == "${BUG_LABEL}" || "${ISSUE_LABEL}" == "${AUTOFIX_APPROVED_LABEL}" ]] && label_is_trigger=true
                 if [[ "${label_is_trigger}" != 'true' ]]; then
                   echo "🧭 issue event ignored: trigger_label=false label='${ISSUE_LABEL:-n/a}' issue='#${ISSUE_NUMBER:-n/a}'"
                 else
@@ -225,6 +237,7 @@ jobs:
                     echo "🧭 issue event ignored: state_open=$([[ "${ISSUE_STATE}" == 'open' ]] && echo true || echo false) bug=${issue_is_bug} ready=${issue_is_ready} approved=${issue_is_approved} trigger_label=${label_is_trigger} sender_permission='${sender_permission:-none}' sender_trusted=${sender_is_trusted} label='${ISSUE_LABEL:-n/a}' issue='#${ISSUE_NUMBER:-n/a}'"
                   fi
                 fi
+              fi
               fi
               ;;
           esac
@@ -259,7 +272,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 180
     concurrency:
-      group: 'qwen-autofix-issue'
+      group: 'qwen-autofix-issue-${{ needs.route.outputs.issue_number || github.run_id }}'
       cancel-in-progress: false
     permissions:
       contents: 'read'


### PR DESCRIPTION
## Problem

The autofix workflow has a concurrency bottleneck: all `issues`-triggered runs share a single concurrency group (`qwen-autofix-issue`), causing 9+ empty runs to queue for 39+ minutes when multiple label events fire in quick succession.

## Changes

### 1. Per-issue concurrency for parallel fixes

Changed `issue-autofix` concurrency group from global `qwen-autofix-issue` to `qwen-autofix-issue-${{ issue_number }}`. Different issues can now be fixed in parallel; duplicate triggers for the same issue still serialize.

### 2. Route job cancel-in-progress

Added `concurrency: { group: qwen-autofix-route, cancel-in-progress: true }` to the route job. When multiple label events fire in rapid succession (e.g. bot applying 5 labels at once), only the latest route job runs — earlier ones are cancelled.

### 3. Assigned event trigger

Added `assigned` to the issues event types. When an issue is assigned to the autofix bot (`qwen-code-dev-bot`), the route job routes directly to the issue phase, bypassing the `ready-for-agent` + `autofix/approved` label gates. The assignee itself serves as the trust signal.

## Test plan

- [ ] Label a non-trigger issue (e.g. `type/documentation`) — verify route job completes in ~4s and subsequent label events cancel earlier runs
- [ ] Assign an open issue to `qwen-code-dev-bot` — verify autofix picks it up without needing labels
- [ ] Open two issues with `ready-for-agent` + `autofix/approved` labels simultaneously — verify both get fixed in parallel (not serialized)