### PR TITLE
fix(triage): require explicit defer comment and prevent hygiene-based defer on re-runs

### DIFF
--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -368,7 +368,7 @@ Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**, b
 3. @mentions the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set, or the most recent human reviewer).
 
 ```bash
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⏸️ Deferring to @$MAINTAINER_HANDLE — <reason>. Needs a human call on this one."
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⏸️ Deferring to @$QWEN_MAINTAINER_HANDLE — <reason>. Needs a human call on this one."
 ```
 
 A defer without an explicit comment is invisible — the maintainer won't know they're needed.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -348,6 +348,8 @@ If `GUARD` is `block`: do **not** run `gh pr review --approve` no matter how cle
 
 If Stage 0 escalated the PR for maintainer awareness, do **not** approve automatically; use the "Genuinely unsure" path below.
 
+**Re-runs (manually triggered via `@qwen-code /triage`):** hygiene concerns (scope mismatch, undocumented changes, naming) that don't block the PR are not a valid reason to defer. Note them in the comment and approve. Only defer if you have genuine blocking uncertainty — something you cannot resolve from the diff, tests, and PR description.
+
 All stages genuinely clean, `GUARD` is `ok`, and no Stage 0 maintainer escalation remains — approve:
 
 ```bash
@@ -360,4 +362,13 @@ Reflection shows it shouldn't merge — request changes immediately, citing the 
 gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "Needs some rethinking — see my notes above. 🙏"
 ```
 
-Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**. Ask the maintainer to weigh in. Use `$QWEN_MAINTAINER_HANDLE` if set.
+Genuinely unsure, or `GUARD` blocked approval — **don't approve or reject**, but **never defer silently**. Post an explicit defer comment that:
+1. States you are escalating to the maintainer.
+2. Names the specific reason(s) for uncertainty — what you cannot resolve from the diff, tests, and PR description.
+3. @mentions the maintainer (use `$QWEN_MAINTAINER_HANDLE` if set, or the most recent human reviewer).
+
+```bash
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⏸️ Deferring to @$MAINTAINER_HANDLE — <reason>. Needs a human call on this one."
+```
+
+A defer without an explicit comment is invisible — the maintainer won't know they're needed.


### PR DESCRIPTION
## What this PR does

Updates the triage workflow guidance so a deferred triage result must leave an explicit visible comment that names the uncertainty, states the escalation, and mentions the maintainer.

It also clarifies that hygiene concerns on a maintainer-triggered re-run, such as scope mismatch, undocumented changes, or naming issues, should be noted in the response but should not by themselves cause the bot to defer. Only genuine blocking uncertainty should defer.

## Why it's needed

On PR #6637, triage completed all stages and found no correctness issue, but still deferred to a human reviewer who had already approved. Because the defer path only updated stage comments and did not post a visible escalation comment, maintainers had no clear signal that action was needed and users could read the run as stalled.

This change makes the defer behavior explicit and keeps re-run triage from treating non-blocking hygiene concerns as blockers.

## Reviewer Test Plan

### How to verify

Review the updated triage workflow guidance and confirm that the defer path now requires a visible comment that explains the uncertainty and @mentions the maintainer.

Trigger `/triage` on a PR where all stages pass but the bot has hygiene concerns, such as scope mismatch, undocumented changes, or naming issues. It should approve or continue with the concerns noted in the comment, not defer only because of those concerns.

Trigger `/triage` on a PR with genuine blocking uncertainty that cannot be resolved from the diff, tests, and PR description. It should defer with a visible comment naming the reason and mentioning the maintainer.

### Evidence (Before & After)

N/A - workflow guidance change only; no UI or TUI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A - no local runtime required for this prompt/workflow guidance update.

## Risk & Scope

- Main risk or tradeoff: The triage prompt may approve a re-run with hygiene concerns when those concerns are non-blocking, so the distinction between hygiene concerns and genuine blocking uncertainty needs to remain clear.
- Not validated / out of scope: This PR updates the workflow guidance; it does not add an automated fixture that simulates both triage paths.
- Breaking changes / migration notes: N/A.

## Linked Issues

References PR #6637.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 triage workflow 指引：当 triage 选择 defer 时，必须留下一个明确可见的评论，说明不确定点、说明升级给维护者，并 @mention 对应 maintainer。

同时明确 maintainer 手动重新触发 triage 时，如果只是 scope mismatch、未记录的变更、命名问题这类 hygiene concern，可以在回复里注明，但不应该仅凭这些问题 defer。只有真正阻塞判断的不确定性才应该 defer。

## 为什么需要

在 PR #6637 上，triage 完成了所有阶段，也没有发现 correctness issue，但仍然 defer 给已经 approve 过的 human reviewer。由于 defer path 只更新了 stage comments，没有发布可见的升级评论，maintainer 没有明确收到需要处理的信号，用户也容易以为 triage 卡住了。

这个变更让 defer 行为显式化，并避免重新触发 triage 时把非阻塞的 hygiene concern 当成 blocker。

## Reviewer Test Plan

### 如何验证

查看更新后的 triage workflow 指引，确认 defer path 现在要求发布一个可见评论，解释不确定点并 @mention maintainer。

在一个所有阶段都通过、但 bot 发现 hygiene concern 的 PR 上触发 `/triage`，例如 scope mismatch、未记录的变更或命名问题。它应该 approve 或继续推进，并在评论里注明这些 concern，而不是只因为这些 concern defer。

在一个存在真正阻塞性不确定点、且无法通过 diff、测试和 PR 描述解决的 PR 上触发 `/triage`。它应该 defer，并发布一个可见评论说明原因、mention maintainer。

### Evidence (Before & After)

N/A - 仅 workflow 指引变更，没有 UI 或 TUI 输出。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A - 这个 prompt/workflow 指引更新不需要本地运行环境。

## Risk & Scope

- Main risk or tradeoff: triage prompt 可能在 re-run 时对非阻塞 hygiene concern 继续 approve，因此需要保持 hygiene concern 和真正阻塞性不确定点之间的区分足够清晰。
- Not validated / out of scope: 这个 PR 更新 workflow 指引，没有新增自动化 fixture 来模拟两个 triage path。
- Breaking changes / migration notes: N/A。

## Linked Issues

关联 PR #6637。

</details>
