### PR TITLE
fix(web-shell): correct stale composerTagIcons import in ScheduledTasksDialog

### DIFF
--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -23,7 +23,7 @@ import type {
   DaemonWorkspaceSkillStatus,
 } from '@qwen-code/sdk/daemon';
 import { useI18n } from '../../i18n';
-import { getComposerTagIconUrl } from '../composerTagIcons';
+import { getComposerTagIconUrl } from '../../utils/composerTag';
 import { cssUrlValue } from '../../utils/cssUrlVar';
 import { DialogShell } from './DialogShell';
 import {


### PR DESCRIPTION
## Summary

Fix broken Vite build on `main` caused by a stale import in `ScheduledTasksDialog.tsx`.

## Root cause

PR #6537 consolidated `client/components/composerTagIcons.ts` → `client/utils/composerTag.ts`, deleting the old file and updating all existing imports.

PR #6589 was branched **before** that consolidation and added a new import in `ScheduledTasksDialog.tsx`:

```ts
import { getComposerTagIconUrl } from '../composerTagIcons';
```

Since PR #6537 never touched `ScheduledTasksDialog.tsx`, there was no merge conflict — but the target file no longer exists, breaking the production build.

## Fix

Update the import path to `'../../utils/composerTag'`.

## Reviewer test plan

- Verify `npm run build --workspace=packages/web-shell` succeeds (the step that fails on `main`).

<details>
<summary>中文版本</summary>

## 概述

修复 `main` 分支上因 `ScheduledTasksDialog.tsx` 中的过期 import 导致的 Vite 构建失败。

## 根因

PR #6537 将 `client/components/composerTagIcons.ts` 整合到了 `client/utils/composerTag.ts`，删除了旧文件并更新了所有已有引用。

PR #6589 的分支基于整合之前的代码，在 `ScheduledTasksDialog.tsx` 中新增了一行 import：

```ts
import { getComposerTagIconUrl } from '../composerTagIcons';
```

由于 PR #6537 从未修改过 `ScheduledTasksDialog.tsx`，合并时没有冲突——但目标文件已不存在，导致生产构建失败。

## 修复

将 import 路径更正为 `'../../utils/composerTag'`。

## 验证方式

- 确认 `npm run build --workspace=packages/web-shell` 能够成功构建（该步骤在 `main` 上失败）。

</details>