### PR TITLE
fix(web-shell): support model & approval-mode changes for non-primary workspace sessions

### DIFF
--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -69,6 +69,17 @@ interface FakeBridge extends AcpSessionBridge {
   }>;
   readonly listCalls: string[];
   readonly summaryCalls: string[];
+  readonly setModelCalls: Array<{
+    sessionId: string;
+    req: { modelId?: unknown; sessionId?: unknown };
+    context?: BridgeClientRequestContext;
+  }>;
+  readonly setApprovalModeCalls: Array<{
+    sessionId: string;
+    mode: string;
+    opts: { persist?: boolean };
+    context?: BridgeClientRequestContext;
+  }>;
 }
 
 function makeSummary(
@@ -150,6 +161,8 @@ function makeBridge(
   const restoreCalls: FakeBridge['restoreCalls'] = [];
   const listCalls: string[] = [];
   const summaryCalls: string[] = [];
+  const setModelCalls: FakeBridge['setModelCalls'] = [];
+  const setApprovalModeCalls: FakeBridge['setApprovalModeCalls'] = [];
   const bridge = {
     permissionPolicy: 'first-responder' as const,
     spawnCalls,
@@ -165,6 +178,8 @@ function makeBridge(
     restoreCalls,
     listCalls,
     summaryCalls,
+    setModelCalls,
+    setApprovalModeCalls,
     get sessionCount() {
       return live.size;
     },
@@ -259,6 +274,33 @@ function makeBridge(
     ) {
       promptCalls.push({ sessionId, ...(context ? { context } : {}) });
       return Promise.resolve({ stopReason: 'end_turn' });
+    },
+    async setSessionModel(
+      sessionId: string,
+      req: { modelId?: unknown; sessionId?: unknown },
+      context?: BridgeClientRequestContext,
+    ) {
+      setModelCalls.push({ sessionId, req, ...(context ? { context } : {}) });
+      return { sessionId, modelId: req.modelId, _meta: { applied: true } };
+    },
+    async setSessionApprovalMode(
+      sessionId: string,
+      mode: string,
+      opts: { persist?: boolean },
+      context?: BridgeClientRequestContext,
+    ) {
+      setApprovalModeCalls.push({
+        sessionId,
+        mode,
+        opts,
+        ...(context ? { context } : {}),
+      });
+      return {
+        sessionId,
+        mode,
+        previous: 'default',
+        persisted: opts?.persist === true,
+      };
     },
     async cancelSession(sessionId: string) {
       cancelCalls.push(sessionId);
@@ -482,6 +524,24 @@ describe('multi-workspace session dispatch', () => {
       workspaceCwd: SECONDARY_CWD,
     });
     expect(res.body.workspaceCwd).toBe(SECONDARY_CWD);
+  });
+
+  it('applies a creation-time approvalMode on the owning non-primary runtime', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness();
+    const res = await request(app)
+      .post('/session')
+      .set('Host', host())
+      .send({ cwd: SECONDARY_CWD, approvalMode: 'yolo' });
+
+    expect(res.status).toBe(200);
+    expect(primaryBridge.spawnCalls).toEqual([]);
+    expect(secondaryBridge.spawnCalls).toHaveLength(1);
+    // The approval mode rides along with creation on the non-primary runtime,
+    // so no follow-up primary-only approval-mode round-trip is required.
+    expect(secondaryBridge.spawnCalls[0]).toMatchObject({
+      workspaceCwd: SECONDARY_CWD,
+      approvalMode: 'yolo',
+    });
   });
 
   it('rejects unknown and untrusted workspace session creation before touching a bridge', async () => {
@@ -776,6 +836,75 @@ describe('multi-workspace session dispatch', () => {
     expect(res.body.workspaceCwd).toBe(SECONDARY_CWD);
     expect(primaryBridge.restoreCalls).toEqual([]);
     expect(secondaryBridge.restoreCalls).toEqual([]);
+  });
+
+  it('routes POST /session/:id/model to the owning non-primary workspace bridge', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness();
+
+    const res = await request(app)
+      .post('/session/secondary-session/model')
+      .set('Host', host())
+      .set('X-Qwen-Client-Id', 'client-1')
+      .send({ modelId: 'qwen3-coder' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ _meta: { applied: true } });
+    expect(secondaryBridge.setModelCalls).toHaveLength(1);
+    expect(secondaryBridge.setModelCalls[0]?.sessionId).toBe(
+      'secondary-session',
+    );
+    expect(secondaryBridge.setModelCalls[0]?.req.modelId).toBe('qwen3-coder');
+    expect(secondaryBridge.setModelCalls[0]?.context).toEqual({
+      clientId: 'client-1',
+    });
+    // Owner-scoped: the mutation must land on the secondary bridge only, never
+    // the primary one.
+    expect(primaryBridge.setModelCalls).toEqual([]);
+  });
+
+  it('routes POST /session/:id/approval-mode to the owning non-primary workspace bridge', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness();
+
+    const res = await request(app)
+      .post('/session/secondary-session/approval-mode')
+      .set('Host', host())
+      .send({ mode: 'yolo', persist: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      sessionId: 'secondary-session',
+      mode: 'yolo',
+      persisted: true,
+    });
+    expect(secondaryBridge.setApprovalModeCalls).toHaveLength(1);
+    expect(secondaryBridge.setApprovalModeCalls[0]).toMatchObject({
+      sessionId: 'secondary-session',
+      mode: 'yolo',
+      opts: { persist: true },
+    });
+    expect(primaryBridge.setApprovalModeCalls).toEqual([]);
+  });
+
+  it('still rejects model/approval-mode mutations on an untrusted non-primary session', async () => {
+    // Opening these routes to non-primary owners must not bypass the trust
+    // gate: an untrusted workspace runtime is refused before the bridge runs.
+    const { app, secondaryBridge } = makeHarness({ secondaryTrusted: false });
+
+    const modelRes = await request(app)
+      .post('/session/secondary-session/model')
+      .set('Host', host())
+      .send({ modelId: 'qwen3-coder' });
+    expect(modelRes.status).toBe(403);
+    expect(modelRes.body.code).toBe('untrusted_workspace');
+    expect(secondaryBridge.setModelCalls).toEqual([]);
+
+    const approvalRes = await request(app)
+      .post('/session/secondary-session/approval-mode')
+      .set('Host', host())
+      .send({ mode: 'yolo' });
+    expect(approvalRes.status).toBe(403);
+    expect(approvalRes.body.code).toBe('untrusted_workspace');
+    expect(secondaryBridge.setApprovalModeCalls).toEqual([]);
   });
 
   it('lists active persisted and live non-primary workspace sessions by workspace id', async () => {

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2444,9 +2444,9 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/model',
     mutate(),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/model',
-      async (req, res, sessionId) => {
+      async (req, res, sessionId, runtime) => {
         const body = safeBody(req);
         const modelId = body['modelId'];
         if (typeof modelId !== 'string' || !modelId) {
@@ -2457,7 +2457,7 @@ export function registerSessionRoutes(
         }
         const clientId = parseClientIdHeader(req, res);
         if (clientId === null) return;
-        const response = await bridge.setSessionModel(
+        const response = await runtime.bridge.setSessionModel(
           sessionId,
           {
             ...(body as object),
@@ -2777,9 +2777,9 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/approval-mode',
     mutate(),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/approval-mode',
-      async (req, res, sessionId) => {
+      async (req, res, sessionId, runtime) => {
         // Validates `mode` against `APPROVAL_MODES` and an optional
         // `persist: boolean` flag.
         const body = safeBody(req);
@@ -2805,7 +2805,7 @@ export function registerSessionRoutes(
         }
         const clientId = parseClientIdHeader(req, res);
         if (clientId === null) return;
-        const response = await bridge.setSessionApprovalMode(
+        const response = await runtime.bridge.setSessionApprovalMode(
           sessionId,
           mode as ApprovalMode,
           { persist: persist === true },

--- a/packages/web-shell/client/utils/sessionPreparation.test.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.test.ts
@@ -4,7 +4,6 @@ import { createAndAttachSessionForPrompt } from './sessionPreparation';
 type CreateSessionArgs = Parameters<typeof createAndAttachSessionForPrompt>[0];
 const sessionResult = { sessionId: 'session-1' };
 const modelResult = { model: 'qwen3' };
-const approvalModeResult = { mode: 'yolo' };
 
 function createActions(
   overrides: Partial<CreateSessionArgs['sessionActions']> = {},
@@ -15,18 +14,13 @@ function createActions(
     closeSession: vi.fn(async () => {}),
     clearSession: vi.fn(async () => {}),
     setModel: vi.fn(async () => modelResult),
-    setApprovalMode: vi.fn(async () => approvalModeResult),
     ...overrides,
   };
 }
 
 describe('createAndAttachSessionForPrompt', () => {
-  it('attaches the session before a model switch failure can abort setup', async () => {
+  it('folds the approval mode into createSession and applies the model after attach', async () => {
     const order: string[] = [];
-    const error = new Error('model failed');
-    const warn = vi.fn();
-    const waitForModel = createDeferred<void>();
-    const approvalStarted = createDeferred<void>();
     const actions = createActions({
       createSession: vi.fn(async () => {
         order.push('create');
@@ -37,76 +31,118 @@ describe('createAndAttachSessionForPrompt', () => {
       }),
       setModel: vi.fn(async () => {
         order.push('model');
-        await waitForModel.promise;
-        throw error;
-      }),
-      setApprovalMode: vi.fn(async () => {
-        order.push('approval');
-        approvalStarted.resolve();
-        return approvalModeResult;
+        return modelResult;
       }),
     });
 
-    const result = createAndAttachSessionForPrompt({
+    await createAndAttachSessionForPrompt({
       sessionActions: actions,
       modelId: 'qwen3',
       modeId: 'yolo',
-      warn,
+      workspaceCwd: '/ws/secondary',
     });
-    await approvalStarted.promise;
-    waitForModel.resolve();
-    await result;
 
-    expect(order.slice(0, 2)).toEqual(['create', 'attach']);
-    expect(order.slice(2).sort()).toEqual(['approval', 'model']);
+    // Approval mode rides along with creation — no follow-up round-trip.
+    expect(actions.createSession).toHaveBeenCalledWith({
+      workspaceCwd: '/ws/secondary',
+      approvalMode: 'yolo',
+    });
+    // Model is still a post-create call, sequenced after attach.
+    expect(order).toEqual(['create', 'attach', 'model']);
+    expect(actions.setModel).toHaveBeenCalledWith('qwen3');
+  });
+
+  it('omits approvalMode when the mode is not a recognized daemon approval mode', async () => {
+    const actions = createActions();
+
+    await createAndAttachSessionForPrompt({
+      sessionActions: actions,
+      modeId: 'not-a-mode',
+    });
+
+    expect(actions.createSession).toHaveBeenCalledWith({
+      workspaceCwd: undefined,
+    });
+  });
+
+  it('creates the session without a model call when no model is selected', async () => {
+    const actions = createActions();
+
+    await createAndAttachSessionForPrompt({
+      sessionActions: actions,
+      modeId: 'plan',
+    });
+
+    expect(actions.createSession).toHaveBeenCalledWith({
+      workspaceCwd: undefined,
+      approvalMode: 'plan',
+    });
+    expect(actions.setModel).not.toHaveBeenCalled();
+  });
+
+  it('warns but resolves when the post-create model switch fails', async () => {
+    const order: string[] = [];
+    const error = new Error('model failed');
+    const warn = vi.fn();
+    const actions = createActions({
+      createSession: vi.fn(async () => {
+        order.push('create');
+        return sessionResult;
+      }),
+      attachSession: vi.fn(async () => {
+        order.push('attach');
+      }),
+      setModel: vi.fn(async () => {
+        order.push('model');
+        throw error;
+      }),
+    });
+
+    await expect(
+      createAndAttachSessionForPrompt({
+        sessionActions: actions,
+        modelId: 'qwen3',
+        modeId: 'yolo',
+        warn,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(order).toEqual(['create', 'attach', 'model']);
     expect(warn).toHaveBeenCalledWith(
       '[WebShell] failed to set model for new session:',
       error,
     );
   });
 
-  it('keeps the attached session when approval mode setup fails', async () => {
-    const order: string[] = [];
-    const error = new Error('mode failed');
-    const warn = vi.fn();
-    const waitForModel = createDeferred<void>();
-    const approvalStarted = createDeferred<void>();
+  it('propagates a create failure (fail-closed approval mode) without attaching or setting the model', async () => {
+    // The daemon tears the session down and rejects `POST /session` when the
+    // requested approval mode can't be applied at spawn. That rejection must
+    // abort the whole flow — no session, no model call — rather than leaving a
+    // half-created session in the wrong mode.
+    const error = new Error('approval_mode_initialization_failed');
     const actions = createActions({
       createSession: vi.fn(async () => {
-        order.push('create');
-        return sessionResult;
-      }),
-      attachSession: vi.fn(async () => {
-        order.push('attach');
-      }),
-      setModel: vi.fn(async () => {
-        order.push('model');
-        await waitForModel.promise;
-        return modelResult;
-      }),
-      setApprovalMode: vi.fn(async () => {
-        order.push('approval');
-        approvalStarted.resolve();
         throw error;
       }),
     });
 
-    const result = createAndAttachSessionForPrompt({
-      sessionActions: actions,
-      modelId: 'qwen3',
-      modeId: 'yolo',
-      warn,
-    });
-    await approvalStarted.promise;
-    waitForModel.resolve();
-    await result;
+    await expect(
+      createAndAttachSessionForPrompt({
+        sessionActions: actions,
+        modelId: 'qwen3',
+        modeId: 'yolo',
+      }),
+    ).rejects.toThrow(error);
 
-    expect(order.slice(0, 2)).toEqual(['create', 'attach']);
-    expect(order.slice(2).sort()).toEqual(['approval', 'model']);
-    expect(warn).toHaveBeenCalledWith(
-      '[WebShell] failed to set approval mode for new session:',
-      error,
-    );
+    expect(actions.createSession).toHaveBeenCalledWith({
+      workspaceCwd: undefined,
+      approvalMode: 'yolo',
+    });
+    expect(actions.attachSession).not.toHaveBeenCalled();
+    expect(actions.setModel).not.toHaveBeenCalled();
+    // Nothing was created client-side, so there is nothing to close/clear.
+    expect(actions.closeSession).not.toHaveBeenCalled();
+    expect(actions.clearSession).not.toHaveBeenCalled();
   });
 
   it('closes and clears the created session when attach fails', async () => {
@@ -138,7 +174,6 @@ describe('createAndAttachSessionForPrompt', () => {
     expect(actions.clearSession).toHaveBeenCalledOnce();
     expect(order).toEqual(['close', 'clear']);
     expect(actions.setModel).not.toHaveBeenCalled();
-    expect(actions.setApprovalMode).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(
       '[WebShell] failed to attach new session:',
       error,
@@ -184,14 +219,3 @@ describe('createAndAttachSessionForPrompt', () => {
     });
   });
 });
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value?: T | PromiseLike<T>) => void;
-} {
-  let resolve!: (value?: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = (value) => res(value as T | PromiseLike<T>);
-  });
-  return { promise, resolve };
-}

--- a/packages/web-shell/client/utils/sessionPreparation.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.ts
@@ -4,12 +4,14 @@ import {
 } from '@qwen-code/webui/daemon-react-sdk';
 
 type PromptSessionActions = {
-  createSession: (options?: { workspaceCwd?: string }) => Promise<unknown>;
+  createSession: (options?: {
+    workspaceCwd?: string;
+    approvalMode?: DaemonApprovalMode;
+  }) => Promise<unknown>;
   attachSession: () => Promise<void>;
   closeSession: () => Promise<void>;
   clearSession: () => Promise<void>;
   setModel: (modelId: string) => Promise<unknown>;
-  setApprovalMode: (mode: DaemonApprovalMode) => Promise<unknown>;
 };
 
 export function isDaemonApprovalMode(mode: string): mode is DaemonApprovalMode {
@@ -29,7 +31,18 @@ export async function createAndAttachSessionForPrompt({
   workspaceCwd?: string;
   warn?: (message?: unknown, ...optionalParams: unknown[]) => void;
 }): Promise<void> {
-  await sessionActions.createSession({ workspaceCwd });
+  // Seed the approval mode in the create request itself so the daemon applies
+  // it atomically at spawn (`POST /session` → `spawnOrAttach({ approvalMode })`),
+  // saving a follow-up round-trip. Approval mode is fail-closed at spawn: if the
+  // requested mode can't be applied the session is not created (this call
+  // rejects), rather than silently running in a different mode than requested.
+  // The model, by contrast, stays a best-effort follow-up below.
+  const approvalMode =
+    modeId && isDaemonApprovalMode(modeId) ? modeId : undefined;
+  await sessionActions.createSession({
+    workspaceCwd,
+    ...(approvalMode ? { approvalMode } : {}),
+  });
   try {
     await sessionActions.attachSession();
   } catch (error) {
@@ -42,19 +55,13 @@ export async function createAndAttachSessionForPrompt({
     });
     throw error;
   }
-  await Promise.all([
-    modelId
-      ? sessionActions.setModel(modelId).catch((error: unknown) => {
-          warn('[WebShell] failed to set model for new session:', error);
-        })
-      : Promise.resolve(),
-    modeId && isDaemonApprovalMode(modeId)
-      ? sessionActions.setApprovalMode(modeId).catch((error: unknown) => {
-          warn(
-            '[WebShell] failed to set approval mode for new session:',
-            error,
-          );
-        })
-      : Promise.resolve(),
-  ]);
+  // The model still needs a post-create call: `POST /session` only accepts a
+  // `modelServiceId`, whereas the composer selects a plain `modelId`. The
+  // `POST /session/:id/model` route now resolves the owning workspace runtime,
+  // so this succeeds for non-primary workspaces too.
+  if (modelId) {
+    await sessionActions.setModel(modelId).catch((error: unknown) => {
+      warn('[WebShell] failed to set model for new session:', error);
+    });
+  }
 }

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -24,6 +24,7 @@ import {
   extractServerTimestamp,
   matchTurnEvent,
   normalizeDaemonEvent,
+  type CreateSessionRequest,
   type DaemonEvent,
   type DaemonTranscriptBlock,
   type DaemonTranscriptState,
@@ -1681,7 +1682,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           workspaceCwd:
             activeWorkspaceCwdRef.current ?? sessionRef.current?.workspaceCwd,
         }),
-        createDetachedSession: (workspaceCwd?: string) => {
+        createDetachedSession: (
+          workspaceCwd?: string,
+          overrides?: Pick<CreateSessionRequest, 'approvalMode'>,
+        ) => {
           const client =
             workspaceClientRef.current ??
             new DaemonClient({
@@ -1695,6 +1699,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               workspaceCwd ??
               activeWorkspaceCwdRef.current ??
               sessionRef.current?.workspaceCwd,
+            ...(overrides?.approvalMode !== undefined
+              ? { approvalMode: overrides.approvalMode }
+              : {}),
           };
           const requestClientId = clientId
             ? clientIdRef.current

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -164,7 +164,7 @@ describe('createDaemonSessionActions', () => {
 
     await actions.createSession({ workspaceCwd: '/ws/secondary' });
 
-    expect(createDetachedSession).toHaveBeenCalledWith('/ws/secondary');
+    expect(createDetachedSession).toHaveBeenCalledWith('/ws/secondary', {});
   });
 
   it('omits the workspaceCwd override on the detached branch by default', async () => {
@@ -177,7 +177,22 @@ describe('createDaemonSessionActions', () => {
 
     await actions.createSession();
 
-    expect(createDetachedSession).toHaveBeenCalledWith(undefined);
+    expect(createDetachedSession).toHaveBeenCalledWith(undefined, {});
+  });
+
+  it('forwards options.approvalMode to the detached create branch', async () => {
+    const nextSession = createMockSession('session-b');
+    const createDetachedSession = vi.fn(async () => nextSession);
+    const { actions } = createActionsHarness({
+      connection: { status: 'connected' },
+      createDetachedSession,
+    });
+
+    await actions.createSession({ approvalMode: 'yolo' });
+
+    expect(createDetachedSession).toHaveBeenCalledWith(undefined, {
+      approvalMode: 'yolo',
+    });
   });
 
   it('merges options.workspaceCwd into the active session request', async () => {
@@ -193,6 +208,22 @@ describe('createDaemonSessionActions', () => {
 
     expect(existingSession.client.createOrAttachSession).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceCwd: '/ws/secondary' }),
+    );
+  });
+
+  it('folds options.approvalMode into the active session request', async () => {
+    const existingSession = createMockSession('session-a');
+    const nextSession = createMockSession('session-b');
+    existingSession.client.createOrAttachSession.mockResolvedValue(nextSession);
+    const { actions } = createActionsHarness({
+      connection: { status: 'connected', sessionId: 'session-a' },
+      session: existingSession,
+    });
+
+    await actions.createSession({ approvalMode: 'yolo' });
+
+    expect(existingSession.client.createOrAttachSession).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalMode: 'yolo' }),
     );
   });
 

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -6,6 +6,7 @@
 
 import type { Dispatch, SetStateAction } from 'react';
 import type {
+  DaemonApprovalMode,
   DaemonSessionContextStatus,
   DaemonSessionClient,
   DaemonSessionBtwResult,
@@ -59,6 +60,7 @@ export interface CreateDaemonSessionActionsArgs {
   getCreateSessionRequest: () => CreateSessionRequest;
   createDetachedSession: (
     workspaceCwd?: string,
+    overrides?: Pick<CreateSessionRequest, 'approvalMode'>,
   ) => Promise<DaemonSessionClient>;
   getConnection: () => DaemonConnectionState;
   hasSessionActivePrompt: () => boolean;
@@ -580,9 +582,22 @@ export function createDaemonSessionActions({
       return startSessionSwitch(sessionId, 'resume');
     },
 
-    async createSession(options?: { workspaceCwd?: string }) {
+    async createSession(options?: {
+      workspaceCwd?: string;
+      approvalMode?: DaemonApprovalMode;
+    }) {
       try {
         manualSessionClearRef.current = false;
+        // Fold the initial approval mode into the create request so the daemon
+        // applies it atomically at spawn (`POST /session` →
+        // `spawnOrAttach({ approvalMode })`), avoiding a follow-up
+        // `setApprovalMode` round-trip. Approval mode is fail-closed at spawn:
+        // an application failure aborts creation (this call rejects) rather than
+        // leaving the session in a different mode than the caller requested.
+        const approvalOverride =
+          options?.approvalMode !== undefined
+            ? { approvalMode: options.approvalMode }
+            : {};
         const session = sessionRef.current;
         const activeSession =
           session && getConnection().sessionId === session.sessionId
@@ -595,6 +610,7 @@ export function createDaemonSessionActions({
               ...(options?.workspaceCwd !== undefined
                 ? { workspaceCwd: options.workspaceCwd }
                 : {}),
+              ...approvalOverride,
             }),
             'Create session timed out',
           );
@@ -603,7 +619,7 @@ export function createDaemonSessionActions({
         }
 
         const nextSession = await withActionTimeout(
-          createDetachedSession(options?.workspaceCwd),
+          createDetachedSession(options?.workspaceCwd, approvalOverride),
           'Create session timed out',
         );
         if (manualSessionClearRef.current) {

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -333,8 +333,15 @@ export interface DaemonSessionActions {
    * `options.workspaceCwd` targets a specific registered workspace runtime for
    * this call only (multi-workspace daemons). Omit it to keep the provider's
    * active workspace / primary fallback.
+   *
+   * `options.approvalMode` seeds the session's approval mode in the create
+   * request itself, so the daemon applies it atomically at spawn instead of
+   * requiring a follow-up `setApprovalMode` call.
    */
-  createSession(options?: { workspaceCwd?: string }): Promise<DaemonSession>;
+  createSession(options?: {
+    workspaceCwd?: string;
+    approvalMode?: DaemonApprovalMode;
+  }): Promise<DaemonSession>;
   attachSession(): Promise<void>;
   clearSession(): Promise<void>;
   newSession(): Promise<void>;


### PR DESCRIPTION
## Summary

Creating a session in a **newly registered (non-primary) workspace** in Web Shell surfaced `Set model failed` / `Set approval mode failed` error toasts:

```
POST /session/:id/model: Route "POST /session/:id/model" is primary-only for non-primary workspace sessions in Phase 2a.
POST /session/:id/approval-mode: Route "POST /session/:id/approval-mode" is primary-only for non-primary workspace sessions in Phase 2a.
```

`POST /session/:id/model` and `POST /session/:id/approval-mode` were wrapped in `withMutableSession`, which hard-rejects any non-primary workspace session with a Phase 2a *primary-only* `400` — even though `POST /session/:id/prompt` already serves non-primary sessions via `withOwnerMutableSession`. These two routes simply had not been migrated.

## Root cause

`withMutableSession` gates on `runtime.primary`:

```ts
if (!runtime.primary) { sendNonPrimarySessionRouteUnsupported(...); return; } // 400
```

Web Shell creates a session and then pushes the picked model + approval mode with follow-up calls; on a non-primary workspace those two calls hit the primary-only gate and fail.

## Changes

**1. Daemon — enable both routes for non-primary *owned* sessions (`packages/cli`)**

- Switch `POST /session/:id/model` and `POST /session/:id/approval-mode` from `withMutableSession` to `withOwnerMutableSession`, and call `runtime.bridge.*` instead of the closed-over primary `bridge.*`. This resolves the session's **owning** `WorkspaceRuntime` — the exact pattern `/prompt` already uses.
- Each `WorkspaceRuntime` owns a full `AcpSessionBridge`, so the mutation lands on the correct workspace, and `persist: true` targets that workspace's own settings. Primary sessions are unchanged: the primary runtime's bridge **is** the closed-over `bridge` object.
- The trust gate is unaffected — `requireSessionRuntime` still returns `403 untrusted_workspace` for a non-primary, non-trusted runtime before the bridge runs.

This fixes the reported error and also makes the manual model dropdown / approval-mode toggle work on non-primary sessions.

**2. Web Shell — apply approval mode at session creation (`packages/web-shell`, `packages/webui`)**

- The daemon + SDK already accept `approvalMode` on `POST /session` (→ `spawnOrAttach({ approvalMode })`), per-runtime. Web Shell now folds the initial approval mode into the create request instead of a follow-up `setApprovalMode` — one fewer round-trip, mode applied atomically at spawn.
- `createSession(options)` gains an optional `approvalMode`, threaded into both the active (`createOrAttachSession`) and detached create branches.
- The **model** stays a best-effort post-create call, because creation only accepts a `modelServiceId`, not the composer's plain `modelId`. That follow-up now works on non-primary workspaces via change #1.

## ⚠️ Behavioral note — approval mode is fail-closed at creation

The daemon treats spawn-time approval-mode application as **fail-closed**: if the requested mode can't be applied it closes the freshly-spawned session and rethrows, so `POST /session` fails. Folding approval mode into creation therefore changes Web Shell from *degrade-to-default + warn* to *abort creation on failure*. This is intentional — it prevents silently running a session in a different (possibly less-safe) mode than requested (e.g. asking for `plan` and silently getting `default`). The **model** path stays fail-open (non-fatal), matching the daemon's own model-vs-approval distinction.

## Testing

Real `vitest run` output (rows marked **NEW** are added by this PR):

![test evidence](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/non-primary-session-model-approval/tests-nonprimary-model-approval.png)

- `packages/cli` · `multi-workspace-sessions.test.ts` — **42 passed**: owner-scoped routing for `/model` & `/approval-mode`, creation-time `approvalMode` on the non-primary runtime, and the untrusted-rejection gate.
- `packages/web-shell` · `sessionPreparation.test.ts` — **8 passed**: approval-into-create fold + fail-closed propagation.
- `packages/webui` · `actions.test.ts` — **18 passed**: `approvalMode` threaded into both create branches.
- Full suites green: `cli` `server.test.ts` **670**, webui `daemon/session` **202**. `tsc --noEmit`, eslint, prettier clean across all three packages.

## Out of scope / follow-ups

Other session-mutation routes stay primary-only (`withMutableSession`): `recap`, `branch` (deliberately primary-only — has a Phase 2a test), `fork`, `rewind`, `goal/clear`, `language`. Some are reachable from Web Shell quick-actions on a non-primary *active* session and would hit the same class of error; they can be migrated the same way, but each warrants its own review, so they are kept out of this focused fix.

<details>
<summary><b>中文版（点击展开）</b></summary>

## 概述

在 Web Shell 中，于**新注册的（非主）工作区**创建会话时会弹出 `Set model failed` / `Set approval mode failed` 报错：

```
POST /session/:id/model: Route "POST /session/:id/model" is primary-only for non-primary workspace sessions in Phase 2a.
POST /session/:id/approval-mode: Route "POST /session/:id/approval-mode" is primary-only for non-primary workspace sessions in Phase 2a.
```

`POST /session/:id/model` 和 `POST /session/:id/approval-mode` 用的是 `withMutableSession` 包装器，会对非主工作区会话直接返回 Phase 2a 的 *primary-only* `400`——而 `POST /session/:id/prompt` 早已通过 `withOwnerMutableSession` 支持非主会话。这两个路由只是没跟上迁移。

## 根因

`withMutableSession` 以 `runtime.primary` 为闸门：

```ts
if (!runtime.primary) { sendNonPrimarySessionRouteUnsupported(...); return; } // 400
```

Web Shell 先建会话、再用后续调用下发所选模型与审批模式；在非主工作区，这两个后续调用命中 primary-only 闸门而失败。

## 改动

**1. 守护进程——为非主的“归属”会话放开这两个路由（`packages/cli`）**

- 将 `POST /session/:id/model` 与 `POST /session/:id/approval-mode` 从 `withMutableSession` 换成 `withOwnerMutableSession`，并调用 `runtime.bridge.*` 而非闭包里的主 `bridge.*`，从而解析出会话所属的 `WorkspaceRuntime`——与 `/prompt` 完全一致的模式。
- 每个 `WorkspaceRuntime` 自带完整的 `AcpSessionBridge`，因此变更会精确落到对应工作区，`persist: true` 也写入该工作区自己的 settings。主会话行为不变：主 runtime 的 bridge **就是**闭包里的 `bridge` 对象。
- 信任闸门不受影响——`requireSessionRuntime` 对“非主且不受信任”的 runtime 仍在触达 bridge 前返回 `403 untrusted_workspace`。

这既修复了报错，也让非主会话里手动切模型 / 切审批模式生效。

**2. Web Shell——在建会话时直接下发审批模式（`packages/web-shell`、`packages/webui`）**

- 守护进程 + SDK 早已在 `POST /session` 上接受 `approvalMode`（→ `spawnOrAttach({ approvalMode })`），且按 runtime 生效。现在 Web Shell 把初始审批模式随建会话请求一起下发，省掉一次 `setApprovalMode` 往返，并在 spawn 时原子应用。
- `createSession(options)` 新增可选 `approvalMode`，贯通到 active（`createOrAttachSession`）与 detached 两条创建分支。
- **模型**仍作为建后尽力而为的调用，因为创建只接受 `modelServiceId`，而 composer 给的是 `modelId`；该后续调用现在也能在非主工作区生效（得益于改动 #1）。

## ⚠️ 行为变化——审批模式在创建时“失败即中止”（fail-closed）

守护进程对 spawn 阶段的审批模式应用采用 fail-closed：若请求的模式无法应用，它会关闭刚创建的会话并重新抛出，于是 `POST /session` 失败。因此把审批模式折入创建，会把 Web Shell 从“降级为默认模式并告警”改为“失败即中止创建”。这是**有意为之**——避免会话悄悄以与请求不同（可能更不安全）的模式运行（例如请求 `plan` 却静默变成 `default`）。**模型**路径仍是 fail-open（非致命），与守护进程对“模型 vs 审批”的区分一致。

## 测试

真实 `vitest run` 输出（标注 **NEW** 的为本 PR 新增）见上方英文版截图。

- `packages/cli` · `multi-workspace-sessions.test.ts` — **42 通过**。
- `packages/web-shell` · `sessionPreparation.test.ts` — **8 通过**。
- `packages/webui` · `actions.test.ts` — **18 通过**。
- 完整套件全绿：`cli` `server.test.ts` **670**、webui `daemon/session` **202**；三个包的 `tsc --noEmit`、eslint、prettier 均干净。

## 范围之外 / 后续

其余会话变更路由仍为 primary-only（`withMutableSession`）：`recap`、`branch`（有意 primary-only，且有 Phase 2a 测试）、`fork`、`rewind`、`goal/clear`、`language`。其中部分可从 Web Shell 快捷操作在非主的**活动**会话上触达，会遇到同类报错；可按同样方式迁移，但每个都需单独评估，故不纳入本次聚焦修复。

</details>
