### PR TITLE
feat(subagents): make Explore inherit the main model by default

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -355,6 +355,12 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 
 See [Memory](../features/memory) for details on how auto-memory works and how to use the `/memory`, `/remember`, and `/dream` commands.
 
+#### agents
+
+| Setting                       | Type   | Description                                                                                                                                                                                                                                               | Default   |
+| ----------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `agents.builtin.exploreModel` | string | Model selector for the built-in Explore subagent. Use `inherit` for the main session model, `fast` for `fastModel`, a model ID, or an `authType:model-id` selector. A custom same-name Explore agent keeps its own model configuration. Requires restart. | `inherit` |
+
 #### permissions
 
 The permissions system provides fine-grained control over which tools can run, which require confirmation, and which are blocked.

--- a/docs/users/features/sub-agents.md
+++ b/docs/users/features/sub-agents.md
@@ -194,6 +194,27 @@ When the selector resolves to another auth type, Qwen Code creates a dedicated
 runtime provider for that subagent request and sends the provider only the bare
 model ID.
 
+The built-in Explore agent inherits the main session model by default. To
+select a different model for only that built-in agent, configure
+`agents.builtin.exploreModel` in `settings.json` and restart Qwen Code:
+
+Earlier versions used `fastModel` for Explore by default. To preserve that
+behavior, set `agents.builtin.exploreModel` to `fast`.
+
+```json
+{
+  "agents": {
+    "builtin": {
+      "exploreModel": "fast"
+    }
+  }
+}
+```
+
+This setting accepts the same selectors described above. It is applied only
+when Qwen Code resolves the built-in Explore definition; a session, project,
+user, or extension agent named Explore keeps its own `model` setting.
+
 #### Permission Mode
 
 Use the optional `approvalMode` frontmatter field to control how a subagent's tool calls are approved. Valid values:

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1150,6 +1150,17 @@ describe('loadCliConfig', () => {
     expect(config.getShellDefaultTimeoutMs()).toBe(300000);
   });
 
+  it('passes agents.builtin.exploreModel from settings to core config', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig(
+      { agents: { builtin: { exploreModel: 'fast' } } },
+      argv,
+    );
+
+    expect(config.getAgentsSettings().builtin?.exploreModel).toBe('fast');
+  });
+
   it('should ignore blank settings fallback models', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2240,6 +2240,11 @@ export async function loadCliConfig(
     },
     agents: settings.agents
       ? {
+          builtin: settings.agents.builtin
+            ? {
+                exploreModel: settings.agents.builtin.exploreModel,
+              }
+            : undefined,
           maxParallelAgents: settings.agents.maxParallelAgents,
           displayMode: settings.agents.displayMode,
           arena: settings.agents.arena

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -179,6 +179,17 @@ describe('SettingsSchema', () => {
       expect(voiceModel.showInDialog).toBe(false);
     });
 
+    it('should define the built-in Explore model setting', () => {
+      const exploreModel =
+        getSettingsSchema().agents.properties.builtin.properties.exploreModel;
+
+      expect(exploreModel.type).toBe('string');
+      expect(exploreModel.category).toBe('Model');
+      expect(exploreModel.default).toBe('inherit');
+      expect(exploreModel.requiresRestart).toBe(true);
+      expect(exploreModel.showInDialog).toBe(false);
+    });
+
     it('should define visionBridgeTimeoutMs as a restart-required bounded integer', () => {
       const timeout = getSettingsSchema().visionBridgeTimeoutMs;
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -2761,9 +2761,30 @@ const SETTINGS_SCHEMA = {
     requiresRestart: false,
     default: {},
     description:
-      'Settings for multi-agent collaboration features (Arena, Team, Swarm).',
+      'Settings for built-in agents and multi-agent collaboration features (Arena, Team, Swarm).',
     showInDialog: false,
     properties: {
+      builtin: {
+        type: 'object',
+        label: 'Built-in Agents',
+        category: 'Advanced',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for built-in subagents.',
+        showInDialog: false,
+        properties: {
+          exploreModel: {
+            type: 'string',
+            label: 'Explore Model',
+            category: 'Model',
+            requiresRestart: true,
+            default: 'inherit' as string,
+            description:
+              'Model selector for the built-in Explore subagent. Use "inherit" for the main session model, "fast" for fastModel, a model ID, or an authType:model-id selector. Custom same-name agents are unaffected.',
+            showInDialog: false,
+          },
+        },
+      },
       maxParallelAgents: {
         type: 'number',
         label: 'Max Parallel Agents',

--- a/packages/cli/src/serve/workspace-agents.ts
+++ b/packages/cli/src/serve/workspace-agents.ts
@@ -94,11 +94,10 @@ import {
  *
  * The daemon doesn't have a full `Config` instance, so we instantiate
  * `SubagentManager` against a CRUD-scoped `Config` stub that
- * implements only `getSdkMode / getProjectRoot / getActiveExtensions`
- * — the methods the manager's CRUD paths actually touch (verified
- * against `subagent-manager.ts:365,932,954,958`). A `Proxy` makes any
- * future use of an unimplemented method throw immediately so a
- * silent dependency creep can't ship as a 500.
+ * implements only `getSdkMode / getProjectRoot / getActiveExtensions /
+ * isSafeMode / getAgentsSettings` — the methods the manager's CRUD paths
+ * actually touch. A `Proxy` makes any future use of an unimplemented method
+ * throw immediately so a silent dependency creep can't ship as a 500.
  */
 
 export interface WorkspaceAgentsRouteDeps {
@@ -1788,11 +1787,12 @@ export function toDetail(config: SubagentConfig): ServeWorkspaceAgentDetail {
 
 /**
  * Build a CRUD-scoped `SubagentManager` for the daemon. The
- * underlying manager only touches four `Config` methods on its
+ * underlying manager only touches five `Config` methods on its
  * read/write paths (`getSdkMode`, `getProjectRoot`,
- * `getActiveExtensions`, `isSafeMode`); a `Proxy` makes any future expansion of
- * that surface throw immediately rather than silently produce
- * incorrect data.
+ * `getActiveExtensions`, `isSafeMode`, `getAgentsSettings`); a `Proxy` makes
+ * any future expansion of that surface throw immediately rather than silently
+ * produce incorrect data. The CRUD catalog has no session settings context,
+ * so built-in agents use their registry defaults here.
  */
 export function createDaemonSubagentManager(
   boundWorkspace: string,
@@ -1803,6 +1803,7 @@ export function createDaemonSubagentManager(
     getProjectRoot: () => boundWorkspace,
     getActiveExtensions: () => [],
     isSafeMode: () => safeMode,
+    getAgentsSettings: () => ({}),
   } as unknown as Record<string | symbol, unknown>;
   const guarded = new Proxy(stub, {
     get(target, prop) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -795,10 +795,6 @@ export interface SandboxConfig {
 }
 
 /**
- * Settings shared across multi-agent collaboration features
- * (Arena, Team, Swarm).
- */
-/**
  * General-purpose worktree settings (Phase D-2). Distinct from
  * {@link AgentsCollabSettings.arena.worktreeBaseDir}, which only governs
  * Arena multi-model worktrees.
@@ -819,7 +815,13 @@ export interface WorktreeSettings {
   symlinkDirectories?: readonly string[];
 }
 
+/** Settings shared across agents and multi-agent collaboration features. */
 export interface AgentsCollabSettings {
+  /** Built-in subagent settings */
+  builtin?: {
+    /** Model selector for the built-in Explore subagent (default: inherit). */
+    exploreModel?: string;
+  };
   /**
    * Global maximum number of background sub-agents running concurrently.
    * When the cap is reached, additional launches wait for a slot.
@@ -1123,7 +1125,7 @@ export interface ConfigParameters {
   modelProvidersConfig?: ModelProvidersConfig;
   /** Maps custom provider ids to their SDK protocol (AuthType) */
   providerProtocolConfig?: ProviderProtocolConfig;
-  /** Multi-agent collaboration settings (Arena, Team, Swarm) */
+  /** Agent and multi-agent collaboration settings */
   agents?: AgentsCollabSettings;
   /** General-purpose worktree settings (Phase D-2). */
   worktree?: WorktreeSettings;

--- a/packages/core/src/subagents/builtin-agents.test.ts
+++ b/packages/core/src/subagents/builtin-agents.test.ts
@@ -36,6 +36,13 @@ describe('BuiltinAgentRegistry', () => {
       expect(generalAgent).toBeDefined();
       expect(generalAgent?.description).toContain('General-purpose agent');
     });
+
+    it('should let the Explore agent inherit the main model', () => {
+      const exploreAgent = BuiltinAgentRegistry.getBuiltinAgent('Explore');
+
+      expect(exploreAgent).toBeDefined();
+      expect(exploreAgent?.model).toBeUndefined();
+    });
   });
 
   describe('getBuiltinAgent', () => {

--- a/packages/core/src/subagents/builtin-agents.ts
+++ b/packages/core/src/subagents/builtin-agents.ts
@@ -54,7 +54,6 @@ Notes:
       name: 'Explore',
       description:
         'Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions.',
-      model: 'fast',
       systemPrompt: `You are a file search specialist agent. You excel at thoroughly navigating and exploring codebases.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -1182,6 +1182,86 @@ You are weird.
   });
 
   describe('loadSubagent', () => {
+    it('applies the configured model only to the built-in Explore agent', async () => {
+      vi.mocked(fs.readdir).mockRejectedValue(new Error('Directory not found'));
+      const configuredManager = new SubagentManager(
+        makeFakeConfig({
+          agents: { builtin: { exploreModel: 'fast' } },
+        }),
+      );
+
+      expect((await configuredManager.loadSubagent('Explore'))?.model).toBe(
+        'fast',
+      );
+      expect(
+        (await configuredManager.loadSubagent('Explore', 'builtin'))?.model,
+      ).toBe('fast');
+
+      const builtins = await configuredManager.listSubagents({
+        level: 'builtin',
+        force: true,
+      });
+      expect(builtins.find((agent) => agent.name === 'Explore')?.model).toBe(
+        'fast',
+      );
+    });
+
+    it('does not apply the built-in Explore model to a same-name session agent', async () => {
+      const configuredManager = new SubagentManager(
+        makeFakeConfig({
+          agents: { builtin: { exploreModel: 'fast' } },
+        }),
+      );
+      configuredManager.loadSessionSubagents([
+        {
+          name: 'Explore',
+          description: 'Session Explore',
+          systemPrompt: 'Use the session agent.',
+          level: 'session',
+        },
+      ]);
+
+      const config = await configuredManager.loadSubagent('Explore');
+
+      expect(config?.level).toBe('session');
+      expect(config?.model).toBeUndefined();
+    });
+
+    it('ignores a non-string built-in Explore model setting', async () => {
+      const configuredManager = new SubagentManager(
+        makeFakeConfig({
+          agents: {
+            builtin: { exploreModel: 1 as unknown as string },
+          },
+        }),
+      );
+
+      const config = await configuredManager.loadSubagent('Explore', 'builtin');
+
+      expect(config?.model).toBeUndefined();
+    });
+
+    it.each([
+      { exploreModel: '   ', expectedModel: undefined },
+      { exploreModel: 'inherit', expectedModel: 'inherit' },
+    ])(
+      'resolves the built-in Explore model setting "$exploreModel"',
+      async ({ exploreModel, expectedModel }) => {
+        const configuredManager = new SubagentManager(
+          makeFakeConfig({
+            agents: { builtin: { exploreModel } },
+          }),
+        );
+
+        const config = await configuredManager.loadSubagent(
+          'Explore',
+          'builtin',
+        );
+
+        expect(config?.model).toBe(expectedModel);
+      },
+    );
+
     it('should load subagent from project level first', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.mocked(fs.readdir).mockResolvedValue(['test-agent.md'] as any);

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -122,6 +122,36 @@ export class SubagentManager {
     }
   }
 
+  private applyBuiltinSettings(config: SubagentConfig): SubagentConfig {
+    if (config.name !== 'Explore') {
+      return config;
+    }
+
+    const configuredModel =
+      this.config.getAgentsSettings().builtin?.exploreModel;
+    if (typeof configuredModel !== 'string') {
+      return config;
+    }
+
+    const exploreModel = configuredModel.trim();
+    if (!exploreModel) {
+      return config;
+    }
+
+    return { ...config, model: exploreModel };
+  }
+
+  private getBuiltinAgent(name: string): SubagentConfig | null {
+    const config = BuiltinAgentRegistry.getBuiltinAgent(name);
+    return config ? this.applyBuiltinSettings(config) : null;
+  }
+
+  private getBuiltinAgents(): SubagentConfig[] {
+    return BuiltinAgentRegistry.getBuiltinAgents().map((config) =>
+      this.applyBuiltinSettings(config),
+    );
+  }
+
   /**
    * Creates a new subagent configuration.
    *
@@ -208,7 +238,7 @@ export class SubagentManager {
     if (level) {
       // Search only the specified level
       if (level === 'builtin') {
-        return BuiltinAgentRegistry.getBuiltinAgent(name);
+        return this.getBuiltinAgent(name);
       }
 
       if (level === 'session') {
@@ -254,7 +284,7 @@ export class SubagentManager {
     }
 
     // Try built-in agents as fallback
-    return BuiltinAgentRegistry.getBuiltinAgent(name);
+    return this.getBuiltinAgent(name);
   }
 
   /**
@@ -1194,7 +1224,7 @@ export class SubagentManager {
   ): Promise<SubagentConfig[]> {
     // Handle built-in agents
     if (level === 'builtin') {
-      return BuiltinAgentRegistry.getBuiltinAgents();
+      return this.getBuiltinAgents();
     }
 
     if (level === 'extension') {

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -1294,9 +1294,20 @@
       }
     },
     "agents": {
-      "description": "Settings for multi-agent collaboration features (Arena, Team, Swarm).",
+      "description": "Settings for built-in agents and multi-agent collaboration features (Arena, Team, Swarm).",
       "type": "object",
       "properties": {
+        "builtin": {
+          "description": "Settings for built-in subagents.",
+          "type": "object",
+          "properties": {
+            "exploreModel": {
+              "description": "Model selector for the built-in Explore subagent. Use \"inherit\" for the main session model, \"fast\" for fastModel, a model ID, or an authType:model-id selector. Custom same-name agents are unaffected.",
+              "type": "string",
+              "default": "inherit"
+            }
+          }
+        },
         "maxParallelAgents": {
           "type": "integer",
           "minimum": 1,


### PR DESCRIPTION
## What this PR does

Changes the built-in Explore subagent to inherit the main session model by default instead of automatically selecting `fastModel`. Adds `agents.builtin.exploreModel` so users can persist an Explore-only selector using `inherit`, `fast`, a model ID, or an `authType:model-id` value. Custom session, project, user, or extension agents named Explore keep their own model configuration.

## Why it's needed

Claude Code 2.1.198 changed its built-in Explore agent to inherit the main model. Matching that behavior avoids an implicit model override, while the new setting preserves user control and lets existing users retain the previous fast-model behavior without replacing the complete built-in agent definition.

## Reviewer Test Plan

### How to verify

- With a main model and `fastModel` configured, leave `agents.builtin.exploreModel` unset and launch Explore. Expect Explore to use the main model.
- Set `agents.builtin.exploreModel` to `fast`, restart Qwen Code, and launch Explore. Expect Explore to use `fastModel`.
- Set the value to `inherit`. Expect Explore to use the main model even when `fastModel` is available.
- Define a custom agent named Explore with its own model. Expect the custom definition to take precedence over the built-in setting.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| Built-in Explore selected `fastModel` when configured. | Built-in Explore inherits the main model by default. |
| No persistent Explore-only model setting. | `agents.builtin.exploreModel` can restore `fast` or select another model. |

Deterministic mock-provider E2E verification recorded the main request using `main-model` and the configured built-in Explore request using `fast-model`.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

### Environment (optional)

Local bundled CLI with a deterministic OpenAI-compatible mock endpoint; approval mode `yolo`, no sandbox.

## Risk & Scope

- Main risk or tradeoff: Explore may use a more capable, slower, or more expensive model after upgrading when the main session model is larger than the configured fast model.
- Not validated / out of scope: configuring models for other built-in agents, hot-reloading the setting, and applying session settings to the daemon's CRUD-only agent catalog.
- Breaking changes / migration notes: users who want the previous behavior should set `agents.builtin.exploreModel` to `fast` and restart Qwen Code.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将内置 Explore subagent 的默认行为从自动选择 `fastModel` 改为继承主会话模型。新增 `agents.builtin.exploreModel`，允许用户通过 `inherit`、`fast`、模型 ID 或 `authType:model-id` 持久化配置仅用于 Explore 的模型选择器。名为 Explore 的自定义 session、project、user 或 extension agent 仍保留自己的模型配置。

## 为什么需要这个改动

Claude Code 2.1.198 将内置 Explore agent 改为继承主模型。保持一致可以避免隐式模型覆盖，同时新配置项保留了用户选择权，让现有用户无需替换完整的内置 agent 定义即可继续使用之前的快速模型行为。

## Reviewer 测试计划

### 如何验证

- 同时配置主模型和 `fastModel`，不设置 `agents.builtin.exploreModel` 并启动 Explore。预期 Explore 使用主模型。
- 将 `agents.builtin.exploreModel` 设置为 `fast`，重启 Qwen Code 并启动 Explore。预期 Explore 使用 `fastModel`。
- 将配置值设为 `inherit`。即使存在 `fastModel`，Explore 也应使用主模型。
- 定义一个拥有自己模型配置的同名自定义 Explore agent。预期自定义定义优先于内置配置。

### 证据（Before & After）

| Before | After |
| --- | --- |
| 配置了 `fastModel` 时，内置 Explore 会选择它。 | 内置 Explore 默认继承主模型。 |
| 没有仅用于 Explore 的持久化模型配置。 | 可以通过 `agents.builtin.exploreModel` 恢复 `fast` 或选择其他模型。 |

确定性的 mock provider E2E 验证记录到主请求使用 `main-model`，配置后的内置 Explore 请求使用 `fast-model`。

### 测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 测试环境（可选）

本地 bundled CLI 和确定性的 OpenAI-compatible mock endpoint；approval mode 为 `yolo`，未启用 sandbox。

## 风险与范围

- 主要风险或权衡：升级后，如果主会话模型大于已配置的快速模型，Explore 可能使用能力更强但更慢或成本更高的模型。
- 未验证或不在范围内：配置其他内置 agent 的模型、热重载该设置，以及让 daemon 的纯 CRUD agent catalog 应用会话设置。
- Breaking changes / 迁移说明：希望保持旧行为的用户应将 `agents.builtin.exploreModel` 设置为 `fast`，然后重启 Qwen Code。

## 关联 Issue

无

</details>