### PR TITLE
feat(web-shell): aggregate scheduled tasks across all workspaces

### DIFF
--- a/packages/cli/src/serve/routes/scheduled-tasks.test.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.test.ts
@@ -18,8 +18,13 @@ import {
 } from '@qwen-code/qwen-code-core';
 import {
   registerScheduledTasksRoutes,
+  registerWorkspaceQualifiedScheduledTasksRoutes,
   scheduledTaskSessionName,
 } from './scheduled-tasks.js';
+import type {
+  WorkspaceRegistry,
+  WorkspaceRuntime,
+} from '../workspace-registry.js';
 
 function safeBody(req: Request): Record<string, unknown> {
   return req.body && typeof req.body === 'object'
@@ -1142,5 +1147,178 @@ describe('scheduledTaskSessionName', () => {
       .map((c) => String.fromCodePoint(c))
       .join('');
     expect(scheduledTaskSessionName(`m${marks}n`)).toBe('⏰ mn');
+  });
+});
+
+// ── Workspace-qualified routes ──────────────────────────────────────────────
+
+interface QualifiedRuntime {
+  workspaceId: string;
+  workspaceCwd: string;
+  trusted: boolean;
+  bridge: StubBridge;
+}
+
+interface QualifiedHarness {
+  app: express.Application;
+  scratch: string;
+  primary: QualifiedRuntime;
+  secondary: QualifiedRuntime;
+  untrusted: QualifiedRuntime;
+}
+
+/** A registry stub exposing only what the qualified route resolver touches:
+ * lookup by id, lookup by cwd, and list (for the mismatch fallback). */
+function makeStubRegistry(runtimes: QualifiedRuntime[]): WorkspaceRegistry {
+  const asRuntime = (r: QualifiedRuntime) => r as unknown as WorkspaceRuntime;
+  return {
+    list: () => runtimes.map(asRuntime),
+    getByWorkspaceId: (id: string) => {
+      const found = runtimes.find((r) => r.workspaceId === id);
+      return found ? asRuntime(found) : undefined;
+    },
+    getByWorkspaceCwd: (cwd: string) => {
+      const found = runtimes.find((r) => r.workspaceCwd === cwd);
+      return found ? asRuntime(found) : undefined;
+    },
+  } as unknown as WorkspaceRegistry;
+}
+
+async function makeQualifiedHarness(): Promise<QualifiedHarness> {
+  const scratch = await fsp.mkdtemp(path.join(os.tmpdir(), 'sched-wsq-'));
+  Storage.setRuntimeBaseDir(scratch);
+
+  const mkRuntime = async (
+    name: string,
+    trusted: boolean,
+  ): Promise<QualifiedRuntime> => {
+    const workspaceCwd = path.join(scratch, name);
+    await fsp.mkdir(workspaceCwd, { recursive: true });
+    return {
+      workspaceId: `id-${name}`,
+      workspaceCwd,
+      trusted,
+      bridge: makeStubBridge(),
+    };
+  };
+
+  const primary = await mkRuntime('primary', true);
+  const secondary = await mkRuntime('secondary', true);
+  const untrusted = await mkRuntime('untrusted', false);
+  const runtimes = [primary, secondary, untrusted];
+
+  const app = express();
+  app.use(express.json());
+  // Both surfaces share the app, as in the real server: the primary's own
+  // cron file behind `/scheduled-tasks`, every workspace behind the qualified
+  // route. `bridge`-per-runtime comes from the registry.
+  registerScheduledTasksRoutes(app, {
+    boundWorkspace: primary.workspaceCwd,
+    mutate: () => (_req, _res, next) => next(),
+    safeBody,
+    bridge: primary.bridge,
+  });
+  registerWorkspaceQualifiedScheduledTasksRoutes(app, {
+    workspaceRegistry: makeStubRegistry(runtimes),
+    mutate: () => (_req, _res, next) => next(),
+    safeBody,
+    manageScheduledTaskSessions: true,
+  });
+  return { app, scratch, primary, secondary, untrusted };
+}
+
+describe('workspace-qualified scheduled-tasks routes', () => {
+  let h: QualifiedHarness;
+
+  beforeEach(async () => {
+    h = await makeQualifiedHarness();
+  });
+  afterEach(async () => {
+    Storage.setRuntimeBaseDir(null);
+    await fsp.rm(h.scratch, { recursive: true, force: true });
+  });
+
+  const qualified = (id: string) => `/workspaces/${id}/scheduled-tasks`;
+
+  it('creates a task in the targeted workspace, isolated from the primary', async () => {
+    const res = await request(h.app)
+      .post(qualified(h.secondary.workspaceId))
+      .send({ cron: '0 9 * * *', prompt: 'secondary work' });
+    expect(res.status).toBe(201);
+    // The bound session was minted through the SECONDARY workspace's bridge.
+    expect(h.secondary.bridge.spawned).toHaveLength(1);
+    expect(h.primary.bridge.spawned).toHaveLength(0);
+
+    // It lands in the secondary's list, and NOT the primary's.
+    const secList = await request(h.app).get(
+      qualified(h.secondary.workspaceId),
+    );
+    expect(secList.body.tasks).toHaveLength(1);
+    expect(secList.body.tasks[0].prompt).toBe('secondary work');
+    const primaryList = await request(h.app).get('/scheduled-tasks');
+    expect(primaryList.body.tasks).toHaveLength(0);
+  });
+
+  it('writes to the targeted workspace’s own cron file on disk', async () => {
+    await request(h.app)
+      .post(qualified(h.secondary.workspaceId))
+      .send({ cron: '0 9 * * *', prompt: 'p' });
+    const onDisk = JSON.parse(
+      await fsp.readFile(getCronFilePath(h.secondary.workspaceCwd), 'utf-8'),
+    );
+    expect(onDisk).toHaveLength(1);
+    // The primary's file was never created.
+    await expect(
+      fsp.readFile(getCronFilePath(h.primary.workspaceCwd), 'utf-8'),
+    ).rejects.toThrow();
+  });
+
+  it('patches / runs / deletes a task addressed by its workspace', async () => {
+    const created = await request(h.app)
+      .post(qualified(h.secondary.workspaceId))
+      .send({ cron: '0 9 * * *', prompt: 'p', name: 'orig' });
+    const id = created.body.id as string;
+
+    const patched = await request(h.app)
+      .patch(`${qualified(h.secondary.workspaceId)}/${id}`)
+      .send({ name: 'renamed' });
+    expect(patched.status).toBe(200);
+    expect(patched.body.name).toBe('renamed');
+
+    const ran = await request(h.app)
+      .post(`${qualified(h.secondary.workspaceId)}/${id}/run`)
+      .send();
+    expect(ran.status).toBe(200);
+    expect(ran.body.lastFiredAt).toBeGreaterThan(0);
+
+    const del = await request(h.app)
+      .delete(`${qualified(h.secondary.workspaceId)}/${id}`)
+      .send();
+    expect(del.status).toBe(200);
+    const after = await request(h.app).get(qualified(h.secondary.workspaceId));
+    expect(after.body.tasks).toHaveLength(0);
+  });
+
+  it('resolves a workspace by absolute path too', async () => {
+    const res = await request(h.app)
+      .post(qualified(encodeURIComponent(h.secondary.workspaceCwd)))
+      .send({ cron: '0 9 * * *', prompt: 'via path' });
+    expect(res.status).toBe(201);
+    expect(h.secondary.bridge.spawned).toHaveLength(1);
+  });
+
+  it('rejects an unknown workspace with 400 workspace_mismatch', async () => {
+    const res = await request(h.app).get(qualified('id-nope')).send();
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('workspace_mismatch');
+  });
+
+  it('rejects an untrusted workspace with 403, without spawning', async () => {
+    const res = await request(h.app)
+      .post(qualified(h.untrusted.workspaceId))
+      .send({ cron: '0 9 * * *', prompt: 'p' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('untrusted_workspace');
+    expect(h.untrusted.bridge.spawned).toHaveLength(0);
   });
 });

--- a/packages/cli/src/serve/routes/scheduled-tasks.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.ts
@@ -20,9 +20,17 @@
  * the same capability class as `POST /session/:id/prompt` (both enqueue a
  * prompt that runs with tool access), and that route is non-strict too, so a
  * loopback web-shell without a token can manage its own schedule.
+ *
+ * The same CRUD handlers are mounted twice: once unqualified (`/scheduled-tasks`,
+ * bound to the primary workspace) and once workspace-qualified
+ * (`/workspaces/:workspace/scheduled-tasks`, resolving the cron file + session
+ * bridge of any registered workspace). Both share {@link
+ * registerScheduledTaskCrudRoutes}; they differ only in how the target
+ * workspace and its bridge are resolved per request, so a multi-workspace Web
+ * Shell manages each project's schedule against that project's own file.
  */
 
-import type { Application, Request, RequestHandler } from 'express';
+import type { Application, Request, RequestHandler, Response } from 'express';
 import {
   readCronTasks,
   updateCronTasks,
@@ -39,6 +47,11 @@ import {
   type CronTaskRun,
 } from '@qwen-code/qwen-code-core';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
+import type { WorkspaceRegistry } from '../workspace-registry.js';
+import {
+  requireTrustedWorkspaceRuntime,
+  resolveWorkspaceRuntimeFromParam,
+} from '../workspace-route-runtime.js';
 
 // The per-file create cap, shared with the scheduler's MAX_JOBS. The scheduler
 // caps DURABLE loads against a durable-only budget of MAX_JOBS (independent of
@@ -101,6 +114,36 @@ export function scheduledTaskSessionName(label: string): string {
   return `⏰ ${short}`;
 }
 
+/**
+ * The workspace a scheduled-task request operates on: the cron file lives under
+ * `workspaceCwd`, and `bridge` mints/tears down the task's bound session. A
+ * missing bridge means tasks are created unbound (shared per-project
+ * durable-owner firing) — the same fallback a bridge-less embedding gets.
+ */
+interface ScheduledTaskTarget {
+  workspaceCwd: string;
+  bridge?: ScheduledTasksSessionBridge;
+}
+
+/**
+ * Resolves the target workspace for one request. Returns null when it can't be
+ * resolved (unknown or untrusted `:workspace`), in which case the resolver has
+ * ALREADY sent the error response and the handler must just return.
+ */
+type ResolveScheduledTaskTarget = (
+  req: Request,
+  res: Response,
+) => ScheduledTaskTarget | null;
+
+interface RegisterScheduledTaskCrudRoutesDeps {
+  /** Path prefix the five routes mount under: `''` for the primary
+   * (unqualified) surface, `'/workspaces/:workspace'` for the qualified one. */
+  prefix: string;
+  resolveTarget: ResolveScheduledTaskTarget;
+  mutate: (opts?: { strict?: boolean }) => RequestHandler;
+  safeBody: (req: Request) => Record<string, unknown>;
+}
+
 interface RegisterScheduledTasksRoutesDeps {
   boundWorkspace: string;
   mutate: (opts?: { strict?: boolean }) => RequestHandler;
@@ -111,6 +154,21 @@ interface RegisterScheduledTasksRoutesDeps {
    * fall back to the shared per-project durable-owner firing model.
    */
   bridge?: ScheduledTasksSessionBridge;
+}
+
+interface RegisterWorkspaceQualifiedScheduledTasksRoutesDeps {
+  workspaceRegistry: WorkspaceRegistry;
+  mutate: (opts?: { strict?: boolean }) => RequestHandler;
+  safeBody: (req: Request) => Record<string, unknown>;
+  /**
+   * When true, a task created through a qualified route binds to a dedicated
+   * session in the target workspace (its bridge mints one). Must mirror the
+   * primary surface's `bridge` gate — the daemon only keeps bound sessions
+   * resident + rehydrated when scheduled-task session management is on, so
+   * binding without it would leave the task firing in a session nothing
+   * revives. Off → tasks are created unbound (shared-owner firing).
+   */
+  manageScheduledTaskSessions: boolean;
 }
 
 /** On-the-wire task shape — normalizes the optional on-disk fields so the
@@ -213,23 +271,26 @@ function canonicalCron(cron: string): string | null {
   }
 }
 
-export function registerScheduledTasksRoutes(
+function registerScheduledTaskCrudRoutes(
   app: Application,
-  deps: RegisterScheduledTasksRoutesDeps,
+  deps: RegisterScheduledTaskCrudRoutesDeps,
 ): void {
-  const { boundWorkspace, mutate, safeBody, bridge } = deps;
+  const { prefix, resolveTarget, mutate, safeBody } = deps;
+  const base = `${prefix}/scheduled-tasks`;
 
   // ── List ──────────────────────────────────────────────────────────
-  app.get('/scheduled-tasks', async (_req, res) => {
+  app.get(base, async (req, res) => {
+    const target = resolveTarget(req, res);
+    if (!target) return;
     try {
-      const tasks = await readCronTasks(boundWorkspace);
+      const tasks = await readCronTasks(target.workspaceCwd);
       res.status(200).json({ v: 1, tasks: tasks.map(toView) });
     } catch (err) {
       // A malformed/corrupt file throws (fix-or-delete contract) rather than
       // reading as empty — surface it instead of hiding the user's tasks
       // behind a silent [].
       writeStderrLine(
-        `qwen serve: GET /scheduled-tasks failed: ${err instanceof Error ? err.message : String(err)}`,
+        `qwen serve: GET ${base} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       res.status(500).json({
         error: 'Failed to read scheduled tasks (the tasks file may be corrupt)',
@@ -239,7 +300,10 @@ export function registerScheduledTasksRoutes(
   });
 
   // ── Create ────────────────────────────────────────────────────────
-  app.post('/scheduled-tasks', mutate(), async (req, res) => {
+  app.post(base, mutate(), async (req, res) => {
+    const target = resolveTarget(req, res);
+    if (!target) return;
+    const { workspaceCwd, bridge } = target;
     const body = safeBody(req);
 
     const cron = typeof body['cron'] === 'string' ? body['cron'].trim() : '';
@@ -331,9 +395,7 @@ export function registerScheduledTasksRoutes(
       // an orphan with no owning task. Best-effort — the write-lock cap check
       // below stays authoritative for the concurrent-create race.
       try {
-        if (
-          (await readCronTasks(boundWorkspace)).length >= MAX_SCHEDULED_TASKS
-        ) {
+        if ((await readCronTasks(workspaceCwd)).length >= MAX_SCHEDULED_TASKS) {
           res.status(409).json({
             error: `Maximum number of scheduled tasks (${MAX_SCHEDULED_TASKS}) reached`,
             code: 'max_tasks_reached',
@@ -345,7 +407,7 @@ export function registerScheduledTasksRoutes(
       }
       try {
         const session = await bridge.spawnOrAttach({
-          workspaceCwd: boundWorkspace,
+          workspaceCwd,
           sessionScope: 'thread',
         });
         boundSessionId = session.sessionId;
@@ -360,7 +422,7 @@ export function registerScheduledTasksRoutes(
         }
       } catch (err) {
         writeStderrLine(
-          `qwen serve: POST /scheduled-tasks failed to create the task's session: ${err instanceof Error ? err.message : String(err)}`,
+          `qwen serve: POST ${base} failed to create the task's session: ${err instanceof Error ? err.message : String(err)}`,
         );
         res.status(500).json({
           error: "Failed to create the task's session",
@@ -394,7 +456,7 @@ export function registerScheduledTasksRoutes(
     const rollbackSession = async () => {
       if (boundSessionId !== undefined && bridge) {
         await bridge.closeSession(boundSessionId).catch(() => {});
-        await new SessionService(boundWorkspace)
+        await new SessionService(workspaceCwd)
           .removeSession(boundSessionId)
           .catch(() => {});
       }
@@ -402,7 +464,7 @@ export function registerScheduledTasksRoutes(
 
     let overCap = false;
     try {
-      await updateCronTasks(boundWorkspace, (tasks) => {
+      await updateCronTasks(workspaceCwd, (tasks) => {
         // Cap check under the write lock so two concurrent creates can't both
         // slip past a stale count. Returning the input unchanged is a no-op
         // (no write), which the flag below turns into a 409.
@@ -415,7 +477,7 @@ export function registerScheduledTasksRoutes(
     } catch (err) {
       await rollbackSession();
       writeStderrLine(
-        `qwen serve: POST /scheduled-tasks failed: ${err instanceof Error ? err.message : String(err)}`,
+        `qwen serve: POST ${base} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       res.status(500).json({
         error: 'Failed to create scheduled task',
@@ -435,7 +497,10 @@ export function registerScheduledTasksRoutes(
   });
 
   // ── Update (name / enabled / cron / prompt / recurring) ────────────
-  app.patch('/scheduled-tasks/:id', mutate(), async (req, res) => {
+  app.patch(`${base}/:id`, mutate(), async (req, res) => {
+    const target = resolveTarget(req, res);
+    if (!target) return;
+    const { workspaceCwd, bridge } = target;
     const id = typeof req.params['id'] === 'string' ? req.params['id'] : '';
     if (id.length === 0) {
       res
@@ -530,7 +595,7 @@ export function registerScheduledTasksRoutes(
     let blockedByArchive = false;
     let blockedLegacy = false;
     try {
-      await updateCronTasks(boundWorkspace, (tasks) => {
+      await updateCronTasks(workspaceCwd, (tasks) => {
         const idx = tasks.findIndex((t) => t.id === id);
         if (idx === -1) return tasks; // not found → no write
         found = true;
@@ -610,7 +675,7 @@ export function registerScheduledTasksRoutes(
       });
     } catch (err) {
       writeStderrLine(
-        `qwen serve: PATCH /scheduled-tasks/${id} failed: ${err instanceof Error ? err.message : String(err)}`,
+        `qwen serve: PATCH ${base}/${id} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       res.status(500).json({
         error: 'Failed to update scheduled task',
@@ -661,7 +726,10 @@ export function registerScheduledTasksRoutes(
   });
 
   // ── Delete ────────────────────────────────────────────────────────
-  app.delete('/scheduled-tasks/:id', mutate(), async (req, res) => {
+  app.delete(`${base}/:id`, mutate(), async (req, res) => {
+    const target = resolveTarget(req, res);
+    if (!target) return;
+    const { workspaceCwd, bridge } = target;
     const id = typeof req.params['id'] === 'string' ? req.params['id'] : '';
     if (id.length === 0) {
       res
@@ -676,7 +744,7 @@ export function registerScheduledTasksRoutes(
     let boundSessionId: string | undefined;
     let removed = false;
     try {
-      await updateCronTasks(boundWorkspace, (tasks) => {
+      await updateCronTasks(workspaceCwd, (tasks) => {
         const idx = tasks.findIndex((t) => t.id === id);
         if (idx === -1) return tasks; // not found → no write
         const match = tasks[idx]!.sessionId;
@@ -688,7 +756,7 @@ export function registerScheduledTasksRoutes(
       });
     } catch (err) {
       writeStderrLine(
-        `qwen serve: DELETE /scheduled-tasks/${id} failed: ${err instanceof Error ? err.message : String(err)}`,
+        `qwen serve: DELETE ${base}/${id} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       res.status(500).json({
         error: 'Failed to delete scheduled task',
@@ -713,7 +781,10 @@ export function registerScheduledTasksRoutes(
   // prompt itself is executed by the client in the task's bound session; this
   // route only records that a run happened, keeping manual and scheduled runs
   // consistent in the history.
-  app.post('/scheduled-tasks/:id/run', mutate(), async (req, res) => {
+  app.post(`${base}/:id/run`, mutate(), async (req, res) => {
+    const target = resolveTarget(req, res);
+    if (!target) return;
+    const { workspaceCwd } = target;
     const id = typeof req.params['id'] === 'string' ? req.params['id'] : '';
     if (id.length === 0) {
       res
@@ -732,7 +803,7 @@ export function registerScheduledTasksRoutes(
     let blockedLegacy = false;
     let updated: DurableCronTask | undefined;
     try {
-      await updateCronTasks(boundWorkspace, (tasks) => {
+      await updateCronTasks(workspaceCwd, (tasks) => {
         const idx = tasks.findIndex((t) => t.id === id);
         if (idx === -1) return tasks; // not found → no write
         found = true;
@@ -777,7 +848,7 @@ export function registerScheduledTasksRoutes(
       });
     } catch (err) {
       writeStderrLine(
-        `qwen serve: POST /scheduled-tasks/${id}/run failed: ${err instanceof Error ? err.message : String(err)}`,
+        `qwen serve: POST ${base}/${id}/run failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       res.status(500).json({
         error: 'Failed to record scheduled task run',
@@ -812,6 +883,59 @@ export function registerScheduledTasksRoutes(
     // gets this object from the SDK).
     if (!updated.recurring) view.nextRunAt = null;
     res.status(200).json(view);
+  });
+}
+
+/**
+ * The primary (unqualified) `/scheduled-tasks` surface, bound to the daemon's
+ * primary workspace. Every request resolves to the same fixed workspace + bridge.
+ */
+export function registerScheduledTasksRoutes(
+  app: Application,
+  deps: RegisterScheduledTasksRoutesDeps,
+): void {
+  const { boundWorkspace, mutate, safeBody, bridge } = deps;
+  registerScheduledTaskCrudRoutes(app, {
+    prefix: '',
+    resolveTarget: () => ({ workspaceCwd: boundWorkspace, bridge }),
+    mutate,
+    safeBody,
+  });
+}
+
+/**
+ * The workspace-qualified `/workspaces/:workspace/scheduled-tasks` surface. Each
+ * request resolves `:workspace` (a workspace id or absolute path) to a
+ * registered runtime, requiring it be trusted before any read or write — the
+ * same gate the other qualified routes use — then targets that workspace's cron
+ * file and, when session management is on, its bridge. Lets a multi-workspace
+ * Web Shell manage every registered project's schedule, not just the primary's.
+ */
+export function registerWorkspaceQualifiedScheduledTasksRoutes(
+  app: Application,
+  deps: RegisterWorkspaceQualifiedScheduledTasksRoutesDeps,
+): void {
+  const { workspaceRegistry, mutate, safeBody, manageScheduledTaskSessions } =
+    deps;
+  registerScheduledTaskCrudRoutes(app, {
+    prefix: '/workspaces/:workspace',
+    resolveTarget: (req, res) => {
+      const runtime = resolveWorkspaceRuntimeFromParam(
+        workspaceRegistry,
+        req,
+        res,
+      );
+      if (!runtime) return null;
+      if (!requireTrustedWorkspaceRuntime(runtime, res)) return null;
+      return {
+        workspaceCwd: runtime.workspaceCwd,
+        // Mirror the primary surface: only bind a session when management is on,
+        // so a bound task always has something to keep it resident + rehydrate it.
+        bridge: manageScheduledTaskSessions ? runtime.bridge : undefined,
+      };
+    },
+    mutate,
+    safeBody,
   });
 }
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -88,7 +88,10 @@ import {
 } from './routes/workspace-trust.js';
 import { registerPermissionRoutes } from './routes/permission.js';
 import { registerSessionRoutes } from './routes/session.js';
-import { registerScheduledTasksRoutes } from './routes/scheduled-tasks.js';
+import {
+  registerScheduledTasksRoutes,
+  registerWorkspaceQualifiedScheduledTasksRoutes,
+} from './routes/scheduled-tasks.js';
 import { registerUsageStatsRoutes } from './routes/usage-stats.js';
 import {
   startScheduledTaskKeepalive,
@@ -1320,6 +1323,17 @@ export function createServeApp(
     bridge: deps.manageScheduledTaskSessions ? bridge : undefined,
   });
 
+  // The same CRUD surface, workspace-qualified, so a multi-workspace Web Shell
+  // manages every registered project's schedule against that project's own cron
+  // file (and its own session bridge) rather than always the primary's. Each
+  // request resolves + trust-checks `:workspace` before any read/write.
+  registerWorkspaceQualifiedScheduledTasksRoutes(app, {
+    workspaceRegistry,
+    mutate,
+    safeBody,
+    manageScheduledTaskSessions: deps.manageScheduledTaskSessions === true,
+  });
+
   // Read-only token-usage dashboard (Daemon Status "统计" tab). Aggregate local
   // usage only; open GET like /daemon/status, with its own short TTL cache.
   registerUsageStatsRoutes(app);
@@ -1336,45 +1350,69 @@ export function createServeApp(
     // when a reaper is active.
     const idleTimeoutMs =
       opts.sessionIdleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS;
-    const keepalive = startScheduledTaskKeepalive({
-      bridge,
-      boundWorkspace,
-      intervalMs: computeKeepaliveIntervalMs(idleTimeoutMs),
-    });
-    // Park the stop fn on `app.locals` (same pattern as `fsFactory` /
-    // `boundWorkspace` / `acpHandle` above) so the shutdown sequence in
-    // run-qwen-serve.ts can invoke it without threading it back through the
-    // createServeApp return type.
-    (
-      app.locals as { stopScheduledTaskKeepalive?: () => void }
-    ).stopScheduledTaskKeepalive = keepalive.stop;
+    const keepaliveIntervalMs = computeKeepaliveIntervalMs(idleTimeoutMs);
 
     // Rehydrate task-owned sessions on boot so their schedulers re-arm after a
     // restart (a bound task fires only in its own session, which nothing else
     // reloads). Fire-and-forget so it never delays the server coming up; a
     // no-op when there are no bound tasks. Deliberately not awaited.
-    void rehydrateScheduledTaskSessions({
-      bridge,
-      boundWorkspace,
-      onError: (sessionId, err) => {
+    const rehydrateWorkspace = (
+      taskBridge: AcpSessionBridge,
+      workspaceCwd: string,
+    ) => {
+      void rehydrateScheduledTaskSessions({
+        bridge: taskBridge,
+        boundWorkspace: workspaceCwd,
+        onError: (sessionId, err) => {
+          process.stderr.write(
+            `qwen serve: failed to rehydrate scheduled-task session ${sessionId}: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+          );
+        },
+        // Outer catch is defense-in-depth: rehydrateScheduledTaskSessions already
+        // catches readCronTasks failures and per-session load errors internally
+        // (returning { loaded, failed }), so this only guards an unexpected throw
+        // from the function entry itself. Log rather than swallow it — a silent
+        // failure here leaves every bound task dormant with no diagnostic.
+      }).catch((err) => {
         process.stderr.write(
-          `qwen serve: failed to rehydrate scheduled-task session ${sessionId}: ${
+          `qwen serve: unexpected scheduled-task rehydration failure: ${
             err instanceof Error ? err.message : String(err)
           }\n`,
         );
-      },
-      // Outer catch is defense-in-depth: rehydrateScheduledTaskSessions already
-      // catches readCronTasks failures and per-session load errors internally
-      // (returning { loaded, failed }), so this only guards an unexpected throw
-      // from the function entry itself. Log rather than swallow it — a silent
-      // failure here leaves every bound task dormant with no diagnostic.
-    }).catch((err) => {
-      process.stderr.write(
-        `qwen serve: unexpected scheduled-task rehydration failure: ${
-          err instanceof Error ? err.message : String(err)
-        }\n`,
-      );
+      });
+    };
+
+    // Every registered workspace gets its own keepalive + rehydration against
+    // its own cron file + bridge, so a bound task created through the
+    // workspace-qualified route fires (and survives a restart) exactly like a
+    // primary-workspace one — otherwise a secondary workspace's tasks would be
+    // written to disk but silently never revived. The registry is fully
+    // populated (primary + every `--workspace`) before createServeApp runs.
+    // A workspace ADDED at runtime (Phase 4 add-workspace) isn't looped here, so
+    // its bound-task sessions aren't kept resident for the rest of this process;
+    // once persisted it registers as a boot workspace and is covered on the next
+    // restart, which is when its rehydration matters most anyway.
+    const keepaliveStops = workspaceRegistry.list().map((runtime) => {
+      const keepalive = startScheduledTaskKeepalive({
+        bridge: runtime.bridge,
+        boundWorkspace: runtime.workspaceCwd,
+        intervalMs: keepaliveIntervalMs,
+      });
+      rehydrateWorkspace(runtime.bridge, runtime.workspaceCwd);
+      return keepalive.stop;
     });
+
+    // Park a combined stop fn on `app.locals` (same pattern as `fsFactory` /
+    // `boundWorkspace` / `acpHandle` above) so the shutdown sequence in
+    // run-qwen-serve.ts can invoke it without threading it back through the
+    // createServeApp return type. Stopping all is idempotent per keepalive.
+    (
+      app.locals as { stopScheduledTaskKeepalive?: () => void }
+    ).stopScheduledTaskKeepalive = () => {
+      for (const stop of keepaliveStops) stop();
+    };
   }
 
   registerPermissionRoutes(app, {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5554,6 +5554,10 @@ export function App({
                   <div className={styles.fullPageBody}>
                     <ScheduledTasksDialog
                       onRunPrompt={runTaskManually}
+                      // Registered workspaces (multi-workspace daemons only) so
+                      // the page aggregates every project's schedule and the New
+                      // form can target one; absent/single → primary-only view.
+                      workspaces={connection.capabilities?.workspaces}
                       onCreateViaChat={() => {
                         // Start a FRESH session and jump to it so the task-
                         // creation chat doesn't pile onto the current

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.module.css
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.module.css
@@ -531,6 +531,31 @@
   color: var(--muted-foreground);
 }
 
+/* Workspace tag on a card in the aggregated multi-workspace view. Bordered +
+ * accent-tinted so it reads as an origin label, distinct from the plain muted
+ * schedule pill. Truncates a long workspace name rather than wrapping the row. */
+.workspacePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 180px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  border-radius: 999px;
+  padding: 2px 9px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.workspaceIcon {
+  font-size: 11px;
+  opacity: 0.85;
+}
+
 .countdown {
   display: inline-flex;
   align-items: center;

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
@@ -887,8 +887,12 @@ describe('ScheduledTasksDialog multi-workspace', () => {
 
   // Fan-out mount: `listScheduledTasks(wsId)` returns each workspace's own tasks
   // (the primary is queried with undefined, secondaries with their id). The
-  // dialog tags each task with its workspace and merges them.
-  async function mountMulti(byWorkspace: Record<string, MockTask[]>) {
+  // dialog tags each task with its workspace and merges them. `ws` overrides the
+  // registered workspaces (e.g. to make the primary untrusted).
+  async function mountMulti(
+    byWorkspace: Record<string, MockTask[]>,
+    ws: typeof WORKSPACES = WORKSPACES,
+  ) {
     actions.listScheduledTasks.mockImplementation(async (wsId?: string) =>
       wsId === undefined
         ? (byWorkspace['primary'] ?? [])
@@ -909,7 +913,7 @@ describe('ScheduledTasksDialog multi-workspace', () => {
           <ScheduledTasksDialog
             onRunPrompt={vi.fn()}
             onCreateViaChat={vi.fn()}
-            workspaces={WORKSPACES}
+            workspaces={ws}
             onError={vi.fn()}
           />
         </I18nProvider>,
@@ -1028,5 +1032,38 @@ describe('ScheduledTasksDialog multi-workspace', () => {
     // The picker is shown (so the user sees the workspace) but disabled — a
     // PATCH can't move a task between per-workspace files.
     expect(wsSelect?.disabled).toBe(true);
+  });
+
+  it('keeps an untrusted primary in the aggregate and picker (trust-free route)', async () => {
+    // Rare: folder-trust on and the primary folder not trusted. The primary is
+    // still reachable via its trust-free unqualified route, so it must not drop
+    // out of the list, and it must stay the selectable default in the New form
+    // (otherwise the picker shows a secondary while a create still lands on the
+    // primary). Secondaries stay gated on trust.
+    const wsUntrustedPrimary = [
+      { id: 'id-main', cwd: '/repo/main', primary: true, trusted: false },
+      { id: 'id-other', cwd: '/repo/other', primary: false, trusted: true },
+    ];
+    await mountMulti(
+      {
+        primary: [baseTask({ id: 'p1', name: 'Primary task' })],
+        'id-other': [baseTask({ id: 's1', name: 'Second task' })],
+      },
+      wsUntrustedPrimary,
+    );
+
+    // The untrusted primary is queried (via its trust-free route) and shown.
+    expect(actions.listScheduledTasks).toHaveBeenCalledWith(undefined);
+    expect(document.body.textContent).toContain('Primary task');
+
+    // In the New form the primary is a selectable option and stays the default,
+    // so the shown selection matches where a create actually lands.
+    click(findButton('New scheduled task'));
+    const wsSelect = findWorkspaceSelect()!;
+    const values = Array.from(wsSelect.querySelectorAll('option')).map(
+      (o) => o.value,
+    );
+    expect(values).toContain(''); // '' = the primary (its undefined action id)
+    expect(wsSelect.value).toBe(''); // default targets the primary, no desync
   });
 });

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
@@ -216,11 +216,15 @@ describe('ScheduledTasksDialog editing', () => {
     click(findButton('Save'));
     await flush();
 
-    expect(actions.updateScheduledTask).toHaveBeenCalledWith('t1', {
-      cron: '30 12 * * 1-5',
-      prompt: 'summarize the day',
-      name: 'Digest',
-    });
+    expect(actions.updateScheduledTask).toHaveBeenCalledWith(
+      't1',
+      {
+        cron: '30 12 * * 1-5',
+        prompt: 'summarize the day',
+        name: 'Digest',
+      },
+      undefined,
+    );
     expect(actions.createScheduledTask).not.toHaveBeenCalled();
   });
 
@@ -252,6 +256,7 @@ describe('ScheduledTasksDialog editing', () => {
       expect.objectContaining({
         prompt: promptText,
       }),
+      undefined,
     );
   });
 
@@ -380,6 +385,7 @@ describe('ScheduledTasksDialog editing', () => {
       expect.objectContaining({
         prompt: '@ext:alibabacloud-compute-suite /review @mcp:repo-tools',
       }),
+      undefined,
     );
   });
 
@@ -411,6 +417,7 @@ describe('ScheduledTasksDialog editing', () => {
       expect.objectContaining({
         prompt: '/review\\ task',
       }),
+      undefined,
     );
   });
 
@@ -521,6 +528,7 @@ describe('ScheduledTasksDialog editing', () => {
       expect.objectContaining({
         prompt: 'x'.repeat(100_000),
       }),
+      undefined,
     );
   });
 
@@ -565,6 +573,7 @@ describe('ScheduledTasksDialog editing', () => {
       expect.objectContaining({
         prompt: '@ext:alibabacloud-compute-suite',
       }),
+      undefined,
     );
   });
 
@@ -581,6 +590,7 @@ describe('ScheduledTasksDialog editing', () => {
     expect(actions.updateScheduledTask).toHaveBeenCalledWith(
       't1',
       expect.objectContaining({ cron: '0 9 * * 1,3,5' }),
+      undefined,
     );
   });
 });
@@ -626,7 +636,7 @@ describe('ScheduledTasksDialog run now', () => {
     click(document.querySelector('[aria-label="Run now"]'));
     await flush();
     // Server-side run record (updates last-run) + client run in the bound session.
-    expect(actions.runScheduledTask).toHaveBeenCalledWith('t1');
+    expect(actions.runScheduledTask).toHaveBeenCalledWith('t1', undefined);
     expect(onRunPrompt).toHaveBeenCalledWith('do it', 'sess-9');
   });
 
@@ -734,7 +744,7 @@ describe('ScheduledTasksDialog run now', () => {
     );
     click(document.querySelector('[aria-label="Run now"]'));
     await flush();
-    expect(actions.runScheduledTask).toHaveBeenCalledWith('t1'); // consumed
+    expect(actions.runScheduledTask).toHaveBeenCalledWith('t1', undefined); // consumed
     expect(onRunPrompt).toHaveBeenCalledWith('do it', 'sess-9');
     expect(onError).toHaveBeenCalledWith(
       expect.any(Error),
@@ -865,5 +875,158 @@ describe('ScheduledTasksDialog next-run countdown', () => {
     expect(
       document.querySelector('[data-testid="scheduled-task-next-run"]'),
     ).toBeNull();
+  });
+});
+
+describe('ScheduledTasksDialog multi-workspace', () => {
+  const WORKSPACES = [
+    { id: 'id-main', cwd: '/repo/main', primary: true, trusted: true },
+    { id: 'id-other', cwd: '/repo/other', primary: false, trusted: true },
+    { id: 'id-locked', cwd: '/repo/locked', primary: false, trusted: false },
+  ];
+
+  // Fan-out mount: `listScheduledTasks(wsId)` returns each workspace's own tasks
+  // (the primary is queried with undefined, secondaries with their id). The
+  // dialog tags each task with its workspace and merges them.
+  async function mountMulti(byWorkspace: Record<string, MockTask[]>) {
+    actions.listScheduledTasks.mockImplementation(async (wsId?: string) =>
+      wsId === undefined
+        ? (byWorkspace['primary'] ?? [])
+        : (byWorkspace[wsId] ?? []),
+    );
+    actions.createScheduledTask.mockResolvedValue(baseTask({}));
+    actions.updateScheduledTask.mockResolvedValue(baseTask({}));
+    actions.deleteScheduledTask.mockResolvedValue(undefined);
+    actions.loadExtensionsStatus.mockResolvedValue({ extensions: [] });
+    actions.loadSkillsStatus.mockResolvedValue({ skills: [] });
+    actions.loadMcpStatus.mockResolvedValue({ servers: [] });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <I18nProvider language="en">
+          <ScheduledTasksDialog
+            onRunPrompt={vi.fn()}
+            onCreateViaChat={vi.fn()}
+            workspaces={WORKSPACES}
+            onError={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+    });
+    await flush();
+  }
+
+  const findWorkspaceSelect = () =>
+    Array.from(document.querySelectorAll('select')).find((s) =>
+      s.querySelector('option[value="id-other"]'),
+    );
+
+  it('aggregates trusted workspaces and badges each card by workspace', async () => {
+    await mountMulti({
+      primary: [baseTask({ id: 'p1', name: 'Primary task', createdAt: 1000 })],
+      'id-other': [
+        baseTask({ id: 's1', name: 'Second task', createdAt: 2000 }),
+      ],
+    });
+
+    // Both workspaces' tasks show up together.
+    expect(document.body.textContent).toContain('Primary task');
+    expect(document.body.textContent).toContain('Second task');
+
+    // The fan-out queried the primary (undefined) and the trusted secondary, but
+    // NOT the untrusted one.
+    expect(actions.listScheduledTasks).toHaveBeenCalledWith(undefined);
+    expect(actions.listScheduledTasks).toHaveBeenCalledWith('id-other');
+    expect(actions.listScheduledTasks).not.toHaveBeenCalledWith('id-locked');
+
+    // Each card carries a workspace badge (title = cwd), the primary marked.
+    const primaryBadge = document.querySelector('[title="/repo/main"]');
+    const secondaryBadge = document.querySelector('[title="/repo/other"]');
+    expect(primaryBadge?.textContent).toContain('main');
+    expect(primaryBadge?.textContent).toContain('(primary)');
+    expect(secondaryBadge?.textContent).toContain('other');
+  });
+
+  it('creates a task in the workspace chosen in the picker', async () => {
+    await mountMulti({ primary: [], 'id-other': [] });
+    click(findButton('New scheduled task'));
+
+    // The picker offers the two trusted workspaces (untrusted excluded).
+    const wsSelect = findWorkspaceSelect();
+    expect(wsSelect).toBeDefined();
+    expect(wsSelect!.querySelectorAll('option')).toHaveLength(2);
+
+    // Choose the secondary workspace.
+    act(() => {
+      wsSelect!.value = 'id-other';
+      wsSelect!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const prompt = document.querySelector<HTMLElement>('[role="textbox"]')!;
+    act(() => {
+      prompt.textContent = 'do secondary work';
+      prompt.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    });
+
+    click(findButton('Create'));
+    await flush();
+
+    expect(actions.createScheduledTask).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'do secondary work' }),
+      'id-other',
+    );
+  });
+
+  it('defaults a new task to the primary workspace', async () => {
+    await mountMulti({ primary: [], 'id-other': [] });
+    click(findButton('New scheduled task'));
+    const prompt = document.querySelector<HTMLElement>('[role="textbox"]')!;
+    act(() => {
+      prompt.textContent = 'primary work';
+      prompt.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    });
+    click(findButton('Create'));
+    await flush();
+    // Primary → undefined workspace id (its trust-free unqualified route).
+    expect(actions.createScheduledTask).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'primary work' }),
+      undefined,
+    );
+  });
+
+  it('threads the task’s own workspace through toggle and delete', async () => {
+    await mountMulti({
+      primary: [],
+      'id-other': [baseTask({ id: 's1', name: 'Second task', enabled: true })],
+    });
+
+    // The secondary's task is the only card → the only toggle switch.
+    click(document.querySelector('[role="switch"]'));
+    await flush();
+    expect(actions.updateScheduledTask).toHaveBeenCalledWith(
+      's1',
+      { enabled: false },
+      'id-other',
+    );
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    click(document.querySelector('[aria-label="Delete"]'));
+    await flush();
+    expect(actions.deleteScheduledTask).toHaveBeenCalledWith('s1', 'id-other');
+    confirmSpy.mockRestore();
+  });
+
+  it('pins the workspace picker read-only while editing', async () => {
+    await mountMulti({
+      primary: [],
+      'id-other': [baseTask({ id: 's1', name: 'Second task' })],
+    });
+    click(document.querySelector('[aria-label="Edit"]'));
+    const wsSelect = findWorkspaceSelect();
+    // The picker is shown (so the user sees the workspace) but disabled — a
+    // PATCH can't move a task between per-workspace files.
+    expect(wsSelect?.disabled).toBe(true);
   });
 });

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -7,6 +7,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -19,6 +20,7 @@ import {
 } from '@qwen-code/webui/daemon-react-sdk';
 import type {
   DaemonExtensionEntry,
+  DaemonWorkspaceCapability,
   DaemonWorkspaceMcpServerStatus,
   DaemonWorkspaceSkillStatus,
 } from '@qwen-code/sdk/daemon';
@@ -79,7 +81,28 @@ interface ScheduledTasksDialogProps {
   /** Open a task's bound session — its transcript IS the task's run history.
    * When absent, tasks fall back to the inline fire-timestamp list. */
   onOpenSession?: (sessionId: string) => void;
+  /** Registered workspaces on a multi-workspace daemon (from capabilities).
+   * When more than one is present the page aggregates every trusted workspace's
+   * tasks (each card tagged with its workspace) and the New-task form offers a
+   * workspace picker. Absent or a single entry → the plain primary-only view. */
+  workspaces?: DaemonWorkspaceCapability[];
   onError: (error: unknown, fallback: string) => void;
+}
+
+/** A short, human-readable label for a workspace card badge / picker option:
+ * the cwd's last path segment, marked when it's the primary. */
+function workspaceLabel(cwd: string, primary: boolean, t: TranslateFn): string {
+  const segments = cwd.split(/[\\/]/).filter(Boolean);
+  const base = segments[segments.length - 1] || cwd;
+  return primary ? `${base} ${t('scheduledTasks.workspacePrimaryTag')}` : base;
+}
+
+/** A stable per-card identity. Task ids are unique only WITHIN a workspace's
+ * file, so the aggregated view keys on (workspace, id) — otherwise two
+ * same-id tasks from different workspaces would collide in the React list and
+ * in the busy/expanded per-card state. */
+function taskKey(task: DaemonScheduledTask): string {
+  return `${task.workspaceId ?? ''}:${task.id}`;
 }
 
 const FREQUENCIES: Frequency[] = [
@@ -433,10 +456,31 @@ export function ScheduledTasksDialog({
   onRunPrompt,
   onCreateViaChat,
   onOpenSession,
+  workspaces,
   onError,
 }: ScheduledTasksDialogProps) {
   const { t } = useI18n();
   const actions = useWorkspaceActions();
+
+  // Multi-workspace aggregation. `workspaces` mirrors the daemon capabilities;
+  // with more than one the page lists every trusted workspace's tasks together
+  // and the New form offers a workspace picker. A single (or absent) workspace
+  // keeps the original primary-only view — no badges, no picker. Memoized so the
+  // derived arrays are stable identities — `reload` depends on them, and a fresh
+  // array each render would re-fire its mount effect in a loop.
+  const workspaceList = useMemo(() => workspaces ?? [], [workspaces]);
+  const isMultiWorkspace = workspaceList.length > 1;
+  const trustedWorkspaces = useMemo(
+    () => workspaceList.filter((ws) => ws.trusted),
+    [workspaceList],
+  );
+  // The workspace id to pass to the per-task actions: primary uses its
+  // trust-free unqualified route (undefined), secondaries their qualified one.
+  const workspaceActionId = useCallback(
+    (ws: DaemonWorkspaceCapability): string | undefined =>
+      ws.primary ? undefined : ws.id,
+    [],
+  );
 
   const [tasks, setTasks] = useState<DaemonScheduledTask[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -450,6 +494,12 @@ export function ScheduledTasksDialog({
   // task being edited (the form is dual-mode — same fields, different verb).
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  // The workspace the form targets. On create it's the picker's value (undefined
+  // = primary); on edit it's pinned to the task's own workspace (a task can't
+  // move files, so the picker is read-only). Passed to create/update actions.
+  const [formWorkspaceId, setFormWorkspaceId] = useState<string | undefined>(
+    undefined,
+  );
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
   const [builder, setBuilder] = useState<BuilderState>(DEFAULT_BUILDER);
@@ -496,18 +546,48 @@ export function ScheduledTasksDialog({
   const reload = useCallback(async () => {
     const seq = ++reloadSeqRef.current;
     try {
-      const list = await actions.listScheduledTasks();
+      let list: DaemonScheduledTask[];
+      let firstError: string | null = null;
+      if (isMultiWorkspace) {
+        // Fan out over every TRUSTED workspace (untrusted ones reject reads and
+        // can't own runnable tasks anyway) and tag each task with its workspace
+        // so the cards can badge it and the mutations can target its file. One
+        // workspace failing (corrupt file, etc.) must not blank the whole list —
+        // keep the others and surface the first error.
+        const results = await Promise.all(
+          trustedWorkspaces.map(async (ws) => {
+            try {
+              const tasks = await actions.listScheduledTasks(
+                workspaceActionId(ws),
+              );
+              return tasks.map((task) => ({
+                ...task,
+                workspaceId: workspaceActionId(ws),
+                workspaceCwd: ws.cwd,
+              }));
+            } catch (err) {
+              if (!firstError) {
+                firstError = err instanceof Error ? err.message : String(err);
+              }
+              return [] as DaemonScheduledTask[];
+            }
+          }),
+        );
+        list = results.flat();
+      } else {
+        list = await actions.listScheduledTasks();
+      }
       if (!mountedRef.current || seq !== reloadSeqRef.current) return;
       // Newest first — matches the reference "sort by created, descending".
       const sorted = [...list].sort((a, b) => b.createdAt - a.createdAt);
       setTasks(sorted);
-      setLoadError(null);
+      setLoadError(firstError);
     } catch (err) {
       if (!mountedRef.current || seq !== reloadSeqRef.current) return;
       setLoadError(err instanceof Error ? err.message : String(err));
       setTasks((prev) => prev ?? []);
     }
-  }, [actions]);
+  }, [actions, isMultiWorkspace, trustedWorkspaces, workspaceActionId]);
 
   useEffect(() => {
     void reload();
@@ -713,11 +793,15 @@ export function ScheduledTasksDialog({
     setFormError(null);
     setShowForm(false);
     setEditingId(null);
+    setFormWorkspaceId(undefined);
     resetReferenceState();
   }, [resetReferenceState]);
 
   const openCreate = useCallback(() => {
     setEditingId(null);
+    // Default a new task to the primary workspace (undefined). The picker can
+    // move it to a trusted secondary before submit.
+    setFormWorkspaceId(undefined);
     setName('');
     setPrompt('');
     setBuilder(DEFAULT_BUILDER);
@@ -729,6 +813,9 @@ export function ScheduledTasksDialog({
   const openEdit = useCallback(
     (task: DaemonScheduledTask) => {
       setEditingId(task.id);
+      // Pin the edit to the task's own workspace — a PATCH can't move a task
+      // between per-workspace files, so the picker is read-only while editing.
+      setFormWorkspaceId(task.workspaceId);
       setName(task.name ?? '');
       setPrompt(task.prompt);
       // Reverse the cron back onto the pickers; an expression the pickers can't
@@ -766,19 +853,26 @@ export function ScheduledTasksDialog({
         // Update only the editable fields; `recurring`/`enabled` are omitted so
         // the PATCH leaves them unchanged (recurring isn't in this form, and
         // enabled is driven by the card toggle). Empty name clears it.
-        await actions.updateScheduledTask(editingId, {
-          cron,
-          prompt: prompt.trim(),
-          name: name.trim() || null,
-        });
+        await actions.updateScheduledTask(
+          editingId,
+          {
+            cron,
+            prompt: prompt.trim(),
+            name: name.trim() || null,
+          },
+          formWorkspaceId,
+        );
       } else {
-        await actions.createScheduledTask({
-          cron,
-          prompt: prompt.trim(),
-          name: name.trim() || null,
-          recurring: true,
-          enabled: true,
-        });
+        await actions.createScheduledTask(
+          {
+            cron,
+            prompt: prompt.trim(),
+            name: name.trim() || null,
+            recurring: true,
+            enabled: true,
+          },
+          formWorkspaceId,
+        );
       }
       if (!mountedRef.current) return;
       resetForm();
@@ -789,13 +883,27 @@ export function ScheduledTasksDialog({
     } finally {
       if (mountedRef.current) setSubmitting(false);
     }
-  }, [actions, builder, editingId, name, prompt, reload, resetForm, t]);
+  }, [
+    actions,
+    builder,
+    editingId,
+    formWorkspaceId,
+    name,
+    prompt,
+    reload,
+    resetForm,
+    t,
+  ]);
 
   const handleToggle = useCallback(
     async (task: DaemonScheduledTask) => {
-      setBusyId(task.id);
+      setBusyId(taskKey(task));
       try {
-        await actions.updateScheduledTask(task.id, { enabled: !task.enabled });
+        await actions.updateScheduledTask(
+          task.id,
+          { enabled: !task.enabled },
+          task.workspaceId,
+        );
         await reload();
       } catch (err) {
         onError(err, t('scheduledTasks.error.toggleFailed'));
@@ -820,7 +928,7 @@ export function ScheduledTasksDialog({
         // session while /run only refuses the RECORD afterward, i.e. a real
         // unrecorded run. Refresh, bail if gone/disabled, and use the FRESH
         // prompt/session so we never run an outdated one.
-        const fresh = (await actions.listScheduledTasks()).find(
+        const fresh = (await actions.listScheduledTasks(task.workspaceId)).find(
           (tk) => tk.id === task.id,
         );
         if (!fresh || !fresh.enabled) {
@@ -838,7 +946,7 @@ export function ScheduledTasksDialog({
           // history still catches up on the next refresh.
           await onRunPrompt(fresh.prompt, fresh.sessionId);
           try {
-            await actions.runScheduledTask(fresh.id);
+            await actions.runScheduledTask(fresh.id, task.workspaceId);
             await reload();
           } catch (err) {
             onError(err, t('scheduledTasks.error.runFailed'));
@@ -850,7 +958,7 @@ export function ScheduledTasksDialog({
           // leaves the task gone AND un-run — and reload() has already dropped it
           // from the list — so surface THAT explicitly rather than the generic
           // "run failed", which would hide the deletion.
-          await actions.runScheduledTask(fresh.id);
+          await actions.runScheduledTask(fresh.id, task.workspaceId);
           await reload();
           try {
             await onRunPrompt(fresh.prompt, fresh.sessionId);
@@ -877,9 +985,9 @@ export function ScheduledTasksDialog({
       if (!window.confirm(t('scheduledTasks.deleteConfirm', { name: label }))) {
         return;
       }
-      setBusyId(task.id);
+      setBusyId(taskKey(task));
       try {
-        await actions.deleteScheduledTask(task.id);
+        await actions.deleteScheduledTask(task.id, task.workspaceId);
         await reload();
       } catch (err) {
         onError(err, t('scheduledTasks.error.deleteFailed'));
@@ -992,6 +1100,31 @@ export function ScheduledTasksDialog({
           onClose={resetForm}
         >
           <div className={styles.formFields}>
+            {isMultiWorkspace && (
+              <label className={styles.field}>
+                <span className={styles.fieldLabel}>
+                  {t('scheduledTasks.workspace')}
+                </span>
+                <select
+                  className={styles.select}
+                  value={formWorkspaceId ?? ''}
+                  // A task lives in one workspace's file; editing can't move it,
+                  // so the picker is fixed while editing and when only one
+                  // workspace is trusted (nothing to choose).
+                  disabled={!!editingId || trustedWorkspaces.length <= 1}
+                  onChange={(e) =>
+                    setFormWorkspaceId(e.target.value || undefined)
+                  }
+                >
+                  {trustedWorkspaces.map((ws) => (
+                    <option key={ws.id} value={workspaceActionId(ws) ?? ''}>
+                      {workspaceLabel(ws.cwd, ws.primary, t)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
             <label className={styles.field}>
               <span className={styles.fieldLabel}>
                 {t('scheduledTasks.name')}
@@ -1226,10 +1359,10 @@ export function ScheduledTasksDialog({
       <div className={styles.list}>
         {(tasks ?? []).map((task) => {
           const title = task.name || task.prompt;
-          const busy = busyId === task.id;
+          const busy = busyId === taskKey(task);
           return (
             <div
-              key={task.id}
+              key={taskKey(task)}
               className={`${styles.card} ${task.enabled ? '' : styles.cardDisabled}`}
             >
               <div className={styles.cardHeader}>
@@ -1292,6 +1425,17 @@ export function ScheduledTasksDialog({
               )}
 
               <div className={styles.cardFooter}>
+                {isMultiWorkspace && task.workspaceCwd && (
+                  <span
+                    className={styles.workspacePill}
+                    title={task.workspaceCwd}
+                  >
+                    <span className={styles.workspaceIcon} aria-hidden="true">
+                      ⌂
+                    </span>
+                    {workspaceLabel(task.workspaceCwd, !task.workspaceId, t)}
+                  </span>
+                )}
                 <span className={styles.schedulePill}>
                   <span className={styles.clockIcon} aria-hidden="true">
                     ◷
@@ -1345,10 +1489,10 @@ export function ScheduledTasksDialog({
                     <button
                       type="button"
                       className={styles.runsToggle}
-                      aria-expanded={expandedRunsId === task.id}
+                      aria-expanded={expandedRunsId === taskKey(task)}
                       onClick={() =>
                         setExpandedRunsId((cur) =>
-                          cur === task.id ? null : task.id,
+                          cur === taskKey(task) ? null : taskKey(task),
                         )
                       }
                     >
@@ -1360,7 +1504,7 @@ export function ScheduledTasksDialog({
                 )}
               </div>
 
-              {expandedRunsId === task.id && task.runs.length > 0 && (
+              {expandedRunsId === taskKey(task) && task.runs.length > 0 && (
                 <ul className={styles.runsList}>
                   {/* Newest first — the ring is stored oldest-first. */}
                   {[...task.runs].reverse().map((run, idx) => (

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -470,8 +470,15 @@ export function ScheduledTasksDialog({
   // array each render would re-fire its mount effect in a loop.
   const workspaceList = useMemo(() => workspaces ?? [], [workspaces]);
   const isMultiWorkspace = workspaceList.length > 1;
-  const trustedWorkspaces = useMemo(
-    () => workspaceList.filter((ws) => ws.trusted),
+  // The workspaces the page can actually read + write: every trusted one, PLUS
+  // the primary even when it is untrusted. The primary is reached through the
+  // trust-free unqualified route (the same one the single-workspace page always
+  // used), so excluding an untrusted primary would silently drop its readable
+  // tasks from the aggregate AND desync the create picker (its default targets
+  // the primary, so the primary must be a selectable option). Secondaries stay
+  // gated on trust — their qualified route rejects an untrusted read/write.
+  const operableWorkspaces = useMemo(
+    () => workspaceList.filter((ws) => ws.primary || ws.trusted),
     [workspaceList],
   );
   // The workspace id to pass to the per-task actions: primary uses its
@@ -549,13 +556,14 @@ export function ScheduledTasksDialog({
       let list: DaemonScheduledTask[];
       let firstError: string | null = null;
       if (isMultiWorkspace) {
-        // Fan out over every TRUSTED workspace (untrusted ones reject reads and
-        // can't own runnable tasks anyway) and tag each task with its workspace
-        // so the cards can badge it and the mutations can target its file. One
-        // workspace failing (corrupt file, etc.) must not blank the whole list —
-        // keep the others and surface the first error.
+        // Fan out over every OPERABLE workspace (trusted secondaries + the
+        // primary, which is always reachable via its trust-free route) and tag
+        // each task with its workspace so the cards can badge it and the
+        // mutations can target its file. One workspace failing (corrupt file,
+        // etc.) must not blank the whole list — keep the others and surface the
+        // first error.
         const results = await Promise.all(
-          trustedWorkspaces.map(async (ws) => {
+          operableWorkspaces.map(async (ws) => {
             try {
               const tasks = await actions.listScheduledTasks(
                 workspaceActionId(ws),
@@ -587,7 +595,7 @@ export function ScheduledTasksDialog({
       setLoadError(err instanceof Error ? err.message : String(err));
       setTasks((prev) => prev ?? []);
     }
-  }, [actions, isMultiWorkspace, trustedWorkspaces, workspaceActionId]);
+  }, [actions, isMultiWorkspace, operableWorkspaces, workspaceActionId]);
 
   useEffect(() => {
     void reload();
@@ -1110,13 +1118,13 @@ export function ScheduledTasksDialog({
                   value={formWorkspaceId ?? ''}
                   // A task lives in one workspace's file; editing can't move it,
                   // so the picker is fixed while editing and when only one
-                  // workspace is trusted (nothing to choose).
-                  disabled={!!editingId || trustedWorkspaces.length <= 1}
+                  // workspace is operable (nothing to choose).
+                  disabled={!!editingId || operableWorkspaces.length <= 1}
                   onChange={(e) =>
                     setFormWorkspaceId(e.target.value || undefined)
                   }
                 >
-                  {trustedWorkspaces.map((ws) => (
+                  {operableWorkspaces.map((ws) => (
                     <option key={ws.id} value={workspaceActionId(ws) ?? ''}>
                       {workspaceLabel(ws.cwd, ws.primary, t)}
                     </option>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -687,6 +687,8 @@ const EN: Messages = {
   'scheduledTasks.chatStarter':
     'Help me set up a recurring scheduled task (keep it long-term). What I want: ',
   'scheduledTasks.name': 'Name',
+  'scheduledTasks.workspace': 'Workspace',
+  'scheduledTasks.workspacePrimaryTag': '(primary)',
   'scheduledTasks.taskId': 'Task ID',
   'scheduledTasks.schedule': 'Schedule',
   'scheduledTasks.type': 'Type',
@@ -2447,6 +2449,8 @@ const ZH: Messages = {
   'scheduledTasks.createViaChat': '通过聊天创建',
   'scheduledTasks.chatStarter': '帮我创建一个长期保留的定时任务，我想：',
   'scheduledTasks.name': '名称',
+  'scheduledTasks.workspace': '工作区',
+  'scheduledTasks.workspacePrimaryTag': '（主）',
   'scheduledTasks.taskId': '任务 ID',
   'scheduledTasks.schedule': '计划',
   'scheduledTasks.type': '类型',

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -466,10 +466,13 @@ export function createDaemonWorkspaceActions({
     // Scheduled tasks (durable cron). Raw fetch like glob/stat/list — the
     // /scheduled-tasks routes are REST-only and not yet on the DaemonClient
     // transport, so this path only reaches the daemon over plain HTTP (the
-    // web-shell's own origin), which is exactly where the page runs.
-    async listScheduledTasks() {
+    // web-shell's own origin), which is exactly where the page runs. A
+    // `workspaceId` selects a non-primary workspace's own cron file via the
+    // workspace-qualified route; omitting it hits the primary surface.
+    async listScheduledTasks(workspaceId) {
       requireClient(getClient, 'List scheduled tasks failed');
-      const url = createDaemonRequestUrl(baseUrl, '/scheduled-tasks');
+      const path = scheduledTasksPath(workspaceId);
+      const url = createDaemonRequestUrl(baseUrl, path);
       const res = await withActionTimeout(
         fetch(serializeDaemonRequestUrl(url, baseUrl), {
           headers: createDaemonHeaders(token),
@@ -477,15 +480,16 @@ export function createDaemonWorkspaceActions({
         'List scheduled tasks timed out',
       );
       if (!res.ok) {
-        throw new Error(await readDaemonError(res, 'GET /scheduled-tasks'));
+        throw new Error(await readDaemonError(res, `GET ${path}`));
       }
       const data = (await res.json()) as { tasks?: DaemonScheduledTask[] };
       return Array.isArray(data.tasks) ? data.tasks : [];
     },
 
-    async createScheduledTask(req) {
+    async createScheduledTask(req, workspaceId) {
       requireClient(getClient, 'Create scheduled task failed');
-      const url = createDaemonRequestUrl(baseUrl, '/scheduled-tasks');
+      const path = scheduledTasksPath(workspaceId);
+      const url = createDaemonRequestUrl(baseUrl, path);
       const res = await withActionTimeout(
         fetch(serializeDaemonRequestUrl(url, baseUrl), {
           method: 'POST',
@@ -495,17 +499,18 @@ export function createDaemonWorkspaceActions({
         'Create scheduled task timed out',
       );
       if (!res.ok) {
-        throw new Error(await readDaemonError(res, 'POST /scheduled-tasks'));
+        throw new Error(await readDaemonError(res, `POST ${path}`));
       }
       return (await res.json()) as DaemonScheduledTask;
     },
 
-    async updateScheduledTask(id, patch) {
+    async updateScheduledTask(id, patch, workspaceId) {
       requireClient(getClient, 'Update scheduled task failed');
-      const url = createDaemonRequestUrl(
-        baseUrl,
-        `/scheduled-tasks/${encodeURIComponent(id)}`,
+      const path = scheduledTasksPath(
+        workspaceId,
+        `/${encodeURIComponent(id)}`,
       );
+      const url = createDaemonRequestUrl(baseUrl, path);
       const res = await withActionTimeout(
         fetch(serializeDaemonRequestUrl(url, baseUrl), {
           method: 'PATCH',
@@ -515,19 +520,18 @@ export function createDaemonWorkspaceActions({
         'Update scheduled task timed out',
       );
       if (!res.ok) {
-        throw new Error(
-          await readDaemonError(res, `PATCH /scheduled-tasks/${id}`),
-        );
+        throw new Error(await readDaemonError(res, `PATCH ${path}`));
       }
       return (await res.json()) as DaemonScheduledTask;
     },
 
-    async runScheduledTask(id) {
+    async runScheduledTask(id, workspaceId) {
       requireClient(getClient, 'Run scheduled task failed');
-      const url = createDaemonRequestUrl(
-        baseUrl,
-        `/scheduled-tasks/${encodeURIComponent(id)}/run`,
+      const path = scheduledTasksPath(
+        workspaceId,
+        `/${encodeURIComponent(id)}/run`,
       );
+      const url = createDaemonRequestUrl(baseUrl, path);
       const res = await withActionTimeout(
         fetch(serializeDaemonRequestUrl(url, baseUrl), {
           method: 'POST',
@@ -536,19 +540,18 @@ export function createDaemonWorkspaceActions({
         'Run scheduled task timed out',
       );
       if (!res.ok) {
-        throw new Error(
-          await readDaemonError(res, `POST /scheduled-tasks/${id}/run`),
-        );
+        throw new Error(await readDaemonError(res, `POST ${path}`));
       }
       return (await res.json()) as DaemonScheduledTask;
     },
 
-    async deleteScheduledTask(id) {
+    async deleteScheduledTask(id, workspaceId) {
       requireClient(getClient, 'Delete scheduled task failed');
-      const url = createDaemonRequestUrl(
-        baseUrl,
-        `/scheduled-tasks/${encodeURIComponent(id)}`,
+      const path = scheduledTasksPath(
+        workspaceId,
+        `/${encodeURIComponent(id)}`,
       );
+      const url = createDaemonRequestUrl(baseUrl, path);
       const res = await withActionTimeout(
         fetch(serializeDaemonRequestUrl(url, baseUrl), {
           method: 'DELETE',
@@ -557,9 +560,7 @@ export function createDaemonWorkspaceActions({
         'Delete scheduled task timed out',
       );
       if (!res.ok) {
-        throw new Error(
-          await readDaemonError(res, `DELETE /scheduled-tasks/${id}`),
-        );
+        throw new Error(await readDaemonError(res, `DELETE ${path}`));
       }
     },
 
@@ -738,6 +739,18 @@ function requireWorkspaceCwd(
     throw new Error('Daemon workspace is not connected');
   }
   return cwd;
+}
+
+// Builds a scheduled-tasks REST path. With a `workspaceId` it targets that
+// workspace's own cron file via the qualified route; without one it hits the
+// primary surface. `suffix` appends the task id (and `/run`) for item routes.
+// The aggregated view passes the primary workspace as `undefined`, so the
+// primary keeps its trust-free unqualified surface while secondaries use the
+// (trust-checked) qualified one.
+function scheduledTasksPath(workspaceId?: string, suffix = ''): string {
+  return workspaceId
+    ? `/workspaces/${encodeURIComponent(workspaceId)}/scheduled-tasks${suffix}`
+    : `/scheduled-tasks${suffix}`;
 }
 
 function createDaemonHeaders(token: string | undefined): HeadersInit {

--- a/packages/webui/src/daemon/workspace/scheduledTasks.actions.test.ts
+++ b/packages/webui/src/daemon/workspace/scheduledTasks.actions.test.ts
@@ -105,4 +105,62 @@ describe('scheduled-tasks workspace actions', () => {
       makeActions().createScheduledTask({ cron: 'x', prompt: 'p' }),
     ).rejects.toThrow(/bad cron/);
   });
+
+  describe('workspace-qualified targeting', () => {
+    it('lists a named workspace via the qualified route', async () => {
+      fetchMock.mockResolvedValue(ok({ v: 1, tasks: [] }));
+      await makeActions().listScheduledTasks('ws-2');
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        '/workspaces/ws-2/scheduled-tasks',
+      );
+    });
+
+    it('creates in a named workspace via the qualified route', async () => {
+      fetchMock.mockResolvedValue(ok({ id: 'x' }));
+      await makeActions().createScheduledTask(
+        { cron: '0 9 * * *', prompt: 'p' },
+        'ws-2',
+      );
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        '/workspaces/ws-2/scheduled-tasks',
+      );
+      expect(initOf(fetchMock.mock.calls[0]).method).toBe('POST');
+    });
+
+    it('patches / runs / deletes a task in a named workspace', async () => {
+      fetchMock.mockResolvedValue(ok({ id: 'a' }));
+      await makeActions().updateScheduledTask('a', { enabled: false }, 'ws-2');
+      await makeActions().runScheduledTask('a', 'ws-2');
+      await makeActions().deleteScheduledTask('a', 'ws-2');
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        '/workspaces/ws-2/scheduled-tasks/a',
+      );
+      expect(fetchMock.mock.calls[1][0]).toBe(
+        '/workspaces/ws-2/scheduled-tasks/a/run',
+      );
+      expect(fetchMock.mock.calls[2][0]).toBe(
+        '/workspaces/ws-2/scheduled-tasks/a',
+      );
+    });
+
+    it('url-encodes both the workspace selector and the task id', async () => {
+      fetchMock.mockResolvedValue(ok({ id: 'a' }));
+      await makeActions().updateScheduledTask(
+        'a/b',
+        { enabled: false },
+        '/abs/path',
+      );
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        '/workspaces/%2Fabs%2Fpath/scheduled-tasks/a%2Fb',
+      );
+    });
+
+    it('falls back to the primary (unqualified) route when omitted', async () => {
+      fetchMock.mockResolvedValue(ok({ v: 1, tasks: [] }));
+      await makeActions().listScheduledTasks();
+      await makeActions().listScheduledTasks(undefined);
+      expect(fetchMock.mock.calls[0][0]).toBe('/scheduled-tasks');
+      expect(fetchMock.mock.calls[1][0]).toBe('/scheduled-tasks');
+    });
+  });
 });

--- a/packages/webui/src/daemon/workspace/types.ts
+++ b/packages/webui/src/daemon/workspace/types.ts
@@ -206,6 +206,13 @@ export interface DaemonScheduledTask {
   /** Bounded, newest-last history of recent fires. Empty for tasks that have
    * not fired (and, by nature, for one-shots — they are deleted on fire). */
   runs: DaemonScheduledTaskRun[];
+  /** The registered workspace this task belongs to, when the aggregated
+   * multi-workspace view tagged it client-side. Absent (single-workspace) means
+   * the primary workspace. `workspaceId` targets its workspace-qualified route;
+   * `workspaceCwd` labels the card. The daemon never sends these — they are
+   * attached by the client after a per-workspace fetch. */
+  workspaceId?: string;
+  workspaceCwd?: string;
 }
 
 export interface DaemonCreateScheduledTaskRequest {
@@ -350,19 +357,29 @@ export interface DaemonWorkspaceActions {
   stat(filePath: string): Promise<DaemonFileStat>;
   listDirectory(dirPath: string): Promise<DaemonDirectoryListing>;
 
-  // Scheduled tasks (durable cron)
-  listScheduledTasks(): Promise<DaemonScheduledTask[]>;
+  // Scheduled tasks (durable cron). The optional `workspaceId` targets a
+  // registered non-primary workspace's own cron file via the workspace-qualified
+  // route; omit it (or pass the primary's) to hit the primary `/scheduled-tasks`
+  // surface. The aggregated Web Shell view fans `listScheduledTasks` out over
+  // every trusted workspace and threads each task's `workspaceId` back into the
+  // mutations.
+  listScheduledTasks(workspaceId?: string): Promise<DaemonScheduledTask[]>;
   createScheduledTask(
     req: DaemonCreateScheduledTaskRequest,
+    workspaceId?: string,
   ): Promise<DaemonScheduledTask>;
   updateScheduledTask(
     id: string,
     patch: DaemonUpdateScheduledTaskRequest,
+    workspaceId?: string,
   ): Promise<DaemonScheduledTask>;
   /** Record a manual run (updates lastFiredAt + appends a 'manual' run). The
    * prompt itself is executed by the caller in the task's bound session. */
-  runScheduledTask(id: string): Promise<DaemonScheduledTask>;
-  deleteScheduledTask(id: string): Promise<void>;
+  runScheduledTask(
+    id: string,
+    workspaceId?: string,
+  ): Promise<DaemonScheduledTask>;
+  deleteScheduledTask(id: string, workspaceId?: string): Promise<void>;
 
   // Providers / env (read-only diagnostics)
   loadProviders(): Promise<DaemonWorkspaceProvidersStatus>;


### PR DESCRIPTION
## What this PR does

Makes the Web Shell "Scheduled tasks" page workspace-aware on a multi-workspace daemon. The page now aggregates the scheduled tasks of **every** registered, trusted workspace into a single list, tags each card with the workspace it belongs to, and lets the "New task" form pick which workspace a task is created in. Creating, editing, running, toggling, and deleting a task each operate on that task's own workspace — its own durable-task file and its own session bridge — instead of always the primary workspace.

Under the hood this adds a workspace-qualified surface for the scheduled-tasks REST API that mirrors the pattern every other per-workspace daemon route already uses (resolve the workspace from the path, trust-check it, then act on that workspace's runtime). The existing primary-only surface is unchanged. Keepalive and boot rehydration of task-owned sessions now run for each registered workspace, so a task bound to a session in a secondary workspace keeps firing and survives a daemon restart just like a primary-workspace one.

## Why it's needed

The scheduled-tasks page was hard-wired to the primary workspace. On a daemon serving several workspaces this was a real footgun: a task created while working in another workspace was silently stored under — and executed in — the primary workspace, and tasks that belonged to secondary workspaces (or were created there by the agent's own tool) never appeared on the page at all. Every other workspace-scoped feature in the daemon already had a per-workspace route; scheduled tasks were the one exception.

## Reviewer Test Plan

### How to verify

- Start a daemon over two workspaces: `qwen serve --workspace <A> --workspace <B>`, open the Web Shell, and open **Scheduled tasks**.
- Expect: tasks from both workspaces in one list, each card badged with its workspace (the primary marked). The **New task** form shows a **Workspace** dropdown (trusted workspaces only) defaulting to the primary. Create a task with `B` selected → it appears under `B`, not the primary; toggling / running / deleting it targets `B`. On a single-workspace daemon the page looks exactly as before (no badges, no dropdown).
- Automated coverage added: 6 daemon route tests (per-workspace create/list/patch/run/delete, path-selector resolution, unknown-workspace `400`, untrusted-workspace `403`), 5 client-targeting tests (qualified URL construction + primary fallback), and 5 dialog tests (aggregation + badges, workspace picker create, primary default, mutation targeting, read-only picker while editing). Existing suites stay green.

### Evidence (Before & After)

**Before:** the page only ever read/wrote the primary workspace's tasks. **After** — aggregated across all workspaces, each card badged with its workspace:

<img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/scheduled-tasks-multi-workspace/screenshots/ui-list-dark.png" width="440"> <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/scheduled-tasks-multi-workspace/screenshots/ui-list-light.png" width="440">

The "New task" form now targets a workspace:

<img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/scheduled-tasks-multi-workspace/screenshots/ui-newform-dark.png" width="480">

**Unit tests** (the new multi-workspace cases across the daemon route, the client, and the dialog — real `vitest` run):

<img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/scheduled-tasks-multi-workspace/screenshots/test-evidence-unit.png" width="780">

**End-to-end** against a real 2-workspace `qwen serve` (create/isolation/patch/run/delete via the qualified route, absolute-path selector, unknown-workspace rejection, primary unqualified route):

<img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/scheduled-tasks-multi-workspace/screenshots/test-evidence-e2e.png" width="780">

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `qwen serve` over two `--workspace` dirs (Node 22), plus package `vitest` suites.

## Risk & Scope

- Main risk or tradeoff: the aggregated list fans out one read per trusted workspace on each refresh; bounded by the small registered-workspace count and isolated so one workspace's corrupt file can't blank the list.
- Not validated / out of scope: a workspace **added at runtime** (dynamic add-workspace) isn't looped into keepalive for the rest of that process — once persisted it is covered as a boot workspace on the next restart. The New-task reference picker (extensions / skills / MCP) still lists the primary workspace's items; the inserted tokens are plain text that resolve in the task's own session at fire time.
- Breaking changes / migration notes: none. The primary `/scheduled-tasks` surface and the single-workspace UI are unchanged; the qualified routes and client parameter are additive.

## Linked Issues

N/A — addresses the multi-workspace gap in the scheduled-tasks page.

<details>
<summary>中文说明</summary>

### 这个 PR 做了什么

让 Web Shell 的「定时任务」页面在多 workspace 的 daemon 下真正按 workspace 工作。页面现在把**每个**已注册且受信任 workspace 的定时任务**聚合**到一个列表里,每张卡片标注它所属的 workspace,「新建任务」表单也能选择任务建到哪个 workspace。新建 / 编辑 / 运行 / 启停 / 删除都作用于任务**自己所属的 workspace**——它自己的 durable-task 文件、自己的 session bridge——而不再一律落到主(primary)workspace。

底层新增了一套 workspace 限定的定时任务 REST 路由 `/workspaces/:workspace/scheduled-tasks`,与 daemon 里其它每个按 workspace 划分的路由用同一套模式(从路径解析 workspace、做信任校验、再操作该 workspace 的运行时);原来的主 workspace 路由完全不变。任务绑定会话的 keepalive 和开机 rehydration 现在对每个已注册 workspace 各跑一份,所以绑定在副 workspace 会话上的任务照样会触发,并能在 daemon 重启后存活——和主 workspace 的任务一样。

### 为什么需要

原来定时任务页面被硬编码到主 workspace。在服务多个 workspace 的 daemon 上这是个实打实的坑:在别的 workspace 里工作时新建的任务会被悄悄存到(并运行在)主 workspace;而属于副 workspace 的任务(或 agent 用工具在那里建的任务)在页面上根本不显示。daemon 里其它按 workspace 划分的能力早就都有各自的 workspace 限定路由,唯独定时任务是漏掉的那个。

### 怎么验证

- 用两个 workspace 起 daemon:`qwen serve --workspace <A> --workspace <B>`,打开 Web Shell 进入「定时任务」。
- 预期:两个 workspace 的任务出现在同一个列表,每张卡片标注所属 workspace(主的会加标记);「新建任务」表单出现 **Workspace** 下拉(只列受信任的,默认主 workspace)。选 `B` 新建 → 任务出现在 `B` 下而不是主 workspace;启停 / 运行 / 删除都定向到 `B`。单 workspace 的 daemon 下页面和以前完全一样(无徽标、无下拉)。
- 新增自动化覆盖:6 个 daemon 路由测试、5 个客户端定向测试、5 个 dialog 测试;既有测试保持全绿。截图里是真实的 `vitest` 运行与真实双 workspace daemon 的端到端冒烟结果。

### 风险与范围

- 主要权衡:聚合列表每次刷新会对每个受信任 workspace 各发一次读取,数量受已注册 workspace 数限制,且按 workspace 隔离——某个 workspace 的文件损坏不会清空整个列表。
- 未覆盖 / 范围外:**运行时动态新增**的 workspace 在本进程内不会被纳入 keepalive 循环,持久化后会在下次重启作为 boot workspace 覆盖。新建表单的引用选择器(扩展 / 技能 / MCP)仍列主 workspace 的条目;插入的只是纯文本 token,会在任务自己的会话里于触发时解析。
- 破坏性变更:无。主 `/scheduled-tasks` 路由与单 workspace UI 均不变,限定路由与客户端参数都是新增的。

</details>
