### PR TITLE
feat(web-shell): support custom composer placeholders

### DIFF
--- a/docs/design/webshell-composer-placeholders.md
+++ b/docs/design/webshell-composer-placeholders.md
@@ -1,0 +1,57 @@
+# WebShell composer placeholders
+
+## Context
+
+Today the main composer resolves its placeholder from internal i18n keys directly.
+Embedders can localize the WebShell UI, but they cannot provide product-specific
+copy for the main composer without forking the component or changing its
+translations.
+
+## Goals
+
+- Let embedders customize main-composer placeholder copy for its semantic UI
+  states.
+- Keep the existing localized placeholder for callers that do not opt in.
+- Preserve the existing shell-mode and follow-up placeholder precedence.
+
+## API
+
+`WebShellProps` accepts an optional `composerPlaceholders` map:
+
+```ts
+type WebShellComposerPlaceholderState = 'idle' | 'loading' | 'processing';
+
+type WebShellComposerPlaceholders = Partial<
+  Record<WebShellComposerPlaceholderState, string>
+>;
+```
+
+Both types are exported from the WebShell entry points. The map is optional and
+its entries are optional so an embedder can customize one state while retaining
+the standard copy for every other state.
+
+## State and fallback behavior
+
+The composer resolves one semantic state before resolving copy:
+
+| State        | Condition                                              |
+| ------------ | ------------------------------------------------------ |
+| `loading`    | The connection is catching up.                         |
+| `processing` | A prompt is being prepared or a response is streaming. |
+| `idle`       | Neither of the above applies.                          |
+
+`loading` takes precedence over `processing`, matching the existing
+placeholder-key behavior. A configured value is used only when it contains
+non-whitespace text; absent or blank values fall back to the corresponding
+localized WebShell placeholder.
+
+The new map affects only the main composer. Shell-mode and follow-up composers
+retain their existing specialized placeholders, and split-view composers keep
+their independent placeholder behavior.
+
+## Verification
+
+Unit tests cover all configured states, partial-map fallback, whitespace
+fallback, and semantic state selection independently from i18n keys. The
+embedding integration should verify its supplied idle copy renders in the host
+without changing the default behavior for unconfigured states.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -35,6 +35,7 @@ type ChatEditorTestProps = {
   skills?: Array<{ name: string; description: string }>;
   isPreparing?: boolean;
   dialogOpen?: boolean;
+  placeholderText?: string;
 };
 
 const {
@@ -715,6 +716,48 @@ afterEach(() => {
 });
 
 describe('App session callbacks', () => {
+  it('uses configured composer placeholders by state and falls back for blank values', async () => {
+    const composerPlaceholders = {
+      idle: 'Ask a question',
+      loading: 'Preparing chat',
+      processing: 'Working on it',
+    };
+    const { rerender } = renderApp({ composerPlaceholders });
+    await flush();
+
+    expect(testState.latestChatEditorProps?.placeholderText).toBe(
+      'Ask a question',
+    );
+
+    testState.streamingState = 'responding';
+    rerender({ composerPlaceholders });
+    await flush();
+    expect(testState.latestChatEditorProps?.placeholderText).toBe(
+      'Working on it',
+    );
+
+    rerender({ composerPlaceholders: { idle: 'Ask a question' } });
+    await flush();
+    expect(testState.latestChatEditorProps?.placeholderText).toBe(
+      'Processing. New messages will be queued.',
+    );
+
+    mockConnection.catchingUp = true;
+    rerender({ composerPlaceholders });
+    await flush();
+    expect(testState.latestChatEditorProps?.placeholderText).toBe(
+      'Preparing chat',
+    );
+
+    mockConnection.catchingUp = false;
+    testState.streamingState = 'idle';
+    rerender({ composerPlaceholders: { idle: '   ' } });
+    await flush();
+    expect(testState.latestChatEditorProps?.placeholderText).toBe(
+      'Type a message or @ file path',
+    );
+  });
+
   it('filters disabled skills from the web-shell skills list', async () => {
     mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({
       skills: [

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -171,8 +171,10 @@ import {
 } from './utils/sessionPreparation';
 import {
   getComposerPlaceholderKey,
+  getComposerPlaceholderState,
   shouldBlockComposerSubmit,
   shouldDisableComposerInput,
+  type ComposerPlaceholderState,
 } from './utils/composerInputState';
 import type { ACPToolCall, Message, PermissionRequest } from './adapters/types';
 import {
@@ -427,6 +429,12 @@ export interface WebShellApi {
   openSessionDrawer: () => void;
 }
 
+export type WebShellComposerPlaceholderState = ComposerPlaceholderState;
+
+export type WebShellComposerPlaceholders = Readonly<
+  Partial<Record<WebShellComposerPlaceholderState, string>>
+>;
+
 export interface WebShellProps {
   /** Called whenever the attached daemon session id changes. */
   onSessionIdChange?: (sessionId: string | undefined) => void;
@@ -463,6 +471,11 @@ export interface WebShellProps {
   shellRef?: React.Ref<WebShellApi>;
   /** Built-in composer toolbar actions to show. Defaults to all actions. */
   composerToolbarActions?: readonly ComposerToolbarAction[];
+  /**
+   * Main-composer copy by semantic state. Omitted or blank entries retain the
+   * WebShell localized default; shell-mode and follow-up copy still wins.
+   */
+  composerPlaceholders?: WebShellComposerPlaceholders;
   /** Called when connection status changes (idle/connecting/connected/disconnected/error). */
   onConnectionChange?: (status: string) => void;
   /** Called when prompt status changes (idle/waiting/responding). */
@@ -959,6 +972,7 @@ export function App({
   messageTurnOutputs,
   shellRef,
   composerToolbarActions,
+  composerPlaceholders,
   compactThinking = false,
   collapseCompletedTurns = true,
   markdownTableMode = 'basic',
@@ -4884,6 +4898,19 @@ export function App({
     pendingApproval: pendingApproval !== null,
     isPreparingPrompt,
   });
+  const composerPlaceholderInputState = {
+    catchingUp: Boolean(connection.catchingUp),
+    isPreparingPrompt,
+    isStreaming: streamingState !== 'idle',
+  };
+  const composerPlaceholderState = getComposerPlaceholderState(
+    composerPlaceholderInputState,
+  );
+  const customComposerPlaceholder =
+    composerPlaceholders?.[composerPlaceholderState];
+  const composerPlaceholderText = customComposerPlaceholder?.trim()
+    ? customComposerPlaceholder
+    : t(getComposerPlaceholderKey(composerPlaceholderInputState));
 
   const handleModelSelect = useCallback(
     (modelId: string) => {
@@ -5986,13 +6013,7 @@ export function App({
                           onDismissFollowup={onDismissFollowup}
                           composerInput={composerInput}
                           composerInputVersion={composerInputVersion}
-                          placeholderText={t(
-                            getComposerPlaceholderKey({
-                              catchingUp: Boolean(connection.catchingUp),
-                              isPreparingPrompt,
-                              isStreaming: streamingState !== 'idle',
-                            }),
-                          )}
+                          placeholderText={composerPlaceholderText}
                         />
                       </div>
                       {CustomFooter ? (

--- a/packages/web-shell/client/index.ts
+++ b/packages/web-shell/client/index.ts
@@ -1,6 +1,8 @@
 export { App as WebShell } from './App';
 export type {
   WebShellApi,
+  WebShellComposerPlaceholders,
+  WebShellComposerPlaceholderState,
   WebShellProps,
   WebShellSidebarOptions,
   BugReportInfo,

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -99,7 +99,13 @@ export function WebShellWithProviders(props: WebShellWithProvidersProps) {
 /** Alias for consumers who prefer a standalone naming style. */
 export const StandaloneWebShell = WebShellWithProviders;
 
-export type { WebShellApi, WebShellProps, WebShellSidebarOptions } from './App';
+export type {
+  WebShellApi,
+  WebShellComposerPlaceholders,
+  WebShellComposerPlaceholderState,
+  WebShellProps,
+  WebShellSidebarOptions,
+} from './App';
 export type { ToastTone } from './components/ToastHost';
 export type { WebShellLanguage } from './i18n';
 export type {

--- a/packages/web-shell/client/utils/composerInputState.test.ts
+++ b/packages/web-shell/client/utils/composerInputState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getComposerPlaceholderKey,
+  getComposerPlaceholderState,
   shouldBlockComposerSubmit,
   shouldDisableComposerInput,
 } from './composerInputState';
@@ -70,6 +71,30 @@ describe('composer input state', () => {
         isStreaming: true,
       }),
     ).toBe('editor.processing');
+  });
+
+  it('exposes the semantic placeholder state independently of i18n keys', () => {
+    expect(
+      getComposerPlaceholderState({
+        catchingUp: false,
+        isPreparingPrompt: false,
+        isStreaming: false,
+      }),
+    ).toBe('idle');
+    expect(
+      getComposerPlaceholderState({
+        catchingUp: true,
+        isPreparingPrompt: true,
+        isStreaming: true,
+      }),
+    ).toBe('loading');
+    expect(
+      getComposerPlaceholderState({
+        catchingUp: false,
+        isPreparingPrompt: true,
+        isStreaming: true,
+      }),
+    ).toBe('processing');
   });
 
   it('still disables editing for pending approvals', () => {

--- a/packages/web-shell/client/utils/composerInputState.ts
+++ b/packages/web-shell/client/utils/composerInputState.ts
@@ -5,6 +5,8 @@ type ComposerConnectionStatus =
   | 'disconnected'
   | 'error';
 
+export type ComposerPlaceholderState = 'idle' | 'loading' | 'processing';
+
 export function shouldDisableComposerInput({
   catchingUp,
   pendingApproval,
@@ -17,7 +19,7 @@ export function shouldDisableComposerInput({
   return Boolean(catchingUp || pendingApproval || isPreparingPrompt);
 }
 
-export function getComposerPlaceholderKey({
+export function getComposerPlaceholderState({
   catchingUp,
   isPreparingPrompt,
   isStreaming,
@@ -25,10 +27,25 @@ export function getComposerPlaceholderKey({
   catchingUp: boolean;
   isPreparingPrompt: boolean;
   isStreaming: boolean;
+}): ComposerPlaceholderState {
+  if (catchingUp) return 'loading';
+  if (isPreparingPrompt || isStreaming) return 'processing';
+  return 'idle';
+}
+
+export function getComposerPlaceholderKey(input: {
+  catchingUp: boolean;
+  isPreparingPrompt: boolean;
+  isStreaming: boolean;
 }): 'common.loading' | 'editor.processing' | 'editor.placeholder' {
-  if (catchingUp) return 'common.loading';
-  if (isPreparingPrompt || isStreaming) return 'editor.processing';
-  return 'editor.placeholder';
+  switch (getComposerPlaceholderState(input)) {
+    case 'loading':
+      return 'common.loading';
+    case 'processing':
+      return 'editor.processing';
+    case 'idle':
+      return 'editor.placeholder';
+  }
 }
 
 export function shouldBlockComposerSubmit({


### PR DESCRIPTION
## What this PR does

Adds an optional `composerPlaceholders` API to WebShell so embedders can supply main-composer placeholder copy for the semantic `idle`, `loading`, and `processing` states. Omitted, partial, or whitespace-only entries keep the existing localized WebShell copy.

## Why it's needed

Different embedding products use different terminology and workflows, while the current main composer always owns its placeholder text. This change makes that copy configurable without forking WebShell and preserves the existing behavior for every caller that does not opt in.

## Reviewer Test Plan

### How to verify

1. Render WebShell with `composerPlaceholders={{ idle: 'Ask a question', loading: 'Preparing chat', processing: 'Working on it' }}`; confirm the main composer displays the configured value for each matching state.
2. Omit the prop, provide only one state, or provide whitespace-only text; confirm the affected state uses the existing localized WebShell placeholder.
3. Switch to shell mode and open a follow-up composer; confirm their existing specialized placeholders still take precedence.

### Evidence (Before & After)

Before: the main composer always used the WebShell localized placeholder for its current state. After: an embedding can provide state-specific main-composer copy while every unconfigured state falls back to that same localized default. The focused upstream tests cover all three states, partial-map fallback, whitespace fallback, and semantic state selection. A private embedding integration also rendered its configured idle copy; no public screenshot can be attached because that host is not publicly accessible.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

macOS local checkout. Passed: `npx vitest run client/App.test.tsx client/utils/composerInputState.test.ts --config vitest.config.ts` (79 tests), `npm run typecheck --workspace=packages/web-shell`, and WebShell package build/test/coverage before the root preflight run.

## Risk & Scope

- Main risk or tradeoff: an embedding can intentionally replace only the main-composer copy; shell-mode, follow-up, and split-view placeholders retain their established behavior.
- Not validated / out of scope: Windows and Linux were not run locally. Root `npm run preflight` reached clean, install, format, lint, build, and typecheck, but its all-workspace test stage failed in unrelated CLI locale assertions and core managed-memory refresh tests.
- Breaking changes / migration notes: None. The API is optional and existing callers keep the current localized placeholders.

## Linked Issues

N/A (no user-provided issue).

<details>
<summary>中文说明</summary>

## 本 PR 做什么

为 WebShell 新增可选的 `composerPlaceholders` API，使嵌入方能够为主输入框的 `idle`、`loading` 和 `processing` 语义状态提供 Placeholder 文案。未传入、只传入部分状态或仅传入空白字符的条目，都会继续使用现有的 WebShell 本地化文案。

## 为什么需要

不同的嵌入产品有不同的术语和工作流，而当前主输入框的 Placeholder 文案始终由 WebShell 固定提供。本改动让这部分文案无需 fork WebShell 即可配置，并且保留所有未选择启用该能力调用方的现有行为。

## Reviewer 测试计划

### 如何验证

1. 使用 `composerPlaceholders={{ idle: 'Ask a question', loading: 'Preparing chat', processing: 'Working on it' }}` 渲染 WebShell；确认主输入框在每个对应状态下显示配置的文案。
2. 不传入该 prop、只提供一个状态，或提供仅包含空白字符的文本；确认受影响状态使用现有的 WebShell 本地化 Placeholder。
3. 切换到 shell 模式并打开 follow-up 输入框；确认它们现有的专用 Placeholder 仍具有更高优先级。

### 证据（改动前与改动后）

改动前：主输入框始终使用当前状态对应的 WebShell 本地化 Placeholder。改动后：嵌入方可以提供按状态区分的主输入框文案，而所有未配置状态都会回退到相同的本地化默认文案。上游定向测试覆盖了全部三个状态、部分 map 回退、空白字符回退和语义状态选择。私有嵌入环境也已验证其配置的 idle 文案能够渲染；由于该宿主环境无法公开访问，不能附上公开截图。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS     | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### 环境（可选）

macOS 本地代码库。已通过：`npx vitest run client/App.test.tsx client/utils/composerInputState.test.ts --config vitest.config.ts`（79 个测试）、`npm run typecheck --workspace=packages/web-shell`，以及根目录 preflight 之前完成的 WebShell 包构建、测试和覆盖率检查。

## 风险与范围

- 主要风险或权衡：嵌入方只能有意替换主输入框文案；shell 模式、follow-up 和 split-view 的 Placeholder 保持既有行为。
- 未验证 / 范围外：未在本地运行 Windows 和 Linux。根目录 `npm run preflight` 已完成清理、安装、格式化、lint、构建和类型检查，但其全工作区测试阶段因无关的 CLI locale 断言和 core managed-memory refresh 测试而失败。
- 破坏性变更 / 迁移说明：无。该 API 为可选项，现有调用方继续使用当前的本地化 Placeholder。

## 关联 Issue

不适用（未提供 Issue）。

</details>
