### PR TITLE
fix(cli): avoid updating active CLI processes

### DIFF
--- a/docs/users/features/sandbox.md
+++ b/docs/users/features/sandbox.md
@@ -114,6 +114,8 @@ Priority order (highest to lowest):
 
 `settings.env.QWEN_SANDBOX_IMAGE` also works as a generic env injection mechanism, but `tools.sandboxImage` is the preferred persistent setting.
 
+Custom images are user-managed. Rebuild them with an up-to-date Qwen Code installation to receive the safe update handoff; older images may still use their original in-process updater.
+
 ### macOS Seatbelt profiles
 
 Built-in profiles (set via `SEATBELT_PROFILE` env var):

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -7,6 +7,7 @@
 import type { Argv } from 'yargs';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  chmodSync,
   copyFileSync,
   mkdirSync,
   mkdtempSync,
@@ -343,6 +344,89 @@ describe('bootstrap import boundaries', () => {
     expect(source).toContain("first === 'mcp'");
     expect(source).toContain("hasFlag('--help', '-h')");
     expect(source).toContain("hasFlag('--version', '-v')");
+    expect(source).toContain('UPDATE_COMPLETE_EXIT_CODE = 44');
+  });
+
+  it('reloads the CLI through a stable shim after an update', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-cli-update-'));
+    const wrongDir = mkdtempSync(path.join(tmpdir(), 'qwen-cli-wrong-'));
+    const oldDir = path.join(tempDir, 'old');
+    const newDir = path.join(tempDir, 'new');
+    const binPath = path.join(tempDir, 'qwen');
+    try {
+      mkdirSync(oldDir);
+      mkdirSync(newDir);
+      copyFileSync(
+        '../../scripts/cli-entry.js',
+        path.join(oldDir, 'entry.mjs'),
+      );
+      copyFileSync(
+        '../../scripts/cli-entry.js',
+        path.join(newDir, 'entry.mjs'),
+      );
+      writeFileSync(
+        path.join(oldDir, 'cli.js'),
+        `import { chmodSync, rmSync, writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(binPath)}, ${JSON.stringify(`#!/bin/sh\nexec "${process.execPath}" "${path.join(newDir, 'entry.mjs')}" "$@"\n`)});\nchmodSync(${JSON.stringify(binPath)}, 0o755);\nrmSync(${JSON.stringify(oldDir)}, { recursive: true, force: true });\nprocess.exit(44);\n`,
+      );
+      writeFileSync(
+        path.join(newDir, 'cli.js'),
+        "process.stdout.write(`${JSON.stringify({ args: process.argv.slice(2), skip: process.env.QWEN_CODE_SKIP_UPDATE_CHECK_ONCE, hasLauncherPid: /^\\d+$/.test(process.env.QWEN_CODE_LAUNCHER_PID ?? ''), launcherPath: process.env.QWEN_CODE_LAUNCHER_PATH })}\\n`);\n",
+      );
+      writeFileSync(
+        binPath,
+        `#!/bin/sh\nexec "${process.execPath}" "${path.join(oldDir, 'entry.mjs')}" "$@"\n`,
+      );
+      chmodSync(binPath, 0o755);
+      writeFileSync(
+        path.join(wrongDir, 'qwen'),
+        '#!/bin/sh\necho wrong-launcher\n',
+      );
+      chmodSync(path.join(wrongDir, 'qwen'), 0o755);
+
+      const output = execFileSync(binPath, ['--prompt', 'a&b'], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${wrongDir}${path.delimiter}${tempDir}${path.delimiter}${process.env['PATH'] ?? ''}`,
+        },
+      });
+
+      expect(JSON.parse(output)).toEqual({
+        args: ['--prompt', 'a&b'],
+        skip: 'true',
+        hasLauncherPid: true,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(wrongDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not pass the standalone launcher hint to child processes', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-cli-launcher-env-'));
+    const entryPath = path.join(tempDir, 'entry.mjs');
+    const launcherPath = path.join(tempDir, 'qwen');
+    try {
+      copyFileSync('../../scripts/cli-entry.js', entryPath);
+      writeFileSync(
+        path.join(tempDir, 'cli.js'),
+        'process.stdout.write(JSON.stringify({ launcherPath: process.env.QWEN_CODE_LAUNCHER_PATH }));\n',
+      );
+      writeFileSync(launcherPath, '#!/bin/sh\n');
+      chmodSync(launcherPath, 0o755);
+
+      const output = execFileSync(process.execPath, [entryPath], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          QWEN_CODE_LAUNCHER_PATH: launcherPath,
+        },
+      });
+
+      expect(JSON.parse(output)).toEqual({});
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('prints CLI_VERSION from the npm bin wrapper version shortcut', () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -429,6 +429,19 @@ describe('bootstrap import boundaries', () => {
     }
   });
 
+  it('ignores malformed relaunch args in the npm bin wrapper', () => {
+    const output = execFileSync(
+      process.execPath,
+      ['../../scripts/cli-entry.js', '--version'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, QWEN_CODE_RELAUNCH_ARGS: 'not-json' },
+      },
+    );
+
+    expect(output.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
   it('prints CLI_VERSION from the npm bin wrapper version shortcut', () => {
     const output = execFileSync(
       process.execPath,

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -33,6 +33,8 @@ const mockHandleListExtensions = vi.hoisted(() => vi.fn());
 const mockStartEarlyStartupPrefetches = vi.hoisted(() => vi.fn());
 const mockStartPostRenderPrefetches = vi.hoisted(() => vi.fn());
 const mockRunAcpAgent = vi.hoisted(() => vi.fn());
+const mockUpdateBeforeRelaunch = vi.hoisted(() => vi.fn());
+const mockGetInstallationInfo = vi.hoisted(() => vi.fn());
 const lspConfigWatcherMock = vi.hoisted(() => ({
   instances: [] as Array<{
     listener?: (event: unknown) => void | Promise<void>;
@@ -159,6 +161,15 @@ vi.mock('./startup/startup-prefetch.js', () => ({
     mockStartPostRenderPrefetches(...args),
 }));
 
+vi.mock('./utils/update-relaunch.js', () => ({
+  updateBeforeRelaunch: (...args: unknown[]) =>
+    mockUpdateBeforeRelaunch(...args),
+}));
+
+vi.mock('./utils/installationInfo.js', () => ({
+  getInstallationInfo: (...args: unknown[]) => mockGetInstallationInfo(...args),
+}));
+
 vi.mock('./acp-integration/acpAgent.js', () => ({
   runAcpAgent: (...args: unknown[]) => mockRunAcpAgent(...args),
 }));
@@ -231,6 +242,10 @@ describe('gemini.tsx main function', () => {
 
   beforeEach(() => {
     lspConfigWatcherMock.instances.length = 0;
+    mockUpdateBeforeRelaunch.mockResolvedValue(true);
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @qwen-code/qwen-code@latest',
+    });
     // Store and clear sandbox-related env variables to ensure a consistent test environment
     originalEnvGeminiSandbox = process.env['QWEN_SANDBOX'];
     originalEnvSandbox = process.env['SANDBOX'];
@@ -341,6 +356,11 @@ describe('gemini.tsx main function', () => {
     // For the sandbox case we still have to load a partial cli config.
     // we can authorize outside the sandbox.
     expect(callOrder).toEqual(['relaunch', 'loadCliConfig']);
+    expect(relaunchAppInChildProcess).toHaveBeenCalledWith(
+      expect.any(Array),
+      [],
+      expect.objectContaining({ onUpdateRelaunch: expect.any(Function) }),
+    );
     processExitSpy.mockRestore();
   });
 
@@ -793,6 +813,7 @@ describe('gemini.tsx main function', () => {
   const runSandboxRelaunch = async (
     argv: string[],
     sessionId = '123e4567-e89b-12d3-a456-426614174000',
+    command: 'docker' | 'podman' | 'sandbox-exec' = 'sandbox-exec',
   ): Promise<string[]> => {
     const originalArgv = process.argv;
     process.argv = argv;
@@ -808,8 +829,10 @@ describe('gemini.tsx main function', () => {
     const { loadSettings } = await import('./config/settings.js');
     const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
     const { start_sandbox } = await import('./utils/sandbox.js');
+    const { relaunchOnExitCode } = await import('./utils/relaunch.js');
 
     vi.mocked(start_sandbox).mockClear();
+    vi.mocked(relaunchOnExitCode).mockClear();
     vi.mocked(parseArguments).mockResolvedValue({
       debug: true,
       prompt: 'hello',
@@ -829,8 +852,8 @@ describe('gemini.tsx main function', () => {
       getProjectHooks: () => undefined,
     } as never);
     vi.mocked(loadSandboxConfig).mockResolvedValue({
-      command: 'sandbox-exec',
-      image: '',
+      command,
+      image: 'ghcr.io/qwenlm/qwen-code:1.0.0',
     });
     vi.mocked(loadCliConfig).mockResolvedValue({
       getModelsConfig: () => ({ getCurrentAuthType: () => null }),
@@ -849,6 +872,9 @@ describe('gemini.tsx main function', () => {
     }
 
     expect(start_sandbox).toHaveBeenCalledOnce();
+    expect(relaunchOnExitCode).toHaveBeenCalledWith(expect.any(Function), {
+      onUpdateRelaunch: expect.any(Function),
+    });
     return vi.mocked(start_sandbox).mock.calls[0]![3]!;
   };
 
@@ -863,6 +889,40 @@ describe('gemini.tsx main function', () => {
     expect(idx).not.toBe(-1);
     expect(sandboxArgs[idx + 1]).toBe(sessionId);
     expect(sandboxArgs).not.toContain('--session-id');
+  });
+
+  it('starts a fresh CLI after the host update completes', async () => {
+    await runSandboxRelaunch(['node', 'script.js', '--debug', '-p', 'hello']);
+    const { relaunchOnExitCode } = await import('./utils/relaunch.js');
+    const [, options] = vi.mocked(relaunchOnExitCode).mock.calls[0]!;
+
+    await expect(options?.onUpdateRelaunch?.()).resolves.toBe(44);
+
+    expect(mockUpdateBeforeRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes host update capability into a container sandbox', async () => {
+    const originalCapability = process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'];
+
+    try {
+      await runSandboxRelaunch(
+        ['node', 'script.js', '--debug', '-p', 'hello'],
+        '',
+        'docker',
+      );
+
+      expect(mockGetInstallationInfo).toHaveBeenCalledWith(
+        expect.any(String),
+        true,
+      );
+      expect(process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH']).toBe('true');
+    } finally {
+      if (originalCapability === undefined) {
+        delete process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'];
+      } else {
+        process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = originalCapability;
+      }
+    }
   });
 
   it('does not pass an empty session ID into the sandbox child process', async () => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -78,6 +78,12 @@ import { initializeWarningHandler } from './utils/warningHandler.js';
 import { writeStderrLine } from './utils/stdioHelpers.js';
 import { getHeadlessYoloSafetyWarning } from './utils/headlessSafetyWarnings.js';
 import { initializeLlmOutputLanguage } from './utils/languageUtils.js';
+import {
+  CUSTOM_SANDBOX_IMAGE_ENV_VAR,
+  HOST_UPDATE_RELAUNCH_ENV_VAR,
+  UPDATE_COMPLETE_EXIT_CODE,
+} from './utils/processUtils.js';
+import { getInstallationInfo } from './utils/installationInfo.js';
 
 const debugLogger = createDebugLogger('STARTUP');
 
@@ -334,7 +340,43 @@ export async function main() {
     const memoryArgs = settings.merged.advanced?.autoConfigureMemory
       ? getNodeMemoryArgs(isDebugMode)
       : [];
+    const updateProjectRoot = process.cwd();
+    const onUpdateRelaunch = async () => {
+      await initializeI18n(
+        resolveLanguageSetting(settings.merged.general?.language as string),
+      );
+      const { updateBeforeRelaunch } = await import(
+        './utils/update-relaunch.js'
+      );
+      const shouldRelaunch = await updateBeforeRelaunch(
+        settings,
+        updateProjectRoot,
+      );
+      return shouldRelaunch ? UPDATE_COMPLETE_EXIT_CODE : 0;
+    };
     const sandboxConfig = await loadSandboxConfig(settings.merged, argv);
+    const customSandboxImage =
+      argv.sandboxImage ??
+      process.env['QWEN_SANDBOX_IMAGE'] ??
+      settings.merged.tools?.sandboxImage;
+    if (
+      sandboxConfig &&
+      sandboxConfig.command !== 'sandbox-exec' &&
+      customSandboxImage
+    ) {
+      // Images built before this handoff protocol must be rebuilt; they cannot
+      // be made to skip their in-process updater from the host.
+      process.env[CUSTOM_SANDBOX_IMAGE_ENV_VAR] = sandboxConfig.image;
+    } else if (sandboxConfig && sandboxConfig.command !== 'sandbox-exec') {
+      const hostInstallationInfo = getInstallationInfo(updateProjectRoot, true);
+      process.env[HOST_UPDATE_RELAUNCH_ENV_VAR] = String(
+        Boolean(
+          hostInstallationInfo.updateCommand ||
+            (hostInstallationInfo.isStandalone &&
+              hostInstallationInfo.standaloneDir),
+        ),
+      );
+    }
     // We intentially omit the list of extensions here because extensions
     // should not impact auth or setting up the sandbox.
     // TODO(jacobr): refactor loadCliConfig so there is a minimal version
@@ -442,8 +484,12 @@ export async function main() {
           )
         : injectStdinIntoArgs(process.argv, stdinData);
 
-      await relaunchOnExitCode(() =>
-        start_sandbox(sandboxConfig, memoryArgs, partialConfig, sandboxArgs),
+      await relaunchOnExitCode(
+        () =>
+          start_sandbox(sandboxConfig, memoryArgs, partialConfig, sandboxArgs),
+        {
+          onUpdateRelaunch,
+        },
       );
       process.exit(0);
     } else {
@@ -451,6 +497,7 @@ export async function main() {
       // restarted if needed.
       await relaunchAppInChildProcess(memoryArgs, [], {
         afterSpawn: clearCorruptionEnvVars,
+        onUpdateRelaunch,
       });
     }
   }

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -2140,6 +2140,16 @@ export default {
     'No es pot actualitzar automàticament aquesta instal·lació autònoma. Reinstal·leu des de:',
   'Manual update required. Please reinstall Qwen Code.':
     'Actualització manual requerida. Reinstal·leu Qwen Code.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'Aquesta sessió utilitza la imatge de sandbox personalitzada {{image}}. Actualitzeu la imatge i reinicieu Qwen Code.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    "Actualitzeu Qwen Code a l'amfitrió i reinicieu l'entorn aïllat.",
+  'The update will be installed after you exit this session.':
+    "L'actualització s'instal·larà després de sortir d'aquesta sessió.",
+  'Run /update to install the update on the host.':
+    "Executeu /update per instal·lar l'actualització a l'amfitrió.",
+  'Run /update to install the update.':
+    "Executeu /update per instal·lar l'actualització.",
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -2184,6 +2184,16 @@ export default {
     'Diese Standalone-Installation kann nicht automatisch aktualisiert werden. Bitte neu installieren von:',
   'Manual update required. Please reinstall Qwen Code.':
     'Manuelles Update erforderlich. Bitte installieren Sie Qwen Code neu.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'Diese Sitzung verwendet das benutzerdefinierte Sandbox-Image {{image}}. Aktualisieren Sie das Image und starten Sie Qwen Code neu.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'Aktualisieren Sie Qwen Code auf dem Host und starten Sie anschließend die Sandbox neu.',
+  'The update will be installed after you exit this session.':
+    'Das Update wird nach dem Beenden dieser Sitzung installiert.',
+  'Run /update to install the update on the host.':
+    'Führen Sie /update aus, um das Update auf dem Host zu installieren.',
+  'Run /update to install the update.':
+    'Führen Sie /update aus, um das Update zu installieren.',
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -2635,6 +2635,15 @@ export default {
     'Unable to auto-update this standalone installation. Please reinstall from:',
   'Manual update required. Please reinstall Qwen Code.':
     'Manual update required. Please reinstall Qwen Code.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'Update Qwen Code on the host, then restart the sandbox.',
+  'The update will be installed after you exit this session.':
+    'The update will be installed after you exit this session.',
+  'Run /update to install the update on the host.':
+    'Run /update to install the update on the host.',
+  'Run /update to install the update.': 'Run /update to install the update.',
   '⚠️ History gap: earlier conversation was lost before this point (storage interruption) and could not be recovered.':
     '⚠️ History gap: earlier conversation was lost before this point (storage interruption) and could not be recovered.',
 

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -2187,6 +2187,16 @@ export default {
     'Impossible de mettre à jour automatiquement cette installation autonome. Veuillez réinstaller depuis :',
   'Manual update required. Please reinstall Qwen Code.':
     'Mise à jour manuelle requise. Veuillez réinstaller Qwen Code.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'Cette session utilise l’image de bac à sable personnalisée {{image}}. Mettez à jour l’image et redémarrez Qwen Code.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'Mettez à jour Qwen Code sur l’hôte, puis redémarrez le bac à sable.',
+  'The update will be installed after you exit this session.':
+    'La mise à jour sera installée après la fermeture de cette session.',
+  'Run /update to install the update on the host.':
+    'Exécutez /update pour installer la mise à jour sur l’hôte.',
+  'Run /update to install the update.':
+    'Exécutez /update pour installer la mise à jour.',
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1951,6 +1951,16 @@ export default {
     'このスタンドアロンインストールを自動更新できません。以下から再インストールしてください：',
   'Manual update required. Please reinstall Qwen Code.':
     '手動更新が必要です。Qwen Codeを再インストールしてください。',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'このセッションではカスタムサンドボックスイメージ {{image}} を使用しています。イメージを更新して Qwen Code を再起動してください。',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'ホスト上の Qwen Code を更新してから、サンドボックスを再起動してください。',
+  'The update will be installed after you exit this session.':
+    'このセッションを終了すると、更新が自動的にインストールされます。',
+  'Run /update to install the update on the host.':
+    '/update を実行してホストに更新をインストールしてください。',
+  'Run /update to install the update.':
+    '/update を実行して更新をインストールしてください。',
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -2170,6 +2170,16 @@ export default {
     'Não foi possível atualizar automaticamente esta instalação independente. Reinstale de:',
   'Manual update required. Please reinstall Qwen Code.':
     'Atualização manual necessária. Reinstale o Qwen Code.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'Esta sessão usa a imagem de sandbox personalizada {{image}}. Atualize a imagem e reinicie o Qwen Code.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'Atualize o Qwen Code no host e reinicie o sandbox.',
+  'The update will be installed after you exit this session.':
+    'A atualização será instalada após você sair desta sessão.',
+  'Run /update to install the update on the host.':
+    'Execute /update para instalar a atualização no host.',
+  'Run /update to install the update.':
+    'Execute /update para instalar a atualização.',
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -2158,6 +2158,16 @@ export default {
     'Невозможно автоматически обновить эту автономную установку. Переустановите с:',
   'Manual update required. Please reinstall Qwen Code.':
     'Требуется ручное обновление. Переустановите Qwen Code.',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    'В этом сеансе используется пользовательский образ песочницы {{image}}. Обновите образ и перезапустите Qwen Code.',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    'Обновите Qwen Code на хосте, затем перезапустите песочницу.',
+  'The update will be installed after you exit this session.':
+    'Обновление будет установлено после выхода из этого сеанса.',
+  'Run /update to install the update on the host.':
+    'Запустите /update, чтобы установить обновление на хосте.',
+  'Run /update to install the update.':
+    'Запустите /update, чтобы установить обновление.',
 
   // ============================================================================
   // reload-plugins command

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -2225,6 +2225,15 @@ export default {
     '無法自動更新此獨立安裝。請從以下位址重新安裝：',
   'Manual update required. Please reinstall Qwen Code.':
     '需要手動更新。請重新安裝 Qwen Code。',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    '此工作階段使用自訂沙箱映像 {{image}}。請更新該映像並重新啟動 Qwen Code。',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    '請在主機上更新 Qwen Code，然後重新啟動沙箱。',
+  'The update will be installed after you exit this session.':
+    '結束目前工作階段後將自動安裝更新。',
+  'Run /update to install the update on the host.':
+    '執行 /update 在主機上安裝更新。',
+  'Run /update to install the update.': '執行 /update 安裝更新。',
   '⚠️ History gap: earlier conversation was lost before this point (storage interruption) and could not be recovered.':
     '⚠️ 歷史記錄缺口：此處之前的會話記錄已遺失（儲存中斷），且無法找回。',
 

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -2427,6 +2427,15 @@ export default {
     '无法自动更新此独立安装。请从以下地址重新安装：',
   'Manual update required. Please reinstall Qwen Code.':
     '需要手动更新。请重新安装 Qwen Code。',
+  'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.':
+    '此会话使用自定义沙箱镜像 {{image}}。请更新该镜像并重启 Qwen Code。',
+  'Update Qwen Code on the host, then restart the sandbox.':
+    '请在宿主机上更新 Qwen Code，然后重启沙箱。',
+  'The update will be installed after you exit this session.':
+    '退出当前会话后将自动安装更新。',
+  'Run /update to install the update on the host.':
+    '运行 /update 在宿主机上安装更新。',
+  'Run /update to install the update.': '运行 /update 安装更新。',
   '⚠️ History gap: earlier conversation was lost before this point (storage interruption) and could not be recovered.':
     '⚠️ 历史记录缺口：此处之前的会话记录已丢失（存储中断），且无法找回。',
 

--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -23,6 +23,8 @@ const mockPreconnectApi = vi.hoisted(() => vi.fn());
 const mockRecordStartupEvent = vi.hoisted(() => vi.fn());
 const mockCheckForUpdatesDetailed = vi.hoisted(() => vi.fn());
 const mockHandleAutoUpdate = vi.hoisted(() => vi.fn());
+const mockRequestUpdateOnExit = vi.hoisted(() => vi.fn());
+const mockGetInstallationInfo = vi.hoisted(() => vi.fn());
 const mockUpdateEventEmit = vi.hoisted(() => vi.fn());
 const mockConnectIdeForStartup = vi.hoisted(() => vi.fn());
 const mockDisconnectIde = vi.hoisted(() => vi.fn());
@@ -54,8 +56,19 @@ vi.mock('../ui/utils/updateCheck.js', () => ({
     mockCheckForUpdatesDetailed(...args),
 }));
 
+vi.mock('../utils/processUtils.js', () => ({
+  CUSTOM_SANDBOX_IMAGE_ENV_VAR: 'QWEN_CODE_CUSTOM_SANDBOX_IMAGE',
+  HOST_UPDATE_RELAUNCH_ENV_VAR: 'QWEN_CODE_HOST_UPDATE_RELAUNCH',
+  SKIP_UPDATE_CHECK_ENV_VAR: 'QWEN_CODE_SKIP_UPDATE_CHECK_ONCE',
+  requestUpdateOnExit: (...args: unknown[]) => mockRequestUpdateOnExit(...args),
+}));
+
 vi.mock('../utils/handleAutoUpdate.js', () => ({
   handleAutoUpdate: (...args: unknown[]) => mockHandleAutoUpdate(...args),
+}));
+
+vi.mock('../utils/installationInfo.js', () => ({
+  getInstallationInfo: (...args: unknown[]) => mockGetInstallationInfo(...args),
 }));
 
 vi.mock('../utils/updateEventEmitter.js', () => ({
@@ -105,11 +118,19 @@ function makeSettings(
 describe('startupPrefetch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'];
+    delete process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'];
+    delete process.env['QWEN_CODE_SKIP_UPDATE_CHECK_ONCE'];
     vi.useRealTimers();
     mockCheckForUpdatesDetailed.mockResolvedValue({
       status: 'up-to-date',
       currentVersion: '1.0.0',
     });
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @qwen-code/qwen-code@latest',
+      isStandalone: false,
+    });
+    mockRequestUpdateOnExit.mockReturnValue(true);
     mockConnectIdeForStartup.mockResolvedValue(undefined);
     mockDisconnectIde.mockResolvedValue(undefined);
     mockGetIdeClientInstance.mockResolvedValue({
@@ -188,7 +209,7 @@ describe('startupPrefetch', () => {
     await vi.dynamicImportSettled();
 
     expect(mockCheckForUpdatesDetailed).toHaveBeenCalledTimes(1);
-    expect(mockHandleAutoUpdate).not.toHaveBeenCalled();
+    expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
     expect(mockRecordStartupEvent).toHaveBeenCalledWith(
       'startup_prefetch_started',
       { name: 'update_check' },
@@ -197,6 +218,138 @@ describe('startupPrefetch', () => {
       'startup_prefetch_completed',
       { name: 'update_check' },
     );
+  });
+
+  it('defers an available update until the session exits', async () => {
+    const config = makeConfig();
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+
+    startPostRenderPrefetches(config, makeSettings());
+
+    await vi.dynamicImportSettled();
+
+    expect(mockRequestUpdateOnExit).toHaveBeenCalledTimes(1);
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-info', {
+      message:
+        'Update available\nThe update will be installed after you exit this session.',
+    });
+  });
+
+  it('prompts for an explicit update when no parent supervisor is available', async () => {
+    mockRequestUpdateOnExit.mockReturnValue(false);
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+
+    startPostRenderPrefetches(makeConfig(), makeSettings());
+    await vi.dynamicImportSettled();
+
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-info', {
+      message: 'Update available\nRun /update to install the update.',
+    });
+  });
+
+  it('defers standalone updates until the session exits', async () => {
+    const config = makeConfig();
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: 'standalone update',
+      isStandalone: true,
+      standaloneDir: '/tmp/qwen-code',
+    });
+
+    startPostRenderPrefetches(config, makeSettings());
+
+    await vi.dynamicImportSettled();
+
+    expect(mockRequestUpdateOnExit).toHaveBeenCalledTimes(1);
+    expect(mockHandleAutoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('keeps a container running until the user updates the host', async () => {
+    process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = 'true';
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+
+    startPostRenderPrefetches(makeConfig(), makeSettings());
+    await vi.dynamicImportSettled();
+
+    expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
+    expect(mockGetInstallationInfo).not.toHaveBeenCalled();
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-info', {
+      message:
+        'Update available\nRun /update to install the update on the host.',
+    });
+  });
+
+  it('keeps a container running when the host requires manual updates', async () => {
+    process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = 'false';
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+
+    startPostRenderPrefetches(makeConfig(), makeSettings());
+    await vi.dynamicImportSettled();
+
+    expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
+    expect(mockHandleAutoUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-info', {
+      message:
+        'Update available\nUpdate Qwen Code on the host, then restart the sandbox.',
+    });
+  });
+
+  it('skips one automatic update check after an update relaunch', async () => {
+    process.env['QWEN_CODE_SKIP_UPDATE_CHECK_ONCE'] = 'true';
+
+    try {
+      startPostRenderPrefetches(makeConfig(), makeSettings());
+      await vi.dynamicImportSettled();
+
+      expect(mockCheckForUpdatesDetailed).not.toHaveBeenCalled();
+    } finally {
+      delete process.env['QWEN_CODE_SKIP_UPDATE_CHECK_ONCE'];
+    }
+  });
+
+  it('leaves explicitly configured sandbox images user-managed', async () => {
+    process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'] =
+      'example.com/custom-qwen:1.0.0';
+
+    try {
+      startPostRenderPrefetches(makeConfig(), makeSettings());
+      await vi.dynamicImportSettled();
+
+      expect(mockCheckForUpdatesDetailed).not.toHaveBeenCalled();
+      expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
+    } finally {
+      delete process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'];
+    }
   });
 
   it('starts post-render tasks without awaiting completion', async () => {
@@ -244,7 +397,7 @@ describe('startupPrefetch', () => {
       message:
         'Failed to check for updates. Please check your network or registry configuration.',
     });
-    expect(mockHandleAutoUpdate).not.toHaveBeenCalled();
+    expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
   });
 
   it('requires connectIde option before connecting IDE', async () => {

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -14,6 +14,12 @@ import type { LoadedSettings } from '../config/settings.js';
 import { preconnectApi } from '../utils/apiPreconnect.js';
 import { AppEvent, appEvents } from '../utils/events.js';
 import { recordStartupEvent } from '../utils/startupProfiler.js';
+import {
+  CUSTOM_SANDBOX_IMAGE_ENV_VAR,
+  HOST_UPDATE_RELAUNCH_ENV_VAR,
+  SKIP_UPDATE_CHECK_ENV_VAR,
+  requestUpdateOnExit,
+} from '../utils/processUtils.js';
 
 const debugLogger = createDebugLogger('STARTUP_PREFETCH');
 
@@ -146,16 +152,22 @@ export function startPostRenderPrefetches(
   if (postRenderStarted.has(config)) return;
   postRenderStarted.add(config);
 
-  if (settings.merged.general?.enableAutoUpdate !== false) {
+  if (
+    settings.merged.general?.enableAutoUpdate !== false &&
+    process.env[SKIP_UPDATE_CHECK_ENV_VAR] !== 'true' &&
+    !process.env[CUSTOM_SANDBOX_IMAGE_ENV_VAR]
+  ) {
     runDeferredTask('update_check', async () => {
       const [
         { checkForUpdatesDetailed },
         { handleAutoUpdate },
+        { getInstallationInfo },
         { updateEventEmitter },
         { t },
       ] = await Promise.all([
         import('../ui/utils/updateCheck.js'),
         import('../utils/handleAutoUpdate.js'),
+        import('../utils/installationInfo.js'),
         import('../utils/updateEventEmitter.js'),
         import('../i18n/index.js'),
       ]);
@@ -165,7 +177,45 @@ export function startPostRenderPrefetches(
       try {
         const result = await checkForUpdatesDetailed();
         if (result.status === 'update') {
-          handleAutoUpdate(result.info, settings, config.getProjectRoot());
+          const projectRoot = config.getProjectRoot();
+          const hostUpdateRelaunch = process.env[HOST_UPDATE_RELAUNCH_ENV_VAR];
+          if (hostUpdateRelaunch === 'true') {
+            updateEventEmitter.emit('update-info', {
+              message: `${result.info.message}\n${t(
+                'Run /update to install the update on the host.',
+              )}`,
+            });
+            return;
+          }
+          if (hostUpdateRelaunch === 'false') {
+            updateEventEmitter.emit('update-info', {
+              message: `${result.info.message}\n${t(
+                'Update Qwen Code on the host, then restart the sandbox.',
+              )}`,
+            });
+            return;
+          }
+          const installationInfo = getInstallationInfo(projectRoot, true);
+          if (
+            installationInfo.updateCommand ||
+            (installationInfo.isStandalone && installationInfo.standaloneDir)
+          ) {
+            if (requestUpdateOnExit()) {
+              updateEventEmitter.emit('update-info', {
+                message: `${result.info.message}\n${t(
+                  'The update will be installed after you exit this session.',
+                )}`,
+              });
+            } else {
+              updateEventEmitter.emit('update-info', {
+                message: `${result.info.message}\n${t(
+                  'Run /update to install the update.',
+                )}`,
+              });
+            }
+          } else {
+            void handleAutoUpdate(result.info, settings, projectRoot);
+          }
         } else if (result.status === 'error') {
           updateEventEmitter.emit('update-failed', {
             message: updateFailedMessage,

--- a/packages/cli/src/ui/commands/update-command.test.ts
+++ b/packages/cli/src/ui/commands/update-command.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 
 const checkForUpdatesDetailed = vi.fn();
-const handleAutoUpdate = vi.fn();
+const relaunchForUpdate = vi.fn();
 const performStandaloneUpdate = vi.fn();
 const getInstallationInfo = vi.fn();
 const resolveUpdateCommand = vi.fn(
@@ -37,7 +37,11 @@ const formatUpdateInstructions = vi.fn(
   },
 );
 vi.mock('../utils/updateCheck.js', () => ({ checkForUpdatesDetailed }));
-vi.mock('../../utils/handleAutoUpdate.js', () => ({ handleAutoUpdate }));
+vi.mock('../../utils/processUtils.js', () => ({
+  CUSTOM_SANDBOX_IMAGE_ENV_VAR: 'QWEN_CODE_CUSTOM_SANDBOX_IMAGE',
+  HOST_UPDATE_RELAUNCH_ENV_VAR: 'QWEN_CODE_HOST_UPDATE_RELAUNCH',
+  relaunchForUpdate,
+}));
 vi.mock('../../utils/standalone-update.js', () => ({
   performStandaloneUpdate,
 }));
@@ -68,6 +72,9 @@ function context(
 describe('updateCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    relaunchForUpdate.mockReset();
+    delete process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'];
+    delete process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'];
     checkForUpdatesDetailed.mockResolvedValue({
       status: 'update',
       info: {
@@ -81,20 +88,13 @@ describe('updateCommand', () => {
     });
   });
 
-  it('delegates to handleAutoUpdate in interactive mode', async () => {
+  it('hands an interactive update off to the parent process', async () => {
     const commandContext = context('interactive');
-    handleAutoUpdate.mockImplementation((_info, settings) => {
-      expect(settings.merged.general?.enableAutoUpdate).toBeUndefined();
-    });
 
     const result = await updateCommand.action!(commandContext, '');
 
     expect(result).toBeUndefined();
-    expect(handleAutoUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Update available: 1.2.3' }),
-      commandContext.services.settings,
-      '/repo',
-    );
+    expect(relaunchForUpdate).toHaveBeenCalledTimes(1);
     expect(
       commandContext.services.settings.merged.general?.enableAutoUpdate,
     ).toBeUndefined();
@@ -110,7 +110,7 @@ describe('updateCommand', () => {
       content:
         'Update available: 1.2.3\nRun the following to update:\n  npm install -g @qwen-code/qwen-code@1.2.3',
     });
-    expect(handleAutoUpdate).not.toHaveBeenCalled();
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
   });
 
   it('returns manual instructions in interactive mode when auto-update is disabled', async () => {
@@ -124,7 +124,7 @@ describe('updateCommand', () => {
       content:
         'Update available: 1.2.3\nRun the following to update:\n  npm install -g @qwen-code/qwen-code@1.2.3',
     });
-    expect(handleAutoUpdate).not.toHaveBeenCalled();
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
     expect(
       commandContext.services.settings.merged.general?.enableAutoUpdate,
     ).toBe(false);
@@ -147,13 +147,26 @@ describe('updateCommand', () => {
       content:
         'Update available: 1.2.3\nManual update required. Please reinstall Qwen Code.',
     });
-    expect(handleAutoUpdate).not.toHaveBeenCalled();
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
     expect(performStandaloneUpdate).not.toHaveBeenCalled();
   });
 
-  it('does not mutate enableAutoUpdate when handleAutoUpdate throws', async () => {
+  it('hands standalone updates off to the parent process', async () => {
+    getInstallationInfo.mockReturnValue({
+      isStandalone: true,
+      standaloneDir: '/tmp/qwen-code',
+    });
     const commandContext = context('interactive');
-    handleAutoUpdate.mockImplementation(() => {
+
+    const result = await updateCommand.action!(commandContext, '');
+
+    expect(result).toBeUndefined();
+    expect(relaunchForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mutate enableAutoUpdate when relaunching throws', async () => {
+    const commandContext = context('interactive');
+    relaunchForUpdate.mockImplementation(() => {
       throw new Error('spawn failed');
     });
 
@@ -178,7 +191,7 @@ describe('updateCommand', () => {
       content:
         'Update available: 1.2.3\nManual update required. Please reinstall Qwen Code.',
     });
-    expect(handleAutoUpdate).not.toHaveBeenCalled();
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
   });
 
   it('returns the manual update command in ACP mode', async () => {
@@ -190,6 +203,65 @@ describe('updateCommand', () => {
       content:
         'Update available: 1.2.3\nRun the following to update:\n  npm install -g @qwen-code/qwen-code@1.2.3',
     });
+  });
+
+  it('keeps explicitly configured sandbox images user-managed', async () => {
+    process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'] =
+      'example.com/custom-qwen:1.0.0';
+
+    try {
+      const result = await updateCommand.action!(context('interactive'), '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Update available: 1.2.3\nThis session uses the custom sandbox image example.com/custom-qwen:1.0.0. Update that image and restart Qwen Code.',
+      });
+      expect(relaunchForUpdate).not.toHaveBeenCalled();
+    } finally {
+      delete process.env['QWEN_CODE_CUSTOM_SANDBOX_IMAGE'];
+    }
+  });
+
+  it('uses the host update capability inside a container', async () => {
+    process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = 'true';
+
+    const result = await updateCommand.action!(context('interactive'), '');
+
+    expect(result).toBeUndefined();
+    expect(relaunchForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects disabled auto-update for a supported host installation', async () => {
+    process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = 'true';
+
+    const result = await updateCommand.action!(
+      context('interactive', false),
+      '',
+    );
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Update available: 1.2.3\nUpdate Qwen Code on the host, then restart the sandbox.',
+    });
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
+  });
+
+  it('shows manual guidance for an unsupported host installation', async () => {
+    process.env['QWEN_CODE_HOST_UPDATE_RELAUNCH'] = 'false';
+
+    const result = await updateCommand.action!(context('interactive'), '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Update available: 1.2.3\nUpdate Qwen Code on the host, then restart the sandbox.',
+    });
+    expect(relaunchForUpdate).not.toHaveBeenCalled();
   });
 
   it('does not append generic fallback when installation info has updateMessage', async () => {

--- a/packages/cli/src/ui/commands/update-command.ts
+++ b/packages/cli/src/ui/commands/update-command.ts
@@ -18,12 +18,16 @@ export const updateCommand: SlashCommand = {
   action: async (context) => {
     const [
       { checkForUpdatesDetailed },
-      { handleAutoUpdate },
+      {
+        CUSTOM_SANDBOX_IMAGE_ENV_VAR,
+        HOST_UPDATE_RELAUNCH_ENV_VAR,
+        relaunchForUpdate,
+      },
       { performStandaloneUpdate },
       installationInfo,
     ] = await Promise.all([
       import('../utils/updateCheck.js'),
-      import('../../utils/handleAutoUpdate.js'),
+      import('../../utils/processUtils.js'),
       import('../../utils/standalone-update.js'),
       import('../../utils/installationInfo.js'),
     ]);
@@ -82,13 +86,38 @@ export const updateCommand: SlashCommand = {
     };
 
     if (context.executionMode === 'interactive' && projectRoot) {
+      const customSandboxImage = process.env[CUSTOM_SANDBOX_IMAGE_ENV_VAR];
+      if (customSandboxImage) {
+        return {
+          type: 'message' as const,
+          messageType: 'info' as const,
+          content: `${info.message}\n${t(
+            'This session uses the custom sandbox image {{image}}. Update that image and restart Qwen Code.',
+            { image: customSandboxImage },
+          )}`,
+        };
+      }
+      const hostUpdateRelaunch = process.env[HOST_UPDATE_RELAUNCH_ENV_VAR];
       const isAutoUpdateEnabled =
         settings.merged.general?.enableAutoUpdate !== false;
+      if (hostUpdateRelaunch === 'true' && isAutoUpdateEnabled) {
+        await relaunchForUpdate();
+        return;
+      }
+      if (hostUpdateRelaunch !== undefined) {
+        return {
+          type: 'message' as const,
+          messageType: 'info' as const,
+          content: `${info.message}\n${t(
+            'Update Qwen Code on the host, then restart the sandbox.',
+          )}`,
+        };
+      }
       const canAutoUpdate =
         installInfo.updateCommand ||
         (installInfo.isStandalone && installInfo.standaloneDir);
       if (isAutoUpdateEnabled && canAutoUpdate) {
-        handleAutoUpdate(info, settings, projectRoot);
+        await relaunchForUpdate();
         return;
       }
       return manualInstructions();

--- a/packages/cli/src/utils/processUtils.test.ts
+++ b/packages/cli/src/utils/processUtils.test.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi } from 'vitest';
-import { RELAUNCH_EXIT_CODE, relaunchApp } from './processUtils.js';
+import { afterEach, beforeEach, vi } from 'vitest';
+import {
+  RELAUNCH_EXIT_CODE,
+  UPDATE_ON_EXIT_MESSAGE,
+  UPDATE_RELAUNCH_EXIT_CODE,
+  relaunchApp,
+  relaunchForUpdate,
+  requestUpdateOnExit,
+} from './processUtils.js';
 import * as cleanup from './cleanup.js';
 
 describe('processUtils', () => {
@@ -13,10 +20,39 @@ describe('processUtils', () => {
     .spyOn(process, 'exit')
     .mockReturnValue(undefined as never);
   const runExitCleanup = vi.spyOn(cleanup, 'runExitCleanup');
+  const originalSend = process.send;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.send = originalSend;
+  });
 
   it('should run cleanup and exit with the relaunch code', async () => {
     await relaunchApp();
     expect(runExitCleanup).toHaveBeenCalledTimes(1);
     expect(processExit).toHaveBeenCalledWith(RELAUNCH_EXIT_CODE);
+  });
+
+  it('should run cleanup and exit with the update relaunch code', async () => {
+    await relaunchForUpdate();
+    expect(runExitCleanup).toHaveBeenCalledTimes(1);
+    expect(processExit).toHaveBeenCalledWith(UPDATE_RELAUNCH_EXIT_CODE);
+  });
+
+  it('requests a deferred update from the parent process', () => {
+    const send = vi.fn();
+    process.send = send;
+
+    expect(requestUpdateOnExit()).toBe(true);
+    expect(send).toHaveBeenCalledWith({ type: UPDATE_ON_EXIT_MESSAGE });
+  });
+
+  it('does not request a deferred update without a parent process', () => {
+    process.send = undefined;
+
+    expect(requestUpdateOnExit()).toBe(false);
   });
 });

--- a/packages/cli/src/utils/processUtils.ts
+++ b/packages/cli/src/utils/processUtils.ts
@@ -11,10 +11,37 @@ import { runExitCleanup } from './cleanup.js';
  */
 export const RELAUNCH_EXIT_CODE = 42;
 
+export const UPDATE_RELAUNCH_EXIT_CODE = 43;
+
+export const UPDATE_COMPLETE_EXIT_CODE = 44;
+
+export const SKIP_UPDATE_CHECK_ENV_VAR = 'QWEN_CODE_SKIP_UPDATE_CHECK_ONCE';
+
+export const CUSTOM_SANDBOX_IMAGE_ENV_VAR = 'QWEN_CODE_CUSTOM_SANDBOX_IMAGE';
+
+export const HOST_UPDATE_RELAUNCH_ENV_VAR = 'QWEN_CODE_HOST_UPDATE_RELAUNCH';
+
+export const UPDATE_ON_EXIT_MESSAGE = 'qwen-code:update-on-exit';
+
 /**
  * Exits the process with a special code to signal that the parent process should relaunch it.
  */
 export async function relaunchApp(): Promise<void> {
   await runExitCleanup();
   process.exit(RELAUNCH_EXIT_CODE);
+}
+
+export async function relaunchForUpdate(): Promise<void> {
+  await runExitCleanup();
+  process.exit(UPDATE_RELAUNCH_EXIT_CODE);
+}
+
+export function requestUpdateOnExit(): boolean {
+  if (!process.send) return false;
+  try {
+    process.send({ type: UPDATE_ON_EXIT_MESSAGE });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -355,7 +355,7 @@ describe('relaunchAppInChildProcess', () => {
       await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
 
       expect(onUpdateRelaunch).toHaveBeenCalledTimes(1);
-      expect(processExitSpy).toHaveBeenCalledWith(0);
+      expect(processExitSpy).toHaveBeenCalledWith(44);
     });
 
     it('should handle null exit code from child process', async () => {

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -14,7 +14,11 @@ import {
   type MockInstance,
 } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { RELAUNCH_EXIT_CODE } from './processUtils.js';
+import {
+  RELAUNCH_EXIT_CODE,
+  UPDATE_ON_EXIT_MESSAGE,
+  UPDATE_RELAUNCH_EXIT_CODE,
+} from './processUtils.js';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
@@ -79,6 +83,31 @@ describe('relaunchOnExitCode', () => {
 
     expect(runner).toHaveBeenCalledTimes(3);
     expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('should update after the child exits', async () => {
+    const onUpdateRelaunch = vi.fn().mockResolvedValue(0);
+    const runner = vi.fn().mockResolvedValue(UPDATE_RELAUNCH_EXIT_CODE);
+
+    await expect(
+      relaunchOnExitCode(runner, { onUpdateRelaunch }),
+    ).rejects.toThrow('PROCESS_EXIT_CALLED');
+
+    expect(onUpdateRelaunch).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('should exit with the updated CLI result', async () => {
+    const runner = vi.fn().mockResolvedValue(UPDATE_RELAUNCH_EXIT_CODE);
+    const onUpdateRelaunch = vi.fn().mockResolvedValue(7);
+
+    await expect(
+      relaunchOnExitCode(runner, { onUpdateRelaunch }),
+    ).rejects.toThrow('PROCESS_EXIT_CALLED');
+
+    expect(processExitSpy).toHaveBeenCalledWith(7);
+    expect(runner).toHaveBeenCalledTimes(1);
   });
 
   it('should handle runner errors', async () => {
@@ -306,6 +335,27 @@ describe('relaunchAppInChildProcess', () => {
 
       // afterSpawn should still be called only once (first spawn)
       expect(afterSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('installs a requested automatic update only after a clean child exit', async () => {
+      process.argv = ['/usr/bin/node', '/app/cli.js'];
+
+      const onUpdateRelaunch = vi.fn().mockResolvedValue(44);
+      const mockChild = createMockChildProcess(0, false);
+      mockedSpawn.mockReturnValue(mockChild);
+
+      const promise = relaunchAppInChildProcess([], [], {
+        onUpdateRelaunch,
+      });
+
+      mockChild.emit('message', { type: UPDATE_ON_EXIT_MESSAGE });
+      expect(onUpdateRelaunch).not.toHaveBeenCalled();
+
+      mockChild.emit('close', 0);
+      await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
+
+      expect(onUpdateRelaunch).toHaveBeenCalledTimes(1);
+      expect(processExitSpy).toHaveBeenCalledWith(0);
     });
 
     it('should handle null exit code from child process', async () => {

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -358,6 +358,31 @@ describe('relaunchAppInChildProcess', () => {
       expect(processExitSpy).toHaveBeenCalledWith(44);
     });
 
+    it('does not carry an update request across relaunches', async () => {
+      process.argv = ['/usr/bin/node', '/app/cli.js'];
+
+      const onUpdateRelaunch = vi.fn().mockResolvedValue(44);
+      const firstChild = createMockChildProcess(0, false);
+      const secondChild = createMockChildProcess(0, false);
+      mockedSpawn
+        .mockReturnValueOnce(firstChild)
+        .mockReturnValueOnce(secondChild);
+
+      const promise = relaunchAppInChildProcess([], [], {
+        onUpdateRelaunch,
+      });
+
+      firstChild.emit('message', { type: UPDATE_ON_EXIT_MESSAGE });
+      firstChild.emit('close', RELAUNCH_EXIT_CODE);
+      await vi.waitFor(() => expect(mockedSpawn).toHaveBeenCalledTimes(2));
+
+      secondChild.emit('close', 0);
+      await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
+
+      expect(onUpdateRelaunch).not.toHaveBeenCalled();
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
     it('should handle null exit code from child process', async () => {
       process.argv = ['/usr/bin/node', '/app/cli.js'];
 

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -51,9 +51,9 @@ export async function relaunchAppInChildProcess(
     return;
   }
 
-  let updateOnExitRequested = false;
-
   const runner = () => {
+    let updateOnExitRequested = false;
+
     // process.argv is [node, script, ...args]
     // We want to construct [ ...nodeArgs, script, ...scriptArgs]
     const script = process.argv[1];

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -5,13 +5,30 @@
  */
 
 import { spawn } from 'node:child_process';
-import { RELAUNCH_EXIT_CODE } from './processUtils.js';
+import {
+  RELAUNCH_EXIT_CODE,
+  UPDATE_ON_EXIT_MESSAGE,
+  UPDATE_RELAUNCH_EXIT_CODE,
+} from './processUtils.js';
 import { writeStderrLine } from './stdioHelpers.js';
 
-export async function relaunchOnExitCode(runner: () => Promise<number>) {
+interface RelaunchOptions {
+  afterSpawn?: () => void;
+  onUpdateRelaunch?: () => Promise<number> | number;
+}
+
+export async function relaunchOnExitCode(
+  runner: () => Promise<number>,
+  options?: Pick<RelaunchOptions, 'onUpdateRelaunch'>,
+) {
   while (true) {
     try {
       const exitCode = await runner();
+
+      if (exitCode === UPDATE_RELAUNCH_EXIT_CODE && options?.onUpdateRelaunch) {
+        const updatedExitCode = await options.onUpdateRelaunch();
+        process.exit(updatedExitCode);
+      }
 
       if (exitCode !== RELAUNCH_EXIT_CODE) {
         process.exit(exitCode);
@@ -28,11 +45,13 @@ export async function relaunchOnExitCode(runner: () => Promise<number>) {
 export async function relaunchAppInChildProcess(
   additionalNodeArgs: string[],
   additionalScriptArgs: string[],
-  options?: { afterSpawn?: () => void },
+  options?: RelaunchOptions,
 ) {
   if (process.env['QWEN_CODE_NO_RELAUNCH']) {
     return;
   }
+
+  let updateOnExitRequested = false;
 
   const runner = () => {
     // process.argv is [node, script, ...args]
@@ -53,8 +72,19 @@ export async function relaunchAppInChildProcess(
     process.stdin.pause();
 
     const child = spawn(process.execPath, nodeArgs, {
-      stdio: 'inherit',
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
       env: newEnv,
+    });
+
+    child.on('message', (message) => {
+      if (
+        typeof message === 'object' &&
+        message !== null &&
+        'type' in message &&
+        message.type === UPDATE_ON_EXIT_MESSAGE
+      ) {
+        updateOnExitRequested = true;
+      }
     });
 
     // Allow the parent to clean up process.env after spawn copies it
@@ -71,10 +101,23 @@ export async function relaunchAppInChildProcess(
       child.on('close', (code) => {
         // Resume stdin before the parent process exits.
         process.stdin.resume();
-        resolve(code ?? 1);
+        const exitCode = code ?? 1;
+        if (
+          exitCode === 0 &&
+          updateOnExitRequested &&
+          options?.onUpdateRelaunch
+        ) {
+          updateOnExitRequested = false;
+          void Promise.resolve(options.onUpdateRelaunch()).then(
+            () => resolve(exitCode),
+            reject,
+          );
+          return;
+        }
+        resolve(exitCode);
       });
     });
   };
 
-  await relaunchOnExitCode(runner);
+  await relaunchOnExitCode(runner, options);
 }

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -109,7 +109,7 @@ export async function relaunchAppInChildProcess(
         ) {
           updateOnExitRequested = false;
           void Promise.resolve(options.onUpdateRelaunch()).then(
-            () => resolve(exitCode),
+            (updatedExitCode) => resolve(updatedExitCode),
             reject,
           );
           return;

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -10,7 +10,11 @@ import { pathToFileURL } from 'node:url';
 import { FatalSandboxError, QWEN_DIR } from '@qwen-code/qwen-code-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
-import { resolveSeatbeltProfileFile, start_sandbox } from './sandbox.js';
+import {
+  getSandboxPassthroughEnvArgs,
+  resolveSeatbeltProfileFile,
+  start_sandbox,
+} from './sandbox.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
 import { parseSandboxMountSpec } from './sandboxMounts.js';
 
@@ -73,6 +77,25 @@ describe('resolveSeatbeltProfileFile', () => {
         `Missing macos seatbelt profile file '${expectedPath}'`,
       ),
     );
+  });
+});
+
+describe('getSandboxPassthroughEnvArgs', () => {
+  it('passes update relaunch state into container sandboxes', () => {
+    expect(
+      getSandboxPassthroughEnvArgs({
+        QWEN_CODE_SKIP_UPDATE_CHECK_ONCE: 'true',
+        QWEN_CODE_CUSTOM_SANDBOX_IMAGE: 'example.com/qwen:1.0.0',
+        QWEN_CODE_HOST_UPDATE_RELAUNCH: 'false',
+      }),
+    ).toEqual([
+      '--env',
+      'QWEN_CODE_SKIP_UPDATE_CHECK_ONCE=true',
+      '--env',
+      'QWEN_CODE_CUSTOM_SANDBOX_IMAGE=example.com/qwen:1.0.0',
+      '--env',
+      'QWEN_CODE_HOST_UPDATE_RELAUNCH=false',
+    ]);
   });
 });
 

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -26,6 +26,11 @@ import { writeStderrLine } from './stdioHelpers.js';
 import { parseSandboxImageName } from './sandboxImageName.js';
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
 import { parseSandboxMountSpec } from './sandboxMounts.js';
+import {
+  CUSTOM_SANDBOX_IMAGE_ENV_VAR,
+  HOST_UPDATE_RELAUNCH_ENV_VAR,
+  SKIP_UPDATE_CHECK_ENV_VAR,
+} from './processUtils.js';
 
 const execAsync = promisify(exec);
 
@@ -60,6 +65,20 @@ const BUILTIN_SEATBELT_PROFILES = [
   'restrictive-closed',
   'restrictive-proxied',
 ];
+
+export function getSandboxPassthroughEnvArgs(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return [
+    'QWEN_DEBUG_LOG_FILE',
+    'QWEN_CODE_LEGACY_MCP_BLOCKING',
+    SKIP_UPDATE_CHECK_ENV_VAR,
+    CUSTOM_SANDBOX_IMAGE_ENV_VAR,
+    HOST_UPDATE_RELAUNCH_ENV_VAR,
+  ].flatMap((envVar) =>
+    env[envVar] === undefined ? [] : ['--env', `${envVar}=${env[envVar]}`],
+  );
+}
 
 export function resolveSeatbeltProfileFile(
   profile: string,
@@ -628,14 +647,7 @@ export async function start_sandbox(
       `QWEN_CODE_TEST_VAR=${process.env['QWEN_CODE_TEST_VAR']}`,
     );
   }
-  for (const envVar of [
-    'QWEN_DEBUG_LOG_FILE',
-    'QWEN_CODE_LEGACY_MCP_BLOCKING',
-  ] as const) {
-    if (process.env[envVar] !== undefined) {
-      args.push('--env', `${envVar}=${process.env[envVar]}`);
-    }
-  }
+  args.push(...getSandboxPassthroughEnvArgs());
   if (process.env['QWEN_CODE_MCP_APPROVALS_PATH']) {
     args.push(
       '--env',

--- a/packages/cli/src/utils/standalone-update.test.ts
+++ b/packages/cli/src/utils/standalone-update.test.ts
@@ -123,6 +123,17 @@ describe('standalone-update', () => {
   });
 
   describe('ensureBinWrapper', () => {
+    it('uses an independent launcher wait budget in the deferred Windows swap script', () => {
+      const source = fs.readFileSync(
+        new URL('./standalone-update.ts', import.meta.url),
+        'utf8',
+      );
+
+      expect(source).toContain('set /a TRIES=0');
+      expect(source).toContain('set /a LAUNCHER_TRIES=0');
+      expect(source).toContain('goto wait_launcher');
+    });
+
     // Unix wrapper test relies on POSIX file permissions (mode bits) and
     // the SHELL env var, neither of which behave consistently on Windows.
     it.skipIf(process.platform === 'win32')(

--- a/packages/cli/src/utils/standalone-update.test.ts
+++ b/packages/cli/src/utils/standalone-update.test.ts
@@ -125,7 +125,7 @@ describe('standalone-update', () => {
   describe('ensureBinWrapper', () => {
     it('uses an independent launcher wait budget in the deferred Windows swap script', () => {
       const source = fs.readFileSync(
-        new URL('./standalone-update.ts', import.meta.url),
+        path.resolve('src/utils/standalone-update.ts'),
         'utf8',
       );
 

--- a/packages/cli/src/utils/standalone-update.ts
+++ b/packages/cli/src/utils/standalone-update.ts
@@ -649,7 +649,11 @@ function atomicReplace(
       `tasklist /FI "PID eq ${process.pid}" 2>nul | find "${process.pid}" >nul && (timeout /t 1 >nul & goto wait)`,
       ...(process.env['QWEN_CODE_LAUNCHER_PID']?.match(/^\d+$/)
         ? [
-            `tasklist /FI "PID eq ${process.env['QWEN_CODE_LAUNCHER_PID']}" 2>nul | find "${process.env['QWEN_CODE_LAUNCHER_PID']}" >nul && (timeout /t 1 >nul & goto wait)`,
+            'set /a LAUNCHER_TRIES=0',
+            ':wait_launcher',
+            'set /a LAUNCHER_TRIES+=1',
+            'if %LAUNCHER_TRIES% GTR 30 goto proceed',
+            `tasklist /FI "PID eq ${process.env['QWEN_CODE_LAUNCHER_PID']}" 2>nul | find "${process.env['QWEN_CODE_LAUNCHER_PID']}" >nul && (timeout /t 1 >nul & goto wait_launcher)`,
           ]
         : []),
       ':proceed',

--- a/packages/cli/src/utils/standalone-update.ts
+++ b/packages/cli/src/utils/standalone-update.ts
@@ -632,7 +632,7 @@ function atomicReplace(
     const deferredMarker = `${standaloneDir}.deferred`;
     const logFile = path.join(path.dirname(standaloneDir), 'qwen-update.log');
     // Bat script runs detached after Node exits. It must:
-    // 1. Wait for this Node process to release file locks (<= 30s).
+    // 1. Wait for the CLI and its launcher to release file locks (<= 30s).
     // 2. Run both moves with errorlevel checks; if move #2 fails, roll back
     //    move #1 so the user is never left without a working install.
     // 3. Log success/failure to qwen-update.log for post-mortem (the bat
@@ -647,6 +647,11 @@ function atomicReplace(
       'set /a TRIES+=1',
       'if %TRIES% GTR 30 goto proceed',
       `tasklist /FI "PID eq ${process.pid}" 2>nul | find "${process.pid}" >nul && (timeout /t 1 >nul & goto wait)`,
+      ...(process.env['QWEN_CODE_LAUNCHER_PID']?.match(/^\d+$/)
+        ? [
+            `tasklist /FI "PID eq ${process.env['QWEN_CODE_LAUNCHER_PID']}" 2>nul | find "${process.env['QWEN_CODE_LAUNCHER_PID']}" >nul && (timeout /t 1 >nul & goto wait)`,
+          ]
+        : []),
       ':proceed',
       `echo [%DATE% %TIME%] starting swap >> "${logFile}"`,
       `move /Y "${standaloneDir}" "${oldDir}"`,

--- a/packages/cli/src/utils/update-relaunch.test.ts
+++ b/packages/cli/src/utils/update-relaunch.test.ts
@@ -68,10 +68,19 @@ describe('updateBeforeRelaunch', () => {
     const update = updateBeforeRelaunch(settings, '/repo');
     await vi.waitFor(() => expect(handleAutoUpdate).toHaveBeenCalledTimes(1));
     updateProcess.emit('close', 1);
-    await update;
+    await expect(update).resolves.toBe(false);
 
     expect(writeStderrLine).toHaveBeenCalledWith(
       'Automatic update failed. Please try updating manually.',
+    );
+  });
+
+  it('does not relaunch when the update check fails', async () => {
+    checkForUpdatesDetailed.mockResolvedValue({ status: 'error' });
+
+    await expect(updateBeforeRelaunch(settings, '/repo')).resolves.toBe(false);
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      'Failed to check for updates. Please check your network or registry configuration.',
     );
   });
 

--- a/packages/cli/src/utils/update-relaunch.test.ts
+++ b/packages/cli/src/utils/update-relaunch.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LoadedSettings } from '../config/settings.js';
+import { EventEmitter } from 'node:events';
+
+const checkForUpdatesDetailed = vi.hoisted(() => vi.fn());
+const handleAutoUpdate = vi.hoisted(() => vi.fn());
+const getInstallationInfo = vi.hoisted(() => vi.fn());
+const performStandaloneUpdate = vi.hoisted(() => vi.fn());
+const writeStderrLine = vi.hoisted(() => vi.fn());
+
+vi.mock('../ui/utils/updateCheck.js', () => ({ checkForUpdatesDetailed }));
+vi.mock('./handleAutoUpdate.js', () => ({ handleAutoUpdate }));
+vi.mock('./installationInfo.js', () => ({ getInstallationInfo }));
+vi.mock('./standalone-update.js', () => ({ performStandaloneUpdate }));
+vi.mock('./stdioHelpers.js', () => ({ writeStderrLine }));
+vi.mock('../i18n/index.js', () => ({ t: (message: string) => message }));
+
+const { updateBeforeRelaunch } = await import('./update-relaunch.js');
+
+describe('updateBeforeRelaunch', () => {
+  const settings = {
+    merged: { general: { enableAutoUpdate: true } },
+  } as LoadedSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkForUpdatesDetailed.mockResolvedValue({
+      status: 'update',
+      info: {
+        message: 'Update available',
+        update: { latest: '2.0.0' },
+      },
+    });
+    getInstallationInfo.mockReturnValue({
+      updateCommand: 'npm install -g @qwen-code/qwen-code@latest',
+    });
+  });
+
+  it('waits for the package-manager update before reporting success', async () => {
+    const updateProcess = new EventEmitter();
+    handleAutoUpdate.mockReturnValue(updateProcess);
+
+    const update = updateBeforeRelaunch(settings, '/repo');
+    await vi.waitFor(() => expect(handleAutoUpdate).toHaveBeenCalledTimes(1));
+    expect(writeStderrLine).toHaveBeenCalledWith('Update available');
+    expect(writeStderrLine).not.toHaveBeenCalledWith(
+      'Update successful! The new version will be used on your next run.',
+    );
+
+    updateProcess.emit('close', 0);
+    await expect(update).resolves.toBe(true);
+
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      'Update successful! The new version will be used on your next run.',
+    );
+  });
+
+  it('reports update failure and returns so the old version can relaunch', async () => {
+    const updateProcess = new EventEmitter();
+    handleAutoUpdate.mockReturnValue(updateProcess);
+
+    const update = updateBeforeRelaunch(settings, '/repo');
+    await vi.waitFor(() => expect(handleAutoUpdate).toHaveBeenCalledTimes(1));
+    updateProcess.emit('close', 1);
+    await update;
+
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      'Automatic update failed. Please try updating manually.',
+    );
+  });
+
+  it('waits for a standalone host update before relaunching', async () => {
+    getInstallationInfo.mockReturnValue({
+      isStandalone: true,
+      standaloneDir: '/qwen',
+    });
+    let finishUpdate: (result: 'done') => void;
+    performStandaloneUpdate.mockReturnValue(
+      new Promise((resolve) => {
+        finishUpdate = resolve;
+      }),
+    );
+
+    const update = updateBeforeRelaunch(settings, '/repo');
+    await vi.waitFor(() =>
+      expect(performStandaloneUpdate).toHaveBeenCalledWith('/qwen', '2.0.0'),
+    );
+    expect(handleAutoUpdate).not.toHaveBeenCalled();
+
+    finishUpdate!('done');
+    await expect(update).resolves.toBe(true);
+  });
+
+  it('exits the supervisor for a deferred standalone update', async () => {
+    getInstallationInfo.mockReturnValue({
+      isStandalone: true,
+      standaloneDir: '/qwen',
+    });
+    performStandaloneUpdate.mockResolvedValue('deferred');
+
+    await expect(updateBeforeRelaunch(settings, '/repo')).resolves.toBe(false);
+    expect(writeStderrLine).toHaveBeenCalledWith(
+      'Update downloaded. It will be applied after you exit this session.',
+    );
+  });
+});

--- a/packages/cli/src/utils/update-relaunch.ts
+++ b/packages/cli/src/utils/update-relaunch.ts
@@ -56,7 +56,7 @@ export async function updateBeforeRelaunch(
           installationInfo.updateMessage ??
             t('Manual update required. Please reinstall Qwen Code.'),
         );
-        return true;
+        return false;
       }
       const updateProcess = handleAutoUpdate(
         result.info,
@@ -76,11 +76,12 @@ export async function updateBeforeRelaunch(
             : UPDATE_FAILED_MESSAGE,
         ),
       );
+      return success;
     } else if (result.status === 'error') {
       writeStderrLine(t(UPDATE_CHECK_FAILED_MESSAGE));
     }
   } catch {
     writeStderrLine(translate(UPDATE_FAILED_MESSAGE));
   }
-  return true;
+  return false;
 }

--- a/packages/cli/src/utils/update-relaunch.ts
+++ b/packages/cli/src/utils/update-relaunch.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LoadedSettings } from '../config/settings.js';
+import { writeStderrLine } from './stdioHelpers.js';
+
+const UPDATE_CHECK_FAILED_MESSAGE =
+  'Failed to check for updates. Please check your network or registry configuration.';
+const UPDATE_FAILED_MESSAGE =
+  'Automatic update failed. Please try updating manually.';
+
+export async function updateBeforeRelaunch(
+  settings: LoadedSettings,
+  projectRoot: string,
+): Promise<boolean> {
+  let translate = (message: string) => message;
+  try {
+    const [
+      { checkForUpdatesDetailed },
+      { handleAutoUpdate },
+      { getInstallationInfo },
+      { performStandaloneUpdate },
+      { t },
+    ] = await Promise.all([
+      import('../ui/utils/updateCheck.js'),
+      import('./handleAutoUpdate.js'),
+      import('./installationInfo.js'),
+      import('./standalone-update.js'),
+      import('../i18n/index.js'),
+    ]);
+    translate = t;
+    const result = await checkForUpdatesDetailed();
+
+    if (result.status === 'update') {
+      writeStderrLine(result.info.message);
+      const installationInfo = getInstallationInfo(projectRoot, true);
+      if (installationInfo.isStandalone && installationInfo.standaloneDir) {
+        const standaloneResult = await performStandaloneUpdate(
+          installationInfo.standaloneDir,
+          result.info.update.latest,
+        );
+        writeStderrLine(
+          t(
+            standaloneResult === 'deferred'
+              ? 'Update downloaded. It will be applied after you exit this session.'
+              : 'Update successful! The new version will be used on your next run.',
+          ),
+        );
+        return standaloneResult !== 'deferred';
+      }
+      if (!installationInfo.updateCommand) {
+        writeStderrLine(
+          installationInfo.updateMessage ??
+            t('Manual update required. Please reinstall Qwen Code.'),
+        );
+        return true;
+      }
+      const updateProcess = handleAutoUpdate(
+        result.info,
+        settings,
+        projectRoot,
+      );
+      const success = updateProcess
+        ? await new Promise<boolean>((resolve) => {
+            updateProcess.once('close', (code) => resolve(code === 0));
+            updateProcess.once('error', () => resolve(false));
+          })
+        : false;
+      writeStderrLine(
+        t(
+          success
+            ? 'Update successful! The new version will be used on your next run.'
+            : UPDATE_FAILED_MESSAGE,
+        ),
+      );
+    } else if (result.status === 'error') {
+      writeStderrLine(t(UPDATE_CHECK_FAILED_MESSAGE));
+    }
+  } catch {
+    writeStderrLine(translate(UPDATE_FAILED_MESSAGE));
+  }
+  return true;
+}

--- a/scripts/cli-entry.js
+++ b/scripts/cli-entry.js
@@ -20,7 +20,12 @@
  */
 
 const relaunchArgs = process.env['QWEN_CODE_RELAUNCH_ARGS'];
-const cliArgs = relaunchArgs ? JSON.parse(relaunchArgs) : process.argv.slice(2);
+let cliArgs = process.argv.slice(2);
+try {
+  cliArgs = relaunchArgs ? JSON.parse(relaunchArgs) : cliArgs;
+} catch {
+  // Ignore stale or user-provided junk; normal argv is still usable.
+}
 delete process.env['QWEN_CODE_RELAUNCH_ARGS'];
 
 function hasFlag(flag, alias) {
@@ -102,6 +107,7 @@ if (isInProcessFastPath()) {
   const entryRootLength = parse(entryPath).root.length;
   const launcherFromEnv = process.env['QWEN_CODE_LAUNCHER_PATH'];
   delete process.env['QWEN_CODE_LAUNCHER_PATH'];
+  delete process.env['QWEN_CODE_LAUNCHER_PID'];
   const launcherCandidates = process.env['PATH']
     ?.split(delimiter)
     .flatMap((dir) => launcherNames.map((name) => join(dir, name)))

--- a/scripts/cli-entry.js
+++ b/scripts/cli-entry.js
@@ -19,8 +19,12 @@
  * monitor.
  */
 
+const relaunchArgs = process.env['QWEN_CODE_RELAUNCH_ARGS'];
+const cliArgs = relaunchArgs ? JSON.parse(relaunchArgs) : process.argv.slice(2);
+delete process.env['QWEN_CODE_RELAUNCH_ARGS'];
+
 function hasFlag(flag, alias) {
-  for (const arg of process.argv.slice(2)) {
+  for (const arg of cliArgs) {
     if (arg === '--') {
       return false;
     }
@@ -32,7 +36,7 @@ function hasFlag(flag, alias) {
 }
 
 function isInProcessFastPath() {
-  const first = process.argv[2];
+  const first = cliArgs[0];
   if (first === 'serve' || first === 'mcp') {
     return true;
   }
@@ -43,7 +47,7 @@ function isInProcessFastPath() {
 }
 
 const isTopLevelVersion =
-  (process.argv[2] === undefined || process.argv[2].startsWith('-')) &&
+  (cliArgs[0] === undefined || cliArgs[0].startsWith('-')) &&
   hasFlag('--version', '-v');
 
 if (isTopLevelVersion && process.env['CLI_VERSION']) {
@@ -51,9 +55,11 @@ if (isTopLevelVersion && process.env['CLI_VERSION']) {
   process.exit(0);
 }
 
-const { existsSync } = await import('node:fs');
+const { existsSync, realpathSync } = await import('node:fs');
 const { fileURLToPath, pathToFileURL } = await import('node:url');
-const { dirname, join } = await import('node:path');
+const { delimiter, dirname, join, parse, resolve, sep } = await import(
+  'node:path'
+);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliPathCandidates = [
@@ -89,15 +95,87 @@ if (isInProcessFastPath()) {
   await import(pathToFileURL(cliPath).href);
 } else {
   const { spawnSync } = await import('node:child_process');
+  const UPDATE_COMPLETE_EXIT_CODE = 44;
+  const launcherNames =
+    process.platform === 'win32' ? ['qwen.cmd', 'qwen.exe', 'qwen'] : ['qwen'];
+  const entryPath = resolve(process.argv[1]);
+  const entryRootLength = parse(entryPath).root.length;
+  const launcherFromEnv = process.env['QWEN_CODE_LAUNCHER_PATH'];
+  delete process.env['QWEN_CODE_LAUNCHER_PATH'];
+  const launcherCandidates = process.env['PATH']
+    ?.split(delimiter)
+    .flatMap((dir) => launcherNames.map((name) => join(dir, name)))
+    .filter((candidate) => existsSync(candidate));
+  const launcher =
+    launcherFromEnv && existsSync(launcherFromEnv)
+      ? launcherFromEnv
+      : launcherCandidates
+          ?.map((candidate) => {
+            if (resolve(candidate) === entryPath) {
+              return { candidate, score: Number.MAX_SAFE_INTEGER };
+            }
+            try {
+              if (realpathSync(candidate) === realpathSync(entryPath)) {
+                return { candidate, score: Number.MAX_SAFE_INTEGER };
+              }
+            } catch {
+              // Fall back to matching the installation prefix.
+            }
+            let parent = resolve(dirname(candidate));
+            while (
+              parent.length > entryRootLength &&
+              entryPath !== parent &&
+              !entryPath.startsWith(`${parent}${sep}`)
+            ) {
+              const next = dirname(parent);
+              if (next === parent) break;
+              parent = next;
+            }
+            return { candidate, score: parent.length };
+          })
+          .filter(({ score }) => score > entryRootLength)
+          .sort((a, b) => b.score - a.score)[0]?.candidate;
+  const env = {
+    ...process.env,
+    QWEN_CODE_LAUNCHER_PID: String(process.pid),
+  };
   const result = spawnSync(
     process.execPath,
-    ['--expose-gc', cliPath, ...process.argv.slice(2)],
-    { stdio: 'inherit' },
+    ['--expose-gc', cliPath, ...cliArgs],
+    { stdio: 'inherit', env },
   );
 
   if (result.signal) {
     process.kill(process.pid, result.signal);
-  } else {
+  } else if (result.status !== UPDATE_COMPLETE_EXIT_CODE) {
     process.exit(result.status ?? 1);
+  } else {
+    if (!launcher) {
+      process.stderr.write(
+        'Update installed. Restart Qwen Code to use the new version.\n',
+      );
+      process.exit(0);
+    }
+    const relaunchEnv = {
+      ...process.env,
+      QWEN_CODE_RELAUNCH_ARGS: JSON.stringify(cliArgs),
+      QWEN_CODE_SKIP_UPDATE_CHECK_ONCE: 'true',
+    };
+    const relaunchResult =
+      process.platform === 'win32' && launcher.endsWith('.cmd')
+        ? spawnSync(
+            process.env['ComSpec'] ?? 'cmd.exe',
+            ['/d', '/s', '/c', `""${launcher}""`],
+            { stdio: 'inherit', env: relaunchEnv },
+          )
+        : spawnSync(launcher, [], {
+            stdio: 'inherit',
+            env: relaunchEnv,
+          });
+    if (relaunchResult.signal) {
+      process.kill(process.pid, relaunchResult.signal);
+    } else {
+      process.exit(relaunchResult.status ?? 1);
+    }
   }
 }

--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -671,10 +671,7 @@ function writeShims(packageRoot) {
   const unixShim = `#!/usr/bin/env sh
 set -e
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-if [ "\${1:-}" = "serve" ]; then
-  exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"
-fi
-exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"
+QWEN_CODE_LAUNCHER_PATH="$ROOT/bin/qwen" exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"
 `;
   const unixShimPath = path.join(binDir, 'qwen');
   fs.writeFileSync(unixShimPath, unixShim);
@@ -683,11 +680,7 @@ exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"
   const windowsShim = `@echo off
 setlocal
 set "ROOT=%~dp0.."
-if "%~1"=="serve" goto serve
-"%ROOT%\\node\\node.exe" --expose-gc "%ROOT%\\lib\\cli.js" %*
-exit /b %ERRORLEVEL%
-
-:serve
+set "QWEN_CODE_LAUNCHER_PATH=%ROOT%\\bin\\qwen.cmd"
 "%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*
 exit /b %ERRORLEVEL%
 `;

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -1749,14 +1749,13 @@ describe('standalone release packaging', () => {
       const shim = readScript(
         path.join(extractDir, 'qwen-code', 'bin', 'qwen.cmd'),
       );
-      expect(shim).toContain('if "%~1"=="serve" goto serve');
       expect(shim).toContain(
-        '"%ROOT%\\node\\node.exe" --expose-gc "%ROOT%\\lib\\cli.js" %*',
+        'set "QWEN_CODE_LAUNCHER_PATH=%ROOT%\\bin\\qwen.cmd"',
       );
       expect(shim).toContain(
         '"%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*',
       );
-      expect((shim.match(/exit \/b %ERRORLEVEL%/g) || []).length).toBe(2);
+      expect((shim.match(/exit \/b %ERRORLEVEL%/g) || []).length).toBe(1);
       expect(readScript(path.join(outDir, 'SHA256SUMS'))).toContain(
         'qwen-code-win-x64.zip',
       );
@@ -1904,7 +1903,7 @@ describe('standalone release packaging', () => {
   });
 
   itOnUnix(
-    'packages a Unix standalone archive with a serve fast path shim',
+    'packages a Unix standalone archive through the CLI entry wrapper',
     () => {
       const createdDist = ensureMinimalDist();
       const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-test-'));
@@ -1923,12 +1922,8 @@ describe('standalone release packaging', () => {
         const shim = readScript(
           path.join(extractDir, 'qwen-code', 'bin', 'qwen'),
         );
-        expect(shim).toContain('if [ "${1:-}" = "serve" ]; then');
         expect(shim).toContain(
-          'exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"',
-        );
-        expect(shim).toContain(
-          'exec "$ROOT/node/bin/node" --expose-gc "$ROOT/lib/cli.js" "$@"',
+          'QWEN_CODE_LAUNCHER_PATH="$ROOT/bin/qwen" exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"',
         );
       } finally {
         restoreMinimalDist(createdDist);


### PR DESCRIPTION
## What this PR does

This PR prevents automatic updates and `/update` from replacing Qwen Code installation files while an interactive process is still running.

When the background check finds an update, it asks the supervisor to install it after the current session exits cleanly. For an explicit `/update`, the interactive child exits first, the host supervisor performs the update, and a stable launcher starts the new version from the same installation.

The handoff covers package-manager and standalone installations, Windows deferred replacement, and sandbox execution. Original arguments are preserved, and environments with multiple Qwen installations restart the launcher associated with the current installation.

## Why it's needed

Qwen Code lazy-loads content-hashed chunks. If an update replaces the installation while an old process is active, later imports from that process can reference hashed files that no longer exist and fail with `Cannot find module ...updateCheck-*.js`.

The update subprocess may still finish successfully, which produces the contradictory result of an import error followed by an “update successful” message. This PR fixes the update boundary so installation files are replaced only after the active interactive process has exited.

## Reviewer Test Plan

### How to verify

1. Start an older interactive build while an update is available and wait for the background update check. The session should remain active and report that the update will be installed after exit.
2. Exit the session cleanly. The update should run after exit, and the next invocation should use the new version.
3. Run `/update` from an older version. The old interactive process should exit before installation begins, then the updated CLI should restart without `ERR_MODULE_NOT_FOUND`.
4. Put multiple Qwen installations on `PATH`. The update handoff should restart the launcher belonging to the current installation.
5. Verify that standalone and sandbox installations use their respective deferred replacement and host-update guidance.

### Evidence (Before & After)

Before: `/update` could report `Cannot find module ...updateCheck-*.js` and then still print an update-success message.

After: background updates no longer interrupt active sessions. Explicit `/update` exits the old process before installing and restarts the updated CLI. Regression coverage exercises the supervisor, stable launcher, sandbox, package-manager, standalone, and Windows deferred-replacement paths.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 22. Windows and Linux update, launcher, and packaging behavior was covered by automated tests, but no live interactive update was performed on those systems.

## Risk & Scope

- Main risk or tradeoff: The update flow now relies on an internal exit-code handoff between the interactive child, supervisor, and stable launcher.
- Not validated / out of scope: Live Windows and Linux TUI updates were not exercised. Existing custom sandbox images must be rebuilt to receive the safe update protocol.
- Breaking changes / migration notes: None. No public API or configuration migration is introduced.

## Linked Issues

Related to #4758. Follow-up to #4760 and #5780.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 避免自动更新或 `/update` 在交互进程仍运行时替换 Qwen Code 安装文件。

后台检查发现更新后，只通知监督进程在当前会话正常退出后安装。显式执行 `/update` 时，先退出旧交互进程，再由宿主监督进程完成更新，并通过同一安装来源的稳定 launcher 启动新版本。

该流程同时覆盖包管理器安装、standalone 安装、Windows 延迟替换和 sandbox。启动参数会原样保留，多份 Qwen 安装并存时不会误启动 PATH 中的其他版本。

## 为什么需要

Qwen Code 使用带内容哈希的延迟加载 chunk。后台更新若在旧进程运行期间替换安装目录，旧进程后续加载 chunk 时会引用已经被删除的旧文件，导致 `Cannot find module ...updateCheck-*.js`。

更新子进程仍可能成功退出，因此界面还会继续显示“更新成功”。此 PR 从更新边界解决问题：任何安装文件替换都发生在活跃交互进程退出之后。

## Reviewer 测试计划

### 如何验证

1. 使用存在可用更新的旧版本启动交互会话，等待后台更新检查完成；会话应保持运行，并提示更新将在退出后安装。
2. 正常退出会话；更新应在退出后执行，下次启动使用新版本。
3. 在旧版本中执行 `/update`；旧交互进程应先退出，更新完成后新版本自动启动，且不出现 `ERR_MODULE_NOT_FOUND`。
4. 在 PATH 中放置多个 Qwen 安装；更新后应重新启动当前安装对应的 launcher。
5. 使用 standalone 和 sandbox 安装时，分别确认延迟替换和宿主更新提示符合预期。

### 证据（Before & After）

Before：`/update` 可能报错 `Cannot find module ...updateCheck-*.js`，随后仍显示更新成功。

After：后台更新不会中断活跃会话；显式 `/update` 会先退出旧进程，再更新并启动新版本。相关监督进程、launcher、sandbox 和 Windows 延迟替换路径均有回归测试覆盖。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js 22。Windows 和 Linux 的更新、launcher 及安装包逻辑通过自动化测试验证，未进行真实系统交互式更新。

## 风险与范围

- 主要风险或权衡：更新流程新增监督进程与稳定 launcher 之间的退出码交接。
- 未验证或范围外：未执行真实 Windows/Linux TUI 更新；旧的自定义 sandbox 镜像需要重新构建才能获得安全更新流程。
- Breaking changes / migration notes：无配置迁移或公开 API 变更。

## 关联 Issue

关联 #4758，是 #4760 和 #5780 的后续修复。

</details>


Closes #6889
