### PR TITLE
fix(ci): avoid apt on self-hosted Playwright smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,7 @@ jobs:
 
       - name: 'Install Playwright Chromium (self-hosted)'
         if: "${{ runner.environment == 'self-hosted' }}"
+        # Self-hosted ECS runners already include system deps; --with-deps can race apt locks.
         run: 'npx playwright install chromium'
 
       - name: 'Choose web-shell Playwright port'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
         needs.classify_pr.outputs.skip_ci != 'true' &&
         needs.test.outputs.ci_profile == 'full'
       }}
-    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
+    runs-on: 'ubuntu-latest'
     timeout-minutes: 20
     permissions:
       contents: 'read'
@@ -398,36 +398,13 @@ jobs:
             exit 1
           fi
 
-      # Self-hosted can't reach nodejs.org reliably; reuse the machine's Node.
-      - name: 'Set up Node.js 22.x (hosted)'
-        if: "${{ runner.environment == 'github-hosted' }}"
+      - name: 'Set up Node.js 22.x'
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version: '22.x'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org/'
-
-      - name: 'Use pre-installed Node.js (self-hosted)'
-        if: "${{ runner.environment == 'self-hosted' }}"
-        run: |-
-          if ! command -v node >/dev/null 2>&1; then
-            echo "::error::Node.js is not on PATH for this self-hosted runner. Provision Node 22.x or set the MAINTAINER_ECS_RUNNER_DISABLED repository variable to 'true' to route PRs back to hosted runners."
-            exit 1
-          fi
-          echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
-          if [[ "$(node -p 'process.versions.node.split(".")[0]')" != "22" ]]; then
-            echo "::warning::Expected Node 22.x but found $(node -v); web-shell smoke tests will run against the runner's Node."
-          fi
-
-      - name: 'Configure persistent npm cache (self-hosted)'
-        if: "${{ runner.environment == 'self-hosted' }}"
-        run: |-
-          cache_dir="${HOME}/.cache/qwen-code/npm"
-          mkdir -p "${cache_dir}"
-          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
-          echo "Using persistent npm cache at ${cache_dir}"
-          du -sh "${cache_dir}" 2>/dev/null || true
 
       - name: 'Configure npm for rate limiting'
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           SAME_REPO: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
           ECS_DISABLED: '${{ vars.MAINTAINER_ECS_RUNNER_DISABLED }}'
           EVENT_NAME: '${{ github.event_name }}'
-          DISPATCH_LINUX_RUNNER: '${{ github.event.inputs.linux_runner || '' }}'
+          DISPATCH_LINUX_RUNNER: '${{ github.event.inputs.linux_runner }}'
         run: |-
           ubuntu_runner='["ubuntu-latest"]'
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ on:
         required: true
         default: 'main'
         type: 'string'
+      linux_runner:
+        description: 'Linux runner to use for manual validation'
+        required: true
+        default: 'self-hosted'
+        type: 'choice'
+        options:
+          - 'self-hosted'
+          - 'hosted'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
@@ -42,7 +50,7 @@ env:
 jobs:
   classify_pr:
     name: 'Classify PR'
-    if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}"
+    if: "${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}"
     # Gate runs on ECS for in-repo PRs and for the merge queue (which runs in the
     # base-repo context), else a busy hosted pool delays it and blocks the
     # ECS-bound jobs. The kill-switch is read here, so flipping it reverts
@@ -98,9 +106,14 @@ jobs:
           SAME_REPO: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
           ECS_DISABLED: '${{ vars.MAINTAINER_ECS_RUNNER_DISABLED }}'
           EVENT_NAME: '${{ github.event_name }}'
+          DISPATCH_LINUX_RUNNER: '${{ github.event.inputs.linux_runner || '' }}'
         run: |-
           ubuntu_runner='["ubuntu-latest"]'
-          if [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${ECS_DISABLED}" != "true" && "${DISPATCH_LINUX_RUNNER}" == "self-hosted" ]]; then
+              ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
+            fi
+          elif [[ "${ECS_DISABLED}" != "true" && ( "${SAME_REPO}" == "true" || "${EVENT_NAME}" == "merge_group" ) ]]; then
             ubuntu_runner='["self-hosted", "linux", "x64", "ecs-qwen"]'
           fi
           echo "ubuntu_runner=${ubuntu_runner}" >> "${GITHUB_OUTPUT}"
@@ -373,7 +386,7 @@ jobs:
     if: |-
       ${{
         !cancelled() &&
-        github.event_name == 'pull_request' &&
+        (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') &&
         needs.classify_pr.outputs.skip_ci != 'true' &&
         needs.test.outputs.ci_profile == 'full'
       }}
@@ -385,10 +398,11 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
-          ref: "${{ format('refs/pull/{0}/head', github.event.pull_request.number) }}"
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || github.ref }}"
           fetch-depth: 1
 
       - name: 'Verify checkout includes expected head commit'
+        if: "${{ github.event_name == 'pull_request' }}"
         env:
           EXPECTED_SHA: '${{ github.event.pull_request.head.sha }}'
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,7 @@ jobs:
         needs.classify_pr.outputs.skip_ci != 'true' &&
         needs.test.outputs.ci_profile == 'full'
       }}
-    runs-on: 'ubuntu-latest'
+    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
     timeout-minutes: 20
     permissions:
       contents: 'read'
@@ -398,13 +398,36 @@ jobs:
             exit 1
           fi
 
-      - name: 'Set up Node.js 22.x'
+      # Self-hosted can't reach nodejs.org reliably; reuse the machine's Node.
+      - name: 'Set up Node.js 22.x (hosted)'
+        if: "${{ runner.environment == 'github-hosted' }}"
         uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
         with:
           node-version: '22.x'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
           registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          if ! command -v node >/dev/null 2>&1; then
+            echo "::error::Node.js is not on PATH for this self-hosted runner. Provision Node 22.x or set the MAINTAINER_ECS_RUNNER_DISABLED repository variable to 'true' to route PRs back to hosted runners."
+            exit 1
+          fi
+          echo "Using pre-installed Node $(node -v) / npm $(npm -v)"
+          if [[ "$(node -p 'process.versions.node.split(".")[0]')" != "22" ]]; then
+            echo "::warning::Expected Node 22.x but found $(node -v); web-shell smoke tests will run against the runner's Node."
+          fi
+
+      - name: 'Configure persistent npm cache (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${HOME}/.cache/qwen-code/npm"
+          mkdir -p "${cache_dir}"
+          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "Using persistent npm cache at ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
 
       - name: 'Configure npm for rate limiting'
         run: |-
@@ -417,8 +440,13 @@ jobs:
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 
-      - name: 'Install Playwright Chromium'
+      - name: 'Install Playwright Chromium (hosted)'
+        if: "${{ runner.environment == 'github-hosted' }}"
         run: 'npx playwright install --with-deps chromium'
+
+      - name: 'Install Playwright Chromium (self-hosted)'
+        if: "${{ runner.environment == 'self-hosted' }}"
+        run: 'npx playwright install chromium'
 
       - name: 'Choose web-shell Playwright port'
         run: |-

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -128,8 +128,7 @@ describe('no-AK integration CI wiring', () => {
     const webShellJob = getWorkflowJob(workflow, 'web_shell_e2e_smoke');
 
     expect(webShellJob).toContain('ubuntu_runner');
-    expect(webShellJob).toContain(
-      "if: \"${{ runner.environment == 'self-hosted' }}\"\n        run: 'npx playwright install chromium'",
-    );
+    expect(webShellJob).toContain("run: 'npx playwright install chromium'");
+    expect(webShellJob).toContain('--with-deps chromium');
   });
 });

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -109,17 +109,27 @@ describe('no-AK integration CI wiring', () => {
     expect(webShellJob).toContain('github.event.pull_request.head.sha');
   });
 
-  it('keeps coverage reporting and Playwright installation on hosted runners', () => {
+  it('keeps the lightweight coverage comment job on the hosted runner', () => {
     const workflow = readFileSync(
       path.join(ROOT, '.github/workflows/ci.yml'),
       'utf8',
     );
     const coverageJob = getWorkflowJob(workflow, 'post_coverage_comment');
+
+    expect(coverageJob).toContain("runs-on: 'ubuntu-latest'");
+    expect(coverageJob).not.toContain('ubuntu_runner');
+  });
+
+  it('does not install Linux packages on self-hosted Playwright runners', () => {
+    const workflow = readFileSync(
+      path.join(ROOT, '.github/workflows/ci.yml'),
+      'utf8',
+    );
     const webShellJob = getWorkflowJob(workflow, 'web_shell_e2e_smoke');
 
-    for (const job of [coverageJob, webShellJob]) {
-      expect(job).toContain("runs-on: 'ubuntu-latest'");
-      expect(job).not.toContain('ubuntu_runner');
-    }
+    expect(webShellJob).toContain('ubuntu_runner');
+    expect(webShellJob).toContain(
+      "if: \"${{ runner.environment == 'self-hosted' }}\"\n        run: 'npx playwright install chromium'",
+    );
   });
 });

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -109,14 +109,17 @@ describe('no-AK integration CI wiring', () => {
     expect(webShellJob).toContain('github.event.pull_request.head.sha');
   });
 
-  it('keeps the lightweight coverage comment job on the hosted runner', () => {
+  it('keeps coverage reporting and Playwright installation on hosted runners', () => {
     const workflow = readFileSync(
       path.join(ROOT, '.github/workflows/ci.yml'),
       'utf8',
     );
     const coverageJob = getWorkflowJob(workflow, 'post_coverage_comment');
+    const webShellJob = getWorkflowJob(workflow, 'web_shell_e2e_smoke');
 
-    expect(coverageJob).toContain("runs-on: 'ubuntu-latest'");
-    expect(coverageJob).not.toContain('ubuntu_runner');
+    for (const job of [coverageJob, webShellJob]) {
+      expect(job).toContain("runs-on: 'ubuntu-latest'");
+      expect(job).not.toContain('ubuntu_runner');
+    }
   });
 });


### PR DESCRIPTION
## What this PR does

Keeps the web-shell browser smoke on the selected Linux runner. GitHub-hosted runners continue installing Chromium with its Linux packages, while self-hosted ECS runners install only the browser and do not invoke `apt-get` during the job.

## Why it's needed

Playwright's `--with-deps` option invokes `apt-get`. CI run 29302774843 failed before the browser test started because another process held the shared ECS runner's apt lock, then passed unchanged on another runner. Linux packages belong in the ECS runner image; the CI job should not mutate the host package database on every run.

## Reviewer Test Plan

### How to verify

Confirm the smoke job still follows the existing selected-runner routing. On GitHub-hosted runners it should run `npx playwright install --with-deps chromium`; on self-hosted runners it should run `npx playwright install chromium` and never invoke apt. The ECS image must already provide Playwright's Linux dependencies.

### Evidence (Before & After)

Before: [CI attempt 1](https://github.com/QwenLM/qwen-code/actions/runs/29302774843/attempts/1) failed in the Playwright install step with `/var/lib/apt/lists/lock` held by another process. After: the focused workflow test passes 5/5, and actionlint and yamllint pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local workflow validation on macOS. This fork PR routes to GitHub-hosted CI, so the ECS branch still requires validation after the runner image rollout.

## Risk & Scope

- Main risk or tradeoff: Self-hosted browser execution now relies on Playwright's Linux dependencies being present in the ECS runner image.
- Not validated / out of scope: The ECS AMI/image and launch template live outside this repository; this PR does not provision them.
- Breaking changes / migration notes: Roll out the runner image before merging this workflow change.

## Linked Issues

Related to #6856

Does not close #6856 until the self-hosted runner image rollout is complete and verified.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

web-shell 浏览器冒烟测试继续使用现有的 selected Linux runner 路由。GitHub-hosted runner 仍安装 Chromium 和 Linux 系统依赖；self-hosted ECS runner 只安装浏览器，不再在任务执行期间调用 `apt-get`。

## 为什么需要

Playwright 的 `--with-deps` 会调用 `apt-get`。CI run 29302774843 在浏览器测试开始前失败，因为共享 ECS runner 上另一个进程持有 apt 锁；代码不变换 runner 重跑后通过。Linux 系统依赖应固化在 ECS runner 镜像中，CI Job 不应每次运行都修改宿主机包数据库。

## Reviewer 测试计划

### 如何验证

确认 smoke Job 仍跟随现有 selected-runner 路由。GitHub-hosted runner 应执行 `npx playwright install --with-deps chromium`；self-hosted runner 应执行 `npx playwright install chromium`，且不调用 apt。ECS 镜像必须已经提供 Playwright 所需的 Linux 系统依赖。

### 证据（Before & After）

Before：[CI attempt 1](https://github.com/QwenLM/qwen-code/actions/runs/29302774843/attempts/1) 在 Playwright 安装阶段因另一个进程持有 `/var/lib/apt/lists/lock` 而失败。After：聚焦 workflow 测试 5/5 通过，actionlint 和 yamllint 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

在 macOS 上完成本地 workflow 验证。fork PR 会路由到 GitHub-hosted CI，因此 ECS 分支仍需在 runner 镜像发布后验证。

## 风险与范围

- 主要风险或取舍：self-hosted 浏览器测试现在依赖 ECS runner 镜像已经包含 Playwright 所需的 Linux 系统依赖。
- 未验证 / 范围外：ECS AMI/镜像及 launch template 位于本仓库之外，本 PR 不负责发布镜像。
- 破坏性变更 / 迁移说明：应先发布 runner 镜像，再合并此 workflow 修改。

## 关联 Issue

关联 #6856

在 self-hosted runner 镜像完成发布并验证前，这个 PR 不应关闭 #6856。

</details>