### PR TITLE
docs(review): cap PR scope after repeated review rounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,12 +288,12 @@ applicable.
 - **Line wrapping**: do not hard-wrap the PR body at a fixed column width.
   GitHub renders single newlines as `<br>`, so a wrapped description displays
   as a narrow column. Write each paragraph or list item as one long line.
-- **Don't let review rounds balloon the PR.** Every accepted suggestion widens
-  the diff and tends to trigger another round, so a PR can drift far past its
+- **Don't let review rounds balloon the PR.** Every accepted change widens the
+  diff and tends to trigger another round, so a PR can drift far past its
   original intent. Once a PR has been through roughly **5 review rounds**, land
   only Critical fixes — correctness, security, data loss, regressions — and
-  defer remaining Suggestions and nice-to-haves to a follow-up issue or PR.
-  Record each deferral in the PR thread so nothing is silently dropped.
+  defer remaining Suggestions to a follow-up issue or PR. Record each deferral
+  in the PR thread so nothing is silently dropped.
 
 ## Project Directories
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,12 @@ applicable.
 - **Line wrapping**: do not hard-wrap the PR body at a fixed column width.
   GitHub renders single newlines as `<br>`, so a wrapped description displays
   as a narrow column. Write each paragraph or list item as one long line.
+- **Don't let review rounds balloon the PR.** Every accepted suggestion widens
+  the diff and tends to trigger another round, so a PR can drift far past its
+  original intent. Once a PR has been through roughly **5 review rounds**, land
+  only Critical fixes — correctness, security, data loss, regressions — and
+  defer remaining Suggestions and nice-to-haves to a follow-up issue or PR.
+  Record each deferral in the PR thread so nothing is silently dropped.
 
 ## Project Directories
 


### PR DESCRIPTION
## What this PR does

Adds a contributor guideline to the "Submitting PRs" section of the agent guide (AGENTS.md): once a pull request has been through roughly five rounds of review, authors should land only Critical fixes — correctness, security, data loss, and regressions — and defer the remaining Suggestions and nice-to-haves to a follow-up issue or PR. Each deferral is recorded in the PR thread so no reasonable feedback is silently dropped.

## Why it's needed

PRs tend to balloon during review: every accepted suggestion widens the diff and often triggers another round, which surfaces yet more suggestions, and so on. A focused change drifts far past its original intent and takes much longer to land. This is especially pronounced for AI agents, which tend to mechanically accept every comment. Giving a clear stop condition — after a handful of rounds, hold the line at Critical fixes and route the rest to a follow-up — breaks that feedback loop while keeping non-critical feedback from being lost.

## Reviewer Test Plan

### How to verify

Documentation-only change. Read the new bullet under "Submitting PRs" in AGENTS.md and confirm it reads clearly, uses the project's existing severity vocabulary (Critical / Suggestion), and is consistent with the review-triage guidance already in the "General workflow" and "Code Review" sections. The pre-commit prettier/markdown checks pass.

### Evidence (Before & After)

N/A — no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

<!-- Docs-only change with no OS-dependent behavior; macOS verified via pre-commit prettier. -->

### Environment (optional)

N/A — docs only; no runtime.

## Risk & Scope

- Main risk or tradeoff: this is a guideline, not an enforced check, so it relies on author judgment; the "5 rounds" threshold is a heuristic ("roughly") and "a round" is intentionally left loosely defined.
- Not validated / out of scope: no tooling or automation enforces the threshold; this PR only documents the convention.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 agent 指南（AGENTS.md）的 “Submitting PRs” 一节新增一条贡献者约定：当一个 PR 已经过大约五轮 review 后，作者应只合入 Critical 类修复——正确性、安全、数据丢失和回归——并将其余的 Suggestion 和 nice-to-have 延后到后续的 issue 或 PR 处理。每一次延后都在 PR 讨论串中记录，以确保没有合理的反馈被静默丢弃。

## 为什么需要

PR 在 review 过程中往往会不断膨胀：每接受一条 suggestion 都会扩大 diff，并常常触发新一轮 review，从而又带来更多 suggestion，如此循环。一个本应聚焦的改动会逐渐偏离最初意图，合入时间也被大幅拉长。这对 AI agent 尤为明显，因为它们倾向于机械地接受每一条评论。给出一个明确的停止条件——在若干轮之后守住只修 Critical 的底线、其余转入后续处理——既能打破这一正反馈循环，又能避免非关键反馈被遗失。

## Reviewer Test Plan

### 如何验证

纯文档改动。阅读 AGENTS.md “Submitting PRs” 下新增的条目，确认表述清晰、使用了项目既有的严重度词汇（Critical / Suggestion），并与 “General workflow” 和 “Code Review” 两节中已有的 review triage 指引保持一致。pre-commit 的 prettier / markdown 检查通过。

### 证据（前后对比）

N/A —— 无用户可见或 TUI 变更。

### 测试平台

仅在 macOS 上通过 pre-commit 的 prettier 格式化验证；该改动不涉及任何与操作系统相关的行为，Windows / Linux 标记为 N/A。

### 运行环境

N/A —— 纯文档，无运行时。

## 风险与范围

- 主要风险 / 取舍：这是一条指南而非强制检查，依赖作者判断；“5 轮” 阈值是启发式（“roughly”），且 “一轮” 有意不作严格定义。
- 未验证 / 范围之外：没有任何工具或自动化强制该阈值；本 PR 仅记录这一约定。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
