### PR TITLE
fix(sdk): escalate process abort termination

### DIFF
--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -29,6 +29,7 @@ export class ProcessTransport implements Transport {
   private inputClosed = false;
   private abortController: AbortController;
   private abortHandler: (() => void) | null = null;
+  private killEscalationTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: TransportOptions) {
     this.options = options;
@@ -211,8 +212,41 @@ export class ProcessTransport implements Transport {
   }
 
   private killChildProcess(): void {
-    if (this.childProcess && !this.childProcess.killed) {
+    this.requestChildProcessExit();
+  }
+
+  private requestChildProcessExit(): void {
+    if (!this.childProcess || this.childProcess.exitCode !== null) {
+      return;
+    }
+
+    if (!this.childProcess.killed) {
       this.childProcess.kill('SIGTERM');
+    }
+
+    this.scheduleChildProcessKillEscalation(this.childProcess);
+  }
+
+  private scheduleChildProcessKillEscalation(childProcess: ChildProcess): void {
+    this.clearKillEscalationTimer();
+
+    this.killEscalationTimer = setTimeout(() => {
+      if (
+        this.childProcess === childProcess &&
+        childProcess.exitCode === null
+      ) {
+        childProcess.kill('SIGKILL');
+      }
+      this.killEscalationTimer = null;
+    }, 5000);
+
+    this.killEscalationTimer.unref?.();
+  }
+
+  private clearKillEscalationTimer(): void {
+    if (this.killEscalationTimer) {
+      clearTimeout(this.killEscalationTimer);
+      this.killEscalationTimer = null;
     }
   }
 
@@ -251,6 +285,7 @@ export class ProcessTransport implements Transport {
     });
 
     this.childProcess.on('close', (code, signal) => {
+      this.clearKillEscalationTimer();
       this.unregisterForProcessExit();
       this.ready = false;
       if (this.abortController.signal.aborted) {
@@ -354,14 +389,7 @@ export class ProcessTransport implements Transport {
       this.abortHandler = null;
     }
 
-    if (this.childProcess && !this.childProcess.killed) {
-      this.childProcess.kill('SIGTERM');
-      setTimeout(() => {
-        if (this.childProcess && !this.childProcess.killed) {
-          this.childProcess.kill('SIGKILL');
-        }
-      }, 5000);
-    }
+    this.requestChildProcessExit();
 
     this.ready = false;
     this.closed = true;

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -116,6 +116,7 @@ describe('ProcessTransport', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -525,8 +526,97 @@ describe('ProcessTransport', () => {
       vi.advanceTimersByTime(5000);
 
       expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
 
-      vi.useRealTimers();
+    it('should escalate abort-triggered SIGTERM to SIGKILL after timeout', () => {
+      vi.useFakeTimers();
+
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+
+      mockChildProcess.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+        if (signal === 'SIGTERM') {
+          mockChildProcess.killed = true;
+        }
+        return true;
+      }) as unknown as typeof mockChildProcess.kill;
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const abortController = new AbortController();
+      new ProcessTransport({
+        pathToQwenExecutable: 'qwen',
+        abortController,
+      });
+
+      abortController.abort();
+
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGTERM');
+
+      vi.advanceTimersByTime(5000);
+
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('should escalate close-triggered SIGTERM even after killed becomes true', async () => {
+      vi.useFakeTimers();
+
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+
+      mockChildProcess.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+        if (signal === 'SIGTERM') {
+          mockChildProcess.killed = true;
+        }
+        return true;
+      }) as unknown as typeof mockChildProcess.kill;
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const transport = new ProcessTransport({
+        pathToQwenExecutable: 'qwen',
+      });
+
+      await transport.close();
+
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGTERM');
+
+      vi.advanceTimersByTime(5000);
+
+      expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    });
+
+    it('should clear the escalation timer when the child exits promptly', () => {
+      vi.useFakeTimers();
+
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const abortController = new AbortController();
+      new ProcessTransport({
+        pathToQwenExecutable: 'qwen',
+        abortController,
+      });
+
+      abortController.abort();
+      mockChildProcess.exitCode = 0;
+      mockChildProcess.emit('close', 0, null);
+
+      vi.advanceTimersByTime(5000);
+
+      expect(mockChildProcess.kill).toHaveBeenCalledTimes(1);
+      expect(mockChildProcess.kill).not.toHaveBeenCalledWith('SIGKILL');
     });
 
     it('should be idempotent when calling close() multiple times', async () => {


### PR DESCRIPTION
## What this PR does

This PR makes SDK process termination bounded when a caller aborts a `ProcessTransport` session. The direct child now receives `SIGTERM` first and escalates to `SIGKILL` after 5 seconds if it is still running. The same termination helper is shared by the regular close path so the close path no longer relies on `ChildProcess.killed`, which only means a signal was sent, not that the child exited. The escalation timer is cleared when the child exits promptly.

## Why it's needed

SDK callers using an abort controller could previously leave a Qwen CLI child process running indefinitely if that process ignored or got stuck during `SIGTERM` cleanup. This is especially visible when cleanup hangs or a tool subprocess keeps the CLI alive. The fix gives abort and close a consistent bounded termination path without expanding scope into process-group termination.

## Reviewer Test Plan

### How to verify

Run the SDK focused process transport tests and confirm the abort path sends `SIGTERM`, escalates to `SIGKILL`, and clears the escalation timer when the child exits before the timeout. For an end-to-end local check, run a temporary executable that ignores `SIGTERM`, start it through the built SDK `query()` API with `pathToQwenExecutable`, abort the query, and confirm the child PID is gone after the 5-second escalation window.

### Evidence (Before & After)

N/A for screenshots because this is SDK process lifecycle behavior, not TUI output. Local evidence is in the command-based verification report posted as a PR comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local runtime: macOS with Node `v22.23.1`.

## Risk & Scope

- Main risk or tradeoff: abort and close now keep a short escalation timer, but it is unref'ed and cleared on child close to avoid holding the event loop open or firing after a clean exit.
- Not validated / out of scope: process-group termination for shell/MCP descendants; that requires spawn-side process group changes and should be handled separately.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6636

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 SDK 的进程终止在调用方 abort `ProcessTransport` 会话时具备有界收敛能力。直接子进程现在会先收到 `SIGTERM`，如果 5 秒后仍在运行，则升级为 `SIGKILL`。普通 close 路径也复用同一个终止 helper，因此不再依赖 `ChildProcess.killed`；该字段只表示信号已发送，不表示子进程已经退出。子进程及时退出时，升级 timer 会被清理。

## 为什么需要

SDK 调用方使用 abort controller 时，如果 Qwen CLI 子进程忽略 `SIGTERM` 或卡在清理逻辑中，之前可能无限期残留。清理逻辑挂起或工具子进程让 CLI 继续存活时尤其明显。该修复让 abort 和 close 使用一致的有界终止路径，同时不把范围扩大到进程组终止。

## Reviewer Test Plan

### 如何验证

运行 SDK focused process transport 测试，确认 abort 路径会发送 `SIGTERM`、随后升级到 `SIGKILL`，并且当子进程在超时前退出时会清理升级 timer。端到端本地验证可以运行一个忽略 `SIGTERM` 的临时可执行文件，通过构建后的 SDK `query()` API 和 `pathToQwenExecutable` 启动它，abort query，并确认 5 秒升级窗口后该子进程 PID 已不可达。

### 证据（Before & After）

不适用截图，因为这是 SDK 进程生命周期行为，不是 TUI 输出。本地证据见 PR 评论中的命令验证报告。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

本地运行环境：macOS，Node `v22.23.1`。

## 风险和范围

- 主要风险或取舍：abort 和 close 现在会保留一个短暂的升级 timer，但该 timer 已 unref，并会在 child close 时清理，避免阻塞事件循环或在正常退出后误触发。
- 未验证 / 范围外：shell/MCP 后代进程的进程组终止；这需要 spawn 侧的进程组变更，应单独处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6636

</details>
