### PR TITLE
fix: restrict template placeholder regex to valid identifiers

### DIFF
--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -35,7 +35,11 @@ import { executeToolCall } from '../../core/nonInteractiveToolExecutor.js';
 import { getInitialChatHistory } from '../../utils/environmentContext.js';
 import type { ToolRegistry } from '../../tools/tool-registry.js';
 import { type AnyDeclarativeTool } from '../../tools/tools.js';
-import { ContextState, AgentHeadless } from './agent-headless.js';
+import {
+  ContextState,
+  AgentHeadless,
+  templateString,
+} from './agent-headless.js';
 import {
   AgentEventEmitter,
   AgentEventType,
@@ -242,6 +246,62 @@ describe('subagent.ts', () => {
     it('should return undefined for missing keys', () => {
       const context = new ContextState();
       expect(context.get('missing')).toBeUndefined();
+    });
+  });
+
+  describe('templateString', () => {
+    it('should replace valid identifier placeholders', () => {
+      const context = new ContextState();
+      context.set('name', 'Agent');
+      context.set('task', 'Testing');
+      const result = templateString(
+        'Hello ${name}, your task is ${task}.',
+        context,
+      );
+      expect(result).toBe('Hello Agent, your task is Testing.');
+    });
+
+    it('should treat ${0} as literal text, not as a placeholder', () => {
+      const context = new ContextState();
+      const result = templateString('Do not write ${0} in your code.', context);
+      expect(result).toBe('Do not write ${0} in your code.');
+    });
+
+    it('should treat ${1} and ${2} as literal text', () => {
+      const context = new ContextState();
+      const result = templateString(
+        'Use {0} and {1}, not ${0} or ${1}.',
+        context,
+      );
+      expect(result).toBe('Use {0} and {1}, not ${0} or ${1}.');
+    });
+
+    it('should still throw for missing valid identifier placeholders', () => {
+      const context = new ContextState();
+      context.set('name', 'Agent');
+      expect(() =>
+        templateString('Hello ${name}, missing ${missing}.', context),
+      ).toThrow('Missing context values for the following keys: missing');
+    });
+
+    it('should handle mixed numeric and identifier placeholders', () => {
+      const context = new ContextState();
+      context.set('var', 'value');
+      // ${var} and ${_private} are valid identifiers; ${0} is literal
+      // ${_private} is missing from context, so it should throw
+      expect(() =>
+        templateString('${var} and ${0} and ${_private}', context),
+      ).toThrow('Missing context values for the following keys: _private');
+    });
+
+    it('should handle ${0} alongside valid placeholders without error', () => {
+      const context = new ContextState();
+      context.set('name', 'Agent');
+      const result = templateString(
+        'Hello ${name}. Do not write ${0} or ${1}.',
+        context,
+      );
+      expect(result).toBe('Hello Agent. Do not write ${0} or ${1}.');
     });
   });
 

--- a/packages/core/src/agents/runtime/agent-headless.ts
+++ b/packages/core/src/agents/runtime/agent-headless.ts
@@ -99,7 +99,7 @@ export function templateString(
   template: string,
   context: ContextState,
 ): string {
-  const placeholderRegex = /\$\{(\w+)\}/g;
+  const placeholderRegex = /\$\{([a-zA-Z_]\w*)\}/g;
 
   // First, find all unique keys required by the template.
   const requiredKeys = new Set(


### PR DESCRIPTION
The templateString() function used /\$\{(\w+)\}/g to find placeholders. Since \w matches digits, ${0} was incorrectly parsed as a placeholder with key "0", causing subagent startup to fail with: "Missing context values for the following keys: 0"

Changed regex to /\$\{([a-zA-Z_]\w*)\}/g so that only valid JavaScript identifier patterns are treated as placeholders. Numeric patterns like ${0}, ${1} now pass through as literal text.

Fixes #6671

<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

<!-- What this PR does. Describe the change in prose, not by file or function names. -->

## Why it's needed

<!-- Why it's needed: the motivation, the problem being solved, or the user-facing benefit. -->

## Reviewer Test Plan

<!--
How a reviewer can confirm this PR: reproduction steps, expected vs observed behavior, and evidence. CI runs on macOS, Windows, and Linux — Tested on is what you verified locally.

User-visible / TUI: Before/After with tmux-real-user-testing skill, screenshots, or a short recording.
Non–user-visible (refactor, types, docs): commands and output below; write N/A under Before/After.
-->

### How to verify

<!-- How you reproduced it and what a reviewer should confirm — steps if needed, expected vs observed behavior. Focus on outcomes; paste logs or test output when helpful. -->

### Evidence (Before & After)

<!-- User-visible / TUI changes: paste before-and-after screenshots, tmux logs, or video side by side. Non-UI changes (docs, refactor, types): N/A -->

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |        |
| 🪟 Windows |        |
|  🐧 Linux  |        |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

<!-- Local runtime: e.g. npm run dev, Docker/Podman sandbox, seatbelt. N/A if only unit tests. -->

## Risk & Scope

- Main risk or tradeoff:
- Not validated / out of scope:
- Breaking changes / migration notes:

## Linked Issues

<!--
Closes #N / Fixes #N / Resolves #N to auto-close.
Otherwise reference without a closing keyword.
-->

<details>
<summary>中文说明</summary>

<!--
完整翻译上面的英文正文，逐段对应，不要省略或缩写。PR 标题保持英文。
-->

</details>
