### PR TITLE
fix(cua-driver): complete coordinate normalization for zoom/scroll/mouse tools

### DIFF
--- a/packages/cua-driver/rust/Cargo.toml
+++ b/packages/cua-driver/rust/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["trycua"]
 license = "MIT"

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
@@ -42,7 +42,7 @@ pub fn px_to_norm(px: f64, dim: u32, scale: f64) -> f64 {
 /// `is_x_axis` true = scale by width, false = by height. `screen_basis` true =
 /// normalize against the SCREEN size (move_cursor moves the agent-cursor
 /// overlay in screen space — it has no window_id); false = against the window's
-/// screenshot size. scroll / page / set_value carry no coordinates → excluded.
+/// screenshot size.
 fn input_coord_fields(tool: &str) -> &'static [(&'static str, bool, bool)] {
     match tool {
         "click" | "double_click" | "right_click" => &[("x", true, false), ("y", false, false)],
@@ -62,6 +62,27 @@ fn input_coord_fields(tool: &str) -> &'static [(&'static str, bool, bool)] {
         ],
         // move_cursor positions the overlay in SCREEN space (no window_id).
         "move_cursor" => &[("x", true, true), ("y", false, true)],
+        // scroll x/y specify WHERE to deliver the wheel event (not scroll amount).
+        // macOS: window-local screenshot pixels. Windows: screen-absolute (desktop
+        // scope only, no pid → screenshot_w=0 → falls back to desktop/screen cache).
+        // Linux: no x/y params. Using window-basis here is safe for both: macOS
+        // gets window-local conversion, Windows desktop-scope hits the screenshot_w=0
+        // fallback path which routes to desktop_screenshot_size / screen_size.
+        "scroll" => &[("x", true, false), ("y", false, false)],
+        // Linux-only stateful mouse tools — window-local coordinates.
+        "mouse_button_down" | "mouse_button_up" => &[("x", true, false), ("y", false, false)],
+        "mouse_drag" => &[("x", true, false), ("y", false, false)],
+        // type_text/press_key/hotkey accept x/y for focus-by-pixel (internally
+        // delegates to click). Listed here so rewrite_coord_desc rewrites their
+        // field descriptions; denormalize_args converts them the same way.
+        "type_text" | "press_key" | "hotkey" => &[("x", true, false), ("y", false, false)],
+        // parallel_mouse_drag has nested coords handled specially in
+        // denormalize_args, but a non-empty entry ensures rewrite_coord_desc
+        // processes its top-level description and from_zoom field.
+        // The from_x/to_x/path fields are inside drags[] so they can't be
+        // listed here; their descriptions are handled by the nested rewrite
+        // in rewrite_coord_desc below.
+        "parallel_mouse_drag" => &[],
         _ => &[],
     }
 }
@@ -71,11 +92,15 @@ fn input_coord_fields(tool: &str) -> &'static [(&'static str, bool, bool)] {
 /// screen-basis fields (move_cursor) use the cached screen size. Desktop-scope
 /// clicks (no pid/window_id → `screenshot_w == 0`) fall back to screen size
 /// since `get_desktop_state` captures in true screen pixels.
-pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screenshot_h: u32) {
+///
+/// Returns `Err` with a guidance message when a required size basis is missing,
+/// so the caller can surface the error to the model instead of silently passing
+/// through unconverted normalized coordinates (which would land clicks at wrong
+/// positions).
+pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screenshot_h: u32) -> Result<(), String> {
     // from_zoom coords live in the zoom-image space, not window-local.
     // Denormalize against the cached zoom image dimensions instead of the
-    // window screenshot size. If no zoom cache exists (e.g. non-normalized
-    // mode, or zoom not yet called), fall through unchanged.
+    // window screenshot size. If no zoom cache exists, return an error.
     if args.get("from_zoom").and_then(|v| v.as_bool()).unwrap_or(false) {
         let pid = args.get("pid").and_then(|v| v.as_i64()).unwrap_or(0);
         if let Some((zw, zh)) = get_zoom_size(pid) {
@@ -86,31 +111,57 @@ pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screens
                     args[field] = json!(norm_to_px(v, dim, scale));
                 }
             }
+        } else {
+            // Only error when the tool actually carries coordinate fields.
+            let has_coords = input_coord_fields(tool).iter().any(|&(f, _, _)| {
+                args.get(f).and_then(|v| v.as_f64()).is_some()
+            });
+            if has_coords {
+                return Err(
+                    "from_zoom=true but no zoom context cached. \
+                     Call zoom first so the driver knows the zoom image dimensions."
+                        .to_string(),
+                );
+            }
         }
-        return;
+        return Ok(());
     }
     let scale = coordinate_scale();
     let screen = screen_size();
     for &(field, is_x, screen_basis) in input_coord_fields(tool) {
+        // Skip fields the caller didn't provide (e.g. element_index addressing).
+        if args.get(field).and_then(|v| v.as_f64()).is_none() {
+            continue;
+        }
         let (dw, dh) = if screen_basis {
             match screen {
                 Some(s) => s,
-                None => continue, // no screen size cached yet → leave field as-is
+                None => return Err(
+                    "Coordinate normalization requires screen size. \
+                     Call get_screen_size first so the driver can convert \
+                     0–1000 coordinates to pixels."
+                        .to_string(),
+                ),
             }
         } else if screenshot_w == 0 {
-            // No window basis available — two distinct cases:
-            //  1. Desktop-scope (no pid/window_id): use desktop screenshot size
-            //     (physical pixels from get_desktop_state).
-            //  2. Window-scope but get_window_state not yet called: leave as-is
-            //     to avoid mapping against the wrong basis.
             let has_window_target = args.get("pid").is_some_and(|v| !v.is_null())
                 || args.get("window_id").is_some_and(|v| !v.is_null());
             if has_window_target {
-                continue;
+                return Err(
+                    "Coordinate normalization requires window screenshot size. \
+                     Call get_window_state for this window first so the driver \
+                     can convert 0–1000 coordinates to pixels."
+                        .to_string(),
+                );
             }
             match desktop_screenshot_size() {
                 Some(s) => s,
-                None => continue,
+                None => return Err(
+                    "Coordinate normalization requires desktop screenshot size. \
+                     Call get_desktop_state first so the driver can convert \
+                     0–1000 coordinates to pixels."
+                        .to_string(),
+                ),
             }
         } else {
             (screenshot_w, screenshot_h)
@@ -120,6 +171,50 @@ pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screens
             args[field] = json!(norm_to_px(v, dim, scale));
         }
     }
+    // parallel_mouse_drag: coordinates are nested inside drags[].{path, from_x,
+    // from_y, to_x, to_y}. Each drag item may have a window_id so we use the
+    // caller-provided screenshot basis (same as click/drag).
+    if tool == "parallel_mouse_drag" {
+        if let Some(drags) = args.get_mut("drags").and_then(|v| v.as_array_mut()) {
+            let scale = coordinate_scale();
+            let (dw, dh) = if screenshot_w > 0 {
+                (screenshot_w, screenshot_h)
+            } else {
+                // parallel_mouse_drag always has window targets
+                return Err(
+                    "Coordinate normalization requires window screenshot size. \
+                     Call get_window_state first so the driver can convert \
+                     0–1000 coordinates to pixels."
+                        .to_string(),
+                );
+            };
+            for item in drags.iter_mut() {
+                // from_x/from_y/to_x/to_y
+                for (field, is_x) in &[("from_x", true), ("from_y", false), ("to_x", true), ("to_y", false)] {
+                    let dim = if *is_x { dw } else { dh };
+                    if let Some(v) = item.get(*field).and_then(|v| v.as_f64()) {
+                        item[*field] = json!(norm_to_px(v, dim, scale));
+                    }
+                }
+                // path: [[x,y], [x,y], ...]
+                if let Some(path) = item.get_mut("path").and_then(|v| v.as_array_mut()) {
+                    for point in path.iter_mut() {
+                        if let Some(arr) = point.as_array_mut() {
+                            if arr.len() >= 2 {
+                                if let Some(x) = arr[0].as_f64() {
+                                    arr[0] = json!(norm_to_px(x, dw, scale));
+                                }
+                                if let Some(y) = arr[1].as_f64() {
+                                    arr[1] = json!(norm_to_px(y, dh, scale));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Extract the downscaled screenshot size a `get_window_state` reported
@@ -177,18 +272,14 @@ pub fn rewrite_coord_desc(tools_list: &mut Value) {
             None => continue,
         };
         let fields = input_coord_fields(&name);
-        if fields.is_empty() {
-            continue; // not a converted tool — leave its docs alone
-        }
-        // Per-field coordinate descriptions. The MCP path emits `inputSchema`
-        // (camelCase); the daemon list path (serve.rs) emits `input_schema`
-        // (snake_case) — reach whichever this payload uses.
-        let schema_key = if tool.get("inputSchema").is_some() {
-            "inputSchema"
-        } else {
-            "input_schema"
-        };
-        if let Some(props) = tool
+        // Per-field coordinate descriptions — only for tools with coord fields.
+        if !fields.is_empty() {
+            let schema_key = if tool.get("inputSchema").is_some() {
+                "inputSchema"
+            } else {
+                "input_schema"
+            };
+            if let Some(props) = tool
             .get_mut(schema_key)
             .and_then(|s| s.get_mut("properties"))
             .and_then(|p| p.as_object_mut())
@@ -222,20 +313,85 @@ pub fn rewrite_coord_desc(tools_list: &mut Value) {
                 );
             }
         }
-        // Top-level description: swap the pixel phrasing. Compute the new string
-        // first so the immutable borrow ends before the mutable write-back.
-        let new_top = tool
-            .get("description")
-            .and_then(|d| d.as_str())
-            .filter(|d| d.contains("window-local screenshot pixels"))
-            .map(|d| {
-                d.replace(
-                    "window-local screenshot pixels",
-                    &format!("0–{scale} normalized coordinates (top-left origin)"),
-                )
-            });
-        if let Some(nd) = new_top {
-            tool["description"] = json!(nd);
+        } // end if !fields.is_empty()
+        // Top-level description: replace pixel-coordinate phrasing with
+        // normalized wording. Multiple variants exist across platforms.
+        if let Some(desc) = tool.get("description").and_then(|d| d.as_str()) {
+            let norm = format!("0–{scale} normalized coordinates (top-left origin)");
+            let mut d = desc.to_string();
+            let mut changed = false;
+            for pixel_phrase in &[
+                "window-local screenshot pixels",
+                "screenshot pixel coordinates",
+                "screenshot pixels",
+                "scaled-image coordinates",
+                "window-local pixels",
+                "window-local x, y pixels",
+            ] {
+                if d.contains(pixel_phrase) {
+                    d = d.replace(pixel_phrase, &norm);
+                    changed = true;
+                }
+            }
+            // Clean up redundant phrases left after replacement.
+            // "...normalized coordinates (top-left origin) — the same space
+            //  get_window_state returns. Top-left origin of the target's window."
+            for redundant in &[
+                " — the same space get_window_state returns. Top-left origin of the target's window.",
+                " — the same space get_window_state returns.",
+                " - the same space get_window_state returns. Top-left origin of the target's window.",
+                " - the same space get_window_state returns.",
+            ] {
+                if d.contains(redundant) {
+                    d = d.replace(redundant, ".");
+                    changed = true;
+                }
+            }
+            // "same pixel space as the screenshot" → "0–N normalized space"
+            if d.contains("same pixel space") {
+                d = d.replace(
+                    "same pixel space as the screenshot",
+                    &format!("0–{scale} normalized space"),
+                );
+                changed = true;
+            }
+            // "Prefer element_index over pixel coordinates" → normalized
+            if d.contains("over pixel coordinates") {
+                d = d.replace(
+                    "over pixel coordinates",
+                    &format!("over 0–{scale} normalized coordinates"),
+                );
+                changed = true;
+            }
+            // "image-pixel -> screen-point" (macOS right_click)
+            if d.contains("image-pixel") {
+                d = d.replace("image-pixel", &format!("0–{scale}-normalized"));
+                changed = true;
+            }
+            // "zoom-image pixel coordinates" (macOS click from_zoom description)
+            if d.contains("zoom-image pixel coordinates") {
+                d = d.replace(
+                    "zoom-image pixel coordinates",
+                    &format!("0–{scale} normalized zoom-image coordinates"),
+                );
+                changed = true;
+            }
+            // "true screen pixels" (get_desktop_state)
+            if d.contains("true screen pixels") {
+                d = d.replace("true screen pixels", &norm);
+                changed = true;
+            }
+            // "screen-absolute pixel" (get_desktop_state)
+            if d.contains("screen-absolute pixel") {
+                d = d.replace(
+                    "screen-absolute pixel",
+                    &format!("0–{scale} normalized"),
+                );
+                changed = true;
+            }
+            if changed {
+                tool["description"] = json!(d);
+            }
         }
     }
 }
@@ -480,17 +636,16 @@ mod tests {
 
     #[test]
     fn denormalize_click_uses_width_for_x_height_for_y() {
-        // Non-square image to catch any axis mix-up.
         let mut args = json!({ "pid": 1, "x": 500.0, "y": 500.0 });
-        denormalize_args("click", &mut args, 800, 600);
-        assert_eq!(args["x"], json!(400.0)); // 500/1000 * 800
-        assert_eq!(args["y"], json!(300.0)); // 500/1000 * 600
+        denormalize_args("click", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x"], json!(400.0));
+        assert_eq!(args["y"], json!(300.0));
     }
 
     #[test]
     fn denormalize_drag_converts_all_four_endpoints() {
         let mut args = json!({ "from_x": 0.0, "from_y": 0.0, "to_x": 1000.0, "to_y": 1000.0 });
-        denormalize_args("drag", &mut args, 800, 600);
+        denormalize_args("drag", &mut args, 800, 600).unwrap();
         assert_eq!(args["from_x"], json!(0.0));
         assert_eq!(args["from_y"], json!(0.0));
         assert_eq!(args["to_x"], json!(800.0));
@@ -503,56 +658,117 @@ mod tests {
     fn denormalize_from_zoom_uses_zoom_cache_when_available() {
         put_zoom_size(990010, 400, 300);
         let mut args = json!({ "pid": 990010, "x": 500.0, "y": 500.0, "from_zoom": true });
-        denormalize_args("click", &mut args, 800, 600);
-        assert_eq!(args["x"], json!(200.0)); // 500/1000 * 400
-        assert_eq!(args["y"], json!(150.0)); // 500/1000 * 300
+        denormalize_args("click", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x"], json!(200.0));
+        assert_eq!(args["y"], json!(150.0));
     }
 
     #[test]
-    fn denormalize_from_zoom_passes_through_without_cache() {
-        // No zoom cache for this pid → coords pass through unchanged.
+    fn denormalize_from_zoom_errors_without_cache() {
         let mut args = json!({ "pid": 990011, "x": 500.0, "y": 500.0, "from_zoom": true });
-        denormalize_args("click", &mut args, 800, 600);
-        assert_eq!(args["x"], json!(500.0));
-        assert_eq!(args["y"], json!(500.0));
+        let err = denormalize_args("click", &mut args, 800, 600).unwrap_err();
+        assert!(err.contains("zoom"), "error should mention zoom: {err}");
     }
 
     #[test]
     fn denormalize_zoom_converts_rect_by_axis() {
-        // zoom is window-basis like click: x1/x2 by width, y1/y2 by height.
         let mut args = json!({ "x1": 400.0, "y1": 400.0, "x2": 600.0, "y2": 600.0 });
-        denormalize_args("zoom", &mut args, 800, 600);
-        assert_eq!(args["x1"], json!(320.0)); // 400/1000*800
-        assert_eq!(args["x2"], json!(480.0)); // 600/1000*800
-        assert_eq!(args["y1"], json!(240.0)); // 400/1000*600
-        assert_eq!(args["y2"], json!(360.0)); // 600/1000*600
+        denormalize_args("zoom", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x1"], json!(320.0));
+        assert_eq!(args["x2"], json!(480.0));
+        assert_eq!(args["y1"], json!(240.0));
+        assert_eq!(args["y2"], json!(360.0));
     }
 
     #[test]
     fn denormalize_move_cursor_uses_screen_size() {
-        // move_cursor is screen-space (no window_id): normalize against the
-        // cached SCREEN size, not the window screenshot size. (Sole test that
-        // writes the screen-size global, so no cross-test race.)
         put_screen_size(1920, 1080);
         let mut args = json!({ "x": 500.0, "y": 500.0 });
-        denormalize_args("move_cursor", &mut args, 800, 600); // window size ignored
-        assert_eq!(args["x"], json!(960.0)); // 500/1000*1920 (screen, not 800)
-        assert_eq!(args["y"], json!(540.0)); // 500/1000*1080 (screen, not 600)
+        denormalize_args("move_cursor", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x"], json!(960.0));
+        assert_eq!(args["y"], json!(540.0));
     }
 
     #[test]
     fn denormalize_leaves_non_coord_tools_untouched() {
+        // scroll without x/y (keystroke path) — no coords to convert.
         let mut args = json!({ "direction": "down", "pid": 1 });
-        denormalize_args("scroll", &mut args, 800, 600);
+        denormalize_args("scroll", &mut args, 800, 600).unwrap();
         assert_eq!(args, json!({ "direction": "down", "pid": 1 }));
     }
 
     #[test]
+    fn denormalize_scroll_converts_xy_when_present() {
+        // scroll with x/y (pixel-wheel path) — coords are window-local.
+        let mut args = json!({ "pid": 1, "window_id": 2, "direction": "down", "x": 500.0, "y": 500.0 });
+        denormalize_args("scroll", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x"], json!(400.0)); // 500/1000 * 800
+        assert_eq!(args["y"], json!(300.0)); // 500/1000 * 600
+    }
+
+    #[test]
+    fn denormalize_mouse_button_down_converts_xy() {
+        let mut args = json!({ "pid": 1, "window_id": 2, "x": 500.0, "y": 500.0 });
+        denormalize_args("mouse_button_down", &mut args, 800, 600).unwrap();
+        assert_eq!(args["x"], json!(400.0));
+        assert_eq!(args["y"], json!(300.0));
+    }
+
+    #[test]
+    fn denormalize_parallel_mouse_drag_converts_nested_coords() {
+        let mut args = json!({
+            "drags": [
+                {
+                    "session": "s1", "window_id": 1,
+                    "from_x": 0.0, "from_y": 0.0, "to_x": 1000.0, "to_y": 1000.0
+                },
+                {
+                    "session": "s2", "window_id": 1,
+                    "path": [[500.0, 500.0], [1000.0, 0.0]]
+                }
+            ]
+        });
+        denormalize_args("parallel_mouse_drag", &mut args, 800, 600).unwrap();
+        let d = args["drags"].as_array().unwrap();
+        // Item 0: from_x/to_x by width, from_y/to_y by height
+        assert_eq!(d[0]["from_x"], json!(0.0));
+        assert_eq!(d[0]["from_y"], json!(0.0));
+        assert_eq!(d[0]["to_x"], json!(800.0));
+        assert_eq!(d[0]["to_y"], json!(600.0));
+        // Item 1: path points
+        let path = d[1]["path"].as_array().unwrap();
+        assert_eq!(path[0][0], json!(400.0)); // 500/1000 * 800
+        assert_eq!(path[0][1], json!(300.0)); // 500/1000 * 600
+        assert_eq!(path[1][0], json!(800.0)); // 1000/1000 * 800
+        assert_eq!(path[1][1], json!(0.0));   // 0/1000 * 600
+    }
+
+    #[test]
     fn denormalize_ignores_missing_coord_fields() {
-        // element_index addressing — no x/y present to convert.
         let mut args = json!({ "pid": 1, "element_index": 3 });
-        denormalize_args("click", &mut args, 800, 600);
+        denormalize_args("click", &mut args, 800, 600).unwrap();
         assert_eq!(args, json!({ "pid": 1, "element_index": 3 }));
+    }
+
+    #[test]
+    fn denormalize_errors_when_window_cache_missing() {
+        // screenshot_w=0 + has pid → window-scope without cache → error
+        let mut args = json!({ "pid": 42, "x": 500.0, "y": 500.0 });
+        let err = denormalize_args("click", &mut args, 0, 0).unwrap_err();
+        assert!(err.contains("get_window_state"), "error should guide to get_window_state: {err}");
+    }
+
+    #[test]
+    fn denormalize_errors_when_screen_cache_missing() {
+        // move_cursor with no screen size cached → error
+        // Use a fresh args without touching any global cache
+        let mut args = json!({ "x": 500.0, "y": 500.0 });
+        // Only test when screen cache is empty (other tests may populate it).
+        // The core assertion: the error message guides to get_screen_size.
+        if screen_size().is_none() {
+            let err = denormalize_args("move_cursor", &mut args, 0, 0).unwrap_err();
+            assert!(err.contains("get_screen_size"), "{err}");
+        }
     }
 
     // ---- output: size basis extraction + result normalization ----
@@ -725,32 +941,27 @@ mod tests {
     fn denormalize_click_falls_back_to_desktop_screenshot_size() {
         put_desktop_screenshot_size(3840, 2160);
         let mut args = json!({ "x": 500.0, "y": 500.0 });
-        // screenshot_w=0 simulates no window cache (desktop-scope, no pid)
-        denormalize_args("click", &mut args, 0, 0);
-        assert_eq!(args["x"], json!(1920.0)); // 500/1000*3840
-        assert_eq!(args["y"], json!(1080.0)); // 500/1000*2160
+        denormalize_args("click", &mut args, 0, 0).unwrap();
+        assert_eq!(args["x"], json!(1920.0));
+        assert_eq!(args["y"], json!(1080.0));
     }
 
     #[test]
-    fn denormalize_click_skips_window_scope_without_cache() {
-        put_desktop_screenshot_size(3840, 2160);
-        // pid present but no get_window_state yet → must NOT fall back
+    fn denormalize_click_errors_window_scope_without_cache() {
+        // pid present but no get_window_state yet → error
         let mut args = json!({ "pid": 42, "x": 500.0, "y": 500.0 });
-        denormalize_args("click", &mut args, 0, 0);
-        assert_eq!(args["x"], json!(500.0)); // unchanged
-        assert_eq!(args["y"], json!(500.0)); // unchanged
+        let err = denormalize_args("click", &mut args, 0, 0).unwrap_err();
+        assert!(err.contains("get_window_state"), "{err}");
     }
 
     #[test]
     fn denormalize_move_cursor_not_affected_by_desktop_cache() {
-        // move_cursor uses screen_size (logical), not desktop_screenshot_size.
-        // Even if desktop cache is populated, move_cursor must use screen cache.
         put_screen_size(1920, 1080);
         put_desktop_screenshot_size(3840, 2160);
         let mut args = json!({ "x": 500.0, "y": 500.0 });
-        denormalize_args("move_cursor", &mut args, 0, 0);
-        assert_eq!(args["x"], json!(960.0));  // 500/1000*1920 (logical)
-        assert_eq!(args["y"], json!(540.0));  // 500/1000*1080 (logical)
+        denormalize_args("move_cursor", &mut args, 0, 0).unwrap();
+        assert_eq!(args["x"], json!(960.0));
+        assert_eq!(args["y"], json!(540.0));
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
@@ -72,9 +72,21 @@ fn input_coord_fields(tool: &str) -> &'static [(&'static str, bool, bool)] {
 /// clicks (no pid/window_id → `screenshot_w == 0`) fall back to screen size
 /// since `get_desktop_state` captures in true screen pixels.
 pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screenshot_h: u32) {
-    // from_zoom coords live in the zoom-image space, not window-local; core has
-    // no crop basis to convert them, so leave the whole call untouched.
+    // from_zoom coords live in the zoom-image space, not window-local.
+    // Denormalize against the cached zoom image dimensions instead of the
+    // window screenshot size. If no zoom cache exists (e.g. non-normalized
+    // mode, or zoom not yet called), fall through unchanged.
     if args.get("from_zoom").and_then(|v| v.as_bool()).unwrap_or(false) {
+        let pid = args.get("pid").and_then(|v| v.as_i64()).unwrap_or(0);
+        if let Some((zw, zh)) = get_zoom_size(pid) {
+            let scale = coordinate_scale();
+            for &(field, is_x, _) in input_coord_fields(tool) {
+                let dim = if is_x { zw } else { zh };
+                if let Some(v) = args.get(field).and_then(|v| v.as_f64()) {
+                    args[field] = json!(norm_to_px(v, dim, scale));
+                }
+            }
+        }
         return;
     }
     let scale = coordinate_scale();
@@ -196,6 +208,18 @@ pub fn rewrite_coord_desc(tools_list: &mut Value) {
                     };
                     fobj.insert("description".to_string(), json!(desc));
                 }
+            }
+            // from_zoom: rewrite to say "normalized" instead of "pixel"
+            // so the model sends 0–scale coords for zoom-image clicks too.
+            if let Some(fobj) = props.get_mut("from_zoom").and_then(|f| f.as_object_mut()) {
+                fobj.insert(
+                    "description".to_string(),
+                    json!(format!(
+                        "When true, x and y are 0–{scale} normalized coordinates \
+                         in the last zoom image for this pid. The driver maps them \
+                         back to window coords."
+                    )),
+                );
             }
         }
         // Top-level description: swap the pixel phrasing. Compute the new string
@@ -369,6 +393,43 @@ pub fn ingest_screen_size(tool: &str, result: &ToolResult) {
     }
 }
 
+// ── Zoom-image size cache (for from_zoom click denormalization) ─────────────
+
+/// Per-pid zoom-image size cache. Keyed on pid alone (matching the platform
+/// `ZoomRegistry`). Written by `ingest_zoom_size` after a `zoom` call,
+/// read by `denormalize_args` when `from_zoom=true`.
+static ZOOM_SIZE_CACHE: OnceLock<Mutex<HashMap<i64, (u32, u32)>>> = OnceLock::new();
+
+fn zoom_size_cache() -> &'static Mutex<HashMap<i64, (u32, u32)>> {
+    ZOOM_SIZE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn put_zoom_size(pid: i64, w: u32, h: u32) {
+    if let Ok(mut cache) = zoom_size_cache().lock() {
+        cache.insert(pid, (w, h));
+    }
+}
+
+pub fn get_zoom_size(pid: i64) -> Option<(u32, u32)> {
+    zoom_size_cache().lock().ok()?.get(&pid).copied()
+}
+
+/// Ingest the zoom image size from a `zoom` result into the cache so that
+/// subsequent `from_zoom=true` clicks can denormalize against it.
+pub fn ingest_zoom_size(tool: &str, args: &Value, result: &ToolResult) {
+    if tool != "zoom" {
+        return;
+    }
+    let pid = args.get("pid").and_then(|v| v.as_i64()).unwrap_or(0);
+    if let Some(sc) = result.structured_content.as_ref() {
+        let w = sc.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let h = sc.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        if w > 0 && h > 0 {
+            put_zoom_size(pid, w, h);
+        }
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -439,10 +500,18 @@ mod tests {
     // ---- exclusions / passthrough ----
 
     #[test]
-    fn denormalize_skips_when_from_zoom_set() {
-        // from_zoom coords are in the zoom-image space; core has no crop basis
-        // to convert them, so they must pass through untouched.
-        let mut args = json!({ "x": 500.0, "y": 500.0, "from_zoom": true });
+    fn denormalize_from_zoom_uses_zoom_cache_when_available() {
+        put_zoom_size(990010, 400, 300);
+        let mut args = json!({ "pid": 990010, "x": 500.0, "y": 500.0, "from_zoom": true });
+        denormalize_args("click", &mut args, 800, 600);
+        assert_eq!(args["x"], json!(200.0)); // 500/1000 * 400
+        assert_eq!(args["y"], json!(150.0)); // 500/1000 * 300
+    }
+
+    #[test]
+    fn denormalize_from_zoom_passes_through_without_cache() {
+        // No zoom cache for this pid → coords pass through unchanged.
+        let mut args = json!({ "pid": 990011, "x": 500.0, "y": 500.0, "from_zoom": true });
         denormalize_args("click", &mut args, 800, 600);
         assert_eq!(args["x"], json!(500.0));
         assert_eq!(args["y"], json!(500.0));
@@ -633,6 +702,24 @@ mod tests {
     }
 
     // ---- desktop-scope ----
+
+    #[test]
+    fn ingest_zoom_size_caches_from_zoom_result() {
+        let args = json!({ "pid": 990020 });
+        let r = ToolResult::text("ok")
+            .with_structured(json!({ "width": 400, "height": 300, "format": "jpeg" }));
+        ingest_zoom_size("zoom", &args, &r);
+        assert_eq!(get_zoom_size(990020), Some((400, 300)));
+    }
+
+    #[test]
+    fn ingest_zoom_size_ignores_non_zoom() {
+        let args = json!({ "pid": 990021 });
+        let r = ToolResult::text("ok")
+            .with_structured(json!({ "width": 400, "height": 300 }));
+        ingest_zoom_size("click", &args, &r);
+        assert_eq!(get_zoom_size(990021), None);
+    }
 
     #[test]
     fn denormalize_click_falls_back_to_desktop_screenshot_size() {

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
@@ -8,7 +8,7 @@
 //!
 //! Three hooks, wired into `ToolRegistry::invoke` / `tools_list`:
 //!   - input  : `denormalize_args`  — 0–1000 → pixels, before the real tool
-//!   - output : `normalize_result`  — pixels → 0–1000, on the way back
+//!   - output : `normalize_result`  — no-op (query results returned unmodified)
 //!   - listing: `rewrite_coord_desc`— pixel wording → normalized wording
 //!
 //! Conversion is anchored to the **downscaled screenshot size** the matching
@@ -227,31 +227,13 @@ pub fn extract_screenshot_size(result: &ToolResult) -> Option<(u32, u32)> {
     Some((w, h))
 }
 
-/// In-place normalize a tool result's pixel coordinates back to 0–`scale`.
-///
-/// Rewrites `screenshot_width/height` to the configured full-scale (default
-/// 1000) so the model treats the returned image as a 0–`scale` grid — matching
-/// the basis `denormalize_args` uses for input. Element frames stay in pixels —
-/// they are screen-global with no window-origin/scale basis available in core
-/// (see design doc §5), so converting them here would introduce error.
-pub fn normalize_result(tool: &str, result: &mut ToolResult) {
-    if tool != "get_window_state" && tool != "get_desktop_state" {
-        return;
-    }
-    let scale = coordinate_scale() as u64;
-    if let Some(obj) = result
-        .structured_content
-        .as_mut()
-        .and_then(|v| v.as_object_mut())
-    {
-        if obj.contains_key("screenshot_width") {
-            obj.insert("screenshot_width".to_string(), json!(scale));
-        }
-        if obj.contains_key("screenshot_height") {
-            obj.insert("screenshot_height".to_string(), json!(scale));
-        }
-    }
-}
+/// No-op in normalized mode. Previously this rewrote `screenshot_width/height`
+/// to 1000 to hint the model about the 0–1000 grid, but that conflicted with
+/// `elements[].frame` (which stays in pixels) and `screen_width/height`,
+/// giving the model contradictory coordinate information. The model is now
+/// guided to use 0–1000 coordinates purely through tool schema descriptions
+/// and MCP instructions; query results are returned unmodified.
+pub fn normalize_result(_tool: &str, _result: &mut ToolResult) {}
 
 /// Rewrite coordinate-field descriptions in a `tools/list` payload from pixel
 /// wording to 0–`scale` normalized wording. Caller gates on normalized mode.
@@ -790,13 +772,15 @@ mod tests {
     }
 
     #[test]
-    fn normalize_result_rewrites_screenshot_dims_to_1000() {
+    fn normalize_result_is_noop() {
+        // normalize_result no longer rewrites screenshot_width/height —
+        // query results are returned unmodified.
         let mut r = ToolResult::text("ok")
             .with_structured(json!({ "screenshot_width": 800, "screenshot_height": 600 }));
         normalize_result("get_window_state", &mut r);
         let sc = r.structured_content.as_ref().unwrap();
-        assert_eq!(sc["screenshot_width"], json!(1000));
-        assert_eq!(sc["screenshot_height"], json!(1000));
+        assert_eq!(sc["screenshot_width"], json!(800));
+        assert_eq!(sc["screenshot_height"], json!(600));
     }
 
     #[test]
@@ -965,7 +949,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_result_rewrites_get_desktop_state() {
+    fn normalize_result_desktop_state_is_noop() {
         let mut r = ToolResult::text("ok")
             .with_structured(json!({
                 "screenshot_width": 3840,
@@ -975,8 +959,10 @@ mod tests {
             }));
         normalize_result("get_desktop_state", &mut r);
         let sc = r.structured_content.as_ref().unwrap();
-        assert_eq!(sc["screenshot_width"], json!(1000));
-        assert_eq!(sc["screenshot_height"], json!(1000));
+        assert_eq!(sc["screenshot_width"], json!(3840));
+        assert_eq!(sc["screenshot_height"], json!(2160));
+        assert_eq!(sc["screen_width"], json!(1920));
+        assert_eq!(sc["screen_height"], json!(1080));
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/coord_norm.rs
@@ -77,11 +77,8 @@ fn input_coord_fields(tool: &str) -> &'static [(&'static str, bool, bool)] {
         // field descriptions; denormalize_args converts them the same way.
         "type_text" | "press_key" | "hotkey" => &[("x", true, false), ("y", false, false)],
         // parallel_mouse_drag has nested coords handled specially in
-        // denormalize_args, but a non-empty entry ensures rewrite_coord_desc
-        // processes its top-level description and from_zoom field.
-        // The from_x/to_x/path fields are inside drags[] so they can't be
-        // listed here; their descriptions are handled by the nested rewrite
-        // in rewrite_coord_desc below.
+        // denormalize_args. Listed here (with empty fields) so
+        // rewrite_coord_desc processes its top-level description.
         "parallel_mouse_drag" => &[],
         _ => &[],
     }
@@ -101,7 +98,11 @@ pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screens
     // from_zoom coords live in the zoom-image space, not window-local.
     // Denormalize against the cached zoom image dimensions instead of the
     // window screenshot size. If no zoom cache exists, return an error.
-    if args.get("from_zoom").and_then(|v| v.as_bool()).unwrap_or(false) {
+    // parallel_mouse_drag does not support from_zoom — skip this block
+    // so its nested handler below is always reached.
+    if tool != "parallel_mouse_drag"
+        && args.get("from_zoom").and_then(|v| v.as_bool()).unwrap_or(false)
+    {
         let pid = args.get("pid").and_then(|v| v.as_i64()).unwrap_or(0);
         if let Some((zw, zh)) = get_zoom_size(pid) {
             let scale = coordinate_scale();
@@ -172,25 +173,29 @@ pub fn denormalize_args(tool: &str, args: &mut Value, screenshot_w: u32, screens
         }
     }
     // parallel_mouse_drag: coordinates are nested inside drags[].{path, from_x,
-    // from_y, to_x, to_y}. Each drag item may have a window_id so we use the
-    // caller-provided screenshot basis (same as click/drag).
+    // from_y, to_x, to_y, x_from, x_to}. Each drag item has its own window_id,
+    // so we look up per-item size from SIZE_CACHE.
     if tool == "parallel_mouse_drag" {
         if let Some(drags) = args.get_mut("drags").and_then(|v| v.as_array_mut()) {
             let scale = coordinate_scale();
-            let (dw, dh) = if screenshot_w > 0 {
-                (screenshot_w, screenshot_h)
-            } else {
-                // parallel_mouse_drag always has window targets
-                return Err(
-                    "Coordinate normalization requires window screenshot size. \
-                     Call get_window_state first so the driver can convert \
-                     0–1000 coordinates to pixels."
-                        .to_string(),
-                );
-            };
             for item in drags.iter_mut() {
-                // from_x/from_y/to_x/to_y
-                for (field, is_x) in &[("from_x", true), ("from_y", false), ("to_x", true), ("to_y", false)] {
+                let item_pid = item.get("pid").and_then(|v| v.as_i64()).unwrap_or(0);
+                let item_wid = item.get("window_id").and_then(|v| v.as_u64()).unwrap_or(0);
+                let (dw, dh) = match get_size(item_pid, item_wid) {
+                    Some(s) => s,
+                    None => return Err(
+                        "Coordinate normalization requires window screenshot size. \
+                         Call get_window_state for this window first so the driver \
+                         can convert 0–1000 coordinates to pixels."
+                            .to_string(),
+                    ),
+                };
+                // from_x/from_y/to_x/to_y + fn domain bounds x_from/x_to
+                for (field, is_x) in &[
+                    ("from_x", true), ("from_y", false),
+                    ("to_x", true), ("to_y", false),
+                    ("x_from", true), ("x_to", true),
+                ] {
                     let dim = if *is_x { dw } else { dh };
                     if let Some(v) = item.get(*field).and_then(|v| v.as_f64()) {
                         item[*field] = json!(norm_to_px(v, dim, scale));
@@ -698,31 +703,42 @@ mod tests {
 
     #[test]
     fn denormalize_parallel_mouse_drag_converts_nested_coords() {
+        // Each drag item uses its own (pid, window_id) for SIZE_CACHE lookup.
+        put_size(990030, 1, 800, 600);
+        put_size(990030, 2, 1024, 768);
         let mut args = json!({
             "drags": [
                 {
-                    "session": "s1", "window_id": 1,
+                    "session": "s1", "pid": 990030, "window_id": 1,
                     "from_x": 0.0, "from_y": 0.0, "to_x": 1000.0, "to_y": 1000.0
                 },
                 {
-                    "session": "s2", "window_id": 1,
+                    "session": "s2", "pid": 990030, "window_id": 1,
                     "path": [[500.0, 500.0], [1000.0, 0.0]]
+                },
+                {
+                    "session": "s3", "pid": 990030, "window_id": 2,
+                    "fn": "sin(x)", "x_from": 0.0, "x_to": 500.0
                 }
             ]
         });
-        denormalize_args("parallel_mouse_drag", &mut args, 800, 600).unwrap();
+        // screenshot_w/h args are ignored — per-item lookup used instead
+        denormalize_args("parallel_mouse_drag", &mut args, 0, 0).unwrap();
         let d = args["drags"].as_array().unwrap();
-        // Item 0: from_x/to_x by width, from_y/to_y by height
+        // Item 0 (window_id=1 → 800x600): from_x/to_x by width, from_y/to_y by height
         assert_eq!(d[0]["from_x"], json!(0.0));
         assert_eq!(d[0]["from_y"], json!(0.0));
         assert_eq!(d[0]["to_x"], json!(800.0));
         assert_eq!(d[0]["to_y"], json!(600.0));
-        // Item 1: path points
+        // Item 1 (window_id=1 → 800x600): path points
         let path = d[1]["path"].as_array().unwrap();
         assert_eq!(path[0][0], json!(400.0)); // 500/1000 * 800
         assert_eq!(path[0][1], json!(300.0)); // 500/1000 * 600
-        assert_eq!(path[1][0], json!(800.0)); // 1000/1000 * 800
-        assert_eq!(path[1][1], json!(0.0));   // 0/1000 * 600
+        assert_eq!(path[1][0], json!(800.0));
+        assert_eq!(path[1][1], json!(0.0));
+        // Item 2 (window_id=2 → 1024x768): fn domain x_from/x_to
+        assert_eq!(d[2]["x_from"], json!(0.0));
+        assert_eq!(d[2]["x_to"], json!(512.0)); // 500/1000 * 1024
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
@@ -203,6 +203,12 @@ fn agent_instructions() -> String {
 
     let (coord_term, coord_note) = coordinate_terms(crate::coord_norm::default_normalized());
 
+    let click_hint = if crate::coord_norm::default_normalized() {
+        "issue a coordinate click or move_cursor first for a visibly gliding demo/recording."
+    } else {
+        "issue a pixel click or move_cursor first for a visibly gliding demo/recording."
+    };
+
     format!(
         r#"cua-driver: cross-platform background computer-use automation.
 
@@ -216,7 +222,7 @@ Workflow per turn:
 4. click/type_text/press_key using element_index from step 3 (+ your `session`)
 5. get_window_state(pid, window_id) again → verify the action landed
 
-Agent cursor: a per-SESSION overlay cursor visualises where a run is acting without moving the real pointer. It is shown only for a DECLARED session (pass `session`), is color-coded by the session id, and is removed by end_session or the idle-TTL. The same id over MCP, the CLI, or the raw socket drives the same cursor. set_agent_cursor_* tools hide/show/customise it. Note: a pure accessibility-action (element_index) click snaps the cursor with a brief pulse on its first action rather than a long glide, so it can be easy to miss — issue a pixel click or move_cursor first for a visibly gliding demo/recording.
+Agent cursor: a per-SESSION overlay cursor visualises where a run is acting without moving the real pointer. It is shown only for a DECLARED session (pass `session`), is color-coded by the session id, and is removed by end_session or the idle-TTL. The same id over MCP, the CLI, or the raw socket drives the same cursor. set_agent_cursor_* tools hide/show/customise it. Note: a pure accessibility-action (element_index) click snaps the cursor with a brief pulse on its first action rather than a long glide, so it can be easy to miss — {click_hint}
 
 If a `cua-driver` skill is loaded in your harness (Claude Code / Codex / OpenClaw / OpenCode dirs), prefer its detailed workflow — SKILL.md plus {platform_skill_pointer}. Install with `cua-driver skills install` if not yet present."#
     )

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -436,6 +436,7 @@ impl ToolRegistry {
         if self.normalized {
             crate::coord_norm::ingest_window_size(resolved_name, &args, &result);
             crate::coord_norm::ingest_screen_size(resolved_name, &result);
+            crate::coord_norm::ingest_zoom_size(resolved_name, &args, &result);
             crate::coord_norm::normalize_result(resolved_name, &mut result);
         }
 

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -423,7 +423,9 @@ impl ToolRegistry {
             let pid = args.opt_i64("pid").unwrap_or(0);
             let window_id = args.opt_u64("window_id").unwrap_or(0);
             let (w, h) = crate::coord_norm::get_size(pid, window_id).unwrap_or((0, 0));
-            crate::coord_norm::denormalize_args(resolved_name, &mut args, w, h);
+            if let Err(msg) = crate::coord_norm::denormalize_args(resolved_name, &mut args, w, h) {
+                return ToolResult::error(msg);
+            }
         }
 
         let mut result = match self.tools.get(resolved_name) {

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/tool.rs
@@ -433,8 +433,7 @@ impl ToolRegistry {
             None => return ToolResult::error(format!("Unknown tool: {name}")),
         };
 
-        // ── coord_norm output hook: cache the size basis, then pixels → 0–1000.
-        // ingest must precede normalize_result (which rewrites the dims to 1000).
+        // ── coord_norm output hook: cache the size basis for subsequent calls.
         if self.normalized {
             crate::coord_norm::ingest_window_size(resolved_name, &args, &result);
             crate::coord_norm::ingest_screen_size(resolved_name, &result);


### PR DESCRIPTION
## What this PR does

Fixes multiple gaps in cua-driver's 0–1000 normalized coordinate mode (`CUA_DRIVER_RS_COORDINATE_SPACE=1`):

1. **Stop rewriting query results**: `normalize_result` no longer overwrites `screenshot_width/height` to 1000 in `get_window_state`/`get_desktop_state` responses — this conflicted with `elements[].frame` which stays in real pixels, giving the model contradictory coordinate info.
2. **Fix zoom + from_zoom click**: Add zoom image size cache (`ZOOM_SIZE_CACHE`); `from_zoom=true` clicks now denormalize against the cached zoom dimensions instead of being silently skipped. Rewrite `from_zoom` schema description from "pixel coordinates" to "0–1000 normalized".
3. **Error on missing cache**: `denormalize_args` returns `Result` and errors when the required size basis is missing, instead of silently passing through unconverted 0–1000 values that land clicks at wrong positions.
4. **Cover missing tools**: Add scroll, type_text, press_key, hotkey, mouse_button_down/up, mouse_drag, parallel_mouse_drag to `input_coord_fields` for coordinate conversion and description rewriting.
5. **Fix parallel_mouse_drag**: Per-item `(pid, window_id)` SIZE_CACHE lookup instead of top-level args; convert `x_from`/`x_to` (fn domain bounds); prevent `from_zoom` early return from skipping nested handler.
6. **Complete description rewrites**: Cover all pixel-related phrases across platforms (zoom, drag, get_desktop_state, etc.) and clean up redundant post-replacement text.
7. **Fix MCP instructions**: "issue a pixel click" → "issue a coordinate click" in normalized mode.

## Why it's needed

Users enabling `CUA_DRIVER_RS_COORDINATE_SPACE=1` for 0–1000 normalized coordinate mode reported that the mode was not fully effective: tool schema descriptions still said "pixel", zoom+from_zoom clicks landed at wrong positions, and some tools (scroll, Linux mouse tools) had no coordinate conversion at all. The `screenshot_width/height → 1000` rewrite also contradicted the real pixel values in `elements[].frame`, confusing the model.

## Reviewer Test Plan

### How to verify

1. Set `CUA_DRIVER_RS_COORDINATE_SPACE=1` in cua-driver MCP env config
2. Call `get_window_state` → verify `screenshot_width/height` returns real pixel values (not 1000)
3. Call `zoom` on a region → verify the returned `width`/`height` are real pixels
4. Call `click(from_zoom=true, x=500, y=500)` → should denormalize 500 against zoom image size and click the center of the zoom region
5. Call `scroll(x=500, y=500, direction=down)` → should denormalize and scroll at the center of the window
6. Check `tools/list` → all coordinate field descriptions should say "0–1000 normalized", including `from_zoom`

### Evidence (Before & After)

**Before**: model sent pixel coords (180,180) for from_zoom click because `from_zoom` description said "pixel coordinates"; `screenshot_width` was rewritten to 1000 but `elements[].frame` stayed in pixels.

**After**: model sends normalized coords (500,498) for from_zoom click; `screenshot_width` returns real value; all descriptions consistent.

Verified via qwen-code headless E2E: sessions `0267ce02` (before) → `6e29f869` (after, from_zoom click correct) → `a36fc2f4` (scroll with normalized coords).

### Tested on

- macOS (cargo test: 154 passed, E2E via qwen-code MCP)

## Risk & Scope

- **Breaking change**: `normalize_result` no longer rewrites `screenshot_width/height` to 1000. Models that relied on seeing `screenshot_width=1000` to decide coordinate scale will now see real pixel values — but the schema descriptions and MCP instructions already tell them to use 0–1000, so this should be a net improvement.
- **Scope**: changes are confined to `cua-driver-core` (coord_norm.rs, tool.rs, protocol.rs) + version bump in workspace Cargo.toml. No platform-layer changes.

## Linked Issues

User-reported: relative coordinate mode not fully effective (zoom clicks wrong, tool descriptions inconsistent, query results tampered).

<details>
<summary>中文说明</summary>

修复 cua-driver 0–1000 归一化坐标模式的多个缺陷：停止篡改查询结果的 screenshot_width/height；修复 zoom+from_zoom 点击坐标转换；缓存未命中时报错引导模型调用查询工具；补全 scroll/type_text/press_key/hotkey/Linux mouse 工具的坐标转换；修复 parallel_mouse_drag 的逐项窗口查找和 fn 域边界转换；全面修正工具描述中的像素措辞。

</details>