### PR TITLE
fix(cli): enable clipboard text and image paste on WSL2/Linux

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -41,6 +41,7 @@ import {
   clipboardHasImage,
   saveClipboardImage,
   cleanupOldClipboardImages,
+  readTextFromClipboard,
 } from '../utils/clipboardUtils.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
@@ -724,9 +725,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     );
   }, [clipboardUnavailableShownRef, uiState.historyManager]);
 
-  // Handle clipboard image pasting with Ctrl+V
+  // Handle clipboard image pasting with Ctrl+V.
+  // Returns true when an image was found and attached.
   const handleClipboardImage = useCallback(
-    async (validated = false) => {
+    async (validated = false): Promise<boolean> => {
       try {
         const hasImage =
           validated || (await clipboardHasImage(reportClipboardUnavailable));
@@ -748,11 +750,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               filename,
             };
             setAttachments((prev) => [...prev, newAttachment]);
+            return true;
           }
         }
       } catch (error) {
         debugLogger.error('Error handling clipboard image:', error);
       }
+      return false;
     },
     [reportClipboardUnavailable],
   );
@@ -1661,9 +1665,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      // Ctrl+V for clipboard image paste
+      // Ctrl+V / Cmd+V: image paste with text fallback.
+      // On Linux/WSL2 the terminal does not intercept Ctrl+V, so the key
+      // event reaches us directly. Previously we consumed it unconditionally
+      // for image-only paste, silently discarding text clipboard content.
+      // Now we fall back to reading text from the system clipboard when no
+      // image is present.
       if (keyMatchers[Command.PASTE_CLIPBOARD_IMAGE](key)) {
-        handleClipboardImage();
+        void handleClipboardImage().then((hadImage) => {
+          if (!hadImage) {
+            const text = readTextFromClipboard();
+            if (text) {
+              buffer.insert(text);
+            }
+          }
+        });
         return true;
       }
 

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -8,11 +8,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 
 // Use vi.hoisted to define mock functions before vi.mock is hoisted
-const { mockSpawn, mockExecSync, clipboardMockState } = vi.hoisted(() => ({
-  mockSpawn: vi.fn(),
-  mockExecSync: vi.fn(),
-  clipboardMockState: { failLoad: false, loadDelayMs: 0 },
-}));
+const { mockSpawn, mockExecSync, mockExecFileSync, clipboardMockState } =
+  vi.hoisted(() => ({
+    mockSpawn: vi.fn(),
+    mockExecSync: vi.fn(),
+    mockExecFileSync: vi.fn(),
+    clipboardMockState: { failLoad: false, loadDelayMs: 0 },
+  }));
 
 // Mock @teddyzhu/clipboard
 vi.mock('@teddyzhu/clipboard', async () => {
@@ -43,11 +45,13 @@ vi.mock('node:child_process', () => ({
   default: {
     spawn: mockSpawn,
     execSync: mockExecSync,
+    execFileSync: mockExecFileSync,
     exec: vi.fn(),
     execFile: vi.fn(),
   },
   spawn: mockSpawn,
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
   exec: vi.fn(),
   execFile: vi.fn(),
 }));
@@ -81,9 +85,8 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   };
 });
 
-// We intentionally do NOT mock node:fs root beyond createWriteStream, to avoid
-// cross-test pollution with other files like startupProfiler.test.ts
-// that use vi.mock('node:fs') (auto-mock).
+// We intentionally do NOT mock node:fs root to avoid breaking indirect
+// dependencies (e.g. debugLogger, symlink) that import from 'node:fs'.
 /**
  * Create a mock child process that emits stdout data and close event.
  */
@@ -153,6 +156,7 @@ describe('clipboardUtils', () => {
   let saveClipboardImage: (dir?: string) => Promise<string | null>;
   let cleanupOldClipboardImages: (dir?: string) => Promise<void>;
   let writeOsc52: (text: string) => boolean;
+  let readTextFromClipboard: () => string;
 
   beforeEach(async () => {
     // Clean up /tmp/test directory from previous runs to ensure
@@ -168,6 +172,14 @@ describe('clipboardUtils', () => {
     clipboardMockState.loadDelayMs = 0;
     vi.resetModules();
     vi.clearAllMocks();
+    // Default: execFileSync throws (no binary found). Tests override as needed.
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+    // Default: execSync throws (command -v fails = binary not found).
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
 
     // Dynamic import after resetModules gives a fresh module instance.
     // Top-level import would be stale after resetModules.
@@ -176,6 +188,7 @@ describe('clipboardUtils', () => {
     saveClipboardImage = mod.saveClipboardImage;
     cleanupOldClipboardImages = mod.cleanupOldClipboardImages;
     writeOsc52 = mod.writeOsc52;
+    readTextFromClipboard = mod.readTextFromClipboard;
     mod.resetLinuxClipboardTool();
     // Set up Wayland env as default
     vi.stubEnv('WAYLAND_DISPLAY', 'wayland-0');
@@ -266,6 +279,28 @@ describe('clipboardUtils', () => {
         const result = await clipboardHasImage();
         expect(result).toBe(false);
       });
+
+      it('should fall back to xclip when wl-paste is not found in Wayland+DISPLAY env', async () => {
+        // Wayland env with X11 display available (e.g. XWayland)
+        vi.stubEnv('WAYLAND_DISPLAY', 'wayland-0');
+        vi.stubEnv('DISPLAY', ':0');
+        // wl-paste not installed, xclip is
+        mockExecSync.mockImplementation((cmd: string) => {
+          if (typeof cmd === 'string' && cmd.includes('wl-paste'))
+            throw new Error('not found');
+          return Buffer.from('/usr/bin/xclip');
+        });
+        const mockChild = createMockChild('image/png\n', 0);
+        mockSpawn.mockReturnValue(mockChild);
+
+        const result = await clipboardHasImage();
+        expect(result).toBe(true);
+        expect(mockSpawn).toHaveBeenCalledWith(
+          'xclip',
+          ['-selection', 'clipboard', '-t', 'TARGETS', '-o'],
+          { stdio: ['ignore', 'pipe', 'ignore'] },
+        );
+      });
     });
 
     describe('saveClipboardImage', () => {
@@ -283,6 +318,96 @@ describe('clipboardUtils', () => {
       // breaking indirect deps (debugLogger, symlink) that import
       // { promises as fs } from 'node:fs'.  Error paths below verify
       // correct spawn construction; clipboardHasImage tests verify detection.
+    });
+  });
+
+  // ─── WSL2 PowerShell fallback tests ──────────────────────────
+
+  describe('WSL2 PowerShell clipboard fallback', () => {
+    it('should detect image via powershell.exe when no Linux tool is available', async () => {
+      // No Linux clipboard tools installed
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+      // powershell.exe binary exists
+      mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
+        if (
+          bin === 'powershell.exe' &&
+          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
+        ) {
+          return 'True';
+        }
+        throw new Error('not found');
+      });
+
+      const result = await clipboardHasImage();
+      expect(result).toBe(true);
+    });
+
+    it('should return false when powershell.exe reports no image', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+      mockExecFileSync.mockImplementation((bin: string) => {
+        if (bin === 'powershell.exe') return 'False';
+        throw new Error('not found');
+      });
+
+      const result = await clipboardHasImage();
+      expect(result).toBe(false);
+    });
+
+    it('should save image via powershell.exe and return the path', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+      mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
+        if (
+          bin === 'powershell.exe' &&
+          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
+        ) {
+          return 'True';
+        }
+        if (
+          bin === 'powershell.exe' &&
+          args.some((a) => typeof a === 'string' && a.includes('GetImage'))
+        ) {
+          return '';
+        }
+        throw new Error('not found');
+      });
+
+      const result = await saveClipboardImage('/tmp/test');
+      expect(result).not.toBe(null);
+      expect(result).toMatch(/clipboard-.*\.png$/);
+    });
+
+    it('should return null when powershell.exe save fails', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+      // powershell.exe: ContainsImage returns True, but GetImage throws
+      let getImageCalled = false;
+      mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
+        if (
+          bin === 'powershell.exe' &&
+          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
+        ) {
+          return 'True';
+        }
+        if (
+          bin === 'powershell.exe' &&
+          args.some((a) => typeof a === 'string' && a.includes('GetImage'))
+        ) {
+          getImageCalled = true;
+          throw new Error('save failed');
+        }
+        throw new Error('not found');
+      });
+
+      const result = await saveClipboardImage('/tmp/test');
+      expect(result).toBe(null);
+      expect(getImageCalled).toBe(true);
     });
   });
 
@@ -792,6 +917,186 @@ describe('clipboardUtils', () => {
         expectedSequence,
         expect.any(Function),
       );
+    });
+  });
+
+  describe('readTextFromClipboard', () => {
+    it('should read text via pbpaste on macOS', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+      mockExecFileSync.mockReturnValue('hello from mac clipboard');
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('hello from mac clipboard');
+      expect(mockExecFileSync).toHaveBeenCalledWith('pbpaste', [], {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+    });
+
+    it('should read text via powershell on Windows', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      mockExecFileSync.mockReturnValue('hello from win clipboard');
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('hello from win clipboard');
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-c', 'Get-Clipboard'],
+        { encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'ignore'] },
+      );
+    });
+
+    it('should read text via xclip on Linux X11', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      // command -v xclip succeeds (probe)
+      mockExecSync.mockReturnValue(Buffer.from('/usr/bin/xclip'));
+      // actual read via execFileSync
+      mockExecFileSync.mockReturnValue('clipboard text');
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('clipboard text');
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'xclip',
+        ['-selection', 'clipboard', '-o'],
+        { encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'ignore'] },
+      );
+    });
+
+    it('should fall back to xsel when xclip is not found on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      // command -v xclip fails, command -v xsel succeeds
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('xclip'))
+          throw new Error('not found');
+        return Buffer.from('/usr/bin/xsel');
+      });
+      mockExecFileSync.mockReturnValue('xsel clipboard text');
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('xsel clipboard text');
+    });
+
+    it('should fall back to wl-paste when xclip and xsel are not found on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (
+          typeof cmd === 'string' &&
+          (cmd.includes('xclip') || cmd.includes('xsel'))
+        )
+          throw new Error('not found');
+        return Buffer.from('/usr/bin/wl-paste');
+      });
+      mockExecFileSync.mockReturnValue('wl-paste text');
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('wl-paste text');
+    });
+
+    it('should return empty string when no clipboard tool is available on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      // All command -v checks fail, powershell.exe probe also fails
+      mockExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string on pbpaste failure on macOS', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('pbpaste failed');
+      });
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('');
+    });
+
+    it('should cache the working Linux clipboard tool across calls', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      // command -v xclip succeeds (probe)
+      mockExecSync.mockReturnValue(Buffer.from('/usr/bin/xclip'));
+      mockExecFileSync.mockReturnValue('clipboard text');
+
+      readTextFromClipboard();
+      const execSyncCountAfterFirst = mockExecSync.mock.calls.length;
+
+      readTextFromClipboard();
+      // Second call should NOT re-probe (cached)
+      expect(mockExecSync.mock.calls.length).toBe(execSyncCountAfterFirst);
+    });
+
+    it('should fall back to powershell.exe on WSL2 when no Linux tool is available', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      // All command -v checks fail
+      mockExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+      // powershell.exe probe and read succeed
+      mockExecFileSync.mockImplementation((bin: string) => {
+        if (bin === 'powershell.exe') return 'windows clipboard text';
+        throw new Error('not found');
+      });
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('windows clipboard text');
+    });
+
+    it('should return empty string when no tool including powershell is available', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      mockExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('');
     });
   });
 });

--- a/packages/cli/src/ui/utils/clipboardUtils.test.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.test.ts
@@ -324,56 +324,42 @@ describe('clipboardUtils', () => {
   // ─── WSL2 PowerShell fallback tests ──────────────────────────
 
   describe('WSL2 PowerShell clipboard fallback', () => {
-    it('should detect image via powershell.exe when no Linux tool is available', async () => {
-      // No Linux clipboard tools installed
+    // clipboardHasImage() no longer calls powershell.exe directly;
+    // image detection via PowerShell happens in saveClipboardImage().
+
+    it('should return false from clipboardHasImage when no Linux tool is available', async () => {
+      // No Linux clipboard tools, no display server
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
       mockExecSync.mockImplementation(() => {
         throw new Error('command not found');
-      });
-      // powershell.exe binary exists
-      mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
-        if (
-          bin === 'powershell.exe' &&
-          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
-        ) {
-          return 'True';
-        }
-        throw new Error('not found');
-      });
-
-      const result = await clipboardHasImage();
-      expect(result).toBe(true);
-    });
-
-    it('should return false when powershell.exe reports no image', async () => {
-      mockExecSync.mockImplementation(() => {
-        throw new Error('command not found');
-      });
-      mockExecFileSync.mockImplementation((bin: string) => {
-        if (bin === 'powershell.exe') return 'False';
-        throw new Error('not found');
       });
 
       const result = await clipboardHasImage();
       expect(result).toBe(false);
     });
 
-    it('should save image via powershell.exe and return the path', async () => {
+    it('should save image via powershell.exe combined check+save', async () => {
+      // No display server → no native Linux tools
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
       mockExecSync.mockImplementation(() => {
         throw new Error('command not found');
       });
+      // Combined ContainsImage+GetImage command succeeds
       mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
         if (
           bin === 'powershell.exe' &&
-          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
-        ) {
-          return 'True';
-        }
-        if (
-          bin === 'powershell.exe' &&
+          args.some(
+            (a) => typeof a === 'string' && a.includes('ContainsImage'),
+          ) &&
           args.some((a) => typeof a === 'string' && a.includes('GetImage'))
         ) {
           return '';
         }
+        if (bin === 'powershell.exe') return '';
         throw new Error('not found');
       });
 
@@ -382,24 +368,47 @@ describe('clipboardUtils', () => {
       expect(result).toMatch(/clipboard-.*\.png$/);
     });
 
-    it('should return null when powershell.exe save fails', async () => {
+    it('should escape single quotes in path for powershell.exe', async () => {
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
       mockExecSync.mockImplementation(() => {
         throw new Error('command not found');
       });
-      // powershell.exe: ContainsImage returns True, but GetImage throws
-      let getImageCalled = false;
+      let savedCommand = '';
       mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
         if (
           bin === 'powershell.exe' &&
           args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
         ) {
-          return 'True';
+          savedCommand =
+            args.find(
+              (a) => typeof a === 'string' && a.includes('ContainsImage'),
+            ) || '';
+          return '';
         }
+        if (bin === 'powershell.exe') return '';
+        throw new Error('not found');
+      });
+
+      await saveClipboardImage("/tmp/user's dir");
+      // Single quotes in path should be escaped as ''
+      expect(savedCommand).toContain("''");
+      expect(savedCommand).not.toMatch(/user's/);
+    });
+
+    it('should return null when powershell.exe save fails', async () => {
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found');
+      });
+      mockExecFileSync.mockImplementation((bin: string, args: string[]) => {
         if (
           bin === 'powershell.exe' &&
-          args.some((a) => typeof a === 'string' && a.includes('GetImage'))
+          args.some((a) => typeof a === 'string' && a.includes('ContainsImage'))
         ) {
-          getImageCalled = true;
           throw new Error('save failed');
         }
         throw new Error('not found');
@@ -407,7 +416,6 @@ describe('clipboardUtils', () => {
 
       const result = await saveClipboardImage('/tmp/test');
       expect(result).toBe(null);
-      expect(getImageCalled).toBe(true);
     });
   });
 
@@ -956,13 +964,8 @@ describe('clipboardUtils', () => {
     });
 
     it('should read text via xclip on Linux X11', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      // command -v xclip succeeds (probe)
+      setupX11Env();
       mockExecSync.mockReturnValue(Buffer.from('/usr/bin/xclip'));
-      // actual read via execFileSync
       mockExecFileSync.mockReturnValue('clipboard text');
 
       const result = readTextFromClipboard();
@@ -975,50 +978,23 @@ describe('clipboardUtils', () => {
       );
     });
 
-    it('should fall back to xsel when xclip is not found on Linux', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      // command -v xclip fails, command -v xsel succeeds
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (typeof cmd === 'string' && cmd.includes('xclip'))
-          throw new Error('not found');
-        return Buffer.from('/usr/bin/xsel');
-      });
-      mockExecFileSync.mockReturnValue('xsel clipboard text');
-
-      const result = readTextFromClipboard();
-
-      expect(result).toBe('xsel clipboard text');
-    });
-
-    it('should fall back to wl-paste when xclip and xsel are not found on Linux', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (
-          typeof cmd === 'string' &&
-          (cmd.includes('xclip') || cmd.includes('xsel'))
-        )
-          throw new Error('not found');
-        return Buffer.from('/usr/bin/wl-paste');
-      });
+    it('should use wl-paste on Wayland session', () => {
+      // Default env: WAYLAND_DISPLAY='wayland-0'
+      mockExecSync.mockReturnValue(Buffer.from('/usr/bin/wl-paste'));
       mockExecFileSync.mockReturnValue('wl-paste text');
 
       const result = readTextFromClipboard();
 
       expect(result).toBe('wl-paste text');
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'wl-paste',
+        ['--no-newline'],
+        { encoding: 'utf-8', timeout: 2000, stdio: ['pipe', 'pipe', 'ignore'] },
+      );
     });
 
-    it('should return empty string when no clipboard tool is available on Linux', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      // All command -v checks fail, powershell.exe probe also fails
+    it('should return empty string when Wayland tool not found and no fallback', () => {
+      // Default env: WAYLAND_DISPLAY='wayland-0'
       mockExecSync.mockImplementation(() => {
         throw new Error('not found');
       });
@@ -1028,6 +1004,8 @@ describe('clipboardUtils', () => {
 
       const result = readTextFromClipboard();
 
+      // getLinuxClipboardTool returns 'wl-paste' (WAYLAND_DISPLAY set),
+      // but execFileSync fails → caught by try/catch → empty string
       expect(result).toBe('');
     });
 
@@ -1046,11 +1024,7 @@ describe('clipboardUtils', () => {
     });
 
     it('should cache the working Linux clipboard tool across calls', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      // command -v xclip succeeds (probe)
+      setupX11Env();
       mockExecSync.mockReturnValue(Buffer.from('/usr/bin/xclip'));
       mockExecFileSync.mockReturnValue('clipboard text');
 
@@ -1062,16 +1036,15 @@ describe('clipboardUtils', () => {
       expect(mockExecSync.mock.calls.length).toBe(execSyncCountAfterFirst);
     });
 
-    it('should fall back to powershell.exe on WSL2 when no Linux tool is available', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
-      });
-      // All command -v checks fail
+    it('should fall back to powershell.exe on WSL2 when no display server', () => {
+      // No display server → getLinuxClipboardTool() returns null
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
       mockExecSync.mockImplementation(() => {
         throw new Error('not found');
       });
-      // powershell.exe probe and read succeed
+      // powershell.exe availability check + read both succeed
       mockExecFileSync.mockImplementation((bin: string) => {
         if (bin === 'powershell.exe') return 'windows clipboard text';
         throw new Error('not found');
@@ -1082,11 +1055,28 @@ describe('clipboardUtils', () => {
       expect(result).toBe('windows clipboard text');
     });
 
-    it('should return empty string when no tool including powershell is available', () => {
-      Object.defineProperty(process, 'platform', {
-        value: 'linux',
-        configurable: true,
+    it('should trim trailing \\r\\n from powershell.exe output', () => {
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
+      mockExecSync.mockImplementation(() => {
+        throw new Error('not found');
       });
+      // PowerShell Get-Clipboard appends \r\n
+      mockExecFileSync.mockImplementation((bin: string) => {
+        if (bin === 'powershell.exe') return 'hello\r\n';
+        throw new Error('not found');
+      });
+
+      const result = readTextFromClipboard();
+
+      expect(result).toBe('hello');
+    });
+
+    it('should return empty string when no tool including powershell is available', () => {
+      vi.stubEnv('WAYLAND_DISPLAY', undefined as unknown as string);
+      vi.stubEnv('XDG_SESSION_TYPE', undefined as unknown as string);
+      vi.stubEnv('DISPLAY', undefined as unknown as string);
       mockExecSync.mockImplementation(() => {
         throw new Error('not found');
       });

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
-import { execSync, spawn } from 'node:child_process';
+import { execFileSync, execSync, spawn } from 'node:child_process';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
@@ -91,11 +91,15 @@ async function getClipboardModule(): Promise<any | null> {
 export function resetLinuxClipboardTool(): void {
   linuxClipboardTool = undefined;
   cachedWlPasteImageTypes = null;
+  linuxTextReadCmd = undefined;
 }
 
 /**
  * Detect the Linux clipboard tool.
  * Handles WSL2 where XDG_SESSION_TYPE may be unset but WAYLAND_DISPLAY is set.
+ * When the preferred tool's binary exists but fails at runtime (e.g. wl-paste
+ * cannot connect to the Wayland socket in WSL2), callers should fall back to
+ * the alternate tool.
  */
 function getLinuxClipboardTool(): 'wl-paste' | 'xclip' | null {
   if (linuxClipboardTool !== undefined) return linuxClipboardTool;
@@ -121,6 +125,17 @@ function getLinuxClipboardTool(): 'wl-paste' | 'xclip' | null {
     return toolName;
   } catch {
     debugLogger.warn(`${toolName} not found`);
+    // If the preferred tool is missing, try the other protocol as fallback.
+    // e.g. Wayland env but wl-paste not installed → try xclip for X11.
+    if (toolName === 'wl-paste' && (sessionType === 'x11' || display)) {
+      try {
+        execSync('command -v xclip', { stdio: 'ignore' });
+        linuxClipboardTool = 'xclip';
+        return 'xclip';
+      } catch {
+        debugLogger.warn('xclip not found (fallback)');
+      }
+    }
     linuxClipboardTool = null;
     return null;
   }
@@ -306,6 +321,10 @@ export async function clipboardHasImage(
   cachedWlPasteImageTypes = null; // Fresh check each time
   if (process.platform === 'linux') {
     try {
+      // WSL2 first: check Windows clipboard via powershell.exe.
+      // This does not consume the clipboard content, unlike wl-paste.
+      if (clipboardHasImageViaPowershell()) return true;
+
       const tool = getLinuxClipboardTool();
       if (tool === 'wl-paste') {
         return checkClipboardForImage('wl-paste', ['--list-types']);
@@ -388,6 +407,58 @@ async function getWlPasteImageTypes(): Promise<string[]> {
       resolve([]);
     });
   });
+}
+
+/**
+ * Check if the Windows clipboard (via powershell.exe) contains an image.
+ * Used as a WSL2 fallback when wl-paste/xclip are unavailable or fail.
+ */
+function clipboardHasImageViaPowershell(): boolean {
+  try {
+    const result = execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-c',
+        'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
+      ],
+      { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] },
+    ).trim();
+    return result === 'True';
+  } catch (e) {
+    debugLogger.debug('PowerShell clipboard image check failed:', e);
+    return false;
+  }
+}
+
+/**
+ * Save the Windows clipboard image to a PNG file via powershell.exe.
+ * Used as a WSL2 fallback when wl-paste/xclip are unavailable or fail.
+ */
+async function saveImageWithPowershell(targetPath: string): Promise<boolean> {
+  const absPath = path.resolve(targetPath);
+  try {
+    execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-c',
+        `Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${absPath}') }`,
+      ],
+      { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    try {
+      const stats = await fs.stat(absPath);
+      return stats.size > 0;
+    } catch {
+      return false;
+    }
+  } catch (e) {
+    debugLogger.debug('PowerShell clipboard image save failed:', e);
+    return false;
+  }
 }
 
 /**
@@ -533,6 +604,12 @@ export async function saveClipboardImage(
         tempDir,
         `clipboard-${timestamp}-${randomUUID()}.png`,
       );
+
+      // WSL2 first: try powershell.exe which reads the Windows clipboard
+      // directly without consuming the Wayland/X11 clipboard content.
+      // This must run before wl-paste, which can consume the image on WSL2.
+      if (await saveImageWithPowershell(pngPath)) return pngPath;
+
       const tool = getLinuxClipboardTool();
 
       if (tool === 'wl-paste') {
@@ -547,11 +624,15 @@ export async function saveClipboardImage(
             /* ignore */
           }
         }
-        return null;
+        // Fall through to xclip fallback
       }
       if (tool === 'xclip') {
         if (await saveFileWithXclip(pngPath)) return pngPath;
-        return null;
+      }
+      try {
+        await fs.unlink(pngPath);
+      } catch {
+        /* ignore */
       }
       return null;
     }
@@ -635,5 +716,91 @@ export async function cleanupOldClipboardImages(
     }
   } catch {
     // Ignore errors in cleanup
+  }
+}
+
+// Cache for Linux text clipboard read command
+let linuxTextReadCmd: string[] | null | undefined;
+
+/**
+ * Read text from the system clipboard.
+ * Used as fallback when Ctrl+V is pressed but clipboard has no image.
+ * @returns clipboard text content, or empty string on failure
+ */
+export function readTextFromClipboard(): string {
+  try {
+    const platform = process.platform;
+    if (platform === 'darwin') {
+      return execFileSync('pbpaste', [], {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).toString();
+    }
+    if (platform === 'win32') {
+      return execFileSync(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-c', 'Get-Clipboard'],
+        {
+          encoding: 'utf-8',
+          timeout: 2000,
+          stdio: ['pipe', 'pipe', 'ignore'],
+        },
+      ).toString();
+    }
+    // Linux/WSL2: probe once, then use cached tool
+    if (linuxTextReadCmd === undefined) {
+      const candidates: Array<[string, string[]]> = [
+        ['xclip', ['-selection', 'clipboard', '-o']],
+        ['xsel', ['--clipboard', '--output']],
+        ['wl-paste', ['--no-newline']],
+      ];
+      linuxTextReadCmd = null;
+      for (const [bin, args] of candidates) {
+        try {
+          execSync('command -v ' + bin, { stdio: 'ignore' });
+          linuxTextReadCmd = [bin, ...args];
+          break;
+        } catch {
+          /* try next */
+        }
+      }
+      // WSL2 fallback: read Windows clipboard via powershell interop.
+      // Works even when no Linux clipboard tools are installed.
+      if (!linuxTextReadCmd) {
+        try {
+          execFileSync(
+            'powershell.exe',
+            ['-NoProfile', '-NonInteractive', '-c', 'echo 1'],
+            {
+              encoding: 'utf-8',
+              timeout: 500,
+              stdio: ['pipe', 'pipe', 'ignore'],
+            },
+          );
+          linuxTextReadCmd = [
+            'powershell.exe',
+            '-NoProfile',
+            '-NonInteractive',
+            '-c',
+            'Get-Clipboard',
+          ];
+        } catch {
+          /* not WSL2 or powershell unavailable */
+        }
+      }
+    }
+    if (linuxTextReadCmd) {
+      const [bin, ...args] = linuxTextReadCmd;
+      return execFileSync(bin, args, {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      }).toString();
+    }
+    return '';
+  } catch (e) {
+    debugLogger.warn('readTextFromClipboard failed:', e);
+    return '';
   }
 }

--- a/packages/cli/src/ui/utils/clipboardUtils.ts
+++ b/packages/cli/src/ui/utils/clipboardUtils.ts
@@ -67,6 +67,9 @@ let cachedWlPasteImageTypes: string[] | null = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let clipboardModulePromise: Promise<any | null> | null = null;
 
+// Cache for powershell.exe availability on WSL2
+let powershellAvailable: boolean | undefined;
+
 /**
  * Get and cache the @teddyzhu/clipboard module.
  * Only used on macOS/Windows as fallback for Linux platform-native tools.
@@ -92,6 +95,7 @@ export function resetLinuxClipboardTool(): void {
   linuxClipboardTool = undefined;
   cachedWlPasteImageTypes = null;
   linuxTextReadCmd = undefined;
+  powershellAvailable = undefined;
 }
 
 /**
@@ -321,10 +325,6 @@ export async function clipboardHasImage(
   cachedWlPasteImageTypes = null; // Fresh check each time
   if (process.platform === 'linux') {
     try {
-      // WSL2 first: check Windows clipboard via powershell.exe.
-      // This does not consume the clipboard content, unlike wl-paste.
-      if (clipboardHasImageViaPowershell()) return true;
-
       const tool = getLinuxClipboardTool();
       if (tool === 'wl-paste') {
         return checkClipboardForImage('wl-paste', ['--list-types']);
@@ -410,34 +410,37 @@ async function getWlPasteImageTypes(): Promise<string[]> {
 }
 
 /**
- * Check if the Windows clipboard (via powershell.exe) contains an image.
- * Used as a WSL2 fallback when wl-paste/xclip are unavailable or fail.
+ * Check if powershell.exe is available (WSL2 interop).
+ * Result is cached to avoid repeated ENOENT spawns on non-WSL2 Linux.
  */
-function clipboardHasImageViaPowershell(): boolean {
+function isPowershellAvailable(): boolean {
+  if (powershellAvailable !== undefined) return powershellAvailable;
   try {
-    const result = execFileSync(
+    execFileSync(
       'powershell.exe',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-c',
-        'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
-      ],
-      { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] },
-    ).trim();
-    return result === 'True';
-  } catch (e) {
-    debugLogger.debug('PowerShell clipboard image check failed:', e);
-    return false;
+      ['-NoProfile', '-NonInteractive', '-c', 'echo 1'],
+      {
+        encoding: 'utf-8',
+        timeout: 500,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      },
+    );
+    powershellAvailable = true;
+  } catch {
+    powershellAvailable = false;
   }
+  return powershellAvailable;
 }
 
 /**
  * Save the Windows clipboard image to a PNG file via powershell.exe.
- * Used as a WSL2 fallback when wl-paste/xclip are unavailable or fail.
+ * Checks ContainsImage() first to avoid creating empty files when no image
+ * is present. Used as a WSL2 fallback when wl-paste/xclip are unavailable.
  */
 async function saveImageWithPowershell(targetPath: string): Promise<boolean> {
+  if (!isPowershellAvailable()) return false;
   const absPath = path.resolve(targetPath);
+  const escapedPath = absPath.replace(/'/g, "''");
   try {
     execFileSync(
       'powershell.exe',
@@ -445,7 +448,7 @@ async function saveImageWithPowershell(targetPath: string): Promise<boolean> {
         '-NoProfile',
         '-NonInteractive',
         '-c',
-        `Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${absPath}') }`,
+        `Add-Type -AssemblyName System.Windows.Forms; if ([System.Windows.Forms.Clipboard]::ContainsImage()) { [System.Windows.Forms.Clipboard]::GetImage().Save('${escapedPath}') }`,
       ],
       { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] },
     );
@@ -624,7 +627,7 @@ export async function saveClipboardImage(
             /* ignore */
           }
         }
-        // Fall through to xclip fallback
+        // wl-paste failed; fall through to cleanup
       }
       if (tool === 'xclip') {
         if (await saveFileWithXclip(pngPath)) return pngPath;
@@ -748,46 +751,23 @@ export function readTextFromClipboard(): string {
         },
       ).toString();
     }
-    // Linux/WSL2: probe once, then use cached tool
+    // Linux/WSL2: reuse getLinuxClipboardTool() for consistent tool priority
+    // with image paste, then fall back to powershell.exe on WSL2.
     if (linuxTextReadCmd === undefined) {
-      const candidates: Array<[string, string[]]> = [
-        ['xclip', ['-selection', 'clipboard', '-o']],
-        ['xsel', ['--clipboard', '--output']],
-        ['wl-paste', ['--no-newline']],
-      ];
       linuxTextReadCmd = null;
-      for (const [bin, args] of candidates) {
-        try {
-          execSync('command -v ' + bin, { stdio: 'ignore' });
-          linuxTextReadCmd = [bin, ...args];
-          break;
-        } catch {
-          /* try next */
-        }
-      }
-      // WSL2 fallback: read Windows clipboard via powershell interop.
-      // Works even when no Linux clipboard tools are installed.
-      if (!linuxTextReadCmd) {
-        try {
-          execFileSync(
-            'powershell.exe',
-            ['-NoProfile', '-NonInteractive', '-c', 'echo 1'],
-            {
-              encoding: 'utf-8',
-              timeout: 500,
-              stdio: ['pipe', 'pipe', 'ignore'],
-            },
-          );
-          linuxTextReadCmd = [
-            'powershell.exe',
-            '-NoProfile',
-            '-NonInteractive',
-            '-c',
-            'Get-Clipboard',
-          ];
-        } catch {
-          /* not WSL2 or powershell unavailable */
-        }
+      const tool = getLinuxClipboardTool();
+      if (tool === 'wl-paste') {
+        linuxTextReadCmd = ['wl-paste', '--no-newline'];
+      } else if (tool === 'xclip') {
+        linuxTextReadCmd = ['xclip', '-selection', 'clipboard', '-o'];
+      } else if (isPowershellAvailable()) {
+        linuxTextReadCmd = [
+          'powershell.exe',
+          '-NoProfile',
+          '-NonInteractive',
+          '-c',
+          'Get-Clipboard',
+        ];
       }
     }
     if (linuxTextReadCmd) {
@@ -796,7 +776,9 @@ export function readTextFromClipboard(): string {
         encoding: 'utf-8',
         timeout: 2000,
         stdio: ['pipe', 'pipe', 'ignore'],
-      }).toString();
+      })
+        .toString()
+        .replace(/\r?\n$/, '');
     }
     return '';
   } catch (e) {


### PR DESCRIPTION
## What this PR does

On Linux/WSL2, pressing Ctrl+V in the CLI silently discards text clipboard content because the key event is consumed by the image-paste handler even when the clipboard contains no image. This PR adds a text-paste fallback so Ctrl+V works for both images and text. It also adds PowerShell-based clipboard image detection and save for WSL2, enabling image paste without requiring `wl-paste` or `xclip` to be installed.

## Why it's needed

On macOS, terminals intercept Cmd+V and send clipboard content as bracketed paste events, so the app never sees the key event. On Linux/WSL2, Ctrl+V reaches the app directly as a key event. The existing `PASTE_CLIPBOARD_IMAGE` handler consumed this key event unconditionally — if the clipboard had no image, the handler did nothing but still returned `true`, swallowing the keystroke. Text paste via Ctrl+V was completely broken on all Linux-based platforms.

Additionally, WSL2 environments often lack `wl-paste` or `xclip`, and the Wayland socket may not be accessible even when `WAYLAND_DISPLAY` is set. Using `powershell.exe` (available via WSL2 interop) to read the Windows clipboard directly bypasses these issues entirely — the same approach Claude Code uses.

## Reviewer Test Plan

### How to verify

1. On a Linux or WSL2 machine, copy text to the clipboard and press Ctrl+V in the CLI input — text should appear in the input buffer.
2. Copy an image (e.g. a screenshot) and press Ctrl+V — a PNG attachment chip should appear.
3. On WSL2 without `wl-paste` or `xclip` installed, repeat steps 1 and 2 — both should work via `powershell.exe` fallback.
4. On macOS, verify Cmd+V still works for both text and image paste (no regression).

### Evidence (Before & After)

Before: Ctrl+V on WSL2/Linux did nothing when clipboard had text (silently consumed). Image paste required `wl-paste` + working Wayland socket or `xclip` + X11.

After: Ctrl+V pastes text on all platforms. Image paste works on WSL2 via `powershell.exe` with zero Linux clipboard tool dependencies.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment

WSL2 (Ubuntu 24.04) on Windows 11, Node.js v24.15.0, `npm run dev`, no sandbox. `wl-clipboard` installed but Wayland socket unreachable (WSLg misconfiguration). `xclip` not installed. Image paste works via `powershell.exe` alone.

## Risk & Scope

- Main risk or tradeoff: On WSL2, `powershell.exe` startup adds ~200-500ms latency to the first Ctrl+V press. Subsequent presses are faster due to OS-level caching. Native Linux desktops (with working wl-paste/xclip) are unaffected since PowerShell is only tried as a fast pre-check.
- Not validated / out of scope: macOS regression testing (no macOS machine available). Windows native (non-WSL) testing. The `readTextFromClipboard()` function is synchronous and blocks the event loop briefly (~50ms) — acceptable for a user-initiated paste action.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #2913
