### PR TITLE
feat(web-shell): use popovers for composer controls

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -1288,6 +1288,7 @@
 
 .toolBtnText {
   min-width: 0;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   color: var(--agent-gray-500);

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -191,10 +191,34 @@
 
 :global([data-web-shell-slash-menu]) {
   width: min(
-    620px,
+    max(
+      240px,
+      calc(
+        var(--slash-command-col) + var(--slash-desc-col) +
+          var(--slash-column-gap) + 20px
+      )
+    ),
     calc(var(--radix-popover-trigger-width) - 32px),
+    var(--radix-popover-content-available-width),
     calc(100vw - 24px)
   );
+  max-height: var(--radix-popover-content-available-height);
+  overflow: hidden;
+}
+
+:global([data-web-shell-slash-detail]) {
+  z-index: calc(var(--web-shell-popover-z-index, 1000) + 1);
+  width: min(
+    320px,
+    var(--radix-popover-content-available-width),
+    calc(100vw - 24px)
+  );
+  max-height: min(200px, var(--radix-popover-content-available-height));
+  overflow: hidden;
+}
+
+:global([data-web-shell-toolbar-popover]) {
+  width: min(18rem, var(--radix-popover-content-available-width));
   max-height: var(--radix-popover-content-available-height);
   overflow: hidden;
 }
@@ -293,6 +317,11 @@
   cursor: pointer;
 }
 
+.slashItem:not([data-has-description]) {
+  grid-template-columns: minmax(0, 1fr);
+  column-gap: 0;
+}
+
 .slashItem:hover,
 .slashItemActive {
   background: var(--accent);
@@ -304,7 +333,11 @@
 }
 
 .slashDetail {
-  max-height: 180px;
+  min-height: 0;
+  max-height: min(
+    180px,
+    max(0px, calc(var(--radix-popover-content-available-height) - 20px))
+  );
   overflow: auto;
   overflow-wrap: anywhere;
 }

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -185,65 +185,42 @@
   }
 }
 
-.slashPortalLayer {
-  display: contents;
-}
-
 .atPortalLayer {
   display: contents;
 }
 
-.slashPanel {
-  position: fixed;
-  z-index: var(--web-shell-popover-z-index, 1000);
-  /* Round cap sized for ~12 command rows plus their section headers/dividers,
-     bounded by 45vh so it stays proportional on short viewports. */
-  --slash-panel-max-height: min(460px, 45vh);
-  --slash-anchor-width: 620px;
-  --slash-command-col: 20ch;
-  --slash-desc-col: 32ch;
-  --slash-column-gap: 2ch;
-  --slash-row-width: calc(
-    var(--slash-command-col) + var(--slash-desc-col) + var(--slash-column-gap) +
-      16px
-  );
-  width: fit-content;
-  min-width: min(240px, calc(var(--slash-anchor-width) - 32px));
-  max-width: min(
+:global([data-web-shell-slash-menu]) {
+  width: min(
     620px,
-    calc(var(--slash-anchor-width) - 32px),
+    calc(var(--radix-popover-trigger-width) - 32px),
     calc(100vw - 24px)
   );
-  max-height: var(--slash-panel-max-height);
-  padding: 6px;
-  overflow: visible;
-  border: 1px solid var(--chat-editor-border-color);
-  border-radius: 8px;
-  background: var(--background);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-  color: var(--chat-editor-text-primary);
+  max-height: var(--radix-popover-content-available-height);
+  overflow: hidden;
+}
+
+.slashPanel {
+  max-height: min(
+    460px,
+    calc(var(--radix-popover-content-available-height) - 20px)
+  );
+  overflow: hidden;
   cursor: default;
-  font-family: var(--font-sans, system-ui, sans-serif);
-  font-size: 13px;
-  line-height: 1.35;
 }
 
 .slashPanelBody {
-  max-height: calc(var(--slash-panel-max-height) - 12px);
+  max-height: inherit;
   overflow: hidden;
-  border-radius: 6px;
 }
 
 .slashList {
   display: flex;
-  width: min(var(--slash-row-width), calc(100vw - 46px));
-  max-width: 100%;
+  width: 100%;
   max-height: inherit;
   flex-direction: column;
   gap: 2px;
   overflow-x: hidden;
   overflow-y: auto;
-  border-radius: 6px;
   scroll-padding-bottom: 12px;
   scrollbar-color: var(--chat-editor-border-color) transparent;
   scrollbar-width: thin;
@@ -302,9 +279,9 @@
   width: 100%;
   min-width: 0;
   grid-template-columns:
-    minmax(0, var(--slash-command-col))
-    minmax(0, var(--slash-desc-col));
-  column-gap: var(--slash-column-gap);
+    minmax(0, 2fr)
+    minmax(0, 3fr);
+  column-gap: 8px;
   align-items: baseline;
   padding: 5px 8px;
   border: 0;
@@ -327,22 +304,9 @@
 }
 
 .slashDetail {
-  position: fixed;
-  z-index: calc(var(--web-shell-popover-z-index, 1000) + 1);
-  width: min(320px, calc(100vw - 48px));
-  padding: 8px 10px;
+  max-height: 180px;
   overflow: auto;
-  border: 1px solid var(--chat-editor-border-color);
-  border-radius: 6px;
-  background: var(--background);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-  color: var(--foreground);
-  font-family: var(--font-sans, system-ui, sans-serif);
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 20px;
   overflow-wrap: anywhere;
-  pointer-events: auto;
 }
 
 .slashDetailCommand {
@@ -699,12 +663,6 @@
 }
 
 @container (max-width: 699px) {
-  .slashPanel {
-    left: 12px;
-    width: calc(100% - 24px);
-    min-width: 0;
-  }
-
   .slashList {
     width: 100%;
   }
@@ -1037,101 +995,13 @@
   pointer-events: none;
 }
 
-@container (max-width: 699px) {
-  .toolbarLeft {
-    flex-wrap: nowrap;
-    gap: 2px;
-  }
-
-  .toolbarLeft .dropdownWrapper {
-    width: 28px;
-    flex: 0 0 28px;
-  }
-
-  .gitBranchChip {
-    width: 28px;
-    max-width: 28px;
-    flex: 0 0 28px;
-    gap: 0;
-    padding: 0 6px;
-  }
-
-  .gitBranchText,
-  .workspaceChipText,
-  .modeToolBtn .toolBtnText,
-  .modelToolBtn .toolBtnText,
-  .modeToolBtn .toolBtnArrow,
-  .modelToolBtn .toolBtnArrow {
-    display: none;
-  }
-
-  .toolbarLeft .workspaceChip,
-  .workspaceSelectTooltipTrigger,
-  .workspaceSelectTrigger,
-  .modeToolBtn,
-  .modelToolBtn {
-    width: 28px;
-    max-width: 28px;
-    flex: 0 0 28px;
-    gap: 0;
-    padding: 0 6px;
-    justify-content: center;
-    box-sizing: border-box;
-  }
-
-  .toolbarLeft .workspaceSelectTrigger [data-slot='select-value'],
-  .workspaceSelectTrigger > svg:last-child {
-    display: none;
-  }
-}
-
 .dropdownWrapper {
   position: relative;
 }
 
-.dropdown {
-  position: fixed;
-  z-index: 100;
-  display: flex;
-  min-width: 0;
-  padding: 4px;
-  overflow: hidden;
-  background: var(--background);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow:
-    0 2px 4px -2px rgba(0, 0, 0, 0.1),
-    0 4px 6px -1px rgba(0, 0, 0, 0.1);
-  flex-direction: column;
-  gap: 2px;
-}
-
-.dropdownRich {
-  padding: 6px;
-  gap: 2px;
-}
-
-.dropdownCheck {
-  padding: 6px;
-  gap: 2px;
-}
-
-.dropdownSearch {
-  width: 100%;
-  min-height: 30px;
-  flex: 0 0 auto;
-  padding: 5px 8px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  outline: none;
-  background: var(--chat-editor-bg-tertiary);
-  color: var(--foreground);
-  font: inherit;
-  font-size: 13px;
-}
-
-.dropdownSearch:focus-visible {
-  border-color: var(--agent-blue-500);
+.dropdownWrapperCompact {
+  width: 28px;
+  flex: 0 0 28px;
 }
 
 .dropdownList {
@@ -1142,6 +1012,10 @@
   gap: 2px;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.dropdownListConstrained {
+  max-height: 250px;
 }
 
 .dropdownEmpty {
@@ -1306,6 +1180,36 @@
   white-space: nowrap;
 }
 
+.gitBranchChipCompact,
+.workspaceChipCompact,
+.workspaceSelectTriggerCompact,
+.toolBtnCompact {
+  width: 28px;
+  max-width: 28px;
+  flex: 0 0 28px;
+  gap: 0;
+  padding: 0 6px;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.workspaceSelectTooltipTriggerCompact {
+  width: 28px;
+  max-width: 28px;
+  flex: 0 0 28px;
+}
+
+.gitBranchChipCompact .gitBranchText,
+.workspaceChipCompact .workspaceChipText,
+.workspaceSelectTriggerCompact [data-slot='select-value'],
+.workspaceSelectTriggerCompact > svg:last-child,
+.workspaceSelectTriggerCompact .toolBtnText,
+.workspaceSelectTriggerCompact .toolBtnArrow,
+.toolBtnCompact .toolBtnText,
+.toolBtnCompact .toolBtnArrow {
+  display: none;
+}
+
 .toolBtn[data-tooltip]:hover::after,
 .toolBtn[data-tooltip]:focus-visible::after {
   position: absolute;
@@ -1384,7 +1288,6 @@
 
 .toolBtnText {
   min-width: 0;
-  overflow: hidden;
   display: inline-flex;
   align-items: center;
   color: var(--agent-gray-500);
@@ -1397,22 +1300,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 10px;
-  height: 10px;
-  margin-left: 2px;
+  width: 16px;
+  height: 16px;
+  color: var(--muted-foreground);
 }
 
 .toolBtnArrow svg {
   display: block;
-}
-
-.chevronDown {
-  width: 7px;
-  height: 7px;
-  border-right: 1px solid currentColor;
-  border-bottom: 1px solid currentColor;
-  transform: rotate(45deg);
-  margin-top: -3px;
+  width: 16px;
+  height: 16px;
 }
 
 .quickActionsPanel {

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -27,6 +27,7 @@ const mockComposerCoreState = vi.hoisted(() => ({
 const composerCoreState = vi.hoisted(() => ({
   slashMenu: null as SlashMenuState | null,
   focus: vi.fn(),
+  closeSlashMenu: vi.fn(),
 }));
 
 Object.defineProperty(window, 'matchMedia', {
@@ -102,7 +103,7 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
       onAcceptFollowup: vi.fn(),
       onDismissFollowup: vi.fn(),
       slashMenu: composerCoreState.slashMenu,
-      closeSlashMenu: vi.fn(),
+      closeSlashMenu: composerCoreState.closeSlashMenu,
       selectSlashCompletion: vi.fn(),
       acceptSlashCompletion: vi.fn(),
       atMenu: null,
@@ -126,6 +127,7 @@ const mounted: Array<{
 afterEach(() => {
   composerCoreState.slashMenu = null;
   composerCoreState.focus.mockReset();
+  composerCoreState.closeSlashMenu.mockReset();
   for (const { root, container, portalRoot } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
@@ -573,5 +575,10 @@ describe('ChatEditor slash command popovers', () => {
     const detail = document.querySelector('[data-web-shell-slash-detail]');
     expect(detail?.getAttribute('data-slot')).toBe('popover-content');
     expect(detail?.textContent).toContain('Show available commands');
+
+    act(() => {
+      detail?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(composerCoreState.closeSlashMenu).not.toHaveBeenCalled();
   });
 });

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -521,6 +521,7 @@ describe('ChatEditor toolbar popovers', () => {
       '[data-web-shell-toolbar-popover] input[type="search"]',
     );
     expect(search).not.toBeNull();
+    expect(document.activeElement).toBe(search);
     expect(search?.getAttribute('data-slot')).toBe('input');
     act(() => {
       const valueSetter = Object.getOwnPropertyDescriptor(

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -158,6 +158,7 @@ function renderChatEditor(props: {
     ...chatEditorProps
   } = props;
   const container = document.createElement('div');
+  container.dataset.webShellRoot = '';
   const portalRoot = document.createElement('div');
   portalRoot.dataset.webShellPortalRoot = '';
   document.body.appendChild(container);
@@ -542,6 +543,45 @@ describe('ChatEditor toolbar popovers', () => {
 
     expect(onSelectModel).toHaveBeenCalledWith('qwen-max');
   });
+
+  it('switches between sibling toolbar popovers without dismissing the target', async () => {
+    const container = renderChatEditor({
+      visibleToolbarActions: ['approvalMode', 'model'],
+      currentModel: 'qwen-plus',
+      availableModels: [{ id: 'qwen-plus', label: 'Qwen Plus' }],
+    });
+    const modeButton = container.querySelector<HTMLButtonElement>(
+      '[data-web-shell-mode-button]',
+    );
+    const modelButton = container.querySelector<HTMLButtonElement>(
+      '[data-web-shell-model-button]',
+    );
+
+    act(() => modeButton?.click());
+    expect(modeButton?.getAttribute('aria-expanded')).toBe('true');
+
+    await act(async () => {
+      modelButton?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(modelButton?.getAttribute('aria-expanded')).toBe('true');
+    expect(
+      document.querySelector(
+        '[data-web-shell-toolbar-popover] input[type="search"]',
+      ),
+    ).not.toBeNull();
+
+    await act(async () => {
+      modeButton?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(modeButton?.getAttribute('aria-expanded')).toBe('true');
+    expect(
+      document.querySelector(
+        '[data-web-shell-toolbar-popover] input[type="search"]',
+      ),
+    ).toBeNull();
+  });
 });
 
 describe('ChatEditor slash command popovers', () => {
@@ -560,6 +600,12 @@ describe('ChatEditor slash command popovers', () => {
           detail: 'Show available commands',
           section: 'Commands',
         },
+        {
+          id: 'history-collapse',
+          label: '/history collapse-on-resume',
+          apply: '/history collapse-on-resume',
+          section: 'Commands',
+        },
       ],
     };
 
@@ -567,6 +613,21 @@ describe('ChatEditor slash command popovers', () => {
 
     const panel = document.querySelector('[data-web-shell-slash-menu]');
     expect(panel?.getAttribute('data-slot')).toBe('popover-content');
+    expect(
+      panel
+        ?.querySelectorAll('[role="option"]')[1]
+        ?.hasAttribute('data-has-description'),
+    ).toBe(false);
+
+    const composingEscape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+    });
+    act(() => document.body.dispatchEvent(composingEscape));
+    expect(composingEscape.defaultPrevented).toBe(false);
+    expect(document.querySelector('[data-web-shell-slash-menu]')).toBe(panel);
 
     const command = panel?.querySelector<HTMLButtonElement>('[role="option"]');
     act(() => {

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -3,21 +3,30 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { I18nProvider } from '../i18n';
-import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
-import type {
-  ComposerTagClickHandler,
-  ComposerTagRenderer,
-  WebShellComposerTag,
+import {
+  WebShellCustomizationProvider,
+  type ComposerTagClickHandler,
+  type ComposerTagRenderer,
+  type WebShellComposerTag,
+  type WebShellCustomization,
 } from '../customization';
-import { WebShellCustomizationProvider } from '../customization';
+import { I18nProvider } from '../i18n';
+import type { SlashMenuState } from '../hooks/useComposerCore';
+import { ChatEditor, type ComposerToolbarAction } from './ChatEditor';
 import { WebShellPortalRootContext } from '../portalRoot';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+Element.prototype.scrollIntoView = vi.fn();
+
 const mockComposerCoreState = vi.hoisted(() => ({
   composerTags: [] as WebShellComposerTag[],
   removeTopTag: vi.fn(),
+}));
+
+const composerCoreState = vi.hoisted(() => ({
+  slashMenu: null as SlashMenuState | null,
+  focus: vi.fn(),
 }));
 
 Object.defineProperty(window, 'matchMedia', {
@@ -38,7 +47,7 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
     useComposerCore: () => ({
       containerRef: React.createRef<HTMLDivElement>(),
       viewRef: { current: null },
-      focus: vi.fn(),
+      focus: composerCoreState.focus,
       submitText: vi.fn(),
       clearText: vi.fn(),
       getText: vi.fn(() => ''),
@@ -92,7 +101,7 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
       disabled: false,
       onAcceptFollowup: vi.fn(),
       onDismissFollowup: vi.fn(),
-      slashMenu: null,
+      slashMenu: composerCoreState.slashMenu,
       closeSlashMenu: vi.fn(),
       selectSlashCompletion: vi.fn(),
       acceptSlashCompletion: vi.fn(),
@@ -115,6 +124,8 @@ const mounted: Array<{
 }> = [];
 
 afterEach(() => {
+  composerCoreState.slashMenu = null;
+  composerCoreState.focus.mockReset();
   for (const { root, container, portalRoot } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
@@ -131,9 +142,19 @@ function renderChatEditor(props: {
   visibleToolbarActions?: readonly ComposerToolbarAction[];
   renderComposerTagTooltip?: ComposerTagRenderer;
   onComposerTagClick?: ComposerTagClickHandler;
+  currentMode?: string;
+  currentModel?: string;
+  availableModels?: Array<{ id: string; label?: string }>;
+  onSelectMode?: (mode: string) => void;
+  onSelectModel?: (model: string) => void;
+  customization?: WebShellCustomization;
 }) {
-  const { renderComposerTagTooltip, onComposerTagClick, ...chatEditorProps } =
-    props;
+  const {
+    customization,
+    renderComposerTagTooltip,
+    onComposerTagClick,
+    ...chatEditorProps
+  } = props;
   const container = document.createElement('div');
   const portalRoot = document.createElement('div');
   portalRoot.dataset.webShellPortalRoot = '';
@@ -146,7 +167,11 @@ function renderChatEditor(props: {
     root.render(
       <WebShellPortalRootContext.Provider value={portalRoot}>
         <WebShellCustomizationProvider
-          value={{ renderComposerTagTooltip, onComposerTagClick }}
+          value={{
+            ...customization,
+            renderComposerTagTooltip,
+            onComposerTagClick,
+          }}
         >
           <I18nProvider language="en">
             <ChatEditor
@@ -389,5 +414,164 @@ describe('ChatEditor top composer tag tooltip', () => {
       accessibleTooltip?.id,
     );
     expect(tag?.hasAttribute('aria-describedby')).toBe(false);
+  });
+});
+
+describe('ChatEditor toolbar popovers', () => {
+  it('opens the approval mode popover and restores editor focus after selection', async () => {
+    const onSelectMode = vi.fn();
+    const container = renderChatEditor({
+      visibleToolbarActions: ['approvalMode'],
+      onSelectMode,
+    });
+    const focusTarget = document.createElement('input');
+    container.appendChild(focusTarget);
+    composerCoreState.focus.mockImplementation(() => focusTarget.focus());
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-web-shell-mode-button]')
+        ?.click();
+    });
+
+    const popover = document.querySelector('[data-web-shell-toolbar-popover]');
+    expect(popover).not.toBeNull();
+    expect(popover?.getAttribute('data-side')).toBe('top');
+
+    const yolo = Array.from(popover?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent?.includes('(yolo)'),
+    );
+    await act(async () => {
+      yolo?.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(onSelectMode).toHaveBeenCalledWith('yolo');
+    expect(document.activeElement).toBe(focusTarget);
+    expect(
+      document.querySelector('[data-web-shell-toolbar-popover]'),
+    ).toBeNull();
+  });
+
+  it('observes custom toolbar render roots when measuring available width', () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const observed = new Set<Element>();
+    globalThis.ResizeObserver = class ResizeObserverMock {
+      constructor(_callback: ResizeObserverCallback) {}
+
+      observe(element: Element) {
+        observed.add(element);
+      }
+
+      unobserve() {}
+
+      disconnect() {}
+    };
+
+    try {
+      renderChatEditor({
+        visibleToolbarActions: [],
+        customization: {
+          renderComposerToolbarStart: () => (
+            <span data-test-toolbar-start>start</span>
+          ),
+          renderComposerToolbarEnd: () => (
+            <span data-test-toolbar-end>end</span>
+          ),
+          renderComposerToolbarRight: () => (
+            <span data-test-toolbar-right>right</span>
+          ),
+        },
+      });
+
+      expect(
+        observed.has(document.querySelector('[data-test-toolbar-start]')!),
+      ).toBe(true);
+      expect(
+        observed.has(document.querySelector('[data-test-toolbar-end]')!),
+      ).toBe(true);
+      expect(
+        observed.has(document.querySelector('[data-test-toolbar-right]')!),
+      ).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it('opens a searchable model popover and selects the filtered model', () => {
+    const onSelectModel = vi.fn();
+    const container = renderChatEditor({
+      visibleToolbarActions: ['model'],
+      availableModels: [
+        { id: 'qwen-plus', label: 'Qwen Plus' },
+        { id: 'qwen-max', label: 'Qwen Max' },
+      ],
+      onSelectModel,
+    });
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-web-shell-model-button]')
+        ?.click();
+    });
+
+    const search = document.querySelector<HTMLInputElement>(
+      '[data-web-shell-toolbar-popover] input[type="search"]',
+    );
+    expect(search).not.toBeNull();
+    expect(search?.getAttribute('data-slot')).toBe('input');
+    act(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      valueSetter?.call(search, 'max');
+      search?.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const options = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[data-web-shell-toolbar-popover] button',
+      ),
+    );
+    expect(options.map((option) => option.textContent)).toEqual(['Qwen Max']);
+    act(() => options[0]?.click());
+
+    expect(onSelectModel).toHaveBeenCalledWith('qwen-max');
+  });
+});
+
+describe('ChatEditor slash command popovers', () => {
+  it('uses shadcn popovers for the command panel and hover detail', () => {
+    composerCoreState.slashMenu = {
+      kind: 'command',
+      from: 0,
+      to: 1,
+      query: '',
+      selectedIndex: 0,
+      items: [
+        {
+          id: 'help',
+          label: '/help',
+          apply: '/help',
+          detail: 'Show available commands',
+          section: 'Commands',
+        },
+      ],
+    };
+
+    renderChatEditor({ visibleToolbarActions: [] });
+
+    const panel = document.querySelector('[data-web-shell-slash-menu]');
+    expect(panel?.getAttribute('data-slot')).toBe('popover-content');
+
+    const command = panel?.querySelector<HTMLButtonElement>('[role="option"]');
+    act(() => {
+      command?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    const detail = document.querySelector('[data-web-shell-slash-detail]');
+    expect(detail?.getAttribute('data-slot')).toBe('popover-content');
+    expect(detail?.textContent).toContain('Show available commands');
   });
 });

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -657,7 +657,7 @@ function ToolbarPopover({
     if (!open) {
       setSearchQuery('');
     }
-  }, [open, searchable]);
+  }, [open]);
 
   const hasCheckItems = hasRichItems || showCheck;
 

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -763,6 +763,7 @@ function SlashCommandPanel({
   menu,
   anchorRef,
   panelRef,
+  detailRef,
   onClose,
   onSelect,
   onAccept,
@@ -770,6 +771,7 @@ function SlashCommandPanel({
   menu: SlashMenuState;
   anchorRef: RefObject<HTMLElement | null>;
   panelRef: RefObject<HTMLDivElement | null>;
+  detailRef: RefObject<HTMLDivElement | null>;
   onClose: () => void;
   onSelect: (index: number) => boolean;
   onAccept: (index?: number) => boolean;
@@ -780,7 +782,6 @@ function SlashCommandPanel({
     label: string;
     detail: string;
   } | null>(null);
-  const detailRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     itemRefs.current[menu.selectedIndex]?.scrollIntoView({
@@ -1108,6 +1109,7 @@ export const ChatEditor = memo(
     const [showQuickActions, setShowQuickActions] = useState(isTouchLikeDevice);
     const containerRef = useRef<HTMLDivElement>(null);
     const slashPanelRef = useRef<HTMLDivElement>(null);
+    const slashDetailRef = useRef<HTMLDivElement>(null);
     const atPanelRef = useRef<HTMLDivElement>(null);
     const toolbarRef = useRef<HTMLDivElement>(null);
     const toolbarLeadingRef = useRef<HTMLDivElement>(null);
@@ -1159,6 +1161,7 @@ export const ChatEditor = memo(
           container &&
           !container.contains(target) &&
           !slashPanelRef.current?.contains(target) &&
+          !slashDetailRef.current?.contains(target) &&
           !atPanelRef.current?.contains(target)
         ) {
           closeSlashMenu();
@@ -1838,6 +1841,7 @@ export const ChatEditor = memo(
                 menu={core.slashMenu}
                 anchorRef={containerRef}
                 panelRef={slashPanelRef}
+                detailRef={slashDetailRef}
                 onClose={core.closeSlashMenu}
                 onSelect={core.selectSlashCompletion}
                 onAccept={core.acceptSlashCompletion}

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -9,8 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { createPortal } from 'react-dom';
-import type { CSSProperties, ReactNode, RefObject } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { Tooltip as TooltipPrimitive } from 'radix-ui';
 import { DAEMON_APPROVAL_MODES } from '@qwen-code/webui/daemon-react-sdk';
 import type { CommandInfo } from '../adapters/types';
@@ -18,7 +17,6 @@ import type { UseDaemonFollowupSuggestionReturn } from '@qwen-code/webui/daemon-
 import type { CommandDisplayCategoryOrder } from '../utils/commandDisplay';
 import type { SkillInfo } from '../completions/slashCompletion';
 import { useI18n } from '../i18n';
-import { useWebShellPortalRoot } from '../portalRoot';
 import {
   useWebShellCustomization,
   type WebShellComposerInput,
@@ -47,7 +45,7 @@ import { useWebShellPortalRoot } from '../portalRoot';
 import { VoiceButton } from '../voice/VoiceButton';
 import { GitBranchIndicator } from './GitBranchIndicator';
 import { WorkspaceIndicator } from './WorkspaceIndicator';
-import { FolderClosedIcon } from 'lucide-react';
+import { ChevronDownIcon, FolderClosedIcon } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -57,6 +55,13 @@ import {
   SelectValue,
 } from './ui/select';
 import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from './ui/popover';
+import { Input } from './ui/input';
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -64,10 +69,9 @@ import {
 } from './ui/tooltip';
 import {
   filterToolbarDropdownItems,
-  getToolbarDropdownGeometry,
-  getToolbarLabelVisibility,
+  getToolbarExpansionBudget,
+  getToolbarItemVisibility,
   resolveToolbarModelLabel,
-  type ToolbarDropdownGeometry,
   type ToolbarDropdownItem,
 } from './toolbarDropdown';
 import styles from './ChatEditor.module.css';
@@ -216,20 +220,6 @@ function isTouchLikeDevice(): boolean {
       window.matchMedia('(hover: none), (pointer: coarse)').matches)
   );
 }
-
-const SLASH_PANEL_THEME_VARS = [
-  '--chat-editor-accent-color',
-  '--accent',
-  '--background',
-  '--chat-editor-bg-tertiary',
-  '--chat-editor-border-color',
-  '--foreground',
-  '--font-mono',
-  '--font-sans',
-  '--muted-foreground',
-  '--chat-editor-text-primary',
-  '--chat-editor-text-secondary',
-] as const;
 
 function TopComposerTag({
   tag,
@@ -489,10 +479,6 @@ function WidthModeIcon({ mode }: { mode: '1000' | 'wide' }) {
   );
 }
 
-function ChevronDownIcon() {
-  return <span className={styles.chevronDown} aria-hidden="true" />;
-}
-
 function ModelIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -635,16 +621,15 @@ function getModeListLabel(modeId: string, t: (key: string) => string): string {
   return labels[modeId] ?? getModeLabel(modeId, t);
 }
 
-function ToolbarDropdown({
+function ToolbarPopover({
   open,
   items,
   activeId,
-  onClose,
+  onOpenChange,
   onSelect,
-  anchorRef,
-  boundaryRef,
+  trigger,
+  tooltip,
   showCheck = false,
-  maxHeight,
   searchable = false,
   searchLabel,
   noResultsLabel,
@@ -652,24 +637,18 @@ function ToolbarDropdown({
   open: boolean;
   items: DropdownItem[];
   activeId: string;
-  onClose: () => void;
+  onOpenChange: (open: boolean) => void;
   onSelect: (id: string) => void;
-  anchorRef: React.RefObject<HTMLButtonElement | null>;
-  boundaryRef: React.RefObject<HTMLElement | null>;
+  trigger: ReactNode;
+  tooltip?: ReactNode;
   showCheck?: boolean;
-  maxHeight?: number;
   searchable?: boolean;
   searchLabel?: string;
   noResultsLabel?: (query: string) => string;
 }) {
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [geometry, setGeometry] = useState<ToolbarDropdownGeometry | null>(
-    null,
-  );
+  const selectionRef = useRef(false);
   const hasRichItems = items.some((item) => item.description || item.icon);
-  const preferredWidth = hasRichItems ? 360 : showCheck ? 300 : 160;
   const visibleItems = searchable
     ? filterToolbarDropdownItems(items, searchQuery)
     : items;
@@ -677,169 +656,106 @@ function ToolbarDropdown({
   useEffect(() => {
     if (!open) {
       setSearchQuery('');
-      setGeometry(null);
-      return;
     }
-    if (!searchable) return;
-    const animationFrame = window.requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-    });
-    return () => window.cancelAnimationFrame(animationFrame);
   }, [open, searchable]);
 
-  useLayoutEffect(() => {
-    if (!open) return undefined;
-    const anchor = anchorRef.current;
-    if (!anchor) return undefined;
-    const boundary =
-      anchor.closest<HTMLElement>('[data-web-shell-root]') ??
-      boundaryRef.current;
-    if (!boundary) return undefined;
-
-    const update = () => {
-      setGeometry(
-        getToolbarDropdownGeometry({
-          anchor: anchor.getBoundingClientRect(),
-          boundary: boundary.getBoundingClientRect(),
-          viewportWidth: window.innerWidth,
-          viewportHeight: window.innerHeight,
-          preferredWidth,
-          maxHeight,
-        }),
-      );
-    };
-
-    update();
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(anchor);
-    resizeObserver.observe(boundary);
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-    };
-  }, [anchorRef, boundaryRef, maxHeight, open, preferredWidth]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerOutside = (event: Event) => {
-      if (event instanceof MouseEvent && event.button !== 0) return;
-      if (event.defaultPrevented) return;
-      const dropdown = dropdownRef.current;
-      const anchor = anchorRef.current;
-      const target = event.target;
-      if (
-        dropdown &&
-        target instanceof Node &&
-        !dropdown.contains(target) &&
-        anchor &&
-        !anchor.contains(target)
-      ) {
-        onClose();
-      }
-    };
-    window.addEventListener('mousedown', onPointerOutside);
-    return () => window.removeEventListener('mousedown', onPointerOutside);
-  }, [open, onClose, anchorRef]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose();
-        window.requestAnimationFrame(() => anchorRef.current?.focus());
-      }
-    };
-    window.addEventListener('keydown', onEscape);
-    return () => window.removeEventListener('keydown', onEscape);
-  }, [open, onClose, anchorRef]);
-
-  if (!open) return null;
-
   const hasCheckItems = hasRichItems || showCheck;
-  const dropdownStyle = geometry
-    ? {
-        left: geometry.left,
-        width: geometry.width,
-        maxHeight: geometry.maxHeight,
-        ...(geometry.placement === 'above'
-          ? { bottom: geometry.bottom }
-          : { top: geometry.top }),
-      }
-    : undefined;
 
   return (
-    <div
-      ref={dropdownRef}
-      className={`${styles.dropdown} ${
-        hasRichItems
-          ? styles.dropdownRich
-          : showCheck
-            ? styles.dropdownCheck
-            : ''
-      }`}
-      data-placement={geometry?.placement}
-      style={dropdownStyle}
-      onClick={(event) => event.stopPropagation()}
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) selectionRef.current = false;
+        onOpenChange(nextOpen);
+      }}
     >
-      {searchable && (
-        <input
-          ref={searchInputRef}
-          type="search"
-          className={styles.dropdownSearch}
-          value={searchQuery}
-          aria-label={searchLabel}
-          placeholder={searchLabel}
-          autoComplete="off"
-          onChange={(event) => setSearchQuery(event.target.value)}
-        />
+      {tooltip ? (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top">{tooltip}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       )}
-      <div className={styles.dropdownList}>
-        {visibleItems.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            className={`${styles.dropdownItem} ${
-              item.id === activeId ? styles.dropdownItemActive : ''
-            }`}
-            onMouseDown={(e) => {
-              e.preventDefault();
-              onSelect(item.id);
-            }}
-          >
-            {hasCheckItems ? (
-              <>
-                {hasRichItems && (
-                  <span className={styles.dropdownItemIcon}>{item.icon}</span>
-                )}
-                <span className={styles.dropdownItemContent}>
-                  <span className={styles.dropdownItemLabel}>{item.label}</span>
-                  {item.description && (
-                    <span className={styles.dropdownItemDesc}>
-                      {item.description}
-                    </span>
-                  )}
-                </span>
-                <span className={styles.dropdownItemCheck}>
-                  {item.id === activeId ? <CheckIcon /> : null}
-                </span>
-              </>
-            ) : (
-              item.label
-            )}
-          </button>
-        ))}
-        {visibleItems.length === 0 && noResultsLabel && (
-          <div className={styles.dropdownEmpty} role="status">
-            {noResultsLabel(searchQuery)}
-          </div>
+      <PopoverContent
+        side="top"
+        align="start"
+        collisionPadding={8}
+        data-web-shell-toolbar-popover
+        onClick={(event) => event.stopPropagation()}
+        onCloseAutoFocus={(event) => {
+          if (!selectionRef.current) return;
+          event.preventDefault();
+          selectionRef.current = false;
+        }}
+      >
+        {searchable && (
+          <Input
+            type="search"
+            value={searchQuery}
+            aria-label={searchLabel}
+            placeholder={searchLabel}
+            autoComplete="off"
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
         )}
-      </div>
-    </div>
+        <div
+          className={`${styles.dropdownList} ${
+            hasRichItems
+              ? styles.dropdownRich
+              : showCheck
+                ? styles.dropdownCheck
+                : ''
+          } ${searchable ? styles.dropdownListConstrained : ''}`}
+        >
+          {visibleItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`${styles.dropdownItem} ${
+                item.id === activeId ? styles.dropdownItemActive : ''
+              }`}
+              onClick={() => {
+                selectionRef.current = true;
+                onSelect(item.id);
+              }}
+            >
+              {hasCheckItems ? (
+                <>
+                  {hasRichItems && (
+                    <span className={styles.dropdownItemIcon}>{item.icon}</span>
+                  )}
+                  <span className={styles.dropdownItemContent}>
+                    <span className={styles.dropdownItemLabel}>
+                      {item.label}
+                    </span>
+                    {item.description && (
+                      <span className={styles.dropdownItemDesc}>
+                        {item.description}
+                      </span>
+                    )}
+                  </span>
+                  <span className={styles.dropdownItemCheck}>
+                    {item.id === activeId ? <CheckIcon /> : null}
+                  </span>
+                </>
+              ) : (
+                item.label
+              )}
+            </button>
+          ))}
+          {visibleItems.length === 0 && noResultsLabel && (
+            <div className={styles.dropdownEmpty} role="status">
+              {noResultsLabel(searchQuery)}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -847,30 +763,22 @@ function SlashCommandPanel({
   menu,
   anchorRef,
   panelRef,
+  onClose,
   onSelect,
   onAccept,
 }: {
   menu: SlashMenuState;
   anchorRef: RefObject<HTMLElement | null>;
   panelRef: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
   onSelect: (index: number) => boolean;
   onAccept: (index?: number) => boolean;
 }) {
-  const portalRoot = useWebShellPortalRoot();
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const [anchorRect, setAnchorRect] = useState<{
-    left: number;
-    bottom: number;
-    width: number;
-  } | null>(null);
-  const [themeVars, setThemeVars] = useState<CSSProperties>({});
+  const hoverAnchorRef = useRef<HTMLButtonElement>(null);
   const [hoverDetail, setHoverDetail] = useState<{
     label: string;
     detail: string;
-    left: number;
-    top?: number;
-    bottom?: number;
-    maxHeight: number;
   } | null>(null);
   const detailRef = useRef<HTMLDivElement | null>(null);
 
@@ -880,209 +788,175 @@ function SlashCommandPanel({
     });
   }, [menu.items, menu.selectedIndex]);
 
-  useLayoutEffect(() => {
-    const anchor = anchorRef.current;
-    if (!anchor) return undefined;
-
-    const update = () => {
-      const rect = anchor.getBoundingClientRect();
-      const computedStyle = getComputedStyle(anchor);
-      const nextThemeVars = Object.fromEntries(
-        SLASH_PANEL_THEME_VARS.map((name) => [
-          name,
-          computedStyle.getPropertyValue(name),
-        ]),
-      ) as CSSProperties;
-      setAnchorRect({
-        left: Math.max(12, Math.min(rect.left + 16, window.innerWidth - 252)),
-        bottom: window.innerHeight - rect.top + 8,
-        width: rect.width,
-      });
-      setThemeVars(nextThemeVars);
-    };
-
-    update();
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(anchor);
-    window.addEventListener('resize', update);
-    window.addEventListener('scroll', update, true);
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update, true);
-    };
-  }, [anchorRef, menu.items]);
-
   useEffect(() => {
     setHoverDetail(null);
   }, [menu.items]);
 
-  const measureText = (text: string) => Array.from(text).length;
-  const maxLabelLength = Math.max(
-    ...menu.items.map((item) => measureText(item.label)),
-    0,
-  );
-  const maxDetailLength = Math.max(
-    ...menu.items.map((item) => measureText(item.detail ?? '')),
-    0,
-  );
-  const hasDetailColumn = maxDetailLength > 0;
-  const panelStyle = {
-    '--slash-command-col': `${Math.min(
-      Math.max(maxLabelLength + 1, 10),
-      24,
-    )}ch`,
-    '--slash-desc-col': hasDetailColumn
-      ? `${Math.min(Math.max(maxDetailLength + 1, 18), 36)}ch`
-      : '0px',
-    '--slash-column-gap': hasDetailColumn ? '2ch' : '0px',
-  } as CSSProperties;
-
-  if (!anchorRect) return null;
-
   const rowPlans = planSlashSectionRows(menu.items, menu.kind);
 
-  const positionedPanelStyle = {
-    ...panelStyle,
-    ...themeVars,
-    left: anchorRect.left,
-    bottom: anchorRect.bottom,
-    '--slash-anchor-width': `${anchorRect.width}px`,
-  } as CSSProperties;
-
-  return createPortal(
-    <div
-      ref={panelRef}
-      className={styles.slashPortalLayer}
-      style={themeVars}
-      data-web-shell-slash-menu
-    >
-      <div
-        className={styles.slashPanel}
-        style={positionedPanelStyle}
-        role="listbox"
-        onMouseDown={(event) => event.preventDefault()}
-        onMouseLeave={(event) => {
-          const nextTarget = event.relatedTarget;
-          if (
-            nextTarget instanceof Node &&
-            detailRef.current?.contains(nextTarget)
-          ) {
-            return;
-          }
-          setHoverDetail(null);
+  return (
+    <>
+      <Popover
+        open
+        onOpenChange={(open) => {
+          if (!open) onClose();
         }}
       >
-        <div className={styles.slashPanelBody}>
-          <div
-            className={styles.slashList}
-            onScroll={() => setHoverDetail(null)}
-          >
-            {menu.items.map((item, index) => {
-              const plan = rowPlans[index];
-              return (
-                <div key={`${item.id}:${index}`} className={styles.slashEntry}>
-                  {plan.showHeader && (
-                    <>
-                      {plan.showDivider && (
-                        <div className={styles.slashSection} />
-                      )}
-                      <div className={styles.slashSectionHeader}>
-                        <span>{item.section}</span>
-                        {plan.count > 0 ? (
-                          <span className={styles.slashSectionCount}>
-                            {plan.count}
-                          </span>
-                        ) : null}
-                      </div>
-                    </>
-                  )}
-                  <button
-                    ref={(node) => {
-                      itemRefs.current[index] = node;
-                    }}
-                    type="button"
-                    role="option"
-                    aria-selected={index === menu.selectedIndex}
-                    className={`${styles.slashItem} ${
-                      index === menu.selectedIndex ? styles.slashItemActive : ''
-                    }`}
-                    onMouseEnter={(event) => {
-                      onSelect(index);
-                      if (!item.detail) {
-                        setHoverDetail(null);
-                        return;
-                      }
-                      const row = event.currentTarget;
-                      const gap = 8;
-                      const detailMaxHeight = 180;
-                      const rowRect = row.getBoundingClientRect();
-                      const detailWidth = 320;
-                      const left = Math.min(
-                        rowRect.left + Math.min(220, rowRect.width * 0.34),
-                        window.innerWidth - detailWidth - 12,
-                      );
-                      const spaceBelow =
-                        window.innerHeight - rowRect.bottom - gap - 12;
-                      const spaceAbove = rowRect.top - gap - 12;
-                      const showBelow =
-                        spaceBelow >= 96 || spaceBelow >= spaceAbove;
-                      const maxHeight = Math.max(
-                        72,
-                        Math.min(
-                          detailMaxHeight,
-                          showBelow ? spaceBelow : spaceAbove,
-                        ),
-                      );
-                      setHoverDetail({
-                        label: item.label,
-                        detail: item.detail,
-                        left: Math.max(12, left),
-                        ...(showBelow
-                          ? { top: rowRect.bottom + gap }
-                          : {
-                              bottom: window.innerHeight - rowRect.top + gap,
-                            }),
-                        maxHeight,
-                      });
-                    }}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      onAccept(index);
-                    }}
-                  >
-                    <span className={styles.slashCommand}>{item.label}</span>
-                    {item.detail && (
-                      <span className={styles.slashDescription}>
-                        {item.detail}
-                      </span>
-                    )}
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-      {hoverDetail && (
-        <div
-          ref={detailRef}
-          className={styles.slashDetail}
-          style={{
-            ...themeVars,
-            left: hoverDetail.left,
-            top: hoverDetail.top,
-            bottom: hoverDetail.bottom,
-            maxHeight: hoverDetail.maxHeight,
+        <PopoverAnchor
+          virtualRef={
+            anchorRef as RefObject<{ getBoundingClientRect(): DOMRect }>
+          }
+        />
+        <PopoverContent
+          ref={panelRef}
+          side="top"
+          align="start"
+          alignOffset={16}
+          sideOffset={8}
+          collisionPadding={12}
+          role="listbox"
+          data-web-shell-slash-menu
+          onOpenAutoFocus={(event) => event.preventDefault()}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onInteractOutside={(event) => {
+            const target = event.target;
+            if (
+              target instanceof Node &&
+              (anchorRef.current?.contains(target) ||
+                detailRef.current?.contains(target))
+            ) {
+              event.preventDefault();
+            }
+          }}
+          onMouseDown={(event) => event.preventDefault()}
+          onMouseLeave={(event) => {
+            const nextTarget = event.relatedTarget;
+            if (
+              nextTarget instanceof Node &&
+              detailRef.current?.contains(nextTarget)
+            ) {
+              return;
+            }
+            setHoverDetail(null);
           }}
         >
-          <div className={styles.slashDetailCommand}>{hoverDetail.label}</div>
-          <div className={styles.slashDetailText}>{hoverDetail.detail}</div>
-        </div>
-      )}
-    </div>,
-    portalRoot ?? document.body,
+          <div className={styles.slashPanel}>
+            <div className={styles.slashPanelBody}>
+              <div
+                className={styles.slashList}
+                onScroll={() => setHoverDetail(null)}
+              >
+                {menu.items.map((item, index) => {
+                  const plan = rowPlans[index];
+                  return (
+                    <div
+                      key={`${item.id}:${index}`}
+                      className={styles.slashEntry}
+                    >
+                      {plan.showHeader && (
+                        <>
+                          {plan.showDivider && (
+                            <div className={styles.slashSection} />
+                          )}
+                          <div className={styles.slashSectionHeader}>
+                            <span>{item.section}</span>
+                            {plan.count > 0 ? (
+                              <span className={styles.slashSectionCount}>
+                                {plan.count}
+                              </span>
+                            ) : null}
+                          </div>
+                        </>
+                      )}
+                      <button
+                        ref={(node) => {
+                          itemRefs.current[index] = node;
+                        }}
+                        type="button"
+                        role="option"
+                        aria-selected={index === menu.selectedIndex}
+                        className={`${styles.slashItem} ${
+                          index === menu.selectedIndex
+                            ? styles.slashItemActive
+                            : ''
+                        }`}
+                        onMouseEnter={(event) => {
+                          onSelect(index);
+                          if (!item.detail) {
+                            setHoverDetail(null);
+                            return;
+                          }
+                          hoverAnchorRef.current = event.currentTarget;
+                          setHoverDetail({
+                            label: item.label,
+                            detail: item.detail,
+                          });
+                        }}
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onAccept(index);
+                        }}
+                      >
+                        <span className={styles.slashCommand}>
+                          {item.label}
+                        </span>
+                        {item.detail && (
+                          <span className={styles.slashDescription}>
+                            {item.detail}
+                          </span>
+                        )}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+      <Popover
+        open={Boolean(hoverDetail)}
+        onOpenChange={(open) => {
+          if (!open) setHoverDetail(null);
+        }}
+      >
+        <PopoverAnchor
+          virtualRef={
+            hoverAnchorRef as RefObject<{ getBoundingClientRect(): DOMRect }>
+          }
+        />
+        {hoverDetail && (
+          <PopoverContent
+            ref={detailRef}
+            side="right"
+            align="start"
+            sideOffset={8}
+            collisionPadding={12}
+            data-web-shell-slash-detail
+            onOpenAutoFocus={(event) => event.preventDefault()}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+            onMouseLeave={(event) => {
+              const nextTarget = event.relatedTarget;
+              if (
+                nextTarget instanceof Node &&
+                panelRef.current?.contains(nextTarget)
+              ) {
+                return;
+              }
+              setHoverDetail(null);
+            }}
+          >
+            <div className={styles.slashDetail}>
+              <div className={styles.slashDetailCommand}>
+                {hoverDetail.label}
+              </div>
+              <div className={styles.slashDetailText}>{hoverDetail.detail}</div>
+            </div>
+          </PopoverContent>
+        )}
+      </Popover>
+    </>
   );
 }
 
@@ -1238,19 +1112,20 @@ export const ChatEditor = memo(
     const toolbarRef = useRef<HTMLDivElement>(null);
     const toolbarLeadingRef = useRef<HTMLDivElement>(null);
     const toolbarRightRef = useRef<HTMLDivElement>(null);
-    const modeCollapsedMeasureRef = useRef<HTMLSpanElement>(null);
-    const modeExpandedMeasureRef = useRef<HTMLSpanElement>(null);
-    const modelCollapsedMeasureRef = useRef<HTMLSpanElement>(null);
-    const modelExpandedMeasureRef = useRef<HTMLSpanElement>(null);
-    const modeBtnRef = useRef<HTMLButtonElement>(null);
-    const modelBtnRef = useRef<HTMLButtonElement>(null);
+    const toolbarStartRef = useRef<HTMLDivElement>(null);
+    const toolbarEndRef = useRef<HTMLDivElement>(null);
+    const toolbarRightCustomRef = useRef<HTMLDivElement>(null);
+    const toolbarMeasurementsRef = useRef<HTMLDivElement>(null);
     const workspaceSelectTriggerRef = useRef<HTMLButtonElement>(null);
     const suppressWorkspaceTooltipRef = useRef(false);
     const workspaceSelectPointerInsideRef = useRef(false);
     const [widthToggleFits, setWidthToggleFits] = useState(false);
     const [toolbarLabelVisibility, setToolbarLabelVisibility] = useState({
-      showModelLabel: false,
-      showModeLabel: false,
+      workspaceSelect: false,
+      workspace: false,
+      gitBranch: false,
+      mode: false,
+      model: false,
     });
     const [lastConfirmedModelLabel, setLastConfirmedModelLabel] = useState('');
     const slashMenu = core.slashMenu;
@@ -1609,6 +1484,15 @@ export const ChatEditor = memo(
           selectedWorkspace.primary ? ` · ${t('sidebar.workspacePrimary')}` : ''
         }`
       : '';
+    const workspaceSelectVisible = Boolean(
+      workspaces && workspaces.length > 1 && onSelectWorkspace,
+    );
+    const workspaceIndicatorVisible = Boolean(
+      workspaceName && showToolbarAction('workspace'),
+    );
+    const gitBranchVisible = Boolean(
+      gitBranch && showToolbarAction('gitBranch'),
+    );
 
     useLayoutEffect(() => {
       if (currentModelLabel && currentModelLabel !== lastConfirmedModelLabel) {
@@ -1616,68 +1500,120 @@ export const ChatEditor = memo(
       }
     }, [currentModelLabel, lastConfirmedModelLabel]);
 
-    const { showModelLabel, showModeLabel } = toolbarLabelVisibility;
+    const showWorkspaceSelectLabel = toolbarLabelVisibility.workspaceSelect;
+    const showWorkspaceLabel = toolbarLabelVisibility.workspace;
+    const showGitBranchLabel = toolbarLabelVisibility.gitBranch;
+    const showModeLabel = toolbarLabelVisibility.mode;
+    const showModelLabel = toolbarLabelVisibility.model;
     const showCancelButton = isRunning && !core.hasContent;
 
     useLayoutEffect(() => {
       const toolbar = toolbarRef.current;
       const toolbarLeading = toolbarLeadingRef.current;
       const toolbarRight = toolbarRightRef.current;
-      const modeCollapsed = modeCollapsedMeasureRef.current;
-      const modeExpanded = modeExpandedMeasureRef.current;
-      const modelCollapsed = modelCollapsedMeasureRef.current;
-      const modelExpanded = modelExpandedMeasureRef.current;
-      if (
-        !toolbar ||
-        !toolbarLeading ||
-        !toolbarRight ||
-        !modeCollapsed ||
-        !modeExpanded ||
-        !modelCollapsed ||
-        !modelExpanded
-      ) {
+      const measurements = toolbarMeasurementsRef.current;
+      if (!toolbar || !toolbarLeading || !toolbarRight || !measurements) {
         return undefined;
       }
 
       const update = () => {
-        const modeLabelWidth = Math.max(
+        const expansionWidth = (id: string) => {
+          const collapsed = measurements.querySelector<HTMLElement>(
+            `[data-toolbar-measure="${id}:collapsed"]`,
+          );
+          const expanded = measurements.querySelector<HTMLElement>(
+            `[data-toolbar-measure="${id}:expanded"]`,
+          );
+          return Math.max(
+            0,
+            (expanded?.getBoundingClientRect().width ?? 0) -
+              (collapsed?.getBoundingClientRect().width ?? 0),
+          );
+        };
+        const items = [
+          ...(workspaceSelectVisible
+            ? [
+                {
+                  id: 'workspaceSelect',
+                  expansionWidth: expansionWidth('workspaceSelect'),
+                },
+              ]
+            : []),
+          ...(workspaceIndicatorVisible
+            ? [
+                {
+                  id: 'workspace',
+                  expansionWidth: expansionWidth('workspace'),
+                },
+              ]
+            : []),
+          ...(gitBranchVisible
+            ? [
+                {
+                  id: 'gitBranch',
+                  expansionWidth: expansionWidth('gitBranch'),
+                },
+              ]
+            : []),
+          ...(showModeAction
+            ? [
+                {
+                  id: 'mode',
+                  expansionWidth: expansionWidth('mode'),
+                },
+              ]
+            : []),
+          ...(showModelAction
+            ? [
+                {
+                  id: 'model',
+                  expansionWidth: expansionWidth('model'),
+                  ready: modelLabelReady,
+                },
+              ]
+            : []),
+        ];
+        const currentExpansionWidth = items.reduce(
+          (total, item) =>
+            total +
+            (toolbarLabelVisibility[
+              item.id as keyof typeof toolbarLabelVisibility
+            ]
+              ? item.expansionWidth
+              : 0),
           0,
-          modeExpanded.getBoundingClientRect().width -
-            modeCollapsed.getBoundingClientRect().width,
         );
-        const modelLabelWidth = Math.max(
-          0,
-          modelExpanded.getBoundingClientRect().width -
-            modelCollapsed.getBoundingClientRect().width,
+        const currentLeadingWidth = Math.max(
+          toolbarLeading.scrollWidth,
+          toolbarLeading.getBoundingClientRect().width,
         );
-        const currentLeadingWidth =
-          toolbarLeading.getBoundingClientRect().width;
-        const baseLeadingWidth =
-          currentLeadingWidth -
-          (showModelLabel ? modelLabelWidth : 0) -
-          (showModeLabel ? modeLabelWidth : 0);
         const gap = Number.parseFloat(getComputedStyle(toolbar).columnGap) || 0;
-        const availableWidth = Math.max(
-          0,
-          toolbar.getBoundingClientRect().width -
-            toolbarRight.getBoundingClientRect().width -
-            baseLeadingWidth -
-            gap,
-        );
-        const next = getToolbarLabelVisibility({
-          availableWidth,
-          modelLabelWidth,
-          modeLabelWidth,
-          modelLabelReady,
-          modelActionVisible: showModelAction,
-          modeActionVisible: showModeAction,
+        const availableWidth = getToolbarExpansionBudget({
+          toolbarWidth: toolbar.getBoundingClientRect().width,
+          leadingWidth: currentLeadingWidth,
+          rightWidth: toolbarRight.getBoundingClientRect().width,
+          currentExpansionWidth,
+          gap,
         });
-        setToolbarLabelVisibility((current) =>
-          current.showModelLabel === next.showModelLabel &&
-          current.showModeLabel === next.showModeLabel
-            ? current
-            : next,
-        );
+        const itemVisibility = getToolbarItemVisibility({
+          availableWidth,
+          items,
+        });
+        const next = {
+          workspaceSelect: itemVisibility.workspaceSelect ?? false,
+          workspace: itemVisibility.workspace ?? false,
+          gitBranch: itemVisibility.gitBranch ?? false,
+          mode: itemVisibility.mode ?? false,
+          model: itemVisibility.model ?? false,
+        };
+        setToolbarLabelVisibility((current) => {
+          const unchanged = Object.keys(next).every(
+            (key) =>
+              current[key as keyof typeof current] ===
+              next[key as keyof typeof next],
+          );
+          return unchanged ? current : next;
+        });
       };
 
       update();
@@ -1685,19 +1621,58 @@ export const ChatEditor = memo(
       resizeObserver.observe(toolbar);
       resizeObserver.observe(toolbarLeading);
       resizeObserver.observe(toolbarRight);
-      resizeObserver.observe(modeCollapsed);
-      resizeObserver.observe(modeExpanded);
-      resizeObserver.observe(modelCollapsed);
-      resizeObserver.observe(modelExpanded);
-      return () => resizeObserver.disconnect();
+      for (const child of measurements.children) {
+        resizeObserver.observe(child);
+      }
+      const customToolbarRoots = [
+        toolbarStartRef.current,
+        toolbarEndRef.current,
+        toolbarRightCustomRef.current,
+      ].filter((element): element is HTMLDivElement => element !== null);
+      const observeCustomToolbarContent = () => {
+        for (const root of customToolbarRoots) {
+          resizeObserver.observe(root);
+          for (const child of root.children) {
+            resizeObserver.observe(child);
+          }
+        }
+      };
+      observeCustomToolbarContent();
+      const mutationObserver = new MutationObserver(() => {
+        observeCustomToolbarContent();
+        update();
+      });
+      for (const root of customToolbarRoots) {
+        mutationObserver.observe(root, {
+          attributes: true,
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+      }
+      return () => {
+        mutationObserver.disconnect();
+        resizeObserver.disconnect();
+      };
     }, [
+      ToolbarEnd,
+      ToolbarRight,
+      ToolbarStart,
+      disabled,
+      gitBranch,
+      gitBranchVisible,
+      isRunning,
       modelLabel,
       modelLabelReady,
       modeLabel,
+      sessionName,
       showModelAction,
       showModeAction,
-      showModelLabel,
-      showModeLabel,
+      toolbarLabelVisibility,
+      workspaceIndicatorVisible,
+      workspaceName,
+      workspaceSelectVisible,
+      selectedWorkspaceLabel,
     ]);
 
     return (
@@ -1863,6 +1838,7 @@ export const ChatEditor = memo(
                 menu={core.slashMenu}
                 anchorRef={containerRef}
                 panelRef={slashPanelRef}
+                onClose={core.closeSlashMenu}
                 onSelect={core.selectSlashCompletion}
                 onAccept={core.acceptSlashCompletion}
               />
@@ -1896,7 +1872,7 @@ export const ChatEditor = memo(
             <div ref={toolbarRef} className={styles.toolbar}>
               <div ref={toolbarLeadingRef} className={styles.toolbarLeading}>
                 {ToolbarStart && (
-                  <div className={styles.toolbarStart}>
+                  <div ref={toolbarStartRef} className={styles.toolbarStart}>
                     <ToolbarStart
                       disabled={disabled}
                       isRunning={isRunning}
@@ -1907,187 +1883,219 @@ export const ChatEditor = memo(
                   </div>
                 )}
                 <div className={styles.toolbarLeft}>
-                  {workspaces && workspaces.length > 1 && onSelectWorkspace && (
-                    <Select
-                      value={selectedWorkspace?.id}
-                      disabled={workspaceSelectionDisabled}
-                      onValueChange={(value) => {
-                        const nextWorkspace = workspaces.find(
-                          (entry) => entry.id === value,
-                        );
-                        if (!nextWorkspace) return;
-                        onSelectWorkspace(
-                          nextWorkspace.primary ? undefined : nextWorkspace.cwd,
-                        );
-                        suppressWorkspaceTooltipRef.current = true;
-                        setWorkspaceTooltipOpen(false);
-                        requestAnimationFrame(() => {
-                          workspaceSelectTriggerRef.current?.blur();
-                        });
-                      }}
-                    >
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip
-                          open={workspaceTooltipOpen}
-                          onOpenChange={(open) => {
-                            if (
-                              open &&
-                              (suppressWorkspaceTooltipRef.current ||
-                                !workspaceSelectPointerInsideRef.current)
-                            ) {
-                              return;
-                            }
-                            setWorkspaceTooltipOpen(open);
-                          }}
-                        >
-                          <TooltipTrigger asChild>
-                            <span
-                              className={styles.workspaceSelectTooltipTrigger}
-                              onPointerEnter={() => {
-                                workspaceSelectPointerInsideRef.current = true;
-                              }}
-                              onPointerLeave={() => {
-                                workspaceSelectPointerInsideRef.current = false;
-                                suppressWorkspaceTooltipRef.current = false;
-                              }}
-                              onBlur={() => {
-                                if (!workspaceSelectPointerInsideRef.current) {
+                  {workspaceSelectVisible &&
+                    workspaces &&
+                    onSelectWorkspace && (
+                      <Select
+                        value={selectedWorkspace?.id}
+                        disabled={workspaceSelectionDisabled}
+                        onValueChange={(value) => {
+                          const nextWorkspace = workspaces.find(
+                            (entry) => entry.id === value,
+                          );
+                          if (!nextWorkspace) return;
+                          onSelectWorkspace(
+                            nextWorkspace.primary
+                              ? undefined
+                              : nextWorkspace.cwd,
+                          );
+                          suppressWorkspaceTooltipRef.current = true;
+                          setWorkspaceTooltipOpen(false);
+                          requestAnimationFrame(() => {
+                            workspaceSelectTriggerRef.current?.blur();
+                          });
+                        }}
+                      >
+                        <TooltipProvider delayDuration={300}>
+                          <Tooltip
+                            open={workspaceTooltipOpen}
+                            onOpenChange={(open) => {
+                              if (
+                                open &&
+                                (suppressWorkspaceTooltipRef.current ||
+                                  !workspaceSelectPointerInsideRef.current)
+                              ) {
+                                return;
+                              }
+                              setWorkspaceTooltipOpen(open);
+                            }}
+                          >
+                            <TooltipTrigger asChild>
+                              <span
+                                className={`${styles.workspaceSelectTooltipTrigger} ${
+                                  showWorkspaceSelectLabel
+                                    ? ''
+                                    : styles.workspaceSelectTooltipTriggerCompact
+                                }`}
+                                onPointerEnter={() => {
+                                  workspaceSelectPointerInsideRef.current = true;
+                                }}
+                                onPointerLeave={() => {
+                                  workspaceSelectPointerInsideRef.current = false;
                                   suppressWorkspaceTooltipRef.current = false;
-                                }
-                              }}
-                            >
-                              <SelectTrigger
-                                ref={workspaceSelectTriggerRef}
-                                size="sm"
-                                className={`${styles.toolBtn} ${styles.workspaceSelectTrigger}`}
-                                aria-label={t('sidebar.workspaceSelectLabel')}
+                                }}
+                                onBlur={() => {
+                                  if (
+                                    !workspaceSelectPointerInsideRef.current
+                                  ) {
+                                    suppressWorkspaceTooltipRef.current = false;
+                                  }
+                                }}
                               >
-                                <FolderClosedIcon size={16} strokeWidth={1.2} />
-                                <SelectValue />
-                              </SelectTrigger>
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="top">
-                            {selectedWorkspaceLabel}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <SelectContent position="popper" align="start">
-                        <SelectGroup>
-                          {workspaces.map((entry) => (
-                            <SelectItem key={entry.id} value={entry.id}>
-                              {entry.label}
-                              {entry.primary
-                                ? ` · ${t('sidebar.workspacePrimary')}`
-                                : ''}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  )}
-                  {workspaceName && showToolbarAction('workspace') && (
+                                <SelectTrigger
+                                  ref={workspaceSelectTriggerRef}
+                                  size="sm"
+                                  className={`${styles.toolBtn} ${styles.workspaceSelectTrigger} ${
+                                    showWorkspaceSelectLabel
+                                      ? ''
+                                      : styles.workspaceSelectTriggerCompact
+                                  }`}
+                                  aria-label={t('sidebar.workspaceSelectLabel')}
+                                >
+                                  <FolderClosedIcon
+                                    size={16}
+                                    strokeWidth={1.2}
+                                  />
+                                  <SelectValue />
+                                </SelectTrigger>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="top">
+                              {selectedWorkspaceLabel}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <SelectContent position="popper" align="start">
+                          <SelectGroup>
+                            {workspaces.map((entry) => (
+                              <SelectItem key={entry.id} value={entry.id}>
+                                {entry.label}
+                                {entry.primary
+                                  ? ` · ${t('sidebar.workspacePrimary')}`
+                                  : ''}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    )}
+                  {workspaceIndicatorVisible && workspaceName && (
                     <WorkspaceIndicator
                       name={workspaceName}
                       title={workspaceTitle ?? workspaceName}
+                      compact={!showWorkspaceLabel}
                       ariaLabel={t('workspace.paneLabel', {
                         name: workspaceName,
                       })}
                     />
                   )}
-                  {gitBranch && showToolbarAction('gitBranch') && (
+                  {gitBranchVisible && gitBranch && (
                     <GitBranchIndicator
                       branch={gitBranch}
+                      compact={!showGitBranchLabel}
                       ariaLabel={t('git.currentBranch', { branch: gitBranch })}
                     />
                   )}
                   {showModeAction && (
-                    <div className={styles.dropdownWrapper}>
-                      <ToolbarDropdown
+                    <div
+                      className={`${styles.dropdownWrapper} ${
+                        showModeLabel ? '' : styles.dropdownWrapperCompact
+                      }`}
+                    >
+                      <ToolbarPopover
                         open={modeDropdownOpen}
                         items={modeItems}
                         activeId={currentMode}
-                        onClose={() => setModeDropdownOpen(false)}
-                        onSelect={handleModeSelect}
-                        anchorRef={modeBtnRef}
-                        boundaryRef={containerRef}
-                      />
-                      <button
-                        ref={modeBtnRef}
-                        className={`${styles.toolBtn} ${styles.modeToolBtn}`}
-                        data-web-shell-mode-button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          core.closeSlashMenu();
-                          core.closeAtMenu();
-                          setQuickActionsOpen(false);
-                          setModeDropdownOpen((v) => !v);
-                          setModelDropdownOpen(false);
+                        onOpenChange={(open) => {
+                          setModeDropdownOpen(open);
+                          if (open) setModelDropdownOpen(false);
                         }}
-                        aria-label={t('status.mode')}
-                      >
-                        <span className={styles.toolBtnModeIcon}>
-                          <ModeIcon mode={currentMode} />
-                        </span>
-                        {showModeLabel && (
-                          <span className={styles.toolBtnText}>
-                            {modeLabel}
-                          </span>
-                        )}
-                        <span className={styles.toolBtnArrow}>
-                          <ChevronDownIcon />
-                        </span>
-                      </button>
+                        onSelect={handleModeSelect}
+                        tooltip={modeLabel}
+                        trigger={
+                          <button
+                            className={`${styles.toolBtn} ${styles.modeToolBtn} ${
+                              showModeLabel ? '' : styles.toolBtnCompact
+                            }`}
+                            data-web-shell-mode-button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              core.closeSlashMenu();
+                              core.closeAtMenu();
+                              setQuickActionsOpen(false);
+                            }}
+                            aria-label={t('status.mode')}
+                          >
+                            <span className={styles.toolBtnModeIcon}>
+                              <ModeIcon mode={currentMode} />
+                            </span>
+                            {showModeLabel && (
+                              <span className={styles.toolBtnText}>
+                                {modeLabel}
+                              </span>
+                            )}
+                            <span className={styles.toolBtnArrow}>
+                              <ChevronDownIcon />
+                            </span>
+                          </button>
+                        }
+                      />
                     </div>
                   )}
                   {showModelAction && (
-                    <div className={styles.dropdownWrapper}>
-                      <ToolbarDropdown
+                    <div
+                      className={`${styles.dropdownWrapper} ${
+                        showModelLabel ? '' : styles.dropdownWrapperCompact
+                      }`}
+                    >
+                      <ToolbarPopover
                         open={modelDropdownOpen}
                         items={modelItems}
                         activeId={currentModel}
-                        onClose={() => setModelDropdownOpen(false)}
+                        onOpenChange={(open) => {
+                          setModelDropdownOpen(open);
+                          if (open) setModeDropdownOpen(false);
+                        }}
                         onSelect={handleModelSelect}
-                        anchorRef={modelBtnRef}
-                        boundaryRef={containerRef}
+                        tooltip={modelLabel}
                         showCheck
-                        maxHeight={300}
                         searchable
                         searchLabel={t('common.search')}
                         noResultsLabel={(query) =>
                           t('model.noMatch', { query })
                         }
+                        trigger={
+                          <button
+                            className={`${styles.toolBtn} ${styles.modelToolBtn} ${
+                              showModelLabel ? '' : styles.toolBtnCompact
+                            }`}
+                            data-web-shell-model-button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              core.closeSlashMenu();
+                              core.closeAtMenu();
+                              setQuickActionsOpen(false);
+                            }}
+                            aria-label={t('model.select')}
+                          >
+                            <span className={styles.toolBtnModelIcon}>
+                              <ModelIcon />
+                            </span>
+                            {showModelLabel && (
+                              <span className={styles.toolBtnText}>
+                                {modelLabel}
+                              </span>
+                            )}
+                            <span className={styles.toolBtnArrow}>
+                              <ChevronDownIcon />
+                            </span>
+                          </button>
+                        }
                       />
-                      <button
-                        ref={modelBtnRef}
-                        className={`${styles.toolBtn} ${styles.modelToolBtn}`}
-                        data-web-shell-model-button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          core.closeSlashMenu();
-                          core.closeAtMenu();
-                          setQuickActionsOpen(false);
-                          setModelDropdownOpen((v) => !v);
-                          setModeDropdownOpen(false);
-                        }}
-                        aria-label={t('model.select')}
-                      >
-                        <span className={styles.toolBtnModelIcon}>
-                          <ModelIcon />
-                        </span>
-                        {showModelLabel && (
-                          <span className={styles.toolBtnText}>
-                            {modelLabel}
-                          </span>
-                        )}
-                        <span className={styles.toolBtnArrow}>
-                          <ChevronDownIcon />
-                        </span>
-                      </button>
                     </div>
                   )}
                   {ToolbarEnd && (
-                    <div className={styles.toolbarEnd}>
+                    <div ref={toolbarEndRef} className={styles.toolbarEnd}>
                       <ToolbarEnd
                         disabled={disabled}
                         isRunning={isRunning}
@@ -2122,7 +2130,10 @@ export const ChatEditor = memo(
                   </button>
                 )}
                 {ToolbarRight && (
-                  <div className={styles.toolbarRightCustom}>
+                  <div
+                    ref={toolbarRightCustomRef}
+                    className={styles.toolbarRightCustom}
+                  >
                     <ToolbarRight
                       disabled={disabled}
                       isRunning={isRunning}
@@ -2241,20 +2252,93 @@ export const ChatEditor = memo(
                 </span>
               </div>
             </div>
-            <div className={styles.toolbarMeasurements} aria-hidden="true">
+            <div
+              ref={toolbarMeasurementsRef}
+              className={styles.toolbarMeasurements}
+              aria-hidden="true"
+            >
+              {workspaceSelectVisible && selectedWorkspace && (
+                <>
+                  <span
+                    data-toolbar-measure="workspaceSelect:collapsed"
+                    className={`${styles.toolBtn} ${styles.workspaceSelectTrigger} ${styles.workspaceSelectTriggerCompact}`}
+                  >
+                    <FolderClosedIcon size={16} strokeWidth={1.2} />
+                    <span className={styles.toolBtnText}>
+                      {selectedWorkspaceLabel}
+                    </span>
+                    <span className={styles.toolBtnArrow}>
+                      <ChevronDownIcon />
+                    </span>
+                  </span>
+                  <span
+                    data-toolbar-measure="workspaceSelect:expanded"
+                    className={`${styles.toolBtn} ${styles.workspaceSelectTrigger}`}
+                  >
+                    <FolderClosedIcon size={16} strokeWidth={1.2} />
+                    <span className={styles.toolBtnText}>
+                      {selectedWorkspaceLabel}
+                    </span>
+                    <span className={styles.toolBtnArrow}>
+                      <ChevronDownIcon />
+                    </span>
+                  </span>
+                </>
+              )}
+              {workspaceIndicatorVisible && workspaceName && (
+                <>
+                  <span
+                    data-toolbar-measure="workspace:collapsed"
+                    className={`${styles.workspaceChip} ${styles.workspaceChipCompact}`}
+                  >
+                    <span className={styles.workspaceChipIcon} />
+                    <span className={styles.workspaceChipText}>
+                      {workspaceName}
+                    </span>
+                  </span>
+                  <span
+                    data-toolbar-measure="workspace:expanded"
+                    className={styles.workspaceChip}
+                  >
+                    <span className={styles.workspaceChipIcon} />
+                    <span className={styles.workspaceChipText}>
+                      {workspaceName}
+                    </span>
+                  </span>
+                </>
+              )}
+              {gitBranchVisible && gitBranch && (
+                <>
+                  <span
+                    data-toolbar-measure="gitBranch:collapsed"
+                    className={`${styles.gitBranchChip} ${styles.gitBranchChipCompact}`}
+                  >
+                    <span className={styles.gitBranchIcon} />
+                    <span className={styles.gitBranchText}>{gitBranch}</span>
+                  </span>
+                  <span
+                    data-toolbar-measure="gitBranch:expanded"
+                    className={styles.gitBranchChip}
+                  >
+                    <span className={styles.gitBranchIcon} />
+                    <span className={styles.gitBranchText}>{gitBranch}</span>
+                  </span>
+                </>
+              )}
               <span
-                ref={modeCollapsedMeasureRef}
-                className={`${styles.toolBtn} ${styles.modeToolBtn}`}
+                data-toolbar-measure="mode:collapsed"
+                className={`${styles.toolBtn} ${styles.modeToolBtn} ${styles.toolBtnCompact}`}
               >
                 <span className={styles.toolBtnModeIcon}>
                   <ModeIcon mode={currentMode} />
                 </span>
+                <span className={styles.toolBtnText}>{modeLabel}</span>
                 <span className={styles.toolBtnArrow}>
                   <ChevronDownIcon />
                 </span>
               </span>
               <span
-                ref={modeExpandedMeasureRef}
+                data-toolbar-measure="mode:expanded"
                 className={`${styles.toolBtn} ${styles.modeToolBtn}`}
               >
                 <span className={styles.toolBtnModeIcon}>
@@ -2266,18 +2350,19 @@ export const ChatEditor = memo(
                 </span>
               </span>
               <span
-                ref={modelCollapsedMeasureRef}
-                className={`${styles.toolBtn} ${styles.modelToolBtn}`}
+                data-toolbar-measure="model:collapsed"
+                className={`${styles.toolBtn} ${styles.modelToolBtn} ${styles.toolBtnCompact}`}
               >
                 <span className={styles.toolBtnModelIcon}>
                   <ModelIcon />
                 </span>
+                <span className={styles.toolBtnText}>{modelLabel}</span>
                 <span className={styles.toolBtnArrow}>
                   <ChevronDownIcon />
                 </span>
               </span>
               <span
-                ref={modelExpandedMeasureRef}
+                data-toolbar-measure="model:expanded"
                 className={`${styles.toolBtn} ${styles.modelToolBtn}`}
               >
                 <span className={styles.toolBtnModelIcon}>

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import type { ReactNode, RefObject } from 'react';
+import type { CSSProperties, ReactNode, RefObject } from 'react';
 import { Tooltip as TooltipPrimitive } from 'radix-ui';
 import { DAEMON_APPROVAL_MODES } from '@qwen-code/webui/daemon-react-sdk';
 import type { CommandInfo } from '../adapters/types';
@@ -647,7 +647,11 @@ function ToolbarPopover({
   noResultsLabel?: (query: string) => string;
 }) {
   const [searchQuery, setSearchQuery] = useState('');
+  const [collisionBoundary, setCollisionBoundary] =
+    useState<HTMLElement | null>(null);
   const selectionRef = useRef(false);
+  const handoffRef = useRef(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const hasRichItems = items.some((item) => item.description || item.icon);
   const visibleItems = searchable
     ? filterToolbarDropdownItems(items, searchQuery)
@@ -665,7 +669,14 @@ function ToolbarPopover({
     <Popover
       open={open}
       onOpenChange={(nextOpen) => {
-        if (nextOpen) selectionRef.current = false;
+        if (nextOpen) {
+          selectionRef.current = false;
+          handoffRef.current = false;
+          setCollisionBoundary(
+            triggerRef.current?.closest<HTMLElement>('[data-web-shell-root]') ??
+              null,
+          );
+        }
         onOpenChange(nextOpen);
       }}
     >
@@ -673,21 +684,47 @@ function ToolbarPopover({
         <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+              <PopoverTrigger ref={triggerRef} asChild>
+                {trigger}
+              </PopoverTrigger>
             </TooltipTrigger>
             <TooltipContent side="top">{tooltip}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       ) : (
-        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverTrigger ref={triggerRef} asChild>
+          {trigger}
+        </PopoverTrigger>
       )}
       <PopoverContent
         side="top"
         align="start"
         collisionPadding={8}
+        collisionBoundary={collisionBoundary ?? undefined}
         data-web-shell-toolbar-popover
         onClick={(event) => event.stopPropagation()}
+        onPointerDownOutside={(event) => {
+          const target = event.target;
+          if (
+            target instanceof Element &&
+            target.closest('[data-web-shell-toolbar-popover-trigger]')
+          ) {
+            handoffRef.current = true;
+          }
+        }}
         onCloseAutoFocus={(event) => {
+          if (handoffRef.current) {
+            event.preventDefault();
+            handoffRef.current = false;
+            return;
+          }
+          if (
+            document.activeElement instanceof HTMLElement &&
+            document.activeElement.closest('[data-web-shell-toolbar-popover]')
+          ) {
+            event.preventDefault();
+            return;
+          }
           if (!selectionRef.current) return;
           event.preventDefault();
           selectionRef.current = false;
@@ -778,6 +815,8 @@ function SlashCommandPanel({
 }) {
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const hoverAnchorRef = useRef<HTMLButtonElement>(null);
+  const [collisionBoundary, setCollisionBoundary] =
+    useState<HTMLElement | null>(null);
   const [hoverDetail, setHoverDetail] = useState<{
     label: string;
     detail: string;
@@ -793,7 +832,60 @@ function SlashCommandPanel({
     setHoverDetail(null);
   }, [menu.items]);
 
+  useLayoutEffect(() => {
+    setCollisionBoundary(
+      anchorRef.current?.closest<HTMLElement>('[data-web-shell-root]') ?? null,
+    );
+  }, [anchorRef]);
+
+  useEffect(() => {
+    const preserveImeEscape = (event: KeyboardEvent) => {
+      if (
+        event.key !== 'Escape' ||
+        (!event.isComposing && event.keyCode !== 229)
+      ) {
+        return;
+      }
+      Object.defineProperty(event, 'key', {
+        configurable: true,
+        value: 'Process',
+      });
+      window.addEventListener(
+        'keydown',
+        (currentEvent) => {
+          if (currentEvent === event) Reflect.deleteProperty(event, 'key');
+        },
+        { once: true },
+      );
+    };
+    window.addEventListener('keydown', preserveImeEscape, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', preserveImeEscape, {
+        capture: true,
+      });
+    };
+  }, []);
+
   const rowPlans = planSlashSectionRows(menu.items, menu.kind);
+  const maxLabelLength = Math.max(
+    ...menu.items.map((item) => Array.from(item.label).length),
+    0,
+  );
+  const maxDetailLength = Math.max(
+    ...menu.items.map((item) => Array.from(item.detail ?? '').length),
+    0,
+  );
+  const hasDetailColumn = maxDetailLength > 0;
+  const panelStyle = {
+    '--slash-command-col': `${Math.min(
+      Math.max(maxLabelLength + 1, 10),
+      24,
+    )}ch`,
+    '--slash-desc-col': hasDetailColumn
+      ? `${Math.min(Math.max(maxDetailLength + 1, 18), 36)}ch`
+      : '0px',
+    '--slash-column-gap': hasDetailColumn ? '2ch' : '0px',
+  } as CSSProperties;
 
   return (
     <>
@@ -815,8 +907,10 @@ function SlashCommandPanel({
           alignOffset={16}
           sideOffset={8}
           collisionPadding={12}
+          collisionBoundary={collisionBoundary ?? undefined}
           role="listbox"
           data-web-shell-slash-menu
+          style={panelStyle}
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
           onInteractOutside={(event) => {
@@ -876,6 +970,7 @@ function SlashCommandPanel({
                         type="button"
                         role="option"
                         aria-selected={index === menu.selectedIndex}
+                        data-has-description={item.detail ? '' : undefined}
                         className={`${styles.slashItem} ${
                           index === menu.selectedIndex
                             ? styles.slashItemActive
@@ -934,6 +1029,7 @@ function SlashCommandPanel({
             align="start"
             sideOffset={8}
             collisionPadding={12}
+            collisionBoundary={collisionBoundary ?? undefined}
             data-web-shell-slash-detail
             onOpenAutoFocus={(event) => event.preventDefault()}
             onCloseAutoFocus={(event) => event.preventDefault()}
@@ -1529,8 +1625,8 @@ export const ChatEditor = memo(
           );
           return Math.max(
             0,
-            (expanded?.getBoundingClientRect().width ?? 0) -
-              (collapsed?.getBoundingClientRect().width ?? 0),
+            Math.ceil(expanded?.getBoundingClientRect().width ?? 0) -
+              Math.ceil(collapsed?.getBoundingClientRect().width ?? 0),
           );
         };
         const items = [
@@ -1586,20 +1682,22 @@ export const ChatEditor = memo(
               : 0),
           0,
         );
-        const currentLeadingWidth = Math.max(
-          toolbarLeading.scrollWidth,
-          toolbarLeading.getBoundingClientRect().width,
+        const currentLeadingWidth = toolbarLeading.scrollWidth;
+        const gap = Math.ceil(
+          Number.parseFloat(getComputedStyle(toolbar).columnGap) || 0,
         );
-        const gap = Number.parseFloat(getComputedStyle(toolbar).columnGap) || 0;
         const availableWidth = getToolbarExpansionBudget({
-          toolbarWidth: toolbar.getBoundingClientRect().width,
+          toolbarWidth: Math.floor(toolbar.getBoundingClientRect().width),
           leadingWidth: currentLeadingWidth,
-          rightWidth: toolbarRight.getBoundingClientRect().width,
+          rightWidth: Math.ceil(toolbarRight.getBoundingClientRect().width),
           currentExpansionWidth,
           gap,
         });
         const itemVisibility = getToolbarItemVisibility({
-          availableWidth,
+          // Individual replica widths and aggregate scrollWidth can differ by
+          // at most one rounded pixel per item. Keep that margin collapsed so
+          // the measured state cannot oscillate at a fractional boundary.
+          availableWidth: Math.max(0, availableWidth - items.length),
           items,
         });
         const next = {
@@ -2022,6 +2120,7 @@ export const ChatEditor = memo(
                               showModeLabel ? '' : styles.toolBtnCompact
                             }`}
                             data-web-shell-mode-button
+                            data-web-shell-toolbar-popover-trigger
                             onClick={(e) => {
                               e.stopPropagation();
                               core.closeSlashMenu();
@@ -2074,6 +2173,7 @@ export const ChatEditor = memo(
                               showModelLabel ? '' : styles.toolBtnCompact
                             }`}
                             data-web-shell-model-button
+                            data-web-shell-toolbar-popover-trigger
                             onClick={(e) => {
                               e.stopPropagation();
                               core.closeSlashMenu();

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -70,7 +70,7 @@ import {
 import {
   filterToolbarDropdownItems,
   getToolbarExpansionBudget,
-  getToolbarItemVisibility,
+  getToolbarItemVisibilityWithHysteresis,
   resolveToolbarModelLabel,
   type ToolbarDropdownItem,
 } from './toolbarDropdown';
@@ -1693,12 +1693,14 @@ export const ChatEditor = memo(
           currentExpansionWidth,
           gap,
         });
-        const itemVisibility = getToolbarItemVisibility({
-          // Individual replica widths and aggregate scrollWidth can differ by
-          // at most one rounded pixel per item. Keep that margin collapsed so
-          // the measured state cannot oscillate at a fractional boundary.
-          availableWidth: Math.max(0, availableWidth - items.length),
+        const itemVisibility = getToolbarItemVisibilityWithHysteresis({
+          availableWidth,
           items,
+          currentVisibility: toolbarLabelVisibility,
+          // Aggregate scrollWidth can differ from the sum of individually
+          // rounded replicas by one pixel per item. Apply that slack only when
+          // expanding so a collapsed/expanded pair cannot form a two-cycle.
+          expansionMargin: items.length,
         });
         const next = {
           workspaceSelect: itemVisibility.workspaceSelect ?? false,

--- a/packages/web-shell/client/components/GitBranchIndicator.tsx
+++ b/packages/web-shell/client/components/GitBranchIndicator.tsx
@@ -31,16 +31,20 @@ function GitBranchIcon() {
 export function GitBranchIndicator({
   branch,
   ariaLabel,
+  compact = false,
 }: {
   branch: string;
   ariaLabel: string;
+  compact?: boolean;
 }) {
   return (
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <output
-            className={styles.gitBranchChip}
+            className={`${styles.gitBranchChip} ${
+              compact ? styles.gitBranchChipCompact : ''
+            }`}
             aria-label={ariaLabel}
             data-web-shell-git-branch
           >

--- a/packages/web-shell/client/components/WorkspaceIndicator.tsx
+++ b/packages/web-shell/client/components/WorkspaceIndicator.tsx
@@ -24,22 +24,24 @@ function WorkspaceFolderIcon() {
  * session belongs to. Mirrors {@link GitBranchIndicator}; both sit in the
  * composer toolbar. Shown only on a multi-workspace daemon (the pane composer
  * opts into the `workspace` toolbar action) so it's clear which workspace a
- * message goes to. Unlike the toolbar action buttons, the name stays visible as
- * the pane narrows — it's the pane's identity — and only tightens and ellipsizes
- * (the full cwd stays in the tooltip).
+ * message goes to.
  */
 export function WorkspaceIndicator({
   name,
   title,
   ariaLabel,
+  compact = false,
 }: {
   name: string;
   title: string;
   ariaLabel: string;
+  compact?: boolean;
 }) {
   return (
     <output
-      className={styles.workspaceChip}
+      className={`${styles.workspaceChip} ${
+        compact ? styles.workspaceChipCompact : ''
+      }`}
       title={title}
       aria-label={ariaLabel}
       data-web-shell-workspace

--- a/packages/web-shell/client/components/toolbarDropdown.test.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.test.ts
@@ -3,6 +3,7 @@ import {
   filterToolbarDropdownItems,
   getToolbarExpansionBudget,
   getToolbarItemVisibility,
+  getToolbarItemVisibilityWithHysteresis,
   resolveToolbarModelLabel,
 } from './toolbarDropdown';
 
@@ -88,6 +89,24 @@ describe('toolbarDropdown', () => {
         rightWidth: base.rightWidth + 40,
       }),
     ).toBe(252);
+  });
+
+  it('does not oscillate when aggregate rounding changes the budget by one pixel', () => {
+    const items = [{ id: 'workspace', expansionWidth: 60 }];
+    let visibility = { workspace: false };
+    const states: boolean[] = [];
+
+    for (let index = 0; index < 4; index += 1) {
+      visibility = getToolbarItemVisibilityWithHysteresis({
+        availableWidth: visibility.workspace ? 60 : 61,
+        items,
+        currentVisibility: visibility,
+        expansionMargin: items.length,
+      });
+      states.push(visibility.workspace);
+    }
+
+    expect(states).toEqual([true, true, true, true]);
   });
 
   it('keeps the confirmed model through a transient empty update', () => {

--- a/packages/web-shell/client/components/toolbarDropdown.test.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   filterToolbarDropdownItems,
-  getToolbarDropdownGeometry,
-  getToolbarLabelVisibility,
+  getToolbarExpansionBudget,
+  getToolbarItemVisibility,
   resolveToolbarModelLabel,
 } from './toolbarDropdown';
-
-const boundary = {
-  left: 100,
-  top: 80,
-  right: 500,
-  bottom: 680,
-  width: 400,
-  height: 600,
-};
 
 describe('toolbarDropdown', () => {
   it('filters by display label and stable model id', () => {
@@ -29,97 +20,31 @@ describe('toolbarDropdown', () => {
     expect(filterToolbarDropdownItems(items, '  ')).toEqual(items);
   });
 
-  it('clamps the right edge when the menu fits in the WebShell boundary', () => {
-    const geometry = getToolbarDropdownGeometry({
-      anchor: {
-        left: 450,
-        top: 600,
-        right: 478,
-        bottom: 628,
-        width: 28,
-        height: 28,
-      },
-      boundary,
-      viewportWidth: 800,
-      viewportHeight: 800,
-      preferredWidth: 360,
-      maxHeight: 300,
+  it('collapses items from left to right as width decreases', () => {
+    const items = [
+      { id: 'branch', expansionWidth: 100 },
+      { id: 'mode', expansionWidth: 64 },
+      { id: 'model', expansionWidth: 80 },
+    ];
+
+    expect(getToolbarItemVisibility({ availableWidth: 244, items })).toEqual({
+      branch: true,
+      mode: true,
+      model: true,
     });
-
-    expect(geometry.width).toBe(360);
-    expect(geometry.left).toBe(132);
-    expect(geometry.placement).toBe('above');
-    expect(geometry.maxHeight).toBe(300);
-  });
-
-  it('clamps the left edge and width to the visible boundary', () => {
-    const geometry = getToolbarDropdownGeometry({
-      anchor: {
-        left: 80,
-        top: 600,
-        right: 108,
-        bottom: 628,
-        width: 28,
-        height: 28,
-      },
-      boundary,
-      viewportWidth: 420,
-      viewportHeight: 800,
-      preferredWidth: 360,
+    expect(getToolbarItemVisibility({ availableWidth: 144, items })).toEqual({
+      branch: false,
+      mode: true,
+      model: true,
     });
-
-    expect(geometry.width).toBe(304);
-    expect(geometry.left).toBe(108);
-  });
-
-  it('uses the lower side only when it has more usable height', () => {
-    const geometry = getToolbarDropdownGeometry({
-      anchor: {
-        left: 160,
-        top: 120,
-        right: 188,
-        bottom: 148,
-        width: 28,
-        height: 28,
-      },
-      boundary,
-      viewportWidth: 800,
-      viewportHeight: 800,
-      preferredWidth: 300,
+    expect(getToolbarItemVisibility({ availableWidth: 80, items })).toEqual({
+      branch: false,
+      mode: false,
+      model: true,
     });
-
-    expect(geometry.placement).toBe('below');
-    expect(geometry.top).toBe(152);
   });
 
-  it('keeps the model label before the approval-mode label', () => {
-    expect(
-      getToolbarLabelVisibility({
-        availableWidth: 144,
-        modelLabelWidth: 80,
-        modeLabelWidth: 64,
-        modelLabelReady: true,
-      }),
-    ).toEqual({ showModelLabel: true, showModeLabel: true });
-    expect(
-      getToolbarLabelVisibility({
-        availableWidth: 80,
-        modelLabelWidth: 80,
-        modeLabelWidth: 64,
-        modelLabelReady: true,
-      }),
-    ).toEqual({ showModelLabel: true, showModeLabel: false });
-    expect(
-      getToolbarLabelVisibility({
-        availableWidth: 79,
-        modelLabelWidth: 80,
-        modeLabelWidth: 64,
-        modelLabelReady: true,
-      }),
-    ).toEqual({ showModelLabel: false, showModeLabel: false });
-  });
-
-  it('keeps both labels hidden while the initial model is pending', () => {
+  it('keeps pending items collapsed without consuming width', () => {
     const pending = resolveToolbarModelLabel({
       currentModelLabel: '',
       lastConfirmedModelLabel: '',
@@ -127,26 +52,42 @@ describe('toolbarDropdown', () => {
 
     expect(pending.modelLabelReady).toBe(false);
     expect(
-      getToolbarLabelVisibility({
-        availableWidth: 300,
-        modelLabelWidth: 0,
-        modeLabelWidth: 64,
-        modelLabelReady: pending.modelLabelReady,
+      getToolbarItemVisibility({
+        availableWidth: 64,
+        items: [
+          { id: 'mode', expansionWidth: 64 },
+          {
+            id: 'model',
+            expansionWidth: 80,
+            ready: pending.modelLabelReady,
+          },
+        ],
       }),
-    ).toEqual({ showModelLabel: false, showModeLabel: false });
+    ).toEqual({ mode: true, model: false });
   });
 
-  it('shows the approval-mode label when it is the only visible action', () => {
+  it('reserves toolbar render-prop widths before expanding built-in items', () => {
+    const base = {
+      toolbarWidth: 500,
+      leadingWidth: 360,
+      rightWidth: 80,
+      currentExpansionWidth: 240,
+      gap: 8,
+    };
+
+    expect(getToolbarExpansionBudget(base)).toBe(292);
     expect(
-      getToolbarLabelVisibility({
-        availableWidth: 64,
-        modelLabelWidth: 0,
-        modeLabelWidth: 64,
-        modelLabelReady: false,
-        modelActionVisible: false,
-        modeActionVisible: true,
+      getToolbarExpansionBudget({
+        ...base,
+        leadingWidth: base.leadingWidth + 50,
       }),
-    ).toEqual({ showModelLabel: false, showModeLabel: true });
+    ).toBe(242);
+    expect(
+      getToolbarExpansionBudget({
+        ...base,
+        rightWidth: base.rightWidth + 40,
+      }),
+    ).toBe(252);
   });
 
   it('keeps the confirmed model through a transient empty update', () => {
@@ -160,14 +101,6 @@ describe('toolbarDropdown', () => {
     });
 
     expect(transientEmpty.modelLabel).toBe('Qwen 3.5 Plus');
-    expect(
-      getToolbarLabelVisibility({
-        availableWidth: 112,
-        modelLabelWidth: 112,
-        modeLabelWidth: 64,
-        modelLabelReady: transientEmpty.modelLabelReady,
-      }),
-    ).toEqual({ showModelLabel: true, showModeLabel: false });
   });
 
   it('uses an arriving replacement for the next measured layout', () => {
@@ -177,13 +110,5 @@ describe('toolbarDropdown', () => {
     });
 
     expect(replacement.modelLabel).toBe('GLM 5.2');
-    expect(
-      getToolbarLabelVisibility({
-        availableWidth: 128,
-        modelLabelWidth: 80,
-        modeLabelWidth: 64,
-        modelLabelReady: replacement.modelLabelReady,
-      }),
-    ).toEqual({ showModelLabel: true, showModeLabel: false });
   });
 });

--- a/packages/web-shell/client/components/toolbarDropdown.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.ts
@@ -46,6 +46,40 @@ export function getToolbarItemVisibility({
   return visibility;
 }
 
+export function getToolbarItemVisibilityWithHysteresis({
+  availableWidth,
+  items,
+  currentVisibility,
+  expansionMargin,
+}: {
+  availableWidth: number;
+  items: ReadonlyArray<{
+    id: string;
+    expansionWidth: number;
+    ready?: boolean;
+  }>;
+  currentVisibility: Readonly<Record<string, boolean>>;
+  expansionMargin: number;
+}): Record<string, boolean> {
+  const collapseVisibility = getToolbarItemVisibility({
+    availableWidth,
+    items,
+  });
+  const expansionVisibility = getToolbarItemVisibility({
+    availableWidth: Math.max(0, availableWidth - expansionMargin),
+    items,
+  });
+
+  return Object.fromEntries(
+    items.map((item) => [
+      item.id,
+      currentVisibility[item.id]
+        ? collapseVisibility[item.id]
+        : expansionVisibility[item.id],
+    ]),
+  );
+}
+
 export function getToolbarExpansionBudget({
   toolbarWidth,
   leadingWidth,

--- a/packages/web-shell/client/components/toolbarDropdown.ts
+++ b/packages/web-shell/client/components/toolbarDropdown.ts
@@ -4,31 +4,6 @@ export interface ToolbarDropdownItem {
   searchText?: string;
 }
 
-export interface ToolbarDropdownRect {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-  width: number;
-  height: number;
-}
-
-export interface ToolbarDropdownGeometry {
-  placement: 'above' | 'below';
-  left: number;
-  top?: number;
-  bottom?: number;
-  width: number;
-  maxHeight: number;
-}
-
-const MENU_GAP = 4;
-const MENU_INSET = 8;
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(value, max));
-}
-
 export function filterToolbarDropdownItems<T extends ToolbarDropdownItem>(
   items: readonly T[],
   query: string,
@@ -42,89 +17,50 @@ export function filterToolbarDropdownItems<T extends ToolbarDropdownItem>(
   );
 }
 
-export function getToolbarDropdownGeometry({
-  anchor,
-  boundary,
-  viewportWidth,
-  viewportHeight,
-  preferredWidth,
-  maxHeight,
-}: {
-  anchor: ToolbarDropdownRect;
-  boundary: ToolbarDropdownRect;
-  viewportWidth: number;
-  viewportHeight: number;
-  preferredWidth: number;
-  maxHeight?: number;
-}): ToolbarDropdownGeometry {
-  const boundaryLeft = Math.max(0, boundary.left);
-  const boundaryRight = Math.min(viewportWidth, boundary.right);
-  const availableWidth = Math.max(
-    0,
-    boundaryRight - boundaryLeft - MENU_INSET * 2,
-  );
-  const width = Math.min(preferredWidth, availableWidth);
-  const left = clamp(
-    anchor.left,
-    boundaryLeft + MENU_INSET,
-    Math.max(boundaryLeft + MENU_INSET, boundaryRight - MENU_INSET - width),
-  );
-
-  const boundaryTop = Math.max(0, boundary.top);
-  const boundaryBottom = Math.min(viewportHeight, boundary.bottom);
-  const above = Math.max(0, anchor.top - boundaryTop - MENU_GAP - MENU_INSET);
-  const below = Math.max(
-    0,
-    boundaryBottom - anchor.bottom - MENU_GAP - MENU_INSET,
-  );
-  const placement = above >= below ? 'above' : 'below';
-  const availableHeight = placement === 'above' ? above : below;
-
-  return {
-    placement,
-    left,
-    ...(placement === 'above'
-      ? { bottom: viewportHeight - anchor.top + MENU_GAP }
-      : { top: anchor.bottom + MENU_GAP }),
-    width,
-    maxHeight:
-      maxHeight === undefined
-        ? availableHeight
-        : Math.min(maxHeight, availableHeight),
-  };
-}
-
-export function getToolbarLabelVisibility({
+export function getToolbarItemVisibility({
   availableWidth,
-  modelLabelWidth,
-  modeLabelWidth,
-  modelLabelReady,
-  modelActionVisible = true,
-  modeActionVisible = true,
+  items,
 }: {
   availableWidth: number;
-  modelLabelWidth: number;
-  modeLabelWidth: number;
-  modelLabelReady: boolean;
-  modelActionVisible?: boolean;
-  modeActionVisible?: boolean;
-}): {
-  showModelLabel: boolean;
-  showModeLabel: boolean;
-} {
-  if (!modelActionVisible) {
-    return {
-      showModelLabel: false,
-      showModeLabel: modeActionVisible && availableWidth >= modeLabelWidth,
-    };
+  items: ReadonlyArray<{
+    id: string;
+    expansionWidth: number;
+    ready?: boolean;
+  }>;
+}): Record<string, boolean> {
+  const visibility = Object.fromEntries(
+    items.map((item) => [item.id, item.ready !== false]),
+  );
+  let usedWidth = items.reduce(
+    (total, item) => total + (visibility[item.id] ? item.expansionWidth : 0),
+    0,
+  );
+
+  for (const item of items) {
+    if (usedWidth <= availableWidth) break;
+    if (!visibility[item.id]) continue;
+    visibility[item.id] = false;
+    usedWidth -= item.expansionWidth;
   }
-  if (!modelLabelReady || availableWidth < modelLabelWidth) {
-    return { showModelLabel: false, showModeLabel: false };
-  }
-  if (availableWidth < modelLabelWidth + modeLabelWidth) {
-    return { showModelLabel: true, showModeLabel: false };
-  }
-  return { showModelLabel: true, showModeLabel: modeActionVisible };
+
+  return visibility;
+}
+
+export function getToolbarExpansionBudget({
+  toolbarWidth,
+  leadingWidth,
+  rightWidth,
+  currentExpansionWidth,
+  gap,
+}: {
+  toolbarWidth: number;
+  leadingWidth: number;
+  rightWidth: number;
+  currentExpansionWidth: number;
+  gap: number;
+}): number {
+  const fixedLeadingWidth = Math.max(0, leadingWidth - currentExpansionWidth);
+  return Math.max(0, toolbarWidth - rightWidth - fixedLeadingWidth - gap);
 }
 
 export function resolveToolbarModelLabel({

--- a/packages/web-shell/client/components/ui/popover.tsx
+++ b/packages/web-shell/client/components/ui/popover.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react';
+import * as React from 'react';
 import { Popover as PopoverPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
@@ -10,22 +10,31 @@ function Popover({
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
-}
+const PopoverTrigger = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Trigger>,
+  React.ComponentProps<typeof PopoverPrimitive.Trigger>
+>(function PopoverTrigger(props, ref) {
+  return (
+    <PopoverPrimitive.Trigger
+      ref={ref}
+      data-slot="popover-trigger"
+      {...props}
+    />
+  );
+});
 
-function PopoverContent({
-  className,
-  align = 'center',
-  sideOffset = 4,
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+const PopoverContent = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentProps<typeof PopoverPrimitive.Content>
+>(function PopoverContent(
+  { className, align = 'center', sideOffset = 4, ...props },
+  ref,
+) {
   const portalRoot = useWebShellPortalRoot();
   return (
     <PopoverPrimitive.Portal container={portalRoot ?? undefined}>
       <PopoverPrimitive.Content
+        ref={ref}
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
@@ -37,13 +46,16 @@ function PopoverContent({
       />
     </PopoverPrimitive.Portal>
   );
-}
+});
 
-function PopoverAnchor({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
-}
+const PopoverAnchor = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Anchor>,
+  React.ComponentProps<typeof PopoverPrimitive.Anchor>
+>(function PopoverAnchor(props, ref) {
+  return (
+    <PopoverPrimitive.Anchor ref={ref} data-slot="popover-anchor" {...props} />
+  );
+});
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (

--- a/packages/web-shell/client/components/ui/popover.tsx
+++ b/packages/web-shell/client/components/ui/popover.tsx
@@ -39,7 +39,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'z-[var(--web-shell-popover-z-index,1000)] flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
+++ b/packages/web-shell/client/components/ui/react18-ref-compat.test.tsx
@@ -8,6 +8,7 @@ import { AlertDialogContent, AlertDialogOverlay } from './alert-dialog';
 import { Button } from './button';
 import { DialogContent, DialogOverlay } from './dialog';
 import { Input } from './input';
+import { PopoverAnchor, PopoverContent, PopoverTrigger } from './popover';
 import { SelectTrigger } from './select';
 
 const FORWARD_REF_TYPE = Symbol.for('react.forward_ref');
@@ -22,6 +23,9 @@ describe('React 18 ref compatibility', () => {
     ['DialogContent', DialogContent],
     ['DialogOverlay', DialogOverlay],
     ['Input', Input],
+    ['PopoverAnchor', PopoverAnchor],
+    ['PopoverContent', PopoverContent],
+    ['PopoverTrigger', PopoverTrigger],
     ['SelectTrigger', SelectTrigger],
   ])('%s forwards refs', (_name, Component) => {
     expect(Component).toHaveProperty('$$typeof', FORWARD_REF_TYPE);

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -257,7 +257,7 @@ for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
 
     const modeButton = page.locator('[data-web-shell-mode-button]');
     await modeButton.click();
-    const modeDropdown = modeButton.locator('..').locator(':scope > div');
+    const modeDropdown = page.locator('[data-web-shell-toolbar-popover]');
     await expect(modeDropdown).toBeVisible();
     await expect
       .poll(async () => {

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -160,6 +160,18 @@ test('opens slash menu, resume dialog, model dialog, and theme dialog @smoke', a
   await gotoSession(page, scenario, daemon);
   await fillComposer(page, '/');
   await expect(page.locator('[data-web-shell-slash-menu]')).toBeVisible();
+  const composingEscapePrevented = await page.evaluate(() => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+    });
+    (document.activeElement ?? document.body).dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(composingEscapePrevented).toBe(false);
+  await expect(page.locator('[data-web-shell-slash-menu]')).toBeVisible();
 
   await submitLocalCommand(page, '/resume');
   await expect(page.locator('[data-web-shell-resume-dialog]')).toBeVisible();
@@ -257,7 +269,9 @@ for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
 
     const modeButton = page.locator('[data-web-shell-mode-button]');
     await modeButton.click();
-    const modeDropdown = page.locator('[data-web-shell-toolbar-popover]');
+    const modeDropdown = page.locator(
+      '[data-web-shell-toolbar-popover][data-state="open"]',
+    );
     await expect(modeDropdown).toBeVisible();
     await expect
       .poll(async () => {
@@ -269,6 +283,15 @@ for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
         return dropdownBox.y + dropdownBox.height - buttonBox.y;
       })
       .toBeLessThanOrEqual(-3);
+
+    const modelButton = page.locator('[data-web-shell-model-button]');
+    await modelButton.click();
+    await expect(
+      page.locator('[data-web-shell-toolbar-popover] input[type="search"]'),
+    ).toBeVisible();
+    await modeButton.click();
+    await expect(modeDropdown).toBeVisible();
+    await expect(modeDropdown.locator('input[type="search"]')).toHaveCount(0);
     await page.keyboard.press('Escape');
 
     await replaceComposerText(page, 'Short draft');


### PR DESCRIPTION
## What this PR does

This updates the Web Shell composer footer to use the shared shadcn Popover primitive for the approval-mode selector, model selector, slash-command panel, and slash-command hover details. The model selector now uses the shared shadcn Input for filtering, and approval/model triggers use consistent tooltips and Lucide chevrons.

The footer now measures the space left by built-in controls and custom toolbar renderers, collapsing labels from left to right only when needed. Slash-command content keeps its established width while adapting its height to the available viewport and scrolling internally in short windows.

## Why it's needed

The previous footer mixed custom overlays with shared primitives and relied on a fixed responsive breakpoint. That made overlay behavior, portal styling, and narrow layouts inconsistent. Using the shared primitives gives the controls consistent collision handling, portal scoping, focus behavior, and styling while allowing the toolbar to react to its actual available width.

## Reviewer Test Plan

### How to verify

1. Open the approval-mode selector and verify it appears above the trigger, shows the active mode, and returns focus to the composer after a selection.
2. Open the model selector and verify the search field is focused, filtering works by display name and model ID, and selecting a model closes the popover.
3. Type `/` and verify the command panel remains keyboard-navigable, keeps its previous width, and scrolls internally when the browser height is reduced.
4. Hover a slash command with details and verify the secondary popover follows the hovered row and remains within the viewport.
5. Resize the composer horizontally and verify workspace, branch, approval-mode, and model labels collapse from left to right as space runs out.
6. Repeat with custom toolbar start, end, and right content and verify changes in their rendered size immediately update the built-in collapse state.

### Evidence (Before & After)

Before: footer selectors and slash-command overlays used custom positioning and a fixed compact breakpoint.

After: the same controls use shared shadcn primitives, viewport-aware placement and height, and measured responsive label collapse.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Web Shell Vitest suite: 101 files and 1,590 tests passed. ESLint and staged-file pre-commit checks passed. The local package typecheck remains blocked by existing errors in untouched extension-manager and composer-core code on the current upstream main revision.

## Risk & Scope

- Main risk or tradeoff: focus restoration and responsive measurement now depend on Radix focus lifecycle and browser ResizeObserver/MutationObserver behavior; regression coverage is included for both paths.
- Not validated / out of scope: Windows and Linux visual verification.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将 Web Shell 编辑器底部的权限模式选择、模型选择、斜杠命令面板以及斜杠命令悬浮详情统一替换为共享的 shadcn Popover。模型选择使用共享的 shadcn Input 进行过滤，权限和模型触发按钮使用一致的提示与 Lucide 下拉图标。

底部工具栏现在会计算内置控件和自定义 toolbar renderer 占用后的剩余空间，仅在需要时从左到右收起标签。斜杠命令面板保持原有宽度，并根据视口可用高度自动缩短，在浏览器高度较小时使用内部滚动。

## 改动原因

此前底部工具栏混用了自定义浮层和共享组件，并依赖固定的响应式断点，导致浮层行为、portal 样式和窄屏布局不一致。改用共享组件后，碰撞处理、portal 作用域、焦点行为和样式保持一致，同时工具栏可以根据真实可用宽度响应。

## Reviewer 测试计划

### 验证方式

1. 打开权限模式选择，确认面板显示在触发按钮上方、标记当前模式，并在选择后将焦点恢复到编辑器。
2. 打开模型选择，确认搜索框自动聚焦，可以按显示名称和模型 ID 过滤，并在选择模型后关闭面板。
3. 输入 `/`，确认命令面板仍可通过键盘操作、保持原有宽度，并在降低浏览器高度时内部滚动。
4. 悬浮带详情的斜杠命令，确认第二层 Popover 跟随当前行且不会超出视口。
5. 水平调整编辑器宽度，确认工作区、分支、权限模式和模型标签会在空间不足时从左到右收起。
6. 添加自定义 toolbar start、end 和 right 内容，确认其渲染尺寸变化会立即更新内置项的收起状态。

### 前后对比证据

改动前：底部选择器和斜杠命令浮层使用自定义定位和固定的紧凑断点。

改动后：相同控件使用共享的 shadcn 组件、视口感知的定位与高度，以及基于测量的响应式标签收起逻辑。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

### 环境（可选）

Web Shell Vitest 全量测试通过：101 个文件、1,590 个测试。ESLint 和 staged-file pre-commit 检查通过。本地 package typecheck 仍被当前 upstream main 中未修改的 extension-manager 和 composer-core 既有错误阻塞。

## 风险与范围

- 主要风险或取舍：焦点恢复和响应式测量依赖 Radix 焦点生命周期以及浏览器 ResizeObserver/MutationObserver 行为；两个路径均已添加回归测试。
- 未验证或不在范围内：Windows 和 Linux 的视觉验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
