### PR TITLE
Revert "fix(core): parse tagged Qwen3 thinking in default provider"

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -568,29 +568,5 @@ describe('DefaultOpenAICompatibleProvider', () => {
       expect(assistant.reasoning_content).toBe('Preserved chain of thought');
       expect(assistant.reasoning).toBeUndefined();
     });
-
-    it('enables tagged thinking parsing for Qwen3 models', () => {
-      mockContentGeneratorConfig.model = 'Qwen/Qwen3.7-Max';
-      provider = new DefaultOpenAICompatibleProvider(
-        mockContentGeneratorConfig,
-        mockCliConfig,
-      );
-
-      expect(provider.getResponseParsingOptions()).toEqual({
-        taggedThinkingTags: true,
-      });
-    });
-
-    it('keeps tagged thinking parsing disabled for non-Qwen3 models', () => {
-      mockContentGeneratorConfig.model = 'gpt-4o';
-      provider = new DefaultOpenAICompatibleProvider(
-        mockContentGeneratorConfig,
-        mockCliConfig,
-      );
-
-      expect(provider.getResponseParsingOptions()).toEqual({
-        taggedThinkingTags: false,
-      });
-    });
   });
 });

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -3,7 +3,6 @@ import type { GenerateContentConfig } from '@google/genai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { DEFAULT_MAX_RETRIES, resolveRequestTimeout } from '../constants.js';
-import type { OpenAIResponseParsingOptions } from '../responseParsingOptions.js';
 import type { OpenAICompatibleProvider } from './types.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
 import {
@@ -122,14 +121,6 @@ export class DefaultOpenAICompatibleProvider
 
   getDefaultGenerationConfig(): GenerateContentConfig {
     return {};
-  }
-
-  getResponseParsingOptions(): OpenAIResponseParsingOptions {
-    return {
-      taggedThinkingTags: shouldMirrorReasoningContentForQwen3(
-        this.contentGeneratorConfig.model ?? '',
-      ),
-    };
   }
 
   /**

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -38,7 +38,7 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     }
   }
 
-  override getResponseParsingOptions(): OpenAIResponseParsingOptions {
+  getResponseParsingOptions(): OpenAIResponseParsingOptions {
     return { taggedThinkingTags: true };
   }
 }


### PR DESCRIPTION
Reverts QwenLM/qwen-code#6751.

## What this PR does

This PR reverts the Qwen3 model-name based tagged-thinking parser gate that was added in #6751.

## Why it's needed

#6751 enabled tagged-thinking response parsing for default OpenAI-compatible provider responses when the model name matches Qwen3. After checking the real failing traces for #6666, that fix is at the wrong abstraction layer.

What went wrong: the observed failure is not simply "Qwen3 returned a complete `<think>...</think>` block in `content`." In the real cases, the stream had already produced structured reasoning / thought content, but raw `<think>` / `</think>` fragments still leaked into visible content. That means the streamed response itself is malformed: the reasoning channel and visible-content channel were mixed.

Why revert instead of fixing forward in the same direction: matching `qwen3` in the model name changes behavior based on routing/model naming rather than the actual response shape. It can also parse or hide literal user-visible `<think>...</think>` text for all Qwen3-compatible endpoints, and it does not reliably handle malformed streams with bare closing tags, split tag fragments, or tool calls emitted in the same bad attempt.

The follow-up fix should be response-shape based: when structured reasoning is already present and visible content contains raw thinking-tag fragments, drop that malformed attempt and retry instead of accepting or cleaning the corrupted content. That follow-up is handled separately in #6754.

## Reviewer Test Plan

### How to verify

Review that this PR only reverts #6751 and restores the default provider behavior before the model-name based parser gate was added.

### Evidence (Before & After)

Before: #6751 made Qwen3 model-name matching opt the default OpenAI-compatible provider into tagged-thinking parsing.

After: the default provider no longer changes response parsing behavior based on a Qwen3 model-name match. The malformed-stream handling is left to #6754, where the condition is based on the actual response shape.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — this PR is a targeted revert of #6751.

## Risk & Scope

- Main risk or tradeoff: this removes the model-name based fallback from #6751; the intended replacement is the response-shape based retry logic in #6754.
- Not validated / out of scope: live provider verification against a real Qwen endpoint in this revert PR.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #6666.

Related to #6754.

<details>
<summary>中文说明</summary>

Reverts QwenLM/qwen-code#6751.

## What this PR does

这个 PR revert 了 #6751 中新增的、基于 Qwen3 模型名启用 tagged-thinking parser 的逻辑。

## Why it's needed

#6751 在默认 OpenAI-compatible provider 中，当模型名匹配 Qwen3 时启用 tagged-thinking response parsing。检查 #6666 的真实失败 trace 后，这个修复位于错误的抽象层。

出了什么问题：真实失败并不只是“Qwen3 在 `content` 里返回了一段完整的 `<think>...</think>` block”。真实 case 里，stream 已经产生了 structured reasoning / thought 内容，但 raw `<think>` / `</think>` 片段仍然泄漏到了 visible content。也就是说，这条 streamed response 本身是 malformed 的：reasoning channel 和 visible-content channel 混在了一起。

为什么 revert，而不是沿着同一个方向继续修：按模型名匹配 `qwen3` 会根据路由/模型命名改变行为，而不是根据实际 response shape 判断。它也可能把所有 Qwen3-compatible endpoint 中用户本来可见的 literal `<think>...</think>` 文本解析或隐藏掉，而且无法可靠处理裸 closing tag、split tag fragment，或者同一个坏 attempt 中同时出现 tool call 的 malformed stream。

后续正确修复应该基于 response shape：当 structured reasoning 已经存在、但 visible content 又包含 raw thinking-tag fragment 时，应该丢弃这次 malformed attempt 并 retry，而不是接受或清洗这段损坏内容。这个后续修复在 #6754 中单独处理。

## Reviewer Test Plan

### How to verify

确认这个 PR 只 revert #6751，并恢复新增 model-name based parser gate 之前的 default provider 行为。

### Evidence (Before & After)

Before：#6751 让默认 OpenAI-compatible provider 在 Qwen3 模型名匹配时启用 tagged-thinking parsing。

After：default provider 不再基于 Qwen3 模型名改变 response parsing 行为。malformed-stream 的处理留给 #6754，由实际 response shape 决定。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — 这个 PR 是对 #6751 的定向 revert。

## Risk & Scope

- Main risk or tradeoff：移除 #6751 的 model-name based fallback；预期替代方案是 #6754 中的 response-shape based retry 逻辑。
- Not validated / out of scope：这个 revert PR 没有做真实 Qwen endpoint 的 live provider 验证。
- Breaking changes / migration notes：无。

## Linked Issues

Related to #6666.

Related to #6754.

</details>
