### PR TITLE
feat(cli): VP mode UX improvements

### DIFF
--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -63,7 +63,11 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import { useThoughtExpanded } from '../contexts/ThoughtExpandedContext.js';
 import { useMouseEvents } from '../hooks/useMouseEvents.js';
 import type { MouseEvent } from '../utils/mouse.js';
-import { measureElementPosition } from '../utils/measure-element-position.js';
+import {
+  measureElementPosition,
+  layoutRowForEvent,
+} from '../utils/measure-element-position.js';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
@@ -117,12 +121,7 @@ const ClickableThinkMessage: React.FC<{
   onToggle,
 }) => {
   const ref = useRef<DOMElement>(null);
-  // Click toggles the thought's inline expansion in place (it then scrolls
-  // with the conversation). Click needs SGR mouse tracking; useMouseEvents
-  // enables it only in VP mode (no `bypassVpGate`), so in non-VP the handler
-  // stays dormant and native scrollback is preserved — the block still toggles
-  // via Alt+T. Advertise "click" in the collapsed hint only in VP, where the
-  // click actually does something.
+  const { rows: terminalHeight } = useTerminalSize();
   const settings = useSettings();
   const clickable = !!settings.merged.ui?.useTerminalBuffer;
   const isActive = !isPending;
@@ -133,7 +132,7 @@ const ClickableThinkMessage: React.FC<{
         if (event.name !== 'left-press' || !ref.current) return;
         const metrics = measureElementPosition(ref.current);
         const col = event.col - 1;
-        const row = event.row - 1;
+        const row = layoutRowForEvent(ref.current, event.row, terminalHeight);
         if (
           col >= metrics.x &&
           col < metrics.x + metrics.width &&
@@ -143,7 +142,7 @@ const ClickableThinkMessage: React.FC<{
           onToggle();
         }
       },
-      [onToggle],
+      [onToggle, terminalHeight],
     ),
     { isActive },
   );

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Static, type DOMElement, useBoxMetrics } from 'ink';
+import { Box, Static } from 'ink';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import { isHistoryItemVisibleAfterRestore } from '../types.js';
@@ -83,12 +83,25 @@ function initialReplayCount(length: number): number {
 // stable completed items when unrelated UIState fields change during streaming.
 const VirtualHistoryItem = memo(HistoryItemDisplay);
 
+// Banner sentinel injected as the first virtual-scroll item so it scrolls with
+// content instead of being pinned at the top (saves vertical space on small
+// terminals).
+type VpBannerItem = { type: 'vp-banner'; id: number };
+type VpItem = HistoryItem | VpBannerItem;
+const VP_BANNER_ID = Number.MIN_SAFE_INTEGER;
+const VP_BANNER_ITEM: VpBannerItem = { type: 'vp-banner', id: VP_BANNER_ID };
+
 // Pure functions with no closure deps — defined outside the component so they
 // are stable references and never trigger useMemo/useCallback invalidation.
-const virtualEstimatedItemHeight = () => 3;
-const virtualKeyExtractor = (item: HistoryItem) =>
-  item.id >= 0 ? `h-${item.id}` : `p-${-item.id - 1}`;
-const virtualIsStaticItem = (item: HistoryItem) => item.id > 0;
+const virtualEstimatedItemHeight = (index: number) => (index === 0 ? 7 : 3);
+const virtualKeyExtractor = (item: VpItem) =>
+  item.id === VP_BANNER_ID
+    ? 'vp-banner'
+    : item.id >= 0
+      ? `h-${item.id}`
+      : `p-${-item.id - 1}`;
+const virtualIsStaticItem = (item: VpItem) =>
+  item.id === VP_BANNER_ID || item.id > 0;
 
 export const MainContent = () => {
   const { version } = useAppContext();
@@ -243,9 +256,11 @@ export const MainContent = () => {
       : historyItemsWithSourceCopyOffsets.slice(0, replayCount);
 
   // Combine completed history + live pending items for the virtualized list.
+  // The banner sentinel is prepended so it scrolls with content (not pinned).
   // Pending items get negative IDs (-(i+1)) so renderItem can tell them apart.
   const allVirtualItems = useMemo(
-    (): HistoryItem[] => [
+    (): VpItem[] => [
+      VP_BANNER_ITEM,
       ...visibleHistory,
       ...pendingHistoryItems.map((item, i) => ({ ...item, id: -(i + 1) })),
     ],
@@ -327,7 +342,16 @@ export const MainContent = () => {
   // Streaming-only state — including pending source-copy offsets — is read
   // from refs so callback identity is stable.
   const renderVirtualItem = useCallback(
-    ({ item }: { item: HistoryItem }) => {
+    ({ item }: { item: VpItem }) => {
+      if (item.type === 'vp-banner') {
+        return (
+          <Box flexDirection="column">
+            <AppHeader version={version} />
+            <DebugModeNotification />
+            <Notifications />
+          </Box>
+        );
+      }
       const isPending = item.id < 0;
       const sourceCopyIndexOffsets = isPending
         ? pendingSourceCopyOffsetsRef.current[-item.id - 1]
@@ -366,6 +390,7 @@ export const MainContent = () => {
       );
     },
     [
+      version,
       terminalWidth,
       mainAreaWidth,
       staticAreaMaxItemHeight,
@@ -374,37 +399,27 @@ export const MainContent = () => {
     ],
   );
 
-  const vpHeaderRef = useRef<DOMElement>(null);
-  const { height: vpHeaderHeight } = useBoxMetrics(vpHeaderRef);
-
   if (useVirtualScroll) {
     const scrollContainerHeight = Math.max(
       0,
-      (uiState.availableTerminalHeight ?? 0) - vpHeaderHeight,
+      uiState.availableTerminalHeight ?? 0,
     );
 
     return (
-      <>
-        <Box ref={vpHeaderRef} flexDirection="column" flexShrink={0}>
-          <AppHeader version={version} />
-          <DebugModeNotification />
-          <Notifications />
-        </Box>
-        <OverflowProvider>
-          <ScrollableList
-            hasFocus={!uiState.dialogsVisible}
-            data={allVirtualItems}
-            renderItem={renderVirtualItem}
-            estimatedItemHeight={virtualEstimatedItemHeight}
-            keyExtractor={virtualKeyExtractor}
-            initialScrollIndex={SCROLL_TO_ITEM_END}
-            isStaticItem={virtualIsStaticItem}
-            containerHeight={scrollContainerHeight}
-            showScrollbar={showScrollbar}
-          />
-          <ShowMoreLines constrainHeight={uiState.constrainHeight} />
-        </OverflowProvider>
-      </>
+      <OverflowProvider>
+        <ScrollableList
+          hasFocus={!uiState.dialogsVisible}
+          data={allVirtualItems}
+          renderItem={renderVirtualItem}
+          estimatedItemHeight={virtualEstimatedItemHeight}
+          keyExtractor={virtualKeyExtractor}
+          initialScrollIndex={SCROLL_TO_ITEM_END}
+          isStaticItem={virtualIsStaticItem}
+          containerHeight={scrollContainerHeight}
+          showScrollbar={showScrollbar}
+        />
+        <ShowMoreLines constrainHeight={uiState.constrainHeight} />
+      </OverflowProvider>
     );
   }
 

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -93,15 +93,16 @@ const VP_BANNER_ITEM: VpBannerItem = { type: 'vp-banner', id: VP_BANNER_ID };
 
 // Pure functions with no closure deps — defined outside the component so they
 // are stable references and never trigger useMemo/useCallback invalidation.
-const virtualEstimatedItemHeight = (index: number) => (index === 0 ? 7 : 3);
+// index 0 is always the banner sentinel (VP_BANNER_ITEM is prepended first).
+const virtualEstimatedItemHeight = (index: number) => (index === 0 ? 10 : 3);
 const virtualKeyExtractor = (item: VpItem) =>
-  item.id === VP_BANNER_ID
+  item.type === 'vp-banner'
     ? 'vp-banner'
     : item.id >= 0
       ? `h-${item.id}`
       : `p-${-item.id - 1}`;
 const virtualIsStaticItem = (item: VpItem) =>
-  item.id === VP_BANNER_ID || item.id > 0;
+  item.type === 'vp-banner' || item.id > 0;
 
 export const MainContent = () => {
   const { version } = useAppContext();
@@ -413,7 +414,9 @@ export const MainContent = () => {
           renderItem={renderVirtualItem}
           estimatedItemHeight={virtualEstimatedItemHeight}
           keyExtractor={virtualKeyExtractor}
-          initialScrollIndex={SCROLL_TO_ITEM_END}
+          initialScrollIndex={
+            allVirtualItems.length <= 1 ? 0 : SCROLL_TO_ITEM_END
+          }
           isStaticItem={virtualIsStaticItem}
           containerHeight={scrollContainerHeight}
           showScrollbar={showScrollbar}


### PR DESCRIPTION
## Summary

VP 模式 (useTerminalBuffer) 的多项体验优化:

- **Banner 随内容滚动**: 将 AppHeader/Notifications 从固定顶部移入 VirtualizedList 作为首项，长对话后 banner 自然滚出视口，不再占用空间
- **思考块点击展开修复**: ClickableThinkMessage 的鼠标坐标映射使用 `layoutRowForEvent` 替代裸 `event.row - 1`，修复 frame 溢出终端高度时点击失效

## Test plan

- [x] VP mode: 新会话 banner 在顶部可见
- [x] VP mode: 输出超过一屏后 banner 随内容滚动消失
- [x] VP mode: Shift+Up 滚动到顶部可完整看到 banner
- [x] VP mode: Option+T 展开/折叠思考块正常
- [x] VP mode: 折叠思考块点击坐标映射正确 (layoutRowForEvent)
- [x] list-mouse.test.ts 全部通过
- [x] tsc --noEmit 无新增类型错误

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)