### PR TITLE
fix(triage): require explicit defer comment and prevent hygiene-based defer on re-runs

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -348,6 +348,8 @@ If `GUARD` is `block`: do **not** run `gh pr review --approve` no matter how cle
 
 If Stage 0 escalated the PR for maintainer awareness, do **not** approve automatically; use the "Genuinely unsure" path below.
 
+**Re-runs (manually triggered via `@qwen-code /triage`):** hygiene concerns (scope mismatch, undocumented changes, naming) that don't block the PR are not a valid reason to defer. Note them in the comment and approve. Only defer if you have genuine blocking uncertainty — something you cannot resolve from the diff, tests, and PR description.
+
 All stages genuinely clean, `GUARD` is `ok`, and no Stage 0 maintainer escalation remains — approve:
 
 ```bash
@@ -360,4 +362,14 @@ Reflection shows it shouldn't merge — request changes immediately, citing the 
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "Needs some rethinking — see my notes above. 🙏"
 ```
 
-Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**. Ask the maintainer to weigh in. Use `$QWEN_MAINTAINER_HANDLE` if set.
+Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**, but **never defer silently**. Post an explicit defer comment that:
+
+1. States you are escalating to the maintainer.
+2. Names the specific reason(s) for uncertainty — what you cannot resolve from the diff, tests, and PR description.
+3. @mentions the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set, or the most recent human reviewer).
+
+```bash
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⏸️ Deferring to @$MAINTAINER_HANDLE — <reason>. Needs a human call on this one."
+```
+
+A defer without an explicit comment is invisible — the maintainer won't know they're needed.


### PR DESCRIPTION
## Summary

- **Defer was silent**: when the bot chose "genuinely unsure → defer", it updated stage comments but never explicitly said "I'm deferring to @maintainer because X". Maintainers had no signal they were needed, and users thought the triage hung.
- **Re-runs deferred on hygiene concerns**: when a maintainer manually triggered `/triage`, the bot would defer instead of approving because of scope mismatch, undocumented changes, or naming issues — hygiene concerns, not blockers.

Observed on [PR #6637](https://github.com/QwenLM/qwen-code/pull/6637#issuecomment-4932103086): the bot ran all 3 stages successfully, found no correctness issues, but deferred to a human reviewer who had already approved — without any visible signal that it was deferring.

## Changes

### 1. Defer path now requires an explicit comment

Replaces the vague "ask the maintainer to weigh in" with a concrete action: post a comment that states the escalation, names the specific uncertainty, and @mentions the maintainer.

### 2. Re-run path clarifies hygiene concerns don't justify defer

Adds a re-run exception before the approve path: hygiene concerns (scope mismatch, undocumented changes, naming) should be noted in the comment but not used as reasons to defer. Only genuine blocking uncertainty should defer.

## Test plan

- [ ] Trigger `/triage` on a PR where all stages pass but the bot has hygiene concerns — should approve with concerns noted in comment
- [ ] Trigger `/triage` on a PR with genuine blocking uncertainty — should defer with an explicit comment naming the reason and @mentioning the maintainer
- [ ] Verify the defer comment is posted and visible (not just updating stage comments silently)