### PR TITLE
feat(web-shell): auto-post visual previews (screenshots + flow GIFs) on PRs

### DIFF
--- a/.github/scripts/web-shell-visuals-publish.mjs
+++ b/.github/scripts/web-shell-visuals-publish.mjs
@@ -36,7 +36,8 @@ import { pathToFileURL } from 'node:url';
 // Bounds on UNTRUSTED artifact content: cap files EXAMINED (so a flood of junk
 // can't burn the budget before valid files), files ACCEPTED, and per-file size.
 export const MAX_CANDIDATES = 200;
-export const MAX_IMAGES = 14;
+export const MAX_SCREENSHOTS = 20;
+export const MAX_GIFS = 6;
 export const MAX_BYTES = 3 * 1024 * 1024;
 
 const PNG_MAGIC = '89504e470d0a1a0a';
@@ -71,8 +72,15 @@ export function classifyMagic(ext, magicHex) {
  */
 export function selectImages(candidates, opts = {}) {
   const maxCandidates = opts.maxCandidates ?? MAX_CANDIDATES;
-  const maxImages = opts.maxImages ?? MAX_IMAGES;
   const maxBytes = opts.maxBytes ?? MAX_BYTES;
+  // Per-kind caps so a large screenshot set can't starve the flow GIFs: a
+  // shared total cap over PNG-first candidates would let >=N screenshots
+  // silently drop every GIF from the preview.
+  const maxPerKind = {
+    png: opts.maxScreenshots ?? MAX_SCREENSHOTS,
+    gif: opts.maxGifs ?? MAX_GIFS,
+  };
+  const kindCount = { png: 0, gif: 0 };
   const accepted = [];
   const warnings = [];
   let examined = 0;
@@ -80,10 +88,6 @@ export function selectImages(candidates, opts = {}) {
     examined += 1;
     if (examined > maxCandidates) {
       warnings.push(`examined ${maxCandidates} candidate files; stopping`);
-      break;
-    }
-    if (accepted.length >= maxImages) {
-      warnings.push(`reached the ${maxImages}-image cap; skipping the rest`);
       break;
     }
     if (c.size > maxBytes) {
@@ -95,6 +99,13 @@ export function selectImages(candidates, opts = {}) {
       warnings.push(`${c.name} is not a valid ${c.ext}; skipping`);
       continue;
     }
+    if (kindCount[kind] >= maxPerKind[kind]) {
+      warnings.push(
+        `reached the ${kind} cap (${maxPerKind[kind]}); skipping ${c.name}`,
+      );
+      continue;
+    }
+    kindCount[kind] += 1;
     accepted.push({
       name: c.name,
       safeName: sanitizeName(basename(c.name)),
@@ -170,7 +181,13 @@ export function buildComment(files, ctx = {}) {
     out.push('');
     for (const g of gifs) {
       const key = g.replace(/\.gif$/i, '');
-      out.push(`**${esc(FLOW_LABELS[key] || pretty(key))}**`);
+      // Own-property only: `FLOW_LABELS[key]` would otherwise inherit
+      // Object.prototype members, so a `toString.gif` would render the function
+      // source as the label.
+      const label = Object.hasOwn(FLOW_LABELS, key)
+        ? FLOW_LABELS[key]
+        : pretty(key);
+      out.push(`**${esc(label)}**`);
       out.push('');
       out.push(`<img src="${url(g)}" width="640" alt="${esc(key)} flow">`);
       out.push('');

--- a/.github/scripts/web-shell-visuals-publish.mjs
+++ b/.github/scripts/web-shell-visuals-publish.mjs
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Staging + comment generation for the web-shell visuals publish workflow.
+ *
+ * Extracted from the inline workflow so the image validation and comment
+ * construction — the parts that consume UNTRUSTED PR output and were
+ * previously untested — have unit coverage. (A shell sanitizer bug once
+ * appended `_` to every filename and silently produced an empty preview; the
+ * pure functions here are covered by web-shell-visuals-publish.test.mjs.)
+ *
+ * The pure helpers (`sanitizeName`, `classifyMagic`, `selectImages`,
+ * `buildComment`) are exported and tested. The file also runs as a CLI for the
+ * workflow:
+ *   node web-shell-visuals-publish.mjs stage   <screenshotsDir> <gifsDir> <stageDir>
+ *   node web-shell-visuals-publish.mjs comment <stageDir> <rawBase> <shortSha> <runUrl> <bodyFile>
+ */
+
+import {
+  closeSync,
+  copyFileSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Bounds on UNTRUSTED artifact content: cap files EXAMINED (so a flood of junk
+// can't burn the budget before valid files), files ACCEPTED, and per-file size.
+export const MAX_CANDIDATES = 200;
+export const MAX_IMAGES = 14;
+export const MAX_BYTES = 3 * 1024 * 1024;
+
+const PNG_MAGIC = '89504e470d0a1a0a';
+const GIF_MAGICS = new Set(['474946383961', '474946383761']); // GIF89a / GIF87a
+
+const FLOW_LABELS = {
+  'model-switch': 'Open the slash menu and switch model',
+  'prompt-stream': 'Submit a prompt and watch the reply stream in',
+};
+
+/**
+ * Sanitize to the hosted-filename charset WITHOUT corrupting the extension.
+ * (The shell version captured `basename` through a pipe, turning its trailing
+ * newline into `_` and breaking the `.png`/`.gif` filter — this cannot.)
+ */
+export function sanitizeName(name) {
+  return String(name).replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+/** Classify by first-bytes magic hex → 'png' | 'gif' | null. */
+export function classifyMagic(ext, magicHex) {
+  const hex = String(magicHex).toLowerCase();
+  if (ext === 'png') return hex.slice(0, 16) === PNG_MAGIC ? 'png' : null;
+  if (ext === 'gif') return GIF_MAGICS.has(hex.slice(0, 12)) ? 'gif' : null;
+  return null;
+}
+
+/**
+ * Pure selection over candidates `[{ name, ext, size, magic }]` (in order):
+ * apply the examined/accepted/size caps and magic validation. Returns
+ * `{ accepted: [{ name, safeName, kind }], warnings: string[] }`.
+ */
+export function selectImages(candidates, opts = {}) {
+  const maxCandidates = opts.maxCandidates ?? MAX_CANDIDATES;
+  const maxImages = opts.maxImages ?? MAX_IMAGES;
+  const maxBytes = opts.maxBytes ?? MAX_BYTES;
+  const accepted = [];
+  const warnings = [];
+  let examined = 0;
+  for (const c of candidates) {
+    examined += 1;
+    if (examined > maxCandidates) {
+      warnings.push(`examined ${maxCandidates} candidate files; stopping`);
+      break;
+    }
+    if (accepted.length >= maxImages) {
+      warnings.push(`reached the ${maxImages}-image cap; skipping the rest`);
+      break;
+    }
+    if (c.size > maxBytes) {
+      warnings.push(`${c.name} exceeds ${maxBytes} bytes; skipping`);
+      continue;
+    }
+    const kind = classifyMagic(c.ext, c.magic);
+    if (!kind) {
+      warnings.push(`${c.name} is not a valid ${c.ext}; skipping`);
+      continue;
+    }
+    accepted.push({
+      name: c.name,
+      safeName: sanitizeName(basename(c.name)),
+      kind,
+    });
+  }
+  return { accepted, warnings };
+}
+
+/** Self-defending HTML escaping for interpolated values. */
+export const esc = (s) =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+export const pretty = (s) =>
+  s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+/**
+ * Pure comment builder. `files` is the list of staged filenames (png + gif).
+ * `ctx` is `{ rawBase, shortSha, runUrl }`. Returns the markdown body.
+ */
+export function buildComment(files, ctx = {}) {
+  const rawBase = ctx.rawBase ?? '';
+  const shortSha = ctx.shortSha ?? '';
+  const runUrl = ctx.runUrl ?? '';
+  const url = (name) => `${rawBase}/${encodeURIComponent(name)}`;
+
+  const shots = files.filter((f) => /\.png$/i.test(f));
+  const views = new Map();
+  for (const f of shots) {
+    const m = f.match(/^(.*)-(light|dark)\.png$/i);
+    if (!m) continue;
+    const [, view, theme] = m;
+    const entry = views.get(view) || {};
+    entry[theme.toLowerCase()] = f;
+    views.set(view, entry);
+  }
+  const gifs = files.filter((f) => /\.gif$/i.test(f)).sort();
+
+  const out = [];
+  out.push('<!-- qwen:web-shell-visuals -->');
+  out.push('### 🖼️ web-shell visual preview');
+  out.push(
+    `Auto-rendered from this PR head \`${esc(shortSha)}\` against a mock daemon (no real backend). Refreshes on every push.`,
+  );
+  out.push('');
+
+  if (views.size > 0) {
+    out.push('#### Screenshots · light / dark');
+    out.push('');
+    out.push('<table>');
+    out.push('<tr><th align="left">view</th><th>light</th><th>dark</th></tr>');
+    for (const [view, pair] of [...views.entries()].sort()) {
+      const light = pair.light
+        ? `<img src="${url(pair.light)}" width="360" alt="${esc(view)} light">`
+        : '—';
+      const dark = pair.dark
+        ? `<img src="${url(pair.dark)}" width="360" alt="${esc(view)} dark">`
+        : '—';
+      out.push(
+        `<tr><td valign="top"><sub>${esc(pretty(view))}</sub></td><td>${light}</td><td>${dark}</td></tr>`,
+      );
+    }
+    out.push('</table>');
+    out.push('');
+  }
+
+  if (gifs.length > 0) {
+    out.push('#### Flows');
+    out.push('');
+    for (const g of gifs) {
+      const key = g.replace(/\.gif$/i, '');
+      out.push(`**${esc(FLOW_LABELS[key] || pretty(key))}**`);
+      out.push('');
+      out.push(`<img src="${url(g)}" width="640" alt="${esc(key)} flow">`);
+      out.push('');
+    }
+  }
+
+  if (runUrl) {
+    out.push(
+      `<sub>Full-resolution recordings (.webm) are attached to the <a href="${esc(runUrl)}">workflow run</a>.</sub>`,
+    );
+  }
+  out.push('');
+  out.push('— _Qwen Code · web-shell visuals_');
+  return out.join('\n') + '\n';
+}
+
+// --- I/O layer (exercised by the CLI; not part of the unit-tested surface) ---
+
+function readMagicHex(path, n = 8) {
+  const fd = openSync(path, 'r');
+  try {
+    const buf = Buffer.alloc(n);
+    const read = readSync(fd, buf, 0, n, 0);
+    return buf.subarray(0, read).toString('hex');
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function gatherCandidates(dir, ext) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return names
+    .filter((n) => n.toLowerCase().endsWith(`.${ext}`))
+    .sort()
+    .map((n) => {
+      const path = join(dir, n);
+      let size = Infinity;
+      let magic = '';
+      try {
+        size = statSync(path).size;
+        magic = readMagicHex(path);
+      } catch {
+        // Unreadable entry: leave size=Infinity/magic='' so it is skipped.
+      }
+      return { name: n, ext, size, magic, path };
+    });
+}
+
+function stageCli(screenshotsDir, gifsDir, stageDir) {
+  const candidates = [
+    ...gatherCandidates(screenshotsDir, 'png'),
+    ...gatherCandidates(gifsDir, 'gif'),
+  ];
+  const { accepted, warnings } = selectImages(candidates);
+  for (const w of warnings) process.stderr.write(`::warning::${w}\n`);
+  mkdirSync(stageDir, { recursive: true });
+  const byName = new Map(candidates.map((c) => [c.name, c.path]));
+  for (const a of accepted) {
+    copyFileSync(byName.get(a.name), join(stageDir, a.safeName));
+  }
+  // stdout = accepted count (the workflow reads it to decide whether to post).
+  process.stdout.write(`${accepted.length}\n`);
+}
+
+function commentCli(stageDir, rawBase, shortSha, runUrl, bodyFile) {
+  let files = [];
+  try {
+    files = readdirSync(stageDir);
+  } catch {
+    // Missing stage dir → empty preview body.
+  }
+  const body = buildComment(files, { rawBase, shortSha, runUrl });
+  writeFileSync(bodyFile, body);
+  process.stderr.write(`Comment body: ${body.split('\n').length} lines.\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd === 'stage') {
+    stageCli(rest[0], rest[1], rest[2]);
+  } else if (cmd === 'comment') {
+    commentCli(rest[0], rest[1], rest[2], rest[3], rest[4]);
+  } else {
+    process.stderr.write(`unknown command: ${cmd ?? '(none)'}\n`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildComment,
+  classifyMagic,
+  MAX_BYTES,
+  MAX_CANDIDATES,
+  MAX_IMAGES,
+  sanitizeName,
+  selectImages,
+} from './web-shell-visuals-publish.mjs';
+
+const PNG = '89504e470d0a1a0a';
+const GIF89 = '474946383961';
+const GIF87 = '474946383761';
+
+test('sanitizeName preserves the extension (regression: a trailing char broke the .png filter)', () => {
+  assert.equal(
+    sanitizeName('session-transcript-light.png'),
+    'session-transcript-light.png',
+  );
+  assert.match(sanitizeName('model-dialog-dark.png'), /\.png$/);
+  assert.match(sanitizeName('model-switch.gif'), /\.gif$/);
+  // Disallowed characters become `_`, but the extension is untouched.
+  assert.equal(sanitizeName('weird name!.png'), 'weird_name_.png');
+  assert.equal(sanitizeName('trailing.png\n'), 'trailing.png_');
+});
+
+test('classifyMagic accepts real PNG/GIF magic and rejects mismatches', () => {
+  assert.equal(classifyMagic('png', PNG), 'png');
+  assert.equal(classifyMagic('gif', GIF89), 'gif');
+  assert.equal(classifyMagic('gif', GIF87), 'gif');
+  assert.equal(classifyMagic('png', GIF89), null); // GIF bytes in a .png
+  assert.equal(classifyMagic('gif', PNG), null); // PNG bytes in a .gif
+  assert.equal(classifyMagic('png', 'deadbeefdeadbeef'), null);
+  assert.equal(classifyMagic('svg', PNG), null); // unknown extension
+});
+
+test('selectImages accepts valid images and keeps safe, extension-correct names', () => {
+  const { accepted, warnings } = selectImages([
+    { name: 'a-light.png', ext: 'png', size: 100, magic: PNG },
+    { name: 'a-dark.png', ext: 'png', size: 100, magic: PNG },
+    { name: 'model-switch.gif', ext: 'gif', size: 100, magic: GIF89 },
+  ]);
+  assert.equal(accepted.length, 3);
+  assert.deepEqual(
+    accepted.map((a) => a.safeName),
+    ['a-light.png', 'a-dark.png', 'model-switch.gif'],
+  );
+  assert.deepEqual(warnings, []);
+});
+
+test('selectImages skips oversized and magic-invalid files', () => {
+  let r = selectImages([
+    { name: 'big.png', ext: 'png', size: MAX_BYTES + 1, magic: PNG },
+  ]);
+  assert.equal(r.accepted.length, 0);
+  assert.ok(r.warnings.some((w) => w.includes('exceeds')));
+
+  r = selectImages([{ name: 'fake.png', ext: 'png', size: 10, magic: GIF89 }]);
+  assert.equal(r.accepted.length, 0);
+  assert.ok(r.warnings.some((w) => w.includes('not a valid')));
+});
+
+test('selectImages enforces the accepted-image cap', () => {
+  const many = Array.from({ length: MAX_IMAGES + 5 }, (_, i) => ({
+    name: `s${i}-light.png`,
+    ext: 'png',
+    size: 10,
+    magic: PNG,
+  }));
+  const { accepted, warnings } = selectImages(many);
+  assert.equal(accepted.length, MAX_IMAGES);
+  assert.ok(warnings.some((w) => w.includes('image cap')));
+});
+
+test('selectImages bounds EXAMINED candidates so a junk flood cannot run forever', () => {
+  const flood = Array.from({ length: MAX_CANDIDATES + 50 }, (_, i) => ({
+    name: `x${i}.png`,
+    ext: 'png',
+    size: 10,
+    magic: '00000000', // all invalid
+  }));
+  const { accepted, warnings } = selectImages(flood);
+  assert.equal(accepted.length, 0);
+  assert.ok(warnings.some((w) => w.includes('candidate files')));
+});
+
+test('buildComment pairs light/dark, lists gifs, labels flows, escapes, links the run', () => {
+  const body = buildComment(
+    [
+      'session-transcript-light.png',
+      'session-transcript-dark.png',
+      'model-switch.gif',
+    ],
+    {
+      rawBase: 'https://raw.example/imgs',
+      shortSha: 'abc1234',
+      runUrl: 'https://run.example/1',
+    },
+  );
+  assert.match(body, /<!-- qwen:web-shell-visuals -->/);
+  assert.match(body, /session-transcript-light\.png/);
+  assert.match(body, /session-transcript-dark\.png/);
+  assert.match(body, /model-switch\.gif/);
+  assert.match(body, /Open the slash menu and switch model/); // flow label
+  assert.match(body, /abc1234/);
+  assert.match(body, /https:\/\/run\.example\/1/);
+  // Exactly one screenshot row: the single view with light+dark paired.
+  const rows = body.split('\n').filter((l) => l.startsWith('<tr><td'));
+  assert.equal(rows.length, 1);
+});
+
+test('buildComment is empty-safe and marks a missing pair with an em dash', () => {
+  const empty = buildComment([], {});
+  assert.match(empty, /web-shell visual preview/);
+  assert.doesNotMatch(empty, /<table>/); // no screenshots section
+
+  const onlyLight = buildComment(['home-light.png'], { rawBase: 'r' });
+  assert.match(onlyLight, /<td>—<\/td>/); // the missing dark cell
+});

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -12,7 +12,8 @@ import {
   classifyMagic,
   MAX_BYTES,
   MAX_CANDIDATES,
-  MAX_IMAGES,
+  MAX_GIFS,
+  MAX_SCREENSHOTS,
   sanitizeName,
   selectImages,
 } from './web-shell-visuals-publish.mjs';
@@ -69,16 +70,31 @@ test('selectImages skips oversized and magic-invalid files', () => {
   assert.ok(r.warnings.some((w) => w.includes('not a valid')));
 });
 
-test('selectImages enforces the accepted-image cap', () => {
-  const many = Array.from({ length: MAX_IMAGES + 5 }, (_, i) => ({
-    name: `s${i}-light.png`,
-    ext: 'png',
+test('selectImages caps screenshots per-kind WITHOUT starving gifs', () => {
+  const many = [
+    ...Array.from({ length: MAX_SCREENSHOTS + 5 }, (_, i) => ({
+      name: `s${i}-light.png`,
+      ext: 'png',
+      size: 10,
+      magic: PNG,
+    })),
+    { name: 'model-switch.gif', ext: 'gif', size: 10, magic: GIF89 },
+  ];
+  const { accepted } = selectImages(many);
+  const png = accepted.filter((a) => a.kind === 'png').length;
+  const gif = accepted.filter((a) => a.kind === 'gif').length;
+  assert.equal(png, MAX_SCREENSHOTS); // screenshots capped
+  assert.equal(gif, 1); // the gif survives the screenshot flood (not starved)
+});
+
+test('selectImages caps gifs per-kind', () => {
+  const gifs = Array.from({ length: MAX_GIFS + 3 }, (_, i) => ({
+    name: `flow${i}.gif`,
+    ext: 'gif',
     size: 10,
-    magic: PNG,
+    magic: GIF89,
   }));
-  const { accepted, warnings } = selectImages(many);
-  assert.equal(accepted.length, MAX_IMAGES);
-  assert.ok(warnings.some((w) => w.includes('image cap')));
+  assert.equal(selectImages(gifs).accepted.length, MAX_GIFS);
 });
 
 test('selectImages bounds EXAMINED candidates so a junk flood cannot run forever', () => {
@@ -116,6 +132,14 @@ test('buildComment pairs light/dark, lists gifs, labels flows, escapes, links th
   // Exactly one screenshot row: the single view with light+dark paired.
   const rows = body.split('\n').filter((l) => l.startsWith('<tr><td'));
   assert.equal(rows.length, 1);
+});
+
+test('buildComment does not leak Object.prototype members as flow labels', () => {
+  const body = buildComment(['toString.gif', 'constructor.gif'], {
+    rawBase: 'r',
+  });
+  assert.doesNotMatch(body, /native code/);
+  assert.match(body, /\*\*ToString\*\*/); // falls back to the prettified filename
 });
 
 test('buildComment is empty-safe and marks a missing pair with an em dash', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           node scripts/lint.js --setup
           node scripts/lint.js --actionlint
           node scripts/lint.js --yamllint
-          node --test .github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/resolve-sandbox-image.test.mjs
+          node --test .github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs
 
       # Self-hosted can't reach nodejs.org reliably; reuse the machine's Node.
       - name: 'Set up Node.js 22.x (hosted)'

--- a/.github/workflows/web-shell-visuals-cleanup.yml
+++ b/.github/workflows/web-shell-visuals-cleanup.yml
@@ -1,0 +1,34 @@
+name: 'Web-shell Visuals Cleanup'
+
+# When a PR closes, delete its per-PR visuals asset branch so the `pr-assets/*`
+# refs (one per PR that ever produced a preview) don't accumulate without bound
+# in the base repository. Runs in the base context (pull_request_target) but
+# never checks out or runs PR code — it only deletes one ref by name.
+on:
+  pull_request_target:
+    types:
+      - 'closed'
+
+permissions:
+  contents: 'read'
+
+jobs:
+  delete-asset-branch:
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    steps:
+      - name: 'Delete the PR asset branch'
+        env:
+          # Deleting a ref needs contents:write, which the CI_BOT_PAT carries.
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+        run: |-
+          set -euo pipefail
+          branch="pr-assets/web-shell-visuals-${PR_NUMBER}"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" >/dev/null 2>&1; then
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}"
+            echo "Deleted ${branch}."
+          else
+            echo "No asset branch ${branch}; nothing to delete."
+          fi

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -80,39 +80,57 @@ jobs:
             echo "::warning::Artifact has no valid PR number; aborting."
             exit 0
           fi
-          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
-          # Guard empty responses (network error / rate limit): jq on empty
-          # stdin would error and `set -e` would kill the job.
-          if [ -z "${pr_json}" ]; then
-            echo "::warning::Empty response fetching PR #${PR} (network / rate limit); skipping."
+
+          # Authenticated bot identity — the dedup lookup filters on this so a
+          # participant who posts the marker can't hijack or redirect the update.
+          BOT_LOGIN="$(gh api user --jq '.login' 2>/dev/null || true)"
+          if [ -z "${BOT_LOGIN}" ]; then
+            echo "::warning::Could not resolve the bot identity; skipping to avoid mis-targeting a comment."
             exit 0
           fi
-          pr_state="$(jq -r '.state // empty' <<< "${pr_json}")"
-          pr_head="$(jq -r '.head.sha // empty' <<< "${pr_json}")"
-          if [ "${pr_state}" != "open" ]; then
-            echo "::notice::PR #${PR} is not open (state='${pr_state:-unknown}'); skipping."
-            exit 0
-          fi
-          if [ -z "${RUN_HEAD_SHA}" ] || [ "${pr_head}" != "${RUN_HEAD_SHA}" ]; then
-            echo "::warning::PR #${PR} head (${pr_head:-none}) != this run's head (${RUN_HEAD_SHA:-none}); refusing to post (stale run or forged/mismatched PR number)."
-            exit 0
-          fi
+
+          # Re-runnable gate: PR must be open AND its current head must equal this
+          # run's authenticated head SHA. This binds the untrusted artifact PR
+          # number to the real run, and is re-checked right before the comment
+          # write to close the validate->write TOCTOU window (a push/close during
+          # asset upload must not let a stale run post).
+          validate_pr() {
+            local j st hd
+            j="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
+            [ -n "${j}" ] || { echo "::warning::Empty response fetching PR #${PR}."; return 1; }
+            st="$(jq -r '.state // empty' <<< "${j}")"
+            hd="$(jq -r '.head.sha // empty' <<< "${j}")"
+            [ "${st}" = "open" ] || { echo "::notice::PR #${PR} not open (state=${st:-unknown})."; return 1; }
+            { [ -n "${RUN_HEAD_SHA}" ] && [ "${hd}" = "${RUN_HEAD_SHA}" ]; } || {
+              echo "::warning::PR #${PR} head (${hd:-none}) != run head (${RUN_HEAD_SHA:-none}); refusing."
+              return 1
+            }
+            return 0
+          }
+          validate_pr || exit 0
           SHORT_SHA="${RUN_HEAD_SHA:0:7}"
 
           # --- Stage + validate the images ----------------------------------
-          # The images are produced by untrusted PR code. Validate magic bytes
-          # with coreutils `od` (no fragile `xxd` dependency), sanitize names,
-          # and CAP count + per-file size so a hostile PR can't blow past the
-          # comment size limit or bloat the pr-assets branch.
+          # Untrusted PR content: bound BOTH the number of candidates EXAMINED
+          # (so tens of thousands of junk files can't burn the job's budget on
+          # wc/od before reaching valid files) and the number ACCEPTED, plus a
+          # per-file size cap. Validate magic bytes with coreutils `od`.
           STAGE="${RUNNER_TEMP}/visuals-stage"
           rm -rf "${STAGE}"
           mkdir -p "${STAGE}"
           shopt -s nullglob
-          MAX_IMAGES=30
-          MAX_BYTES=$((6 * 1024 * 1024))
+          MAX_CANDIDATES=200
+          MAX_IMAGES=14
+          MAX_BYTES=$((3 * 1024 * 1024))
+          examined=0
           count=0
           for f in "${ART}"/screenshots/*.png "${ART}"/gifs/*.gif; do
             [ -f "${f}" ] || continue
+            examined=$((examined + 1))
+            if [ "${examined}" -gt "${MAX_CANDIDATES}" ]; then
+              echo "::warning::Examined ${MAX_CANDIDATES} candidate files; stopping."
+              break
+            fi
             if [ "${count}" -ge "${MAX_IMAGES}" ]; then
               echo "::warning::Reached the ${MAX_IMAGES}-image cap; skipping the rest."
               break
@@ -139,7 +157,11 @@ jobs:
                 esac
                 ;;
             esac
-            safe="$(basename "${f}" | tr -c 'A-Za-z0-9._-' '_')"
+            # Capture basename FIRST so command substitution strips its trailing
+            # newline BEFORE `tr` — otherwise `tr -c` turns that newline into `_`,
+            # producing "name.png_" and breaking the .png/.gif extension filter.
+            base="$(basename "${f}")"
+            safe="$(printf '%s' "${base}" | tr -c 'A-Za-z0-9._-' '_')"
             cp "${f}" "${STAGE}/${safe}"
             count=$((count + 1))
           done
@@ -149,54 +171,29 @@ jobs:
           fi
           echo "Staged ${count} image(s) for PR #${PR}."
 
-          # --- Host the images on the pr-assets branch ----------------------
-          # Per-PR asset branch under the repo's existing `pr-assets/<slug>`
-          # convention. A bare `pr-assets` branch would D/F-conflict with the
-          # existing `pr-assets/*` refs, and per-PR branches also avoid cross-PR
-          # push contention. Reference images by immutable commit SHA so URLs
-          # never break as later runs append. Each run writes a unique <run>
-          # subdir, so a concurrent same-PR push only needs a fast-forward
-          # rebase, never a content merge.
+          # --- Host on the PR's own pr-assets branch (bounded) --------------
+          # Replace the branch with a SINGLE orphan snapshot each run and
+          # force-push, so untrusted PR content can't accumulate unbounded
+          # history in the base repo. The comment always points at the new
+          # immutable commit SHA; the previous snapshot becomes unreachable and
+          # is GC'd. Per-PR branch under the existing pr-assets/<slug> convention
+          # (a bare `pr-assets` branch would D/F-conflict with pr-assets/*), and
+          # the per-PR concurrency group serializes same-PR runs so the
+          # force-push never drops a concurrent snapshot.
           BRANCH="pr-assets/web-shell-visuals-${PR}"
-          DEST="${RUN_ID}"
-          WORK="${RUNNER_TEMP}/pr-assets"
           AUTH_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          WORK="${RUNNER_TEMP}/pr-assets"
           rm -rf "${WORK}"
-          mkdir -p "${WORK}"
+          mkdir -p "${WORK}/imgs"
+          cp "${STAGE}"/* "${WORK}/imgs/"
           cd "${WORK}"
           git init -q
           git config user.name 'qwen-code-bot'
           git config user.email 'qwen-code-bot@users.noreply.github.com'
-          git remote add origin "${AUTH_URL}"
-          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
-            git fetch -q --depth 1 origin "${BRANCH}"
-            git checkout -q -B "${BRANCH}" FETCH_HEAD
-          else
-            echo "Branch ${BRANCH} does not exist yet; creating it."
-            git checkout -q --orphan "${BRANCH}"
-          fi
-          mkdir -p "${DEST}"
-          cp "${STAGE}"/* "${DEST}/"
-          git add "${DEST}"
-          if git diff --cached --quiet; then
-            echo "Images already present on ${BRANCH}; reusing the existing commit."
-          else
-            git commit -q -m "web-shell visuals: PR #${PR} (run ${RUN_ID})"
-            pushed=0
-            for attempt in 1 2 3 4 5; do
-              if git push -q origin "HEAD:${BRANCH}" 2>/dev/null; then
-                pushed=1
-                break
-              fi
-              echo "::notice::push attempt ${attempt} rejected; rebasing onto the latest ${BRANCH}."
-              git fetch -q --depth 1 origin "${BRANCH}" || true
-              git rebase -q FETCH_HEAD || git rebase --abort >/dev/null 2>&1 || true
-            done
-            if [ "${pushed}" -ne 1 ]; then
-              echo "::error::Failed to push web-shell visuals to ${BRANCH} after retries."
-              exit 1
-            fi
-          fi
+          git checkout -q --orphan snapshot
+          git add imgs
+          git commit -q -m "web-shell visuals: PR #${PR} (run ${RUN_ID})"
+          git push -q --force "${AUTH_URL}" "HEAD:${BRANCH}"
           ASSET_SHA="$(git rev-parse HEAD)"
           cd "${GITHUB_WORKSPACE}"
           echo "web-shell visuals hosted on ${BRANCH} at ${ASSET_SHA}."
@@ -205,7 +202,7 @@ jobs:
           BODY_FILE="${RUNNER_TEMP}/visuals-comment.md"
           export STAGE
           export BODY_FILE
-          export RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/${DEST}"
+          export RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/imgs"
           export SHORT_SHA RUN_URL
           node <<'NODE'
           const fs = require('node:fs');
@@ -289,7 +286,7 @@ jobs:
 
           if (runUrl) {
             out.push(
-              `<sub>Full-resolution recordings (.webm) are attached to the <a href="${runUrl}">workflow run</a>.</sub>`,
+              `<sub>Full-resolution recordings (.webm) are attached to the <a href="${esc(runUrl)}">workflow run</a>.</sub>`,
             );
           }
           out.push('');
@@ -299,15 +296,29 @@ jobs:
           console.log(`Comment body: ${out.length} lines, ${shots.length} screenshots, ${gifs.length} gifs.`);
           NODE
 
-          # --- Post or update the PR comment (dedup on the marker) ----------
+          # --- Post or update the PR comment --------------------------------
+          # Re-validate immediately before the write (TOCTOU): a push/close during
+          # asset upload must not let this now-stale run post a preview.
+          validate_pr || { echo "::notice::PR #${PR} changed during publish; not posting."; exit 0; }
+
+          # Dedup only against OUR OWN prior comment (bot author + marker), and
+          # only after a SUCCESSFUL listing — a failed/partial list must not read
+          # as "no existing comment" (that would POST a duplicate on every failure).
           MARKER='<!-- qwen:web-shell-visuals -->'
-          if ! EXISTING="$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
-              --method GET --paginate -F per_page=100 \
-              | jq -sr --arg m "${MARKER}" '[.[][] | select(.body | contains($m))] | last | .id // empty'
-          )"; then
-            echo "::warning::Failed to list existing comments; will create a new one."
-            EXISTING=''
+          EXISTING=''
+          listed=0
+          for attempt in 1 2 3; do
+            if resp="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --method GET --paginate -F per_page=100 2>/dev/null)"; then
+              EXISTING="$(jq -sr --arg m "${MARKER}" --arg u "${BOT_LOGIN}" \
+                '[.[][] | select((.user.login == $u) and (.body | contains($m)))] | last | .id // empty' <<< "${resp}")"
+              listed=1
+              break
+            fi
+            echo "::notice::comment lookup attempt ${attempt} failed; retrying."
+          done
+          if [ "${listed}" -ne 1 ]; then
+            echo "::error::Could not list PR comments after retries; not posting (avoids duplicates)."
+            exit 1
           fi
           if [ -n "${EXISTING}" ]; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -F body=@"${BODY_FILE}" >/dev/null

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -70,6 +70,11 @@ jobs:
           # Authenticated (NOT artifact-sourced) head SHA of the run that
           # triggered this publish — used to bind the artifact to its real PR.
           RUN_HEAD_SHA: '${{ github.event.workflow_run.head_sha }}'
+          # Authenticated head repo + branch. A (repo, branch) pair maps to at
+          # most one open PR, so binding on it rejects a sibling PR that merely
+          # shares the same head commit SHA.
+          RUN_HEAD_REPO: '${{ github.event.workflow_run.head_repository.full_name }}'
+          RUN_HEAD_BRANCH: '${{ github.event.workflow_run.head_branch }}'
         run: |-
           set -euo pipefail
 
@@ -105,14 +110,22 @@ jobs:
           # write to close the validate->write TOCTOU window (a push/close during
           # asset upload must not let a stale run post).
           validate_pr() {
-            local j st hd
+            local j st hd rr rf
             j="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
             [ -n "${j}" ] || { echo "::warning::Empty response fetching PR #${PR}."; return 1; }
             st="$(jq -r '.state // empty' <<< "${j}")"
             hd="$(jq -r '.head.sha // empty' <<< "${j}")"
+            rr="$(jq -r '.head.repo.full_name // empty' <<< "${j}")"
+            rf="$(jq -r '.head.ref // empty' <<< "${j}")"
             [ "${st}" = "open" ] || { echo "::notice::PR #${PR} not open (state=${st:-unknown})."; return 1; }
             { [ -n "${RUN_HEAD_SHA}" ] && [ "${hd}" = "${RUN_HEAD_SHA}" ]; } || {
               echo "::warning::PR #${PR} head (${hd:-none}) != run head (${RUN_HEAD_SHA:-none}); refusing."
+              return 1
+            }
+            # Also bind repo+branch: two open PRs can share a head SHA (same
+            # commit on different branches) but not the same (repo, branch).
+            { [ -n "${RUN_HEAD_REPO}" ] && [ "${rr}" = "${RUN_HEAD_REPO}" ] && [ "${rf}" = "${RUN_HEAD_BRANCH}" ]; } || {
+              echo "::warning::PR #${PR} head ${rr:-none}#${rf:-none} != run ${RUN_HEAD_REPO:-none}#${RUN_HEAD_BRANCH:-none}; refusing."
               return 1
             }
             return 0
@@ -133,6 +146,11 @@ jobs:
             exit 0
           fi
           echo "Staged ${count} image(s) for PR #${PR}."
+
+          # Re-validate right before the force-push too: a close/new-head during
+          # download+staging must not force-push a stale snapshot (which would
+          # orphan the commit the existing comment still points at).
+          validate_pr || { echo "::notice::PR #${PR} changed before hosting; not publishing."; exit 0; }
 
           # --- Host on the PR's own pr-assets branch (bounded) --------------
           # Replace the branch with a SINGLE orphan snapshot each run and
@@ -186,10 +204,6 @@ jobs:
             "${SHORT_SHA}" "${RUN_URL}" "${BODY_FILE}"
 
           # --- Post or update the PR comment --------------------------------
-          # Re-validate immediately before the write (TOCTOU): a push/close during
-          # asset upload must not let this now-stale run post a preview.
-          validate_pr || { echo "::notice::PR #${PR} changed during publish; not posting."; exit 0; }
-
           # Dedup only against OUR OWN prior comment (bot author + marker), and
           # only after a SUCCESSFUL listing — a failed/partial list must not read
           # as "no existing comment" (that would POST a duplicate on every failure).
@@ -209,6 +223,12 @@ jobs:
             echo "::error::Could not list PR comments after retries; not posting (avoids duplicates)."
             exit 1
           fi
+
+          # Final TOCTOU gate: re-validate (open + head SHA + repo/branch) AFTER
+          # the paginated/retried lookup, immediately before the write — a
+          # close or new head during validation/lookup must not post a stale one.
+          validate_pr || { echo "::notice::PR #${PR} changed during publish; not posting."; exit 0; }
+
           if [ -n "${EXISTING}" ]; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -F body=@"${BODY_FILE}" >/dev/null
             echo "Updated existing web-shell visuals comment on PR #${PR}."

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -109,10 +109,18 @@ jobs:
           # number to the real run, and is re-checked right before the comment
           # write to close the validate->write TOCTOU window (a push/close during
           # asset upload must not let a stale run post).
+          # Returns 0 = valid, 1 = genuinely invalid (closed / head mismatch),
+          # 2 = TRANSIENT API failure (empty after retries) — distinguished so a
+          # blip fails loudly (re-triggerable) instead of silently skipping.
           validate_pr() {
-            local j st hd rr rf
-            j="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
-            [ -n "${j}" ] || { echo "::warning::Empty response fetching PR #${PR}."; return 1; }
+            local j st hd rr rf attempt
+            j=''
+            for attempt in 1 2 3; do
+              j="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
+              [ -n "${j}" ] && break
+              sleep 2
+            done
+            [ -n "${j}" ] || { echo "::warning::Could not fetch PR #${PR} after retries."; return 2; }
             st="$(jq -r '.state // empty' <<< "${j}")"
             hd="$(jq -r '.head.sha // empty' <<< "${j}")"
             rr="$(jq -r '.head.repo.full_name // empty' <<< "${j}")"
@@ -130,7 +138,20 @@ jobs:
             }
             return 0
           }
-          validate_pr || exit 0
+          # Gate: proceed when valid; a genuine invalid state SKIPS quietly, but a
+          # transient failure EXITS 1 so the publish surfaces as re-triggerable.
+          gate() {
+            local rc
+            if validate_pr; then rc=0; else rc=$?; fi
+            [ "${rc}" -eq 0 ] && return 0
+            if [ "${rc}" -eq 2 ]; then
+              echo "::error::Transient API failure validating PR #${PR}; failing so the publish can be re-triggered."
+              exit 1
+            fi
+            echo "::notice::PR #${PR} no longer valid for publishing; skipping."
+            exit 0
+          }
+          gate
           SHORT_SHA="${RUN_HEAD_SHA:0:7}"
 
           # --- Stage + validate the images ----------------------------------
@@ -150,7 +171,7 @@ jobs:
           # Re-validate right before the force-push too: a close/new-head during
           # download+staging must not force-push a stale snapshot (which would
           # orphan the commit the existing comment still points at).
-          validate_pr || { echo "::notice::PR #${PR} changed before hosting; not publishing."; exit 0; }
+          gate
 
           # --- Host on the PR's own pr-assets branch (bounded) --------------
           # Replace the branch with a SINGLE orphan snapshot each run and
@@ -218,6 +239,7 @@ jobs:
               break
             fi
             echo "::notice::comment lookup attempt ${attempt} failed; retrying."
+            sleep 2
           done
           if [ "${listed}" -ne 1 ]; then
             echo "::error::Could not list PR comments after retries; not posting (avoids duplicates)."
@@ -227,7 +249,7 @@ jobs:
           # Final TOCTOU gate: re-validate (open + head SHA + repo/branch) AFTER
           # the paginated/retried lookup, immediately before the write — a
           # close or new head during validation/lookup must not post a stale one.
-          validate_pr || { echo "::notice::PR #${PR} changed during publish; not posting."; exit 0; }
+          gate
 
           if [ -n "${EXISTING}" ]; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -F body=@"${BODY_FILE}" >/dev/null

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -1,0 +1,299 @@
+name: 'Web-shell Visuals Publish'
+
+# Privileged companion to `web-shell-visuals.yml`. It runs AFTER that workflow
+# via workflow_run, so it executes in the base-repo context with a write token
+# but NEVER checks out or runs PR code — it only downloads the image artifact
+# (opaque bytes), hosts it on the `pr-assets` branch, and posts an inline
+# comment. This is the GitHub-recommended split for commenting on fork PRs with
+# the results of untrusted-code execution.
+on:
+  workflow_run:
+    workflows:
+      - 'Web-shell Visuals'
+    types:
+      - 'completed'
+
+# GITHUB_TOKEN only needs to read the triggering run's artifact; the branch push
+# and PR comment are done with CI_BOT_PAT, which carries its own scope.
+permissions:
+  actions: 'read'
+
+# All publishes push to the single `pr-assets` branch, so serialize them to
+# avoid racing on that push. Never cancel an in-flight publish.
+concurrency:
+  group: 'web-shell-visuals-publish-${{ github.event.workflow_run.head_branch }}'
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  publish:
+    name: 'Publish web-shell visuals to the PR'
+    if: >-
+      github.repository == 'QwenLM/qwen-code' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    steps:
+      - name: 'Download visuals artifact'
+        id: 'download'
+        continue-on-error: true
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v5.0.0
+        with:
+          name: 'web-shell-visuals'
+          run-id: '${{ github.event.workflow_run.id }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          path: 'visuals'
+
+      - name: 'Publish visuals to the PR'
+        env:
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          RUN_ID: '${{ github.event.workflow_run.id }}'
+          RUN_URL: '${{ github.event.workflow_run.html_url }}'
+          # Authenticated (NOT artifact-sourced) head SHA of the run that
+          # triggered this publish — used to bind the artifact to its real PR.
+          RUN_HEAD_SHA: '${{ github.event.workflow_run.head_sha }}'
+        run: |-
+          set -euo pipefail
+
+          ART='visuals'
+          if [ ! -d "${ART}" ]; then
+            echo "::notice::No visuals artifact was downloaded; nothing to publish."
+            exit 0
+          fi
+
+          # --- Validate + bind the untrusted PR number ----------------------
+          # pr.txt is written by a job that ran PR code, so it is UNTRUSTED: a
+          # malicious PR could put a *victim* PR number here. Sanitize it, then
+          # BIND it to this run — require the PR's current head SHA to equal the
+          # authenticated head SHA of the run that produced the artifact. A
+          # victim PR's head won't match, so the misdirection is rejected.
+          PR="$(tr -dc '0-9' < "${ART}/pr.txt" 2>/dev/null | head -c 12 || true)"
+          if [ -z "${PR}" ]; then
+            echo "::warning::Artifact has no valid PR number; aborting."
+            exit 0
+          fi
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
+          pr_state="$(jq -r '.state // empty' <<< "${pr_json}")"
+          pr_head="$(jq -r '.head.sha // empty' <<< "${pr_json}")"
+          if [ "${pr_state}" != "open" ]; then
+            echo "::notice::PR #${PR} is not open (state='${pr_state:-unknown}'); skipping."
+            exit 0
+          fi
+          if [ -z "${RUN_HEAD_SHA}" ] || [ "${pr_head}" != "${RUN_HEAD_SHA}" ]; then
+            echo "::warning::PR #${PR} head (${pr_head:-none}) != this run's head (${RUN_HEAD_SHA:-none}); refusing to post (stale run or forged/mismatched PR number)."
+            exit 0
+          fi
+          SHORT_SHA="${RUN_HEAD_SHA:0:7}"
+
+          # --- Stage + validate the images ----------------------------------
+          # The images are produced by untrusted PR code. Validate magic bytes
+          # with coreutils `od` (no fragile `xxd` dependency), sanitize names,
+          # and CAP count + per-file size so a hostile PR can't blow past the
+          # comment size limit or bloat the pr-assets branch.
+          STAGE="${RUNNER_TEMP}/visuals-stage"
+          rm -rf "${STAGE}"
+          mkdir -p "${STAGE}"
+          shopt -s nullglob
+          MAX_IMAGES=30
+          MAX_BYTES=$((6 * 1024 * 1024))
+          count=0
+          for f in "${ART}"/screenshots/*.png "${ART}"/gifs/*.gif; do
+            [ -f "${f}" ] || continue
+            if [ "${count}" -ge "${MAX_IMAGES}" ]; then
+              echo "::warning::Reached the ${MAX_IMAGES}-image cap; skipping the rest."
+              break
+            fi
+            if [ "$(wc -c < "${f}")" -gt "${MAX_BYTES}" ]; then
+              echo "::warning::$(basename "${f}") exceeds ${MAX_BYTES} bytes; skipping."
+              continue
+            fi
+            sig="$(od -An -v -tx1 -N8 "${f}" | tr -d ' \n')"
+            case "${f}" in
+              *.png)
+                [ "${sig:0:16}" = "89504e470d0a1a0a" ] || {
+                  echo "::warning::${f} is not a PNG; skipping."
+                  continue
+                }
+                ;;
+              *.gif)
+                case "${sig:0:12}" in
+                  474946383961 | 474946383761) : ;; # GIF89a / GIF87a
+                  *)
+                    echo "::warning::${f} is not a GIF; skipping."
+                    continue
+                    ;;
+                esac
+                ;;
+            esac
+            safe="$(basename "${f}" | tr -c 'A-Za-z0-9._-' '_')"
+            cp "${f}" "${STAGE}/${safe}"
+            count=$((count + 1))
+          done
+          if [ "${count}" -eq 0 ]; then
+            echo "::notice::No valid images in the artifact; nothing to publish."
+            exit 0
+          fi
+          echo "Staged ${count} image(s) for PR #${PR}."
+
+          # --- Host the images on the pr-assets branch ----------------------
+          # Per-PR asset branch under the repo's existing `pr-assets/<slug>`
+          # convention. A bare `pr-assets` branch would D/F-conflict with the
+          # existing `pr-assets/*` refs, and per-PR branches also avoid cross-PR
+          # push contention. Reference images by immutable commit SHA so URLs
+          # never break as later runs append. Each run writes a unique <run>
+          # subdir, so a concurrent same-PR push only needs a fast-forward
+          # rebase, never a content merge.
+          BRANCH="pr-assets/web-shell-visuals-${PR}"
+          DEST="${RUN_ID}"
+          WORK="${RUNNER_TEMP}/pr-assets"
+          AUTH_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          rm -rf "${WORK}"
+          mkdir -p "${WORK}"
+          cd "${WORK}"
+          git init -q
+          git config user.name 'qwen-code-bot'
+          git config user.email 'qwen-code-bot@users.noreply.github.com'
+          git remote add origin "${AUTH_URL}"
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch -q --depth 1 origin "${BRANCH}"
+            git checkout -q -B "${BRANCH}" FETCH_HEAD
+          else
+            echo "Branch ${BRANCH} does not exist yet; creating it."
+            git checkout -q --orphan "${BRANCH}"
+          fi
+          mkdir -p "${DEST}"
+          cp "${STAGE}"/* "${DEST}/"
+          git add "${DEST}"
+          if git diff --cached --quiet; then
+            echo "Images already present on ${BRANCH}; reusing the existing commit."
+          else
+            git commit -q -m "web-shell visuals: PR #${PR} (run ${RUN_ID})"
+            pushed=0
+            for attempt in 1 2 3 4 5; do
+              if git push -q origin "HEAD:${BRANCH}" 2>/dev/null; then
+                pushed=1
+                break
+              fi
+              echo "::notice::push attempt ${attempt} rejected; rebasing onto the latest ${BRANCH}."
+              git fetch -q --depth 1 origin "${BRANCH}" || true
+              git rebase -q FETCH_HEAD || git rebase --abort >/dev/null 2>&1 || true
+            done
+            if [ "${pushed}" -ne 1 ]; then
+              echo "::error::Failed to push web-shell visuals to ${BRANCH} after retries."
+              exit 1
+            fi
+          fi
+          ASSET_SHA="$(git rev-parse HEAD)"
+          cd "${GITHUB_WORKSPACE}"
+          echo "web-shell visuals hosted on ${BRANCH} at ${ASSET_SHA}."
+
+          # --- Build the comment body ---------------------------------------
+          BODY_FILE="${RUNNER_TEMP}/visuals-comment.md"
+          export STAGE
+          export BODY_FILE
+          export RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/${DEST}"
+          export SHORT_SHA RUN_URL
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const stage = process.env.STAGE;
+          const rawBase = process.env.RAW_BASE;
+          const shortSha = process.env.SHORT_SHA || '';
+          const runUrl = process.env.RUN_URL || '';
+          const files = fs.readdirSync(stage);
+
+          const url = (name) => `${rawBase}/${encodeURIComponent(name)}`;
+          const pretty = (s) =>
+            s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+          // Screenshots: pair <view>-light.png with <view>-dark.png.
+          const shots = files.filter((f) => /\.png$/i.test(f));
+          const views = new Map();
+          for (const f of shots) {
+            const m = f.match(/^(.*)-(light|dark)\.png$/i);
+            if (!m) continue;
+            const [, view, theme] = m;
+            const entry = views.get(view) || {};
+            entry[theme.toLowerCase()] = f;
+            views.set(view, entry);
+          }
+
+          const gifs = files.filter((f) => /\.gif$/i.test(f)).sort();
+          const flowLabels = {
+            'model-switch': 'Open the slash menu and switch model',
+            'prompt-stream': 'Submit a prompt and watch the reply stream in',
+          };
+
+          const out = [];
+          out.push('<!-- qwen:web-shell-visuals -->');
+          out.push('### 🖼️ web-shell visual preview');
+          out.push(
+            `Auto-rendered from this PR head \`${shortSha}\` against a mock daemon (no real backend). Refreshes on every push.`,
+          );
+          out.push('');
+
+          if (views.size > 0) {
+            out.push('#### Screenshots · light / dark');
+            out.push('');
+            out.push('<table>');
+            out.push('<tr><th align="left">view</th><th>light</th><th>dark</th></tr>');
+            for (const [view, pair] of [...views.entries()].sort()) {
+              const light = pair.light
+                ? `<img src="${url(pair.light)}" width="360" alt="${view} light">`
+                : '—';
+              const dark = pair.dark
+                ? `<img src="${url(pair.dark)}" width="360" alt="${view} dark">`
+                : '—';
+              out.push(
+                `<tr><td valign="top"><sub>${pretty(view)}</sub></td><td>${light}</td><td>${dark}</td></tr>`,
+              );
+            }
+            out.push('</table>');
+            out.push('');
+          }
+
+          if (gifs.length > 0) {
+            out.push('#### Flows');
+            out.push('');
+            for (const g of gifs) {
+              const key = g.replace(/\.gif$/i, '');
+              out.push(`**${flowLabels[key] || pretty(key)}**`);
+              out.push('');
+              out.push(`<img src="${url(g)}" width="640" alt="${key} flow">`);
+              out.push('');
+            }
+          }
+
+          if (runUrl) {
+            out.push(
+              `<sub>Full-resolution recordings (.webm) are attached to the <a href="${runUrl}">workflow run</a>.</sub>`,
+            );
+          }
+          out.push('');
+          out.push('— _Qwen Code · web-shell visuals_');
+
+          fs.writeFileSync(process.env.BODY_FILE, out.join('\n') + '\n');
+          console.log(`Comment body: ${out.length} lines, ${shots.length} screenshots, ${gifs.length} gifs.`);
+          NODE
+
+          # --- Post or update the PR comment (dedup on the marker) ----------
+          MARKER='<!-- qwen:web-shell-visuals -->'
+          if ! EXISTING="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              --method GET --paginate -F per_page=100 \
+              | jq -sr --arg m "${MARKER}" '[.[][] | select(.body | contains($m))] | last | .id // empty'
+          )"; then
+            echo "::warning::Failed to list existing comments; will create a new one."
+            EXISTING=''
+          fi
+          if [ -n "${EXISTING}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -F body=@"${BODY_FILE}" >/dev/null
+            echo "Updated existing web-shell visuals comment on PR #${PR}."
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -F body=@"${BODY_FILE}" >/dev/null
+            echo "Posted web-shell visuals comment on PR #${PR}."
+          fi

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -42,6 +42,15 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     steps:
+      # Trusted base-repo script (staging + comment builder). workflow_run
+      # checks out the default branch, never PR code. Sparse — just the script.
+      - name: 'Checkout the publish script'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          sparse-checkout: '.github/scripts/web-shell-visuals-publish.mjs'
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: 'Download visuals artifact'
         id: 'download'
         continue-on-error: true
@@ -111,61 +120,14 @@ jobs:
           SHORT_SHA="${RUN_HEAD_SHA:0:7}"
 
           # --- Stage + validate the images ----------------------------------
-          # Untrusted PR content: bound BOTH the number of candidates EXAMINED
-          # (so tens of thousands of junk files can't burn the job's budget on
-          # wc/od before reaching valid files) and the number ACCEPTED, plus a
-          # per-file size cap. Validate magic bytes with coreutils `od`.
+          # Delegated to the unit-tested script: magic-byte validation, filename
+          # sanitization, and the examined/accepted/size caps over untrusted
+          # artifact content live in web-shell-visuals-publish.mjs (covered by
+          # web-shell-visuals-publish.test.mjs). It prints the accepted count.
           STAGE="${RUNNER_TEMP}/visuals-stage"
           rm -rf "${STAGE}"
-          mkdir -p "${STAGE}"
-          shopt -s nullglob
-          MAX_CANDIDATES=200
-          MAX_IMAGES=14
-          MAX_BYTES=$((3 * 1024 * 1024))
-          examined=0
-          count=0
-          for f in "${ART}"/screenshots/*.png "${ART}"/gifs/*.gif; do
-            [ -f "${f}" ] || continue
-            examined=$((examined + 1))
-            if [ "${examined}" -gt "${MAX_CANDIDATES}" ]; then
-              echo "::warning::Examined ${MAX_CANDIDATES} candidate files; stopping."
-              break
-            fi
-            if [ "${count}" -ge "${MAX_IMAGES}" ]; then
-              echo "::warning::Reached the ${MAX_IMAGES}-image cap; skipping the rest."
-              break
-            fi
-            if [ "$(wc -c < "${f}")" -gt "${MAX_BYTES}" ]; then
-              echo "::warning::$(basename "${f}") exceeds ${MAX_BYTES} bytes; skipping."
-              continue
-            fi
-            sig="$(od -An -v -tx1 -N8 "${f}" | tr -d ' \n')"
-            case "${f}" in
-              *.png)
-                [ "${sig:0:16}" = "89504e470d0a1a0a" ] || {
-                  echo "::warning::${f} is not a PNG; skipping."
-                  continue
-                }
-                ;;
-              *.gif)
-                case "${sig:0:12}" in
-                  474946383961 | 474946383761) : ;; # GIF89a / GIF87a
-                  *)
-                    echo "::warning::${f} is not a GIF; skipping."
-                    continue
-                    ;;
-                esac
-                ;;
-            esac
-            # Capture basename FIRST so command substitution strips its trailing
-            # newline BEFORE `tr` — otherwise `tr -c` turns that newline into `_`,
-            # producing "name.png_" and breaking the .png/.gif extension filter.
-            base="$(basename "${f}")"
-            safe="$(printf '%s' "${base}" | tr -c 'A-Za-z0-9._-' '_')"
-            cp "${f}" "${STAGE}/${safe}"
-            count=$((count + 1))
-          done
-          if [ "${count}" -eq 0 ]; then
+          count="$(node .github/scripts/web-shell-visuals-publish.mjs stage "${ART}/screenshots" "${ART}/gifs" "${STAGE}")"
+          if [ -z "${count}" ] || [ "${count}" = "0" ]; then
             echo "::notice::No valid images in the artifact; nothing to publish."
             exit 0
           fi
@@ -199,102 +161,13 @@ jobs:
           echo "web-shell visuals hosted on ${BRANCH} at ${ASSET_SHA}."
 
           # --- Build the comment body ---------------------------------------
+          # Delegated to the same unit-tested script (light/dark pairing, flow
+          # labels, and HTML escaping live in web-shell-visuals-publish.mjs).
           BODY_FILE="${RUNNER_TEMP}/visuals-comment.md"
-          export STAGE
-          export BODY_FILE
-          export RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/imgs"
-          export SHORT_SHA RUN_URL
-          node <<'NODE'
-          const fs = require('node:fs');
-          const path = require('node:path');
-          const stage = process.env.STAGE;
-          const rawBase = process.env.RAW_BASE;
-          const shortSha = process.env.SHORT_SHA || '';
-          const runUrl = process.env.RUN_URL || '';
-          const files = fs.readdirSync(stage);
-
-          const url = (name) => `${rawBase}/${encodeURIComponent(name)}`;
-          // Self-defending HTML escaping for interpolated values. Filenames are
-          // already sanitized to [A-Za-z0-9._-] upstream, but don't rely on that
-          // being an HTML defense — escape at the interpolation point too.
-          const esc = (s) =>
-            String(s)
-              .replace(/&/g, '&amp;')
-              .replace(/"/g, '&quot;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;');
-          const pretty = (s) =>
-            s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-
-          // Screenshots: pair <view>-light.png with <view>-dark.png.
-          const shots = files.filter((f) => /\.png$/i.test(f));
-          const views = new Map();
-          for (const f of shots) {
-            const m = f.match(/^(.*)-(light|dark)\.png$/i);
-            if (!m) continue;
-            const [, view, theme] = m;
-            const entry = views.get(view) || {};
-            entry[theme.toLowerCase()] = f;
-            views.set(view, entry);
-          }
-
-          const gifs = files.filter((f) => /\.gif$/i.test(f)).sort();
-          const flowLabels = {
-            'model-switch': 'Open the slash menu and switch model',
-            'prompt-stream': 'Submit a prompt and watch the reply stream in',
-          };
-
-          const out = [];
-          out.push('<!-- qwen:web-shell-visuals -->');
-          out.push('### 🖼️ web-shell visual preview');
-          out.push(
-            `Auto-rendered from this PR head \`${shortSha}\` against a mock daemon (no real backend). Refreshes on every push.`,
-          );
-          out.push('');
-
-          if (views.size > 0) {
-            out.push('#### Screenshots · light / dark');
-            out.push('');
-            out.push('<table>');
-            out.push('<tr><th align="left">view</th><th>light</th><th>dark</th></tr>');
-            for (const [view, pair] of [...views.entries()].sort()) {
-              const light = pair.light
-                ? `<img src="${url(pair.light)}" width="360" alt="${esc(view)} light">`
-                : '—';
-              const dark = pair.dark
-                ? `<img src="${url(pair.dark)}" width="360" alt="${esc(view)} dark">`
-                : '—';
-              out.push(
-                `<tr><td valign="top"><sub>${esc(pretty(view))}</sub></td><td>${light}</td><td>${dark}</td></tr>`,
-              );
-            }
-            out.push('</table>');
-            out.push('');
-          }
-
-          if (gifs.length > 0) {
-            out.push('#### Flows');
-            out.push('');
-            for (const g of gifs) {
-              const key = g.replace(/\.gif$/i, '');
-              out.push(`**${esc(flowLabels[key] || pretty(key))}**`);
-              out.push('');
-              out.push(`<img src="${url(g)}" width="640" alt="${esc(key)} flow">`);
-              out.push('');
-            }
-          }
-
-          if (runUrl) {
-            out.push(
-              `<sub>Full-resolution recordings (.webm) are attached to the <a href="${esc(runUrl)}">workflow run</a>.</sub>`,
-            );
-          }
-          out.push('');
-          out.push('— _Qwen Code · web-shell visuals_');
-
-          fs.writeFileSync(process.env.BODY_FILE, out.join('\n') + '\n');
-          console.log(`Comment body: ${out.length} lines, ${shots.length} screenshots, ${gifs.length} gifs.`);
-          NODE
+          node .github/scripts/web-shell-visuals-publish.mjs comment \
+            "${STAGE}" \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/imgs" \
+            "${SHORT_SHA}" "${RUN_URL}" "${BODY_FILE}"
 
           # --- Post or update the PR comment --------------------------------
           # Re-validate immediately before the write (TOCTOU): a push/close during

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -77,6 +77,12 @@ jobs:
             exit 0
           fi
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
+          # Guard empty responses (network error / rate limit): jq on empty
+          # stdin would error and `set -e` would kill the job.
+          if [ -z "${pr_json}" ]; then
+            echo "::warning::Empty response fetching PR #${PR} (network / rate limit); skipping."
+            exit 0
+          fi
           pr_state="$(jq -r '.state // empty' <<< "${pr_json}")"
           pr_head="$(jq -r '.head.sha // empty' <<< "${pr_json}")"
           if [ "${pr_state}" != "open" ]; then

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -19,10 +19,11 @@ permissions:
   actions: 'read'
 
 # Serialize publishes for the SAME PR (identified by its source repo + branch),
-# since they push to that PR's own `pr-assets/web-shell-visuals-<n>` branch; the
-# push-retry loop below covers any residual same-branch race. Different PRs —
-# including forks that happen to share a branch name like `main` — get distinct
-# groups and publish in parallel. Never cancel an in-flight publish.
+# since they force-push to that PR's own `pr-assets/web-shell-visuals-<n>`
+# branch; serializing means the force-push never has to reconcile a concurrent
+# same-PR snapshot (a bounded retry below covers transient failures). Different
+# PRs — including forks that happen to share a branch name like `main` — get
+# distinct groups and publish in parallel. Never cancel an in-flight publish.
 concurrency:
   group: >-
     web-shell-visuals-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
@@ -155,7 +156,22 @@ jobs:
           git checkout -q --orphan snapshot
           git add imgs
           git commit -q -m "web-shell visuals: PR #${PR} (run ${RUN_ID})"
-          git push -q --force "${AUTH_URL}" "HEAD:${BRANCH}"
+          # Bounded retry for transient push failures (network / brief lock).
+          # Same-PR runs are serialized by concurrency, so this never needs to
+          # reconcile a concurrent snapshot — a plain retry suffices.
+          pushed=0
+          for attempt in 1 2 3; do
+            if git push -q --force "${AUTH_URL}" "HEAD:${BRANCH}"; then
+              pushed=1
+              break
+            fi
+            echo "::notice::force-push attempt ${attempt} failed; retrying."
+            sleep 2
+          done
+          if [ "${pushed}" -ne 1 ]; then
+            echo "::error::Failed to push web-shell visuals to ${BRANCH} after retries."
+            exit 1
+          fi
           ASSET_SHA="$(git rev-parse HEAD)"
           cd "${GITHUB_WORKSPACE}"
           echo "web-shell visuals hosted on ${BRANCH} at ${ASSET_SHA}."

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -18,10 +18,14 @@ on:
 permissions:
   actions: 'read'
 
-# All publishes push to the single `pr-assets` branch, so serialize them to
-# avoid racing on that push. Never cancel an in-flight publish.
+# Serialize publishes for the SAME PR (identified by its source repo + branch),
+# since they push to that PR's own `pr-assets/web-shell-visuals-<n>` branch; the
+# push-retry loop below covers any residual same-branch race. Different PRs —
+# including forks that happen to share a branch name like `main` — get distinct
+# groups and publish in parallel. Never cancel an in-flight publish.
 concurrency:
-  group: 'web-shell-visuals-publish-${{ github.event.workflow_run.head_branch }}'
+  group: >-
+    web-shell-visuals-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 defaults:
@@ -213,6 +217,15 @@ jobs:
           const files = fs.readdirSync(stage);
 
           const url = (name) => `${rawBase}/${encodeURIComponent(name)}`;
+          // Self-defending HTML escaping for interpolated values. Filenames are
+          // already sanitized to [A-Za-z0-9._-] upstream, but don't rely on that
+          // being an HTML defense — escape at the interpolation point too.
+          const esc = (s) =>
+            String(s)
+              .replace(/&/g, '&amp;')
+              .replace(/"/g, '&quot;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
           const pretty = (s) =>
             s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 
@@ -249,13 +262,13 @@ jobs:
             out.push('<tr><th align="left">view</th><th>light</th><th>dark</th></tr>');
             for (const [view, pair] of [...views.entries()].sort()) {
               const light = pair.light
-                ? `<img src="${url(pair.light)}" width="360" alt="${view} light">`
+                ? `<img src="${url(pair.light)}" width="360" alt="${esc(view)} light">`
                 : '—';
               const dark = pair.dark
-                ? `<img src="${url(pair.dark)}" width="360" alt="${view} dark">`
+                ? `<img src="${url(pair.dark)}" width="360" alt="${esc(view)} dark">`
                 : '—';
               out.push(
-                `<tr><td valign="top"><sub>${pretty(view)}</sub></td><td>${light}</td><td>${dark}</td></tr>`,
+                `<tr><td valign="top"><sub>${esc(pretty(view))}</sub></td><td>${light}</td><td>${dark}</td></tr>`,
               );
             }
             out.push('</table>');
@@ -267,9 +280,9 @@ jobs:
             out.push('');
             for (const g of gifs) {
               const key = g.replace(/\.gif$/i, '');
-              out.push(`**${flowLabels[key] || pretty(key)}**`);
+              out.push(`**${esc(flowLabels[key] || pretty(key))}**`);
               out.push('');
-              out.push(`<img src="${url(g)}" width="640" alt="${key} flow">`);
+              out.push(`<img src="${url(g)}" width="640" alt="${esc(key)} flow">`);
               out.push('');
             }
           }

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -113,13 +113,14 @@ jobs:
         env:
           OUT_DIR: '${{ runner.temp }}/web-shell-visuals'
           PR_NUMBER: '${{ github.event.pull_request.number }}'
-          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
         run: |-
           set -euo pipefail
           mkdir -p "${OUT_DIR}"
-          # Consumed by the workflow_run publish job (which validates them).
+          # PR number for the workflow_run publish job (which validates it).
+          # The head SHA is intentionally NOT shipped in the artifact: the
+          # publish job binds to the authenticated github.event.workflow_run
+          # .head_sha, and an artifact-sourced SHA would be untrusted.
           printf '%s\n' "${PR_NUMBER}" > "${OUT_DIR}/pr.txt"
-          printf '%s\n' "${HEAD_SHA}" > "${OUT_DIR}/head_sha.txt"
           echo "Screenshots: $(find "${OUT_DIR}/screenshots" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')"
           echo "GIFs: $(find "${OUT_DIR}/gifs" -name '*.gif' 2>/dev/null | wc -l | tr -d ' ')"
 
@@ -132,6 +133,5 @@ jobs:
             ${{ runner.temp }}/web-shell-visuals/gifs
             ${{ runner.temp }}/web-shell-visuals/video
             ${{ runner.temp }}/web-shell-visuals/pr.txt
-            ${{ runner.temp }}/web-shell-visuals/head_sha.txt
           if-no-files-found: 'warn'
           retention-days: 7

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 'Checkout PR head'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: '${{ github.event.pull_request.head.sha }}'
           fetch-depth: 1
@@ -98,13 +98,16 @@ jobs:
             gif="${OUT_DIR}/gifs/${name}.gif"
             # -ss 1 trims the ~1s blank while the page loads. Two-pass palette
             # (generate + apply) keeps the GIF sharp at a fraction of naive size.
-            if ffmpeg -y -ss 1 -i "${webm}" \
+            if err="$(ffmpeg -y -ss 1 -i "${webm}" \
               -vf "fps=12,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3" \
-              "${gif}" >/dev/null 2>&1; then
+              "${gif}" 2>&1)"; then
               echo "converted ${name}.webm -> gifs/${name}.gif ($(du -h "${gif}" | cut -f1))"
               converted=$((converted + 1))
             else
-              echo "::warning::ffmpeg failed to convert ${name}.webm; skipping its GIF."
+              # Surface ffmpeg's own diagnostic (codec/container/filter error)
+              # instead of a bare "failed", so a future breakage is actionable.
+              detail="$(printf '%s' "${err}" | tr '\n' ' ' | tail -c 400)"
+              echo "::warning::ffmpeg failed to convert ${name}.webm; skipping its GIF. ${detail}"
               rm -f "${gif}"
             fi
           done

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -22,6 +22,7 @@ on:
       - 'packages/web-shell/client/**'
       - 'packages/web-shell/package.json'
       - 'packages/web-shell/vite.config.ts'
+      - 'packages/web-shell/playwright.visuals.config.ts'
 
 permissions:
   contents: 'read'

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -23,6 +23,11 @@ on:
       - 'packages/web-shell/package.json'
       - 'packages/web-shell/vite.config.ts'
       - 'packages/web-shell/playwright.visuals.config.ts'
+      # The visuals dev server aliases these runtime sources (see the `resolve.
+      # alias` block in packages/web-shell/vite.config.ts), so UI-affecting
+      # changes there must also refresh the preview.
+      - 'packages/webui/src/**'
+      - 'packages/sdk-typescript/src/**'
 
 permissions:
   contents: 'read'
@@ -119,23 +124,40 @@ jobs:
           PR_NUMBER: '${{ github.event.pull_request.number }}'
         run: |-
           set -euo pipefail
-          mkdir -p "${OUT_DIR}"
+          # Ensure both dirs exist so the counts below are robust even when an
+          # upstream step produced none (e.g. no ffmpeg -> no gifs/). (The finds
+          # sit inside `echo "$(...)"`, so a missing dir wouldn't actually trip
+          # set -e — echo masks it — but create them for clarity all the same.)
+          mkdir -p "${OUT_DIR}/screenshots" "${OUT_DIR}/gifs"
           # PR number for the workflow_run publish job (which validates it).
           # The head SHA is intentionally NOT shipped in the artifact: the
           # publish job binds to the authenticated github.event.workflow_run
           # .head_sha, and an artifact-sourced SHA would be untrusted.
           printf '%s\n' "${PR_NUMBER}" > "${OUT_DIR}/pr.txt"
-          echo "Screenshots: $(find "${OUT_DIR}/screenshots" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')"
-          echo "GIFs: $(find "${OUT_DIR}/gifs" -name '*.gif' 2>/dev/null | wc -l | tr -d ' ')"
+          echo "Screenshots: $(find "${OUT_DIR}/screenshots" -name '*.png' | wc -l | tr -d ' ')"
+          echo "GIFs: $(find "${OUT_DIR}/gifs" -name '*.gif' | wc -l | tr -d ' ')"
 
-      - name: 'Upload web-shell visuals artifact'
+      # The privileged publish workflow downloads THIS artifact, so keep the raw
+      # videos out of it: an untrusted PR could drop a multi-GB file under
+      # video/ and exhaust the publisher's bandwidth/disk/timeout. Screenshots
+      # and GIFs (which the publisher hosts) are size-capped again on that side.
+      - name: 'Upload web-shell visuals artifact (published)'
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
         with:
           name: 'web-shell-visuals'
           path: |-
             ${{ runner.temp }}/web-shell-visuals/screenshots
             ${{ runner.temp }}/web-shell-visuals/gifs
-            ${{ runner.temp }}/web-shell-visuals/video
             ${{ runner.temp }}/web-shell-visuals/pr.txt
           if-no-files-found: 'warn'
+          retention-days: 7
+
+      # Raw recordings live in a SEPARATE artifact the publish workflow never
+      # downloads — they're only the "full-resolution recordings" link target.
+      - name: 'Upload raw flow recordings'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
+        with:
+          name: 'web-shell-visuals-video'
+          path: '${{ runner.temp }}/web-shell-visuals/video'
+          if-no-files-found: 'ignore'
           retention-days: 7

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -28,6 +28,8 @@ on:
       # changes there must also refresh the preview.
       - 'packages/webui/src/**'
       - 'packages/sdk-typescript/src/**'
+      # The capture pipeline itself, so a workflow-only change is exercised.
+      - '.github/workflows/web-shell-visuals.yml'
 
 permissions:
   contents: 'read'
@@ -129,6 +131,24 @@ jobs:
           # sit inside `echo "$(...)"`, so a missing dir wouldn't actually trip
           # set -e — echo masks it — but create them for clarity all the same.)
           mkdir -p "${OUT_DIR}/screenshots" "${OUT_DIR}/gifs"
+          # Bound artifact contents BEFORE upload: this job ran untrusted PR
+          # code, so drop oversized files and cap the count per directory —
+          # otherwise a hostile spec could bloat the published artifact (which
+          # the privileged publisher downloads) or the retained video artifact.
+          MAX_FILE_BYTES=$((6 * 1024 * 1024))
+          MAX_FILES=40
+          for d in screenshots gifs video; do
+            dir="${OUT_DIR}/${d}"
+            [ -d "${dir}" ] || continue
+            find "${dir}" -maxdepth 1 -type f -size "+${MAX_FILE_BYTES}c" \
+              -printf '::warning::dropping oversized artifact file %p\n' -delete || true
+            find "${dir}" -maxdepth 1 -type f -printf '%f\n' | LC_ALL=C sort \
+              | tail -n "+$((MAX_FILES + 1))" \
+              | while IFS= read -r extra; do
+                  echo "::warning::dropping excess artifact file ${d}/${extra}"
+                  rm -f "${dir}/${extra}"
+                done
+          done
           # PR number for the workflow_run publish job (which validates it).
           # The head SHA is intentionally NOT shipped in the artifact: the
           # publish job binds to the authenticated github.event.workflow_run

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -1,0 +1,137 @@
+name: 'Web-shell Visuals'
+
+# Auto-capture web-shell screenshots (light + dark) and short flow recordings
+# for PRs that touch the web-shell UI, then hand the images to the companion
+# `web-shell-visuals-publish.yml` (workflow_run) which posts them inline on the
+# PR.
+#
+# Security model: this workflow BUILDS AND RENDERS untrusted PR code, so it runs
+# on the `pull_request` trigger (fork PRs get a read-only token and NO secrets),
+# on an ephemeral hosted runner, with `contents: read` and no secrets of its
+# own. It produces only image/video bytes as an artifact. The privileged step
+# that needs a write token — pushing the images and commenting on the PR — lives
+# in the separate workflow_run workflow that never checks out PR code.
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release/**'
+    # Matches the /tmux flow's web-shell surface: only the client UI, so
+    # doc/config-only PRs don't trigger a full build + render.
+    paths:
+      - 'packages/web-shell/client/**'
+      - 'packages/web-shell/package.json'
+      - 'packages/web-shell/vite.config.ts'
+
+permissions:
+  contents: 'read'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  capture:
+    name: 'Capture web-shell visuals (ubuntu-latest, Node 22.x)'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 20
+    steps:
+      - name: 'Checkout PR head'
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: 'Set up Node.js 22.x'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Configure npm for rate limiting'
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      - name: 'Install dependencies'
+        run: 'npm ci --prefer-offline --no-audit --progress=false'
+
+      - name: 'Install Playwright Chromium'
+        run: 'npx playwright install --with-deps chromium'
+
+      - name: 'Choose web-shell Playwright port'
+        run: |-
+          port="$(node -e "const net=require('node:net');const server=net.createServer();server.listen(0,'127.0.0.1',()=>{console.log(server.address().port);server.close();});")"
+          echo "PLAYWRIGHT_PORT=${port}" >> "${GITHUB_ENV}"
+          echo "Using web-shell Playwright port ${port}"
+
+      - name: 'Capture screenshots and flow recordings'
+        env:
+          WEB_SHELL_VISUALS_OUTPUT_DIR: '${{ runner.temp }}/web-shell-visuals'
+        run: 'npm run test:e2e:visuals --workspace=packages/web-shell'
+
+      - name: 'Convert flow recordings to inline GIFs'
+        env:
+          OUT_DIR: '${{ runner.temp }}/web-shell-visuals'
+        run: |-
+          set -euo pipefail
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            echo "::warning::ffmpeg not found on the runner; skipping GIF conversion (raw .webm is still uploaded)."
+            exit 0
+          fi
+          mkdir -p "${OUT_DIR}/gifs"
+          shopt -s nullglob
+          converted=0
+          for webm in "${OUT_DIR}"/video/*.webm; do
+            name="$(basename "${webm%.webm}")"
+            gif="${OUT_DIR}/gifs/${name}.gif"
+            # -ss 1 trims the ~1s blank while the page loads. Two-pass palette
+            # (generate + apply) keeps the GIF sharp at a fraction of naive size.
+            if ffmpeg -y -ss 1 -i "${webm}" \
+              -vf "fps=12,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3" \
+              "${gif}" >/dev/null 2>&1; then
+              echo "converted ${name}.webm -> gifs/${name}.gif ($(du -h "${gif}" | cut -f1))"
+              converted=$((converted + 1))
+            else
+              echo "::warning::ffmpeg failed to convert ${name}.webm; skipping its GIF."
+              rm -f "${gif}"
+            fi
+          done
+          echo "GIFs produced: ${converted}"
+
+      - name: 'Record PR metadata for the publish workflow'
+        env:
+          OUT_DIR: '${{ runner.temp }}/web-shell-visuals'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          set -euo pipefail
+          mkdir -p "${OUT_DIR}"
+          # Consumed by the workflow_run publish job (which validates them).
+          printf '%s\n' "${PR_NUMBER}" > "${OUT_DIR}/pr.txt"
+          printf '%s\n' "${HEAD_SHA}" > "${OUT_DIR}/head_sha.txt"
+          echo "Screenshots: $(find "${OUT_DIR}/screenshots" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')"
+          echo "GIFs: $(find "${OUT_DIR}/gifs" -name '*.gif' 2>/dev/null | wc -l | tr -d ' ')"
+
+      - name: 'Upload web-shell visuals artifact'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
+        with:
+          name: 'web-shell-visuals'
+          path: |-
+            ${{ runner.temp }}/web-shell-visuals/screenshots
+            ${{ runner.temp }}/web-shell-visuals/gifs
+            ${{ runner.temp }}/web-shell-visuals/video
+            ${{ runner.temp }}/web-shell-visuals/pr.txt
+            ${{ runner.temp }}/web-shell-visuals/head_sha.txt
+          if-no-files-found: 'warn'
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ junit.xml
 packages/*/coverage/
 packages/web-shell/client/e2e/playwright-report/
 packages/web-shell/client/e2e/test-results/
+packages/web-shell/client/e2e/visuals/output/
+packages/web-shell/client/e2e/visuals/.playwright/
 
 # PR body draft
 pr_body.md

--- a/packages/web-shell/client/e2e/visuals/constants.ts
+++ b/packages/web-shell/client/e2e/visuals/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fixed capture viewport — the single source of truth shared by
+ * playwright.visuals.config.ts and the visuals harness/specs, so the value
+ * cannot drift between the config and what actually renders.
+ */
+export const VISUAL_VIEWPORT = { width: 1280, height: 800 } as const;

--- a/packages/web-shell/client/e2e/visuals/flows.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/flows.spec.ts
@@ -83,3 +83,17 @@ test('flow: submit a prompt and watch the reply stream in', async ({
     await beat(page, 900);
   });
 });
+
+// Guards the error-handling path in recordFlow: a throwing `drive` must
+// surface its own error (not a masked video-save / context-close error), even
+// though the video is saved best-effort.
+test('flow: a drive error propagates instead of being masked', async ({
+  browser,
+}, testInfo) => {
+  const url = resolveBaseURL(testInfo);
+  await expect(
+    recordFlow(browser, url, 'drive-error', async () => {
+      throw new Error('drive-boom');
+    }),
+  ).rejects.toThrow('drive-boom');
+});

--- a/packages/web-shell/client/e2e/visuals/flows.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/flows.spec.ts
@@ -49,6 +49,9 @@ test('flow: open the slash menu and switch model', async ({
       .locator('[data-web-shell-model-option][data-model-id="qwen-test-alt"]')
       .click();
     await expect(page.locator('[data-web-shell-model-dialog]')).toHaveCount(0);
+    // Confirm the switch actually reached the daemon (not just the dialog UI
+    // closing), so the "switch model" GIF reflects a real model change.
+    await expect.poll(() => daemon.modelRequests().length).toBe(1);
     await beat(page, 900);
   });
 });

--- a/packages/web-shell/client/e2e/visuals/flows.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/flows.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, test } from '@playwright/test';
+import {
+  assistantTextEvent,
+  createWebShellDaemonScenario,
+  turnCompleteEvent,
+} from '../utils/mockDaemon';
+import {
+  beat,
+  fillComposer,
+  gotoSession,
+  installScenario,
+  recordFlow,
+  resolveBaseURL,
+} from './harness';
+
+// Flows are recorded as video (later converted to an inline GIF). Each flow
+// runs in its own browser context (recordFlow) rather than the shared page
+// fixture. Dark theme only — the animation, not the palette, is the point.
+// (No serial mode: a flake in one flow must not skip/lose the other's recording.)
+
+test('flow: open the slash menu and switch model', async ({
+  browser,
+}, testInfo) => {
+  const url = resolveBaseURL(testInfo);
+  await recordFlow(browser, url, 'model-switch', async (page) => {
+    const scenario = createWebShellDaemonScenario();
+    const daemon = await installScenario(page, scenario, url);
+    await gotoSession(page, scenario, daemon, 'dark');
+    await beat(page);
+
+    const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+    await editor.click();
+    await page.keyboard.type('/');
+    await expect(page.locator('[data-web-shell-slash-menu]')).toBeVisible();
+    await beat(page);
+    await page.keyboard.type('model');
+    await beat(page);
+    await page.locator('[data-web-shell-composer-submit]').click();
+
+    await expect(page.locator('[data-web-shell-model-dialog]')).toBeVisible();
+    await beat(page);
+    await page
+      .locator('[data-web-shell-model-option][data-model-id="qwen-test-alt"]')
+      .click();
+    await expect(page.locator('[data-web-shell-model-dialog]')).toHaveCount(0);
+    await beat(page, 900);
+  });
+});
+
+test('flow: submit a prompt and watch the reply stream in', async ({
+  browser,
+}, testInfo) => {
+  const url = resolveBaseURL(testInfo);
+  await recordFlow(browser, url, 'prompt-stream', async (page) => {
+    const scenario = createWebShellDaemonScenario();
+    const daemon = await installScenario(page, scenario, url);
+    await gotoSession(page, scenario, daemon, 'dark');
+    await beat(page);
+
+    await fillComposer(page, 'Summarize the web-shell architecture.');
+    await beat(page);
+    await page.locator('[data-web-shell-composer-submit]').click();
+
+    await expect.poll(() => daemon.promptRequests().length).toBe(1);
+    await daemon.sse.split(
+      assistantTextEvent('Streaming a reply from the mock daemon', { id: 10 }),
+    );
+    await beat(page);
+    // The mock returns promptId 'prompt-e2e' for a prompt with no
+    // _meta.promptId, so complete the live turn with that id (clears the
+    // streaming spinner before the recording ends).
+    await daemon.sendEvent(turnCompleteEvent('prompt-e2e', { id: 11 }));
+
+    await expect(page.locator('[data-web-shell-message-list]')).toContainText(
+      'Streaming a reply',
+    );
+    await beat(page, 900);
+  });
+});

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -179,9 +179,15 @@ export async function recordFlow(
   } finally {
     try {
       await context.close();
-    } catch {
-      // Best-effort close (the browser may have crashed mid-drive); preserve
-      // the drive failure for the re-throw below instead of masking it here.
+    } catch (closeError) {
+      // If the drive already failed, keep that original error (the close error
+      // is secondary). But if the drive SUCCEEDED, a close failure is a real
+      // problem (it can also leave the video unfinalized) — promote it so the
+      // flow fails instead of masking it.
+      if (!driveFailed) {
+        driveFailed = true;
+        driveError = closeError;
+      }
     }
   }
 
@@ -190,21 +196,20 @@ export async function recordFlow(
     // The flow errored — discard the partial recording rather than publishing a
     // meaningless "failed flow" video into the artifact.
     await video?.delete().catch(() => {});
-  } else if (video) {
-    try {
-      await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
-      await video.delete(); // drop the hash-named raw copy; keep only the named one
-    } catch (videoError) {
-      // Drive succeeded but the video failed to finalize — surface it so a
-      // missing recording isn't swallowed silently.
-      console.warn(`video.saveAs failed for flow "${name}":`, videoError);
-    }
-  } else {
-    console.warn(
-      `No video recorded for flow "${name}" — recording may not have started.`,
+    throw driveError;
+  }
+
+  // Drive succeeded, so the recording IS the deliverable: let a save failure or
+  // a missing recording FAIL the flow (a silent pass with no .webm makes the
+  // downstream GIF-conversion step fail confusingly). Deleting the raw copy is
+  // best-effort.
+  if (!video) {
+    throw new Error(
+      `No video recorded for flow "${name}" — recording did not start.`,
     );
   }
-  if (driveFailed) throw driveError;
+  await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
+  await video.delete().catch(() => {});
 }
 
 /** A short, human-readable pause so a recorded flow is legible as a GIF. */

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -176,8 +176,13 @@ export async function recordFlow(
   }
   const video = page?.video();
   if (video) {
-    await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
-    await video.delete(); // drop the hash-named raw copy; keep only the named one
+    try {
+      await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
+      await video.delete(); // drop the hash-named raw copy; keep only the named one
+    } catch {
+      // Best-effort video capture; if `drive` failed the video may never have
+      // finalized — don't let that I/O error mask the real drive failure below.
+    }
   }
   if (driveError) throw driveError;
 }

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -172,7 +172,12 @@ export async function recordFlow(
   } catch (error) {
     driveError = error;
   } finally {
-    await context.close();
+    try {
+      await context.close();
+    } catch {
+      // Best-effort close (the browser may have crashed mid-drive); preserve
+      // driveError for the re-throw below instead of masking it here.
+    }
   }
   const video = page?.video();
   if (video) {

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  expect,
+  type Browser,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from '@playwright/test';
+import {
+  installMockDaemon,
+  replayCompleteEvent,
+  type MockDaemonController,
+  type WebShellDaemonScenario,
+} from '../utils/mockDaemon';
+
+export type VisualTheme = 'dark' | 'light';
+
+/** Fixed viewport so captures have a stable layout/size run to run. */
+export const VISUAL_VIEWPORT = { width: 1280, height: 800 } as const;
+
+/** localStorage key the web-shell reads for its persisted theme (see index.html). */
+const THEME_STORAGE_KEY = 'qwen-code-web-shell-theme';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Root the capture pipeline collects. The CI job points
+ * WEB_SHELL_VISUALS_OUTPUT_DIR at a temp dir; locally it defaults next to the
+ * spec so `npm run test:e2e:visuals` drops artifacts under the package.
+ */
+export const VISUALS_OUTPUT_DIR = process.env['WEB_SHELL_VISUALS_OUTPUT_DIR']
+  ? resolve(process.env['WEB_SHELL_VISUALS_OUTPUT_DIR'])
+  : join(HERE, 'output');
+
+export const SCREENSHOTS_DIR = join(VISUALS_OUTPUT_DIR, 'screenshots');
+export const VIDEO_DIR = join(VISUALS_OUTPUT_DIR, 'video');
+/** Playwright writes raw per-context videos here before we save them by name. */
+const VIDEO_RAW_DIR = join(VISUALS_OUTPUT_DIR, 'video-raw');
+
+/**
+ * Force a theme deterministically: seed localStorage before any app code runs,
+ * then navigate with `?theme=`. `getInitialTheme()` consumes the query param on
+ * load (main.tsx strips it afterwards), and the localStorage seed is the
+ * belt-and-suspenders fallback if the app ever re-reads.
+ */
+async function primeTheme(page: Page, theme: VisualTheme): Promise<void> {
+  await page.addInitScript(
+    ([key, value]) => {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch {
+        // Private-mode / storage-disabled: the ?theme= param still applies.
+      }
+    },
+    [THEME_STORAGE_KEY, theme] as const,
+  );
+}
+
+export function resolveBaseURL(testInfo: TestInfo): string {
+  const value = testInfo.project.use.baseURL;
+  if (!value)
+    throw new Error('Expected a Playwright baseURL to be configured.');
+  return value;
+}
+
+export async function installScenario(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  baseURL: string,
+): Promise<MockDaemonController> {
+  return installMockDaemon(page, scenario, { baseURL });
+}
+
+/**
+ * Navigate to a session in the requested theme and wait for the replayed
+ * transcript to settle. Asserts the theme actually took effect so a
+ * mislabelled light/dark capture fails loudly instead of shipping silently.
+ */
+export async function gotoSession(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  daemon: MockDaemonController,
+  theme: VisualTheme,
+): Promise<void> {
+  await primeTheme(page, theme);
+  await page.goto(
+    `/session/${encodeURIComponent(scenario.sessionId)}?theme=${theme}`,
+  );
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  await expect(page.locator('html')).toHaveClass(new RegExp(`theme-${theme}`));
+  await completeReplay(
+    page,
+    daemon,
+    scenario.sessionId,
+    scenario.events.length,
+  );
+}
+
+export async function completeReplay(
+  page: Page,
+  daemon: MockDaemonController,
+  sessionId?: string,
+  replayedCount = 0,
+): Promise<void> {
+  const connection = await daemon.sse.waitForConnection(sessionId);
+  await daemon.sendEvent(
+    replayCompleteEvent({ sessionId: connection.sessionId, replayedCount }),
+  );
+  await expect(page.getByText('Loading...')).toHaveCount(0);
+}
+
+export async function fillComposer(page: Page, text: string): Promise<void> {
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await editor.click();
+  await page.keyboard.press(
+    process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+  );
+  await page.keyboard.type(text);
+}
+
+export async function submitLocalCommand(
+  page: Page,
+  text: string,
+): Promise<void> {
+  await fillComposer(page, text);
+  await page.locator('[data-web-shell-composer-submit]').click();
+}
+
+/** Capture the current viewport to `<output>/screenshots/<name>.png`. */
+export async function captureScreenshot(
+  page: Page,
+  name: string,
+): Promise<void> {
+  mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+  await page.screenshot({
+    path: join(SCREENSHOTS_DIR, `${name}.png`),
+    animations: 'disabled',
+  });
+}
+
+/**
+ * Record a continuous flow to `<output>/video/<name>.webm`. A dedicated
+ * browser context owns the video lifecycle so the file can be saved under a
+ * stable name (the CI job converts it to an inline GIF).
+ */
+export async function recordFlow(
+  browser: Browser,
+  baseURL: string,
+  name: string,
+  drive: (page: Page) => Promise<void>,
+): Promise<void> {
+  mkdirSync(VIDEO_DIR, { recursive: true });
+  mkdirSync(VIDEO_RAW_DIR, { recursive: true });
+  const context: BrowserContext = await browser.newContext({
+    baseURL,
+    viewport: { ...VISUAL_VIEWPORT },
+    recordVideo: { dir: VIDEO_RAW_DIR, size: { ...VISUAL_VIEWPORT } },
+  });
+  let page: Page | undefined;
+  let driveError: unknown;
+  try {
+    page = await context.newPage();
+    await drive(page);
+  } catch (error) {
+    driveError = error;
+  } finally {
+    await context.close();
+  }
+  const video = page?.video();
+  if (video) {
+    await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
+    await video.delete(); // drop the hash-named raw copy; keep only the named one
+  }
+  if (driveError) throw driveError;
+}
+
+/** A short, human-readable pause so a recorded flow is legible as a GIF. */
+export async function beat(page: Page, ms = 650): Promise<void> {
+  await page.waitForTimeout(ms);
+}

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -165,39 +165,46 @@ export async function recordFlow(
     recordVideo: { dir: VIDEO_RAW_DIR, size: { ...VISUAL_VIEWPORT } },
   });
   let page: Page | undefined;
+  // Track failure with an explicit boolean, not the truthiness of the caught
+  // value: `throw undefined` / `throw null` / `Promise.reject()` must still mark
+  // the flow failed (otherwise an aborted flow would look passed).
+  let driveFailed = false;
   let driveError: unknown;
   try {
     page = await context.newPage();
     await drive(page);
   } catch (error) {
+    driveFailed = true;
     driveError = error;
   } finally {
     try {
       await context.close();
     } catch {
       // Best-effort close (the browser may have crashed mid-drive); preserve
-      // driveError for the re-throw below instead of masking it here.
+      // the drive failure for the re-throw below instead of masking it here.
     }
   }
+
   const video = page?.video();
-  if (video) {
+  if (driveFailed) {
+    // The flow errored — discard the partial recording rather than publishing a
+    // meaningless "failed flow" video into the artifact.
+    await video?.delete().catch(() => {});
+  } else if (video) {
     try {
       await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
       await video.delete(); // drop the hash-named raw copy; keep only the named one
     } catch (videoError) {
-      // If drive() failed, the video may never have finalized — keep the real
-      // driveError (rethrown below) rather than masking it. If drive() SUCCEEDED,
-      // surface the video failure so a missing recording isn't swallowed silently.
-      if (!driveError) {
-        console.warn(`video.saveAs failed for flow "${name}":`, videoError);
-      }
+      // Drive succeeded but the video failed to finalize — surface it so a
+      // missing recording isn't swallowed silently.
+      console.warn(`video.saveAs failed for flow "${name}":`, videoError);
     }
-  } else if (!driveError) {
+  } else {
     console.warn(
       `No video recorded for flow "${name}" — recording may not have started.`,
     );
   }
-  if (driveError) throw driveError;
+  if (driveFailed) throw driveError;
 }
 
 /** A short, human-readable pause so a recorded flow is legible as a GIF. */

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -184,10 +184,18 @@ export async function recordFlow(
     try {
       await video.saveAs(join(VIDEO_DIR, `${name}.webm`));
       await video.delete(); // drop the hash-named raw copy; keep only the named one
-    } catch {
-      // Best-effort video capture; if `drive` failed the video may never have
-      // finalized — don't let that I/O error mask the real drive failure below.
+    } catch (videoError) {
+      // If drive() failed, the video may never have finalized — keep the real
+      // driveError (rethrown below) rather than masking it. If drive() SUCCEEDED,
+      // surface the video failure so a missing recording isn't swallowed silently.
+      if (!driveError) {
+        console.warn(`video.saveAs failed for flow "${name}":`, videoError);
+      }
     }
+  } else if (!driveError) {
+    console.warn(
+      `No video recorded for flow "${name}" — recording may not have started.`,
+    );
   }
   if (driveError) throw driveError;
 }

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -20,11 +20,11 @@ import {
   type MockDaemonController,
   type WebShellDaemonScenario,
 } from '../utils/mockDaemon';
+import { VISUAL_VIEWPORT } from './constants';
 
 export type VisualTheme = 'dark' | 'light';
 
-/** Fixed viewport so captures have a stable layout/size run to run. */
-export const VISUAL_VIEWPORT = { width: 1280, height: 800 } as const;
+export { VISUAL_VIEWPORT };
 
 /** localStorage key the web-shell reads for its persisted theme (see index.html). */
 const THEME_STORAGE_KEY = 'qwen-code-web-shell-theme';

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, test } from '@playwright/test';
+import {
+  assistantTextEvent,
+  createWebShellDaemonScenario,
+  permissionRequestEvent,
+  turnCompleteEvent,
+  userTextEvent,
+} from '../utils/mockDaemon';
+import {
+  captureScreenshot,
+  fillComposer,
+  gotoSession,
+  installScenario,
+  resolveBaseURL,
+  submitLocalCommand,
+  VISUAL_VIEWPORT,
+  type VisualTheme,
+} from './harness';
+
+const THEMES: readonly VisualTheme[] = ['dark', 'light'];
+
+test.use({ viewport: { ...VISUAL_VIEWPORT } });
+
+for (const theme of THEMES) {
+  test.describe(`web-shell screenshots (${theme})`, () => {
+    test(`session transcript`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario({
+        events: [
+          userTextEvent('Render the web-shell so I can review the layout.', {
+            id: 1,
+          }),
+          assistantTextEvent(
+            'Here is a **streamed** reply with a code block:\n\n```ts\nexport const greeting = "hello from web-shell";\n```',
+            { id: 2 },
+          ),
+          turnCompleteEvent('prompt-visual', { id: 3 }),
+        ],
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      await expect(page.locator('[data-web-shell-message-list]')).toContainText(
+        'Here is a',
+      );
+      // Shiki swaps in `<pre class="shiki">` asynchronously; wait for it so the
+      // code block is captured highlighted (not the plain fallback) every run.
+      await expect(
+        page.locator('[data-web-shell-message-list] pre.shiki').first(),
+      ).toBeVisible();
+      await captureScreenshot(page, `session-transcript-${theme}`);
+    });
+
+    test(`slash menu`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario();
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      await fillComposer(page, '/');
+      await expect(page.locator('[data-web-shell-slash-menu]')).toBeVisible();
+      await captureScreenshot(page, `slash-menu-${theme}`);
+    });
+
+    test(`model dialog`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario();
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      await submitLocalCommand(page, '/model');
+      await expect(page.locator('[data-web-shell-model-dialog]')).toBeVisible();
+      await captureScreenshot(page, `model-dialog-${theme}`);
+    });
+
+    test(`theme dialog`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario();
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      await submitLocalCommand(page, '/theme');
+      await expect(page.locator('[data-web-shell-theme-dialog]')).toBeVisible();
+      await captureScreenshot(page, `theme-dialog-${theme}`);
+    });
+
+    test(`permission panel`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario({
+        events: [permissionRequestEvent('perm-visual', { id: 1 })],
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      await expect(
+        page.locator('[data-web-shell-permission-panel]'),
+      ).toBeVisible();
+      await captureScreenshot(page, `permission-panel-${theme}`);
+    });
+  });
+}

--- a/packages/web-shell/package.json
+++ b/packages/web-shell/package.json
@@ -28,6 +28,7 @@
     "test:coverage": "vitest run --config vitest.config.ts --coverage",
     "test:e2e:smoke": "playwright test --config playwright.config.ts --grep @smoke",
     "test:e2e": "playwright test --config playwright.config.ts",
+    "test:e2e:visuals": "playwright test --config playwright.visuals.config.ts",
     "test:e2e:report": "playwright show-report client/e2e/playwright-report",
     "verify": "npm run lint && npm run format:check && npm run typecheck && npm run test:ci"
   },

--- a/packages/web-shell/playwright.config.ts
+++ b/packages/web-shell/playwright.config.ts
@@ -6,6 +6,9 @@ const baseURL =
 
 export default defineConfig({
   testDir: './client/e2e',
+  // The visuals suite (screenshot/video capture) runs under its own
+  // playwright.visuals.config.ts; keep it out of the smoke/e2e runs.
+  testIgnore: '**/visuals/**',
   outputDir: './client/e2e/test-results',
   timeout: 60_000,
   expect: {

--- a/packages/web-shell/playwright.visuals.config.ts
+++ b/packages/web-shell/playwright.visuals.config.ts
@@ -5,6 +5,7 @@
  */
 
 import { defineConfig, devices } from '@playwright/test';
+import { VISUAL_VIEWPORT } from './client/e2e/visuals/constants';
 
 // Separate port default from playwright.config.ts (5174) so a stray base-config
 // dev server does not collide when both are run locally back to back.
@@ -12,9 +13,8 @@ const port = Number(process.env['PLAYWRIGHT_PORT'] ?? 5175);
 const baseURL =
   process.env['PLAYWRIGHT_BASE_URL'] ?? `http://127.0.0.1:${port}`;
 
-// Fixed viewport so captures are stable across runs. Must match VISUAL_VIEWPORT
-// in client/e2e/visuals/harness.ts.
-const viewport = { width: 1280, height: 800 };
+// Single source of truth for the capture viewport (shared with the harness).
+const viewport = { ...VISUAL_VIEWPORT };
 
 export default defineConfig({
   testDir: './client/e2e/visuals',

--- a/packages/web-shell/playwright.visuals.config.ts
+++ b/packages/web-shell/playwright.visuals.config.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+// Separate port default from playwright.config.ts (5174) so a stray base-config
+// dev server does not collide when both are run locally back to back.
+const port = Number(process.env['PLAYWRIGHT_PORT'] ?? 5175);
+const baseURL =
+  process.env['PLAYWRIGHT_BASE_URL'] ?? `http://127.0.0.1:${port}`;
+
+// Fixed viewport so captures are stable across runs. Must match VISUAL_VIEWPORT
+// in client/e2e/visuals/harness.ts.
+const viewport = { width: 1280, height: 800 };
+
+export default defineConfig({
+  testDir: './client/e2e/visuals',
+  outputDir: './client/e2e/visuals/.playwright',
+  // Retry in CI so one transient flake doesn't sink the whole preview (the job
+  // is all-or-nothing). Output filenames are deterministic, so a retry just
+  // overwrites the same PNG/webm. No auto-screenshots/traces we don't collect.
+  retries: process.env['CI'] ? 2 : 0,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  forbidOnly: !!process.env['CI'],
+  reporter: [['line']],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120_000,
+  },
+  use: {
+    baseURL,
+    viewport,
+    trace: 'off',
+    // Screenshots are captured explicitly; flows record video via their own
+    // browser context (client/e2e/visuals/harness.ts) for stable filenames.
+    screenshot: 'off',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport },
+    },
+  ],
+});


### PR DESCRIPTION
## What

PRs that touch the web-shell UI now get an auto-updated comment with **light/dark screenshots** of key views and short **GIF recordings** of common flows, so reviewers can see the rendered UI without checking out the branch. Everything renders against the existing **mock daemon** — no real backend, no model, no secrets.

Captured today:
- **Screenshots** (light + dark): session transcript, slash menu, model dialog, theme dialog, permission panel
- **Flows** (GIF): open slash menu → switch model; submit a prompt → watch the reply stream in
- Full-resolution `.webm` recordings are attached to the workflow run

## How it's wired (security)

Capture runs **untrusted PR code**, so it's split into two workflows and the write token is never in the same job as PR code:

| Workflow | Trigger | Permissions | Role |
|---|---|---|---|
| `web-shell-visuals.yml` | `pull_request` (web-shell client paths) | `contents: read`, **no secrets** | checkout PR head → build → Playwright capture (PNG + webm) → ffmpeg webm→GIF → upload artifact |
| `web-shell-visuals-publish.yml` | `workflow_run` (base context) | `actions: read` + `CI_BOT_PAT` | download artifact → **bind to PR by head SHA** → host images on a per-PR `pr-assets/web-shell-visuals-<n>` branch (immutable commit SHA) → post/update one inline comment. **Never checks out PR code.** |

Fork PRs run capture with a read-only token and no secrets (standard `pull_request` isolation). The privileged publish step only ever handles opaque image bytes plus a PR number it validates and **binds to the run's authenticated head SHA** (so a forged PR number can't redirect the comment).

## Capture infra

Self-contained in `packages/web-shell`, reusing the existing mock-daemon e2e harness:
- `playwright.visuals.config.ts` — dedicated config, isolated from the smoke suite
- `client/e2e/visuals/{harness,screenshots.spec,flows.spec}.ts`
- Run locally: `npm run test:e2e:visuals --workspace=packages/web-shell`

## Verification

- Visuals suite locally (CI mode): **13/13 pass**, 10 PNGs (1280×800, light+dark) + 2 webm; spot-checked the output (light/dark correct, dialogs render, code block highlighted, flow ends with the reply settled).
- webm→GIF (the exact CI command) verified with ffmpeg: valid animated GIF89a.
- Workflows: YAML valid, all `run:` scripts pass `bash -n`; ESLint + Prettier clean on new TS. actionlint/shellcheck run in CI.
- The GitHub-side orchestration (`workflow_run` handoff, `pr-assets` push, comment) first exercises on a real PR once this is on the default branch.

> `workflow_run` publish must be on the default branch to fire, so previews activate for **subsequent** web-shell PRs after this merges.

<details>
<summary>中文说明</summary>

## 做了什么

改动 web-shell UI 的 PR 会自动收到一条(自动更新的)评论,内含关键视图的 **light/dark 截图**和常见操作的 **GIF 录屏**,评审无需 checkout 分支即可看到渲染效果。全部基于现成的 **mock daemon** 渲染——无需真后端、真模型、真密钥。

当前覆盖:
- **截图**(亮/暗双主题):会话记录、slash 菜单、model 弹窗、theme 弹窗、权限面板
- **流程 GIF**:打开 slash 菜单→切换模型;提交 prompt→回复流式渲染
- 原始 `.webm` 高清录像挂在 workflow run 的 artifact 里

## 安全架构

截图 job 会**执行不可信 PR 代码**,因此拆成两个 workflow,写 token 绝不与跑 PR 代码同 job:

- `web-shell-visuals.yml`(`pull_request` 触发,web-shell client 路径):`contents: read`、**无密钥**;checkout PR head → 构建 → Playwright 截图/录像 → ffmpeg 转 GIF → 上传 artifact。fork PR 以只读 token、无密钥运行。
- `web-shell-visuals-publish.yml`(`workflow_run`,base 上下文):`actions: read` + `CI_BOT_PAT`;下载 artifact → **用 run 的已认证 head SHA 绑定到真实 PR**(伪造 PR 号无法把评论导向他人)→ 把图片托管到每 PR 独立的 `pr-assets/web-shell-visuals-<n>` 分支(按 commit SHA 引用,URL 不失效)→ 发/更新一条内联评论。**从不 checkout PR 代码。**

## 本地验证

- 视觉套件本地(CI 模式)**13/13 通过**,产出 10 张 PNG + 2 个 webm;肉眼确认亮/暗正确、弹窗渲染、代码高亮、流程结束时回复已落定。
- webm→GIF(即 CI 用的命令)用 ffmpeg 验证:有效动图 GIF89a。
- 两个 workflow:YAML 合法、`run:` 脚本 `bash -n` 通过;新增 TS 的 ESLint/Prettier 干净。actionlint/shellcheck 由 CI 跑。
- GitHub 侧编排(`workflow_run` 交接、`pr-assets` 推送、发评论)会在合入默认分支后,于后续 web-shell PR 上首次实跑。

</details>

