### PR TITLE
fix(web-shell): align split view chat interactions

### DIFF
--- a/packages/web-shell/client/components/ChatPane.module.css
+++ b/packages/web-shell/client/components/ChatPane.module.css
@@ -78,7 +78,6 @@
 
 .footer {
   flex: 0 0 auto;
-  border-top: 1px solid var(--border);
   padding: 8px;
   position: relative;
 }

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act } from 'react';
+import { act, forwardRef, useImperativeHandle } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider } from '../i18n';
 
@@ -19,14 +19,23 @@ let pendingPermission: any;
 let latestOnSubmit:
   | ((text: string, images?: unknown, commit?: () => void) => boolean)
   | undefined;
-let sendPromptResolve: (() => void) | undefined;
-let sendPromptReject: ((e: unknown) => void) | undefined;
-let sendPromptAdmit: (() => void) | undefined;
+let latestChatEditorProps: any;
+let latestFollowupAccept: ((suggestion: string) => void) | undefined;
+const clearFollowup = vi.fn();
+const transcriptDispatch = vi.fn();
 const sendPrompt = vi.fn(async () => ({}) as any);
 const submitPermission = vi.fn(async () => {});
 const cancel = vi.fn(async () => {});
 const setApprovalMode = vi.fn(async (mode: string) => ({ mode }));
 const setModel = vi.fn(async () => ({}) as any);
+const enqueuePrompt = vi.fn(() => true);
+const removeQueuedPrompt = vi.fn();
+const insertQueuedPrompt = vi.fn();
+const editQueuedPrompt = vi.fn();
+const editLastQueuedPrompt = vi.fn(() => false);
+const clearQueuedPrompts = vi.fn(() => false);
+let queuedPromptsMock: any[] = [];
+let queuedTextsMock: string[] = [];
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   DAEMON_APPROVAL_MODES: ['default', 'plan', 'auto-edit', 'auto', 'yolo'],
@@ -38,8 +47,33 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
     setModel,
   }),
   useConnection: () => connectionState,
+  useDaemonFollowupSuggestion: (options: any) => {
+    latestFollowupAccept = options?.onAccept;
+    return {
+      followupState: { suggestion: 'next idea', isVisible: true },
+      onAcceptFollowup: vi.fn(),
+      onDismissFollowup: vi.fn(),
+      clear: clearFollowup,
+    };
+  },
   useStreamingState: () => streamingStateValue,
   useTranscriptBlocks: () => [],
+  useTranscriptStore: () => ({
+    dispatch: transcriptDispatch,
+  }),
+}));
+
+vi.mock('../hooks/useQueuedPrompts', () => ({
+  useQueuedPrompts: () => ({
+    queuedPrompts: queuedPromptsMock,
+    queuedTexts: queuedTextsMock,
+    enqueuePrompt,
+    removeQueuedPrompt,
+    insertQueuedPrompt,
+    editQueuedPrompt,
+    editLastQueuedPrompt,
+    clearQueuedPrompts,
+  }),
 }));
 
 let messagesState: any[];
@@ -73,8 +107,12 @@ vi.mock('./StreamingStatus', () => ({
   ),
 }));
 vi.mock('./ChatEditor', () => ({
-  ChatEditor: (props: any) => {
+  ChatEditor: forwardRef(function MockChatEditor(props: any, ref: any) {
     latestOnSubmit = props.onSubmit;
+    latestChatEditorProps = props;
+    useImperativeHandle(ref, () => ({
+      insertText: vi.fn(),
+    }));
     return (
       <div>
         <button
@@ -117,9 +155,20 @@ vi.mock('./ChatEditor', () => ({
         <span data-testid="pane-models">
           {JSON.stringify(props.availableModels ?? null)}
         </span>
+        <span data-testid="pane-queued-messages">
+          {JSON.stringify(props.queuedMessages ?? null)}
+        </span>
+        <span data-testid="pane-followup">
+          {String(props.followupState?.suggestion ?? '')}
+        </span>
       </div>
     );
-  },
+  }),
+}));
+vi.mock('./QueuedPromptDisplay', () => ({
+  QueuedPromptDisplay: (props: any) => (
+    <div data-testid="pane-queue">{String(props.prompts.length)}</div>
+  ),
 }));
 vi.mock('./messages/ToolApproval', () => ({
   ToolApproval: (props: any) => (
@@ -160,23 +209,25 @@ beforeEach(() => {
   pendingPermission = null;
   messagesState = [{ id: 'm1', role: 'user', content: 'hi' }];
   latestOnSubmit = undefined;
+  latestChatEditorProps = undefined;
+  latestFollowupAccept = undefined;
+  queuedPromptsMock = [];
+  queuedTextsMock = [];
   sendPrompt.mockReset();
-  // Each sendPrompt returns a promise the test controls, so we can assert the
-  // draft is committed on admission (onAdmitted) rather than on turn completion
-  // (promise resolution). `sendPromptAdmit` captures the options.onAdmitted hook.
-  sendPromptAdmit = undefined;
-  sendPrompt.mockImplementation(
-    (_text?: string, options?: { onAdmitted?: () => void }) =>
-      new Promise<unknown>((resolve, reject) => {
-        sendPromptAdmit = options?.onAdmitted;
-        sendPromptResolve = () => resolve({});
-        sendPromptReject = (e) => reject(e);
-      }),
-  );
+  sendPrompt.mockResolvedValue({} as any);
+  clearFollowup.mockClear();
   submitPermission.mockClear();
   cancel.mockClear();
   setApprovalMode.mockClear();
   setModel.mockClear();
+  enqueuePrompt.mockClear();
+  enqueuePrompt.mockReturnValue(true);
+  removeQueuedPrompt.mockClear();
+  insertQueuedPrompt.mockClear();
+  editQueuedPrompt.mockClear();
+  editLastQueuedPrompt.mockClear();
+  clearQueuedPrompts.mockClear();
+  transcriptDispatch.mockClear();
 });
 
 afterEach(() => {
@@ -217,7 +268,7 @@ describe('ChatPane', () => {
     );
   });
 
-  it('sends a prompt to its own session on submit', () => {
+  it('sends an idle prompt directly so the pane enters loading immediately', () => {
     render();
     act(() =>
       testid('pane-submit')!.dispatchEvent(
@@ -225,70 +276,58 @@ describe('ChatPane', () => {
       ),
     );
     expect(sendPrompt).toHaveBeenCalledTimes(1);
-    expect((sendPrompt.mock.calls[0] as unknown[])[0]).toBe('hello there');
+    expect(sendPrompt).toHaveBeenCalledWith('hello there', {});
+    expect(clearFollowup).toHaveBeenCalledTimes(1);
+    expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
-  it('commits the draft on admission, without waiting for the turn to finish', async () => {
+  it('accepts an idle prompt so the editor commits the draft immediately', () => {
+    render();
+    let returned: boolean | undefined;
+    act(() => {
+      returned = latestOnSubmit!('hi');
+    });
+    expect(returned).toBe(true);
+  });
+
+  it('queues a prompt while the pane is already running', () => {
+    streamingStateValue = 'responding';
+    render();
+    const commit = vi.fn();
+    let returned: boolean | undefined;
+    act(() => {
+      returned = latestOnSubmit!('queued next', undefined, commit);
+    });
+    expect(returned).toBe(true);
+    expect(enqueuePrompt).toHaveBeenCalledWith('queued next', undefined);
+    expect(sendPrompt).not.toHaveBeenCalled();
+  });
+
+  it('preserves the draft when the busy queue rejects the prompt', () => {
+    streamingStateValue = 'responding';
+    enqueuePrompt.mockReturnValueOnce(false);
     render();
     const commit = vi.fn();
     let returned: boolean | undefined;
     act(() => {
       returned = latestOnSubmit!('hi', undefined, commit);
     });
-    // Returns false (keep the draft) and does NOT commit before admission.
     expect(returned).toBe(false);
     expect(commit).not.toHaveBeenCalled();
-    // The daemon admits the prompt (onAdmitted). The draft clears now, even
-    // though the turn promise is still pending — a long response must not strand
-    // the sent text in the composer until the turn ends.
-    await act(async () => {
-      sendPromptAdmit!();
-      await Promise.resolve();
-    });
-    expect(commit).toHaveBeenCalledTimes(1);
-    // The turn finishing later must NOT commit again — guards against regressing
-    // to committing on promise resolution (turn end) instead of admission.
-    await act(async () => {
-      sendPromptResolve!();
-      await Promise.resolve();
-    });
-    expect(commit).toHaveBeenCalledTimes(1);
   });
 
-  it('does not commit (preserves the draft) when the prompt is rejected', async () => {
-    render();
-    const commit = vi.fn();
-    act(() => {
-      latestOnSubmit!('hi', undefined, commit);
-    });
-    await act(async () => {
-      sendPromptReject!(new Error('session busy'));
-      await Promise.resolve();
-    });
-    expect(commit).not.toHaveBeenCalled();
-  });
-
-  it('keeps the draft cleared and still reports the error when the turn fails after admission', async () => {
+  it('reports an idle prompt failure to the pane error handler', async () => {
     const onError = vi.fn();
+    sendPrompt.mockRejectedValueOnce(new Error('disconnected'));
     render({ onError });
-    const commit = vi.fn();
-    act(() => {
-      latestOnSubmit!('hi', undefined, commit);
-    });
-    // Admission clears the draft.
     await act(async () => {
-      sendPromptAdmit!();
+      latestOnSubmit!('hi');
       await Promise.resolve();
     });
-    expect(commit).toHaveBeenCalledTimes(1);
-    // The turn then fails mid-flight: the draft stays cleared (no second commit)
-    // and the failure is still surfaced to onError.
-    await act(async () => {
-      sendPromptReject!(new Error('turn crashed'));
-      await Promise.resolve();
-    });
-    expect(commit).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Failed to send prompt',
+    );
   });
 
   it('keeps pane approvals click-only (no global keyboard shortcuts)', () => {
@@ -362,19 +401,29 @@ describe('ChatPane', () => {
     });
     expect(returned).toBe(false);
     expect(sendPrompt).not.toHaveBeenCalled();
+    expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
-  it('routes send failures to the onError prop', async () => {
-    const onError = vi.fn();
-    render({ onError });
-    act(() => {
-      latestOnSubmit!('hi', undefined, vi.fn());
-    });
-    await act(async () => {
-      sendPromptReject!(new Error('disconnected'));
-      await Promise.resolve();
-    });
-    expect(onError).toHaveBeenCalled();
+  it('passes queued prompts and queue editing controls to the pane editor', () => {
+    queuedPromptsMock = [{ id: 1, text: 'queued next' }];
+    queuedTextsMock = ['queued next'];
+    render();
+    expect(testid('pane-queue')?.textContent).toBe('1');
+    expect(testid('pane-queued-messages')?.textContent).toBe(
+      JSON.stringify(['queued next']),
+    );
+    expect(latestChatEditorProps.onPopQueuedMessages()).toBe(false);
+    expect(latestChatEditorProps.onClearQueuedMessages()).toBe(false);
+    expect(editLastQueuedPrompt).toHaveBeenCalledTimes(1);
+    expect(clearQueuedPrompts).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes follow-up suggestions to the pane editor', () => {
+    render();
+    expect(testid('pane-followup')?.textContent).toBe('next idea');
+    expect(latestChatEditorProps.onAcceptFollowup).toBeTypeOf('function');
+    expect(latestChatEditorProps.onDismissFollowup).toBeTypeOf('function');
+    expect(latestFollowupAccept).toBeTypeOf('function');
   });
 
   it('surfaces a connection-loss banner when the pane connection drops', () => {

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -21,7 +21,9 @@ let latestOnSubmit:
   | undefined;
 let latestChatEditorProps: any;
 let latestFollowupAccept: ((suggestion: string) => void) | undefined;
+let sendPromptAdmit: (() => void) | undefined;
 const clearFollowup = vi.fn();
+const insertText = vi.fn();
 const transcriptDispatch = vi.fn();
 const sendPrompt = vi.fn(async () => ({}) as any);
 const submitPermission = vi.fn(async () => {});
@@ -111,7 +113,7 @@ vi.mock('./ChatEditor', () => ({
     latestOnSubmit = props.onSubmit;
     latestChatEditorProps = props;
     useImperativeHandle(ref, () => ({
-      insertText: vi.fn(),
+      insertText,
     }));
     return (
       <div>
@@ -199,6 +201,7 @@ let container: HTMLDivElement | null = null;
 
 beforeEach(() => {
   connectionState = {
+    status: 'connected',
     sessionId: 'sess-1',
     displayName: 'Refactor core',
     workspaceCwd: '/w',
@@ -211,11 +214,16 @@ beforeEach(() => {
   latestOnSubmit = undefined;
   latestChatEditorProps = undefined;
   latestFollowupAccept = undefined;
+  sendPromptAdmit = undefined;
   queuedPromptsMock = [];
   queuedTextsMock = [];
   sendPrompt.mockReset();
-  sendPrompt.mockResolvedValue({} as any);
+  sendPrompt.mockImplementation(async (_text: string, options?: any) => {
+    sendPromptAdmit = options?.onAdmitted;
+    return {} as any;
+  });
   clearFollowup.mockClear();
+  insertText.mockClear();
   submitPermission.mockClear();
   cancel.mockClear();
   setApprovalMode.mockClear();
@@ -276,18 +284,37 @@ describe('ChatPane', () => {
       ),
     );
     expect(sendPrompt).toHaveBeenCalledTimes(1);
-    expect(sendPrompt).toHaveBeenCalledWith('hello there', {});
-    expect(clearFollowup).toHaveBeenCalledTimes(1);
+    expect(sendPrompt).toHaveBeenCalledWith('hello there', {
+      onAdmitted: expect.any(Function),
+    });
+    expect(clearFollowup).not.toHaveBeenCalled();
     expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
-  it('accepts an idle prompt so the editor commits the draft immediately', () => {
+  it('commits an idle prompt only after daemon admission', () => {
     render();
+    const commit = vi.fn();
     let returned: boolean | undefined;
     act(() => {
-      returned = latestOnSubmit!('hi');
+      returned = latestOnSubmit!('hi', undefined, commit);
     });
-    expect(returned).toBe(true);
+    expect(returned).toBe(false);
+    expect(commit).not.toHaveBeenCalled();
+    act(() => sendPromptAdmit!());
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(clearFollowup).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards images with an idle prompt', () => {
+    const images = [{ data: 'image-data', media_type: 'image/png' }];
+    render();
+    act(() => {
+      latestOnSubmit!('with image', images);
+    });
+    expect(sendPrompt).toHaveBeenCalledWith('with image', {
+      images,
+      onAdmitted: expect.any(Function),
+    });
   });
 
   it('queues a prompt while the pane is already running', () => {
@@ -303,27 +330,39 @@ describe('ChatPane', () => {
     expect(sendPrompt).not.toHaveBeenCalled();
   });
 
-  it('preserves the draft when the busy queue rejects the prompt', () => {
+  it('forwards images with a queued prompt', () => {
     streamingStateValue = 'responding';
-    enqueuePrompt.mockReturnValueOnce(false);
+    const images = [{ data: 'image-data', media_type: 'image/png' }];
     render();
-    const commit = vi.fn();
+    act(() => {
+      latestOnSubmit!('queued image', images);
+    });
+    expect(enqueuePrompt).toHaveBeenCalledWith('queued image', images);
+  });
+
+  it('does not submit while the pane is disconnected', () => {
+    connectionState.status = 'disconnected';
+    render();
     let returned: boolean | undefined;
     act(() => {
-      returned = latestOnSubmit!('hi', undefined, commit);
+      returned = latestOnSubmit!('hi');
     });
     expect(returned).toBe(false);
-    expect(commit).not.toHaveBeenCalled();
+    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
   it('reports an idle prompt failure to the pane error handler', async () => {
     const onError = vi.fn();
     sendPrompt.mockRejectedValueOnce(new Error('disconnected'));
     render({ onError });
+    const commit = vi.fn();
     await act(async () => {
-      latestOnSubmit!('hi');
+      latestOnSubmit!('hi', undefined, commit);
       await Promise.resolve();
     });
+    expect(commit).not.toHaveBeenCalled();
+    expect(clearFollowup).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledWith(
       expect.any(Error),
       'Failed to send prompt',
@@ -424,6 +463,8 @@ describe('ChatPane', () => {
     expect(latestChatEditorProps.onAcceptFollowup).toBeTypeOf('function');
     expect(latestChatEditorProps.onDismissFollowup).toBeTypeOf('function');
     expect(latestFollowupAccept).toBeTypeOf('function');
+    act(() => latestFollowupAccept!('test suggestion'));
+    expect(insertText).toHaveBeenCalledWith('test suggestion');
   });
 
   it('surfaces a connection-loss banner when the pane connection drops', () => {

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -8,14 +8,17 @@ import { useCallback, useMemo, useRef } from 'react';
 import {
   useActions,
   useConnection,
+  useDaemonFollowupSuggestion,
   useStreamingState,
   useTranscriptBlocks,
+  useTranscriptStore,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../i18n';
 import { useMessages } from '../hooks/useMessages';
 import { extractPendingPermission } from '../adapters/transcriptAdapter';
 import type { PromptImage } from '../adapters/promptTypes';
-import type { ComposerSubmitCommit } from '../hooks/useComposerCore';
+import type { EditorHandle } from '../hooks/useComposerCore';
+import { useQueuedPrompts } from '../hooks/useQueuedPrompts';
 import { isAskUserPermission } from '../utils/askUserPermission';
 import { isDaemonApprovalMode } from '../utils/sessionPreparation';
 import { isVisibleComposerModel } from '../utils/composerModels';
@@ -29,6 +32,7 @@ import { mergeCommands } from '../hooks/daemonSessionMappers';
 import { MessageList } from './MessageList';
 import { StreamingStatus } from './StreamingStatus';
 import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
+import { QueuedPromptDisplay } from './QueuedPromptDisplay';
 import { ToolApproval } from './messages/ToolApproval';
 import { AskUserQuestion } from './messages/AskUserQuestion';
 import styles from './ChatPane.module.css';
@@ -63,7 +67,19 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   const actions = useActions();
   const messages = useMessages(t);
   const blocks = useTranscriptBlocks();
+  const store = useTranscriptStore();
   const streamingState = useStreamingState();
+  const editorRef = useRef<EditorHandle | null>(null);
+  const {
+    followupState,
+    onAcceptFollowup,
+    onDismissFollowup,
+    clear: clearFollowup,
+  } = useDaemonFollowupSuggestion({
+    onAccept: (suggestion) => {
+      editorRef.current?.insertText(suggestion);
+    },
+  });
 
   const reportError = useCallback(
     (error: unknown, fallback: string) => {
@@ -90,6 +106,28 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   const approvalActive =
     pendingToolApproval !== null || pendingAskUserApproval !== null;
   const isResponding = streamingState !== 'idle';
+  const {
+    queuedPrompts,
+    queuedTexts,
+    enqueuePrompt,
+    removeQueuedPrompt,
+    insertQueuedPrompt,
+    editQueuedPrompt,
+    editLastQueuedPrompt,
+    clearQueuedPrompts,
+  } = useQueuedPrompts({
+    connected: connection.status === 'connected',
+    sessionId: connection.sessionId,
+    clientId: connection.clientId,
+    streamingState,
+    sessionActions: actions,
+    store,
+    editorRef,
+    reportError,
+    notifySuccess: (message) =>
+      store.dispatch([{ type: 'status', text: message }]),
+    t,
+  });
 
   // Anchor the streaming timer to the turn's own start (the last user message's
   // timestamp) rather than letting StreamingStatus fall back to "now" — so a
@@ -104,30 +142,23 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   }, [messages, isResponding]);
 
   const handleSubmit = useCallback(
-    (
-      text: string,
-      images?: PromptImage[],
-      commitAccepted?: ComposerSubmitCommit,
-    ): boolean => {
+    (text: string, images?: PromptImage[]): boolean => {
       const trimmed = text.trim();
       if (!trimmed) return false;
-      // Keep the draft (return false) and clear it only once the daemon ADMITS
-      // the prompt. `onAdmitted` fires at acceptance; the sendPrompt promise
-      // itself resolves only when the whole (possibly long) turn finishes, so
-      // committing on resolution would strand the sent text in the composer for
-      // the entire response. If the prompt is rejected before admission
-      // (transcript still loading, session disconnected, or a turn already
-      // active) onAdmitted never fires, so the draft is preserved and the error
-      // is surfaced.
-      actions
-        .sendPrompt(trimmed, {
-          ...(images && images.length ? { images } : {}),
-          onAdmitted: commitAccepted,
-        })
-        .catch((error: unknown) => reportError(error, 'Failed to send prompt'));
-      return false;
+      if (streamingState === 'idle') {
+        clearFollowup();
+        actions
+          .sendPrompt(trimmed, {
+            ...(images && images.length ? { images } : {}),
+          })
+          .catch((error: unknown) =>
+            reportError(error, 'Failed to send prompt'),
+          );
+        return true;
+      }
+      return enqueuePrompt(trimmed, images);
     },
-    [actions, reportError],
+    [actions, clearFollowup, enqueuePrompt, reportError, streamingState],
   );
 
   const handleConfirm = useCallback(
@@ -307,11 +338,22 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
         {/* Panes keep the composer status compact: spinner + elapsed time +
             token count + cancel hint, but no rotating "witty" loading phrase. */}
         <StreamingStatus startedAt={activeTurnStartedAt} showPhrase={false} />
+        <QueuedPromptDisplay
+          prompts={queuedPrompts}
+          t={t}
+          onDelete={removeQueuedPrompt}
+          onInsert={insertQueuedPrompt}
+          onEdit={editQueuedPrompt}
+        />
         <ChatEditor
+          ref={editorRef}
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           isRunning={isResponding}
           commands={commands}
+          queuedMessages={queuedTexts}
+          onPopQueuedMessages={editLastQueuedPrompt}
+          onClearQueuedMessages={clearQueuedPrompts}
           visibleToolbarActions={PANE_TOOLBAR_ACTIONS}
           currentMode={connection.currentMode ?? 'default'}
           currentModel={connection.currentModel ?? ''}
@@ -319,6 +361,9 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
           onSelectMode={handleSelectMode}
           onSelectModel={handleSelectModel}
           dialogOpen={approvalActive}
+          followupState={followupState}
+          onAcceptFollowup={onAcceptFollowup}
+          onDismissFollowup={onDismissFollowup}
           placeholderText={t('splitView.composerPlaceholder')}
         />
       </div>

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -17,7 +17,10 @@ import { useI18n } from '../i18n';
 import { useMessages } from '../hooks/useMessages';
 import { extractPendingPermission } from '../adapters/transcriptAdapter';
 import type { PromptImage } from '../adapters/promptTypes';
-import type { EditorHandle } from '../hooks/useComposerCore';
+import type {
+  ComposerSubmitCommit,
+  EditorHandle,
+} from '../hooks/useComposerCore';
 import { useQueuedPrompts } from '../hooks/useQueuedPrompts';
 import { isAskUserPermission } from '../utils/askUserPermission';
 import { isDaemonApprovalMode } from '../utils/sessionPreparation';
@@ -69,6 +72,8 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   const blocks = useTranscriptBlocks();
   const store = useTranscriptStore();
   const streamingState = useStreamingState();
+  const streamingStateRef = useRef(streamingState);
+  streamingStateRef.current = streamingState;
   const editorRef = useRef<EditorHandle | null>(null);
   const {
     followupState,
@@ -87,6 +92,10 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
       else console.error(fallback, error);
     },
     [onError],
+  );
+  const notifySuccess = useCallback(
+    (message: string) => store.dispatch([{ type: 'status', text: message }]),
+    [store],
   );
 
   const pendingApproval = useMemo(
@@ -124,8 +133,7 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
     store,
     editorRef,
     reportError,
-    notifySuccess: (message) =>
-      store.dispatch([{ type: 'status', text: message }]),
+    notifySuccess,
     t,
   });
 
@@ -142,23 +150,31 @@ export function ChatPane({ title, onClose, onError }: ChatPaneProps) {
   }, [messages, isResponding]);
 
   const handleSubmit = useCallback(
-    (text: string, images?: PromptImage[]): boolean => {
+    (
+      text: string,
+      images?: PromptImage[],
+      commitAccepted?: ComposerSubmitCommit,
+    ): boolean => {
       const trimmed = text.trim();
       if (!trimmed) return false;
-      if (streamingState === 'idle') {
-        clearFollowup();
+      if (connection.status !== 'connected') return false;
+      if (streamingStateRef.current === 'idle') {
         actions
           .sendPrompt(trimmed, {
             ...(images && images.length ? { images } : {}),
+            onAdmitted: () => {
+              clearFollowup();
+              commitAccepted?.();
+            },
           })
           .catch((error: unknown) =>
             reportError(error, 'Failed to send prompt'),
           );
-        return true;
+        return false;
       }
       return enqueuePrompt(trimmed, images);
     },
-    [actions, clearFollowup, enqueuePrompt, reportError, streamingState],
+    [actions, clearFollowup, connection.status, enqueuePrompt, reportError],
   );
 
   const handleConfirm = useCallback(

--- a/packages/web-shell/client/components/SessionOverviewPanel.module.css
+++ b/packages/web-shell/client/components/SessionOverviewPanel.module.css
@@ -42,6 +42,9 @@
 .actionButton:disabled {
   opacity: 0.55;
   cursor: default;
+  border-color: var(--border);
+  background: transparent;
+  color: var(--muted-foreground);
 }
 
 .refreshButton {

--- a/packages/web-shell/client/components/SessionOverviewPanel.module.css
+++ b/packages/web-shell/client/components/SessionOverviewPanel.module.css
@@ -28,18 +28,19 @@
 }
 
 .actionButton {
+  appearance: none;
   padding: 4px 12px;
   border: 1px solid var(--primary);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
-  color: var(--primary);
-  font-size: 12px;
-  font-weight: 600;
+  border-radius: 8px;
+  background: var(--primary);
+  color: var(--background);
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
 }
 
 .actionButton:disabled {
-  opacity: 0.45;
+  opacity: 0.55;
   cursor: default;
 }
 

--- a/packages/web-shell/client/components/SplitView.module.css
+++ b/packages/web-shell/client/components/SplitView.module.css
@@ -62,6 +62,9 @@
 .addButton:disabled {
   opacity: 0.55;
   cursor: default;
+  border-color: var(--border);
+  background: transparent;
+  color: var(--muted-foreground);
 }
 
 .picker {

--- a/packages/web-shell/client/components/SplitView.module.css
+++ b/packages/web-shell/client/components/SplitView.module.css
@@ -48,22 +48,20 @@
 }
 
 .addButton {
-  padding: 5px 12px;
+  appearance: none;
+  padding: 4px 12px;
   border: 1px solid var(--primary);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--primary) 14%, transparent);
-  color: var(--primary);
-  font-size: 12px;
-  font-weight: 600;
+  border-radius: 8px;
+  background: var(--primary);
+  color: var(--background);
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
 }
 
 .addButton:disabled {
-  opacity: 0.45;
+  opacity: 0.55;
   cursor: default;
-  border-color: var(--border);
-  background: transparent;
-  color: var(--muted-foreground);
 }
 
 .picker {


### PR DESCRIPTION
## What this PR does

This PR brings split-view chat panes in line with the normal single-chat interaction model. Each pane now displays and accepts follow-up suggestions, sends prompts directly while idle so the loading state appears immediately, and queues additional prompts while that pane is already running. Queued prompts are visible and retain the same edit, insert, remove, and clear controls as the main chat.

It also removes the extra divider above each pane composer and updates the split-view session actions to use the existing primary-button visual treatment.

## Why it's needed

Split-view panes previously omitted follow-up suggestions and attempted to send every prompt directly. As a result, a second prompt submitted during an active turn was rejected instead of entering the queue, and the split experience behaved differently from the single-chat view. The final idle-versus-busy routing preserves immediate loading feedback without losing queue support.

## Reviewer Test Plan

### How to verify

1. Open two or more sessions in Split View and send a prompt in an idle pane. Confirm the submitted text clears and the pane enters its loading state immediately.
2. While that pane is still running, submit another prompt. Confirm it appears in that pane's queue and can be edited, inserted, removed, or cleared without affecting another pane.
3. Complete a turn that returns a follow-up suggestion. Confirm the suggestion appears in the pane composer and can be accepted or dismissed.
4. Compare a normal single-chat session before and after the change. Confirm its loading, queue, and follow-up behavior is unchanged.
5. Confirm Add session, Open in new tab, and Open in split use the primary-button treatment, and that the extra divider above split-pane composers is gone.

### Evidence (Before & After)

Before: split panes did not show follow-up suggestions, and prompts submitted during an active turn did not enter the queue.

After: split panes use the same follow-up and queued-prompt interactions as the single-chat view, while idle submissions still enter loading immediately.

### Screenshots (Automated Testing)

The following screenshots were captured using Playwright headless browser to verify the fixes:

**Split View Entry**
- `01-session-overview.png` - Session overview page with action buttons
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/7ee57aec-9aad-435f-8f95-2fc1d14f9bd1" />

- `02-split-view-entry.png` - Entering split view via the "分屏" button
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/0cf52c7b-f0e9-42d1-9b73-f316540a8e3f" />

- `03-add-pane-picker.png` - Session picker for adding panes
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/32306921-8ced-4e22-8027-333b42a785f9" />

- `04-split-one-pane.png` - Single pane in split view (no extra divider above composer)
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b14bd1ef-55a2-4903-9da8-b51252a2b453" />

- `05-split-two-panes.png` - Two panes side by side
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/7c25c050-27ab-4dcf-bd10-2acdc9472d55" />


**Queue Message Functionality**
- `06-pane-prompt-typed.png` - Typing a prompt in a pane
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/90e880f1-9a9b-4c2c-acae-db8593860072" />

- `07-pane-loading-state.png` - Loading state appears immediately after sending
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3cf2b6a7-ae49-481f-9d50-2f2a84693742" />

- `08-pane-queued-typed.png` - Typing a second message while the pane is running
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e4e01fe7-73ea-47a5-9eca-5ff358fc505a" />

- `09-pane-queued-visible.png` - Queued message visible with edit/insert/remove/clear controls
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b56bb287-f555-4dc7-adf7-3b0a3b5c5740" />


**Response Complete**
- `10-pane-response-complete.png` - Response completed, composer returns to normal
- 
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/22fff6d9-b09c-49ff-b63d-bfec7fdc39cc" />

- `11-overview-action-buttons.png` - Back to overview showing primary-button treatment
- 
![Uploading image.png…]()


Screenshots location: `.qwen/pr-screenshots/`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local macOS workspace with the web-shell unit tests, monorepo build, and workspace typecheck. Automated screenshots captured using Playwright 1.61.1.

## Risk & Scope

- Main risk or tradeoff: split panes now instantiate the existing queued-prompt and follow-up controllers for each pane; the surrounding daemon session provider keeps their state scoped to the correct session.
- Not validated / out of scope: Windows and Linux browser rendering were not manually tested.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让分屏聊天窗格与普通单会话聊天保持一致。每个窗格现在都可以展示和接受后续建议；空闲时直接发送消息，使 loading 状态立即出现；该窗格正在执行时，后续消息会进入队列。队列中的消息可见，并支持与主聊天相同的编辑、插入、删除和清空操作。

同时移除了每个分屏输入区上方多余的分隔线，并将分屏相关的会话操作按钮调整为项目现有的主按钮样式。

## 为什么需要

此前分屏窗格没有接入后续建议，并且所有消息都会尝试直接发送。因此，在当前轮次执行期间提交第二条消息时，消息会被拒绝而不是进入队列，分屏体验与单会话聊天不一致。最终采用空闲与执行中分流的方式，在支持队列的同时保留立即出现 loading 的反馈。

## Reviewer 测试计划

### 如何验证

1. 在分屏中打开两个或更多会话，在空闲窗格中发送消息。确认输入内容被清空，并且该窗格立即进入 loading 状态。
2. 在该窗格仍在执行时再次发送消息。确认消息进入该窗格自己的队列，并且可以编辑、插入、删除或清空，不影响其他窗格。
3. 完成一个会返回后续建议的轮次。确认建议显示在该窗格输入框中，并且可以接受或关闭。
4. 修改前后对比普通单会话聊天，确认其 loading、队列和后续建议行为没有变化。
5. 确认"添加会话""在新标签页打开"和"打开到分屏"使用主按钮样式，并且分屏输入区上方多余的分隔线已移除。

### 证据（修改前后）

修改前：分屏窗格不显示后续建议，执行期间提交的消息不会进入队列。

修改后：分屏窗格使用与单会话聊天相同的后续建议和消息队列交互，同时空闲发送仍会立即进入 loading。

### 截图（自动化测试）

使用 Playwright 无头浏览器捕获以下截图来验证修复：

**进入分屏视图**
- `01-session-overview.png` - 会话总览页面，显示操作按钮
- `02-split-view-entry.png` - 通过"分屏"按钮进入分屏视图
- `03-add-pane-picker.png` - 添加窗格的会话选择器
- `04-split-one-pane.png` - 分屏中的单个窗格（composer 上方没有多余分隔线）
- `05-split-two-panes.png` - 两个窗格并排显示

**队列消息功能**
- `06-pane-prompt-typed.png` - 在窗格中输入消息
- `07-pane-loading-state.png` - 发送后立即显示加载状态
- `08-pane-queued-typed.png` - 在窗格执行期间输入第二条消息
- `09-pane-queued-visible.png` - 队列消息可见，带有编辑/插入/删除/清空控件

**响应完成**
- `10-pane-response-complete.png` - 响应完成，composer 恢复正常
- `11-overview-action-buttons.png` - 返回总览页面，显示主按钮样式

截图位置：`.qwen/pr-screenshots/`

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 macOS 工作区，执行了 web-shell 单元测试、monorepo build 和 workspace typecheck。使用 Playwright 1.61.1 捕获自动化截图。

## 风险与范围

- 主要风险或取舍：每个分屏窗格现在都会实例化现有的消息队列和后续建议控制器；外层 daemon session provider 会确保这些状态限定在正确的会话中。
- 未验证或范围外：未在 Windows 和 Linux 浏览器中进行手动渲染测试。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
