### PR TITLE
feat(serve): expose skill installation paths

### DIFF
--- a/docs/design/2026-07-13-workspace-skills-installed-path.md
+++ b/docs/design/2026-07-13-workspace-skills-installed-path.md
@@ -1,0 +1,33 @@
+# Workspace Skill Installation Paths
+
+Date: 2026-07-13
+
+## Contract
+
+Each skill returned by `GET /workspace/skills` and
+`GET /workspaces/:workspace/skills` includes `installedPath`, the existing
+absolute `SkillConfig.filePath` that points to its `SKILL.md` file. The value is
+copied as stored; the status layer does not resolve symlinks or canonicalize it
+again.
+
+## Compatibility
+
+This is an additive v1 field. The current daemon always emits it, while the ACP
+bridge and TypeScript SDK public status types keep it optional so clients stay
+compatible with older daemons. The protocol version and capability list do not
+change.
+
+## Data Flow
+
+`SkillManager.listSkills()` supplies `SkillConfig` records. The shared
+`mapSkillConfigToStatus()` function copies `filePath` to `installedPath`. Both
+the live ACP snapshot and daemon-local fallback use that mapper, so project,
+user, bundled, extension, inactive-extension, and disabled skills have the same
+shape. The workspace status service forwards that shared result to both route
+forms.
+
+## Redaction Boundary
+
+The status mapper remains an explicit metadata allowlist. It exposes the
+installation file path but not the skill body, hooks, `skillRoot`, or any other
+skill configuration. This change adds no UI behavior.

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -819,14 +819,20 @@ Recommended poll cadence: aligned with whatever already polls `/workspace/mcp`; 
       "description": "Review code",
       "level": "project",
       "modelInvocable": true,
+      "installedPath": "/home/alice/project/.qwen/skills/review/SKILL.md",
       "argumentHint": "[path]"
     }
   ]
 }
 ```
 
-`level` is one of `project`, `user`, `extension`, or `bundled`. `errors` is
-omitted when discovery succeeds.
+`level` is one of `project`, `user`, `extension`, or `bundled`.
+`installedPath` is the existing absolute path to the skill's `SKILL.md`; the
+daemon returns it as stored without separately resolving symlinks or
+canonicalizing it. Current daemons emit it for every skill, while clients must
+tolerate its absence from older v1 daemons. Skill bodies, hooks, `skillRoot`,
+and other skill configuration remain excluded. `errors` is omitted when
+discovery succeeds.
 
 ### `GET /workspace/providers`
 

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -416,6 +416,7 @@ export interface ServeWorkspaceSkillStatus extends ServeStatusCell {
   description: string;
   level: ServeSkillLevel;
   modelInvocable: boolean;
+  installedPath?: string;
   argumentHint?: string;
   model?: string;
   extensionName?: string;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2560,6 +2560,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           level: 'project',
           argumentHint: '[path]',
           modelInvocable: true,
+          installedPath: '/secret/SKILL.md',
         }),
         expect.objectContaining({
           kind: 'skill',
@@ -2577,6 +2578,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           description: 'Disabled by settings',
           level: 'project',
           modelInvocable: true,
+          installedPath: '/disabled/SKILL.md',
         }),
         expect.objectContaining({
           kind: 'skill',
@@ -2595,6 +2597,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           level: 'extension',
           extensionName: 'GSD Core',
           modelInvocable: true,
+          installedPath: '/ext/gsd-core/skills/gsd-display-stale/SKILL.md',
         }),
         expect.objectContaining({
           kind: 'skill',
@@ -2604,6 +2607,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           level: 'extension',
           extensionName: 'GSD Core',
           modelInvocable: true,
+          installedPath: '/ext/gsd-core/skills/gsd-config-only/SKILL.md',
         }),
       ]),
     });
@@ -2622,7 +2626,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(JSON.stringify(skills)).not.toContain('extension secret body');
     expect(JSON.stringify(skills)).not.toContain('display stale body');
     expect(JSON.stringify(skills)).not.toContain('config only body');
-    expect(JSON.stringify(skills)).not.toContain('/secret');
+    expect(JSON.stringify(skills)).not.toContain('"skillRoot"');
     expect(JSON.stringify(skills)).not.toContain('secret-hook');
 
     expect(providers).toMatchObject({

--- a/packages/cli/src/serve/workspace-skills-mapping.test.ts
+++ b/packages/cli/src/serve/workspace-skills-mapping.test.ts
@@ -13,8 +13,10 @@ function makeSkill(overrides: Partial<SkillConfig> = {}): SkillConfig {
     name: 'review',
     description: 'Review changed code',
     level: 'bundled',
+    filePath: '/skills/review/SKILL.md',
+    body: 'Review instructions',
     ...overrides,
-  } as SkillConfig;
+  };
 }
 
 describe('mapSkillConfigToStatus', () => {
@@ -31,6 +33,7 @@ describe('mapSkillConfigToStatus', () => {
       level: 'bundled',
       modelInvocable: true,
       argumentHint: '[pr-number]',
+      installedPath: '/skills/review/SKILL.md',
     });
   });
 

--- a/packages/cli/src/serve/workspace-skills-mapping.ts
+++ b/packages/cli/src/serve/workspace-skills-mapping.ts
@@ -28,6 +28,7 @@ export function mapSkillConfigToStatus(
     description: skill.description,
     level: skill.level,
     modelInvocable,
+    installedPath: skill.filePath,
     ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
     ...(skill.model ? { model: skill.model } : {}),
     ...(skill.extensionName ? { extensionName: skill.extensionName } : {}),

--- a/packages/cli/src/serve/workspace-skills-status.test.ts
+++ b/packages/cli/src/serve/workspace-skills-status.test.ts
@@ -99,10 +99,12 @@ describe('createWorkspaceSkillsStatusProvider', () => {
       {
         name: 'enabled',
         status: 'ok',
+        installedPath: '/skills/enabled/SKILL.md',
       },
       {
         name: 'disabled',
         status: 'disabled',
+        installedPath: '/skills/disabled/SKILL.md',
       },
     ]);
   });

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1073,6 +1073,7 @@ export interface DaemonWorkspaceSkillStatus extends DaemonStatusCell {
   description: string;
   level: DaemonSkillLevel;
   modelInvocable: boolean;
+  installedPath?: string;
   argumentHint?: string;
   model?: string;
   extensionName?: string;


### PR DESCRIPTION
## What this PR does

Workspace skill status responses now include `installedPath`, the absolute path to each skill's `SKILL.md`. The field is populated through the shared status mapping used by live ACP snapshots and the daemon-local fallback, so singular and workspace-qualified routes stay aligned across project, user, bundled, extension, inactive-extension, and disabled skills. Public bridge and TypeScript SDK types keep the field optional for compatibility with older v1 daemons.

The response remains a metadata allowlist: skill bodies, hooks, `skillRoot`, and other configuration stay excluded. Paths are returned exactly as recorded by the loader without an additional symlink or realpath resolution step. This does not change the protocol version, capability tags, or UI behavior.

## Why it's needed

Clients that enumerate installed skills need a stable way to locate the backing skill definition. Returning the loader's existing absolute path avoids duplicating discovery logic while preserving the current status endpoint's redaction boundary.

## Reviewer Test Plan

### How to verify

1. Start the locally built daemon for a workspace containing project and bundled skills without creating a session, then request `GET /workspace/skills`. Confirm every skill includes an absolute `installedPath` ending in `/SKILL.md`.
2. Request `GET /workspaces/:workspace/skills` for the same workspace and confirm it returns the same path field.
3. Confirm disabled and extension skills in the focused regression coverage retain their status metadata and receive their exact source paths.
4. Inspect either response and confirm it does not include skill bodies, hooks, `skillRoot`, or other configuration.
5. Compatibility check: an older v1 daemon response without `installedPath` remains accepted by the optional public client types.

### Evidence (Before & After)

Before: global `qwen 0.18.5-preview.0` returned 41 skills and no item contained `installedPath`.

After: the local bundle returned 43 skills before session creation (19 project, 9 bundled, 15 user); every item contained an absolute `SKILL.md` path on both route forms, with no body, hooks, or `skillRoot` fields.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, locally built HTTP daemon with bearer auth disabled on loopback.

## Risk & Scope

- Main risk or tradeoff: The status API deliberately exposes absolute local installation paths; it continues to redact skill content and other configuration.
- Not validated / out of scope: Windows and Linux manual daemon checks, UI consumption, internal prerelease publishing, and any broader skill discovery changes.
- Breaking changes / migration notes: None. This is an additive v1 field, and public client types keep it optional for old-daemon compatibility.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Workspace skill 状态响应现在会包含 `installedPath`，即每个 skill 对应 `SKILL.md` 的绝对路径。该字段通过 ACP 实时快照与 daemon 本地兜底共用的状态映射填充，因此单工作区路由和带 workspace 参数的路由会保持一致，并统一覆盖 project、user、bundled、extension、inactive-extension 以及 disabled skill。bridge 与 TypeScript SDK 的公共类型仍将该字段声明为可选，以兼容仍返回 v1、但没有该字段的旧版 daemon。

响应仍然遵守元数据白名单边界：skill body、hooks、`skillRoot` 和其他配置不会被返回。路径直接沿用加载器记录的值，不额外解析 symlink 或 realpath。本变更不升级协议版本、不新增 capability tag，也不修改 UI 行为。

## 为什么需要

枚举已安装 skill 的客户端需要一种稳定方式定位底层 skill 定义。直接返回加载器已有的绝对路径，可以避免客户端重复实现 discovery 逻辑，同时保持状态接口现有的脱敏边界。

## Reviewer 测试计划

### 如何验证

1. 在包含 project 和 bundled skill 的 workspace 中启动本地构建 daemon，不创建 session，然后请求 `GET /workspace/skills`。确认每个 skill 都包含以 `/SKILL.md` 结尾的绝对 `installedPath`。
2. 对同一个 workspace 请求 `GET /workspaces/:workspace/skills`，确认返回相同的路径字段。
3. 检查聚焦回归测试中的 disabled 和 extension skill，确认它们保留原有状态元数据，并得到准确的源文件路径。
4. 检查任一响应，确认其中不包含 skill body、hooks、`skillRoot` 或其他配置。
5. 兼容性检查：旧版 v1 daemon 缺少 `installedPath` 的响应仍可被字段可选的公共客户端类型接受。

### 前后证据

变更前：全局 `qwen 0.18.5-preview.0` 返回 41 个 skill，所有条目都没有 `installedPath`。

变更后：本地 bundle 在创建 session 前返回 43 个 skill（19 个 project、9 个 bundled、15 个 user）；两个路由形式的所有条目都包含绝对 `SKILL.md` 路径，且没有 body、hooks 或 `skillRoot` 字段。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22，本地构建的 HTTP daemon；loopback 上未启用 bearer auth。

## 风险与范围

- 主要风险或取舍：状态 API 会有意暴露本地绝对安装路径；skill 内容和其他配置仍保持脱敏。
- 未验证 / 不在范围内：Windows 与 Linux 手工 daemon 验证、UI 消费、内部预发发布，以及更广泛的 skill discovery 改造。
- 破坏性变更 / 迁移说明：无。这是 v1 的增量字段，公共客户端类型保持可选以兼容旧版 daemon。

## 关联 Issue

无。

</details>
