### PR TITLE
fix(acp): reject fractional readTextFile limits

### DIFF
--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -268,6 +268,28 @@ describe('BridgeClient — BridgeFileSystem injection seam (F1 step 5)', () => {
       expect((err.data as { hint?: unknown }).hint).toBeUndefined();
     });
 
+    it('readTextFile maps parse_error FsError to invalid params', async () => {
+      const readText = vi.fn(async (): Promise<ReadTextFileResponse> => {
+        throw makeFsError(
+          'parse_error',
+          'limit must be a positive integer, got 1.5',
+          { status: 400 },
+        );
+      });
+      const client = makeClient({ writeText: vi.fn(), readText });
+
+      const err = (await client
+        .readTextFile({ path: '/x', sessionId: 'sess:test', limit: 1.5 })
+        .catch((e) => e)) as Error & { code?: number; data?: unknown };
+
+      expect(err.name).toBe('RequestError');
+      expect(err.code).toBe(-32602);
+      expect(err.data).toMatchObject({
+        errorKind: 'parse_error',
+        status: 400,
+      });
+    });
+
     it('passes non-FsError errors through unchanged (no RequestError wrap)', async () => {
       // Plain Error → bridgeClient must NOT wrap it. Only structured
       // FsError gets the reshape. ACP's default serialization is
@@ -418,7 +440,27 @@ describe('BridgeClient — BridgeFileSystem injection seam (F1 step 5)', () => {
 
       expect(err).toBeInstanceOf(RequestError);
       expect((err as Error).message).toContain(
-        '`limit` must be a positive integer.',
+        '`limit` must be a positive integer, got 1.5',
+      );
+    });
+
+    it('readTextFile rejects fractional positive lines before slicing inline content', async () => {
+      const client = makeClient(/* no fileSystem */);
+      const target = path.join(tmpDir, 'lines.txt');
+      await fsp.writeFile(target, 'a\nb\nc\n', 'utf8');
+
+      const err = await client
+        .readTextFile({
+          path: target,
+          sessionId: 'sess:test',
+          line: 1.5,
+          limit: 1,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(RequestError);
+      expect((err as Error).message).toContain(
+        '`line` must be a positive integer, got 1.5',
       );
     });
   });

--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -401,6 +401,26 @@ describe('BridgeClient — BridgeFileSystem injection seam (F1 step 5)', () => {
 
       expect(response.content).toBe('on-disk-content');
     });
+
+    it('readTextFile rejects fractional positive limits before slicing inline content', async () => {
+      const client = makeClient(/* no fileSystem */);
+      const target = path.join(tmpDir, 'lines.txt');
+      await fsp.writeFile(target, 'a\nb\nc\n', 'utf8');
+
+      const err = await client
+        .readTextFile({
+          path: target,
+          sessionId: 'sess:test',
+          line: 1,
+          limit: 1.5,
+        })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(RequestError);
+      expect((err as Error).message).toContain(
+        '`limit` must be a positive integer.',
+      );
+    });
   });
 });
 

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -320,7 +320,8 @@ function isTrustedArtifactToolUpdate(
  */
 function preserveFsErrorOverAcp(err: unknown): never {
   if (isFsErrorShape(err)) {
-    throw new RequestError(-32603, err.message, {
+    const code = err.kind === 'parse_error' ? -32602 : -32603;
+    throw new RequestError(code, err.message, {
       errorKind: err.kind,
       ...(err.hint !== undefined ? { hint: err.hint } : {}),
       ...(err.status !== undefined ? { status: err.status } : {}),
@@ -1886,7 +1887,17 @@ export class BridgeClient implements Client {
     ) {
       throw RequestError.invalidParams(
         undefined,
-        '`limit` must be a positive integer.',
+        `\`limit\` must be a positive integer, got ${params.limit}`,
+      );
+    }
+    if (
+      typeof params.line === 'number' &&
+      params.line > 0 &&
+      !Number.isSafeInteger(params.line)
+    ) {
+      throw RequestError.invalidParams(
+        undefined,
+        `\`line\` must be a positive integer, got ${params.line}`,
       );
     }
     // BSA0E: cap the file size we'll buffer into RSS at 100 MiB so a

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -1879,6 +1879,16 @@ export class BridgeClient implements Client {
     if (typeof params.limit === 'number' && params.limit <= 0) {
       return { content: '' };
     }
+    if (
+      typeof params.limit === 'number' &&
+      params.limit > 0 &&
+      !Number.isSafeInteger(params.limit)
+    ) {
+      throw RequestError.invalidParams(
+        undefined,
+        '`limit` must be a positive integer.',
+      );
+    }
     // BSA0E: cap the file size we'll buffer into RSS at 100 MiB so a
     // request like `{ line: 1, limit: 10 }` against a 500 MB log
     // doesn't cost the daemon 500 MB of memory just to return 10

--- a/packages/cli/src/serve/bridge-file-system-adapter.test.ts
+++ b/packages/cli/src/serve/bridge-file-system-adapter.test.ts
@@ -365,6 +365,28 @@ describe('createBridgeFileSystemAdapter', () => {
       });
       expect(response.content).toBe('x\ny\n');
     });
+
+    it('propagates parse_error for fractional positive limits', async () => {
+      const target = path.join(tmpDir, 'fractional-limit.txt');
+      await fsp.writeFile(target, 'x\ny\nz\n', 'utf8');
+      const adapter = createBridgeFileSystemAdapter(
+        buildFactory({ trusted: true }),
+      );
+
+      const err = await adapter
+        .readText({
+          path: target,
+          sessionId: 'sess:test',
+          line: 1,
+          limit: 1.5,
+        })
+        .catch((e: unknown) => e);
+
+      expect((err as { kind?: string }).kind).toBe('parse_error');
+      expect((err as Error).message).toContain(
+        'limit must be a positive integer',
+      );
+    });
   });
 
   describe('boundary enforcement', () => {

--- a/packages/cli/src/serve/bridge-file-system-adapter.test.ts
+++ b/packages/cli/src/serve/bridge-file-system-adapter.test.ts
@@ -366,7 +366,7 @@ describe('createBridgeFileSystemAdapter', () => {
       expect(response.content).toBe('x\ny\n');
     });
 
-    it('propagates parse_error for fractional positive limits', async () => {
+    it('readText surfaces workspace-file-system parse_error for fractional positive limits', async () => {
       const target = path.join(tmpDir, 'fractional-limit.txt');
       await fsp.writeFile(target, 'x\ny\nz\n', 'utf8');
       const adapter = createBridgeFileSystemAdapter(


### PR DESCRIPTION
## What this PR does

Rejects positive fractional `line` / `limit` values in the ACP `readTextFile` inline fallback before they reach manual line slicing.

This is intentionally scoped to the embedded/no-`BridgeFileSystem` fallback path. The normal stock `qwen serve` path already routes ACP file reads through `createBridgeFileSystemAdapter(...)` and `WorkspaceFileSystem.readText()`, which rejects malformed positive fractional windows as `parse_error`. This PR keeps an adapter regression test to document that existing production-path validation, and also maps ACP-wrapped `FsError('parse_error')` to JSON-RPC Invalid Params (`-32602`) so the injected and inline paths classify malformed read-window params consistently.

## Why it's needed

### What Problem This Solves

`readTextFile.line` and `readTextFile.limit` are discrete line-window controls. `line` selects a 1-based starting line and `limit` caps the maximum number of lines returned. Positive fractional values such as `1.5` do not have a meaningful line-window interpretation.

Before this change, the inline `BridgeClient.readTextFile()` fallback only handled non-positive `limit` values. A malformed positive fractional request could continue into manual slicing when no `BridgeFileSystem` was injected:

```ts
await client.readTextFile({
  path: 'lines.txt',
  sessionId: 'sess:test',
  line: 1,
  limit: 1.5,
});
```

A sibling malformed request with `line: 1.5` could also compute a fractional `start` before calling `sliceLineRange()`:

```ts
await client.readTextFile({
  path: 'lines.txt',
  sessionId: 'sess:test',
  line: 1.5,
  limit: 1,
});
```

The realistic application scope is narrow: custom or embedded ACP consumers that construct `@qwen-code/acp-bridge` / `createAcpSessionBridge(...)` without `BridgeOptions.fileSystem`, then accept raw ACP `readTextFile` params from a custom child. This is not a demonstrated stock-user `qwen serve` bug.

### Changes

```diff
 if (typeof params.limit === 'number' && params.limit <= 0) {
   return { content: '' };
 }
+if (
+  typeof params.limit === 'number' &&
+  params.limit > 0 &&
+  !Number.isSafeInteger(params.limit)
+) {
+  throw RequestError.invalidParams(
+    undefined,
+    `\`limit\` must be a positive integer, got ${params.limit}`,
+  );
+}
+if (
+  typeof params.line === 'number' &&
+  params.line > 0 &&
+  !Number.isSafeInteger(params.line)
+) {
+  throw RequestError.invalidParams(
+    undefined,
+    `\`line\` must be a positive integer, got ${params.line}`,
+  );
+}
```

The inline fallback now rejects positive non-safe-integer `line` / `limit` values before opening the file or entering manual line slicing. Existing non-positive `limit` behavior is preserved.

The ACP error wrapper now maps `FsError('parse_error')` to JSON-RPC Invalid Params (`-32602`) while still preserving `data.errorKind`, `data.status`, and `data.hint`. Other `FsError` kinds continue to use the existing internal-error wrapper.

The adapter test is intentionally named as existing-path coverage: it confirms that `createBridgeFileSystemAdapter()` -> `WorkspaceFileSystem.readText()` already rejects positive fractional `limit` values in the production injected filesystem path.

### Evidence

The new inline fallback tests cover both malformed values:

- `limit: 1.5` now fails with ACP invalid params before slicing.
- `line: 1.5` now fails with ACP invalid params before calculating a fractional start line.

The new FsError wrapping test confirms that adapter-path `parse_error` failures now use JSON-RPC `-32602` while preserving structured error data.

The serve adapter test covers the sibling production path and confirms its pre-existing behavior: `WorkspaceFileSystem.readText()` rejects `limit: 1.5` as `parse_error`.

Local validation:

```text
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
✓ src/bridgeClient.test.ts (61 tests)

npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
✓ src/serve/bridge-file-system-adapter.test.ts (19 tests)

npm --workspace packages/acp-bridge run typecheck
✓ tsc --noEmit

npm --workspace packages/cli run typecheck
✓ tsc --noEmit

git diff --check
✓ no whitespace errors
```

### Possible call chain / impact

Embedded fallback path changed by this PR:

```text
custom / embedded ACP host
  -> createAcpSessionBridge({ ..., fileSystem: undefined })
  -> BridgeClient constructed without BridgeFileSystem
  -> custom ACP child sends raw readTextFile params
  -> BridgeClient.readTextFile inline fallback
  -> line / limit validation
  -> sliceLineRange(content, start, end)
```

Stock `qwen serve` read-window validation remains owned by `WorkspaceFileSystem.readText()`:

```text
ACP readTextFile request
  -> BridgeClient.readTextFile()
  -> createBridgeFileSystemAdapter().readText()
  -> WorkspaceFileSystem.readText()
  -> existing parse_error for malformed numeric windows
  -> preserveFsErrorOverAcp()
  -> JSON-RPC Invalid Params (-32602) with errorKind: parse_error
```

This PR does not change non-positive `limit` handling, `WorkspaceFileSystem.readText()` validation, or lower-level `readTextRange()` slicing helpers.

## Reviewer Test Plan

### How to verify

A reviewer can verify this with the focused tests:

```powershell
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
npm --workspace packages/acp-bridge run typecheck
npm --workspace packages/cli run typecheck
```

The important behavior is that malformed positive fractional `line` / `limit` values no longer reach inline manual slicing when no `BridgeFileSystem` is injected. The serve adapter test documents the existing production-path `WorkspaceFileSystem` `parse_error` behavior, and the bridge client test confirms that ACP-wrapped `parse_error` now maps to Invalid Params.

### Evidence (Before & After)

Before: `BridgeClient.readTextFile()` only checked `limit <= 0`, so positive fractional `limit` or `line` values could flow into `sliceLineRange()` through the inline fallback.

After: `BridgeClient.readTextFile()` rejects positive non-safe-integer `line` / `limit` values before reading/slicing. The adapter-path test name now makes clear that it covers the existing `WorkspaceFileSystem.readText()` validation path, not the new inline guard. The ACP error wrapper also maps `parse_error` to `-32602`, aligning malformed read-window params with `RequestError.invalidParams()`.

Local validation on Windows:

```text
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
✓ src/bridgeClient.test.ts (61 tests)

npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
✓ src/serve/bridge-file-system-adapter.test.ts (19 tests)

npm --workspace packages/acp-bridge run typecheck
✓ tsc --noEmit

npm --workspace packages/cli run typecheck
✓ tsc --noEmit

git diff --check
✓ no whitespace errors
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Windows local validation used the repository npm workspace scripts.

## Risk & Scope

- Main risk or tradeoff: malformed positive fractional `line` / `limit` values now fail earlier in the ACP inline fallback instead of being interpreted by manual slicing.
- Application scope: this is embedded ACP fallback hardening for custom/no-`BridgeFileSystem` consumers. It is not a demonstrated stock-user `qwen serve` bug.
- Error-code scope: `FsError('parse_error')` now maps to JSON-RPC `-32602`; other `FsError` kinds keep the existing `-32603` behavior.
- Not changed: this PR does not change stock `qwen serve` validation, `WorkspaceFileSystem.readText()` behavior, non-positive `limit` behavior, or lower-level `readTextRange()` helpers.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 会在 ACP `readTextFile` 的 inline fallback 路径里提前拒绝正的小数 `line` / `limit`，避免它进入手写的行切片逻辑。

这个改动刻意限定在 embedded / no-`BridgeFileSystem` fallback 路径。正常 stock `qwen serve` 路径已经会通过 `createBridgeFileSystemAdapter(...)` 和 `WorkspaceFileSystem.readText()` 处理 ACP 文件读取，并将格式错误的正小数窗口拒绝为 `parse_error`。本 PR 保留 adapter 回归测试只是为了记录这个既有生产路径 validation；同时会把 ACP 包装后的 `FsError('parse_error')` 映射到 JSON-RPC Invalid Params (`-32602`)，让 injected path 和 inline path 对 malformed read-window params 的分类保持一致。

## Why it's needed

### What Problem This Solves

`readTextFile.line` 和 `readTextFile.limit` 都是离散的行窗口控制。`line` 表示 1-based 起始行，`limit` 表示最多返回多少行。像 `1.5` 这样的正小数没有合理的行窗口语义。

在这个改动之前，inline `BridgeClient.readTextFile()` fallback 只处理了非正数 `limit`。当没有注入 `BridgeFileSystem` 时，格式错误的正小数请求仍可能进入手写切片：

```ts
await client.readTextFile({
  path: 'lines.txt',
  sessionId: 'sess:test',
  line: 1,
  limit: 1.5,
});
```

同类的 `line: 1.5` 也会在调用 `sliceLineRange()` 前算出小数 `start`：

```ts
await client.readTextFile({
  path: 'lines.txt',
  sessionId: 'sess:test',
  line: 1.5,
  limit: 1,
});
```

真实应用范围很窄：自定义或 embedded ACP consumer 使用 `@qwen-code/acp-bridge` / `createAcpSessionBridge(...)`，但没有传入 `BridgeOptions.fileSystem`，并且接受自定义 child 发来的 raw ACP `readTextFile` 参数。这不是已经证明存在的 stock-user `qwen serve` bug。

### Changes

```diff
 if (typeof params.limit === 'number' && params.limit <= 0) {
   return { content: '' };
 }
+if (
+  typeof params.limit === 'number' &&
+  params.limit > 0 &&
+  !Number.isSafeInteger(params.limit)
+) {
+  throw RequestError.invalidParams(
+    undefined,
+    `\`limit\` must be a positive integer, got ${params.limit}`,
+  );
+}
+if (
+  typeof params.line === 'number' &&
+  params.line > 0 &&
+  !Number.isSafeInteger(params.line)
+) {
+  throw RequestError.invalidParams(
+    undefined,
+    `\`line\` must be a positive integer, got ${params.line}`,
+  );
+}
```

inline fallback 现在会在打开文件或进入手写行切片逻辑之前拒绝正数但非 safe integer 的 `line` / `limit`。现有非正数 `limit` 行为保持不变。

ACP error wrapper 现在会把 `FsError('parse_error')` 映射到 JSON-RPC Invalid Params (`-32602`)，同时继续保留 `data.errorKind`、`data.status` 和 `data.hint`。其他 `FsError` kind 继续沿用既有 internal-error wrapper。

adapter 测试也刻意改成既有路径覆盖：它确认 `createBridgeFileSystemAdapter()` -> `WorkspaceFileSystem.readText()` 在生产注入文件系统路径中本来就会拒绝正小数 `limit`。

### Evidence

新增 inline fallback 测试覆盖两类 malformed 值：

- `limit: 1.5` 现在会在切片前以 ACP invalid params 失败。
- `line: 1.5` 现在会在计算小数起始行前以 ACP invalid params 失败。

新增 FsError wrapping 测试确认 adapter-path `parse_error` failure 现在会使用 JSON-RPC `-32602`，并保留结构化 error data。

serve adapter 测试覆盖 sibling 生产路径，并确认其既有行为：`WorkspaceFileSystem.readText()` 会把 `limit: 1.5` 拒绝为 `parse_error`。

本地验证：

```text
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
✓ src/bridgeClient.test.ts (61 tests)

npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
✓ src/serve/bridge-file-system-adapter.test.ts (19 tests)

npm --workspace packages/acp-bridge run typecheck
✓ tsc --noEmit

npm --workspace packages/cli run typecheck
✓ tsc --noEmit

git diff --check
✓ no whitespace errors
```

### Possible call chain / impact

本 PR 修改的 embedded fallback 路径：

```text
custom / embedded ACP host
  -> createAcpSessionBridge({ ..., fileSystem: undefined })
  -> BridgeClient constructed without BridgeFileSystem
  -> custom ACP child sends raw readTextFile params
  -> BridgeClient.readTextFile inline fallback
  -> line / limit validation
  -> sliceLineRange(content, start, end)
```

stock `qwen serve` 的 read-window validation 仍由 `WorkspaceFileSystem.readText()` 负责：

```text
ACP readTextFile request
  -> BridgeClient.readTextFile()
  -> createBridgeFileSystemAdapter().readText()
  -> WorkspaceFileSystem.readText()
  -> existing parse_error for malformed numeric windows
  -> preserveFsErrorOverAcp()
  -> JSON-RPC Invalid Params (-32602) with errorKind: parse_error
```

本 PR 不改变非正数 `limit` 行为、不改变 `WorkspaceFileSystem.readText()` 校验，也不改动更底层的 `readTextRange()` 切片 helper。

## Reviewer Test Plan

### How to verify

Reviewer 可以通过聚焦测试验证：

```powershell
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
npm --workspace packages/acp-bridge run typecheck
npm --workspace packages/cli run typecheck
```

核心行为是：当没有注入 `BridgeFileSystem` 时，格式错误的正小数 `line` / `limit` 不再进入 inline 手写切片逻辑。serve adapter 测试则用于记录既有生产路径 `WorkspaceFileSystem` `parse_error` 行为；bridge client 测试确认 ACP 包装后的 `parse_error` 现在会映射到 Invalid Params。

### Evidence (Before & After)

Before：`BridgeClient.readTextFile()` 只检查 `limit <= 0`，所以正小数 `limit` 或 `line` 可以通过 inline fallback 进入 `sliceLineRange()`。

After：`BridgeClient.readTextFile()` 会在读文件/切片之前拒绝正的非 safe integer `line` / `limit`。adapter 路径测试名也已明确它覆盖的是既有 `WorkspaceFileSystem.readText()` validation 路径，而不是新的 inline guard。ACP error wrapper 也会把 `parse_error` 映射到 `-32602`，与 `RequestError.invalidParams()` 对 malformed read-window params 的分类保持一致。

Windows 本地验证：

```text
npm --workspace packages/acp-bridge run test -- bridgeClient.test.ts
✓ src/bridgeClient.test.ts (61 tests)

npm --workspace packages/cli run test -- src/serve/bridge-file-system-adapter.test.ts
✓ src/serve/bridge-file-system-adapter.test.ts (19 tests)

npm --workspace packages/acp-bridge run typecheck
✓ tsc --noEmit

npm --workspace packages/cli run typecheck
✓ tsc --noEmit

git diff --check
✓ no whitespace errors
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested locally |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Windows 本地验证使用仓库 npm workspace scripts。

## Risk & Scope

- Main risk or tradeoff: malformed 的正小数 `line` / `limit` 现在会在 ACP inline fallback 中更早失败，而不是被手写切片逻辑解释。
- Application scope: 这是针对 custom/no-`BridgeFileSystem` consumer 的 embedded ACP fallback hardening，不是已经证明存在的 stock-user `qwen serve` bug。
- Error-code scope: `FsError('parse_error')` 现在映射到 JSON-RPC `-32602`；其他 `FsError` kind 继续沿用既有 `-32603` 行为。
- Not changed: 本 PR 不改变 stock `qwen serve` validation、不改变 `WorkspaceFileSystem.readText()` 行为、不改变非正数 `limit` 行为，也不改变底层 `readTextRange()` helper。

## Linked Issues

N/A

</details>