### PR TITLE
fix(cli): escape < in insight report data to prevent script breakout

### DIFF
--- a/packages/cli/src/services/insight/generators/TemplateRenderer.test.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { InsightData } from '../types/StaticInsightTypes.js';
+
+// Stub the web-templates bundle so the renderer can be imported in isolation.
+vi.mock('@qwen-code/web-templates', () => ({
+  INSIGHT_JS: '',
+  INSIGHT_CSS: '',
+}));
+
+const { TemplateRenderer } = await import('./TemplateRenderer.js');
+
+function makeInsights(overrides: Partial<InsightData> = {}): InsightData {
+  return {
+    heatmap: {},
+    currentStreak: 0,
+    longestStreak: 0,
+    longestWorkDate: null,
+    longestWorkDuration: 0,
+    activeHours: {},
+    latestActiveTime: null,
+    ...overrides,
+  } as InsightData;
+}
+
+describe('TemplateRenderer', () => {
+  it('escapes `<` in report data so it cannot break out of the inline script', async () => {
+    const renderer = new TemplateRenderer();
+    const payload = '</script><img src=x onerror=alert(1)>';
+    const html = await renderer.renderInsightHTML(
+      makeInsights({ latestActiveTime: payload }),
+    );
+
+    // The raw closing tag / injected element must not appear verbatim.
+    expect(html).not.toContain('</script><img');
+    expect(html).toContain('\\u003c/script>');
+  });
+
+  it('preserves the original data after JSON.parse (escape round-trips)', async () => {
+    const renderer = new TemplateRenderer();
+    const payload = '</script><b>hi</b>';
+    const html = await renderer.renderInsightHTML(
+      makeInsights({ latestActiveTime: payload }),
+    );
+
+    const match = html.match(/window\.INSIGHT_DATA = (.*);/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]) as InsightData;
+    expect(parsed.latestActiveTime).toBe(payload);
+  });
+});

--- a/packages/cli/src/services/insight/generators/TemplateRenderer.test.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.test.ts
@@ -41,6 +41,29 @@ describe('TemplateRenderer', () => {
     expect(html).toContain('\\u003c/script>');
   });
 
+  it('escapes U+2028/U+2029 so pre-ES2019 engines can still parse the script', async () => {
+    const renderer = new TemplateRenderer();
+    // U+2028 (line separator) and U+2029 (paragraph separator) are passed
+    // through raw by JSON.stringify but are line terminators to older engines.
+    const payload = 'line1\u2028line2\u2029line3';
+    const html = await renderer.renderInsightHTML(
+      makeInsights({ latestActiveTime: payload }),
+    );
+
+    // The raw separators must not survive into the inline script; the escaped
+    // forms must appear instead.
+    expect(html).not.toContain('\u2028');
+    expect(html).not.toContain('\u2029');
+    expect(html).toContain('\\u2028');
+    expect(html).toContain('\\u2029');
+
+    // And the escape must round-trip back to the original characters.
+    const match = html.match(/window\.INSIGHT_DATA = (.*);/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]) as InsightData;
+    expect(parsed.latestActiveTime).toBe(payload);
+  });
+
   it('preserves the original data after JSON.parse (escape round-trips)', async () => {
     const renderer = new TemplateRenderer();
     const payload = '</script><b>hi</b>';

--- a/packages/cli/src/services/insight/generators/TemplateRenderer.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.ts
@@ -10,6 +10,11 @@ import type { InsightData } from '../types/StaticInsightTypes.js';
 export class TemplateRenderer {
   // Render the complete HTML file
   async renderInsightHTML(insights: InsightData): Promise<string> {
+    // Escape `<` so a `</script>` (or `<script`, `<!--`) inside the report data
+    // — chat summaries, file/tool names, LLM output — cannot terminate the
+    // inline <script> that carries it. The `<` escape is valid JSON and
+    // parses back to `<`, so the data reaching the page is unchanged.
+    const insightJson = JSON.stringify(insights).replace(/</g, '\\u003c');
     const html = `<!doctype html>
 <html lang="en">
   <head>
@@ -37,7 +42,7 @@ export class TemplateRenderer {
 
     <!-- Application Data -->
     <script>
-      window.INSIGHT_DATA = ${JSON.stringify(insights)};
+      window.INSIGHT_DATA = ${insightJson};
     </script>
 
     <!-- App Script -->

--- a/packages/cli/src/services/insight/generators/TemplateRenderer.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.ts
@@ -12,9 +12,15 @@ export class TemplateRenderer {
   async renderInsightHTML(insights: InsightData): Promise<string> {
     // Escape `<` so a `</script>` (or `<script`, `<!--`) inside the report data
     // — chat summaries, file/tool names, LLM output — cannot terminate the
-    // inline <script> that carries it. The `<` escape is valid JSON and
-    // parses back to `<`, so the data reaching the page is unchanged.
-    const insightJson = JSON.stringify(insights).replace(/</g, '\\u003c');
+    // inline <script> that carries it. Also escape U+2028/U+2029, which
+    // JSON.stringify emits raw but which are line terminators to pre-ES2019
+    // engines (embedded WebViews, older Electron) and would throw SyntaxError.
+    // All three are valid JSON escapes and parse back to the original
+    // characters, so the data reaching the page is unchanged.
+    const insightJson = JSON.stringify(insights)
+      .replace(/</g, '\\u003c')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029');
     const html = `<!doctype html>
 <html lang="en">
   <head>


### PR DESCRIPTION
## What this PR does

Escapes `<` in the insight report's embedded data so a `</script>` inside that data can no longer break out of the inline `<script>` that carries it. Adds a regression test (the module had none).

## Why it's needed

`TemplateRenderer.renderInsightHTML` builds the `/insight` HTML report by embedding the data directly in an inline script:

```html
<script>
  window.INSIGHT_DATA = ${JSON.stringify(insights)};
</script>
```

`insights` contains user-derived content — chat summaries, file/tool names, and LLM output. HTML parses `</script>` inside an inline script literally: a `</script>` substring anywhere in that data closes the tag early, which at best breaks the generated report page and at worst injects markup/script into the locally-opened HTML (self-XSS). The fix escapes `<` to `<` in the stringified JSON. `<` is valid JSON that parses back to `<`, so the data reaching the page is byte-for-byte the same after `JSON.parse`, while `</script>`, `<script`, and `<!--` can no longer be formed in the raw HTML. This is the standard mitigation for embedding JSON in an inline script.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/services/insight/generators/TemplateRenderer.test.ts` from `packages/cli` (the `@qwen-code/web-templates` workspace package must be built first — `npm run build --workspace @qwen-code/web-templates`). The `escapes \`<\`` test feeds a `</script><img src=x onerror=alert(1)>` payload and asserts the raw tag does not appear in the output; it fails against the previous unescaped embedding (verified locally by reverting). The round-trip test confirms `JSON.parse` of the embedded value returns the original string unchanged.

### Evidence (Before & After)

Before: `latestActiveTime: '</script><img src=x onerror=alert(1)>'` renders as `... "latestActiveTime":"</script><img src=x onerror=alert(1)>"` — the `</script>` closes the data script.
After: it renders as `... "latestActiveTime":"</script><img src=x onerror=alert(1)>"`, and `JSON.parse` still yields `</script><img src=x onerror=alert(1)>`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: built web-templates, ran the new test (2 pass), confirmed the escape test fails against the pre-fix code, and ran `prettier --check` + `eslint` on both files (clean). Windows/Linux: N/A — pure string generation with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-cli` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — only `<` characters are rewritten to their `<` JSON escape; the parsed `window.INSIGHT_DATA` object is identical to before, so the report renders the same for all non-malicious data.
- Not validated / out of scope: the trusted `INSIGHT_JS` bundle embedded in the adjacent script is unchanged (it is a build constant, not user data).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

对 insight 报告中嵌入的数据里的 `<` 进行转义，使数据中出现的 `</script>` 不再能从承载它的内联 `<script>` 中"逃逸"。并补充回归测试（该模块此前没有测试）。

## 为什么需要

`TemplateRenderer.renderInsightHTML` 通过把数据直接嵌入内联脚本来生成 `/insight` HTML 报告：

```html
<script>
  window.INSIGHT_DATA = ${JSON.stringify(insights)};
</script>
```

`insights` 包含来自用户的内容——聊天摘要、文件/工具名、LLM 输出。HTML 会按字面解析内联脚本中的 `</script>`：数据中任意位置出现的 `</script>` 子串都会提前关闭该标签，轻则破坏生成的报告页面，重则向本地打开的 HTML 注入标记/脚本（self-XSS）。修复方式是把 stringify 后 JSON 中的 `<` 转义为 `<`。`<` 是合法 JSON，`JSON.parse` 后仍还原为 `<`，因此到达页面的数据逐字节不变，而原始 HTML 中再也无法构成 `</script>`、`<script`、`<!--`。这是把 JSON 嵌入内联脚本的标准做法。

## 复核测试计划

### 如何验证

在 `packages/cli` 下运行 `npx vitest run src/services/insight/generators/TemplateRenderer.test.ts`（需先构建 `@qwen-code/web-templates` 工作区包：`npm run build --workspace @qwen-code/web-templates`）。`escapes \`<\`` 用例注入 `</script><img src=x onerror=alert(1)>` 载荷并断言原始标签不出现在输出中；它在修复前的未转义嵌入下会失败（已在本地通过回退验证）。round-trip 用例确认嵌入值经 `JSON.parse` 后仍为原始字符串。

### 证据（修复前后对比）

修复前：`latestActiveTime: '</script><img src=x onerror=alert(1)>'` 渲染为 `... "latestActiveTime":"</script><img src=x onerror=alert(1)>"`——`</script>` 关闭了数据脚本。
修复后：渲染为 `... "latestActiveTime":"</script><img src=x onerror=alert(1)>"`，且 `JSON.parse` 仍得到 `</script><img src=x onerror=alert(1)>`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：构建了 web-templates，运行了新增测试（2 个通过），确认转义测试在修复前失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯字符串生成，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-cli` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——只有 `<` 被改写为其 `<` JSON 转义；解析后的 `window.INSIGHT_DATA` 对象与之前完全一致，因此对所有非恶意数据，报告渲染结果不变。
- 未验证 / 范围之外：相邻脚本中嵌入的受信任 `INSIGHT_JS` 包未改动（它是构建常量，非用户数据）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
