### PR TITLE
fix(serve): route session actions to the owning workspace

### DIFF
--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1740,6 +1740,12 @@ If an active JSONL already exists for the id, unarchive reports a conflict in `e
 
 ACP-over-HTTP uses the same request and response bodies through vendor methods `_qwen/sessions/archive` and `_qwen/sessions/unarchive`. The REST route table maps `POST /sessions/archive` and `POST /sessions/unarchive` to those methods for ACP transports.
 
+### Multi-workspace live-session routing
+
+When `multi_workspace_sessions` is advertised, live-session operations identify their workspace from the `sessionId`; clients do not add a workspace selector to the URL. In addition to the existing owner-routed lifecycle operations, this applies to `PATCH /session/:id/metadata`, `POST /session/:id/recap`, `POST /session/:id/btw`, `POST /session/:id/mid-turn-message`, `POST /session/:id/tasks/:taskId/cancel`, and `POST /session/:id/goal/clear`. The daemon routes each request to the trusted runtime that owns the live session. An untrusted non-primary owner returns `403 untrusted_workspace`, a missing live owner returns `404 session_not_found`, and an ambiguous owner fails closed with `500 ambiguous_session_owner`.
+
+This rule is live-session-only and does not make every workspace-less session route multi-workspace-aware. Persisted or archived operations use their documented workspace-qualified routes, while remaining Phase 2a primary-only routes continue to return `non_primary_session_route_not_supported` for non-primary owners.
+
 ### `POST /session/:id/prompt`
 
 Forward a prompt to the agent. Multi-prompt callers FIFO-queue per session (ACP guarantees one active prompt per session).

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -43,6 +43,8 @@ import {
 const PRIMARY_CWD = path.resolve(path.sep, 'work', 'primary');
 const SECONDARY_CWD = path.resolve(path.sep, 'work', 'secondary');
 const UNKNOWN_CWD = path.resolve(path.sep, 'work', 'unknown');
+const TEST_TOKEN = 'test-token';
+const TEST_AUTHORIZATION = `Bearer ${TEST_TOKEN}`;
 
 const baseOpts: ServeOptions = {
   hostname: '127.0.0.1',
@@ -89,6 +91,32 @@ interface FakeBridge extends AcpSessionBridge {
     opts: { persist?: boolean };
     context?: BridgeClientRequestContext;
   }>;
+  readonly metadataCalls: Array<{
+    sessionId: string;
+    metadata: { displayName?: string };
+    context?: BridgeClientRequestContext;
+  }>;
+  readonly recapCalls: Array<{
+    sessionId: string;
+    context?: BridgeClientRequestContext;
+  }>;
+  readonly btwCalls: Array<{
+    sessionId: string;
+    question: string;
+    signal?: AbortSignal;
+    context?: BridgeClientRequestContext;
+  }>;
+  readonly midTurnMessageCalls: Array<{
+    sessionId: string;
+    message: string;
+    context?: BridgeClientRequestContext;
+  }>;
+  readonly taskCancelCalls: Array<{
+    sessionId: string;
+    taskId: string;
+    taskKind: 'agent' | 'shell' | 'monitor';
+  }>;
+  readonly goalClearCalls: string[];
 }
 
 function makeSummary(
@@ -204,6 +232,12 @@ function makeBridge(
   const summaryCalls: string[] = [];
   const setModelCalls: FakeBridge['setModelCalls'] = [];
   const setApprovalModeCalls: FakeBridge['setApprovalModeCalls'] = [];
+  const metadataCalls: FakeBridge['metadataCalls'] = [];
+  const recapCalls: FakeBridge['recapCalls'] = [];
+  const btwCalls: FakeBridge['btwCalls'] = [];
+  const midTurnMessageCalls: FakeBridge['midTurnMessageCalls'] = [];
+  const taskCancelCalls: FakeBridge['taskCancelCalls'] = [];
+  const goalClearCalls: string[] = [];
   const bridge = {
     permissionPolicy: 'first-responder' as const,
     spawnCalls,
@@ -221,6 +255,12 @@ function makeBridge(
     summaryCalls,
     setModelCalls,
     setApprovalModeCalls,
+    metadataCalls,
+    recapCalls,
+    btwCalls,
+    midTurnMessageCalls,
+    taskCancelCalls,
+    goalClearCalls,
     get sessionCount() {
       return live.size;
     },
@@ -343,6 +383,68 @@ function makeBridge(
         persisted: opts?.persist === true,
       };
     },
+    updateSessionMetadata(
+      sessionId: string,
+      metadata: { displayName?: string },
+      context?: BridgeClientRequestContext,
+    ) {
+      metadataCalls.push({
+        sessionId,
+        metadata,
+        ...(context ? { context } : {}),
+      });
+      return {
+        displayName: `${workspaceCwd}:${metadata.displayName ?? ''}`,
+      };
+    },
+    async generateSessionRecap(
+      sessionId: string,
+      context?: BridgeClientRequestContext,
+    ) {
+      recapCalls.push({ sessionId, ...(context ? { context } : {}) });
+      return { sessionId, recap: `${workspaceCwd}:recap` };
+    },
+    async generateSessionBtw(
+      sessionId: string,
+      question: string,
+      signal?: AbortSignal,
+      context?: BridgeClientRequestContext,
+    ) {
+      btwCalls.push({
+        sessionId,
+        question,
+        ...(signal ? { signal } : {}),
+        ...(context ? { context } : {}),
+      });
+      return { sessionId, answer: `${workspaceCwd}:answer` };
+    },
+    enqueueMidTurnMessage(
+      sessionId: string,
+      message: string,
+      context?: BridgeClientRequestContext,
+    ) {
+      midTurnMessageCalls.push({
+        sessionId,
+        message,
+        ...(context ? { context } : {}),
+      });
+      return { accepted: workspaceCwd === SECONDARY_CWD };
+    },
+    async cancelSessionTask(
+      sessionId: string,
+      taskId: string,
+      taskKind: 'agent' | 'shell' | 'monitor',
+    ) {
+      taskCancelCalls.push({ sessionId, taskId, taskKind });
+      return { cancelled: workspaceCwd === SECONDARY_CWD };
+    },
+    async clearSessionGoal(sessionId: string) {
+      goalClearCalls.push(sessionId);
+      return {
+        cleared: workspaceCwd === SECONDARY_CWD,
+        condition: workspaceCwd,
+      };
+    },
     async cancelSession(sessionId: string) {
       cancelCalls.push(sessionId);
     },
@@ -441,6 +543,7 @@ function makeHarness(opts?: {
   secondaryChannelLive?: boolean;
   daemonLog?: DaemonLogger;
   secondarySummaries?: BridgeSessionSummary[];
+  token?: string;
 }) {
   const primaryBridge = makeBridge(
     PRIMARY_CWD,
@@ -471,7 +574,11 @@ function makeHarness(opts?: {
     }),
   ]);
   const app = createServeApp(
-    { ...baseOpts, workspace: PRIMARY_CWD },
+    {
+      ...baseOpts,
+      workspace: PRIMARY_CWD,
+      ...(opts?.token !== undefined ? { token: opts.token } : {}),
+    },
     undefined,
     {
       workspaceRegistry: registry,
@@ -947,6 +1054,256 @@ describe('multi-workspace session dispatch', () => {
     expect(approvalRes.status).toBe(403);
     expect(approvalRes.body.code).toBe('untrusted_workspace');
     expect(secondaryBridge.setApprovalModeCalls).toEqual([]);
+  });
+
+  it('routes owner-local actions to the owning non-primary workspace bridge', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness({
+      token: TEST_TOKEN,
+    });
+
+    const metadataRes = await request(app)
+      .patch('/session/secondary-session/metadata')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .set('X-Qwen-Client-Id', 'secondary-client')
+      .send({ displayName: 'renamed' });
+    expect(metadataRes.status).toBe(200);
+    expect(metadataRes.body).toEqual({
+      sessionId: 'secondary-session',
+      displayName: `${SECONDARY_CWD}:renamed`,
+    });
+
+    const recapRes = await request(app)
+      .post('/session/secondary-session/recap')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .set('X-Qwen-Client-Id', 'secondary-client')
+      .send({});
+    expect(recapRes.status).toBe(200);
+    expect(recapRes.body).toEqual({
+      sessionId: 'secondary-session',
+      recap: `${SECONDARY_CWD}:recap`,
+    });
+
+    const btwRes = await request(app)
+      .post('/session/secondary-session/btw')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .set('X-Qwen-Client-Id', 'secondary-client')
+      .send({ question: '  why?  ' });
+    expect(btwRes.status).toBe(200);
+    expect(btwRes.body).toEqual({
+      sessionId: 'secondary-session',
+      answer: `${SECONDARY_CWD}:answer`,
+    });
+
+    const midTurnRes = await request(app)
+      .post('/session/secondary-session/mid-turn-message')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .set('X-Qwen-Client-Id', 'secondary-client')
+      .send({ message: '  remember this  ' });
+    expect(midTurnRes.status).toBe(200);
+    expect(midTurnRes.body).toEqual({ accepted: true });
+
+    const taskCancelRes = await request(app)
+      .post('/session/secondary-session/tasks/task-1/cancel')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .send({ kind: 'shell' });
+    expect(taskCancelRes.status).toBe(200);
+    expect(taskCancelRes.body).toEqual({ cancelled: true });
+
+    const goalClearRes = await request(app)
+      .post('/session/secondary-session/goal/clear')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .send({});
+    expect(goalClearRes.status).toBe(200);
+    expect(goalClearRes.body).toEqual({
+      cleared: true,
+      condition: SECONDARY_CWD,
+    });
+
+    expect(secondaryBridge.metadataCalls).toEqual([
+      {
+        sessionId: 'secondary-session',
+        metadata: { displayName: 'renamed' },
+        context: { clientId: 'secondary-client' },
+      },
+    ]);
+    expect(secondaryBridge.recapCalls).toEqual([
+      {
+        sessionId: 'secondary-session',
+        context: { clientId: 'secondary-client' },
+      },
+    ]);
+    expect(secondaryBridge.btwCalls).toEqual([
+      expect.objectContaining({
+        sessionId: 'secondary-session',
+        question: 'why?',
+        signal: expect.any(AbortSignal),
+        context: { clientId: 'secondary-client' },
+      }),
+    ]);
+    expect(secondaryBridge.btwCalls[0]?.signal?.aborted).toBe(false);
+    expect(secondaryBridge.midTurnMessageCalls).toEqual([
+      {
+        sessionId: 'secondary-session',
+        message: 'remember this',
+        context: { clientId: 'secondary-client' },
+      },
+    ]);
+    expect(secondaryBridge.taskCancelCalls).toEqual([
+      {
+        sessionId: 'secondary-session',
+        taskId: 'task-1',
+        taskKind: 'shell',
+      },
+    ]);
+    expect(secondaryBridge.goalClearCalls).toEqual(['secondary-session']);
+
+    for (const calls of [
+      primaryBridge.metadataCalls,
+      primaryBridge.recapCalls,
+      primaryBridge.btwCalls,
+      primaryBridge.midTurnMessageCalls,
+      primaryBridge.taskCancelCalls,
+      primaryBridge.goalClearCalls,
+    ]) {
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it('preserves primary routing for owner-local actions', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness({
+      token: TEST_TOKEN,
+    });
+
+    const res = await request(app)
+      .patch('/session/primary-session/metadata')
+      .set('Host', host())
+      .set('Authorization', TEST_AUTHORIZATION)
+      .send({ displayName: 'primary renamed' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.displayName).toBe(`${PRIMARY_CWD}:primary renamed`);
+    expect(primaryBridge.metadataCalls).toEqual([
+      {
+        sessionId: 'primary-session',
+        metadata: { displayName: 'primary renamed' },
+      },
+    ]);
+    expect(secondaryBridge.metadataCalls).toEqual([]);
+  });
+
+  it('keeps strict owner-local actions behind bearer authentication', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness({
+      token: TEST_TOKEN,
+    });
+
+    const res = await request(app)
+      .patch('/session/secondary-session/metadata')
+      .set('Host', host())
+      .send({ displayName: 'unauthorized' });
+
+    expect(res.status).toBe(401);
+    expect(primaryBridge.metadataCalls).toEqual([]);
+    expect(secondaryBridge.metadataCalls).toEqual([]);
+  });
+
+  it('rejects invalid secondary owner-local inputs before bridge actions', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness({
+      token: TEST_TOKEN,
+    });
+
+    const responses = await Promise.all([
+      request(app)
+        .patch('/session/secondary-session/metadata')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ displayName: 42 }),
+      request(app)
+        .post('/session/secondary-session/btw')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ question: '   ' }),
+      request(app)
+        .post('/session/secondary-session/mid-turn-message')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ message: '   ' }),
+      request(app)
+        .post('/session/secondary-session/tasks/task-1/cancel')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ kind: 'invalid' }),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([
+      400, 400, 400, 400,
+    ]);
+    for (const bridge of [primaryBridge, secondaryBridge]) {
+      expect(bridge.metadataCalls).toEqual([]);
+      expect(bridge.btwCalls).toEqual([]);
+      expect(bridge.midTurnMessageCalls).toEqual([]);
+      expect(bridge.taskCancelCalls).toEqual([]);
+    }
+  });
+
+  it('rejects all owner-local actions for an untrusted non-primary owner', async () => {
+    const { app, primaryBridge, secondaryBridge } = makeHarness({
+      secondaryTrusted: false,
+      token: TEST_TOKEN,
+    });
+
+    const responses = await Promise.all([
+      request(app)
+        .patch('/session/secondary-session/metadata')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ displayName: 'blocked' }),
+      request(app)
+        .post('/session/secondary-session/recap')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({}),
+      request(app)
+        .post('/session/secondary-session/btw')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ question: 'blocked?' }),
+      request(app)
+        .post('/session/secondary-session/mid-turn-message')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ message: 'blocked' }),
+      request(app)
+        .post('/session/secondary-session/tasks/task-1/cancel')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({ kind: 'agent' }),
+      request(app)
+        .post('/session/secondary-session/goal/clear')
+        .set('Host', host())
+        .set('Authorization', TEST_AUTHORIZATION)
+        .send({}),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([
+      403, 403, 403, 403, 403, 403,
+    ]);
+    for (const response of responses) {
+      expect(response.body.code).toBe('untrusted_workspace');
+    }
+    for (const bridge of [primaryBridge, secondaryBridge]) {
+      expect(bridge.metadataCalls).toEqual([]);
+      expect(bridge.recapCalls).toEqual([]);
+      expect(bridge.btwCalls).toEqual([]);
+      expect(bridge.midTurnMessageCalls).toEqual([]);
+      expect(bridge.taskCancelCalls).toEqual([]);
+      expect(bridge.goalClearCalls).toEqual([]);
+    }
   });
 
   it('lists active persisted and live non-primary workspace sessions by workspace id', async () => {

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -1202,14 +1202,30 @@ describe('multi-workspace session dispatch', () => {
       token: TEST_TOKEN,
     });
 
-    const res = await request(app)
-      .patch('/session/secondary-session/metadata')
-      .set('Host', host())
-      .send({ displayName: 'unauthorized' });
+    const responses = await Promise.all([
+      request(app)
+        .patch('/session/secondary-session/metadata')
+        .set('Host', host())
+        .send({ displayName: 'unauthorized' }),
+      request(app)
+        .post('/session/secondary-session/tasks/task-1/cancel')
+        .set('Host', host())
+        .send({ kind: 'shell' }),
+      request(app)
+        .post('/session/secondary-session/goal/clear')
+        .set('Host', host())
+        .send({}),
+    ]);
 
-    expect(res.status).toBe(401);
+    expect(responses.map((response) => response.status)).toEqual([
+      401, 401, 401,
+    ]);
     expect(primaryBridge.metadataCalls).toEqual([]);
     expect(secondaryBridge.metadataCalls).toEqual([]);
+    expect(primaryBridge.taskCancelCalls).toEqual([]);
+    expect(secondaryBridge.taskCancelCalls).toEqual([]);
+    expect(primaryBridge.goalClearCalls).toEqual([]);
+    expect(secondaryBridge.goalClearCalls).toEqual([]);
   });
 
   it('rejects invalid secondary owner-local inputs before bridge actions', async () => {

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1698,9 +1698,9 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/tasks/:taskId/cancel',
     mutate({ strict: true }),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/tasks/:taskId/cancel',
-      async (req, res, sessionId) => {
+      async (req, res, sessionId, runtime) => {
         const taskId = req.params['taskId'];
         if (!taskId) {
           res.status(400).json({
@@ -1718,7 +1718,9 @@ export function registerSessionRoutes(
         }
         res
           .status(200)
-          .json(await bridge.cancelSessionTask(sessionId, taskId, kind));
+          .json(
+            await runtime.bridge.cancelSessionTask(sessionId, taskId, kind),
+          );
       },
     ),
   );
@@ -1726,10 +1728,10 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/goal/clear',
     mutate({ strict: true }),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/goal/clear',
-      async (_req, res, sessionId) => {
-        res.status(200).json(await bridge.clearSessionGoal(sessionId));
+      async (_req, res, sessionId, runtime) => {
+        res.status(200).json(await runtime.bridge.clearSessionGoal(sessionId));
       },
     ),
   );
@@ -2167,30 +2169,36 @@ export function registerSessionRoutes(
   app.patch(
     '/session/:id/metadata',
     mutate({ strict: true }),
-    withMutableSession('PATCH /session/:id/metadata', (req, res, sessionId) => {
-      const body = safeBody(req);
-      const clientId = parseClientIdHeader(req, res);
-      if (clientId === null) return;
-      const rawDisplayName = body['displayName'];
-      if (rawDisplayName !== undefined && typeof rawDisplayName !== 'string') {
-        res.status(400).json({
-          error: '`displayName` must be a string',
-          code: 'invalid_metadata',
-          field: 'displayName',
-        });
-        return;
-      }
-      const displayName =
-        typeof rawDisplayName === 'string'
-          ? rawDisplayName.slice(0, 256)
-          : undefined;
-      const effective = bridge.updateSessionMetadata(
-        sessionId,
-        { displayName },
-        clientId !== undefined ? { clientId } : undefined,
-      );
-      res.status(200).json({ sessionId, ...effective });
-    }),
+    withOwnerMutableSession(
+      'PATCH /session/:id/metadata',
+      (req, res, sessionId, runtime) => {
+        const body = safeBody(req);
+        const clientId = parseClientIdHeader(req, res);
+        if (clientId === null) return;
+        const rawDisplayName = body['displayName'];
+        if (
+          rawDisplayName !== undefined &&
+          typeof rawDisplayName !== 'string'
+        ) {
+          res.status(400).json({
+            error: '`displayName` must be a string',
+            code: 'invalid_metadata',
+            field: 'displayName',
+          });
+          return;
+        }
+        const displayName =
+          typeof rawDisplayName === 'string'
+            ? rawDisplayName.slice(0, 256)
+            : undefined;
+        const effective = runtime.bridge.updateSessionMetadata(
+          sessionId,
+          { displayName },
+          clientId !== undefined ? { clientId } : undefined,
+        );
+        res.status(200).json({ sessionId, ...effective });
+      },
+    ),
   );
 
   type SessionOrganizationTarget = {
@@ -2689,16 +2697,16 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/recap',
     mutate(),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/recap',
-      async (req, res, sessionId) => {
+      async (req, res, sessionId, runtime) => {
         // Wraps `generateSessionRecap` so daemon clients can fetch a
         // one-sentence "where did I leave off" summary without a full
         // prompt turn. Best-effort — `recap: null` on short history or
         // transient model failure is a normal 200, not an error.
         const clientId = parseClientIdHeader(req, res);
         if (clientId === null) return;
-        const response = await bridge.generateSessionRecap(
+        const response = await runtime.bridge.generateSessionRecap(
           sessionId,
           clientId !== undefined ? { clientId } : undefined,
         );
@@ -2719,53 +2727,56 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/btw',
     mutate(),
-    withMutableSession('POST /session/:id/btw', async (req, res, sessionId) => {
-      const body = safeBody(req);
-      const question = body['question'];
-      if (
-        typeof question !== 'string' ||
-        question.trim().length === 0 ||
-        question.length > BTW_MAX_INPUT_LENGTH
-      ) {
-        res.status(400).json({
-          error: `\`question\` is required, must be a non-empty string, and at most ${BTW_MAX_INPUT_LENGTH} characters`,
-        });
-        return;
-      }
-      const abort = new AbortController();
-      const onResClose = () => {
-        if (!res.writableEnded) abort.abort();
-      };
-      res.once('close', onResClose);
-      const clientId = parseClientIdHeader(req, res);
-      if (clientId === null) {
-        res.off('close', onResClose);
-        return;
-      }
-      try {
-        const result = await bridge.generateSessionBtw(
-          sessionId,
-          question.trim(),
-          abort.signal,
-          clientId !== undefined ? { clientId } : undefined,
-        );
-        res.status(200).json(result);
-      } catch (err) {
+    withOwnerMutableSession(
+      'POST /session/:id/btw',
+      async (req, res, sessionId, runtime) => {
+        const body = safeBody(req);
+        const question = body['question'];
         if (
-          err instanceof DOMException &&
-          err.name === 'AbortError' &&
-          abort.signal.aborted
+          typeof question !== 'string' ||
+          question.trim().length === 0 ||
+          question.length > BTW_MAX_INPUT_LENGTH
         ) {
+          res.status(400).json({
+            error: `\`question\` is required, must be a non-empty string, and at most ${BTW_MAX_INPUT_LENGTH} characters`,
+          });
           return;
         }
-        sendBridgeError(res, err, {
-          route: 'POST /session/:id/btw',
-          sessionId,
-        });
-      } finally {
-        res.off('close', onResClose);
-      }
-    }),
+        const abort = new AbortController();
+        const onResClose = () => {
+          if (!res.writableEnded) abort.abort();
+        };
+        res.once('close', onResClose);
+        const clientId = parseClientIdHeader(req, res);
+        if (clientId === null) {
+          res.off('close', onResClose);
+          return;
+        }
+        try {
+          const result = await runtime.bridge.generateSessionBtw(
+            sessionId,
+            question.trim(),
+            abort.signal,
+            clientId !== undefined ? { clientId } : undefined,
+          );
+          res.status(200).json(result);
+        } catch (err) {
+          if (
+            err instanceof DOMException &&
+            err.name === 'AbortError' &&
+            abort.signal.aborted
+          ) {
+            return;
+          }
+          sendBridgeError(res, err, {
+            route: 'POST /session/:id/btw',
+            sessionId,
+          });
+        } finally {
+          res.off('close', onResClose);
+        }
+      },
+    ),
   );
 
   // Queue a user message typed while the session's turn is still running. The
@@ -2785,9 +2796,9 @@ export function registerSessionRoutes(
   app.post(
     '/session/:id/mid-turn-message',
     mutate(),
-    withMutableSession(
+    withOwnerMutableSession(
       'POST /session/:id/mid-turn-message',
-      (req, res, sessionId) => {
+      (req, res, sessionId, runtime) => {
         const body = safeBody(req);
         const message = body['message'];
         // Validate (and length-check, and enqueue) the TRIMMED value — the bridge
@@ -2812,7 +2823,7 @@ export function registerSessionRoutes(
         // originator for SSE echo routing. `null` = malformed id (already answered).
         const clientId = parseClientIdHeader(req, res);
         if (clientId === null) return;
-        const result = bridge.enqueueMidTurnMessage(
+        const result = runtime.bridge.enqueueMidTurnMessage(
           sessionId,
           trimmed,
           clientId !== undefined ? { clientId } : undefined,

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -49,6 +49,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import {
   ApprovalMode,
+  BTW_MAX_INPUT_LENGTH,
   ExtensionManager,
   ExtensionUpdateState,
   SessionService,
@@ -540,6 +541,12 @@ interface FakeBridgeOpts {
     sessionId: string,
     context?: BridgeClientRequestContext,
   ) => Promise<{ sessionId: string; recap: string | null }>;
+  generateSessionBtwImpl?: (
+    sessionId: string,
+    question: string,
+    signal?: AbortSignal,
+    context?: BridgeClientRequestContext,
+  ) => Promise<{ sessionId: string; answer: string | null }>;
   launchSessionForkAgentImpl?: (
     sessionId: string,
     directive: string,
@@ -769,6 +776,12 @@ interface FakeBridge extends AcpSessionBridge {
   }>;
   generateSessionRecapCalls: Array<{
     sessionId: string;
+    context?: BridgeClientRequestContext;
+  }>;
+  generateSessionBtwCalls: Array<{
+    sessionId: string;
+    question: string;
+    signal?: AbortSignal;
     context?: BridgeClientRequestContext;
   }>;
   forkCalls: Array<{
@@ -1243,6 +1256,13 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionId,
       recap: 'Default fake recap.',
     }));
+  const generateSessionBtwCalls: FakeBridge['generateSessionBtwCalls'] = [];
+  const generateSessionBtwImpl =
+    opts.generateSessionBtwImpl ??
+    (async (sessionId: string) => ({
+      sessionId,
+      answer: 'mock btw answer',
+    }));
   const forkCalls: FakeBridge['forkCalls'] = [];
   const launchSessionForkAgentImpl =
     opts.launchSessionForkAgentImpl ??
@@ -1384,6 +1404,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     setApprovalModeCalls,
     shellCalls,
     generateSessionRecapCalls,
+    generateSessionBtwCalls,
     forkCalls,
     workspaceMemoryRememberCalls,
     workspaceMemoryForgetCalls,
@@ -1661,8 +1682,14 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       });
       return generateSessionRecapImpl(sessionId, context);
     },
-    async generateSessionBtw(sessionId, _question, _signal, _context) {
-      return { sessionId, answer: 'mock btw answer' };
+    async generateSessionBtw(sessionId, question, signal, context) {
+      generateSessionBtwCalls.push({
+        sessionId,
+        question,
+        ...(signal ? { signal } : {}),
+        ...(context ? { context } : {}),
+      });
+      return generateSessionBtwImpl(sessionId, question, signal, context);
     },
     async launchSessionForkAgent(sessionId, directive, context) {
       forkCalls.push({
@@ -9389,6 +9416,85 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send();
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('POST /session/:id/btw', () => {
+    it('trims the question and forwards client identity plus an abort signal', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+
+      const res = await request(app)
+        .post('/session/session-A/btw')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ question: '  what now?  ' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        sessionId: 'session-A',
+        answer: 'mock btw answer',
+      });
+      expect(bridge.generateSessionBtwCalls).toEqual([
+        expect.objectContaining({
+          sessionId: 'session-A',
+          question: 'what now?',
+          signal: expect.any(AbortSignal),
+          context: { clientId: 'client-1' },
+        }),
+      ]);
+      expect(bridge.generateSessionBtwCalls[0]?.signal?.aborted).toBe(false);
+    });
+
+    it('rejects empty and oversized questions before bridge dispatch', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+
+      const empty = await request(app)
+        .post('/session/session-A/btw')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ question: '   ' });
+      const oversized = await request(app)
+        .post('/session/session-A/btw')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ question: 'x'.repeat(BTW_MAX_INPUT_LENGTH + 1) });
+
+      expect(empty.status).toBe(400);
+      expect(oversized.status).toBe(400);
+      expect(bridge.generateSessionBtwCalls).toEqual([]);
+    });
+
+    it('rejects a malformed client id before bridge dispatch', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+
+      const res = await request(app)
+        .post('/session/session-A/btw')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'bad client id')
+        .send({ question: 'what now?' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('invalid_client_id');
+      expect(bridge.generateSessionBtwCalls).toEqual([]);
+    });
+
+    it('maps bridge errors through the standard route error response', async () => {
+      const bridge = fakeBridge({
+        generateSessionBtwImpl: async () => {
+          throw new Error('btw failed');
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+
+      const res = await request(app)
+        .post('/session/session-A/btw')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ question: 'what now?' });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'btw failed' });
+      expect(bridge.generateSessionBtwCalls).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## What this PR does

Routes six existing workspace-less live-session REST actions to the trusted workspace runtime that owns the session identified by `sessionId`: metadata update, recap, BTW, mid-turn message, task cancellation, and goal clear. The existing URLs, request and response contracts, authentication, capability advertisement, archive lease, validation, client identity forwarding, and error mapping remain unchanged.

## Why it's needed

In a multi-workspace daemon, these actions resolved a secondary live session correctly but then stopped at the Phase 2a primary-only guard, so normal WebShell and SDK actions such as rename and recap failed with `non_primary_session_route_not_supported`. Dispatching through the owning runtime makes trusted secondary sessions behave like primary sessions without adding a workspace selector or changing clients.

## Reviewer Test Plan

### How to verify

Run the multi-workspace tests and confirm that all six authenticated secondary requests reach the secondary fake bridge with the exact session id, trimmed values, client context, and BTW abort signal, while primary call arrays stay empty. Confirm primary routing, strict unauthenticated 401, invalid-input validation, and untrusted-secondary 403 behavior. Run the BTW server tests and the existing server regression suite; the expected bridge-error log in the BTW mapping test is intentional. A local bundled daemon smoke test with two trusted disposable workspaces should return metadata 200, recap 200 with nullable recap, idle mid-turn `{ accepted: false }`, nonexistent task cancellation `{ cancelled: false }`, absent goal `{ cleared: false }`, and BTW validation 400 rather than the Phase 2a guard.

### Evidence (Before & After)

Before: the global 0.19.9 daemon returned HTTP 400 `non_primary_session_route_not_supported` for all six authenticated secondary routes. After: the local bundle returned metadata 200, recap 200, mid-turn 200, task-cancel 200, goal-clear 200, and BTW invalid-input 400 from route validation; the secondary workspace was shown in capabilities and the created session response. WebShell screenshot capture was not run in the headless environment; deterministic SSE/UI coverage remains in the existing tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v24.12.0 on macOS; local `npm run build` and `npm run bundle`; isolated trusted workspaces, runtime directory, port, and bearer token for daemon smoke testing; global baseline CLI 0.19.9.

## Risk & Scope

- Main risk or tradeoff: incorrect owner resolution could dispatch an action to the wrong workspace; the implementation reuses the existing trusted live-owner resolver and shared archive lease, and the tests use workspace-specific bridge sentinels to catch misrouting.
- Not validated / out of scope: real WebShell screenshots, model-backed BTW answers, active-turn injection, running-task stopping, and active-goal clearing were not exercised in the headless smoke test; remaining primary-only routes, ACP metadata mapping, telemetry attribution, and matcher/schema/SDK changes are intentionally excluded.
- Breaking changes / migration notes: none; URLs, payloads, responses, capabilities, and client behavior are unchanged.

## Linked Issues

Refs #6378

<details>
<summary>中文说明</summary>

## What this PR does

将六个现有的无 workspace 参数 live-session REST 操作路由到拥有该 `sessionId` 的可信 workspace runtime：metadata 更新、recap、BTW、mid-turn 消息、任务取消和 goal 清除。现有 URL、请求和响应协议、鉴权、capability 广告、archive lease、参数校验、client identity 传递及错误映射均保持不变。

## Why it's needed

在 multi-workspace daemon 中，这些操作能够正确解析 secondary live session，却随后被 Phase 2a primary-only guard 拦截，因此重命名、recap 等 WebShell 和 SDK 操作会失败并返回 `non_primary_session_route_not_supported`。通过 owning runtime 分发后，可信 secondary session 可与 primary session 一致工作，不增加 workspace selector，也不改变客户端。

## Reviewer Test Plan

### How to verify

运行 multi-workspace 测试，确认六个带认证的 secondary 请求都到达 secondary fake bridge，并收到准确的 session id、trim 后值、client context 和 BTW abort signal，同时 primary 调用数组为空。确认 primary 路由、严格鉴权的未认证 401、无效输入校验和不可信 secondary 的 403 行为。运行 BTW server 测试及现有 server 回归套件；BTW 错误映射测试中的 bridge-error 日志是有意触发的。使用两个可信临时 workspace 启动本地 bundle daemon 做 smoke test，应得到 metadata 200、recap 200 且 recap 可为空、idle mid-turn `{ accepted: false }`、不存在任务的取消 `{ cancelled: false }`、无 goal 的 `{ cleared: false }`，以及来自路由校验的 BTW 400，而不是 Phase 2a guard。

### Evidence (Before & After)

修复前：global 0.19.9 daemon 的六个带认证 secondary 路由全部返回 HTTP 400 `non_primary_session_route_not_supported`。修复后：local bundle 返回 metadata 200、recap 200、mid-turn 200、task-cancel 200、goal-clear 200，以及由路由校验返回的 BTW 无效输入 400；capabilities 显示了 secondary workspace，创建 session 的响应也显示了该 workspace。当前无头环境未执行 WebShell 截图；确定性的 SSE/UI 覆盖仍由现有测试提供。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### Environment (optional)

macOS 上的 Node.js v24.12.0；本地执行 `npm run build` 和 `npm run bundle`；daemon smoke test 使用隔离的可信 workspace、runtime 目录、端口和 bearer token；global baseline CLI 为 0.19.9。

## Risk & Scope

- 主要风险或权衡：错误的 owner 解析可能将操作分发到错误 workspace；本实现复用现有可信 live-owner resolver 和 shared archive lease，测试使用按 workspace 区分的 bridge sentinel 来捕获错误路由。
- 未验证 / 范围外：无头 smoke test 未执行真实 WebShell 截图、模型驱动的 BTW 答案、active-turn 注入、运行中任务停止及 active goal 清除；其余 primary-only 路由、ACP metadata 映射、telemetry 归属以及 matcher/schema/SDK 变更均明确排除。
- 破坏性变更 / 迁移说明：无；URL、payload、response、capability 和客户端行为均未改变。

## Linked Issues

Refs #6378

</details>
