### PR TITLE
fix(cli): drain rewrites enqueued during waitForPendingRewrites

### DIFF
--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
@@ -347,4 +347,93 @@ describe('MessageRewriteMiddleware', () => {
       }
     });
   });
+
+  describe('waitForPendingRewrites — draining late arrivals', () => {
+    it('waits for a rewrite enqueued while it is already draining', async () => {
+      const { LlmRewriter } = await import('./LlmRewriter.js');
+      const mockable = LlmRewriter as unknown as {
+        mockImplementation: (fn: unknown) => void;
+      };
+
+      // Hand out a controllable promise per rewrite so we can complete the
+      // first turn's rewrite while a second turn is enqueued mid-drain.
+      const deferreds: Array<{
+        resolve: (v: string) => void;
+        promise: Promise<string>;
+      }> = [];
+      const nextDeferred = () => {
+        let resolve!: (v: string) => void;
+        const promise = new Promise<string>((r) => (resolve = r));
+        const d = { resolve, promise };
+        deferreds.push(d);
+        return d;
+      };
+
+      try {
+        mockable.mockImplementation(() => ({
+          rewrite: vi.fn(() => nextDeferred().promise),
+        }));
+
+        const mockSendUpdate = vi.fn().mockResolvedValue(undefined);
+        const middleware = new MessageRewriteMiddleware(
+          {} as Config,
+          { enabled: true, target: 'all', prompt: 'test prompt' },
+          mockSendUpdate,
+        );
+        const flushMicrotasks = () =>
+          new Promise((resolve) => setImmediate(resolve));
+
+        // Turn 1 → enqueues the first pending rewrite (awaiting deferreds[0]).
+        await middleware.interceptUpdate({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'turn one content' },
+        } as unknown as SessionUpdate);
+        await middleware.flushTurn();
+
+        // Start draining; it captures the first rewrite and awaits it.
+        let drained = false;
+        const waitPromise = middleware.waitForPendingRewrites().then(() => {
+          drained = true;
+        });
+
+        // Turn 2 lands *during* the drain → enqueues a second pending rewrite.
+        await middleware.interceptUpdate({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'turn two content' },
+        } as unknown as SessionUpdate);
+        await middleware.flushTurn();
+
+        // Complete only the first rewrite.
+        deferreds[0].resolve('rewritten one');
+        await flushMicrotasks();
+        await flushMicrotasks();
+
+        // The second rewrite is still pending, so the drain must not be done.
+        // Pre-fix, waitForPendingRewrites snapshotted only the first rewrite
+        // and returned here, dropping the second.
+        expect(drained).toBe(false);
+
+        // Complete the second rewrite; the drain now resolves and both
+        // rewritten messages have been emitted.
+        deferreds[1].resolve('rewritten two');
+        await waitPromise;
+        expect(drained).toBe(true);
+
+        const rewriteCalls = mockSendUpdate.mock.calls.filter(
+          (call: unknown[]) =>
+            (
+              (call[0] as Record<string, unknown>)['_meta'] as
+                | Record<string, unknown>
+                | undefined
+            )?.['rewritten'] === true,
+        );
+        expect(rewriteCalls).toHaveLength(2);
+      } finally {
+        // Restore the default mock so later runs are unaffected.
+        mockable.mockImplementation(() => ({
+          rewrite: vi.fn().mockResolvedValue('rewritten text'),
+        }));
+      }
+    });
+  });
 });

--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.ts
@@ -192,9 +192,15 @@ export class MessageRewriteMiddleware {
    * Call this before session ends to ensure all rewrites are flushed.
    */
   async waitForPendingRewrites(): Promise<void> {
-    if (this.pendingRewrites.length > 0) {
-      await Promise.allSettled(this.pendingRewrites);
+    // Drain in a loop: a flushTurn that lands while we're awaiting appends to
+    // pendingRewrites, so snapshotting once and then reassigning to [] would
+    // silently drop those late arrivals. Take the current batch, clear the
+    // queue so concurrent pushes go into a fresh array, await it, then repeat
+    // until nothing new was enqueued.
+    while (this.pendingRewrites.length > 0) {
+      const inFlight = this.pendingRewrites;
       this.pendingRewrites = [];
+      await Promise.allSettled(inFlight);
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Fixes `MessageRewriteMiddleware.waitForPendingRewrites()` so a rewrite enqueued while it is already draining is still awaited, instead of being silently dropped. Adds a regression test.

## Why it's needed

`waitForPendingRewrites()` did:

```ts
if (this.pendingRewrites.length > 0) {
  await Promise.allSettled(this.pendingRewrites);
  this.pendingRewrites = [];
}
```

`Promise.allSettled` captures the array's current elements, then the method awaits. A `flushTurn()` that lands during that await appends a new rewrite promise to `this.pendingRewrites` — but the subsequent `this.pendingRewrites = []` discards it, so that rewrite is never awaited. It is called before session end (to flush all rewrites), so a late-arriving turn's rewritten message can be lost if the session tears down before the orphaned promise finishes. Draining in a loop — take the current batch, clear the queue so concurrent pushes land in a fresh array, await it, repeat until empty — guarantees every enqueued rewrite is awaited.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts` from `packages/cli`. The added `waits for a rewrite enqueued while it is already draining` test completes turn 1's rewrite while turn 2 is enqueued mid-drain and asserts the drain does not resolve until turn 2 also completes; it fails against the previous snapshot-and-clear implementation (verified locally by reverting) and passes with the loop.

### Evidence (Before & After)

Before: with a second `flushTurn()` occurring during the await, `waitForPendingRewrites()` resolves after only the first rewrite settles — the second is dropped from tracking (its `agent_message_chunk` may never be emitted before shutdown).
After: `waitForPendingRewrites()` resolves only after both rewrites settle; both rewritten messages are emitted.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `MessageRewriteMiddleware` suite (13 pass), confirmed the new test fails against the pre-fix code, and ran `prettier --check` + `eslint` on both files (clean). Windows/Linux: N/A — pure async control-flow with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-cli` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — the loop awaits the same promises as before plus any that arrive during draining; it terminates once no new rewrite is enqueued during an await, which is the steady state at session end.
- Not validated / out of scope: no change to when `flushTurn()` enqueues rewrites or how they are emitted.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `MessageRewriteMiddleware.waitForPendingRewrites()`，使得在其排空（draining）过程中新入队的改写仍会被等待，而不是被静默丢弃。并补充回归测试。

## 为什么需要

`waitForPendingRewrites()` 原本是：

```ts
if (this.pendingRewrites.length > 0) {
  await Promise.allSettled(this.pendingRewrites);
  this.pendingRewrites = [];
}
```

`Promise.allSettled` 会捕获数组当时的元素，随后方法进入 await。若在此 await 期间发生一次 `flushTurn()`，它会向 `this.pendingRewrites` 追加一个新的改写 promise——但紧接着的 `this.pendingRewrites = []` 会将其丢弃，导致该改写从未被等待。该方法在会话结束前调用（用于冲刷所有改写），因此如果会话在这个被遗弃的 promise 完成前就拆除，一次迟到轮次的改写消息可能丢失。改为循环排空——取出当前批次、清空队列使并发入队进入新数组、await 之、重复直到为空——即可保证每个入队的改写都被等待。

## 复核测试计划

### 如何验证

在 `packages/cli` 下运行 `npx vitest run src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts`。新增的 `waits for a rewrite enqueued while it is already draining` 用例会在第 2 轮于排空过程中入队时先完成第 1 轮的改写，并断言排空要等到第 2 轮也完成才结束；它在修复前的 snapshot-and-clear 实现下失败（已在本地通过回退验证），在循环实现下通过。

### 证据（修复前后对比）

修复前：若在 await 期间发生第二次 `flushTurn()`，`waitForPendingRewrites()` 在第一个改写完成后即返回——第二个被从跟踪中丢弃（其 `agent_message_chunk` 可能在拆除前从未发出）。
修复后：`waitForPendingRewrites()` 只有在两个改写都完成后才返回；两条改写消息都会发出。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `MessageRewriteMiddleware` 测试（13 个通过），确认新增测试在修复前失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯异步控制流，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-cli` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——循环等待的是与之前相同的一批 promise，外加排空期间新到达的那些；一旦某次 await 期间没有新的改写入队即终止，而这正是会话结束时的稳定状态。
- 未验证 / 范围之外：未改动 `flushTurn()` 何时入队改写，也未改动它们的发送方式。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
