### PR TITLE
ci(review): default review timeout to 180 minutes, allow up to 240

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -40,7 +40,7 @@ on:
       timeout_minutes:
         description: 'Review timeout in minutes'
         required: false
-        default: '120'
+        default: '180'
         type: 'number'
       dry_run:
         description: 'Run /resolve without pushing'
@@ -398,14 +398,14 @@ jobs:
           TRIGGER_BODY: "${{ github.event.comment.body || github.event.review.body || '' }}"
         run: |-
           set -euo pipefail
-          DEFAULT_TIMEOUT_MINUTES=120
+          DEFAULT_TIMEOUT_MINUTES=180
           TIMEOUT_MINUTES="$DEFAULT_TIMEOUT_MINUTES"
           TRIGGER_COMMAND="${TRIGGER_BODY%%$'\n'*}"
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
             REVIEW_MODE="${{ github.event.inputs.review_mode }}"
-            TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '120' }}"
+            TIMEOUT_MINUTES="${{ github.event.inputs.timeout_minutes || '180' }}"
           elif [ "${{ github.event_name }}" = "issue_comment" ]; then
             if ! printf '%s\n' "$TRIGGER_COMMAND" | grep -Eq '^@qwen-code[[:space:]]+/review([[:space:]]|$)'; then
               echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -347,7 +347,7 @@ jobs:
          startsWith(github.event.review.body, '@qwen-code /review ') ||
          startsWith(github.event.review.body, format('@qwen-code /review{0}', '\n'))) &&
         needs.authorize.outputs.should_review == 'true'))
-    timeout-minutes: 200
+    timeout-minutes: 260
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
@@ -684,8 +684,8 @@ jobs:
           if [ "$TIMEOUT_MINUTES" -le 5 ]; then
             fail "timeout_minutes must be greater than 5"
           fi
-          if [ "$TIMEOUT_MINUTES" -gt 180 ]; then
-            fail "timeout_minutes must not exceed 180 minutes"
+          if [ "$TIMEOUT_MINUTES" -gt 240 ]; then
+            fail "timeout_minutes must not exceed 240 minutes"
           fi
 
           if ! PR_DATA="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefOid --jq '[.state, .headRefOid] | @tsv')"; then
@@ -802,10 +802,10 @@ jobs:
             exit 0
           fi
           if [ "$FAILURE_KIND" = "timeout" ]; then
-            if [ "$TIMEOUT_MINUTES" -lt 180 ]; then
-              body="**Qwen Code review timed out.** ${FAILURE_REASON} For large PRs, retry with a longer timeout by commenting: \`@qwen-code /review --timeout=180\`. See [workflow logs](${RUN_URL})."
+            if [ "$TIMEOUT_MINUTES" -lt 240 ]; then
+              body="**Qwen Code review timed out.** ${FAILURE_REASON} For large PRs, retry with a longer timeout by commenting: \`@qwen-code /review --timeout=240\`. See [workflow logs](${RUN_URL})."
             else
-              body="**Qwen Code review timed out.** ${FAILURE_REASON} This run already used the maximum 180 minute timeout. See [workflow logs](${RUN_URL})."
+              body="**Qwen Code review timed out.** ${FAILURE_REASON} This run already used the maximum 240 minute timeout. See [workflow logs](${RUN_URL})."
             fi
           else
             body="**Qwen Code review did not complete successfully.** ${FAILURE_REASON} See [workflow logs](${RUN_URL})."


### PR DESCRIPTION
## What this PR does

Raises the default timeout for the automated PR review workflow from 120 minutes to 180 minutes, and raises the maximum allowed override from 180 to 240 minutes so `@qwen-code /review --timeout=240` becomes available for the largest PRs. All three places that establish the default move together: the `workflow_dispatch` input default, the script-level default used by lifecycle and comment triggers, and the dispatch fallback value. The timeout-cap validation and the timeout fallback comment now reference 240, and the job-level timeout grows from 200 to 260 minutes to keep the same headroom (max review time plus setup and fallback-comment posting) established in #5961.

## Why it's needed

Large PRs routinely exceed the 120-minute default and fail with a timeout comment asking the author to retry with a longer timeout (see the timeout on #6680). Since retrying at the previous 180-minute maximum was the standard remedy, defaulting to it removes a predictable failure-and-retry round trip. Raising the cap to 240 keeps an escalation path available for reviews that exceed the new default instead of leaving the default and the ceiling at the same value.

## Reviewer Test Plan

### How to verify

1. Confirm the default is established consistently: the dispatch input default, `DEFAULT_TIMEOUT_MINUTES`, and the dispatch fallback all read 180.
2. Confirm the override ceiling: the validation rejects values above 240, and `--timeout=240` passes validation.
3. Confirm the timeout fallback comment degrades correctly: a run timing out below 240 minutes suggests retrying with `--timeout=240`, while a run that already used 240 states the maximum was reached.
4. Confirm the job-level budget: the review job allows 260 minutes, preserving the ~20-minute headroom over the maximum review duration for checkout, CLI install, and fallback-comment posting.

### Evidence (Before & After)

N/A — CI workflow configuration change, no TUI surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

N/A — YAML-only change, validated by parsing the workflow file.

## Risk & Scope

- Main risk or tradeoff: reviews that would previously fail at 120 minutes now hold a runner for up to 60 additional minutes by default, and an explicit `--timeout=240` can hold a self-hosted runner slot for up to 4 hours plus headroom; genuinely hung reviews occupy the slot longer before the fallback comment posts.
- Not validated / out of scope: no change to the `--timeout=` override syntax, trigger authorization, or the resolve job.
- Breaking changes / migration notes: none.

## Linked Issues

N/A (motivated by the review timeout on #6680)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将自动 PR review 工作流的缺省超时从 120 分钟提高到 180 分钟,并把允许的最大覆盖值从 180 提高到 240 分钟,使超大 PR 可以使用 `@qwen-code /review --timeout=240`。三处缺省值同步修改:`workflow_dispatch` 输入的默认值、lifecycle 与评论触发使用的脚本级默认值,以及 dispatch 的回退值。超时上限校验和超时回退评论现在引用 240;job 级超时从 200 提高到 260 分钟,以保持 #5961 中确立的余量设计(最大 review 时长加环境准备与回退评论开销)。

## 为什么需要

大型 PR 经常超过 120 分钟的缺省值,失败后机器人会留言要求作者用更长超时重试(见 #6680 上的超时)。既然按之前 180 分钟最大值重试就是标准处理方式,直接把缺省值设为 180 可以消除一次可预期的"失败-重试"往返。把上限提高到 240 则为超过新缺省值的 review 保留了升级手段,避免缺省值与上限相同而无路可退。

## Reviewer 测试计划

### 如何验证

1. 确认缺省值一致:dispatch 输入默认值、`DEFAULT_TIMEOUT_MINUTES` 和 dispatch 回退值均为 180。
2. 确认覆盖上限:校验拒绝超过 240 的值,`--timeout=240` 可通过校验。
3. 确认超时回退评论正确降级:低于 240 分钟超时的运行会建议用 `--timeout=240` 重试;已使用 240 的运行会提示已达最大值。
4. 确认 job 级预算:review job 允许 260 分钟,在最大 review 时长之上保留约 20 分钟余量用于 checkout、CLI 安装和回退评论。

### 前后证据

N/A——CI 工作流配置变更,无 TUI 界面。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境(可选)

N/A——仅 YAML 变更,已通过解析工作流文件验证。

## 风险与范围

- 主要风险或取舍:原本在 120 分钟失败的 review 现在缺省最多多占用 runner 60 分钟;显式 `--timeout=240` 会让 self-hosted runner 槽位被占用最长 4 小时加余量;真正卡死的 review 在回退评论发出前占用时间更久。
- 未验证 / 不在范围内:不改变 `--timeout=` 覆盖语法、触发授权或 resolve job。
- Breaking changes / 迁移说明:无。

## 关联 Issue

N/A(由 #6680 上的 review 超时引发)

</details>
