### PR TITLE
fix(webui): honor follow-up accept callback suppression

### DIFF
--- a/packages/webui/src/hooks/useFollowupSuggestions.test.tsx
+++ b/packages/webui/src/hooks/useFollowupSuggestions.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useFollowupSuggestions,
+  type UseFollowupSuggestionsReturn,
+} from './useFollowupSuggestions.js';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+describe('useFollowupSuggestions', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let followup: UseFollowupSuggestionsReturn;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.useRealTimers();
+  });
+
+  async function renderHook(onAccept: (suggestion: string) => void) {
+    function HookHost() {
+      followup = useFollowupSuggestions({ onAccept });
+      return null;
+    }
+
+    await act(async () => root.render(<HookHost />));
+    act(() => {
+      followup.setSuggestion('Run the tests');
+      vi.advanceTimersByTime(300);
+    });
+  }
+
+  it('skips onAccept when the caller submits the suggestion directly', async () => {
+    const onAccept = vi.fn();
+    await renderHook(onAccept);
+
+    await act(async () => {
+      followup.accept('enter', { skipOnAccept: true });
+      await Promise.resolve();
+    });
+
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(followup.state.isVisible).toBe(false);
+  });
+
+  it('calls onAccept for the normal accept path', async () => {
+    const onAccept = vi.fn();
+    await renderHook(onAccept);
+
+    await act(async () => {
+      followup.accept('tab');
+      await Promise.resolve();
+    });
+
+    expect(onAccept).toHaveBeenCalledOnce();
+    expect(onAccept).toHaveBeenCalledWith('Run the tests');
+  });
+});

--- a/packages/webui/src/hooks/useFollowupSuggestions.ts
+++ b/packages/webui/src/hooks/useFollowupSuggestions.ts
@@ -33,7 +33,10 @@ interface FollowupControllerOptions {
 
 interface FollowupControllerActions {
   setSuggestion: (text: string | null) => void;
-  accept: (method?: 'tab' | 'enter' | 'right') => void;
+  accept: (
+    method?: 'tab' | 'enter' | 'right',
+    options?: { skipOnAccept?: boolean },
+  ) => void;
   dismiss: () => void;
   clear: () => void;
   cleanup: () => void;
@@ -85,7 +88,10 @@ function createFollowupController(
     }, SUGGESTION_DELAY_MS);
   };
 
-  const accept = (method?: 'tab' | 'enter' | 'right'): void => {
+  const accept = (
+    method?: 'tab' | 'enter' | 'right',
+    options?: { skipOnAccept?: boolean },
+  ): void => {
     if (accepting) {
       return;
     }
@@ -119,7 +125,9 @@ function createFollowupController(
 
     queueMicrotask(() => {
       try {
-        getOnAccept?.()?.(text);
+        if (!options?.skipOnAccept) {
+          getOnAccept?.()?.(text);
+        }
       } catch (error: unknown) {
         console.error('[followup] onAccept callback threw:', error);
       } finally {


### PR DESCRIPTION
## What this PR does

Aligns the exported WebUI follow-up suggestion controller with its public accept contract. When a consumer submits a visible suggestion directly, acceptance can now clear the suggestion and record the accepted outcome without asynchronously inserting the same text back into the input. Normal Tab and Right Arrow acceptance still invoke the consumer callback.

## Why it's needed

The shared input already uses callback suppression for the Enter path because it submits the suggestion itself. The exported hook declared that option but ignored it, so future consumers combining the two APIs could submit once and then receive a delayed duplicate input update. This completes the controller alignment tracked by #3030.

## Reviewer Test Plan

### How to verify

Use the exported follow-up hook with the shared input, show a suggestion, and press Enter while the input is empty. Confirm the suggestion is submitted once, the visible state clears, and the consumer accept callback does not reinsert the text. Then accept a suggestion with Tab and confirm the callback still receives the suggestion exactly once.

Local verification completed: WebUI lint, typecheck, all 313 WebUI unit tests, focused red-to-green regression tests, and the WebUI production build.

### Evidence (Before & After)

N/A — this fixes an exported controller contract that does not yet have an active VS Code consumer in this repository. The focused regression test captures the original callback duplication and the corrected behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 22, local workspace dependencies, no sandbox.

## Risk & Scope

- Main risk or tradeoff: Callback suppression is opt-in and only skips the text insertion callback; state clearing, accepted outcome reporting, and debounce behavior remain unchanged.
- Not validated / out of scope: End-to-end VS Code behavior, because the VS Code companion does not currently wire this exported follow-up flow.
- Breaking changes / migration notes: None. The implementation now matches the existing public type.

## Linked Issues

Fixes #3030

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让导出的 WebUI follow-up suggestion controller 与公开的 accept 合约保持一致。当 consumer 直接提交可见 suggestion 时，现在可以清除 suggestion 并记录 accepted outcome，而不会再异步把同一段文本写回输入框。普通的 Tab 和右方向键接受仍会调用 consumer callback。

## 为什么需要

共享输入框的 Enter 路径会自行提交 suggestion，因此已经使用 callback suppression。导出的 hook 虽然声明了这个选项，却没有实际处理；未来 consumer 组合这两个 API 时，可能先提交一次，随后又收到一次延迟的重复输入更新。此修改完成了 #3030 跟踪的 controller 对齐工作。

## Reviewer Test Plan

### 如何验证

将导出的 follow-up hook 与共享输入框组合，展示一个 suggestion，并在输入为空时按 Enter。确认 suggestion 只提交一次、可见状态被清除，并且 consumer accept callback 不会把文本重新写回。然后使用 Tab 接受 suggestion，确认 callback 仍然只收到一次 suggestion。

本地验证已完成：WebUI lint、typecheck、全部 313 个 WebUI 单元测试、聚焦的红转绿回归测试，以及 WebUI 生产构建。

### Evidence（Before & After）

N/A——此修改修复的是一个尚未在本仓库 VS Code consumer 中启用的导出 controller 合约。聚焦回归测试覆盖了原始 callback 重复问题和修复后的行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### Environment（可选）

Node.js 22，本地 workspace 依赖，无 sandbox。

## Risk & Scope

- 主要风险或取舍：Callback suppression 仅在显式请求时生效，并且只跳过文本插入 callback；状态清理、accepted outcome 上报和 debounce 行为保持不变。
- 未验证 / 不在范围：VS Code 端到端行为，因为 VS Code companion 当前尚未接入这条导出的 follow-up flow。
- Breaking changes / 迁移说明：无。实现现在与已有公开类型一致。

## Linked Issues

Fixes #3030

</details>