### PR TITLE
fix(release): raise package size budget to 85 MiB

### DIFF
--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -19,7 +19,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultRootDir = path.resolve(__dirname, '..');
 const TEST_FILE_RE = /\.(test|spec)\.(d\.)?[mc]?[jt]s(\.map)?$/;
-const DEFAULT_MAX_NPM_PACKAGE_UNPACKED_BYTES = 80 * 1024 * 1024;
+const DEFAULT_MAX_NPM_PACKAGE_UNPACKED_BYTES = 85 * 1024 * 1024;
 const PACKAGE_TEXT_FILE_RE =
   /\.(?:[cm]?[jt]sx?|json|md|html|css|txt|ya?ml|sh|svg|map)$/i;
 const PACKAGE_SCAN_FORBIDDEN_LITERALS = [

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -11,6 +11,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  truncateSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -322,6 +323,33 @@ describe('package asset scripts', () => {
         maxPackageUnpackedBytes: 50_000,
       }),
     ).toThrow(/Prepared package unpacked size \d+ bytes exceeds 50000 bytes/);
+  });
+
+  it('enforces an 85 MiB default unpacked size budget', () => {
+    const rootDir = createFixtureRoot();
+    createBundleArtifacts(rootDir);
+    writeFile(rootDir, 'dist/chunks/large.bin', '');
+    const largeFile = path.join(rootDir, 'dist', 'chunks', 'large.bin');
+    truncateSync(largeFile, 84 * 1024 * 1024);
+    stubConsole();
+
+    expect(() =>
+      preparePackage({
+        rootDir,
+        requireNativeAudioCapture: false,
+      }),
+    ).not.toThrow();
+
+    truncateSync(largeFile, 85 * 1024 * 1024);
+
+    expect(() =>
+      preparePackage({
+        rootDir,
+        requireNativeAudioCapture: false,
+      }),
+    ).toThrow(
+      /Prepared package unpacked size \d+ bytes exceeds 89128960 bytes/,
+    );
   });
 
   it('omits bundledDependencies when audio-capture artifacts are missing', () => {


### PR DESCRIPTION
## What this PR does

Raises the prepared npm package unpacked-size safety budget from 80 MiB to 85 MiB while retaining a hard upper bound. Adds a boundary regression test that accepts a package below 85 MiB and rejects one above it.

## Why it's needed

The release workflow currently fails while building the Docker sandbox because the prepared package is 84,497,689 bytes, exceeding the existing 83,886,080-byte budget. The new limit gives the current package about 4.42 MiB of headroom without removing the package-size guard.

## Reviewer Test Plan

### How to verify

Run the script test suite and confirm the package-size test accepts a sparse 84 MiB payload while rejecting an 85 MiB payload plus fixture overhead with an 89,128,960-byte limit. Build, bundle, and prepare the package; the current release package should pass preparation instead of failing the size guard.

### Evidence (Before & After)

N/A — non-UI release guard change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22; local npm build, typecheck, bundle, package preparation, and script tests.

## Risk & Scope

- Main risk or tradeoff: Releases may grow up to 5 MiB larger before the safety guard blocks them.
- Not validated / out of scope: Docker execution on Linux and reducing the existing package contents.
- Breaking changes / migration notes: None.

## Linked Issues

Related failing release: https://github.com/QwenLM/qwen-code/actions/runs/29110517358/job/86421715805

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 npm 发布包的解压尺寸安全上限从 80 MiB 提高到 85 MiB，同时保留明确的硬上限。新增边界回归测试，验证低于 85 MiB 的包可以通过、超过上限的包会被拒绝。

## 为什么需要

当前发布流程在构建 Docker sandbox 时失败，因为准备后的发布包为 84,497,689 字节，超过原有的 83,886,080 字节预算。新上限为当前包保留约 4.42 MiB 余量，同时不移除包尺寸保护。

## Reviewer 测试计划

### 如何验证

运行脚本测试套件，确认包尺寸测试允许 84 MiB 的稀疏载荷，并在 85 MiB 载荷加 fixture 开销超过 89,128,960 字节时拒绝。执行构建、bundle 和发布包准备流程；当前发布包应通过准备步骤，不再触发尺寸门禁失败。

### 证据（Before & After）

N/A——非 UI 的发布门禁改动。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22；本地完成 npm build、typecheck、bundle、发布包准备和脚本测试。

## 风险与范围

- 主要风险或权衡：发布包在触发安全门禁前最多可以再增长 5 MiB。
- 未验证 / 不在范围内：Linux Docker 实际执行，以及缩减现有发布包内容。
- 破坏性变更 / 迁移说明：无。

## 关联问题

相关失败发布：https://github.com/QwenLM/qwen-code/actions/runs/29110517358/job/86421715805

</details>
