### PR TITLE
feat(core): add unified session recovery planning

### DIFF
--- a/docs/design/session-crash-recovery/session-crash-recovery-interruption-detection.md
+++ b/docs/design/session-crash-recovery/session-crash-recovery-interruption-detection.md
@@ -1,0 +1,406 @@
+# Session Crash Recovery and Unified Recovery Service Design
+
+## 1. Design Goals
+
+The Recovery Service is the unified decision layer for session recovery. It
+reads recovered session history, classifies the current recovery state, builds
+the protocol repairs and continuation payloads required to proceed, and exposes
+the same result to the TUI, daemon, SDK, and headless entrypoints.
+
+Existing capabilities include:
+
+- Append-only JSONL session storage.
+- Session load and API history reconstruction.
+- Orphaned `tool_use` / `tool_result` repair.
+- Three-state interruption detection.
+- Continue entrypoints for headless, nonInteractive control, and ACP.
+
+The main issue today is not that recovery capability is entirely missing. The
+issue is that:
+
+- Recovery decisions are spread across multiple entrypoints.
+- TUI / daemon / SDK do not see the same recovery state.
+- Repair happens implicitly at a low level and is not visible to users or
+  clients.
+- Any future recovery state would need to be wired repeatedly into multiple
+  entrypoints.
+
+The goals of a unified Recovery Service are:
+
+- Unified classification: every entrypoint uses the same recovery plan.
+- Unified repair: every entrypoint reuses the same tool-pair repair and
+  interruption classification.
+- Unified visibility: TUI / daemon / SDK can all tell whether a resume is clean,
+  interrupted, or degraded.
+- Unified debugging data: repairs, synthesized results, and drops are exposed
+  as structured output for display and logs.
+- Unified testing: the same crash fixtures can cover the core plan and each
+  entrypoint adapter.
+
+## 2. Core Design: Recovery Service
+
+Add a core service:
+
+```text
+packages/core/src/core/session-recovery.ts
+```
+
+It does not render UI and does not execute tools. Its only responsibility is to
+produce a deterministic `SessionRecoveryPlan` from the session transcript and
+the current chat history.
+
+Suggested types:
+
+```ts
+export type SessionRecoveryKind =
+  | 'clean'
+  | 'interrupted_prompt'
+  | 'interrupted_turn'
+  | 'degraded_history';
+
+export type RecoveryRepair =
+  | { type: 'synthesized_tool_result'; callId: string; name: string }
+  | { type: 'dropped_duplicate_tool_result'; callId: string; name: string }
+  | { type: 'history_gap'; childUuid: string; missingParentUuid: string };
+
+export interface SessionRecoveryPlan {
+  planId: string;
+  sessionId: string;
+  kind: SessionRecoveryKind;
+  originalApiHistory: Content[];
+  apiHistory: Content[];
+  repairs: RecoveryRepair[];
+  canContinue: boolean;
+  canAutoContinue: boolean;
+  requiresUserConfirmation: boolean;
+  visibleNotice?: string;
+  continuation?: {
+    mode: 'retry_user_parts' | 'tool_result_parts';
+    parts: Part[];
+    displayText: string;
+  };
+}
+```
+
+Suggested entrypoint:
+
+```ts
+export function buildSessionRecoveryPlan(input: {
+  sessionId: string;
+  conversation: ConversationRecord;
+  historyGaps?: HistoryGap[];
+  options?: {
+    allowAutoContinue?: boolean;
+  };
+}): SessionRecoveryPlan;
+```
+
+Core flow:
+
+1. Build `originalApiHistory` from `ConversationRecord`.
+2. If non-ignorable `historyGaps` exist, classify the session as
+   `degraded_history`.
+3. Run `detectTurnInterruption` on `originalApiHistory`. This must happen
+   before repair. Otherwise a dangling `model[functionCall]` would first be
+   closed by a synthetic `functionResponse`, making it impossible to classify
+   the state as `interrupted_turn`.
+4. Clone `originalApiHistory` into provider-safe history, run the existing
+   `repairOrphanedToolUseTurns` on the clone, and store the result in
+   `plan.apiHistory`.
+5. Build the continuation payload from the classification:
+   - `interrupted_prompt`: replay trailing user parts with Retry semantics.
+   - `interrupted_turn`: close dangling tool calls with synthetic error
+     `functionResponse` parts.
+6. Produce `visibleNotice` and `repairs` for UI / daemon / SDK display and
+   debugging.
+
+Naming compatibility:
+
+- Keep using the existing public protocol string `interrupted_turn`; do not add
+  `interrupted_tool_turn`. nonInteractive control, ACP, and existing tests
+  already depend on `interrupted_turn`, and the Recovery Service should not add
+  migration cost.
+
+## 3. Role and Value of the Recovery Service
+
+### 3.1 Robustness
+
+A unified service turns the current implicit and scattered recovery behavior
+into an explicit state machine.
+
+Current state:
+
+- Resume initialization repairs orphaned `tool_use` entries, but entrypoints do
+  not always know that repair happened.
+- Headless / ACP can continue, but the TUI does not know what to tell the user.
+- Parent-chain gaps already have partial visible handling:
+  `SessionService.loadSession` returns `historyGaps`, and TUI / ACP can display
+  gap notices. However, there is still no unified recovery metadata or
+  consistent safe-mode policy.
+
+After introducing the Recovery Service:
+
+- Every resume first produces an explicit state: `clean`,
+  `interrupted_prompt`, `interrupted_turn`, or `degraded_history`.
+- Any entrypoint can decide whether to continue, notify, or degrade based on the
+  same plan.
+- History gaps are not silently treated as clean history.
+- If new recovery states are added later, only plan construction needs to be
+  extended; every entrypoint does not need to reimplement the logic.
+
+The robustness gain is that recovery moves from "each place repairs a little as
+needed" to "each recovery has one unified classification result."
+
+### 3.2 Safety
+
+The biggest safety risk in recovery is automatically repeating side-effecting
+actions, such as shell commands, file writes, or external API calls.
+
+Recovery Service safety principles:
+
+- Do not automatically replay unknown tools by default.
+- Convert dangling tool calls into failed `functionResponse` parts by default,
+  and let the model decide whether to retry.
+- `interrupted_turn` defaults to `requiresUserConfirmation = true` unless the
+  caller explicitly opts in.
+- `degraded_history` is never auto-continued.
+- All synthetic repairs are included in `repairs` for logs and debugging.
+
+This prioritizes:
+
+- Providers do not receive invalid history.
+- Users do not repeat dangerous actions because of recovery logic.
+- TUI / SDK can clearly show which tool results were synthesized as recovery
+  failures.
+
+The safety value is that recovery does not blindly resume execution. It first
+repairs protocol shape, then continues with conservative policy.
+
+### 3.3 Completeness
+
+This design does not immediately solve every crash scenario. It focuses on the
+states that current capabilities can classify reliably.
+
+Covered immediately:
+
+- Clean resume.
+- Trailing user prompt: `interrupted_prompt`.
+- Trailing tool result submission: also classified as `interrupted_prompt` and
+  replayed with Retry.
+- Dangling tool call: `interrupted_turn`, with synthesized error tool results.
+- Non-adjacent tool result: existing repair hoists it into a legal position.
+  The first version of this plan does not record hoist details separately
+  unless the repair API is later extended to return them.
+- Duplicate tool result: drop duplicate.
+- Parent-chain gap: `degraded_history`.
+
+Not covered yet:
+
+- A model text stream that disconnects midway but leaves a tail that looks like
+  ordinary model text.
+- Fine-grained distinction between graceful abort and unknown crash.
+
+Completeness here does not come from adding a large amount of code at once. It
+comes from consolidating current capabilities into a unified plan so the states
+that can be classified today are handled consistently.
+
+### 3.4 Engineering Architecture
+
+The Recovery Service should live in core rather than in CLI, TUI, daemon, or any
+single entrypoint.
+
+Reasons:
+
+- `SessionService`, `buildApiHistoryFromConversation`, `GeminiChat` repair, and
+  `detectTurnInterruption` are all in core or core-adjacent layers.
+- TUI / headless / ACP / daemon / SDK are adapters.
+- Recovery classification is domain logic, not UI rendering logic.
+
+Suggested layering:
+
+```text
+SessionService
+  Read JSONL, rebuild ConversationRecord, return historyGaps
+
+SessionRecoveryService
+  Build RecoveryPlan from ConversationRecord + historyGaps
+
+GeminiClient / GeminiChat
+  Consume plan.apiHistory to initialize chat
+  Execute plan.continuation when needed
+
+TUI / headless / ACP / daemon / SDK
+  Display plan.visibleNotice
+  Trigger continuation from user or API requests
+```
+
+Benefits of this layering:
+
+- Core owns facts and decisions.
+- UI owns display.
+- daemon / SDK own protocol output.
+- Tests can exercise the core plan directly without booting a full TUI.
+
+### 3.5 Visibility and Debuggability
+
+The plan produced by the Recovery Service should be convertible into two kinds
+of output:
+
+1. User-visible notice:
+
+```text
+The previous session stopped after tool execution. Marked 2 unfinished tool
+calls as failed so the history can be sent safely. You can continue the task;
+the model will decide whether to retry based on the failure results.
+```
+
+2. Debug log or optional system record:
+
+```ts
+type RecoveryDebugPayload = {
+  planId: string;
+  kind: SessionRecoveryKind;
+  repairs: RecoveryRepair[];
+  timestamp: string;
+};
+```
+
+This information does not enter API history. It is only for diagnostics,
+export, and debug. Persisting it as a system record can be deferred and is not a
+hard requirement of this design.
+
+Value:
+
+- Users know what happened during recovery.
+- SDK clients can show accurate state.
+- Bug reports can include `planId` and `repairs`.
+- The same interrupted tail is less likely to be auto-continued multiple times.
+
+## 4. Entrypoint Integration
+
+### 4.1 TUI
+
+After `/resume` or startup with `--resume`:
+
+1. `SessionService.loadSession(sessionId)`.
+2. `buildSessionRecoveryPlan(...)`.
+3. `config.startNewSession(sessionId, sessionData, recoveryPlan)`, or an
+   equivalent mechanism to retain the plan.
+4. Load UI history.
+5. If `plan.kind !== 'clean'`, insert an INFO item.
+6. Provide `/continue` or a "Continue interrupted turn" action.
+
+The TUI does not auto-continue `interrupted_turn` / `degraded_history` by
+default.
+
+### 4.2 Headless / nonInteractive Control
+
+`continueInterrupted` or `continue_last_turn` no longer calls scattered
+detectors directly. Instead:
+
+1. Build a plan from current chat history or the resumed conversation.
+2. If `plan.canContinue = false`, return no-op.
+3. If continuation is allowed, execute `plan.continuation`.
+
+### 4.3 ACP / daemon
+
+Add recovery metadata to the `loadSession` / `resumeSession` response:
+
+```ts
+{
+  recovered: boolean;
+  recoveryKind: SessionRecoveryKind;
+  canContinue: boolean;
+  requiresUserConfirmation: boolean;
+  repairs: {
+    type: string;
+    count: number;
+  }
+  [];
+}
+```
+
+`continueLastTurn` should also accept / reject based on the plan, then
+revalidate immediately before execution.
+
+### 4.4 SDK
+
+SDK integration needs to distinguish two categories:
+
+- daemon-backed SDK: consumes recovery metadata from daemon `loadSession` /
+  `resumeSession` responses, shows a recovery banner, and allows the user or
+  host application to trigger continue.
+- process-backed SDK: starts the CLI through `ProcessTransport` and uses
+  `--resume` / `--continue` flags. It needs equivalent recovery metadata
+  exposed through a stream-json system message or an SDK protocol field.
+
+Neither SDK category should directly understand low-level JSONL or tool-pair
+repair. They should only consume the structured recovery result exposed by the
+entrypoint layer, and they should block auto-continuation in degraded states.
+
+## 5. Unit Test Design
+
+The Recovery Service must have independent unit tests that do not depend on the
+TUI or a real provider.
+
+Core fixtures:
+
+1. Clean history:
+   - Model text tail.
+   - Complete tool call + tool result + final model.
+
+2. `interrupted_prompt`:
+   - Last entry is user text.
+   - Last entry is a group of user functionResponse parts.
+   - Multiple trailing user entries.
+
+3. `interrupted_turn`:
+   - Model functionCall with no functionResponse.
+   - Multiple functionCalls with only some completed.
+   - FunctionCall without id is skipped.
+
+4. Repair:
+   - Non-adjacent functionResponse is hoisted and provider-safe history is
+     legal.
+   - Duplicate functionResponse is dropped.
+   - Synthetic tool result shape remains consistent with existing repair.
+
+5. `degraded_history`:
+   - `historyGaps` is non-empty.
+   - Confirm `canAutoContinue = false`.
+   - Confirm `visibleNotice` includes gap information.
+
+6. Compression checkpoint:
+   - Tail after the latest compression is detected correctly.
+   - System records do not enter API history.
+
+Entrypoint adapter tests:
+
+- TUI `/resume` inserts an INFO item after receiving a non-clean plan.
+- Headless `continueInterrupted` uses plan continuation and does not duplicate
+  the user message.
+- ACP `continueLastTurn` returns the same recovery kind for the same fixture.
+- daemon `loadSession` response includes recovery metadata.
+
+The key test goal is: the same history fixture should produce the same recovery
+kind in core / TUI / ACP / daemon.
+
+## 6. Conclusion
+
+A unified Recovery Service is the highest-value change at this stage because it
+mostly consolidates existing capabilities instead of introducing many new
+mechanisms immediately.
+
+Its direct value:
+
+- Makes recovery state consistent across TUI / daemon / SDK / headless.
+- Turns existing orphan `tool_use` repair from an implicit 400-prevention step
+  into an explicit recovery plan.
+- Turns interrupted-turn continuation from a local headless / ACP capability
+  into reusable core capability.
+- Provides a stable extension point for future recovery states.
+
+It does not solve every crash problem by itself, especially mid-text stream
+crashes. This document intentionally keeps those extensions out of scope for
+this round to avoid over-design. The current goal is to unify the recovery
+capabilities that already exist and can be classified reliably.

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -78,9 +78,7 @@ import {
   getArenaSystemReminder,
   getStartupContextLength,
   isSystemReminderContent,
-  detectTurnInterruption,
-  buildSyntheticToolResponseParts,
-  ORPHAN_TOOL_USE_REPAIR_REASON,
+  buildSessionRecoveryPlanFromApiHistory,
   TURN_INTERRUPTION_HISTORY_TAIL_COUNT,
   evaluatePermissionFlow,
   getEffectivePermissionForConfirmation,
@@ -1524,17 +1522,23 @@ export class Session implements SessionContext {
     // not need to structuredClone the whole history. The authoritative
     // re-detection inside the fired prompt() reads full history for the strip.
     const chat = this.#getCurrentChat();
-    const detection = detectTurnInterruption(
-      chat.getHistoryTailShallow?.(TURN_INTERRUPTION_HISTORY_TAIL_COUNT) ??
+    const recoveryPlan = buildSessionRecoveryPlanFromApiHistory({
+      sessionId: this.sessionId,
+      apiHistory:
+        chat.getHistoryTailShallow?.(TURN_INTERRUPTION_HISTORY_TAIL_COUNT) ??
         chat.getHistoryTail(TURN_INTERRUPTION_HISTORY_TAIL_COUNT),
-    );
-    if (detection.kind === 'none') {
+    });
+    if (!recoveryPlan.continuation) {
       return { accepted: false, interruption: 'none' };
     }
+    const interruption =
+      recoveryPlan.kind === 'interrupted_prompt'
+        ? 'interrupted_prompt'
+        : 'interrupted_turn';
     // A prompt (or an earlier continuation) is still in flight: there is no
     // settled turn to continue. Reject rather than abort the live turn.
     if (this.pendingPrompt && !this.pendingPrompt.signal.aborted) {
-      return { accepted: false, interruption: detection.kind };
+      return { accepted: false, interruption };
     }
 
     // Accepted. This method only classifies — the daemon bridge drives the
@@ -1545,7 +1549,7 @@ export class Session implements SessionContext {
     // daemon would report the session idle and a racing prompt could abort the
     // continuation), which is exactly what routing through the bridge fixes.
 
-    return { accepted: true, interruption: detection.kind };
+    return { accepted: true, interruption };
   }
 
   /**
@@ -1727,10 +1731,11 @@ export class Session implements SessionContext {
             let strippedOrphanEntries: Content[] | null = null;
             let orphanPushCountSnapshot = 0;
             if (isContinue) {
-              const detection = detectTurnInterruption(
-                this.#getCurrentChat().getHistory(),
-              );
-              if (detection.kind === 'none') {
+              const recoveryPlan = buildSessionRecoveryPlanFromApiHistory({
+                sessionId: this.sessionId,
+                apiHistory: this.#getCurrentChat().getHistory(),
+              });
+              if (!recoveryPlan.continuation) {
                 // History moved between continueLastTurn()'s accept and this
                 // re-detection (e.g. a concurrent turn settled it). Nothing to
                 // continue; log so an abandoned continuation is diagnosable.
@@ -1749,18 +1754,15 @@ export class Session implements SessionContext {
                 );
                 return { stopReason: 'end_turn' };
               }
-              if (detection.kind === 'interrupted_prompt') {
+              if (recoveryPlan.continuation.mode === 'retry_user_parts') {
                 strippedOrphanEntries =
                   this.#getCurrentChat().stripOrphanedUserEntriesFromHistory() ??
                   null;
                 orphanPushCountSnapshot =
                   this.#getCurrentChat().getUserContentPushCount?.() ?? 0;
-                continuationParts = detection.parts;
+                continuationParts = recoveryPlan.continuation.parts;
               } else {
-                continuationParts = buildSyntheticToolResponseParts(
-                  detection.danglingCalls,
-                  ORPHAN_TOOL_USE_REPAIR_REASON,
-                );
+                continuationParts = recoveryPlan.continuation.parts;
               }
             }
 

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -10,7 +10,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import {
   createDebugLogger,
-  detectTurnInterruption,
+  buildSessionRecoveryPlanFromApiHistory,
   SendMessageType,
   TURN_INTERRUPTION_HISTORY_TAIL_COUNT,
 } from '@qwen-code/qwen-code-core';
@@ -497,32 +497,39 @@ class Session {
     const historyTail =
       chat.getHistoryTailShallow?.(TURN_INTERRUPTION_HISTORY_TAIL_COUNT) ??
       chat.getHistoryTail(TURN_INTERRUPTION_HISTORY_TAIL_COUNT);
-    const detection = detectTurnInterruption(historyTail);
-    debugLogger.info('[Session] requestContinueLastTurn detection', {
+    const recoveryPlan = buildSessionRecoveryPlanFromApiHistory({
       sessionId: this.sessionId,
-      kind: detection.kind,
+      apiHistory: historyTail,
     });
-    if (detection.kind === 'none') {
+    debugLogger.info('[Session] requestContinueLastTurn recovery', {
+      sessionId: this.sessionId,
+      kind: recoveryPlan.kind,
+    });
+    if (!recoveryPlan.continuation) {
       debugLogger.debug(
         '[Session] continue_last_turn rejected: no interrupted turn',
       );
       return { accepted: false, interruption: 'none' };
     }
+    const interruption =
+      recoveryPlan.kind === 'interrupted_prompt'
+        ? 'interrupted_prompt'
+        : 'interrupted_turn';
     if (this.pendingContinueTurn || this.continueTurnInProgress) {
       debugLogger.debug(
         '[Session] continue_last_turn rejected: continuation already pending',
-        { kind: detection.kind },
+        { kind: recoveryPlan.kind },
       );
-      return { accepted: false, interruption: detection.kind };
+      return { accepted: false, interruption };
     }
 
     this.pendingContinueTurn = true;
     this.ensureProcessingStarted();
     debugLogger.info('[Session] continue_last_turn accepted', {
       sessionId: this.sessionId,
-      kind: detection.kind,
+      kind: recoveryPlan.kind,
     });
-    return { accepted: true, interruption: detection.kind };
+    return { accepted: true, interruption };
   }
 
   /**

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -31,9 +31,7 @@ import {
   detectAutonomousSentinel,
   detectLoopSentinel,
   SendMessageType,
-  buildSyntheticToolResponseParts,
-  detectTurnInterruption,
-  ORPHAN_TOOL_USE_REPAIR_REASON,
+  buildSessionRecoveryPlanFromApiHistory,
   restoreWorktreeContext,
   TeamEventType,
   ApprovalMode,
@@ -587,21 +585,16 @@ export async function runNonInteractive(
         // client.ts strips the ENTIRE trailing user run, so detection must
         // re-submit exactly that run or the oldest orphans get dropped. This
         // runs once per (rare) continue request, so the full clone is fine.
-        const detection = detectTurnInterruption(
-          geminiClient.getChat().getHistory(),
-        );
-        debugLogger.info('[runNonInteractive] continueInterrupted detection', {
-          kind: detection.kind,
-          partsCount:
-            detection.kind === 'interrupted_prompt'
-              ? detection.parts.length
-              : 0,
-          danglingCallCount:
-            detection.kind === 'interrupted_turn'
-              ? detection.danglingCalls.length
-              : 0,
+        const recoveryPlan = buildSessionRecoveryPlanFromApiHistory({
+          sessionId,
+          apiHistory: geminiClient.getChat().getHistory(),
         });
-        if (detection.kind === 'none') {
+        debugLogger.info('[runNonInteractive] continueInterrupted recovery', {
+          kind: recoveryPlan.kind,
+          repairs: recoveryPlan.repairs,
+          hasContinuation: recoveryPlan.continuation !== undefined,
+        });
+        if (!recoveryPlan.continuation) {
           await emitNonInteractiveFinalMessage({
             message: 'No interrupted turn to continue.',
             isError: false,
@@ -611,18 +604,11 @@ export async function runNonInteractive(
           });
           return 0;
         }
-        if (detection.kind === 'interrupted_prompt') {
-          // Re-submit the orphaned user content under Retry semantics. The
-          // Retry send path strips the orphaned original from history and
-          // restores it if the send never starts, so history is neither
-          // duplicated nor lost — no separate strip/restore needed here.
-          initialPartList = detection.parts;
+
+        initialPartList = recoveryPlan.continuation.parts;
+        if (recoveryPlan.continuation.mode === 'retry_user_parts') {
           continueSendType = SendMessageType.Retry;
         } else {
-          initialPartList = buildSyntheticToolResponseParts(
-            detection.danglingCalls,
-            ORPHAN_TOOL_USE_REPAIR_REASON,
-          );
           continueSendType = SendMessageType.ToolResult;
         }
 

--- a/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -13,6 +13,7 @@ import {
 import { useHistory } from './useHistoryManager.js';
 import { restoreGoalFromHistory } from '../utils/restoreGoal.js';
 
+import type { Content } from '@google/genai';
 import type { LoadedSettings } from '../../config/settings.js';
 
 const mockSettings = {
@@ -34,6 +35,24 @@ const resumeMocks = vi.hoisted(() => {
     | undefined;
 
   return {
+    makeConversation(messages: Content[]) {
+      return {
+        sessionId: 'session-1',
+        projectHash: 'project-1',
+        startTime: '2026-07-11T00:00:00.000Z',
+        lastUpdated: '2026-07-11T00:00:00.000Z',
+        messages: messages.map((message, index) => ({
+          uuid: `m-${index}`,
+          parentUuid: index === 0 ? null : `m-${index - 1}`,
+          sessionId: 'session-1',
+          timestamp: '2026-07-11T00:00:00.000Z',
+          type: message.role === 'model' ? 'assistant' : 'user',
+          cwd: '/tmp/project',
+          version: 'test',
+          message,
+        })),
+      };
+    },
     createPendingLoadSession() {
       pendingLoadSession = new Promise((resolve) => {
         resolveLoadSession = resolve;
@@ -77,7 +96,9 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
       return (
         resumeMocks.getPendingLoadSession() ??
         Promise.resolve({
-          conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
+          conversation: resumeMocks.makeConversation([
+            { role: 'user', parts: [{ text: 'hello' }] },
+          ]),
         })
       );
     }
@@ -289,7 +310,9 @@ describe('useResumeCommand', () => {
 
     // Now finish the async load and let the handler complete.
     resumeMocks.resolvePendingLoadSession({
-      conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      conversation: resumeMocks.makeConversation([
+        { role: 'user', parts: [{ text: 'hello' }] },
+      ]),
     });
     await act(async () => {
       await resumePromise;
@@ -315,6 +338,96 @@ describe('useResumeCommand', () => {
       expect.any(Array),
       config,
       historyManager.addItem,
+    );
+  });
+
+  it('adds a recovery notice when resuming an interrupted tool turn', async () => {
+    resumeMocks.reset();
+    resumeMocks.createPendingLoadSession();
+
+    const historyManager = {
+      addItem: vi.fn(),
+      clearItems: vi.fn(),
+      loadHistory: vi.fn(),
+    };
+    const startNewSession = vi.fn();
+    const geminiClient = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const config = {
+      getSessionId: () => 'old-session-id',
+      getTargetDir: () => '/tmp',
+      getGeminiClient: () => geminiClient,
+      startNewSession: vi.fn(),
+      getBackgroundTaskRegistry: () => ({
+        hasRunningTasks: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+      }),
+      getBackgroundShellRegistry: () => ({
+        getAll: vi.fn().mockReturnValue([]),
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+      }),
+      getMonitorRegistry: () => ({
+        getRunning: vi.fn().mockReturnValue([]),
+        reset: vi.fn(),
+      }),
+      getWorkflowRunRegistry: () => ({
+        hasRunningEntries: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+        abortAll: vi.fn(),
+      }),
+      loadPausedBackgroundAgents: vi.fn().mockResolvedValue([]),
+      getBackgroundAgentResumeService: () => ({
+        buildRecoveredBackgroundAgentsNotice: vi.fn(),
+      }),
+      getChatRecordingService: () => ({ rebuildTurnBoundaries: vi.fn() }),
+      getDebugLogger: () => ({
+        warn: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      }),
+    } as unknown as import('@qwen-code/qwen-code-core').Config;
+
+    const { result } = renderHook(() =>
+      useResumeCommand({
+        config,
+        settings: mockSettings,
+        historyManager,
+        startNewSession,
+      }),
+    );
+
+    const resumePromise = result.current.handleResume('session-2');
+    resumeMocks.resolvePendingLoadSession({
+      conversation: resumeMocks.makeConversation([
+        { role: 'user', parts: [{ text: 'read file' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-1',
+                name: 'read_file',
+                args: { path: 'a.txt' },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+    await act(async () => {
+      await resumePromise;
+    });
+
+    expect(historyManager.loadHistory).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'info',
+          text: expect.stringContaining('stopped during tool execution'),
+        }),
+      ]),
     );
   });
 
@@ -384,7 +497,9 @@ describe('useResumeCommand', () => {
     });
 
     resumeMocks.resolvePendingLoadSession({
-      conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
+      conversation: resumeMocks.makeConversation([
+        { role: 'user', parts: [{ text: 'hello' }] },
+      ]),
     });
     await act(async () => {
       await resumePromise;

--- a/packages/cli/src/ui/hooks/useResumeCommand.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.ts
@@ -7,6 +7,7 @@
 import { useState, useCallback } from 'react';
 import {
   SessionService,
+  buildSessionRecoveryPlan,
   type Config,
   type SessionListItem,
 } from '@qwen-code/qwen-code-core';
@@ -120,6 +121,11 @@ export function useResumeCommand(
         const customTitle = sessionService.getSessionTitle(sessionId);
 
         // Build UI history items.
+        const recoveryPlan = buildSessionRecoveryPlan({
+          sessionId,
+          conversation: sessionData.conversation,
+          historyGaps: sessionData.historyGaps,
+        });
         const rawItems = buildResumedHistoryItems(sessionData, config);
         const collapseOnResume =
           settings.merged.ui?.history?.collapseOnResume ?? false;
@@ -131,6 +137,18 @@ export function useResumeCommand(
           collapseOnResume,
           collapsePreviewCount,
         );
+        if (
+          recoveryPlan.kind !== 'clean' &&
+          recoveryPlan.kind !== 'degraded_history' &&
+          recoveryPlan.visibleNotice
+        ) {
+          const nextId = (uiHistoryItems.at(-1)?.id ?? 0) + 1;
+          uiHistoryItems.push({
+            id: nextId,
+            type: MessageType.INFO,
+            text: recoveryPlan.visibleNotice,
+          });
+        }
 
         // 1. Swap core first. Matches useBranchCommand's core-before-UI
         //    pattern: if anything fails between core swap and UI swap,

--- a/packages/core/src/core/session-recovery.test.ts
+++ b/packages/core/src/core/session-recovery.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Content } from '@google/genai';
+import type { ConversationRecord } from '../services/sessionService.js';
+import { buildSessionRecoveryPlan } from './session-recovery.js';
+
+function conversation(messages: Content[]): ConversationRecord {
+  return {
+    sessionId: 'session-1',
+    projectHash: 'project-1',
+    startTime: '2026-07-11T00:00:00.000Z',
+    lastUpdated: '2026-07-11T00:00:00.000Z',
+    messages: messages.map((message, index) => ({
+      uuid: `m-${index}`,
+      parentUuid: index === 0 ? null : `m-${index - 1}`,
+      sessionId: 'session-1',
+      timestamp: '2026-07-11T00:00:00.000Z',
+      type: message.role === 'model' ? 'assistant' : 'user',
+      cwd: '/tmp/project',
+      version: 'test',
+      message,
+    })),
+  };
+}
+
+describe('buildSessionRecoveryPlan', () => {
+  it('returns clean for a completed model text tail', () => {
+    const plan = buildSessionRecoveryPlan({
+      sessionId: 'session-1',
+      conversation: conversation([
+        { role: 'user', parts: [{ text: 'hello' }] },
+        { role: 'model', parts: [{ text: 'done' }] },
+      ]),
+    });
+
+    expect(plan.kind).toBe('clean');
+    expect(plan.canContinue).toBe(false);
+    expect(plan.repairs).toEqual([]);
+  });
+
+  it('detects an interrupted prompt before applying provider-safe repair', () => {
+    const plan = buildSessionRecoveryPlan({
+      sessionId: 'session-1',
+      conversation: conversation([
+        { role: 'model', parts: [{ text: 'ready' }] },
+        { role: 'user', parts: [{ text: 'do the thing' }] },
+      ]),
+    });
+
+    expect(plan.kind).toBe('interrupted_prompt');
+    expect(plan.continuation).toMatchObject({
+      mode: 'retry_user_parts',
+      parts: [{ text: 'do the thing' }],
+    });
+  });
+
+  it('detects dangling tool calls from original history and repairs apiHistory', () => {
+    const plan = buildSessionRecoveryPlan({
+      sessionId: 'session-1',
+      conversation: conversation([
+        { role: 'user', parts: [{ text: 'read file' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-1',
+                name: 'read_file',
+                args: { path: 'a.txt' },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+
+    expect(plan.kind).toBe('interrupted_turn');
+    expect(plan.continuation).toMatchObject({
+      mode: 'tool_result_parts',
+      parts: [
+        {
+          functionResponse: {
+            id: 'call-1',
+            name: 'read_file',
+          },
+        },
+      ],
+    });
+    expect(plan.repairs).toEqual([
+      {
+        type: 'synthesized_tool_result',
+        callId: 'call-1',
+        name: 'read_file',
+      },
+    ]);
+    expect(plan.originalApiHistory.at(-1)?.role).toBe('model');
+    expect(plan.apiHistory.at(-1)?.role).toBe('user');
+    expect(plan.apiHistory.at(-1)?.parts?.[0]?.functionResponse?.id).toBe(
+      'call-1',
+    );
+  });
+
+  it('marks sessions with history gaps as degraded and disables continuation', () => {
+    const plan = buildSessionRecoveryPlan({
+      sessionId: 'session-1',
+      conversation: conversation([
+        { role: 'user', parts: [{ text: 'hello' }] },
+      ]),
+      historyGaps: [{ childUuid: 'm-1', missingParentUuid: 'missing' }],
+    });
+
+    expect(plan.kind).toBe('degraded_history');
+    expect(plan.canContinue).toBe(false);
+    expect(plan.canAutoContinue).toBe(false);
+    expect(plan.requiresUserConfirmation).toBe(true);
+    expect(plan.repairs).toContainEqual({
+      type: 'history_gap',
+      childUuid: 'm-1',
+      missingParentUuid: 'missing',
+    });
+  });
+});

--- a/packages/core/src/core/session-recovery.ts
+++ b/packages/core/src/core/session-recovery.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, Part } from '@google/genai';
+import {
+  buildApiHistoryFromConversation,
+  type ConversationRecord,
+} from '../services/sessionService.js';
+import type { HistoryGap } from '../utils/conversation-chain.js';
+import {
+  detectTurnInterruption,
+  buildSyntheticToolResponseParts,
+} from './turn-interruption.js';
+import {
+  ORPHAN_TOOL_USE_REPAIR_REASON,
+  repairOrphanedToolUseTurns,
+} from './geminiChat.js';
+
+export type SessionRecoveryKind =
+  | 'clean'
+  | 'interrupted_prompt'
+  | 'interrupted_turn'
+  | 'degraded_history';
+
+export type RecoveryRepair =
+  | { type: 'synthesized_tool_result'; callId: string; name: string }
+  | { type: 'dropped_duplicate_tool_result'; callId: string; name: string }
+  | { type: 'history_gap'; childUuid: string; missingParentUuid: string };
+
+export interface SessionRecoveryContinuation {
+  mode: 'retry_user_parts' | 'tool_result_parts';
+  parts: Part[];
+  displayText: string;
+}
+
+export interface SessionRecoveryPlan {
+  planId: string;
+  sessionId: string;
+  kind: SessionRecoveryKind;
+  originalApiHistory: Content[];
+  apiHistory: Content[];
+  repairs: RecoveryRepair[];
+  canContinue: boolean;
+  canAutoContinue: boolean;
+  requiresUserConfirmation: boolean;
+  visibleNotice?: string;
+  continuation?: SessionRecoveryContinuation;
+}
+
+export interface BuildSessionRecoveryPlanInput {
+  sessionId: string;
+  conversation: ConversationRecord;
+  historyGaps?: HistoryGap[];
+  options?: {
+    allowAutoContinue?: boolean;
+  };
+}
+
+export interface BuildSessionRecoveryPlanFromApiHistoryInput {
+  sessionId: string;
+  apiHistory: Content[];
+  historyGaps?: HistoryGap[];
+  options?: {
+    allowAutoContinue?: boolean;
+  };
+}
+
+function createPlanId(sessionId: string, historyLength: number): string {
+  return `${sessionId}:${historyLength}`;
+}
+
+function buildVisibleNotice(
+  kind: SessionRecoveryKind,
+  repairs: RecoveryRepair[],
+  historyGaps: HistoryGap[],
+): string | undefined {
+  if (kind === 'clean') {
+    return undefined;
+  }
+
+  if (kind === 'degraded_history') {
+    return (
+      `Resumed session history is incomplete: detected ` +
+      `${historyGaps.length} missing parent link(s). Automatic continuation ` +
+      `is disabled for this recovery.`
+    );
+  }
+
+  if (kind === 'interrupted_prompt') {
+    return 'Previous session appears to have stopped after user input before the model completed a response.';
+  }
+
+  const synthesized = repairs.filter(
+    (repair) => repair.type === 'synthesized_tool_result',
+  ).length;
+  if (synthesized > 0) {
+    return (
+      `Previous session appears to have stopped during tool execution. ` +
+      `Synthesized ${synthesized} failed tool result(s) so the history can continue safely.`
+    );
+  }
+
+  return 'Previous session appears to have stopped during tool execution.';
+}
+
+export function buildSessionRecoveryPlan({
+  sessionId,
+  conversation,
+  historyGaps,
+  options,
+}: BuildSessionRecoveryPlanInput): SessionRecoveryPlan {
+  return buildSessionRecoveryPlanFromApiHistory({
+    sessionId,
+    apiHistory: buildApiHistoryFromConversation(conversation),
+    historyGaps,
+    options,
+  });
+}
+
+export function buildSessionRecoveryPlanFromApiHistory({
+  sessionId,
+  apiHistory: inputApiHistory,
+  historyGaps,
+  options,
+}: BuildSessionRecoveryPlanFromApiHistoryInput): SessionRecoveryPlan {
+  const originalApiHistory = structuredClone(inputApiHistory);
+  const gaps = historyGaps ?? [];
+  const planId = createPlanId(sessionId, originalApiHistory.length);
+
+  const apiHistory = structuredClone(originalApiHistory);
+  const repairResult = repairOrphanedToolUseTurns(apiHistory);
+  const repairs: RecoveryRepair[] = [
+    ...repairResult.injected.map((repair) => ({
+      type: 'synthesized_tool_result' as const,
+      callId: repair.callId,
+      name: repair.name,
+    })),
+    ...repairResult.droppedDuplicates.map((repair) => ({
+      type: 'dropped_duplicate_tool_result' as const,
+      callId: repair.callId,
+      name: repair.name,
+    })),
+    ...gaps.map((gap) => ({
+      type: 'history_gap' as const,
+      childUuid: gap.childUuid,
+      missingParentUuid: gap.missingParentUuid,
+    })),
+  ];
+
+  if (gaps.length > 0) {
+    return {
+      planId,
+      sessionId,
+      kind: 'degraded_history',
+      originalApiHistory,
+      apiHistory,
+      repairs,
+      canContinue: false,
+      canAutoContinue: false,
+      requiresUserConfirmation: true,
+      visibleNotice: buildVisibleNotice('degraded_history', repairs, gaps),
+    };
+  }
+
+  const interruption = detectTurnInterruption(originalApiHistory);
+  if (interruption.kind === 'none') {
+    return {
+      planId,
+      sessionId,
+      kind: 'clean',
+      originalApiHistory,
+      apiHistory,
+      repairs,
+      canContinue: false,
+      canAutoContinue: false,
+      requiresUserConfirmation: false,
+    };
+  }
+
+  if (interruption.kind === 'interrupted_prompt') {
+    const continuation: SessionRecoveryContinuation = {
+      mode: 'retry_user_parts',
+      parts: interruption.parts,
+      displayText: 'Continue interrupted user prompt',
+    };
+    return {
+      planId,
+      sessionId,
+      kind: 'interrupted_prompt',
+      originalApiHistory,
+      apiHistory,
+      repairs,
+      canContinue: true,
+      canAutoContinue: options?.allowAutoContinue === true,
+      requiresUserConfirmation: options?.allowAutoContinue !== true,
+      visibleNotice: buildVisibleNotice('interrupted_prompt', repairs, gaps),
+      continuation,
+    };
+  }
+
+  const continuation: SessionRecoveryContinuation = {
+    mode: 'tool_result_parts',
+    parts: buildSyntheticToolResponseParts(
+      interruption.danglingCalls,
+      ORPHAN_TOOL_USE_REPAIR_REASON,
+    ),
+    displayText: 'Continue interrupted tool turn',
+  };
+
+  return {
+    planId,
+    sessionId,
+    kind: 'interrupted_turn',
+    originalApiHistory,
+    apiHistory,
+    repairs,
+    canContinue: true,
+    canAutoContinue: false,
+    requiresUserConfirmation: true,
+    visibleNotice: buildVisibleNotice('interrupted_turn', repairs, gaps),
+    continuation,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export * from './core/insightProtocol.js';
 export * from './core/logger.js';
 export * from './core/nonInteractiveToolExecutor.js';
 export * from './core/prompts.js';
+export * from './core/session-recovery.js';
 export * from './core/tokenLimits.js';
 export * from './core/toolCallIdUtils.js';
 export * from './core/turn.js';


### PR DESCRIPTION
## What this PR does

Centralizes session recovery classification behind a core recovery plan so each entrypoint can make the same decision about interrupted prompts, dangling tool calls, and degraded history.

This adds a shared recovery plan builder that keeps the original API history for interruption detection, builds provider-safe repaired history for resumed sends, and exposes structured repair metadata. Headless, stream-json control, and ACP continue paths now consume that shared plan instead of duplicating recovery decisions. TUI resume also shows a visible notice when an interrupted tool turn is detected.

The PR also documents the Recovery Service design and adds focused tests for the core plan and TUI resume notice.

## Why it's needed

Session recovery behavior already exists, but it is split across lower-level repair code and several entrypoints. That makes it easy for TUI, headless, ACP, daemon, and SDK flows to disagree about whether a resumed session is clean, interrupted, or degraded.

A single recovery plan makes this behavior easier to reason about, safer to extend, and more auditable. It also preserves the safer recovery behavior for dangling tool calls: synthesize failed tool results instead of blindly replaying side-effecting tools.

## Reviewer Test Plan

### How to verify

Run the focused core and CLI tests. Reviewers should confirm that recovery planning correctly distinguishes clean history, interrupted prompts, interrupted tool turns, and degraded history, and that TUI resume receives a visible notice for interrupted tool turns.

```bash
cd packages/core && npx vitest run src/core/session-recovery.test.ts
cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/nonInteractive/session.test.ts src/ui/hooks/useResumeCommand.test.ts
npm run build
npm run typecheck
```

### Evidence (Before & After)
N/A for screenshots. The change is mostly core recovery behavior and entrypoint wiring, covered by unit tests and typecheck.
Before: recovery classification and continuation planning were spread across entrypoints.
After: headless, stream-json control, ACP, and TUI resume consume a shared recovery plan.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |     ✅   |
| 🪟 Windows |    ⚠️    |
|  🐧 Linux  |    ⚠️    |


### Environment (optional)

Local macOS development environment with Node.js workspace commands. No sandbox-specific behavior was required.

## Risk & Scope

- Main risk or tradeoff: Recovery classification is now centralized, so regressions in the shared plan could affect multiple entrypoints at once. The implementation keeps existing protocol strings and synthetic tool-result behavior to reduce migration risk.
- Not validated / out of scope: Mid-model-text stream crash detection is not handled here because existing history alone cannot reliably distinguish it from a clean model text tail. Full daemon / SDK metadata exposure is also left for follow-up work.
- Breaking changes / migration notes: None expected. Existing interrupted_turn protocol naming is preserved.

## Linked Issues

Closes #6730


<details>
<summary>中文说明</summary>

## What this PR does

将会话恢复分类收敛到 core 层的统一 recovery plan 中，让各个入口可以基于同一份结果判断 interrupted prompt、dangling tool call 和 degraded history。

本 PR 新增共享 recovery plan builder：它保留 original API history 用于中断检测，构建 provider-safe repaired history 用于恢复后的发送，并暴露结构化 repair metadata。headless、stream-json control 和 ACP continue 路径现在都消费这份共享 plan，而不是各自重复实现恢复判断。TUI resume 在检测到 interrupted tool turn 时也会展示可见提示。

本 PR 还补充了 Recovery Service 设计文档，并为 core plan 和 TUI resume notice 增加了聚焦测试。

## Why it's needed

当前项目已经有一部分会话恢复能力，但这些能力分散在底层 repair 逻辑和多个入口中。这会导致 TUI、headless、ACP、daemon 和 SDK 流程对恢复状态的理解不一致，例如无法统一判断一个 resumed session 是 clean、interrupted 还是 degraded。

统一 recovery plan 能让恢复行为更容易理解、更安全地扩展，也更方便审计。同时它保留了 dangling tool call 的保守恢复策略：合成失败 tool result，而不是盲目重放可能有副作用的工具调用。

## Reviewer Test Plan

### How to verify

运行下面的 core 和 CLI 聚焦测试。Reviewer 应确认 recovery planning 能正确区分 clean history、interrupted prompt、interrupted tool turn 和 degraded history，并确认 TUI resume 在 interrupted tool turn 场景下会收到可见提示。

```bash
cd packages/core && npx vitest run src/core/session-recovery.test.ts
cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/nonInteractive/session.test.ts src/ui/hooks/useResumeCommand.test.ts
npm run build
npm run typecheck
```

## Evidence (Before & After)
N/A for screenshots. 这次改动主要是 core recovery 行为和入口接线，已通过单元测试和 typecheck 覆盖。
Before: recovery classification 和 continuation planning 分散在多个入口中。
After: headless、stream-json control、ACP 和 TUI resume 都消费共享 recovery plan。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |     ✅   |
| 🪟 Windows |    ⚠️    |
|  🐧 Linux  |    ⚠️    |

## Environment (optional)
本地 macOS 开发环境，使用 Node.js workspace 命令验证。未涉及 sandbox 特定行为。

## Risk & Scope
- Main risk or tradeoff: recovery classification 被集中到共享 plan 后，如果共享 plan 出现回归，可能同时影响多个入口。当前实现保留了既有协议字符串和 synthetic tool-result 行为，以降低迁移风险。
- Not validated / out of scope: mid-model-text stream crash detection 不在本 PR 范围内，因为仅凭现有 history 无法可靠地区分它和 clean model text tail。完整 daemon / SDK recovery metadata 暴露也留给后续工作。
- Breaking changes / migration notes: 无预期 breaking changes。继续保留现有 interrupted_turn 协议命名。

## Linked Issues
Closes #6730

</details>
