### PR TITLE
fix(cli): wrap long compact tool summaries

### DIFF
--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -10,6 +10,7 @@ import { Text } from 'ink';
 import {
   CompactToolGroupDisplay,
   buildToolSummary,
+  estimateCompactToolGroupHeight,
   isCollapsibleTool,
 } from './CompactToolGroupDisplay.js';
 import { ToolCallStatus } from '../../types.js';
@@ -305,6 +306,24 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary(tools, false)).toBe(
       'Searched pattern, listed /src',
     );
+  });
+});
+
+describe('estimateCompactToolGroupHeight', () => {
+  it('returns 0 when there are no tool calls', () => {
+    expect(estimateCompactToolGroupHeight([], 80)).toBe(0);
+  });
+
+  it('returns 1 for summaries that fit on one line', () => {
+    expect(estimateCompactToolGroupHeight([toolCall()], 80)).toBe(1);
+  });
+
+  it('accounts for wrapped long summaries', () => {
+    const description =
+      'packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx';
+    const tool = toolCall({ name: 'ReadFile', description });
+
+    expect(estimateCompactToolGroupHeight([tool], 30)).toBeGreaterThan(1);
   });
 });
 

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -325,6 +325,30 @@ describe('estimateCompactToolGroupHeight', () => {
 
     expect(estimateCompactToolGroupHeight([tool], 30)).toBeGreaterThan(1);
   });
+
+  it('reserves additional width for active summary status', () => {
+    const description =
+      'packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx';
+    const completed = toolCall({ name: 'ReadFile', description });
+    const active = toolCall({
+      name: 'ReadFile',
+      description,
+      status: ToolCallStatus.Executing,
+    });
+
+    expect(estimateCompactToolGroupHeight([active], 30)).toBeGreaterThan(
+      estimateCompactToolGroupHeight([completed], 30),
+    );
+  });
+
+  it('uses terminal display width for wide characters', () => {
+    const tool = toolCall({
+      name: 'ReadFile',
+      description: '中文中文中文中文',
+    });
+
+    expect(estimateCompactToolGroupHeight([tool], 12)).toBe(3);
+  });
 });
 
 describe('isCollapsibleTool', () => {

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -341,6 +341,25 @@ describe('estimateCompactToolGroupHeight', () => {
     );
   });
 
+  it('reserves timeout label width for active shell summaries', () => {
+    const description =
+      'npm test -- --filter packages/cli/src/ui/components/messages';
+    const activeShell = shellTool({ description });
+    const activeShellWithTimeout = shellTool({
+      description,
+      resultDisplay: {
+        ansiOutput: [],
+        totalLines: 0,
+        totalBytes: 0,
+        timeoutMs: 30_000,
+      },
+    });
+
+    expect(
+      estimateCompactToolGroupHeight([activeShellWithTimeout], 55),
+    ).toBeGreaterThan(estimateCompactToolGroupHeight([activeShell], 55));
+  });
+
   it('uses terminal display width for wide characters', () => {
     const tool = toolCall({
       name: 'ReadFile',

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -147,6 +147,20 @@ describe('<CompactToolGroupDisplay /> — summary label', () => {
     );
     expect(lastFrame()).toContain('Ran ls -la');
   });
+
+  it('wraps long summaries instead of truncating them', () => {
+    const description =
+      'packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx';
+    const tool = toolCall({ name: 'ReadFile', description });
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={[tool]} contentWidth={30} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame.split('\n').length).toBeGreaterThan(1);
+    expect(frame).not.toContain('…');
+    expect(frame.replace(/\s/g, '')).toContain(`Read${description}`);
+  });
 });
 
 describe('buildToolSummary', () => {

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -6,6 +6,8 @@
 
 import type React from 'react';
 import { Box, Text } from 'ink';
+import stringWidth from 'string-width';
+import wrapAnsi from 'wrap-ansi';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
 import type { AnsiOutputDisplay } from '@qwen-code/qwen-code-core';
@@ -17,6 +19,7 @@ import {
   ToolStatusIndicator,
 } from '../shared/ToolStatusIndicator.js';
 import { ToolElapsedTime } from '../shared/ToolElapsedTime.js';
+import { formatDuration } from '../../utils/formatters.js';
 
 interface CompactToolGroupDisplayProps {
   toolCalls: IndividualToolCallDisplay[];
@@ -24,7 +27,8 @@ interface CompactToolGroupDisplayProps {
 }
 
 const COMPACT_GROUP_HORIZONTAL_PADDING = 2;
-const ACTIVE_ELAPSED_TIME_RESERVED_WIDTH = 4;
+const ELAPSED_TIME_MARGIN_LEFT = 1;
+const EXECUTING_ELAPSED_TIME_RESERVED_LABEL = '99h 59m 59s';
 
 // Priority: Confirming > Executing > Error > Canceled > Pending > Success
 export function getOverallStatus(
@@ -66,6 +70,29 @@ function getShellTimeoutMs(
     return (display as AnsiOutputDisplay).timeoutMs;
   }
   return undefined;
+}
+
+function isToolGroupActive(status: ToolCallStatus): boolean {
+  return (
+    status === ToolCallStatus.Executing ||
+    status === ToolCallStatus.Pending ||
+    status === ToolCallStatus.Confirming
+  );
+}
+
+function getElapsedTimeReservedWidth(
+  tool: IndividualToolCallDisplay,
+  status: ToolCallStatus,
+): number {
+  if (status !== ToolCallStatus.Executing) return 0;
+
+  const timeoutMs = getShellTimeoutMs(tool);
+  const label =
+    timeoutMs != null && timeoutMs > 0
+      ? `(0s · timeout ${formatDuration(timeoutMs, { hideTrailingZeros: true })})`
+      : EXECUTING_ELAPSED_TIME_RESERVED_LABEL;
+
+  return ELAPSED_TIME_MARGIN_LEFT + stringWidth(label);
 }
 
 type ToolCategory =
@@ -325,20 +352,22 @@ export function estimateCompactToolGroupHeight(
   if (toolCalls.length === 0) return 0;
 
   const overallStatus = getOverallStatus(toolCalls);
-  const isActive =
-    overallStatus === ToolCallStatus.Executing ||
-    overallStatus === ToolCallStatus.Pending ||
-    overallStatus === ToolCallStatus.Confirming;
+  const activeTool = getActiveTool(toolCalls);
+  const isActive = isToolGroupActive(overallStatus);
   const summary = `${buildToolSummary(toolCalls, isActive)}${isActive ? '…' : ''}`;
   const summaryWidth = Math.max(
     1,
     contentWidth -
       COMPACT_GROUP_HORIZONTAL_PADDING -
       STATUS_INDICATOR_WIDTH -
-      (isActive ? ACTIVE_ELAPSED_TIME_RESERVED_WIDTH : 0),
+      getElapsedTimeReservedWidth(activeTool, overallStatus),
   );
+  const wrappedSummary = wrapAnsi(summary, summaryWidth, {
+    hard: true,
+    trim: false,
+  });
 
-  return Math.max(1, Math.ceil(Array.from(summary).length / summaryWidth));
+  return Math.max(1, wrappedSummary.split('\n').length);
 }
 
 export const CompactToolGroupDisplay: React.FC<
@@ -348,10 +377,7 @@ export const CompactToolGroupDisplay: React.FC<
 
   const overallStatus = getOverallStatus(toolCalls);
   const activeTool = getActiveTool(toolCalls);
-  const isActive =
-    overallStatus === ToolCallStatus.Executing ||
-    overallStatus === ToolCallStatus.Pending ||
-    overallStatus === ToolCallStatus.Confirming;
+  const isActive = isToolGroupActive(overallStatus);
 
   return (
     <Box flexDirection="column" width={contentWidth} paddingX={1} gap={0}>

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -12,13 +12,19 @@ import type { AnsiOutputDisplay } from '@qwen-code/qwen-code-core';
 import { ToolDisplayNames } from '@qwen-code/qwen-code-core';
 import { t } from '../../../i18n/index.js';
 import { SHELL_COMMAND_NAME } from '../../constants.js';
-import { ToolStatusIndicator } from '../shared/ToolStatusIndicator.js';
+import {
+  STATUS_INDICATOR_WIDTH,
+  ToolStatusIndicator,
+} from '../shared/ToolStatusIndicator.js';
 import { ToolElapsedTime } from '../shared/ToolElapsedTime.js';
 
 interface CompactToolGroupDisplayProps {
   toolCalls: IndividualToolCallDisplay[];
   contentWidth: number;
 }
+
+const COMPACT_GROUP_HORIZONTAL_PADDING = 2;
+const ACTIVE_ELAPSED_TIME_RESERVED_WIDTH = 4;
 
 // Priority: Confirming > Executing > Error > Canceled > Pending > Success
 export function getOverallStatus(
@@ -310,6 +316,29 @@ export function buildToolSummary(
   }
 
   return parts.join(', ');
+}
+
+export function estimateCompactToolGroupHeight(
+  toolCalls: IndividualToolCallDisplay[],
+  contentWidth: number,
+): number {
+  if (toolCalls.length === 0) return 0;
+
+  const overallStatus = getOverallStatus(toolCalls);
+  const isActive =
+    overallStatus === ToolCallStatus.Executing ||
+    overallStatus === ToolCallStatus.Pending ||
+    overallStatus === ToolCallStatus.Confirming;
+  const summary = `${buildToolSummary(toolCalls, isActive)}${isActive ? '…' : ''}`;
+  const summaryWidth = Math.max(
+    1,
+    contentWidth -
+      COMPACT_GROUP_HORIZONTAL_PADDING -
+      STATUS_INDICATOR_WIDTH -
+      (isActive ? ACTIVE_ELAPSED_TIME_RESERVED_WIDTH : 0),
+  );
+
+  return Math.max(1, Math.ceil(Array.from(summary).length / summaryWidth));
 }
 
 export const CompactToolGroupDisplay: React.FC<

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -87,10 +87,13 @@ function getElapsedTimeReservedWidth(
   if (status !== ToolCallStatus.Executing) return 0;
 
   const timeoutMs = getShellTimeoutMs(tool);
-  const label =
-    timeoutMs != null && timeoutMs > 0
-      ? `(0s · timeout ${formatDuration(timeoutMs, { hideTrailingZeros: true })})`
-      : EXECUTING_ELAPSED_TIME_RESERVED_LABEL;
+  let label = EXECUTING_ELAPSED_TIME_RESERVED_LABEL;
+  if (timeoutMs != null && timeoutMs > 0) {
+    const maxElapsedStr = formatDuration(timeoutMs, {
+      hideTrailingZeros: true,
+    });
+    label = `(${maxElapsedStr} · timeout ${maxElapsedStr})`;
+  }
 
   return ELAPSED_TIME_MARGIN_LEFT + stringWidth(label);
 }

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -329,7 +329,7 @@ export const CompactToolGroupDisplay: React.FC<
       <Box flexDirection="row">
         <ToolStatusIndicator status={overallStatus} name={activeTool.name} />
         <Box flexGrow={1}>
-          <Text wrap="truncate-end" bold>
+          <Text wrap="wrap" bold>
             {buildToolSummary(toolCalls, isActive)}
             {isActive && <Text key="ellipsis">…</Text>}
           </Text>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -1002,6 +1002,40 @@ describe('<ToolGroupMessage />', () => {
       );
       expect(lastFrame()).toMatchSnapshot();
     });
+
+    it('reserves wrapped compact summary height before sizing tool results', () => {
+      vi.mocked(ToolMessage).mockClear();
+      const toolCalls = [
+        createToolCall({
+          callId: 'read-long',
+          name: 'ReadFile',
+          description:
+            'packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx',
+          status: ToolCallStatus.Success,
+        }),
+        createToolCall({
+          callId: 'shell-result',
+          name: 'Shell',
+          description: 'npm test',
+          status: ToolCallStatus.Success,
+          resultDisplay: 'shell output',
+        }),
+      ];
+
+      renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          contentWidth={30}
+          toolCalls={toolCalls}
+          availableTerminalHeight={12}
+        />,
+      );
+
+      const call = vi
+        .mocked(ToolMessage)
+        .mock.calls.find((c) => c[0].callId === 'shell-result');
+      expect(call?.[0].availableTerminalHeight).toBe(8);
+    });
   });
 
   describe('Confirmation Handling', () => {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -13,6 +13,7 @@ import { ToolMessage } from './ToolMessage.js';
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
 import {
   CompactToolGroupDisplay,
+  estimateCompactToolGroupHeight,
   isCollapsibleTool,
 } from './CompactToolGroupDisplay.js';
 import { InlineParallelAgentsDisplay } from './InlineParallelAgentsDisplay.js';
@@ -432,7 +433,10 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   }
 
   // Full expanded view for non-collapsible tools
-  const collapsibleSummaryHeight = collapsibleTools.length > 0 ? 1 : 0;
+  const collapsibleSummaryHeight = estimateCompactToolGroupHeight(
+    collapsibleTools,
+    contentWidth,
+  );
   const memoryBadgeHeight = hasMemoryBadge ? 1 : 0;
   const staticHeight =
     /* marginBottom */ 1 + collapsibleSummaryHeight + memoryBadgeHeight;


### PR DESCRIPTION
## What this PR does

This PR makes completed compact tool summary lines wrap within their available width instead of truncating the hidden suffix at the terminal edge. It also adds focused Ink rendering coverage for a long file path in a narrow 30-column display, verifying that the result spans multiple lines, contains no truncation ellipsis, and preserves the complete summary.

## Why it's needed

Long file paths and command text currently lose useful information when compact tool summaries exceed the terminal width. Wrapping keeps the full summary visible while preserving the existing status indicator and elapsed-time layout. The change is limited to the compact tool summary line; other intentional single-line `truncate-end` usages remain unchanged.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx` with Node.js 22 or newer and confirm all 27 tests pass, including `wraps long summaries instead of truncating them`.
2. Render a completed `ReadFile` tool whose description is `packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx` with `contentWidth={30}` and confirm the summary wraps across lines without `…` while retaining the complete path.
3. Run `npm run typecheck --workspace=packages/cli` and confirm it exits successfully.

### Evidence (Before & After)

Captured from `ink-testing-library` using the same completed `ReadFile` tool and 30-column content width.

Before (`wrap="truncate-end"`):

```text
 •Read packages/cli/src/ui/c…
```

After (`wrap="wrap"`):

```text
 •Read packages/cli/src/ui/co
  mponents/messages/CompactTo
  olGroupDisplay.tsx
```

The focused regression test fails against the previous implementation with `expected 1 to be greater than 1` because only one line is rendered, and passes with this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows local workspace with Node.js 24.14.0, npm 10.8.2, Vitest 3.2.4, and `ink-testing-library`. The focused test file passed 27/27 tests; CLI typecheck, Prettier checks for both changed files, and ESLint with zero warnings also passed.

## Risk & Scope

- Main risk or tradeoff: Long summaries can consume additional vertical terminal space, which is the intended tradeoff for keeping their full content visible.
- Not validated / out of scope: Manual end-to-end TUI testing on macOS and Linux, changes to summary wording, and other intentional `truncate-end` usages elsewhere in the UI.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6814

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将已完成的紧凑工具摘要行改为在可用宽度内自动换行，而不是在终端边缘截断并隐藏后续内容。同时增加了一个聚焦的 Ink 渲染测试，使用 30 列窄布局中的长文件路径，验证结果会渲染为多行、不包含截断省略号，并完整保留摘要内容。

## 修改原因

当紧凑工具摘要超过终端宽度时，较长的文件路径和命令文本目前会丢失有用信息。自动换行可以让完整摘要保持可见，同时保留现有的状态指示器和耗时布局。本次修改仅限于紧凑工具摘要行；其他有意保持单行的 `truncate-end` 用法均不变。

## Reviewer 测试计划

### 验证方式

1. 使用 Node.js 22 或更高版本运行 `cd packages/cli && npx vitest run src/ui/components/messages/CompactToolGroupDisplay.test.tsx`，确认全部 27 个测试通过，其中包括 `wraps long summaries instead of truncating them`。
2. 渲染一个已完成的 `ReadFile` 工具，将其 description 设置为 `packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx`，并设置 `contentWidth={30}`；确认摘要会跨行显示、不包含 `…`，并且完整路径得到保留。
3. 运行 `npm run typecheck --workspace=packages/cli`，确认命令成功退出。

### 修改前后证据

以下内容由 `ink-testing-library` 使用同一个已完成的 `ReadFile` 工具和 30 列内容宽度渲染得到。

修改前（`wrap="truncate-end"`）：

```text
 •Read packages/cli/src/ui/c…
```

修改后（`wrap="wrap"`）：

```text
 •Read packages/cli/src/ui/co
  mponents/messages/CompactTo
  olGroupDisplay.tsx
```

针对性的回归测试在旧实现上会失败并报告 `expected 1 to be greater than 1`，因为输出只有一行；应用本次修改后，该测试通过。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    | ⚠️ 未测试 |
| 🪟 Windows   | ✅ 已测试 |
|  🐧 Linux    | ⚠️ 未测试 |

### 环境（可选）

Windows 本地工作区，使用 Node.js 24.14.0、npm 10.8.2、Vitest 3.2.4 和 `ink-testing-library`。目标测试文件的 27/27 个测试全部通过；CLI 类型检查、两个修改文件的 Prettier 检查以及零警告 ESLint 检查也均通过。

## 风险与范围

- 主要风险或取舍：较长的摘要可能占用额外的终端垂直空间，这是为了保持完整内容可见而有意接受的取舍。
- 未验证或不在范围内：macOS 和 Linux 上的手动端到端 TUI 测试、摘要文案修改，以及 UI 其他位置有意使用的 `truncate-end`。
- 破坏性修改或迁移说明：无。

## 关联 Issue

Fixes #6814

</details>
