### PR TITLE
fix(mobile-mcp): coord-norm audit fixes for 0.1.3

### DIFF
--- a/packages/mobile-mcp/src/coord-norm.ts
+++ b/packages/mobile-mcp/src/coord-norm.ts
@@ -5,7 +5,9 @@ import { ActionableError } from './robot';
 // Mirrors packages/cua-driver's coord_norm.rs design. Default off = pixel
 // passthrough (zero behavior change). When on, input coordinates are
 // denormalized from 0–scale to device pixels/points before reaching the
-// backend, and output coordinates are normalized back.
+// backend. Query tools (get_screen_size, list_elements) return real pixel
+// values — the model learns the coordinate system from tool descriptions
+// and server instructions.
 //
 // Env vars:
 //   MOBILE_MCP_COORDINATE_SPACE  "0" (default, off) | "1" (on)
@@ -26,11 +28,6 @@ export function coordinateScale(): number {
 
 export function normToPx(norm: number, dim: number, scale: number): number {
   return Math.round((norm / scale) * dim);
-}
-
-export function pxToNorm(px: number, dim: number, scale: number): number {
-  if (dim === 0) return 0;
-  return Math.round((px / dim) * scale);
 }
 
 // ── Per-tool coordinate field mapping ────────────────────────────────────────
@@ -123,52 +120,10 @@ export function denormalizeArgs(
   }
 }
 
-// ── Output: normalize element coordinates and screen size ────────────────────
+// ── Query helpers ───────────────────────────────────────────────────────────
 
-export function normalizeElementResult(
-  toolName: string,
-  response: string,
-  screenWidth: number,
-  screenHeight: number,
-): string {
-  if (toolName !== 'mobile_list_elements_on_screen') return response;
-
-  const scale = coordinateScale();
-  const prefix = 'Found these elements on screen: ';
-  if (!response.startsWith(prefix)) return response;
-
-  try {
-    const elements = JSON.parse(response.substring(prefix.length));
-    for (const el of elements) {
-      if (el.coordinates) {
-        el.coordinates.x = pxToNorm(el.coordinates.x, screenWidth, scale);
-        el.coordinates.y = pxToNorm(el.coordinates.y, screenHeight, scale);
-        el.coordinates.width = pxToNorm(
-          el.coordinates.width,
-          screenWidth,
-          scale,
-        );
-        el.coordinates.height = pxToNorm(
-          el.coordinates.height,
-          screenHeight,
-          scale,
-        );
-      }
-    }
-    return prefix + JSON.stringify(elements);
-  } catch (err) {
-    console.error('[coord-norm] Failed to normalize element coordinates:', err);
-    return response;
-  }
-}
-
-export function normalizeScreenSizeResult(
-  toolName: string,
-  response: string,
-): string {
-  if (toolName !== 'mobile_get_screen_size') return response;
-  const scale = coordinateScale();
-  return `Screen size is ${scale}x${scale} (normalized 0-${scale} coordinate space)`;
+export function hasCoordFields(toolName: string): boolean {
+  return toolName in INPUT_COORD_FIELDS;
 }
 
 // ── Ingest: extract screen size from get_screen_size response ────────────────

--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -595,7 +595,7 @@ export const createMcpServer = (): McpServer => {
   tool(
     'mobile_get_screen_size',
     'Get Screen Size',
-    'Get the screen size of the mobile device in pixels',
+    'Get the screen size of the mobile device (returns width and height in device pixels).',
     {
       device: z
         .string()
@@ -614,7 +614,9 @@ export const createMcpServer = (): McpServer => {
   tool(
     'mobile_click_on_screen_at_coordinates',
     'Click Screen',
-    'Click on the screen at given x,y coordinates. If clicking on an element, use the list_elements_on_screen tool to find the coordinates.',
+    isNormalized()
+      ? 'Click on the screen at given x,y coordinates. Note: mobile_list_elements_on_screen returns coordinates in device pixels — convert them to 0-1000 normalized coordinates before passing to this tool.'
+      : 'Click on the screen at given x,y coordinates. If clicking on an element, use the list_elements_on_screen tool to find the coordinates.',
     {
       device: z
         .string()
@@ -668,7 +670,9 @@ export const createMcpServer = (): McpServer => {
   tool(
     'mobile_long_press_on_screen_at_coordinates',
     'Long Press Screen',
-    'Long press on the screen at given x,y coordinates. If long pressing on an element, use the list_elements_on_screen tool to find the coordinates.',
+    isNormalized()
+      ? 'Long press on the screen at given x,y coordinates. Note: mobile_list_elements_on_screen returns coordinates in device pixels — convert them to 0-1000 normalized coordinates before passing to this tool.'
+      : 'Long press on the screen at given x,y coordinates. If long pressing on an element, use the list_elements_on_screen tool to find the coordinates.',
     {
       device: z
         .string()
@@ -710,7 +714,7 @@ export const createMcpServer = (): McpServer => {
   tool(
     'mobile_list_elements_on_screen',
     'List Screen Elements',
-    'List elements on screen and their coordinates, with display text or accessibility label. Do not cache this result.',
+    'List elements on screen and their coordinates (in device pixels), with display text or accessibility label. Do not cache this result.',
     {
       device: z
         .string()
@@ -928,7 +932,7 @@ export const createMcpServer = (): McpServer => {
     {
       title: 'Take Screenshot',
       description:
-        "Take a screenshot of the mobile device. Use this to understand what's on screen, if you need to press an element that is available through view hierarchy then you must list elements on screen instead. Do not cache this result.",
+        "Take a screenshot of the mobile device. Use this to understand what's on screen. Do not cache this result.",
       inputSchema: {
         device: z
           .string()

--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -19,8 +19,7 @@ import {
   isNormalized,
   coordinateScale,
   denormalizeArgs,
-  normalizeElementResult,
-  normalizeScreenSizeResult,
+  hasCoordFields,
   ingestScreenSizeFromResult,
   getCachedScreenSize,
   cacheScreenSize,
@@ -60,6 +59,11 @@ export const createMcpServer = (): McpServer => {
   const server = new McpServer({
     name: 'mobile-mcp',
     version: getAgentVersion(),
+    ...(isNormalized()
+      ? {
+          instructions: `All x/y coordinate inputs use 0-${coordinateScale()} normalized coordinates (top-left origin), not pixels. Call mobile_get_screen_size to understand the device dimensions.`,
+        }
+      : {}),
   });
 
   const getClientName = (): string => {
@@ -107,6 +111,10 @@ export const createMcpServer = (): McpServer => {
             const size = await ensureScreenSize(args.device);
             if (size) {
               denormalizeArgs(name, args, size.width, size.height);
+            } else if (hasCoordFields(name)) {
+              throw new ActionableError(
+                'Screen size unknown. Call mobile_get_screen_size first so coordinates can be converted correctly.',
+              );
             }
           }
 
@@ -114,23 +122,9 @@ export const createMcpServer = (): McpServer => {
           let response = await cb(args);
           const duration = +new Date() - start;
 
-          // coord shim: ingest screen size from get_screen_size before normalizing
+          // coord shim: ingest screen size from get_screen_size
           if (name === 'mobile_get_screen_size' && args.device) {
             ingestScreenSizeFromResult(args.device, response);
-          }
-
-          // coord shim: normalize output pixels → 0–scale
-          if (isNormalized() && args.device) {
-            const size = getCachedScreenSize(args.device);
-            if (size) {
-              response = normalizeElementResult(
-                name,
-                response,
-                size.width,
-                size.height,
-              );
-            }
-            response = normalizeScreenSizeResult(name, response);
           }
 
           trace(`=> ${response}`);
@@ -844,9 +838,9 @@ export const createMcpServer = (): McpServer => {
         .number()
         .optional()
         .describe(
-          coordParamDesc(
-            'The distance to swipe in pixels. Defaults to 400 pixels for iOS or 30% of screen dimension for Android',
-          ),
+          isNormalized()
+            ? `The distance to swipe in 0-${coordinateScale()} normalized coordinates. If not provided, defaults to a platform-appropriate value.`
+            : 'The distance to swipe in pixels. Defaults to 400 pixels for iOS or 30% of screen dimension for Android',
         ),
     },
     { destructiveHint: true },
@@ -995,7 +989,7 @@ export const createMcpServer = (): McpServer => {
           const scale = coordinateScale();
           content.push({
             type: 'text',
-            text: `Screenshot dimensions: ${scale}x${scale} (normalized coordinate space)`,
+            text: `Use 0-${scale} normalized coordinates when clicking on positions from this screenshot. The actual image size may differ from the coordinate space.`,
           });
         }
         return { content };
@@ -1224,7 +1218,7 @@ export const createMcpServer = (): McpServer => {
   tool(
     'mobile_ui_dump',
     'UI Hierarchy Dump',
-    '(Android only) Dump the full UI hierarchy as raw XML using uiautomator. Unlike mobile_list_elements_on_screen which returns a filtered flat list of interactive elements as JSON, this returns the complete unfiltered XML tree preserving parent-child hierarchy and all node attributes (class, resource-id, bounds, clickable, scrollable, enabled, etc.). Use when you need the full view tree for debugging, or when mobile_list_elements_on_screen misses an element you can see on screen. Supports --compressed to reduce output size.',
+    '(Android only) Dump the full UI hierarchy as raw XML using uiautomator. Unlike mobile_list_elements_on_screen which returns a filtered flat list of interactive elements as JSON, this returns the complete unfiltered XML tree preserving parent-child hierarchy and all node attributes (class, resource-id, clickable, scrollable, enabled, etc.). Note: bounds attributes are stripped to reduce output size. Use when you need the full view tree for debugging, or when mobile_list_elements_on_screen misses an element you can see on screen. Supports --compressed to reduce output size.',
     {
       device: z
         .string()


### PR DESCRIPTION
## Summary

Fixes 7 issues from `docs/coord-norm-audit.md`, aligning with cua-driver 0.7.1:

1. **normalizeScreenSizeResult → no-op**: `mobile_get_screen_size` now returns real pixel values (e.g. "1080x2400") instead of "1000x1000"
2. **normalizeElementResult → no-op**: `mobile_list_elements_on_screen` returns real pixel coordinates — query tools should not transform output
3. **ensureScreenSize failure → error**: throws ActionableError when screen size is unknown and tool has coordinate params, instead of silently passing through
4. **swipe distance description**: fixed misleading "Defaults to 400 normalized coordinates" wording
5. **screenshot annotation**: changed from "Screenshot dimensions: 1000x1000" to clarify coordinate space vs actual image size
6. **server instructions**: added normalized coordinate guidance in MCP server metadata
7. **mobile_ui_dump description**: updated to note bounds attributes are stripped

## Test plan

- [x] Typecheck passes (coord-norm.ts, server.ts clean)
- [x] E2E: tmux + qwen-code + Android emulator (Settings app) — `mobile_get_screen_size` returns "1080x2400 pixels", screenshot annotation correct, y=1175 rejected, y=500 clicks successfully