### PR TITLE
fix(cli): keep exit_plan_mode plan visible inside the pending viewport clamp (#6867)

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -360,6 +360,13 @@ export const ToolConfirmationMessage: React.FC<
           isPending={false}
           availableTerminalHeight={planHeight}
           contentWidth={contentWidth}
+          // Live pending items render inside MainContent's maxHeight +
+          // overflow="hidden" wrapper, and Ink clips the BOTTOM. Without a
+          // height-aware pre-slice, a long plan silently loses its tail
+          // (including the option buttons below). Opt into the same pre-slice
+          // the streaming path uses so the body respects the viewport budget.
+          // See #6867.
+          enforceHeightBudget
         />
       </Box>
     );

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -151,6 +151,56 @@ describe('<MarkdownDisplay />', () => {
       expect(lastFrame() ?? '').toContain('line 60');
     });
 
+    it('clips a non-pending message when enforceHeightBudget is set (#6867)', () => {
+      // Regression for #6867: the `exit_plan_mode` confirmation dialog renders
+      // a non-pending plan body inside MainContent's `maxHeight` +
+      // `overflow="hidden"` wrapper. Ink clips the BOTTOM (newest content) so
+      // without a height-aware pre-slice, a long plan silently loses its tail
+      // (including the option buttons rendered after it). `enforceHeightBudget`
+      // lets bounded-container callers opt into the same slice the streaming
+      // path uses.
+      const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+        eol,
+      );
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={false}
+          availableTerminalHeight={10}
+          enforceHeightBudget
+        />,
+      );
+      const output = lastFrame() ?? '';
+      const lineCount = output.split('\n').length;
+      // Budget = availableTerminalHeight - 2 headroom = 8; slice must respect
+      // it. Without the fix this would render all 60 lines.
+      expect(lineCount).toBeLessThanOrEqual(10);
+      // Head of the plan is preserved.
+      expect(output).toContain('line 1');
+      // Tail is dropped.
+      expect(output).not.toContain('line 60');
+    });
+
+    it('leaves a non-pending message full when enforceHeightBudget is false', () => {
+      // Committed non-pending renders (transcript, tool result markdown) must
+      // stay uncapped. Guards against enforceHeightBudget defaulting to true
+      // or the isPending gate being accidentally dropped.
+      const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+        eol,
+      );
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={false}
+          availableTerminalHeight={10}
+          enforceHeightBudget={false}
+        />,
+      );
+      expect(lastFrame() ?? '').toContain('line 60');
+    });
+
     it('handles a code fence spanning the clip boundary', () => {
       // The head-slice can cut between an opening fence and its close; the
       // parser's EOF inCodeBlock flush then renders the (unclosed) block. The

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -173,13 +173,76 @@ describe('<MarkdownDisplay />', () => {
       );
       const output = lastFrame() ?? '';
       const lineCount = output.split('\n').length;
-      // Budget = availableTerminalHeight - 2 headroom = 8; slice must respect
-      // it. Without the fix this would render all 60 lines.
+      // Budget = availableTerminalHeight - 2 headroom = 8; the slice keeps
+      // roughly that many content lines and a single truncation-cue row is
+      // appended, so the total stays within the terminal's row budget. Without
+      // the fix this would render all 60 lines.
       expect(lineCount).toBeLessThanOrEqual(10);
       // Head of the plan is preserved.
       expect(output).toContain('line 1');
       // Tail is dropped.
       expect(output).not.toContain('line 60');
+    });
+
+    it('shows a truncation cue when a non-streaming plan is clipped (#6867)', () => {
+      // Without a visible cue, a model-authored plan could hide dangerous
+      // steps past the viewport budget and users would approve them blind.
+      // For a COMPLETE plan (enforceHeightBudget + !isPending), the cue must
+      // appear so approvers know content is missing.
+      const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+        eol,
+      );
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={false}
+          availableTerminalHeight={10}
+          enforceHeightBudget
+        />,
+      );
+      const output = lastFrame() ?? '';
+      // Cue names the count of dropped source lines and the reason.
+      expect(output).toMatch(/\d+ more lines? not shown/);
+      expect(output).toContain('viewport too small');
+    });
+
+    it('does not show a truncation cue when streaming (isPending=true)', () => {
+      // While streaming, the tail IS still on its way (incremental commit
+      // pushes it into <Static> in real time). Emitting "N more lines not
+      // shown" during streaming would be misleading — content is not missing,
+      // just not here yet. Guards against the cue leaking into the streaming
+      // path.
+      const text = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join(
+        eol,
+      );
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={true}
+          availableTerminalHeight={10}
+        />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).not.toMatch(/more lines? not shown/);
+    });
+
+    it('does not show a truncation cue when nothing was actually dropped', () => {
+      // A short plan that fits under the budget must not display the cue.
+      const text = 'a short plan line';
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay
+          {...baseProps}
+          text={text}
+          isPending={false}
+          availableTerminalHeight={10}
+          enforceHeightBudget
+        />,
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('a short plan line');
+      expect(output).not.toMatch(/more lines? not shown/);
     });
 
     it('leaves a non-pending message full when enforceHeightBudget is false', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -195,6 +195,14 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // line/table alone overflows (e.g. a single very wide/CJK line that wraps past
   // the budget): render nothing rather than an oversized row.
   let lines = allLines;
+  // Track how many source lines were dropped by the pre-slice so a non-streaming
+  // caller (e.g. the `exit_plan_mode` confirmation dialog) can render a visible
+  // "N more lines" cue. For streaming content the cue is intentionally omitted:
+  // the rest is still on its way. But when the caller opts into the budget for
+  // a COMPLETE plan (`enforceHeightBudget && !isPending`), silently dropping the
+  // tail means the user is asked to approve a plan whose remainder never
+  // appears — a model could hide steps past the budget. See #6867.
+  let droppedSourceLines = 0;
   if (pendingRenderedBudget !== undefined) {
     const tableClampRows =
       availableTerminalHeight !== undefined
@@ -208,8 +216,11 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
     );
     if (keptLines < allLines.length) {
       lines = allLines.slice(0, keptLines);
+      droppedSourceLines = allLines.length - keptLines;
     }
   }
+  const showTruncationCue =
+    enforceHeightBudget && !isPending && droppedSourceLines > 0;
 
   // Hold back a still-forming table at the streaming frontier. A table is only
   // recognized once its separator line (matching the header's column count) has
@@ -784,6 +795,23 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // "... generating more ..." cue — incremental scrollback commit (PR #6170)
   // already streams content to <Static> in real-time, so clipped content is
   // not "delayed output" but rather "still streaming".
+  //
+  // For non-streaming callers that opted in via `enforceHeightBudget` (currently
+  // the `exit_plan_mode` confirmation dialog), the tail is NOT still on its way
+  // — the rest of the plan simply won't render. Show a dim, single-line cue so
+  // the approver knows content was cut and cannot be tricked into approving a
+  // plan whose dangerous steps sit past the budget. See #6867.
+  if (showTruncationCue) {
+    contentBlocks.push(
+      <Text
+        key={`truncation-cue-${contentBlocks.length}`}
+        color={theme.text.secondary}
+        wrap="truncate-end"
+      >
+        {`... ${droppedSourceLines} more line${droppedSourceLines === 1 ? '' : 's'} not shown (viewport too small) ...`}
+      </Text>,
+    );
+  }
   return <>{contentBlocks}</>;
 };
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -40,6 +40,20 @@ interface MarkdownDisplayProps {
   contentWidth: number;
   textColor?: string;
   sourceCopyIndexOffsets?: MarkdownSourceCopyIndexOffsets;
+  /**
+   * When true, enforce the rendered-height budget from `availableTerminalHeight`
+   * even for non-pending content. Normally the height-aware pre-slice
+   * (`fitPendingSlice`) only engages while streaming (`isPending`), because
+   * committed content is rendered by `<Static>` and does not risk the
+   * scroll-to-top lock. However, MainContent wraps the live pending region in
+   * `maxHeight` + `overflow="hidden"` as an Ink backstop, and Ink clips the
+   * BOTTOM (newest content) — so a non-pending item that renders inside that
+   * wrapper (e.g. the `exit_plan_mode` confirmation dialog's plan body) gets
+   * silently clipped without the pre-slice's clamp/indicator. Callers that
+   * render inside such a bounded container should pass `true` so the plan body
+   * respects the same viewport budget the outer wrapper enforces. See #6867.
+   */
+  enforceHeightBudget?: boolean;
 }
 
 export interface MarkdownSourceCopyIndexOffsets {
@@ -121,6 +135,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   contentWidth,
   textColor = theme.text.primary,
   sourceCopyIndexOffsets,
+  enforceHeightBudget = false,
 }) => {
   const { renderMode } = useRenderMode();
   if (!text) return <></>;
@@ -151,8 +166,13 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   // the live frame never exceeds the viewport regardless of how the streaming
   // layer chunks content, because rendered height ≠ source-line count (a table
   // renders ~2 rows per data row; a wide/CJK line wraps to multiple rows).
+  //
+  // Non-pending callers that render inside a bounded parent (e.g. the
+  // `exit_plan_mode` confirmation dialog inside MainContent's `maxHeight` +
+  // `overflow="hidden"` wrapper) can opt in via `enforceHeightBudget` so their
+  // content is pre-sliced the same way, avoiding silent bottom-clipping.
   const pendingRenderedBudget =
-    isPending && availableTerminalHeight !== undefined
+    (isPending || enforceHeightBudget) && availableTerminalHeight !== undefined
       ? Math.max(MIN_PENDING_CONTENT_LINES, availableTerminalHeight - 2)
       : undefined;
   const headerRegex = /^ *(#{1,4}) +(.*)/;


### PR DESCRIPTION
## What this PR does

Stops the `exit_plan_mode` confirmation dialog from silently clipping the tail of its plan (and, in narrower terminals, the option buttons rendered below it). The plan body opts into the same rendered-height pre-slice that streaming markdown already uses, so the visible portion always fits the viewport budget the outer wrapper enforces.

## Why it's needed

The confirmation dialog renders its plan through `MarkdownDisplay` with `isPending={false}`. That skips `fitPendingSlice` — the source-line pre-slice that normally bounds height — because it is gated on `isPending && availableTerminalHeight !== undefined` (`MarkdownDisplay.tsx:154`). The full plan then renders inside MainContent's `maxHeight` + `overflow="hidden"` wrapper (re-added by #6421 as an Ink backstop against the scroll-to-top lock on streaming tables). Ink's `overflow="hidden"` clips the BOTTOM (newest content) — the same behavior called out in the revert note of #6081 — so a long plan loses its tail and, when the plan is tall enough, the option buttons below it. Users report seeing only the first few lines and no way to proceed. #6867 has the full trace.

The fix should not remove MainContent's clamp (it prevents a real regression on streaming tables) and should not turn on pre-slicing for every non-pending caller (transcripts, tool result markdown, and PlanSummaryDisplay must render in full). Instead, add an opt-in flag so bounded-container callers can share the streaming path's rendered-height slice, and enable it on exactly the site that renders inside the clamped region.

## Reviewer Test Plan

### How to verify

1. Enter plan mode (Shift+Tab).
2. Ask the model for a plan long enough that its markdown exceeds the viewport (e.g. a step-by-step plan with 30+ lines).
3. When the model calls `exit_plan_mode`, confirm the plan body renders up to the viewport budget without silently losing lines past the bottom edge, and the option buttons ("Yes, and auto-accept…", "No, keep planning…") remain visible and reachable.
4. Committed content unrelated to the confirmation dialog (chat transcript, tool result markdown, `PlanSummaryDisplay` after acceptance) still renders in full — no new truncation on those surfaces.

Unit coverage:

- `packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` — two new cases: `clips a non-pending message when enforceHeightBudget is set (#6867)` and `leaves a non-pending message full when enforceHeightBudget is false`. Ran locally alongside the existing suite:
  - `MarkdownDisplay.test.tsx` — 176/176 pass
  - `ToolConfirmationMessage.test.tsx` — 21/21 pass
  - `MainContent.test.tsx` — 14/14 pass
  - `HistoryItemDisplay.test.tsx` — 28/28 pass
  - `ToolMessage.test.tsx` — 61/61 pass

### Evidence (Before & After)

I don't have a repro of the TUI clip to record here — the behavior is deterministic from the source path (`ToolConfirmationMessage.tsx:360` → `MarkdownDisplay.tsx:154` → `MainContent.tsx:462-467`) and is covered by the new snapshot-free line-count regression in `MarkdownDisplay.test.tsx`. Happy to add a tmux capture on request.

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ⚠️    |
| 🪟 Windows |    ✅    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

`npx vitest run` on the affected test files. No `npm run dev` or sandbox exercise for the TUI itself.

## Risk & Scope

- Main risk or tradeoff: `enforceHeightBudget` is a new opt-in prop on `MarkdownDisplay`; forgetting to pass it on a future bounded-container caller reproduces the same silent clip. Documented in a JSDoc block on the prop that names the failure mode (`overflow="hidden"` clips the bottom) and the concrete caller pattern.
- Not validated / out of scope: the 29 other `<Text wrap="truncate-end">` sites called out on #6814 and the alternative "give ToolConfirmationMessage its own outer `maxHeight`" refactor (direction 2 in the issue). This PR does not revert #6421's clamp.
- Breaking changes / migration notes: none. The new prop defaults to `false`, so all existing callers keep their current behavior.

## Linked Issues

Fixes #6867

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 `exit_plan_mode` 确认对话框静默裁剪 plan 尾部（在较窄终端里连下方选项按钮也会被截断）的问题。让 plan 主体走和流式 markdown 相同的按渲染高度预切片逻辑，可见内容始终匹配外层容器强制的视口预算。

## 为什么需要

确认对话框用 `isPending={false}` 调用 `MarkdownDisplay` 渲染 plan。`fitPendingSlice`（负责按源码行数预切片，从而限制高度）的门控条件是 `isPending && availableTerminalHeight !== undefined`（`MarkdownDisplay.tsx:154`），所以此路径下预切片被跳过。完整 plan 因此渲染进了 MainContent 的 `maxHeight` + `overflow="hidden"` 包装（PR #6421 用作对抗流式表格 scroll-to-top lock 的 Ink 兜底）。Ink 的 `overflow="hidden"` 是从**底部**裁剪（最新内容），这一行为在 #6081 的回滚说明里也提到过——所以较长的 plan 会丢失尾部，plan 足够高时选项按钮也会一起被截。用户看到只有前几行、没法继续操作。#6867 有完整链路。

修复不能移除 MainContent 的 clamp（它保护流式表格路径的真实回归），也不能给所有非 pending caller 打开预切片（transcript、tool 结果 markdown、`PlanSummaryDisplay` 必须完整渲染）。做法是加一个可选开关，让"内容渲染在有界容器内"的调用方按需接入流式路径的按渲染高度切片，并只在真正位于 clamp 区域内的那一处启用它。

## 复审测试计划

### 如何验证

1. 进入 plan 模式（Shift+Tab）。
2. 让模型输出一份 markdown 超出视口的 plan（例如 30 行以上的分步计划）。
3. 模型调用 `exit_plan_mode` 时，确认 plan 主体按视口预算渲染、不会静默丢失底部行；选项按钮（"Yes, and auto-accept…"、"No, keep planning…"）保持可见且可操作。
4. 确认对话框以外的已提交内容（聊天 transcript、工具结果 markdown、接受 plan 后的 `PlanSummaryDisplay`）依然完整渲染，无新增截断。

单测覆盖：

- `packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` 新增两个用例：`clips a non-pending message when enforceHeightBudget is set (#6867)` 和 `leaves a non-pending message full when enforceHeightBudget is false`。本地跑过：
  - `MarkdownDisplay.test.tsx` 176/176 通过
  - `ToolConfirmationMessage.test.tsx` 21/21 通过
  - `MainContent.test.tsx` 14/14 通过
  - `HistoryItemDisplay.test.tsx` 28/28 通过
  - `ToolMessage.test.tsx` 61/61 通过

### 证据（Before & After）

暂无 TUI 截屏——行为可由源码路径确定性推出（`ToolConfirmationMessage.tsx:360` → `MarkdownDisplay.tsx:154` → `MainContent.tsx:462-467`），并由 `MarkdownDisplay.test.tsx` 中新增的按行数回归断言覆盖。如需 tmux 录像可再补。

### 测试环境

|     系统     |  状态  |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

对相关测试文件运行 `npx vitest run`。未对 TUI 本体做 `npm run dev` 或 sandbox 实机验证。

## 风险与范围

- 主要风险 / 取舍：`enforceHeightBudget` 是 `MarkdownDisplay` 的新可选 prop；未来若新增位于有界容器内的调用方而忘记传该参数，会重现同样的静默裁剪。JSDoc 明确记录了失效场景（`overflow="hidden"` 从底部裁剪）与具体调用方模式。
- 未验证 / 范围之外：#6814 中列出的其他 29 处 `<Text wrap="truncate-end">`、以及 issue 里 direction 2（给 `ToolConfirmationMessage` 加独立外层 `maxHeight`）的替代重构。本 PR 不回滚 #6421 的 clamp。
- 破坏性变更 / 迁移说明：无。新 prop 默认 `false`，所有现有调用方保持原行为。

## 关联 Issue

Fixes #6867

</details>
