### PR TITLE
fix(mcp): recover OAuth authentication after HTTP 401

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -1471,6 +1471,72 @@ describe('McpClientManager', () => {
     neverResolve();
   });
 
+  it('runs automatic OAuth outside the discovery timeout before reconnecting', async () => {
+    const order: string[] = [];
+    const connect = vi.fn().mockImplementation(async () => {
+      order.push('connect');
+    });
+    const discover = vi.fn().mockImplementation(async () => {
+      order.push('discover');
+    });
+    vi.mocked(McpClient).mockImplementation(
+      () =>
+        ({
+          connect,
+          discover,
+          disconnect: vi.fn().mockResolvedValue(undefined),
+          getStatus: vi.fn(),
+        }) as unknown as McpClient,
+    );
+    const mcpClientModule = await import('./mcp-client.js');
+    const authenticate = vi
+      .spyOn(mcpClientModule, 'attemptAutomaticMcpOAuth')
+      .mockImplementation(async () => {
+        order.push('authenticate');
+        return true;
+      });
+    const probe = vi
+      .spyOn(mcpClientModule, 'probeMcpServerForOAuth')
+      .mockImplementation(async () => {
+        order.push('probe');
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        return true;
+      });
+    const serverConfig = {
+      httpUrl: 'https://example.com/mcp',
+      discoveryTimeoutMs: 50,
+    };
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({ oauth: serverConfig }),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () =>
+        ({ removePromptsByServer: vi.fn() }) as unknown as PromptRegistry,
+      getResourceRegistry: () => ({ removeResourcesByServer: vi.fn() }),
+      getWorkspaceContext: () => ({}) as WorkspaceContext,
+      getDebugMode: () => false,
+      isMcpServerDisabled: () => false,
+      isInteractive: () => true,
+      isBrowserLaunchSuppressed: () => false,
+    } as unknown as Config;
+    const manager = mkManager({ config: mockConfig });
+
+    await manager.discoverAllMcpToolsIncremental(mockConfig);
+
+    expect(probe).toHaveBeenCalledWith('oauth', serverConfig);
+    expect(authenticate).toHaveBeenCalledWith('oauth', serverConfig, true);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(discover).toHaveBeenCalledTimes(2);
+    expect(order).toEqual([
+      'connect',
+      'discover',
+      'probe',
+      'authenticate',
+      'connect',
+      'discover',
+    ]);
+  });
+
   it('discoverAllMcpToolsIncremental skips servers flagged as disabled', async () => {
     // PR-A regression guard: the new incremental path used to iterate
     // `Object.entries(servers)` without consulting `isMcpServerDisabled`,

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -11,8 +11,10 @@ import {
   McpClient,
   MCPDiscoveryState,
   MCPServerStatus,
+  attemptAutomaticMcpOAuth,
   getMCPServerStatus,
   populateMcpServerCommand,
+  probeMcpServerForOAuth,
   removeMCPServerStatus,
   setMCPDiscoveryState,
 } from './mcp-client.js';
@@ -1346,6 +1348,7 @@ export class McpClientManager {
     const existingClient = this.clients.get(serverName);
     if (existingClient) {
       try {
+        existingClient.clearOAuthState?.();
         await existingClient.disconnect();
       } catch (error) {
         debugLogger.error(
@@ -1711,6 +1714,10 @@ export class McpClientManager {
                   `budget=${err.budget}, reservedCount=${err.reservedCount})`,
               );
             } else {
+              // The shared pool is injected by the ACP daemon, where opening
+              // a local browser is invalid. Record the OAuth requirement so a
+              // mediated client can authenticate, but do not auto-retry here.
+              await probeMcpServerForOAuth(name, config);
               debugLogger.error(
                 `Pool acquire failed for ${name}: ${getErrorMessage(err)}`,
               );
@@ -1835,6 +1842,7 @@ export class McpClientManager {
     const disconnectionPromises = Array.from(this.clients.entries()).map(
       async ([name, client]) => {
         try {
+          client.clearOAuthState?.();
           await client.disconnect();
         } catch (error) {
           debugLogger.error(
@@ -1886,6 +1894,7 @@ export class McpClientManager {
     const client = this.clients.get(serverName);
     if (client) {
       try {
+        client.clearOAuthState?.();
         await client.disconnect();
       } catch (error) {
         debugLogger.error(
@@ -2249,6 +2258,18 @@ export class McpClientManager {
           await this.runWithDiscoveryTimeout(name, serverConfig, () =>
             this.discoverMcpToolsForServer(name, cliConfig),
           );
+          await probeMcpServerForOAuth(name, serverConfig);
+          const authenticated = await attemptAutomaticMcpOAuth(
+            name,
+            serverConfig,
+            cliConfig.isInteractive?.() === true &&
+              cliConfig.isBrowserLaunchSuppressed?.() !== true,
+          );
+          if (authenticated) {
+            await this.runWithDiscoveryTimeout(name, serverConfig, () =>
+              this.discoverMcpToolsForServer(name, cliConfig),
+            );
+          }
           // `discoverMcpToolsForServerInternal` swallows connect/discover
           // errors (best-effort discovery semantics — see its catch block),
           // so the try here resolves even for failed servers. Only the
@@ -2518,6 +2539,7 @@ export class McpClientManager {
     const client = this.clients.get(serverName);
     if (client) {
       try {
+        client.clearOAuthState?.();
         await client.disconnect();
       } catch (error) {
         debugLogger.error(

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -24,6 +24,7 @@ import type { ResourceRegistry } from '../resources/resource-registry.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
   addMCPStatusChangeListener,
+  attemptAutomaticMcpOAuth,
   connectToMcpServer,
   createStreamableHttpCompatibilityFetch,
   createTransport,
@@ -38,8 +39,10 @@ import {
   listMcpResources,
   MCPServerStatus,
   McpClient,
+  mcpServerRequiresOAuth,
   discoverTools,
   populateMcpServerCommand,
+  probeMcpServerForOAuth,
   removeMCPServerStatus,
   removeMCPStatusChangeListener,
   updateMCPServerStatus,
@@ -491,7 +494,11 @@ describe('mcp-client', () => {
         discoverOAuthConfig,
         getValidToken,
         workspaceContext,
-      } = setupHttpOAuthRetry(new Error('HTTP 401 Unauthorized'));
+      } = setupHttpOAuthRetry(
+        new Error(
+          'Streamable HTTP error: Error POSTing to endpoint: {"error":"unauthorized"}',
+        ),
+      );
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         new Response(null, { status: 401 }),
       );
@@ -673,6 +680,237 @@ describe('mcp-client', () => {
   });
 
   describe('McpClient', () => {
+    it('recovers HTTP connections when the SDK omits the 401 status', async () => {
+      const connect = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Streamable HTTP error: Error POSTing to endpoint: {"error":"unauthorized"}',
+          ),
+        )
+        .mockResolvedValueOnce(undefined);
+      vi.mocked(ClientLib.Client).mockReturnValue({
+        connect,
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        getInstructions: vi.fn(),
+      } as unknown as ClientLib.Client);
+      const getCredentials = vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ clientId: 'client-id' });
+      vi.mocked(MCPOAuthTokenStorage).mockImplementation(
+        () =>
+          ({
+            getCredentials,
+          }) as unknown as MCPOAuthTokenStorage,
+      );
+      const authenticate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(MCPOAuthProvider).mockImplementation(
+        () =>
+          ({
+            authenticate,
+            getValidToken: vi.fn().mockResolvedValue('access-token'),
+          }) as unknown as MCPOAuthProvider,
+      );
+      vi.spyOn(OAuthUtils, 'discoverOAuthConfig').mockResolvedValue({
+        authorizationUrl: 'https://auth.example/authorize',
+        tokenUrl: 'https://auth.example/token',
+        scopes: ['mcp.read'],
+      });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'www-authenticate':
+              'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"',
+          },
+        }),
+      );
+      const serverName = 'active-http-oauth-server';
+      const serverConfig = {
+        httpUrl: 'https://example.com/mcp',
+        headers: { 'X-Tenant': 'tenant-a' },
+      };
+      const client = new McpClient(
+        serverName,
+        serverConfig,
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {
+          getDirectories: vi.fn().mockReturnValue([]),
+        } as unknown as WorkspaceContext,
+        false,
+      );
+      await expect(client.connect()).rejects.toThrow('unauthorized');
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
+
+      await expect(
+        Promise.all([
+          probeMcpServerForOAuth(serverName, serverConfig),
+          probeMcpServerForOAuth(serverName, serverConfig),
+        ]),
+      ).resolves.toEqual([true, true]);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://example.com/mcp',
+        expect.objectContaining({
+          method: 'HEAD',
+          headers: expect.objectContaining({ 'X-Tenant': 'tenant-a' }),
+          redirect: 'manual',
+        }),
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(mcpServerRequiresOAuth.get(serverName)).toBe(true);
+      expect(authenticate).not.toHaveBeenCalled();
+
+      await expect(
+        attemptAutomaticMcpOAuth(serverName, serverConfig, false),
+      ).resolves.toBe(false);
+      expect(authenticate).not.toHaveBeenCalled();
+
+      await expect(
+        Promise.all([
+          attemptAutomaticMcpOAuth(serverName, serverConfig, true),
+          attemptAutomaticMcpOAuth(serverName, serverConfig, true),
+        ]),
+      ).resolves.toEqual([true, true]);
+      await expect(client.connect()).resolves.toBeUndefined();
+
+      expect(authenticate).toHaveBeenCalledOnce();
+      expect(connect).toHaveBeenCalledTimes(2);
+      expect(client.getStatus()).toBe(MCPServerStatus.CONNECTED);
+      expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
+    });
+
+    it('does not classify a non-401 HTTP failure as OAuth', async () => {
+      vi.mocked(ClientLib.Client).mockReturnValue({
+        connect: vi
+          .fn()
+          .mockRejectedValue(
+            new Error(
+              'HTTP 403 Forbidden\nwww-authenticate: Bearer error="insufficient_scope"',
+            ),
+          ),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        getInstructions: vi.fn(),
+      } as unknown as ClientLib.Client);
+      vi.mocked(MCPOAuthTokenStorage).mockImplementation(
+        () =>
+          ({
+            getCredentials: vi.fn().mockResolvedValue(null),
+          }) as unknown as MCPOAuthTokenStorage,
+      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(null, { status: 503 }),
+      );
+      const serverName = 'active-http-non-oauth-server';
+      const client = new McpClient(
+        serverName,
+        { httpUrl: 'https://example.com/mcp' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {
+          getDirectories: vi.fn().mockReturnValue([]),
+        } as unknown as WorkspaceContext,
+        false,
+      );
+      mcpServerRequiresOAuth.set(serverName, true);
+
+      await expect(client.connect()).rejects.toThrow('HTTP 403 Forbidden');
+
+      await expect(
+        probeMcpServerForOAuth(serverName, {
+          httpUrl: 'https://example.com/mcp',
+        }),
+      ).resolves.toBe(false);
+
+      expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
+    });
+
+    it('serializes browser OAuth across servers and isolates requirements by URL', async () => {
+      const firstConfig = { httpUrl: 'https://first.example/mcp' };
+      const secondConfig = { httpUrl: 'https://second.example/mcp' };
+      const unauthorized = Object.assign(new Error('unauthorized'), {
+        status: 401,
+      });
+      await probeMcpServerForOAuth('queued-first', firstConfig, unauthorized);
+      await probeMcpServerForOAuth('queued-second', secondConfig, unauthorized);
+      vi.spyOn(OAuthUtils, 'discoverOAuthConfig').mockResolvedValue({
+        authorizationUrl: 'https://auth.example/authorize',
+        tokenUrl: 'https://auth.example/token',
+        scopes: [],
+      });
+      let activeAuthentications = 0;
+      let maxActiveAuthentications = 0;
+      const authenticate = vi.fn().mockImplementation(async () => {
+        activeAuthentications += 1;
+        maxActiveAuthentications = Math.max(
+          maxActiveAuthentications,
+          activeAuthentications,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        activeAuthentications -= 1;
+      });
+      vi.mocked(MCPOAuthProvider).mockImplementation(
+        () => ({ authenticate }) as unknown as MCPOAuthProvider,
+      );
+
+      await expect(
+        attemptAutomaticMcpOAuth(
+          'queued-first',
+          { httpUrl: 'https://other.example/mcp' },
+          true,
+        ),
+      ).resolves.toBe(false);
+      await expect(
+        Promise.all([
+          attemptAutomaticMcpOAuth('queued-first', firstConfig, true),
+          attemptAutomaticMcpOAuth('queued-second', secondConfig, true),
+        ]),
+      ).resolves.toEqual([true, true]);
+
+      expect(authenticate).toHaveBeenCalledTimes(2);
+      expect(maxActiveAuthentications).toBe(1);
+    });
+
+    it('clears only the matching URL from the name-level OAuth marker', async () => {
+      const serverName = 'shared-name-oauth-server';
+      const firstConfig = { httpUrl: 'https://first.example/mcp' };
+      const secondConfig = { httpUrl: 'https://second.example/mcp' };
+      const unauthorized = Object.assign(new Error('unauthorized'), {
+        status: 401,
+      });
+      await probeMcpServerForOAuth(serverName, firstConfig, unauthorized);
+      await probeMcpServerForOAuth(serverName, secondConfig, unauthorized);
+      const registries = [
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {} as WorkspaceContext,
+      ] as const;
+      const firstClient = new McpClient(
+        serverName,
+        firstConfig,
+        ...registries,
+        false,
+      );
+      const secondClient = new McpClient(
+        serverName,
+        secondConfig,
+        ...registries,
+        false,
+      );
+
+      firstClient.clearOAuthState();
+      expect(mcpServerRequiresOAuth.get(serverName)).toBe(true);
+
+      secondClient.clearOAuthState();
+      expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
+    });
+
     it('should discover tools', async () => {
       const mockedClient = {
         connect: vi.fn(),

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -94,6 +94,7 @@ describe('mcp-client', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     process.env = ORIGINAL_ENV;
   });
@@ -875,6 +876,74 @@ describe('mcp-client', () => {
 
       expect(authenticate).toHaveBeenCalledTimes(2);
       expect(maxActiveAuthentications).toBe(1);
+    });
+
+    it('times out automatic OAuth so discovery can settle', async () => {
+      vi.useFakeTimers();
+      const serverName = 'hanging-oauth-server';
+      const serverConfig = { httpUrl: 'https://hanging.example/mcp' };
+      const unauthorized = Object.assign(new Error('unauthorized'), {
+        status: 401,
+      });
+      await probeMcpServerForOAuth(serverName, serverConfig, unauthorized);
+      vi.spyOn(OAuthUtils, 'discoverOAuthConfig').mockResolvedValue({
+        authorizationUrl: 'https://auth.example/authorize',
+        tokenUrl: 'https://auth.example/token',
+        scopes: [],
+      });
+      vi.mocked(MCPOAuthProvider).mockImplementation(
+        () =>
+          ({
+            authenticate: vi.fn(() => new Promise(() => undefined)),
+          }) as unknown as MCPOAuthProvider,
+      );
+
+      const recovery = attemptAutomaticMcpOAuth(serverName, serverConfig, true);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await expect(recovery).resolves.toBe(false);
+    });
+
+    it('ignores stale OAuth probe results after the requirement is cleared', async () => {
+      let resolveProbe!: (response: Response) => void;
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockReturnValue(
+        new Promise<Response>((resolve) => {
+          resolveProbe = resolve;
+        }),
+      );
+      const serverName = 'cleared-oauth-probe-server';
+      const serverConfig = { httpUrl: 'https://example.com/mcp' };
+      vi.mocked(ClientLib.Client).mockReturnValue({
+        connect: vi.fn().mockRejectedValue(new Error('unauthorized')),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        getInstructions: vi.fn(),
+      } as unknown as ClientLib.Client);
+      vi.mocked(MCPOAuthTokenStorage).mockImplementation(
+        () =>
+          ({
+            getCredentials: vi.fn().mockResolvedValue(null),
+          }) as unknown as MCPOAuthTokenStorage,
+      );
+      const client = new McpClient(
+        serverName,
+        serverConfig,
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {
+          getDirectories: vi.fn().mockReturnValue([]),
+        } as unknown as WorkspaceContext,
+        false,
+      );
+      await expect(client.connect()).rejects.toThrow('unauthorized');
+
+      const probe = probeMcpServerForOAuth(serverName, serverConfig);
+      client.clearOAuthState();
+      resolveProbe(new Response(null, { status: 401 }));
+
+      await expect(probe).resolves.toBe(false);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
     });
 
     it('clears only the matching URL from the name-level OAuth marker', async () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -76,6 +76,7 @@ export type SendSdkMcpMessage = (
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
 const debugLogger = createDebugLogger('MCP');
+const AUTOMATIC_MCP_OAUTH_TIMEOUT_MS = 60_000;
 
 const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400]);
 const STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT = 512;
@@ -655,6 +656,7 @@ const mcpServerOAuthChallenges = new Map<string, string>();
 const mcpServerOAuthRequirements = new Set<string>();
 const mcpServerOAuthProbeCandidates = new Set<string>();
 const mcpServerOAuthProbeInFlight = new Map<string, Promise<boolean>>();
+const mcpServerOAuthProbeVersions = new Map<string, number>();
 const automaticOAuthInFlight = new Map<string, Promise<boolean>>();
 let automaticOAuthQueue: Promise<void> = Promise.resolve();
 
@@ -750,6 +752,10 @@ function clearMcpOAuthRequirement(
   mcpServerConfig: MCPServerConfig,
 ): void {
   const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
+  mcpServerOAuthProbeVersions.set(
+    key,
+    (mcpServerOAuthProbeVersions.get(key) ?? 0) + 1,
+  );
   mcpServerOAuthProbeCandidates.delete(key);
   mcpServerOAuthRequirements.delete(key);
   mcpServerOAuthChallenges.delete(key);
@@ -801,6 +807,7 @@ export async function probeMcpServerForOAuth(
   if (existingProbe) {
     return existingProbe;
   }
+  const probeVersion = mcpServerOAuthProbeVersions.get(key) ?? 0;
 
   const probe = (async () => {
     try {
@@ -819,6 +826,9 @@ export async function probeMcpServerForOAuth(
         },
       );
       if (response.status === 401) {
+        if ((mcpServerOAuthProbeVersions.get(key) ?? 0) !== probeVersion) {
+          return false;
+        }
         setMcpOAuthRequirement(
           mcpServerName,
           mcpServerConfig,
@@ -919,6 +929,30 @@ async function handleAutomaticOAuth(
   }
 }
 
+async function withAutomaticOAuthTimeout(
+  recovery: Promise<boolean>,
+  mcpServerName: string,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<boolean>((resolve) => {
+    timeout = setTimeout(() => {
+      debugLogger.error(
+        `Timed out handling automatic OAuth for server '${mcpServerName}'. ` +
+          getMcpOAuthDialogInstruction('authenticate', mcpServerName),
+      );
+      resolve(false);
+    }, AUTOMATIC_MCP_OAUTH_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([recovery, timedOut]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export async function attemptAutomaticMcpOAuth(
   mcpServerName: string,
   mcpServerConfig: MCPServerConfig,
@@ -943,10 +977,13 @@ export async function attemptAutomaticMcpOAuth(
 
   const recovery = automaticOAuthQueue
     .then(() =>
-      handleAutomaticOAuth(
+      withAutomaticOAuthTimeout(
+        handleAutomaticOAuth(
+          mcpServerName,
+          mcpServerConfig,
+          mcpServerOAuthChallenges.get(key) ?? '',
+        ),
         mcpServerName,
-        mcpServerConfig,
-        mcpServerOAuthChallenges.get(key) ?? '',
       ),
     )
     .finally(() => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -55,7 +55,7 @@ import { OAuthUtils } from '../mcp/oauth-utils.js';
 import type { OAuthCredentials } from '../mcp/token-storage/types.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { ResourceRegistry } from '../resources/resource-registry.js';
-import { getErrorMessage } from '../utils/errors.js';
+import { getErrorMessage, getErrorStatus } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { retryWithBackoff } from './mcp-retry.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
@@ -312,6 +312,7 @@ export class McpClient {
    */
   async connect(): Promise<void> {
     this.isDisconnecting = false;
+    clearMcpOAuthRequirement(this.serverName, this.serverConfig);
     // clear stale upstream error from
     // any prior connect/disconnect cycle. The silent-drop reader
     // is otherwise satisfied by `undefined` and falls back to the
@@ -369,6 +370,22 @@ export class McpClient {
       this.updateStatus(MCPServerStatus.CONNECTED);
     } catch (error) {
       this.instructions = undefined;
+      if (
+        hasNetworkTransport(this.serverConfig) &&
+        supportsMcpOAuth(this.serverConfig)
+      ) {
+        const key = oauthRecoveryKey(this.serverName, this.serverConfig);
+        const oauthChallenge = getMcpOAuthChallengeFromError(error);
+        if (oauthChallenge.confirmed401) {
+          setMcpOAuthRequirement(
+            this.serverName,
+            this.serverConfig,
+            oauthChallenge.wwwAuthenticate,
+          );
+        } else {
+          mcpServerOAuthProbeCandidates.add(key);
+        }
+      }
       this.updateStatus(MCPServerStatus.DISCONNECTED);
       throw error;
     }
@@ -574,6 +591,10 @@ export class McpClient {
     return this.instructions;
   }
 
+  clearOAuthState(): void {
+    clearMcpOAuthRequirement(this.serverName, this.serverConfig);
+  }
+
   async readResource(
     uri: string,
     options?: { signal?: AbortSignal },
@@ -630,6 +651,13 @@ let mcpDiscoveryState: MCPDiscoveryState = MCPDiscoveryState.NOT_STARTED;
  */
 export const mcpServerRequiresOAuth: Map<string, boolean> = new Map();
 
+const mcpServerOAuthChallenges = new Map<string, string>();
+const mcpServerOAuthRequirements = new Set<string>();
+const mcpServerOAuthProbeCandidates = new Set<string>();
+const mcpServerOAuthProbeInFlight = new Map<string, Promise<boolean>>();
+const automaticOAuthInFlight = new Map<string, Promise<boolean>>();
+let automaticOAuthQueue: Promise<void> = Promise.resolve();
+
 /**
  * Get the current MCP discovery state
  */
@@ -677,6 +705,140 @@ function extractWWWAuthenticateHeader(errorString: string): string | null {
   }
 
   return null;
+}
+
+function oauthRecoveryKey(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+): string {
+  return `${mcpServerName}\0${mcpServerConfig.httpUrl ?? mcpServerConfig.url ?? ''}`;
+}
+
+function supportsMcpOAuth(mcpServerConfig: MCPServerConfig): boolean {
+  return (
+    !mcpServerConfig.authProviderType ||
+    mcpServerConfig.authProviderType === AuthProviderType.DYNAMIC_DISCOVERY
+  );
+}
+
+function getMcpOAuthChallengeFromError(error: unknown): {
+  confirmed401: boolean;
+  wwwAuthenticate: string;
+} {
+  const errorString = getErrorMessage(error);
+  return {
+    confirmed401:
+      getErrorStatus(error) === 401 || /(^|\D)401(\D|$)/.test(errorString),
+    wwwAuthenticate: extractWWWAuthenticateHeader(errorString) ?? '',
+  };
+}
+
+function setMcpOAuthRequirement(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+  wwwAuthenticate: string,
+): void {
+  const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
+  mcpServerOAuthProbeCandidates.delete(key);
+  mcpServerOAuthRequirements.add(key);
+  mcpServerOAuthChallenges.set(key, wwwAuthenticate);
+  mcpServerRequiresOAuth.set(mcpServerName, true);
+}
+
+function clearMcpOAuthRequirement(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+): void {
+  const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
+  mcpServerOAuthProbeCandidates.delete(key);
+  mcpServerOAuthRequirements.delete(key);
+  mcpServerOAuthChallenges.delete(key);
+  const serverPrefix = `${mcpServerName}\0`;
+  if (
+    ![...mcpServerOAuthRequirements].some((candidate) =>
+      candidate.startsWith(serverPrefix),
+    )
+  ) {
+    mcpServerRequiresOAuth.delete(mcpServerName);
+  }
+}
+
+export async function probeMcpServerForOAuth(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+  error?: unknown,
+): Promise<boolean> {
+  if (
+    !hasNetworkTransport(mcpServerConfig) ||
+    !supportsMcpOAuth(mcpServerConfig)
+  ) {
+    return false;
+  }
+
+  const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
+  if (error !== undefined) {
+    const challenge = getMcpOAuthChallengeFromError(error);
+    if (challenge.confirmed401) {
+      setMcpOAuthRequirement(
+        mcpServerName,
+        mcpServerConfig,
+        challenge.wwwAuthenticate,
+      );
+      return true;
+    }
+  } else if (
+    !mcpServerOAuthProbeCandidates.has(key) &&
+    !mcpServerOAuthRequirements.has(key)
+  ) {
+    return false;
+  }
+
+  if (mcpServerOAuthRequirements.has(key)) {
+    return true;
+  }
+
+  const existingProbe = mcpServerOAuthProbeInFlight.get(key);
+  if (existingProbe) {
+    return existingProbe;
+  }
+
+  const probe = (async () => {
+    try {
+      const response = await fetch(
+        mcpServerConfig.httpUrl || mcpServerConfig.url!,
+        {
+          method: 'HEAD',
+          headers: {
+            ...mcpServerConfig.headers,
+            Accept: mcpServerConfig.httpUrl
+              ? 'application/json'
+              : 'text/event-stream',
+          },
+          redirect: 'manual',
+          signal: AbortSignal.timeout(5000),
+        },
+      );
+      if (response.status === 401) {
+        setMcpOAuthRequirement(
+          mcpServerName,
+          mcpServerConfig,
+          response.headers.get('www-authenticate') ?? '',
+        );
+        return true;
+      }
+    } catch (fetchError) {
+      debugLogger.debug(
+        `Failed to probe MCP server for OAuth challenge: ${getErrorMessage(fetchError)}`,
+      );
+    }
+
+    mcpServerOAuthProbeCandidates.delete(key);
+    return false;
+  })().finally(() => {
+    mcpServerOAuthProbeInFlight.delete(key);
+  });
+  mcpServerOAuthProbeInFlight.set(key, probe);
+  return probe;
 }
 
 /**
@@ -755,6 +917,47 @@ async function handleAutomaticOAuth(
     );
     return false;
   }
+}
+
+export async function attemptAutomaticMcpOAuth(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+  allowBrowserLaunch: boolean,
+): Promise<boolean> {
+  if (
+    !allowBrowserLaunch ||
+    !supportsMcpOAuth(mcpServerConfig) ||
+    (!mcpServerConfig.httpUrl && !mcpServerConfig.oauth?.enabled)
+  ) {
+    return false;
+  }
+
+  const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
+  if (!mcpServerOAuthRequirements.has(key)) {
+    return false;
+  }
+  const existing = automaticOAuthInFlight.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const recovery = automaticOAuthQueue
+    .then(() =>
+      handleAutomaticOAuth(
+        mcpServerName,
+        mcpServerConfig,
+        mcpServerOAuthChallenges.get(key) ?? '',
+      ),
+    )
+    .finally(() => {
+      automaticOAuthInFlight.delete(key);
+    });
+  automaticOAuthInFlight.set(key, recovery);
+  automaticOAuthQueue = recovery.then(
+    () => undefined,
+    () => undefined,
+  );
+  return recovery;
 }
 
 /**
@@ -935,7 +1138,7 @@ export async function connectAndDiscover(
     updateMCPServerStatus(mcpServerName, MCPServerStatus.CONNECTED);
     // A successful connect proves authentication works now — clear the sticky
     // 401 marker so later unrelated outages aren't mislabeled as auth failures.
-    mcpServerRequiresOAuth.delete(mcpServerName);
+    clearMcpOAuthRequirement(mcpServerName, mcpServerConfig);
 
     // Register any discovered tools
     for (const tool of tools) {
@@ -1301,6 +1504,7 @@ export async function connectToMcpServer(
   workspaceContext: WorkspaceContext,
   sendSdkMcpMessage?: SendSdkMcpMessage,
 ): Promise<Client> {
+  clearMcpOAuthRequirement(mcpServerName, mcpServerConfig);
   const mcpClient = new Client({
     name: 'qwen-code-mcp-client',
     version: '0.0.1',
@@ -1385,6 +1589,7 @@ export async function connectToMcpServer(
       await mcpClient.connect(transport, {
         timeout: mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
       });
+      clearMcpOAuthRequirement(mcpServerName, mcpServerConfig);
       return mcpClient;
     } catch (error) {
       unlistenDirectories?.();
@@ -1395,10 +1600,12 @@ export async function connectToMcpServer(
   } catch (error) {
     unlistenDirectories?.();
     unlistenDirectories = undefined;
-    // Check if this is a 401 error that might indicate OAuth is required
-    const errorString = String(error);
-    if (errorString.includes('401') && hasNetworkTransport(mcpServerConfig)) {
-      mcpServerRequiresOAuth.set(mcpServerName, true);
+    const requiresOAuth = await probeMcpServerForOAuth(
+      mcpServerName,
+      mcpServerConfig,
+      error,
+    );
+    if (requiresOAuth) {
       // Only trigger automatic OAuth discovery for HTTP servers or when OAuth is explicitly configured
       // For SSE servers, we should not trigger new OAuth flows automatically
       const shouldTriggerOAuth =
@@ -1439,42 +1646,10 @@ export async function connectToMcpServer(
         throw new Error(oauthMessage);
       }
 
-      // Try to extract www-authenticate header from the error
-      let wwwAuthenticate = extractWWWAuthenticateHeader(errorString);
-
-      // If we didn't get the header from the error string, try to get it from the server
-      if (!wwwAuthenticate && hasNetworkTransport(mcpServerConfig)) {
-        debugLogger.debug(
-          `No www-authenticate header in error, trying to fetch it from server...`,
-        );
-        try {
-          const urlToFetch = mcpServerConfig.httpUrl || mcpServerConfig.url!;
-          const response = await fetch(urlToFetch, {
-            method: 'HEAD',
-            headers: {
-              Accept: mcpServerConfig.httpUrl
-                ? 'application/json'
-                : 'text/event-stream',
-            },
-            signal: AbortSignal.timeout(5000),
-          });
-
-          if (response.status === 401) {
-            wwwAuthenticate = response.headers.get('www-authenticate');
-            if (wwwAuthenticate) {
-              debugLogger.debug(
-                `Found www-authenticate header from server: ${wwwAuthenticate}`,
-              );
-            }
-          }
-        } catch (fetchError) {
-          debugLogger.debug(
-            `Failed to fetch www-authenticate header: ${getErrorMessage(
-              fetchError,
-            )}`,
-          );
-        }
-      }
+      const wwwAuthenticate =
+        mcpServerOAuthChallenges.get(
+          oauthRecoveryKey(mcpServerName, mcpServerConfig),
+        ) ?? '';
 
       if (wwwAuthenticate) {
         debugLogger.debug(
@@ -1521,6 +1696,7 @@ export async function connectToMcpServer(
                       mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
                   });
                   // Connection successful with OAuth
+                  clearMcpOAuthRequirement(mcpServerName, mcpServerConfig);
                   return mcpClient;
                 } catch (retryError) {
                   debugLogger.error(
@@ -1651,6 +1827,7 @@ export async function connectToMcpServer(
                         mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC,
                     });
                     // Connection successful with OAuth
+                    clearMcpOAuthRequirement(mcpServerName, mcpServerConfig);
                     return mcpClient;
                   } catch (retryError) {
                     debugLogger.error(


### PR DESCRIPTION
## What this PR does

This change restores OAuth recovery for Streamable HTTP MCP servers on the active progressive-discovery path. When the SDK drops the HTTP status from a failed connection, Qwen Code performs a bounded, non-redirecting HEAD probe, records a confirmed 401 challenge, runs interactive OAuth outside the discovery timeout, and retries discovery with the stored token.

OAuth probes and authentication are de-duplicated per server endpoint, while browser-based flows for different servers are serialized because they share one local callback listener. Headless, `--no-browser`, ACP, URL-only SSE, and non-OAuth credential-provider paths do not launch a browser.

## Why it's needed

The startup path currently marks an HTTP MCP server as disconnected as soon as its initial POST returns 401. The existing OAuth recovery code lives on a legacy path, and its error-string gate is unreliable because the MCP SDK often omits the status code. As a result, affected servers stay offline with no automatic authentication or actionable OAuth state.

## Reviewer Test Plan

### How to verify

Configure an approved `httpUrl` MCP server whose initial POST returns 401 and whose HEAD response returns 401 with a Bearer `WWW-Authenticate` challenge. In an interactive session, confirm that exactly one OAuth browser flow starts, successful authentication is followed by a fresh connection, and the server becomes connected with its tools available.

Repeat with `--no-browser` or a non-interactive session and confirm that no browser opens while the server is reported as requiring authentication. With two OAuth-required servers, confirm their browser flows run sequentially rather than competing for the callback listener.

### Evidence (Before & After)

Before: the local protocol harness received only `POST /mcp`; the server ended as `disconnected` with `requiresOAuth: false`.

After: the same harness receives `POST /mcp` followed by `HEAD /mcp`; the confirmed 401 produces `disconnected` with `requiresOAuth: true`, enabling the automatic interactive recovery path. Focused regression suites pass 98 MCP client tests and 112 manager tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, sandbox disabled for the loopback-only protocol harness.

## Risk & Scope

- Main risk or tradeoff: a failed eligible network connection may perform one bounded HEAD request to the configured endpoint; redirects are not followed, and concurrent probes are de-duplicated.
- Not validated / out of scope: a real third-party browser OAuth provider was not exercised end to end; Windows and Linux are left to CI. ACP remains mediated and never opens a local browser.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6639

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个改动为当前渐进式发现链路上的 Streamable HTTP MCP 服务恢复 OAuth 处理。当 SDK 丢失连接失败的 HTTP 状态码时，Qwen Code 会发起一个有超时且不跟随重定向的 HEAD 探测；确认 401 challenge 后记录认证状态，在 discovery timeout 之外执行交互式 OAuth，并使用已保存的 token 重新发现服务。

同一服务端点的 OAuth 探测和认证会被去重；不同服务的浏览器认证会串行执行，因为它们共享同一个本地 callback listener。无头模式、`--no-browser`、ACP、仅 URL 的 SSE 和非 OAuth credential provider 链路都不会打开浏览器。

## 为什么需要

当前启动链路在 HTTP MCP 服务首次 POST 返回 401 后会直接把它标记为断开。已有 OAuth recovery 只存在于旧链路，而且依赖错误字符串中的 401；MCP SDK 经常不保留状态码，因此这个判断并不可靠。结果是受影响的服务持续离线，既不会自动认证，也没有正确的 OAuth 状态。

## Reviewer Test Plan

### 如何验证

配置一个已批准的 `httpUrl` MCP 服务：首次 POST 返回 401，HEAD 返回 401 和 Bearer `WWW-Authenticate` challenge。在交互式会话中确认只启动一次 OAuth 浏览器流程；认证成功后建立新连接，并且服务恢复连接、工具可用。

使用 `--no-browser` 或非交互会话重复验证，确认不会打开浏览器，同时服务会报告需要认证。配置两个需要 OAuth 的服务，确认两个浏览器流程串行执行，不会争抢 callback listener。

### 证据（修复前后）

修复前：本地协议 harness 只收到 `POST /mcp`；服务最终为 `disconnected`，并且 `requiresOAuth: false`。

修复后：同一 harness 依次收到 `POST /mcp` 和 `HEAD /mcp`；确认 401 后服务为 `disconnected`，并且 `requiresOAuth: true`，从而进入交互式自动恢复链路。聚焦回归测试通过 98 个 MCP client 用例和 112 个 manager 用例。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22；仅在运行 loopback 协议 harness 时关闭 sandbox。

## 风险与范围

- 主要风险或取舍：符合条件的网络连接失败后可能会向已配置端点发送一次有超时的 HEAD 请求；不会跟随重定向，并发探测会被去重。
- 未验证 / 不在范围内：未对真实第三方浏览器 OAuth provider 做完整端到端验证；Windows 和 Linux 留给 CI。ACP 继续使用中介认证，不会打开本地浏览器。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6639

</details>
