### PR TITLE
feat(cli): allow long /goal conditions

### DIFF
--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -11,6 +11,7 @@ import type { Config } from '@qwen-code/qwen-code-core';
 import {
   __resetActiveGoalStoreForTests,
   clearActiveGoal,
+  getActiveGoal,
   notifyGoalTerminal,
 } from '@qwen-code/qwen-code-core';
 
@@ -86,14 +87,30 @@ describe('goalCommand', () => {
     expect((result as { content: string }).content).toMatch(/disabled/i);
   });
 
-  it('rejects oversized conditions', async () => {
-    const ctx = createMockCommandContext({
-      services: { config: makeConfig() as unknown as Config },
-    });
-    const result = await goalCommand.action!(ctx, 'x'.repeat(4001));
-    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
-    expect((result as { content: string }).content).toMatch(/limited/i);
-  });
+  it.each(['interactive', 'non_interactive', 'acp'] as const)(
+    'accepts conditions longer than 4,000 characters in %s mode',
+    async (executionMode) => {
+      const ctx = createMockCommandContext({
+        executionMode,
+        services: { config: makeConfig() as unknown as Config },
+      });
+      const condition = `${'x'.repeat(4_001)}-goal-condition-end`;
+
+      const result = await goalCommand.action!(ctx, condition);
+
+      expect(result).toMatchObject({ type: 'submit_prompt' });
+      const submit = result as { content: Array<{ text: string }> };
+      expect(submit.content[0].text).toContain(condition);
+      expect(getActiveGoal('sess-1')?.condition).toBe(condition);
+      expect(
+        (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      ).toMatchObject({
+        type: 'goal_status',
+        kind: 'set',
+        condition,
+      });
+    },
+  );
 
   it('clears existing goal on clear keyword and emits a cleared card', async () => {
     const cfg = makeConfig();

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -34,8 +34,6 @@ const CLEAR_KEYWORDS = new Set([
   'cancel',
 ]);
 
-const MAX_GOAL_LENGTH = 4000;
-
 // Keep the surrounding `"…"` quote structure intact: collapse newlines so the
 // condition stays on one line, and downgrade embedded double-quotes to single
 // quotes so they don't visually close the wrapping quote.
@@ -165,14 +163,7 @@ export const goalCommand: SlashCommand = {
       return;
     }
 
-    // ── Branch 3: length cap ─────────────────────────────────────────────
-    if (q.length > MAX_GOAL_LENGTH) {
-      return errorMessage(
-        `Goal condition is limited to ${MAX_GOAL_LENGTH} characters (got ${q.length}).`,
-      );
-    }
-
-    // ── Branch 4: gates ──────────────────────────────────────────────────
+    // ── Branch 3: gates ──────────────────────────────────────────────────
     if (!config.isTrustedFolder()) {
       return errorMessage(
         '/goal is only available in trusted workspaces. Trust this folder via `/trust` and try again.',
@@ -189,7 +180,7 @@ export const goalCommand: SlashCommand = {
       );
     }
 
-    // ── Branch 5: register hook + emit set card + kick off first turn ────
+    // ── Branch 4: register hook + emit set card + kick off first turn ────
     let registered;
     try {
       registered = registerGoalHook({

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -312,6 +312,23 @@ describe('judgeGoal', () => {
     expect(text).not.toContain('Condition: done"');
   });
 
+  it('does not truncate long conditions in the judge prompt', async () => {
+    const client = makeMockClient({});
+    const config = makeConfig({ client });
+    const condition = `${'x'.repeat(4_001)}-goal-condition-end`;
+
+    await judgeGoal(config, {
+      condition,
+      lastAssistantText: 'not done',
+      signal: new AbortController().signal,
+    });
+
+    const [contents] = client.generateContent.mock.calls[0];
+    const wrapped = contents.at(-1) as Content;
+    const text = (wrapped.parts ?? []).map((p) => p.text ?? '').join('');
+    expect(text).toContain(JSON.stringify(condition));
+  });
+
   it('uses a bounded history tail without cloning the full session when available', async () => {
     const tail: Content[] = [
       { role: 'user', parts: [{ text: 'recent prompt' }] },


### PR DESCRIPTION
## What this PR does

Removes the fixed 4,000-character command-level limit from `/goal` conditions so detailed, self-contained task specifications can be used in interactive, non-interactive, and ACP sessions.

The existing judge evidence bounds remain unchanged. Recent transcript parts are still bounded, while the authoritative goal condition continues to be appended separately and in full. Regression coverage verifies both behaviors.

## Why it's needed

Complex coding tasks can require more than 4,000 characters of requirements, constraints, checklists, and verification criteria. Moving those requirements into a file is not equivalent because the one-shot goal judge has no tools and cannot independently read the file. The fixed command-level rejection therefore prevents valid self-contained stopping conditions even when the configured models can accept them.

## Reviewer Test Plan

### How to verify

Set a `/goal` condition longer than 4,000 characters in interactive, non-interactive, and ACP execution modes. Confirm that the command is accepted, the unique suffix at the end of the condition is preserved in active goal state and the initial model instruction, and the judge receives the complete condition. Separately confirm that an oversized ordinary transcript part remains truncated before judge evaluation.

### Evidence (Before & After)

Before: the released `qwen 0.19.8` CLI exits with status 1 and reports `Goal condition is limited to 4000 characters (got 4001).`

After: the locally built bundle accepts the same 4,001-character condition and advances to the expected safe-mode hooks policy gate. Targeted regressions confirm that the complete condition reaches the initial instruction, active goal state, status history, and judge request while ordinary transcript evidence remains bounded.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v24.18.0, local source build and bundled CLI, no sandbox for unit/static checks; safe mode for the deterministic bundled CLI smoke test.

## Risk & Scope

- Main risk or tradeoff: Very large conditions can increase model input cost and latency and remain subject to provider and model context-window limits.
- Not validated / out of scope: File-backed goal specifications, token-aware limits, and independent tool-enabled judge verification.
- Breaking changes / migration notes: None. Existing short goals and transcript evidence limits are unchanged.

## Linked Issues

Fixes #6663

Related to #4228

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除 `/goal` condition 固定的 4,000 字符命令层限制，使交互模式、非交互模式和 ACP 会话都可以使用详细且自包含的任务规格。

现有 judge 证据边界保持不变。最近的 transcript part 仍然受限，而权威 goal condition 继续作为独立内容完整追加。回归测试分别验证了这两种行为。

## 为什么需要

复杂编码任务的需求、约束、检查清单和验证标准可能超过 4,000 字符。把这些需求移到文件中并不等价，因为一次性 goal judge 没有工具，无法独立读取该文件。因此，即使已配置的模型能够接受更长输入，固定的命令层拒绝仍会阻止有效且自包含的停止条件。

## Reviewer Test Plan

### 如何验证

分别在交互、非交互和 ACP 执行模式中设置超过 4,000 字符的 `/goal` condition。确认命令被接受，condition 末尾的唯一标记在 active goal state 和初始模型指令中保持完整，并且 judge 收到完整 condition。另行确认超长的普通 transcript part 在 judge 评估前仍会被截断。

### 证据（修改前与修改后）

修改前：已发布的 `qwen 0.19.8` CLI 以状态码 1 退出，并报告 `Goal condition is limited to 4000 characters (got 4001).`

修改后：本地构建的 bundle 接受相同的 4,001 字符 condition，并继续进入预期的 safe mode hooks policy gate。定向回归测试确认完整 condition 会到达初始指令、active goal state、状态历史和 judge 请求，同时普通 transcript 证据仍然有界。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Node.js v24.18.0，本地源码构建和 bundle CLI；单元/静态检查未使用 sandbox，确定性 bundle CLI smoke test 使用 safe mode。

## 风险与范围

- 主要风险或取舍：非常长的 condition 会增加模型输入成本和延迟，并且仍受 provider 和模型上下文窗口限制。
- 未验证/范围外：基于文件的 goal 规格、token-aware 限制以及具备工具能力的独立 judge 验证。
- 破坏性变更/迁移说明：无。现有短 goal 和 transcript 证据限制保持不变。

## 关联 Issue

Fixes #6663

Related to #4228

</details>
