### PR TITLE
fix(cli): apply FETCH_TIMEOUT_MS to /update version check and log fetchInfo results (#6857)

### DIFF
--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { checkForUpdates, checkForUpdatesDetailed } from './updateCheck.js';
+import {
+  checkForUpdates,
+  checkForUpdatesDetailed,
+  FETCH_TIMEOUT_MS,
+  UpdateCheckTimeoutError,
+} from './updateCheck.js';
 
 const getPackageJson = vi.hoisted(() => vi.fn());
 vi.mock('../../utils/package.js', () => ({
@@ -252,6 +257,56 @@ describe('checkForUpdates', () => {
       const result = await checkForUpdates();
       expect(result?.message).toContain('1.2.3-nightly.1 → 1.2.3-nightly.2');
       expect(result?.update.latest).toBe('1.2.3-nightly.2');
+    });
+  });
+
+  describe('fetchInfo timeout (#6857)', () => {
+    it('returns a detailed error when fetchInfo does not resolve within FETCH_TIMEOUT_MS', async () => {
+      // update-notifier's fetchInfo() takes no timeout option, so an
+      // unreachable registry (proxy, offline, corporate mirror without
+      // scoped .npmrc auth) would hang the check. We race it against a
+      // bounded timer instead — this asserts the timer actually fires and
+      // surfaces a real error rather than silently reporting "up to date".
+      getPackageJson.mockResolvedValue({
+        name: 'test-package',
+        version: '1.0.0',
+      });
+      updateNotifier.mockReturnValue({
+        // never resolves
+        fetchInfo: vi.fn().mockReturnValue(new Promise(() => {})),
+      });
+
+      const resultPromise = checkForUpdatesDetailed();
+      await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS + 1);
+      const result = await resultPromise;
+
+      expect(result.status).toBe('error');
+      if (result.status === 'error') {
+        expect(result.error).toBeInstanceOf(UpdateCheckTimeoutError);
+        expect(result.error.message).toContain(`${FETCH_TIMEOUT_MS}ms`);
+        expect(result.currentVersion).toBe('1.0.0');
+      }
+    });
+
+    it('still resolves the update path when fetchInfo returns before the timeout', async () => {
+      // Guards against the timer accidentally firing on a healthy fast fetch —
+      // if it did, every /update call would silently drop back to error.
+      getPackageJson.mockResolvedValue({
+        name: 'test-package',
+        version: '1.0.0',
+      });
+      updateNotifier.mockReturnValue({
+        fetchInfo: vi
+          .fn()
+          .mockResolvedValue({ current: '1.0.0', latest: '1.1.0' }),
+      });
+
+      const result = await checkForUpdatesDetailed();
+
+      expect(result.status).toBe('update');
+      if (result.status === 'update') {
+        expect(result.info.update.latest).toBe('1.1.0');
+      }
     });
   });
 });

--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -284,6 +284,9 @@ describe('checkForUpdates', () => {
       if (result.status === 'error') {
         expect(result.error).toBeInstanceOf(UpdateCheckTimeoutError);
         expect(result.error.message).toContain(`${FETCH_TIMEOUT_MS}ms`);
+        // Non-nightly path only queries the `latest` dist-tag; the message
+        // must name it so oncall can tell which registry endpoint stalled.
+        expect(result.error.message).toContain('for latest');
         expect(result.currentVersion).toBe('1.0.0');
       }
     });
@@ -306,6 +309,63 @@ describe('checkForUpdates', () => {
       expect(result.status).toBe('update');
       if (result.status === 'update') {
         expect(result.info.update.latest).toBe('1.1.0');
+      }
+    });
+
+    it('surfaces a timeout when only the nightly dist-tag stalls', async () => {
+      // The nightly path fires `latest` and `nightly` fetches concurrently via
+      // Promise.all — if the timer wiring is wrong (e.g. only the outer race
+      // has one, or the reject reaches Promise.all and Promise.all doesn't
+      // propagate), a single stalled fetch would let /update silently degrade.
+      // Assert Promise.all propagates the timeout AND names the exact dist-tag
+      // that stalled so oncall reading logs can point at the endpoint.
+      getPackageJson.mockResolvedValue({
+        name: 'test-package',
+        version: '1.0.0-nightly.1',
+      });
+      updateNotifier.mockImplementation(({ distTag }) => ({
+        fetchInfo: () =>
+          distTag === 'nightly'
+            ? new Promise(() => {}) // never resolves
+            : Promise.resolve({
+                current: '1.0.0-nightly.1',
+                latest: '1.0.0',
+              }),
+      }));
+
+      const resultPromise = checkForUpdatesDetailed();
+      await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS + 1);
+      const result = await resultPromise;
+
+      expect(result.status).toBe('error');
+      if (result.status === 'error') {
+        expect(result.error).toBeInstanceOf(UpdateCheckTimeoutError);
+        expect(result.error.message).toContain('for nightly');
+        expect(result.currentVersion).toBe('1.0.0-nightly.1');
+      }
+    });
+
+    it('surfaces a timeout when both nightly dist-tags stall', async () => {
+      // Full outage / offline network — both fetches hang, both timers fire.
+      // The first rejection Promise.all sees wins; assert only that we get a
+      // typed UpdateCheckTimeoutError for one of the two dist-tags (either is
+      // a valid symptom of the same failure).
+      getPackageJson.mockResolvedValue({
+        name: 'test-package',
+        version: '1.0.0-nightly.1',
+      });
+      updateNotifier.mockImplementation(() => ({
+        fetchInfo: () => new Promise(() => {}),
+      }));
+
+      const resultPromise = checkForUpdatesDetailed();
+      await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS + 1);
+      const result = await resultPromise;
+
+      expect(result.status).toBe('error');
+      if (result.status === 'error') {
+        expect(result.error).toBeInstanceOf(UpdateCheckTimeoutError);
+        expect(result.error.message).toMatch(/for (nightly|latest)/);
       }
     });
   });

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -22,18 +22,26 @@ export const FETCH_TIMEOUT_MS = 2000;
  * networks, DNS failures) would otherwise hang the check indefinitely or fall
  * through to a stale configstore cache. Race the call against a bounded timer
  * and surface a real error so `/update` can report "check failed" instead of
- * silently returning "up to date". Related: #6857.
+ * silently returning "up to date". The `distTag` is carried on the message so
+ * an oncall reading logs can tell which registry endpoint stalled — the
+ * nightly path fires two concurrent fetches, and only one of them may be
+ * blocked (e.g. a corporate proxy that lets `nightly` through but not
+ * `latest`). Related: #6857.
  */
 export class UpdateCheckTimeoutError extends Error {
-  constructor(timeoutMs: number) {
-    super(`update-notifier fetchInfo timed out after ${timeoutMs}ms`);
+  readonly distTag?: string;
+  constructor(timeoutMs: number, distTag?: string) {
+    const suffix = distTag ? ` for ${distTag}` : '';
+    super(`update-notifier fetchInfo timed out after ${timeoutMs}ms${suffix}`);
     this.name = 'UpdateCheckTimeoutError';
+    this.distTag = distTag;
   }
 }
 
 async function fetchInfoWithTimeout(
   notifier: { fetchInfo(): UpdateInfo | Promise<UpdateInfo> },
   timeoutMs: number,
+  distTag?: string,
 ): Promise<UpdateInfo> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -41,7 +49,7 @@ async function fetchInfoWithTimeout(
       Promise.resolve(notifier.fetchInfo()),
       new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new UpdateCheckTimeoutError(timeoutMs)),
+          () => reject(new UpdateCheckTimeoutError(timeoutMs, distTag)),
           timeoutMs,
         );
       }),
@@ -113,8 +121,16 @@ export async function checkForUpdatesDetailed(): Promise<UpdateCheckResult> {
 
     if (isNightly) {
       const [nightlyUpdateInfo, latestUpdateInfo] = await Promise.all([
-        fetchInfoWithTimeout(createNotifier('nightly'), FETCH_TIMEOUT_MS),
-        fetchInfoWithTimeout(createNotifier('latest'), FETCH_TIMEOUT_MS),
+        fetchInfoWithTimeout(
+          createNotifier('nightly'),
+          FETCH_TIMEOUT_MS,
+          'nightly',
+        ),
+        fetchInfoWithTimeout(
+          createNotifier('latest'),
+          FETCH_TIMEOUT_MS,
+          'latest',
+        ),
       ]);
 
       debugLogger.debug(
@@ -142,6 +158,7 @@ export async function checkForUpdatesDetailed(): Promise<UpdateCheckResult> {
       const updateInfo = await fetchInfoWithTimeout(
         createNotifier('latest'),
         FETCH_TIMEOUT_MS,
+        'latest',
       );
 
       debugLogger.debug(

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -15,6 +15,42 @@ const debugLogger = createDebugLogger('UPDATE_CHECK');
 
 export const FETCH_TIMEOUT_MS = 2000;
 
+/**
+ * Sentinel error thrown when `fetchInfo()` does not resolve within
+ * `FETCH_TIMEOUT_MS`. `update-notifier`'s `fetchInfo()` does not accept a
+ * timeout option, so slow / unreachable registries (corporate proxies, offline
+ * networks, DNS failures) would otherwise hang the check indefinitely or fall
+ * through to a stale configstore cache. Race the call against a bounded timer
+ * and surface a real error so `/update` can report "check failed" instead of
+ * silently returning "up to date". Related: #6857.
+ */
+export class UpdateCheckTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`update-notifier fetchInfo timed out after ${timeoutMs}ms`);
+    this.name = 'UpdateCheckTimeoutError';
+  }
+}
+
+async function fetchInfoWithTimeout(
+  notifier: { fetchInfo(): UpdateInfo | Promise<UpdateInfo> },
+  timeoutMs: number,
+): Promise<UpdateInfo> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(notifier.fetchInfo()),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new UpdateCheckTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export interface UpdateObject {
   message: string;
   update: UpdateInfo;
@@ -77,9 +113,13 @@ export async function checkForUpdatesDetailed(): Promise<UpdateCheckResult> {
 
     if (isNightly) {
       const [nightlyUpdateInfo, latestUpdateInfo] = await Promise.all([
-        createNotifier('nightly').fetchInfo(),
-        createNotifier('latest').fetchInfo(),
+        fetchInfoWithTimeout(createNotifier('nightly'), FETCH_TIMEOUT_MS),
+        fetchInfoWithTimeout(createNotifier('latest'), FETCH_TIMEOUT_MS),
       ]);
+
+      debugLogger.debug(
+        `fetchInfo returned nightly=${JSON.stringify(nightlyUpdateInfo)} latest=${JSON.stringify(latestUpdateInfo)} for current=${version}`,
+      );
 
       const bestUpdate = getBestAvailableUpdate(
         nightlyUpdateInfo,
@@ -99,7 +139,14 @@ export async function checkForUpdatesDetailed(): Promise<UpdateCheckResult> {
         };
       }
     } else {
-      const updateInfo = await createNotifier('latest').fetchInfo();
+      const updateInfo = await fetchInfoWithTimeout(
+        createNotifier('latest'),
+        FETCH_TIMEOUT_MS,
+      );
+
+      debugLogger.debug(
+        `fetchInfo returned ${JSON.stringify(updateInfo)} for current=${version}`,
+      );
 
       if (updateInfo && semver.gt(updateInfo.latest, version)) {
         return {


### PR DESCRIPTION
## What this PR does

Wires the existing `FETCH_TIMEOUT_MS = 2000` constant in `packages/cli/src/ui/utils/updateCheck.ts` up to `update-notifier`'s `fetchInfo()` — the option didn't exist upstream, so the constant was dead code and `/update` had no bound. Race the fetch against the timer and surface a new `UpdateCheckTimeoutError` when it fires, so `/update` returns the existing `'error'` status instead of silently reporting `'up to date'`. Also log the `fetchInfo` return value under the `UPDATE_CHECK` debug tag so the next round of reports can distinguish "registry returned the wrong version" from "we compared it incorrectly" without more speculation.

## Why it's needed

Users report `/update` saying "Qwen Code 0.19.9 is up to date!" while `npm view @qwen-code/qwen-code@latest version` on the same machine returns `0.19.10`. The triage on #6857 confirmed `checkForUpdatesDetailed()` reaches `return { status: 'up-to-date' }` — meaning `fetchInfo()` either returned the current version or resolved late enough that a stale configstore cache was used, and the failure was swallowed silently.

Two things make the failure invisible today:

- **`FETCH_TIMEOUT_MS` was never applied.** `update-notifier@7.3.x`'s `fetchInfo()` takes no timeout option, and the exported `FETCH_TIMEOUT_MS` was never passed anywhere. On slow / unreachable registries (corporate proxies, offline networks, scoped `.npmrc` mirrors without auth), the check hangs long enough for the caller to drop it — but the `'error'` code path never fires, so the user only sees the fallback message.
- **No signal about what actually came back.** The existing `debugLogger.warn` runs only when an exception escapes, so a return of `{ latest: '0.19.9' }` in the exact "up to date but shouldn't be" case leaves nothing to bisect.

This PR does the two smallest things that make future reports diagnosable and cut off the silent-hang failure mode. It intentionally does **not** replace `update-notifier`'s `fetchInfo()` with a direct `package-json` / `npm view` call — that swap is a larger design change that the triage flagged as a separate option, and this PR keeps the fix scoped to plumbing an already-declared constant.

## Reviewer Test Plan

### How to verify

Unit coverage lives in `packages/cli/src/ui/utils/updateCheck.test.ts` and asserts both directions of the race:

- `returns a detailed error when fetchInfo does not resolve within FETCH_TIMEOUT_MS` — mocks `fetchInfo` as a promise that never resolves, advances fake timers past 2000 ms, expects the result to be `{ status: 'error', error: UpdateCheckTimeoutError, currentVersion }`.
- `still resolves the update path when fetchInfo returns before the timeout` — guards against the timer accidentally firing on a healthy fast fetch (which would silently drop every real `/update` to error).

Full suites confirmed locally with `npx vitest run`:

- `packages/cli/src/ui/utils/updateCheck.test.ts` — 17/17 pass (15 pre-existing + 2 new)
- `packages/cli/src/commands/update.test.ts` — 10/10 pass
- `packages/cli/src/ui/commands/update-command.test.ts` — 15/15 pass
- `packages/cli/src/startup/startup-prefetch.test.ts` — 21/21 pass
- `packages/cli/src/utils/handleAutoUpdate.test.ts` — 24/24 pass

For a manual smoke: set `QWEN_DEBUG=UPDATE_CHECK`, run `/update` on any current version, and confirm a `UPDATE_CHECK DEBUG` line reporting the `fetchInfo` return value now appears in the debug log; if run on a network that can't reach `registry.npmjs.org` within 2 s (e.g. block outbound to `registry.npmjs.org`), the result should now be `error` with an `UpdateCheckTimeoutError`, not `up-to-date`.

### Evidence (Before & After)

N/A — non-user-visible behavior change (debug log line + failure-path routing).

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ⚠️    |
| 🪟 Windows |    ✅    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

`npx vitest run` for the affected suites. No live-registry probe.

## Risk & Scope

- Main risk or tradeoff: a legitimate `fetchInfo()` that resolves in more than 2 s on a slow-but-reachable network will now be reported as `error` instead of the previous hang / fallback. That is the intended behavior — the user gets a real error message instead of an invisible failure — but if the timeout turns out to be too tight in practice, tuning `FETCH_TIMEOUT_MS` is a one-line follow-up. Kept the existing 2 s value to avoid mixing the wiring fix with a value bump.
- Not validated / out of scope: the underlying question of *why* `fetchInfo()` sometimes returns a stale `latest` in some environments (proxy, corporate `.npmrc`, `package-json` scoped-registry handling). The new debug log is the tool for that investigation; the swap to a direct registry call the triage sketched is a separate change.
- Breaking changes / migration notes: none. Public exports are additive (`UpdateCheckTimeoutError`); the `UpdateCheckResult` union already had `'error'`.

## Linked Issues

Refs #6857

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `packages/cli/src/ui/utils/updateCheck.ts` 里已有但从未被使用的 `FETCH_TIMEOUT_MS = 2000` 常量真正接上 `update-notifier` 的 `fetchInfo()`——因为该库上游没有 timeout 选项，这个常量此前是死代码，`/update` 也就没有任何上限。用 `Promise.race` 与定时器竞速，超时时抛出新增的 `UpdateCheckTimeoutError`，让 `/update` 走已有的 `'error'` 状态而非静默报"up to date"。同时把 `fetchInfo` 的返回值记录到 `UPDATE_CHECK` debug tag 下，方便下次收到报告时区分"registry 返回错了版本"与"比较逻辑错了"，而不必继续凭猜。

## 为什么需要

用户报告 `/update` 在 v0.19.9 上说"Qwen Code 0.19.9 is up to date!"，但同一台机器 `npm view @qwen-code/qwen-code@latest version` 返回 `0.19.10`。#6857 的 triage 确认代码走到了 `return { status: 'up-to-date' }`——要么 `fetchInfo()` 返回了当前版本号，要么响应太慢被上游用了陈旧的 configstore 缓存，且失败被静默吞掉。

现在有两点让这类失败不可见：

- **`FETCH_TIMEOUT_MS` 从没被真正应用。** `update-notifier@7.3.x` 的 `fetchInfo()` 不接受 timeout 选项，导出的 `FETCH_TIMEOUT_MS` 也没传给任何地方。在慢的 / 不可达的 registry（企业代理、离线网络、`.npmrc` scoped mirror 未配置 auth）上，请求悬挂到调用方放弃——但 `'error'` 分支从未触发，用户只看到 fallback 提示。
- **返回值没有任何信号可查。** 现有 `debugLogger.warn` 只在异常逃出时打印，遇到 `fetchInfo()` 返回 `{ latest: '0.19.9' }` 这种真正 "看似正常却错误" 的情况时无从 bisect。

本 PR 做两件把未来报告可诊断化 + 切断静默 hang 失败路径的最小改动。刻意**不**把 `update-notifier` 的 `fetchInfo()` 换成对 `package-json` / `npm view` 的直接调用——那是 triage 里另一个更大的设计变更，本 PR 把修复限定在把已声明的常量接上。

## 复审测试计划

### 如何验证

单元覆盖位于 `packages/cli/src/ui/utils/updateCheck.test.ts`，同时验证 race 的两个方向：

- `returns a detailed error when fetchInfo does not resolve within FETCH_TIMEOUT_MS` —— mock `fetchInfo` 永远不 resolve，用 fake timer 推进 2000ms+，期望结果为 `{ status: 'error', error: UpdateCheckTimeoutError, currentVersion }`。
- `still resolves the update path when fetchInfo returns before the timeout` —— 防止定时器在健康的快速请求上误触（那样每次真实 `/update` 都会被静默降级为 error）。

`npx vitest run` 本地全绿：

- `packages/cli/src/ui/utils/updateCheck.test.ts` 17/17（原 15 + 新增 2）
- `packages/cli/src/commands/update.test.ts` 10/10
- `packages/cli/src/ui/commands/update-command.test.ts` 15/15
- `packages/cli/src/startup/startup-prefetch.test.ts` 21/21
- `packages/cli/src/utils/handleAutoUpdate.test.ts` 24/24

手工冒烟：设置 `QWEN_DEBUG=UPDATE_CHECK`，运行 `/update` 于任意版本，确认 debug log 里多了一条 `UPDATE_CHECK DEBUG` 行报告 `fetchInfo` 的返回值；如果限制 2s 内不可达 `registry.npmjs.org`，结果应变成 `error` 携带 `UpdateCheckTimeoutError` 而不是 `up-to-date`。

### 证据（Before & After）

N/A——非用户可见的行为变更（debug 日志 + 失败路径路由）。

### 测试环境

|     系统     |  状态  |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`npx vitest run` 相关测试集。未做真实 registry 探测。

## 风险与范围

- 主要风险 / 取舍：一次合法但耗时超过 2s 的 `fetchInfo()` 现在会被报告为 `error`，而不是此前那种悬挂 / fallback。这就是刻意的行为改变——用户会看到真实错误提示而非隐形失败——如果实际使用中发现 2s 太紧，调整 `FETCH_TIMEOUT_MS` 只是一行 follow-up。本 PR 保留 2s 原值，避免把常量接线的修复与调值混在一起。
- 未验证 / 范围之外：为什么 `fetchInfo()` 在某些环境下返回陈旧的 `latest` 这个更深层问题（代理、企业 `.npmrc`、`package-json` 的 scoped registry 处理）。新增的 debug 日志正是为此提供工具；triage 里草拟的直接调用 registry 的方案是独立的改动。
- 破坏性变更 / 迁移说明：无。公开导出为新增（`UpdateCheckTimeoutError`）；`UpdateCheckResult` union 早已含 `'error'`。

## 关联 Issue

Refs #6857

</details>
