### PR TITLE
fix(web-shell): remove duplicate useWebShellPortalRoot import in ChatEditor

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -43,7 +43,6 @@ import { isSafeImageSrc } from './messages/Markdown';
 import { ModeIcon } from './ModeIcon';
 import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
-import { useWebShellPortalRoot } from '../portalRoot';
 import { VoiceButton } from '../voice/VoiceButton';
 import { GitBranchIndicator } from './GitBranchIndicator';
 import { WorkspaceIndicator } from './WorkspaceIndicator';


### PR DESCRIPTION
## What this PR does

Removes the duplicate `import { useWebShellPortalRoot } from '../portalRoot'` at `packages/web-shell/client/components/ChatEditor.tsx:46`, keeping the earlier one at line 21.

## Why it's needed

PR #6872 (`fix(web-shell): make composer height adaptive`) added a second identical import next to a new `useWebShellPortalRoot()` call site without noticing the same specifier was already imported earlier in the file. TypeScript reports:

```
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
```

That fails the `web-shell` `build` script (`vite build && vite build --config vite.lib.config.ts && tsc -p tsconfig.lib.json`), which runs from `scripts/prepare.js` during `npm ci` in CI. So every PR opened against `main` after #6872 landed sees its `Install dependencies` step abort before any tests run — the two failing PRs I noticed while testing #6887 both surfaced this same duplicate identifier error, entirely unrelated to their own diffs.

Removing the duplicate line at 46 keeps the two `useWebShellPortalRoot()` call sites (lines 247 and 858) resolving to the single retained import at line 21, which is what `main` had before #6872 and what the code intends.

## Reviewer Test Plan

### How to verify

- `git blame packages/web-shell/client/components/ChatEditor.tsx | grep useWebShellPortalRoot` on `main` before this PR shows the same line imported twice (one from the pre-existing import block, one added by #6872's diff at line 46).
- After this PR the specifier appears exactly once: `line 21: import { useWebShellPortalRoot } from '../portalRoot';`, with the two consumers unchanged at lines 247 and 858.
- Running `npm run typecheck` inside `packages/web-shell` no longer reports `TS2300: Duplicate identifier 'useWebShellPortalRoot'`. (Other pre-existing errors from unresolved workspace modules on a partially-built tree remain — they are unrelated to this fix and vanish after a full `npm ci` build, i.e. in CI.)

### Evidence (Before & After)

Before (excerpt from #6887 CI run 29331201533):

```
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
npm error Lifecycle script `build` failed with error:
npm error code 2
npm error workspace @qwen-code/web-shell@0.19.10
```

After: the `useWebShellPortalRoot` line at 46 is deleted; only the line-21 import remains. No user-visible behavior change — the file still uses `useWebShellPortalRoot()` in the same two places it did before.

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ⚠️    |
| 🪟 Windows |    ✅    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

`npm run typecheck` inside `packages/web-shell`. Verified the duplicate identifier error is gone; remaining local-only errors are workspace-resolution issues that clear once `npm ci` runs (as it does in CI).

## Risk & Scope

- Main risk or tradeoff: none. The duplicate was a no-op accepted by JavaScript at runtime but rejected by TypeScript at build time; removing it restores intent.
- Not validated / out of scope: nothing else in `ChatEditor.tsx` — only the extra import line was removed.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #6872 (introduced the duplicate). No dedicated issue was filed; the failure is visible on every open PR's CI, e.g. #6887's `Test (ubuntu-latest, Node 22.x)` and `web-shell E2E Smoke` runs.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

移除 `packages/web-shell/client/components/ChatEditor.tsx:46` 处重复的 `import { useWebShellPortalRoot } from '../portalRoot'`，保留第 21 行原有那个。

## 为什么需要

PR #6872（`fix(web-shell): make composer height adaptive`）在新的 `useWebShellPortalRoot()` 调用旁边添加了第二个完全相同的 import，没注意到文件靠上位置已经有了同名 import。TypeScript 报错：

```
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
```

这让 `web-shell` 的 `build` 脚本（`vite build && vite build --config vite.lib.config.ts && tsc -p tsconfig.lib.json`）失败，而 `build` 会在 CI 的 `npm ci` 过程中通过 `scripts/prepare.js` 执行。因此 #6872 合入后每个针对 `main` 打开的 PR，`Install dependencies` 步骤都会在跑任何测试之前中断——我测试 #6887 时发现的两个失败 PR 都是同一处 duplicate identifier 错误，跟它们自己的 diff 完全无关。

删除第 46 行后，两个 `useWebShellPortalRoot()` 调用（第 247、858 行）继续 resolve 到第 21 行保留下来的那个 import，与 #6872 之前 `main` 的状态一致，也符合代码原意。

## 复审测试计划

### 如何验证

- 在本 PR 之前，`git blame packages/web-shell/client/components/ChatEditor.tsx | grep useWebShellPortalRoot` 在 `main` 上会看到同一 specifier 被 import 两次（一个来自原有 import 块，一个是 #6872 diff 在第 46 行新加的）。
- 本 PR 后，specifier 精确出现一次：`第 21 行: import { useWebShellPortalRoot } from '../portalRoot';`，两个消费者（第 247、858 行）不变。
- 在 `packages/web-shell` 里 `npm run typecheck` 不再报 `TS2300: Duplicate identifier 'useWebShellPortalRoot'`。（部分构建下 workspace 模块未解析产生的其他既有错误与本修复无关，全量 `npm ci` 后消失，即 CI 环境。）

### 证据（Before & After）

Before（摘自 #6887 CI 运行 29331201533）：

```
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
npm error Lifecycle script `build` failed with error:
npm error code 2
npm error workspace @qwen-code/web-shell@0.19.10
```

After：第 46 行 `useWebShellPortalRoot` import 被删除，仅保留第 21 行的 import。无用户可见行为变更——文件仍在原来的两处使用 `useWebShellPortalRoot()`。

### 测试环境

|     系统     |  状态  |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`packages/web-shell` 中的 `npm run typecheck`。已确认 duplicate identifier 错误消失；剩余本地 only 错误是 workspace 解析问题，CI 中 `npm ci` 后即消失。

## 风险与范围

- 主要风险 / 取舍：无。重复 import 在 JavaScript 运行时被接受为 no-op，但被 TypeScript 编译时拒绝；移除它即恢复代码原意。
- 未验证 / 范围之外：`ChatEditor.tsx` 中除该 import 外别无它改。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

跟进 #6872（引入了 duplicate）。无专门 issue；每个打开的 PR 都能看到该失败，例如 #6887 的 `Test (ubuntu-latest, Node 22.x)` 和 `web-shell E2E Smoke` 运行。

</details>
