### PR TITLE
fix(core): strip only a trailing .git from GitHub repo names

### DIFF
--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -1508,6 +1508,20 @@ describe('git extension helpers', () => {
       expect(repo).toBe('repo');
     });
 
+    it('should not strip .git from the middle of a repo name (GitHub Pages)', () => {
+      const source = 'https://github.com/owner/owner.github.io';
+      const { owner, repo } = parseGitHubRepoForReleases(source);
+      expect(owner).toBe('owner');
+      expect(repo).toBe('owner.github.io');
+    });
+
+    it('should only strip a trailing .git, not an embedded one', () => {
+      const { repo } = parseGitHubRepoForReleases(
+        'owner/my.gitignore-tools.git',
+      );
+      expect(repo).toBe('my.gitignore-tools');
+    });
+
     it('should fail on a GitHub SSH URL', () => {
       const source = 'git@github.com:owner/repo.git';
       expect(() => parseGitHubRepoForReleases(source)).toThrow(

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -183,7 +183,10 @@ export function parseGitHubRepoForReleases(source: string): {
     );
   }
   const owner = parts[0];
-  const repo = parts[1].replace('.git', '');
+  // Strip a trailing `.git` suffix (from clone-style URLs like `owner/repo.git`)
+  // only. An unanchored replace would mangle repo names that merely contain
+  // `.git`, e.g. GitHub Pages repos named `<user>.github.io`.
+  const repo = parts[1].replace(/\.git$/, '');
 
   if (owner.startsWith('git@github.com')) {
     throw new Error(


### PR DESCRIPTION
## What this PR does

Fixes `parseGitHubRepoForReleases` so it strips only a **trailing** `.git` from a repository name instead of the first `.git` found anywhere in it. Adds regression tests.

## Why it's needed

The repo name was derived with `parts[1].replace('.git', '')`. A string-argument `replace` removes only the **first** occurrence, and it isn't anchored — so any repo name that contains `.git` as a substring is corrupted. The clearest real-world case is GitHub Pages repositories, which are named `<user>.github.io`: the `.git` inside `.github` is stripped, turning `owner.github.io` into `ownerhub.io`. `parseGitHubRepoForReleases` feeds the release API URL (`https://api.github.com/repos/<owner>/<repo>/releases/...`), so a release-based extension install from any such repo requests a nonexistent repo and 404s. Anchoring the strip to the end (`/\.git$/`) keeps the intended behavior for clone-style URLs like `owner/repo.git` (→ `repo`) while leaving embedded `.git` intact.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/extension/github.test.ts -t parseGitHubRepoForReleases` from `packages/core` and confirm all cases pass, including the two added regressions. The `should not strip .git from the middle of a repo name (GitHub Pages)` and `should only strip a trailing .git, not an embedded one` cases fail against the previous unanchored `replace('.git', '')` (verified locally by reverting the one-line change) and pass with the anchored regex.

### Evidence (Before & After)

Before: `parseGitHubRepoForReleases('https://github.com/owner/owner.github.io')` → `repo: 'ownerhub.io'`.
After: → `repo: 'owner.github.io'`. `owner/repo.git` still → `repo: 'repo'`; `owner/repo` still → `repo: 'repo'`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `parseGitHubRepoForReleases` suite (all pass), confirmed the two new tests fail against the pre-fix code, and ran `prettier --check` + `eslint` on both files (clean). Windows/Linux: N/A — pure string parsing with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — the anchored regex produces identical output to the old code for every input that did not contain an embedded `.git` (i.e. all previously-working inputs); it only stops corrupting names that contain `.git` as a substring.
- Not validated / out of scope: no change to URL/host parsing or the SSH/non-GitHub rejection paths.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `parseGitHubRepoForReleases`，使其只剥离仓库名**末尾**的 `.git`，而不是名字中第一个出现的 `.git`。并补充回归测试。

## 为什么需要

仓库名此前由 `parts[1].replace('.git', '')` 得到。字符串参数的 `replace` 只替换**第一个**匹配，且未锚定到结尾——因此任何名字中包含 `.git` 子串的仓库都会被破坏。最典型的真实场景是 GitHub Pages 仓库，其命名为 `<user>.github.io`：`.github` 里的 `.git` 被剥离，`owner.github.io` 变成了 `ownerhub.io`。`parseGitHubRepoForReleases` 的结果会用于拼接 release API 地址（`https://api.github.com/repos/<owner>/<repo>/releases/...`），因此从这类仓库进行基于 release 的扩展安装会请求一个不存在的仓库而返回 404。将剥离锚定到结尾（`/\.git$/`）既保留了对 `owner/repo.git` 这类 clone 式 URL 的既有行为（→ `repo`），又不会误删中间的 `.git`。

## 复核测试计划

### 如何验证

在 `packages/core` 下运行 `npx vitest run src/extension/github.test.ts -t parseGitHubRepoForReleases`，确认所有用例通过，包括新增的两个回归用例。`should not strip .git from the middle of a repo name (GitHub Pages)` 与 `should only strip a trailing .git, not an embedded one` 在旧的未锚定 `replace('.git', '')` 下会失败（已在本地通过回退该单行改动验证），在锚定正则下通过。

### 证据（修复前后对比）

修复前：`parseGitHubRepoForReleases('https://github.com/owner/owner.github.io')` → `repo: 'ownerhub.io'`。
修复后：→ `repo: 'owner.github.io'`。`owner/repo.git` 仍为 `repo: 'repo'`；`owner/repo` 仍为 `repo: 'repo'`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `parseGitHubRepoForReleases` 测试（全部通过），确认两个新增测试在修复前失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯字符串解析，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——对于所有不含内嵌 `.git` 的输入（即此前能正常工作的全部输入），锚定正则的输出与旧代码完全一致；它只是不再破坏包含 `.git` 子串的名字。
- 未验证 / 范围之外：未改动 URL/host 解析，也未改动 SSH/非 GitHub 的拒绝路径。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
