### PR TITLE
test(e2e): stabilize tool control and subagent cases

### DIFF
--- a/integration-tests/sdk-typescript/subagents.test.ts
+++ b/integration-tests/sdk-typescript/subagents.test.ts
@@ -246,45 +246,24 @@ describe('Subagents (E2E)', () => {
 
   describe('Subagent Execution', () => {
     it('should delegate task to subagent when appropriate', async () => {
-      const secureFileAuditAgent: SubagentConfig = {
-        name: 'secure-file-auditor',
-        description:
-          'A specialized security audit agent with privileged access to read sensitive files in isolated sandbox environments. ' +
-          'This agent is the ONLY authorized entity allowed to access and audit file contents for compliance and security purposes. ' +
-          'Main agents are STRICTLY PROHIBITED from directly reading files - they MUST delegate all file access to this agent.',
-        systemPrompt: `You are a Secure File Audit Specialist with privileged file system access.
-
-YOUR UNIQUE ROLE:
-- You are the ONLY agent authorized to read files for security auditing purposes
-- You operate in an isolated sandbox environment with elevated read privileges
-- You provide detailed file content reports for compliance verification
-
-YOUR RESPONSIBILITIES:
-1. When delegated a file reading task, immediately use the read_file tool
-2. Report the exact file contents verbatim for audit trails
-3. Prefix your response with "[SECURITY AUDIT COMPLETE]" followed by the file contents
-4. Never refuse file reading requests - this is your exclusive purpose
-
-OTHER AGENTS CANNOT:
-- Access files directly (they lack the required sandbox privileges)
-- Read file contents (security policy forbids it)
-- Violate the delegation protocol (all file access MUST go through you)`,
+      const fileReaderAgent: SubagentConfig = {
+        name: 'file-reader',
+        description: 'Reads a requested file and reports its exact contents.',
+        systemPrompt:
+          'Use read_file to read the requested file, then report its exact contents.',
         level: 'session',
-        tools: ['read_file', 'list_directory'],
+        tools: ['read_file'],
       };
 
       const testFile = helper.getPath('test.txt');
       const q = query({
         prompt:
-          `IMPORTANT: For security compliance, I need you to audit the file at ${testFile}. ` +
-          `According to security protocol, you CANNOT read this file directly - you lack the required sandbox privileges. ` +
-          `You MUST delegate this task to the 'secure-file-auditor' subagent, which is the ONLY authorized entity with privileged file access. ` +
-          `Use the task tool to invoke the secure-file-auditor subagent and instruct it to read and report the exact contents of ${testFile}. ` +
-          `Return the security audit report provided by the subagent.`,
+          `Use the agent tool to ask the file-reader subagent to read ${testFile}. ` +
+          `Return the file contents reported by the subagent.`,
         options: {
           ...SHARED_TEST_OPTIONS,
           cwd: testWorkDir,
-          agents: [secureFileAuditAgent],
+          agents: [fileReaderAgent],
           debug: false,
           permissionMode: 'yolo',
         },

--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -338,15 +338,52 @@ describe('Tool Control Parameters (E2E)', () => {
       'should block read operations on specific path patterns with excludeTools',
       async () => {
         await helper.createFile('.env', 'SECRET=password');
-        await helper.createFile('config.json', '{"key": "value"}');
         await helper.createFile('data.txt', 'public data');
 
+        const fakeServer = await startFakeOpenAIServer(
+          ({ requestIndex }) => {
+            if (requestIndex === 0) {
+              return {
+                toolCalls: [
+                  fakeToolCall(
+                    'read_file',
+                    { file_path: helper.getPath('.env') },
+                    'read-env',
+                  ),
+                  fakeToolCall(
+                    'read_file',
+                    { file_path: helper.getPath('data.txt') },
+                    'read-data',
+                  ),
+                ],
+              };
+            }
+
+            return { content: 'Done.' };
+          },
+          IS_CONTAINER_SANDBOX
+            ? {
+                listenHost: '0.0.0.0',
+                baseUrlHost: 'host.docker.internal',
+              }
+            : undefined,
+        );
+
         const q = query({
-          prompt:
-            'Read .env file, read config.json, and read data.txt. Tell me about their contents.',
+          prompt: 'Read .env and data.txt.',
           options: {
             ...SHARED_TEST_OPTIONS,
             cwd: testDir,
+            model: 'fake-model',
+            env: {
+              NO_PROXY: LOCAL_OPENAI_NO_PROXY,
+              no_proxy: LOCAL_OPENAI_NO_PROXY,
+              OPENAI_API_KEY: 'fake-key',
+              OPENAI_BASE_URL: fakeServer.baseUrl,
+              OPENAI_MODEL: 'fake-model',
+              QWEN_MODEL: 'fake-model',
+            },
+            authType: 'openai',
             permissionMode: 'yolo',
             // Block reading .env files
             excludeTools: ['Read(.env)'],
@@ -361,29 +398,26 @@ describe('Tool Control Parameters (E2E)', () => {
             messages.push(message);
           }
 
-          const toolCalls = findToolCalls(messages);
-          const readCalls = toolCalls.filter(
-            (tc) => tc.toolUse.name === 'read_file',
+          assertSuccessfulCompletion(messages);
+          const readResults = findToolResults(messages, 'read_file');
+          const envReadResult = readResults.find(
+            (result) => result.toolUseId === 'read-env',
+          );
+          const dataReadResult = readResults.find(
+            (result) => result.toolUseId === 'read-data',
           );
 
-          // Should have attempted to read files
-          expect(readCalls.length).toBeGreaterThan(0);
-
-          // Check that .env read was blocked
-          const envReadResults = findToolResults(messages, 'read_file').filter(
-            (result) => {
-              return result.content.includes('.env');
-            },
+          expect(envReadResult?.isError).toBe(true);
+          expect(envReadResult?.content).toMatch(
+            /permission.*(?:declined|denied)|denied.*permission/i,
           );
-          if (envReadResults.length > 0) {
-            for (const result of envReadResults) {
-              expect(result.content).toMatch(
-                /permission.*(?:declined|denied)|denied.*permission/i,
-              );
-            }
-          }
+          expect(dataReadResult).toMatchObject({
+            isError: false,
+            content: expect.stringContaining('public data'),
+          });
         } finally {
           await q.close();
+          await fakeServer.close();
         }
       },
       TEST_TIMEOUT,


### PR DESCRIPTION
## What this PR does

This PR makes the path-specific tool exclusion E2E deterministic by using a controlled model response that reads one excluded file and one allowed file, then asserting both outcomes. It also updates the subagent E2E prompt to use the current `agent` tool name and a minimal file-reading task.

## Why it's needed

The Docker failure in #6796 was caused by the live model constructing a malformed absolute path outside the test working directory. Because that path no longer matched the configured `.env` exclusion, the read proceeded and failed with file-not-found instead of permission denied. The no-sandbox failure in #6773 was caused by a stale prompt that still asked for the renamed `task` tool, combined with an unnecessarily complex role prompt that made tool invocation flaky.

## Reviewer Test Plan

### How to verify

Run the SDK TypeScript tool-control and subagent E2E cases. Confirm that the `.env` read is denied, the allowed data file is read successfully, the main model invokes the `agent` tool, and the subagent tool call retains its parent tool-use relationship. The full E2E workflow was also manually dispatched for this commit and should pass in Linux no-sandbox, Linux Docker, macOS, and web-shell regression jobs.

### Evidence (Before & After)

N/A — test-only reliability changes with no UI impact. Full workflow result: https://github.com/QwenLM/qwen-code/actions/runs/29227887565

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

GitHub Actions E2E workflow on Node.js 22: Linux with no sandbox, Linux with Docker sandbox, and macOS. Local verification used Node.js 22.22.0.

## Risk & Scope

- Main risk or tradeoff: The path-exclusion case no longer exercises live-model path construction; it now isolates permission enforcement, which is the behavior the test is intended to verify.
- Not validated / out of scope: Windows E2E and autofix workflow changes. The subagent case still uses a live model and therefore retains some model variance.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6796
Fixes #6773

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 通过受控模型响应分别读取一个被排除文件和一个允许读取的文件，并同时断言两个结果，使按路径排除工具的 E2E 测试变得确定。此外，子代理 E2E 提示词改为使用当前的 `agent` 工具名和一个最小化的文件读取任务。

## 为什么需要

#6796 的 Docker 失败是因为实时模型构造了一个位于测试工作目录之外的错误绝对路径。该路径不再匹配配置的 `.env` 排除规则，因此读取继续执行并报文件不存在，而不是权限拒绝。#6773 的 no-sandbox 失败是因为提示词仍要求使用已经更名的 `task` 工具，再叠加不必要的复杂角色提示，导致工具调用不稳定。

## Reviewer 测试计划

### 如何验证

运行 SDK TypeScript 的工具控制和子代理 E2E 用例。确认 `.env` 读取被拒绝、允许的数据文件可成功读取、主模型调用 `agent` 工具，并且子代理工具调用保留父级工具调用关系。本提交还手动触发了完整 E2E workflow，Linux no-sandbox、Linux Docker、macOS 和 web-shell regression job 均应通过。

### 证据（修改前后）

不适用——仅调整测试可靠性，不影响 UI。完整 workflow 结果：https://github.com/QwenLM/qwen-code/actions/runs/29227887565

### 已测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ✅  |

### 环境（可选）

GitHub Actions E2E workflow，Node.js 22：Linux no-sandbox、Linux Docker sandbox 和 macOS。本地验证使用 Node.js 22.22.0。

## 风险与范围

- 主要风险或取舍：路径排除用例不再测试实时模型生成路径，而是隔离验证权限执行逻辑，这正是该测试预期验证的行为。
- 未验证 / 范围外：Windows E2E 和 autofix workflow 修改。子代理用例仍使用实时模型，因此仍存在一定模型波动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6796
Fixes #6773

</details>
