### PR TITLE
docs(core): fix inaccurate token-limit comment and two comment typos

### DIFF
--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -191,7 +191,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^qwen3-max/, LIMITS['256k']],
   // Open-source Qwen3 variants: 256K native
   [/^qwen3-coder-/, LIMITS['256k']],
-  // Qwen fallback (VL, turbo, plus, 2.5, etc.): 128K
+  // Qwen fallback (VL, turbo, plus, 2.5, etc.): 256K
   [/^qwen/, LIMITS['256k']],
 
   // -------------------

--- a/packages/core/src/test-utils/config.ts
+++ b/packages/core/src/test-utils/config.ts
@@ -20,7 +20,7 @@ export const DEFAULT_CONFIG_PARAMETERS: ConfigParameters = {
 };
 
 /**
- * Produces a config.  Default paramters are set to
+ * Produces a config.  Default parameters are set to
  * {@link DEFAULT_CONFIG_PARAMETERS}, optionally, fields can be specified to
  * override those defaults.
  */

--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -213,7 +213,7 @@ class RecursiveFileSearch implements FileSearch {
     // Initialize fuzzy search if enabled (or undefined, default true).
     if (this.options.enableFuzzySearch !== false) {
       // The v1 algorithm is much faster since it only looks at the first
-      // occurence of the pattern. We use it for search spaces that have >20k
+      // occurrence of the pattern. We use it for search spaces that have >20k
       // files, because the v2 algorithm is just too slow in those cases.
       //
       // Construction is the actual main-thread freeze on large workspaces


### PR DESCRIPTION
## What this PR does

Corrects three inaccurate code comments in `packages/core` — one that states the wrong token limit and two misspellings. Comments only; no code, types, or behavior change.

## Why it's needed

`tokenLimits.ts` labels the `^qwen` fallback pattern as `128K`, but the pattern returns `LIMITS['256k']` (262,144). The `128K` value is stale: commit `66dbc50de` collapsed the earlier per-model Qwen patterns (a mix of 128K and 256K entries) into this single 256K fallback but left the old figure in the comment, so the comment now contradicts the code and misleads anyone reasoning about Qwen context sizing. The other two are plain typos (`paramters` → `parameters`, `occurence` → `occurrence`) that reduce readability when grepping or reading the surrounding logic.

## Reviewer Test Plan

### How to verify

Read the diff and confirm each comment now matches the code it describes: the `^qwen` fallback maps to `LIMITS['256k']`, so the comment should read `256K`; the two typo fixes are standard spelling corrections. There is no runtime surface — the change touches only comment text.

### Evidence (Before & After)

N/A — comment-only change with no user-visible or runtime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: verified `npx prettier --check` passes on the three files. Windows/Linux: N/A — no platform-dependent behavior in a comment change.

### Environment (optional)

N/A — no runtime involved; only Prettier formatting was checked.

## Risk & Scope

- Main risk or tradeoff: none — comments only, zero runtime impact.
- Not validated / out of scope: no code, types, or tests changed.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修正 `packages/core` 中三处不准确的代码注释——其中一处标注了错误的 token 上限，另外两处是拼写错误。仅涉及注释，不改动任何代码、类型或行为。

## 为什么需要

`tokenLimits.ts` 将 `^qwen` 兜底匹配注释为 `128K`，但该匹配返回的是 `LIMITS['256k']`（262,144）。`128K` 这一数值已过时：提交 `66dbc50de` 把此前各个 Qwen 模型的匹配项（既有 128K 也有 256K）合并为这一条 256K 的兜底规则，却在注释里保留了旧数值，导致注释与代码相互矛盾，会误导阅读 Qwen 上下文大小相关逻辑的人。另外两处是普通拼写错误（`paramters` → `parameters`，`occurence` → `occurrence`），会在检索或阅读周边逻辑时降低可读性。

## 复核测试计划

### 如何验证

阅读 diff，确认每条注释现在都与其描述的代码一致：`^qwen` 兜底映射到 `LIMITS['256k']`，因此注释应为 `256K`；另外两处为标准拼写修正。此改动没有运行时影响——仅涉及注释文本。

### 证据（修复前后对比）

N/A——仅注释改动，无用户可见或运行时行为变化。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：已验证三个文件通过 `npx prettier --check`。Windows/Linux：N/A——注释改动不涉及任何平台相关行为。

### 运行环境（可选）

N/A——不涉及运行时；仅检查了 Prettier 格式。

## 风险与影响范围

- 主要风险或权衡：无——仅注释，零运行时影响。
- 未验证 / 范围之外：未改动任何代码、类型或测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
