### PR TITLE
fix(web-shell): make composer height adaptive

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -14,7 +14,11 @@
   border-radius: 12px;
   margin: 0;
   cursor: text;
+  --chat-editor-min-height: 140px;
+  --chat-editor-max-height: min(350px, 40vh);
+  --chat-editor-input-min-height: 44px;
   --chat-editor-input-max-height: 300px;
+  --chat-editor-attachments-max-height: 136px;
   --dac-glow-on: 0;
   --dac-glow-pulse: 0;
   --dac-g1: #6a78ff;
@@ -27,8 +31,11 @@
   position: relative;
   z-index: 2;
   display: flex;
-  height: 140px;
+  box-sizing: border-box;
+  min-height: var(--chat-editor-min-height, 140px);
+  max-height: var(--chat-editor-max-height, min(350px, 40vh));
   flex-direction: column;
+  overflow: visible;
   border: 1.5px solid var(--agent-gray-200);
   border-radius: inherit;
   background: var(--chat-editor-bg-primary);
@@ -709,8 +716,19 @@
   }
 }
 
+.attachments {
+  display: flex;
+  min-height: 0;
+  max-height: var(--chat-editor-attachments-max-height, 136px);
+  flex: 0 1 auto;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .tags {
   display: flex;
+  flex: 0 0 auto;
   flex-wrap: wrap;
   gap: 6px;
   padding: 0 0 8px;
@@ -731,14 +749,23 @@
   line-height: 1.2;
 }
 
+.tagContent {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  flex: 1 1 auto;
+  align-items: center;
+}
+
 .tagTooltip {
-  position: absolute;
   z-index: calc(var(--web-shell-tooltip-z-index, 1000) + 1);
-  top: calc(100% + 6px);
-  left: 0;
-  display: none;
+  box-sizing: border-box;
   min-width: 160px;
   max-width: min(320px, 80vw);
+  max-height: min(
+    calc(100vh - 16px),
+    var(--radix-tooltip-content-available-height, calc(100vh - 16px))
+  );
   padding: 8px 10px;
   border: 1px solid var(--chat-editor-border-color);
   border-radius: 6px;
@@ -748,12 +775,10 @@
   font-family: var(--font-sans, system-ui, sans-serif);
   font-size: 12px;
   line-height: 1.5;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  pointer-events: auto;
   white-space: normal;
-}
-
-.tag:hover .tagTooltip,
-.tag:focus-within .tagTooltip {
-  display: block;
 }
 
 .tagLabel,
@@ -819,20 +844,34 @@
 .editorArea {
   display: flex;
   flex: 1 1 auto;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 6px;
-  min-height: 0;
+  min-height: var(--chat-editor-input-min-height, 44px);
   padding: 4px 0;
-  overflow: auto;
+  overflow: clip;
 }
 
 .editorArea > :last-child {
+  display: grid;
   min-width: 0;
+  min-height: var(--chat-editor-input-min-height, 44px);
   flex: 1;
+  overflow: clip;
+}
+
+.editorArea :global(.cm-editor) {
+  height: 100%;
+  min-height: 0;
+}
+
+.editorArea :global(.cm-scroller) {
+  height: 100%;
+  min-height: 0;
 }
 
 .shellPrefix {
   flex: 0 0 auto;
+  align-self: flex-start;
   padding-top: 1px;
   color: var(--chat-editor-accent-color);
   font-family: var(--font-mono);
@@ -870,6 +909,7 @@
 
 .toolbar {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   min-width: 0;
@@ -1613,6 +1653,7 @@
 
 .images {
   display: flex;
+  flex: 0 0 auto;
   gap: 6px;
   padding: 4px 0 0;
   flex-wrap: wrap;

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -5,8 +5,20 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../i18n';
 import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
+import type {
+  ComposerTagClickHandler,
+  ComposerTagRenderer,
+  WebShellComposerTag,
+} from '../customization';
+import { WebShellCustomizationProvider } from '../customization';
+import { WebShellPortalRootContext } from '../portalRoot';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const mockComposerCoreState = vi.hoisted(() => ({
+  composerTags: [] as WebShellComposerTag[],
+  removeTopTag: vi.fn(),
+}));
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -44,8 +56,8 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
       },
       pastedImages: [],
       removeImage: vi.fn(),
-      composerTags: [],
-      removeTopTag: vi.fn(),
+      composerTags: mockComposerCoreState.composerTags,
+      removeTopTag: mockComposerCoreState.removeTopTag,
       addTags: vi.fn(),
       removeInlineTags: vi.fn(),
       insertText: vi.fn(),
@@ -96,13 +108,20 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
   };
 });
 
-const mounted: Array<{ root: Root; container: HTMLDivElement }> = [];
+const mounted: Array<{
+  root: Root;
+  container: HTMLDivElement;
+  portalRoot: HTMLDivElement;
+}> = [];
 
 afterEach(() => {
-  for (const { root, container } of mounted.splice(0)) {
+  for (const { root, container, portalRoot } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
+    portalRoot.remove();
   }
+  mockComposerCoreState.composerTags = [];
+  mockComposerCoreState.removeTopTag.mockReset();
 });
 
 function renderChatEditor(props: {
@@ -110,24 +129,37 @@ function renderChatEditor(props: {
   workspaceName?: string;
   workspaceTitle?: string;
   visibleToolbarActions?: readonly ComposerToolbarAction[];
+  renderComposerTagTooltip?: ComposerTagRenderer;
+  onComposerTagClick?: ComposerTagClickHandler;
 }) {
+  const { renderComposerTagTooltip, onComposerTagClick, ...chatEditorProps } =
+    props;
   const container = document.createElement('div');
+  const portalRoot = document.createElement('div');
+  portalRoot.dataset.webShellPortalRoot = '';
   document.body.appendChild(container);
+  document.body.appendChild(portalRoot);
   const root = createRoot(container);
-  mounted.push({ root, container });
+  mounted.push({ root, container, portalRoot });
 
   act(() => {
     root.render(
-      <I18nProvider language="en">
-        <ChatEditor
-          onSubmit={() => undefined}
-          commands={[]}
-          showChatWidthToggle={false}
-          currentMode="default"
-          currentModel="qwen"
-          {...props}
-        />
-      </I18nProvider>,
+      <WebShellPortalRootContext.Provider value={portalRoot}>
+        <WebShellCustomizationProvider
+          value={{ renderComposerTagTooltip, onComposerTagClick }}
+        >
+          <I18nProvider language="en">
+            <ChatEditor
+              onSubmit={() => undefined}
+              commands={[]}
+              showChatWidthToggle={false}
+              currentMode="default"
+              currentModel="qwen"
+              {...chatEditorProps}
+            />
+          </I18nProvider>
+        </WebShellCustomizationProvider>
+      </WebShellPortalRootContext.Provider>,
     );
   });
 
@@ -220,5 +252,142 @@ describe('ChatEditor workspace toolbar integration', () => {
     expect(
       ws!.compareDocumentPosition(git!) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+});
+
+describe('ChatEditor top composer tag tooltip', () => {
+  it('activates the plain tag from click and keyboard with the outer tag rect', () => {
+    mockComposerCoreState.composerTags = [
+      { id: 'orders', label: 'Table', value: 'orders', removable: false },
+    ];
+    const onComposerTagClick = vi.fn();
+    const container = renderChatEditor({
+      onComposerTagClick,
+      visibleToolbarActions: [],
+    });
+    const tag = container.querySelector<HTMLElement>(
+      '[data-web-shell-composer-tag]',
+    )!;
+    const trigger = tag.querySelector<HTMLElement>(
+      '[data-web-shell-composer-tag-trigger]',
+    )!;
+    const outerRect = { width: 200 } as DOMRect;
+    const innerRect = { width: 120 } as DOMRect;
+    tag.getBoundingClientRect = vi.fn(() => outerRect);
+    trigger.getBoundingClientRect = vi.fn(() => innerRect);
+
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      trigger.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+      trigger.dispatchEvent(
+        new KeyboardEvent('keydown', { key: ' ', bubbles: true }),
+      );
+    });
+
+    expect(onComposerTagClick).toHaveBeenCalledTimes(3);
+    for (const [info] of onComposerTagClick.mock.calls) {
+      expect(info).toMatchObject({
+        tag: mockComposerCoreState.composerTags[0],
+        placement: 'composer',
+        readonly: false,
+        anchorRect: outerRect,
+      });
+    }
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+
+  it('removes a tag without activating it', () => {
+    mockComposerCoreState.composerTags = [
+      { id: 'orders', label: 'Table', value: 'orders' },
+    ];
+    const onComposerTagClick = vi.fn();
+    const container = renderChatEditor({
+      onComposerTagClick,
+      visibleToolbarActions: [],
+    });
+    const remove = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Remove orders"]',
+    )!;
+
+    act(() => {
+      remove.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      remove.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+      remove.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(mockComposerCoreState.removeTopTag).toHaveBeenCalledTimes(3);
+    expect(mockComposerCoreState.removeTopTag).toHaveBeenCalledWith('orders');
+    expect(onComposerTagClick).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a plain tag when custom tooltip rendering throws', () => {
+    mockComposerCoreState.composerTags = [
+      { id: 'orders', label: 'Table', value: 'orders' },
+    ];
+    const error = new Error('bad composer tooltip');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const container = renderChatEditor({
+      renderComposerTagTooltip: () => {
+        throw error;
+      },
+      visibleToolbarActions: [],
+    });
+
+    expect(container.textContent).toContain('Table');
+    expect(container.textContent).toContain('orders');
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      '[WebShell] composer tag tooltip render failed',
+      error,
+    );
+    warn.mockRestore();
+  });
+
+  it('opens custom content from a top tag in the configured portal root', () => {
+    mockComposerCoreState.composerTags = [
+      { id: 'orders', label: 'Table', value: 'orders' },
+    ];
+    const container = renderChatEditor({
+      renderComposerTagTooltip: () => 'Table details',
+      visibleToolbarActions: [],
+    });
+    const portalRoot = document.body.querySelector<HTMLElement>(
+      '[data-web-shell-portal-root]',
+    );
+    const tag = container.querySelector<HTMLElement>(
+      '[data-web-shell-composer-tag]',
+    );
+    const trigger = tag?.querySelector<HTMLElement>(
+      '[data-web-shell-composer-tag-trigger]',
+    );
+    const removeButton = tag?.querySelector<HTMLButtonElement>('button');
+
+    expect(trigger).not.toBeNull();
+    expect(trigger?.getAttribute('role')).toBeNull();
+    expect(trigger?.tabIndex).toBe(0);
+    expect(removeButton).not.toBeNull();
+    expect(trigger?.contains(removeButton ?? null)).toBe(false);
+    act(() => trigger?.focus());
+
+    const content = portalRoot?.querySelector<HTMLElement>(
+      '[data-web-shell-composer-tag-tooltip]',
+    );
+    const accessibleTooltip =
+      portalRoot?.querySelector<HTMLElement>('[role="tooltip"]');
+    expect(content).not.toBeNull();
+    expect(content?.textContent).toContain('Table details');
+    expect(container.contains(content ?? null)).toBe(false);
+    expect(portalRoot?.contains(content ?? null)).toBe(true);
+    expect(accessibleTooltip).not.toBeNull();
+    expect(trigger?.getAttribute('aria-describedby')).toBe(
+      accessibleTooltip?.id,
+    );
+    expect(tag?.hasAttribute('aria-describedby')).toBe(false);
   });
 });

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import type { CSSProperties, ReactNode, RefObject } from 'react';
+import { Tooltip as TooltipPrimitive } from 'radix-ui';
 import { DAEMON_APPROVAL_MODES } from '@qwen-code/webui/daemon-react-sdk';
 import type { CommandInfo } from '../adapters/types';
 import type { UseDaemonFollowupSuggestionReturn } from '@qwen-code/webui/daemon-react-sdk';
@@ -41,6 +42,7 @@ import { isSafeImageSrc } from './messages/Markdown';
 import { ModeIcon } from './ModeIcon';
 import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
+import { useWebShellPortalRoot } from '../portalRoot';
 import { VoiceButton } from '../voice/VoiceButton';
 import { GitBranchIndicator } from './GitBranchIndicator';
 import { WorkspaceIndicator } from './WorkspaceIndicator';
@@ -202,6 +204,105 @@ const SLASH_PANEL_THEME_VARS = [
   '--chat-editor-text-primary',
   '--chat-editor-text-secondary',
 ] as const;
+
+function TopComposerTag({
+  tag,
+  content,
+  tooltip,
+  onActivate,
+  onRemove,
+}: {
+  tag: WebShellComposerTag;
+  content: ReactNode;
+  tooltip: ReactNode | null | undefined;
+  onActivate?: (anchorRect: DOMRectReadOnly) => void;
+  onRemove?: () => void;
+}) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const portalRoot = useWebShellPortalRoot();
+  const hasTooltip = tooltip !== undefined && tooltip !== null;
+  const tagContent = (
+    <span
+      className={styles.tagContent}
+      data-web-shell-composer-tag-trigger
+      role={onActivate ? 'button' : undefined}
+      tabIndex={onActivate || hasTooltip ? 0 : undefined}
+      onClick={(event) => {
+        if (!onActivate) return;
+        event.stopPropagation();
+        onActivate(
+          anchorRef.current?.getBoundingClientRect() ??
+            event.currentTarget.getBoundingClientRect(),
+        );
+      }}
+      onKeyDown={(event) => {
+        if (!onActivate) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        onActivate(
+          anchorRef.current?.getBoundingClientRect() ??
+            event.currentTarget.getBoundingClientRect(),
+        );
+      }}
+    >
+      {content}
+    </span>
+  );
+  const tagElement = (
+    <span ref={anchorRef} className={styles.tag} data-web-shell-composer-tag>
+      {hasTooltip ? (
+        <TooltipPrimitive.Trigger asChild>
+          {tagContent}
+        </TooltipPrimitive.Trigger>
+      ) : (
+        tagContent
+      )}
+      {onRemove && (
+        <button
+          type="button"
+          className={styles.tagRemove}
+          aria-label={`Remove ${getComposerTagDisplay(tag)}`}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.stopPropagation();
+              return;
+            }
+            if (event.key !== 'Backspace' && event.key !== 'Delete') return;
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove();
+          }}
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+
+  if (!hasTooltip) return tagElement;
+
+  return (
+    <TooltipPrimitive.Root disableHoverableContent={false}>
+      {tagElement}
+      <TooltipPrimitive.Portal container={portalRoot ?? undefined}>
+        <TooltipPrimitive.Content
+          className={styles.tagTooltip}
+          data-web-shell-composer-tag-tooltip
+          sideOffset={6}
+          collisionPadding={8}
+          avoidCollisions
+        >
+          {tooltip}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
+  );
+}
 
 function SendIcon() {
   return (
@@ -1634,102 +1735,82 @@ export const ChatEditor = memo(
             </div>
           )}
           <div className={styles.content}>
-            {core.composerTags.length > 0 && (
-              <div className={styles.tags}>
-                {core.composerTags.map((tag) => {
-                  const tagInfo = {
-                    tag,
-                    placement: 'composer' as const,
-                    readonly: false,
-                  };
-                  const tooltip = renderComposerTagTooltip?.(tagInfo);
-                  return (
-                    <span
-                      key={tag.id}
-                      className={styles.tag}
-                      role={onComposerTagClick ? 'button' : undefined}
-                      tabIndex={onComposerTagClick ? 0 : undefined}
-                      onClick={(event) => {
-                        if (!onComposerTagClick) return;
-                        event.stopPropagation();
-                        onComposerTagClick({
-                          ...tagInfo,
-                          anchorRect:
-                            event.currentTarget.getBoundingClientRect(),
-                        });
-                      }}
-                      onKeyDown={(event) => {
-                        if (!onComposerTagClick) return;
-                        if (event.key !== 'Enter' && event.key !== ' ') return;
-                        event.preventDefault();
-                        onComposerTagClick({
-                          ...tagInfo,
-                          anchorRect:
-                            event.currentTarget.getBoundingClientRect(),
-                        });
-                      }}
-                    >
-                      {renderComposerTagContent(tag)}
-                      {tag.removable !== false && (
+            {(core.composerTags.length > 0 || core.pastedImages.length > 0) && (
+              <div
+                className={styles.attachments}
+                data-web-shell-composer-attachments
+              >
+                {core.composerTags.length > 0 && (
+                  <TooltipPrimitive.Provider
+                    delayDuration={0}
+                    disableHoverableContent={false}
+                  >
+                    <div className={styles.tags}>
+                      {core.composerTags.map((tag) => {
+                        const tagInfo = {
+                          tag,
+                          placement: 'composer' as const,
+                          readonly: false,
+                        };
+                        let tooltip: ReactNode | null | undefined;
+                        try {
+                          tooltip = renderComposerTagTooltip?.(tagInfo);
+                        } catch (error) {
+                          console.warn(
+                            '[WebShell] composer tag tooltip render failed',
+                            error,
+                          );
+                        }
+                        return (
+                          <TopComposerTag
+                            key={tag.id}
+                            tag={tag}
+                            content={renderComposerTagContent(tag)}
+                            tooltip={tooltip}
+                            onActivate={
+                              onComposerTagClick
+                                ? (anchorRect) =>
+                                    onComposerTagClick({
+                                      ...tagInfo,
+                                      anchorRect,
+                                    })
+                                : undefined
+                            }
+                            onRemove={
+                              tag.removable !== false
+                                ? () => {
+                                    core.removeTopTag(tag.id);
+                                    core.viewRef.current?.focus();
+                                  }
+                                : undefined
+                            }
+                          />
+                        );
+                      })}
+                    </div>
+                  </TooltipPrimitive.Provider>
+                )}
+                {core.pastedImages.length > 0 && (
+                  <div className={styles.images}>
+                    {core.pastedImages.map((img, i) => (
+                      <div key={i} className={styles.imageThumb}>
+                        <img
+                          src={`data:${img.media_type};base64,${img.data}`}
+                          alt=""
+                        />
                         <button
-                          type="button"
-                          className={styles.tagRemove}
-                          aria-label={`Remove ${getComposerTagDisplay(tag)}`}
-                          onMouseDown={(event) => event.preventDefault()}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            core.removeTopTag(tag.id);
-                            core.viewRef.current?.focus();
-                          }}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter' || event.key === ' ') {
-                              event.stopPropagation();
-                              return;
-                            }
-                            if (
-                              event.key !== 'Backspace' &&
-                              event.key !== 'Delete'
-                            ) {
-                              return;
-                            }
-                            event.preventDefault();
-                            event.stopPropagation();
-                            core.removeTopTag(tag.id);
-                            core.viewRef.current?.focus();
+                          className={styles.imageRemove}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            core.removeImage(i);
                           }}
                         >
                           ×
                         </button>
-                      )}
-                      {tooltip !== undefined && tooltip !== null && (
-                        <span className={styles.tagTooltip} role="tooltip">
-                          {tooltip}
-                        </span>
-                      )}
-                    </span>
-                  );
-                })}
-              </div>
-            )}
-            {core.pastedImages.length > 0 && (
-              <div className={styles.images}>
-                {core.pastedImages.map((img, i) => (
-                  <div key={i} className={styles.imageThumb}>
-                    <img
-                      src={`data:${img.media_type};base64,${img.data}`}
-                      alt=""
-                    />
-                    <button
-                      className={styles.imageRemove}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        core.removeImage(i);
-                      }}
-                    >
-                      ×
-                    </button>
+                      </div>
+                    ))}
                   </div>
-                ))}
+                )}
               </div>
             )}
             {core.slashMenu && (

--- a/packages/web-shell/client/e2e/composer-layout-harness.html
+++ b/packages/web-shell/client/e2e/composer-layout-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Composer layout harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/e2e/composer-layout-harness.tsx"></script>
+  </body>
+</html>

--- a/packages/web-shell/client/e2e/composer-layout-harness.tsx
+++ b/packages/web-shell/client/e2e/composer-layout-harness.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '../styles/standalone.css';
+
+const indexEntry = '../index.tsx';
+const { WebShellWithProviders } = await import(/* @vite-ignore */ indexEntry);
+
+const params = new URLSearchParams(window.location.search);
+const sessionId = params.get('sessionId') ?? 'composer-layout-e2e';
+const tags = Array.from({ length: 18 }, (_, index) => ({
+  id: `table-${index + 1}`,
+  label: 'Table',
+  value: `analytics_table_${index + 1}`,
+}));
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <WebShellWithProviders
+      baseUrl={window.location.origin}
+      sessionId={sessionId}
+      sidebar={false}
+      composerInput={{ tags, tagPlacement: 'top' }}
+      composerInputVersion={1}
+      renderComposerTagTooltip={({ tag }) => `Details for ${tag.value}`}
+    />
+  </React.StrictMode>,
+);

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from '@playwright/test';
 import {
   assistantTextEvent,
   createWebShellDaemonScenario,
@@ -11,6 +17,8 @@ import {
   type MockDaemonController,
   type WebShellDaemonScenario,
 } from './utils/mockDaemon';
+
+const COMPOSER_VIEWPORT_HEIGHTS = [1000, 800, 600] as const;
 
 test('loads replayed transcript and connects to fake daemon @smoke', async ({
   page,
@@ -197,6 +205,198 @@ test('opens slash menu, resume dialog, model dialog, and theme dialog @smoke', a
   await expect(page.locator('[data-web-shell-theme-dialog]')).toHaveCount(0);
 });
 
+for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
+  test(`grows long text to the responsive composer cap at ${viewportHeight}px @smoke`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: 1280, height: viewportHeight });
+    const scenario = createWebShellDaemonScenario();
+    const daemon = await installScenario(page, scenario, testInfo);
+
+    await gotoSession(page, scenario, daemon);
+    const surface = page.locator('[data-web-shell-composer-surface]');
+    const initialHeight = await composerHeight(page);
+    expect(initialHeight).toBe(140);
+
+    await replaceComposerText(
+      page,
+      Array.from(
+        { length: 10 },
+        (_, index) => `Visible line ${index + 1}`,
+      ).join('\n'),
+    );
+    await expect
+      .poll(() => composerHeight(page))
+      .toBeGreaterThan(initialHeight);
+
+    await replaceComposerText(
+      page,
+      Array.from({ length: 80 }, (_, index) => `Capped line ${index + 1}`).join(
+        '\n',
+      ),
+    );
+    await expectCappedComposerLayout(page, viewportHeight);
+    await expect(surface).toBeVisible();
+
+    await page.keyboard.press('Control+r');
+    const historySearch = surface.locator('input');
+    await expect(historySearch).toBeVisible();
+    const searchPanel = historySearch.locator('..').locator('..');
+    await expect
+      .poll(async () => {
+        const [panelBox, surfaceBox] = await Promise.all([
+          searchPanel.boundingBox(),
+          surface.boundingBox(),
+        ]);
+        if (!panelBox || !surfaceBox) return Number.POSITIVE_INFINITY;
+        return panelBox.y + panelBox.height - surfaceBox.y;
+      })
+      .toBeLessThanOrEqual(-7);
+    await page.keyboard.press('Escape');
+    await expect(historySearch).toHaveCount(0);
+
+    const modeButton = page.locator('[data-web-shell-mode-button]');
+    await modeButton.click();
+    const modeDropdown = modeButton.locator('..').locator(':scope > div');
+    await expect(modeDropdown).toBeVisible();
+    await expect
+      .poll(async () => {
+        const [dropdownBox, buttonBox] = await Promise.all([
+          modeDropdown.boundingBox(),
+          modeButton.boundingBox(),
+        ]);
+        if (!dropdownBox || !buttonBox) return Number.POSITIVE_INFINITY;
+        return dropdownBox.y + dropdownBox.height - buttonBox.y;
+      })
+      .toBeLessThanOrEqual(-3);
+    await page.keyboard.press('Escape');
+
+    await replaceComposerText(page, 'Short draft');
+    await expect.poll(() => composerHeight(page)).toBe(initialHeight);
+  });
+}
+
+for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
+  test(`bounds shared attachments and long text at ${viewportHeight}px @smoke`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: 1280, height: viewportHeight });
+    const scenario = createWebShellDaemonScenario({
+      sessionId: `composer-layout-${viewportHeight}`,
+    });
+    const daemon = await installScenario(page, scenario, testInfo);
+
+    await gotoComposerLayoutHarness(page, scenario, daemon);
+    const tags = page.locator('[data-web-shell-composer-tag]');
+    await expect(tags).toHaveCount(18);
+    await expect(tags.first()).toBeVisible();
+
+    await pasteComposerImages(page, 8);
+    const images = page.locator(
+      '[data-web-shell-composer-attachments] img[src^="data:image/png;base64,"]',
+    );
+    await expect(images).toHaveCount(8);
+    await expectImagesDecoded(images);
+    await replaceComposerText(
+      page,
+      Array.from(
+        { length: 80 },
+        (_, index) => `Attachment line ${index + 1}`,
+      ).join('\n'),
+    );
+
+    await expectCappedComposerLayout(page, viewportHeight);
+    const attachments = page.locator('[data-web-shell-composer-attachments]');
+    await expect(attachments).toBeVisible();
+    await expect
+      .poll(async () => (await attachments.boundingBox())?.height ?? 0)
+      .toBeLessThanOrEqual(136);
+    await expect
+      .poll(() =>
+        attachments.evaluate(
+          (element) => element.scrollHeight > element.clientHeight + 1,
+        ),
+      )
+      .toBe(true);
+
+    if (viewportHeight === 600) {
+      await tags
+        .first()
+        .locator('[data-web-shell-composer-tag-trigger]')
+        .hover();
+      const portalRoot = page.locator('[data-web-shell-portal-root]');
+      const tooltip = portalRoot.locator(
+        '[data-web-shell-composer-tag-tooltip]',
+      );
+      await expect(tooltip).toBeVisible();
+      await expect
+        .poll(async () =>
+          tooltip.evaluate((element) => {
+            const rect = element.getBoundingClientRect();
+            const tolerance = 1;
+            return (
+              getComputedStyle(element).overflowY === 'auto' &&
+              rect.top >= 8 - tolerance &&
+              rect.left >= 8 - tolerance &&
+              rect.right <= window.innerWidth - 8 + tolerance &&
+              rect.bottom <= window.innerHeight - 8 + tolerance
+            );
+          }),
+        )
+        .toBe(true);
+    }
+
+    await attachments.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await expect
+      .poll(async () => {
+        const [attachmentsBox, imageBox] = await Promise.all([
+          attachments.boundingBox(),
+          images.last().boundingBox(),
+        ]);
+        if (!attachmentsBox || !imageBox) return false;
+        const tolerance = 1;
+        return (
+          imageBox.y >= attachmentsBox.y - tolerance &&
+          imageBox.y + imageBox.height <=
+            attachmentsBox.y + attachmentsBox.height + tolerance
+        );
+      })
+      .toBe(true);
+  });
+}
+
+test('lets a pasted image grow the composer without collapsing the text viewport @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario();
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoSession(page, scenario, daemon);
+  const initialHeight = await composerHeight(page);
+  await pasteComposerImages(page, 1);
+
+  const image = page.locator(
+    '[data-web-shell-composer-surface] img[src^="data:image/png;base64,"]',
+  );
+  await expect(image).toHaveCount(1);
+  await expectImagesDecoded(image);
+  await expect.poll(() => composerHeight(page)).toBeGreaterThan(initialHeight);
+  await expect
+    .poll(async () => {
+      const box = await page
+        .locator('[data-web-shell-composer-editor]')
+        .boundingBox();
+      return box?.height ?? 0;
+    })
+    .toBeGreaterThanOrEqual(44);
+
+  await image.locator('..').getByRole('button').click();
+  await expect(image).toHaveCount(0);
+  await expect.poll(() => composerHeight(page)).toBe(initialHeight);
+});
+
 async function installScenario(
   page: Page,
   scenario: WebShellDaemonScenario,
@@ -222,6 +422,18 @@ async function gotoSession(
   );
 }
 
+async function gotoComposerLayoutHarness(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  daemon: MockDaemonController,
+): Promise<void> {
+  await page.goto(
+    `/e2e/composer-layout-harness.html?sessionId=${encodeURIComponent(scenario.sessionId)}`,
+  );
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  await completeReplay(page, daemon, scenario.sessionId);
+}
+
 async function completeReplay(
   page: Page,
   daemon: MockDaemonController,
@@ -245,6 +457,144 @@ async function fillComposer(page: Page, text: string): Promise<void> {
     process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
   );
   await page.keyboard.type(text);
+}
+
+async function replaceComposerText(page: Page, text: string): Promise<void> {
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await editor.click();
+  await page.keyboard.press(
+    process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+  );
+  await page.keyboard.insertText(text);
+}
+
+async function pasteComposerImages(page: Page, count: number): Promise<void> {
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await editor.evaluate((element, imageCount) => {
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    const binary = atob(pngBase64);
+    const pngBytes = Uint8Array.from(binary, (byte) => byte.charCodeAt(0));
+    const clipboard = new DataTransfer();
+    for (let index = 0; index < imageCount; index += 1) {
+      clipboard.items.add(
+        new File([pngBytes], `pasted-${index + 1}.png`, { type: 'image/png' }),
+      );
+    }
+    element.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: clipboard,
+      }),
+    );
+  }, count);
+}
+
+async function expectImagesDecoded(images: Locator): Promise<void> {
+  await expect
+    .poll(() =>
+      images.evaluateAll((elements) =>
+        elements.every(
+          (element) =>
+            element instanceof HTMLImageElement &&
+            element.complete &&
+            element.naturalWidth > 0 &&
+            element.naturalHeight > 0,
+        ),
+      ),
+    )
+    .toBe(true);
+}
+
+async function expectCappedComposerLayout(
+  page: Page,
+  viewportHeight: number,
+): Promise<void> {
+  const maximumHeight = Math.min(350, viewportHeight * 0.4);
+  await expect
+    .poll(() => composerHeight(page))
+    .toBeGreaterThanOrEqual(maximumHeight - 1);
+  await expect
+    .poll(() => composerHeight(page))
+    .toBeLessThanOrEqual(maximumHeight + 1);
+
+  const surface = page.locator('[data-web-shell-composer-surface]');
+  const editorHost = page.locator('[data-web-shell-composer-editor]');
+  const editorArea = editorHost.locator('..');
+  const scroller = editorHost.locator('.cm-scroller');
+  const content = scroller.locator('.cm-content');
+  const toolbar = page
+    .locator('[data-web-shell-composer-submit]')
+    .locator('..')
+    .locator('..');
+
+  await expect
+    .poll(async () => (await editorArea.boundingBox())?.height ?? 0)
+    .toBeGreaterThanOrEqual(44);
+  await expect(toolbar).toBeVisible();
+  await expect
+    .poll(async () => {
+      const [surfaceBox, toolbarBox] = await Promise.all([
+        surface.boundingBox(),
+        toolbar.boundingBox(),
+      ]);
+      if (!surfaceBox || !toolbarBox) return false;
+      return (
+        toolbarBox.y >= surfaceBox.y - 1 &&
+        toolbarBox.y + toolbarBox.height <= surfaceBox.y + surfaceBox.height + 1
+      );
+    })
+    .toBe(true);
+
+  await expect
+    .poll(() =>
+      editorArea.evaluate((element) => getComputedStyle(element).overflowY),
+    )
+    .toBe('clip');
+  await expect
+    .poll(() =>
+      editorHost.evaluate((element) => getComputedStyle(element).overflowY),
+    )
+    .toBe('clip');
+  await expect
+    .poll(() =>
+      scroller.evaluate((element) => getComputedStyle(element).overflowY),
+    )
+    .toBe('auto');
+  await expect
+    .poll(() =>
+      editorArea.evaluate(
+        (element) => element.scrollHeight <= element.clientHeight + 1,
+      ),
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
+      editorHost.evaluate(
+        (element) => element.scrollHeight <= element.clientHeight + 1,
+      ),
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
+      scroller.evaluate(
+        (element) => element.scrollHeight > element.clientHeight + 1,
+      ),
+    )
+    .toBe(true);
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop > 0))
+    .toBe(true);
+  await expect(content).toBeFocused();
+}
+
+async function composerHeight(page: Page): Promise<number> {
+  const box = await page
+    .locator('[data-web-shell-composer-surface]')
+    .boundingBox();
+  if (!box) throw new Error('Expected the composer surface to be visible.');
+  return box.height;
 }
 
 async function submitLocalCommand(page: Page, text: string): Promise<void> {


### PR DESCRIPTION
## What this PR does

Makes the Web Shell composer grow with long text and pasted image attachments while keeping the total composer height bounded by `min(350px, 40vh)`. The editor remains at least 44px tall, attachments share a 136px scroll budget, and CodeMirror owns long-text scrolling after the cap is reached. Tooltip portals are scoped to the Web Shell container so growing the composer does not misplace overlays.

## Why it's needed

The previous fixed-height composer made long prompts difficult to read. Pasting images also consumed the existing editor space instead of expanding the composer, leaving an even smaller visible typing area. A bounded adaptive height improves both cases without allowing the composer to take over the viewport.

## Reviewer Test Plan

### How to verify

1. Open Web Shell and enter enough multiline text to exceed the initial composer height. Confirm the composer grows, then CodeMirror scrolls once the composer reaches `min(350px, 40vh)`.
2. Paste one or more images. Confirm the attachment area expands the composer upward, the editor keeps a usable minimum height, and overflowing attachments scroll within their own area.
3. Repeat at viewport heights of 1000px, 800px, and 600px. Confirm the 350px absolute cap applies on taller viewports and the 40vh cap applies on shorter viewports.
4. Hover tags and toolbar controls near the expanded composer and remove an attachment. Confirm tooltips remain in the Web Shell viewport and removing an attachment does not activate its tag.
5. Automated evidence: ChatEditor unit tests passed (10/10), Chromium composer layout matrix passed (7/7), Web Shell package tests passed (95 files, 1576 tests), package typecheck passed, package build passed, and the staged pre-commit checks passed. The root preflight passed install, formatting, lint, build, and typecheck; its CLI test workspace reported three unrelated baseline/environment failures (locale text assertion and server fixture/timeout behavior), so the remaining root workspace tests were stopped rather than rerunning the full monorepo suite.

### Evidence (Before & After)

Before: long text stayed inside a fixed-height composer, and pasted images reduced the visible editor area.

After: text and attachments grow the composer until `min(350px, 40vh)`; beyond that point, text and attachments scroll in their designated regions while the toolbar and overlays remain stable. Verified locally in the pre-DW IDE flow.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Web Shell/IDE verification plus Vitest and Playwright Chromium tests.

## Risk & Scope

- Main risk or tradeoff: The composer can occupy more vertical space than before, but it is bounded by both an absolute and viewport-relative cap.
- Not validated / out of scope: Windows and Linux browser rendering were not tested locally; unrelated CLI baseline test failures were not changed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

让 Web Shell 输入框在输入长文本和粘贴图片附件时自适应增高，同时将总高度限制为 `min(350px, 40vh)`。编辑区域始终至少保留 44px 高度，附件区域共享 136px 的滚动空间，达到高度上限后由 CodeMirror 承担长文本滚动。Tooltip Portal 被限制在 Web Shell 容器内，避免输入框增高后浮层错位。

## 为什么需要这个改动

原先固定高度的输入框会让长提示词难以阅读。粘贴图片后，图片还会挤占已有的编辑区域，而不是向上扩展整个输入框，导致可见输入空间进一步缩小。设置有上限的自适应高度可以改善这两种场景，同时避免输入框占满整个视口。

## 评审测试计划

### 如何验证

1. 打开 Web Shell，输入足够多的多行文本，使内容超过初始输入框高度。确认输入框会自动增高，并在达到 `min(350px, 40vh)` 后由 CodeMirror 滚动。
2. 粘贴一张或多张图片。确认附件区域会把输入框向上撑开，编辑区域仍保留可用的最小高度，附件溢出后在附件区域内部滚动。
3. 分别在 1000px、800px 和 600px 的视口高度下重复验证。确认较高视口受 350px 绝对上限约束，较矮视口受 40vh 上限约束。
4. 在增高后的输入框附近悬停标签和工具栏控件，并移除附件。确认 Tooltip 始终位于 Web Shell 视口内，移除附件不会误触发其标签。
5. 自动化验证证据：ChatEditor 单测通过（10/10），Chromium 输入框布局矩阵通过（7/7），Web Shell 包测试通过（95 个文件、1576 个测试），包级 typecheck 通过，包级 build 通过，暂存文件的 pre-commit 检查通过。根级 preflight 的依赖安装、格式化、lint、build 和 typecheck 已通过；CLI 测试工作区出现 3 个与本改动无关的基线/环境失败（locale 文案断言以及 server fixture/超时行为），因此没有继续重复运行剩余的 monorepo 全量测试。

### 改动前后证据

改动前：长文本被限制在固定高度的输入框内，粘贴图片会进一步压缩可见编辑区域。

改动后：文本和附件会将输入框撑高到 `min(350px, 40vh)`；超过上限后，文本和附件分别在指定区域内滚动，工具栏和浮层保持稳定。已在本地 pre-DW IDE 流程中验证。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

本地 Web Shell/IDE 验证，以及 Vitest 和 Playwright Chromium 测试。

## 风险与范围

- 主要风险或权衡：输入框可能比之前占用更多垂直空间，但同时受到绝对高度和视口相对高度的双重限制。
- 未验证或不在范围内：未在本地验证 Windows 和 Linux 的浏览器渲染；未修改无关的 CLI 基线测试失败。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
