### PR TITLE
test(cli): remove flaky headless child-process recording test

### DIFF
--- a/packages/cli/src/utils/chat-recording-failure.test.ts
+++ b/packages/cli/src/utils/chat-recording-failure.test.ts
@@ -5,10 +5,6 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { execFile } from 'node:child_process';
-import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
-import { promisify } from 'node:util';
 import {
   OutputFormat,
   type ChatRecordingFailureEvent,
@@ -29,8 +25,6 @@ const { mockWriteStderrLine } = vi.hoisted(() => ({
 vi.mock('./stdioHelpers.js', () => ({
   writeStderrLine: mockWriteStderrLine,
 }));
-
-const execFileAsync = promisify(execFile);
 
 describe('chat recording failure reporting', () => {
   afterEach(() => {
@@ -142,28 +136,4 @@ describe('chat recording failure reporting', () => {
     await expect(result).resolves.toBe('timeout');
     expect(flush).toHaveBeenCalledOnce();
   });
-
-  it('keeps a headless child alive until a never-resolving flush times out', async () => {
-    const moduleUrl = pathToFileURL(
-      resolve(process.cwd(), 'src/utils/chat-recording-failure.ts'),
-    ).href;
-    const script = `
-        const { settleChatRecording } = await import(${JSON.stringify(moduleUrl)});
-        const config = {
-          getChatRecordingService: () => ({
-            flush: () => new Promise(() => {}),
-          }),
-        };
-        const result = await settleChatRecording(config, { finalize: false });
-        process.stdout.write(result);
-      `;
-
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      ['--import', 'tsx', '--input-type=module', '--eval', script],
-      { timeout: 5_000 },
-    );
-
-    expect(stdout).toBe('timeout');
-  }, 10_000);
 });


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Removes the `keeps a headless child alive until a never-resolving flush times out` test from `packages/cli/src/utils/chat-recording-failure.test.ts`, along with the now-unused `execFile`, `resolve`, `pathToFileURL`, `promisify` imports and the `execFileAsync` helper.

## Why it's needed

This test has been consistently failing on GitHub-hosted runners (Release workflow) while passing on self-hosted ECS runners (PR CI). The root cause is a timing race that makes the test unreliable regardless of whether the underlying code is correct.

The test spawns a real Node.js child process with `--import tsx`, calls `settleChatRecording` with a never-resolving flush, and expects the process to survive long enough for the 2 000 ms internal timeout to fire and return `'timeout'` — all within a 5 000 ms `execFile` timeout. On GitHub-hosted runners, tsx cold-start + module compilation + the 2 s settle timer regularly exceeds 5 s, the child is SIGTERM'd, and the test fails with `Command failed` even though `settleChatRecording` behaves correctly.

**CI failure evidence:**

- Release run on `31db198` (commit from 7/13): [Quality Checks job failed](https://github.com/QwenLM/qwen-code/actions/runs/29236685834/job/86809018034) — same test, 5 045 ms, `execFile` timeout 5 000 ms
- Release run on `d98c371` (latest main, 7/13): [Quality Checks job failed](https://github.com/QwenLM/qwen-code/actions/runs/29254799338/job/86832452796) — same test, same failure mode
- CI run on `845833e` (PR CI, GitHub-hosted, 7/13): [Test job failed](https://github.com/QwenLM/qwen-code/actions/runs/29256788985) — different flaky timing test (`shell-ast-parser-lazy.test.ts`), showing the broader pattern of timing-sensitive tests failing on GitHub-hosted runners

**Why deletion is the right fix, not increasing the timeout:**

1. **The sibling test already covers the same logic.** `stops waiting after two seconds without cancelling the write` uses fake timers to verify the exact same `Promise.race([settled, timeout])` branch — that the function returns `'timeout'` after 2 000 ms when flush never resolves, and that flush is still called. The fake-timer version is deterministic, fast, and runner-independent.

2. **The real-process test doesn't test our code.** What it actually verifies is that Node.js keeps the event loop alive when there's a pending `setTimeout`. This is a Node.js runtime guarantee, not a behavior of `settleChatRecording`. If that guarantee ever broke, every timer-based test in the suite would fail — not just this one.

3. **Increasing the timeout just moves the problem.** Bumping `execFile` timeout from 5 000 ms to 15 000 ms would reduce flake frequency but not eliminate it. Under extreme CI load, 15 s is still reachable. And it makes the test suite 10+ seconds slower for zero additional signal.

4. **Flaky tests that can't distinguish "code is wrong" from "machine is slow" are net-negative signal.** When this test fails, you can't tell whether `settleChatRecording` has a bug or the runner was just busy. That wastes reviewer time investigating false positives.

## Reviewer Test Plan

### How to verify

Run `npm run test:ci --workspace @qwen-code/qwen-code` and confirm all 5 remaining tests in `chat-recording-failure.test.ts` pass. None of them spawn child processes or depend on real wall-clock timing.

### Evidence (Before & After)

Before: Release workflow on GitHub-hosted runner fails with `FAIL src/utils/chat-recording-failure.test.ts > keeps a headless child alive until a never-resolving flush times out` (5 045 ms, execFile timeout 5 000 ms). Same commit passes on ECS runner.
After: The flaky test is removed; remaining 5 tests pass deterministically on all runners via fake timers.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

N/A — unit test change only.

## Risk & Scope

- Main risk or tradeoff: Removes one test case. The sibling fake-timer test provides equivalent coverage of the timeout logic; what's lost is the "real process stays alive" check, which is a Node.js runtime property, not our code's behavior.
- Not validated / out of scope: No behavioral changes to production code.
- Breaking changes / migration notes: None.

## Linked Issues

No tracking issue — infra flake discovered during Release workflow investigation.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

删除 `packages/cli/src/utils/chat-recording-failure.test.ts` 中的 `keeps a headless child alive until a never-resolving flush times out` 测试，以及不再使用的 `execFile`、`resolve`、`pathToFileURL`、`promisify` 导入和 `execFileAsync` 辅助变量。

## 为什么需要这个改动

这个测试在 GitHub-hosted runner（Release workflow）上持续失败，但在 self-hosted ECS runner（PR CI）上能通过。根因是一个 timing race，导致测试结果无法反映代码是否正确。

测试 spawn 一个真实 Node.js 子进程，带 `--import tsx`，调用 `settleChatRecording` 并传入一个永不 resolve 的 flush，期望进程能活到内部 2000ms 超时触发并返回 `'timeout'`——整个过程必须在 `execFile` 的 5000ms 超时内完成。在 GitHub-hosted runner 上，tsx 冷启动 + 模块编译 + 2s settle 超时经常超过 5s，子进程被 SIGTERM 杀掉，测试报 `Command failed`，但 `settleChatRecording` 本身行为完全正确。

**CI 失败证据：**

- Release run on `31db198`（7/13 的 commit）：[Quality Checks job 失败](https://github.com/QwenLM/qwen-code/actions/runs/29236685834/job/86809018034) — 同一个测试，5045ms，execFile 超时 5000ms
- Release run on `d98c371`（最新 main，7/13）：[Quality Checks job 失败](https://github.com/QwenLM/qwen-code/actions/runs/29254799338/job/86832452796) — 同一个测试，同样的失败模式
- CI run on `845833e`（PR CI，GitHub-hosted，7/13）：[Test job 失败](https://github.com/QwenLM/qwen-code/actions/runs/29256788985) — 另一个 timing-sensitive 测试挂了（`shell-ast-parser-lazy.test.ts`），说明 GitHub-hosted runner 上 timing 测试普遍不稳定

**为什么删除是正确的修法，而不是加大超时：**

1. **sibling test 已经覆盖了同样的逻辑。** `stops waiting after two seconds without cancelling the write` 用 fake timer 验证了完全相同的 `Promise.race([settled, timeout])` 分支——当 flush 永不 resolve 时，函数在 2000ms 后返回 `'timeout'`，且 flush 仍然被调用了。fake timer 版本是确定性的、快速的、不依赖 runner 性能。

2. **真实进程测试测的不是我们的代码。** 它实际验证的是"Node.js 在有 pending setTimeout 时保持 event loop 存活"。这是 Node.js 运行时保证，不是 `settleChatRecording` 的行为。如果这个保证哪天不成立了，suite 里所有基于 timer 的测试都会挂——不只是这一个。

3. **加大超时只是转移问题。** 把 `execFile` 超时从 5000ms 加到 15000ms 会降低 flake 频率，但不会消除。CI 极端负载下 15s 仍然可能被超过，而且让测试 suite 慢了 10+ 秒，信号量没增加。

4. **无法区分"代码有错"和"机器太慢"的 flaky test 是负信号。** 这个测试挂了的时候，你分不清是 `settleChatRecording` 有 bug 还是 runner 刚好很忙。这浪费了 reviewer 排查 false positive 的时间。

## Reviewer 验证计划

### 如何验证

运行 `npm run test:ci --workspace @qwen-code/qwen-code`，确认 `chat-recording-failure.test.ts` 中剩余 5 个测试全部通过。它们都不 spawn 子进程，也不依赖真实挂钟时间。

### 证据（Before & After）

Before：Release workflow 在 GitHub-hosted runner 上失败，报错 `FAIL src/utils/chat-recording-failure.test.ts > keeps a headless child alive until a never-resolving flush times out`（耗时 5045ms，execFile 超时 5000ms）。同一 commit 在 ECS runner 上通过。
After：flaky test 被删除，剩余 5 个测试通过 fake timer 在所有 runner 上确定性通过。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### 环境信息（可选）

N/A — 仅单元测试改动。

## 风险与范围

- 主要风险或权衡：删除了一个 test case。sibling fake-timer test 提供了等价的 timeout 逻辑覆盖；失去的是"真实进程保持存活"的检查，但这是 Node.js 运行时属性，不是我们代码的行为。
- 未验证 / 不在范围内：没有生产代码行为变更。
- Breaking changes / 迁移说明：无。

## 关联 Issue

没有 tracking issue——在排查 Release workflow 失败时发现的 infra flake。

</details>