### PR TITLE
fix(channels): distinguish slash-command output

### DIFF
--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -324,6 +324,39 @@ describe('AcpBridge', () => {
     );
   });
 
+  it('returns only the final slash-command output', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    }) as unknown as TestableAcpBridge;
+    bridge.child = { killed: false, exitCode: null };
+    bridge.connection = {
+      extMethod: vi.fn(),
+      prompt: vi.fn(async () => {
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Compressing context...' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Context compressed.' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+      }),
+    };
+
+    await expect(bridge.prompt('s-1', 'question')).resolves.toBe(
+      'Context compressed.',
+    );
+  });
+
   it('returns only the final turn text after auto-approved tool calls', async () => {
     const bridge = new AcpBridge({
       cliEntryPath: '/tmp/qwen',

--- a/packages/channels/base/src/AcpBridge.test.ts
+++ b/packages/channels/base/src/AcpBridge.test.ts
@@ -357,6 +357,54 @@ describe('AcpBridge', () => {
     );
   });
 
+  it('prefers model text over slash-command output', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    }) as unknown as TestableAcpBridge;
+    bridge.child = { killed: false, exitCode: null };
+    bridge.connection = {
+      extMethod: vi.fn(),
+      prompt: vi.fn(async () => {
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Slash output' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+        bridge.emit('textChunk', 's-1', 'Model text');
+      }),
+    };
+
+    await expect(bridge.prompt('s-1', 'question')).resolves.toBe('Model text');
+  });
+
+  it('clears slash-command output at response boundaries', async () => {
+    const bridge = new AcpBridge({
+      cliEntryPath: '/tmp/qwen',
+      cwd: '/tmp',
+    }) as unknown as TestableAcpBridge;
+    bridge.child = { killed: false, exitCode: null };
+    bridge.connection = {
+      extMethod: vi.fn(),
+      prompt: vi.fn(async () => {
+        bridge.handleSessionUpdate({
+          sessionId: 's-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Stale slash output' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+        bridge.emit('responseBoundary', 's-1');
+      }),
+    };
+
+    await expect(bridge.prompt('s-1', 'question')).resolves.toBe('');
+  });
+
   it('returns only the final turn text after auto-approved tool calls', async () => {
     const bridge = new AcpBridge({
       cliEntryPath: '/tmp/qwen',

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -219,13 +219,21 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
     const conn = this.ensureConnection();
 
     const chunks: string[] = [];
+    let slashCommandOutput = '';
     const onChunk = (sid: string, chunk: string) => {
       if (sid === sessionId) chunks.push(chunk);
     };
+    const onSlashCommandOutput = (sid: string, chunk: string) => {
+      if (sid === sessionId) slashCommandOutput = chunk;
+    };
     const clearChunks = (sid: string) => {
-      if (sid === sessionId) chunks.length = 0;
+      if (sid === sessionId) {
+        chunks.length = 0;
+        slashCommandOutput = '';
+      }
     };
     this.on('textChunk', onChunk);
+    this.on('slashCommandOutput', onSlashCommandOutput);
     this.on('responseBoundary', clearChunks);
 
     const prompt: Array<Record<string, unknown>> = [];
@@ -245,10 +253,11 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
       });
     } finally {
       this.off('textChunk', onChunk);
+      this.off('slashCommandOutput', onSlashCommandOutput);
       this.off('responseBoundary', clearChunks);
     }
 
-    return chunks.join('');
+    return chunks.join('') || slashCommandOutput;
   }
 
   async cancelSession(sessionId: string): Promise<void> {
@@ -312,7 +321,13 @@ export class AcpBridge extends EventEmitter implements ChannelAgentBridge {
           | { type?: string; text?: string }
           | undefined;
         if (content?.type === 'text' && content.text) {
-          this.emit('textChunk', sessionId, content.text);
+          this.emit(
+            meta?.['source'] === 'slash_command'
+              ? 'slashCommandOutput'
+              : 'textChunk',
+            sessionId,
+            content.text,
+          );
         }
         break;
       }

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -8213,9 +8213,14 @@ describe('ChannelBase', () => {
       expect(ch.sent.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('block-streams slash-command output', async () => {
+    it('block-streams only the final slash-command response', async () => {
       (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
         (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'slashCommandOutput',
+            sid,
+            'Compressing context...',
+          );
           (bridge as unknown as EventEmitter).emit(
             'slashCommandOutput',
             sid,
@@ -8262,29 +8267,6 @@ describe('ChannelBase', () => {
       await ch.handleInbound(envelope());
 
       expect(ch.sent.map((message) => message.text)).toEqual(['Model text']);
-    });
-
-    it('does not stream slash-command output cleared at a response boundary', async () => {
-      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
-        (sid: string) => {
-          (bridge as unknown as EventEmitter).emit(
-            'slashCommandOutput',
-            sid,
-            'Stale slash output',
-          );
-          (bridge as unknown as EventEmitter).emit('responseBoundary', sid);
-          return Promise.resolve('');
-        },
-      );
-      const ch = createChannel({
-        blockStreaming: 'on',
-        blockStreamingChunk: { minChars: 1, maxChars: 1000 },
-        blockStreamingCoalesce: { idleMs: 0 },
-      });
-
-      await ch.handleInbound(envelope());
-
-      expect(ch.sent).toEqual([]);
     });
 
     it('drops buffered block stream text at response boundaries', async () => {

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -8213,6 +8213,80 @@ describe('ChannelBase', () => {
       expect(ch.sent.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('block-streams slash-command output', async () => {
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'slashCommandOutput',
+            sid,
+            'Context compressed.',
+          );
+          return Promise.resolve('Context compressed.');
+        },
+      );
+      const ch = createChannel({
+        blockStreaming: 'on',
+        blockStreamingChunk: { minChars: 100, maxChars: 1000 },
+        blockStreamingCoalesce: { idleMs: 0 },
+      });
+
+      await ch.handleInbound(envelope());
+
+      expect(ch.sent.map((message) => message.text)).toEqual([
+        'Context compressed.',
+      ]);
+    });
+
+    it('prefers model text over slash-command output when block streaming', async () => {
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'slashCommandOutput',
+            sid,
+            'Slash output',
+          );
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'Model text',
+          );
+          return Promise.resolve('Model text');
+        },
+      );
+      const ch = createChannel({
+        blockStreaming: 'on',
+        blockStreamingChunk: { minChars: 100, maxChars: 1000 },
+        blockStreamingCoalesce: { idleMs: 0 },
+      });
+
+      await ch.handleInbound(envelope());
+
+      expect(ch.sent.map((message) => message.text)).toEqual(['Model text']);
+    });
+
+    it('does not stream slash-command output cleared at a response boundary', async () => {
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'slashCommandOutput',
+            sid,
+            'Stale slash output',
+          );
+          (bridge as unknown as EventEmitter).emit('responseBoundary', sid);
+          return Promise.resolve('');
+        },
+      );
+      const ch = createChannel({
+        blockStreaming: 'on',
+        blockStreamingChunk: { minChars: 1, maxChars: 1000 },
+        blockStreamingCoalesce: { idleMs: 0 },
+      });
+
+      await ch.handleInbound(envelope());
+
+      expect(ch.sent).toEqual([]);
+    });
+
     it('drops buffered block stream text at response boundaries', async () => {
       (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
         (sid: string) => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -3825,8 +3825,10 @@ export abstract class ChannelBase {
       // to any visible sink could send output the cancel can't recall. On a
       // failed cancel they're replayed; on success, discarded.
       const heldChunks: string[] = [];
+      let hasStreamedText = false;
       const releaseHeldChunks = () => {
         for (const held of heldChunks.splice(0)) {
+          hasStreamedText = true;
           this.emitTaskLifecycle({
             ...this.lifecycleBase(
               envelope.chatId,
@@ -3858,6 +3860,7 @@ export abstract class ChannelBase {
           return;
         }
         heldChunks.length = 0;
+        hasStreamedText = false;
         this.onResponseBoundary(envelope.chatId, sessionId);
         streamer?.stop();
       };
@@ -3880,6 +3883,9 @@ export abstract class ChannelBase {
         if (!promptState.cancelled && response) {
           promptState.deliveryStarted = true;
           if (streamer) {
+            if (!hasStreamedText) {
+              streamer.push(response);
+            }
             await streamer.flush();
           } else {
             await this.onResponseComplete(envelope.chatId, response, sessionId);

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -370,6 +370,55 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
+  it('returns only the final slash-command output from the daemon', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      events.push({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Compressing context...' },
+            _meta: { source: 'slash_command' },
+          },
+        },
+      });
+      events.push({
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Context compressed.' },
+            _meta: { source: 'slash_command' },
+          },
+        },
+      });
+      events.push(turnCompleteEvent());
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe(
+      'Context compressed.',
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
   it('returns only the final turn text after daemon auto-approved tool calls', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -419,6 +419,40 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
+  it('ignores slash-command output from another daemon session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      events.push({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-2',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Other session output' },
+            _meta: { source: 'slash_command' },
+          },
+        },
+      });
+      events.push(turnCompleteEvent());
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe('');
+
+    events.close();
+    bridge.stop();
+  });
+
   it('returns only the final turn text after daemon auto-approved tool calls', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -419,7 +419,55 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
-  it('ignores slash-command output from another daemon session', async () => {
+  it('prefers daemon model text over slash-command output', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      events.push({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Slash output' },
+            _meta: { source: 'slash_command' },
+          },
+        },
+      });
+      events.push({
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Model text' },
+          },
+        },
+      });
+      events.push(turnCompleteEvent());
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe(
+      'Model text',
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('drops slash-command updates from another daemon session', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
     session.prompt.mockImplementation(async () => {
@@ -437,6 +485,27 @@ describe('DaemonChannelBridge', () => {
         },
       });
       events.push(turnCompleteEvent());
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe('');
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('ignores emitted slash-command output for another prompt session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      bridge.emit('slashCommandOutput', 'session-2', 'Other session output');
       return { stopReason: 'end_turn' };
     });
     const bridge = new DaemonChannelBridge({

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -321,14 +321,21 @@ export class DaemonChannelBridge
     controllers.add(controller);
 
     const chunks: string[] = [];
+    let slashCommandOutput = '';
     const onChunk = (sid: string, chunk: string) => {
       if (sid === sessionId) {
         chunks.push(chunk);
       }
     };
+    const onSlashCommandOutput = (sid: string, chunk: string) => {
+      if (sid === sessionId) {
+        slashCommandOutput = chunk;
+      }
+    };
     const clearChunks = (sid: string) => {
       if (sid === sessionId) {
         chunks.length = 0;
+        slashCommandOutput = '';
       }
     };
     const onSessionDied = (info: { sessionId: string }) => {
@@ -337,6 +344,7 @@ export class DaemonChannelBridge
       }
     };
     this.on('textChunk', onChunk);
+    this.on('slashCommandOutput', onSlashCommandOutput);
     this.on('responseBoundary', clearChunks);
     this.on('sessionDied', onSessionDied);
     const turnBarrier = this.createTurnBarrier(sessionId);
@@ -360,7 +368,7 @@ export class DaemonChannelBridge
         turnBarrier,
         new Promise<void>((resolve) => setTimeout(resolve, 0)),
       ]);
-      const textResult = chunks.join('');
+      const textResult = chunks.join('') || slashCommandOutput;
       this.emit('promptComplete', {
         sessionId,
         text: textResult,
@@ -370,6 +378,7 @@ export class DaemonChannelBridge
     } finally {
       this.clearTurnBarrier(sessionId);
       this.off('textChunk', onChunk);
+      this.off('slashCommandOutput', onSlashCommandOutput);
       this.off('responseBoundary', clearChunks);
       this.off('sessionDied', onSessionDied);
       this.activePrompts.delete(sessionId);
@@ -634,7 +643,13 @@ export class DaemonChannelBridge
         }
         const text = getTextContent(update['content']);
         if (text) {
-          this.emit('textChunk', sessionId, text);
+          this.emit(
+            meta?.['source'] === 'slash_command'
+              ? 'slashCommandOutput'
+              : 'textChunk',
+            sessionId,
+            text,
+          );
         }
         break;
       }

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -583,6 +583,13 @@ export class DaemonChannelBridge
   ): void {
     switch (event.type) {
       case 'session_update':
+        if (
+          isRecord(event.data) &&
+          typeof event.data['sessionId'] === 'string' &&
+          event.data['sessionId'] !== session.sessionId
+        ) {
+          break;
+        }
         this.handleSessionUpdate(session.sessionId, event.data);
         break;
       case 'permission_request':

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -8152,6 +8152,54 @@ describe('Session', () => {
 
         expect(mockGeminiClient.tryCompressChat).not.toHaveBeenCalled();
         expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
+        expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
+          sessionId: 'test-session-id',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Already compressed.' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+      });
+
+      it('marks streamed slash-command messages with their source', async () => {
+        vi.mocked(
+          nonInteractiveCliCommands.handleSlashCommand,
+        ).mockResolvedValueOnce({
+          type: 'stream_messages',
+          messages: (async function* () {
+            yield {
+              messageType: 'info' as const,
+              content: 'Compressing context...',
+            };
+            yield {
+              messageType: 'info' as const,
+              content: 'Context compressed.',
+            };
+          })(),
+        });
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: '/compress' }],
+        });
+
+        expect(mockClient.sessionUpdate).toHaveBeenNthCalledWith(1, {
+          sessionId: 'test-session-id',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Compressing context...' },
+            _meta: { source: 'slash_command' },
+          },
+        });
+        expect(mockClient.sessionUpdate).toHaveBeenNthCalledWith(2, {
+          sessionId: 'test-session-id',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Context compressed.' },
+            _meta: { source: 'slash_command' },
+          },
+        });
       });
 
       it('keeps goal terminal observer after ACP /goal set', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -5627,7 +5627,7 @@ export class Session implements SessionContext {
         // Replace bare \n with Markdown hard line-breaks (two trailing spaces)
         // so Zed's Markdown renderer preserves the line structure.
         const rendered = (result.content || '').replace(/\n/g, '  \n');
-        await this.messageEmitter.emitAgentMessage(rendered);
+        await this.messageEmitter.emitSlashCommandOutput(rendered);
         // Write a system/slash_command record so history replay on restart can
         // re-emit this message. system records are skipped by
         // buildApiHistoryFromConversation, so this won't pollute model context.
@@ -5652,7 +5652,7 @@ export class Session implements SessionContext {
           if (msg.messageType === 'error') {
             throw new Error(msg.content || 'Slash command failed.');
           }
-          await this.messageEmitter.emitAgentMessage(
+          await this.messageEmitter.emitSlashCommandOutput(
             (msg.content || '').replace(/\n/g, '  \n'),
           );
           chunks.push(msg.content || '');

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.test.ts
@@ -98,6 +98,18 @@ describe('MessageEmitter', () => {
     });
   });
 
+  describe('emitSlashCommandOutput', () => {
+    it('should identify slash-command output in metadata', async () => {
+      await emitter.emitSlashCommandOutput('Compressing context...');
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Compressing context...' },
+        _meta: { source: 'slash_command' },
+      });
+    });
+  });
+
   describe('emitGoalTerminal', () => {
     it('should send a goal terminal update in metadata', async () => {
       const event = {

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -148,6 +148,21 @@ export class MessageEmitter extends BaseEmitter {
     });
   }
 
+  async emitSlashCommandOutput(
+    text: string,
+    timestamp?: string | number,
+  ): Promise<void> {
+    const epochMs = BaseEmitter.toEpochMs(timestamp);
+    await this.sendUpdate({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text },
+      _meta: {
+        source: 'slash_command',
+        ...(epochMs != null ? { timestamp: epochMs } : {}),
+      },
+    });
+  }
+
   /**
    * Emits usage metadata.
    */

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -964,6 +964,37 @@ describe('HistoryReplayer', () => {
 
       expect(sendUpdateSpy).not.toHaveBeenCalled();
     });
+
+    it('preserves slash-command provenance when replaying results', async () => {
+      const systemRecord: ChatRecord = {
+        uuid: 'system-uuid',
+        parentUuid: null,
+        sessionId: 'test-session',
+        timestamp: new Date().toISOString(),
+        type: 'system',
+        subtype: 'slash_command',
+        cwd: '/test',
+        version: '1.0.0',
+        systemPayload: {
+          phase: 'result',
+          rawCommand: '/compress-fast',
+          outputHistoryItems: [
+            { type: 'assistant', text: 'Context compressed.' },
+          ],
+        },
+      };
+
+      await replayer.replay([systemRecord]);
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Context compressed.' },
+        _meta: {
+          source: 'slash_command',
+          timestamp: toEpochMs(systemRecord.timestamp),
+        },
+      });
+    });
   });
 
   describe('mixed record types', () => {

--- a/packages/cli/src/acp-integration/session/history-replayer.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.ts
@@ -426,7 +426,7 @@ export class HistoryReplayer {
     for (const item of payload.outputHistoryItems) {
       const text = typeof item['text'] === 'string' ? item['text'] : '';
       if (text) {
-        await this.messageEmitter.emitAgentMessage(
+        await this.messageEmitter.emitSlashCommandOutput(
           text.replace(/\n/g, '  \n'),
           record.timestamp,
         );

--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
@@ -73,28 +73,31 @@ describe('MessageRewriteMiddleware', () => {
   });
 
   describe('interceptUpdate — target filtering', () => {
-    it('does not carry slash-command metadata into the next message rewrite', async () => {
-      const { middleware, mockSendUpdate } = createMiddleware('message');
+    it.each(['message', 'all'] as const)(
+      'does not carry slash-command metadata into the next %s rewrite',
+      async (target) => {
+        const { middleware, mockSendUpdate } = createMiddleware(target);
 
-      await middleware.interceptUpdate({
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: 'Context compressed.' },
-        _meta: { source: 'slash_command' },
-      } as unknown as SessionUpdate);
-      await middleware.interceptUpdate({
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: 'Normal model response.' },
-      } as unknown as SessionUpdate);
+        await middleware.interceptUpdate({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Context compressed.' },
+          _meta: { source: 'slash_command' },
+        } as unknown as SessionUpdate);
+        await middleware.interceptUpdate({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Normal model response.' },
+        } as unknown as SessionUpdate);
 
-      await middleware.flushTurn();
-      await middleware.waitForPendingRewrites();
+        await middleware.flushTurn();
+        await middleware.waitForPendingRewrites();
 
-      expect(mockSendUpdate).toHaveBeenNthCalledWith(3, {
-        sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: 'rewritten text' },
-        _meta: { rewritten: true, turnIndex: 1 },
-      });
-    });
+        expect(mockSendUpdate).toHaveBeenNthCalledWith(3, {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'rewritten text' },
+          _meta: { rewritten: true, turnIndex: 1 },
+        });
+      },
+    );
 
     it('should accumulate messages when target is "message"', async () => {
       const { middleware, mockSendUpdate } = createMiddleware('message');

--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
@@ -96,6 +96,19 @@ describe('MessageRewriteMiddleware', () => {
           content: { type: 'text', text: 'rewritten text' },
           _meta: { rewritten: true, turnIndex: 1 },
         });
+
+        const { LlmRewriter } = await import('./LlmRewriter.js');
+        const rewriter = vi.mocked(LlmRewriter).mock.results[0]?.value as {
+          rewrite: ReturnType<typeof vi.fn>;
+        };
+        expect(rewriter.rewrite).toHaveBeenCalledWith(
+          {
+            thoughts: [],
+            messages: ['Normal model response.'],
+            hasToolCalls: false,
+          },
+          expect.any(AbortSignal),
+        );
       },
     );
 

--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.test.ts
@@ -73,6 +73,29 @@ describe('MessageRewriteMiddleware', () => {
   });
 
   describe('interceptUpdate — target filtering', () => {
+    it('does not carry slash-command metadata into the next message rewrite', async () => {
+      const { middleware, mockSendUpdate } = createMiddleware('message');
+
+      await middleware.interceptUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Context compressed.' },
+        _meta: { source: 'slash_command' },
+      } as unknown as SessionUpdate);
+      await middleware.interceptUpdate({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'Normal model response.' },
+      } as unknown as SessionUpdate);
+
+      await middleware.flushTurn();
+      await middleware.waitForPendingRewrites();
+
+      expect(mockSendUpdate).toHaveBeenNthCalledWith(3, {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'rewritten text' },
+        _meta: { rewritten: true, turnIndex: 1 },
+      });
+    });
+
     it('should accumulate messages when target is "message"', async () => {
       const { middleware, mockSendUpdate } = createMiddleware('message');
 

--- a/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/MessageRewriteMiddleware.ts
@@ -88,6 +88,15 @@ export class MessageRewriteMiddleware {
     // Always send original message as-is
     await this.sendUpdate(update);
 
+    if (
+      updateType === 'agent_message_chunk' &&
+      (updateRecord['_meta'] as Record<string, unknown> | undefined)?.[
+        'source'
+      ] === 'slash_command'
+    ) {
+      return;
+    }
+
     // Accumulate for turn-end rewriting
     let didAccumulate = false;
     if (updateType === 'agent_thought_chunk') {

--- a/packages/cli/src/ui/commands/compressFastCommand.test.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.test.ts
@@ -65,6 +65,79 @@ describe('compressFastCommand', () => {
     expect(mockTryCompressChatFast).toHaveBeenCalledWith();
   });
 
+  it('should reject trailing text in ACP mode', async () => {
+    const ctx = createMockCommandContext({
+      executionMode: 'acp',
+      invocation: {
+        raw: '/compress-fast continue investigating',
+        name: 'compress-fast',
+        args: 'continue investigating',
+      },
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChatFast: mockTryCompressChatFast,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+
+    const result = await compressFastCommand.action!(ctx, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'The /compress-fast command does not accept arguments.',
+    });
+    expect(mockTryCompressChatFast).not.toHaveBeenCalled();
+  });
+
+  it('should accept whitespace-only arguments in ACP mode', async () => {
+    mockTryCompressChatFast.mockResolvedValue({
+      originalTokenCount: 200,
+      newTokenCount: 100,
+      compressionStatus: CompressionStatus.COMPRESSED,
+    } satisfies ChatCompressionInfo);
+    const ctx = createMockCommandContext({
+      executionMode: 'acp',
+      invocation: {
+        raw: '/compress-fast   ',
+        name: 'compress-fast',
+        args: '   ',
+      },
+      services: {
+        config: {
+          getGeminiClient: () =>
+            ({
+              tryCompressChatFast: mockTryCompressChatFast,
+            }) as unknown as GeminiClient,
+        },
+      },
+    });
+
+    const result = await compressFastCommand.action!(ctx, '');
+    expect(result?.type).toBe('stream_messages');
+    const messages = [];
+    if (result?.type === 'stream_messages') {
+      for await (const message of result.messages) {
+        messages.push(message);
+      }
+    }
+
+    expect(messages).toEqual([
+      {
+        messageType: 'info',
+        content: 'Compressing context (fast)...',
+      },
+      {
+        messageType: 'info',
+        content: 'Context compressed (200 -> 100).',
+      },
+    ]);
+    expect(mockTryCompressChatFast).toHaveBeenCalledWith();
+  });
+
   it('should display compression result on success (interactive)', async () => {
     mockTryCompressChatFast.mockResolvedValue({
       originalTokenCount: 200,

--- a/packages/cli/src/ui/commands/compressFastCommand.ts
+++ b/packages/cli/src/ui/commands/compressFastCommand.ts
@@ -35,6 +35,14 @@ export const compressFastCommand: SlashCommand = {
       return;
     }
 
+    if (context.invocation?.args?.trim()) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t('The /compress-fast command does not accept arguments.'),
+      };
+    }
+
     const pendingMessage: HistoryItemCompression = {
       type: MessageType.COMPRESSION,
       compression: {


### PR DESCRIPTION
## What this PR does

ACP slash-command output now carries explicit `slash_command` provenance in both live updates and replayed history. Channel bridges keep that output separate from model text: progress updates are not streamed to messaging channels, only the final command result is eligible for delivery, and model output takes precedence whenever a turn produces both. `/compress-fast` also rejects non-whitespace trailing arguments with a clear, deliverable command result instead of silently consuming them.

## Why it's needed

Messaging channels previously treated `/compress-fast` progress strings as assistant text, so DingTalk users received raw compression status output. Trailing question text was also silently discarded because the command still ran. Preserving provenance lets channel adapters apply a command-aware delivery policy without matching English strings, while retaining useful one-result commands such as `/status`.

## Reviewer Test Plan

### How to verify

Send `/compress-fast` through an ACP-backed messaging channel and confirm that the channel receives only the final compression result, never `Compressing context (fast)...`. Send `/compress-fast continue investigating` and confirm that compression does not run and the exact argument-rejection message is returned. Confirm that a single-result slash command still returns its result and that ordinary model responses are unchanged.

### Evidence (Before & After)

Before: `/compress-fast` was delivered as concatenated progress and completion text, and trailing text was silently ignored.

After: channel bridges retain only the final slash-command result, preserve single-result commands, prefer model output when present, and return a clear rejection for non-whitespace `/compress-fast` arguments.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace; focused ACP session and channel bridge unit tests, full build, typecheck, and lint.

## Risk & Scope

- Main risk or tradeoff: Channel bridges now retain the latest slash-command result separately until the turn completes; model text remains authoritative when present.
- Not validated / out of scope: Live DingTalk credentials were unavailable, so verification used the same ACP and channel delivery boundaries with deterministic tests.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6810

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

ACP 的斜杠命令输出现在会在实时更新和历史回放中携带明确的 `slash_command` 来源信息。Channel bridge 会将这类输出与模型文本分开处理：不会向消息渠道流式发送进度，只保留最后一条命令结果用于投递；如果同一轮同时产生模型输出，则优先使用模型输出。`/compress-fast` 现在也会对非空白尾随参数返回清晰且可投递的拒绝信息，不再静默吞掉这些参数。

## 为什么需要

此前消息渠道会把 `/compress-fast` 的进度字符串当作助手文本，因此钉钉用户会收到原始压缩状态。命令后面的提问文本也会因为命令仍然执行而被静默丢弃。保留来源信息后，channel adapter 可以基于命令来源制定投递策略，无需匹配英文字符串，同时仍能保留 `/status` 这类有用的单结果命令。

## Reviewer Test Plan

### 如何验证

通过 ACP 支持的消息渠道发送 `/compress-fast`，确认渠道只收到最终压缩结果，绝不会收到 `Compressing context (fast)...`。发送 `/compress-fast continue investigating`，确认不会执行压缩，并返回准确的参数拒绝信息。再确认单结果斜杠命令仍会返回结果，普通模型回复不受影响。

### 证据（修复前后）

修复前：`/compress-fast` 会把进度和完成文本拼接后投递，尾随文本会被静默忽略。

修复后：channel bridge 只保留最后一条斜杠命令结果，保留单结果命令，在有模型输出时优先模型输出，并对 `/compress-fast` 的非空白参数返回明确拒绝信息。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
| 🍏 macOS     |  ✅  |
| 🪟 Windows   |  ⚠️  |
| 🐧 Linux     |  ⚠️  |

### 环境（可选）

Node.js 22 工作区；已运行聚焦的 ACP session 与 channel bridge 单元测试、完整 build、typecheck 和 lint。

## 风险与范围

- 主要风险或取舍：channel bridge 会在一轮结束前单独保留最新的斜杠命令结果；存在模型文本时仍以模型文本为准。
- 未验证 / 不在范围内：没有可用的钉钉凭据，因此使用相同的 ACP 与渠道投递边界进行了确定性测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6810

</details>
