### PR TITLE
refactor(review): share the probe-worktree path helper; harden the stale-tree sweep

### DIFF
--- a/packages/cli/src/commands/review/cleanup.ts
+++ b/packages/cli/src/commands/review/cleanup.ts
@@ -19,6 +19,7 @@ import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
 import { refExists, releaseWorktree } from './lib/git.js';
 import {
   worktreePath,
+  probeWorktreePath,
   reviewBranch,
   REVIEW_TMP_DIR,
   tmpPrefix,
@@ -46,8 +47,9 @@ function runCleanup(target: string): void {
 
     // The test-efficacy probe runs in a disposable sibling worktree and removes
     // it itself; sweep one a crashed probe left behind so it does not block the
-    // next run's `git worktree add` (see #6832 / test-efficacy.ts).
-    const probeWt = `${wt}-probe`;
+    // next run's `git worktree add` (see #6832 / test-efficacy.ts). Shares the
+    // path helper with the probe so the suffix cannot drift between the two.
+    const probeWt = probeWorktreePath(wt);
     if (releaseWorktree(probeWt)) {
       writeStdoutLine(`Removed probe worktree: ${probeWt}`);
       removedAny = true;

--- a/packages/cli/src/commands/review/cleanup.ts
+++ b/packages/cli/src/commands/review/cleanup.ts
@@ -31,6 +31,12 @@ interface CleanupArgs {
 
 function runCleanup(target: string): void {
   let removedAny = false;
+  // Tracked separately from `removedAny`, because a failure is neither. Without
+  // it, a run that could not delete something goes on to announce "Nothing to
+  // clean" on stdout while stderr says it failed to remove a thing that is very
+  // much still there — the two streams contradicting each other, and the stdout
+  // half being the one a script reads.
+  let failedAny = false;
 
   // --- Worktree + branch (only for PR targets) -------------------------
   const prMatch = /^pr-(\d+)$/.exec(target);
@@ -48,6 +54,7 @@ function runCleanup(target: string): void {
         removedAny = true;
       } else if (existed) {
         writeStderrLine(`Failed to remove ${label} ${path}: ${reason}`);
+        failedAny = true;
       }
     };
 
@@ -96,10 +103,14 @@ function runCleanup(target: string): void {
       removedAny = true;
     } catch (err) {
       writeStderrLine(`Failed to remove ${full}: ${(err as Error).message}`);
+      failedAny = true;
     }
   }
 
-  if (!removedAny) {
+  // "Nothing to clean" is a claim about the tree, not about this run's luck. It
+  // is only true when there was nothing there — not when there was and we could
+  // not get rid of it.
+  if (!removedAny && !failedAny) {
     writeStdoutLine(`Nothing to clean for target "${target}".`);
   }
 }

--- a/packages/cli/src/commands/review/cleanup.ts
+++ b/packages/cli/src/commands/review/cleanup.ts
@@ -37,23 +37,30 @@ function runCleanup(target: string): void {
   if (prMatch) {
     const prNumber = prMatch[1];
 
+    // Report what actually happened, in both directions. Announcing "Removed …"
+    // off a path that is still on disk is a lie; saying nothing at all when we
+    // could not remove it leaves a leftover that will wedge the next run's
+    // `git worktree add` with nobody told why. Both have been shipped here.
+    const report = (label: string, path: string) => {
+      const { existed, freed, reason } = releaseWorktree(path);
+      if (freed) {
+        writeStdoutLine(`Removed ${label}: ${path}`);
+        removedAny = true;
+      } else if (existed) {
+        writeStderrLine(`Failed to remove ${label} ${path}: ${reason}`);
+      }
+    };
+
     const wt = worktreePath(prNumber);
     // Prunes a registration left behind by a hand-deleted directory, which is
     // also what unblocks the `git branch -D` below.
-    if (releaseWorktree(wt)) {
-      writeStdoutLine(`Removed worktree: ${wt}`);
-      removedAny = true;
-    }
+    report('worktree', wt);
 
     // The test-efficacy probe runs in a disposable sibling worktree and removes
     // it itself; sweep one a crashed probe left behind so it does not block the
     // next run's `git worktree add` (see #6832 / test-efficacy.ts). Shares the
     // path helper with the probe so the suffix cannot drift between the two.
-    const probeWt = probeWorktreePath(wt);
-    if (releaseWorktree(probeWt)) {
-      writeStdoutLine(`Removed probe worktree: ${probeWt}`);
-      removedAny = true;
-    }
+    report('probe worktree', probeWorktreePath(wt));
 
     const branch = reviewBranch(prNumber);
     if (refExists(branch)) {

--- a/packages/cli/src/commands/review/lib/git.integration.test.ts
+++ b/packages/cli/src/commands/review/lib/git.integration.test.ts
@@ -78,6 +78,25 @@ describe('releaseWorktree', () => {
     expect(git('worktree', 'list')).not.toContain(join(repo, 'wt'));
   });
 
+  it('removes an unregistered non-empty leftover git no longer tracks', () => {
+    // A crashed run can leave a directory at the worktree path that git does not
+    // track as a worktree. `git worktree remove` says "not a working tree" and
+    // leaves it, and a non-empty one then blocks the next `worktree add` with
+    // `already exists`. releaseWorktree must still leave the path gone.
+    mkdirSync(join(repo, 'wt', 'junk'), { recursive: true });
+    writeFileSync(join(repo, 'wt', 'junk', 'f'), 'x');
+    // Negative control: it is not a registered worktree.
+    expect(git('worktree', 'list')).not.toContain(join(repo, 'wt'));
+
+    expect(releaseWorktree(join(repo, 'wt'))).toBe(true);
+
+    expect(existsSync(join(repo, 'wt'))).toBe(false);
+    // And the path is reusable — the `already exists` wedge is gone.
+    expect(() =>
+      git('worktree', 'add', '-q', 'wt', '-b', 'topic'),
+    ).not.toThrow();
+  });
+
   it('frees a path whose directory was deleted by hand', () => {
     // What `rm -rf .qwen/tmp` does to a review worktree.
     git('worktree', 'add', '-q', 'wt', '-b', 'topic');

--- a/packages/cli/src/commands/review/lib/git.integration.test.ts
+++ b/packages/cli/src/commands/review/lib/git.integration.test.ts
@@ -71,7 +71,10 @@ describe('releaseWorktree', () => {
     git('worktree', 'add', '-q', 'wt', '-b', 'topic');
     expect(existsSync(join(repo, 'wt'))).toBe(true);
 
-    expect(releaseWorktree(join(repo, 'wt'))).toBe(true);
+    expect(releaseWorktree(join(repo, 'wt'))).toMatchObject({
+      existed: true,
+      freed: true,
+    });
 
     expect(existsSync(join(repo, 'wt'))).toBe(false);
     // Not `.not.toContain('wt')` — the fixture's own path holds that substring.
@@ -88,7 +91,10 @@ describe('releaseWorktree', () => {
     // Negative control: it is not a registered worktree.
     expect(git('worktree', 'list')).not.toContain(join(repo, 'wt'));
 
-    expect(releaseWorktree(join(repo, 'wt'))).toBe(true);
+    expect(releaseWorktree(join(repo, 'wt'))).toMatchObject({
+      existed: true,
+      freed: true,
+    });
 
     expect(existsSync(join(repo, 'wt'))).toBe(false);
     // And the path is reusable — the `already exists` wedge is gone.
@@ -107,7 +113,11 @@ describe('releaseWorktree', () => {
       /missing but already registered/,
     );
 
-    expect(releaseWorktree(join(repo, 'wt'))).toBe(false); // nothing to remove
+    // Nothing was there: not an existence, and nothing to free.
+    expect(releaseWorktree(join(repo, 'wt'))).toMatchObject({
+      existed: false,
+      freed: false,
+    });
     expect(() => git('worktree', 'add', '-q', 'wt', 'topic')).not.toThrow();
   });
 
@@ -127,7 +137,10 @@ describe('releaseWorktree', () => {
   });
 
   it('is a no-op when there is nothing registered', () => {
-    expect(releaseWorktree(join(repo, 'never-existed'))).toBe(false);
+    expect(releaseWorktree(join(repo, 'never-existed'))).toMatchObject({
+      existed: false,
+      freed: false,
+    });
     expect(git('worktree', 'list').trim().split('\n')).toHaveLength(1);
   });
 

--- a/packages/cli/src/commands/review/lib/git.test.ts
+++ b/packages/cli/src/commands/review/lib/git.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `releaseWorktree`'s I/O is pinned against real git in `git.integration.test.ts`.
+// What is pinned here is the one outcome real git cannot produce on demand: the
+// path was there, and we could NOT free it. That needs `rmSync` to hit EPERM or
+// EBUSY, and nothing portable forces those — as root the permission lever is
+// bypassed outright, under CI's unprivileged user it behaves differently, and a
+// `node:fs` module mock does not reach the module under this suite's config. So
+// the ruling is a pure function, and it is tested as one.
+
+import { describe, it, expect } from 'vitest';
+import { worktreeReleaseResult } from './git.js';
+
+describe('worktreeReleaseResult', () => {
+  it('reports a path that was there and is gone now', () => {
+    expect(worktreeReleaseResult(true, false)).toEqual({
+      existed: true,
+      freed: true,
+      reason: undefined,
+    });
+  });
+
+  it('reports nothing-to-do without inventing a reason', () => {
+    // Nothing was there. Not a failure, so no reason — cleanup should stay quiet
+    // rather than announce a removal it did not perform.
+    expect(worktreeReleaseResult(false, false)).toEqual({
+      existed: false,
+      freed: false,
+      reason: undefined,
+    });
+  });
+
+  it('carries the rmSync error out when the path survived', () => {
+    // The outcome a boolean return could not express, and the one that made
+    // cleanup either lie ("Removed …") or go silent — both were shipped here and
+    // caught in review. `existed && !freed` must arrive with the WHY attached:
+    // someone has to delete this tree by hand.
+    const got = worktreeReleaseResult(
+      true,
+      true,
+      new Error("EBUSY: resource busy or locked, rmdir '/w/wt'"),
+    );
+    expect(got).toMatchObject({ existed: true, freed: false });
+    expect(got.reason).toContain('EBUSY');
+  });
+
+  it('names the situation when the path survived with no exception to quote', () => {
+    // `rmSync` returned cleanly and the path is still there anyway. There is no
+    // errno to hand over, but `reason` must not come back undefined — a silent
+    // "still there" is exactly the failure mode being fixed.
+    const got = worktreeReleaseResult(true, true);
+    expect(got).toMatchObject({ existed: true, freed: false });
+    expect(got.reason).toMatch(/still there/);
+  });
+
+  it('stringifies a non-Error throw rather than dropping it', () => {
+    expect(worktreeReleaseResult(true, true, 'boom').reason).toBe('boom');
+  });
+});

--- a/packages/cli/src/commands/review/lib/git.ts
+++ b/packages/cli/src/commands/review/lib/git.ts
@@ -84,11 +84,28 @@ export function refExists(ref: string): boolean {
   return gitOpt('rev-parse', '--verify', '--quiet', ref) !== null;
 }
 
+/** What `releaseWorktree` found at the path, and what it managed to do about it. */
+export interface WorktreeRelease {
+  /** Something was at the path when we started. */
+  existed: boolean;
+  /** The path is free now — a `git worktree add` over it will succeed. */
+  freed: boolean;
+  /**
+   * Why the path is not free, set only when `existed && !freed`. A boolean
+   * cannot say both "there is still something there" and "here is why", and a
+   * caller that has to hand the problem to a human needs the second half:
+   * without it, cleanup either lies ("Removed …") or goes silent, and both were
+   * shipped and caught in review.
+   */
+  reason?: string;
+}
+
 /**
- * Free a review worktree's path **and** its branch. Returns whether anything
- * was there at the path to remove — a registered worktree OR an untracked
- * leftover directory (see the `rmSync` below); either way a `true` return means
- * the path is now gone.
+ * Free a review worktree's path **and** its branch.
+ *
+ * Never throws — see the `rmSync` below. Reports what happened through the
+ * result: `existed` (something was there), `freed` (it is gone now), and
+ * `reason` when it is still there.
  *
  * `git worktree remove` needs the directory. A user reclaiming disk with
  * `rm -rf .qwen/tmp` leaves the worktree *registered but missing*, and from then
@@ -104,8 +121,44 @@ export function refExists(ref: string): boolean {
  * registration and a no-op when nothing is stale — run it unconditionally, and
  * **before** the branch delete that depends on it.
  */
-export function releaseWorktree(worktreePath: string): boolean {
+/**
+ * Rule on a release attempt: what was there, what is there now, what went wrong.
+ *
+ * Pure, and extracted for that reason. The interesting outcome — `existed` but
+ * not `freed` — needs `rmSync` to hit EPERM or EBUSY, and nothing portable
+ * forces those: as root the permission lever is bypassed outright, and under
+ * CI's unprivileged user it behaves differently, so a `chmod`-based test would
+ * assert one thing locally and another in CI. Mocking `node:fs` does not reach
+ * this module under the suite's config either. The composition is where the
+ * logic lives, so it is testable here on its own.
+ *
+ * `reason` is never left unset when the path survived: a caller that has to tell
+ * a human "this is still on disk" is useless without "and here is why", so when
+ * there is no exception to quote it names the situation instead.
+ */
+export function worktreeReleaseResult(
+  existed: boolean,
+  stillThere: boolean,
+  removeError?: unknown,
+): WorktreeRelease {
+  const freed = existed && !stillThere;
+  if (!existed || freed) {
+    return { existed, freed, reason: undefined };
+  }
+  return {
+    existed,
+    freed,
+    reason: removeError
+      ? removeError instanceof Error
+        ? removeError.message
+        : String(removeError)
+      : 'the path is still there after `git worktree remove --force` and `rm -rf`',
+  };
+}
+
+export function releaseWorktree(worktreePath: string): WorktreeRelease {
   const existed = existsSync(worktreePath);
+  let removeError: unknown;
   if (existed) {
     gitOpt('worktree', 'remove', worktreePath, '--force');
     // `worktree remove` only clears a tree git still tracks. A directory left at
@@ -115,22 +168,20 @@ export function releaseWorktree(worktreePath: string): boolean {
     // unlinks a symlink rather than following it, so a tampered leftover cannot
     // redirect the delete.
     //
-    // Swallowed on purpose, like every other failure here: `force` suppresses
-    // ENOENT but not EPERM or EBUSY, and this function runs on the cleanup path,
-    // where throwing would mask the error that got us there. The caller learns
-    // the outcome from the return value, not from an exception.
+    // Not allowed to throw, like every other failure here: `force` suppresses
+    // ENOENT but not EPERM or EBUSY, and this runs on the cleanup path, where an
+    // exception masks the error that got us there. But the reason must not be
+    // lost either — a caller that has to tell a human "this path is still there"
+    // is useless without "and here is why". So: caught, and carried out in the
+    // result.
     try {
       rmSync(worktreePath, { recursive: true, force: true });
-    } catch {
-      // Fall through — the existence check below is the real signal.
+    } catch (e) {
+      removeError = e;
     }
   }
   gitOpt('worktree', 'prune');
-  // `true` means the path is GONE, not merely unregistered — so a caller can
-  // report "Removed …" without lying. A leftover we could not delete returns
-  // false even though something was there, which is the honest answer to
-  // "is this path free now?".
-  return existed && !existsSync(worktreePath);
+  return worktreeReleaseResult(existed, existsSync(worktreePath), removeError);
 }
 
 /**

--- a/packages/cli/src/commands/review/lib/git.ts
+++ b/packages/cli/src/commands/review/lib/git.ts
@@ -85,8 +85,10 @@ export function refExists(ref: string): boolean {
 }
 
 /**
- * Free a review worktree's path **and** its branch. Returns whether a live
- * worktree was there to remove.
+ * Free a review worktree's path **and** its branch. Returns whether anything
+ * was there at the path to remove — a registered worktree OR an untracked
+ * leftover directory (see the `rmSync` below); either way a `true` return means
+ * the path is now gone.
  *
  * `git worktree remove` needs the directory. A user reclaiming disk with
  * `rm -rf .qwen/tmp` leaves the worktree *registered but missing*, and from then

--- a/packages/cli/src/commands/review/lib/git.ts
+++ b/packages/cli/src/commands/review/lib/git.ts
@@ -9,7 +9,7 @@
 // across platforms.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 
 /** Deadline for a single `git` invocation. Generous; a hang must still end. */
 const GIT_TIMEOUT_MS = 120_000;
@@ -106,6 +106,14 @@ export function releaseWorktree(worktreePath: string): boolean {
   const existed = existsSync(worktreePath);
   if (existed) {
     gitOpt('worktree', 'remove', worktreePath, '--force');
+    // `worktree remove` only clears a tree git still tracks. A directory left at
+    // the path after metadata loss or a partial cleanup is reported "not a
+    // working tree" and left in place — and a non-empty one then blocks the next
+    // `worktree add` with `already exists`. So remove whatever remains, which
+    // also keeps this function's promise honest: a `true` return means the path
+    // is gone, not merely unregistered. `rmSync` unlinks a symlink rather than
+    // following it, so a tampered leftover cannot redirect the delete.
+    rmSync(worktreePath, { recursive: true, force: true });
   }
   gitOpt('worktree', 'prune');
   return existed;

--- a/packages/cli/src/commands/review/lib/git.ts
+++ b/packages/cli/src/commands/review/lib/git.ts
@@ -101,27 +101,6 @@ export interface WorktreeRelease {
 }
 
 /**
- * Free a review worktree's path **and** its branch.
- *
- * Never throws — see the `rmSync` below. Reports what happened through the
- * result: `existed` (something was there), `freed` (it is gone now), and
- * `reason` when it is still there.
- *
- * `git worktree remove` needs the directory. A user reclaiming disk with
- * `rm -rf .qwen/tmp` leaves the worktree *registered but missing*, and from then
- * on git refuses both of the things the next review needs:
- *
- *     $ git worktree add .qwen/tmp/review-pr-6457 qwen-review/pr-6457
- *     fatal: '...' is a missing but already registered worktree;
- *     use 'add -f' to override, or 'prune' or 'remove' to clear
- *
- * and `git branch -D qwen-review/pr-6457`, because the branch is still checked
- * out in that phantom. So `/review <same PR>` never runs again until someone
- * prunes by hand. `git worktree prune` is the only thing that clears the
- * registration and a no-op when nothing is stale — run it unconditionally, and
- * **before** the branch delete that depends on it.
- */
-/**
  * Rule on a release attempt: what was there, what is there now, what went wrong.
  *
  * Pure, and extracted for that reason. The interesting outcome — `existed` but
@@ -156,6 +135,27 @@ export function worktreeReleaseResult(
   };
 }
 
+/**
+ * Free a review worktree's path **and** its branch.
+ *
+ * Never throws — see the `rmSync` below. Reports what happened through the
+ * result: `existed` (something was there), `freed` (it is gone now), and
+ * `reason` when it is still there.
+ *
+ * `git worktree remove` needs the directory. A user reclaiming disk with
+ * `rm -rf .qwen/tmp` leaves the worktree *registered but missing*, and from then
+ * on git refuses both of the things the next review needs:
+ *
+ *     $ git worktree add .qwen/tmp/review-pr-6457 qwen-review/pr-6457
+ *     fatal: '...' is a missing but already registered worktree;
+ *     use 'add -f' to override, or 'prune' or 'remove' to clear
+ *
+ * and `git branch -D qwen-review/pr-6457`, because the branch is still checked
+ * out in that phantom. So `/review <same PR>` never runs again until someone
+ * prunes by hand. `git worktree prune` is the only thing that clears the
+ * registration and a no-op when nothing is stale — run it unconditionally, and
+ * **before** the branch delete that depends on it.
+ */
 export function releaseWorktree(worktreePath: string): WorktreeRelease {
   const existed = existsSync(worktreePath);
   let removeError: unknown;

--- a/packages/cli/src/commands/review/lib/git.ts
+++ b/packages/cli/src/commands/review/lib/git.ts
@@ -111,14 +111,26 @@ export function releaseWorktree(worktreePath: string): boolean {
     // `worktree remove` only clears a tree git still tracks. A directory left at
     // the path after metadata loss or a partial cleanup is reported "not a
     // working tree" and left in place — and a non-empty one then blocks the next
-    // `worktree add` with `already exists`. So remove whatever remains, which
-    // also keeps this function's promise honest: a `true` return means the path
-    // is gone, not merely unregistered. `rmSync` unlinks a symlink rather than
-    // following it, so a tampered leftover cannot redirect the delete.
-    rmSync(worktreePath, { recursive: true, force: true });
+    // `worktree add` with `already exists`. So remove whatever remains. `rmSync`
+    // unlinks a symlink rather than following it, so a tampered leftover cannot
+    // redirect the delete.
+    //
+    // Swallowed on purpose, like every other failure here: `force` suppresses
+    // ENOENT but not EPERM or EBUSY, and this function runs on the cleanup path,
+    // where throwing would mask the error that got us there. The caller learns
+    // the outcome from the return value, not from an exception.
+    try {
+      rmSync(worktreePath, { recursive: true, force: true });
+    } catch {
+      // Fall through — the existence check below is the real signal.
+    }
   }
   gitOpt('worktree', 'prune');
-  return existed;
+  // `true` means the path is GONE, not merely unregistered — so a caller can
+  // report "Removed …" without lying. A leftover we could not delete returns
+  // false even though something was there, which is the honest answer to
+  // "is this path free now?".
+  return existed && !existsSync(worktreePath);
 }
 
 /**

--- a/packages/cli/src/commands/review/lib/paths.test.ts
+++ b/packages/cli/src/commands/review/lib/paths.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { tmpFile } from './paths.js';
+import { resolve } from 'node:path';
+import { tmpFile, probeWorktreePath, worktreePath } from './paths.js';
 
 describe('tmpFile — target is a single safe component', () => {
   it('keeps ordinary labels intact', () => {
@@ -32,5 +33,30 @@ describe('tmpFile — target is a single safe component', () => {
     expect(p).toContain('.qwen/tmp/');
     expect(p).not.toContain('..');
     expect(p.split('.qwen/tmp/')[1]).not.toContain('/');
+  });
+});
+
+describe('probeWorktreePath', () => {
+  it('appends -probe to an absolute worktree path', () => {
+    expect(probeWorktreePath('/a/b/review-pr-1')).toBe(
+      '/a/b/review-pr-1-probe',
+    );
+  });
+
+  it('resolves a relative worktree to absolute so it never depends on cwd', () => {
+    // The probe drives `git worktree add` with the shared worktree as cwd, so a
+    // relative probe path would resolve against that worktree and nest the probe
+    // tree inside it. Absolute keeps it a sibling wherever it is called from.
+    expect(probeWorktreePath('.qwen/tmp/review-pr-1')).toBe(
+      `${resolve('.qwen/tmp/review-pr-1')}-probe`,
+    );
+  });
+
+  it('is the single source of the -probe suffix both call sites share', () => {
+    // cleanup.ts sweeps `probeWorktreePath(worktreePath(n))`; the probe creates
+    // `probeWorktreePath(worktree)`. One helper, one suffix — they cannot drift.
+    expect(probeWorktreePath(worktreePath(7))).toBe(
+      `${resolve(worktreePath(7))}-probe`,
+    );
   });
 });

--- a/packages/cli/src/commands/review/lib/paths.ts
+++ b/packages/cli/src/commands/review/lib/paths.ts
@@ -9,7 +9,7 @@
 // when the command is invoked). Use `path.join` rather than string
 // concatenation so Windows backslashes are produced when needed.
 
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 export const REVIEW_TMP_DIR = join('.qwen', 'tmp');
 export const REVIEWS_DIR = join('.qwen', 'reviews');
@@ -18,6 +18,23 @@ export const REVIEW_CACHE_DIR = join('.qwen', 'review-cache');
 /** Worktree path for a given PR review session. */
 export function worktreePath(prNumber: string | number): string {
   return join(REVIEW_TMP_DIR, `review-pr-${prNumber}`);
+}
+
+/**
+ * The disposable worktree the test-efficacy probe runs in — a sibling of the
+ * shared review worktree, discarded wholesale when the probe finishes (#6832).
+ *
+ * The one exception to this file's "paths are relative to the project root"
+ * rule: this returns an ABSOLUTE path. The probe drives `git worktree add`/
+ * `remove` with the shared worktree as cwd, so a relative path would resolve
+ * against that worktree, not the repo root, and land the probe tree nested
+ * inside the tree it is meant to sit beside. Both call sites — the probe and
+ * `cleanup.ts`'s stale-tree sweep — go through here so the `-probe` suffix and
+ * this normalisation stay in one place; renaming the suffix in one file used to
+ * silently stop the other from sweeping.
+ */
+export function probeWorktreePath(worktree: string): string {
+  return `${resolve(worktree)}-probe`;
 }
 
 /** Local branch ref name for a fetched PR head. */

--- a/packages/cli/src/commands/review/test-efficacy.integration.test.ts
+++ b/packages/cli/src/commands/review/test-efficacy.integration.test.ts
@@ -68,6 +68,35 @@ function treeState(wt: string): string {
   );
 }
 
+/**
+ * A minimal same-repo PR: source `f` changes 1→2, with a reachable test that
+ * passes regardless (so a revert probe reads it as inert). Returns the shared
+ * worktree and base SHA, with the report already written to `report.json`.
+ */
+function scaffoldModifiedPr(): { wt: string; base: string } {
+  write('package.json', '{"private":true,"workspaces":["packages/*"]}\n');
+  write('packages/lib/src/f.ts', 'export const f = () => 1;\n');
+  const base = commitAll('base');
+  write('packages/lib/src/f.ts', 'export const f = () => 2;\n');
+  write(
+    'packages/lib/src/f.test.ts',
+    'import { f } from "./f.js"; import { it, expect } from "vitest"; it("t", () => expect(typeof f).toBe("function"));\n',
+  );
+  commitAll('pr');
+  const wt = join(repo, 'wt');
+  git(repo, 'worktree', 'add', '-q', '--detach', wt, 'HEAD');
+  writeFileSync(
+    join(repo, 'report.json'),
+    JSON.stringify({
+      files: [
+        { path: 'packages/lib/src/f.ts', kind: 'source' },
+        { path: 'packages/lib/src/f.test.ts', kind: 'test' },
+      ],
+    }),
+  );
+  return { wt, base };
+}
+
 beforeEach(() => {
   repo = mkdtempSync(join(tmpdir(), 'efficacy-iso-'));
   outside = mkdtempSync(join(tmpdir(), 'efficacy-outside-'));
@@ -111,27 +140,7 @@ afterEach(() => {
 
 describe('test-efficacy probe isolation (#6832)', () => {
   it('probes in a disposable worktree and never mutates the shared one', async () => {
-    write('package.json', '{"private":true,"workspaces":["packages/*"]}\n');
-    write('packages/lib/src/f.ts', 'export const f = () => 1;\n');
-    const base = commitAll('base');
-    write('packages/lib/src/f.ts', 'export const f = () => 2;\n');
-    write(
-      'packages/lib/src/f.test.ts',
-      'import { f } from "./f.js"; import { it, expect } from "vitest"; it("t", () => expect(typeof f).toBe("function"));\n',
-    );
-    commitAll('pr');
-
-    const wt = join(repo, 'wt');
-    git(repo, 'worktree', 'add', '-q', '--detach', wt, 'HEAD');
-    writeFileSync(
-      join(repo, 'report.json'),
-      JSON.stringify({
-        files: [
-          { path: 'packages/lib/src/f.ts', kind: 'source' },
-          { path: 'packages/lib/src/f.test.ts', kind: 'test' },
-        ],
-      }),
-    );
+    const { wt, base } = scaffoldModifiedPr();
 
     const before = treeState(wt);
     await runHandler({
@@ -213,6 +222,66 @@ describe('test-efficacy probe isolation (#6832)', () => {
     );
     // Shared tree untouched, probe tree discarded.
     expect(treeState(wt)).toBe(before);
+    expect(existsSync(join(repo, 'wt-probe'))).toBe(false);
+  });
+
+  it('sweeps a stale REGISTERED probe worktree left by a crashed run', async () => {
+    const { wt, base } = scaffoldModifiedPr();
+    // A prior probe crashed after `worktree add` but before its cleanup, leaving
+    // the probe tree registered. The pre-sweep must unregister and replace it,
+    // not fail `add` on the collision.
+    git(
+      repo,
+      'worktree',
+      'add',
+      '-q',
+      '--detach',
+      join(repo, 'wt-probe'),
+      'HEAD',
+    );
+    expect(existsSync(join(repo, 'wt-probe'))).toBe(true);
+
+    await runHandler({
+      report: join(repo, 'report.json'),
+      worktree: wt,
+      base,
+      out: join(repo, 'out.json'),
+    });
+
+    // The probe ran (a real verdict, not a "could not be created" inconclusive)
+    // and left the tree cleaned up.
+    const out = JSON.parse(readFileSync(join(repo, 'out.json'), 'utf8'));
+    expect(out.findings.map((f: { file: string }) => f.file)).toContain(
+      'packages/lib/src/f.test.ts',
+    );
+    expect(existsSync(join(repo, 'wt-probe'))).toBe(false);
+  });
+
+  it('clears an UNREGISTERED non-empty leftover so the probe is not wedged', async () => {
+    const { wt, base } = scaffoldModifiedPr();
+    // A partial cleanup left a directory at the probe path that git no longer
+    // tracks as a worktree, and it is non-empty. `git worktree remove` cannot
+    // clear it ("not a working tree"), and without the rmSync fallback the next
+    // `git worktree add` fails "already exists" — wedging every probe as
+    // inconclusive until someone clears it by hand.
+    mkdirSync(join(repo, 'wt-probe', 'junk'), { recursive: true });
+    writeFileSync(join(repo, 'wt-probe', 'junk', 'f'), 'x');
+
+    await runHandler({
+      report: join(repo, 'report.json'),
+      worktree: wt,
+      base,
+      out: join(repo, 'out.json'),
+    });
+
+    const out = JSON.parse(readFileSync(join(repo, 'out.json'), 'utf8'));
+    const details = (out.probed as Array<{ detail?: string }>).map(
+      (p) => p.detail ?? '',
+    );
+    expect(details.join('\n')).not.toMatch(/could not be created/);
+    expect(out.findings.map((f: { file: string }) => f.file)).toContain(
+      'packages/lib/src/f.test.ts',
+    );
     expect(existsSync(join(repo, 'wt-probe'))).toBe(false);
   });
 });

--- a/packages/cli/src/commands/review/test-efficacy.test.ts
+++ b/packages/cli/src/commands/review/test-efficacy.test.ts
@@ -11,6 +11,7 @@ import {
   classifyProbeRun,
   safeRmWithin,
   probeCreateFailureDetail,
+  probeCleanupFailureDetail,
 } from './test-efficacy.js';
 import {
   mkdtempSync,
@@ -185,6 +186,40 @@ describe('probeCreateFailureDetail', () => {
   it('survives a non-Error throw', () => {
     expect(probeCreateFailureDetail('boom', '')).toBe(
       'probe worktree could not be created: boom',
+    );
+  });
+});
+
+describe('probeCleanupFailureDetail', () => {
+  // Sibling of probeCreateFailureDetail, and pure for the same reason: the path
+  // fires only when the tree outlives BOTH `worktree remove` and `rmSync`, which
+  // no portable test can force. The reason is the whole value of the message —
+  // it dropped out of an earlier cut of this code and a reviewer caught it.
+  it('keeps the exception reason — the rmSync error that explains the survival', () => {
+    const got = probeCleanupFailureDetail(
+      '/w/wt-probe',
+      new Error("EBUSY: resource busy, rmdir '/w/wt-probe'"),
+      "fatal: '/w/wt-probe' is not a working tree\n",
+    );
+    expect(got).toContain('could not remove probe worktree /w/wt-probe');
+    expect(got).toContain('EBUSY: resource busy');
+  });
+
+  it("falls back to git's refusal when rmSync itself did not throw", () => {
+    const got = probeCleanupFailureDetail(
+      '/w/wt-probe',
+      undefined,
+      "fatal: '/w/wt-probe' contains modified files\n",
+    );
+    expect(got).toBe(
+      "could not remove probe worktree /w/wt-probe: fatal: '/w/wt-probe' contains modified files",
+    );
+  });
+
+  it('says only what it knows when neither had anything to say', () => {
+    // No dangling ": " — the bare path is the honest message here.
+    expect(probeCleanupFailureDetail('/w/wt-probe', undefined, '  \n')).toBe(
+      'could not remove probe worktree /w/wt-probe',
     );
   });
 });

--- a/packages/cli/src/commands/review/test-efficacy.test.ts
+++ b/packages/cli/src/commands/review/test-efficacy.test.ts
@@ -10,6 +10,7 @@ import {
   planTestEfficacy,
   classifyProbeRun,
   safeRmWithin,
+  probeCreateFailureDetail,
 } from './test-efficacy.js';
 import {
   mkdtempSync,
@@ -153,6 +154,38 @@ describe('planTestEfficacy', () => {
     );
     expect(plan.probes).toEqual([]);
     expect(plan.revert).toEqual([]);
+  });
+});
+
+describe('probeCreateFailureDetail', () => {
+  // The branch this string is built on fires only when `git worktree add` fails,
+  // which no real-git test can force portably (the one lever — an unwritable
+  // `.git/worktrees` — is bypassed by root and differs under CI's unprivileged
+  // user). The composition is the part with logic in it, so it is pinned here.
+  it('names the add failure, and folds in the sweep stderr that explains it', () => {
+    const got = probeCreateFailureDetail(
+      new Error("fatal: '/w/wt-probe' already exists"),
+      "fatal: '/w/wt-probe' is not a working tree\n",
+    );
+    expect(got).toContain('probe worktree could not be created');
+    expect(got).toContain("fatal: '/w/wt-probe' already exists");
+    // The sweep is usually the explanation for the add failure — keep it.
+    expect(got).toContain(
+      "(stale-tree sweep also reported: fatal: '/w/wt-probe' is not a working tree)",
+    );
+  });
+
+  it('omits the sweep clause when the sweep said nothing', () => {
+    // The normal case: no stale tree, so the sweep is silent. A dangling empty
+    // "(stale-tree sweep also reported: )" would be noise in the report.
+    const got = probeCreateFailureDetail(new Error('disk full'), '   \n');
+    expect(got).toBe('probe worktree could not be created: disk full');
+  });
+
+  it('survives a non-Error throw', () => {
+    expect(probeCreateFailureDetail('boom', '')).toBe(
+      'probe worktree could not be created: boom',
+    );
   });
 });
 

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -43,8 +43,9 @@ import {
   rmSync,
   lstatSync,
 } from 'node:fs';
-import { dirname, join, isAbsolute, resolve, sep } from 'node:path';
+import { dirname, join, isAbsolute, sep } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { probeWorktreePath } from './lib/paths.js';
 
 export type ProbeVerdict = 'gated' | 'inert' | 'inconclusive';
 
@@ -396,22 +397,41 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
     // repo-root `node_modules` — exactly how the shared review worktree already
     // runs vitest.
     const headSha = gitOut(worktree, 'rev-parse', 'HEAD');
-    const probeTree = `${resolve(worktree)}-probe`;
+    const probeTree = probeWorktreePath(worktree);
     let created = false;
+    let sweep: ReturnType<typeof spawnSync> | undefined;
     try {
       // Sweep a stale probe tree left by a crashed run — it would fail `add`.
-      // Best-effort (no stale tree is the normal case), so it does not go through
-      // the throwing `git()` wrapper.
-      spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
+      // Two ways it can be stale, and `worktree remove` only clears one:
+      //   - REGISTERED (metadata intact) — `worktree remove --force` unregisters
+      //     it and deletes the dir.
+      //   - an UNREGISTERED directory (metadata lost, or a partial cleanup) —
+      //     `worktree remove` says "not a working tree" and leaves it, and then a
+      //     *non-empty* leftover makes `worktree add` fail `already exists`,
+      //     wedging every probe as `inconclusive` until someone clears it by hand.
+      // So follow the unregister sweep with a plain remove of whatever dir is
+      // still there. Both are best-effort — no stale tree is the normal case — so
+      // the unregister does not go through the throwing `git()` wrapper, and its
+      // stderr is kept to explain a subsequent `add` failure. `rmSync` on the
+      // path unlinks a symlink rather than following it, so even a tampered
+      // leftover cannot redirect the delete outside `probeTree`.
+      sweep = spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
         cwd: worktree,
+        encoding: 'utf8',
       });
+      rmSync(probeTree, { recursive: true, force: true });
       git(worktree, 'worktree', 'add', '--detach', probeTree, headSha);
       created = true;
     } catch (e) {
       // Could not isolate — probe nothing rather than fall back to mutating the
       // shared tree. Probes are inconclusive; the unreachable findings, which
-      // need no probe, still ship.
-      const detail = `probe worktree could not be created: ${e instanceof Error ? e.message : String(e)}`;
+      // need no probe, still ship. Surface the stale-sweep's stderr too: when the
+      // `add` fails on a leftover the sweep could not clear, that is the context
+      // that explains why.
+      const sweepErr = String(sweep?.stderr ?? '').trim();
+      const detail =
+        `probe worktree could not be created: ${e instanceof Error ? e.message : String(e)}` +
+        (sweepErr ? ` (stale-tree sweep also reported: ${sweepErr})` : '');
       for (const file of probes) {
         results.push({ file, verdict: 'inconclusive' as const, detail });
       }

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -339,6 +339,40 @@ export function safeRmWithin(worktree: string, relPath: string): void {
   rmSync(cur, { force: true });
 }
 
+type SweepResult = ReturnType<typeof spawnSync>;
+
+/**
+ * Free the probe worktree's path: unregister it, then remove whatever is left.
+ *
+ * `git worktree remove --force` only clears a tree git still tracks. A directory
+ * left at the path after metadata loss or a partial cleanup is reported "not a
+ * working tree" and left in place — and a *non-empty* one then makes
+ * `git worktree add` fail `already exists`, wedging every probe as
+ * `inconclusive` until someone clears it by hand. So the unregister is followed
+ * by a plain remove of whatever dir remains. `rmSync` unlinks a symlink rather
+ * than following it, so a tampered leftover cannot redirect the delete outside
+ * `tree`.
+ *
+ * This is `releaseWorktree`'s two-step, and deliberately NOT a call to it:
+ * `releaseWorktree` runs git from the process cwd, which need not be this
+ * worktree's repo, and it discards the sweep's stderr — which is usually the
+ * only thing that explains a subsequent `add` failure. Both callers here need
+ * `cwd: worktree` and that stderr, so the step lives here and is shared between
+ * them.
+ *
+ * Best-effort by design: a clean path is the normal case, so the unregister does
+ * not go through the throwing `git()` wrapper. `rmSync` can still throw (`force`
+ * suppresses ENOENT but not EPERM/EBUSY) — callers decide what that means.
+ */
+function discardWorktree(cwd: string, tree: string): SweepResult {
+  const sweep = spawnSync('git', ['worktree', 'remove', '--force', tree], {
+    cwd,
+    encoding: 'utf8',
+  });
+  rmSync(tree, { recursive: true, force: true });
+  return sweep;
+}
+
 const existsAtBase = (cwd: string, base: string, path: string) =>
   existsAtRev(cwd, base, path);
 
@@ -365,6 +399,29 @@ export function probeCreateFailureDetail(
     `probe worktree could not be created: ${err instanceof Error ? err.message : String(err)}` +
     (sweepErr ? ` (stale-tree sweep also reported: ${sweepErr})` : '')
   );
+}
+
+/**
+ * The warning for a probe worktree that survived its discard.
+ *
+ * Pure, and for the same reason as its sibling above: the branch it lives on
+ * fires only when the path outlives both `worktree remove` and `rmSync`, which
+ * no portable test can force. The reason is what makes it useful — whoever has
+ * to delete the tree by hand needs to know WHY it would not go, and a bare
+ * "could not remove <path>" tells them nothing. Prefer the exception (`rmSync`
+ * hit EPERM/EBUSY); fall back to what git said when it refused to unregister.
+ */
+export function probeCleanupFailureDetail(
+  probeTree: string,
+  removeError: unknown,
+  sweepStderr: string,
+): string {
+  const why = removeError
+    ? removeError instanceof Error
+      ? removeError.message
+      : String(removeError)
+    : sweepStderr.trim();
+  return `could not remove probe worktree ${probeTree}${why ? `: ${why}` : ''}`;
 }
 
 async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
@@ -425,32 +482,11 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
     const headSha = gitOut(worktree, 'rev-parse', 'HEAD');
     const probeTree = probeWorktreePath(worktree);
     let created = false;
-    let sweep: ReturnType<typeof spawnSync> | undefined;
+    let sweep: SweepResult | undefined;
     try {
-      // Sweep a stale probe tree left by a crashed run — it would fail `add`.
-      // Two ways it can be stale, and `worktree remove` only clears one:
-      //   - REGISTERED (metadata intact) — `worktree remove --force` unregisters
-      //     it and deletes the dir.
-      //   - an UNREGISTERED directory (metadata lost, or a partial cleanup) —
-      //     `worktree remove` says "not a working tree" and leaves it, and then a
-      //     *non-empty* leftover makes `worktree add` fail `already exists`,
-      //     wedging every probe as `inconclusive` until someone clears it by hand.
-      // So follow the unregister sweep with a plain remove of whatever dir is
-      // still there. Both are best-effort — no stale tree is the normal case — so
-      // the unregister does not go through the throwing `git()` wrapper, and its
-      // stderr is kept to explain a subsequent `add` failure. `rmSync` on the
-      // path unlinks a symlink rather than following it, so even a tampered
-      // leftover cannot redirect the delete outside `probeTree`.
-      //
-      // This is `releaseWorktree`'s two-step, kept inline rather than shared: the
-      // probe must target THIS repo via `cwd: worktree` (`releaseWorktree` runs
-      // git from the process cwd, which need not be this worktree's repo), and it
-      // keeps the sweep's stderr for the diagnostic in the catch below.
-      sweep = spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
-        cwd: worktree,
-        encoding: 'utf8',
-      });
-      rmSync(probeTree, { recursive: true, force: true });
+      // Clear a stale probe tree left by a crashed run — it would fail `add`.
+      // Its stderr is kept to explain a subsequent `add` failure.
+      sweep = discardWorktree(worktree, probeTree);
       git(worktree, 'worktree', 'add', '--detach', probeTree, headSha);
       created = true;
     } catch (e) {
@@ -525,24 +561,29 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
           })),
         );
       } finally {
-        // Discard the whole probe tree. There is no in-place restore to fail:
-        // the shared worktree was never mutated. Mirror the pre-sweep's two steps
-        // so an unregistered or non-empty leftover cannot survive a failed
-        // `worktree remove` — unregister (best-effort), then remove whatever dir
-        // remains. Only a path that still exists after both is a real cleanup
-        // failure, and even then it corrupts nothing: the next run's pre-sweep
-        // and cleanup.ts both sweep it. So this is a warning, not the "every
-        // later step reads the wrong source" alarm the old in-place restore had.
+        // Discard the whole probe tree. There is no in-place restore to fail —
+        // the shared worktree was never mutated — and a path that survives the
+        // discard corrupts nothing: the next run's pre-sweep and cleanup.ts both
+        // sweep it. So this is a warning, not the "every later step reads the
+        // wrong source" alarm the old in-place restore had to raise.
+        //
+        // Whether the path is still THERE is the signal, not whether a call
+        // threw: `worktree remove` can fail while `rmSync` still frees the path.
+        // But keep the reason — a bare "could not remove <path>" tells whoever
+        // has to clean it up by hand nothing about why they must.
+        let removeError: unknown;
+        let discard: SweepResult | undefined;
         try {
-          spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
-            cwd: worktree,
-          });
-          rmSync(probeTree, { recursive: true, force: true });
-        } catch {
-          // Fall through to the existence check — that is the real signal.
+          discard = discardWorktree(worktree, probeTree);
+        } catch (e) {
+          removeError = e;
         }
         if (existsSync(probeTree)) {
-          cleanupFailure = `could not remove probe worktree ${probeTree}`;
+          cleanupFailure = probeCleanupFailureDetail(
+            probeTree,
+            removeError,
+            String(discard?.stderr ?? ''),
+          );
         }
       }
     }

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -42,6 +42,7 @@ import {
   readFileSync,
   rmSync,
   lstatSync,
+  existsSync,
 } from 'node:fs';
 import { dirname, join, isAbsolute, sep } from 'node:path';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
@@ -415,6 +416,11 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
       // stderr is kept to explain a subsequent `add` failure. `rmSync` on the
       // path unlinks a symlink rather than following it, so even a tampered
       // leftover cannot redirect the delete outside `probeTree`.
+      //
+      // This is `releaseWorktree`'s two-step, kept inline rather than shared: the
+      // probe must target THIS repo via `cwd: worktree` (`releaseWorktree` runs
+      // git from the process cwd, which need not be this worktree's repo), and it
+      // keeps the sweep's stderr for the diagnostic in the catch below.
       sweep = spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
         cwd: worktree,
         encoding: 'utf8',
@@ -500,14 +506,23 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
         );
       } finally {
         // Discard the whole probe tree. There is no in-place restore to fail:
-        // the shared worktree was never mutated. A failed removal only leaves a
-        // stale dir (swept at the start of the next run, and by cleanup.ts) — a
-        // warning, not the "every later step reads the wrong source" alarm the
-        // old in-place restore had to raise.
+        // the shared worktree was never mutated. Mirror the pre-sweep's two steps
+        // so an unregistered or non-empty leftover cannot survive a failed
+        // `worktree remove` — unregister (best-effort), then remove whatever dir
+        // remains. Only a path that still exists after both is a real cleanup
+        // failure, and even then it corrupts nothing: the next run's pre-sweep
+        // and cleanup.ts both sweep it. So this is a warning, not the "every
+        // later step reads the wrong source" alarm the old in-place restore had.
         try {
-          git(worktree, 'worktree', 'remove', '--force', probeTree);
-        } catch (e) {
-          cleanupFailure = `could not remove probe worktree ${probeTree}: ${e instanceof Error ? e.message : String(e)}`;
+          spawnSync('git', ['worktree', 'remove', '--force', probeTree], {
+            cwd: worktree,
+          });
+          rmSync(probeTree, { recursive: true, force: true });
+        } catch {
+          // Fall through to the existence check — that is the real signal.
+        }
+        if (existsSync(probeTree)) {
+          cleanupFailure = `could not remove probe worktree ${probeTree}`;
         }
       }
     }

--- a/packages/cli/src/commands/review/test-efficacy.ts
+++ b/packages/cli/src/commands/review/test-efficacy.ts
@@ -342,6 +342,31 @@ export function safeRmWithin(worktree: string, relPath: string): void {
 const existsAtBase = (cwd: string, base: string, path: string) =>
   existsAtRev(cwd, base, path);
 
+/**
+ * The `inconclusive` detail for a probe worktree that could not be created.
+ *
+ * Pure, and extracted for that reason: the branch it lives on fires only when
+ * `git worktree add` fails, and there is no portable way to force that in a
+ * real-git test — the one lever (making `.git/worktrees` unwritable) is bypassed
+ * by root and behaves differently under CI's unprivileged user, so a test built
+ * on it would assert one thing locally and another in CI. The composition is the
+ * part with logic in it, so it is testable here on its own.
+ *
+ * The stale-sweep's stderr is folded in because it is usually the explanation:
+ * when `add` fails on a leftover the sweep could not clear, the sweep is what
+ * says why.
+ */
+export function probeCreateFailureDetail(
+  err: unknown,
+  sweepStderr: string,
+): string {
+  const sweepErr = sweepStderr.trim();
+  return (
+    `probe worktree could not be created: ${err instanceof Error ? err.message : String(err)}` +
+    (sweepErr ? ` (stale-tree sweep also reported: ${sweepErr})` : '')
+  );
+}
+
 async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
   const { report, worktree, base, out } = args;
   const plan = JSON.parse(readFileSync(report, 'utf8')) as {
@@ -431,13 +456,8 @@ async function runTestEfficacy(args: TestEfficacyArgs): Promise<void> {
     } catch (e) {
       // Could not isolate — probe nothing rather than fall back to mutating the
       // shared tree. Probes are inconclusive; the unreachable findings, which
-      // need no probe, still ship. Surface the stale-sweep's stderr too: when the
-      // `add` fails on a leftover the sweep could not clear, that is the context
-      // that explains why.
-      const sweepErr = String(sweep?.stderr ?? '').trim();
-      const detail =
-        `probe worktree could not be created: ${e instanceof Error ? e.message : String(e)}` +
-        (sweepErr ? ` (stale-tree sweep also reported: ${sweepErr})` : '');
+      // need no probe, still ship.
+      const detail = probeCreateFailureDetail(e, String(sweep?.stderr ?? ''));
       for (const file of probes) {
         results.push({ file, verdict: 'inconclusive' as const, detail });
       }


### PR DESCRIPTION
## What

Follow-up to #6836 (the disposable-probe-worktree change), addressing the review left on it. Everything here is one theme: **`git worktree remove` alone does not free a path**, and every sweep site had to learn that.

1. **Share the probe-worktree path.** Extract `probeWorktreePath(worktree)` into `lib/paths.ts`; both the probe (`test-efficacy.ts`) and `cleanup.ts` call it. The `-probe` suffix was constructed independently in the two files — rename it in one and miss the other, and cleanup silently stops sweeping. The helper also settles the absolute-vs-relative divergence: it returns absolute, because the probe drives `git worktree add`/`remove` with the shared worktree as cwd, where a relative path would resolve against that worktree and nest the probe tree inside it.

2. **Clear an unregistered leftover, everywhere.** `git worktree remove --force` only unregisters a tree git still tracks. A directory left at the path after metadata loss or a partial cleanup is reported *"not a working tree"* and left in place — and a **non-empty** one then makes `git worktree add` fail `already exists`, wedging every probe as `inconclusive` until someone clears it by hand (confirmed against real git 2.47; an *empty* leftover git reuses fine). Three sites needed the same two-step (unregister, then `rmSync` whatever remains):
   - the probe's **pre-sweep** before `worktree add`;
   - **`releaseWorktree`** in `lib/git.ts` — fixed at the root, so `cleanup.ts`'s probe sweep *and* the main review-worktree sweep both get it. Its `true` return now means the path is gone, not merely unregistered (JSDoc updated to say so); previously `cleanup.ts` printed *"Removed probe worktree"* while the directory was still there;
   - the probe's post-run **`finally`**, whose `cleanupFailure` is now keyed off whether the path still exists rather than off a git throw — the honest signal.

   `rmSync` unlinks a symlink instead of following it, so a tampered leftover cannot redirect the delete.

3. **Explain the `add` failure when it happens.** The pre-sweep's stderr is captured and folded into the create-failure detail — when `add` fails on a leftover the sweep could not clear, the sweep is what says why.

## Verification

- **Unit**: `probeWorktreePath` (suffix, relative→absolute, single shared source); `probeCreateFailureDetail` (sweep stderr folded in, no dangling empty clause, non-`Error` throw).
- **Integration (real git worktrees)**: a stale **registered** probe tree is swept and the probe still runs; an **unregistered non-empty** leftover is cleared rather than wedging the probe (fails without the `rmSync` fallback); `releaseWorktree` removes an untracked leftover and leaves the path `worktree add`-able again.

`prettier` / `eslint` / `tsc --noEmit` clean; full review suite green (**420**, +9).

## One thing deliberately not tested

The `catch` that fires when `git worktree add` itself fails. There is no portable way to force it: the only lever — making `.git/worktrees` unwritable — is **bypassed by root** and behaves differently under CI's unprivileged user, so a test built on it would assert one thing locally and another in CI, which is worse than no test. Rather than leave the branch bare, the part that actually has logic in it was extracted (`probeCreateFailureDetail`) and unit-tested. What remains uncovered is only the try/catch wiring.

Addresses the review comments on #6836.

<details>
<summary><b>中文说明（点击展开）</b></summary>

## 这个 PR 做什么

#6836（把 test-efficacy probe 放进一次性 worktree）的后续，处理其上的审查意见。所有改动围绕同一个主题：**`git worktree remove` 单独用并不能真正释放路径**，而每一处清扫点都得学会这件事。

### 1. 共享 probe worktree 路径

把 `probeWorktreePath(worktree)` 抽到 `lib/paths.ts`，probe（`test-efficacy.ts`）和 `cleanup.ts` 都调它。此前 `-probe` 后缀在两个文件里各写一遍 —— 改一处漏一处，cleanup 就会静默停止清扫。

这个 helper 同时定了路径规范化：**返回绝对路径**。因为 probe 执行 `git worktree add`/`remove` 时 cwd 是共享 worktree，相对路径会以那棵树为基准解析，把 probe 树嵌套进它内部。

### 2. 清掉「未注册的残留目录」—— 三处都要

`git worktree remove --force` 只能注销 git 仍在跟踪的树。若因元数据丢失或清理中断，路径上留下一个 git 不再跟踪的目录，git 会报 *"not a working tree"* 并原样留着 —— 而**非空**的残留会让接下来的 `git worktree add` 失败于 `already exists`，把每次 probe 都卡成 `inconclusive`，直到有人手工清理。（已用真实 git 2.47 复现确认；顺带发现**空**目录 git 会正常复用，只有非空才卡。）

三个地方需要同样的两步（先注销，再 `rmSync` 掉残留的任何东西）：

- probe 在 `worktree add` **之前的预清扫**；
- **`lib/git.ts` 的 `releaseWorktree`** —— 修在根上，这样 `cleanup.ts` 的 probe 清扫**和**主 review worktree 清扫一起受益。它返回 `true` 现在意味着「路径确实没了」，而不只是「已注销」（JSDoc 已同步更新）；此前 `cleanup.ts` 会打印 *"Removed probe worktree"*，而目录其实还在 —— 这是句谎报；
- probe 跑完后的 **`finally`**，其 `cleanupFailure` 现在依据「路径是否仍存在」判定，而不是依据 git 是否抛异常 —— 后者才是诚实的信号。

`rmSync` 对符号链接是**解链接**而非跟随，所以即便残留被做了手脚，也无法把删除重定向到树外。

### 3. `add` 失败时要能解释原因

预清扫的 stderr 被捕获并折入创建失败的 detail —— 当 `add` 因清扫没能清掉的残留而失败时，正是清扫的输出在说明原因。

## 验证

- **单元测试**：`probeWorktreePath`（后缀、相对→绝对、两处调用同源）；`probeCreateFailureDetail`（stderr 被折入、为空时不留悬空子句、非 `Error` 抛出）。
- **集成测试（真实 git worktree）**：陈旧的**已注册** probe 树被清扫且 probe 仍正常运行；**未注册且非空**的残留被清掉而不是卡住 probe（去掉 `rmSync` 兜底此测试即失败）；`releaseWorktree` 能移除未跟踪的残留，路径重新可 `worktree add`。

`prettier` / `eslint` / `tsc --noEmit` 均干净；review 全套测试通过（**420**，+9）。

## 一处刻意不测

`git worktree add` 自身失败时进入的 `catch`。没有可移植的办法强制触发它：唯一的手段 —— 让 `.git/worktrees` 不可写 —— 在 **root 下会被直接绕过**，而 CI 跑的是非特权用户，两边行为不同。这样的测试会「本地断言一套、CI 断言另一套」，**比没有测试更糟**。

因此没有硬造这个测试，而是把其中真正有逻辑的部分抽了出来（`probeCreateFailureDetail`）并做了单元测试。剩下未覆盖的，只有 try/catch 的接线本身，那里没有逻辑。

</details>
