### PR TITLE
fix(core): guide agent to pivot to read-only tools when plan mode blocks

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -6239,7 +6239,9 @@ describe('CoreToolScheduler plan mode with ask_user_question', () => {
       expect(responseJson).toContain('"error"');
       expect(responseJson).toContain('Tool blocked by plan mode');
       expect(responseJson).toContain('write_file');
-      // Plan-required teammates get exit_plan_mode hint
+      // Plan-required teammates get pivot-to-read-only then exit_plan_mode hint
+      expect(responseJson).toContain('Do NOT retry');
+      expect(responseJson).toContain('Pivot to read-only');
       expect(responseJson).toContain('exit_plan_mode');
       expect(completedCalls[0].response.error).toBeInstanceOf(Error);
       expect(completedCalls[0].response.errorType).toBe(
@@ -6312,12 +6314,14 @@ describe('CoreToolScheduler plan mode with ask_user_question', () => {
       expect(completedCalls[0].status).toBe('error');
       if (completedCalls[0].status === 'error') {
         // SDK, subagent, and teammate paths all get the same error format
-        // but different guidance: SDK/subagents get "Present your plan directly"
+        // but different guidance: SDK/subagents get "present your plan directly"
         const responseParts = completedCalls[0].response.responseParts;
         const responseJson = JSON.stringify(responseParts);
         expect(responseJson).toContain('"error"');
         expect(responseJson).toContain('Tool blocked by plan mode');
-        expect(responseJson).toContain('Present your plan directly');
+        expect(responseJson).toContain('Do NOT retry');
+        expect(responseJson).toContain('Pivot to read-only');
+        expect(responseJson).toContain('present your plan directly');
         expect(responseJson).not.toContain('exit_plan_mode');
         expect(completedCalls[0].response.error).toBeInstanceOf(Error);
         expect(completedCalls[0].response.errorType).toBe(

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -2467,9 +2467,10 @@ export class CoreToolScheduler {
                 `Tool blocked by plan mode: "${reqInfo.name}" is not a read-only tool. ` +
                   `Only read-only tools (read_file, grep_search, glob, list_directory, ` +
                   `web_fetch, etc.) are allowed in plan mode.` +
+                  ` Do NOT retry this tool. ` +
                   (isPlanRequiredTeammate
-                    ? ` Call exit_plan_mode to exit plan mode and execute this tool.`
-                    : ` Present your plan directly to the caller instead of executing this tool.`),
+                    ? `Pivot to read-only alternatives to gather the information you need, then call exit_plan_mode with a plan that covers this tool's purpose.`
+                    : `Pivot to read-only alternatives to gather equivalent information, then present your plan directly to the caller.`),
               );
               this.setStatusInternal(reqInfo.callId, 'error', {
                 ...createErrorResponse(

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -498,6 +498,14 @@ describe('getPlanModeSystemReminder', () => {
     expect(result).toContain('exit_plan_mode tool');
   });
 
+  it('should include guidance when a tool is blocked by plan mode', () => {
+    const result = getPlanModeSystemReminder();
+
+    expect(result).toContain('When a Tool is Blocked by Plan Mode');
+    expect(result).toContain('Do NOT retry');
+    expect(result).toContain('Pivot to read-only');
+  });
+
   it('should be deterministic', () => {
     const result1 = getPlanModeSystemReminder();
     const result2 = getPlanModeSystemReminder();

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -893,6 +893,14 @@ Start by quickly scanning a few key files to form an initial understanding of th
 - Reference existing functions and utilities you found that should be reused, with their file paths.
 - Include a verification section describing how to test the changes end-to-end.
 
+### When a Tool is Blocked by Plan Mode
+
+If a non-read-only tool is blocked:
+- Do NOT retry the blocked tool or repeatedly attempt similar non-read-only tools
+- Do NOT immediately call exit_plan_mode just to unblock it — continue gathering context with read-only tools first
+- Pivot to read-only tools (read_file, grep_search, glob, list_directory, agents) to gather the information the blocked tool would have provided
+- Once you have enough context to form a complete plan, call exit_plan_mode
+
 ### When to Converge
 
 Your plan is ready when you have addressed all ambiguities and it covers: what to change, which files to modify, what existing code to reuse (with file paths), and how to verify the changes. Present your plan ${planOnly ? 'directly' : `by calling the ${ToolNames.EXIT_PLAN_MODE} tool, which will prompt the user to confirm the plan`}. Do NOT make any file changes or run any tools that modify the system state in any way until the user has confirmed the plan.


### PR DESCRIPTION
## What this PR does

Changes the plan mode blocked error message and system prompt to guide the agent to pivot to read-only alternatives instead of immediately exiting plan mode. When a non-read-only tool is blocked, the agent is now told "Do NOT retry this tool" and instructed to gather equivalent context via read-only tools first, then call `exit_plan_mode` with a complete plan.

## Why it's needed

After the plan mode response format fix, the error message still implied the agent should immediately call `exit_plan_mode` to unblock. This creates a negative feedback loop: the agent receives a blocked tool error, reads "Call exit_plan_mode to exit plan mode and execute this tool," and exits prematurely without gathering enough context to form a useful plan. The system prompt also lacked any guidance on what to do when a tool is blocked.

## Reviewer Test Plan

### How to verify

1. Enter plan mode with the CLI
2. Ask the agent to do something that requires a non-read-only tool (e.g., `npm install`, `write_file`)
3. Verify the agent receives the error containing "Do NOT retry" and "Pivot to read-only"
4. Verify the agent attempts to gather equivalent information via read-only tools instead of immediately exiting or retrying
5. Run the unit tests:
   - `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t "plan mode"`
   - `cd packages/core && npx vitest run src/core/prompts.test.ts -t "getPlanModeSystemReminder"`

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: Message text change only — no logic changes to blocking behavior
- Not validated / out of scope: Actual LLM behavior with the new message (requires end-to-end testing with a real model)
- Breaking changes / migration notes: None

## Linked Issues

Closes #6763

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修改了 plan mode 阻塞时的错误消息和系统提示，引导 agent 先转向只读工具收集信息，而不是立即退出 plan mode。当非只读工具被阻塞时，agent 现在会收到 "Do NOT retry this tool" 的提示，并被指示先通过只读工具收集等效上下文，然后用完整计划调用 `exit_plan_mode`。

## 为什么需要

在 plan mode 响应格式修复之后，错误消息仍然暗示 agent 应该立即调用 `exit_plan_mode` 来解除阻塞。这导致负反馈循环：agent 收到阻塞错误后，看到 "Call exit_plan_mode to exit plan mode and execute this tool"，于是在收集到足够上下文之前就过早退出。系统提示也缺少关于工具被阻塞时该怎么做的指导。

## Reviewer 测试计划

### 如何验证

1. 在 CLI 中进入 plan mode
2. 让 agent 执行需要非只读工具的操作（如 `npm install`、`write_file`）
3. 确认 agent 收到的错误消息包含 "Do NOT retry" 和 "Pivot to read-only"
4. 确认 agent 尝试通过只读工具收集等效信息，而不是立即退出或重试
5. 运行单元测试：
   - `cd packages/core && npx vitest run src/core/coreToolScheduler.test.ts -t "plan mode"`
   - `cd packages/core && npx vitest run src/core/prompts.test.ts -t "getPlanModeSystemReminder"`

### 证据（Before & After）

N/A

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

## 风险与范围

- 主要风险/权衡：仅修改消息文本，不改变阻塞逻辑
- 未验证/超出范围：新消息下 LLM 的实际行为（需要真实模型端到端测试）
- 破坏性变更/迁移说明：无

## 关联 Issue

Closes #6763

</details>
