### PR TITLE
fix(core): parse tagged Qwen3 thinking in default provider

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -568,5 +568,29 @@ describe('DefaultOpenAICompatibleProvider', () => {
       expect(assistant.reasoning_content).toBe('Preserved chain of thought');
       expect(assistant.reasoning).toBeUndefined();
     });
+
+    it('enables tagged thinking parsing for Qwen3 models', () => {
+      mockContentGeneratorConfig.model = 'Qwen/Qwen3.7-Max';
+      provider = new DefaultOpenAICompatibleProvider(
+        mockContentGeneratorConfig,
+        mockCliConfig,
+      );
+
+      expect(provider.getResponseParsingOptions()).toEqual({
+        taggedThinkingTags: true,
+      });
+    });
+
+    it('keeps tagged thinking parsing disabled for non-Qwen3 models', () => {
+      mockContentGeneratorConfig.model = 'gpt-4o';
+      provider = new DefaultOpenAICompatibleProvider(
+        mockContentGeneratorConfig,
+        mockCliConfig,
+      );
+
+      expect(provider.getResponseParsingOptions()).toEqual({
+        taggedThinkingTags: false,
+      });
+    });
   });
 });

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -3,6 +3,7 @@ import type { GenerateContentConfig } from '@google/genai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { DEFAULT_MAX_RETRIES, resolveRequestTimeout } from '../constants.js';
+import type { OpenAIResponseParsingOptions } from '../responseParsingOptions.js';
 import type { OpenAICompatibleProvider } from './types.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
 import {
@@ -121,6 +122,14 @@ export class DefaultOpenAICompatibleProvider
 
   getDefaultGenerationConfig(): GenerateContentConfig {
     return {};
+  }
+
+  getResponseParsingOptions(): OpenAIResponseParsingOptions {
+    return {
+      taggedThinkingTags: shouldMirrorReasoningContentForQwen3(
+        this.contentGeneratorConfig.model ?? '',
+      ),
+    };
   }
 
   /**

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -38,7 +38,7 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     }
   }
 
-  getResponseParsingOptions(): OpenAIResponseParsingOptions {
+  override getResponseParsingOptions(): OpenAIResponseParsingOptions {
     return { taggedThinkingTags: true };
   }
 }


### PR DESCRIPTION
## What this PR does

Fixes #6666.

- enable tagged-thinking response parsing for Qwen3 on the default OpenAI-compatible provider
- keep the existing request-side `reasoning_content` mirroring aligned with the same Qwen3 model gate
- add provider tests so Qwen3 enables the fallback while non-Qwen3 models keep it disabled

## Why it's needed

Qwen3 can sometimes return `<think>...</think>` blocks inside `content` instead of `reasoning_content`. The converter already knows how to extract those tags safely, but the default provider never opted into that response parsing path for Qwen3, so the raw tags leaked into visible output.

This keeps the fix scoped to Qwen3 and avoids reopening the broader default-provider behavior that was reverted for DashScope GLM in #6248.

## Reviewer Test Plan

- Confirm `DefaultOpenAICompatibleProvider` now returns `taggedThinkingTags: true` for Qwen3 models and `false` for non-Qwen3 models.
- Confirm tagged-thinking converter coverage still passes for the shared parsing path.

Commands run locally:

- `npm run typecheck --workspace=packages/core`
- `npm run test --workspace=packages/core -- src/core/openaiContentGenerator/provider/default.test.ts`
- `npm run test --workspace=packages/core -- src/core/openaiContentGenerator/converter.test.ts -t 'OpenAI -> Gemini tagged thinking content'`

## Risk & Scope

- Main risk or tradeoff: model-name gating may miss a future Qwen alias that does not include `qwen3`.
- Not validated / out of scope: live provider verification against a real DashScope/Qwen endpoint.
- Breaking changes / migration notes: none.
