### PR TITLE
fix(ci): skip empty SDK release PR

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -312,6 +312,7 @@ jobs:
       - name: 'Commit and Push package version (stable only)'
         if: |-
           ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
+        id: 'persist_source'
         env:
           BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
           RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
@@ -320,8 +321,10 @@ jobs:
           git add packages/sdk-typescript/package.json package-lock.json
           if git diff --staged --quiet; then
             echo "No version changes to commit"
+            echo "HAS_PERSISTED_SOURCE=false" >> "${GITHUB_OUTPUT}"
           else
             git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
+            echo "HAS_PERSISTED_SOURCE=true" >> "${GITHUB_OUTPUT}"
           fi
           echo "Pushing release branch to remote..."
           git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
@@ -385,7 +388,7 @@ jobs:
 
       - name: 'Create PR to merge release branch into main'
         if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
+          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' && steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true' }}
         id: 'pr'
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
@@ -408,7 +411,7 @@ jobs:
 
       - name: 'Enable auto-merge for release PR'
         if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
+          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' && steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true' }}
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -340,16 +340,20 @@ jobs:
           PREVIOUS_RELEASE_TAG: '${{ steps.version.outputs.PREVIOUS_RELEASE_TAG }}'
           IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
           IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
+          HAS_PERSISTED_SOURCE: '${{ steps.persist_source.outputs.HAS_PERSISTED_SOURCE }}'
           REF: '${{ github.event.inputs.ref || github.sha }}'
           CLI_VERSION: "${{ steps.cli_source.outputs.mode == 'npm_latest' && steps.cli_version_npm.outputs.CLI_VERSION || steps.cli_build.outputs.CLI_VERSION }}"
           CLI_SOURCE_MODE: '${{ steps.cli_source.outputs.mode }}'
         run: |-
-          # For stable releases, use the release branch; for nightly/preview, use the current ref
+          # For stable releases, use the release branch when it was pushed.
           if [[ "${IS_NIGHTLY}" == "true" || "${IS_PREVIEW}" == "true" ]]; then
             TARGET="${REF}"
             PRERELEASE_FLAG="--prerelease"
-          else
+          elif [[ "${HAS_PERSISTED_SOURCE}" == "true" ]]; then
             TARGET="${RELEASE_BRANCH}"
+            PRERELEASE_FLAG=""
+          else
+            TARGET="${REF}"
             PRERELEASE_FLAG=""
           fi
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -321,13 +321,14 @@ jobs:
           git add packages/sdk-typescript/package.json package-lock.json
           if git diff --staged --quiet; then
             echo "No version changes to commit"
+            echo "::notice::No version changes in sdk-typescript; skipping release branch push and PR creation."
             echo "HAS_PERSISTED_SOURCE=false" >> "${GITHUB_OUTPUT}"
           else
             git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
             echo "HAS_PERSISTED_SOURCE=true" >> "${GITHUB_OUTPUT}"
+            echo "Pushing release branch to remote..."
+            git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
           fi
-          echo "Pushing release branch to remote..."
-          git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
 
       - name: 'Create GitHub Release and Tag'
         if: |-

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -332,7 +332,7 @@ jobs:
 
       - name: 'Create GitHub Release and Tag'
         if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' }}
+          ${{ steps.vars.outputs.is_dry_run == 'false' && (steps.vars.outputs.is_nightly == 'true' || steps.vars.outputs.is_preview == 'true' || steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true') }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           RELEASE_BRANCH: '${{ steps.release_branch.outputs.BRANCH_NAME }}'

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -21,11 +21,19 @@ describe('TypeScript SDK release workflow', () => {
     expect(workflow).toContain(
       'echo "::notice::No version changes in sdk-typescript; skipping release branch push and PR creation."',
     );
-    const persistedSourceGuardCount = (
-      workflow.match(
-        /steps\.persist_source\.outputs\.HAS_PERSISTED_SOURCE == 'true'/g,
-      ) ?? []
-    ).length;
-    expect(persistedSourceGuardCount).toBe(2);
+    for (const stepName of [
+      'Create GitHub Release and Tag',
+      'Create PR to merge release branch into main',
+      'Enable auto-merge for release PR',
+    ]) {
+      const stepStart = workflow.indexOf(`name: '${stepName}'`);
+      const step = workflow.slice(
+        stepStart,
+        workflow.indexOf('\n      - name:', stepStart + 1),
+      );
+      expect(step).toContain(
+        "steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true'",
+      );
+    }
   });
 });

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('TypeScript SDK release workflow', () => {
+  const workflow = readFileSync('.github/workflows/release-sdk.yml', 'utf8');
+
+  it('only creates a release PR when the package version changed', () => {
+    expect(workflow).toContain("id: 'persist_source'");
+    expect(workflow).toContain(
+      'echo "HAS_PERSISTED_SOURCE=false" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(workflow).toContain(
+      'echo "HAS_PERSISTED_SOURCE=true" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(
+      workflow.split(
+        "steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true'",
+      ),
+    ).toHaveLength(3);
+  });
+});

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -18,10 +18,14 @@ describe('TypeScript SDK release workflow', () => {
     expect(workflow).toContain(
       'echo "HAS_PERSISTED_SOURCE=true" >> "${GITHUB_OUTPUT}"',
     );
-    expect(
-      workflow.split(
-        "steps.persist_source.outputs.HAS_PERSISTED_SOURCE == 'true'",
-      ),
-    ).toHaveLength(3);
+    expect(workflow).toContain(
+      'echo "::notice::No version changes in sdk-typescript; skipping release branch push and PR creation."',
+    );
+    const persistedSourceGuardCount = (
+      workflow.match(
+        /steps\.persist_source\.outputs\.HAS_PERSISTED_SOURCE == 'true'/g,
+      ) ?? []
+    ).length;
+    expect(persistedSourceGuardCount).toBe(2);
   });
 });

--- a/scripts/tests/release-sdk-workflow.test.js
+++ b/scripts/tests/release-sdk-workflow.test.js
@@ -21,6 +21,12 @@ describe('TypeScript SDK release workflow', () => {
     expect(workflow).toContain(
       'echo "::notice::No version changes in sdk-typescript; skipping release branch push and PR creation."',
     );
+    expect(workflow).toContain(
+      "HAS_PERSISTED_SOURCE: '${{ steps.persist_source.outputs.HAS_PERSISTED_SOURCE }}'",
+    );
+    expect(workflow).toContain('elif [[ "${HAS_PERSISTED_SOURCE}" == "true" ]]');
+    expect(workflow).toContain('TARGET="${RELEASE_BRANCH}"');
+    expect(workflow).toContain('TARGET="${REF}"');
     const persistedSourceGuardCount = (
       workflow.match(
         /steps\.persist_source\.outputs\.HAS_PERSISTED_SOURCE == 'true'/g,


### PR DESCRIPTION
## What this PR does

This PR records whether the SDK version persistence step produced a commit. The workflow only creates and auto-merges a release PR when the package version actually changed. No-op version updates now complete without trying to open an empty PR.

A regression test covers the persistence output, step ID, and both downstream guards.

## Why it's needed

The SDK 0.1.8 package and GitHub Release were published successfully, but the repository already contained version 0.1.8, so the version update produced no commit. The workflow still attempted to create a release PR, and GitHub rejected it with `No commits between main and release/sdk-typescript/v0.1.8`.

This made a successful release appear failed because of an unnecessary cleanup step.

## Reviewer Test Plan

### How to verify

Confirm that a no-op version update reports no persisted source and skips both PR creation and auto-merge. A real version change should continue through the existing release PR flow.

Validated with:

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/release-sdk-workflow.test.js`
- `node scripts/lint.js --actionlint`
- `npx prettier --check scripts/tests/release-sdk-workflow.test.js`
- `git diff --check`
- `npm run build`

### Evidence (Before & After)

Before: publishing, tests, npm publish, and GitHub Release creation succeeded, but the workflow failed while creating an empty PR.

After: when there is no version commit, the workflow skips PR creation and auto-merge instead of marking the completed release as failed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js workspace.

## Risk & Scope

- Main risk or tradeoff: This only changes the stable SDK release cleanup path. Releases with a real version change continue through the existing PR flow.
- Not validated / out of scope: The 0.1.8 release was not rerun because the package is already published. `npm run typecheck` did not pass locally due to errors in untouched `acp-bridge` and CLI code.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6858

<details>
<summary>中文说明</summary>

## 此 PR 的改动

记录 SDK 版本持久化步骤是否实际产生提交。仅在存在版本变更时创建发布 PR 并启用自动合并；无变更时正常完成发布流程。增加回归测试覆盖持久化输出、步骤 ID 和两个下游条件。

## 为什么需要此改动

SDK 0.1.8 已成功发布到 npm 和 GitHub Release，但仓库中的版本原本就是 0.1.8，因此版本更新没有产生提交。工作流仍尝试创建发布 PR，GitHub 返回 `No commits between main and release/sdk-typescript/v0.1.8`，导致已成功的发布任务显示失败。

## Reviewer Test Plan

确认无版本差异时持久化步骤输出 false，创建 PR 和自动合并步骤均被跳过；存在版本差异时输出 true，原发布 PR 流程继续执行。

已通过目标回归测试、actionlint、Prettier、git diff 检查和 build。

## 风险与范围

此改动仅影响稳定版 SDK 发布的收尾 PR；真实版本变更仍走原流程。未重跑 0.1.8 发布，因为包已发布，重跑会在 npm publish 阶段失败。全仓 typecheck 在未修改的 acp-bridge 和 CLI 代码上未通过。无破坏性变更。

</details>
