### PR TITLE
fix(mobile-mcp): reject out-of-range normalized coordinates

### DIFF
--- a/packages/mobile-mcp/src/coord-norm.ts
+++ b/packages/mobile-mcp/src/coord-norm.ts
@@ -1,3 +1,5 @@
+import { ActionableError } from './robot';
+
 // coord-norm.ts — Opt-in 0–1000 relative-coordinate shim for mobile-mcp.
 //
 // Mirrors packages/cua-driver's coord_norm.rs design. Default off = pixel
@@ -93,6 +95,12 @@ export function denormalizeArgs(
 
   for (const { field, isX } of fields) {
     if (typeof args[field] === 'number') {
+      if (args[field] < 0 || args[field] > scale) {
+        throw new ActionableError(
+          `Coordinate '${field}' value ${args[field]} is out of the normalized range [0, ${scale}]. ` +
+            `Use normalized coordinates (0-${scale}), not pixel coordinates.`,
+        );
+      }
       const dim = isX ? screenWidth : screenHeight;
       args[field] = normToPx(args[field], dim, scale);
     }
@@ -103,6 +111,12 @@ export function denormalizeArgs(
     toolName === 'mobile_swipe_on_screen' &&
     typeof args.distance === 'number'
   ) {
+    if (args.distance < 0 || args.distance > scale) {
+      throw new ActionableError(
+        `Swipe 'distance' value ${args.distance} is out of the normalized range [0, ${scale}]. ` +
+          `Use normalized coordinates (0-${scale}), not pixel values.`,
+      );
+    }
     const dir = args.direction;
     const dim = dir === 'up' || dir === 'down' ? screenHeight : screenWidth;
     args.distance = normToPx(args.distance, dim, scale);


### PR DESCRIPTION
## Summary

- In coordinate normalization mode, reject coordinates outside `[0, scale]` with an ActionableError
- Catches the common model mistake of passing screenshot pixel coordinates instead of normalized coordinates (e.g. `y=1175` on a 900x2000 device when the valid range is 0-1000)
- Also validates swipe `distance` parameter

## Context

In a production trace, the model repeatedly passed `y=1175` (exceeding the 0-1000 normalized range) because it confused screenshot pixel coordinates with normalized coordinates. The click silently mapped to device pixel `y=2350` (off-screen), and the model wasted 3 attempts before self-correcting.

## Test plan

- [ ] Typecheck passes
- [ ] Existing `coord-norm.test.ts` tests pass
- [ ] In normalized mode, `mobile_click_on_screen_at_coordinates` with `y=1175` returns ActionableError instead of silently clicking off-screen