### PR TITLE
fix(core): include skill results in microcompaction

### DIFF
--- a/packages/core/src/services/microcompaction/microcompact.test.ts
+++ b/packages/core/src/services/microcompaction/microcompact.test.ts
@@ -781,6 +781,33 @@ describe('microcompactHistory', () => {
     ).toBe('Y'.repeat(25_500));
   });
 
+  it('size-compacts old skill results and keeps the most recent result', () => {
+    const oldSkillContent = 'old skill instructions '.repeat(20);
+    const recentSkillContent = 'recent skill instructions';
+    const history: Content[] = [
+      makeToolCall('skill'),
+      makeToolResult('skill', oldSkillContent),
+      makeToolCall('skill'),
+      makeToolResult('skill', recentSkillContent),
+    ];
+
+    const result = microcompactHistory(history, Date.now(), {
+      ...DEFAULT_SETTINGS,
+      toolResultsTotalCharsThreshold: 100,
+    });
+
+    expect(result.meta).toBeDefined();
+    expect(result.meta!.triggerReason).toBe('size');
+    expect(result.meta!.toolsCleared).toBe(1);
+    expect(result.meta!.toolsKept).toBe(1);
+    expect(
+      result.history[1]!.parts![0]!.functionResponse!.response!['output'],
+    ).toBe(MICROCOMPACT_CLEARED_MESSAGE);
+    expect(
+      result.history[3]!.parts![0]!.functionResponse!.response!['output'],
+    ).toBe(recentSkillContent);
+  });
+
   it('counts pending content as a virtual tail for size-triggered compaction', () => {
     const history: Content[] = [];
     for (let i = 0; i < 4; i++) {

--- a/packages/core/src/services/microcompaction/microcompact.ts
+++ b/packages/core/src/services/microcompaction/microcompact.ts
@@ -26,6 +26,7 @@ const COMPACTABLE_TOOLS = new Set<string>([
   ToolNames.READ_MCP_RESOURCE,
   ToolNames.EDIT,
   ToolNames.WRITE_FILE,
+  ToolNames.SKILL,
 ]);
 
 /**


### PR DESCRIPTION
## What this PR does

Makes Skill tool results eligible for the existing microcompaction policy, allowing older Skill bodies to be cleared when accumulated tool output exceeds the configured context threshold or when idle/forced compaction runs.

Adds focused regression coverage showing that an older Skill result is cleared during size-based compaction while the most recent Skill result remains available.

## Why it's needed

Skill bodies currently enter conversation history as tool results but are excluded from microcompaction, so stale instructions continue consuming context for the rest of the session. This focused Phase 1 MVP reuses the existing compaction behavior to reclaim those tokens without introducing a new lifecycle abstraction.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/services/microcompaction/microcompact.test.ts`. Confirm that all 64 tests pass, including the case where two Skill results exceed the configured size threshold: the older result should be replaced with the standard cleared-result placeholder and the most recent result should remain unchanged.

Run `cd packages/core && npm run lint -- --max-warnings 0`, then run `npx prettier --check packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts` from the repository root. Both checks should pass.

Local Core typecheck and build were also attempted, but they currently stop on out-of-scope type errors in the existing DashScope and default OpenAI providers where `fetchOptions.timeout` is typed as `false | undefined` but the installed client types expect `number | undefined`. Neither provider is changed by this PR.

### Evidence (Before & After)

N/A - non-UI internal context-management change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Windows, Node.js 24.14.0, Vitest 3.2.4, local npm workspace.

## Risk & Scope

- Main risk or tradeoff: This Phase 1 change only clears stale Skill results through the existing policy; it does not synchronize the loaded-skill deduplication state, so a compacted Skill is not reloadable until the existing state is reset.
- Not validated / out of scope: `/unskill`, TTL eviction, `lifecycle: one-shot`, a `<loaded_skills>` prompt section, and loaded-skill state synchronization.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #6762 (Phase 1 MVP).

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

让 Skill 工具结果进入现有的 microcompaction 策略，从而在累计工具输出超过配置的上下文阈值，或运行空闲/强制压缩时清理较旧的 Skill 正文。

添加聚焦的回归测试，验证尺寸触发压缩时较旧的 Skill 结果会被清理，而最近的 Skill 结果仍然保留。

## 为什么需要

Skill 正文目前作为工具结果进入对话历史，但被排除在 microcompaction 之外，因此过时的指令会在会话剩余时间里持续占用上下文。这个范围明确的 Phase 1 MVP 复用现有压缩行为来回收这些 token，不引入新的生命周期抽象。

## 审阅者测试计划

### 如何验证

运行 `cd packages/core && npx vitest run src/services/microcompaction/microcompact.test.ts`。确认全部 64 个测试通过，其中包括两个 Skill 结果超过配置尺寸阈值的场景：较旧的结果应被替换为标准的已清理结果占位符，最近的结果应保持不变。

在 `packages/core` 中运行 `npm run lint -- --max-warnings 0`，然后从仓库根目录运行 `npx prettier --check packages/core/src/services/microcompaction/microcompact.ts packages/core/src/services/microcompaction/microcompact.test.ts`。两项检查均应通过。

本地也尝试了 Core 类型检查和构建，但它们目前会停止在现有 DashScope 和默认 OpenAI provider 中、超出本 PR 范围的类型错误上：`fetchOptions.timeout` 的类型是 `false | undefined`，但已安装的客户端类型要求 `number | undefined`。本 PR 没有修改这两个 provider。

### 证据（修改前与修改后）

N/A - 非 UI 的内部上下文管理变更。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      | N/A  |
|   🪟 Windows     |  ✅  |
|     🐧 Linux     | N/A  |

### 环境（可选）

Windows、Node.js 24.14.0、Vitest 3.2.4、本地 npm workspace。

## 风险和范围

- 主要风险或权衡：这个 Phase 1 变更只通过现有策略清理过时的 Skill 结果；它不会同步已加载 Skill 的去重状态，因此被压缩的 Skill 在现有状态重置前无法重新加载。
- 未验证或超出范围：`/unskill`、TTL 驱逐、`lifecycle: one-shot`、`<loaded_skills>` 提示词段落，以及已加载 Skill 的状态同步。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Refs #6762（Phase 1 MVP）。

</details>
