### PR TITLE
fix(web-shell): restore packaged dialog styles on React 18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,33 @@ npm run preflight  # Full check: clean → install → format → lint → build
 - **Commits**: Conventional Commits (e.g., `feat(cli): Add --json flag`)
 - **Node.js**: Development and production both require `>=22` (Ink 7 + React 19.2 requirement)
 
+### Web Shell UI development
+
+- Prefer the shared primitives in
+  `packages/web-shell/client/components/ui` when developing Web Shell UI. Do
+  not duplicate an existing primitive or rewrite stable CSS Modules solely for
+  consistency.
+- If a required primitive is missing, run
+  `npx shadcn@latest add <component>` from `packages/web-shell`, then review the
+  generated diff. Do not let the CLI overwrite the existing global CSS,
+  semantic tokens, CSS scoping, or portal-root integration. Keep generated
+  components internal unless a public package API is explicitly required.
+- Web Shell supports React 18 and React 19. Generated shadcn components often
+  assume React 19 ref semantics, so wrappers that accept or receive refs —
+  including Radix `asChild`, `Slot`, `Presence`, and portal children — must use
+  `React.forwardRef` and pass the ref to the underlying DOM or Radix primitive.
+  Add a regression test for any ref-sensitive component path.
+- Use unprefixed Tailwind classes and shadcn semantic color tokens such as
+  `background`, `primary`, and `muted`. The package build scopes generated CSS
+  to the Web Shell root and portal root and prefixes global animations and CSS
+  property registrations; changes must preserve that isolation from host-page
+  styles.
+- Components with portals, such as dialogs, popovers, dropdown menus, and
+  tooltips, must use `useWebShellPortalRoot()` as the Radix portal container so
+  themes, scoped CSS, and z-index variables continue to apply. Preserve
+  existing `data-web-shell-*` attributes and public `--web-shell-*` CSS
+  variables. See `packages/web-shell/README.md` for the full conventions.
+
 ## Development Guidelines
 
 ### General workflow

--- a/packages/web-shell/client/build-artifact.test.ts
+++ b/packages/web-shell/client/build-artifact.test.ts
@@ -75,6 +75,29 @@ describe('build artifact — package boundary', () => {
     expect(unscoped).toEqual([]);
   });
 
+  it('applies Tailwind theme variables to WebShell roots', () => {
+    const themeRules: string[] = [];
+    postcss.parse(readInjectedCss()).walkRules((rule) => {
+      if (
+        rule.nodes.some(
+          (node) => node.type === 'decl' && node.prop === '--spacing',
+        )
+      ) {
+        themeRules.push(rule.selector);
+      }
+    });
+
+    expect(themeRules).toContain(
+      ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn])',
+    );
+    expect(themeRules).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(':root'),
+        expect.stringContaining(':host'),
+      ]),
+    );
+  });
+
   it('prefixes global CSS registrations and animations', () => {
     const unscoped: string[] = [];
     postcss.parse(readInjectedCss()).walkAtRules((atRule) => {

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
@@ -54,6 +54,12 @@ function submit() {
 }
 
 describe('AddWorkspaceDialog', () => {
+  it('focuses the path input when opened', () => {
+    mount(<AddWorkspaceDialog onClose={vi.fn()} onAdd={vi.fn()} />);
+
+    expect(document.activeElement).toBe(input());
+  });
+
   it('describes the input with the hint and no error initially', () => {
     mount(<AddWorkspaceDialog onClose={vi.fn()} onAdd={vi.fn()} />);
     // Hint is always associated; error id is only added once an error exists so

--- a/packages/web-shell/client/components/ui/alert-dialog.tsx
+++ b/packages/web-shell/client/components/ui/alert-dialog.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import * as React from 'react';
 import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
@@ -33,12 +33,13 @@ function AlertDialogPortal({
   );
 }
 
-function AlertDialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+const AlertDialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentProps<typeof AlertDialogPrimitive.Overlay>
+>(function AlertDialogOverlay({ className, ...props }, ref) {
   return (
     <AlertDialogPrimitive.Overlay
+      ref={ref}
       data-slot="alert-dialog-overlay"
       className={cn(
         'fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
@@ -47,19 +48,23 @@ function AlertDialogOverlay({
       {...props}
     />
   );
-}
+});
 
-function AlertDialogContent({
-  className,
-  size = 'default',
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+type AlertDialogContentProps = React.ComponentProps<
+  typeof AlertDialogPrimitive.Content
+> & {
   size?: 'default' | 'sm';
-}) {
+};
+
+const AlertDialogContent = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+  AlertDialogContentProps
+>(function AlertDialogContent({ className, size = 'default', ...props }, ref) {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
+        ref={ref}
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
@@ -70,7 +75,7 @@ function AlertDialogContent({
       />
     </AlertDialogPortal>
   );
-}
+});
 
 function AlertDialogHeader({
   className,

--- a/packages/web-shell/client/components/ui/button.tsx
+++ b/packages/web-shell/client/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 
@@ -41,20 +41,26 @@ const buttonVariants = cva(
   },
 );
 
-function Button({
-  className,
-  variant = 'default',
-  size = 'default',
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
+type ButtonProps = React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
-  }) {
+  };
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    className,
+    variant = 'default',
+    size = 'default',
+    asChild = false,
+    ...props
+  },
+  ref,
+) {
   const Comp = asChild ? Slot.Root : 'button';
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
@@ -62,6 +68,6 @@ function Button({
       {...props}
     />
   );
-}
+});
 
 export { Button, buttonVariants };

--- a/packages/web-shell/client/components/ui/dialog.tsx
+++ b/packages/web-shell/client/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type * as React from 'react';
+import * as React from 'react';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
@@ -40,12 +40,13 @@ function DialogClose({
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentProps<typeof DialogPrimitive.Overlay>
+>(function DialogOverlay({ className, ...props }, ref) {
   return (
     <DialogPrimitive.Overlay
+      ref={ref}
       data-slot="dialog-overlay"
       className={cn(
         'fixed inset-0 isolate z-[var(--web-shell-dialog-backdrop-z-index,50)] bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
@@ -54,22 +55,27 @@ function DialogOverlay({
       {...props}
     />
   );
-}
+});
 
-function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  overlayProps,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+type DialogContentProps = React.ComponentProps<
+  typeof DialogPrimitive.Content
+> & {
   showCloseButton?: boolean;
   overlayProps?: React.ComponentProps<typeof DialogPrimitive.Overlay>;
-}) {
+};
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  DialogContentProps
+>(function DialogContent(
+  { className, children, showCloseButton = true, overlayProps, ...props },
+  ref,
+) {
   return (
     <DialogPortal>
       <DialogOverlay {...overlayProps} />
       <DialogPrimitive.Content
+        ref={ref}
         data-slot="dialog-content"
         className={cn(
           'fixed top-1/2 left-1/2 z-[var(--web-shell-dialog-backdrop-z-index,50)] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
@@ -93,7 +99,7 @@ function DialogContent({
       </DialogPrimitive.Content>
     </DialogPortal>
   );
-}
+});
 
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/packages/web-shell/client/components/ui/input.tsx
+++ b/packages/web-shell/client/components/ui/input.tsx
@@ -1,19 +1,22 @@
-import type * as React from 'react';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  function Input({ className, type, ...props }, ref) {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(
+          'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
 
 export { Input };

--- a/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
+++ b/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { AlertDialogContent, AlertDialogOverlay } from './alert-dialog';
+import { Button } from './button';
+import { DialogContent, DialogOverlay } from './dialog';
+import { Input } from './input';
+import { SelectTrigger } from './select';
+
+const FORWARD_REF_TYPE = Symbol.for('react.forward_ref');
+
+describe('React 18 ref compatibility', () => {
+  it.each([
+    ['AlertDialogContent', AlertDialogContent],
+    ['AlertDialogOverlay', AlertDialogOverlay],
+    ['Button', Button],
+    ['DialogContent', DialogContent],
+    ['DialogOverlay', DialogOverlay],
+    ['Input', Input],
+    ['SelectTrigger', SelectTrigger],
+  ])('%s forwards refs', (_name, Component) => {
+    expect(Component).toHaveProperty('$$typeof', FORWARD_REF_TYPE);
+  });
+});

--- a/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
+++ b/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
@@ -1,3 +1,7 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
 import { describe, expect, it } from 'vitest';
 
 import { AlertDialogContent, AlertDialogOverlay } from './alert-dialog';
@@ -7,6 +11,8 @@ import { Input } from './input';
 import { SelectTrigger } from './select';
 
 const FORWARD_REF_TYPE = Symbol.for('react.forward_ref');
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 describe('React 18 ref compatibility', () => {
   it.each([
@@ -19,5 +25,18 @@ describe('React 18 ref compatibility', () => {
     ['SelectTrigger', SelectTrigger],
   ])('%s forwards refs', (_name, Component) => {
     expect(Component).toHaveProperty('$$typeof', FORWARD_REF_TYPE);
+  });
+
+  it('forwards a Button ref to its DOM element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => root.render(<Button ref={ref}>Button</Button>));
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => root.unmount());
+    container.remove();
   });
 });

--- a/packages/web-shell/client/components/ui/select.tsx
+++ b/packages/web-shell/client/components/ui/select.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type * as React from 'react';
+import * as React from 'react';
 import { Select as SelectPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
@@ -32,16 +32,22 @@ function SelectValue({
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
-function SelectTrigger({
-  className,
-  size = 'default',
-  children,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+type SelectTriggerProps = React.ComponentProps<
+  typeof SelectPrimitive.Trigger
+> & {
   size?: 'sm' | 'default';
-}) {
+};
+
+const SelectTrigger = React.forwardRef<
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
+  SelectTriggerProps
+>(function SelectTrigger(
+  { className, size = 'default', children, ...props },
+  ref,
+) {
   return (
     <SelectPrimitive.Trigger
+      ref={ref}
       data-slot="select-trigger"
       data-size={size}
       className={cn(
@@ -56,7 +62,7 @@ function SelectTrigger({
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
-}
+});
 
 function SelectContent({
   className,

--- a/packages/web-shell/vite.lib.config.ts
+++ b/packages/web-shell/vite.lib.config.ts
@@ -8,6 +8,8 @@ import pkg from './package.json' with { type: 'json' };
 
 const COMPONENT_SCOPE =
   ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn], [data-web-shell-root][data-web-shell-shadcn] *, [data-web-shell-portal-root][data-web-shell-shadcn] *)';
+const COMPONENT_ROOT_SCOPE =
+  ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn])';
 
 function scopeComponentCss(css: string): string {
   const root = postcss.parse(css);
@@ -57,6 +59,14 @@ function scopeComponentCss(css: string): string {
         return;
       }
       parent = parent.parent;
+    }
+    if (
+      rule.selectors.every(
+        (selector) => selector === ':root' || selector === ':host',
+      )
+    ) {
+      rule.selector = COMPONENT_ROOT_SCOPE;
+      return;
     }
     rule.selector = selectorParser((selectors) => {
       selectors.each((selector) => {


### PR DESCRIPTION
## What this PR does

This change restores Tailwind theme variables when Web Shell is consumed as a packaged component and preserves refs across the dialog controls used by React 18 hosts. It also covers the workspace selector and alert dialog variants that share the same ref behavior, with regression tests for both the generated CSS and ref-capable component wrappers. The repository guidance now documents how Web Shell contributors should reuse or add shadcn primitives while preserving React 18 compatibility, CSS isolation, semantic tokens, and portal-root behavior.

## Why it's needed

The package CSS scoping pass transformed Tailwind's `:root, :host` theme rule into selectors that could never match the Web Shell root. As a result, spacing and other theme variables were missing in package consumers, leaving the Add Workspace dialog visibly unstyled. In React 18, Radix Presence and Slot also attach refs to their child components; wrappers that did not forward those refs emitted console warnings when the dialog opened.

## Reviewer Test Plan

### How to verify

Build the Web Shell package and install it in a React 18 host. Open the project add menu and select Add Workspace. Confirm that the dialog has normal spacing, border, typography, overlay, and positioning, that its input receives focus, and that the browser console does not report `Function components cannot be given refs`. Also open the workspace selector and an alert dialog, when available, and confirm the same absence of ref warnings.

### Evidence (Before & After)

Before: the packaged Add Workspace dialog was missing spacing-dependent styles and emitted React ref warnings. After: the generated package CSS binds Tailwind theme variables to Web Shell roots, and all currently exercised Radix/React 18 ref paths are implemented with forwarding wrappers. Automated build-artifact and compatibility tests pass; final host visual verification remains part of the reviewer plan.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22; Web Shell production and library builds, TypeScript typecheck, targeted Vitest tests, ESLint, and Prettier.

## Risk & Scope

- Main risk or tradeoff: CSS theme declarations now apply to the two explicit Web Shell roots instead of the document root, and ref wrapper identities change for the affected internal UI components.
- Not validated / out of scope: final visual verification after publishing and installing the package into the separate React 18 host; Windows and Linux hosts.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

此改动恢复 Web Shell 以 npm 包组件方式接入时的 Tailwind 主题变量，并确保 React 18 宿主中弹窗相关控件能够正确转发 ref。同时覆盖具有相同 ref 行为的工作区选择器和 Alert Dialog，并为生成后的 CSS 与可转发 ref 的组件封装补充回归测试。仓库开发指引也补充了 Web Shell 贡献者复用或新增 shadcn 基础组件时应遵循的 React 18 兼容、CSS 隔离、语义 token 和 Portal root 约定。

## 为什么需要

包构建时的 CSS 作用域处理把 Tailwind 的 `:root, :host` 主题规则转换成了无法匹配 Web Shell 根节点的选择器，导致包消费者缺少间距等主题变量，使“添加工作区”弹窗看起来没有样式。React 18 下，Radix Presence 和 Slot 还会向子组件附加 ref；未转发 ref 的封装组件会在弹窗打开时输出控制台警告。

## Reviewer 测试计划

### 如何验证

构建 Web Shell npm 包并安装到 React 18 宿主中，打开项目添加菜单并选择“添加工作区”。确认弹窗的间距、边框、排版、遮罩和定位正常，输入框能够获得焦点，并且浏览器控制台没有 `Function components cannot be given refs`。如果页面有入口，再打开工作区选择器和 Alert Dialog，确认同样没有 ref 警告。

### 证据（修改前后）

修改前：npm 包模式下的“添加工作区”弹窗缺少依赖间距变量的样式，并出现 React ref 警告。修改后：生成的包 CSS 会把 Tailwind 主题变量绑定到 Web Shell 根节点，当前实际使用的 Radix/React 18 ref 路径都通过可转发 ref 的封装实现。构建产物和兼容性自动化测试已通过；最终宿主视觉验证保留在 Reviewer 测试计划中。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|   🍏 macOS   |  ✅  |
|  🪟 Windows  | N/A  |
|   🐧 Linux   | N/A  |

### 环境（可选）

Node.js 22；已完成 Web Shell 生产与库构建、TypeScript 类型检查、定向 Vitest 测试、ESLint 和 Prettier。

## 风险与范围

- 主要风险或取舍：CSS 主题声明现在只应用到两个明确的 Web Shell 根节点；受影响的内部 UI 组件改为 ref 转发封装后组件标识会变化。
- 未验证或范围外：重新发布并安装到独立 React 18 宿主后的最终视觉验证，以及 Windows、Linux 宿主。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
