### PR TITLE
fix(ci): avoid oversized desktop release notes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -578,16 +578,15 @@ jobs:
             create_args=(
               "$RELEASE_TAG"
               "${assets[@]}"
-              --generate-notes
               --target "$RELEASE_TARGET"
               --title "$title"
             )
             if [ -n "$previous_tag" ]; then
-              echo "Using $previous_tag as the release notes start tag."
-              create_args+=(--notes-start-tag "$previous_tag")
+              release_notes="[Full changelog](https://github.com/${GH_REPO}/compare/${previous_tag}...${RELEASE_TAG})"
             else
-              echo "No previous published stable release found for release notes."
+              release_notes="Desktop release ${RELEASE_TAG}."
             fi
+            create_args+=(--notes "$release_notes")
             if [ "$RELEASE_DRAFT" = "true" ]; then
               create_args+=(--draft)
             fi


### PR DESCRIPTION
## What this PR does

Desktop releases now use a short release body with a full changelog comparison link instead of asking GitHub to generate the complete monorepo release notes. The first desktop release, where no previous stable desktop tag exists, uses a short fallback description.

## Why it's needed

The Desktop Release workflow failed while publishing `desktop-v0.0.5` because GitHub generated 125,425 characters of release notes between `desktop-v0.0.4` and `desktop-v0.0.5`, exceeding the Releases API limit of 125,000 characters. The generated notes included changes across the entire monorepo rather than only desktop changes. A bounded release body prevents publishing from failing as the repository accumulates changes while preserving access to the full comparison.

## Reviewer Test Plan

### How to verify

Run the Desktop Release workflow for a new version after a stable desktop release exists. Confirm that the versioned release is created with a short Full changelog link, all installer assets are uploaded, and the stable `desktop-latest` feed is updated. For the no-previous-release path, confirm that the release is created with the short fallback description. The previously failing generated body contained 125,425 characters; the replacement body for the same tags contains 93 characters.

### Evidence (Before & After)

Before: publishing failed with HTTP 422, `body is too long (maximum is 125000 characters)`. After: the workflow passes a bounded release body through `--notes` and no longer requests generated notes. N/A for UI screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local repository validation on macOS with Node.js 22: `npm run build`, `npm run typecheck`, and `git diff --check` passed.

## Risk & Scope

- Main risk or tradeoff: Versioned desktop releases show a comparison link instead of an inline generated list of every monorepo change.
- Not validated / out of scope: The workflow was not dispatched because doing so would create and publish a real release; installer construction and update-feed behavior are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Failed workflow: https://github.com/QwenLM/qwen-code/actions/runs/29220052156/job/86724848107

<details>
<summary>中文说明</summary>

## 本 PR 的改动

Desktop Release 现在使用简短的发布正文并附带完整 changelog 对比链接，不再要求 GitHub 生成整个 monorepo 的完整 release notes。如果不存在上一个稳定的 desktop tag，则使用简短的兜底说明。

## 为什么需要此改动

Desktop Release workflow 在发布 `desktop-v0.0.5` 时失败，因为 GitHub 在 `desktop-v0.0.4` 与 `desktop-v0.0.5` 之间生成了 125,425 个字符的 release notes，超过 Releases API 的 125,000 字符上限。生成内容包含整个 monorepo 的变更，而不只是 desktop 变更。使用长度有界的发布正文可以避免仓库累积大量变更后发布失败，同时保留查看完整对比的入口。

## Reviewer 测试计划

### 如何验证

在已有稳定 desktop release 的情况下，为新版本运行 Desktop Release workflow。确认版本 Release 成功创建并包含简短的 Full changelog 链接、所有安装包成功上传、稳定的 `desktop-latest` feed 正常更新。对于没有历史 Release 的路径，确认 Release 使用简短的兜底说明成功创建。之前失败的自动生成正文包含 125,425 个字符；相同 tags 对应的新正文只有 93 个字符。

### 证据（修改前后）

修改前：发布失败并返回 HTTP 422，`body is too long (maximum is 125000 characters)`。修改后：workflow 通过 `--notes` 传递长度有界的正文，不再请求自动生成 release notes。UI 截图不适用。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

在 macOS 和 Node.js 22 环境完成本地仓库验证：`npm run build`、`npm run typecheck` 和 `git diff --check` 均通过。

## 风险与范围

- 主要风险或取舍：版本化 desktop release 将展示对比链接，而不是内联展示整个 monorepo 的自动生成变更列表。
- 未验证 / 范围外：没有实际触发 workflow，因为这会创建并发布真实 Release；安装包构建和 update feed 行为未发生变化。
- Breaking changes / 迁移说明：无。

## 关联事项

失败的 workflow：https://github.com/QwenLM/qwen-code/actions/runs/29220052156/job/86724848107

</details>
