### PR TITLE
fix(web-shell): polyfill Range layout APIs in tests

### DIFF
--- a/packages/web-shell/client/test/setup.test.ts
+++ b/packages/web-shell/client/test/setup.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+
+describe('web-shell test setup', () => {
+  it('provides range layout methods used by CodeMirror', () => {
+    const range = document.createRange();
+
+    expect(typeof range.getClientRects).toBe('function');
+    expect(typeof range.getBoundingClientRect).toBe('function');
+    expect(range.getClientRects()).toHaveLength(0);
+    expect(range.getBoundingClientRect()).toMatchObject({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    });
+  });
+});

--- a/packages/web-shell/client/test/setup.ts
+++ b/packages/web-shell/client/test/setup.ts
@@ -6,8 +6,34 @@ import { vi } from 'vitest';
 
 const globalWithDom = globalThis as typeof globalThis & {
   Element?: typeof Element;
+  Range?: typeof Range;
   ResizeObserver?: typeof ResizeObserver;
 };
+
+function createEmptyDOMRect(): DOMRect {
+  if (typeof DOMRect === 'function') {
+    return new DOMRect(0, 0, 0, 0);
+  }
+
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function createEmptyDOMRectList(): DOMRectList {
+  return {
+    length: 0,
+    item: () => null,
+  } as DOMRectList;
+}
 
 if (typeof globalWithDom.ResizeObserver === 'undefined') {
   globalWithDom.ResizeObserver = class ResizeObserverStub {
@@ -22,6 +48,16 @@ if (
   !globalWithDom.Element.prototype.scrollIntoView
 ) {
   globalWithDom.Element.prototype.scrollIntoView = () => {};
+}
+
+if (typeof globalWithDom.Range !== 'undefined') {
+  const rangePrototype = globalWithDom.Range.prototype as Range & {
+    getBoundingClientRect?: () => DOMRect;
+    getClientRects?: () => DOMRectList;
+  };
+
+  rangePrototype.getBoundingClientRect ??= createEmptyDOMRect;
+  rangePrototype.getClientRects ??= createEmptyDOMRectList;
 }
 
 if (typeof navigator !== 'undefined' && !navigator.clipboard) {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -5378,21 +5378,22 @@ describe('DaemonSessionProvider', () => {
       modelServices: [],
       workspaceCwd: '/mock-workspace',
     });
+    const releaseHeartbeatFailure = createDeferred<void>();
     const heartbeat = vi.fn(async () => {
+      await releaseHeartbeatFailure.promise;
       throw Object.assign(new Error('session gone'), { status: 410 });
     });
+    const submitStarted = createDeferred<void>();
     const session = createMockSession({
       heartbeat,
-      submitPrompt: vi.fn(
-        (_req: unknown, signal?: AbortSignal) =>
-          new Promise<NonBlockingPromptAccepted>((_resolve, reject) => {
-            signal?.addEventListener(
-              'abort',
-              () => reject(createAbortError()),
-              { once: true },
-            );
-          }),
-      ),
+      submitPrompt: vi.fn((_req: unknown, signal?: AbortSignal) => {
+        submitStarted.resolve();
+        return new Promise<NonBlockingPromptAccepted>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(createAbortError()), {
+            once: true,
+          });
+        });
+      }),
       events: createIdleEvents(),
     });
     sdkMocks.sessions.push(session);
@@ -5415,10 +5416,12 @@ describe('DaemonSessionProvider', () => {
     let promptResult: Promise<unknown> | undefined;
     await act(async () => {
       promptResult = providerActions.sendPrompt('still running');
+      await submitStarted.promise;
       await flushPromises();
     });
 
     await act(async () => {
+      releaseHeartbeatFailure.resolve();
       await wait(50);
       await flushPromises();
     });


### PR DESCRIPTION
## What this PR does

Adds a web-shell test setup polyfill for the jsdom `Range` layout methods that CodeMirror calls during asynchronous editor measurement, and adds a focused setup test that locks this environment contract.

## Why it's needed

The Ubuntu PR CI can finish all web-shell assertions successfully and still fail because Vitest catches an unhandled `TypeError: textRange(...).getClientRects is not a function` from CodeMirror after `useComposerCore.dom.test.tsx` schedules a jsdom animation-frame measurement. jsdom does not provide these `Range` layout methods, so the shared test setup should provide stable empty geometry for editor tests.

## Reviewer Test Plan

### How to verify

Confirm that jsdom `document.createRange()` exposes `getClientRects` and `getBoundingClientRect`, then run the web-shell DOM composer test and full web-shell CI test command. The expected result is that all tests pass without the CodeMirror `getClientRects` unhandled error.

### Evidence (Before & After)

Before: `npm -w packages/web-shell run test -- test/setup.test.ts` failed with `expected 'undefined' to be 'function'` for `range.getClientRects`.

After: `npm -w packages/web-shell run test -- test/setup.test.ts` passed 1 test; `npm -w packages/web-shell run test -- hooks/useComposerCore.dom.test.tsx` passed 4 tests; `npm -w packages/web-shell run test:ci` passed 83 files and 1340 tests; `npm -w packages/web-shell run typecheck` passed; `npm -w packages/web-shell run lint` passed; `./node_modules/.bin/prettier --check packages/web-shell/client/test/setup.ts packages/web-shell/client/test/setup.test.ts` passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node v22.22.0, package workspace installed with `npm ci` in an isolated git worktree.

## Risk & Scope

- Main risk or tradeoff: The polyfill returns empty layout geometry, which is appropriate for jsdom tests but does not simulate real browser layout.
- Not validated / out of scope: I did not run the suite locally on Linux or Windows; GitHub Actions should validate those environments.
- Breaking changes / migration notes: N/A.

## Linked Issues

Related to #6578 and the failing PR CI observed on #6662.

<details>
<summary>中文说明</summary>

## What this PR does

为 web-shell 的测试环境补上 jsdom `Range` layout 方法 polyfill，覆盖 CodeMirror 在异步编辑器测量里会调用的 `getClientRects` 和 `getBoundingClientRect`，并新增一个聚焦的 setup 测试锁住这个测试环境契约。

## Why it's needed

Ubuntu PR CI 里 web-shell 的断言本身可以全部通过，但 Vitest 随后会捕获 CodeMirror 在 `useComposerCore.dom.test.tsx` 相关异步 animation-frame 测量中抛出的 `TypeError: textRange(...).getClientRects is not a function`。jsdom 本身不提供这些 `Range` layout 方法，所以应该在共享测试 setup 里提供稳定的空布局几何，避免编辑器测试出现 unhandled error。

## Reviewer Test Plan

### How to verify

确认 jsdom 的 `document.createRange()` 暴露 `getClientRects` 和 `getBoundingClientRect`，然后运行 web-shell 的 DOM composer 测试和 full web-shell CI 测试命令。预期结果是所有测试通过，并且不再出现 CodeMirror `getClientRects` unhandled error。

### Evidence (Before & After)

Before：`npm -w packages/web-shell run test -- test/setup.test.ts` 在 `range.getClientRects` 上失败，错误为 `expected 'undefined' to be 'function'`。

After：`npm -w packages/web-shell run test -- test/setup.test.ts` 通过 1 个测试；`npm -w packages/web-shell run test -- hooks/useComposerCore.dom.test.tsx` 通过 4 个测试；`npm -w packages/web-shell run test:ci` 通过 83 个文件和 1340 个测试；`npm -w packages/web-shell run typecheck` 通过；`npm -w packages/web-shell run lint` 通过；`./node_modules/.bin/prettier --check packages/web-shell/client/test/setup.ts packages/web-shell/client/test/setup.test.ts` 通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node v22.22.0，在独立 git worktree 中通过 `npm ci` 安装 workspace 依赖。

## Risk & Scope

- Main risk or tradeoff：polyfill 返回空布局几何，适合 jsdom 测试，但不模拟真实浏览器布局。
- Not validated / out of scope：未在本地 Linux 或 Windows 环境运行测试；这些环境交给 GitHub Actions 验证。
- Breaking changes / migration notes：N/A。

## Linked Issues

关联 #6578 以及 #6662 上观察到的 PR CI 失败。

</details>


## CI Follow-up

After the first push, Ubuntu full CI no longer reproduced the CodeMirror getClientRects unhandled error, and packages/web-shell passed 83 files / 1340 tests in the GitHub Actions log. The same full CI run then exposed an unrelated timing-sensitive packages/webui heartbeat prompt cleanup test. This PR now also stabilizes that test by releasing the simulated terminal heartbeat failure only after submitPrompt has started.

<details>
<summary>CI follow-up 中文说明</summary>

第一次 push 后，Ubuntu full CI 已经没有再复现 CodeMirror getClientRects unhandled error，GitHub Actions 日志里 packages/web-shell 通过了 83 个文件 / 1340 个测试。随后同一次 full CI 暴露了一个无关的 packages/webui heartbeat prompt cleanup 计时型测试问题。这个 PR 现在也把该测试稳定化：只有在 submitPrompt 已经启动后，才释放模拟的 terminal heartbeat 失败。

</details>