### PR TITLE
feat(serve): Bound persisted transcript pages

### DIFF
--- a/docs/design/untrusted-persisted-transcript.md
+++ b/docs/design/untrusted-persisted-transcript.md
@@ -38,7 +38,7 @@ Replay is page-transactional at the protocol boundary: updates emitted before a 
 
 ## Compatibility and limits
 
-The old singular route, persisted cursor key and ACP error mapping remain intact. The new route keeps the existing default page size of 100, maximum of 500, 256 MiB snapshot cap, 32-entry/64 MiB index cache and five-minute cache lifetime. The first index scan remains linear in the frozen snapshot size.
+The old singular route, persisted cursor key and ACP error mapping remain intact. The new route keeps the existing default page size of 100, maximum of 500, 256 MiB snapshot cap, 32-entry/64 MiB index cache and five-minute cache lifetime. The workspace-qualified route additionally caps each page at 4 MiB of persisted source records, 32 MiB of serialized response JSON and 64 KiB of cursor state. `limit` is therefore a record-count ceiling rather than a promise that every successful page contains that many records. A single aggregate record over the source budget returns `transcript_page_too_large`; an oversized replay cursor terminates the otherwise successful page as partial without issuing a continuation cursor. The first index scan remains linear in the frozen snapshot size.
 
 The TypeScript SDK exposes the method on `WorkspaceDaemonClient`. It forces native REST transport and has no ACP route mapping. Older daemons can be detected through the new capability and continue returning 404 for the route.
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1461,12 +1461,15 @@ To protect daemon memory and latency, snapshots above the transcript indexing ca
 - `409` — `session_archived`, `session_archiving`, or `session_conflict` from the same loadability checks as `/load`.
 - `409` — transcript snapshot is unavailable because the file was deleted, truncated, replaced, or archived after the cursor was issued; this also applies when preflight can no longer find the active file for a cursor request.
 - `413` — `transcript_too_large` when the frozen transcript snapshot exceeds the daemon indexing cap.
+- `413` — `transcript_page_too_large` when one aggregate record exceeds the workspace-qualified page budget or the serialized page exceeds its response budget.
 
 ### `GET /workspaces/:workspace/session/:id/transcript`
 
 Return the same `DaemonSessionTranscriptPage` projection as the singular route from the selected registered workspace's active persisted JSONL. Pre-flight `workspace_persisted_transcript`; this capability is independent of `multi_workspace_sessions` and works for a trusted single-workspace primary selected by id or cwd.
 
 The selector and query parameters follow the existing plural workspace and transcript rules. Trusted primary and secondary runtimes and untrusted secondary runtimes may read. An untrusted primary returns `403 untrusted_workspace`. Archived content is not returned.
+
+For this workspace-qualified route, `limit` is the maximum record count. A page may stop earlier at the 4 MiB persisted-source budget and return a continuation cursor. Serialized responses are capped at 32 MiB and cursors at 64 KiB. If replay state would exceed the cursor cap, the page returns its successfully converted events with `partial: true`, `hasMore: false`, and no `nextCursor`.
 
 Unlike the legacy singular route, this path is implemented entirely inside the daemon process. It does not call the workspace bridge, start ACP, load settings, parse project-defined agents or skills, or create/repair `session-transcript-cursor-key`. Tool frames use persisted tool names and descriptions without consulting the runtime tool registry. Its HMAC cursor key exists only in daemon memory, is isolated per workspace, and rotates on restart; a cursor from a previous daemon process returns `400 invalid_transcript_cursor`.
 

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -9,7 +9,6 @@ import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
 import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
-import type { Response } from 'express';
 import {
   Storage,
   createDebugLogger,
@@ -37,8 +36,8 @@ import {
 } from './workspace-registry.js';
 import { createSessionOrganizationService } from './session-organization-helpers.js';
 import {
-  parseTranscriptCursorQueryForTest,
-  serializeWorkspaceTranscriptResponseForTest,
+  serializeWorkspaceTranscriptResponseForTesting,
+  workspaceTranscriptCursorExceedsLimitForTesting,
 } from './routes/session.js';
 
 const PRIMARY_CWD = path.resolve(path.sep, 'work', 'primary');
@@ -1639,30 +1638,22 @@ describe('multi-workspace session dispatch', () => {
     });
   });
 
-  it('rejects oversized workspace transcript cursors before reading storage', async () => {
-    const json = vi.fn();
-    const status = vi.fn(() => ({ json }));
-    const response = { status } as unknown as Response;
-
+  it('enforces the workspace transcript cursor byte boundary', () => {
     expect(
-      parseTranscriptCursorQueryForTest(
+      workspaceTranscriptCursorExceedsLimitForTesting(
         'a'.repeat(64 * 1024 + 1),
-        response,
-        64 * 1024,
       ),
-    ).toBeNull();
-    expect(status).toHaveBeenCalledWith(400);
-    expect(json).toHaveBeenCalledWith({
-      error: '`cursor` exceeds the maximum size',
-      code: 'invalid_transcript_cursor',
-    });
+    ).toBe(true);
+    expect(
+      workspaceTranscriptCursorExceedsLimitForTesting('a'.repeat(64 * 1024)),
+    ).toBe(false);
   });
 
   it('rejects workspace transcript responses over the serialized byte budget', () => {
     const sessionId = '550e8400-e29b-41d4-a716-446655440279';
 
     expect(() =>
-      serializeWorkspaceTranscriptResponseForTest(
+      serializeWorkspaceTranscriptResponseForTesting(
         { events: ['response too large'] },
         sessionId,
         8,
@@ -1739,6 +1730,8 @@ describe('multi-workspace session dispatch', () => {
       );
       expect(response.body.hasMore).toBe(false);
       expect(response.body.nextCursor).toBeUndefined();
+      expect(Array.isArray(response.body.events)).toBe(true);
+      expect(response.body.events.length).toBeGreaterThan(0);
       expect(secondaryBridge.spawnCalls).toEqual([]);
       expect(secondaryBridge.restoreCalls).toEqual([]);
     });

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -9,6 +9,7 @@ import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
 import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
+import type { Response } from 'express';
 import {
   Storage,
   createDebugLogger,
@@ -35,6 +36,10 @@ import {
   type WorkspaceRuntime,
 } from './workspace-registry.js';
 import { createSessionOrganizationService } from './session-organization-helpers.js';
+import {
+  parseTranscriptCursorQueryForTest,
+  serializeWorkspaceTranscriptResponseForTest,
+} from './routes/session.js';
 
 const PRIMARY_CWD = path.resolve(path.sep, 'work', 'primary');
 const SECONDARY_CWD = path.resolve(path.sep, 'work', 'secondary');
@@ -1599,6 +1604,143 @@ describe('multi-workspace session dispatch', () => {
       expect(expired.status).toBe(400);
       expect(expired.body.code).toBe('invalid_transcript_cursor');
       expect(expired.body.sessionId).toBe(sessionId);
+    });
+  });
+
+  it('rejects an oversized untrusted transcript record without starting the bridge', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440276';
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:00:00.000Z',
+        prompt: 'x'.repeat(4 * 1024 * 1024),
+        mtime: new Date('2026-07-08T00:00:00.000Z'),
+      });
+      const { app, secondaryBridge } = makeHarness({
+        secondaryTrusted: false,
+      });
+
+      const response = await request(app)
+        .get(`/workspaces/secondary-id/session/${sessionId}/transcript`)
+        .set('Host', host());
+
+      expect(response.status).toBe(413);
+      expect(response.body).toMatchObject({
+        code: 'transcript_page_too_large',
+        sessionId,
+        maxBytes: 4 * 1024 * 1024,
+      });
+      expect(response.body.pageBytes).toBeGreaterThan(
+        response.body.maxBytes as number,
+      );
+      expect(secondaryBridge.spawnCalls).toEqual([]);
+      expect(secondaryBridge.restoreCalls).toEqual([]);
+    });
+  });
+
+  it('rejects oversized workspace transcript cursors before reading storage', async () => {
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+    const response = { status } as unknown as Response;
+
+    expect(
+      parseTranscriptCursorQueryForTest(
+        'a'.repeat(64 * 1024 + 1),
+        response,
+        64 * 1024,
+      ),
+    ).toBeNull();
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      error: '`cursor` exceeds the maximum size',
+      code: 'invalid_transcript_cursor',
+    });
+  });
+
+  it('rejects workspace transcript responses over the serialized byte budget', () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440279';
+
+    expect(() =>
+      serializeWorkspaceTranscriptResponseForTest(
+        { events: ['response too large'] },
+        sessionId,
+        8,
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'SessionTranscriptPageTooLargeError',
+        sessionId,
+        maxBytes: 8,
+      }),
+    );
+  });
+
+  it('stops pagination when replay state would produce an oversized cursor', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440278';
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:00:00.000Z',
+        prompt: 'pending tools',
+        mtime: new Date('2026-07-08T00:00:00.000Z'),
+      });
+      const transcriptPath = path.join(
+        new Storage(SECONDARY_CWD).getProjectDir(),
+        'chats',
+        `${sessionId}.jsonl`,
+      );
+      let parentUuid = `${sessionId}-user-1`;
+      const records: Array<Record<string, unknown>> = [];
+      for (let index = 0; index < 500; index++) {
+        const uuid = `pending-tool-${index}`;
+        records.push({
+          uuid,
+          parentUuid,
+          sessionId,
+          timestamp: new Date(Date.UTC(2026, 6, 8, 0, 0, index)).toISOString(),
+          type: 'assistant',
+          message: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: `pending-call-${index}-${'x'.repeat(96)}`,
+                  name: 'run_shell_command',
+                  args: { command: 'true' },
+                },
+              },
+            ],
+          },
+          cwd: SECONDARY_CWD,
+        });
+        parentUuid = uuid;
+      }
+      await fsp.appendFile(
+        transcriptPath,
+        `${records.map((record) => JSON.stringify(record)).join('\n')}\n`,
+        'utf8',
+      );
+      const { app, secondaryBridge } = makeHarness({
+        secondaryTrusted: false,
+      });
+
+      const response = await request(app)
+        .get(
+          `/workspaces/secondary-id/session/${sessionId}/transcript?limit=500`,
+        )
+        .set('Host', host())
+        .expect(200);
+
+      expect(response.body.partial).toBe(true);
+      expect(response.body.replayError).toBe(
+        'Transcript pagination state exceeds the safe limit',
+      );
+      expect(response.body.hasMore).toBe(false);
+      expect(response.body.nextCursor).toBeUndefined();
+      expect(secondaryBridge.spawnCalls).toEqual([]);
+      expect(secondaryBridge.restoreCalls).toEqual([]);
     });
   });
 

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -13,6 +13,7 @@ import {
   SessionService,
   SessionOrganizationError,
   SESSION_TRANSCRIPT_MAX_LIMIT,
+  SessionTranscriptPageTooLargeError,
   SessionTranscriptCursorCodec,
   SessionTranscriptReader,
   SessionTranscriptSnapshotUnavailableError,
@@ -94,6 +95,12 @@ interface RegisterSessionRoutesDeps {
   sessionShellCommandEnabled: boolean;
   languageCodes: string[];
 }
+
+const WORKSPACE_TRANSCRIPT_PAGE_SOURCE_MAX_BYTES = 4 * 1024 * 1024;
+const WORKSPACE_TRANSCRIPT_RESPONSE_MAX_BYTES = 32 * 1024 * 1024;
+const WORKSPACE_TRANSCRIPT_CURSOR_MAX_BYTES = 64 * 1024;
+const TRANSCRIPT_CURSOR_TOO_LARGE_REPLAY_ERROR =
+  'Transcript pagination state exceeds the safe limit';
 
 function isReadOnlyWorkspaceInspection(runtime: WorkspaceRuntime): boolean {
   return !runtime.primary && !runtime.trusted;
@@ -194,6 +201,7 @@ function parseTranscriptLimitQuery(
 function parseTranscriptCursorQuery(
   rawCursor: unknown,
   res: Response,
+  maxBytes?: number,
 ): string | undefined | null {
   if (rawCursor === undefined) return undefined;
   if (typeof rawCursor !== 'string' || rawCursor.trim() === '') {
@@ -203,8 +211,37 @@ function parseTranscriptCursorQuery(
     });
     return null;
   }
+  if (maxBytes !== undefined && Buffer.byteLength(rawCursor) > maxBytes) {
+    res.status(400).json({
+      error: '`cursor` exceeds the maximum size',
+      code: 'invalid_transcript_cursor',
+    });
+    return null;
+  }
   return rawCursor;
 }
+
+export const parseTranscriptCursorQueryForTest = parseTranscriptCursorQuery;
+
+function serializeWorkspaceTranscriptResponse(
+  result: unknown,
+  sessionId: string,
+  maxBytes = WORKSPACE_TRANSCRIPT_RESPONSE_MAX_BYTES,
+): string {
+  const serialized = JSON.stringify(result);
+  const responseBytes = Buffer.byteLength(serialized);
+  if (responseBytes > maxBytes) {
+    throw new SessionTranscriptPageTooLargeError(
+      sessionId,
+      responseBytes,
+      maxBytes,
+    );
+  }
+  return serialized;
+}
+
+export const serializeWorkspaceTranscriptResponseForTest =
+  serializeWorkspaceTranscriptResponse;
 
 function transcriptSnapshotUnavailableError(sessionId: string): Error & {
   data: { errorKind: 'transcript_snapshot_unavailable'; sessionId: string };
@@ -1369,7 +1406,11 @@ export function registerSessionRoutes(
     }
     const limit = parseTranscriptLimitQuery(req.query['limit'], res);
     if (limit === null) return;
-    const cursor = parseTranscriptCursorQuery(req.query['cursor'], res);
+    const cursor = parseTranscriptCursorQuery(
+      req.query['cursor'],
+      res,
+      WORKSPACE_TRANSCRIPT_CURSOR_MAX_BYTES,
+    );
     if (cursor === null) return;
 
     try {
@@ -1389,6 +1430,7 @@ export function registerSessionRoutes(
             page = await reader.readPage(sessionId, {
               ...(limit !== undefined ? { limit } : {}),
               ...(cursor !== undefined ? { cursor } : {}),
+              maxBytes: WORKSPACE_TRANSCRIPT_PAGE_SOURCE_MAX_BYTES,
             });
           } catch (error) {
             if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -1414,6 +1456,10 @@ export function registerSessionRoutes(
             page,
             encodeCursor: (state) => codec.encode(state),
           });
+          const cursorTooLarge =
+            replay.nextCursor !== undefined &&
+            Buffer.byteLength(replay.nextCursor) >
+              WORKSPACE_TRANSCRIPT_CURSOR_MAX_BYTES;
           return {
             v: 1 as const,
             sessionId,
@@ -1422,20 +1468,32 @@ export function registerSessionRoutes(
               type: 'session_update' as const,
               data: update,
             })),
-            ...(replay.nextCursor ? { nextCursor: replay.nextCursor } : {}),
-            hasMore: replay.hasMore,
+            ...(replay.nextCursor && !cursorTooLarge
+              ? { nextCursor: replay.nextCursor }
+              : {}),
+            hasMore: cursorTooLarge ? false : replay.hasMore,
             startTime: replay.startTime,
             lastUpdated: replay.lastUpdated,
-            ...(replay.partial
+            ...(replay.partial || cursorTooLarge
               ? {
                   partial: true as const,
-                  replayError: replay.replayError,
+                  replayError: cursorTooLarge
+                    ? TRANSCRIPT_CURSOR_TOO_LARGE_REPLAY_ERROR
+                    : replay.replayError,
                 }
               : {}),
           };
         }),
       );
-      res.status(200).set('Cache-Control', 'no-store').json(result);
+      const serialized = serializeWorkspaceTranscriptResponse(
+        result,
+        sessionId,
+      );
+      res
+        .status(200)
+        .set('Cache-Control', 'no-store')
+        .type('application/json')
+        .send(serialized);
     } catch (err) {
       sendBridgeError(res, err, { route, sessionId });
     }

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -201,7 +201,6 @@ function parseTranscriptLimitQuery(
 function parseTranscriptCursorQuery(
   rawCursor: unknown,
   res: Response,
-  maxBytes?: number,
 ): string | undefined | null {
   if (rawCursor === undefined) return undefined;
   if (typeof rawCursor !== 'string' || rawCursor.trim() === '') {
@@ -211,17 +210,18 @@ function parseTranscriptCursorQuery(
     });
     return null;
   }
-  if (maxBytes !== undefined && Buffer.byteLength(rawCursor) > maxBytes) {
-    res.status(400).json({
-      error: '`cursor` exceeds the maximum size',
-      code: 'invalid_transcript_cursor',
-    });
-    return null;
-  }
   return rawCursor;
 }
 
-export const parseTranscriptCursorQueryForTest = parseTranscriptCursorQuery;
+function workspaceTranscriptCursorExceedsLimit(
+  cursor: string,
+  maxBytes = WORKSPACE_TRANSCRIPT_CURSOR_MAX_BYTES,
+): boolean {
+  return Buffer.byteLength(cursor) > maxBytes;
+}
+
+export const workspaceTranscriptCursorExceedsLimitForTesting =
+  workspaceTranscriptCursorExceedsLimit;
 
 function serializeWorkspaceTranscriptResponse(
   result: unknown,
@@ -240,7 +240,7 @@ function serializeWorkspaceTranscriptResponse(
   return serialized;
 }
 
-export const serializeWorkspaceTranscriptResponseForTest =
+export const serializeWorkspaceTranscriptResponseForTesting =
   serializeWorkspaceTranscriptResponse;
 
 function transcriptSnapshotUnavailableError(sessionId: string): Error & {
@@ -1406,12 +1406,15 @@ export function registerSessionRoutes(
     }
     const limit = parseTranscriptLimitQuery(req.query['limit'], res);
     if (limit === null) return;
-    const cursor = parseTranscriptCursorQuery(
-      req.query['cursor'],
-      res,
-      WORKSPACE_TRANSCRIPT_CURSOR_MAX_BYTES,
-    );
+    const cursor = parseTranscriptCursorQuery(req.query['cursor'], res);
     if (cursor === null) return;
+    if (cursor !== undefined && workspaceTranscriptCursorExceedsLimit(cursor)) {
+      res.status(400).json({
+        error: '`cursor` exceeds the maximum size',
+        code: 'invalid_transcript_cursor',
+      });
+      return;
+    }
 
     try {
       const result = await runWithoutDebugLogSession(() =>

--- a/packages/cli/src/serve/server/error-response.ts
+++ b/packages/cli/src/serve/server/error-response.ts
@@ -9,6 +9,7 @@ import {
   InvalidSessionTranscriptCursorError,
   recordDaemonBridgeError,
   recordDaemonError,
+  SessionTranscriptPageTooLargeError,
   SessionTranscriptSnapshotUnavailableError,
   SessionTranscriptTooLargeError,
   TrustGateError,
@@ -164,6 +165,16 @@ export function sendBridgeError(
       error: err.message,
       code: 'transcript_snapshot_unavailable',
       ...(ctx?.sessionId ? { sessionId: ctx.sessionId } : {}),
+    });
+    return;
+  }
+  if (err instanceof SessionTranscriptPageTooLargeError) {
+    res.status(413).json({
+      error: err.message,
+      code: 'transcript_page_too_large',
+      sessionId: err.sessionId,
+      pageBytes: err.pageBytes,
+      maxBytes: err.maxBytes,
     });
     return;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,6 +243,7 @@ export {
   SESSION_TRANSCRIPT_MAX_LIMIT,
   SessionTranscriptCursorCodec,
   SessionTranscriptReader,
+  SessionTranscriptPageTooLargeError,
   SessionTranscriptSnapshotUnavailableError,
   SessionTranscriptTooLargeError,
 } from './services/session-transcript-reader.js';

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -31,6 +31,7 @@ import {
   resetSessionTranscriptIndexCacheForTest,
   setSessionTranscriptIndexCacheMaxBytesForTest,
   SessionTranscriptCursorCodec,
+  SessionTranscriptPageTooLargeError,
   SessionTranscriptSnapshotUnavailableError,
   SessionTranscriptReader,
 } from './session-transcript-reader.js';
@@ -155,6 +156,67 @@ describe('SessionTranscriptReader', () => {
       ).rejects.toBeInstanceOf(RangeError);
     },
   );
+
+  it.each([0, -1, 1.5])(
+    'rejects invalid page byte limit %s',
+    async (maxBytes) => {
+      await expect(
+        new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
+          maxBytes,
+        }),
+      ).rejects.toBeInstanceOf(RangeError);
+    },
+  );
+
+  it('stops at a record boundary when the page byte budget is reached', async () => {
+    const records = [
+      record('u1', null, 'first'),
+      record('a1', 'u1', 'second'),
+      record('u2', 'a1', 'third'),
+    ];
+    await writeRecords(records);
+    const firstTwoBytes =
+      Buffer.byteLength(JSON.stringify(records[0])) +
+      Buffer.byteLength(JSON.stringify(records[1]));
+    const reader = new SessionTranscriptReader(workspaceDir);
+
+    const first = await reader.readPage(sessionId, {
+      limit: 3,
+      maxBytes: firstTwoBytes,
+    });
+    const second = await reader.readPage(sessionId, {
+      cursor: encodeCursor(first.nextCursorState!),
+      limit: 3,
+      maxBytes: firstTwoBytes,
+    });
+
+    expect(first.records.map((item) => item.uuid)).toEqual(['u1', 'a1']);
+    expect(first.hasMore).toBe(true);
+    expect(first.nextCursorState?.position).toBe(2);
+    expect(second.records.map((item) => item.uuid)).toEqual(['u2']);
+    expect(second.hasMore).toBe(false);
+  });
+
+  it('rejects a single aggregate record over the page byte budget', async () => {
+    const first = record('u1', null, 'first');
+    const second = record('u1', null, 'second fragment');
+    await writeRecords([first, second, record('a1', 'u1', 'reply')]);
+    const aggregateBytes =
+      Buffer.byteLength(JSON.stringify(first)) +
+      Buffer.byteLength(JSON.stringify(second));
+
+    await expect(
+      new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
+        limit: 1,
+        maxBytes: aggregateBytes - 1,
+      }),
+    ).rejects.toMatchObject({
+      name: 'SessionTranscriptPageTooLargeError',
+      sessionId,
+      pageBytes: aggregateBytes,
+      maxBytes: aggregateBytes - 1,
+    } satisfies Partial<SessionTranscriptPageTooLargeError>);
+  });
 
   it('pages only the active parentUuid chain and skips abandoned branches', async () => {
     await writeRecords([
@@ -500,6 +562,22 @@ describe('SessionTranscriptReader', () => {
       { text: 'hello' },
       { text: ' world' },
     ]);
+  });
+
+  it('counts glued-line fragments conservatively against the byte budget', async () => {
+    const first = record('u1', null, 'hello');
+    const second = record('u1', null, ' world');
+    const gluedLine = `${JSON.stringify(first)}${JSON.stringify(second)}`;
+    await writeRawTranscript(
+      `${gluedLine}\n${JSON.stringify(record('a1', 'u1', 'reply'))}\n`,
+    );
+
+    await expect(
+      new SessionTranscriptReader(workspaceDir).readPage(sessionId, {
+        limit: 1,
+        maxBytes: Buffer.byteLength(gluedLine) * 2 - 1,
+      }),
+    ).rejects.toBeInstanceOf(SessionTranscriptPageTooLargeError);
   });
 
   it('skips non-ChatRecord JSON lines while indexing', async () => {

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -47,6 +47,19 @@ export class SessionTranscriptTooLargeError extends Error {
   }
 }
 
+export class SessionTranscriptPageTooLargeError extends Error {
+  constructor(
+    readonly sessionId: string,
+    readonly pageBytes: number,
+    readonly maxBytes: number,
+  ) {
+    super(
+      `Transcript page for session ${sessionId} exceeds the page budget (${pageBytes} bytes, max ${maxBytes} bytes)`,
+    );
+    this.name = 'SessionTranscriptPageTooLargeError';
+  }
+}
+
 export interface SessionTranscriptCursorState {
   v: typeof SESSION_TRANSCRIPT_CURSOR_VERSION;
   sessionId: string;
@@ -62,6 +75,7 @@ export interface SessionTranscriptCursorState {
 export interface SessionTranscriptReadPageOptions {
   cursor?: string;
   limit?: number;
+  maxBytes?: number;
 }
 
 export interface SessionTranscriptRecordPage {
@@ -390,6 +404,47 @@ function normalizeLimit(limit: number | undefined): number {
     );
   }
   return limit;
+}
+
+function normalizeMaxBytes(maxBytes: number | undefined): number | undefined {
+  if (maxBytes === undefined) return undefined;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new RangeError(
+      'Transcript page byte limit must be a positive integer',
+    );
+  }
+  return maxBytes;
+}
+
+function recordSegmentBytes(index: TranscriptIndex, uuid: string): number {
+  const entry = index.byUuid.get(uuid);
+  return (
+    entry?.segments.reduce((total, segment) => total + segment.length, 0) ?? 0
+  );
+}
+
+function selectPageUuids(
+  index: TranscriptIndex,
+  sessionId: string,
+  position: number,
+  limit: number,
+  maxBytes: number | undefined,
+): string[] {
+  const candidates = index.activeUuids.slice(position, position + limit);
+  if (maxBytes === undefined) return candidates;
+
+  const selected: string[] = [];
+  let selectedBytes = 0;
+  for (const uuid of candidates) {
+    const bytes = recordSegmentBytes(index, uuid);
+    if (selected.length === 0 && bytes > maxBytes) {
+      throw new SessionTranscriptPageTooLargeError(sessionId, bytes, maxBytes);
+    }
+    if (selectedBytes + bytes > maxBytes) break;
+    selected.push(uuid);
+    selectedBytes += bytes;
+  }
+  return selected;
 }
 
 function fileIdentityFromStats(stats: fs.Stats): SessionTranscriptFileIdentity {
@@ -883,6 +938,7 @@ export class SessionTranscriptReader {
     options: SessionTranscriptReadPageOptions = {},
   ): Promise<SessionTranscriptRecordPage> {
     const limit = normalizeLimit(options.limit);
+    const maxBytes = normalizeMaxBytes(options.maxBytes);
     const cursor =
       options.cursor !== undefined
         ? (this.cursorCodec?.decode(options.cursor) ??
@@ -935,8 +991,14 @@ export class SessionTranscriptReader {
       );
       throw new InvalidSessionTranscriptCursorError();
     }
-    const nextPosition = Math.min(position + limit, index.activeUuids.length);
-    const pageUuids = index.activeUuids.slice(position, nextPosition);
+    const pageUuids = selectPageUuids(
+      index,
+      sessionId,
+      position,
+      limit,
+      maxBytes,
+    );
+    const nextPosition = position + pageUuids.length;
     const records = await readAggregatedRecords(index, pageUuids);
     const hasMore = nextPosition < index.activeUuids.length;
     const nextCursorState: SessionTranscriptCursorState | undefined = hasMore


### PR DESCRIPTION
## What this PR does

This PR adds bounded resource handling to the workspace-qualified persisted transcript reader. A page now stops at record boundaries after 4 MiB of persisted source data, rejects an individually oversized aggregate record, caps serialized responses at 32 MiB, and caps request and response cursors at 64 KiB. Existing record-count pagination and cursor semantics continue across byte-limited pages, while an oversized replay cursor returns the successfully converted content as a terminal partial page.

The legacy ACP-backed transcript route keeps its existing behavior. Protocol and design documentation now describe the additional workspace-qualified limits and the new `transcript_page_too_large` error.

## Why it's needed

The read-only Web Shell transcript viewer will consume data controlled by an untrusted workspace. Frontend filtering happens only after the browser has received and parsed JSON, so the daemon must prevent a single page or replay cursor from growing to the full transcript snapshot limit. These bounds make the persisted-only route safe to expose without changing its successful response schema or starting ACP.

## Reviewer Test Plan

### How to verify

Request a workspace-qualified transcript whose first records fit below 4 MiB and confirm the response may contain fewer than the requested `limit`, returns `hasMore: true`, and continues from the correct record with `nextCursor`. Request a transcript with one aggregate record above 4 MiB and confirm the daemon returns `413 transcript_page_too_large` without starting or restoring an ACP session. Confirm an oversized replay cursor terminates the successful page with `partial: true`, `hasMore: false`, and no continuation cursor. Finally, confirm the legacy singular transcript route remains unchanged.

Local verification completed with the focused core transcript reader tests, the multi-workspace serve tests, a full build, full typecheck, relevant ESLint checks, and `git diff --check`.

### Evidence (Before & After)

N/A — daemon/API resource-boundary change with no UI in this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js 22-compatible repository toolchain, package-local Vitest.

## Risk & Scope

- Main risk or tradeoff: Workspace-qualified transcript pages may contain fewer records than requested, and a single aggregate record above 4 MiB cannot be viewed through this route.
- Not validated / out of scope: Archived transcripts, reverse pagination, live follow, cross-restart cursors, and the Web Shell viewer are not included here. Windows and Linux were not tested locally.
- Breaking changes / migration notes: No successful response schema or SDK signature changes. Clients should already treat `limit` as a maximum and must handle the new structured 413 error.

## Linked Issues

Related to #6378

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 为 workspace-qualified persisted transcript reader 增加有界资源处理。页面现在会在累计 4 MiB persisted source data 后于 record 边界停止，拒绝单个超限的聚合 record，将序列化响应限制为 32 MiB，并将请求与响应 cursor 限制为 64 KiB。现有按 record 数量分页和 cursor 语义会跨字节受限页面继续保持；如果 replay cursor 过大，则把已经成功转换的内容作为终止性的 partial 页面返回。

旧的 ACP-backed transcript route 保持现有行为。协议和设计文档补充了 workspace-qualified 限额以及新的 `transcript_page_too_large` 错误。

## 为什么需要

只读 Web Shell transcript viewer 将消费由 untrusted workspace 控制的数据。前端过滤发生在浏览器接收并解析 JSON 之后，因此 daemon 必须阻止单页或 replay cursor 增长到完整 transcript snapshot 上限。这些边界让 persisted-only route 可以安全开放，同时不改变成功响应 schema，也不启动 ACP。

## Reviewer 测试计划

### 如何验证

请求一个前几个 records 总量低于 4 MiB 的 workspace-qualified transcript，确认响应可以少于请求的 `limit`，返回 `hasMore: true`，并通过 `nextCursor` 从正确 record 继续。请求包含一个超过 4 MiB 聚合 record 的 transcript，确认 daemon 返回 `413 transcript_page_too_large`，且不启动或恢复 ACP session。确认超大 replay cursor 会让成功页面以 `partial: true`、`hasMore: false` 且无 continuation cursor 的形式终止。最后确认旧 singular transcript route 行为不变。

本地已完成 core transcript reader 定向测试、multi-workspace serve 测试、完整 build、完整 typecheck、相关 ESLint 检查和 `git diff --check`。

### 证据（修改前后）

N/A——本 PR 是 daemon/API 资源边界变更，不包含 UI。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

macOS、兼容 Node.js 22 的仓库工具链、package-local Vitest。

## 风险与范围

- 主要风险或权衡：Workspace-qualified transcript 页面可能少于请求的 record 数，单个超过 4 MiB 的聚合 record 无法通过此 route 查看。
- 未验证 / 范围外：Archived transcript、reverse pagination、live follow、跨重启 cursor 和 Web Shell viewer 均不包含在此 PR。未在 Windows 和 Linux 本地测试。
- 破坏性变更 / 迁移说明：成功响应 schema 和 SDK 签名均不变。客户端应已将 `limit` 视为最大值，并需要处理新的结构化 413 错误。

## 关联 Issue

Related to #6378

</details>
