### PR TITLE
fix(cli): bound LlmRewriter outputHistory to contextTurns

### DIFF
--- a/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
@@ -94,6 +94,54 @@ describe('LlmRewriter', () => {
       expect(secondInput).not.toContain('上一轮改写结果');
     });
 
+    // Regression: outputHistory previously grew unboundedly — every rewrite was
+    // pushed even though only the last `contextTurns` are ever read.
+    function historyOf(rewriter: unknown): string[] {
+      return (rewriter as { outputHistory: string[] }).outputHistory;
+    }
+
+    it('bounds outputHistory to contextTurns instead of growing unboundedly', async () => {
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        contextTurns: 2,
+      } as MessageRewriteConfig);
+
+      for (let i = 0; i < 6; i++) {
+        await rewriter.rewrite(makeTurn([`message number ${i} with length`]));
+      }
+
+      expect(historyOf(rewriter).length).toBe(2);
+    });
+
+    it('stores nothing when contextTurns=0', async () => {
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        contextTurns: 0,
+      } as MessageRewriteConfig);
+
+      for (let i = 0; i < 4; i++) {
+        await rewriter.rewrite(makeTurn([`message number ${i} with length`]));
+      }
+
+      expect(historyOf(rewriter).length).toBe(0);
+    });
+
+    it("keeps the full history when contextTurns is 'all'", async () => {
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        contextTurns: 'all',
+      } as MessageRewriteConfig);
+
+      for (let i = 0; i < 4; i++) {
+        await rewriter.rewrite(makeTurn([`message number ${i} with length`]));
+      }
+
+      expect(historyOf(rewriter).length).toBe(4);
+    });
+
     it('should include last N rewrites when contextTurns=N', async () => {
       mockGenerateContent
         .mockResolvedValueOnce({

--- a/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.ts
@@ -147,8 +147,19 @@ export class LlmRewriter {
           `--- OUTPUT ---\n${rewritten}\n---`,
       );
 
-      // Update context for next turn
-      this.outputHistory.push(rewritten);
+      // Update context for next turn. Only the last `contextTurns` outputs are
+      // ever read (see the context slice above), so keep at most that many to
+      // avoid unbounded growth over a long session. Infinity ('all') keeps
+      // everything; 0 means the history is never read, so store nothing.
+      if (this.contextTurns > 0) {
+        this.outputHistory.push(rewritten);
+        if (
+          Number.isFinite(this.contextTurns) &&
+          this.outputHistory.length > this.contextTurns
+        ) {
+          this.outputHistory = this.outputHistory.slice(-this.contextTurns);
+        }
+      }
 
       return rewritten;
     } catch (error) {


### PR DESCRIPTION
## What this PR does

Bounds `LlmRewriter.outputHistory` to the configured `contextTurns` so it no longer grows for the lifetime of a session. Adds regression tests.

## Why it's needed

`rewrite()` pushes every successful rewrite onto `outputHistory`, but the only reader (`slice(-contextTurns)` when finite, or the whole array when `'all'`) never looks past the last `contextTurns` entries. So on a long ACP session the array accumulates one string per turn indefinitely, holding references that can never be used. The worst case is `contextTurns: 0`, where the history is *never* read yet still grows on every turn. The fix keeps at most what can be read: store nothing when `contextTurns` is `0`, keep everything when it is `'all'` (`Infinity`), and otherwise trim to the last `contextTurns` after each push. Behavior visible to the model is unchanged — the context slice sent on each turn is identical.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/acp-integration/session/rewrite/LlmRewriter.test.ts` from `packages/cli` and confirm all pass, including the three added `contextTurns` cases. `bounds outputHistory to contextTurns` and `stores nothing when contextTurns=0` fail against the previous unconditional `push` (verified locally by reverting to the old one-liner); the `'all'` case keeps the full history.

### Evidence (Before & After)

Before: with `contextTurns: 2`, six rewrites leave `outputHistory.length === 6`.
After: the same sequence leaves `outputHistory.length === 2`. With `contextTurns: 0` it stays `0`; with `'all'` it retains all six.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `LlmRewriter` suite (12 pass), confirmed the two new bounding tests fail against the pre-fix code, and ran `prettier --check` + `eslint` on both files (clean). Windows/Linux: N/A — pure in-memory array logic with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-cli` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — the per-turn context passed to the rewrite model is unchanged (it already only used the last `contextTurns`); this only stops retaining entries that were never read.
- Not validated / out of scope: no change to the rewrite prompt, model selection, or emission path.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

将 `LlmRewriter.outputHistory` 限制在配置的 `contextTurns` 范围内，使其不再在整个会话生命周期内持续增长。并补充回归测试。

## 为什么需要

`rewrite()` 会把每次成功的改写结果 push 进 `outputHistory`，但唯一的读取处（有限时取 `slice(-contextTurns)`，`'all'` 时取整个数组）永远不会用到最后 `contextTurns` 条之前的内容。因此在较长的 ACP 会话中，该数组每轮累加一个字符串且永不释放，保留着永远用不到的引用。最坏情况是 `contextTurns: 0`——历史从不被读取，却仍每轮增长。修复方式是只保留可能被读取的部分：`contextTurns` 为 `0` 时不存储，为 `'all'`（`Infinity`）时全部保留，其余情况在每次 push 后裁剪到最后 `contextTurns` 条。对模型可见的行为不变——每轮发送的上下文切片完全一致。

## 复核测试计划

### 如何验证

在 `packages/cli` 下运行 `npx vitest run src/acp-integration/session/rewrite/LlmRewriter.test.ts`，确认全部通过，包括新增的三个 `contextTurns` 用例。`bounds outputHistory to contextTurns` 与 `stores nothing when contextTurns=0` 在修复前的无条件 `push` 下会失败（已在本地通过回退旧写法验证）；`'all'` 用例保留完整历史。

### 证据（修复前后对比）

修复前：`contextTurns: 2` 时，六次改写后 `outputHistory.length === 6`。
修复后：同样的序列后 `outputHistory.length === 2`。`contextTurns: 0` 时保持为 `0`；`'all'` 时保留全部六条。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `LlmRewriter` 测试（12 个通过），确认两个新增的限界测试在修复前失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯内存数组逻辑，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-cli` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——每轮传给改写模型的上下文不变（本就只用最后 `contextTurns` 条）；此改动只是不再保留从未被读取的条目。
- 未验证 / 范围之外：未改动改写提示词、模型选择或发送路径。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
