### PR TITLE
fix(cli): Scope session organization mutations by workspace

### DIFF
--- a/docs/design/daemon-multi-workspace-session-organization-mutations.md
+++ b/docs/design/daemon-multi-workspace-session-organization-mutations.md
@@ -1,0 +1,137 @@
+# Multi-workspace session organization mutations
+
+## Summary
+
+Add `PATCH /workspaces/:workspace/session/:id/organization` as a
+workspace-qualified session organization mutation.
+
+The route applies pin, group, and color changes to the session organization
+store owned by the selected workspace. It extends the existing plural REST
+surface without changing capabilities, request or response schemas, ACP, or UI
+behavior.
+
+## Problem
+
+Workspace-qualified session reads already target the selected workspace.
+`GET /workspaces/:workspace/sessions` can return persisted, archived, and live
+sessions from a trusted non-primary runtime and can apply organized views and
+group filters against that runtime's organization store.
+
+The only organization mutation today is
+`PATCH /session/:id/organization`. That legacy route is primary-workspace-only.
+Consequently, a client can read organization state for a secondary workspace
+but cannot update it through the matching workspace-qualified REST surface.
+
+## Decision
+
+Register `PATCH /workspaces/:workspace/session/:id/organization` beside the
+other workspace-qualified session storage routes.
+
+The `:workspace` selector resolves exactly like the existing plural routes:
+
+1. Match an exact registered workspace id.
+2. Otherwise decode and canonicalize an absolute cwd selector.
+3. Return the existing unknown-workspace error if neither resolves.
+
+The selected runtime is the complete scope of the operation. Session lookup,
+group validation, organization mutation, and persistence all use that
+runtime's workspace cwd and stores. The handler never falls back to the primary
+runtime or searches another registered workspace.
+
+## Data flow
+
+1. The request passes the daemon's normal host, bearer, and JSON middleware.
+2. The plural route resolves `:workspace` to one registered runtime.
+3. The plural mutation trust gate requires that runtime to be trusted.
+4. The target runtime checks for `:id` in its active persisted store, archived
+   persisted store, or live bridge.
+5. The request body passes the existing organization request validation.
+6. If `groupId` is present and non-null, the target runtime's group store
+   validates that group.
+7. The target runtime's organization store applies `isPinned`, `groupId`, and
+   `color` with the existing semantics.
+8. The route returns the same organization response as the legacy mutation.
+
+Persisted active sessions, persisted archived sessions, and matching live-only
+sessions are valid targets. Organization remains sidecar state: the mutation
+does not rewrite transcript JSONL or change transcript modification time.
+
+## Trust and error order
+
+Plural route conventions determine the observable order:
+
+1. An unknown workspace selector returns the existing
+   `400 { code: "workspace_mismatch" }` response.
+2. A known but untrusted workspace returns
+   `403 { code: "untrusted_workspace" }` before session or group existence is
+   disclosed.
+3. A session absent from the selected runtime's active, archived, and live
+   sets returns the existing session-not-found `404`.
+4. Invalid organization update fields return the existing organization
+   validation error after the trusted target session has been found.
+5. A non-null group id absent from the selected runtime's group store returns
+   `404 { code: "group_not_found" }`.
+6. An unreadable organization sidecar returns
+   `500 { code: "session_organization_store_unreadable" }`.
+
+Archive and delete conflicts retain the existing archive coordinator errors.
+
+There is no cross-workspace fallback at any error stage. A session or group
+that exists only in the primary workspace remains unknown when a secondary
+workspace is selected, and vice versa.
+
+## Legacy compatibility
+
+`PATCH /session/:id/organization` retains its current primary-only behavior,
+including its mutation gate, validation, lookup, persistence, error shapes,
+and response schema. Existing clients therefore keep the same routing and
+duplicate-id behavior.
+
+Clients use the plural mutation only after both `session_organization` and
+`workspace_qualified_rest_core` are advertised. No new capability tag is
+introduced.
+
+## ACP behavior
+
+ACP dispatch does not change. The qualified dispatcher already operates on
+`rt.bridge` and `rt.workspaceCwd`, so workspace-qualified ACP session actions
+are already bound to the selected runtime. This change is limited to the REST
+organization mutation that was missing from the plural surface.
+
+## Concurrency and store locks
+
+`SessionOrganizationService` uses its existing per-sidecar lock only to
+serialize group and session-organization read-modify-write operations against
+that same sidecar. The existing archive coordinator coordinates organization
+updates with archive and delete transitions. This route adds no daemon-wide
+lock and no new cross-service transaction or atomicity guarantee.
+
+## Testing and acceptance
+
+The automated tests and real E2E acceptance strategy together cover:
+
+- Workspace id and URL-encoded canonical cwd selectors reach the same runtime.
+- A trusted secondary workspace can mutate organization for active persisted,
+  archived persisted, and live-only sessions.
+- Pinning, grouping, ungrouping, and supported color or `null` updates return
+  the existing response shape.
+- Organized lists and pinned/group filters reflect the mutation.
+- Organization state survives daemon restart for persisted sessions.
+- A secondary mutation does not modify the primary workspace's organization
+  state.
+- The legacy route remains primary-only and returns `404` for a session that
+  exists only in a secondary workspace.
+- Known untrusted workspaces return `403` before session or group lookup.
+- Unknown selectors, unknown target-scoped sessions, and unknown target-scoped
+  groups return their existing errors without cross-workspace fallback.
+
+Acceptance also includes build, typecheck, focused route and SDK tests, and an
+E2E pass covering two trusted workspaces plus negative trust and selector
+cases.
+
+## Explicit non-goals
+
+This change introduces no capability tag or capability payload change, no
+request or response schema change, no ACP behavior change, and no UI change.
+It does not make the legacy route multi-workspace-aware, add cross-workspace
+session discovery, or change archive, list, group, or transcript semantics.

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -207,7 +207,7 @@ registry. Clients **must** gate UI off `features`, not off `mode` (per design
 
 `session_close` and `session_metadata` advertise `DELETE /session/:id` and `PATCH /session/:id/metadata`. Older daemons return `404`; pre-flight these tags before exposing close or rename affordances.
 
-`session_organization` advertises custom session groups and pinning. It adds `GET/POST/PATCH/DELETE /workspace/:id/session-groups`, `PATCH /session/:id/organization`, and the opt-in organized list view `GET /workspace/:id/sessions?view=organized`. Older daemons return `404` for the mutation/group routes and ignore the organized view contract, so WebShell/SDK clients must pre-flight this tag before showing grouping or pinning UI.
+`session_organization` advertises custom session groups and pinning. It adds `GET/POST/PATCH/DELETE /workspace/:id/session-groups`, `PATCH /session/:id/organization`, and the opt-in organized list view `GET /workspace/:id/sessions?view=organized`. When both `session_organization` and `workspace_qualified_rest_core` are advertised, the workspace-qualified organization mutation `PATCH /workspaces/:workspace/session/:id/organization` is also available. The legacy mutation remains primary-workspace-only. Older daemons return `404` for the mutation/group routes and ignore the organized view contract, so WebShell/SDK clients must pre-flight these tags before showing the matching grouping or pinning UI.
 
 `session_archive` advertises the v1 directory-state archive API: `POST /sessions/archive`, `POST /sessions/unarchive`, and `GET /workspace/:id/sessions?archiveState=active|archived`. Archived sessions cannot be loaded or resumed until they are unarchived.
 
@@ -1401,7 +1401,7 @@ curl http://127.0.0.1:4170/workspace/$(jq -rn --arg c "$PWD" '$c|@uri')/sessions
 curl http://127.0.0.1:4170/workspaces/<workspace-id>/sessions
 ```
 
-When `workspace_qualified_rest_core` is advertised, workspace-scoped session batch operations and group CRUD are available under `/workspaces/:workspace/sessions/{delete,archive,unarchive}` and `/workspaces/:workspace/session-groups`. Workspace-less batch routes remain primary-workspace-only for compatibility.
+When `workspace_qualified_rest_core` is advertised, workspace-scoped session batch operations, group CRUD, and session organization mutation are available under `/workspaces/:workspace/sessions/{delete,archive,unarchive}`, `/workspaces/:workspace/session-groups`, and `/workspaces/:workspace/session/:id/organization`. Workspace-less batch and organization mutation routes remain primary-workspace-only for compatibility.
 
 Query parameters:
 
@@ -1662,9 +1662,9 @@ Response:
 
 Publishes a `session_metadata_updated` event on the session's SSE stream with `{ sessionId, displayName }`.
 
-### `PATCH /session/:id/organization`
+### `PATCH /session/:id/organization` and `PATCH /workspaces/:workspace/session/:id/organization`
 
-Update local session organization state. Strict mutation gate. Pre-flight `caps.features.includes('session_organization')`.
+Update local session organization state through the existing mutation gate. Pre-flight `caps.features.includes('session_organization')`; the plural route additionally requires `workspace_qualified_rest_core`. On the plural route, `:workspace` resolves as an exact registered workspace id first and then as a URL-encoded canonical absolute cwd. The selected runtime must be trusted. Session existence and non-null `groupId` validation are scoped to that runtime's active persisted, archived persisted, and live session state and group store, with no fallback to the primary or another workspace. The legacy route remains primary-workspace-only.
 
 Request:
 
@@ -1676,6 +1676,7 @@ Request:
 | ---------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | `isPinned` | no       | Boolean. `true` sets `pinnedAt` if it was not already pinned; `false` clears `pinnedAt`.             |
 | `groupId`  | no       | Custom group id or `null` for ungrouped. Unknown group ids return `404 { code: "group_not_found" }`. |
+| `color`    | no       | A supported session color token, or `null` to clear the session color.                               |
 
 Response:
 
@@ -1683,6 +1684,7 @@ Response:
 {
   "sessionId": "<uuid>",
   "groupId": "018f...",
+  "color": "blue",
   "isPinned": true,
   "pinnedAt": "2026-07-04T12:00:00.000Z",
   "updatedAt": "2026-07-04T12:00:00.000Z"

--- a/packages/cli/src/serve/acp-http/workspace-qualified-acp.test.ts
+++ b/packages/cli/src/serve/acp-http/workspace-qualified-acp.test.ts
@@ -6,10 +6,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
+import { promises as fsp } from 'node:fs';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import WebSocket from 'ws';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
+import { Storage } from '@qwen-code/qwen-code-core';
 import { type AcpHttpHandle, mountAcpHttp } from './index.js';
 import { DeviceFlowRegistry } from '../auth/device-flow.js';
 import { CdpTunnelRegistry } from '../cdp-tunnel/cdp-tunnel-registry.js';
@@ -23,6 +27,7 @@ import { WorkspaceRememberTaskLane } from '../workspace-remember.js';
 import type { WorkspaceFileSystemFactory } from '../fs/index.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
+import { createSessionOrganizationService } from '../session-organization-helpers.js';
 
 vi.mock('../../utils/stdioHelpers.js', () => ({ writeStderrLine: vi.fn() }));
 
@@ -70,6 +75,42 @@ const INITIALIZE = JSON.stringify({
   id: 1,
   method: 'initialize',
 });
+
+async function writeStoredSession(sessionId: string, cwd: string) {
+  const chatsDir = path.join(new Storage(cwd).getProjectDir(), 'chats');
+  await fsp.mkdir(chatsDir, { recursive: true });
+  await fsp.writeFile(
+    path.join(chatsDir, `${sessionId}.jsonl`),
+    `${JSON.stringify({
+      uuid: `${sessionId}-user-1`,
+      parentUuid: null,
+      sessionId,
+      timestamp: '2026-07-11T00:00:00.000Z',
+      type: 'user',
+      message: { role: 'user', parts: [{ text: 'secondary session' }] },
+      cwd,
+    })}\n`,
+    'utf8',
+  );
+}
+
+async function withRuntimeDir<T>(fn: () => Promise<T>): Promise<T> {
+  const previousRuntimeDir = process.env['QWEN_RUNTIME_DIR'];
+  const runtimeDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), 'qwen-workspace-qualified-acp-'),
+  );
+  process.env['QWEN_RUNTIME_DIR'] = runtimeDir;
+  try {
+    return await fn();
+  } finally {
+    if (previousRuntimeDir === undefined) {
+      delete process.env['QWEN_RUNTIME_DIR'];
+    } else {
+      process.env['QWEN_RUNTIME_DIR'] = previousRuntimeDir;
+    }
+    await fsp.rm(runtimeDir, { recursive: true, force: true });
+  }
+}
 
 describe('workspace-qualified ACP (/workspaces/:workspace/acp)', () => {
   let server: Server;
@@ -337,6 +378,48 @@ describe('workspace-qualified ACP (/workspaces/:workspace/acp)', () => {
     });
 
     expect(response['error']).toMatchObject({ code: -32602 });
+  });
+
+  it('updates persisted organization in the selected workspace only', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440180';
+      await writeStoredSession(sessionId, '/ws-b');
+
+      const response = await sendWsRequest('/workspaces/secondary-id/acp', {
+        jsonrpc: '2.0',
+        id: 2,
+        method: '_qwen/session/update_organization',
+        params: { sessionId, isPinned: true },
+      });
+
+      expect(response['result']).toMatchObject({ sessionId, isPinned: true });
+      const listed = await sendWsRequest('/workspaces/secondary-id/acp', {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'session/list',
+        params: { view: 'organized', group: 'pinned' },
+      });
+      expect(listed['result']).toMatchObject({
+        sessions: [expect.objectContaining({ sessionId, isPinned: true })],
+      });
+
+      const legacy = await sendWsRequest('/acp', {
+        jsonrpc: '2.0',
+        id: 4,
+        method: '_qwen/session/update_organization',
+        params: { sessionId, isPinned: false },
+      });
+      expect(legacy['error']).toMatchObject({ code: -32602 });
+
+      const secondarySnapshot =
+        await createSessionOrganizationService('/ws-b').readSnapshot();
+      const primarySnapshot =
+        await createSessionOrganizationService('/ws').readSnapshot();
+      expect(secondarySnapshot.sessions.get(sessionId)).toMatchObject({
+        isPinned: true,
+      });
+      expect(primarySnapshot.sessions.has(sessionId)).toBe(false);
+    });
   });
 
   it('rejects an untrusted workspace with 403 untrusted_workspace', async () => {

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -1233,7 +1233,7 @@ describe('multi-workspace session dispatch', () => {
     );
   });
 
-  it('updates a persisted secondary session organization without touching the primary sidecar', async () => {
+  it('updates a persisted secondary session by encoded cwd without touching the primary sidecar', async () => {
     await withRuntimeDir(async () => {
       const sessionId = '550e8400-e29b-41d4-a716-446655440160';
       await writeStoredSession({
@@ -1252,7 +1252,9 @@ describe('multi-workspace session dispatch', () => {
       const groupId = createdGroup.body.group.id as string;
 
       const updated = await request(app)
-        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .patch(
+          `/workspaces/${encodeURIComponent(SECONDARY_CWD)}/session/${sessionId}/organization`,
+        )
         .set('Host', host())
         .send({ isPinned: true, groupId });
       expect(updated.status).toBe(200);

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -1303,14 +1303,36 @@ describe('multi-workspace session dispatch', () => {
         expect.objectContaining({ sessionId, groupId, color: 'purple' }),
       ]);
 
+      const ungrouped = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ groupId: null })
+        .expect(200);
+      expect(ungrouped.body).toMatchObject({
+        sessionId,
+        groupId: null,
+        color: 'purple',
+      });
+
+      const clearedColor = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ color: null })
+        .expect(200);
+      expect(clearedColor.body).toMatchObject({
+        sessionId,
+        groupId: null,
+        color: null,
+      });
+
       const secondarySnapshot =
         await createSessionOrganizationService(SECONDARY_CWD).readSnapshot();
       const primarySnapshot =
         await createSessionOrganizationService(PRIMARY_CWD).readSnapshot();
       expect(secondarySnapshot.sessions.get(sessionId)).toMatchObject({
         isPinned: true,
-        groupId,
-        color: 'purple',
+        groupId: null,
+        color: null,
       });
       expect(primarySnapshot.sessions.has(sessionId)).toBe(false);
     });

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -68,6 +68,7 @@ interface FakeBridge extends AcpSessionBridge {
     req: BridgeRestoreSessionRequest;
   }>;
   readonly listCalls: string[];
+  readonly summaryCalls: string[];
 }
 
 function makeSummary(
@@ -148,6 +149,7 @@ function makeBridge(
   const removePendingPromptCalls: FakeBridge['removePendingPromptCalls'] = [];
   const restoreCalls: FakeBridge['restoreCalls'] = [];
   const listCalls: string[] = [];
+  const summaryCalls: string[] = [];
   const bridge = {
     permissionPolicy: 'first-responder' as const,
     spawnCalls,
@@ -162,6 +164,7 @@ function makeBridge(
     removePendingPromptCalls,
     restoreCalls,
     listCalls,
+    summaryCalls,
     get sessionCount() {
       return live.size;
     },
@@ -240,6 +243,7 @@ function makeBridge(
       );
     },
     getSessionSummary(sessionId: string) {
+      summaryCalls.push(sessionId);
       const summary = live.get(sessionId);
       if (!summary) throw new SessionNotFoundError(sessionId);
       return summary;
@@ -1227,6 +1231,303 @@ describe('multi-workspace session dispatch', () => {
         workspaceCwd: PRIMARY_CWD,
       }),
     );
+  });
+
+  it('updates a persisted secondary session organization without touching the primary sidecar', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440160';
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:30:00.000Z',
+        prompt: 'secondary pin target',
+        mtime: new Date('2026-07-08T00:30:00.000Z'),
+      });
+      const { app } = makeHarness({ secondarySummaries: [] });
+      const createdGroup = await request(app)
+        .post('/workspaces/secondary-id/session-groups')
+        .set('Host', host())
+        .send({ name: 'Secondary Work', color: 'blue' })
+        .expect(201);
+      const groupId = createdGroup.body.group.id as string;
+
+      const updated = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: true, groupId });
+      expect(updated.status).toBe(200);
+      expect(updated.body).toMatchObject({
+        sessionId,
+        isPinned: true,
+        groupId,
+      });
+
+      const pinned = await request(app)
+        .get('/workspaces/secondary-id/sessions?view=organized&group=pinned')
+        .set('Host', host())
+        .expect(200);
+      expect(pinned.body.sessions).toEqual([
+        expect.objectContaining({
+          sessionId,
+          isPinned: true,
+          groupId,
+        }),
+      ]);
+
+      const grouped = await request(app)
+        .get(
+          `/workspaces/secondary-id/sessions?view=organized&group=${encodeURIComponent(groupId)}`,
+        )
+        .set('Host', host())
+        .expect(200);
+      expect(grouped.body.sessions).toEqual([
+        expect.objectContaining({ sessionId, groupId }),
+      ]);
+
+      const colored = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ color: 'purple' });
+      expect(colored.status).toBe(200);
+      expect(colored.body).toMatchObject({
+        sessionId,
+        groupId,
+        color: 'purple',
+      });
+
+      const organized = await request(app)
+        .get('/workspaces/secondary-id/sessions?view=organized&group=all')
+        .set('Host', host())
+        .expect(200);
+      expect(organized.body.sessions).toEqual([
+        expect.objectContaining({ sessionId, groupId, color: 'purple' }),
+      ]);
+
+      const secondarySnapshot =
+        await createSessionOrganizationService(SECONDARY_CWD).readSnapshot();
+      const primarySnapshot =
+        await createSessionOrganizationService(PRIMARY_CWD).readSnapshot();
+      expect(secondarySnapshot.sessions.get(sessionId)).toMatchObject({
+        isPinned: true,
+        groupId,
+        color: 'purple',
+      });
+      expect(primarySnapshot.sessions.has(sessionId)).toBe(false);
+    });
+  });
+
+  it('updates a live-only secondary session organization through the target bridge fallback', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440161';
+      const missingSessionId = '550e8400-e29b-41d4-a716-446655440163';
+      const { app } = makeHarness({
+        secondarySummaries: [makeSummary(sessionId, SECONDARY_CWD)],
+      });
+
+      const missing = await request(app)
+        .patch(
+          `/workspaces/secondary-id/session/${missingSessionId}/organization`,
+        )
+        .set('Host', host())
+        .send({ isPinned: 'yes' });
+      expect(missing.status).toBe(404);
+      expect(missing.body).toEqual({
+        error: `No session with id "${missingSessionId}"`,
+        sessionId: missingSessionId,
+      });
+
+      const updated = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: true });
+      expect(updated.status).toBe(200);
+
+      const pinned = await request(app)
+        .get('/workspaces/secondary-id/sessions?view=organized&group=pinned')
+        .set('Host', host())
+        .expect(200);
+      expect(pinned.body.sessions).toEqual([
+        expect.objectContaining({
+          sessionId,
+          workspaceCwd: SECONDARY_CWD,
+          isPinned: true,
+        }),
+      ]);
+    });
+  });
+
+  it('rejects organization updates for an untrusted secondary workspace', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440162';
+      const { app, secondaryBridge } = makeHarness({
+        secondaryTrusted: false,
+        secondarySummaries: [makeSummary(sessionId, SECONDARY_CWD)],
+      });
+
+      const res = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: 'yes' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('untrusted_workspace');
+      const secondarySnapshot =
+        await createSessionOrganizationService(SECONDARY_CWD).readSnapshot();
+      expect(secondarySnapshot.sessions.has(sessionId)).toBe(false);
+      expect(secondaryBridge.summaryCalls).toEqual([]);
+    });
+  });
+
+  it('updates an archived secondary session without changing its archive state', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440164';
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:40:00.000Z',
+        prompt: 'secondary archived organization target',
+        mtime: new Date('2026-07-08T00:40:00.000Z'),
+      });
+      const { app } = makeHarness({ secondarySummaries: [] });
+
+      await request(app)
+        .post('/workspaces/secondary-id/sessions/archive')
+        .set('Host', host())
+        .send({ sessionIds: [sessionId] })
+        .expect(200);
+
+      const updated = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: true, color: 'green' })
+        .expect(200);
+      expect(updated.body).toMatchObject({
+        sessionId,
+        isPinned: true,
+        color: 'green',
+      });
+
+      const archived = await request(app)
+        .get(
+          '/workspaces/secondary-id/sessions?view=organized&archiveState=archived&group=pinned',
+        )
+        .set('Host', host())
+        .expect(200);
+      expect(archived.body.sessions).toEqual([
+        expect.objectContaining({
+          sessionId,
+          isArchived: true,
+          isPinned: true,
+          color: 'green',
+        }),
+      ]);
+    });
+  });
+
+  it('does not fall back across workspaces for organization updates', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440165';
+      await writeStoredSession({
+        sessionId,
+        cwd: PRIMARY_CWD,
+        timestamp: '2026-07-08T00:50:00.000Z',
+        prompt: 'primary-only organization target',
+        mtime: new Date('2026-07-08T00:50:00.000Z'),
+      });
+      const { app, primaryBridge, secondaryBridge } = makeHarness({
+        secondarySummaries: [],
+      });
+
+      const res = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: true });
+
+      expect(res.status).toBe(404);
+      expect(primaryBridge.summaryCalls).toEqual([]);
+      expect(secondaryBridge.summaryCalls).toEqual([sessionId]);
+      const primarySnapshot =
+        await createSessionOrganizationService(PRIMARY_CWD).readSnapshot();
+      const secondarySnapshot =
+        await createSessionOrganizationService(SECONDARY_CWD).readSnapshot();
+      expect(primarySnapshot.sessions.has(sessionId)).toBe(false);
+      expect(secondarySnapshot.sessions.has(sessionId)).toBe(false);
+    });
+  });
+
+  it('rejects an unknown organization workspace selector before probing bridges', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness();
+
+    const res = await request(app)
+      .patch(
+        '/workspaces/missing-id/session/550e8400-e29b-41d4-a716-446655440166/organization',
+      )
+      .set('Host', host())
+      .send({ isPinned: 'yes' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('workspace_mismatch');
+    expect(primaryBridge.summaryCalls).toEqual([]);
+    expect(secondaryBridge.summaryCalls).toEqual([]);
+  });
+
+  it('keeps organization validation and store errors scoped to the selected workspace', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440167';
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T01:00:00.000Z',
+        prompt: 'secondary validation target',
+        mtime: new Date('2026-07-08T01:00:00.000Z'),
+      });
+      const { app } = makeHarness({ secondarySummaries: [] });
+      const primaryGroup = await request(app)
+        .post('/workspaces/primary-id/session-groups')
+        .set('Host', host())
+        .send({ name: 'Primary Only', color: 'orange' })
+        .expect(201);
+      const primaryGroupId = primaryGroup.body.group.id as string;
+
+      const wrongGroup = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ groupId: primaryGroupId });
+      expect(wrongGroup.status).toBe(404);
+      expect(wrongGroup.body.code).toBe('group_not_found');
+
+      const invalid = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ isPinned: 'yes' });
+      expect(invalid.status).toBe(400);
+      expect(invalid.body.code).toBe('invalid_session_organization');
+
+      const empty = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({});
+      expect(empty.status).toBe(200);
+      expect(empty.body).toMatchObject({ sessionId, isPinned: false });
+
+      const secondaryService = createSessionOrganizationService(SECONDARY_CWD);
+      await fsp.mkdir(path.dirname(secondaryService.getStorePath()), {
+        recursive: true,
+      });
+      await fsp.writeFile(secondaryService.getStorePath(), '{broken', 'utf8');
+      const unreadable = await request(app)
+        .patch(`/workspaces/secondary-id/session/${sessionId}/organization`)
+        .set('Host', host())
+        .send({ color: 'red' });
+      expect(unreadable.status).toBe(500);
+      expect(unreadable.body.code).toBe(
+        'session_organization_store_unreadable',
+      );
+
+      const primarySnapshot =
+        await createSessionOrganizationService(PRIMARY_CWD).readSnapshot();
+      expect(primarySnapshot.sessions.has(sessionId)).toBe(false);
+    });
   });
 
   it('routes plural batch archive, unarchive, and delete to the selected workspace', async () => {

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1970,19 +1970,29 @@ export function registerSessionRoutes(
     }),
   );
 
-  app.patch('/session/:id/organization', mutate(), async (req, res) => {
+  type SessionOrganizationTarget = {
+    workspaceCwd: string;
+    bridge: AcpSessionBridge;
+    route: string;
+  };
+
+  const handleSessionOrganizationUpdate = async (
+    req: Request,
+    res: Response,
+    target: SessionOrganizationTarget,
+  ): Promise<void> => {
     const sessionId = requireSessionId(req, res);
     if (sessionId === null) return;
     try {
       await archiveCoordinator.runSharedMany([sessionId], async () => {
         // Organization is workspace-scoped sidecar state, not live-session
         // metadata. It intentionally applies to persisted and archived sessions.
-        const sessionService = new SessionService(boundWorkspace);
+        const sessionService = new SessionService(target.workspaceCwd);
         let exists = await sessionService.sessionExistsInAnyState(sessionId);
         if (!exists) {
           try {
-            const summary = bridge.getSessionSummary(sessionId);
-            exists = summary.workspaceCwd === boundWorkspace;
+            const summary = target.bridge.getSessionSummary(sessionId);
+            exists = summary.workspaceCwd === target.workspaceCwd;
           } catch {
             exists = false;
           }
@@ -2034,7 +2044,7 @@ export function registerSessionRoutes(
         }
 
         const organization = await createSessionOrganizationService(
-          boundWorkspace,
+          target.workspaceCwd,
         ).updateSessionOrganization(sessionId, {
           ...(rawIsPinned !== undefined ? { isPinned: rawIsPinned } : {}),
           ...(rawGroupId !== undefined
@@ -2049,11 +2059,34 @@ export function registerSessionRoutes(
     } catch (err) {
       if (sendSessionOrganizationError(res, err)) return;
       sendBridgeError(res, err, {
-        route: 'PATCH /session/:id/organization',
+        route: target.route,
         sessionId,
       });
     }
+  };
+
+  app.patch('/session/:id/organization', mutate(), async (req, res) => {
+    await handleSessionOrganizationUpdate(req, res, {
+      workspaceCwd: boundWorkspace,
+      bridge,
+      route: 'PATCH /session/:id/organization',
+    });
   });
+
+  app.patch(
+    '/workspaces/:workspace/session/:id/organization',
+    mutate(),
+    async (req, res) => {
+      const route = 'PATCH /workspaces/:workspace/session/:id/organization';
+      const runtime = requireTrustedRuntimeForWorkspaceRoute(req, res, route);
+      if (!runtime) return;
+      await handleSessionOrganizationUpdate(req, res, {
+        workspaceCwd: runtime.workspaceCwd,
+        bridge: runtime.bridge,
+        route,
+      });
+    },
+  );
 
   app.get('/workspace/:id/session-groups', async (req, res) => {
     const key = resolveWorkspaceParam(req, res);

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2061,6 +2061,7 @@ export function registerSessionRoutes(
       sendBridgeError(res, err, {
         route: target.route,
         sessionId,
+        workspaceCwd: target.workspaceCwd,
       });
     }
   };

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -3652,6 +3652,19 @@ export class WorkspaceDaemonClient {
     );
   }
 
+  updateSessionOrganization(
+    sessionId: string,
+    update: DaemonSessionOrganizationUpdate,
+    clientId?: string,
+  ): Promise<DaemonSessionOrganizationResult> {
+    return this.client.workspaceJsonRequest<DaemonSessionOrganizationResult>(
+      this.workspaceSelector,
+      `/session/${urlEncode(sessionId)}/organization`,
+      'PATCH /workspaces/:workspace/session/:id/organization',
+      { method: 'PATCH', body: update, clientId },
+    );
+  }
+
   deleteSessionsData(
     sessionIds: string[],
     clientId?: string,

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -23,6 +23,7 @@ import type {
   DaemonCapabilities,
   DaemonSessionContextStatus,
   DaemonSessionLspStatus,
+  DaemonSessionOrganizationResult,
   DaemonSessionSupportedCommandsStatus,
   DaemonSessionTasksStatus,
   DaemonWorkspaceEnvStatus,
@@ -4621,6 +4622,58 @@ describe('DaemonClient', () => {
       expect(calls[0]?.method).toBe('DELETE');
       expect(calls[0]?.url).toBe(
         'http://daemon/workspaces/%2Ftmp%2Fwork%20space/session-groups/group%2F1',
+      );
+    });
+
+    it('workspaceById updates session organization on the workspace-qualified route', async () => {
+      const reply: DaemonSessionOrganizationResult = {
+        sessionId: 'session/1',
+        isPinned: true,
+        groupId: 'group/1',
+        color: 'purple',
+        updatedAt: '2026-07-11T00:00:00.000Z',
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, reply));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      const result: DaemonSessionOrganizationResult = await client
+        .workspaceById('workspace/id')
+        .updateSessionOrganization(
+          'session/1',
+          { isPinned: true, groupId: 'group/1', color: 'purple' },
+          'client-1',
+        );
+
+      expect(result).toEqual(reply);
+      expect(calls[0]?.method).toBe('PATCH');
+      expect(calls[0]?.url).toBe(
+        'http://daemon/workspaces/workspace%2Fid/session/session%2F1/organization',
+      );
+      expect(JSON.parse(calls[0]!.body!)).toEqual({
+        isPinned: true,
+        groupId: 'group/1',
+        color: 'purple',
+      });
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+    });
+
+    it('workspaceByCwd encodes the selector when updating session organization', async () => {
+      const reply: DaemonSessionOrganizationResult = {
+        sessionId: 'session-1',
+        isPinned: false,
+        groupId: null,
+        updatedAt: '2026-07-11T00:00:00.000Z',
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, reply));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      const result: DaemonSessionOrganizationResult = await client
+        .workspaceByCwd('/tmp/work space')
+        .updateSessionOrganization('session-1', { isPinned: false });
+
+      expect(result).toEqual(reply);
+      expect(calls[0]?.url).toBe(
+        'http://daemon/workspaces/%2Ftmp%2Fwork%20space/session/session-1/organization',
       );
     });
   });


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR adds `PATCH /workspaces/:workspace/session/:id/organization` so trusted non-primary workspaces can update pin, group, and color state through the same workspace-qualified REST surface used for session reads. The selected runtime supplies both the workspace-scoped organization store and live-session bridge, while the existing primary-only endpoint keeps its current behavior.

The TypeScript daemon SDK now exposes the mutation from clients created with `workspaceById()` or `workspaceByCwd()`. The change reuses the existing request and response types, validation, archive/delete coordination, sidecar format, capability tags, and mutation gate. It also adds REST, SDK, and ACP regression coverage plus protocol and design documentation.

## Why it's needed

Workspace-qualified reads can list organized sessions from trusted secondary workspaces, and workspace-qualified group routes can create groups there, but the only REST organization mutation is bound to the primary workspace. As a result, clients can observe secondary organization state and create secondary groups but cannot pin sessions, assign those groups, or set colors for sessions owned by the secondary workspace. This completes the missing write path without introducing unreliable global session-owner discovery or changing legacy routing.

## Reviewer Test Plan

### How to verify

1. Start a daemon with primary and secondary trusted workspaces, create or identify active persisted, archived persisted, and live-only sessions in the secondary workspace, and call `PATCH /workspaces/<secondary>/session/<id>/organization`. Each mutation should succeed and organized list filters should read back the pin, group, and color state from the secondary workspace only.
2. Repeat with an unknown selector, an untrusted workspace, a session owned only by another workspace, and a group owned only by another workspace. Expect the existing workspace mismatch, trust, session-not-found, and group-not-found responses without any cross-workspace write.
3. Confirm `PATCH /session/:id/organization` remains primary-only and that workspace-qualified ACP organization updates continue to write only the selected runtime's sidecar.
4. Run `cd packages/cli && npx vitest run --no-file-parallelism src/serve/multi-workspace-sessions.test.ts src/serve/acp-http/workspace-qualified-acp.test.ts src/serve/server.test.ts`; expect 736 tests to pass.
5. Run `cd packages/sdk-typescript && npx vitest run test/unit/DaemonClient.test.ts test/unit/acpRouteTable.test.ts`; expect 328 tests to pass. Then run `npm run build`, `npm run typecheck`, and `npm run lint` from the repository root; expect all commands to succeed.

### Evidence (Before & After)

N/A — daemon REST/SDK behavior only; no TUI or WebShell changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS Darwin 25.4.0 arm64, Node.js v22.22.3, npm 10.9.8, local Vitest/build/typecheck/lint execution without a sandbox.

## Risk & Scope

- Main risk or tradeoff: An incorrectly selected runtime could write organization state to the wrong sidecar; route tests cover workspace-id and cwd selection, trust ordering, target bridge fallback, duplicate ownership boundaries, and primary/secondary store isolation.
- Not validated / out of scope: A manual restart-based E2E against two real trusted workspaces was not run locally. Secondary WebShell controls, owner-routed legacy mutations, new capabilities, ACP protocol changes, and archive coordinator key changes are intentionally out of scope.
- Breaking changes / migration notes: None. The existing endpoint remains primary-only, request and response schemas are unchanged, and clients should use the plural route only when both `session_organization` and `workspace_qualified_rest_core` are advertised.

## Linked Issues

Closes #6646.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 新增 `PATCH /workspaces/:workspace/session/:id/organization`，使受信任的非主 workspace 可以通过与 session 读取一致的 workspace-qualified REST 接口更新置顶、分组和颜色状态。解析出的 runtime 同时提供 workspace 范围内的 organization store 和 live-session bridge，现有仅面向主 workspace 的接口保持原有行为。

TypeScript daemon SDK 现在从 `workspaceById()` 或 `workspaceByCwd()` 创建的客户端暴露该 mutation。此变更复用现有请求与响应类型、校验、archive/delete 协调机制、sidecar 格式、capability tag 和 mutation gate。同时补充 REST、SDK 和 ACP 回归测试，以及协议和设计文档。

## 为什么需要

Workspace-qualified 读取已经能够列出受信任 secondary workspace 中的 organized session，workspace-qualified group 路由也能在其中创建分组，但唯一的 REST organization mutation 仍绑定主 workspace。因此，客户端可以观察 secondary organization 状态并创建 secondary group，却无法置顶 secondary workspace 拥有的 session、为其分配分组或设置颜色。本 PR 在不引入不可靠的全局 session owner 发现、也不改变 legacy 路由的前提下补齐缺失的写入路径。

## Reviewer 测试计划

### 如何验证

1. 启动包含 primary 和 secondary trusted workspace 的 daemon，在 secondary workspace 中创建或找到 active persisted、archived persisted 和 live-only session，并调用 `PATCH /workspaces/<secondary>/session/<id>/organization`。每次 mutation 都应成功，organized list filter 应仅从 secondary workspace 读回置顶、分组和颜色状态。
2. 分别使用未知 selector、未受信任 workspace、仅属于另一 workspace 的 session，以及仅属于另一 workspace 的 group 重试。应得到现有的 workspace mismatch、trust、session-not-found 和 group-not-found 响应，且不发生跨 workspace 写入。
3. 确认 `PATCH /session/:id/organization` 仍然仅面向主 workspace，并确认 workspace-qualified ACP organization 更新仍只写入所选 runtime 的 sidecar。
4. 运行 `cd packages/cli && npx vitest run --no-file-parallelism src/serve/multi-workspace-sessions.test.ts src/serve/acp-http/workspace-qualified-acp.test.ts src/serve/server.test.ts`；预期 736 个测试通过。
5. 运行 `cd packages/sdk-typescript && npx vitest run test/unit/DaemonClient.test.ts test/unit/acpRouteTable.test.ts`；预期 328 个测试通过。然后在仓库根目录运行 `npm run build`、`npm run typecheck` 和 `npm run lint`；预期所有命令成功。

### 证据（修改前与修改后）

N/A——仅涉及 daemon REST/SDK 行为，没有 TUI 或 WebShell 变更。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS Darwin 25.4.0 arm64、Node.js v22.22.3、npm 10.9.8，在无 sandbox 的本地环境执行 Vitest、build、typecheck 和 lint。

## 风险与范围

- 主要风险或取舍：如果选择了错误的 runtime，organization 状态可能写入错误的 sidecar；路由测试覆盖 workspace id 和 cwd 选择、trust 错误顺序、目标 bridge fallback、重复 ownership 边界以及 primary/secondary store 隔离。
- 未验证或范围外：本地未针对两个真实 trusted workspace 执行基于重启的人工 E2E。Secondary WebShell 控件、owner-routed legacy mutation、新 capability、ACP 协议变更以及 archive coordinator key 变更均明确不在本次范围内。
- 破坏性变更或迁移说明：无。现有接口继续保持 primary-only，请求与响应 schema 不变；客户端只有在同时检测到 `session_organization` 和 `workspace_qualified_rest_core` 时才应使用 plural route。

## 关联 Issue

Closes #6646。

</details>
