### PR TITLE
fix(feishu): validate credentials before WebSocket startup

### DIFF
--- a/docs/superpowers/plans/2026-07-12-feishu-worker-credential-validation.md
+++ b/docs/superpowers/plans/2026-07-12-feishu-worker-credential-validation.md
@@ -1,230 +1,67 @@
 # Feishu Worker Credential Validation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
-**Goal:** Make Feishu WebSocket startup reject invalid credentials and wait for a real initial WebSocket handshake before a daemon-managed channel worker reports ready.
-
-**Architecture:** Keep the fix inside the Feishu adapter. Preflight the existing tenant-token request, then adapt the Lark SDK's callback-based readiness events into a bounded promise, following the readiness pattern already shipped in the SDK's higher-level `LarkChannel` implementation.
-
-**Tech Stack:** TypeScript, Vitest, `@larksuiteoapi/node-sdk`, Qwen Code daemon-managed channel worker.
-
-## Global Constraints
-
-- Branch name is `fix/feishu-worker-credential-validation`; do not use a `codex/` prefix.
-- All commits use `hit_aran <hit_aran@163.com>` and Conventional Commits.
-- Limit production changes to the Feishu adapter; do not patch or fork the Lark SDK.
-- Preserve Feishu webhook behavior and post-ready SDK automatic reconnect behavior.
-- Use the repository PR template, push the branch, include `Fixes #6779`, and post E2E evidence as a separate PR comment.
-
----
-
-### Task 1: Implement the Feishu WebSocket readiness contract with TDD
-
-**Files:**
-- Modify: `packages/channels/feishu/src/FeishuAdapter.ts`
-- Modify: `packages/channels/feishu/src/adapter.test.ts`
-- Test: `packages/channels/feishu/src/adapter.test.ts`
-
-**Interfaces:**
-- Consumes: `FeishuChannel.connect(): Promise<void>`, `getTenantAccessToken(): Promise<string | undefined>`, and the Lark `WSClient` constructor callbacks.
-- Produces: A bounded authenticated `connectWebSocket(): Promise<void>` plus regression coverage for credential preflight, `onReady` gating, `onError` propagation, and a 15-second startup timeout.
-
-- [ ] **Step 1: Add a hoisted Lark `WSClient` test double**
-
-Use `vi.hoisted()` because the state is consumed by `vi.mock()` at module-load time. Preserve the real SDK exports and replace only `WSClient`:
-
-```ts
-const wsMock = vi.hoisted(() => ({
-  close: vi.fn(),
-  options: undefined as
-    | { onReady?: () => void; onError?: (error: Error) => void }
-    | undefined,
-  start: vi.fn<() => Promise<void>>(),
-}));
-
-vi.mock('@larksuiteoapi/node-sdk', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@larksuiteoapi/node-sdk')>();
-  return {
-    ...actual,
-    WSClient: class {
-      constructor(options: typeof wsMock.options) {
-        wsMock.options = options;
-      }
-
-      start = wsMock.start;
-      close = wsMock.close;
-    },
-  };
-});
-```
-
-Reset the test double before each WebSocket-connect test and default `start()` to a resolved promise.
-
-- [ ] **Step 2: Add the invalid-credential regression test**
-
-Mock the tenant-token request with HTTP 401, call `connect()`, and assert:
-
-```ts
-await expect(channel.connect()).rejects.toThrow(
-  'failed to authenticate Feishu credentials',
-);
-expect(wsMock.start).not.toHaveBeenCalled();
-```
-
-- [ ] **Step 3: Add initial WebSocket readiness tests**
-
-Use a successful tenant-token response and verify that `connect()` remains pending until `wsMock.options?.onReady?.()` is invoked. Add a second test invoking `onError(new Error('credential rejected'))` and assert that `connect()` rejects with Feishu WebSocket context and closes the SDK client.
-
-- [ ] **Step 4: Add the handshake-timeout test**
-
-Use Vitest fake timers, return a successful token, leave both SDK callbacks silent, advance 15 seconds, and assert that `connect()` rejects with `WebSocket handshake did not complete within 15000ms` and closes the SDK client. Restore real timers in `finally`.
-
-- [ ] **Step 5: Run the focused tests and verify RED**
-
-Run from `packages/channels/feishu`:
-
-```bash
-node ../../../node_modules/vitest/vitest.mjs run src/adapter.test.ts
-```
-
-Expected: the new tests fail because the current adapter neither authenticates before constructing `WSClient` nor waits for the SDK readiness callbacks.
-
-- [ ] **Step 6: Add the startup timeout constant**
-
-Define the adapter-local bound next to the existing constants:
-
-```ts
-const FEISHU_WS_STARTUP_TIMEOUT_MS = 15_000;
-```
-
-- [ ] **Step 7: Require credential preflight for WebSocket mode**
-
-Before `connectWebSocket()` is called, reuse the existing token cache path:
-
-```ts
-const token = await this.getTenantAccessToken();
-if (!token) {
-  throw new Error(
-    `Channel "${this.name}" failed to authenticate Feishu credentials.`,
-  );
-}
-await this.connectWebSocket();
-```
-
-Do not add this gate to webhook mode.
-
-- [ ] **Step 8: Convert SDK callbacks into a bounded readiness promise**
-
-Construct the SDK client with `autoReconnect: true`, `onReady`, and `onError`. Use one settle function that clears the timer. On failure, close the client, clear `this.wsClient`, and reject. Start the SDK client with `void client.start(...).catch(fail)` so synchronous or promise-level SDK errors also reject.
-
-The timeout error text must be:
-
-```text
-Feishu WebSocket handshake did not complete within 15000ms.
-```
-
-The SDK error wrapper must begin with:
-
-```text
-Feishu WebSocket connection failed:
-```
-
-- [ ] **Step 9: Run the focused tests and verify GREEN**
-
-Run:
-
-```bash
-node ../../../node_modules/vitest/vitest.mjs run src/adapter.test.ts
-```
-
-Expected: all Feishu adapter tests pass with no unhandled promise rejection or leaked fake timer.
-
-- [ ] **Step 10: Run package typecheck/build verification**
-
-Run from the repository root with the bundled Node runtime on `PATH`:
-
-```bash
-node node_modules/typescript/bin/tsc --build packages/channels/feishu --pretty false
-```
-
-Expected: exit code 0.
-
-- [ ] **Step 11: Commit the implementation**
-
-```bash
-git add packages/channels/feishu/src/FeishuAdapter.ts packages/channels/feishu/src/adapter.test.ts
-git commit -m "fix(feishu): wait for authenticated WebSocket startup"
-```
-
-### Task 2: Verify the real daemon-worker regression
-
-**Files:**
-- Create: `.qwen/e2e-tests/feishu-worker-credential-validation.md`
-- Verify: `packages/cli/dist/index.js`
-
-**Interfaces:**
-- Consumes: `qwen serve --channel <name>` and `GET /daemon/status`.
-- Produces: Reproduction evidence that invalid Feishu credentials prevent worker readiness and terminate startup.
-
-- [ ] **Step 1: Build the CLI and channel packages**
-
-Run the repository build using the available Node runtime. If the complete build fails outside the changed packages, record the exact unrelated failure and build the Feishu and CLI package outputs needed by the E2E instead.
-
-- [ ] **Step 2: Run the isolated invalid-credential E2E**
-
-Create temporary `QWEN_HOME`, `QWEN_RUNTIME_DIR`, and workspace directories under `/tmp`. Configure a Feishu WebSocket channel with `clientId: "cli_0000000000000000"` and `clientSecret: "definitely-not-a-feishu-secret"`. Start `qwen serve --channel bad-feishu` with fake local model configuration.
-
-Expected evidence:
-
-```text
-[Channel] Failed to connect "bad-feishu": Channel "bad-feishu" failed to authenticate Feishu credentials.
-[Channel] daemon worker failed: No channels connected.
-Channel worker exited before ready (code=1, signal=null).
-```
-
-Confirm the worker never reports `"bad-feishu" connected`, never sends `ready`, and the serve process exits with code 1.
-
-- [ ] **Step 3: Record the E2E report**
-
-Write `.qwen/e2e-tests/feishu-worker-credential-validation.md` with the tested commit, commands, redacted configuration, timestamps, exit code, and before/after log excerpts. This path is git-ignored and must not be committed.
-
-### Task 3: Final verification, review, and PR delivery
-
-**Files:**
-- Review: all changes from `origin/main...HEAD`, including untracked files.
-- Use: `.github/pull_request_template.md`
-
-**Interfaces:**
-- Consumes: committed design, implementation, unit-test evidence, typecheck/build evidence, and E2E report.
-- Produces: pushed branch and a GitHub pull request linked to #6779.
-
-- [ ] **Step 1: Run final focused verification**
-
-Run the full Feishu adapter test file, Feishu package build/typecheck, `git diff --check`, and the isolated daemon-worker regression. Record exact pass counts and exit codes.
-
-- [ ] **Step 2: Perform the repository self-audit**
-
-Read the complete diff and new files without targeting a specific suspected defect. Verify every behavioral claim and green test under the assumption it may be wrong. Continue until two consecutive passes find no issue; any fix resets the clean-pass count and reruns verification.
-
-- [ ] **Step 3: Run code review and triage findings**
-
-Run the available review workflow against the exact HEAD. Classify each result as valid, false positive, or overthinking. Apply valid fixes through another RED/GREEN cycle and repeat verification.
-
-- [ ] **Step 4: Push the branch**
-
-```bash
-git push -u fork fix/feishu-worker-credential-validation
-```
-
-- [ ] **Step 5: Create the PR from the repository template**
-
-Create the PR from `BenGuanRan:fix/feishu-worker-credential-validation` to `QwenLM/qwen-code:main`. Describe motivation and behavior in prose without naming implementation files or functions. Include reviewer behavior checks, macOS evidence, risk boundaries, a complete Chinese translation, and:
-
-```text
-Fixes #6779
-```
-
-- [ ] **Step 6: Post the separate E2E report comment**
-
-Post the contents of `.qwen/e2e-tests/feishu-worker-credential-validation.md` as a PR comment, then verify the PR URL, head commit, linked issue text, checks state, and comment URL through `gh`.
+**Goal:** Reject invalid Feishu WebSocket credentials before a daemon-managed
+channel worker reports the channel as connected, without waiting for a real
+WebSocket handshake or extending daemon startup time by a handshake timeout.
+
+**Architecture:** Keep the change inside the Feishu adapter. Reuse the existing
+tenant-token request as a WebSocket-only credential preflight, then preserve the
+original `WSClient.start()` semantics and SDK reconnect defaults.
+
+**Tech Stack:** TypeScript, Vitest, `@larksuiteoapi/node-sdk`, Qwen Code
+daemon-managed channel worker.
+
+## Constraints
+
+- Use branch `fix/feishu-worker-credential-validation` without a `codex/`
+  prefix.
+- Use Conventional Commits and author `hit_aran <hit_aran@163.com>`.
+- Limit production changes to the Feishu adapter.
+- Do not patch or fork the Lark SDK.
+- Preserve webhook behavior.
+- Do not wait for `onReady`, handle adapter-level `onError`, or add a handshake
+  timeout.
+- Do not override the SDK's reconnect defaults.
+
+## Implementation
+
+### 1. Add credential-only regression coverage
+
+- [x] Use a hoisted `WSClient` test double because the mock is consumed by
+      `vi.mock()` at module load time.
+- [x] Verify an HTTP 401 token response rejects `connect()` with sanitized
+      Feishu authentication context before `WSClient.start()` is called.
+- [x] Verify successful token and bot-info responses allow `connect()` to
+      resolve when `WSClient.start()` resolves, without invoking `onReady`.
+- [x] Remove tests that require `onReady` gating, adapter-level `onError`
+      propagation, handshake timeout, or late-callback cleanup.
+- [x] Run the start-promise test against the callback-gated implementation and
+      confirm it fails because `connect()` remains pending.
+
+### 2. Implement the minimal adapter change
+
+- [x] In WebSocket mode, obtain a tenant access token before constructing the
+      SDK client.
+- [x] Throw a concise authentication error when no token is returned.
+- [x] Leave webhook mode outside the new preflight.
+- [x] Restore simple `WSClient` construction followed by `await start()`.
+- [x] Remove the adapter handshake timeout, readiness callbacks, and socket
+      callback state machine.
+
+### 3. Verify and audit
+
+- Run the focused WebSocket connect tests and complete Feishu adapter test file.
+- Run the Feishu TypeScript build.
+- Verify Prettier formatting for changed tracked files and run
+  `git diff --check`.
+- Review the complete branch diff for unrelated changes and stale
+  handshake-readiness claims.
+- Commit the narrowed change without pushing or mutating the existing pull
+  request or issue.
+
+## Accepted Boundary
+
+With valid credentials, worker `ready` still indicates that credential
+validation and the SDK start call completed; it does not prove the WebSocket
+handshake completed. A consistent, cancellable readiness contract across all
+channel adapters is future architecture work rather than part of issue #6779.

--- a/docs/superpowers/plans/2026-07-12-feishu-worker-credential-validation.md
+++ b/docs/superpowers/plans/2026-07-12-feishu-worker-credential-validation.md
@@ -1,0 +1,230 @@
+# Feishu Worker Credential Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Feishu WebSocket startup reject invalid credentials and wait for a real initial WebSocket handshake before a daemon-managed channel worker reports ready.
+
+**Architecture:** Keep the fix inside the Feishu adapter. Preflight the existing tenant-token request, then adapt the Lark SDK's callback-based readiness events into a bounded promise, following the readiness pattern already shipped in the SDK's higher-level `LarkChannel` implementation.
+
+**Tech Stack:** TypeScript, Vitest, `@larksuiteoapi/node-sdk`, Qwen Code daemon-managed channel worker.
+
+## Global Constraints
+
+- Branch name is `fix/feishu-worker-credential-validation`; do not use a `codex/` prefix.
+- All commits use `hit_aran <hit_aran@163.com>` and Conventional Commits.
+- Limit production changes to the Feishu adapter; do not patch or fork the Lark SDK.
+- Preserve Feishu webhook behavior and post-ready SDK automatic reconnect behavior.
+- Use the repository PR template, push the branch, include `Fixes #6779`, and post E2E evidence as a separate PR comment.
+
+---
+
+### Task 1: Implement the Feishu WebSocket readiness contract with TDD
+
+**Files:**
+- Modify: `packages/channels/feishu/src/FeishuAdapter.ts`
+- Modify: `packages/channels/feishu/src/adapter.test.ts`
+- Test: `packages/channels/feishu/src/adapter.test.ts`
+
+**Interfaces:**
+- Consumes: `FeishuChannel.connect(): Promise<void>`, `getTenantAccessToken(): Promise<string | undefined>`, and the Lark `WSClient` constructor callbacks.
+- Produces: A bounded authenticated `connectWebSocket(): Promise<void>` plus regression coverage for credential preflight, `onReady` gating, `onError` propagation, and a 15-second startup timeout.
+
+- [ ] **Step 1: Add a hoisted Lark `WSClient` test double**
+
+Use `vi.hoisted()` because the state is consumed by `vi.mock()` at module-load time. Preserve the real SDK exports and replace only `WSClient`:
+
+```ts
+const wsMock = vi.hoisted(() => ({
+  close: vi.fn(),
+  options: undefined as
+    | { onReady?: () => void; onError?: (error: Error) => void }
+    | undefined,
+  start: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@larksuiteoapi/node-sdk')>();
+  return {
+    ...actual,
+    WSClient: class {
+      constructor(options: typeof wsMock.options) {
+        wsMock.options = options;
+      }
+
+      start = wsMock.start;
+      close = wsMock.close;
+    },
+  };
+});
+```
+
+Reset the test double before each WebSocket-connect test and default `start()` to a resolved promise.
+
+- [ ] **Step 2: Add the invalid-credential regression test**
+
+Mock the tenant-token request with HTTP 401, call `connect()`, and assert:
+
+```ts
+await expect(channel.connect()).rejects.toThrow(
+  'failed to authenticate Feishu credentials',
+);
+expect(wsMock.start).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 3: Add initial WebSocket readiness tests**
+
+Use a successful tenant-token response and verify that `connect()` remains pending until `wsMock.options?.onReady?.()` is invoked. Add a second test invoking `onError(new Error('credential rejected'))` and assert that `connect()` rejects with Feishu WebSocket context and closes the SDK client.
+
+- [ ] **Step 4: Add the handshake-timeout test**
+
+Use Vitest fake timers, return a successful token, leave both SDK callbacks silent, advance 15 seconds, and assert that `connect()` rejects with `WebSocket handshake did not complete within 15000ms` and closes the SDK client. Restore real timers in `finally`.
+
+- [ ] **Step 5: Run the focused tests and verify RED**
+
+Run from `packages/channels/feishu`:
+
+```bash
+node ../../../node_modules/vitest/vitest.mjs run src/adapter.test.ts
+```
+
+Expected: the new tests fail because the current adapter neither authenticates before constructing `WSClient` nor waits for the SDK readiness callbacks.
+
+- [ ] **Step 6: Add the startup timeout constant**
+
+Define the adapter-local bound next to the existing constants:
+
+```ts
+const FEISHU_WS_STARTUP_TIMEOUT_MS = 15_000;
+```
+
+- [ ] **Step 7: Require credential preflight for WebSocket mode**
+
+Before `connectWebSocket()` is called, reuse the existing token cache path:
+
+```ts
+const token = await this.getTenantAccessToken();
+if (!token) {
+  throw new Error(
+    `Channel "${this.name}" failed to authenticate Feishu credentials.`,
+  );
+}
+await this.connectWebSocket();
+```
+
+Do not add this gate to webhook mode.
+
+- [ ] **Step 8: Convert SDK callbacks into a bounded readiness promise**
+
+Construct the SDK client with `autoReconnect: true`, `onReady`, and `onError`. Use one settle function that clears the timer. On failure, close the client, clear `this.wsClient`, and reject. Start the SDK client with `void client.start(...).catch(fail)` so synchronous or promise-level SDK errors also reject.
+
+The timeout error text must be:
+
+```text
+Feishu WebSocket handshake did not complete within 15000ms.
+```
+
+The SDK error wrapper must begin with:
+
+```text
+Feishu WebSocket connection failed:
+```
+
+- [ ] **Step 9: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+node ../../../node_modules/vitest/vitest.mjs run src/adapter.test.ts
+```
+
+Expected: all Feishu adapter tests pass with no unhandled promise rejection or leaked fake timer.
+
+- [ ] **Step 10: Run package typecheck/build verification**
+
+Run from the repository root with the bundled Node runtime on `PATH`:
+
+```bash
+node node_modules/typescript/bin/tsc --build packages/channels/feishu --pretty false
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 11: Commit the implementation**
+
+```bash
+git add packages/channels/feishu/src/FeishuAdapter.ts packages/channels/feishu/src/adapter.test.ts
+git commit -m "fix(feishu): wait for authenticated WebSocket startup"
+```
+
+### Task 2: Verify the real daemon-worker regression
+
+**Files:**
+- Create: `.qwen/e2e-tests/feishu-worker-credential-validation.md`
+- Verify: `packages/cli/dist/index.js`
+
+**Interfaces:**
+- Consumes: `qwen serve --channel <name>` and `GET /daemon/status`.
+- Produces: Reproduction evidence that invalid Feishu credentials prevent worker readiness and terminate startup.
+
+- [ ] **Step 1: Build the CLI and channel packages**
+
+Run the repository build using the available Node runtime. If the complete build fails outside the changed packages, record the exact unrelated failure and build the Feishu and CLI package outputs needed by the E2E instead.
+
+- [ ] **Step 2: Run the isolated invalid-credential E2E**
+
+Create temporary `QWEN_HOME`, `QWEN_RUNTIME_DIR`, and workspace directories under `/tmp`. Configure a Feishu WebSocket channel with `clientId: "cli_0000000000000000"` and `clientSecret: "definitely-not-a-feishu-secret"`. Start `qwen serve --channel bad-feishu` with fake local model configuration.
+
+Expected evidence:
+
+```text
+[Channel] Failed to connect "bad-feishu": Channel "bad-feishu" failed to authenticate Feishu credentials.
+[Channel] daemon worker failed: No channels connected.
+Channel worker exited before ready (code=1, signal=null).
+```
+
+Confirm the worker never reports `"bad-feishu" connected`, never sends `ready`, and the serve process exits with code 1.
+
+- [ ] **Step 3: Record the E2E report**
+
+Write `.qwen/e2e-tests/feishu-worker-credential-validation.md` with the tested commit, commands, redacted configuration, timestamps, exit code, and before/after log excerpts. This path is git-ignored and must not be committed.
+
+### Task 3: Final verification, review, and PR delivery
+
+**Files:**
+- Review: all changes from `origin/main...HEAD`, including untracked files.
+- Use: `.github/pull_request_template.md`
+
+**Interfaces:**
+- Consumes: committed design, implementation, unit-test evidence, typecheck/build evidence, and E2E report.
+- Produces: pushed branch and a GitHub pull request linked to #6779.
+
+- [ ] **Step 1: Run final focused verification**
+
+Run the full Feishu adapter test file, Feishu package build/typecheck, `git diff --check`, and the isolated daemon-worker regression. Record exact pass counts and exit codes.
+
+- [ ] **Step 2: Perform the repository self-audit**
+
+Read the complete diff and new files without targeting a specific suspected defect. Verify every behavioral claim and green test under the assumption it may be wrong. Continue until two consecutive passes find no issue; any fix resets the clean-pass count and reruns verification.
+
+- [ ] **Step 3: Run code review and triage findings**
+
+Run the available review workflow against the exact HEAD. Classify each result as valid, false positive, or overthinking. Apply valid fixes through another RED/GREEN cycle and repeat verification.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u fork fix/feishu-worker-credential-validation
+```
+
+- [ ] **Step 5: Create the PR from the repository template**
+
+Create the PR from `BenGuanRan:fix/feishu-worker-credential-validation` to `QwenLM/qwen-code:main`. Describe motivation and behavior in prose without naming implementation files or functions. Include reviewer behavior checks, macOS evidence, risk boundaries, a complete Chinese translation, and:
+
+```text
+Fixes #6779
+```
+
+- [ ] **Step 6: Post the separate E2E report comment**
+
+Post the contents of `.qwen/e2e-tests/feishu-worker-credential-validation.md` as a PR comment, then verify the PR URL, head commit, linked issue text, checks state, and comment URL through `gh`.

--- a/docs/superpowers/specs/2026-07-12-feishu-worker-credential-validation-design.md
+++ b/docs/superpowers/specs/2026-07-12-feishu-worker-credential-validation-design.md
@@ -2,32 +2,28 @@
 
 ## Problem
 
-In Feishu WebSocket mode, the adapter currently treats the Lark SDK's `WSClient.start()` promise as proof that the socket connected. The SDK actually starts its reconnect loop in the background and resolves `start()` immediately. Invalid credentials are therefore logged asynchronously while the adapter resolves `connect()`, causing the daemon-managed channel worker to report `ready` and remain `running`.
+In Feishu WebSocket mode, the Lark SDK's `WSClient.start()` resolves after it
+starts its background connection loop. Invalid app credentials are rejected
+asynchronously by that loop, after the adapter's `connect()` has resolved. A
+daemon-managed channel worker can therefore report the Feishu channel as
+connected and send `ready` even though authentication has failed.
 
-DingTalk provides the expected control behavior: its adapter waits for credential acquisition and socket readiness, rejects invalid credentials, and prevents the worker from sending `ready`.
-
-This change fixes issue #6779 for Feishu's default WebSocket transport. Feishu webhook mode is out of scope.
+DingTalk rejects invalid credentials during startup. Issue #6779 asks Feishu to
+provide the same immediate credential-failure behavior. This change is limited
+to credential validation for Feishu's default WebSocket transport.
 
 ## Selected Approach
 
-The adapter will perform two sequential startup checks:
+Before constructing the WebSocket client, the adapter obtains a tenant access
+token through its existing token-cache path. If the request does not return a
+token, `connect()` throws a sanitized authentication error and never calls
+`WSClient.start()`.
 
-1. Validate the configured app ID and secret by obtaining a tenant access token before starting the WebSocket client. Failure to obtain a token rejects `connect()` immediately with a sanitized Feishu authentication error.
-2. Wait for the SDK's first successful WebSocket handshake through `onReady`. Reject through `onError`, and reject if no handshake completes within 15 seconds.
-
-This matches the readiness pattern already implemented by the installed Lark SDK's higher-level `LarkChannel`: credential-dependent bot identity retrieval happens before WebSocket startup, and WebSocket startup resolves only after `onReady` with a 15-second bound.
-
-The SDK client keeps `autoReconnect: true` after the initial connection, so existing post-start reconnect behavior is preserved.
-
-## Alternatives Considered
-
-### Credential preflight only
-
-This is smaller, but it still allows valid credentials with a failed WebSocket handshake to be reported as connected. It does not satisfy the adapter's `connect()` contract or the expectation recorded in #6779.
-
-### Patch the Lark SDK
-
-Changing `WSClient.start()` itself would affect every SDK consumer and add dependency maintenance burden. The SDK already exposes `onReady`, `onError`, and handshake state for adapters to implement a bounded readiness contract, so a repository-local adapter fix is sufficient.
+After successful credential validation, startup keeps its original semantics:
+construct `WSClient`, await its `start()` promise, then continue normal adapter
+initialization. The adapter does not add `onReady` or `onError` callbacks, does
+not impose a handshake timeout, and does not override the SDK's reconnect
+defaults.
 
 ## Startup Flow
 
@@ -35,35 +31,56 @@ For WebSocket mode:
 
 1. Build and register the event dispatcher.
 2. Request a tenant access token using the configured app ID and secret.
-3. If no token is returned, throw an authentication error without constructing or starting `WSClient`.
-4. Construct `WSClient` with `autoReconnect: true`, `onReady`, `onError`, and the existing credentials.
-5. Start the SDK client and wait for either `onReady`, `onError`, or the 15-second startup timer.
-6. On failure or timeout, close the SDK client and reject `connect()`.
-7. On success, fetch bot metadata using the cached tenant token, start adapter housekeeping, and resolve `connect()`.
-8. The worker adds the channel to its connected set and sends `ready` only after step 7.
+3. If no token is returned, throw a concise authentication error without
+   constructing or starting `WSClient`.
+4. Construct `WSClient` with the existing credentials and logger level.
+5. Await `WSClient.start()` using the SDK's existing semantics.
+6. Fetch bot metadata using the cached tenant token and finish adapter startup.
 
-Webhook mode retains its current local validation, listener startup, and bot metadata behavior.
+Webhook mode keeps its existing validation, listener startup, and bot metadata
+behavior. It does not run the new WebSocket credential preflight.
 
-## Error Handling
+## Readiness Boundary
 
-- Invalid or rejected credentials produce a concise adapter error that does not include the app secret or raw response payload.
-- An SDK `onError` failure is wrapped with Feishu WebSocket context while preserving the original message.
-- A missing `onReady` callback after 15 seconds produces a deterministic handshake timeout error.
-- Failed WebSocket startup closes the SDK client and clears the stored client reference so daemon-worker cleanup remains idempotent.
-- Once the initial handshake succeeds, existing SDK automatic reconnect behavior remains unchanged.
+For invalid credentials, the worker now receives an immediate adapter failure
+and cannot count that Feishu channel as connected.
+
+For valid credentials, worker `ready` still means credential validation and
+the SDK start call completed; it does not prove that the first WebSocket
+handshake completed. Waiting for a real handshake is intentionally outside this
+fix because the installed SDK cannot safely cancel its provisional socket after
+a timeout while preserving its normal reconnect lifecycle.
+
+Unifying readiness semantics across channel adapters, parallelizing multi-
+channel startup, and adding a cancellable Feishu handshake lifecycle are future
+architecture work.
+
+## Alternatives Considered
+
+### Wait for the SDK `onReady` callback
+
+This would make Feishu readiness closer to DingTalk readiness, but it adds the
+network handshake to daemon startup time. More importantly, timing out the
+adapter-level wait cannot reliably stop the SDK's provisional socket or later
+automatic retries through the public API.
+
+### Patch or fork the Lark SDK
+
+Owning the socket lifecycle in a dependency fork could support cancellable
+handshake readiness, but it is disproportionate to the credential-validation
+bug and would add cross-dependency maintenance.
 
 ## Tests
 
-Unit tests will cover these observable behaviors:
+Unit coverage verifies that:
 
-1. Invalid credentials reject before `WSClient.start()` and do not report a successful connection.
-2. `connect()` stays pending until the SDK invokes `onReady`, then resolves.
-3. SDK `onError` rejects `connect()` and closes the client.
-4. A missing callback rejects after the configured 15-second startup bound using fake timers.
-5. Existing webhook behavior and the full Feishu adapter test file remain green.
-
-The regression will also be verified through an isolated daemon-worker E2E using fake Feishu credentials. Expected behavior is `Failed to connect`, `No channels connected`, worker exit before `ready`, and final `qwen serve` exit code 1. The DingTalk control remains unchanged.
+1. Invalid credentials reject before `WSClient.start()`.
+2. After successful token and bot-info responses, `connect()` resolves when
+   `WSClient.start()` resolves without requiring an `onReady` callback.
+3. Existing Feishu adapter behavior, including webhook behavior, remains green.
 
 ## Delivery
 
-The implementation will use branch `fix/feishu-worker-credential-validation`, Conventional Commits, and the repository pull request template. The PR body will include `Fixes #6779`. The E2E report will be posted as a separate PR comment, as required by the repository guidelines.
+The implementation uses branch `fix/feishu-worker-credential-validation`,
+Conventional Commits, and author `hit_aran <hit_aran@163.com>`. The pull request
+links issue #6779 with `Fixes #6779`.

--- a/docs/superpowers/specs/2026-07-12-feishu-worker-credential-validation-design.md
+++ b/docs/superpowers/specs/2026-07-12-feishu-worker-credential-validation-design.md
@@ -1,0 +1,69 @@
+# Feishu Worker Credential Validation Design
+
+## Problem
+
+In Feishu WebSocket mode, the adapter currently treats the Lark SDK's `WSClient.start()` promise as proof that the socket connected. The SDK actually starts its reconnect loop in the background and resolves `start()` immediately. Invalid credentials are therefore logged asynchronously while the adapter resolves `connect()`, causing the daemon-managed channel worker to report `ready` and remain `running`.
+
+DingTalk provides the expected control behavior: its adapter waits for credential acquisition and socket readiness, rejects invalid credentials, and prevents the worker from sending `ready`.
+
+This change fixes issue #6779 for Feishu's default WebSocket transport. Feishu webhook mode is out of scope.
+
+## Selected Approach
+
+The adapter will perform two sequential startup checks:
+
+1. Validate the configured app ID and secret by obtaining a tenant access token before starting the WebSocket client. Failure to obtain a token rejects `connect()` immediately with a sanitized Feishu authentication error.
+2. Wait for the SDK's first successful WebSocket handshake through `onReady`. Reject through `onError`, and reject if no handshake completes within 15 seconds.
+
+This matches the readiness pattern already implemented by the installed Lark SDK's higher-level `LarkChannel`: credential-dependent bot identity retrieval happens before WebSocket startup, and WebSocket startup resolves only after `onReady` with a 15-second bound.
+
+The SDK client keeps `autoReconnect: true` after the initial connection, so existing post-start reconnect behavior is preserved.
+
+## Alternatives Considered
+
+### Credential preflight only
+
+This is smaller, but it still allows valid credentials with a failed WebSocket handshake to be reported as connected. It does not satisfy the adapter's `connect()` contract or the expectation recorded in #6779.
+
+### Patch the Lark SDK
+
+Changing `WSClient.start()` itself would affect every SDK consumer and add dependency maintenance burden. The SDK already exposes `onReady`, `onError`, and handshake state for adapters to implement a bounded readiness contract, so a repository-local adapter fix is sufficient.
+
+## Startup Flow
+
+For WebSocket mode:
+
+1. Build and register the event dispatcher.
+2. Request a tenant access token using the configured app ID and secret.
+3. If no token is returned, throw an authentication error without constructing or starting `WSClient`.
+4. Construct `WSClient` with `autoReconnect: true`, `onReady`, `onError`, and the existing credentials.
+5. Start the SDK client and wait for either `onReady`, `onError`, or the 15-second startup timer.
+6. On failure or timeout, close the SDK client and reject `connect()`.
+7. On success, fetch bot metadata using the cached tenant token, start adapter housekeeping, and resolve `connect()`.
+8. The worker adds the channel to its connected set and sends `ready` only after step 7.
+
+Webhook mode retains its current local validation, listener startup, and bot metadata behavior.
+
+## Error Handling
+
+- Invalid or rejected credentials produce a concise adapter error that does not include the app secret or raw response payload.
+- An SDK `onError` failure is wrapped with Feishu WebSocket context while preserving the original message.
+- A missing `onReady` callback after 15 seconds produces a deterministic handshake timeout error.
+- Failed WebSocket startup closes the SDK client and clears the stored client reference so daemon-worker cleanup remains idempotent.
+- Once the initial handshake succeeds, existing SDK automatic reconnect behavior remains unchanged.
+
+## Tests
+
+Unit tests will cover these observable behaviors:
+
+1. Invalid credentials reject before `WSClient.start()` and do not report a successful connection.
+2. `connect()` stays pending until the SDK invokes `onReady`, then resolves.
+3. SDK `onError` rejects `connect()` and closes the client.
+4. A missing callback rejects after the configured 15-second startup bound using fake timers.
+5. Existing webhook behavior and the full Feishu adapter test file remain green.
+
+The regression will also be verified through an isolated daemon-worker E2E using fake Feishu credentials. Expected behavior is `Failed to connect`, `No channels connected`, worker exit before `ready`, and final `qwen serve` exit code 1. The DingTalk control remains unchanged.
+
+## Delivery
+
+The implementation will use branch `fix/feishu-worker-credential-validation`, Conventional Commits, and the repository pull request template. The PR body will include `Fixes #6779`. The E2E report will be posted as a separate PR comment, as required by the repository guidelines.

--- a/packages/channels/feishu/src/FeishuAdapter.ts
+++ b/packages/channels/feishu/src/FeishuAdapter.ts
@@ -311,7 +311,13 @@ export class FeishuChannel extends ChannelBase {
         appSecret: this.config.clientSecret!,
         loggerLevel: lark.LoggerLevel.warn,
         autoReconnect: true,
-        onReady: () => settle(),
+        onReady: () => {
+          if (settled) {
+            client.close();
+            return;
+          }
+          settle();
+        },
         onError: fail,
       });
       this.wsClient = client;

--- a/packages/channels/feishu/src/FeishuAdapter.ts
+++ b/packages/channels/feishu/src/FeishuAdapter.ts
@@ -85,8 +85,6 @@ const DEDUP_TTL_MS = 5 * 60 * 1000;
 /** Minimum interval between card updates (ms) to avoid API rate limiting. */
 const CARD_UPDATE_INTERVAL_MS = 1500;
 
-const FEISHU_WS_STARTUP_TIMEOUT_MS = 15_000;
-
 const FEISHU_RUNNING_STATUS_LABEL = '运行中...';
 const FEISHU_STOPPED_STATUS_LABEL = '已停止生成';
 const FEISHU_STOP_FAILED_STATUS_LABEL = '停止失败，请重试';
@@ -284,53 +282,13 @@ export class FeishuChannel extends ChannelBase {
   }
 
   private async connectWebSocket(): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      let client: lark.WSClient;
-
-      const settle = (error?: Error) => {
-        if (settled) return;
-        settled = true;
-        if (timer) clearTimeout(timer);
-        if (error) {
-          client.close();
-          this.wsClient = undefined;
-          reject(error);
-        } else {
-          resolve();
-        }
-      };
-      const fail = (error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
-        settle(new Error(`Feishu WebSocket connection failed: ${message}`));
-      };
-
-      client = new lark.WSClient({
-        appId: this.config.clientId!,
-        appSecret: this.config.clientSecret!,
-        loggerLevel: lark.LoggerLevel.warn,
-        autoReconnect: true,
-        onReady: () => {
-          if (settled) {
-            client.close();
-            return;
-          }
-          settle();
-        },
-        onError: fail,
-      });
-      this.wsClient = client;
-      timer = setTimeout(() => {
-        settle(
-          new Error(
-            `Feishu WebSocket handshake did not complete within ${FEISHU_WS_STARTUP_TIMEOUT_MS}ms.`,
-          ),
-        );
-      }, FEISHU_WS_STARTUP_TIMEOUT_MS);
-
-      void client.start({ eventDispatcher: this.eventDispatcher }).catch(fail);
+    this.wsClient = new lark.WSClient({
+      appId: this.config.clientId!,
+      appSecret: this.config.clientSecret!,
+      loggerLevel: lark.LoggerLevel.warn,
     });
+
+    await this.wsClient.start({ eventDispatcher: this.eventDispatcher });
   }
 
   private async connectWebhook(

--- a/packages/channels/feishu/src/FeishuAdapter.ts
+++ b/packages/channels/feishu/src/FeishuAdapter.ts
@@ -85,6 +85,8 @@ const DEDUP_TTL_MS = 5 * 60 * 1000;
 /** Minimum interval between card updates (ms) to avoid API rate limiting. */
 const CARD_UPDATE_INTERVAL_MS = 1500;
 
+const FEISHU_WS_STARTUP_TIMEOUT_MS = 15_000;
+
 const FEISHU_RUNNING_STATUS_LABEL = '运行中...';
 const FEISHU_STOPPED_STATUS_LABEL = '已停止生成';
 const FEISHU_STOP_FAILED_STATUS_LABEL = '停止失败，请重试';
@@ -216,6 +218,12 @@ export class FeishuChannel extends ChannelBase {
       await this.connectWebhook(webhookPort, verificationToken, encryptKey);
     } else {
       // WebSocket mode (default, like DingTalk Stream)
+      const token = await this.getTenantAccessToken();
+      if (!token) {
+        throw new Error(
+          `Channel "${this.name}" failed to authenticate Feishu credentials.`,
+        );
+      }
       await this.connectWebSocket();
     }
 
@@ -276,13 +284,47 @@ export class FeishuChannel extends ChannelBase {
   }
 
   private async connectWebSocket(): Promise<void> {
-    this.wsClient = new lark.WSClient({
-      appId: this.config.clientId!,
-      appSecret: this.config.clientSecret!,
-      loggerLevel: lark.LoggerLevel.warn,
-    });
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let client: lark.WSClient;
 
-    await this.wsClient.start({ eventDispatcher: this.eventDispatcher });
+      const settle = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (error) {
+          client.close();
+          this.wsClient = undefined;
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+      const fail = (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        settle(new Error(`Feishu WebSocket connection failed: ${message}`));
+      };
+
+      client = new lark.WSClient({
+        appId: this.config.clientId!,
+        appSecret: this.config.clientSecret!,
+        loggerLevel: lark.LoggerLevel.warn,
+        autoReconnect: true,
+        onReady: () => settle(),
+        onError: fail,
+      });
+      this.wsClient = client;
+      timer = setTimeout(() => {
+        settle(
+          new Error(
+            `Feishu WebSocket handshake did not complete within ${FEISHU_WS_STARTUP_TIMEOUT_MS}ms.`,
+          ),
+        );
+      }, FEISHU_WS_STARTUP_TIMEOUT_MS);
+
+      void client.start({ eventDispatcher: this.eventDispatcher }).catch(fail);
+    });
   }
 
   private async connectWebhook(

--- a/packages/channels/feishu/src/adapter.test.ts
+++ b/packages/channels/feishu/src/adapter.test.ts
@@ -1,4 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const wsMock = vi.hoisted(() => ({
+  close: vi.fn(),
+  options: undefined as
+    | { onReady?: () => void; onError?: (error: Error) => void }
+    | undefined,
+  start: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@larksuiteoapi/node-sdk')>();
+  return {
+    ...actual,
+    WSClient: class {
+      constructor(options: typeof wsMock.options) {
+        wsMock.options = options;
+      }
+
+      start = wsMock.start;
+      close = wsMock.close;
+    },
+  };
+});
+
 import { FeishuChannel } from './FeishuAdapter.js';
 import type {
   ChannelAgentBridge,
@@ -862,6 +887,104 @@ describe('FeishuChannel', () => {
       });
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('connect: WebSocket', () => {
+    beforeEach(() => {
+      wsMock.close.mockReset();
+      wsMock.options = undefined;
+      wsMock.start.mockReset().mockResolvedValue(undefined);
+    });
+
+    function mockSuccessfulTokenFetch(): void {
+      vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+        if (String(input).includes('/tenant_access_token/internal')) {
+          return new Response(
+            JSON.stringify({
+              tenant_access_token: 'test_token',
+              expire: 3600,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ bot: { open_id: 'bot_id' } }), {
+          status: 200,
+        });
+      });
+    }
+
+    it('rejects invalid credentials before starting WebSocket', async () => {
+      const channel = createChannel();
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(null, { status: 401 }),
+      );
+
+      await expect(channel.connect()).rejects.toThrow(
+        'failed to authenticate Feishu credentials',
+      );
+      expect(wsMock.start).not.toHaveBeenCalled();
+    });
+
+    it('waits for the initial WebSocket handshake', async () => {
+      const channel = createChannel();
+      mockSuccessfulTokenFetch();
+      let settled = false;
+
+      const connectPromise = channel.connect();
+      void connectPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await vi.waitFor(() => expect(wsMock.start).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(settled).toBe(false);
+
+      wsMock.options?.onReady?.();
+      await connectPromise;
+      expect(settled).toBe(true);
+      channel.disconnect();
+    });
+
+    it('rejects and closes when the initial WebSocket handshake fails', async () => {
+      const channel = createChannel();
+      mockSuccessfulTokenFetch();
+
+      const connectPromise = channel.connect();
+      await vi.waitFor(() => expect(wsMock.start).toHaveBeenCalledOnce());
+      wsMock.options?.onError?.(new Error('credential rejected'));
+
+      await expect(connectPromise).rejects.toThrow(
+        'Feishu WebSocket connection failed: credential rejected',
+      );
+      expect(wsMock.close).toHaveBeenCalledOnce();
+    });
+
+    it('rejects and closes when the initial WebSocket handshake times out', async () => {
+      vi.useFakeTimers();
+      try {
+        const channel = createChannel();
+        mockSuccessfulTokenFetch();
+
+        const connectPromise = channel.connect();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(wsMock.start).toHaveBeenCalledOnce();
+        const rejection = expect(connectPromise).rejects.toThrow(
+          'WebSocket handshake did not complete within 15000ms',
+        );
+
+        await vi.advanceTimersByTimeAsync(15_000);
+
+        await rejection;
+        expect(wsMock.close).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/channels/feishu/src/adapter.test.ts
+++ b/packages/channels/feishu/src/adapter.test.ts
@@ -982,6 +982,9 @@ describe('FeishuChannel', () => {
 
         await rejection;
         expect(wsMock.close).toHaveBeenCalledOnce();
+
+        wsMock.options?.onReady?.();
+        expect(wsMock.close).toHaveBeenCalledTimes(2);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/channels/feishu/src/adapter.test.ts
+++ b/packages/channels/feishu/src/adapter.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const wsMock = vi.hoisted(() => ({
   close: vi.fn(),
-  options: undefined as
-    | { onReady?: () => void; onError?: (error: Error) => void }
-    | undefined,
   start: vi.fn<() => Promise<void>>(),
 }));
 
@@ -14,10 +11,6 @@ vi.mock('@larksuiteoapi/node-sdk', async (importOriginal) => {
   return {
     ...actual,
     WSClient: class {
-      constructor(options: typeof wsMock.options) {
-        wsMock.options = options;
-      }
-
       start = wsMock.start;
       close = wsMock.close;
     },
@@ -893,7 +886,6 @@ describe('FeishuChannel', () => {
   describe('connect: WebSocket', () => {
     beforeEach(() => {
       wsMock.close.mockReset();
-      wsMock.options = undefined;
       wsMock.start.mockReset().mockResolvedValue(undefined);
     });
 
@@ -926,68 +918,14 @@ describe('FeishuChannel', () => {
       expect(wsMock.start).not.toHaveBeenCalled();
     });
 
-    it('waits for the initial WebSocket handshake', async () => {
+    it('resolves after the SDK start promise without waiting for onReady', async () => {
       const channel = createChannel();
       mockSuccessfulTokenFetch();
-      let settled = false;
 
-      const connectPromise = channel.connect();
-      void connectPromise.then(
-        () => {
-          settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
-      await vi.waitFor(() => expect(wsMock.start).toHaveBeenCalledOnce());
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await channel.connect();
 
-      expect(settled).toBe(false);
-
-      wsMock.options?.onReady?.();
-      await connectPromise;
-      expect(settled).toBe(true);
+      expect(wsMock.start).toHaveBeenCalledOnce();
       channel.disconnect();
-    });
-
-    it('rejects and closes when the initial WebSocket handshake fails', async () => {
-      const channel = createChannel();
-      mockSuccessfulTokenFetch();
-
-      const connectPromise = channel.connect();
-      await vi.waitFor(() => expect(wsMock.start).toHaveBeenCalledOnce());
-      wsMock.options?.onError?.(new Error('credential rejected'));
-
-      await expect(connectPromise).rejects.toThrow(
-        'Feishu WebSocket connection failed: credential rejected',
-      );
-      expect(wsMock.close).toHaveBeenCalledOnce();
-    });
-
-    it('rejects and closes when the initial WebSocket handshake times out', async () => {
-      vi.useFakeTimers();
-      try {
-        const channel = createChannel();
-        mockSuccessfulTokenFetch();
-
-        const connectPromise = channel.connect();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(wsMock.start).toHaveBeenCalledOnce();
-        const rejection = expect(connectPromise).rejects.toThrow(
-          'WebSocket handshake did not complete within 15000ms',
-        );
-
-        await vi.advanceTimersByTimeAsync(15_000);
-
-        await rejection;
-        expect(wsMock.close).toHaveBeenCalledOnce();
-
-        wsMock.options?.onReady?.();
-        expect(wsMock.close).toHaveBeenCalledTimes(2);
-      } finally {
-        vi.useRealTimers();
-      }
     });
   });
 


### PR DESCRIPTION
## What this PR does

Feishu WebSocket startup now validates configured credentials through a tenant-token request before starting the SDK WebSocket client. Invalid credentials reject channel startup immediately, so the failed Feishu channel is not reported connected and cannot make an all-failed daemon worker ready. Successful credentials continue through the existing SDK startup behavior.

## Why it's needed

Previously, credential rejection happened asynchronously after Feishu startup had already returned success. A daemon-managed worker could therefore report an invalid Feishu channel connected and remain running. This change aligns invalid-credential behavior with DingTalk while keeping the fix limited to authentication.

## Reviewer Test Plan

### How to verify

Start a daemon-managed Feishu channel with correctly shaped invalid credentials. Confirm that credential validation fails before the channel is reported connected, worker states are limited to `starting` and `stopped`, and an all-failed server exits naturally with code 1 before ready. Then verify that real valid Feishu credentials still produce a running worker, and that invalid Feishu plus valid DingTalk keeps the worker running with only DingTalk connected.

Accepted limitation: for valid credentials, worker readiness still follows the SDK start promise and does not prove that the first WebSocket handshake completed. This PR adds neither a handshake callback nor an adapter handshake timeout; a cancellable, unified readiness contract is future architecture work.

### Evidence (Before & After)

Before: correctly shaped invalid Feishu credentials could be followed by an incorrect connected report and a `running` worker.

After at `8c60fd49280fa4afd3fd39fd404e060dac18213c`: an explicit Feishu application rejection arrived in 127 ms; the invalid-only server ran for 4.032 seconds, returned 193 status samples with only `starting` and `stopped`, never reported Feishu connected or `running`, and exited naturally with code 1 before ready. A real valid Feishu run reached `running` in 4.398 seconds with only Feishu requested and connected. A 3.389-second mixed run kept the worker running with only valid DingTalk connected while invalid Feishu failed. No real identifiers or secrets are included, and captured output did not expose them.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js v24.14.0 and npm 11.6.2. The complete Feishu adapter test file passed 71/71 tests; the focused WebSocket cases passed 2/2; the Feishu package build, TypeScript build, formatting, and diff checks exited 0. The known full-repository build failure remains unrelated shared dependency resolution before the changed package and was not rerun.

## Risk & Scope

- Main risk or tradeoff: WebSocket startup now requires one tenant-token request before SDK startup. The invalid-credential probe completed in 127 ms in the final run, but token-service availability and latency now directly affect channel startup.
- Not validated / out of scope: Valid credentials do not wait for a proven initial WebSocket handshake; Feishu webhook behavior is unchanged; Windows and Linux were not tested locally; unrelated full-repository dependency failures were not addressed.
- Breaking changes / migration notes: None. Existing valid Feishu configuration and the SDK's existing reconnect/startup behavior are preserved.

## Linked Issues

Fixes #6779

<details>
<summary>中文说明</summary>

## 本 PR 的改动

飞书 WebSocket 启动现在会在启动 SDK WebSocket 客户端之前，通过租户令牌请求校验已配置的凭证。无效凭证会立即使渠道启动失败，因此失败的飞书渠道不会被报告为已连接，也无法让所有渠道都失败的守护进程 worker 进入就绪状态。有效凭证仍沿用现有 SDK 启动行为。

## 为什么需要此改动

此前，凭证拒绝会在飞书启动已经返回成功后异步发生。因此，守护进程管理的 worker 可能把无效的飞书渠道报告为已连接并继续运行。本改动让无效凭证行为与钉钉一致，同时将修复范围限定在身份认证。

## 评审测试计划

### 验证方法

使用格式正确但无效的凭证启动守护进程管理的飞书渠道。确认凭证校验在渠道被报告为已连接前失败，worker 状态仅出现 `starting` 和 `stopped`，并且当所有渠道都失败时，服务会在就绪前自然退出且退出码为 1。随后验证真实有效的飞书凭证仍能让 worker 进入运行状态，并验证无效飞书加有效钉钉时，worker 会继续运行且只有钉钉处于已连接状态。

已接受的限制：对于有效凭证，worker 就绪仍跟随 SDK 启动 Promise，并不能证明首次 WebSocket 握手已经完成。本 PR 不增加握手回调，也不增加适配器握手超时；可取消且统一的就绪契约属于后续架构工作。

### 证据（改动前后）

改动前：格式正确但无效的飞书凭证可能先触发失败，随后渠道仍被错误报告为已连接，worker 也会保持 `running`。

改动后，在 `8c60fd49280fa4afd3fd39fd404e060dac18213c` 上：飞书在 127 毫秒内返回明确的应用层拒绝；仅包含无效飞书的服务运行 4.032 秒，共返回 193 个状态样本，状态只有 `starting` 和 `stopped`，从未把飞书报告为已连接，也从未进入 `running`，最终在就绪前自然退出且退出码为 1。真实有效飞书运行在 4.398 秒内进入 `running`，请求和连接的渠道都只有飞书。3.389 秒的混合运行保持 worker 运行，只有有效钉钉连接，无效飞书保持失败。正文不包含任何真实标识符或密钥，采集输出也没有暴露这些信息。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|     🪟 Windows    |  ⚠️  |
|      🐧 Linux     |  ⚠️  |

### 环境（可选）

macOS，Node.js v24.14.0，npm 11.6.2。完整飞书适配器测试文件通过 71/71 个测试；聚焦 WebSocket 用例通过 2/2；飞书包构建、TypeScript 构建、格式检查和差异检查均以退出码 0 完成。已知的完整仓库构建失败来自修改包之前的无关共享依赖解析问题，本次没有重新运行。

## 风险与范围

- 主要风险或权衡：WebSocket 启动现在需要在 SDK 启动前执行一次租户令牌请求。最终运行中的无效凭证探测耗时 127 毫秒，但令牌服务的可用性和延迟现在会直接影响渠道启动。
- 未验证 / 不在范围内：有效凭证不会等待已证明成功的首次 WebSocket 握手；飞书 webhook 行为未改变；未在本地测试 Windows 和 Linux；未处理无关的完整仓库依赖失败。
- 破坏性变更 / 迁移说明：无。现有有效飞书配置以及 SDK 现有的重连和启动行为保持不变。

## 关联问题

Fixes #6779

</details>
