### PR TITLE
fix(core): reorder LruCache entries on get() for falsy values

### DIFF
--- a/packages/core/src/utils/LruCache.test.ts
+++ b/packages/core/src/utils/LruCache.test.ts
@@ -65,6 +65,20 @@ describe('LruCache', () => {
     expect(cache.get('c')).toBe(3);
   });
 
+  it('updates an existing key in place without evicting another entry', () => {
+    // Covers the set() update branch: re-setting the *newer* key on a full
+    // cache must delete + reinsert it, leaving the older entry intact. Without
+    // that branch, set() would instead evict the LRU ('a') and overwrite 'b'
+    // in place, wrongly dropping 'a'.
+    const cache = new LruCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('b', 99); // update the newer key on a full cache
+
+    expect(cache.get('a')).toBe(1); // must not have been evicted
+    expect(cache.get('b')).toBe(99); // value updated in place
+  });
+
   it('clear() empties the cache', () => {
     const cache = new LruCache<string, number>(2);
     cache.set('a', 1);

--- a/packages/core/src/utils/LruCache.test.ts
+++ b/packages/core/src/utils/LruCache.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LruCache } from './LruCache.js';
+
+describe('LruCache', () => {
+  it('stores and retrieves values, including falsy ones', () => {
+    const cache = new LruCache<string, number | string | boolean | null>(10);
+    cache.set('zero', 0);
+    cache.set('empty', '');
+    cache.set('false', false);
+    cache.set('null', null);
+
+    // Retrieval must return the stored falsy value, not undefined.
+    expect(cache.get('zero')).toBe(0);
+    expect(cache.get('empty')).toBe('');
+    expect(cache.get('false')).toBe(false);
+    expect(cache.get('null')).toBe(null);
+  });
+
+  it('returns undefined for a missing key', () => {
+    const cache = new LruCache<string, number>(2);
+    expect(cache.get('nope')).toBeUndefined();
+  });
+
+  it('evicts the least-recently-used entry when over capacity', () => {
+    const cache = new LruCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3); // 'a' is LRU and should be evicted
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('promotes an entry on get() so it survives eviction', () => {
+    const cache = new LruCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a'); // promote 'a' → 'b' becomes LRU
+    cache.set('c', 3); // should evict 'b', not 'a'
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('promotes a falsy-valued entry on get() so it survives eviction', () => {
+    // Regression: the previous `if (value)` guard skipped the recency reorder
+    // for falsy values, so a get() on a 0/''/false/null entry did not mark it
+    // as recently used and it was wrongly evicted next.
+    const cache = new LruCache<string, number>(2);
+    cache.set('a', 0); // falsy value
+    cache.set('b', 2);
+    cache.get('a'); // promote 'a' → 'b' becomes LRU
+    cache.set('c', 3); // should evict 'b', not 'a'
+
+    expect(cache.get('a')).toBe(0);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('clear() empties the cache', () => {
+    const cache = new LruCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/LruCache.ts
+++ b/packages/core/src/utils/LruCache.ts
@@ -14,12 +14,13 @@ export class LruCache<K, V> {
   }
 
   get(key: K): V | undefined {
-    const value = this.cache.get(key);
-    if (value) {
-      // Move to end to mark as recently used
-      this.cache.delete(key);
-      this.cache.set(key, value);
+    if (!this.cache.has(key)) {
+      return undefined;
     }
+    const value = this.cache.get(key) as V;
+    // Move to end to mark as recently used
+    this.cache.delete(key);
+    this.cache.set(key, value);
     return value;
   }
 


### PR DESCRIPTION
## What this PR does

Fixes `LruCache.get()` so an entry with a falsy value (`0`, `''`, `false`, `null`) is still promoted to most-recently-used on access, and adds the regression test that was requested in review. Supersedes #2968.

> Reopening #2968 was not mechanically possible (GitHub returns a 422 once a closed PR's branch has been force-pushed), so this fresh PR carries the same fix — rebased onto current `main` per @tanzhenxin's invitation — plus the falsy-value regression test @wenshao and @DragonnZhang asked for. The original fix was reviewed and **approved** in #2968 and closed only as part of a queue-tidying pass.

## Why it's needed

`get()` guarded the recency reorder with `if (value)`, a truthy check. For an entry whose value is falsy, the guard was skipped, so the entry was *not* moved to the most-recently-used position even though it had just been accessed — leaving it incorrectly positioned as least-recently-used and liable to be evicted next. `set()` already uses `Map.has()` for its existence check, so `get()` is now consistent with it. The fix switches to `Map.has()` (missing key → return `undefined`; present key → return the stored value and promote it), which does not conflate a missing key with a key holding a falsy value.

The class is not yet imported by any other module, so today the bug is latent — but as the approving review noted, landing the fix now (with tests) prevents a surprise the first time a consumer stores falsy values.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/utils/LruCache.test.ts` from `packages/core` and confirm all 6 cases pass. The `promotes a falsy-valued entry on get() so it survives eviction` case is the regression pin: it fails against the previous `if (value)` guard and passes with the `Map.has()` fix (verified locally by temporarily reverting `get()`).

### Evidence (Before & After)

Before: with capacity 2, `set('a', 0); set('b', 2); get('a'); set('c', 3)` evicts `'a'` — `get('a')` → `undefined` (the `get('a')` did not promote the falsy entry).
After: the same sequence evicts `'b'` instead — `get('a')` → `0`, `get('b')` → `undefined`. Non-falsy behavior is unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the 6 tests (all pass), verified the regression case fails against the pre-fix `get()`, and ran `prettier --check` + `eslint` on both files (clean). Windows/Linux: N/A — pure in-memory `Map` logic with no platform-dependent behavior (the prior PR's CI also passed on macOS/Ubuntu/Windows, Node 20/22/24).

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — behavior for non-falsy values is unchanged; the fix only corrects recency ordering for falsy-valued entries. `get()`'s return values are identical to before.
- Not validated / out of scope: no consumer of `LruCache` exists yet, so there is no downstream behavior to exercise beyond the class's own tests.
- Breaking changes / migration notes: none.

## Linked Issues

Supersedes #2968 (approved, closed during a queue-tidying pass with an invitation to reopen + rebase).

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `LruCache.get()`，使值为假值（`0`、`''`、`false`、`null`）的条目在被访问时仍会被提升为"最近使用"，并补充了评审中要求的回归测试。取代 #2968。

> 由于关闭的 PR 分支被 force-push 后 GitHub 无法重新打开（返回 422），本 PR 以全新 PR 承载同一修复——按 @tanzhenxin 的邀请 rebase 到当前 `main`——并加入 @wenshao 与 @DragonnZhang 要求的假值回归测试。原修复已在 #2968 中获得**批准**，仅因清理队列而被关闭。

## 为什么需要

`get()` 用 `if (value)`（真值判断）来守卫最近使用重排序。当条目的值为假值时，该守卫被跳过，因此即便条目刚被访问也不会被移动到最近使用位置，从而被错误地保留在最久未使用的位置，容易在下一次被淘汰。`set()` 已使用 `Map.has()` 做存在性判断，因此 `get()` 现在与之保持一致。修复改用 `Map.has()`（键不存在返回 `undefined`；键存在则返回存储值并提升），不会把"缺失键"与"值为假值的键"混为一谈。

该类目前尚未被任何模块引用，因此当前该 bug 是潜在的——但正如批准评审所指出，现在连同测试一起合入，可避免将来第一个使用方存储假值时出现意外。

## 复核测试计划

### 如何验证

在 `packages/core` 下运行 `npx vitest run src/utils/LruCache.test.ts`，确认 6 个用例全部通过。其中 `promotes a falsy-valued entry on get() so it survives eviction` 是回归锚点：它在旧的 `if (value)` 守卫下失败，在 `Map.has()` 修复下通过（已在本地通过临时回退 `get()` 验证）。

### 证据（修复前后对比）

修复前：容量为 2 时，`set('a', 0); set('b', 2); get('a'); set('c', 3)` 会淘汰 `'a'`——`get('a')` → `undefined`（`get('a')` 未提升该假值条目）。
修复后：同样的序列改为淘汰 `'b'`——`get('a')` → `0`，`get('b')` → `undefined`。非假值行为保持不变。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 6 个测试（全部通过），验证回归用例在修复前的 `get()` 下失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯内存 `Map` 逻辑，无平台相关行为（前一个 PR 的 CI 也在 macOS/Ubuntu/Windows、Node 20/22/24 上通过）。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——非假值的行为保持不变；修复仅纠正假值条目的最近使用排序。`get()` 的返回值与之前完全一致。
- 未验证 / 范围之外：目前尚无 `LruCache` 的使用方，因此除该类自身的测试外没有下游行为可供验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

取代 #2968（已批准，在清理队列时关闭，并附带重新打开 + rebase 的邀请）。

</details>
