### PR TITLE
fix(mcp): skip OAuth browser flow in non-interactive mode

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -528,6 +528,34 @@ describe('mcp-client', () => {
       });
     });
 
+    it('skips OAuth without opening a browser in non-interactive mode on 401', async () => {
+      const { authenticate, connect, workspaceContext } = setupHttpOAuthRetry(
+        new Error(
+          'HTTP 401 Unauthorized\nwww-authenticate: Bearer realm="example", resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+        ),
+      );
+
+      await expect(
+        connectToMcpServer(
+          'http-server',
+          { httpUrl: 'http://test-server/mcp' },
+          false,
+          workspaceContext,
+          undefined,
+          false, // non-interactive (`-p`)
+        ),
+      ).rejects.toThrow(
+        // Pin the non-interactive branch specifically: the dialog-instruction
+        // substring alone appears in many OAuth error paths.
+        /non-interactive mode/,
+      );
+
+      // The interactive OAuth flow (which opens a browser) must not run.
+      expect(authenticate).not.toHaveBeenCalled();
+      // Only the initial connect attempt happens; no retry after OAuth.
+      expect(connect).toHaveBeenCalledTimes(1);
+    });
+
     it('falls back to base-url OAuth discovery when www-authenticate lacks resource metadata', async () => {
       const { authenticate, connect, discoverOAuthConfig, workspaceContext } =
         setupHttpOAuthRetry(

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -901,6 +901,7 @@ export async function connectAndDiscover(
       debugMode,
       workspaceContext,
       sendSdkMcpMessage,
+      cliConfig.isInteractive(),
     );
 
     mcpClient.onerror = (error) => {
@@ -1291,6 +1292,7 @@ export function hasNetworkTransport(config: MCPServerConfig): boolean {
  * @param mcpServerName The name of the MCP server, used for logging and identification.
  * @param mcpServerConfig The configuration specifying how to connect to the server.
  * @param sendSdkMcpMessage Optional callback for SDK MCP servers to route messages via control plane.
+ * @param interactive When false (non-interactive/headless `-p` mode), skip OAuth flows that open a browser; the connection is rejected instead of blocking on a callback.
  * @returns A promise that resolves to a connected MCP `Client` instance.
  * @throws An error if the connection fails or the configuration is invalid.
  */
@@ -1300,6 +1302,10 @@ export async function connectToMcpServer(
   debugMode: boolean,
   workspaceContext: WorkspaceContext,
   sendSdkMcpMessage?: SendSdkMcpMessage,
+  // When false (non-interactive `-p` mode), never open a browser for MCP OAuth.
+  // A server that would require an interactive OAuth flow is skipped instead of
+  // blocking startup on a browser callback.
+  interactive: boolean = true,
 ): Promise<Client> {
   const mcpClient = new Client({
     name: 'qwen-code-mcp-client',
@@ -1435,6 +1441,18 @@ export async function connectToMcpServer(
           }
         }
         const oauthMessage = getSseOAuth401Message(mcpServerName, tokenState);
+        debugLogger.warn(oauthMessage);
+        throw new Error(oauthMessage);
+      }
+
+      // In non-interactive mode (`-p`) we must never open a browser for OAuth,
+      // as it would block startup on a callback the user can't complete. Skip
+      // this server instead — it surfaces via the normal failed-connection path.
+      if (!interactive) {
+        const oauthMessage =
+          `The MCP server '${mcpServerName}' requires OAuth authentication, ` +
+          `but Qwen Code is running in non-interactive mode. Skipping this server. ` +
+          getMcpOAuthDialogInstruction('authenticate', mcpServerName);
         debugLogger.warn(oauthMessage);
         throw new Error(oauthMessage);
       }


### PR DESCRIPTION
## Summary

In `-p` / non-interactive mode, a configured MCP server that requires interactive OAuth currently opens a browser and blocks startup on the OAuth callback — which the user cannot complete in a non-interactive session. This makes `qwen -p "..."` hang on startup whenever such an MCP server is configured.

## Root cause

MCP discovery/connection runs unconditionally in `Config.initialize()` regardless of interactivity, and non-interactive mode additionally `await`s `waitForMcpReady()`, turning the connection into a synchronous block. When an HTTP MCP server responds with `401`, `connectToMcpServer` eagerly runs the automatic OAuth flow (`handleAutomaticOAuth` / `authenticate`), which opens a browser and blocks on the callback. None of this path is gated on interactive vs non-interactive.

## Fix

- Thread an `interactive` flag into `connectToMcpServer` (defaults to `true`, preserving existing behavior).
- `connectAndDiscover` passes `cliConfig.isInteractive()`.
- On a `401` that would trigger OAuth, when non-interactive, skip the browser-based flow and throw a clear error (reusing `getMcpOAuthDialogInstruction`). The server then fails through the normal failed-connection path (`DISCONNECTED` + startup banner) instead of hanging startup.

The `!interactive` gate is placed exactly above the two browser-opening paths (`handleAutomaticOAuth` and `authProvider.authenticate`) and below the already-safe SSE-without-OAuth branch, which never opens a browser and emits a more specific token-state diagnostic.

Servers with a cached/refreshable token connect normally in both modes (refresh happens in `createTransport` before the 401 handler). `oauth.enabled` servers were already safe (their transport path only calls `getValidToken`, which never opens a browser).

## Testing

- `npm run typecheck` (core) passes.
- `mcp-client.test.ts`: 95 tests pass, including a case asserting that a `401` in non-interactive mode does **not** call `authenticate` (no browser), only attempts the initial connect, and rejects with the non-interactive-specific message.
- ESLint passes on the changed files.

---
_Supersedes #6657 (rebuilt as a single squashed commit)._