### PR TITLE
fix(dingtalk): preserve markdown tables

### DIFF
--- a/docs/users/features/channels/dingtalk.md
+++ b/docs/users/features/channels/dingtalk.md
@@ -99,14 +99,14 @@ You can send photos and documents to the bot, not just text.
 
 - **Authentication:** AppKey + AppSecret instead of a static bot token. The SDK manages access token refresh automatically.
 - **Connection:** WebSocket stream instead of polling — no public IP or webhook URL needed.
-- **Formatting:** Responses use DingTalk's markdown dialect (a limited subset). Tables are automatically converted to plain text since DingTalk doesn't render them. Long messages are split into chunks at ~3800 characters.
+- **Formatting:** Responses use DingTalk's markdown dialect. Markdown tables are passed through to the DingTalk client; long messages are split into chunks at ~3800 characters.
 - **Working indicator:** A 👀 emoji reaction is added to the user's message while processing, then removed when the response is sent.
 - **Media download:** Two-step process — a `downloadCode` from the message is exchanged for a temporary download URL via DingTalk's API.
 - **Groups:** DingTalk uses `isInAtList` for @mention detection instead of parsing message entities.
 
 ## Tips
 
-- **Use DingTalk markdown-aware instructions** — DingTalk supports a limited markdown subset (headers, bold, links, code blocks, but not tables). Adding instructions like "Use DingTalk markdown. Avoid tables." helps the agent format responses correctly.
+- **Use DingTalk markdown-aware instructions** — DingTalk supports headings, bold text, links, code blocks, and tables. Keep tables compact because narrow screens may scroll horizontally.
 - **Restrict access** — In an organization context, `senderPolicy: "open"` may be acceptable. For tighter control, use `"allowlist"` or `"pairing"`. See [DM Pairing](./overview#dm-pairing) for details.
 - **Referenced messages** — Quoting (replying to) a user message includes the quoted text as context for the agent. Quoting bot responses is not yet supported.
 

--- a/packages/channels/dingtalk/src/markdown.test.ts
+++ b/packages/channels/dingtalk/src/markdown.test.ts
@@ -1,58 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
-  convertTables,
   splitChunks,
   extractTitle,
   normalizeDingTalkMarkdown,
 } from './markdown.js';
 
 describe('DingTalk markdown utilities', () => {
-  describe('convertTables', () => {
-    it('converts markdown tables to readable text', () => {
-      const input = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n');
-
-      expect(convertTables(input)).toBe('A | B  \n1 | 2');
-    });
-
-    it('passes through non-table pipe text', () => {
-      expect(convertTables('Use foo | bar in text')).toBe(
-        'Use foo | bar in text',
-      );
-    });
-
-    it('preserves text around converted tables', () => {
-      const input = [
-        'before',
-        '| A | B |',
-        '| --- | --- |',
-        '| 1 | 2 |',
-        'after',
-      ].join('\n');
-
-      expect(convertTables(input)).toBe('before\nA | B  \n1 | 2\nafter');
-    });
-
-    it('supports alignment colons in table separators', () => {
-      const input = ['| Left | Right |', '| :--- | ---: |', '| 1 | 2 |'].join(
-        '\n',
-      );
-
-      expect(convertTables(input)).toBe('Left | Right  \n1 | 2');
-    });
-
-    it('does not convert tables inside code fences', () => {
-      const input = [
-        '```',
-        '| A | B |',
-        '| --- | --- |',
-        '| 1 | 2 |',
-        '```',
-      ].join('\n');
-
-      expect(convertTables(input)).toBe(input);
-    });
-  });
-
   describe('splitChunks', () => {
     it('returns single chunk for short text', () => {
       expect(splitChunks('short text')).toEqual(['short text']);
@@ -211,10 +164,10 @@ describe('DingTalk markdown utilities', () => {
   });
 
   describe('normalizeDingTalkMarkdown', () => {
-    it('converts markdown tables to readable text while splitting into chunks', () => {
+    it('preserves markdown tables while splitting into chunks', () => {
       const input = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n');
       const result = normalizeDingTalkMarkdown(input);
-      expect(result).toEqual(['A | B  \n1 | 2']);
+      expect(result).toEqual([input]);
     });
 
     it('passes through plain text', () => {

--- a/packages/channels/dingtalk/src/markdown.ts
+++ b/packages/channels/dingtalk/src/markdown.ts
@@ -2,82 +2,11 @@
  * DingTalk markdown normalization.
  *
  * DingTalk's markdown renderer is a limited subset with quirks:
- * - Tables don't render consistently - convert to pipe-separated plain text
  * - Max message length ~3800 chars — split into chunks
  * - Code fences must be closed/reopened across chunk boundaries
  */
 
 const CHUNK_LIMIT = 3800;
-
-// --- Table conversion ---
-
-function isTableSeparator(line: string): boolean {
-  const trimmed = line.trim();
-  if (!trimmed.includes('-')) return false;
-  const cells = trimmed
-    .replace(/^\|/, '')
-    .replace(/\|$/, '')
-    .split('|')
-    .map((cell) => cell.trim());
-  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
-}
-
-function isTableRow(line: string): boolean {
-  const trimmed = line.trim();
-  return trimmed.includes('|') && !trimmed.startsWith('```');
-}
-
-function parseTableRow(line: string): string[] {
-  return line
-    .trim()
-    .replace(/^\|/, '')
-    .replace(/\|$/, '')
-    .split('|')
-    .map((cell) => cell.trim());
-}
-
-function renderTable(lines: string[]): string {
-  const rows = lines.map(parseTableRow).filter((cells) => cells.length > 0);
-  return rows.map((cells) => cells.join(' | ')).join('  \n');
-}
-
-export function convertTables(text: string): string {
-  const lines = text.split('\n');
-  const output: string[] = [];
-  let i = 0;
-  let inCode = false;
-
-  while (i < lines.length) {
-    const line = lines[i] || '';
-    if (line.trim().startsWith('```')) {
-      inCode = !inCode;
-      output.push(line);
-      i++;
-      continue;
-    }
-
-    if (
-      !inCode &&
-      i + 1 < lines.length &&
-      isTableRow(line) &&
-      isTableSeparator(lines[i + 1] || '')
-    ) {
-      const tableLines = [line];
-      i += 2;
-      while (i < lines.length && isTableRow(lines[i] || '')) {
-        tableLines.push(lines[i] || '');
-        i++;
-      }
-      output.push(renderTable(tableLines));
-      continue;
-    }
-
-    output.push(line);
-    i++;
-  }
-
-  return output.join('\n');
-}
 
 // --- Chunk splitting ---
 
@@ -194,7 +123,7 @@ export function extractTitle(text: string): string {
   return cleaned || 'Reply';
 }
 
-/** Full normalization pipeline: tables, then chunks. */
+/** Split long Markdown messages without changing their formatting. */
 export function normalizeDingTalkMarkdown(text: string): string[] {
-  return splitChunks(convertTables(text));
+  return splitChunks(text);
 }


### PR DESCRIPTION
## What this PR does

Preserves Markdown tables in DingTalk bot responses instead of converting them to pipe-delimited plain text. The DingTalk guide now documents table passthrough and the need to keep tables compact on narrow screens.

## Why it's needed

Current DingTalk clients render Markdown tables, but the adapter flattened them before delivery. This made Qwen Code responses less readable than other DingTalk bots and prevented native table rendering.

## Reviewer Test Plan

### How to verify

Start a DingTalk channel and ask the bot to return a Markdown table. Confirm the reply renders as a native table with headers and rows rather than pipe-delimited text.

### Evidence (Before & After)

Before: Markdown table syntax was converted to plain text before it was sent.

After: A local DingTalk bot session rendered a four-column Markdown table with headers and rows in the DingTalk desktop client.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
| 🐧 Linux | ⚠️ |

### Environment (optional)

macOS local checkout using the DingTalk Stream channel.

## Risk & Scope

- Main risk or tradeoff: Table layout is controlled by the DingTalk client and may scroll horizontally on narrow screens.
- Not validated / out of scope: Older DingTalk client versions were not tested.
- Breaking changes / migration notes: Responses that previously used pipe-delimited table text will now use native Markdown table rendering.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

保留钉钉机器人响应中的 Markdown 表格，不再将其转换为用竖线分隔的纯文本。钉钉使用文档也已更新，说明表格会原样透传，并建议在窄屏上保持表格紧凑。

## 为什么需要

当前钉钉客户端可以渲染 Markdown 表格，但适配器在发送前将其拍平。这使 Qwen Code 的响应可读性低于其他钉钉机器人，也无法使用原生表格渲染。

## 审阅测试计划

### 验证方式

启动钉钉频道后，要求机器人返回一个 Markdown 表格。确认回复显示为包含表头和行的原生表格，而非以竖线分隔的纯文本。

### 证据（改动前后）

改动前：Markdown 表格语法会在发送前转换为纯文本。

改动后：本地钉钉机器人会话已在钉钉桌面端渲染出带表头和行的四列表格。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
| 🐧 Linux | ⚠️ |

### 环境（可选）

macOS 本地检出，使用钉钉 Stream 频道。

## 风险与范围

- 主要风险或取舍：表格布局由钉钉客户端控制，在窄屏上可能会横向滚动。
- 未验证或不在范围内：未测试旧版本钉钉客户端。
- 破坏性变更或迁移说明：此前显示为竖线分隔表格文本的响应现在会使用原生 Markdown 表格渲染。

## 关联 Issue

无。

</details>