### PR TITLE
fix(ui): refine reasoning duration displays

### DIFF
--- a/packages/cli/src/ui/components/LoadingIndicator.test.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.test.tsx
@@ -72,7 +72,7 @@ describe('<LoadingIndicator />', () => {
     const output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Loading...');
-    expect(output).toContain('5.0s');
+    expect(output).toContain('5s');
     expect(output).toContain('esc to cancel');
   });
 
@@ -89,7 +89,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏'); // Static char for WaitingForConfirmation
     expect(output).toContain('Confirm action');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain('10.0s');
+    expect(output).not.toContain('10s');
   });
 
   it('should display the currentLoadingPhrase correctly', () => {
@@ -104,27 +104,25 @@ describe('<LoadingIndicator />', () => {
     expect(lastFrame()).toContain('Processing data...');
   });
 
-  it('should keep a fixed-width time string across 0.5s ticks below one minute (#6402)', () => {
-    // The timer ticks at 0.5s resolution; without the fixed decimal the
-    // string alternates between "1s" and "1.5s" and the status line jitters.
+  it('should display whole elapsed seconds below one minute', () => {
     const half = renderWithContext(
-      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={1.5} />,
+      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={17.5} />,
       StreamingState.Responding,
     );
-    expect(half.lastFrame()).toContain('(1.5s · esc to cancel)');
+    expect(half.lastFrame()).toContain('(17s · esc to cancel)');
 
     const whole = renderWithContext(
-      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={2} />,
+      <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={18} />,
       StreamingState.Responding,
     );
-    expect(whole.lastFrame()).toContain('(2.0s · esc to cancel)');
+    expect(whole.lastFrame()).toContain('(18s · esc to cancel)');
 
     // Timer start / reset publishes exactly 0.
     const zero = renderWithContext(
       <LoadingIndicator currentLoadingPhrase="Working..." elapsedTime={0} />,
       StreamingState.Responding,
     );
-    expect(zero.lastFrame()).toContain('(0.0s · esc to cancel)');
+    expect(zero.lastFrame()).toContain('(0s · esc to cancel)');
   });
 
   it('should display the elapsedTime correctly when Responding', () => {
@@ -179,7 +177,7 @@ describe('<LoadingIndicator />', () => {
     let output = lastFrame();
     expect(output).toContain('MockRespondingSpinner');
     expect(output).toContain('Now Responding');
-    expect(output).toContain('(2.0s · esc to cancel)');
+    expect(output).toContain('(2s · esc to cancel)');
 
     // Transition to WaitingForConfirmation
     rerender(
@@ -194,7 +192,7 @@ describe('<LoadingIndicator />', () => {
     expect(output).toContain('⠏');
     expect(output).toContain('Please Confirm');
     expect(output).not.toContain('(esc to cancel)');
-    expect(output).not.toContain('15.0s');
+    expect(output).not.toContain('15s');
 
     // Transition back to Idle
     rerender(
@@ -234,7 +232,7 @@ describe('<LoadingIndicator />', () => {
       // Check for single line output
       expect(output?.includes('\n')).toBe(false);
       expect(output).toContain('Loading...');
-      expect(output).toContain('(5.0s · esc to cancel)');
+      expect(output).toContain('(5s · esc to cancel)');
       expect(output).toContain('Right');
     });
 
@@ -256,8 +254,8 @@ describe('<LoadingIndicator />', () => {
       expect(lines).toHaveLength(3);
       if (lines) {
         expect(lines[0]).toContain('Loading...');
-        expect(lines[0]).not.toContain('5.0s');
-        expect(lines[1]).toContain('5.0s');
+        expect(lines[0]).not.toContain('5s');
+        expect(lines[1]).toContain('5s');
         expect(lines[2]).toContain('Right');
       }
     });
@@ -290,7 +288,7 @@ describe('<LoadingIndicator />', () => {
       const output = lastFrame();
       expect(output).toContain('↓ 847 tokens');
       expect(output).not.toContain('↑');
-      expect(output).toContain('5.0s');
+      expect(output).toContain('5s');
       expect(output).toContain('esc to cancel');
     });
 
@@ -343,7 +341,7 @@ describe('<LoadingIndicator />', () => {
         120,
       );
       const output = lastFrame();
-      expect(output).toContain('(5.0s · ↓ 5.4k tokens · esc to cancel)');
+      expect(output).toContain('(5s · ↓ 5.4k tokens · esc to cancel)');
     });
 
     it('should not show response tokens/sec by default', () => {

--- a/packages/cli/src/ui/components/LoadingIndicator.tsx
+++ b/packages/cli/src/ui/components/LoadingIndicator.tsx
@@ -90,11 +90,11 @@ export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
   const showTokens = !isNarrow && outputTokens > 0;
   const tokenArrow = isReceivingContent ? '↓' : '↑';
 
-  // Fixed one-decimal width below the minute mark so the 0.5s-resolution
-  // ticks ("1s" vs "1.5s") don't shift the rest of the status line (#6402).
+  // Keep the timer's sub-second precision for rate calculations, but display
+  // only completed whole seconds in the status line.
   const timeStr =
     elapsedTime < 60
-      ? `${elapsedTime.toFixed(1)}s`
+      ? `${Math.floor(Math.max(0, elapsedTime))}s`
       : formatDuration(elapsedTime * 1000);
 
   const tokenStr = showTokens

--- a/packages/cli/src/ui/components/__snapshots__/LoadingIndicator.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/LoadingIndicator.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<LoadingIndicator /> > should truncate long primary text instead of wrapping 1`] = `
-"  MockResponding This is an extremely long loading phrase that should be truncated i (5.0s · esc to
-  Spinner                                                                           cancel)"
+"  MockResponding This is an extremely long loading phrase that should be truncated in (5s · esc to
+  Spinner                                                                            cancel)"
 `;

--- a/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.test.tsx
@@ -87,6 +87,40 @@ describe('<ThinkMessage />', () => {
     expect(output).toContain(`${toggleKeyHint} to expand`);
   });
 
+  it.each([0, 999])(
+    'should describe a %dms completed thought as brief',
+    (durationMs) => {
+      for (const expanded of [false, true]) {
+        const { lastFrame } = render(
+          <ThinkMessage
+            {...defaultProps}
+            isPending={false}
+            expanded={expanded}
+            durationMs={durationMs}
+          />,
+        );
+        const output = lastFrame();
+        expect(output).toContain('Thought briefly');
+        expect(output).not.toContain('Thought for');
+        expect(output).not.toContain('0s');
+      }
+    },
+  );
+
+  it('should show a numeric duration at the one-second boundary', () => {
+    const { lastFrame } = render(
+      <ThinkMessage
+        {...defaultProps}
+        isPending={false}
+        expanded={false}
+        durationMs={1000}
+      />,
+    );
+    const output = lastFrame();
+    expect(output).toContain('Thought for 1s');
+    expect(output).not.toContain('Thought briefly');
+  });
+
   it('should show present-tense duration while pending (streaming)', () => {
     const { lastFrame } = render(
       <ThinkMessage {...defaultProps} isPending={true} durationMs={8000} />,

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -269,6 +269,7 @@ export const AssistantMessageContent: React.FC<
 );
 
 const MAX_STREAMING_THINKING_VISUAL_LINES = 4;
+const BRIEF_THOUGHT_THRESHOLD_MS = 1_000;
 
 function tailVisualLines(
   text: string,
@@ -342,12 +343,15 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
 }) => {
   const durationSuffix =
     durationMs != null ? ` ${formatDuration(durationMs)}` : '';
+  const completedLabel =
+    durationMs == null
+      ? null
+      : durationMs < BRIEF_THOUGHT_THRESHOLD_MS
+        ? t('Thought briefly')
+        : `${t('Thought for')} ${formatDuration(durationMs)}`;
 
   if (!isPending && !expanded) {
-    const label =
-      durationMs != null
-        ? `${t('Thought for')} ${formatDuration(durationMs)}`
-        : t('Thinking');
+    const label = completedLabel ?? t('Thinking');
     const hint = clickable
       ? t('(click or {{keyHint}} to expand)', { keyHint: toggleKeyHint })
       : t('({{keyHint}} to expand)', { keyHint: toggleKeyHint });
@@ -361,9 +365,7 @@ export const ThinkMessage: React.FC<ThinkMessageProps> = ({
 
   const label = isPending
     ? `${t('Thinking')}…${durationSuffix}`
-    : durationMs != null
-      ? `${t('Thought for')} ${formatDuration(durationMs)}`
-      : `${t('Thinking')}…`;
+    : (completedLabel ?? `${t('Thinking')}…`);
   const collapseHint =
     !isPending && expanded
       ? ` ${t('({{keyHint}} to collapse)', { keyHint: toggleKeyHint })}`

--- a/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
@@ -42,6 +42,30 @@ function render(node: ReactNode): HTMLElement {
   return container;
 }
 
+function renderCompletedThinking(
+  durationMs: number,
+  language: 'en' | 'zh-CN' = 'en',
+): HTMLElement {
+  vi.setSystemTime(0);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const tree = (isStreaming: boolean) => (
+    <I18nProvider language={language}>
+      <ThinkingMessage
+        content="private chain of thought"
+        isStreaming={isStreaming}
+        timestamp={0}
+      />
+    </I18nProvider>
+  );
+  act(() => root.render(tree(true)));
+  vi.setSystemTime(durationMs);
+  act(() => root.render(tree(false)));
+  mounted.push({ root, container });
+  return container;
+}
+
 describe('AssistantMessage thinking logic', () => {
   it('uses the running summary while streaming before answer content', () => {
     expect(getThinkingSummaryKey({ isStreaming: true })).toBe(
@@ -52,6 +76,10 @@ describe('AssistantMessage thinking logic', () => {
   it('uses the finished summary after streaming ends', () => {
     expect(getThinkingSummaryKey({ isStreaming: false })).toBe('thinking.done');
     expect(getThinkingSummaryKey({})).toBe('thinking.done');
+    expect(getThinkingSummaryKey({ durationMs: 999 })).toBe(
+      'thinking.doneBriefly',
+    );
+    expect(getThinkingSummaryKey({ durationMs: 1000 })).toBe('thinking.done');
   });
 
   it('formats thinking durations', () => {
@@ -63,13 +91,35 @@ describe('AssistantMessage thinking logic', () => {
     expect(formatThinkingDuration(120_000)).toBe('2m');
   });
 
-  it('omits the duration after thinking finishes', () => {
+  it('keeps replayed completed thinking durationless', () => {
     const container = render(
       <ThinkingMessage content="private chain of thought" timestamp={0} />,
     );
 
     expect(container.textContent).toContain('Done thinking');
     expect(container.textContent).not.toContain('Thought for');
+  });
+
+  it.each([
+    [999, 'Thought briefly'],
+    [1000, 'Thought for 1s'],
+  ] as const)(
+    'shows the completed label for a %dms live thought',
+    (durationMs, expectedLabel) => {
+      const container = renderCompletedThinking(durationMs);
+
+      expect(container.textContent).toContain(expectedLabel);
+      const toggle = container.querySelector<HTMLButtonElement>('button');
+      act(() => toggle?.click());
+      expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+      expect(container.textContent).toContain(expectedLabel);
+    },
+  );
+
+  it('localizes a brief completed thought in Simplified Chinese', () => {
+    const container = renderCompletedThinking(999, 'zh-CN');
+
+    expect(container.textContent).toContain('思考片刻');
   });
 
   it('keeps the duration while thinking is running', () => {

--- a/packages/web-shell/client/components/messages/AssistantMessage.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.tsx
@@ -197,8 +197,7 @@ export const ThinkingMessage = memo(function ThinkingMessage({
   const { t } = useI18n();
   const compactMode = useContext(CompactModeContext);
   const [thinkingExpanded, setThinkingExpanded] = useState(false);
-  const thinkingSummaryKey = getThinkingSummaryKey({ isStreaming });
-  const thinkingActive = thinkingSummaryKey === 'thinking.running';
+  const thinkingActive = isStreaming === true;
   const startTimeRef = useRef(timestamp ?? Date.now());
   const sawActiveRef = useRef(thinkingActive);
   const [now, setNow] = useState(() => Date.now());
@@ -223,11 +222,17 @@ export const ThinkingMessage = memo(function ThinkingMessage({
     }
   }, [content, finishedAt, thinkingActive]);
 
+  const thinkingDurationMs =
+    thinkingActive || finishedAt !== null
+      ? (thinkingActive ? now : finishedAt!) - startTimeRef.current
+      : undefined;
+  const thinkingSummaryKey = getThinkingSummaryKey({
+    isStreaming,
+    durationMs: thinkingDurationMs,
+  });
   const thinkingDuration =
-    thinkingActive || finishedAt
-      ? formatThinkingDuration(
-          (thinkingActive ? now : finishedAt!) - startTimeRef.current,
-        )
+    thinkingDurationMs !== undefined
+      ? formatThinkingDuration(thinkingDurationMs)
       : '';
 
   const handleToggle = useCallback(() => {
@@ -264,7 +269,7 @@ export const ThinkingMessage = memo(function ThinkingMessage({
               >
                 {t(
                   thinkingSummaryKey,
-                  thinkingActive ? { duration: thinkingDuration } : {},
+                  thinkingDuration ? { duration: thinkingDuration } : {},
                 )}
               </span>
               <span
@@ -302,10 +307,15 @@ export const ThinkingMessage = memo(function ThinkingMessage({
 
 export function getThinkingSummaryKey({
   isStreaming,
+  durationMs,
 }: {
   isStreaming?: boolean;
-}): 'thinking.running' | 'thinking.done' {
-  return isStreaming ? 'thinking.running' : 'thinking.done';
+  durationMs?: number;
+}): 'thinking.running' | 'thinking.done' | 'thinking.doneBriefly' {
+  if (isStreaming) return 'thinking.running';
+  return durationMs !== undefined && durationMs < 1_000
+    ? 'thinking.doneBriefly'
+    : 'thinking.done';
 }
 
 export function formatThinkingDuration(ms: number): string {

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1697,6 +1697,7 @@ const EN: Messages = {
   'thinking.expand': 'Expand thinking',
   'thinking.collapse': 'Collapse thinking',
   'thinking.running': (v) => `Thinking${v?.duration ? ` ${v.duration}` : ''}`,
+  'thinking.doneBriefly': 'Thought briefly',
   'thinking.done': (v) =>
     v?.duration ? `Thought for ${v.duration}` : 'Done thinking',
   'sessionsOverview.count': (v) => `${v?.count ?? 0} sessions`,
@@ -3405,6 +3406,7 @@ const ZH: Messages = {
   'thinking.expand': '展开思考',
   'thinking.collapse': '收起思考',
   'thinking.running': (v) => `正在思考${v?.duration ? ` ${v.duration}` : ''}`,
+  'thinking.doneBriefly': '思考片刻',
   'thinking.done': (v) => (v?.duration ? `已思考 ${v.duration}` : '思考完成'),
   'welcome.changeModel': '(/model 切换)',
   'welcome.defaultModel': '未知模型',


### PR DESCRIPTION
<!-- PR title: fix(ui): refine reasoning duration displays -->

## What this PR does

This PR changes completed reasoning summaries in both the terminal UI and Web Shell so sub-second reasoning is described as `Thought briefly` instead of showing a misleading numeric duration. Reasoning that lasts at least one second keeps the existing `Thought for <duration>` wording.

The terminal UI applies the same label in collapsed and expanded reasoning blocks without changing the live `Thinking…` state. Web Shell applies the threshold when a thinking block transitions from streaming to completed, adds the Simplified Chinese `思考片刻` translation, and keeps replayed completed blocks as `Done thinking` because historical transcripts do not persist a duration.

The terminal streaming status line now displays elapsed time in completed whole seconds, so an internal value of `17.5s` appears as `17s` and advances to `18s`. The underlying timer keeps its 500 ms precision for token-rate calculations.

## Why it's needed

Very short reasoning can currently appear as `Thought for 0s` in the terminal UI, which suggests that no reasoning happened even when an expandable reasoning block is present. Web Shell has a related inconsistency: it measures elapsed time while reasoning is live, but drops that duration when the block completes. Using a clear sub-second label and consistent completed-duration behavior makes both surfaces easier to understand without introducing false precision.

The streaming footer currently exposes half-second values such as `17.5s`. Whole seconds are calmer and easier to scan while still accurately representing completed elapsed time.

## Reviewer Test Plan

### How to verify

1. Complete a reasoning response in under one second and confirm the terminal UI shows `Thought briefly`, preserves the expand affordance, and shows the same label when expanded.
2. Complete a reasoning response at or above one second and confirm the terminal UI continues to show `Thought for 1s` or the corresponding longer duration.
3. In Web Shell, observe a thinking block transition from running to completed in under one second and confirm it changes from `Thinking <duration>` to `Thought briefly`.
4. Repeat the Web Shell check with a duration of at least one second and confirm it displays `Thought for <duration>`.
5. Reload a historical Web Shell transcript and confirm a completed thinking block without persisted timing data still displays `Done thinking`.
6. Switch Web Shell to Simplified Chinese and confirm a brief completed thought displays `思考片刻`.
7. While the terminal UI is streaming, confirm the footer displays only whole seconds (`17s`, then `18s`) and never a half-second value such as `17.5s`.

### Evidence (Before & After)

| Surface | Before | After |
| --- | --- | --- |
| Terminal UI, sub-second completion | `Thought for 0s` | `Thought briefly` |
| Terminal UI, one-second completion | `Thought for 1s` | `Thought for 1s` |
| Web Shell, live completion | `Done thinking` | `Thought briefly` or `Thought for <duration>` |
| Web Shell, replayed completion | `Done thinking` | `Done thinking` |
| Terminal UI, streaming footer | `17.5s` | `17s` |

<table>
  <tr>
    <th>Terminal UI — sub-second completion</th>
    <th>Web Shell — sub-second completion</th>
  </tr>
  <tr>
    <td><img width="440" alt="Terminal UI showing Thought briefly" src="https://github.com/user-attachments/assets/3a9c4510-d213-4829-977f-50bf67f3ab6c" /></td>
    <td><img width="440" alt="Web Shell showing Thought briefly" src="https://github.com/user-attachments/assets/527a42cd-bb9e-48e9-84ab-8e74fa712c0a" /></td>
  </tr>
</table>

Automated verification covered the exact 0 ms, 999 ms, and 1,000 ms reasoning boundaries in the terminal UI; live-to-completed React transitions at 999 ms and 1,000 ms in Web Shell; the Simplified Chinese label; expansion stability; the running label; the duration-less replay fallback; and fractional streaming timer values. The targeted terminal UI suites passed 45/45 tests and the Web Shell component suite passed 10/10 tests. Targeted linting, formatting, CLI build, CLI typecheck, bundling, and diff checks passed. Deterministic interactive terminal runs reproduced `Thought for 0s` before the change and verified `Thought briefly` and `Thought for 1s` after it. A separate 100 ms interactive sampler observed 37 streaming frames containing only `0s` through `4s`, with no decimal-second values.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.12.0 on macOS. Terminal UI evidence used the local bundled CLI in an interactive PTY with a deterministic OpenAI-compatible reasoning stream. Web Shell behavior was verified with jsdom component integration tests and a local Vite capture harness that rendered the real thinking component, styles, and i18n messages.

## Risk & Scope

- Main risk or tradeoff: Web Shell completion timing uses the browser wall clock, so heavy scheduling delays or clock skew can affect the displayed numeric duration near the threshold.
- Terminal footer timing is floored for display, so it intentionally shows the last completed second while retaining the precise internal value for calculations.
- Not validated / out of scope: Historical Web Shell transcripts still have no persisted thinking duration and intentionally retain `Done thinking`. A full daemon/browser E2E, Windows, and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 调整了终端 UI 和 Web Shell 中已完成思考的摘要文案：不足一秒的思考显示为 `Thought briefly`，不再显示容易误解的数字时长；达到一秒及以上的思考继续沿用 `Thought for <duration>`。

终端 UI 在折叠和展开的思考块中使用同一文案，不改变运行中的 `Thinking…` 状态。Web Shell 在思考块从 streaming 转为完成时应用同一阈值，新增简体中文文案 `思考片刻`；历史回放中的已完成思考仍显示 `Done thinking`，因为历史 transcript 没有持久化思考时长。

终端 streaming 状态栏的耗时现在只显示已完成的整数秒，因此内部值 `17.5s` 会显示为 `17s`，下一整秒再变为 `18s`。底层计时器仍保留 500 ms 精度，供 token rate 计算使用。

## 为什么需要这个改动

非常短的思考目前可能在终端 UI 中显示为 `Thought for 0s`，即使存在可展开的 reasoning block，也会让人误以为模型没有思考。Web Shell 还有一个相关的不一致：运行中会计算并显示耗时，但完成后会丢弃该时长。使用清晰的亚秒级文案并统一完成态时长行为，可以让两个界面更容易理解，同时避免伪精度。

streaming footer 目前还会暴露 `17.5s` 这类半秒值。整数秒更安静、更容易扫读，同时仍准确表示已经过去的完整时间。

## Reviewer 测试计划

### 如何验证

1. 让一次 reasoning 在一秒内完成，确认终端 UI 显示 `Thought briefly`、保留展开入口，并且展开后文案不变。
2. 让一次 reasoning 在一秒或更久后完成，确认终端 UI 继续显示 `Thought for 1s` 或对应的更长时长。
3. 在 Web Shell 中观察 thinking block 从运行中切换为完成，且耗时不足一秒，确认它从 `Thinking <duration>` 变为 `Thought briefly`。
4. 使用至少一秒的耗时重复 Web Shell 验证，确认显示 `Thought for <duration>`。
5. 重新加载历史 Web Shell transcript，确认没有持久化时长的已完成 thinking block 仍显示 `Done thinking`。
6. 将 Web Shell 切换为简体中文，确认短思考完成后显示 `思考片刻`。
7. 在终端 UI streaming 过程中，确认 footer 只显示整数秒（例如先 `17s`，再 `18s`），不会出现 `17.5s` 这样的半秒值。

### 证据（Before & After）

| 界面 | Before | After |
| --- | --- | --- |
| 终端 UI，亚秒级完成 | `Thought for 0s` | `Thought briefly` |
| 终端 UI，一秒完成 | `Thought for 1s` | `Thought for 1s` |
| Web Shell，实时完成 | `Done thinking` | `Thought briefly` 或 `Thought for <duration>` |
| Web Shell，历史回放完成 | `Done thinking` | `Done thinking` |
| 终端 UI，streaming footer | `17.5s` | `17s` |

<table>
  <tr>
    <th>终端 UI — 亚秒级完成态</th>
    <th>Web Shell — 亚秒级完成态</th>
  </tr>
  <tr>
    <td><img width="440" alt="终端 UI 显示 Thought briefly" src="https://github.com/user-attachments/assets/3a9c4510-d213-4829-977f-50bf67f3ab6c" /></td>
    <td><img width="440" alt="Web Shell 显示 Thought briefly" src="https://github.com/user-attachments/assets/527a42cd-bb9e-48e9-84ab-8e74fa712c0a" /></td>
  </tr>
</table>

其他边界和 streaming footer 行为由表格、自动化测试及 interactive 采样结果覆盖。

自动化验证覆盖了终端 UI 的 0 ms、999 ms 和 1,000 ms reasoning 精确边界；Web Shell 在 999 ms 和 1,000 ms 的真实 React live-to-completed 状态转换；简体中文文案；展开后标签稳定性；运行中文案；无时长历史回放回退；以及 streaming timer 的小数输入。终端 UI 定向测试 45/45 通过，Web Shell 组件测试 10/10 通过。定向 lint、格式化、CLI build、CLI typecheck、bundle 和 diff 检查均通过。确定性的终端 interactive 测试在改动前复现了 `Thought for 0s`，并在改动后验证了 `Thought briefly` 和 `Thought for 1s`。另一个每 100 ms 采样的 interactive 验证观察到 37 个 streaming 帧，耗时只出现 `0s` 到 `4s` 的整数值，没有任何小数秒。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS，Node.js 22.12.0。终端 UI 证据使用本地 bundle CLI，通过 interactive PTY 和确定性的 OpenAI-compatible reasoning stream 生成。Web Shell 行为使用 jsdom 组件集成测试和本地 Vite capture harness 验证；该 harness 渲染了真实的 thinking 组件、样式和 i18n 文案。

## 风险与范围

- 主要风险或取舍：Web Shell 完成时长使用浏览器墙钟，因此繁忙调度或时钟偏移可能影响阈值附近显示的数字时长。
- 终端 footer 的显示值会向下取整，因此它有意展示最近一个已完成的整数秒；内部精确值仍用于计算。
- 未验证 / 范围外：历史 Web Shell transcript 仍未持久化 thinking duration，因此有意保留 `Done thinking`。完整 daemon/browser E2E、Windows 和 Linux 未在本地测试。
- Breaking changes / 迁移说明：无。

## 关联 Issue

N/A

</details>
