### PR TITLE
feat(cli): enable VP mode by default and remove redundant bypassVpGate

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1016,7 +1016,7 @@ const SETTINGS_SCHEMA = {
         label: 'Virtualized History (reduces flicker on long sessions)',
         category: 'UI',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
           'Render conversation history in an in-app scrollable viewport instead of the terminal scrollback buffer. Recommended if you see flicker, scroll-storm, or interface freeze on long sessions, after Ctrl+O, after Ctrl+E / Ctrl+F (expand), after window resize, or when alt-tabbing back. Scroll with Shift+↑/↓ (line), PgUp/PgDn (page), Ctrl+Home/End (top/bottom), or the mouse wheel. Also enables mouse interactions: click an option in a menu/dialog to select it, hover to highlight it, and click in the prompt to position the cursor. Does NOT use the host terminal scrollback while enabled; for native text selection, hold Shift (or Option on macOS) while dragging.',
         showInDialog: true,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1091,7 +1091,7 @@ export const AppContainer = (props: AppContainerProps) => {
   // visible refresh in VP mode comes for free from the React tree
   // re-reading `mergedHistory` / `allVirtualItems` on whatever state
   // change triggered refreshStatic (Ctrl+O, model change, etc.).
-  const useTerminalBuffer = settings.merged.ui?.useTerminalBuffer ?? false;
+  const useTerminalBuffer = settings.merged.ui?.useTerminalBuffer ?? true;
   const showScrollbar = settings.merged.ui?.showScrollbar ?? true;
   const refreshStatic = useCallback(() => {
     // While the transcript (alt-screen) owns the whole screen, suppress static

--- a/packages/cli/src/ui/components/shared/ScrollableList.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.tsx
@@ -180,9 +180,12 @@ function ScrollableList<T>(
     [scheduleScrollFlush, cancelPendingScroll],
   );
 
-  // The VP viewport owns the wheel (this IS the in-app scroller), so opt out
-  // of the VP gate — though in practice ScrollableList only mounts in VP mode.
-  useMouseEvents(handleMouseEvent, { isActive: hasFocus, bypassVpGate: true });
+  // ScrollableList only mounts inside the VP-mode branch of MainContent, so
+  // the useMouseEvents VP gate (`isVpMode`) is already satisfied — no need for
+  // bypassVpGate. Omitting it keeps the hook's behavior purely data-driven by
+  // the setting, and avoids enabling mouse tracking in any hypothetical non-VP
+  // context where ScrollableList might be reused.
+  useMouseEvents(handleMouseEvent, { isActive: hasFocus });
 
   // ScrollableList is a thin keyboard / mouse wrapper around VirtualizedList.
   // The previous outer <Box flexGrow={1}> wrapper carried a never-read

--- a/packages/cli/src/ui/hooks/useMouseEvents.ts
+++ b/packages/cli/src/ui/hooks/useMouseEvents.ts
@@ -151,7 +151,7 @@ export function useMouseEvents(
   // pass `bypassVpGate` to opt in. This keeps the non-VP transcript scrollable
   // no matter how many click/hover subscribers are added later.
   const settings = useContext(SettingsContext);
-  const isVpMode = settings?.merged.ui?.useTerminalBuffer ?? false;
+  const isVpMode = settings?.merged.ui?.useTerminalBuffer ?? true;
   const vpGateOpen = isVpMode || bypassVpGate;
 
   const handlerRef = useRef(handler);

--- a/packages/cli/src/ui/startInteractiveUI.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.tsx
@@ -184,7 +184,7 @@ export async function startInteractiveUI(
     );
   };
 
-  const useVP = settings.merged.ui?.useTerminalBuffer ?? false;
+  const useVP = settings.merged.ui?.useTerminalBuffer ?? true;
   const instance = render(
     process.env['DEBUG'] ? (
       <React.StrictMode>


### PR DESCRIPTION
## Summary

- Change `ui.useTerminalBuffer` default from `false` to `true`, making the virtualized viewport (VP mode) the default rendering mode for all users. This resolves non-VP scroll inability (#6149) and Linux scroll-storm issues (#5971).
- Remove redundant `bypassVpGate: true` from ScrollableList — the component only mounts inside the VP-mode branch of MainContent, so the `useMouseEvents` VP gate is already satisfied (#6808).
- Align all `?? false` fallbacks to `?? true` so runtime behavior matches the schema default when the setting is unset.

## Test plan

- [x] `useMouseEvents.test.tsx` passes (7 tests)
- [x] `ConversationMessages.test.tsx` passes (17 tests)
- [x] Type check passes (`tsc --noEmit`)
- [ ] Manual: verify VP mode activates by default on fresh install (no `.settings.json`)
- [ ] Manual: verify mouse wheel scrolling works in the conversation viewport
- [ ] Manual: verify `ui.useTerminalBuffer: false` still disables VP mode

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)