### PR TITLE
feat(web-shell): show sub-agents as a chronological transcript with a parallel-agent timeline

### DIFF
--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.module.css
@@ -166,6 +166,9 @@
   margin: 5px 0;
   min-width: 0;
   overflow: hidden;
+  /* Sizes the timeline ruler's visibility to the panel itself (split
+     view panes are narrower than the viewport). */
+  container-type: inline-size;
 }
 
 .header {
@@ -231,4 +234,97 @@
 
 .detail {
   margin-top: 4px;
+}
+
+/* Shared-axis mini timeline: one bar per agent laid out against the
+   group's combined wall-clock span. */
+.track {
+  position: relative;
+  height: 6px;
+  margin: 1px 0 5px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 14%, transparent);
+}
+
+.bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 60%, transparent);
+}
+
+.barRunning {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--agent-blue-500) 55%, transparent),
+    var(--agent-blue-500)
+  );
+}
+
+.barRunning::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--agent-blue-500);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .barRunning::after {
+    animation: bar-pulse 1.6s ease-out infinite;
+  }
+}
+
+@keyframes bar-pulse {
+  0% {
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agent-blue-500) 55%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+.ruler {
+  position: relative;
+  height: 15px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.tick {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  padding-top: 2px;
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-foreground);
+}
+
+.tick::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: 3px;
+  background: var(--border);
+}
+
+/* Narrow panels (split view, mobile): the bars still read — overlap and
+   relative duration — while each row keeps its absolute numbers, so only
+   the ruler goes. */
+@container (max-width: 380px) {
+  .ruler {
+    display: none;
+  }
 }

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import type { ACPToolCall } from '../../../adapters/types';
+
+// ParallelAgentsGroup renders SubAgentPanel, which pulls in ToolGroup;
+// ToolGroup imports App only for CompactModeContext — loading the real
+// App module would drag the whole application graph into this unit test.
+vi.mock('../../../App', async () => {
+  const { createContext } = await import('react');
+  return { CompactModeContext: createContext(false) };
+});
+
+const { computeAgentsTimeline } = await import('./ParallelAgentsGroup');
+
+function agent(partial: Partial<ACPToolCall>): ACPToolCall {
+  return {
+    callId: 'a1',
+    toolName: 'Task',
+    status: 'completed',
+    ...partial,
+  } as ACPToolCall;
+}
+
+describe('computeAgentsTimeline', () => {
+  it('returns null for a single agent or missing start times', () => {
+    expect(
+      computeAgentsTimeline([agent({ startTime: 0, endTime: 5_000 })], 10_000),
+    ).toBeNull();
+    expect(
+      computeAgentsTimeline(
+        [
+          agent({ callId: 'a1', startTime: 0, endTime: 5_000 }),
+          agent({ callId: 'a2' }),
+        ],
+        10_000,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for a sub-second span (nothing to compare)', () => {
+    expect(
+      computeAgentsTimeline(
+        [
+          agent({ callId: 'a1', startTime: 0, endTime: 400 }),
+          agent({ callId: 'a2', startTime: 100, endTime: 600 }),
+        ],
+        1_000,
+      ),
+    ).toBeNull();
+  });
+
+  it('lays out bars against the combined span, running bars ending at now', () => {
+    const timeline = computeAgentsTimeline(
+      [
+        agent({ callId: 'a1', startTime: 0, endTime: 24_000 }),
+        agent({ callId: 'a2', startTime: 3_000, status: 'in_progress' }),
+      ],
+      15_000,
+    )!;
+    expect(timeline).not.toBeNull();
+
+    const done = timeline.rows.get('a1')!;
+    expect(done.leftPct).toBe(0);
+    expect(done.widthPct).toBe(100);
+    expect(done.running).toBe(false);
+
+    const running = timeline.rows.get('a2')!;
+    expect(running.leftPct).toBeCloseTo(12.5);
+    expect(running.widthPct).toBeCloseTo(50);
+    expect(running.running).toBe(true);
+  });
+
+  it('keeps a visible sliver for near-instant agents, clamped to the edge', () => {
+    const timeline = computeAgentsTimeline(
+      [
+        agent({ callId: 'a1', startTime: 0, endTime: 10_000 }),
+        agent({ callId: 'a2', startTime: 10_000, endTime: 10_000 }),
+      ],
+      10_000,
+    )!;
+    const sliver = timeline.rows.get('a2')!;
+    expect(sliver.widthPct).toBe(2);
+    expect(sliver.leftPct + sliver.widthPct).toBeLessThanOrEqual(100);
+  });
+
+  it('picks nice ruler ticks that stop short of the right edge', () => {
+    const timeline = computeAgentsTimeline(
+      [
+        agent({ callId: 'a1', startTime: 0, endTime: 24_000 }),
+        agent({ callId: 'a2', startTime: 3_000, endTime: 20_000 }),
+      ],
+      24_000,
+    )!;
+    expect(timeline.ticks.map((tick) => tick.label)).toEqual([
+      '0s',
+      '10s',
+      '20s',
+    ]);
+    expect(timeline.ticks[2].leftPct).toBeCloseTo((20_000 / 24_000) * 100);
+  });
+});

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { I18nProvider } from '../../../i18n';
 import type { ACPToolCall } from '../../../adapters/types';
 
 // ParallelAgentsGroup renders SubAgentPanel, which pulls in ToolGroup;
@@ -10,7 +13,13 @@ vi.mock('../../../App', async () => {
   return { CompactModeContext: createContext(false) };
 });
 
-const { computeAgentsTimeline } = await import('./ParallelAgentsGroup');
+const { computeAgentsTimeline, ParallelAgentsGroup } = await import(
+  './ParallelAgentsGroup'
+);
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 function agent(partial: Partial<ACPToolCall>): ACPToolCall {
   return {
@@ -19,6 +28,34 @@ function agent(partial: Partial<ACPToolCall>): ACPToolCall {
     status: 'completed',
     ...partial,
   } as ACPToolCall;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+// Render the group and expand it (it starts collapsed) so the per-agent
+// timeline is in the DOM.
+function renderExpandedGroup(agents: ACPToolCall[]): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <ParallelAgentsGroup agents={agents} />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  const summary = container.querySelector('[aria-expanded]') as HTMLElement;
+  act(() => summary.click());
+  return container;
 }
 
 describe('computeAgentsTimeline', () => {
@@ -97,5 +134,52 @@ describe('computeAgentsTimeline', () => {
       '20s',
     ]);
     expect(timeline.ticks[2].leftPct).toBeCloseTo((20_000 / 24_000) * 100);
+  });
+
+  it('emits a single tick for a span barely over 1s, so the ruler is dropped', () => {
+    // Only 0s fits before the 92% cutoff; the component gates the ruler on
+    // ticks.length >= 2, so this span renders bars without a ruler.
+    const timeline = computeAgentsTimeline(
+      [
+        agent({ callId: 'a1', startTime: 0, endTime: 1_050 }),
+        agent({ callId: 'a2', startTime: 0, endTime: 1_050 }),
+      ],
+      1_050,
+    )!;
+    expect(timeline).not.toBeNull();
+    expect(timeline.ticks.length).toBe(1);
+  });
+});
+
+describe('ParallelAgentsGroup timeline rendering', () => {
+  it('renders one bar per agent and a ruler when the span is comparable', () => {
+    const container = renderExpandedGroup([
+      agent({ callId: 'a1', startTime: 0, endTime: 24_000 }),
+      agent({ callId: 'a2', startTime: 3_000, endTime: 20_000 }),
+    ]);
+    // The computed geometry actually reaches the DOM: a bar per agent...
+    expect(container.querySelectorAll('[class*="bar"]').length).toBe(2);
+    // ...and the ruler with its nice ticks.
+    expect(container.querySelector('[class*="ruler"]')).not.toBeNull();
+    expect(container.textContent).toContain('0s');
+    expect(container.textContent).toContain('10s');
+  });
+
+  it('renders the bars but no ruler when the span yields a single tick', () => {
+    const container = renderExpandedGroup([
+      agent({ callId: 'a1', startTime: 0, endTime: 1_050 }),
+      agent({ callId: 'a2', startTime: 0, endTime: 1_050 }),
+    ]);
+    expect(container.querySelectorAll('[class*="bar"]').length).toBe(2);
+    expect(container.querySelector('[class*="ruler"]')).toBeNull();
+  });
+
+  it('renders no timeline at all when bars would not be comparable', () => {
+    // A single agent → computeAgentsTimeline returns null → plain list.
+    const container = renderExpandedGroup([
+      agent({ callId: 'a1', startTime: 0, endTime: 24_000 }),
+    ]);
+    expect(container.querySelector('[class*="track"]')).toBeNull();
+    expect(container.querySelector('[class*="ruler"]')).toBeNull();
   });
 });

--- a/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
+++ b/packages/web-shell/client/components/messages/tools/ParallelAgentsGroup.tsx
@@ -33,6 +33,76 @@ function formatDuration(ms: number): string {
   return sec > 0 ? `${min}m ${sec}s` : `${min}m`;
 }
 
+export interface TimelineRow {
+  leftPct: number;
+  widthPct: number;
+  running: boolean;
+}
+
+export interface TimelineTick {
+  leftPct: number;
+  label: string;
+}
+
+export interface AgentsTimeline {
+  rows: Map<string, TimelineRow>;
+  ticks: TimelineTick[];
+}
+
+/**
+ * Geometry for the shared-axis mini timeline: one bar per agent against
+ * the group's combined wall-clock span, so overlap and relative duration
+ * read at a glance. Returns null when the bars would not be comparable
+ * (an agent without a start time) or carry no information (single agent,
+ * sub-second span) — the list then renders without a timeline.
+ */
+export function computeAgentsTimeline(
+  agents: ACPToolCall[],
+  now: number,
+): AgentsTimeline | null {
+  if (agents.length < 2) return null;
+  const starts: number[] = [];
+  for (const agent of agents) {
+    if (typeof agent.startTime !== 'number') return null;
+    starts.push(agent.startTime);
+  }
+  const ends = agents.map((agent, i) =>
+    agent.status === 'in_progress'
+      ? Math.max(now, starts[i])
+      : Math.max(agent.endTime ?? starts[i], starts[i]),
+  );
+  const t0 = Math.min(...starts);
+  const span = Math.max(...ends) - t0;
+  if (span < 1000) return null;
+
+  const rows = new Map<string, TimelineRow>();
+  agents.forEach((agent, i) => {
+    // Keep a visible sliver for near-instant agents, clamped so it never
+    // overflows the right edge.
+    const width = Math.max((ends[i] - starts[i]) / span, 0.02);
+    const left = Math.min((starts[i] - t0) / span, 1 - width);
+    rows.set(agent.callId, {
+      leftPct: left * 100,
+      widthPct: width * 100,
+      running: agent.status === 'in_progress',
+    });
+  });
+
+  // Ruler at 0 / step / 2·step… with a "nice" step (1-2-5 × 10ᵏ seconds),
+  // stopping short of the right edge so labels don't collide with it.
+  const targetSec = Math.max(span / 1000 / 2.2, 1);
+  const pow = Math.pow(10, Math.floor(Math.log10(targetSec)));
+  const stepSec =
+    [5, 2, 1].map((m) => m * pow).find((s) => s <= targetSec) ?? pow;
+  const ticks: TimelineTick[] = [];
+  for (let m = 0; ticks.length < 4; m++) {
+    const atMs = m * stepSec * 1000;
+    if (atMs > span * 0.92) break;
+    ticks.push({ leftPct: (atMs / span) * 100, label: formatDuration(atMs) });
+  }
+  return { rows, ticks };
+}
+
 function getAgentStats(agent: ACPToolCall, now: number): string {
   const parts: string[] = [];
   const taskExec = getTaskExecutionRecord(agent.rawOutput);
@@ -121,6 +191,7 @@ export function ParallelAgentsGroup({
     ? agents.find((a) => toolContainsCallId(a, pendingApproval.toolCallId!))
     : undefined;
   const showGroup = groupExpanded || !!approvalAgent;
+  const timeline = showGroup ? computeAgentsTimeline(agents, now) : null;
   const summaryStatus = agents.some(
     (a) => getAgentDisplayStatus(a) === 'failed',
   )
@@ -174,6 +245,7 @@ export function ParallelAgentsGroup({
               const stats = getAgentStats(agent, now);
               const status = getAgentDisplayStatus(agent);
               const isExpanded = expandedId === agent.callId;
+              const track = timeline?.rows.get(agent.callId);
               return (
                 <div key={agent.callId}>
                   <div
@@ -193,6 +265,21 @@ export function ParallelAgentsGroup({
                     </span>
                     {stats && <span className={styles.rowStats}>{stats}</span>}
                   </div>
+                  {track && (
+                    <div className={styles.track} aria-hidden="true">
+                      <span
+                        className={
+                          track.running
+                            ? `${styles.bar} ${styles.barRunning}`
+                            : styles.bar
+                        }
+                        style={{
+                          left: `${track.leftPct}%`,
+                          width: `${track.widthPct}%`,
+                        }}
+                      />
+                    </div>
+                  )}
                   {isExpanded && (
                     <div className={styles.detail}>
                       <SubAgentPanel tool={agent} hideHeader />
@@ -202,6 +289,19 @@ export function ParallelAgentsGroup({
               );
             })}
           </div>
+          {timeline && timeline.ticks.length >= 2 && (
+            <div className={styles.ruler} aria-hidden="true">
+              {timeline.ticks.map((tick) => (
+                <span
+                  key={tick.label}
+                  className={styles.tick}
+                  style={{ left: `${tick.leftPct}%` }}
+                >
+                  {tick.label}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.module.css
@@ -82,8 +82,9 @@
   overflow: hidden;
 }
 
-/* Result and sub-tool list: scroll within the same cap as the live
-   stream so the enclosing panel never grows past a screen. */
+/* Result (compact mode) and the step list (always): scroll within the
+   same cap as the live stream so the enclosing panel never grows past a
+   screen. */
 .scrollWindow {
   max-height: 400px;
   overflow-y: auto;
@@ -104,31 +105,24 @@
   color: var(--muted-foreground);
 }
 
-.tabBar {
+/* Hairline-ruled caption separating the conclusion from the step
+   timeline when both are present. */
+.sectionCap {
   display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 6px;
-}
-
-.tab {
-  padding: 4px 12px;
-  font-size: 12px;
-  color: var(--muted-foreground);
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.tab:hover {
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--muted-foreground);
 }
 
-.tabActive {
-  color: var(--foreground);
-  border-bottom-color: var(--agent-blue-500);
+.sectionCap::after {
+  content: '';
+  height: 1px;
+  flex: 1;
+  background: var(--border);
 }
 
 .tools {
@@ -139,6 +133,49 @@
 
 .tools .panel {
   border-left-width: 2px;
+}
+
+/* Step rail: a dot per step plus per-step segments of vertical line, so
+   the sub-tool list reads as one chronological timeline. Segments (not
+   one absolute line on the scroll container) because the container's
+   height is the scrollport, not the content. */
+.step {
+  position: relative;
+  padding-left: 16px;
+}
+
+.step::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 7px;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 55%, transparent);
+  z-index: 1;
+}
+
+.step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 16px;
+  bottom: -8px;
+  width: 1px;
+  background: var(--border);
+}
+
+.step[data-status='in_progress']::before,
+.step[data-status='pending']::before {
+  background: var(--agent-blue-500);
+}
+
+.step[data-status='failed']::before,
+.step[data-status='error']::before,
+.step[data-status='cancelled']::before,
+.step[data-status='canceled']::before {
+  background: var(--error-color);
 }
 
 /*

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
@@ -152,8 +152,43 @@ describe('SubAgentPanel sub-tool timestamps', () => {
     });
     expect(container.textContent).toContain('Grep');
     expect(container.textContent).toContain('scanning for usages…');
+    // The live stream renders as a <pre>; while running it must be present.
+    expect(container.querySelector('[class*="stream"]')).not.toBeNull();
     // The running flow is uncaptioned — no conclusion exists yet.
     expect(container.textContent).not.toContain('Result');
+  });
+
+  it('renders a completed agent stream text as the conclusion, not the live stream', () => {
+    // The conclusion-first invariant: once complete, subContent is the
+    // conclusion (assistant markdown), never the running <pre> stream.
+    const container = renderPanel({
+      callId: 'agent-1',
+      toolName: 'Task',
+      status: 'completed',
+      subContent: 'the final answer',
+    });
+    const conclusion = container.querySelector(
+      '[data-markdown-source="assistant"]',
+    );
+    expect(conclusion).not.toBeNull();
+    expect(conclusion?.textContent).toContain('the final answer');
+    expect(container.querySelector('[class*="stream"]')).toBeNull();
+  });
+
+  it('always scroll-caps the step list, regardless of compactThinking', () => {
+    // The tabs are gone, so the conclusion renders above the steps; the step
+    // list carries the scroll cap unconditionally (previously compact-only)
+    // so a long list can never push the conclusion off-screen. The test runs
+    // with the default (non-compact) customization.
+    const container = renderPanel({
+      callId: 'agent-1',
+      toolName: 'Task',
+      status: 'completed',
+      subTools: [{ callId: 'sub-1', toolName: 'Grep', status: 'completed' }],
+    });
+    const stepWindow = container.querySelector('[class*="scrollWindow"]');
+    expect(stepWindow).not.toBeNull();
+    expect(stepWindow?.className).toContain('tools');
   });
 
   it('hides non-standard sub-tool summaries until the row is expanded', () => {

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.test.tsx
@@ -127,6 +127,35 @@ describe('SubAgentPanel sub-tool timestamps', () => {
     expect(container.textContent).toContain('second line');
   });
 
+  it('shows the conclusion and the step list together when complete', () => {
+    const container = renderPanel({
+      callId: 'agent-1',
+      toolName: 'Task',
+      status: 'completed',
+      rawOutput: { type: 'task_execution', result: 'all references found' },
+      subTools: [{ callId: 'sub-1', toolName: 'Grep', status: 'completed' }],
+    });
+    // No tab switching: both sections render at once, captioned.
+    expect(container.textContent).toContain('all references found');
+    expect(container.textContent).toContain('Grep');
+    expect(container.textContent).toContain('Result');
+    expect(container.textContent).toContain('Tools (1)');
+  });
+
+  it('shows steps and the live stream together while running', () => {
+    const container = renderPanel({
+      callId: 'agent-1',
+      toolName: 'Task',
+      status: 'in_progress',
+      subContent: 'scanning for usages…',
+      subTools: [{ callId: 'sub-1', toolName: 'Grep', status: 'in_progress' }],
+    });
+    expect(container.textContent).toContain('Grep');
+    expect(container.textContent).toContain('scanning for usages…');
+    // The running flow is uncaptioned — no conclusion exists yet.
+    expect(container.textContent).not.toContain('Result');
+  });
+
   it('hides non-standard sub-tool summaries until the row is expanded', () => {
     const container = renderPanel(
       makeAgentWithSubTool({

--- a/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
+++ b/packages/web-shell/client/components/messages/tools/SubAgentPanel.tsx
@@ -151,8 +151,6 @@ function getAgentResultText(tool: ACPToolCall): string {
   return '';
 }
 
-type SubAgentTab = 'result' | 'tools';
-
 /**
  * Live sub-agent stream (thinking + output) shown while the agent runs.
  * With compactThinking enabled it collapses to a 5-line window pinned to
@@ -227,10 +225,11 @@ function SubAgentResult({ content }: { content: string }) {
 }
 
 /**
- * Sub-tool list, capped to the same scrollable window as the result
- * with compactThinking enabled. While the agent is still running the
- * window follows the newest call; once it completes it snaps back to
- * the top for reading.
+ * Step timeline: the sub-tool list in execution order, always capped to
+ * its own scrollable window — with the conclusion rendered above it (no
+ * tabs), an uncapped list would grow the panel past a screen. While the
+ * agent is still running the window follows the newest call; once it
+ * completes it snaps back to the top for reading.
  */
 function SubAgentTools({
   pinTail,
@@ -241,24 +240,16 @@ function SubAgentTools({
   itemCount: number;
   children: ReactNode;
 }) {
-  const { compactThinking } = useWebShellCustomization();
   const windowRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const el = windowRef.current;
-    if (!el || !compactThinking) return;
+    if (!el) return;
     el.scrollTop = pinTail ? el.scrollHeight : 0;
-  }, [compactThinking, pinTail, itemCount]);
+  }, [pinTail, itemCount]);
 
   return (
-    <div
-      ref={windowRef}
-      className={
-        compactThinking
-          ? `${styles.tools} ${styles.scrollWindow}`
-          : styles.tools
-      }
-    >
+    <div ref={windowRef} className={`${styles.tools} ${styles.scrollWindow}`}>
       {children}
     </div>
   );
@@ -274,7 +265,6 @@ export function SubAgentPanel({
   const isComplete = tool.status === 'completed' || tool.status === 'failed';
   const displayStatus = getAgentDisplayStatus(tool);
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
-  const [activeTab, setActiveTab] = useState<SubAgentTab>('result');
 
   const taskExec = isTaskExecution(tool.rawOutput) ? tool.rawOutput : null;
 
@@ -302,7 +292,10 @@ export function SubAgentPanel({
     (tool.subTools && tool.subTools.length > 0) ||
     (taskToolCalls && taskToolCalls.length > 0)
   );
-  const showTabs = hasResult && hasTools;
+  // Captions only where they disambiguate: a completed agent showing both
+  // its conclusion and the steps that produced it. A single section — or
+  // the live steps+stream flow while running — reads on its own.
+  const showSectionCaps = isComplete && hasResult && hasTools;
 
   return (
     <div className={inline ? undefined : styles.panel}>
@@ -328,56 +321,62 @@ export function SubAgentPanel({
 
       {(expanded || hideHeader) && (
         <div className={styles.body}>
-          {showTabs && (
-            <div className={styles.tabBar}>
-              <button
-                className={`${styles.tab} ${activeTab === 'result' ? styles.tabActive : ''}`}
-                onClick={() => setActiveTab('result')}
-              >
-                {t('subagent.result')}
-              </button>
-              <button
-                className={`${styles.tab} ${activeTab === 'tools' ? styles.tabActive : ''}`}
-                onClick={() => setActiveTab('tools')}
-              >
-                {t('subagent.tools', { count: subToolCount })}
-              </button>
-            </div>
-          )}
-
-          {(!showTabs || activeTab === 'result') && hasResult && (
+          {/* One chronological story instead of Result/Tools tabs.
+              Completed: conclusion first, then the steps that produced it
+              in their own scroll window, so the payoff stays in view.
+              Running: no conclusion exists yet — the step window pins to
+              the newest call and the live stream tails it. */}
+          {isComplete && hasResult && (
             <div className={styles.content}>
-              {isComplete ? (
-                <SubAgentResult content={tool.subContent || resultText} />
-              ) : (
-                tool.subContent && <SubAgentStream text={tool.subContent} />
+              {showSectionCaps && (
+                <div className={styles.sectionCap}>{t('subagent.result')}</div>
               )}
+              <SubAgentResult content={tool.subContent || resultText} />
             </div>
           )}
 
-          {(!showTabs || activeTab === 'tools') && (
-            <>
-              {tool.subTools && tool.subTools.length > 0 && (
-                <SubAgentTools
-                  pinTail={!isComplete}
-                  itemCount={tool.subTools.length}
+          {showSectionCaps && (
+            <div className={styles.sectionCap}>
+              {t('subagent.tools', { count: subToolCount })}
+            </div>
+          )}
+          {tool.subTools && tool.subTools.length > 0 && (
+            <SubAgentTools
+              pinTail={!isComplete}
+              itemCount={tool.subTools.length}
+            >
+              {tool.subTools.map((sub) => (
+                <div
+                  key={sub.callId}
+                  className={styles.step}
+                  data-status={sub.status}
                 >
-                  {tool.subTools.map((sub) => (
-                    <SubToolLine key={sub.callId} tool={sub} />
-                  ))}
-                </SubAgentTools>
-              )}
-              {taskToolCalls && taskToolCalls.length > 0 && (
-                <SubAgentTools
-                  pinTail={!isComplete}
-                  itemCount={taskToolCalls.length}
+                  <SubToolLine tool={sub} />
+                </div>
+              ))}
+            </SubAgentTools>
+          )}
+          {taskToolCalls && taskToolCalls.length > 0 && (
+            <SubAgentTools
+              pinTail={!isComplete}
+              itemCount={taskToolCalls.length}
+            >
+              {taskToolCalls.map((tc) => (
+                <div
+                  key={tc.callId}
+                  className={styles.step}
+                  data-status={tc.status}
                 >
-                  {taskToolCalls.map((tc) => (
-                    <TaskToolCallLine key={tc.callId} tc={tc} />
-                  ))}
-                </SubAgentTools>
-              )}
-            </>
+                  <TaskToolCallLine tc={tc} />
+                </div>
+              ))}
+            </SubAgentTools>
+          )}
+
+          {!isComplete && tool.subContent && (
+            <div className={styles.content}>
+              <SubAgentStream text={tool.subContent} />
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## What this PR does

Reworks how sub-agents are displayed in the Web Shell transcript. A single sub-agent no longer splits its output across Result / Tools tabs — it now renders as one chronological view: the conclusion first, then the steps that produced it on a stepped rail, reading like the nested conversation it actually is. While the agent is still running there is no conclusion yet, so the step list pins to the newest call and the live stream tails below it. The step list keeps its own scroll cap so the conclusion stays in view rather than the panel growing past a screen.

A group of parallel sub-agents gains a shared-axis mini timeline: one bar per agent laid out against the group's combined wall-clock span, with a ruler beneath it. A running agent's bar animates a pulsing leading edge. The whole treatment degrades gracefully — the ruler hides on narrow panels (split view, mobile) via a container query while the bars keep the relationships and each row keeps its absolute numbers, and it falls back to the previous plain list whenever the bars would not be comparable (an agent with no start time, a single agent, or a sub-second span).

## Why it's needed

A sub-agent is a nested mini-conversation — thinking, a sequence of tool calls, then a conclusion — but the previous panel presented it as a tool with two disjoint tabs, so you could never see how a conclusion was reached without flipping to another tab and back. And a group of parallel agents rendered as a flat list carried no time information at all, so the one thing worth conveying — that the agents ran concurrently, who overlapped whom, who is still running — was invisible. This change makes both read at a glance.

## Reviewer Test Plan

### How to verify

In the Web Shell, run a prompt that delegates to a sub-agent (the Task tool) and expand it: the conclusion sits at the top under a `Result` caption, with the tool calls that produced it listed below under `Tools (N)` on a stepped rail (dots colored by status — a failed step shows red). There are no Result / Tools tabs. While it is still running, expand it mid-flight: the step list follows the newest call and the live stream tails beneath it, with no captions (there is no conclusion yet).

Run a prompt that spawns several sub-agents concurrently and expand the "Parallel agents" group: each row now has a bar on a shared time axis, a still-running agent's bar has a pulsing edge, and a ruler sits below. Narrow the panel (open the split view, or shrink the window): the ruler disappears while the bars remain and each row keeps its `Ns · Nk` numbers.

Unit tests: `cd packages/web-shell && npx vitest run client/components/messages/tools/SubAgentPanel.test.tsx client/components/messages/tools/ParallelAgentsGroup.test.tsx` — covers the completed conclusion+steps layout, the running steps+stream layout, and the timeline geometry (span/overlap math, near-instant sliver clamping, nice ruler ticks, and the null-fallback cases).

### Evidence (Before & After)

**Light**

![SubAgentView before/after, light theme](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-subagent-view/ba-light.png)

**Dark**

![SubAgentView before/after, dark theme](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-subagent-view/ba-dark.png)

Rendered from the components' real DOM and the shipped `*.module.css` rules against the app's real theme tokens; the narrow-panel container-query behavior (ruler hides, bars remain) was asserted programmatically.

#### State coverage (running, failed step, narrow panel)

The before/after above shows the completed sub-agent and the wide parallel group; these cover the remaining states — a sub-agent still running (steps pinned to the newest call, live stream tailing below, no captions), a failed step (red rail dot), and a parallel group in a narrow panel where the ruler drops out while the bars stay.

**Light**

![SubAgentView states — completed, running, wide timeline, narrow timeline, light theme](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-subagent-view/states-light.png)

**Dark**

![SubAgentView states — completed, running, wide timeline, narrow timeline, dark theme](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-subagent-view/states-dark.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests + visual verification via Playwright/Chromium. Not exercised against a live daemon; the changes are presentation-only in the message renderer.

## Risk & Scope

- Main risk or tradeoff: presentation-only, contained to the two message-renderer components. No data-model or protocol change; the sub-agent tool data (sub-tools, result, per-agent start/end times) is already present. When compact-thinking is off the conclusion renders at full height, so a very long conclusion pushes the (independently scrollable) step list down — the same trade the old Result tab made.
- Not validated / out of scope: no live-daemon end-to-end run; deep sub-agent nesting (agents within agents) reuses the existing rail and was not separately stress-tested.
- Breaking changes / migration notes: none. Existing i18n keys are reused, so no new translations are required.

## Linked Issues

N/A — originated from an internal review of the SubAgentView display.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重构 Web Shell 里子代理(sub-agent)的展示方式。

**① 单体子代理**:不再用 Result / Tools 标签页把输出切成两半,改为一条时间线叙事——结论置顶,下面是产出该结论的步骤,沿一条带圆点的竖轨排列,读起来就是它本来的样子:一段嵌套的小对话。运行中还没有结论,此时步骤列表钉住最新一步、实时流跟在末尾。步骤列表有独立的滚动上限,所以结论始终留在视野内,面板不会越长越高超出一屏。

**② 并行子代理**:为并行代理组加了共享时间轴的迷你时间线——每个代理一条横条,按整组的合并墙钟跨度布局,下方配刻度尺;运行中的代理横条有脉冲端点。整体平滑降级:窄面板(分屏、移动端)用容器查询隐藏刻度尺、保留横条(横条承载重叠与相对时长,每行仍有绝对数值);当横条无法比较时(某代理无开始时间、只有单个代理、或跨度不足 1 秒)回退为原来的纯列表。

## 为什么需要

子代理本质是一段嵌套的小对话(思考 → 一串工具调用 → 结论),但原面板把它当成带两个割裂标签页的工具,看结论时无法同时看到它是怎么得出的。并行代理组渲染成纯列表则完全没有时间信息,最该传达的「它们在并行、谁和谁重叠、谁还在跑」反而不可见。本次改动让两者都一目了然。

## 验证要点

- 运行会派生子代理(Task 工具)的 prompt 并展开:结论在 `Result` 标题下置顶,产出它的工具调用在 `Tools (N)` 下沿竖轨列出(圆点按状态着色,失败步骤为红色),没有标签页。运行中展开:步骤跟随最新一步、实时流跟在下方,无分节标题。
- 运行并发派生多个子代理的 prompt 并展开「并行智能体」组:每行在共享时间轴上有横条,运行中代理的横条端点脉冲,下方是刻度尺。收窄面板(开分屏或缩小窗口):刻度尺消失、横条保留、每行保留 `Ns · Nk` 数值。
- 单元测试:`cd packages/web-shell && npx vitest run client/components/messages/tools/SubAgentPanel.test.tsx client/components/messages/tools/ParallelAgentsGroup.test.tsx`。

## 风险与范围

纯展示层改动,仅限两个消息渲染组件;无数据模型/协议变更(子代理的子工具、结果、各代理起止时间均已有数据)。复用现有 i18n key,无需新翻译。未做实时 daemon 端到端验证;深层子代理嵌套沿用现有竖轨、未单独压测。

</details>
