### PR TITLE
fix(mcp): skip OAuth browser flow in non-interactive mode

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -528,6 +528,34 @@ describe('mcp-client', () => {
       });
     });
 
+    it('skips OAuth without opening a browser in non-interactive mode on 401', async () => {
+      const { authenticate, connect, workspaceContext } = setupHttpOAuthRetry(
+        new Error(
+          'HTTP 401 Unauthorized\nwww-authenticate: Bearer realm="example", resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+        ),
+      );
+
+      await expect(
+        connectToMcpServer(
+          'http-server',
+          { httpUrl: 'http://test-server/mcp' },
+          false,
+          workspaceContext,
+          undefined,
+          false, // non-interactive (`-p`)
+        ),
+      ).rejects.toThrow(
+        // Pin the non-interactive branch specifically: the dialog-instruction
+        // substring alone appears in many OAuth error paths.
+        /non-interactive mode/,
+      );
+
+      // The interactive OAuth flow (which opens a browser) must not run.
+      expect(authenticate).not.toHaveBeenCalled();
+      // Only the initial connect attempt happens; no retry after OAuth.
+      expect(connect).toHaveBeenCalledTimes(1);
+    });
+
     it('falls back to base-url OAuth discovery when www-authenticate lacks resource metadata', async () => {
       const { authenticate, connect, discoverOAuthConfig, workspaceContext } =
         setupHttpOAuthRetry(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -901,6 +901,7 @@ export async function connectAndDiscover(
       debugMode,
       workspaceContext,
       sendSdkMcpMessage,
+      cliConfig.isInteractive(),
     );
 
     mcpClient.onerror = (error) => {
@@ -1291,6 +1292,7 @@ export function hasNetworkTransport(config: MCPServerConfig): boolean {
  * @param mcpServerName The name of the MCP server, used for logging and identification.
  * @param mcpServerConfig The configuration specifying how to connect to the server.
  * @param sendSdkMcpMessage Optional callback for SDK MCP servers to route messages via control plane.
+ * @param interactive When false (non-interactive/headless `-p` mode), skip OAuth flows that open a browser; the connection is rejected instead of blocking on a callback.
  * @returns A promise that resolves to a connected MCP `Client` instance.
  * @throws An error if the connection fails or the configuration is invalid.
  */
@@ -1300,6 +1302,10 @@ export async function connectToMcpServer(
   debugMode: boolean,
   workspaceContext: WorkspaceContext,
   sendSdkMcpMessage?: SendSdkMcpMessage,
+  // When false (non-interactive `-p` mode), never open a browser for MCP OAuth.
+  // A server that would require an interactive OAuth flow is skipped instead of
+  // blocking startup on a browser callback.
+  interactive: boolean = true,
 ): Promise<Client> {
   const mcpClient = new Client({
     name: 'qwen-code-mcp-client',
@@ -1435,6 +1441,18 @@ export async function connectToMcpServer(
           }
         }
         const oauthMessage = getSseOAuth401Message(mcpServerName, tokenState);
+        debugLogger.warn(oauthMessage);
+        throw new Error(oauthMessage);
+      }
+
+      // In non-interactive mode (`-p`) we must never open a browser for OAuth,
+      // as it would block startup on a callback the user can't complete. Skip
+      // this server instead — it surfaces via the normal failed-connection path.
+      if (!interactive) {
+        const oauthMessage =
+          `The MCP server '${mcpServerName}' requires OAuth authentication, ` +
+          `but Qwen Code is running in non-interactive mode. Skipping this server. ` +
+          getMcpOAuthDialogInstruction('authenticate', mcpServerName);
         debugLogger.warn(oauthMessage);
         throw new Error(oauthMessage);
       }


### PR DESCRIPTION
## What this PR does

Adds an `interactive` flag to the MCP connection path so that, in non-interactive (`-p`) mode, Qwen Code never launches a browser-based OAuth flow for an MCP server. The flag defaults to `true`, so all existing (interactive) behavior is unchanged. `connectAndDiscover` passes `config.isInteractive()` down to `connectToMcpServer`. When a server responds with `401` on a transport that would normally trigger automatic OAuth (HTTP transport, or `oauth.enabled`), the non-interactive path skips the browser flow entirely and throws a clear, actionable error instead of opening a browser and blocking on the OAuth callback. The server then fails through the existing failed-connection path (marked `DISCONNECTED`, surfaced in the startup banner), and the model turn proceeds. Servers with a cached or refreshable token still connect normally in both modes, and `oauth.enabled` servers were already safe because their transport path only calls `getValidToken`, which never opens a browser.

## Why it's needed

In `-p` / non-interactive mode a configured MCP server that requires interactive OAuth currently opens a browser and blocks startup on the OAuth callback — which the user cannot complete in a non-interactive session. The result is that `qwen -p "..."` hangs on startup whenever such a server is configured. Root cause: MCP discovery/connection runs unconditionally in `Config.initialize()` regardless of interactivity, and non-interactive mode additionally awaits `waitForMcpReady()`, turning the connection into a synchronous block; the eager OAuth trigger on `401` was never gated on interactive vs non-interactive. `-p` mode should fail fast with guidance ("authenticate once interactively first") rather than hang.

## Reviewer Test Plan

### How to verify

1. Configure an MCP server that requires OAuth (HTTP transport that returns `401`), with no cached token in the OAuth token store.
2. Run `qwen -p "hello"`.
3. Expected (after this PR): startup does **not** open a browser and does **not** hang; the server is reported as failed to connect, and the prompt is answered. In debug mode the log shows the skip message with the guidance text.
4. Observed (before this PR): startup opens a browser and blocks indefinitely on the OAuth callback.
5. Interactive path unchanged: run interactive `qwen`, trigger the same server, confirm the `/mcp` OAuth flow still opens a browser and authenticates.
6. Cached-token path: authenticate once in an interactive session, then run `qwen -p "hello"` again — the server connects normally.

### Evidence (Before & After)

A full end-to-end capture needs an external OAuth-protected MCP server, so evidence here comes from unit tests that exercise the exact `401` OAuth branch, plus the exact error text a user sees. The end-to-end run (steps above) was not executed locally and is left for reviewer confirmation.

**Before (interactive — unchanged):** on `401`, the automatic OAuth flow runs and `authenticate()` is called (this is what opens the browser):

```
✓ src/tools/mcp-client.test.ts > connectToMcpServer > retries HTTP connections after base-url OAuth discovery without www-authenticate
```

**After (non-interactive):** on `401`, `authenticate()` is **not** called (no browser); `connect` is attempted once, then a clear error is thrown:

```
✓ src/tools/mcp-client.test.ts > connectToMcpServer > skips OAuth without opening a browser in non-interactive mode on 401
```

Exact error surfaced in non-interactive mode (server name `my-oauth-server` for illustration):

```
The MCP server 'my-oauth-server' requires OAuth authentication, but Qwen Code is running in non-interactive mode. Skipping this server. In interactive Qwen Code sessions, open the /mcp dialog to authenticate with MCP server 'my-oauth-server'. For headless or SDK usage, configure MCP OAuth with qwen mcp add --oauth-* or settings.json, then authenticate once in an interactive session before connecting.
```

Full suite for the touched file: 95 tests pass. `npm run typecheck` (core) and ESLint on the changed files pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

macOS 26.5.1 (darwin 25.5.0), Node v24.14.1: typecheck + unit tests + ESLint. Windows/Linux not tested locally (CI covers them).

### Environment (optional)

Unit tests only (`npm run typecheck`, `vitest`, `eslint`). The live `qwen -p` run against a real OAuth MCP server was not exercised locally.

## Risk & Scope

- Main risk or tradeoff: purely a behavior change in non-interactive mode when an MCP server needs OAuth and has no usable token — it now fails fast (server marked disconnected) instead of blocking on a browser. Any workflow that somehow relied on a browser opening during `-p` would no longer get it (that behavior was the bug).
- Not validated / out of scope: end-to-end run against a live OAuth-protected MCP server; the interactive-mode OAuth flow is intentionally unchanged; eager MCP discovery itself is not changed — only the browser OAuth trigger is gated.
- Breaking changes / migration notes: none. The new `interactive` parameter defaults to `true`, preserving behavior for every existing caller; only `connectAndDiscover` opts into the non-interactive gating.

## Linked Issues

Related to #6639 (same HTTP `401` / MCP OAuth code path). That issue asks for OAuth recovery to trigger on `401`; this PR is complementary and does not regress it — recovery still runs in interactive mode, and only the non-interactive browser flow is skipped. No closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 MCP 连接路径增加了一个 `interactive` 标志，使得在非交互（`-p`）模式下，Qwen Code 永远不会为某个 MCP 服务器拉起基于浏览器的 OAuth 流程。该标志默认为 `true`，因此所有现有（交互式）行为保持不变。`connectAndDiscover` 会把 `config.isInteractive()` 传递给 `connectToMcpServer`。当某个服务器在本会触发自动 OAuth 的传输方式上（HTTP 传输，或 `oauth.enabled`）返回 `401` 时，非交互路径会完全跳过浏览器流程，转而抛出一个清晰、可操作的错误，而不是打开浏览器并阻塞在 OAuth 回调上。该服务器随后走既有的连接失败路径（标记为 `DISCONNECTED`，在启动横幅中呈现），主流程继续执行。拥有缓存或可刷新 token 的服务器在两种模式下仍能正常连接；`oauth.enabled` 类型的服务器本就是安全的，因为其传输路径只调用 `getValidToken`，从不打开浏览器。

## 为什么需要它

在 `-p` / 非交互模式下，一个需要交互式 OAuth 的已配置 MCP 服务器目前会打开浏览器并阻塞在 OAuth 回调上——而用户在非交互会话中无法完成该授权。结果是：只要配置了这类服务器，`qwen -p "..."` 就会在启动时挂起。根因：MCP 发现/连接在 `Config.initialize()` 中无条件运行，与交互性无关；非交互模式还会 `await waitForMcpReady()`，把连接过程变成同步阻塞；而 `401` 上的急切 OAuth 触发从未按交互/非交互进行门控。`-p` 模式应当快速失败并给出指引（"先在交互式会话里授权一次"），而不是挂起。

## 审查者测试计划

### 如何验证

1. 配置一个需要 OAuth 的 MCP 服务器（返回 `401` 的 HTTP 传输），且 OAuth token 存储中没有缓存 token。
2. 运行 `qwen -p "hello"`。
3. 预期（本 PR 之后）：启动**不会**打开浏览器、**不会**挂起；该服务器被报告为连接失败，提示词得到回答。debug 模式下日志会显示带指引文案的跳过信息。
4. 现象（本 PR 之前）：启动会打开浏览器并无限阻塞在 OAuth 回调上。
5. 交互路径不变：运行交互式 `qwen`，触发同一服务器，确认 `/mcp` OAuth 流程仍会打开浏览器并完成授权。
6. 缓存 token 路径：先在交互式会话里授权一次，再运行 `qwen -p "hello"`——该服务器可正常连接。

### 证据（前后对比）

完整的端到端验证需要一个外部的、受 OAuth 保护的 MCP 服务器，因此这里的证据来自覆盖了 `401` OAuth 分支的单元测试，以及用户会看到的确切错误文案。端到端运行（上述步骤）未在本地执行，留待审查者确认。

**之前（交互式——不变）：** `401` 时会运行自动 OAuth 流程并调用 `authenticate()`（这正是打开浏览器的地方）：

```
✓ src/tools/mcp-client.test.ts > connectToMcpServer > retries HTTP connections after base-url OAuth discovery without www-authenticate
```

**之后（非交互）：** `401` 时**不会**调用 `authenticate()`（无浏览器）；只尝试一次 `connect`，随后抛出清晰错误：

```
✓ src/tools/mcp-client.test.ts > connectToMcpServer > skips OAuth without opening a browser in non-interactive mode on 401
```

非交互模式下抛出的确切错误（服务器名 `my-oauth-server` 仅为示例）：

```
The MCP server 'my-oauth-server' requires OAuth authentication, but Qwen Code is running in non-interactive mode. Skipping this server. In interactive Qwen Code sessions, open the /mcp dialog to authenticate with MCP server 'my-oauth-server'. For headless or SDK usage, configure MCP OAuth with qwen mcp add --oauth-* or settings.json, then authenticate once in an interactive session before connecting.
```

该文件相关测试全部通过：95 个测试通过。`npm run typecheck`（core）与对改动文件的 ESLint 均通过。

### 测试环境

macOS 26.5.1（darwin 25.5.0），Node v24.14.1：typecheck + 单元测试 + ESLint。Windows/Linux 未在本地测试（由 CI 覆盖）。

### 运行环境（可选）

仅单元测试（`npm run typecheck`、`vitest`、`eslint`）。针对真实 OAuth MCP 服务器的 `qwen -p` 实机运行未在本地执行。

## 风险与范围

- 主要风险/权衡：这纯粹是非交互模式下的行为变化——当某 MCP 服务器需要 OAuth 且没有可用 token 时，它现在会快速失败（服务器标记为断开），而不是阻塞在浏览器上。任何曾依赖 `-p` 期间打开浏览器的流程将不再触发（而该行为本身就是 bug）。
- 未验证/不在范围内：针对真实的、受 OAuth 保护的 MCP 服务器的端到端运行；交互模式的 OAuth 流程有意保持不变；急切的 MCP 发现本身未改动——仅对浏览器 OAuth 触发做了门控。
- 破坏性变更/迁移说明：无。新增的 `interactive` 参数默认为 `true`，保留了所有现有调用方的行为；只有 `connectAndDiscover` 选择启用非交互门控。

## 关联 Issue

与 #6639 相关（同一 HTTP `401` / MCP OAuth 代码路径）。该 issue 希望在 `401` 时触发 OAuth 恢复；本 PR 与之互补且不会造成回退——恢复在交互模式下仍会运行，仅跳过非交互下的浏览器流程。未使用自动关闭关键字。

</details>