### PR TITLE
fix(core): ignore reasoning in goal judge verdicts

### DIFF
--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -91,6 +91,31 @@ describe('judgeGoal', () => {
     expect(client.generateContent.mock.calls[0][3]).toBe('fast-judge');
   });
 
+  it('ignores thought parts when parsing the response', async () => {
+    const client = makeMockClient({});
+    client.generateContent.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: 'Return {"ok": false}.', thought: true },
+              { text: '{"ok": true, "reason": "tests passing"}' },
+            ],
+          },
+        },
+      ],
+    });
+    const config = makeConfig({ client });
+
+    const verdict = await judgeGoal(config, {
+      condition: 'tests pass',
+      lastAssistantText: 'all green',
+      signal: new AbortController().signal,
+    });
+
+    expect(verdict).toMatchObject({ kind: 'met' });
+  });
+
   it('preserves the legacy result fields alongside the outcome kind', async () => {
     const client = makeMockClient({
       reply: '{"ok": false, "reason": "still running"}',
@@ -362,7 +387,10 @@ describe('judgeGoal', () => {
       Object.keys(generationConfig.responseSchema.properties).sort(),
     ).toEqual([...JUDGE_RESULT_SCHEMA_KEYS].sort());
     expect(generationConfig.responseSchema.additionalProperties).toBe(false);
-    expect(generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+    expect(generationConfig.thinkingConfig).toEqual({
+      thinkingBudget: 0,
+      includeThoughts: false,
+    });
     expect(generationConfig.temperature).toBe(0);
   });
 

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -99,6 +99,7 @@ describe('judgeGoal', () => {
           content: {
             parts: [
               { text: 'Return {"ok": false}.', thought: true },
+              null,
               { text: '{"ok": true, "reason": "tests passing"}' },
             ],
           },

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -359,7 +359,7 @@ function extractText(response: unknown): string {
   const parts = first?.content?.parts;
   if (!Array.isArray(parts)) return '';
   return parts
-    .filter((part) => part.thought !== true)
+    .filter((part) => part?.thought !== true)
     .map((p) => (typeof p?.text === 'string' ? p.text : ''))
     .join('')
     .trim();

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -190,7 +190,7 @@ export async function judgeGoal(
         responseSchema: RESPONSE_SCHEMA,
         // Disable extended thinking: the judge is a binary check, and
         // thinking burns latency and tokens for no quality gain.
-        thinkingConfig: { thinkingBudget: 0 },
+        thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
       },
       args.signal,
       model,
@@ -354,11 +354,12 @@ function extractText(response: unknown): string {
     ?.candidates;
   if (!Array.isArray(candidates) || candidates.length === 0) return '';
   const first = candidates[0] as
-    | { content?: { parts?: Array<{ text?: unknown }> } }
+    | { content?: { parts?: Array<{ text?: unknown; thought?: unknown }> } }
     | undefined;
   const parts = first?.content?.parts;
   if (!Array.isArray(parts)) return '';
   return parts
+    .filter((part) => part.thought !== true)
     .map((p) => (typeof p?.text === 'string' ? p.text : ''))
     .join('')
     .trim();


### PR DESCRIPTION
## What this PR does

This prevents hidden reasoning from contaminating the structured JSON verdict used by automatic `/goal` evaluation. Goal evaluation now explicitly opts out of reasoning output and ignores any response part marked as a thought before parsing the visible verdict.

## Why it's needed

Thinking-capable OpenAI-compatible providers can return a reasoning part before an otherwise valid `{"ok": true}` verdict. The existing evaluator concatenated both parts, so reasoning that mentioned JSON made the combined payload malformed even though telemetry showed a valid visible verdict. The evaluator then paused as unavailable instead of completing the goal. Providers that honor the per-request opt-out avoid the extra reasoning cost, while response-side filtering keeps the evaluator correct when a provider still returns reasoning.

## Reviewer Test Plan

### How to verify

Run the goal evaluator tests with a response containing a contradictory JSON-bearing thought part followed by a valid visible `ok: true` verdict. Confirm the visible verdict produces a met outcome, the judge request opts out of thoughts, and the existing malformed, empty, impossible, and lifecycle cases remain unchanged. Then run the complete core goal test directory.

### Evidence (Before & After)

Before the production change, the new regression case failed with `expected kind: met` but received `kind: error` (1 failed, 25 passed). After the change, the focused evaluator suite passed 26/26 and the complete core goal suite passed 65/65.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js v22.17.0, non-sandboxed unit-test environment.

## Risk & Scope

- Main risk or tradeoff: Providers that ignore the request-side opt-out may still spend reasoning tokens, but marked thought parts are excluded before verdict parsing.
- Not validated / out of scope: Live-model interactive E2E, Windows and Linux local runs, and provider responses that embed unmarked `<think>` text directly in visible content.
- Breaking changes / migration notes: None. The evaluator result contract and lifecycle behavior are unchanged.

## Linked Issues

Follow-up to #6681. Related reasoning-part normalization: #6192.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 防止隐藏推理内容污染自动 `/goal` 判定使用的结构化 JSON 结论。目标判定现在会显式关闭推理输出，并在解析可见结论前忽略所有标记为 thought 的响应部分。

## 为什么需要

支持 thinking 的 OpenAI 兼容 provider 可能会在一个本来有效的 `{"ok": true}` 结论之前返回推理部分。原有判定器会把两部分拼接起来，因此只要推理中提到 JSON，组合结果就会变成畸形内容，即使遥测中展示的可见结论完全有效。随后判定器会以 unavailable 暂停，而不是完成目标。遵守单次请求关闭指令的 provider 可以避免额外推理成本；响应侧过滤则保证 provider 仍返回推理时判定保持正确。

## Reviewer 测试计划

### 如何验证

运行目标判定测试，构造一个响应：先返回包含矛盾 JSON 的 thought part，再返回有效的可见 `ok: true` 结论。确认判定采用可见结论并得到 met，judge 请求明确关闭 thoughts，同时现有的畸形、空响应、impossible 和生命周期用例保持不变。随后运行完整的 core goal 测试目录。

### 证据（修改前后）

修改生产代码前，新增回归用例失败：期望 `kind: met`，实际得到 `kind: error`（1 个失败、25 个通过）。修改后，定向判定测试 26/26 通过，完整 core goal 测试 65/65 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js v22.17.0、非沙箱单元测试环境。

## 风险与范围

- 主要风险或权衡：忽略请求侧关闭指令的 provider 仍可能消耗推理 token，但带 thought 标记的响应部分会在结论解析前被排除。
- 未验证 / 范围外：真实模型交互式 E2E、Windows 和 Linux 本地运行，以及 provider 把未标记的 `<think>` 文本直接放入可见 content 的情况。
- Breaking change / 迁移说明：无。判定结果契约和生命周期行为均未改变。

## 关联 Issue

#6681 的后续修复。相关推理部分规范化：#6192。

</details>
