### PR TITLE
feat(web-shell): add workspace path lock

### DIFF
--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -142,22 +142,45 @@ export function App() {
 
 包含 `WebShell` 的所有 Props，加上 Provider 配置：
 
-| 属性        | 类型     | 说明                                                 |
-| ----------- | -------- | ---------------------------------------------------- |
-| `baseUrl`   | `string` | daemon API 地址，未传时使用 `window.location.origin` |
-| `token`     | `string` | daemon API Bearer token                              |
-| `sessionId` | `string` | 要连接的 session id；未传或 `undefined` 时保持空页面 |
+| 属性               | 类型     | 说明                                                                                 |
+| ------------------ | -------- | ------------------------------------------------------------------------------------ |
+| `baseUrl`          | `string` | daemon API 地址，未传时使用 `window.location.origin`                                 |
+| `token`            | `string` | daemon API Bearer token                                                              |
+| `sessionId`        | `string` | 要连接的 session id；未传或 `undefined` 时保持空页面                                 |
+| `workspaceId`      | `string` | 已注册工作区 id，主要用于定位已有 session；不会注册或锁定工作区                      |
+| `workspaceCwd`     | `string` | 已注册工作区路径，语义同 `workspaceId`；不会注册或锁定工作区，且优先于 `workspaceId` |
+| `lockWorkspaceCwd` | `string` | 锁定到指定工作区路径；未注册时自动持久注册，并隐藏其他工作区及添加、移除和选择入口   |
 
 ### WebShell
 
-| 属性                | 类型                                                             | 说明                                                                             |
-| ------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `onSessionIdChange` | `(sessionId: string \| undefined, workspaceId?: string) => void` | 当前 session id 或 workspace id 变化或清空时触发                                 |
-| `onSessionCreated`  | `(sessionId: string) => Promise<void> \| void`                   | 新 session 创建后触发；完成前会阻塞 session 初始化和 prompt 提交，最长等待 30 秒 |
-| `theme`             | `'dark' \| 'light'`                                              | UI 主题，默认 `dark`                                                             |
-| `onThemeChange`     | `(theme: WebShellTheme) => void`                                 | `/theme` 命令切换主题后触发                                                      |
-| `language`          | `'en' \| 'zh-CN' \| 'zh' \| 'zh-cn'`                             | UI 语言                                                                          |
-| `onLanguageChange`  | `(language: WebShellLanguage) => void`                           | `/language ui` 切换 UI 语言后触发                                                |
+| 属性                | 类型                                                                                    | 说明                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `onSessionIdChange` | `(sessionId: string \| undefined, workspaceId?: string, workspaceCwd?: string) => void` | 当前 session 或工作区变化时触发                                                  |
+| `onSessionCreated`  | `(sessionId: string) => Promise<void> \| void`                                          | 新 session 创建后触发；完成前会阻塞 session 初始化和 prompt 提交，最长等待 30 秒 |
+| `theme`             | `'dark' \| 'light'`                                                                     | UI 主题，默认 `dark`                                                             |
+| `onThemeChange`     | `(theme: WebShellTheme) => void`                                                        | `/theme` 命令切换主题后触发                                                      |
+| `language`          | `'en' \| 'zh-CN' \| 'zh' \| 'zh-cn'`                                                    | UI 语言                                                                          |
+| `onLanguageChange`  | `(language: WebShellLanguage) => void`                                                  | `/language ui` 切换 UI 语言后触发                                                |
+
+锁定工作区时，可以自定义 Sidebar 文件夹行的内容：
+
+```tsx
+<WebShellWithProviders
+  lockWorkspaceCwd="/path/to/workspace"
+  sidebar={{
+    lockedWorkspace: {
+      render: (workspace, { expanded }) => (
+        <span>
+          {expanded ? '📂' : '📁'} {workspace.cwd}
+        </span>
+      ),
+    },
+  }}
+/>
+```
+
+自定义内容仍使用内置的展开、收起行为，`expanded` 会随状态更新；文件夹行右侧的内置操作不会渲染。
+未提供 `lockWorkspaceCwd` 时，该 renderer 不会执行。
 
 ## 可选图表 Renderer
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -36,6 +36,8 @@ type ChatEditorTestProps = {
   isPreparing?: boolean;
   dialogOpen?: boolean;
   placeholderText?: string;
+  workspaces?: Array<{ id: string; cwd: string }>;
+  atWorkspaceCwd?: string;
 };
 
 const {
@@ -132,6 +134,8 @@ const {
           sessionId: string | null,
         ) => Promise<void>;
         onCreateViaChat?: () => void;
+        workspaces?: Array<{ id: string; cwd: string }>;
+        lockedWorkspace?: { id: string; cwd: string; primary: boolean };
       } | null,
     },
     sidebarTokens: [] as Array<number | undefined>,
@@ -583,6 +587,8 @@ vi.doMock('./components/dialogs/ScheduledTasksDialog', async () => {
   return {
     ScheduledTasksDialog: (props: {
       onRunPrompt?: (prompt: string, sessionId: string | null) => Promise<void>;
+      workspaces?: Array<{ id: string; cwd: string }>;
+      lockedWorkspace?: { id: string; cwd: string; primary: boolean };
     }) => {
       testState.latestScheduledTasksProps = props;
       return React.createElement('div');
@@ -718,6 +724,7 @@ beforeEach(() => {
     })),
   });
   mockConnection.sessionId = 'session-1';
+  mockConnection.workspaceCwd = '/tmp/project';
   mockConnection.status = 'connected';
   mockConnection.displayName = 'Session One';
   mockConnection.error = undefined;
@@ -725,6 +732,9 @@ beforeEach(() => {
   mockConnection.missingSession = false;
   mockConnection.loadingTranscript = false;
   mockConnection.catchingUp = false;
+  mockWorkspace.capabilities = {
+    workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+  };
   testState.prompt = 'hello';
   testState.inputAnnotations = undefined;
   testState.streamingState = 'idle';
@@ -784,6 +794,82 @@ afterEach(() => {
 });
 
 describe('App session callbacks', () => {
+  it('reports the current workspace id and path', async () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true },
+        { id: 'secondary', cwd: '/work/secondary', primary: false },
+      ],
+    };
+    const onSessionIdChange = vi.fn();
+
+    renderApp({ onSessionIdChange });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      'session-1',
+      'secondary',
+      '/work/secondary',
+    );
+  });
+
+  it('creates new sessions in the locked workspace without a selector', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true },
+        { id: 'secondary', cwd: '/work/secondary', primary: false },
+      ],
+    };
+    renderApp({ lockedWorkspaceCwd: '/work/secondary' });
+    await flush();
+
+    expect(testState.latestChatEditorProps?.workspaces).toBeUndefined();
+    expect(testState.latestChatEditorProps?.atWorkspaceCwd).toBe(
+      '/work/secondary',
+    );
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('locked prompt');
+      await vi.waitFor(() => {
+        expect(mockSessionActions.createSession).toHaveBeenCalled();
+      });
+    });
+    expect(mockSessionActions.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceCwd: '/work/secondary' }),
+    );
+  });
+
+  it('uses a registered capability fallback while the workspace list is stale', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/workspace',
+      workspaces: undefined,
+    };
+    const lockedWorkspaceCapability = {
+      id: 'secondary',
+      cwd: '/work/secondary',
+      primary: false,
+      trusted: true,
+    };
+    testState.prompt = '/schedule';
+    const { container } = renderApp({
+      lockedWorkspaceCwd: '/work/secondary',
+      lockedWorkspaceCapability,
+    });
+    await flush();
+    await clickSubmit(container);
+    await flush();
+
+    expect(testState.latestScheduledTasksProps?.workspaces).toEqual([
+      lockedWorkspaceCapability,
+    ]);
+    expect(testState.latestScheduledTasksProps?.lockedWorkspace).toEqual(
+      lockedWorkspaceCapability,
+    );
+  });
+
   it('uses configured composer placeholders by state and falls back for blank values', async () => {
     const composerPlaceholders = {
       idle: 'Ask a question',

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -34,6 +34,7 @@ import type {
   DaemonTranscriptBlock,
   DaemonSessionTaskStatus,
   DaemonSessionArtifact,
+  DaemonWorkspaceCapability,
 } from '@qwen-code/sdk/daemon';
 import { extractPendingPermission } from './adapters/transcriptAdapter';
 import { MessageList, type MessageListHandle } from './components/MessageList';
@@ -107,6 +108,7 @@ import {
   WebShellSidebar,
   type WebShellSidebarBranding,
   type WebShellSidebarFooterOptions,
+  type WebShellSidebarLockedWorkspace,
 } from './components/sidebar/WebShellSidebar';
 import {
   getLocalCommands,
@@ -419,6 +421,8 @@ export interface WebShellSidebarOptions {
   branding?: false | WebShellSidebarBranding;
   /** Hide the footer completely or select the built-in entries it exposes. */
   footer?: false | WebShellSidebarFooterOptions;
+  /** Customize the workspace row shown when lockWorkspaceCwd is active. */
+  lockedWorkspace?: WebShellSidebarLockedWorkspace;
 }
 
 export type SessionChangeEvent =
@@ -440,10 +444,11 @@ export type WebShellComposerPlaceholders = Readonly<
 >;
 
 export interface WebShellProps {
-  /** Called whenever the attached daemon session id changes. */
+  /** Called whenever the attached daemon session or workspace changes. */
   onSessionIdChange?: (
     sessionId: string | undefined,
     workspaceId?: string,
+    workspaceCwd?: string,
   ) => void;
   /** Called after a new session is created. Session setup waits up to 30 seconds. */
   onSessionCreated?: (sessionId: string) => Promise<void> | void;
@@ -585,6 +590,11 @@ export interface WebShellProps {
   }) => Promise<void>;
 }
 
+interface AppProps extends WebShellProps {
+  lockedWorkspaceCwd?: string;
+  lockedWorkspaceCapability?: DaemonWorkspaceCapability;
+}
+
 type SessionActionsWithCreate = {
   createSession: (options?: {
     workspaceCwd?: string;
@@ -620,6 +630,7 @@ function resolveSidebarOptions(sidebar: WebShellProps['sidebar']): {
   showCompactToggle: boolean;
   branding?: false | WebShellSidebarBranding;
   footer?: false | WebShellSidebarFooterOptions;
+  lockedWorkspace?: WebShellSidebarLockedWorkspace;
 } {
   if (sidebar === true) {
     return { enabled: true, defaultCollapsed: false, showCompactToggle: true };
@@ -633,6 +644,7 @@ function resolveSidebarOptions(sidebar: WebShellProps['sidebar']): {
     showCompactToggle: sidebar.showCompactToggle ?? true,
     branding: sidebar.branding,
     footer: sidebar.footer,
+    lockedWorkspace: sidebar.lockedWorkspace,
   };
 }
 
@@ -1017,7 +1029,9 @@ export function App({
   composerInputVersion,
   onSessionChange,
   onSubmitBefore,
-}: WebShellProps = {}) {
+  lockedWorkspaceCwd,
+  lockedWorkspaceCapability,
+}: AppProps = {}) {
   const [chatWidthMode, setChatWidthMode] =
     useState<ChatWidthMode>(readChatWidthMode);
   const [selectedLanguage, setSelectedLanguage] = useState<WebShellLanguage>(
@@ -1161,9 +1175,24 @@ export function App({
   const blocks = useTranscriptBlocks();
   const connection = useConnection();
   const workspace = useWorkspace();
-  const workspaces = useMemo(
-    () => workspace.capabilities?.workspaces ?? [],
-    [workspace.capabilities?.workspaces],
+  const workspaces = useMemo(() => {
+    const capabilityWorkspaces = workspace.capabilities?.workspaces ?? [];
+    if (
+      lockedWorkspaceCapability &&
+      !capabilityWorkspaces.some(
+        (entry) => entry.cwd === lockedWorkspaceCapability.cwd,
+      )
+    ) {
+      return [...capabilityWorkspaces, lockedWorkspaceCapability];
+    }
+    return capabilityWorkspaces;
+  }, [lockedWorkspaceCapability, workspace.capabilities?.workspaces]);
+  const visibleWorkspaces = useMemo(
+    () =>
+      lockedWorkspaceCwd
+        ? workspaces.filter((entry) => entry.cwd === lockedWorkspaceCwd)
+        : workspaces,
+    [lockedWorkspaceCwd, workspaces],
   );
   const sessionActions = useActions();
   const { notices, dismissNotice } = useSessionNotices();
@@ -1185,7 +1214,8 @@ export function App({
       return;
     }
     const primaryWorkspaceCwd = workspaces.find((entry) => entry.primary)?.cwd;
-    const workspaceCwd = selectedWorkspaceCwd ?? primaryWorkspaceCwd;
+    const workspaceCwd =
+      lockedWorkspaceCwd ?? selectedWorkspaceCwd ?? primaryWorkspaceCwd;
     if (!workspaceCwd) {
       setSelectedWorkspaceGitBranch(undefined);
       return;
@@ -1208,6 +1238,7 @@ export function App({
     };
   }, [
     connection.sessionId,
+    lockedWorkspaceCwd,
     selectedWorkspaceCwd,
     workspaces,
     workspace.client,
@@ -1251,6 +1282,7 @@ export function App({
   const currentSessionIdRef = useRef(connection.sessionId);
   const lastNotifiedSessionIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceIdRef = useRef<string | undefined>(undefined);
+  const lastNotifiedWorkspaceCwdRef = useRef<string | undefined>(undefined);
   const lastGoalSessionIdRef = useRef(connection.sessionId);
   const displayMessages = useMemo(() => {
     const localMessages = [recapMessage].filter(
@@ -2491,7 +2523,10 @@ export function App({
           SessionActionsWithCreate,
         modelId,
         modeId,
-        workspaceCwd: selectedWorkspaceCwdRef.current ?? primaryWorkspaceCwd,
+        workspaceCwd:
+          lockedWorkspaceCwd ??
+          selectedWorkspaceCwdRef.current ??
+          primaryWorkspaceCwd,
         onSessionCreated: onSessionCreatedRef.current,
         onSessionAllocated: (sessionId) => {
           preparingSessionIdRef.current = sessionId;
@@ -2512,7 +2547,7 @@ export function App({
     };
     void promise.then(clearPreparation, clearPreparation);
     return promise;
-  }, [sessionActions, workspaces]);
+  }, [lockedWorkspaceCwd, sessionActions, workspaces]);
   const onSubmitBeforeRef = useRef(onSubmitBefore);
   onSubmitBeforeRef.current = onSubmitBefore;
   const [sessionListReloadToken, setSessionListReloadToken] = useState(0);
@@ -3330,6 +3365,7 @@ export function App({
       // new chat; clearing it here would immediately hide the recovery state.
       lastNotifiedSessionIdRef.current = connection.sessionId;
       lastNotifiedWorkspaceIdRef.current = undefined;
+      lastNotifiedWorkspaceCwdRef.current = undefined;
       return;
     }
     const activeWorkspace = workspaces.find(
@@ -3342,13 +3378,19 @@ export function App({
         : undefined;
     if (
       lastNotifiedSessionIdRef.current === connection.sessionId &&
-      lastNotifiedWorkspaceIdRef.current === workspaceId
+      lastNotifiedWorkspaceIdRef.current === workspaceId &&
+      lastNotifiedWorkspaceCwdRef.current === connection.workspaceCwd
     ) {
       return;
     }
     lastNotifiedSessionIdRef.current = connection.sessionId;
     lastNotifiedWorkspaceIdRef.current = workspaceId;
-    onSessionIdChange?.(connection.sessionId, workspaceId);
+    lastNotifiedWorkspaceCwdRef.current = connection.workspaceCwd;
+    onSessionIdChange?.(
+      connection.sessionId,
+      workspaceId,
+      connection.workspaceCwd,
+    );
   }, [
     connection.missingSession,
     connection.sessionId,
@@ -3545,8 +3587,9 @@ export function App({
 
   const createNewSession = useCallback(
     async (workspaceCwd?: string) => {
-      selectedWorkspaceCwdRef.current = workspaceCwd;
-      setSelectedWorkspaceCwd(workspaceCwd);
+      const targetWorkspaceCwd = lockedWorkspaceCwd ?? workspaceCwd;
+      selectedWorkspaceCwdRef.current = targetWorkspaceCwd;
+      setSelectedWorkspaceCwd(targetWorkspaceCwd);
       // Close the drawer before awaiting so a failed createSession() doesn't leave
       // it stuck open with the page scroll still locked, matching loadSidebarSession.
       closeMobileDrawer();
@@ -3563,7 +3606,13 @@ export function App({
         return false;
       }
     },
-    [closeMobileDrawer, closePanel, reportError, sessionActions],
+    [
+      closeMobileDrawer,
+      closePanel,
+      lockedWorkspaceCwd,
+      reportError,
+      sessionActions,
+    ],
   );
   const handleMissingSessionNewSession = useCallback(async () => {
     if (creatingMissingSessionRef.current) return;
@@ -5570,6 +5619,7 @@ export function App({
               onClose={() => setShowResumeDialog(false)}
             >
               <ResumeDialog
+                workspaceCwd={lockedWorkspaceCwd}
                 onSelect={(sessionId) => {
                   closeMobileDrawer();
                   closePanel();
@@ -5767,6 +5817,7 @@ export function App({
               onClose={() => setShowDeleteDialog(false)}
             >
               <DeleteSessionDialog
+                workspaceCwd={lockedWorkspaceCwd}
                 onDeleted={(sessionIds) => {
                   store.dispatch([
                     {
@@ -5797,6 +5848,7 @@ export function App({
               onClose={() => setShowReleaseDialog(false)}
             >
               <ReleaseSessionDialog
+                workspaceCwd={lockedWorkspaceCwd}
                 onReleased={(sessionId) => {
                   store.dispatch([
                     {
@@ -5903,6 +5955,9 @@ export function App({
                   sessionListReloadToken={sessionListReloadToken}
                   selectedWorkspaceCwd={selectedWorkspaceCwd}
                   onSelectWorkspace={setSelectedWorkspaceCwd}
+                  workspaces={workspaces}
+                  lockedWorkspaceCwd={lockedWorkspaceCwd}
+                  lockedWorkspace={sidebarOptions.lockedWorkspace}
                   branding={sidebarOptions.branding}
                   footer={sidebarOptions.footer}
                 />
@@ -6071,6 +6126,8 @@ export function App({
                       <SessionOverviewPanel
                         onOpenSession={handleOpenSessionFromOverview}
                         onOpenSplit={openSplitView}
+                        includeOtherWorkspaces={!lockedWorkspaceCwd}
+                        workspaceCwd={lockedWorkspaceCwd}
                       />
                     )}
                   </div>
@@ -6113,7 +6170,12 @@ export function App({
                       // Registered workspaces (multi-workspace daemons only) so
                       // the page aggregates every project's schedule and the New
                       // form can target one; absent/single → primary-only view.
-                      workspaces={connection.capabilities?.workspaces}
+                      workspaces={
+                        lockedWorkspaceCwd
+                          ? visibleWorkspaces
+                          : workspaces
+                      }
+                      lockedWorkspace={lockedWorkspaceCapability}
                       onCreateViaChat={() => {
                         // Start a FRESH session and jump to it so the task-
                         // creation chat doesn't pile onto the current
@@ -6187,6 +6249,8 @@ export function App({
                         // Refresh the "add pane" picker when the session list
                         // changes elsewhere, matching the sidebar.
                         sessionListReloadToken={sessionListReloadToken}
+                        includeOtherWorkspaces={!lockedWorkspaceCwd}
+                        workspaceCwd={lockedWorkspaceCwd}
                         // Back returns to the Session Overview (the hub the split
                         // is launched from), not the single-session chat.
                         onExit={handleSplitExit}
@@ -6505,7 +6569,7 @@ export function App({
                           onSelectMode={handleSetMode}
                           onSelectModel={handleModelSelect}
                           workspaces={
-                            workspaces.length > 1
+                            !lockedWorkspaceCwd && workspaces.length > 1
                               ? workspaces.map((entry) => ({
                                     id: entry.id,
                                     cwd: entry.cwd,
@@ -6532,10 +6596,11 @@ export function App({
                             connection.sessionId,
                           )}
                           atWorkspaceCwd={
-                            connection.sessionId
+                            lockedWorkspaceCwd ??
+                            (connection.sessionId
                               ? connection.workspaceCwd
                               : (selectedWorkspaceCwd ??
-                                workspaces.find((entry) => entry.primary)?.cwd)
+                                workspaces.find((entry) => entry.primary)?.cwd))
                           }
                           onSelectWorkspace={(cwd) => {
                             selectedWorkspaceCwdRef.current = cwd;

--- a/packages/web-shell/client/components/SessionOverviewPanel.tsx
+++ b/packages/web-shell/client/components/SessionOverviewPanel.tsx
@@ -7,7 +7,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useConnection,
-  useSessions,
   useStatusReport,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type {
@@ -25,6 +24,7 @@ import {
   workspaceBasename,
 } from '../utils/workspace';
 import { useOtherWorkspaceSessions } from '../hooks/useOtherWorkspaceSessions';
+import { useScopedSessions } from '../hooks/useScopedSessions';
 import { getDaemonToken } from '../config/daemon';
 import {
   SESSION_LIST_PAGE_SIZE,
@@ -154,9 +154,13 @@ function statusClass(status: SessionCardStatus): string {
 function SessionOverviewPanelInner({
   onOpenSession,
   onOpenSplit,
+  includeOtherWorkspaces,
+  workspaceCwd,
 }: {
   onOpenSession: (sessionId: string) => void;
   onOpenSplit?: (sessionIds: string[]) => void;
+  includeOtherWorkspaces: boolean;
+  workspaceCwd?: string;
 }) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -165,7 +169,7 @@ function SessionOverviewPanelInner({
     connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE) ??
     false;
 
-  const { sessions, loading, error, reload } = useSessions({
+  const { sessions, loading, error, reload } = useScopedSessions(workspaceCwd, {
     autoLoad: true,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
@@ -177,12 +181,15 @@ function SessionOverviewPanelInner({
   // single-workspace daemon), so the overview is mission control for every
   // workspace, not just the primary one.
   const { sessions: otherSessions, reload: reloadOther } =
-    useOtherWorkspaceSessions();
+    useOtherWorkspaceSessions(includeOtherWorkspaces && !workspaceCwd);
   const mergedSessions = useMemo(
     () => mergeSessionsById(sessions, otherSessions),
     [sessions, otherSessions],
   );
-  const multiWorkspace = hasMultipleWorkspaces(connection.capabilities);
+  const multiWorkspace =
+    !workspaceCwd &&
+    includeOtherWorkspaces &&
+    hasMultipleWorkspaces(connection.capabilities);
   const status = useStatusReport({ autoLoad: true, detail: 'full' });
   const statusReload = status.reload;
   const statusReport = status.report;
@@ -473,9 +480,13 @@ function SessionOverviewPanelInner({
 export function SessionOverviewPanel({
   onOpenSession,
   onOpenSplit,
+  includeOtherWorkspaces = true,
+  workspaceCwd,
 }: {
   onOpenSession: (sessionId: string) => void;
   onOpenSplit?: (sessionIds: string[]) => void;
+  includeOtherWorkspaces?: boolean;
+  workspaceCwd?: string;
 }) {
   const { t } = useI18n();
   return (
@@ -492,6 +503,8 @@ export function SessionOverviewPanel({
       <SessionOverviewPanelInner
         onOpenSession={onOpenSession}
         onOpenSplit={onOpenSplit}
+        includeOtherWorkspaces={includeOtherWorkspaces}
+        workspaceCwd={workspaceCwd}
       />
     </ErrorBoundary>
   );

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -21,7 +21,10 @@ let sessionsState: any[];
 let otherWorkspaceSessions: Record<string, any[]>;
 // Stable client object (assigned once per test) so the other-workspace hook's
 // load callback keeps a stable identity and its effect doesn't loop.
-let workspaceClient: { listWorkspaceSessions: ReturnType<typeof vi.fn> };
+let workspaceClient: {
+  listWorkspaceSessions: ReturnType<typeof vi.fn>;
+  workspaceByCwd: ReturnType<typeof vi.fn>;
+};
 // Stable across renders (assigned once per test) so SplitView's reload effects,
 // which depend on `reload`'s identity, don't re-fire on every render.
 let reloadMock: ReturnType<typeof vi.fn>;
@@ -97,6 +100,11 @@ beforeEach(() => {
     listWorkspaceSessions: vi.fn(
       async (cwd: string) => otherWorkspaceSessions[cwd] ?? [],
     ),
+    workspaceByCwd: vi.fn((cwd: string) => ({
+      listWorkspaceSessions: vi.fn(
+        async () => otherWorkspaceSessions[cwd] ?? [],
+      ),
+    })),
   };
   reloadMock = vi.fn();
 });
@@ -501,6 +509,31 @@ describe('SplitView', () => {
         ?.querySelector('[data-testid="chat-pane"]')
         ?.getAttribute('data-pane-workspace'),
     ).toBe('/wsB');
+  });
+
+  it('loads and attaches only the locked secondary workspace', async () => {
+    connectionState.capabilities = MULTI_WORKSPACE_CAPS;
+    otherWorkspaceSessions['/wsB'] = [
+      { sessionId: 'b1', workspaceCwd: '/wsB', displayName: 'Beta' },
+    ];
+
+    render({
+      sessionIds: ['b1'],
+      includeOtherWorkspaces: false,
+      workspaceCwd: '/wsB',
+    });
+    await flushAsync();
+
+    expect(titles()).toEqual(['Beta']);
+    expect(
+      container!
+        .querySelector('[data-session="b1"]')
+        ?.getAttribute('data-workspace'),
+    ).toBe('/wsB');
+    openPicker();
+    expect(pickerOptions().some((option) => option.includes('One'))).toBe(
+      false,
+    );
   });
 
   it('remounts a deep-linked pane under its workspace once the session list resolves', async () => {

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   DaemonSessionProvider,
   useConnection,
-  useSessions,
   type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
@@ -25,6 +24,7 @@ import {
   SESSION_ORGANIZATION_FEATURE,
 } from '../constants/sessions';
 import { useOtherWorkspaceSessions } from '../hooks/useOtherWorkspaceSessions';
+import { useScopedSessions } from '../hooks/useScopedSessions';
 import {
   hasMultipleWorkspaces,
   isNonPrimaryWorkspaceSession,
@@ -62,6 +62,9 @@ export interface SplitViewProps {
    * offers a session that has since been removed or misses one just created.
    */
   sessionListReloadToken?: number;
+  includeOtherWorkspaces?: boolean;
+  /** Limit session discovery and pane attachment to this workspace. */
+  workspaceCwd?: string;
 }
 
 /**
@@ -80,6 +83,8 @@ export function SplitView({
   onPaneArtifactsChange,
   messageTurnOutputs,
   sessionListReloadToken,
+  includeOtherWorkspaces = true,
+  workspaceCwd,
 }: SplitViewProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -87,7 +92,7 @@ export function SplitView({
   const organizationEnabled =
     connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE) ??
     false;
-  const { sessions, reload } = useSessions({
+  const { sessions, reload } = useScopedSessions(workspaceCwd, {
     autoLoad: true,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
@@ -99,12 +104,16 @@ export function SplitView({
   // and a pane can attach to — sessions that aren't in the primary workspace.
   // Empty (a no-op) on a single-workspace daemon.
   const { sessions: otherSessions, reload: reloadOther } =
-    useOtherWorkspaceSessions();
+    useOtherWorkspaceSessions(includeOtherWorkspaces && !workspaceCwd);
   const allSessions = useMemo(
     () => mergeSessionsById(sessions, otherSessions),
     [sessions, otherSessions],
   );
-  const multiWorkspace = hasMultipleWorkspaces(connection.capabilities);
+  const multiWorkspace =
+    !workspaceCwd &&
+    includeOtherWorkspaces &&
+    hasMultipleWorkspaces(connection.capabilities);
+  const scopePanesByWorkspace = Boolean(workspaceCwd) || multiWorkspace;
   // The primary workspace cwd, for labeling picker items the same way the
   // Session Overview labels its cards (primary → the localized tag, others →
   // the workspace basename).
@@ -165,9 +174,8 @@ export function SplitView({
     };
   }, [pickerOpen]);
 
-  // Refresh the list the moment the picker opens — `useSessions` only fetches on
-  // mount, so without this the picker would offer whatever was current when the
-  // split was first entered, missing sessions created since.
+  // Refresh the list the moment the picker opens so it includes sessions
+  // created since the split was first entered.
   useEffect(() => {
     if (pickerOpen) {
       void reload();
@@ -374,7 +382,7 @@ export function SplitView({
                 // a `?split=` deep link) remounts under the right workspace rather
                 // than staying attached with the primary cwd.
                 key={
-                  multiWorkspace
+                  scopePanesByWorkspace
                     ? `${sessionId}:${paneWorkspaceCwd ?? ''}`
                     : sessionId
                 }
@@ -410,7 +418,11 @@ export function SplitView({
                     // to the primary cwd once the list resolves, needlessly
                     // re-attaching it. Undefined falls back to the provider's
                     // primary cwd, i.e. today's behavior.
-                    workspaceCwd={multiWorkspace ? paneWorkspaceCwd : undefined}
+                    workspaceCwd={
+                      scopePanesByWorkspace
+                        ? (paneWorkspaceCwd ?? workspaceCwd)
+                        : undefined
+                    }
                     // Distinct from the main view's client (and from any other
                     // tab's panes) for the same session, so the attachments don't
                     // collide on one client identity.

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { WifiOffIcon } from 'lucide-react';
 import {
   DaemonSessionProvider,
   useWorkspace,
+  useWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
+import type { DaemonWorkspaceCapability } from '@qwen-code/sdk/daemon';
 import { App, type WebShellProps } from '../App';
 import { getTranslator, normalizeLanguage } from '../i18n';
 import { Spinner } from './ui/spinner';
@@ -12,6 +14,8 @@ import { WorkspaceUnavailableState } from './WorkspaceUnavailableState';
 interface WorkspaceSessionProviderProps {
   sessionId?: string;
   workspaceId?: string;
+  workspaceCwd?: string;
+  lockWorkspaceCwd?: string;
   clientId?: string;
   webShellProps: WebShellProps;
 }
@@ -19,23 +23,128 @@ interface WorkspaceSessionProviderProps {
 export function WorkspaceSessionProvider({
   sessionId,
   workspaceId,
+  workspaceCwd,
+  lockWorkspaceCwd,
   clientId,
   webShellProps,
 }: WorkspaceSessionProviderProps) {
   const workspace = useWorkspace();
+  const workspaceActions = useWorkspaceActions();
   const [usePrimaryNewSession, setUsePrimaryNewSession] = useState(false);
-  useEffect(() => setUsePrimaryNewSession(false), [sessionId, workspaceId]);
-  const effectiveSessionId = usePrimaryNewSession ? undefined : sessionId;
-  const effectiveWorkspaceId = usePrimaryNewSession ? undefined : workspaceId;
-  const targetWorkspace = workspace.capabilities?.workspaces?.find(
-    (entry) => entry.id === effectiveWorkspaceId,
+  const [registeredWorkspace, setRegisteredWorkspace] = useState<{
+    requestedCwd: string;
+    workspace: DaemonWorkspaceCapability;
+  }>();
+  const [registrationErrorCwd, setRegistrationErrorCwd] = useState<string>();
+  const registrationRef = useRef<
+    | {
+        cwd: string;
+        promise: Promise<DaemonWorkspaceCapability>;
+      }
+    | undefined
+  >(undefined);
+  useEffect(
+    () => setUsePrimaryNewSession(false),
+    [sessionId, lockWorkspaceCwd, workspaceCwd, workspaceId],
   );
+  const effectiveSessionId = usePrimaryNewSession ? undefined : sessionId;
+  const effectiveWorkspaceCwd = usePrimaryNewSession
+    ? undefined
+    : (lockWorkspaceCwd ?? workspaceCwd);
+  const effectiveWorkspaceId = effectiveWorkspaceCwd ? undefined : workspaceId;
+  const pathWorkspace = useMemo(() => {
+    const listedWorkspace = workspace.capabilities?.workspaces?.find(
+      (entry) => entry.cwd === effectiveWorkspaceCwd,
+    );
+    if (listedWorkspace) return listedWorkspace;
+    if (
+      effectiveWorkspaceCwd &&
+      effectiveWorkspaceCwd === workspace.capabilities?.workspaceCwd
+    ) {
+      return {
+        id: 'primary',
+        cwd: effectiveWorkspaceCwd,
+        primary: true,
+        trusted: true,
+      };
+    }
+    return undefined;
+  }, [
+    effectiveWorkspaceCwd,
+    workspace.capabilities?.workspaceCwd,
+    workspace.capabilities?.workspaces,
+  ]);
+  const registeredLockedWorkspace =
+    lockWorkspaceCwd && registeredWorkspace?.requestedCwd === lockWorkspaceCwd
+      ? registeredWorkspace.workspace
+      : undefined;
+  const targetWorkspace = effectiveWorkspaceCwd
+    ? (pathWorkspace ?? registeredLockedWorkspace)
+    : workspace.capabilities?.workspaces?.find(
+        (entry) => entry.id === effectiveWorkspaceId,
+      );
   const t = useMemo(
     () => getTranslator(normalizeLanguage(webShellProps.language)),
     [webShellProps.language],
   );
 
-  if (effectiveWorkspaceId && workspace.status === 'error') {
+  useEffect(() => {
+    if (!lockWorkspaceCwd || !workspace.capabilities || pathWorkspace) return;
+    if (registeredWorkspace?.requestedCwd === lockWorkspaceCwd) return;
+    if (registrationErrorCwd === lockWorkspaceCwd) return;
+
+    if (registrationRef.current?.cwd !== lockWorkspaceCwd) {
+      registrationRef.current = {
+        cwd: lockWorkspaceCwd,
+        promise: workspaceActions
+          .addWorkspace(lockWorkspaceCwd, { persist: true })
+          .then((result) => {
+            if (result.persisted !== true) {
+              throw new Error('Workspace registration was not persisted');
+            }
+            return result;
+          }),
+      };
+    }
+
+    let cancelled = false;
+    void registrationRef.current.promise
+      .then(async (result) => {
+        if (cancelled) return;
+        setRegisteredWorkspace({
+          requestedCwd: lockWorkspaceCwd,
+          workspace: result,
+        });
+        setRegistrationErrorCwd(undefined);
+        try {
+          await workspace.refreshCapabilities?.();
+        } catch {
+          // Registration succeeded; a later capabilities refresh can reconcile.
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRegistrationErrorCwd(lockWorkspaceCwd);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    pathWorkspace,
+    registeredWorkspace,
+    registrationErrorCwd,
+    workspace,
+    workspace.capabilities,
+    workspace.refreshCapabilities,
+    workspaceActions,
+    lockWorkspaceCwd,
+  ]);
+
+  if (
+    (effectiveWorkspaceCwd || effectiveWorkspaceId) &&
+    workspace.status === 'error'
+  ) {
     return (
       <WorkspaceUnavailableState
         title={t('workspace.loadFailed')}
@@ -49,7 +158,10 @@ export function WorkspaceSessionProvider({
       />
     );
   }
-  if (effectiveWorkspaceId && !workspace.capabilities) {
+  if (
+    (effectiveWorkspaceCwd || effectiveWorkspaceId) &&
+    !workspace.capabilities
+  ) {
     return (
       <div
         data-web-shell-root
@@ -63,7 +175,36 @@ export function WorkspaceSessionProvider({
       </div>
     );
   }
-  if (effectiveWorkspaceId && !targetWorkspace) {
+  if (lockWorkspaceCwd && registrationErrorCwd === lockWorkspaceCwd) {
+    return (
+      <WorkspaceUnavailableState
+        title={t('workspace.loadFailed')}
+        description={t('workspace.loadFailedDescription')}
+        actionLabel={t('common.retry')}
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+        onAction={() => {
+          registrationRef.current = undefined;
+          setRegistrationErrorCwd(undefined);
+        }}
+      />
+    );
+  }
+  if (lockWorkspaceCwd && !targetWorkspace) {
+    return (
+      <div
+        data-web-shell-root
+        data-web-shell-shadcn
+        className={`flex min-h-32 w-full items-center justify-center gap-2 text-sm text-muted-foreground ${webShellProps.theme === 'dark' ? 'dark' : ''}`}
+        role="status"
+        aria-live="polite"
+      >
+        <Spinner />
+        <span>{t('common.loading')}</span>
+      </div>
+    );
+  }
+  if ((effectiveWorkspaceCwd || effectiveWorkspaceId) && !targetWorkspace) {
     return (
       <WorkspaceUnavailableState
         title={t('workspace.notFound')}
@@ -80,13 +221,19 @@ export function WorkspaceSessionProvider({
 
   return (
     <DaemonSessionProvider
-      key={`${effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`}
+      key={`${targetWorkspace?.id ?? effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`}
       sessionId={effectiveSessionId}
       workspaceCwd={targetWorkspace?.cwd}
       clientId={clientId}
       suppressOwnUserEcho
     >
-      <App {...webShellProps} />
+      <App
+        {...webShellProps}
+        lockedWorkspaceCwd={lockWorkspaceCwd ? targetWorkspace?.cwd : undefined}
+        lockedWorkspaceCapability={
+          lockWorkspaceCwd ? targetWorkspace : undefined
+        }
+      />
     </DaemonSessionProvider>
   );
 }

--- a/packages/web-shell/client/components/dialogs/DeleteSessionDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/DeleteSessionDialog.test.tsx
@@ -38,6 +38,7 @@ const initialSessions = sessions.slice();
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useConnection: () => ({ sessionId: 'me' }),
+  useWorkspace: () => ({ client: {} }),
   useSessions: () => ({
     sessions,
     loading: false,

--- a/packages/web-shell/client/components/dialogs/DeleteSessionDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/DeleteSessionDialog.tsx
@@ -1,15 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { dp } from './dialogStyles';
-import { useConnection, useSessions } from '@qwen-code/webui/daemon-react-sdk';
+import { useConnection } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
 import { useListboxKeyboard } from '../../hooks/useListboxKeyboard';
 import { useFilterInput } from '../../hooks/useFilterInput';
 import { SessionRow } from './SessionRow';
+import { useScopedSessions } from '../../hooks/useScopedSessions';
 
 interface DeleteSessionDialogProps {
   onDeleted: (sessionIds: string[]) => void;
   onError: (error: unknown) => void;
   onClose: () => void;
+  workspaceCwd?: string;
 }
 
 const LIST_ID = 'delete-session-list';
@@ -19,6 +21,7 @@ export function DeleteSessionDialog({
   onDeleted,
   onError,
   onClose,
+  workspaceCwd,
 }: DeleteSessionDialogProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -28,7 +31,7 @@ export function DeleteSessionDialog({
     error: sessionsError,
     deleteSession,
     deleteSessions,
-  } = useSessions({ autoLoad: true });
+  } = useScopedSessions(workspaceCwd, { autoLoad: true });
   const currentSessionId = connection.sessionId;
   const [deleting, setDeleting] = useState(false);
   // `selectedIdx` is the keyboard/hover cursor (roving highlight, -1 = none —

--- a/packages/web-shell/client/components/dialogs/ReleaseSessionDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ReleaseSessionDialog.test.tsx
@@ -41,6 +41,7 @@ const sessions = [
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useConnection: () => ({ sessionId: 'me' }),
+  useWorkspace: () => ({ client: {} }),
   useSessions: () => ({
     sessions,
     loading: false,

--- a/packages/web-shell/client/components/dialogs/ReleaseSessionDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ReleaseSessionDialog.tsx
@@ -2,18 +2,19 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { dp } from './dialogStyles';
 import {
   useConnection,
-  useSessions,
   type DaemonSessionSummary,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
 import { useListboxKeyboard } from '../../hooks/useListboxKeyboard';
 import { useFilterInput } from '../../hooks/useFilterInput';
 import { SessionRow } from './SessionRow';
+import { useScopedSessions } from '../../hooks/useScopedSessions';
 
 interface ReleaseSessionDialogProps {
   onReleased: (sessionId: string) => void;
   onError: (error: unknown) => void;
   onClose: () => void;
+  workspaceCwd?: string;
 }
 
 const LIST_ID = 'release-session-list';
@@ -23,6 +24,7 @@ export function ReleaseSessionDialog({
   onReleased,
   onError,
   onClose,
+  workspaceCwd,
 }: ReleaseSessionDialogProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -31,7 +33,7 @@ export function ReleaseSessionDialog({
     loading,
     error: sessionsError,
     releaseSession,
-  } = useSessions({ autoLoad: true });
+  } = useScopedSessions(workspaceCwd, { autoLoad: true });
   const currentSessionId = connection.sessionId;
   const [deleting, setDeleting] = useState(false);
   // -1 = no highlight; see ResumeDialog for the rationale.

--- a/packages/web-shell/client/components/dialogs/ResumeDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ResumeDialog.test.tsx
@@ -34,6 +34,7 @@ const sessions = [
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useConnection: () => ({ sessionId: 'me' }),
+  useWorkspace: () => ({ client: {} }),
   useSessions: () => ({
     sessions,
     loading: false,

--- a/packages/web-shell/client/components/dialogs/ResumeDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ResumeDialog.tsx
@@ -1,23 +1,31 @@
 import { useState, useEffect, useRef } from 'react';
 import { dp } from './dialogStyles';
-import { useConnection, useSessions } from '@qwen-code/webui/daemon-react-sdk';
+import { useConnection } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
 import { useListboxKeyboard } from '../../hooks/useListboxKeyboard';
 import { useFilterInput } from '../../hooks/useFilterInput';
 import { SessionRow } from './SessionRow';
+import { useScopedSessions } from '../../hooks/useScopedSessions';
 
 interface ResumeDialogProps {
   onSelect: (sessionId: string) => void;
   onClose: () => void;
+  workspaceCwd?: string;
 }
 
 const LIST_ID = 'resume-session-list';
 const optionId = (index: number) => `${LIST_ID}-opt-${index}`;
 
-export function ResumeDialog({ onSelect, onClose }: ResumeDialogProps) {
+export function ResumeDialog({
+  onSelect,
+  onClose,
+  workspaceCwd,
+}: ResumeDialogProps) {
   const { t } = useI18n();
   const connection = useConnection();
-  const { sessions, loading, error } = useSessions({ autoLoad: true });
+  const { sessions, loading, error } = useScopedSessions(workspaceCwd, {
+    autoLoad: true,
+  });
   const currentSessionId = connection.sessionId;
   // -1 = no highlight. The dialog opens with nothing highlighted and resets to
   // none on filter edits, so Enter in the search box cannot confirm a row the

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
@@ -892,6 +892,7 @@ describe('ScheduledTasksDialog multi-workspace', () => {
   async function mountMulti(
     byWorkspace: Record<string, MockTask[]>,
     ws: typeof WORKSPACES = WORKSPACES,
+    lockedWorkspace?: (typeof WORKSPACES)[number],
   ) {
     actions.listScheduledTasks.mockImplementation(async (wsId?: string) =>
       wsId === undefined
@@ -914,6 +915,7 @@ describe('ScheduledTasksDialog multi-workspace', () => {
             onRunPrompt={vi.fn()}
             onCreateViaChat={vi.fn()}
             workspaces={ws}
+            lockedWorkspace={lockedWorkspace}
             onError={vi.fn()}
           />
         </I18nProvider>,
@@ -979,6 +981,38 @@ describe('ScheduledTasksDialog multi-workspace', () => {
 
     expect(actions.createScheduledTask).toHaveBeenCalledWith(
       expect.objectContaining({ prompt: 'do secondary work' }),
+      'id-other',
+    );
+  });
+
+  it('lists and creates tasks in a locked secondary workspace', async () => {
+    const secondary = WORKSPACES[1]!;
+    await mountMulti(
+      {
+        primary: [baseTask({ id: 'p1', name: 'Primary task' })],
+        'id-other': [baseTask({ id: 's1', name: 'Secondary task' })],
+      },
+      [secondary],
+      secondary,
+    );
+
+    expect(actions.listScheduledTasks).toHaveBeenCalledWith('id-other');
+    expect(actions.listScheduledTasks).not.toHaveBeenCalledWith(undefined);
+    expect(document.body.textContent).toContain('Secondary task');
+    expect(document.body.textContent).not.toContain('Primary task');
+
+    click(findButton('New scheduled task'));
+    expect(findWorkspaceSelect()).toBeUndefined();
+    const prompt = document.querySelector<HTMLElement>('[role="textbox"]')!;
+    act(() => {
+      prompt.textContent = 'do locked work';
+      prompt.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    });
+    click(findButton('Create'));
+    await flush();
+
+    expect(actions.createScheduledTask).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'do locked work' }),
       'id-other',
     );
   });

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -86,6 +86,8 @@ interface ScheduledTasksDialogProps {
    * tasks (each card tagged with its workspace) and the New-task form offers a
    * workspace picker. Absent or a single entry → the plain primary-only view. */
   workspaces?: DaemonWorkspaceCapability[];
+  /** Forces all task operations through this workspace's route. */
+  lockedWorkspace?: DaemonWorkspaceCapability;
   onError: (error: unknown, fallback: string) => void;
 }
 
@@ -457,6 +459,7 @@ export function ScheduledTasksDialog({
   onCreateViaChat,
   onOpenSession,
   workspaces,
+  lockedWorkspace,
   onError,
 }: ScheduledTasksDialogProps) {
   const { t } = useI18n();
@@ -469,7 +472,7 @@ export function ScheduledTasksDialog({
   // derived arrays are stable identities — `reload` depends on them, and a fresh
   // array each render would re-fire its mount effect in a loop.
   const workspaceList = useMemo(() => workspaces ?? [], [workspaces]);
-  const isMultiWorkspace = workspaceList.length > 1;
+  const isMultiWorkspace = !lockedWorkspace && workspaceList.length > 1;
   // The workspaces the page can actually read + write: every trusted one, PLUS
   // the primary even when it is untrusted. The primary is reached through the
   // trust-free unqualified route (the same one the single-workspace page always
@@ -488,6 +491,9 @@ export function ScheduledTasksDialog({
       ws.primary ? undefined : ws.id,
     [],
   );
+  const lockedWorkspaceId = lockedWorkspace
+    ? workspaceActionId(lockedWorkspace)
+    : undefined;
 
   const [tasks, setTasks] = useState<DaemonScheduledTask[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -505,7 +511,7 @@ export function ScheduledTasksDialog({
   // = primary); on edit it's pinned to the task's own workspace (a task can't
   // move files, so the picker is read-only). Passed to create/update actions.
   const [formWorkspaceId, setFormWorkspaceId] = useState<string | undefined>(
-    undefined,
+    lockedWorkspaceId,
   );
   const [name, setName] = useState('');
   const [prompt, setPrompt] = useState('');
@@ -555,7 +561,15 @@ export function ScheduledTasksDialog({
     try {
       let list: DaemonScheduledTask[];
       let firstError: string | null = null;
-      if (isMultiWorkspace) {
+      if (lockedWorkspace) {
+        list = (await actions.listScheduledTasks(lockedWorkspaceId)).map(
+          (task) => ({
+            ...task,
+            workspaceId: lockedWorkspaceId,
+            workspaceCwd: lockedWorkspace.cwd,
+          }),
+        );
+      } else if (isMultiWorkspace) {
         // Fan out over every OPERABLE workspace (trusted secondaries + the
         // primary, which is always reachable via its trust-free route) and tag
         // each task with its workspace so the cards can badge it and the
@@ -595,7 +609,14 @@ export function ScheduledTasksDialog({
       setLoadError(err instanceof Error ? err.message : String(err));
       setTasks((prev) => prev ?? []);
     }
-  }, [actions, isMultiWorkspace, operableWorkspaces, workspaceActionId]);
+  }, [
+    actions,
+    isMultiWorkspace,
+    lockedWorkspace,
+    lockedWorkspaceId,
+    operableWorkspaces,
+    workspaceActionId,
+  ]);
 
   useEffect(() => {
     void reload();
@@ -801,22 +822,22 @@ export function ScheduledTasksDialog({
     setFormError(null);
     setShowForm(false);
     setEditingId(null);
-    setFormWorkspaceId(undefined);
+    setFormWorkspaceId(lockedWorkspaceId);
     resetReferenceState();
-  }, [resetReferenceState]);
+  }, [lockedWorkspaceId, resetReferenceState]);
 
   const openCreate = useCallback(() => {
     setEditingId(null);
-    // Default a new task to the primary workspace (undefined). The picker can
-    // move it to a trusted secondary before submit.
-    setFormWorkspaceId(undefined);
+    // Default to the locked workspace, or primary when the page is unlocked.
+    // In the latter case the picker can move it to a trusted secondary.
+    setFormWorkspaceId(lockedWorkspaceId);
     setName('');
     setPrompt('');
     setBuilder(DEFAULT_BUILDER);
     setFormError(null);
     resetReferenceState();
     setShowForm(true);
-  }, [resetReferenceState]);
+  }, [lockedWorkspaceId, resetReferenceState]);
 
   const openEdit = useCallback(
     (task: DaemonScheduledTask) => {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -642,18 +642,6 @@
   cursor: pointer;
 }
 
-.groupedSessionRow {
-  min-height: 42px;
-  margin-left: 12px;
-  padding: 8px;
-  color: var(--muted-foreground);
-}
-
-.groupedSessionRow:not(.currentSession):hover,
-.groupedSessionRow:not(.currentSession):focus-visible {
-  color: var(--sidebar-accent-foreground);
-}
-
 .currentSession {
   background: var(--sidebar-accent);
   color: var(--sidebar-accent-foreground);

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -122,6 +122,14 @@ export interface WebShellSidebarBranding {
   hideWhenCompact?: boolean;
 }
 
+export interface WebShellSidebarLockedWorkspace {
+  /** Replace the locked workspace row content while preserving its built-in behavior. */
+  render?: (
+    workspace: DaemonWorkspaceCapability,
+    state: { expanded: boolean },
+  ) => ReactNode;
+}
+
 export interface WebShellSidebarFooterOptions {
   /** Built-in footer entries to expose. Entries use the canonical footer order. */
   items?: readonly WebShellSidebarFooterItem[];
@@ -212,6 +220,9 @@ interface WebShellSidebarProps {
    */
   selectedWorkspaceCwd?: string;
   onSelectWorkspace?: (workspaceCwd: string | undefined) => void;
+  workspaces?: DaemonWorkspaceCapability[];
+  lockedWorkspaceCwd?: string;
+  lockedWorkspace?: WebShellSidebarLockedWorkspace;
   branding?: false | WebShellSidebarBranding;
   footer?: false | WebShellSidebarFooterOptions;
 }
@@ -394,6 +405,9 @@ export function WebShellSidebar({
   sessionListReloadToken,
   selectedWorkspaceCwd,
   onSelectWorkspace,
+  workspaces: providedWorkspaces,
+  lockedWorkspaceCwd,
+  lockedWorkspace: lockedWorkspaceOptions,
   branding,
   footer,
 }: WebShellSidebarProps) {
@@ -415,9 +429,14 @@ export function WebShellSidebar({
   // Phase 4: registered workspaces on a multi-workspace daemon (absent or a
   // single entry otherwise). Drives the new-session workspace picker.
   const workspaces = useMemo(
-    () => workspace.capabilities?.workspaces ?? [],
-    [workspace.capabilities?.workspaces],
+    () => providedWorkspaces ?? workspace.capabilities?.workspaces ?? [],
+    [providedWorkspaces, workspace.capabilities?.workspaces],
   );
+  const lockedWorkspace = lockedWorkspaceCwd
+    ? workspaces.find((entry) => entry.cwd === lockedWorkspaceCwd)
+    : undefined;
+  const includePrimaryWorkspaceSessions =
+    !lockedWorkspaceCwd || lockedWorkspace?.primary === true;
   const {
     sessions,
     loading,
@@ -428,6 +447,7 @@ export function WebShellSidebar({
     archiveSession,
   } = useSessions({
     autoLoad: true,
+    enabled: includePrimaryWorkspaceSessions,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
     ...(organizationEnabled
@@ -437,7 +457,7 @@ export function WebShellSidebar({
   const { sessions: primaryPinnedSessions, reload: reloadPinnedSessions } =
     useSessions({
       autoLoad: organizationEnabled,
-      enabled: organizationEnabled,
+      enabled: organizationEnabled && includePrimaryWorkspaceSessions,
       pageSize: SESSION_LIST_PAGE_SIZE,
       archiveState: 'active',
       view: 'organized',
@@ -457,7 +477,7 @@ export function WebShellSidebar({
     unarchiveSession,
   } = useSessions({
     autoLoad: true,
-    enabled: archivedExpanded,
+    enabled: archivedExpanded && includePrimaryWorkspaceSessions,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'archived',
     ...(organizationEnabled
@@ -564,8 +584,8 @@ export function WebShellSidebar({
     connection.capabilities?.features?.includes('session_export') ?? false;
   const projectName =
     getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
-  const displayedWorkspaces = useMemo<DaemonWorkspaceCapability[]>(
-    () =>
+  const displayedWorkspaces = useMemo<DaemonWorkspaceCapability[]>(() => {
+    const availableWorkspaces =
       workspaces.length > 0
         ? workspaces
         : [
@@ -575,19 +595,25 @@ export function WebShellSidebar({
               primary: true,
               trusted: true,
             },
-          ],
-    [connection.workspaceCwd, projectName, workspaces],
-  );
+          ];
+    return lockedWorkspaceCwd
+      ? availableWorkspaces.filter((entry) => entry.cwd === lockedWorkspaceCwd)
+      : availableWorkspaces;
+  }, [connection.workspaceCwd, lockedWorkspaceCwd, projectName, workspaces]);
   const pinnedSessions = useMemo(() => {
     const byId = new Map<string, DaemonSessionSummary>();
     for (const session of [
-      ...primaryPinnedSessions,
+      ...(includePrimaryWorkspaceSessions ? primaryPinnedSessions : []),
       ...secondaryPinnedSessions,
     ]) {
       byId.set(session.sessionId, session);
     }
     return [...byId.values()];
-  }, [primaryPinnedSessions, secondaryPinnedSessions]);
+  }, [
+    includePrimaryWorkspaceSessions,
+    primaryPinnedSessions,
+    secondaryPinnedSessions,
+  ]);
   const getSessionWorkspaceActions = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionWorkspace = displayedWorkspaces.find(
@@ -649,9 +675,22 @@ export function WebShellSidebar({
     workspaceSessionsReloadToken,
   ]);
   const allArchivedSessions = useMemo(
-    () => [...archivedSessions, ...secondaryArchivedSessions],
-    [archivedSessions, secondaryArchivedSessions],
+    () => [
+      ...(includePrimaryWorkspaceSessions ? archivedSessions : []),
+      ...secondaryArchivedSessions,
+    ],
+    [
+      archivedSessions,
+      includePrimaryWorkspaceSessions,
+      secondaryArchivedSessions,
+    ],
   );
+  const effectiveArchivedLoading =
+    (includePrimaryWorkspaceSessions && archivedLoading) ||
+    secondaryArchivedLoading;
+  const effectiveArchivedError =
+    (includePrimaryWorkspaceSessions && Boolean(archivedError)) ||
+    secondaryArchivedError;
 
   useEffect(() => {
     if (!archivedExpanded) return;
@@ -660,6 +699,7 @@ export function WebShellSidebar({
     );
     if (secondaryWorkspaces.length === 0) {
       setSecondaryArchivedSessions([]);
+      setSecondaryArchivedLoading(false);
       setSecondaryArchivedError(false);
       return;
     }
@@ -2038,7 +2078,6 @@ export function WebShellSidebar({
       session: DaemonSessionSummary,
       options: {
         isArchived?: boolean;
-        grouped?: boolean;
         // Suppress the per-session mutation actions (pin/group/archive/export/
         // more). Used for non-primary workspace rows: the daemon is bound to the
         // primary workspace, so those routes can't resolve another workspace's
@@ -2046,7 +2085,7 @@ export function WebShellSidebar({
         readOnly?: boolean;
       } = {},
     ) => {
-      const { isArchived = false, grouped = false, readOnly = false } = options;
+      const { isArchived = false, readOnly = false } = options;
       const label = getSessionLabel(session);
       const stamp = session.updatedAt || session.createdAt;
       const time = stamp ? formatRelativeTime(stamp, t) : '';
@@ -2156,7 +2195,6 @@ export function WebShellSidebar({
           key={session.sessionId}
           className={cx(
             styles.sessionRow,
-            grouped && styles.groupedSessionRow,
             isCurrent && styles.currentSession,
             session.isPinned && styles.pinnedSession,
             session.hasActivePrompt && styles.runningSession,
@@ -2439,9 +2477,7 @@ export function WebShellSidebar({
           deleteLabel={t('sidebar.groupDelete')}
           actionsDisabled={groupBusy}
         >
-          {section.sessions.map((session) =>
-            renderSessionRow(session, { grouped: true }),
-          )}
+          {section.sessions.map((session) => renderSessionRow(session))}
         </SessionGroupSection>
       );
     });
@@ -2504,17 +2540,11 @@ export function WebShellSidebar({
       </button>
     );
     let content: ReactNode;
-    if (
-      (archivedLoading || secondaryArchivedLoading) &&
-      allArchivedSessions.length === 0
-    ) {
+    if (effectiveArchivedLoading && allArchivedSessions.length === 0) {
       content = (
         <div className={styles.notice}>{t('sidebar.loadingSessions')}</div>
       );
-    } else if (
-      (archivedError || secondaryArchivedError) &&
-      allArchivedSessions.length === 0
-    ) {
+    } else if (effectiveArchivedError && allArchivedSessions.length === 0) {
       content = retry;
     } else if (allArchivedSessions.length === 0) {
       content = (
@@ -2526,7 +2556,7 @@ export function WebShellSidebar({
           {allArchivedSessions.map((session) =>
             renderSessionRow(session, { isArchived: true }),
           )}
-          {(archivedError || secondaryArchivedError) && retry}
+          {effectiveArchivedError && retry}
         </>
       );
     }
@@ -2538,17 +2568,15 @@ export function WebShellSidebar({
       </div>
     );
   }, [
-    archivedError,
     archivedExpanded,
-    archivedLoading,
     allArchivedSessions,
     collapsed,
+    effectiveArchivedError,
+    effectiveArchivedLoading,
     reloadArchived,
     renderSessionRow,
     searchQuery,
     setSecondaryArchivedReloadToken,
-    secondaryArchivedError,
-    secondaryArchivedLoading,
     t,
   ]);
 
@@ -3056,17 +3084,19 @@ export function WebShellSidebar({
                   >
                     <SearchIcon />
                   </button>
-                  <button
-                    className={styles.projectsHeaderAction}
-                    type="button"
-                    title={t('sidebar.addWorkspace')}
-                    aria-label={t('sidebar.addWorkspace')}
-                    onClick={() => {
-                      setShowAddWorkspaceDialog(true);
-                    }}
-                  >
-                    <PlusIcon />
-                  </button>
+                  {!lockedWorkspaceCwd && (
+                    <button
+                      className={styles.projectsHeaderAction}
+                      type="button"
+                      title={t('sidebar.addWorkspace')}
+                      aria-label={t('sidebar.addWorkspace')}
+                      onClick={() => {
+                        setShowAddWorkspaceDialog(true);
+                      }}
+                    >
+                      <PlusIcon />
+                    </button>
+                  )}
                 </div>
               </div>
             )}
@@ -3097,14 +3127,16 @@ export function WebShellSidebar({
                         <Fragment key={ws.id}>
                           <WorkspaceSection
                             workspace={ws}
-                            client={workspace.client}
-                            isActive={
-                              currentSessionId
-                                ? connection.workspaceCwd === ws.cwd
-                                : ws.primary
-                                  ? selectedWorkspaceCwd === undefined
-                                  : selectedWorkspaceCwd === ws.cwd
+                            renderHeader={
+                              lockedWorkspaceCwd &&
+                              lockedWorkspaceOptions?.render
+                                ? (expanded) =>
+                                    lockedWorkspaceOptions.render?.(ws, {
+                                      expanded,
+                                    })
+                                : undefined
                             }
+                            client={workspace.client}
                             reloadToken={workspaceSessionsReloadToken}
                             primaryLabel={
                               displayedWorkspaces.length > 1
@@ -3136,17 +3168,21 @@ export function WebShellSidebar({
                               ws.primary ? setProjectExpanded : undefined
                             }
                             renderSessions={!ws.primary}
-                            renderSession={(session, options) =>
-                              renderSessionRow(
-                                {
-                                  ...session,
-                                  workspaceCwd: ws.cwd,
-                                },
-                                options,
-                              )
+                            renderSession={(session) =>
+                              renderSessionRow({
+                                ...session,
+                                workspaceCwd: ws.cwd,
+                              })
                             }
                             headerActions={(visible) => {
+                              if (
+                                lockedWorkspaceCwd &&
+                                lockedWorkspaceOptions?.render
+                              ) {
+                                return null;
+                              }
                               const canRemove =
+                                !lockedWorkspaceCwd &&
                                 workspaceRemovalEnabled &&
                                 !ws.primary &&
                                 ws.removable === true;
@@ -3388,7 +3424,7 @@ export function WebShellSidebar({
           onPointerDown={handleResizePointerDown}
         />
       </aside>
-      {showAddWorkspaceDialog && (
+      {!lockedWorkspaceCwd && showAddWorkspaceDialog && (
         <AddWorkspaceDialog
           onClose={() => setShowAddWorkspaceDialog(false)}
           onAdd={handleAddWorkspace}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -2,15 +2,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import type { ReactNode } from 'react';
 import {
   DaemonHttpError,
+  type DaemonSessionSummary,
   type DaemonWorkspaceCapability,
 } from '@qwen-code/sdk/daemon';
 
 const { connection, workspace, workspaceActions, active, archived } =
   vi.hoisted(() => {
     const makeSessions = () => ({
-      sessions: [],
+      sessions: [] as DaemonSessionSummary[],
       loading: false,
       error: null,
       reload: vi.fn().mockResolvedValue(undefined),
@@ -123,6 +125,10 @@ function renderSidebar(
     selectedWorkspaceCwd?: string;
     onSelectWorkspace?: (cwd: string | undefined) => void;
     onError?: (error: unknown, message: string) => void;
+    lockedWorkspaceCwd?: string;
+    lockedWorkspace?: {
+      render?: (workspace: DaemonWorkspaceCapability) => ReactNode;
+    };
   } = {},
 ) {
   act(() => {
@@ -141,6 +147,8 @@ function renderSidebar(
           onError={overrides.onError ?? (() => {})}
           selectedWorkspaceCwd={overrides.selectedWorkspaceCwd}
           onSelectWorkspace={overrides.onSelectWorkspace}
+          lockedWorkspaceCwd={overrides.lockedWorkspaceCwd}
+          lockedWorkspace={overrides.lockedWorkspace}
         />
       </I18nProvider>,
     );
@@ -196,10 +204,17 @@ beforeEach(() => {
   workspace.capabilities = capabilities;
   workspace.refreshCapabilities.mockReset();
   workspace.refreshCapabilities.mockResolvedValue(capabilities);
+  workspace.client.workspaceByCwd.mockReset();
+  workspace.client.workspaceByCwd.mockImplementation(() => ({
+    listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+    listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+  }));
   workspaceActions.removeWorkspace.mockReset();
   workspaceActions.removeWorkspace.mockResolvedValue({ removed: true });
   active.reload.mockClear();
   archived.reload.mockClear();
+  active.sessions.length = 0;
+  archived.sessions.length = 0;
 });
 
 afterEach(() => {
@@ -209,6 +224,135 @@ afterEach(() => {
 });
 
 describe('WebShellSidebar workspace removal', () => {
+  it('scopes pinned and archived sessions to a locked secondary workspace', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    active.sessions.push({
+      sessionId: 'primary-pinned',
+      displayName: 'Primary pinned',
+      workspaceCwd: '/tmp/project',
+    });
+    archived.sessions.push({
+      sessionId: 'primary-archived',
+      displayName: 'Primary archived',
+      workspaceCwd: '/tmp/project',
+      isArchived: true,
+    });
+    const listSecondarySessions = vi.fn(
+      async (options?: { archiveState?: string; group?: string }) => {
+        if (options?.group === 'pinned') {
+          return [
+            {
+              sessionId: 'secondary-pinned',
+              displayName: 'Secondary pinned',
+            },
+          ];
+        }
+        if (options?.archiveState === 'archived') {
+          return [
+            {
+              sessionId: 'secondary-archived',
+              displayName: 'Secondary archived',
+              isArchived: true,
+            },
+          ];
+        }
+        return [];
+      },
+    );
+    workspace.client.workspaceByCwd.mockImplementation(() => ({
+      listWorkspaceSessions: listSecondarySessions,
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+    }));
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    const pinnedCallIndex = listSecondarySessions.mock.calls.findIndex(
+      ([options]) => options?.group === 'pinned',
+    );
+    expect(pinnedCallIndex).toBeGreaterThanOrEqual(0);
+    await act(async () => {
+      await listSecondarySessions.mock.results[pinnedCallIndex]?.value;
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Secondary pinned');
+    expect(container.textContent).not.toContain('Primary pinned');
+
+    const archivedButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent?.includes('Archived'));
+    expect(archivedButton).toBeDefined();
+    act(() => click(archivedButton!));
+    const archivedCallIndex = listSecondarySessions.mock.calls.findIndex(
+      ([options]) => options?.archiveState === 'archived',
+    );
+    expect(archivedCallIndex).toBeGreaterThanOrEqual(0);
+    await act(async () => {
+      await listSecondarySessions.mock.results[archivedCallIndex]?.value;
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Secondary archived');
+    expect(container.textContent).not.toContain('Primary archived');
+  });
+
+  it('shows only the locked workspace without registration controls', () => {
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+
+    expect(container.textContent).toContain('other');
+    expect(container.textContent).not.toContain('project');
+    expect(container.textContent).not.toContain('danger');
+    expect(
+      container.querySelector('button[aria-label="Add workspace"]'),
+    ).toBeNull();
+    expect(workspaceAction('/tmp/other')).toBeUndefined();
+  });
+
+  it('uses custom workspace row content only when the workspace is locked', async () => {
+    const render = vi.fn((ws: DaemonWorkspaceCapability) => (
+      <span data-testid="custom-workspace">Custom {ws.cwd}</span>
+    ));
+    const lockedWorkspace = { render };
+
+    renderSidebar({ lockedWorkspace });
+    expect(render).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('project');
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      lockedWorkspace,
+    });
+    expect(render).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'secondary', cwd: '/tmp/other' }),
+      { expanded: false },
+    );
+    expect(
+      container.querySelector('[data-testid="custom-workspace"]')?.textContent,
+    ).toBe('Custom /tmp/other');
+    expect(
+      container
+        .querySelector('[data-testid="custom-workspace"]')
+        ?.closest('button')
+        ?.parentElement?.querySelectorAll('button'),
+    ).toHaveLength(1);
+    expect(container.textContent).not.toContain('project');
+
+    await act(async () => {
+      click(
+        container
+          .querySelector('[data-testid="custom-workspace"]')!
+          .closest('button')!,
+      );
+      await Promise.resolve();
+    });
+    expect(render).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'secondary', cwd: '/tmp/other' }),
+      { expanded: true },
+    );
+  });
+
   it('hides removal when the daemon does not publish the feature', () => {
     connection.capabilities = {
       ...capabilities,

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.module.css
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.module.css
@@ -31,11 +31,6 @@
   background: var(--sidebar-accent);
 }
 
-.headerActive {
-  background: var(--sidebar-accent);
-  font-weight: 600;
-}
-
 .headerDisabled {
   opacity: 0.5;
 }

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -44,8 +44,8 @@ function WorkspaceFolderIcon({ open }: { open: boolean }) {
 
 interface WorkspaceSectionProps {
   workspace: DaemonWorkspaceCapability;
+  renderHeader?: (expanded: boolean) => ReactNode;
   client: DaemonClient;
-  isActive: boolean;
   reloadToken: number;
   primaryLabel: string;
   untrustedLabel: string;
@@ -67,10 +67,7 @@ interface WorkspaceSectionProps {
    * type scale, hover actions (pin, archive, export, more…), and states —
    * instead of a bespoke, feature-poor row.
    */
-  renderSession: (
-    session: DaemonSessionSummary,
-    options?: { grouped?: boolean },
-  ) => ReactNode;
+  renderSession: (session: DaemonSessionSummary) => ReactNode;
   headerActions?: (visible: boolean) => ReactNode;
   onRenameGroup?: (group: DaemonSessionGroup, workspaceCwd: string) => void;
   onDeleteGroup?: (group: DaemonSessionGroup, workspaceCwd: string) => void;
@@ -82,8 +79,8 @@ interface WorkspaceSectionProps {
 
 export function WorkspaceSection({
   workspace,
+  renderHeader,
   client,
-  isActive,
   reloadToken,
   primaryLabel,
   untrustedLabel,
@@ -229,11 +226,7 @@ export function WorkspaceSection({
   return (
     <div className={styles.section}>
       <div
-        className={cx(
-          styles.headerRow,
-          isActive && styles.headerActive,
-          disabled && styles.headerDisabled,
-        )}
+        className={cx(styles.headerRow, disabled && styles.headerDisabled)}
         onMouseEnter={() => setActionsVisible(true)}
         onMouseLeave={() => setActionsVisible(false)}
         onFocus={() => setActionsVisible(true)}
@@ -254,21 +247,31 @@ export function WorkspaceSection({
             onExpandedChange?.(nextExpanded);
           }}
         >
-          <span className={cx(styles.chevron, expanded && styles.chevronOpen)}>
-            <WorkspaceFolderIcon open={expanded} />
-          </span>
-          <span className={styles.headerContent}>
-            <span className={styles.name}>
-              {getWorkspaceName(workspace.cwd)}
-            </span>
-            {workspace.primary && primaryLabel && (
-              <span className={styles.badge}>{primaryLabel}</span>
-            )}
-          </span>
-          {!workspace.trusted && (
-            <span className={styles.badge}>{untrustedLabel}</span>
+          {renderHeader ? (
+            renderHeader(expanded)
+          ) : (
+            <>
+              <span
+                className={cx(styles.chevron, expanded && styles.chevronOpen)}
+              >
+                <WorkspaceFolderIcon open={expanded} />
+              </span>
+              <span className={styles.headerContent}>
+                <span className={styles.name}>
+                  {getWorkspaceName(workspace.cwd)}
+                </span>
+                {workspace.primary && primaryLabel && (
+                  <span className={styles.badge}>{primaryLabel}</span>
+                )}
+              </span>
+              {!workspace.trusted && (
+                <span className={styles.badge}>{untrustedLabel}</span>
+              )}
+              {readOnly && (
+                <span className={styles.badge}>{readOnlyLabel}</span>
+              )}
+            </>
           )}
-          {readOnly && <span className={styles.badge}>{readOnlyLabel}</span>}
         </button>
         {headerActions?.(actionsVisible)}
       </div>
@@ -314,9 +317,7 @@ export function WorkspaceSection({
                     deleteLabel={deleteGroupLabel}
                     actionsDisabled={groupActionsDisabled}
                   >
-                    {sessions.map((session) =>
-                      renderSession(session, { grouped: true }),
-                    )}
+                    {sessions.map((session) => renderSession(session))}
                   </SessionGroupSection>
                 ))}
                 {groupedSessions.ungrouped.length > 0 && (
@@ -335,7 +336,7 @@ export function WorkspaceSection({
                     }}
                   >
                     {groupedSessions.ungrouped.map((session) =>
-                      renderSession(session, { grouped: true }),
+                      renderSession(session),
                     )}
                   </SessionGroupSection>
                 )}

--- a/packages/web-shell/client/hooks/useOtherWorkspaceSessions.test.tsx
+++ b/packages/web-shell/client/hooks/useOtherWorkspaceSessions.test.tsx
@@ -35,9 +35,10 @@ const { useOtherWorkspaceSessions } = await import(
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 let latest: ReturnType<typeof useOtherWorkspaceSessions>;
+let enabled = true;
 
 function Harness() {
-  latest = useOtherWorkspaceSessions();
+  latest = useOtherWorkspaceSessions(enabled);
   return null;
 }
 
@@ -70,6 +71,7 @@ function session(id: string, cwd: string): DaemonSessionSummary {
 }
 
 beforeEach(() => {
+  enabled = true;
   capabilities = {};
   listWorkspaceSessions = vi.fn(async () => []);
   client = { listWorkspaceSessions };
@@ -82,6 +84,19 @@ afterEach(() => {
 });
 
 describe('useOtherWorkspaceSessions', () => {
+  it('does not query other workspaces when disabled', async () => {
+    enabled = false;
+    capabilities = {
+      workspaces: [ws('/w', true, true), ws('/b', false, true)],
+    };
+
+    render();
+    await flush();
+
+    expect(latest.sessions).toEqual([]);
+    expect(listWorkspaceSessions).not.toHaveBeenCalled();
+  });
+
   it('returns [] and never queries the daemon without a workspaces list', async () => {
     render();
     await flush();

--- a/packages/web-shell/client/hooks/useOtherWorkspaceSessions.ts
+++ b/packages/web-shell/client/hooks/useOtherWorkspaceSessions.ts
@@ -39,17 +39,21 @@ const EMPTY: DaemonSessionSummary[] = [];
  *   `capabilities.workspaces`, or only the primary), so merging it is a no-op
  *   and the single-workspace UI is byte-identical.
  */
-export function useOtherWorkspaceSessions(): OtherWorkspaceSessionsResult {
+export function useOtherWorkspaceSessions(
+  enabled = true,
+): OtherWorkspaceSessionsResult {
   const workspace = useWorkspace();
   const client = workspace.client;
 
   // A newline-joined key of the non-primary trusted cwds, so `load` (and the
   // effect that runs it) only change identity when the actual target set does —
   // not on every capabilities re-render.
-  const targetsKey = (workspace.capabilities?.workspaces ?? [])
-    .filter((w) => !w.primary && w.trusted)
-    .map((w) => w.cwd)
-    .join('\n');
+  const targetsKey = enabled
+    ? (workspace.capabilities?.workspaces ?? [])
+        .filter((w) => !w.primary && w.trusted)
+        .map((w) => w.cwd)
+        .join('\n')
+    : '';
 
   const [sessions, setSessions] = useState<DaemonSessionSummary[]>(EMPTY);
 

--- a/packages/web-shell/client/hooks/useScopedSessions.test.tsx
+++ b/packages/web-shell/client/hooks/useScopedSessions.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonSessionSummary } from '@qwen-code/sdk/daemon';
+
+const primarySessions = [
+  { sessionId: 'primary', workspaceCwd: '/primary' },
+] as DaemonSessionSummary[];
+const primaryDeleteSessions = vi.fn();
+const primaryReload = vi.fn();
+const primaryDeleteSession = vi.fn();
+const primaryReleaseSession = vi.fn();
+const listWorkspaceSessions = vi.fn();
+const deleteSessionsData = vi.fn();
+const workspaceByCwd = vi.fn(() => ({
+  listWorkspaceSessions,
+  deleteSessionsData,
+}));
+const workspaceClient = { workspaceByCwd };
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  useSessions: () => ({
+    sessions: primarySessions,
+    loading: false,
+    error: undefined,
+    reload: primaryReload,
+    deleteSession: primaryDeleteSession,
+    deleteSessions: primaryDeleteSessions,
+    releaseSession: primaryReleaseSession,
+  }),
+  useWorkspace: () => ({ client: workspaceClient }),
+}));
+
+const { useScopedSessions } = await import('./useScopedSessions');
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function Probe({ cwd }: { cwd?: string }) {
+  const { sessions, deleteSessions } = useScopedSessions(cwd, {
+    autoLoad: true,
+  });
+  return (
+    <div>
+      <span data-testid="sessions">
+        {sessions.map((session) => session.sessionId).join(',')}
+      </span>
+      <button onClick={() => void deleteSessions(['secondary'])}>delete</button>
+    </div>
+  );
+}
+
+function render(cwd?: string) {
+  act(() => root!.render(<Probe cwd={cwd} />));
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  listWorkspaceSessions.mockReset();
+  deleteSessionsData.mockReset();
+  workspaceByCwd.mockClear();
+  primaryDeleteSessions.mockReset();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('useScopedSessions', () => {
+  it('loads and mutates sessions through the requested workspace', async () => {
+    listWorkspaceSessions.mockResolvedValue([
+      { sessionId: 'secondary', workspaceCwd: '/wrong' },
+    ] satisfies DaemonSessionSummary[]);
+    deleteSessionsData.mockResolvedValue({
+      removed: ['secondary'],
+      notFound: [],
+      errors: [],
+    });
+
+    render('/secondary');
+    await act(async () => {
+      await listWorkspaceSessions.mock.results[0]?.value;
+    });
+
+    expect(
+      container!.querySelector('[data-testid="sessions"]')?.textContent,
+    ).toBe('secondary');
+    expect(workspaceByCwd).toHaveBeenCalledWith('/secondary');
+    expect(listWorkspaceSessions).toHaveBeenCalledWith({
+      pageSize: undefined,
+      archiveState: undefined,
+      view: undefined,
+      group: undefined,
+    });
+
+    await act(async () => {
+      container!.querySelector('button')!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(deleteSessionsData).toHaveBeenCalledWith(['secondary']);
+    expect(primaryDeleteSessions).not.toHaveBeenCalled();
+  });
+
+  it('ignores an older workspace response after the cwd changes', async () => {
+    let resolveA!: (sessions: DaemonSessionSummary[]) => void;
+    let resolveB!: (sessions: DaemonSessionSummary[]) => void;
+    listWorkspaceSessions
+      .mockImplementationOnce(
+        () =>
+          new Promise<DaemonSessionSummary[]>((resolve) => {
+            resolveA = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<DaemonSessionSummary[]>((resolve) => {
+            resolveB = resolve;
+          }),
+      );
+
+    render('/a');
+    render('/b');
+    await act(async () => {
+      resolveA([{ sessionId: 'a', workspaceCwd: '/a' }]);
+      await Promise.resolve();
+    });
+    expect(
+      container!.querySelector('[data-testid="sessions"]')?.textContent,
+    ).toBe('');
+
+    await act(async () => {
+      resolveB([{ sessionId: 'b', workspaceCwd: '/b' }]);
+      await Promise.resolve();
+    });
+    expect(
+      container!.querySelector('[data-testid="sessions"]')?.textContent,
+    ).toBe('b');
+  });
+});

--- a/packages/web-shell/client/hooks/useScopedSessions.ts
+++ b/packages/web-shell/client/hooks/useScopedSessions.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSessions, useWorkspace } from '@qwen-code/webui/daemon-react-sdk';
+import type {
+  DaemonSessionArchiveState,
+  DaemonSessionSummary,
+} from '@qwen-code/sdk/daemon';
+
+interface ScopedSessionsOptions {
+  autoLoad?: boolean;
+  enabled?: boolean;
+  pageSize?: number;
+  archiveState?: DaemonSessionArchiveState;
+  view?: 'organized';
+  group?: string;
+}
+
+interface ScopedState {
+  cwd?: string;
+  sessions: DaemonSessionSummary[];
+  loading: boolean;
+  error?: Error;
+}
+
+export function useScopedSessions(
+  workspaceCwd: string | undefined,
+  options: ScopedSessionsOptions = {},
+) {
+  const {
+    autoLoad = false,
+    enabled = true,
+    pageSize,
+    archiveState,
+    view,
+    group,
+  } = options;
+  const primary = useSessions({
+    autoLoad,
+    enabled: enabled && !workspaceCwd,
+    pageSize,
+    archiveState,
+    view,
+    group,
+  });
+  const {
+    reload: reloadPrimary,
+    deleteSession: deletePrimarySession,
+    deleteSessions: deletePrimarySessions,
+  } = primary;
+  const workspace = useWorkspace();
+  const requestSequence = useRef(0);
+  const [scoped, setScoped] = useState<ScopedState>({
+    sessions: [],
+    loading: false,
+  });
+
+  const reloadScoped = useCallback(async () => {
+    if (!workspaceCwd || !enabled) return [];
+    const sequence = ++requestSequence.current;
+    setScoped((current) => ({
+      cwd: workspaceCwd,
+      sessions: current.cwd === workspaceCwd ? current.sessions : [],
+      loading: true,
+    }));
+    try {
+      const sessions = await workspace.client
+        .workspaceByCwd(workspaceCwd)
+        .listWorkspaceSessions({ pageSize, archiveState, view, group });
+      const scopedSessions = sessions.map((session) => ({
+        ...session,
+        workspaceCwd,
+      }));
+      if (requestSequence.current === sequence) {
+        setScoped({
+          cwd: workspaceCwd,
+          sessions: scopedSessions,
+          loading: false,
+        });
+      }
+      return scopedSessions;
+    } catch (error) {
+      const normalized =
+        error instanceof Error ? error : new Error(String(error));
+      if (requestSequence.current === sequence) {
+        setScoped({
+          cwd: workspaceCwd,
+          sessions: [],
+          loading: false,
+          error: normalized,
+        });
+      }
+      throw normalized;
+    }
+  }, [
+    archiveState,
+    enabled,
+    group,
+    pageSize,
+    view,
+    workspace.client,
+    workspaceCwd,
+  ]);
+
+  useEffect(() => {
+    if (!workspaceCwd) return;
+    requestSequence.current += 1;
+    setScoped({
+      cwd: workspaceCwd,
+      sessions: [],
+      loading: autoLoad && enabled,
+    });
+    if (autoLoad && enabled) void reloadScoped().catch(() => undefined);
+    return () => {
+      requestSequence.current += 1;
+    };
+  }, [autoLoad, enabled, reloadScoped, workspaceCwd]);
+
+  const reload = useCallback(
+    () => (workspaceCwd ? reloadScoped() : reloadPrimary()),
+    [reloadPrimary, reloadScoped, workspaceCwd],
+  );
+  const deleteSessions = useCallback(
+    async (sessionIds: string[]) => {
+      if (!workspaceCwd) return deletePrimarySessions(sessionIds);
+      const result = await workspace.client
+        .workspaceByCwd(workspaceCwd)
+        .deleteSessionsData(sessionIds);
+      await reloadScoped();
+      return result;
+    },
+    [deletePrimarySessions, reloadScoped, workspace.client, workspaceCwd],
+  );
+  const deleteSession = useCallback(
+    async (sessionId: string) => {
+      if (!workspaceCwd) return deletePrimarySession(sessionId);
+      const result = await deleteSessions([sessionId]);
+      if (result.errors.length > 0) {
+        throw new Error(result.errors[0]!.error);
+      }
+      return result.removed.length > 0 || result.notFound.length > 0;
+    },
+    [deletePrimarySession, deleteSessions, workspaceCwd],
+  );
+
+  if (!workspaceCwd) return primary;
+  const current = scoped.cwd === workspaceCwd ? scoped : undefined;
+  return {
+    sessions: current?.sessions ?? [],
+    loading: current?.loading ?? (autoLoad && enabled),
+    error: current?.error,
+    reload,
+    deleteSession,
+    deleteSessions,
+    releaseSession: primary.releaseSession,
+  };
+}

--- a/packages/web-shell/client/index.test.tsx
+++ b/packages/web-shell/client/index.test.tsx
@@ -8,6 +8,21 @@ import { createRoot, type Root } from 'react-dom/client';
 // under them couldn't catch their own throw).
 let workspaceShouldThrow = false;
 const sessionProviderProps: Array<Record<string, unknown>> = [];
+const appProps: Array<Record<string, unknown>> = [];
+let workspaceCapabilities: {
+  workspaceCwd?: string;
+  workspaces?: Array<{
+    id: string;
+    cwd: string;
+    primary: boolean;
+    trusted?: boolean;
+  }>;
+} = {
+  workspaceCwd: '/workspace',
+  workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+};
+const addWorkspace = vi.fn();
+const refreshCapabilities = vi.fn();
 vi.mock('@qwen-code/webui/daemon-react-sdk', async () => {
   const React = await import('react');
   return {
@@ -25,16 +40,19 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async () => {
       return React.createElement(React.Fragment, null, children);
     },
     useWorkspace: () => ({
-      capabilities: {
-        workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
-      },
+      capabilities: workspaceCapabilities,
+      refreshCapabilities,
     }),
+    useWorkspaceActions: () => ({ addWorkspace }),
   };
 });
 vi.mock('./App', async () => {
   const React = await import('react');
   return {
-    App: () => React.createElement('div', { 'data-testid': 'app-ok' }, 'app'),
+    App: (props: Record<string, unknown>) => {
+      appProps.push(props);
+      return React.createElement('div', { 'data-testid': 'app-ok' }, 'app');
+    },
   };
 });
 
@@ -65,6 +83,13 @@ afterEach(() => {
   }
   workspaceShouldThrow = false;
   sessionProviderProps.length = 0;
+  appProps.length = 0;
+  workspaceCapabilities = {
+    workspaceCwd: '/workspace',
+    workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+  };
+  addWorkspace.mockReset();
+  refreshCapabilities.mockReset();
   vi.restoreAllMocks();
 });
 
@@ -93,6 +118,191 @@ describe('WebShellWithProviders top-level boundary', () => {
   it('passes explicit undefined sessionId to the daemon session provider', () => {
     render(<WebShellWithProviders sessionId={undefined} />);
     expect(sessionProviderProps[0]).toHaveProperty('sessionId', undefined);
+  });
+
+  it('selects a registered workspace by path without locking the UI', () => {
+    workspaceCapabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true },
+        { id: 'secondary', cwd: '/work/secondary', primary: false },
+      ],
+    };
+
+    render(
+      <WebShellWithProviders
+        workspaceId="primary"
+        workspaceCwd="/work/secondary"
+      />,
+    );
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps[0]).toMatchObject({
+      workspaceCwd: '/work/secondary',
+    });
+    expect(appProps[0]?.lockedWorkspaceCwd).toBeUndefined();
+  });
+
+  it('does not register an unknown unlocked workspace path', () => {
+    const container = render(
+      <WebShellWithProviders workspaceCwd="/work/missing" />,
+    );
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps).toHaveLength(0);
+    expect(container.textContent).toContain('Workspace not found');
+  });
+
+  it('locks directly to an already registered workspace path', () => {
+    workspaceCapabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true },
+        { id: 'secondary', cwd: '/work/secondary', primary: false },
+      ],
+    };
+
+    render(<WebShellWithProviders lockWorkspaceCwd="/work/secondary" />);
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps[0]).toMatchObject({
+      workspaceCwd: '/work/secondary',
+    });
+    expect(appProps[0]).toMatchObject({
+      lockedWorkspaceCwd: '/work/secondary',
+    });
+  });
+
+  it('locks to the primary workspace without registering it again', () => {
+    render(<WebShellWithProviders lockWorkspaceCwd="/workspace" />);
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps[0]).toMatchObject({
+      workspaceCwd: '/workspace',
+    });
+    expect(appProps[0]).toMatchObject({
+      lockedWorkspaceCwd: '/workspace',
+    });
+  });
+
+  it('recognizes the primary path when single-workspace capabilities omit workspaces', () => {
+    workspaceCapabilities = { workspaceCwd: '/workspace' };
+
+    render(<WebShellWithProviders lockWorkspaceCwd="/workspace" />);
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps[0]).toMatchObject({
+      workspaceCwd: '/workspace',
+    });
+    expect(appProps[0]).toMatchObject({
+      lockedWorkspaceCwd: '/workspace',
+      lockedWorkspaceCapability: expect.objectContaining({
+        cwd: '/workspace',
+        primary: true,
+      }),
+    });
+  });
+
+  it('selects the primary path without locking when workspaces are omitted', () => {
+    workspaceCapabilities = { workspaceCwd: '/workspace' };
+
+    render(<WebShellWithProviders workspaceCwd="/workspace" />);
+
+    expect(addWorkspace).not.toHaveBeenCalled();
+    expect(sessionProviderProps[0]).toMatchObject({
+      workspaceCwd: '/workspace',
+    });
+    expect(appProps[0]?.lockedWorkspaceCwd).toBeUndefined();
+  });
+
+  it('registers a missing workspace persistently before rendering', async () => {
+    addWorkspace.mockResolvedValue({
+      id: 'secondary',
+      cwd: '/canonical/secondary',
+      primary: false,
+      trusted: true,
+      persisted: true,
+    });
+
+    const container = render(
+      <WebShellWithProviders lockWorkspaceCwd="/work/../work/secondary" />,
+    );
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+
+    await act(async () => {
+      await addWorkspace.mock.results[0]?.value;
+    });
+
+    expect(addWorkspace).toHaveBeenCalledTimes(1);
+    expect(addWorkspace).toHaveBeenCalledWith('/work/../work/secondary', {
+      persist: true,
+    });
+    expect(sessionProviderProps.at(-1)).toMatchObject({
+      workspaceCwd: '/canonical/secondary',
+    });
+    expect(appProps.at(-1)).toMatchObject({
+      lockedWorkspaceCwd: '/canonical/secondary',
+    });
+  });
+
+  it('keeps the registered workspace available when capabilities refresh fails', async () => {
+    addWorkspace.mockResolvedValue({
+      id: 'secondary',
+      cwd: '/work/secondary',
+      primary: false,
+      trusted: true,
+      persisted: true,
+    });
+    refreshCapabilities.mockRejectedValue(new Error('offline'));
+
+    render(<WebShellWithProviders lockWorkspaceCwd="/work/secondary" />);
+    await act(async () => {
+      await addWorkspace.mock.results[0]?.value;
+      await Promise.resolve();
+    });
+
+    expect(appProps.at(-1)).toMatchObject({
+      lockedWorkspaceCwd: '/work/secondary',
+      lockedWorkspaceCapability: expect.objectContaining({
+        id: 'secondary',
+        cwd: '/work/secondary',
+      }),
+    });
+  });
+
+  it('ignores an older registration response after the locked path changes', async () => {
+    let resolveA!: (workspace: {
+      id: string;
+      cwd: string;
+      primary: boolean;
+      persisted: true;
+    }) => void;
+    let resolveB!: typeof resolveA;
+    addWorkspace.mockImplementation((cwd: string) => {
+      return new Promise((resolve) => {
+        if (cwd === '/a') resolveA = resolve;
+        else resolveB = resolve;
+      });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+    act(() => root.render(<WebShellWithProviders lockWorkspaceCwd="/a" />));
+    act(() => root.render(<WebShellWithProviders lockWorkspaceCwd="/b" />));
+
+    await act(async () => {
+      resolveA({ id: 'a', cwd: '/a', primary: false, persisted: true });
+      await Promise.resolve();
+    });
+    expect(appProps).toHaveLength(0);
+
+    await act(async () => {
+      resolveB({ id: 'b', cwd: '/b', primary: false, persisted: true });
+      await Promise.resolve();
+    });
+    expect(sessionProviderProps.at(-1)).toMatchObject({ workspaceCwd: '/b' });
+    expect(appProps.at(-1)).toMatchObject({ lockedWorkspaceCwd: '/b' });
+    expect(refreshCapabilities).toHaveBeenCalledTimes(1);
   });
 
   it('catches a daemon-provider render crash instead of white-screening', () => {

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -15,6 +15,13 @@ export interface WebShellWithProvidersProps extends WebShellProps {
   sessionId?: string;
   /** Registered daemon workspace id for the session. Undefined uses primary. */
   workspaceId?: string;
+  /** Registered daemon workspace path for the session. Takes precedence over workspaceId. */
+  workspaceCwd?: string;
+  /**
+   * Workspace path to lock this shell to. Missing paths are registered
+   * persistently before rendering. Takes precedence over workspaceCwd and workspaceId.
+   */
+  lockWorkspaceCwd?: string;
   /** Client identity to reuse when attaching to an externally created session. */
   clientId?: string;
 }
@@ -72,8 +79,16 @@ export function WebShell(props: WebShellProps) {
  * are available without extra setup.
  */
 export function WebShellWithProviders(props: WebShellWithProvidersProps) {
-  const { baseUrl, token, sessionId, workspaceId, clientId, ...webShellProps } =
-    props;
+  const {
+    baseUrl,
+    token,
+    sessionId,
+    workspaceId,
+    workspaceCwd,
+    lockWorkspaceCwd,
+    clientId,
+    ...webShellProps
+  } = props;
   const resolvedBaseUrl = resolveBaseUrl(baseUrl);
 
   return (
@@ -88,6 +103,8 @@ export function WebShellWithProviders(props: WebShellWithProvidersProps) {
         <WorkspaceSessionProvider
           sessionId={sessionId}
           workspaceId={workspaceId}
+          workspaceCwd={workspaceCwd}
+          lockWorkspaceCwd={lockWorkspaceCwd}
           clientId={clientId}
           webShellProps={webShellProps}
         />
@@ -113,6 +130,7 @@ export type {
   WebShellSidebarBranding,
   WebShellSidebarFooterItem,
   WebShellSidebarFooterOptions,
+  WebShellSidebarLockedWorkspace,
 } from './components/sidebar/WebShellSidebar';
 export type { WebShellLanguage } from './i18n';
 export type { WebShellTheme } from './themeContext';


### PR DESCRIPTION
## What this PR does

Adds path-based workspace selection and a lockWorkspaceCwd option to the embeddable Web Shell. Locked mode automatically registers an unknown secondary workspace, limits workspace and session UI to that workspace, disables workspace management entry points, and supports custom rendering for the locked workspace row. It also makes file mentions search across the workspace and restores composer focus when creating or opening a session.

The locked workspace capability is carried through the app while daemon capabilities refresh, so the sidebar and scheduled tasks remain correctly scoped. Single-workspace daemon responses that expose only workspaceCwd are recognized as the primary workspace.

## Why it is needed

Embedding hosts often know the project path but not the daemon workspace id. They need a simple way to bind Web Shell to that project without exposing unrelated registered workspaces or allowing users to switch and manage workspaces. Scheduled task operations must also stay inside the locked workspace, including when the target is a secondary workspace.

## Reviewer Test Plan

### How to verify

- Mount Web Shell with lockWorkspaceCwd set to the primary workspace path. Confirm only that workspace and its sessions appear, workspace add/remove controls are unavailable, and no registration request is made.
- Mount it with an unregistered secondary path. Confirm the workspace is registered persistently, only that workspace appears, and the UI remains usable if the immediate capabilities refresh fails.
- Open Scheduled Tasks while locked to a secondary workspace. Confirm listing, creation, updates, run-now, and deletion use the secondary workspace rather than the primary workspace.
- Mount with workspaceCwd without locking. Confirm the matching workspace is selected while normal workspace management remains available.
- Type an at-file query and confirm matching files from nested directories are returned.
- Create a new session and open an existing session. Confirm the composer receives focus.

### Evidence (Before & After)

Before: Embedders could select only by workspace id, unrelated workspaces remained visible, single-workspace primary capabilities could be misidentified, and a locked secondary Scheduled Tasks page could route operations to the primary workspace.

After: Embedders can select or lock by path, locked UI and session operations stay scoped to that workspace, single-workspace primary responses are handled, and scheduled tasks use the explicit locked workspace route.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js workspace. Web Shell unit tests, TypeScript typecheck, ESLint, and production build completed successfully.

## Risk & Scope

- Main risk or tradeoff: Workspace behavior now depends on path equality with daemon-reported canonical paths; unknown locked paths trigger persistent registration.
- Not validated / out of scope: Windows and Linux browser-level manual testing, and automatic creation of missing directories.
- Breaking changes / migration notes: None. The new props are optional.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

为可嵌入的 Web Shell 增加基于路径的工作区选择，以及 lockWorkspaceCwd 锁定选项。锁定模式会自动注册未知的次工作区，将工作区和会话界面限制在该工作区，禁用工作区管理入口，并支持自定义渲染锁定工作区行。同时，文件 @ 搜索会覆盖整个工作区，新建或打开会话时输入框会恢复焦点。

在 daemon capabilities 刷新期间，应用会继续携带已锁定的工作区能力信息，因此侧栏和定时任务仍会正确限定范围。对于只返回 workspaceCwd 的单工作区 daemon，也会正确识别主工作区。

## 为什么需要

嵌入方通常知道项目路径，但不知道 daemon workspace id。它们需要一种简单方式将 Web Shell 绑定到该项目，同时不展示无关的已注册工作区，也不允许用户切换和管理工作区。定时任务操作也必须始终位于锁定工作区内，包括目标为次工作区时。

## Reviewer Test Plan

### 验证方式

- 使用主工作区路径设置 lockWorkspaceCwd 挂载 Web Shell。确认只展示该工作区及其会话，添加和移除工作区入口不可用，且不会发起注册请求。
- 使用未注册的次工作区路径挂载。确认工作区被持久注册，只展示该工作区，并且即时 capabilities 刷新失败时界面仍可用。
- 锁定到次工作区后打开定时任务。确认列表、创建、更新、立即运行和删除都操作次工作区，而不是主工作区。
- 使用 workspaceCwd 但不锁定进行挂载。确认选择匹配的工作区，同时保留正常的工作区管理能力。
- 输入文件 @ 查询，确认可返回嵌套目录中的匹配文件。
- 新建会话并打开已有会话，确认输入框自动获取焦点。

### 前后对比证据

改动前：嵌入方只能通过 workspace id 选择工作区，无关工作区仍会显示，单工作区主目录可能被误判，锁定次工作区后的定时任务操作可能被路由到主工作区。

改动后：嵌入方可以按路径选择或锁定工作区，锁定界面和会话操作始终限定在该工作区，单工作区主目录响应可正确处理，定时任务使用明确的锁定工作区路由。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境

本地 Node.js workspace。Web Shell 单元测试、TypeScript 类型检查、ESLint 和生产构建均成功完成。

## 风险与范围

- 主要风险或取舍：工作区行为依赖传入路径与 daemon 返回的规范路径相等；未知锁定路径会触发持久注册。
- 未验证或超出范围：Windows 与 Linux 浏览器级手动测试，以及自动创建不存在的目录。
- 破坏性变更或迁移说明：无。新增属性均为可选。

## 关联 Issue

无

</details>