### PR TITLE
fix(core): preserve managed memory during microcompaction

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -557,6 +557,7 @@ describe('Gemini Client (client.ts)', () => {
       getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
       getUseModelRouter: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
+      getTargetDir: vi.fn().mockReturnValue('/test/project/root'),
       getCwd: vi.fn().mockReturnValue('/test/project/root'),
       storage: {
         getProjectTempDir: vi.fn().mockReturnValue('/test/temp'),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1764,7 +1764,7 @@ export class GeminiClient {
         this.getHistoryShallow(),
         lastCompletionTimestamp,
         this.config.getClearContextOnIdle(),
-        opts,
+        { ...opts, projectRoot: this.config.getTargetDir() },
       );
       if (!mcResult.meta) {
         return false;

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -1775,7 +1775,7 @@ export class GeminiChat {
       this.history,
       null,
       this.config.getClearContextOnIdle(),
-      { force: true },
+      { force: true, projectRoot: this.config.getTargetDir() },
     );
     const mcMeta = mcResult.meta;
 

--- a/packages/core/src/services/memoryPressureMonitor.test.ts
+++ b/packages/core/src/services/memoryPressureMonitor.test.ts
@@ -162,6 +162,7 @@ function createMockConfig(
         }
       : overrides.geminiClient;
   return {
+    getTargetDir: () => '/project',
     getFileReadCache: () =>
       ({
         clear: vi.fn(),

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -716,13 +716,18 @@ export class MemoryPressureMonitor extends EventEmitter {
           const chat = client.getChat();
           const history = chat.getHistoryShallow?.() ?? chat.getHistory();
           const settings = this.coreConfig.getClearContextOnIdle();
-          const result = microcompactHistory(history, Date.now() - 1, {
-            ...settings,
-            toolResultsThresholdMinutes:
-              (settings.toolResultsThresholdMinutes ?? 0) < 0
-                ? settings.toolResultsThresholdMinutes
-                : 0,
-          });
+          const result = microcompactHistory(
+            history,
+            Date.now() - 1,
+            {
+              ...settings,
+              toolResultsThresholdMinutes:
+                (settings.toolResultsThresholdMinutes ?? 0) < 0
+                  ? settings.toolResultsThresholdMinutes
+                  : 0,
+            },
+            { projectRoot: this.coreConfig.getTargetDir() },
+          );
           if (result.meta) {
             chat.setHistory(result.history);
             // Explicitly clear fileReadCache here instead of relying on

--- a/packages/core/src/services/microcompaction/microcompact.test.ts
+++ b/packages/core/src/services/microcompaction/microcompact.test.ts
@@ -5,8 +5,13 @@
  */
 
 import { describe, expect, it, afterEach } from 'vitest';
+import path from 'node:path';
 import type { Content } from '@google/genai';
 import type { ClearContextOnIdleSettings } from '../../config/config.js';
+import {
+  getAutoMemoryRoot,
+  getUserAutoMemoryRoot,
+} from '../../memory/paths.js';
 
 import {
   evaluateTimeBasedTrigger,
@@ -1266,6 +1271,131 @@ describe('microcompactHistory evictedReadPaths (issue #4239)', () => {
 
     // No trigger → no meta at all (and therefore no eviction data).
     expect(result.meta).toBeUndefined();
+  });
+});
+
+describe('microcompactHistory managed memory reads (issue #6713)', () => {
+  const projectRoot = '/project';
+  const managedMemoryPath = path.join(
+    getAutoMemoryRoot(projectRoot),
+    'user',
+    'preferences.md',
+  );
+
+  function fileCall(id: string, filePath: string): Content {
+    return {
+      role: 'model',
+      parts: [
+        {
+          functionCall: {
+            id,
+            name: 'read_file',
+            args: { file_path: filePath },
+          },
+        },
+      ],
+    };
+  }
+
+  function fileResult(id: string, output: string): Content {
+    return {
+      role: 'user',
+      parts: [
+        { functionResponse: { id, name: 'read_file', response: { output } } },
+      ],
+    };
+  }
+
+  it('keeps managed memory reads during idle compaction', () => {
+    const history: Content[] = [
+      fileCall('memory', managedMemoryPath),
+      fileResult('memory', 'managed memory content'),
+      fileCall('ordinary', '/project/old.ts'),
+      fileResult('ordinary', 'ordinary content '.repeat(50)),
+      fileCall('recent', '/project/recent.ts'),
+      fileResult('recent', 'recent content'),
+    ];
+
+    const result = microcompactHistory(
+      history,
+      Date.now() - 2 * 60 * 60 * 1000,
+      {
+        toolResultsThresholdMinutes: 5,
+        toolResultsNumToKeep: 1,
+      },
+      { projectRoot },
+    );
+
+    expect(
+      result.history[1]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe('managed memory content');
+    expect(
+      result.history[3]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe(MICROCOMPACT_CLEARED_MESSAGE);
+    expect(result.meta?.toolsCleared).toBe(1);
+  });
+
+  it('keeps managed memory reads during size compaction', () => {
+    const history: Content[] = [
+      fileCall('memory', managedMemoryPath),
+      fileResult('memory', 'managed memory content '.repeat(50)),
+      fileCall('ordinary', '/project/old.ts'),
+      fileResult('ordinary', 'ordinary content '.repeat(50)),
+      fileCall('recent', '/project/recent.ts'),
+      fileResult('recent', 'recent content'),
+    ];
+
+    const result = microcompactHistory(
+      history,
+      Date.now(),
+      {
+        toolResultsThresholdMinutes: 60,
+        toolResultsNumToKeep: 1,
+        toolResultsTotalCharsThreshold: 20,
+      },
+      { sizeOnly: true, projectRoot },
+    );
+
+    expect(
+      result.history[1]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe('managed memory content '.repeat(50));
+    expect(
+      result.history[3]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe(MICROCOMPACT_CLEARED_MESSAGE);
+    expect(result.meta?.toolsCleared).toBe(1);
+  });
+
+  it('keeps user-level managed memory reads during idle compaction', () => {
+    const userMemoryPath = path.join(
+      getUserAutoMemoryRoot(),
+      'user',
+      'preferences.md',
+    );
+    const history: Content[] = [
+      fileCall('memory', userMemoryPath),
+      fileResult('memory', 'user memory content'),
+      fileCall('ordinary', '/project/old.ts'),
+      fileResult('ordinary', 'ordinary content '.repeat(50)),
+      fileCall('recent', '/project/recent.ts'),
+      fileResult('recent', 'recent content'),
+    ];
+
+    const result = microcompactHistory(
+      history,
+      Date.now() - 2 * 60 * 60 * 1000,
+      {
+        toolResultsThresholdMinutes: 5,
+        toolResultsNumToKeep: 1,
+      },
+      { projectRoot },
+    );
+
+    expect(
+      result.history[1]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe('user memory content');
+    expect(
+      result.history[3]?.parts?.[0]?.functionResponse?.response?.['output'],
+    ).toBe(MICROCOMPACT_CLEARED_MESSAGE);
   });
 });
 

--- a/packages/core/src/services/microcompaction/microcompact.ts
+++ b/packages/core/src/services/microcompaction/microcompact.ts
@@ -8,6 +8,7 @@ import type { Content, Part } from '@google/genai';
 
 import type { ClearContextOnIdleSettings } from '../../config/config.js';
 import { DEFAULT_TOOL_RESULTS_TOTAL_CHARS_THRESHOLD } from '../../config/clearContextDefaults.js';
+import { isAnyAutoMemPath } from '../../memory/paths.js';
 import { sanitizeMimeForPlaceholder } from '../compactionInputSlimming.js';
 import { ToolNames } from '../../tools/tool-names.js';
 
@@ -149,17 +150,37 @@ function hasNestedMedia(part: Part): boolean {
  * `toolResultsNumToKeep: 1` keeps 1 tool result AND 1 media item, not
  * 1 entry total across the combined list.
  */
-function collectCompactablePartRefs(history: Content[]): CollectedRefs {
+function isManagedMemoryRead(
+  part: Part,
+  callIdToFilePath: Map<string, string[]>,
+  projectRoot: string | undefined,
+): boolean {
+  if (!projectRoot || part.functionResponse?.name !== ToolNames.READ_FILE) {
+    return false;
+  }
+  const paths = getFilePathsForResponse(part, callIdToFilePath);
+  return paths?.length === 1 && isAnyAutoMemPath(paths[0]!, projectRoot);
+}
+
+function collectCompactablePartRefs(
+  history: Content[],
+  projectRoot?: string,
+): CollectedRefs {
   const tool: PartRef[] = [];
   const media: PartRef[] = [];
   const nestedMedia: PartRef[] = [];
+  const callIdToFilePath = buildCallIdToFilePath(history);
   for (let ci = 0; ci < history.length; ci++) {
     const content = history[ci]!;
     if (content.role !== 'user' || !content.parts) continue;
     for (let pi = 0; pi < content.parts.length; pi++) {
       const part = content.parts[pi]!;
       const fnName = part.functionResponse?.name;
-      if (fnName && COMPACTABLE_TOOLS.has(fnName)) {
+      if (
+        fnName &&
+        COMPACTABLE_TOOLS.has(fnName) &&
+        !isManagedMemoryRead(part, callIdToFilePath, projectRoot)
+      ) {
         tool.push({ contentIndex: ci, partIndex: pi, kind: 'tool' });
       } else if (part.functionResponse && hasNestedMedia(part)) {
         // Non-compactable tool result with media attached — clear only
@@ -347,6 +368,7 @@ function planSizeBasedClearing(
   settings: ClearContextOnIdleSettings,
   keepRecent: number,
   pendingContent: Content | Content[] | undefined,
+  projectRoot?: string,
 ): SizeClearPlan | null {
   const threshold = getToolResultsTotalCharsThreshold(settings);
   if (!Number.isFinite(threshold) || threshold < 0) {
@@ -356,7 +378,7 @@ function planSizeBasedClearing(
   const pending = normalizePendingContent(pendingContent);
   const virtualHistory =
     pending.length > 0 ? [...history, ...pending] : history;
-  const { tool } = collectCompactablePartRefs(virtualHistory);
+  const { tool } = collectCompactablePartRefs(virtualHistory, projectRoot);
   const charsByRef = new Map<string, number>();
   let totalChars = 0;
   let pendingChars = 0;
@@ -412,6 +434,7 @@ export interface MicrocompactOptions {
   force?: boolean;
   sizeOnly?: boolean;
   pendingContent?: Content | Content[];
+  projectRoot?: string;
 }
 
 export interface MicrocompactMeta {
@@ -494,7 +517,10 @@ export function microcompactHistory(
   }
 
   if (triggerReason === 'force' || triggerReason === 'idle') {
-    ({ tool, media, nestedMedia } = collectCompactablePartRefs(history));
+    ({ tool, media, nestedMedia } = collectCompactablePartRefs(
+      history,
+      opts?.projectRoot,
+    ));
     // Each kind gets its own keepRecent budget: setting
     // `toolResultsNumToKeep: 1` keeps 1 of each, not 1 total. This
     // matches what users typically expect when they configure the
@@ -514,6 +540,7 @@ export function microcompactHistory(
       settings,
       keepRecent,
       pending,
+      opts?.projectRoot,
     );
     if (!sizePlan) {
       return { history };


### PR DESCRIPTION
## What this PR does

Prevents managed auto-memory reads from being cleared by microcompaction. Project-level and user-level managed memory remain available after both idle-triggered and size-triggered compaction, while ordinary old tool results continue to be compacted.

## Why it's needed

Managed memory can be intentionally loaded into a conversation for durable context. Previously, microcompaction treated these reads like ordinary file output and replaced their content with a placeholder, which made the memory unavailable later in the session.

## Reviewer Test Plan

### How to verify

1. Create a history that contains an older `read_file` response for a managed-memory path, followed by ordinary file reads.
2. Trigger idle or size-based microcompaction.
3. Confirm the managed-memory response remains intact and ordinary older output is cleared.

### Evidence (Before & After)

Before: managed-memory `read_file` responses were cleared with ordinary tool output.

After: the focused regression coverage confirms project-level and user-level managed memory is retained for idle compaction, and project-level memory is retained for size compaction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit test + core typecheck |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js v24.14.0.

## Risk & Scope

- Main risk or tradeoff: managed memory is deliberately excluded from microcompaction, so it can retain a small amount of additional context.
- Not validated / out of scope: full integration and cross-platform suites.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6713

## AI-assisted contribution

This contribution was implemented with Codex and independently reviewed before submission.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

防止受管理的自动记忆读取结果被微压缩清除。项目级和用户级的受管理记忆在空闲触发和大小触发的压缩后仍可使用，而普通的旧工具结果仍会被压缩。

## 为什么需要它

受管理记忆会被有意加载到对话中，作为可持续使用的上下文。此前，微压缩会把这些读取结果当作普通文件输出，并用占位符替换其内容，导致记忆在同一会话后续阶段不可用。

## 审查者测试计划

### 如何验证

1. 创建一段历史，其中包含一个较早的、读取受管理记忆路径的 `read_file` 响应，随后加入普通文件读取。
2. 触发基于空闲时间或结果大小的微压缩。
3. 确认受管理记忆响应仍保持完整，而普通较旧输出被清除。

### 证据（修改前与修改后）

修改前：受管理记忆的 `read_file` 响应会和普通工具输出一起被清除。

修改后：聚焦的回归测试确认项目级和用户级受管理记忆在空闲压缩中会被保留，项目级受管理记忆在大小压缩中也会被保留。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 单元测试和 core 类型检查 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS，Node.js v24.14.0。

## 风险与范围

- 主要风险或取舍：受管理记忆会被有意排除在微压缩之外，因此可能保留少量额外上下文。
- 未验证或不在范围内：完整集成测试与跨平台测试套件。
- 破坏性变更或迁移说明：无。

## 关联 Issue

修复 #6713

## AI 辅助贡献

本贡献由 Codex 协助实现，并在提交前进行了独立审查。

</details>
