### PR TITLE
fix(core): use decimal Claude output limits

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -247,7 +247,7 @@ describe('DefaultOpenAICompatibleProvider', () => {
         'prompt-id',
       );
 
-      expect(result.max_tokens).toBe(131072);
+      expect(result.max_tokens).toBe(128_000);
     });
 
     it('should ignore malformed QWEN_CODE_MAX_OUTPUT_TOKENS values', () => {

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -309,9 +309,9 @@ describe('tokenLimit with output type', () => {
     });
 
     it('should return correct output limits for Claude Opus 4.6 through 4.8', () => {
-      expect(tokenLimit('claude-opus-4-6', 'output')).toBe(131072);
-      expect(tokenLimit('claude-opus-4-7', 'output')).toBe(131072);
-      expect(tokenLimit('vertex/claude-opus-4-8', 'output')).toBe(131072);
+      expect(tokenLimit('claude-opus-4-6', 'output')).toBe(128_000);
+      expect(tokenLimit('claude-opus-4-7', 'output')).toBe(128_000);
+      expect(tokenLimit('vertex/claude-opus-4-8', 'output')).toBe(128_000);
       expect(tokenLimit('claude-sonnet-4-6', 'output')).toBe(65536);
     });
   });
@@ -469,9 +469,9 @@ describe('defaultOutputCeiling', () => {
   });
 
   it('allows Claude Opus 4.6 through 4.8 to use the full 128K default', () => {
-    expect(defaultOutputCeiling('claude-opus-4-6')).toBe(131_072);
-    expect(defaultOutputCeiling('claude-opus-4-7')).toBe(131_072);
-    expect(defaultOutputCeiling('vertex/claude-opus-4-8')).toBe(131_072);
+    expect(defaultOutputCeiling('claude-opus-4-6')).toBe(128_000);
+    expect(defaultOutputCeiling('claude-opus-4-7')).toBe(128_000);
+    expect(defaultOutputCeiling('vertex/claude-opus-4-8')).toBe(128_000);
   });
 
   it('uses the default output limit for an unknown model', () => {

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -245,7 +245,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^o\d/, LIMITS['128k']], // o-series: 128K
 
   // Anthropic Claude
-  [/^claude-opus-4-(?:6|7|8)/, LIMITS['128k']], // Opus 4.6-4.8: 128K
+  [/^claude-opus-4-(?:6|7|8)/, 128_000 as TokenCount], // Opus 4.6-4.8: 128K
   [/^claude-sonnet-4-6/, LIMITS['64k']], // Sonnet 4.6: 64K
   [/^claude-/, LIMITS['64k']], // Claude fallback: 64K
 


### PR DESCRIPTION
## What this PR does

Updates the default `max_tokens` for Claude Opus 4.6, 4.7, and 4.8 from the binary `131072` value to Anthropic's exact API ceiling of `128000`. The shared `LIMITS['128k']` value remains unchanged, so models such as GLM that accept `131072` are unaffected.

## Why it's needed

#6718 added the 1M context and 128K output rules for Opus 4.6-4.8, but reused the binary 128K constant. Anthropic-compatible endpoints reject `131072` because their maximum is `128000`, causing a 400 for users who do not explicitly configure `samplingParams.max_tokens`.

## Reviewer Test Plan

### How to verify

Remove any explicit `samplingParams.max_tokens` from a Claude Opus model configuration, then confirm that `claude-opus-4-6`, `claude-opus-4-7`, and provider-prefixed IDs such as `vertex/claude-opus-4-8` resolve to `128000`. Also confirm that an OpenAI-compatible request without `max_tokens` injects `128000`.

### Evidence (Before & After)

Tmux testing: before this change, `claude-opus-4-6` was rejected with `max_tokens: 131072 > 128000`. After this change, the same path with an isolated `QWEN_HOME` and no explicit `max_tokens` returned `TMUX_46_128000_OK` with exit code 0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
| 🐧 Linux  | ⚠️ |

### Environment (optional)

macOS arm64; `npm run dev`; isolated `QWEN_HOME`; qwen-code 0.19.9.

## Risk & Scope

- Main risk or tradeoff: This only lowers the Claude Opus 4.6-4.8 default by 3,072 tokens so default requests match Anthropic's exact API boundary.
- Not validated / out of scope: The native `claude-opus-4-8` tmux request was blocked by test-account model authorization. Full typecheck is blocked by pre-existing `packages/web-shell` daemon SDK type errors on current `main`.
- Breaking changes / migration notes: None. Explicit `samplingParams.max_tokens` behavior is unchanged.

## Linked Issues

Resolves #6734