### PR TITLE
fix(web-shell): keep composer Git branch chip from crowding the toolbar on narrow screens

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -955,6 +955,23 @@
   .toolbarLeft .toolBtnText {
     display: none;
   }
+
+  /* Keep the leading controls on a single row on narrow screens. The branch
+     chip yields space first — truncating via its ellipsis, down to just the
+     icon if needed — instead of pushing the mode/model buttons onto a second
+     line and making the composer taller. */
+  .toolbarLeft {
+    flex-wrap: nowrap;
+  }
+
+  .toolbarLeft .dropdownWrapper {
+    flex: 0 0 auto;
+  }
+
+  .gitBranchChip {
+    max-width: 140px;
+    flex-shrink: 1;
+  }
 }
 
 .dropdownWrapper {


### PR DESCRIPTION
## What this PR does

Fixes a narrow-screen layout regression introduced by #6725. The new Git branch chip in the composer toolbar keeps `max-width: 180px` on narrow screens, while the mode/model buttons there already collapse to icon-only. Inside the wrapping `.toolbarLeft`, the chip therefore claims roughly half the row and **pushes the mode/model buttons onto a second line**, making the composer taller on phones.

## The fix

One change, folded into the existing `@container (max-width: 699px)` block in `ChatEditor.module.css`: keep the leading controls on a single row and let the branch chip yield space first — truncating via its existing ellipsis, down to just the icon if space is really tight.

```css
.toolbarLeft { flex-wrap: nowrap; }
.toolbarLeft .dropdownWrapper { flex: 0 0 auto; } /* mode/model keep their icons */
.gitBranchChip { max-width: 140px; flex-shrink: 1; } /* chip absorbs the squeeze */
```

The mode/model buttons stay fixed-size; only the branch chip shrinks. Desktop (composer width > 699px) is outside the query and **completely unchanged**.

## Evidence (Before &amp; After)

Real app, captured against the mock-daemon Playwright harness with touch/mobile emulation (so the composer renders its real phone toolbar), branch `feature/web-shell-git-branch-indicator`:

![composer branch chip — before vs after on narrow screens](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-git-branch-narrow/composer-branch-narrow-before-after.png)

| composer width | Before | After |
| --- | --- | --- |
| 320px / 350px | mode &amp; model wrap to a 2nd row | one row |
| 390px | chip fills ~180px of the row | one row, chip truncates to fit |
| 1000px (desktop) | full labels, one row | identical — untouched |

## Testing

- `npm run test --workspace @qwen-code/web-shell -- ChatEditor GitBranchIndicator` — 4/4 pass.
- `prettier --check` on the changed file passes.
- Swept composer widths 280–1000px: single row with no wrap or horizontal overflow down to 280px; the chip shrinks gracefully, and the full branch name remains available via the chip's `title`/`aria-label`.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 #6725 引入的窄屏布局问题。输入框工具栏里新增的 Git 分支标签在窄屏下仍保留 `max-width: 180px`，而同一行的 mode/model 按钮此时已经收成纯图标。由于 `.toolbarLeft` 是 `flex-wrap: wrap`，这个标签会占掉近一半宽度，**把 mode/model 按钮挤到第二行**，让手机上的输入框变高。

## 修复方式

只改一处，合并进已有的 `@container (max-width: 699px)` 区块：让左侧控件保持一行，并让分支标签优先让出空间——靠它自带的省略号截断，空间极紧时最多缩到只剩图标。

```css
.toolbarLeft { flex-wrap: nowrap; }
.toolbarLeft .dropdownWrapper { flex: 0 0 auto; } /* mode/model 保持图标不被压缩 */
.gitBranchChip { max-width: 140px; flex-shrink: 1; } /* 由分支标签吸收挤压 */
```

mode/model 按钮尺寸不变，只有分支标签会收缩。桌面端（输入框宽度 > 699px）不在该媒体查询范围内，**完全不受影响**。

## 验证

- 真实应用截图：基于 mock-daemon 的 Playwright 用例，开启触摸/移动端模拟（这样才会渲染真实的手机版工具栏），分支名为 `feature/web-shell-git-branch-indicator`（见上方对比图）。
- `ChatEditor` + `GitBranchIndicator` 单测 4/4 通过；改动文件 `prettier --check` 通过。
- 从 280px 到 1000px 逐档验证：全程一行，280px 都不换行、不横向溢出；标签平滑收缩，完整分支名仍可通过 `title`/`aria-label` 查看。

</details>
