### PR TITLE
fix(cli): compute latestActiveTime from the real activity timestamp

### DIFF
--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -1110,6 +1110,61 @@ describe('DataProcessor', () => {
       });
     });
 
+    it('reports the wall-clock time of the most recent user interaction', async () => {
+      const early = '2025-01-15T09:12:00Z';
+      const late = '2025-01-16T14:37:00Z';
+      const mockRecords: ChatRecord[] = [
+        {
+          sessionId: 'session1',
+          timestamp: late,
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'later' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+        {
+          sessionId: 'session1',
+          timestamp: early,
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'earlier' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+      ];
+
+      mockedReadJsonlFile.mockResolvedValue(mockRecords);
+
+      const files = [{ path: '/test/chat.jsonl', mtime: 1234567890 }];
+      const result = (await (
+        dataProcessor as unknown as {
+          generateMetrics(
+            files: Array<{ path: string; mtime: number }>,
+          ): Promise<{ latestActiveTime: string | null }>;
+        }
+      ).generateMetrics(files)) as { latestActiveTime: string | null };
+
+      // Reflects the real latest timestamp's wall-clock time (in local tz),
+      // regardless of input order.
+      const expected = new Date(late).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      expect(result.latestActiveTime).toBe(expected);
+
+      // Regression: the old code derived the time from date-only heatmap keys,
+      // so `new Date(key)` was UTC midnight and the time was a constant — never
+      // the real activity time.
+      const buggyConstant = new Date('2025-01-16').toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      expect(result.latestActiveTime).not.toBe(buggyConstant);
+    });
+
     it('should track tool usage correctly', async () => {
       const mockRecords: ChatRecord[] = [
         {

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -1028,6 +1028,8 @@ None captured`;
     // Initialize data structures
     const heatmap: HeatMapData = {};
     const activeHours: { [hour: number]: number } = {};
+    // Real timestamp of the most recent user interaction, for latestActiveTime.
+    let latestActiveTimestamp: Date | null = null;
     const sessionStartTimes: { [sessionId: string]: Date } = {};
     const sessionEndTimes: { [sessionId: string]: Date } = {};
     let totalMessages = 0;
@@ -1067,6 +1069,14 @@ None captured`;
 
               // Update active hours
               activeHours[hour] = (activeHours[hour] || 0) + 1;
+
+              // Track the most recent activity for latestActiveTime.
+              if (
+                latestActiveTimestamp === null ||
+                timestamp > latestActiveTimestamp
+              ) {
+                latestActiveTimestamp = timestamp;
+              }
             }
 
             // Track session times
@@ -1166,19 +1176,16 @@ None captured`;
 
     const totalHours = Math.round(totalDurationMs / (1000 * 60 * 60));
 
-    // Calculate latest active time
-    let latestActiveTime: string | null = null;
-    let latestTimestamp = new Date(0);
-    for (const dateStr in heatmap) {
-      const date = new Date(dateStr);
-      if (date > latestTimestamp) {
-        latestTimestamp = date;
-        latestActiveTime = date.toLocaleTimeString([], {
+    // Format the most recent activity's wall-clock time. (This previously
+    // iterated the date-only heatmap keys, so `new Date(key)` was UTC midnight
+    // and the derived time was a constant — the timezone offset — rather than
+    // the real last-active time.)
+    const latestActiveTime: string | null = latestActiveTimestamp
+      ? latestActiveTimestamp.toLocaleTimeString([], {
           hour: '2-digit',
           minute: '2-digit',
-        });
-      }
-    }
+        })
+      : null;
 
     // Calculate top tools
     const topTools = Object.entries(toolUsage)


### PR DESCRIPTION
## What this PR does

Fixes `latestActiveTime` in the `/insight` report so it reflects the real time of the user's most recent activity, instead of a constant. Adds a regression test.

## Why it's needed

`latestActiveTime` was computed by iterating the **date-only** heatmap keys (`"2025-01-16"`) and formatting them:

```ts
for (const dateStr in heatmap) {
  const date = new Date(dateStr);       // date-only string → UTC midnight
  if (date > latestTimestamp) {
    latestTimestamp = date;
    latestActiveTime = date.toLocaleTimeString(...); // always the same value
  }
}
```

`new Date("2025-01-16")` is UTC midnight, so `toLocaleTimeString()` always yields the same wall-clock value — the user's UTC offset expressed as a time (e.g. `12:00 AM` at UTC+0, `07:00 PM` at UTC-5). It is a fixed function of the timezone offset and never reflects when the user was actually last active. The fix tracks the most recent user-interaction timestamp in the metrics loop (where the full record timestamp is available) and formats that.

This is independent of the separate UTC-vs-local day-bucketing questions elsewhere in this file (heatmap/streak/active-hours) — those are left untouched.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/services/insight/generators/DataProcessor.test.ts` from `packages/cli`. The added `reports the wall-clock time of the most recent user interaction` test feeds two user records (out of order) and asserts `latestActiveTime` equals the local-time formatting of the later timestamp; it fails against the previous date-key derivation (verified locally by reverting) and passes with the fix.

### Evidence (Before & After)

For records at `2025-01-15T09:12:00Z` and `2025-01-16T14:37:00Z`:
Before: `latestActiveTime` = `new Date("2025-01-16").toLocaleTimeString()` — the UTC-midnight constant (e.g. `12:00 AM` at UTC+0), independent of the actual `14:37` activity.
After: `latestActiveTime` = the local-time formatting of `2025-01-16T14:37:00Z` (e.g. `02:37 PM` at UTC+0).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `DataProcessor` suite (46 pass, including the new test; no existing test changed), confirmed the new test fails against the pre-fix code, and ran `prettier --check` + `eslint` on both files (clean). The test computes its expected value with the same `toLocaleTimeString` call, so it is timezone-agnostic. Windows/Linux: N/A — pure in-memory computation with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-cli` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note — the change only affects the single `latestActiveTime` field, which was previously a constant with no real meaning.
- Not validated / out of scope: the UTC-vs-local basis of the heatmap/streak/active-hours (tracked separately) is intentionally not touched here.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `/insight` 报告中的 `latestActiveTime`，使其反映用户最近一次活动的真实时间，而不是一个常量。并补充回归测试。

## 为什么需要

`latestActiveTime` 此前是通过遍历**仅含日期**的 heatmap 键（`"2025-01-16"`）并格式化得到的：

```ts
for (const dateStr in heatmap) {
  const date = new Date(dateStr);       // 仅日期字符串 → UTC 午夜
  if (date > latestTimestamp) {
    latestTimestamp = date;
    latestActiveTime = date.toLocaleTimeString(...); // 永远是同一个值
  }
}
```

`new Date("2025-01-16")` 是 UTC 午夜，因此 `toLocaleTimeString()` 永远返回同一个墙钟值——即用户的 UTC 偏移量表示成的时间（UTC+0 为 `12:00 AM`，UTC-5 为 `07:00 PM`）。它只是时区偏移的固定函数，完全不反映用户实际最后活动的时间。修复方式是在 metrics 循环中（此处能拿到完整的记录时间戳）跟踪最近一次用户交互的时间戳，并格式化它。

这与该文件中另外的 UTC/本地"按天分桶"问题（heatmap/streak/active-hours）无关——那些此处不做改动。

## 复核测试计划

### 如何验证

在 `packages/cli` 下运行 `npx vitest run src/services/insight/generators/DataProcessor.test.ts`。新增的 `reports the wall-clock time of the most recent user interaction` 用例给入两条（乱序的）用户记录，并断言 `latestActiveTime` 等于较晚时间戳的本地时间格式；它在修复前的日期键推导下会失败（已在本地通过回退验证），在修复下通过。

### 证据（修复前后对比）

对于 `2025-01-15T09:12:00Z` 与 `2025-01-16T14:37:00Z` 两条记录：
修复前：`latestActiveTime` = `new Date("2025-01-16").toLocaleTimeString()`——UTC 午夜常量（UTC+0 下为 `12:00 AM`），与实际的 `14:37` 活动无关。
修复后：`latestActiveTime` = `2025-01-16T14:37:00Z` 的本地时间格式（UTC+0 下为 `02:37 PM`）。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `DataProcessor` 测试（46 个通过，含新增用例；没有改动任何既有测试），确认新增测试在修复前失败，并对两个文件运行 `prettier --check` 与 `eslint`（均无问题）。测试用相同的 `toLocaleTimeString` 调用计算期望值，因此与时区无关。Windows/Linux：N/A——纯内存计算，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-cli` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有——改动只影响 `latestActiveTime` 这一个字段，而它此前是一个没有实际意义的常量。
- 未验证 / 范围之外：heatmap/streak/active-hours 的 UTC/本地基准（单独跟踪）在此有意不动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
