### PR TITLE
feat(web-shell): improve composer model selector

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -4,6 +4,10 @@
   margin: 0 0 14px;
 }
 
+.editorShellDropdownOpen {
+  z-index: 7;
+}
+
 .container {
   position: relative;
   container-type: inline-size;
@@ -885,6 +889,7 @@
 
 .toolbarLeading {
   margin-left: -5px;
+  min-width: 0;
 }
 
 .toolbarStart {
@@ -897,7 +902,7 @@
 
 .toolbarLeft {
   min-width: 0;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .gitBranchChip {
@@ -945,17 +950,18 @@
   align-items: center;
 }
 
+.toolbarMeasurements {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 @container (max-width: 699px) {
-  .toolbarLeft .toolBtn {
-    width: auto;
-    padding: 0 6px;
-    justify-content: center;
-  }
-
-  .toolbarLeft .toolBtnText {
-    display: none;
-  }
-
   /* Keep the leading controls on a single row on narrow screens. The branch
      chip yields space first — truncating via its ellipsis, down to just the
      icon if needed — instead of pushing the mode/model buttons onto a second
@@ -979,33 +985,65 @@
 }
 
 .dropdown {
-  position: absolute;
-  bottom: calc(100% + 4px);
-  left: 0;
-  min-width: 160px;
+  position: fixed;
+  z-index: 100;
+  display: flex;
+  min-width: 0;
   padding: 4px;
+  overflow: hidden;
   background: var(--background);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow:
     0 2px 4px -2px rgba(0, 0, 0, 0.1),
     0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  z-index: 100;
-  display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
 .dropdownRich {
-  min-width: min(360px, calc(100vw - 32px));
   padding: 6px;
   gap: 2px;
 }
 
 .dropdownCheck {
-  min-width: min(300px, calc(100vw - 32px));
   padding: 6px;
   gap: 2px;
+}
+
+.dropdownSearch {
+  width: 100%;
+  min-height: 30px;
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  outline: none;
+  background: var(--chat-editor-bg-tertiary);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 13px;
+}
+
+.dropdownSearch:focus-visible {
+  border-color: var(--agent-blue-500);
+}
+
+.dropdownList {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.dropdownEmpty {
+  padding: 8px 9px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 18px;
 }
 
 .dropdownItem {
@@ -1118,6 +1156,10 @@
   white-space: nowrap;
 }
 
+.modelToolBtn {
+  min-width: 0;
+}
+
 .toolBtn:hover {
   background: var(--chat-editor-bg-tertiary);
   color: var(--chat-editor-text-primary);
@@ -1200,10 +1242,14 @@
 }
 
 .toolBtnText {
+  min-width: 0;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   color: var(--agent-gray-500);
   line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .toolBtnArrow {

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -1156,6 +1156,7 @@
   white-space: nowrap;
 }
 
+.modeToolBtn,
 .modelToolBtn {
   min-width: 0;
 }

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -567,6 +567,7 @@ function ToolbarDropdown({
         getToolbarDropdownGeometry({
           anchor: anchor.getBoundingClientRect(),
           boundary: boundary.getBoundingClientRect(),
+          viewportWidth: window.innerWidth,
           viewportHeight: window.innerHeight,
           preferredWidth,
           maxHeight,
@@ -616,11 +617,12 @@ function ToolbarDropdown({
         e.preventDefault();
         e.stopPropagation();
         onClose();
+        window.requestAnimationFrame(() => anchorRef.current?.focus());
       }
     };
     window.addEventListener('keydown', onEscape);
     return () => window.removeEventListener('keydown', onEscape);
-  }, [open, onClose]);
+  }, [open, onClose, anchorRef]);
 
   if (!open) return null;
 
@@ -658,16 +660,15 @@ function ToolbarDropdown({
           value={searchQuery}
           aria-label={searchLabel}
           placeholder={searchLabel}
+          autoComplete="off"
           onChange={(event) => setSearchQuery(event.target.value)}
         />
       )}
-      <div className={styles.dropdownList} role="listbox">
+      <div className={styles.dropdownList}>
         {visibleItems.map((item) => (
           <button
             key={item.id}
             type="button"
-            role="option"
-            aria-selected={item.id === activeId}
             className={`${styles.dropdownItem} ${
               item.id === activeId ? styles.dropdownItemActive : ''
             }`}
@@ -1198,6 +1199,8 @@ export const ChatEditor = memo(
       if (!visibleActionSet) return true;
       return visibleActionSet.has(action);
     };
+    const showModeAction = showToolbarAction('approvalMode');
+    const showModelAction = showToolbarAction('model');
     const commandNames = useMemo(
       () =>
         new Set(commands.map((command) => command.name.replace(/^\/+/, ''))),
@@ -1511,6 +1514,8 @@ export const ChatEditor = memo(
           modelLabelWidth,
           modeLabelWidth,
           modelLabelReady,
+          modelActionVisible: showModelAction,
+          modeActionVisible: showModeAction,
         });
         setToolbarLabelVisibility((current) =>
           current.showModelLabel === next.showModelLabel &&
@@ -1530,7 +1535,15 @@ export const ChatEditor = memo(
       resizeObserver.observe(modelCollapsed);
       resizeObserver.observe(modelExpanded);
       return () => resizeObserver.disconnect();
-    }, [modelLabel, modelLabelReady, modeLabel, showModelLabel, showModeLabel]);
+    }, [
+      modelLabel,
+      modelLabelReady,
+      modeLabel,
+      showModelAction,
+      showModeAction,
+      showModelLabel,
+      showModeLabel,
+    ]);
 
     return (
       <div
@@ -1765,7 +1778,7 @@ export const ChatEditor = memo(
                       ariaLabel={t('git.currentBranch', { branch: gitBranch })}
                     />
                   )}
-                  {showToolbarAction('approvalMode') && (
+                  {showModeAction && (
                     <div className={styles.dropdownWrapper}>
                       <ToolbarDropdown
                         open={modeDropdownOpen}
@@ -1804,7 +1817,7 @@ export const ChatEditor = memo(
                       </button>
                     </div>
                   )}
-                  {showToolbarAction('model') && (
+                  {showModelAction && (
                     <div className={styles.dropdownWrapper}>
                       <ToolbarDropdown
                         open={modelDropdownOpen}

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -43,6 +43,14 @@ import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
 import { VoiceButton } from '../voice/VoiceButton';
 import { GitBranchIndicator } from './GitBranchIndicator';
+import {
+  filterToolbarDropdownItems,
+  getToolbarDropdownGeometry,
+  getToolbarLabelVisibility,
+  resolveToolbarModelLabel,
+  type ToolbarDropdownGeometry,
+  type ToolbarDropdownItem,
+} from './toolbarDropdown';
 import styles from './ChatEditor.module.css';
 
 export type ComposerToolbarAction =
@@ -373,9 +381,7 @@ function ModelIcon() {
   );
 }
 
-interface DropdownItem {
-  id: string;
-  label: string;
+interface DropdownItem extends ToolbarDropdownItem {
   description?: string;
   icon?: ReactNode;
 }
@@ -502,8 +508,12 @@ function ToolbarDropdown({
   onClose,
   onSelect,
   anchorRef,
+  boundaryRef,
   showCheck = false,
   maxHeight,
+  searchable = false,
+  searchLabel,
+  noResultsLabel,
 }: {
   open: boolean;
   items: DropdownItem[];
@@ -511,10 +521,71 @@ function ToolbarDropdown({
   onClose: () => void;
   onSelect: (id: string) => void;
   anchorRef: React.RefObject<HTMLButtonElement | null>;
+  boundaryRef: React.RefObject<HTMLElement | null>;
   showCheck?: boolean;
   maxHeight?: number;
+  searchable?: boolean;
+  searchLabel?: string;
+  noResultsLabel?: (query: string) => string;
 }) {
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [geometry, setGeometry] = useState<ToolbarDropdownGeometry | null>(
+    null,
+  );
+  const hasRichItems = items.some((item) => item.description || item.icon);
+  const preferredWidth = hasRichItems ? 360 : showCheck ? 300 : 160;
+  const visibleItems = searchable
+    ? filterToolbarDropdownItems(items, searchQuery)
+    : items;
+
+  useEffect(() => {
+    if (!open) {
+      setSearchQuery('');
+      setGeometry(null);
+      return;
+    }
+    if (!searchable) return;
+    const animationFrame = window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [open, searchable]);
+
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+    const anchor = anchorRef.current;
+    if (!anchor) return undefined;
+    const boundary =
+      anchor.closest<HTMLElement>('[data-web-shell-root]') ??
+      boundaryRef.current;
+    if (!boundary) return undefined;
+
+    const update = () => {
+      setGeometry(
+        getToolbarDropdownGeometry({
+          anchor: anchor.getBoundingClientRect(),
+          boundary: boundary.getBoundingClientRect(),
+          viewportHeight: window.innerHeight,
+          preferredWidth,
+          maxHeight,
+        }),
+      );
+    };
+
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(anchor);
+    resizeObserver.observe(boundary);
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [anchorRef, boundaryRef, maxHeight, open, preferredWidth]);
 
   useEffect(() => {
     if (!open) return;
@@ -553,8 +624,17 @@ function ToolbarDropdown({
 
   if (!open) return null;
 
-  const hasRichItems = items.some((item) => item.description || item.icon);
   const hasCheckItems = hasRichItems || showCheck;
+  const dropdownStyle = geometry
+    ? {
+        left: geometry.left,
+        width: geometry.width,
+        maxHeight: geometry.maxHeight,
+        ...(geometry.placement === 'above'
+          ? { bottom: geometry.bottom }
+          : { top: geometry.top }),
+      }
+    : undefined;
 
   return (
     <div
@@ -566,42 +646,64 @@ function ToolbarDropdown({
             ? styles.dropdownCheck
             : ''
       }`}
-      style={maxHeight ? { maxHeight, overflowY: 'auto' } : undefined}
+      data-placement={geometry?.placement}
+      style={dropdownStyle}
+      onClick={(event) => event.stopPropagation()}
     >
-      {items.map((item) => (
-        <button
-          key={item.id}
-          type="button"
-          className={`${styles.dropdownItem} ${
-            item.id === activeId ? styles.dropdownItemActive : ''
-          }`}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            onSelect(item.id);
-          }}
-        >
-          {hasCheckItems ? (
-            <>
-              {hasRichItems && (
-                <span className={styles.dropdownItemIcon}>{item.icon}</span>
-              )}
-              <span className={styles.dropdownItemContent}>
-                <span className={styles.dropdownItemLabel}>{item.label}</span>
-                {item.description && (
-                  <span className={styles.dropdownItemDesc}>
-                    {item.description}
-                  </span>
+      {searchable && (
+        <input
+          ref={searchInputRef}
+          type="search"
+          className={styles.dropdownSearch}
+          value={searchQuery}
+          aria-label={searchLabel}
+          placeholder={searchLabel}
+          onChange={(event) => setSearchQuery(event.target.value)}
+        />
+      )}
+      <div className={styles.dropdownList} role="listbox">
+        {visibleItems.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="option"
+            aria-selected={item.id === activeId}
+            className={`${styles.dropdownItem} ${
+              item.id === activeId ? styles.dropdownItemActive : ''
+            }`}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(item.id);
+            }}
+          >
+            {hasCheckItems ? (
+              <>
+                {hasRichItems && (
+                  <span className={styles.dropdownItemIcon}>{item.icon}</span>
                 )}
-              </span>
-              <span className={styles.dropdownItemCheck}>
-                {item.id === activeId ? <CheckIcon /> : null}
-              </span>
-            </>
-          ) : (
-            item.label
-          )}
-        </button>
-      ))}
+                <span className={styles.dropdownItemContent}>
+                  <span className={styles.dropdownItemLabel}>{item.label}</span>
+                  {item.description && (
+                    <span className={styles.dropdownItemDesc}>
+                      {item.description}
+                    </span>
+                  )}
+                </span>
+                <span className={styles.dropdownItemCheck}>
+                  {item.id === activeId ? <CheckIcon /> : null}
+                </span>
+              </>
+            ) : (
+              item.label
+            )}
+          </button>
+        ))}
+        {visibleItems.length === 0 && noResultsLabel && (
+          <div className={styles.dropdownEmpty} role="status">
+            {noResultsLabel(searchQuery)}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -988,9 +1090,21 @@ export const ChatEditor = memo(
     const containerRef = useRef<HTMLDivElement>(null);
     const slashPanelRef = useRef<HTMLDivElement>(null);
     const atPanelRef = useRef<HTMLDivElement>(null);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+    const toolbarLeadingRef = useRef<HTMLDivElement>(null);
+    const toolbarRightRef = useRef<HTMLDivElement>(null);
+    const modeCollapsedMeasureRef = useRef<HTMLSpanElement>(null);
+    const modeExpandedMeasureRef = useRef<HTMLSpanElement>(null);
+    const modelCollapsedMeasureRef = useRef<HTMLSpanElement>(null);
+    const modelExpandedMeasureRef = useRef<HTMLSpanElement>(null);
     const modeBtnRef = useRef<HTMLButtonElement>(null);
     const modelBtnRef = useRef<HTMLButtonElement>(null);
     const [widthToggleFits, setWidthToggleFits] = useState(false);
+    const [toolbarLabelVisibility, setToolbarLabelVisibility] = useState({
+      showModelLabel: false,
+      showModeLabel: false,
+    });
+    const [lastConfirmedModelLabel, setLastConfirmedModelLabel] = useState('');
     const slashMenu = core.slashMenu;
     const closeSlashMenu = core.closeSlashMenu;
     const atMenu = core.atMenu;
@@ -1210,6 +1324,7 @@ export const ChatEditor = memo(
         availableModels.map((m) => ({
           id: m.id,
           label: getModelDisplayName(m.label || m.id),
+          searchText: `${m.label ?? ''}\n${m.id}`,
         })),
       [availableModels],
     );
@@ -1329,12 +1444,104 @@ export const ChatEditor = memo(
     // Mode display label
     const modeLabel = getModeLabel(currentMode, t);
 
-    // Model display label
-    const modelLabel = getModelDisplayName(currentModel);
+    const currentModelLabel = currentModel
+      ? getModelDisplayName(currentModel)
+      : '';
+    const { modelLabel, modelLabelReady } = resolveToolbarModelLabel({
+      currentModelLabel,
+      lastConfirmedModelLabel,
+    });
+
+    useLayoutEffect(() => {
+      if (currentModelLabel && currentModelLabel !== lastConfirmedModelLabel) {
+        setLastConfirmedModelLabel(currentModelLabel);
+      }
+    }, [currentModelLabel, lastConfirmedModelLabel]);
+
+    const { showModelLabel, showModeLabel } = toolbarLabelVisibility;
     const showCancelButton = isRunning && !core.hasContent;
 
+    useLayoutEffect(() => {
+      const toolbar = toolbarRef.current;
+      const toolbarLeading = toolbarLeadingRef.current;
+      const toolbarRight = toolbarRightRef.current;
+      const modeCollapsed = modeCollapsedMeasureRef.current;
+      const modeExpanded = modeExpandedMeasureRef.current;
+      const modelCollapsed = modelCollapsedMeasureRef.current;
+      const modelExpanded = modelExpandedMeasureRef.current;
+      if (
+        !toolbar ||
+        !toolbarLeading ||
+        !toolbarRight ||
+        !modeCollapsed ||
+        !modeExpanded ||
+        !modelCollapsed ||
+        !modelExpanded
+      ) {
+        return undefined;
+      }
+
+      const update = () => {
+        const modeLabelWidth = Math.max(
+          0,
+          modeExpanded.getBoundingClientRect().width -
+            modeCollapsed.getBoundingClientRect().width,
+        );
+        const modelLabelWidth = Math.max(
+          0,
+          modelExpanded.getBoundingClientRect().width -
+            modelCollapsed.getBoundingClientRect().width,
+        );
+        const currentLeadingWidth =
+          toolbarLeading.getBoundingClientRect().width;
+        const baseLeadingWidth =
+          currentLeadingWidth -
+          (showModelLabel ? modelLabelWidth : 0) -
+          (showModeLabel ? modeLabelWidth : 0);
+        const gap = Number.parseFloat(getComputedStyle(toolbar).columnGap) || 0;
+        const availableWidth = Math.max(
+          0,
+          toolbar.getBoundingClientRect().width -
+            toolbarRight.getBoundingClientRect().width -
+            baseLeadingWidth -
+            gap,
+        );
+        const next = getToolbarLabelVisibility({
+          availableWidth,
+          modelLabelWidth,
+          modeLabelWidth,
+          modelLabelReady,
+        });
+        setToolbarLabelVisibility((current) =>
+          current.showModelLabel === next.showModelLabel &&
+          current.showModeLabel === next.showModeLabel
+            ? current
+            : next,
+        );
+      };
+
+      update();
+      const resizeObserver = new ResizeObserver(update);
+      resizeObserver.observe(toolbar);
+      resizeObserver.observe(toolbarLeading);
+      resizeObserver.observe(toolbarRight);
+      resizeObserver.observe(modeCollapsed);
+      resizeObserver.observe(modeExpanded);
+      resizeObserver.observe(modelCollapsed);
+      resizeObserver.observe(modelExpanded);
+      return () => resizeObserver.disconnect();
+    }, [modelLabel, modelLabelReady, modeLabel, showModelLabel, showModeLabel]);
+
     return (
-      <div className={styles.editorShell} data-composer data-web-shell-composer>
+      <div
+        className={`${styles.editorShell} ${
+          modeDropdownOpen || modelDropdownOpen
+            ? styles.editorShellDropdownOpen
+            : ''
+        }`}
+        data-composer
+        data-web-shell-composer
+      >
         <div
           ref={containerRef}
           className={styles.container}
@@ -1538,8 +1745,8 @@ export const ChatEditor = memo(
               )}
               <div ref={core.containerRef} data-web-shell-composer-editor />
             </div>
-            <div className={styles.toolbar}>
-              <div className={styles.toolbarLeading}>
+            <div ref={toolbarRef} className={styles.toolbar}>
+              <div ref={toolbarLeadingRef} className={styles.toolbarLeading}>
                 {ToolbarStart && (
                   <div className={styles.toolbarStart}>
                     <ToolbarStart
@@ -1567,10 +1774,11 @@ export const ChatEditor = memo(
                         onClose={() => setModeDropdownOpen(false)}
                         onSelect={handleModeSelect}
                         anchorRef={modeBtnRef}
+                        boundaryRef={containerRef}
                       />
                       <button
                         ref={modeBtnRef}
-                        className={styles.toolBtn}
+                        className={`${styles.toolBtn} ${styles.modeToolBtn}`}
                         data-web-shell-mode-button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1585,7 +1793,11 @@ export const ChatEditor = memo(
                         <span className={styles.toolBtnModeIcon}>
                           <ModeIcon mode={currentMode} />
                         </span>
-                        <span className={styles.toolBtnText}>{modeLabel}</span>
+                        {showModeLabel && (
+                          <span className={styles.toolBtnText}>
+                            {modeLabel}
+                          </span>
+                        )}
                         <span className={styles.toolBtnArrow}>
                           <ChevronDownIcon />
                         </span>
@@ -1601,12 +1813,18 @@ export const ChatEditor = memo(
                         onClose={() => setModelDropdownOpen(false)}
                         onSelect={handleModelSelect}
                         anchorRef={modelBtnRef}
+                        boundaryRef={containerRef}
                         showCheck
                         maxHeight={300}
+                        searchable
+                        searchLabel={t('common.search')}
+                        noResultsLabel={(query) =>
+                          t('model.noMatch', { query })
+                        }
                       />
                       <button
                         ref={modelBtnRef}
-                        className={styles.toolBtn}
+                        className={`${styles.toolBtn} ${styles.modelToolBtn}`}
                         data-web-shell-model-button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1621,7 +1839,11 @@ export const ChatEditor = memo(
                         <span className={styles.toolBtnModelIcon}>
                           <ModelIcon />
                         </span>
-                        <span className={styles.toolBtnText}>{modelLabel}</span>
+                        {showModelLabel && (
+                          <span className={styles.toolBtnText}>
+                            {modelLabel}
+                          </span>
+                        )}
                         <span className={styles.toolBtnArrow}>
                           <ChevronDownIcon />
                         </span>
@@ -1641,7 +1863,7 @@ export const ChatEditor = memo(
                   )}
                 </div>
               </div>
-              <div className={styles.toolbarRight}>
+              <div ref={toolbarRightRef} className={styles.toolbarRight}>
                 {showQuickActions && quickActions.length > 0 && (
                   <button
                     className={`${styles.toolBtn} ${styles.quickActionsBtn}`}
@@ -1782,6 +2004,54 @@ export const ChatEditor = memo(
                   {isRunning && cancelArmed ? t('stream.cancelArmed') : ''}
                 </span>
               </div>
+            </div>
+            <div className={styles.toolbarMeasurements} aria-hidden="true">
+              <span
+                ref={modeCollapsedMeasureRef}
+                className={`${styles.toolBtn} ${styles.modeToolBtn}`}
+              >
+                <span className={styles.toolBtnModeIcon}>
+                  <ModeIcon mode={currentMode} />
+                </span>
+                <span className={styles.toolBtnArrow}>
+                  <ChevronDownIcon />
+                </span>
+              </span>
+              <span
+                ref={modeExpandedMeasureRef}
+                className={`${styles.toolBtn} ${styles.modeToolBtn}`}
+              >
+                <span className={styles.toolBtnModeIcon}>
+                  <ModeIcon mode={currentMode} />
+                </span>
+                <span className={styles.toolBtnText}>{modeLabel}</span>
+                <span className={styles.toolBtnArrow}>
+                  <ChevronDownIcon />
+                </span>
+              </span>
+              <span
+                ref={modelCollapsedMeasureRef}
+                className={`${styles.toolBtn} ${styles.modelToolBtn}`}
+              >
+                <span className={styles.toolBtnModelIcon}>
+                  <ModelIcon />
+                </span>
+                <span className={styles.toolBtnArrow}>
+                  <ChevronDownIcon />
+                </span>
+              </span>
+              <span
+                ref={modelExpandedMeasureRef}
+                className={`${styles.toolBtn} ${styles.modelToolBtn}`}
+              >
+                <span className={styles.toolBtnModelIcon}>
+                  <ModelIcon />
+                </span>
+                <span className={styles.toolBtnText}>{modelLabel}</span>
+                <span className={styles.toolBtnArrow}>
+                  <ChevronDownIcon />
+                </span>
+              </span>
             </div>
           </div>
         </div>

--- a/packages/web-shell/client/components/toolbarDropdown.test.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.test.ts
@@ -20,14 +20,16 @@ describe('toolbarDropdown', () => {
     const items = [
       { id: 'a', label: 'Qwen 3.5', searchText: 'qwen3.5-plus (oauth)' },
       { id: 'b', label: 'GLM 5.2', searchText: 'glm-5.2 (gateway)' },
+      { id: 'c', label: 'Local model' },
     ];
 
     expect(filterToolbarDropdownItems(items, 'glm')).toEqual([items[1]]);
     expect(filterToolbarDropdownItems(items, 'oauth')).toEqual([items[0]]);
+    expect(filterToolbarDropdownItems(items, 'local')).toEqual([items[2]]);
     expect(filterToolbarDropdownItems(items, '  ')).toEqual(items);
   });
 
-  it('clamps width and position to the WebShell boundary', () => {
+  it('clamps the right edge when the menu fits in the WebShell boundary', () => {
     const geometry = getToolbarDropdownGeometry({
       anchor: {
         left: 450,
@@ -38,6 +40,7 @@ describe('toolbarDropdown', () => {
         height: 28,
       },
       boundary,
+      viewportWidth: 800,
       viewportHeight: 800,
       preferredWidth: 360,
       maxHeight: 300,
@@ -47,6 +50,26 @@ describe('toolbarDropdown', () => {
     expect(geometry.left).toBe(132);
     expect(geometry.placement).toBe('above');
     expect(geometry.maxHeight).toBe(300);
+  });
+
+  it('clamps the left edge and width to the visible boundary', () => {
+    const geometry = getToolbarDropdownGeometry({
+      anchor: {
+        left: 80,
+        top: 600,
+        right: 108,
+        bottom: 628,
+        width: 28,
+        height: 28,
+      },
+      boundary,
+      viewportWidth: 420,
+      viewportHeight: 800,
+      preferredWidth: 360,
+    });
+
+    expect(geometry.width).toBe(304);
+    expect(geometry.left).toBe(108);
   });
 
   it('uses the lower side only when it has more usable height', () => {
@@ -60,6 +83,7 @@ describe('toolbarDropdown', () => {
         height: 28,
       },
       boundary,
+      viewportWidth: 800,
       viewportHeight: 800,
       preferredWidth: 300,
     });
@@ -110,6 +134,19 @@ describe('toolbarDropdown', () => {
         modelLabelReady: pending.modelLabelReady,
       }),
     ).toEqual({ showModelLabel: false, showModeLabel: false });
+  });
+
+  it('shows the approval-mode label when it is the only visible action', () => {
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 64,
+        modelLabelWidth: 0,
+        modeLabelWidth: 64,
+        modelLabelReady: false,
+        modelActionVisible: false,
+        modeActionVisible: true,
+      }),
+    ).toEqual({ showModelLabel: false, showModeLabel: true });
   });
 
   it('keeps the confirmed model through a transient empty update', () => {

--- a/packages/web-shell/client/components/toolbarDropdown.test.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterToolbarDropdownItems,
+  getToolbarDropdownGeometry,
+  getToolbarLabelVisibility,
+  resolveToolbarModelLabel,
+} from './toolbarDropdown';
+
+const boundary = {
+  left: 100,
+  top: 80,
+  right: 500,
+  bottom: 680,
+  width: 400,
+  height: 600,
+};
+
+describe('toolbarDropdown', () => {
+  it('filters by display label and stable model id', () => {
+    const items = [
+      { id: 'a', label: 'Qwen 3.5', searchText: 'qwen3.5-plus (oauth)' },
+      { id: 'b', label: 'GLM 5.2', searchText: 'glm-5.2 (gateway)' },
+    ];
+
+    expect(filterToolbarDropdownItems(items, 'glm')).toEqual([items[1]]);
+    expect(filterToolbarDropdownItems(items, 'oauth')).toEqual([items[0]]);
+    expect(filterToolbarDropdownItems(items, '  ')).toEqual(items);
+  });
+
+  it('clamps width and position to the WebShell boundary', () => {
+    const geometry = getToolbarDropdownGeometry({
+      anchor: {
+        left: 450,
+        top: 600,
+        right: 478,
+        bottom: 628,
+        width: 28,
+        height: 28,
+      },
+      boundary,
+      viewportHeight: 800,
+      preferredWidth: 360,
+      maxHeight: 300,
+    });
+
+    expect(geometry.width).toBe(360);
+    expect(geometry.left).toBe(132);
+    expect(geometry.placement).toBe('above');
+    expect(geometry.maxHeight).toBe(300);
+  });
+
+  it('uses the lower side only when it has more usable height', () => {
+    const geometry = getToolbarDropdownGeometry({
+      anchor: {
+        left: 160,
+        top: 120,
+        right: 188,
+        bottom: 148,
+        width: 28,
+        height: 28,
+      },
+      boundary,
+      viewportHeight: 800,
+      preferredWidth: 300,
+    });
+
+    expect(geometry.placement).toBe('below');
+    expect(geometry.top).toBe(152);
+  });
+
+  it('keeps the model label before the approval-mode label', () => {
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 144,
+        modelLabelWidth: 80,
+        modeLabelWidth: 64,
+        modelLabelReady: true,
+      }),
+    ).toEqual({ showModelLabel: true, showModeLabel: true });
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 80,
+        modelLabelWidth: 80,
+        modeLabelWidth: 64,
+        modelLabelReady: true,
+      }),
+    ).toEqual({ showModelLabel: true, showModeLabel: false });
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 79,
+        modelLabelWidth: 80,
+        modeLabelWidth: 64,
+        modelLabelReady: true,
+      }),
+    ).toEqual({ showModelLabel: false, showModeLabel: false });
+  });
+
+  it('keeps both labels hidden while the initial model is pending', () => {
+    const pending = resolveToolbarModelLabel({
+      currentModelLabel: '',
+      lastConfirmedModelLabel: '',
+    });
+
+    expect(pending.modelLabelReady).toBe(false);
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 300,
+        modelLabelWidth: 0,
+        modeLabelWidth: 64,
+        modelLabelReady: pending.modelLabelReady,
+      }),
+    ).toEqual({ showModelLabel: false, showModeLabel: false });
+  });
+
+  it('keeps the confirmed model through a transient empty update', () => {
+    const confirmed = resolveToolbarModelLabel({
+      currentModelLabel: 'Qwen 3.5 Plus',
+      lastConfirmedModelLabel: '',
+    });
+    const transientEmpty = resolveToolbarModelLabel({
+      currentModelLabel: '',
+      lastConfirmedModelLabel: confirmed.nextConfirmedModelLabel,
+    });
+
+    expect(transientEmpty.modelLabel).toBe('Qwen 3.5 Plus');
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 112,
+        modelLabelWidth: 112,
+        modeLabelWidth: 64,
+        modelLabelReady: transientEmpty.modelLabelReady,
+      }),
+    ).toEqual({ showModelLabel: true, showModeLabel: false });
+  });
+
+  it('uses an arriving replacement for the next measured layout', () => {
+    const replacement = resolveToolbarModelLabel({
+      currentModelLabel: 'GLM 5.2',
+      lastConfirmedModelLabel: 'Qwen 3.5 Plus',
+    });
+
+    expect(replacement.modelLabel).toBe('GLM 5.2');
+    expect(
+      getToolbarLabelVisibility({
+        availableWidth: 128,
+        modelLabelWidth: 80,
+        modeLabelWidth: 64,
+        modelLabelReady: replacement.modelLabelReady,
+      }),
+    ).toEqual({ showModelLabel: true, showModeLabel: false });
+  });
+});

--- a/packages/web-shell/client/components/toolbarDropdown.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.ts
@@ -1,0 +1,138 @@
+export interface ToolbarDropdownItem {
+  id: string;
+  label: string;
+  searchText?: string;
+}
+
+export interface ToolbarDropdownRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+export interface ToolbarDropdownGeometry {
+  placement: 'above' | 'below';
+  left: number;
+  top?: number;
+  bottom?: number;
+  width: number;
+  maxHeight: number;
+}
+
+const MENU_GAP = 4;
+const MENU_INSET = 8;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
+}
+
+export function filterToolbarDropdownItems<T extends ToolbarDropdownItem>(
+  items: readonly T[],
+  query: string,
+): T[] {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (!normalized) return [...items];
+  return items.filter((item) =>
+    `${item.label}\n${item.searchText ?? ''}`
+      .toLocaleLowerCase()
+      .includes(normalized),
+  );
+}
+
+export function getToolbarDropdownGeometry({
+  anchor,
+  boundary,
+  viewportHeight,
+  preferredWidth,
+  maxHeight,
+}: {
+  anchor: ToolbarDropdownRect;
+  boundary: ToolbarDropdownRect;
+  viewportHeight: number;
+  preferredWidth: number;
+  maxHeight?: number;
+}): ToolbarDropdownGeometry {
+  const boundaryLeft = Math.max(0, boundary.left);
+  const boundaryRight = Math.min(
+    typeof window === 'undefined' ? boundary.right : window.innerWidth,
+    boundary.right,
+  );
+  const availableWidth = Math.max(
+    0,
+    boundaryRight - boundaryLeft - MENU_INSET * 2,
+  );
+  const width = Math.min(preferredWidth, availableWidth);
+  const left = clamp(
+    anchor.left,
+    boundaryLeft + MENU_INSET,
+    Math.max(boundaryLeft + MENU_INSET, boundaryRight - MENU_INSET - width),
+  );
+
+  const boundaryTop = Math.max(0, boundary.top);
+  const boundaryBottom = Math.min(viewportHeight, boundary.bottom);
+  const above = Math.max(0, anchor.top - boundaryTop - MENU_GAP - MENU_INSET);
+  const below = Math.max(
+    0,
+    boundaryBottom - anchor.bottom - MENU_GAP - MENU_INSET,
+  );
+  const placement = above >= below ? 'above' : 'below';
+  const availableHeight = placement === 'above' ? above : below;
+
+  return {
+    placement,
+    left,
+    ...(placement === 'above'
+      ? { bottom: viewportHeight - anchor.top + MENU_GAP }
+      : { top: anchor.bottom + MENU_GAP }),
+    width,
+    maxHeight:
+      maxHeight === undefined
+        ? availableHeight
+        : Math.min(maxHeight, availableHeight),
+  };
+}
+
+export function getToolbarLabelVisibility({
+  availableWidth,
+  modelLabelWidth,
+  modeLabelWidth,
+  modelLabelReady,
+}: {
+  availableWidth: number;
+  modelLabelWidth: number;
+  modeLabelWidth: number;
+  modelLabelReady: boolean;
+}): {
+  showModelLabel: boolean;
+  showModeLabel: boolean;
+} {
+  if (!modelLabelReady || availableWidth < modelLabelWidth) {
+    return { showModelLabel: false, showModeLabel: false };
+  }
+  if (availableWidth < modelLabelWidth + modeLabelWidth) {
+    return { showModelLabel: true, showModeLabel: false };
+  }
+  return { showModelLabel: true, showModeLabel: true };
+}
+
+export function resolveToolbarModelLabel({
+  currentModelLabel,
+  lastConfirmedModelLabel,
+}: {
+  currentModelLabel: string;
+  lastConfirmedModelLabel: string;
+}): {
+  modelLabel: string;
+  modelLabelReady: boolean;
+  nextConfirmedModelLabel: string;
+} {
+  const nextConfirmedModelLabel = currentModelLabel || lastConfirmedModelLabel;
+  return {
+    modelLabel: nextConfirmedModelLabel,
+    modelLabelReady: Boolean(nextConfirmedModelLabel),
+    nextConfirmedModelLabel,
+  };
+}

--- a/packages/web-shell/client/components/toolbarDropdown.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.ts
@@ -45,21 +45,20 @@ export function filterToolbarDropdownItems<T extends ToolbarDropdownItem>(
 export function getToolbarDropdownGeometry({
   anchor,
   boundary,
+  viewportWidth,
   viewportHeight,
   preferredWidth,
   maxHeight,
 }: {
   anchor: ToolbarDropdownRect;
   boundary: ToolbarDropdownRect;
+  viewportWidth: number;
   viewportHeight: number;
   preferredWidth: number;
   maxHeight?: number;
 }): ToolbarDropdownGeometry {
   const boundaryLeft = Math.max(0, boundary.left);
-  const boundaryRight = Math.min(
-    typeof window === 'undefined' ? boundary.right : window.innerWidth,
-    boundary.right,
-  );
+  const boundaryRight = Math.min(viewportWidth, boundary.right);
   const availableWidth = Math.max(
     0,
     boundaryRight - boundaryLeft - MENU_INSET * 2,
@@ -100,22 +99,32 @@ export function getToolbarLabelVisibility({
   modelLabelWidth,
   modeLabelWidth,
   modelLabelReady,
+  modelActionVisible = true,
+  modeActionVisible = true,
 }: {
   availableWidth: number;
   modelLabelWidth: number;
   modeLabelWidth: number;
   modelLabelReady: boolean;
+  modelActionVisible?: boolean;
+  modeActionVisible?: boolean;
 }): {
   showModelLabel: boolean;
   showModeLabel: boolean;
 } {
+  if (!modelActionVisible) {
+    return {
+      showModelLabel: false,
+      showModeLabel: modeActionVisible && availableWidth >= modeLabelWidth,
+    };
+  }
   if (!modelLabelReady || availableWidth < modelLabelWidth) {
     return { showModelLabel: false, showModeLabel: false };
   }
   if (availableWidth < modelLabelWidth + modeLabelWidth) {
     return { showModelLabel: true, showModeLabel: false };
   }
-  return { showModelLabel: true, showModeLabel: true };
+  return { showModelLabel: true, showModeLabel: modeActionVisible };
 }
 
 export function resolveToolbarModelLabel({


### PR DESCRIPTION
## What this PR does

Improves the WebShell composer’s model and approval-mode controls: the model selector can be searched by its displayed name or stable model ID, selector menus stay within the embedded WebShell boundary, and the toolbar uses measured available space to keep the model label visible before the approval-mode label. It also keeps the toolbar icon-only while the initial model is still loading and retains a confirmed model label across a transient empty update, preventing a mode-only-to-model label jump on refresh.

## Why it's needed

In an embedded host, the composer may be narrow, have host-provided toolbar slots, and sit beneath other status UI. The previous controls could overflow or be covered, hid labels based on a fixed breakpoint despite available space, and visibly changed priority while asynchronous model metadata arrived. These behaviors made model selection harder and the composer less stable.

## Reviewer Test Plan

### How to verify

1. Open a WebShell composer with several available models, open the model menu, and search using both a display-name fragment and a model-ID fragment; only matching models should remain and selection should work.
2. Put the composer in a narrow embedded container with toolbar slots or adjacent status UI, then open both selectors near each horizontal edge; each menu should remain inside the WebShell boundary and render above the composer’s surrounding status content.
3. Resize the composer while keeping the lower toolbar on one row. When only one label fits, the model label should remain visible before the approval-mode label; when neither fits, both controls should stay icon-only.
4. Refresh while model metadata is loading. The toolbar should remain icon-only until a model is known, and a previously confirmed model should not briefly fall back to an approval-mode-only label during a transient empty update.

### Evidence (Before & After)

Before: the model menu could not filter, menus could be obscured or escape a narrow embedded composer, and label visibility used a fixed breakpoint that could hide both labels despite usable space. After: filtering, boundary-aware placement, measured model-first label priority, and async-stable model display were verified manually in the pre-production embedded IDE. No public screenshot or recording is available because that verification environment is internal.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ pre-production embedded IDE manual verification; focused WebShell tests and lint |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS; pre-production embedded DataWorks IDE through the local WebShell build. `npm run test --workspace=packages/web-shell -- components/toolbarDropdown.test.ts` passed (7/7), and `npm run lint --workspace=packages/web-shell` passed. The exact root `npm run preflight` completed clean/install/format/lint/build/typecheck but exited during unrelated existing CLI/Core tests: the unchanged extensions-list test expects English output while the current i18n runtime emits Chinese, and unchanged managed-memory refresh assertions fail. This PR does not modify either package.

## Risk & Scope

- Main risk or tradeoff: selector placement and label visibility now depend on measured DOM bounds; the implementation clamps all menus to the WebShell boundary and keeps the existing toolbar semantics.
- Not validated / out of scope: public-host visual capture, Windows/Linux manual verification, and unrelated CLI/Core baseline test failures in the full preflight suite.
- Breaking changes / migration notes: none; this adds no public API or configuration change.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的内容

改进 WebShell 对话输入框中的模型与审批模式控件：模型选择器可以按展示名称或稳定的模型 ID 搜索；选择器菜单会保持在嵌入式 WebShell 边界内；工具栏会根据实际可用空间进行测量，优先展示模型名称，其次才是审批模式文案。初始模型仍在加载时，工具栏保持纯图标展示；已经确认的模型名称会跨越一次短暂的空值更新继续保留，从而避免刷新时先显示审批模式、再跳变为模型名称。

## 为什么需要此改动

嵌入式宿主中的输入框可能较窄、包含宿主提供的工具栏插槽，并且位于其他状态 UI 之下。旧控件可能溢出或被遮挡，即使仍有可用空间也会因固定断点隐藏文案，并且在异步模型元数据到达时出现可见的优先级跳变。这些行为让模型选择更困难，也降低了输入框展示的稳定性。

## 审阅者测试计划

### 如何验证

1. 在有多个可用模型的 WebShell 输入框中打开模型菜单，分别用展示名称片段和模型 ID 片段搜索；应只保留匹配的模型，并且可以正常选择。
2. 将输入框放入带有工具栏插槽或相邻状态 UI 的窄嵌入容器中，在两个水平边缘附近打开两个选择器；每个菜单都应保持在 WebShell 边界内，并显示在输入框周围状态内容的上方。
3. 在保持底部工具栏单行的情况下调整输入框尺寸。仅能容纳一个文案时，应优先展示模型名称而非审批模式文案；两个都容纳不下时，两个控件都应仅显示图标。
4. 在模型元数据加载期间刷新。模型已知前工具栏应保持纯图标；已经确认的模型不应在一次短暂空值更新中回退成仅展示审批模式文案。

### 证据（改动前与改动后）

改动前：模型菜单不能筛选，菜单可能被遮挡或溢出窄嵌入输入框，文案展示依赖固定断点，即使有可用空间也可能隐藏两个文案。改动后：已在预发嵌入式 IDE 中人工验证筛选、边界感知定位、按实际空间优先展示模型名称，以及异步加载时稳定的模型展示。该验证环境为内部环境，因此没有可公开的截图或录屏。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|      🍏 macOS      | ✅ 已在预发嵌入式 IDE 人工验证；WebShell 聚焦测试和 lint 均通过 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS；通过本地 WebShell 构建接入预发 DataWorks IDE。`npm run test --workspace=packages/web-shell -- components/toolbarDropdown.test.ts` 通过（7/7），`npm run lint --workspace=packages/web-shell` 通过。精确执行根目录的 `npm run preflight` 后，clean/install/format/lint/build/typecheck 均完成，但在与本 PR 无关的既有 CLI/Core 测试阶段退出：未改动的 extensions-list 测试期望英文输出，而当前 i18n 运行时输出中文；未改动的 managed-memory refresh 断言也失败。本 PR 未修改这两个包。

## 风险与范围

- 主要风险或权衡：选择器定位与文案展示现在依赖 DOM 实际边界测量；实现会将所有菜单限制在 WebShell 边界内，并保留现有工具栏语义。
- 未验证 / 不在范围内：公共宿主的可视化录制、Windows/Linux 人工验证，以及完整 preflight 中无关的 CLI/Core 基线测试失败。
- 破坏性变更 / 迁移说明：无；不新增公共 API 或配置变更。

## 关联 Issue

N/A

</details>
