### PR TITLE
docs(agents): add a bounded self-audit step to the pre-done workflow

### DIFF
--- a/.qwen/skills/bugfix/SKILL.md
+++ b/.qwen/skills/bugfix/SKILL.md
@@ -85,12 +85,15 @@ Run unit tests for any packages you modified. If the test engineer wrote a
 failing test during reproduction, make sure it passes after the fix. Otherwise,
 add focused regression coverage for the failure scenario.
 
-## Step 6: Code Review
+## Step 6: Self-Audit and Code Review
 
 First self-audit the full diff per the self-audit step in AGENTS.md's General
-workflow. Skip the review below only for a plain one-line or trivial config
-fix. For anything else, run `/review` with a review task listing all changed
-files. Triage each comment with a verdict:
+workflow (open-ended passes plus presume-wrong verification, until two
+consecutive clean passes; one clean pass suffices for a trivial fix). If the
+audit changes source, re-run Step 4 before resuming it. Skip the review below
+only for a plain one-line or trivial config fix. For anything else, run
+`/review` with a review task listing all changed files. Triage each comment
+with a verdict:
 
 - **Valid**: real bug or meaningful improvement. Fix it.
 - **False positive**: reviewer missed context. Skip it.
@@ -103,5 +106,6 @@ check.
 ## Iteration Rules
 
 - If Step 4 fails, go back to Step 3, then re-run Step 4.
-- If Step 6 finds valid issues, fix them, then re-run Step 4 as a sanity check.
+- If Step 6 finds valid issues, fix them, re-run Step 4 as a sanity check,
+  and re-run the self-audit.
 - Do not loop more than 3 times between Steps 3-6 without asking the user.

--- a/.qwen/skills/bugfix/SKILL.md
+++ b/.qwen/skills/bugfix/SKILL.md
@@ -87,9 +87,10 @@ add focused regression coverage for the failure scenario.
 
 ## Step 6: Code Review
 
-Skip this only for a plain one-line or trivial config fix. For anything else,
-run `/review` with a review task listing all changed files. Triage each comment
-with a verdict:
+First self-audit the full diff per the self-audit step in AGENTS.md's General
+workflow. Skip the review below only for a plain one-line or trivial config
+fix. For anything else, run `/review` with a review task listing all changed
+files. Triage each comment with a verdict:
 
 - **Valid**: real bug or meaningful improvement. Fix it.
 - **False positive**: reviewer missed context. Skip it.

--- a/.qwen/skills/feat-dev/SKILL.md
+++ b/.qwen/skills/feat-dev/SKILL.md
@@ -2,7 +2,8 @@
 name: feat-dev
 description: End-to-end workflow for implementing a non-trivial qwen-code
   feature. Covers requirements investigation, design, E2E test planning,
-  baseline dry-run, implementation, verification, code review, and iteration.
+  baseline dry-run, implementation, verification, self-audit, code review,
+  and iteration.
 ---
 
 # Feature Development Workflow
@@ -113,11 +114,13 @@ pass.
 
 Output: E2E results appended to the test plan.
 
-## Phase 7: Code Review
+## Phase 7: Self-Audit and Code Review
 
 First self-audit the full diff per the self-audit step in AGENTS.md's General
-workflow. Then run `/review` with a review task listing all changed files.
-Triage each comment before acting:
+workflow (open-ended passes plus presume-wrong verification, until two
+consecutive clean passes). If the audit changes source, return through
+Phases 5-6 before resuming it. Then run `/review` with a review task listing
+all changed files. Triage each comment before acting:
 
 - **Valid**: real bug or meaningful improvement. Fix it.
 - **False positive**: reviewer missed context. Skip it.
@@ -137,6 +140,7 @@ separate PR comment when applicable.
 ## Iteration Rules
 
 - If Phase 6 fails, return to Phase 5 and then re-run Phase 6.
-- If Phase 7 finds valid issues, fix them and run a quick Phase 6 sanity check.
+- If Phase 7 finds valid issues, fix them, run a quick Phase 6 sanity check,
+  and re-run the self-audit.
 - Do not loop more than 3 times between Phases 5-7 without asking the user.
 - If the test plan is inaccurate, update it and document why.

--- a/.qwen/skills/feat-dev/SKILL.md
+++ b/.qwen/skills/feat-dev/SKILL.md
@@ -115,8 +115,9 @@ Output: E2E results appended to the test plan.
 
 ## Phase 7: Code Review
 
-Run `/review` with a review task listing all changed files. Triage each comment
-before acting:
+First self-audit the full diff per the self-audit step in AGENTS.md's General
+workflow. Then run `/review` with a review task listing all changed files.
+Triage each comment before acting:
 
 - **Valid**: real bug or meaningful improvement. Fix it.
 - **False positive**: reviewer missed context. Skip it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,20 +166,29 @@ npm run preflight  # Full check: clean → install → format → lint → build
 2. **Test plan for behavioral changes** — write an E2E test plan in
    `.qwen/e2e-tests/` when the change affects user-observable behavior. Dry-run
    against the global `qwen` CLI first to confirm the baseline.
-3. **Build + typecheck before declaring done**:
-   `npm run build && npm run typecheck`.
-4. **Code review** — run `/review` when available. Triage each comment:
-   valid / false positive / overthinking.
+3. **Build, typecheck, and test before declaring done**:
+   `npm run build && npm run typecheck`, plus unit tests for the files you
+   changed.
+4. **Self-audit before declaring done** — read the full diff you are about
+   to ship in open-ended passes, not hunting for anything specific. Then
+   verify each change, and each green test you rely on as evidence, presuming
+   it wrong (a passing test can assert the wrong thing). Stop after two
+   consecutive clean passes — a clean pass is evidence about that pass, not
+   the code — or five passes total (say so rather than claim convergence).
+   A fix re-runs step 3 and resets the clean-pass count. Scale to the diff:
+   one careful pass suffices for a trivial change.
+5. **Code review** — run `/review` when available. Triage each comment:
+   valid / false positive / overthinking. Fixes go back through steps 3-4.
 
 ### Feature development
 
 Use the `/feat-dev` skill for the full workflow: investigate, design, test plan,
-dry-run, implement, verify, code review, and iterate.
+dry-run, implement, verify, self-audit, code review, and iterate.
 
 ### Bugfix
 
 Use the `/bugfix` skill for the reproduce-first workflow: reproduce, fix,
-verify, test, and code review.
+verify, test, self-audit, and code review.
 
 ## Code Review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,13 +170,15 @@ npm run preflight  # Full check: clean → install → format → lint → build
    `npm run build && npm run typecheck`, plus unit tests for the files you
    changed.
 4. **Self-audit before declaring done** — read the full diff you are about
-   to ship in open-ended passes, not hunting for anything specific. Then
-   verify each change, and each green test you rely on as evidence, presuming
-   it wrong (a passing test can assert the wrong thing). Stop after two
-   consecutive clean passes — a clean pass is evidence about that pass, not
-   the code — or five passes total (say so rather than claim convergence).
-   A fix re-runs step 3 and resets the clean-pass count. Scale to the diff:
-   one careful pass suffices for a trivial change.
+   to ship, including new untracked files, in open-ended passes, not hunting
+   for anything specific. Then verify each change, and each green test you
+   rely on as evidence, presuming it wrong (a passing test can assert the
+   wrong thing). Stop after two consecutive clean passes — a clean pass is
+   evidence about that pass, not the code. A fix re-runs step 3, resets the
+   clean-pass count, and gets a further pass over the updated diff — never
+   exit on a pass that found something. If five passes bring no convergence,
+   say so instead of declaring done. Scale to the diff: one clean, careful
+   pass suffices for a trivial change.
 5. **Code review** — run `/review` when available. Triage each comment:
    valid / false positive / overthinking. Fixes go back through steps 3-4.
 


### PR DESCRIPTION
## What this PR does

Adds a self-audit step to the general development workflow, between the build gate and machine code review. Before declaring work done, the author reads the full outgoing diff in open-ended passes (not hunting for anything specific), then verifies each change — and each green test relied on as evidence — presuming it wrong. The loop stops after two consecutive clean passes, or after five passes total with the cap reported honestly rather than presented as convergence. Any fix re-runs the build gate and resets the clean-pass count, and the effort scales with the diff: one careful pass suffices for a trivial change.

It also wires the step into the surrounding workflow so it actually binds: the build gate now includes unit tests for the changed files (so the green tests the audit presumes wrong actually exist), fixes coming out of review triage are routed back through the build gate and the audit (so late fixes cannot ship unbuilt or unaudited), and the feature-development and bugfix skill workflows point to the new step at their review phases, keeping the delegated flows and the workflow summaries consistent with the general list.

## Why it's needed

The workflow previously jumped straight from a green build to machine review. Green builds and green tests are necessary but not sufficient — a passing test can assert the wrong thing — and an author pass with full task context catches a class of defects that fresh-context reviewers miss, before review rounds are spent on them.

The wording deliberately follows the repo's existing review vocabulary and precedent. The review pipeline already reserves "reverse audit" for an open-ended re-read rather than a targeted check, so the new step says "verify, presuming it wrong" instead of overloading that term; and the five-pass hard cap with honest reporting mirrors the pipeline's own bounded stop rule (two consecutive dry rounds, hard-capped, with a cap stop reported as such).

## Reviewer Test Plan

### How to verify

Read the new step as a literal instruction-follower and confirm it cannot be read two ways: a single unit ("pass") is used throughout; a fix resets only the clean-pass count, never the five-pass cap; a trivial change legitimately exits after one careful pass; and every step in the list is anchored to the same "before declaring done" trigger, so the audit also fires in flows that never commit.

Confirm the two skill workflows gained only a pointer sentence at their review phases — no phases or steps were renumbered, and their iteration rules still reference the same numbers.

Formatting checks pass on all three touched documents (Prettier is clean and no added line exceeds the 80-column width).

### Evidence (Before & After)

N/A (docs-only change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A (docs only; verified with the repo formatting check).

## Risk & Scope

- Main risk or tradeoff: adds a mandatory pre-done process cost to every change-set; bounded by the five-pass cap and the scale-to-the-diff clause, so trivial changes pay one careful pass.
- Not validated / out of scope: the unattended autofix flow keeps its lighter single-pass skeptical re-read; its diffs are small enough that the proportionality clause covers them, so aligning its text is deliberately left out.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在通用开发工作流中、构建门禁与机器代码评审之间,新增一个自审(self-audit)步骤。在宣布工作完成之前,作者先以开放式方式(不带特定目标)通读即将交付的完整 diff;随后对每一处改动——以及作为证据所依赖的每一个绿色测试——以"推定它有错"的姿态逐一验证。循环在连续两轮零发现后停止,或在总计五轮时封顶(如实说明是被上限终止,而不是宣称已收敛)。任何修复都会重跑构建门禁并重置"连续干净轮次"计数;投入随 diff 规模伸缩:琐碎改动一轮认真通读即可。

同时把该步骤接入周边工作流,使其真正生效:构建门禁现在包含对改动文件的单元测试(让自审所推定有错的"绿色测试"确实存在);评审分诊产出的修复会被路由回构建门禁与自审(避免最后阶段的修复未经构建或未经审计就交付);功能开发与缺陷修复两个技能工作流在各自的评审阶段指向新步骤,使被委托的流程及工作流摘要与通用清单保持一致。

## 为什么需要

原有工作流从"构建变绿"直接跳到机器评审。绿色构建与绿色测试是必要而不充分的——一个通过的测试可能断言了错误的行为——而作者带着完整任务上下文的自查,能在消耗评审轮次之前,抓住新鲜上下文评审者容易漏掉的一类缺陷。

措辞刻意沿用仓库既有的评审词汇与先例:评审流水线已将 "reverse audit" 保留给开放式重读(而非针对性核查),因此新步骤使用"以推定有错的方式验证"的表述,避免术语重载;五轮硬上限与如实报告,对应流水线自身的有界停止规则(连续两轮无新发现、带硬上限、被上限终止时如实说明)。

## 评审验证计划

### 如何验证

以字面执行指令的视角阅读新步骤,确认它不存在两种读法:全程只使用一个单位("pass");修复只重置连续干净轮次计数,而不会重置五轮上限;琐碎改动一轮认真通读即可合法退出;清单中的每一步都锚定在同一个"宣布完成之前"的触发点上,因此在从不提交 commit 的流程里自审同样会生效。

确认两个技能工作流仅在评审阶段增加了一句指向性说明——没有任何阶段或步骤被重新编号,其迭代规则引用的编号保持不变。

三个被改动的文档均通过格式检查(Prettier 干净,新增行均不超过 80 列)。

### 证据(前后对比)

N/A(纯文档改动)。

### 测试平台

Linux 已验证(格式检查);macOS / Windows 不适用。

### 环境(可选)

N/A(仅文档;以仓库格式检查验证)。

## 风险与范围

- 主要风险或取舍:为每个变更集增加了一道强制的完成前流程成本;由五轮上限与"随 diff 伸缩"条款兜底,琐碎改动只需一轮认真通读。
- 未验证 / 超出范围:无人值守的 autofix 流程保留其更轻量的单轮怀疑式重读;其 diff 足够小,比例条款已可覆盖,故有意不改动其文本。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

无。

</details>
