### PR TITLE
fix(core): detect dotfiles in getLanguageFromFilePath

### DIFF
--- a/packages/core/src/utils/language-detection.test.ts
+++ b/packages/core/src/utils/language-detection.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getLanguageFromFilePath } from './language-detection.js';
+
+describe('getLanguageFromFilePath', () => {
+  it('detects languages from a normal extension', () => {
+    expect(getLanguageFromFilePath('src/index.ts')).toBe('TypeScript');
+    expect(getLanguageFromFilePath('main.py')).toBe('Python');
+    expect(getLanguageFromFilePath('/abs/path/App.tsx')).toBe('TypeScript');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(getLanguageFromFilePath('README.MD')).toBe('Markdown');
+    expect(getLanguageFromFilePath('Main.PY')).toBe('Python');
+  });
+
+  it('detects extensionless names keyed with a leading dot', () => {
+    expect(getLanguageFromFilePath('Dockerfile')).toBe('Dockerfile');
+    expect(getLanguageFromFilePath('deploy/Dockerfile')).toBe('Dockerfile');
+  });
+
+  it('detects dotfiles whose basename already starts with a dot', () => {
+    // Regression: these were previously probed as `..gitignore` etc. and never
+    // matched, because path.extname() returns '' for a leading-dot basename.
+    expect(getLanguageFromFilePath('.gitignore')).toBe('Git');
+    expect(getLanguageFromFilePath('.dockerignore')).toBe('Docker');
+    expect(getLanguageFromFilePath('.npmignore')).toBe('npm');
+    expect(getLanguageFromFilePath('.editorconfig')).toBe('EditorConfig');
+    expect(getLanguageFromFilePath('.prettierrc')).toBe('Prettier');
+    expect(getLanguageFromFilePath('.eslintrc')).toBe('ESLint');
+    expect(getLanguageFromFilePath('.babelrc')).toBe('Babel');
+  });
+
+  it('detects dotfiles nested in a directory', () => {
+    expect(getLanguageFromFilePath('project/.gitignore')).toBe('Git');
+    expect(getLanguageFromFilePath('/abs/path/.editorconfig')).toBe(
+      'EditorConfig',
+    );
+  });
+
+  it('returns undefined for unknown extensions and bare names', () => {
+    expect(getLanguageFromFilePath('archive.zip')).toBeUndefined();
+    expect(getLanguageFromFilePath('LICENSE')).toBeUndefined();
+    expect(getLanguageFromFilePath('.unknownrc')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/language-detection.ts
+++ b/packages/core/src/utils/language-detection.ts
@@ -98,6 +98,13 @@ export function getLanguageFromFilePath(filePath: string): string | undefined {
   if (extension) {
     return extensionToLanguageMap[extension];
   }
+  // No extension: the basename is either a dotfile (`.gitignore`, keyed
+  // verbatim in the map) or an extensionless name (`Dockerfile`, keyed as
+  // `.dockerfile`). `path.extname` returns '' for both, so try the basename
+  // as-is first, then with a leading dot. Without the as-is lookup, dotfiles
+  // would be probed as `..gitignore` and never match.
   const filename = path.basename(filePath).toLowerCase();
-  return extensionToLanguageMap[`.${filename}`];
+  return (
+    extensionToLanguageMap[filename] ?? extensionToLanguageMap[`.${filename}`]
+  );
 }


### PR DESCRIPTION
## What this PR does

Fixes `getLanguageFromFilePath` so it detects dotfiles (`.gitignore`, `.editorconfig`, etc.), and adds the module's first test file. Previously every dotfile-style key in the language map was unreachable.

## Why it's needed

For a file with no extension, the function falls back to looking up the basename with a leading dot prepended (so `Dockerfile` → `.dockerfile`, which is how those keys are stored). But a dotfile's basename *already* starts with a dot, and `path.extname('.gitignore')` returns `''` — so `.gitignore` also hit the extensionless branch and was looked up as `..gitignore`, which never matches. As a result every dotfile key in the map was dead: `.gitignore`, `.dockerignore`, `.npmignore`, `.editorconfig`, `.prettierrc`, `.eslintrc`, `.babelrc`. The fix tries the basename as-is first, then with a leading dot, so both `Dockerfile`-style and `.gitignore`-style names resolve. This is purely additive: non-dotfile names never start with a dot, so the as-is lookup is always a miss for them and the existing behavior is unchanged. The function feeds the `programmingLanguage` telemetry attribute on the edit/write tools, so today edits to those config files are silently unattributed.

## Reviewer Test Plan

### How to verify

Run the new test file — `npx vitest run src/utils/language-detection.test.ts` from `packages/core` — and confirm all 6 cases pass, including the dotfile regression cases (`.gitignore` → `Git`, `.editorconfig` → `EditorConfig`, etc.). Or read the diff: the added `extensionToLanguageMap[filename]` lookup resolves a leading-dot basename against its verbatim map key before falling back to the previous prepend-a-dot behavior.

### Evidence (Before & After)

Before: `getLanguageFromFilePath('.gitignore')` → `undefined` (looked up as `..gitignore`).
After: `getLanguageFromFilePath('.gitignore')` → `'Git'`. `getLanguageFromFilePath('Dockerfile')` still → `'Dockerfile'`; `getLanguageFromFilePath('src/index.ts')` still → `'TypeScript'`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the 6 new tests (all pass), `prettier --check`, and `eslint` on both files (clean). Windows/Linux: N/A — the change is platform-independent path-string logic with no filesystem access; `path.extname`/`path.basename` behave identically here across platforms.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — the added lookup only matches basenames that begin with a dot, so behavior for all previously-working paths is unchanged; the change strictly enables previously-dead map keys.
- Not validated / out of scope: the contents of the language map itself are unchanged (no new languages/extensions added).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `getLanguageFromFilePath`，使其能够识别点文件（`.gitignore`、`.editorconfig` 等），并为该模块补充了首个测试文件。此前语言映射表中所有点文件形式的键都无法被命中。

## 为什么需要

对于没有扩展名的文件，函数会在基础名前补一个点再查表（例如 `Dockerfile` → `.dockerfile`，这正是这类键的存储形式）。但点文件的基础名本身就以点开头，而 `path.extname('.gitignore')` 返回 `''`，因此 `.gitignore` 同样走进了"无扩展名"分支，被查成 `..gitignore`，永远匹配不上。结果映射表里所有点文件键都成了死键：`.gitignore`、`.dockerignore`、`.npmignore`、`.editorconfig`、`.prettierrc`、`.eslintrc`、`.babelrc`。修复方式是先按基础名原样查表，再退回到补点查表，这样 `Dockerfile` 形式与 `.gitignore` 形式都能解析。此改动纯属增量：非点文件的名字不会以点开头，因此原样查表对它们始终不命中，既有行为保持不变。该函数为 edit/write 工具的 `programmingLanguage` 遥测属性提供数据，因此目前对这些配置文件的编辑在归因上被静默丢失。

## 复核测试计划

### 如何验证

运行新增的测试文件——在 `packages/core` 下执行 `npx vitest run src/utils/language-detection.test.ts`——确认全部 6 个用例通过，包括点文件回归用例（`.gitignore` → `Git`、`.editorconfig` → `EditorConfig` 等）。或阅读 diff：新增的 `extensionToLanguageMap[filename]` 查表会先用以点开头的基础名去匹配其原样键，再退回到此前"补点"的行为。

### 证据（修复前后对比）

修复前：`getLanguageFromFilePath('.gitignore')` → `undefined`（被查成 `..gitignore`）。
修复后：`getLanguageFromFilePath('.gitignore')` → `'Git'`。`getLanguageFromFilePath('Dockerfile')` 仍为 `'Dockerfile'`；`getLanguageFromFilePath('src/index.ts')` 仍为 `'TypeScript'`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 6 个新增测试（全部通过）、`prettier --check` 以及对两个文件的 `eslint`（均无问题）。Windows/Linux：N/A——该改动是与平台无关的路径字符串逻辑，不访问文件系统；`path.extname`/`path.basename` 在各平台行为一致。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——新增的查表只会命中以点开头的基础名，因此此前能正常工作的所有路径行为保持不变；此改动只是启用了此前的死键。
- 未验证 / 范围之外：语言映射表本身内容未改动（未新增语言/扩展名）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
