### PR TITLE
fix(review): build the chunk agent's prompt in code — they were launched blind

### DIFF
--- a/packages/cli/src/commands/review.test.ts
+++ b/packages/cli/src/commands/review.test.ts
@@ -45,6 +45,7 @@ describe('reviewCommand', () => {
       'plan-diff',
       'pr-context',
       'load-rules',
+      'agent-prompt',
       'resolve-anchors',
       'check-coverage',
       'presubmit',

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -19,6 +19,7 @@ import { loadRulesCommand } from './review/load-rules.js';
 import { presubmitCommand } from './review/presubmit.js';
 import { resolveAnchorsCommand } from './review/resolve-anchors.js';
 import { checkCoverageCommand } from './review/check-coverage.js';
+import { agentPromptCommand } from './review/agent-prompt.js';
 import { submitCommand } from './review/submit.js';
 import { testEfficacyCommand } from './review/test-efficacy.js';
 import { cleanupCommand } from './review/cleanup.js';
@@ -35,6 +36,7 @@ export const reviewCommand: CommandModule = {
       .command(planDiffCommand)
       .command(prContextCommand)
       .command(loadRulesCommand)
+      .command(agentPromptCommand)
       .command(resolveAnchorsCommand)
       .command(checkCoverageCommand)
       .command(presubmitCommand)
@@ -44,7 +46,7 @@ export const reviewCommand: CommandModule = {
       .command(cleanupCommand)
       .demandCommand(
         1,
-        'Specify a subcommand: parse-args, fetch-pr, capture-local, plan-diff, pr-context, load-rules, resolve-anchors, check-coverage, presubmit, test-efficacy, compose-review, submit, or cleanup.',
+        'Specify a subcommand: parse-args, fetch-pr, capture-local, plan-diff, pr-context, load-rules, agent-prompt, resolve-anchors, check-coverage, presubmit, test-efficacy, compose-review, submit, or cleanup.',
       )
       .version(false),
   handler: () => {

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -11,7 +11,7 @@
 // is in the prompt, the read call is in the prompt, and the agent is not handed a
 // sentence to recite when it finds nothing.
 
-import { describe, it, expect, vi, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -194,6 +194,13 @@ describe('buildChunkAgentPrompt — refuses a plan it cannot build from', () => 
 });
 
 describe('agent-prompt (command boundary)', () => {
+  // Without this, `calls[0]` is the first call *ever* made to the mock across the
+  // file — correct today only because nothing earlier invokes the handler, and
+  // silently wrong the moment something does.
+  beforeEach(() => {
+    (writeStdoutLine as unknown as Mock).mockClear();
+  });
+
   it('prints the prompt for the chunk it was asked for', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ap-cmd-'));
     try {
@@ -203,7 +210,9 @@ describe('agent-prompt (command boundary)', () => {
         plan,
         chunk: 13,
       });
-      const printed = (writeStdoutLine as unknown as Mock).mock.calls[0][0];
+      const calls = (writeStdoutLine as unknown as Mock).mock.calls;
+      expect(calls).toHaveLength(1);
+      const printed = calls[0][0];
       expect(printed).toContain('offset=3807');
       expect(printed).toContain(PLAN.diffPathAbsolute);
     } finally {
@@ -218,5 +227,46 @@ describe('agent-prompt (command boundary)', () => {
         chunk: 1,
       }),
     ).toThrow(/cannot read the plan/);
+  });
+  it('injects the project rules the review loaded', () => {
+    // They were loaded, written to a file, and dropped: `buildChunkAgentPrompt`
+    // took a `rules` argument that the CLI had no flag to supply. The review
+    // enforced no project rule at all and said nothing about it.
+    const dir = mkdtempSync(join(tmpdir(), 'ap-rules-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      const rules = join(dir, 'rules.md');
+      writeFileSync(rules, 'No `any` in new code.\n');
+
+      (agentPromptCommand.handler as (a: unknown) => void)({
+        plan,
+        chunk: 13,
+        rules,
+      });
+
+      const printed = (writeStdoutLine as unknown as Mock).mock.calls[0][0];
+      expect(printed).toContain('Project rules');
+      expect(printed).toContain('No `any` in new code.');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a rules path that does not resolve, rather than reviewing without them', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ap-rules2-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      expect(() =>
+        (agentPromptCommand.handler as (a: unknown) => void)({
+          plan,
+          chunk: 13,
+          rules: join(dir, 'no-such-rules.md'),
+        }),
+      ).toThrow(/cannot read the rules/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The subject is 23 review agents launched with no way to read the diff.
+//
+// Every test that matters here asserts a property that was MISSING from all 23
+// real launch prompts, measured off the harness's own transcripts: the diff path
+// is in the prompt, the read call is in the prompt, and the agent is not handed a
+// sentence to recite when it finds nothing.
+
+import { describe, it, expect } from 'vitest';
+import { buildChunkAgentPrompt } from './agent-prompt.js';
+
+const PLAN = {
+  diffPathAbsolute: '/abs/.qwen/tmp/qwen-review-pr-6771-diff.txt',
+  chunks: [
+    {
+      id: 13,
+      startLine: 3808,
+      endLine: 4024,
+      lines: 217,
+      chars: 9000,
+      maxLineChars: 120,
+      oversized: false,
+      files: [
+        {
+          path: 'packages/cli/src/commands/review/x.test.ts',
+          newStart: 1,
+          newEnd: 211,
+        },
+      ],
+    },
+    {
+      id: 14,
+      startLine: 4025,
+      endLine: 4200,
+      lines: 176,
+      chars: 40_000,
+      maxLineChars: 90,
+      oversized: true,
+      files: [{ path: 'a.ts', newStart: 1, newEnd: 20 }],
+    },
+    {
+      id: 15,
+      startLine: 4201,
+      endLine: 4202,
+      lines: 2,
+      chars: 60_000,
+      maxLineChars: 59_000, // a minified bundle: one line no paging can reach
+      oversized: true,
+      files: [{ path: 'bundle.min.js', newStart: 1, newEnd: 1 }],
+    },
+  ],
+};
+
+describe('buildChunkAgentPrompt — what the real launches left out', () => {
+  it('names the diff file — the agents could not open what they were never given', () => {
+    // The bug, stated as an assertion. All 23 real prompts described the chunk
+    // ("chunk 13 of 23, covering lines 3808-4024") and named no file at all.
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).toContain('/abs/.qwen/tmp/qwen-review-pr-6771-diff.txt');
+  });
+
+  it('spells out the read call, with a 0-based offset', () => {
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    // startLine 3808 (1-based) → offset 3807; limit = 4024 - 3808 + 1 = 217.
+    expect(p).toContain('offset=3807');
+    expect(p).toContain('limit=217');
+    expect(p).toMatch(/read_file\(file_path="[^"]+", offset=3807, limit=217\)/);
+  });
+
+  it('does NOT hand the agent a sentence to recite when it finds nothing', () => {
+    // Every real prompt ended with: `If you find no issues, say "No issues found
+    // — reviewed chunk 13 (x.test.ts)"`. An agent that cannot open the diff will
+    // still say it — and did, 23 times. A receipt the prompt wrote is not
+    // evidence of work.
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).not.toMatch(/say ["“]No issues found/i);
+    expect(p).not.toMatch(/If you find no issues, say/i);
+    // It asks for evidence instead.
+    expect(p).toContain('say what you examined');
+  });
+
+  it('tells the agent to page a truncated read', () => {
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).toContain('isTruncated');
+    expect(p).toMatch(/larger `?offset`?/);
+  });
+
+  it('flags an oversized chunk as one that will need paging', () => {
+    expect(buildChunkAgentPrompt(PLAN, 14)).toContain('oversized');
+  });
+
+  it('tells an unreachable chunk to return Uncoverable, not a receipt', () => {
+    // A single line longer than one read: every page starts at a line boundary,
+    // so its tail is unreachable by any offset. It must not be receipted.
+    const p = buildChunkAgentPrompt(PLAN, 15);
+    expect(p).toContain('Uncoverable: chunk 15');
+    expect(p).toContain('exceeds the read limit');
+  });
+
+  it('scopes the agent to its own territory', () => {
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).toContain('lines 3808-4024');
+    expect(p).toContain('belong to other agents');
+    // And names the source files it covers.
+    expect(p).toContain('packages/cli/src/commands/review/x.test.ts');
+  });
+
+  it('carries the severity definitions, so test-coverage is not filed as Critical', () => {
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).toContain('**Critical**');
+    expect(p).toContain('**Suggestion**');
+  });
+
+  it('appends project rules when there are any', () => {
+    const p = buildChunkAgentPrompt(PLAN, 13, 'No `any` in new code.');
+    expect(p).toContain('Project rules');
+    expect(p).toContain('No `any` in new code.');
+    expect(buildChunkAgentPrompt(PLAN, 13)).not.toContain('Project rules');
+  });
+});
+
+describe('buildChunkAgentPrompt — refuses a plan it cannot build from', () => {
+  it('refuses a plan with no diff path — that is the bug, not a default', () => {
+    // A prompt built without the diff path is exactly what shipped 23 times. It
+    // must be an error, never a prompt that merely describes the chunk.
+    expect(() => buildChunkAgentPrompt({ chunks: PLAN.chunks }, 13)).toThrow(
+      /diffPathAbsolute/,
+    );
+  });
+
+  it('refuses a plan with no chunks', () => {
+    expect(() =>
+      buildChunkAgentPrompt({ diffPathAbsolute: '/x/diff.txt' }, 1),
+    ).toThrow(/chunks/);
+  });
+
+  it('refuses a chunk id the plan does not have', () => {
+    expect(() => buildChunkAgentPrompt(PLAN, 99)).toThrow(/no chunk 99/);
+  });
+
+  it('refuses a chunk whose line range is unusable', () => {
+    const bad = {
+      diffPathAbsolute: '/x/diff.txt',
+      chunks: [{ id: 1, startLine: 0, endLine: -5, files: [] }],
+    };
+    expect(() => buildChunkAgentPrompt(bad, 1)).toThrow(/line range/);
+  });
+});

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -11,8 +11,14 @@
 // is in the prompt, the read call is in the prompt, and the agent is not handed a
 // sentence to recite when it finds nothing.
 
-import { describe, it, expect } from 'vitest';
-import { buildChunkAgentPrompt } from './agent-prompt.js';
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../../utils/stdioHelpers.js', () => ({ writeStdoutLine: vi.fn() }));
+import { writeStdoutLine } from '../../utils/stdioHelpers.js';
+import { buildChunkAgentPrompt, agentPromptCommand } from './agent-prompt.js';
 
 const PLAN = {
   diffPathAbsolute: '/abs/.qwen/tmp/qwen-review-pr-6771-diff.txt',
@@ -94,6 +100,41 @@ describe('buildChunkAgentPrompt — what the real launches left out', () => {
     expect(buildChunkAgentPrompt(PLAN, 14)).toContain('oversized');
   });
 
+  it('asks a normal chunk for the receipt check-coverage parses', () => {
+    // The structured line the downstream check reads. Nothing else asserted it,
+    // so dropping it would have been a silent regression.
+    const p = buildChunkAgentPrompt(PLAN, 13);
+    expect(p).toContain('Covered: chunk 13 lines 3808-4024');
+  });
+
+  it('does not ask an unreachable chunk for BOTH Uncoverable and Covered', () => {
+    // It was told to return `Uncoverable`, and then also told to end with
+    // `Covered:` — two instructions that contradict each other. A chunk that
+    // reports itself both uncoverable and covered is neither.
+    const p = buildChunkAgentPrompt(PLAN, 15);
+    expect(p).toContain('Uncoverable: chunk 15');
+    expect(p).not.toContain('Covered: chunk 15');
+  });
+
+  it('handles a chunk with no recorded files', () => {
+    const plan = {
+      diffPathAbsolute: '/d.txt',
+      chunks: [
+        {
+          id: 1,
+          startLine: 1,
+          endLine: 10,
+          lines: 10,
+          chars: 100,
+          maxLineChars: 50,
+          oversized: false,
+          files: [],
+        },
+      ],
+    };
+    expect(buildChunkAgentPrompt(plan, 1)).toContain('(none recorded)');
+  });
+
   it('tells an unreachable chunk to return Uncoverable, not a receipt', () => {
     // A single line longer than one read: every page starts at a line boundary,
     // so its tail is unreachable by any offset. It must not be receipted.
@@ -149,5 +190,33 @@ describe('buildChunkAgentPrompt — refuses a plan it cannot build from', () => 
       chunks: [{ id: 1, startLine: 0, endLine: -5, files: [] }],
     };
     expect(() => buildChunkAgentPrompt(bad, 1)).toThrow(/line range/);
+  });
+});
+
+describe('agent-prompt (command boundary)', () => {
+  it('prints the prompt for the chunk it was asked for', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ap-cmd-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      (agentPromptCommand.handler as (a: unknown) => void)({
+        plan,
+        chunk: 13,
+      });
+      const printed = (writeStdoutLine as unknown as Mock).mock.calls[0][0];
+      expect(printed).toContain('offset=3807');
+      expect(printed).toContain(PLAN.diffPathAbsolute);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('names the plan it could not read, instead of a raw stack', () => {
+    expect(() =>
+      (agentPromptCommand.handler as (a: unknown) => void)({
+        plan: '/no/such/plan.json',
+        chunk: 1,
+      }),
+    ).toThrow(/cannot read the plan/);
   });
 });

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -116,6 +116,34 @@ describe('buildChunkAgentPrompt — what the real launches left out', () => {
     expect(p).not.toContain('Covered: chunk 15');
   });
 
+  it('drops a malformed files[] entry instead of rendering "undefined"', () => {
+    // The plan is cast off disk unchecked. A bad entry would otherwise print
+    // `- undefined (new-side lines undefined-undefined)` and send the agent
+    // looking for a file that does not exist.
+    const plan = {
+      diffPathAbsolute: '/d.txt',
+      chunks: [
+        {
+          id: 1,
+          startLine: 1,
+          endLine: 10,
+          lines: 10,
+          chars: 100,
+          maxLineChars: 50,
+          oversized: false,
+          files: [
+            null,
+            { newStart: 1, newEnd: 2 },
+            { path: 'real.ts', newStart: 1, newEnd: 9 },
+          ],
+        },
+      ],
+    } as never;
+    const p = buildChunkAgentPrompt(plan, 1);
+    expect(p).not.toContain('undefined');
+    expect(p).toContain('real.ts');
+  });
+
   it('handles a chunk with no recorded files', () => {
     const plan = {
       diffPathAbsolute: '/d.txt',

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -137,7 +137,15 @@ export function buildChunkAgentPrompt(
   const offset = chunk.startLine - 1;
   const limit = chunk.endLine - chunk.startLine + 1;
 
-  const files = (chunk.files ?? [])
+  // The plan is parsed off disk with an unchecked cast, so guard the elements too,
+  // not just the array. A malformed entry would otherwise render as
+  // `- undefined (new-side lines undefined-undefined)` and send the agent looking
+  // for a file that does not exist.
+  const files = (Array.isArray(chunk.files) ? chunk.files : [])
+    .filter(
+      (f): f is DiffChunk['files'][number] =>
+        !!f && typeof f.path === 'string' && f.path.length > 0,
+    )
     .map((f) => `- ${f.path} (new-side lines ${f.newStart}-${f.newEnd})`)
     .join('\n');
 

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `qwen review agent-prompt`: build a review agent's launch prompt in code.
+//
+// The prompt used to be composed by the orchestrator, from a paragraph of the
+// skill's instructions telling it what to include. Measured against the harness's
+// own record of what the agents were actually launched with — the first record of
+// each subagent transcript, written at launch and not retconnable — the
+// orchestrator did not include it:
+//
+//   23 of 23 chunk agents were launched with a prompt that named NO diff file:
+//   no `diffPathAbsolute`, no `read_file`, no offset, no limit. All 23 made zero
+//   tool calls.
+//
+// They were handed a *description* of a chunk they had no way to open ("The
+// changes are in chunk 13 of 23, covering lines 3808-4024 of the diff"), and a
+// sentence to say if they found nothing ("If you find no issues, say 'No issues
+// found — reviewed chunk 13 (...)'"). They said it. Every one of them.
+//
+// So the agents never whiffed. They were launched blind, and then dutifully read
+// their line. The receipts they returned — which looked like proof of work — were
+// in the prompt that launched them.
+//
+// This is the same failure this skill has now fixed five times over: a rule the
+// prompt states in prose is a rule that will eventually not be followed, and the
+// fix is always to move it into code that can say no. It was applied to the
+// review target, the posting gate, the verdict, and the coverage report. The
+// agent's own prompt — the thing that decides whether a review can happen at all
+// — was the one place it was not.
+//
+// The orchestrator now asks for the prompt instead of writing it. What comes back
+// carries the diff path, the agent's exact byte range, and the paging and
+// uncoverable rules, because those are not things a caller should be trusted to
+// remember.
+
+import type { CommandModule } from 'yargs';
+import { readFileSync } from 'node:fs';
+import { writeStdoutLine } from '../../utils/stdioHelpers.js';
+import type { DiffChunk } from './lib/diff-plan.js';
+
+interface AgentPromptArgs {
+  plan: string;
+  chunk: number;
+}
+
+/** The plan report, as far as this command needs it. */
+interface PlanReport {
+  diffPathAbsolute?: unknown;
+  chunks?: unknown;
+}
+
+/**
+ * The severity definitions, verbatim.
+ *
+ * A chunk agent owns the test-coverage dimension with no dedicated agent to
+ * calibrate it, and an uncalibrated agent files "zero test coverage" as Critical.
+ * It has happened.
+ */
+const SEVERITY = `Apply the severity definitions:
+- **Critical** — the code does something wrong. A bug that produces incorrect behaviour, a security hole, data loss, a resource or state leak, a build or test failure.
+- **Suggestion** — a recommended improvement to code that works.
+- **Nice to have** — optional.`;
+
+const FINDING_FORMAT = `Format each finding using this structure:
+- **File:** <file path>:<line number or range>
+- **Anchor:** <1-3 consecutive lines copied VERBATIM from the diff>
+- **Source:** [review]
+- **Issue:** <one-line statement of the defect>
+- **Failure scenario:** <the concrete trigger and the concrete wrong outcome: what input, state, timing, or config makes this code misbehave, and what incorrect output / crash / leak / exposure results>
+- **Suggested fix:** <concrete code suggestion when possible, or "N/A">
+- **Severity:** Critical | Suggestion | Nice to have
+- **Confidence:** high | low`;
+
+/** Validate the plan and pull out the one chunk this agent owns. */
+function chunkFrom(
+  report: PlanReport,
+  id: number,
+): {
+  diffPath: string;
+  chunk: DiffChunk;
+  total: number;
+} {
+  const diffPath = report.diffPathAbsolute;
+  if (typeof diffPath !== 'string' || diffPath.length === 0) {
+    throw new Error(
+      'agent-prompt: the plan has no `diffPathAbsolute`. Without it the agent ' +
+        'has no way to reach the diff — which is the entire bug this command ' +
+        'exists to prevent. Pass the report written by fetch-pr / plan-diff / ' +
+        'capture-local.',
+    );
+  }
+  if (!Array.isArray(report.chunks) || report.chunks.length === 0) {
+    throw new Error('agent-prompt: the plan has no `chunks[]`.');
+  }
+  const chunks = report.chunks as DiffChunk[];
+  const chunk = chunks.find((c) => c?.id === id);
+  if (!chunk) {
+    throw new Error(
+      `agent-prompt: the plan has no chunk ${id} (it has ${chunks.length}: ` +
+        `${chunks.map((c) => c?.id).join(', ')}).`,
+    );
+  }
+  if (
+    !Number.isSafeInteger(chunk.startLine) ||
+    !Number.isSafeInteger(chunk.endLine) ||
+    chunk.startLine < 1 ||
+    chunk.endLine < chunk.startLine
+  ) {
+    throw new Error(
+      `agent-prompt: chunk ${id} has no usable line range ` +
+        `(startLine=${chunk.startLine}, endLine=${chunk.endLine}).`,
+    );
+  }
+  return { diffPath, chunk, total: chunks.length };
+}
+
+/**
+ * The launch prompt for the agent that owns `chunk`.
+ *
+ * Exported for the tests, which assert the properties that were missing from
+ * every real launch: the diff path is in it, the read call is in it, and the
+ * agent is not handed a sentence to recite when it finds nothing.
+ */
+export function buildChunkAgentPrompt(
+  report: PlanReport,
+  id: number,
+  rules?: string,
+): string {
+  const { diffPath, chunk, total } = chunkFrom(report, id);
+
+  // `read_file` takes a 0-based line offset; the plan's ranges are 1-based.
+  const offset = chunk.startLine - 1;
+  const limit = chunk.endLine - chunk.startLine + 1;
+
+  const files = (chunk.files ?? [])
+    .map((f) => `- ${f.path} (new-side lines ${f.newStart}-${f.newEnd})`)
+    .join('\n');
+
+  // The uncoverable case: a single line longer than one read returns. Paging
+  // starts every page at a line boundary, so the tail of that line is
+  // unreachable by any offset. Such a chunk must not be receipted as covered.
+  const unreachable = chunk.maxLineChars > 25_000;
+
+  const parts = [
+    `You are reviewing chunk ${chunk.id} of ${total} of a code diff.`,
+    '',
+    '**Read your chunk first. It is a file on disk — nothing in this prompt contains the code.**',
+    '',
+    '```',
+    `read_file(file_path="${diffPath}", offset=${offset}, limit=${limit})`,
+    '```',
+    '',
+    `That is your territory: lines ${chunk.startLine}-${chunk.endLine} of the diff ` +
+      `(${chunk.lines} lines, ${chunk.chars} characters). The surrounding chunks belong ` +
+      `to other agents — do not review them.`,
+    '',
+    'It covers these source files:',
+    files || '- (none recorded)',
+    '',
+    '**If the read comes back with `isTruncated` set, you do not have your chunk.** ' +
+      'Keep calling `read_file` with a larger `offset` until you have the whole range. ' +
+      'A receipt for a range you only half read makes the coverage guarantee a lie, ' +
+      'which is worse than not having one.',
+  ];
+
+  if (unreachable) {
+    parts.push(
+      '',
+      `**This chunk contains a single line of ${chunk.maxLineChars} characters** — longer ` +
+        'than one read returns, and paging cannot reach its tail (every page starts at a ' +
+        'line boundary). Do not claim to have reviewed it. Return exactly:',
+      '',
+      `    Uncoverable: chunk ${chunk.id} — line exceeds the read limit`,
+    );
+  } else if (chunk.oversized) {
+    parts.push(
+      '',
+      '**This chunk is oversized** — it is a single hunk with no safe place to cut, and it ' +
+        'may exceed one read. Expect to page.',
+    );
+  }
+
+  parts.push(
+    '',
+    'You may also `read_file` the **full source files** above from the worktree whenever a ' +
+      "hunk's correctness depends on code outside it. Diff context is three lines deep; state " +
+      'invariants are not. Page a source file that comes back truncated rather than reasoning ' +
+      'from its first screenful.',
+    '',
+    '## What to review',
+    '',
+    'For your territory only, you own every dimension: line-by-line correctness, the ' +
+      'removed-behavior audit of your own deleted lines, security, code quality, performance, ' +
+      'test coverage, and the adversarial reading. Two duties are NOT yours, because a chunk ' +
+      'agent is structurally blind to them: cross-file tracing (a caller in another chunk) and ' +
+      'the cross-chunk half of removed-behavior. Audit the deletions in your own territory; do ' +
+      'not conclude a deletion is unreplaced merely because its replacement is not in your range.',
+    '',
+    FINDING_FORMAT,
+    '',
+    SEVERITY,
+    '',
+    'Review the diff, not pre-existing issues in unchanged code.',
+  );
+
+  if (rules && rules.trim()) {
+    parts.push('', '## Project rules', '', rules.trim());
+  }
+
+  // Deliberately NOT included: a sentence for the agent to recite when it finds
+  // nothing. Every real launch handed the agent its own receipt text — `If you
+  // find no issues, say "No issues found — reviewed chunk 13 (...)"` — and an
+  // agent that cannot open the diff will still happily say it. A receipt the
+  // prompt wrote is not evidence of work. Report what you examined, in your own
+  // words, from what you read.
+  parts.push(
+    '',
+    '## When you are done',
+    '',
+    'If you found nothing, say so **and say what you examined** — the specific lines, files ' +
+      'and cases you walked, in your own words. Do not recite a stock sentence: a return that ' +
+      'names nothing you read is indistinguishable from never having read anything, and will ' +
+      'be treated as such.',
+    '',
+    `Then, on its own final line: \`Covered: chunk ${chunk.id} lines ${chunk.startLine}-${chunk.endLine}\``,
+  );
+
+  return parts.join('\n');
+}
+
+function runAgentPrompt(args: AgentPromptArgs): void {
+  const report = JSON.parse(readFileSync(args.plan, 'utf8')) as PlanReport;
+  writeStdoutLine(buildChunkAgentPrompt(report, args.chunk));
+}
+
+export const agentPromptCommand: CommandModule = {
+  command: 'agent-prompt',
+  describe:
+    "Build a chunk agent's launch prompt from the plan (the diff path and its " +
+    'byte range are welded in, not left to the caller to remember)',
+  builder: (yargs) =>
+    yargs
+      .option('plan', {
+        type: 'string',
+        demandOption: true,
+        describe:
+          'Path to the plan report from fetch-pr / plan-diff / capture-local',
+      })
+      .option('chunk', {
+        type: 'number',
+        demandOption: true,
+        describe: 'Which chunk id this agent owns',
+      }),
+  handler: (argv) => {
+    runAgentPrompt(argv as unknown as AgentPromptArgs);
+  },
+};

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -40,7 +40,7 @@
 import type { CommandModule } from 'yargs';
 import { readFileSync } from 'node:fs';
 import { writeStdoutLine } from '../../utils/stdioHelpers.js';
-import type { DiffChunk } from './lib/diff-plan.js';
+import { READ_FILE_CHAR_CAP, type DiffChunk } from './lib/diff-plan.js';
 
 interface AgentPromptArgs {
   plan: string;
@@ -143,7 +143,7 @@ export function buildChunkAgentPrompt(
   // The uncoverable case: a single line longer than one read returns. Paging
   // starts every page at a line boundary, so the tail of that line is
   // unreachable by any offset. Such a chunk must not be receipted as covered.
-  const unreachable = chunk.maxLineChars > 25_000;
+  const unreachable = chunk.maxLineChars > READ_FILE_CHAR_CAP;
 
   const parts = [
     `You are reviewing chunk ${chunk.id} of ${total} of a code diff.`,
@@ -225,15 +225,31 @@ export function buildChunkAgentPrompt(
       'and cases you walked, in your own words. Do not recite a stock sentence: a return that ' +
       'names nothing you read is indistinguishable from never having read anything, and will ' +
       'be treated as such.',
-    '',
-    `Then, on its own final line: \`Covered: chunk ${chunk.id} lines ${chunk.startLine}-${chunk.endLine}\``,
   );
+
+  // The receipt, but NOT for an unreachable chunk: that one has already been told
+  // to return `Uncoverable`, and asking for both hands the agent two instructions
+  // that contradict each other. Downstream, a chunk that reports itself both
+  // uncoverable and covered is neither, and the honest one loses.
+  if (!unreachable) {
+    parts.push(
+      '',
+      `Then, on its own final line: \`Covered: chunk ${chunk.id} lines ${chunk.startLine}-${chunk.endLine}\``,
+    );
+  }
 
   return parts.join('\n');
 }
 
 function runAgentPrompt(args: AgentPromptArgs): void {
-  const report = JSON.parse(readFileSync(args.plan, 'utf8')) as PlanReport;
+  let report: PlanReport;
+  try {
+    report = JSON.parse(readFileSync(args.plan, 'utf8')) as PlanReport;
+  } catch (err) {
+    throw new Error(
+      `agent-prompt: cannot read the plan ${args.plan}: ${(err as Error).message}`,
+    );
+  }
   writeStdoutLine(buildChunkAgentPrompt(report, args.chunk));
 }
 

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -45,6 +45,7 @@ import { READ_FILE_CHAR_CAP, type DiffChunk } from './lib/diff-plan.js';
 interface AgentPromptArgs {
   plan: string;
   chunk: number;
+  rules?: string;
 }
 
 /** The plan report, as far as this command needs it. */
@@ -250,7 +251,27 @@ function runAgentPrompt(args: AgentPromptArgs): void {
       `agent-prompt: cannot read the plan ${args.plan}: ${(err as Error).message}`,
     );
   }
-  writeStdoutLine(buildChunkAgentPrompt(report, args.chunk));
+
+  // The project rules Step 2 loaded. They belong in the agent's prompt — the
+  // skill now says this command builds it and to pass what it prints verbatim, so
+  // there is no longer a later step in which the orchestrator would staple them
+  // on. Without this flag they were loaded, written to a file, and silently
+  // dropped: the review would enforce no project rule at all and say nothing.
+  let rules: string | undefined;
+  if (args.rules) {
+    try {
+      rules = readFileSync(args.rules, 'utf8');
+    } catch (err) {
+      throw new Error(
+        `agent-prompt: cannot read the rules ${args.rules}: ` +
+          `${(err as Error).message}. Omit --rules if this review has none; ` +
+          'passing a path that does not resolve would silently review without ' +
+          'the project rules it was told to enforce.',
+      );
+    }
+  }
+
+  writeStdoutLine(buildChunkAgentPrompt(report, args.chunk, rules));
 }
 
 export const agentPromptCommand: CommandModule = {
@@ -270,6 +291,12 @@ export const agentPromptCommand: CommandModule = {
         type: 'number',
         demandOption: true,
         describe: 'Which chunk id this agent owns',
+      })
+      .option('rules', {
+        type: 'string',
+        describe:
+          'Path to the project rules file from `load-rules` (omit when the ' +
+          'review has none)',
       }),
   handler: (argv) => {
     runAgentPrompt(argv as unknown as AgentPromptArgs);

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -249,7 +249,19 @@ Every agent reads the whole diff, **by walking the `chunks[]` ranges** — usual
 
 Eleven agents all reading the same diff (every 3A agent except Build & Test walks the whole chunk plan) multiplies redundant reading of the early hunks; it does not add coverage. Once there is enough production code to divide, fan out along **territory** as well: one agent per chunk, with the review dimensions folded into that agent's brief, plus a small set of whole-diff agents for the concerns that only exist at diff scale.
 
-**Chunk agents — one per entry in `chunks[]`.** Each is a `general-purpose` subagent whose prompt gives it:
+**Chunk agents — one per entry in `chunks[]`.** Each is a `general-purpose` subagent. **Do not write its prompt. Ask for it:**
+
+```bash
+qwen review agent-prompt --plan <the plan report from Step 1> --chunk <id>
+```
+
+Pass what it prints to the agent **verbatim**. It already carries the diff path, the agent's exact `offset`/`limit`, its `files[]`, the paging rule, the uncoverable rule, and the severity definitions.
+
+Why this is a command and not a paragraph: **the agents were launched blind.** Measured against the harness's own record of what they were actually started with — the first record of each subagent transcript, written at launch — **23 of 23 chunk agents got a prompt that named no diff file at all**: no path, no `read_file`, no offset. They were handed a _description_ of a chunk they had no way to open ("The changes are in chunk 13 of 23, covering lines 3808-4024 of the diff") and a sentence to say if they found nothing ("If you find no issues, say `No issues found — reviewed chunk 13 (…)`"). All 23 made **zero tool calls**, and all 23 said the sentence. The receipts that looked like proof of work were in the prompt that launched them. This paragraph used to say what the prompt must contain; saying it was not enough.
+
+The prompt it returns deliberately does **not** hand the agent a stock sentence to recite when it finds nothing — it asks the agent to name what it examined instead. A return that names nothing it read is indistinguishable from never having read anything.
+
+Everything below still governs what the agent is asked to do; the command builds it for you.
 
 - `diffPathAbsolute`, its own `offset` (= `startLine - 1`) and `limit` (= `endLine - startLine + 1`), and its `files[]` list. Tell it to read exactly that range, and that the surrounding chunks belong to other agents.
 - **An instruction to page.** Ordinary chunks are sized to fit one un-truncated read, but a chunk whose `oversized` flag is set is a single hunk that offered no safe place to cut, and its `chars` can exceed one read's ~25 000. Tell the agent: if the read comes back with `isTruncated`, keep calling `read_file` with a larger `offset` until it has the whole range. An agent that returns a `Covered:` receipt for a range it only half read makes the coverage guarantee a lie — which is worse than not having one.

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -252,10 +252,13 @@ Eleven agents all reading the same diff (every 3A agent except Build & Test walk
 **Chunk agents — one per entry in `chunks[]`.** Each is a `general-purpose` subagent. **Do not write its prompt. Ask for it:**
 
 ```bash
-qwen review agent-prompt --plan <the plan report from Step 1> --chunk <id>
+qwen review agent-prompt \
+  --plan <the plan report from Step 1> \
+  --chunk <id> \
+  [--rules <the rules file from Step 2, if the project has any>]
 ```
 
-Pass what it prints to the agent **verbatim**. It already carries the diff path, the agent's exact `offset`/`limit`, its `files[]`, the paging rule, the uncoverable rule, and the severity definitions.
+Pass what it prints to the agent **verbatim**. It already carries the diff path, the agent's exact `offset`/`limit`, its `files[]`, the paging rule, the uncoverable rule, the severity definitions, and the project rules. **Pass `--rules` whenever Step 2 found any** — this command builds the whole prompt, so there is no later step in which you would staple them on, and a review that silently enforces no project rule is one of the things this skill exists to prevent.
 
 Why this is a command and not a paragraph: **the agents were launched blind.** Measured against the harness's own record of what they were actually started with — the first record of each subagent transcript, written at launch — **23 of 23 chunk agents got a prompt that named no diff file at all**: no path, no `read_file`, no offset. They were handed a _description_ of a chunk they had no way to open ("The changes are in chunk 13 of 23, covering lines 3808-4024 of the diff") and a sentence to say if they found nothing ("If you find no issues, say `No issues found — reviewed chunk 13 (…)`"). All 23 made **zero tool calls**, and all 23 said the sentence. The receipts that looked like proof of work were in the prompt that launched them. This paragraph used to say what the prompt must contain; saying it was not enough.
 


### PR DESCRIPTION
## What this PR does

**The review agents did not whiff. They were never given the diff.**

Measured against the harness's own record of what they were actually launched with — the first record of each subagent transcript, written at launch and not retconnable — **23 of 23 chunk agents got a prompt that named no diff file at all**: no path, no `read_file`, no offset, no limit. **All 23 made zero tool calls.**

Here is a real launch prompt, verbatim from the transcript:

> You are a code reviewer examining **the following chunk of changes**. …
>
> The changes are in **chunk 13 of 23, covering lines 3808-4024 of the diff**, affecting these files:
> - packages/cli/src/commands/review/resolve-anchors.test.ts (lines 1-211)
>
> …
> **If you find no issues, say "No issues found — reviewed chunk 13 (packages/cli/src/commands/review/resolve-anchors.test.ts)".**

It says "the following chunk of changes" and then contains no changes. It gives a *description* of a chunk the agent has no way to open, and a sentence to say if it finds nothing. Every one of the 23 said the sentence.

**The receipts that looked like proof of work were in the prompt that launched them**, and the coverage machinery downstream was reading them back.

`qwen review agent-prompt --plan <report> --chunk <id>` now builds the prompt. The orchestrator passes what it prints, verbatim.

## Why it's needed

The skill has always specified what that prompt must contain — `diffPathAbsolute`, the agent's own `offset` and `limit`, the paging rule, the uncoverable rule. It said so in a paragraph (SKILL.md), and left the orchestrator to compose the prompt.

This is the same failure the skill has now fixed five times over: **a rule stated in prose is a rule that will eventually not be followed, and the fix is to move it into code that can say no.** It was applied to the review target, the posting gate, the verdict, and the coverage report (#6771). The agent's own prompt — the thing that decides whether a review can happen **at all** — was the one place it was not.

A plan with no `diffPathAbsolute` is now an **error**, not a prompt that merely describes the chunk. That prompt *is* the bug.

The generated prompt also deliberately **does not** hand the agent a stock sentence to recite when it finds nothing. It asks the agent to name what it examined. A return that names nothing it read is indistinguishable from never having read anything — and an agent that cannot open the diff will recite the sentence anyway.

## Evidence (Before & After)

Same chunk, same plan. Left: what the orchestrator actually sent. Right: what the command produces.

| | Orchestrator (measured) | `agent-prompt` |
| --- | --- | --- |
| diff file path | **absent** | present |
| `read_file` call | **absent** | present |
| `offset` / `limit` | **absent** | present |
| paging rule (`isTruncated`) | **absent** | present |
| a sentence to recite | **present** | **absent** |
| asks what you examined | absent | **present** |

The generated prompt opens with:

```
You are reviewing chunk 13 of 25 of a code diff.

**Read your chunk first. It is a file on disk — nothing in this prompt contains the code.**

read_file(file_path="/…/.qwen/tmp/qwen-review-pr-6771-diff.txt", offset=3541, limit=341)
```

## Reviewer Test Plan

Build a plan for any PR (`qwen review fetch-pr <n> <owner>/<repo> --out plan.json`), then `qwen review agent-prompt --plan plan.json --chunk 1`. Confirm the printed prompt names the diff file, gives a 0-based `offset` and a `limit`, and does not tell the agent what to say when it finds nothing.

Then confirm it refuses to build a prompt it cannot make honest: a plan with no `diffPathAbsolute`, no `chunks[]`, an unknown chunk id, or an unusable line range each raise rather than emitting a chunk description.

Tests assert exactly the properties that were missing from all 23 real launches, and each is mutation-verified: removing the read call, breaking the 0-based offset, or dropping the missing-path check each turns a test red.

## Risk & Scope

- Additive: one new subcommand, one SKILL step rewritten to call it. No existing subcommand changes behaviour.
- The prompt's content is unchanged in substance from what SKILL.md already specified — it is the same brief, now assembled by code.
- Follow-up (not in this PR): the coverage check still reads a file the orchestrator writes, and `compose-review` still accepts a hand-typed `coverage` object. Those are tracked separately.

## Linked Issues

Follows #6771, and corrects its diagnosis: that PR attributed the failure to agents whiffing. They were launched blind.


---

<details>
<summary>中文说明(点击展开)</summary>

## 这个 PR 做了什么

**review 的 agent 不是偷懒。是从来没人把 diff 给它们。**

对照 harness 自己的记录 —— 每份 subagent transcript 的第一条记录,在 agent 启动那一刻写下,事后无法追改 —— **23 个 chunk agent,23 个的 prompt 里都没有提到任何 diff 文件**:没有路径、没有 `read_file`、没有 offset、没有 limit。**23 个全部零工具调用。**

一份真实的 launch prompt,逐字摘录:

> You are a code reviewer examining **the following chunk of changes**. …
>
> The changes are in **chunk 13 of 23, covering lines 3808-4024 of the diff**, affecting these files:
> - packages/cli/src/commands/review/resolve-anchors.test.ts (lines 1-211)
>
> …
> **If you find no issues, say "No issues found — reviewed chunk 13 (packages/cli/src/commands/review/resolve-anchors.test.ts)".**

它说「以下这段变更」,然后**没有给出任何变更**。它给的是一段**文字描述**,描述一个 agent 根本无从打开的 chunk;外加**一句「没发现问题就照念」的台词**。23 个 agent,一个不落,全都念了。

**那些看起来像「工作证明」的回执,是发起它们的 prompt 直接塞给它们的** —— 而下游的覆盖率装置,又把这些回执读了回来。

现在由 `qwen review agent-prompt --plan <report> --chunk <id>` 生成这个 prompt,编排器**逐字**转交。

## 为什么需要

SKILL 一直明确规定了这个 prompt 必须包含什么:`diffPathAbsolute`、该 agent 自己的 `offset` 和 `limit`、分页规则、不可达规则。**它把这些写成了一段散文**,然后让编排器自己去组装 prompt。

这和这个 skill 已经修过五次的失败是**同一个**:

> **一条以散文形式陈述的规则,终将不被遵守;解法是把它变成一段能说「不」的代码。**

这条教训被用在了 review 目标解析、发布授权门、裁决合成、覆盖率报告(#6771)上。**唯独 agent 自己的 prompt —— 那个决定 review 究竟能不能发生的东西 —— 是唯一没有被这样处理的地方。**

一个没有 `diffPathAbsolute` 的 plan 现在是**错误**,而不是降级成「只描述 chunk」的 prompt。因为那个 prompt **本身就是 bug**。

生成的 prompt 还**刻意不给** agent 那句「没发现问题就照念」的台词,而是要求它**说出自己检查了什么**。一个说不出自己读了什么的返回,和从没读过无法区分 —— 而一个打不开 diff 的 agent,照样会把那句台词念出来。

## 证据(前后对比)

同一个 chunk、同一份 plan。左:编排器实际发出的。右:命令生成的。

| | 编排器(实测) | `agent-prompt` |
| --- | --- | --- |
| diff 文件路径 | **没有** | 有 |
| `read_file` 调用 | **没有** | 有 |
| `offset` / `limit` | **没有** | 有 |
| 分页规则(`isTruncated`) | **没有** | 有 |
| 一句照念的台词 | **有** | **没有** |
| 要求说出检查了什么 | 没有 | **有** |

生成的 prompt 开头:

```
You are reviewing chunk 13 of 25 of a code diff.

**Read your chunk first. It is a file on disk — nothing in this prompt contains the code.**

read_file(file_path="/…/.qwen/tmp/qwen-review-pr-6771-diff.txt", offset=3541, limit=341)
```

## 风险与范围

- 纯新增:一个新子命令,SKILL 里一步改为调用它。现有子命令行为不变。
- prompt 的**内容**相对 SKILL 早已规定的东西没有实质变化 —— 是同一份 brief,只是改由代码组装。
- 后续(不在本 PR):覆盖率检查仍在读一个编排器写的文件 —— 见 #6843。

</details>
