### PR TITLE
fix(core): fix tool_use/tool_result pairing for Anthropic-compatible providers

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -8,6 +8,7 @@ import type { Argv } from 'yargs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import {
   copyFileSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -376,15 +377,17 @@ describe('bootstrap import boundaries', () => {
     expect(output).toBe(`${expectedVersion}\n`);
   });
 
-  it('falls through to cli.js when wrapper package.json parsing fails', () => {
+  it('falls through to cli.js when wrapper package.json lookup fails', () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-cli-entry-'));
+    const entryDir = path.join(tempDir, 'bin');
     try {
+      mkdirSync(entryDir);
       copyFileSync(
         '../../scripts/cli-entry.js',
-        path.join(tempDir, 'cli-entry.mjs'),
+        path.join(entryDir, 'cli-entry.mjs'),
       );
       writeFileSync(
-        path.join(tempDir, 'cli.js'),
+        path.join(entryDir, 'cli.js'),
         "process.stdout.write('fallback-cli\\n');\n",
       );
       const env = { ...process.env };
@@ -392,7 +395,7 @@ describe('bootstrap import boundaries', () => {
 
       const output = execFileSync(
         process.execPath,
-        [path.join(tempDir, 'cli-entry.mjs'), '--version'],
+        [path.join(entryDir, 'cli-entry.mjs'), '--version'],
         {
           encoding: 'utf8',
           env,

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -204,29 +204,6 @@ describe('AnthropicContentConverter', () => {
               },
             ],
           },
-        ],
-      });
-
-      expect(messages).toEqual([
-        {
-          role: 'assistant',
-          content: [
-            { type: 'text', text: 'preface' },
-            {
-              type: 'tool_use',
-              id: 'call-1',
-              name: 'tool_name',
-              input: { a: 1 },
-            },
-          ],
-        },
-      ]);
-    });
-
-    it('converts functionResponse parts into user tool_result messages', () => {
-      const { messages } = converter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
           {
             role: 'user',
             parts: [
@@ -242,25 +219,80 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'call-1',
-              content: 'ok',
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        },
-      ]);
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'preface' },
+          {
+            type: 'tool_use',
+            id: 'call-1',
+            name: 'tool_name',
+            input: { a: 1 },
+          },
+        ],
+      });
+    });
+
+    it('converts functionResponse parts into user tool_result messages', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'tool_name',
+                  args: {},
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call-1',
+                  name: 'tool_name',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-1',
+            content: 'ok',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
     });
 
     it('extracts function response error field when present', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'tool_name',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -276,7 +308,7 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages[0]).toEqual({
+      expect(messages[1]).toEqual({
         role: 'user',
         content: [
           {
@@ -294,6 +326,18 @@ describe('AnthropicContentConverter', () => {
         model: 'models/test',
         contents: [
           {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'read_file',
+                  args: {},
+                },
+              },
+            ],
+          },
+          {
             role: 'user',
             parts: [
               {
@@ -310,7 +354,7 @@ describe('AnthropicContentConverter', () => {
 
       // Should create a tool result with empty string content
       // This is required because Anthropic API expects every tool use to have a corresponding result
-      expect(messages[0]).toEqual({
+      expect(messages[1]).toEqual({
         role: 'user',
         content: [
           {
@@ -327,6 +371,18 @@ describe('AnthropicContentConverter', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -350,35 +406,45 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'call-1',
-              content: [
-                { type: 'text', text: 'Image content' },
-                {
-                  type: 'image',
-                  source: {
-                    type: 'base64',
-                    media_type: 'image/png',
-                    data: 'base64encodeddata',
-                  },
+      expect(messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-1',
+            content: [
+              { type: 'text', text: 'Image content' },
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'base64encodeddata',
                 },
-              ],
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        },
-      ]);
+              },
+            ],
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
     });
 
     it('renders non-image inlineData as a text block (avoids invalid image media_type)', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -402,10 +468,10 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toHaveLength(1);
-      expect(messages[0]?.role).toBe('user');
+      expect(messages).toHaveLength(2);
+      expect(messages[1]?.role).toBe('user');
 
-      const toolResult = messages[0]?.content?.[0] as {
+      const toolResult = messages[1]?.content?.[0] as {
         type: string;
         content: Array<{ type: string; text?: string }>;
       };
@@ -426,6 +492,18 @@ describe('AnthropicContentConverter', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -449,35 +527,45 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'call-1',
-              content: [
-                { type: 'text', text: 'PDF content' },
-                {
-                  type: 'document',
-                  source: {
-                    type: 'base64',
-                    media_type: 'application/pdf',
-                    data: 'pdfbase64data',
-                  },
+      expect(messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-1',
+            content: [
+              { type: 'text', text: 'PDF content' },
+              {
+                type: 'document',
+                source: {
+                  type: 'base64',
+                  media_type: 'application/pdf',
+                  data: 'pdfbase64data',
                 },
-              ],
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        },
-      ]);
+              },
+            ],
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
     });
 
     it('converts fileData with image into image url block', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -502,34 +590,44 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'call-1',
-              content: [
-                { type: 'text', text: 'Image content' },
-                {
-                  type: 'image',
-                  source: {
-                    type: 'url',
-                    url: 'https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg',
-                  },
+      expect(messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-1',
+            content: [
+              { type: 'text', text: 'Image content' },
+              {
+                type: 'image',
+                source: {
+                  type: 'url',
+                  url: 'https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg',
                 },
-              ],
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        },
-      ]);
+              },
+            ],
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
     });
 
     it('converts fileData with PDF into document url block', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -554,34 +652,44 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'call-1',
-              content: [
-                { type: 'text', text: 'PDF content' },
-                {
-                  type: 'document',
-                  source: {
-                    type: 'url',
-                    url: 'https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model-Card-October-Addendum.pdf',
-                  },
+      expect(messages[1]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-1',
+            content: [
+              { type: 'text', text: 'PDF content' },
+              {
+                type: 'document',
+                source: {
+                  type: 'url',
+                  url: 'https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model-Card-October-Addendum.pdf',
                 },
-              ],
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        },
-      ]);
+              },
+            ],
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
     });
 
     it('renders unsupported fileData as a text block', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -606,7 +714,7 @@ describe('AnthropicContentConverter', () => {
         ],
       });
 
-      const toolResult = messages[0]?.content?.[0] as {
+      const toolResult = messages[1]?.content?.[0] as {
         type: string;
         content: Array<{ type: string; text?: string }>;
       };
@@ -627,6 +735,25 @@ describe('AnthropicContentConverter', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+              {
+                functionCall: {
+                  id: 'call-2',
+                  name: 'Read',
+                  args: {},
+                },
+              },
+            ],
+          },
           {
             role: 'user',
             parts: [
@@ -668,8 +795,8 @@ describe('AnthropicContentConverter', () => {
       });
 
       // Multiple tool_result blocks are emitted in order
-      expect(messages).toHaveLength(1);
-      expect(messages[0]).toEqual({
+      expect(messages).toHaveLength(2);
+      expect(messages[1]).toEqual({
         role: 'user',
         content: [
           {
@@ -705,6 +832,204 @@ describe('AnthropicContentConverter', () => {
           },
         ],
       });
+    });
+
+    it('merges consecutive assistant messages into one', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 't1', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 't1',
+                  name: 'tool',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Hello!' },
+            { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 't1',
+              content: 'ok',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('merges thinking blocks before non-thinking blocks', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { text: 'thought A', thought: true, thoughtSignature: 'sigA' },
+              { text: 'text A' },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'thought B', thought: true, thoughtSignature: 'sigB' },
+              { functionCall: { id: 't1', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 't1',
+                  name: 'tool',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const assistant = messages[1];
+      expect(assistant?.role).toBe('assistant');
+      const blocks = assistant?.content as Array<{ type: string }>;
+      expect(blocks[0]?.type).toBe('thinking');
+      expect(blocks[1]?.type).toBe('thinking');
+      expect(blocks[2]?.type).toBe('text');
+      expect(blocks[3]?.type).toBe('tool_use');
+    });
+
+    it('cleans orphaned tool_use blocks without matching tool_result', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { text: 'Let me help' },
+              { functionCall: { id: 'orphan', name: 'tool', args: {} } },
+            ],
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hi', cache_control: { type: 'ephemeral' } },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Let me help' }],
+        },
+      ]);
+    });
+
+    it('cleans orphaned tool_result blocks without matching tool_use', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello' }] },
+          {
+            role: 'user',
+            parts: [
+              { text: 'extra' },
+              {
+                functionResponse: {
+                  id: 'orphan',
+                  name: 'tool',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'extra', cache_control: { type: 'ephemeral' } },
+          ],
+        },
+      ]);
+    });
+
+    it('deduplicates tool_use blocks by id during merge', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 'dup', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 'dup', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'dup',
+                  name: 'tool',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const assistant = messages[1];
+      const toolUseBlocks = (assistant?.content as Array<{ type: string }>).filter(
+        (b) => b.type === 'tool_use',
+      );
+      expect(toolUseBlocks).toHaveLength(1);
     });
   });
 
@@ -761,6 +1086,18 @@ describe('AnthropicContentConverter', () => {
                 },
               ],
             },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'call-1',
+                    name: 'glob',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
           ],
         },
         enableThinking,
@@ -795,6 +1132,18 @@ describe('AnthropicContentConverter', () => {
                   thoughtSignature: 'sig',
                 },
                 { functionCall: { id: 't1', name: 'tool', args: {} } },
+              ],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
               ],
             },
           ],
@@ -945,19 +1294,31 @@ describe('AnthropicContentConverter', () => {
                 { functionCall: { id: 't1', name: 'tool', args: {} } },
               ],
             },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
           ],
         },
         { stripAssistantThinking: true },
       );
 
-      // Both assistant turns have their thinking blocks removed.
+      // Both assistant turns have their thinking blocks removed, and the
+      // two consecutive model turns merge into a single assistant message.
       expect(messages[1]).toEqual({
         role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
-      });
-      expect(messages[2]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
+        content: [
+          { type: 'text', text: 'Hello!' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+        ],
       });
     });
 
@@ -1024,6 +1385,18 @@ describe('AnthropicContentConverter', () => {
                 { functionCall: { id: 't1', name: 'tool', args: {} } },
               ],
             },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
           ],
         },
         enableThinking,
@@ -1055,6 +1428,18 @@ describe('AnthropicContentConverter', () => {
                   thoughtSignature: 'real-sig',
                 },
                 { functionCall: { id: 't1', name: 'tool', args: {} } },
+              ],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
               ],
             },
           ],
@@ -1126,6 +1511,18 @@ describe('AnthropicContentConverter', () => {
               parts: [
                 { text: 'Let me check that' },
                 { functionCall: { id: 't1', name: 'lookup', args: {} } },
+              ],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'lookup',
+                    response: { output: 'ok' },
+                  },
+                },
               ],
             },
           ],

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -842,9 +842,7 @@ describe('AnthropicContentConverter', () => {
           { role: 'model', parts: [{ text: 'Hello!' }] },
           {
             role: 'model',
-            parts: [
-              { functionCall: { id: 't1', name: 'tool', args: {} } },
-            ],
+            parts: [{ functionCall: { id: 't1', name: 'tool', args: {} } }],
           },
           {
             role: 'user',
@@ -987,7 +985,141 @@ describe('AnthropicContentConverter', () => {
         {
           role: 'user',
           content: [
-            { type: 'text', text: 'extra', cache_control: { type: 'ephemeral' } },
+            {
+              type: 'text',
+              text: 'extra',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('keeps tool results split across consecutive user messages', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { functionCall: { id: 'x', name: 'tool', args: {} } },
+              { functionCall: { id: 'y', name: 'tool', args: {} } },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'x',
+                  name: 'tool',
+                  response: { output: 'first' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'y',
+                  name: 'tool',
+                  response: { output: 'second' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(
+        (messages[1]?.content as Array<{ id?: string; type: string }>).filter(
+          (block) => block.type === 'tool_use',
+        ),
+      ).toHaveLength(2);
+      expect(messages[2]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'x',
+            content: 'first',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'y',
+            content: 'second',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
+    });
+
+    it('merges users when dropping an orphan-only assistant turn', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'before' }] },
+          {
+            role: 'model',
+            parts: [{ functionCall: { id: 'orphan', name: 'tool', args: {} } }],
+          },
+          { role: 'user', parts: [{ text: 'after' }] },
+        ],
+      });
+
+      expect(messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'before' },
+            {
+              type: 'text',
+              text: 'after',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('drops tool results that do not lead user content', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [{ functionCall: { id: 't1', name: 'tool', args: {} } }],
+          },
+          {
+            role: 'user',
+            parts: [
+              { text: 'preface' },
+              {
+                functionResponse: {
+                  id: 't1',
+                  name: 'tool',
+                  response: { output: 'late' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hi' },
+            {
+              type: 'text',
+              text: 'preface',
+              cache_control: { type: 'ephemeral' },
+            },
           ],
         },
       ]);
@@ -1000,15 +1132,11 @@ describe('AnthropicContentConverter', () => {
           { role: 'user', parts: [{ text: 'Hi' }] },
           {
             role: 'model',
-            parts: [
-              { functionCall: { id: 'dup', name: 'tool', args: {} } },
-            ],
+            parts: [{ functionCall: { id: 'dup', name: 'tool', args: {} } }],
           },
           {
             role: 'model',
-            parts: [
-              { functionCall: { id: 'dup', name: 'tool', args: {} } },
-            ],
+            parts: [{ functionCall: { id: 'dup', name: 'tool', args: {} } }],
           },
           {
             role: 'user',
@@ -1026,9 +1154,9 @@ describe('AnthropicContentConverter', () => {
       });
 
       const assistant = messages[1];
-      const toolUseBlocks = (assistant?.content as Array<{ type: string }>).filter(
-        (b) => b.type === 'tool_use',
-      );
+      const toolUseBlocks = (
+        assistant?.content as Array<{ type: string }>
+      ).filter((b) => b.type === 'tool_use');
       expect(toolUseBlocks).toHaveLength(1);
     });
   });
@@ -1319,6 +1447,49 @@ describe('AnthropicContentConverter', () => {
           { type: 'text', text: 'Hello!' },
           { type: 'tool_use', id: 't1', name: 'tool', input: {} },
         ],
+      });
+    });
+
+    it('strips thinking after consecutive assistant turns are merged', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'preserved before merge',
+                  thought: true,
+                  thoughtSignature: 'sig',
+                },
+              ],
+            },
+            {
+              role: 'model',
+              parts: [{ functionCall: { id: 't1', name: 'tool', args: {} } }],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 't1',
+                    name: 'tool',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        { stripAssistantThinking: true },
+      );
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
       });
     });
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -1085,6 +1085,48 @@ describe('AnthropicContentConverter', () => {
       ]);
     });
 
+    it('keeps tool results before text when merging consecutive users', () => {
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [{ functionCall: { id: 't1', name: 'tool', args: {} } }],
+          },
+          { role: 'user', parts: [{ text: 'preface' }] },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 't1',
+                  name: 'tool',
+                  response: { output: 'ok' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages[2]).toEqual({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 't1',
+            content: 'ok',
+          },
+          {
+            type: 'text',
+            text: 'preface',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      });
+    });
+
     it('drops tool results that do not lead user content', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -1050,9 +1050,17 @@ function mergeConsecutiveUserMessages(
       Array.isArray(message.content) &&
       Array.isArray(lastMessage.content)
     ) {
-      lastMessage.content = [
+      const combined = [
         ...(lastMessage.content as AnthropicContentBlockParam[]),
         ...(message.content as AnthropicContentBlockParam[]),
+      ];
+      lastMessage.content = [
+        ...combined.filter(
+          (b) => (b as { type?: string }).type === 'tool_result',
+        ),
+        ...combined.filter(
+          (b) => (b as { type?: string }).type !== 'tool_result',
+        ),
       ];
       continue;
     }

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -159,6 +159,10 @@ export class AnthropicContentConverter {
     messages = mergeConsecutiveAssistantMessages(messages);
     messages = cleanOrphanedToolCalls(messages);
     messages = mergeConsecutiveAssistantMessages(messages);
+    if (options.stripAssistantThinking) {
+      this.stripThinkingFromAssistantMessages(messages);
+    }
+    messages = mergeConsecutiveUserMessages(messages);
 
     // Add cache_control to enable prompt caching (if enabled). Prefer the
     // per-call override when the caller (typically the generator) passes
@@ -943,7 +947,8 @@ function mergeConsecutiveAssistantMessages(
 function cleanOrphanedToolCalls(
   messages: AnthropicMessageParam[],
 ): AnthropicMessageParam[] {
-  const survivingToolCallIds = new Set<string>();
+  const validToolUseBlocks = new WeakSet<object>();
+  const validToolResultBlocks = new WeakSet<object>();
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]!;
@@ -952,33 +957,37 @@ function cleanOrphanedToolCalls(
     }
 
     const blocks = message.content as AnthropicContentBlockParam[];
-    const toolUseIds = new Set<string>();
+    const toolUseBlocks = new Map<string, AnthropicContentBlockParam>();
     for (const block of blocks) {
       if ((block as { type?: string }).type === 'tool_use') {
         const id = (block as { id?: string }).id;
-        if (id) toolUseIds.add(id);
+        if (id && !toolUseBlocks.has(id)) toolUseBlocks.set(id, block);
       }
     }
-    if (toolUseIds.size === 0) continue;
+    if (toolUseBlocks.size === 0) continue;
 
-    const nextMessage = messages[i + 1];
-    const toolResultIds = new Set<string>();
-    if (
-      nextMessage &&
-      nextMessage.role === 'user' &&
-      Array.isArray(nextMessage.content)
-    ) {
+    for (let j = i + 1; j < messages.length; j++) {
+      const nextMessage = messages[j];
+      if (
+        !nextMessage ||
+        nextMessage.role !== 'user' ||
+        !Array.isArray(nextMessage.content)
+      ) {
+        break;
+      }
+
+      let seenNonToolResult = false;
       for (const block of nextMessage.content as AnthropicContentBlockParam[]) {
         if ((block as { type?: string }).type === 'tool_result') {
           const id = (block as { tool_use_id?: string }).tool_use_id;
-          if (id) toolResultIds.add(id);
+          const toolUseBlock = id ? toolUseBlocks.get(id) : undefined;
+          if (!seenNonToolResult && toolUseBlock) {
+            validToolUseBlocks.add(toolUseBlock as object);
+            validToolResultBlocks.add(block as object);
+          }
+        } else {
+          seenNonToolResult = true;
         }
-      }
-    }
-
-    for (const id of toolUseIds) {
-      if (toolResultIds.has(id)) {
-        survivingToolCallIds.add(id);
       }
     }
   }
@@ -1007,11 +1016,11 @@ function cleanOrphanedToolCalls(
       const t = (b as { type?: string }).type;
       if (t === 'tool_use') {
         const id = (b as { id?: string }).id;
-        return !id || survivingToolCallIds.has(id);
+        return !id || validToolUseBlocks.has(b as object);
       }
       if (t === 'tool_result') {
         const id = (b as { tool_use_id?: string }).tool_use_id;
-        return !id || survivingToolCallIds.has(id);
+        return !id || validToolResultBlocks.has(b as object);
       }
       return true;
     });
@@ -1026,4 +1035,29 @@ function cleanOrphanedToolCalls(
   }
 
   return cleaned;
+}
+
+function mergeConsecutiveUserMessages(
+  messages: AnthropicMessageParam[],
+): AnthropicMessageParam[] {
+  const merged: AnthropicMessageParam[] = [];
+
+  for (const message of messages) {
+    const lastMessage = merged[merged.length - 1];
+    if (
+      message.role === 'user' &&
+      lastMessage?.role === 'user' &&
+      Array.isArray(message.content) &&
+      Array.isArray(lastMessage.content)
+    ) {
+      lastMessage.content = [
+        ...(lastMessage.content as AnthropicContentBlockParam[]),
+        ...(message.content as AnthropicContentBlockParam[]),
+      ];
+      continue;
+    }
+    merged.push(message);
+  }
+
+  return merged;
 }

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -25,6 +25,7 @@ import {
   convertSchema,
   type SchemaComplianceMode,
 } from '../../utils/schemaConverter.js';
+import { createDebugLogger } from '../../utils/debugLogger.js';
 
 type AnthropicMessageParam = Anthropic.MessageParam;
 // `scope: 'global'` is sent under the `prompt-caching-scope-2026-01-05` beta
@@ -41,6 +42,8 @@ type AnthropicTextBlockParam = Anthropic.TextBlockParam & {
   cache_control?: AnthropicCacheControl;
 };
 type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
+
+const debugLogger = createDebugLogger('AnthropicConverter');
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
@@ -124,7 +127,7 @@ export class AnthropicContentConverter {
     system?: AnthropicTextBlockParam[] | string;
     messages: AnthropicMessageParam[];
   } {
-    const messages: AnthropicMessageParam[] = [];
+    let messages: AnthropicMessageParam[] = [];
 
     const systemText = this.extractTextFromContentUnion(
       request.config?.systemInstruction,
@@ -143,6 +146,19 @@ export class AnthropicContentConverter {
     if (options.injectThinkingOnToolUseTurns) {
       this.injectEmptyThinkingOnToolUseTurns(messages);
     }
+
+    // Merge consecutive assistant messages and clean orphaned tool calls.
+    // When the Gemini history has consecutive model turns (e.g. from
+    // streaming chunk-level recording, max_tokens recovery, or adaptive
+    // thinking splits), processContent emits one Anthropic message per
+    // Content. The Anthropic API requires that tool_use blocks be
+    // immediately followed by tool_result blocks in the next message —
+    // consecutive assistant messages break this pairing and cause HTTP 400
+    // "tool_use ids were found without tool_result blocks immediately
+    // after". Mirrors the same functions in the OpenAI converter.
+    messages = mergeConsecutiveAssistantMessages(messages);
+    messages = cleanOrphanedToolCalls(messages);
+    messages = mergeConsecutiveAssistantMessages(messages);
 
     // Add cache_control to enable prompt caching (if enabled). Prefer the
     // per-call override when the caller (typically the generator) passes
@@ -842,4 +858,172 @@ export class AnthropicContentConverter {
       }
     }
   }
+}
+
+/**
+ * Merge consecutive assistant messages into a single message.
+ *
+ * When the Gemini history has consecutive model turns (e.g. from streaming
+ * chunk-level recording, max_tokens recovery, or adaptive thinking splits),
+ * processContent emits one Anthropic message per Content. The Anthropic API
+ * requires that tool_use blocks be immediately followed by tool_result
+ * blocks in the next message — consecutive assistant messages break this
+ * pairing and cause HTTP 400 "tool_use ids were found without tool_result
+ * blocks immediately after".
+ *
+ * Thinking blocks must come first in Anthropic's content array, so merged
+ * blocks are reordered: all thinking blocks (from both messages) precede
+ * non-thinking blocks (text, tool_use, etc.).
+ *
+ * Mirrors the same-name function in the OpenAI converter.
+ */
+function mergeConsecutiveAssistantMessages(
+  messages: AnthropicMessageParam[],
+): AnthropicMessageParam[] {
+  const merged: AnthropicMessageParam[] = [];
+
+  for (const message of messages) {
+    if (
+      message.role === 'assistant' &&
+      merged.length > 0 &&
+      Array.isArray(message.content)
+    ) {
+      const lastMessage = merged[merged.length - 1]!;
+      if (
+        lastMessage.role === 'assistant' &&
+        Array.isArray(lastMessage.content)
+      ) {
+        const lastBlocks = lastMessage.content as AnthropicContentBlockParam[];
+        const currentBlocks = message.content as AnthropicContentBlockParam[];
+
+        const isThinking = (b: AnthropicContentBlockParam): boolean => {
+          const t = (b as { type?: string }).type;
+          return t === 'thinking' || t === 'redacted_thinking';
+        };
+
+        const seenToolUseIds = new Set<string>();
+        const combined: AnthropicContentBlockParam[] = [
+          ...lastBlocks.filter(isThinking),
+          ...currentBlocks.filter(isThinking),
+          ...lastBlocks.filter((b) => !isThinking(b)),
+          ...currentBlocks.filter((b) => !isThinking(b)),
+        ].filter((b) => {
+          const t = (b as { type?: string }).type;
+          if (t === 'tool_use') {
+            const id = (b as { id?: string }).id;
+            if (id) {
+              if (seenToolUseIds.has(id)) return false;
+              seenToolUseIds.add(id);
+            }
+          }
+          return true;
+        });
+
+        lastMessage.content = combined;
+        continue;
+      }
+    }
+    merged.push(message);
+  }
+
+  return merged;
+}
+
+/**
+ * Remove tool_use blocks that have no matching tool_result in the
+ * immediately following user message, and remove tool_result blocks that
+ * have no matching tool_use in the immediately preceding assistant message.
+ *
+ * Empty messages produced by the cleanup are dropped entirely. A subsequent
+ * mergeConsecutiveAssistantMessages call fixes any alternation issues
+ * created by dropped messages.
+ *
+ * Mirrors the same-name function in the OpenAI converter.
+ */
+function cleanOrphanedToolCalls(
+  messages: AnthropicMessageParam[],
+): AnthropicMessageParam[] {
+  const survivingToolCallIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]!;
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    const blocks = message.content as AnthropicContentBlockParam[];
+    const toolUseIds = new Set<string>();
+    for (const block of blocks) {
+      if ((block as { type?: string }).type === 'tool_use') {
+        const id = (block as { id?: string }).id;
+        if (id) toolUseIds.add(id);
+      }
+    }
+    if (toolUseIds.size === 0) continue;
+
+    const nextMessage = messages[i + 1];
+    const toolResultIds = new Set<string>();
+    if (
+      nextMessage &&
+      nextMessage.role === 'user' &&
+      Array.isArray(nextMessage.content)
+    ) {
+      for (const block of nextMessage.content as AnthropicContentBlockParam[]) {
+        if ((block as { type?: string }).type === 'tool_result') {
+          const id = (block as { tool_use_id?: string }).tool_use_id;
+          if (id) toolResultIds.add(id);
+        }
+      }
+    }
+
+    for (const id of toolUseIds) {
+      if (toolResultIds.has(id)) {
+        survivingToolCallIds.add(id);
+      }
+    }
+  }
+
+  const cleaned: AnthropicMessageParam[] = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      cleaned.push(message);
+      continue;
+    }
+
+    const blocks = message.content as AnthropicContentBlockParam[];
+    const hasToolUse = blocks.some(
+      (b) => (b as { type?: string }).type === 'tool_use',
+    );
+    const hasToolResult = blocks.some(
+      (b) => (b as { type?: string }).type === 'tool_result',
+    );
+
+    if (!hasToolUse && !hasToolResult) {
+      cleaned.push(message);
+      continue;
+    }
+
+    const filtered = blocks.filter((b) => {
+      const t = (b as { type?: string }).type;
+      if (t === 'tool_use') {
+        const id = (b as { id?: string }).id;
+        return !id || survivingToolCallIds.has(id);
+      }
+      if (t === 'tool_result') {
+        const id = (b as { tool_use_id?: string }).tool_use_id;
+        return !id || survivingToolCallIds.has(id);
+      }
+      return true;
+    });
+
+    if (filtered.length > 0) {
+      cleaned.push({ ...message, content: filtered });
+    } else {
+      debugLogger.debug(
+        'cleanOrphanedToolCalls: dropping message with only orphaned tool blocks',
+      );
+    }
+  }
+
+  return cleaned;
 }

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2290,6 +2290,78 @@ describe('ChatCompressionService.compress — claude-code-style full-history com
     expect(calledWith.contents[0].parts[0].text).toContain('first request');
   });
 
+  it('includes a pending tool result in the summary side-query', async () => {
+    const runSideQuerySpy = vi
+      .spyOn(sideQueryModule, 'runSideQuery')
+      .mockResolvedValue({
+        text: 'TEST SUMMARY',
+        usage: {
+          promptTokenCount: 170_000,
+          candidatesTokenCount: 500,
+          totalTokenCount: 170_500,
+        },
+      } as never);
+
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'inspect the repository' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'tool-call-1',
+              name: 'read_file',
+              args: { file_path: 'README.md' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await new ChatCompressionService().compress(
+      makeFakeChat(history),
+      {
+        promptId: 'p',
+        force: true,
+        model: 'qwen-vl',
+        config: makeFakeConfig(),
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+        trigger: 'auto',
+        pendingUserMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'tool-call-1',
+                name: 'read_file',
+                response: { output: 'README contents' },
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    const calledWith = runSideQuerySpy.mock.calls[0]![1] as {
+      contents: Array<{
+        parts: Array<{
+          functionResponse?: { id?: string };
+          text?: string;
+        }>;
+      }>;
+    };
+    expect(calledWith.contents).toHaveLength(4);
+    expect(calledWith.contents[2].parts[0].functionResponse?.id).toBe(
+      'tool-call-1',
+    );
+    expect(
+      result.newHistory
+        ?.at(-1)
+        ?.parts?.some((part) => part.functionCall?.id === 'tool-call-1'),
+    ).toBe(true);
+  });
+
   it('produces newHistory composed via composePostCompactHistory', async () => {
     vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
       text: 'SUM_TXT',

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -2362,6 +2362,61 @@ describe('ChatCompressionService.compress — claude-code-style full-history com
     ).toBe(true);
   });
 
+  it('does not subtract pending tool result tokens from original history', async () => {
+    vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
+      text: 'TEST SUMMARY',
+      usage: {
+        promptTokenCount: 220_000,
+        candidatesTokenCount: 500,
+        totalTokenCount: 220_500,
+      },
+    } as never);
+
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'inspect the repository' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'tool-call-1',
+              name: 'read_file',
+              args: { file_path: 'README.md' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await new ChatCompressionService().compress(
+      makeFakeChat(history),
+      {
+        promptId: 'p',
+        force: true,
+        model: 'qwen-vl',
+        config: makeFakeConfig(),
+        consecutiveFailures: 0,
+        originalTokenCount: 180_000,
+        trigger: 'auto',
+        pendingUserMessage: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'tool-call-1',
+                name: 'read_file',
+                response: { output: 'x'.repeat(160_000) },
+              },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+    expect(result.info.newTokenCount).toBeGreaterThan(0);
+  });
+
   it('produces newHistory composed via composePostCompactHistory', async () => {
     vi.spyOn(sideQueryModule, 'runSideQuery').mockResolvedValue({
       text: 'SUM_TXT',

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -424,7 +424,7 @@ export class ChatCompressionService {
       }
     }
 
-    // Compression only reads the existing history while deciding the split and
+    // Compression reads existing history plus any pending tool result while
     // preparing the side-query payload. Avoid `getHistory(true)` here: long
     // tool-heavy sessions can make a defensive deep clone larger than the
     // remaining V8 heap headroom at exactly the moment compaction is trying to
@@ -497,10 +497,21 @@ export class ChatCompressionService {
       }
     }
 
+    // A tool result is still pending when automatic compaction runs before
+    // sendMessageStream commits the current user turn to chat history. Include
+    // it in the side-query so Anthropic-compatible providers see it immediately
+    // after the preceding tool_use block.
+    const pendingToolResult = opts.pendingUserMessage?.parts?.some(
+      (part) => !!part.functionResponse,
+    );
+    const sideQueryHistory = pendingToolResult
+      ? [...curatedHistory, opts.pendingUserMessage!]
+      : curatedHistory;
+
     // Slim the side-query input: replace inlineData with placeholders.
     // The original history (with images) is preserved separately for
     // the post-compact image restoration block.
-    const slim = slimCompactionInput(curatedHistory);
+    const slim = slimCompactionInput(sideQueryHistory);
     if (slim.stats.imagesStripped > 0 || slim.stats.documentsStripped > 0) {
       config
         .getDebugLogger()

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -507,6 +507,12 @@ export class ChatCompressionService {
     const sideQueryHistory = pendingToolResult
       ? [...curatedHistory, opts.pendingUserMessage!]
       : curatedHistory;
+    const pendingToolResultTokenCount = pendingToolResult
+      ? estimateContentTokens(
+          [opts.pendingUserMessage!],
+          slimmingConfig.imageTokenEstimate,
+        )
+      : 0;
 
     // Slim the side-query input: replace inlineData with placeholders.
     // The original history (with images) is preserved separately for
@@ -751,10 +757,14 @@ export class ChatCompressionService {
         compressionOutputTokenCount > 0
       ) {
         canCalculateNewTokenCount = true;
+        const compressedHistoryTokenCount = Math.max(
+          0,
+          compressionInputTokenCount - 1000 - pendingToolResultTokenCount,
+        );
         newTokenCount = Math.max(
           0,
           originalTokenCount -
-            (compressionInputTokenCount - 1000) +
+            compressedHistoryTokenCount +
             compressionOutputTokenCount,
         );
         // The composer injects file-restoration blocks (up to


### PR DESCRIPTION
## What this PR does

Fixes the `tool_use ids were found without tool_result blocks immediately after` HTTP 400 error that occurs with Anthropic-compatible providers (notably Claude 4.6 with adaptive thinking). The fix has two complementary layers:

**Layer 1 — Compaction side-query (first commit):** When automatic compaction runs during a tool loop before the tool result is committed to chat history, the compaction side-query now includes the pending tool result so Anthropic-compatible providers see it immediately after the preceding tool_use block.

**Layer 2 — Anthropic converter merge/clean (second commit):** Adds `mergeConsecutiveAssistantMessages` and `cleanOrphanedToolCalls` to the Anthropic converter, mirroring the same-name functions already present in the OpenAI converter. When the Gemini history has consecutive model turns (from streaming chunk-level recording, max_tokens recovery, or adaptive thinking splits), `processContent` emits one Anthropic message per Content. The Anthropic API requires tool_use blocks to be immediately followed by tool_result blocks — consecutive assistant messages break this pairing. The merge pass combines consecutive assistant messages into one (thinking blocks first, then non-thinking). The clean pass removes orphaned tool_use and tool_result blocks. A second merge pass fixes any alternation issues created by dropped messages.

## Why it is needed

Anthropic-compatible providers require every `tool_use` block to be followed immediately by its corresponding `tool_result`. Multiple code paths can create consecutive model Content entries that violate this requirement:

| Trigger path | Layer 1 | Layer 2 |
|---|:---:|:---:|
| Compaction runs before pending tool result is committed | Yes | Yes |
| Streaming chunk-level recording creates separate model Content entries | No | Yes |
| max_tokens recovery creates extra model turns | No | Yes |
| Adaptive thinking splits a single response into multiple turns | No | Yes |

Layer 1 is a targeted fix for the compaction timing window. Layer 2 is a converter-level fallback that covers all trigger paths. Together they provide comprehensive coverage.

## Reviewer Test Plan

### How to verify

Trigger a tool-heavy session with an Anthropic-compatible model (e.g. Claude Opus 4.6) and confirm that tool loops, compaction, and subagent spawning all complete without a missing-tool_result 400 error. Specifically: spawn a subagent that makes multiple tool calls in a single response, then verify the continuation request succeeds.

### Evidence (Before & After)

N/A. This is a non-UI change.

### Tested on

| OS | Status |
| :---: | :---: |
| macOS | Done |
| Windows | Not tested |
| Linux | Not tested |

### Environment (optional)

macOS. `cd packages/core && npx vitest run src/core/anthropicContentGenerator/converter.test.ts src/services/chatCompressionService.test.ts` — 145 tests passed. ESLint clean.

## Risk & Scope

- Main risk or tradeoff: Layer 2 changes are in the Anthropic converter post-processing pipeline, running for all Anthropic models (not just DeepSeek). The merge logic is identical in structure to the OpenAI converter proven implementation. Existing tests were updated to include proper tool_use/tool_result pairs (previously single-turn tests had orphaned blocks that would be rejected by the real API anyway).
- Not validated / out of scope: No live Anthropic-compatible API E2E run. Pre-existing `@lydell/node-pty` typecheck error on clean branch is outside this change.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #6654

<details>
<summary>中文说明</summary>

## What this PR does

修复 Anthropic-compatible 提供方（尤其是 Claude 4.6 adaptive thinking）出现的 `tool_use ids were found without tool_result blocks immediately after` 400 错误。包含两层互补修复：

**第一层 — 压缩 side-query（第一个提交）：** 自动压缩在工具循环中、工具结果尚未写入历史时触发，side-query 现在会携带待发送的工具结果。

**第二层 — Anthropic 转换器合并/清理（第二个提交）：** 在 Anthropic 转换器中添加 `mergeConsecutiveAssistantMessages` 和 `cleanOrphanedToolCalls`，与 OpenAI 转换器中已有的同名函数对齐。当 Gemini 历史中出现连续 model turn（流式 chunk 级别存储、max_tokens 恢复、adaptive thinking 分裂等），转换器逐 Content 生成 Anthropic 消息导致连续 assistant 消息，违反 API 的 tool_use → tool_result 配对要求。合并步骤将连续 assistant 消息合并为一条（thinking 块在前），清理步骤移除孤立的 tool_use/tool_result 块。

## Why it is needed

Anthropic-compatible 提供方要求每个 `tool_use` 紧随对应的 `tool_result`。多个代码路径会产生违反此要求的连续 model Content：

| 触发路径 | 第一层 | 第二层 |
|---|:---:|:---:|
| 压缩在 pending tool result 提交前触发 | 是 | 是 |
| 流式 chunk 级别产生连续 model Content | 否 | 是 |
| max_tokens 恢复产生连续 model turn | 否 | 是 |
| adaptive thinking 分裂产生连续 model turn | 否 | 是 |

第一层是压缩时机窗口的针对性修复，第二层是转换器层面的兜底方案，覆盖所有触发路径。

## Reviewer Test Plan

### How to verify

使用 Anthropic-compatible 模型（如 Claude Opus 4.6）进行工具密集型会话，确认工具循环、压缩、子代理启动均不出现缺少 tool_result 的 400 错误。具体：启动一个在单次响应中发起多个工具调用的子代理，验证后续请求成功。

### Evidence (Before & After)

N/A，非 UI 变更。

### Tested on

| OS | Status |
| :---: | :---: |
| macOS | Done |
| Windows | Not tested |
| Linux | Not tested |

### Environment (optional)

macOS；`cd packages/core && npx vitest run src/core/anthropicContentGenerator/converter.test.ts src/services/chatCompressionService.test.ts`，145 tests passed；ESLint clean。

## Risk & Scope

- Main risk or tradeoff: 第二层改动在 Anthropic 转换器的后处理流水线中，对所有 Anthropic 模型生效（不仅限于 DeepSeek）。合并逻辑结构与 OpenAI 转换器已验证的实现一致。已有测试更新为包含正确的 tool_use/tool_result 配对（此前单轮测试中的孤立块本来也会被真实 API 拒绝）。
- Not validated / out of scope: 未运行真实 Anthropic-compatible API E2E；干净分支预存的 `@lydell/node-pty` typecheck 错误不在本次修改范围。
- Breaking changes / migration notes: None。

## Linked Issues

无关联 issue — 此 bug 在 Claude 4.6 测试中发现。如需跟踪可由 maintainer 创建 issue。

</details>