### PR TITLE
test(cli): isolate cli entry fallback fixture

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -8,6 +8,7 @@ import type { Argv } from 'yargs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import {
   copyFileSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -376,15 +377,17 @@ describe('bootstrap import boundaries', () => {
     expect(output).toBe(`${expectedVersion}\n`);
   });
 
-  it('falls through to cli.js when wrapper package.json parsing fails', () => {
+  it('falls through to cli.js when wrapper package.json lookup fails', () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-cli-entry-'));
+    const entryDir = path.join(tempDir, 'bin');
     try {
+      mkdirSync(entryDir);
       copyFileSync(
         '../../scripts/cli-entry.js',
-        path.join(tempDir, 'cli-entry.mjs'),
+        path.join(entryDir, 'cli-entry.mjs'),
       );
       writeFileSync(
-        path.join(tempDir, 'cli.js'),
+        path.join(entryDir, 'cli.js'),
         "process.stdout.write('fallback-cli\\n');\n",
       );
       const env = { ...process.env };
@@ -392,7 +395,7 @@ describe('bootstrap import boundaries', () => {
 
       const output = execFileSync(
         process.execPath,
-        [path.join(tempDir, 'cli-entry.mjs'), '--version'],
+        [path.join(entryDir, 'cli-entry.mjs'), '--version'],
         {
           encoding: 'utf8',
           env,


### PR DESCRIPTION
## What this PR does

Isolates the CLI entry fallback test fixture so the copied entry script runs from a nested temporary directory without accidentally discovering package metadata from the runner workspace.

## Why it's needed

PR #6603 is failing the Ubuntu unit-test job in Qwen Code CI because the fallback test receives `unknown` instead of `fallback-cli`. The test is intended to exercise the no-package-metadata fallback path, but the temporary fixture can still discover unrelated parent `package.json` files in CI. This is a repository-level test fixture issue, not a behavior change in #6603.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/cli.test.ts`. The bootstrap import-boundaries tests should pass, including the fallback case that expects `fallback-cli`.

### Evidence (Before & After)

Before: Qwen Code CI for #6603 failed in `Test (ubuntu-latest, Node 22.x)` with `expected 'unknown\n' to be 'fallback-cli\n'`.

After: Local targeted verification passed: `src/cli.test.ts (37 tests)` and `npx prettier --check packages/cli/src/cli.test.ts`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ CI pending |

### Environment (optional)

Node.js workspace dependencies installed with `npm install --ignore-scripts` in a clean worktree.

## Risk & Scope

- Main risk or tradeoff: Test-only fixture change; no production runtime behavior is changed.
- Not validated / out of scope: Full repository test matrix and non-macOS local runs were not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

References #6603 and the prior #6605 CI investigation.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 隔离 CLI entry fallback 测试夹具，让复制出来的 entry script 在临时目录的嵌套子目录里运行，避免误读 CI runner 或仓库上层的 package metadata。

## Why it's needed

#6603 当前挂在 Qwen Code CI 的 Ubuntu unit-test job，失败表现是 fallback 测试拿到 `unknown`，而不是期望的 `fallback-cli`。这个用例本意是覆盖找不到 package metadata 时的 fallback 路径，但原来的临时目录结构在 CI 里仍可能向上找到无关的 `package.json`。这是仓库级测试夹具问题，不是 #6603 的行为改动导致的。

## Reviewer Test Plan

### How to verify

运行 `cd packages/cli && npx vitest run src/cli.test.ts`。bootstrap import-boundaries 相关用例应该全部通过，包括期望输出 `fallback-cli` 的 fallback case。

### Evidence (Before & After)

Before：#6603 的 Qwen Code CI 在 `Test (ubuntu-latest, Node 22.x)` 中失败，日志显示 `expected 'unknown\n' to be 'fallback-cli\n'`。

After：本地定向验证通过：`src/cli.test.ts (37 tests)`，并且 `npx prettier --check packages/cli/src/cli.test.ts` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ CI pending |

### Environment (optional)

在干净 worktree 中用 `npm install --ignore-scripts` 安装 Node.js workspace 依赖后验证。

## Risk & Scope

- Main risk or tradeoff：只改测试夹具，不改变生产运行时行为。
- Not validated / out of scope：本地没有跑完整仓库测试矩阵，也没有本地验证非 macOS 平台。
- Breaking changes / migration notes：无。

## Linked Issues

关联 #6603 以及之前 #6605 的 CI 排查。

</details>
