### PR TITLE
fix(channels): suppress nested subagent output

### DIFF
--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -289,6 +289,41 @@ describe('AcpBridge', () => {
     );
   });
 
+  it('excludes nested subagent text from the final response', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    }) as unknown as TestableAcpBridge;
+    bridge.child = { killed: false, exitCode: null };
+    bridge.connection = {
+      extMethod: vi.fn(),
+      prompt: vi.fn(async () => {
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Nested research report.' },
+            _meta: {
+              parentToolCallId: 'agent-call-1',
+              subagentType: 'Explore',
+            },
+          },
+        });
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Final answer.' },
+          },
+        });
+      }),
+    };
+
+    await expect(bridge.prompt('s-1', 'question')).resolves.toBe(
+      'Final answer.',
+    );
+  });
+
   it('returns only the final turn text after auto-approved tool calls', async () => {
     const bridge = new AcpBridge({
       cliEntryPath: '/tmp/qwen',

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -304,6 +304,10 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
 
     switch (type) {
       case 'agent_message_chunk': {
+        const meta = update['_meta'] as Record<string, unknown> | undefined;
+        if (typeof meta?.['parentToolCallId'] === 'string') {
+          break;
+        }
         const content = update['content'] as
           | { type?: string; text?: string }
           | undefined;

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -313,6 +313,57 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
+  it('excludes nested subagent text from the daemon response', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      events.push({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Nested research report.' },
+            _meta: {
+              parentToolCallId: 'agent-call-1',
+              subagentType: 'Explore',
+            },
+          },
+        },
+      });
+      events.push({
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Final answer.' },
+          },
+        },
+      });
+      events.push(turnCompleteEvent());
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe(
+      'Final answer.',
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
   it('returns only the final turn text after daemon auto-approved tool calls', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -560,6 +560,10 @@ export class DaemonChannelBridge
     const type = getString(update['sessionUpdate']);
     switch (type) {
       case 'agent_message_chunk': {
+        const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+        if (typeof meta?.['parentToolCallId'] === 'string') {
+          break;
+        }
         const text = getTextContent(update['content']);
         if (text) {
           this.emit('textChunk', sessionId, text);


### PR DESCRIPTION
## What this PR does

This PR prevents channel delivery from collecting assistant message chunks that belong to nested subagents. Root-agent chunks continue through the existing response-boundary handling, while nested Agent/Explore reports remain available as ACP session updates for clients that render subagent activity.

## Why it's needed

Nested subagent output is emitted as an assistant message chunk with parent-tool metadata. Channel bridges previously treated those chunks as root-agent response text, so an intermediate research report, including absolute local paths, could be delivered to DingTalk before the root agent's final answer. Filtering at the channel boundary preserves ACP observability without exposing intermediate subagent content to messaging platforms.

## Reviewer Test Plan

### How to verify

Exercise both a direct ACP-backed channel session and a daemon-managed channel session with an Agent/Explore subagent that emits a research report before the root agent responds. Confirm the completed channel response contains only the root agent's final answer. Also confirm ordinary root-agent chunks are still delivered and the raw ACP session update for nested activity remains available to non-channel clients.

### Evidence (Before & After)

Before: the focused regression tests returned `Nested research report.Final answer.`. After: both paths return only `Final answer.`, and 59 focused bridge tests pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node.js workspace after `npm install`; focused Vitest tests plus full build and typecheck.

## Risk & Scope

- Main risk or tradeoff: Channel adapters no longer surface nested subagent prose, by design; root-agent output and raw ACP updates are unchanged.
- Not validated / out of scope: Live DingTalk delivery with production credentials.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6694

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 阻止 channel 投递收集属于嵌套子代理的 assistant message chunk。根代理文本仍沿用现有 response boundary 处理；嵌套 Agent/Explore 报告仍作为 ACP session update 保留，供需要展示子代理活动的客户端使用。

## 为什么需要

嵌套子代理输出会以带有父工具元数据的 assistant message chunk 发出。此前 channel bridge 会把这些 chunk 当作根代理回复文本，因此包含绝对本地路径的中间研究报告可能在根代理最终回复前被投递到钉钉。把过滤放在 channel 边界既保留 ACP 可观测性，又避免向消息平台暴露子代理中间内容。

## Reviewer 测试计划

### 如何验证

分别通过直接 ACP channel session 和 daemon 管理的 channel session 触发 Agent/Explore 子代理，使其在根代理回复前输出研究报告。确认 channel 完整回复只包含根代理最终答案；同时确认普通根代理 chunk 仍正常投递，嵌套活动的原始 ACP session update 仍可供非 channel 客户端使用。

### 证据（修复前后）

修复前：聚焦回归测试返回 `Nested research report.Final answer.`。修复后：两条路径都只返回 `Final answer.`，59 个 bridge 聚焦测试全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ⚠️ 未测试   |

### 环境（可选）

执行 `npm install` 后的 Node.js 工作区；运行了聚焦 Vitest 测试、完整 build 和 typecheck。

## 风险与范围

- 主要风险或权衡：channel adapter 不再展示嵌套子代理文本，这是预期行为；根代理输出和原始 ACP update 不变。
- 未验证 / 不在范围内：需要生产凭据的真实钉钉投递。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6694

</details>
