### PR TITLE
fix(web-shell): drop a duplicate import that breaks every PR's CI

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -43,7 +43,6 @@ import { isSafeImageSrc } from './messages/Markdown';
 import { ModeIcon } from './ModeIcon';
 import { planSlashSectionRows } from '../utils/slashSectionPlan';
 import { getModelDisplayName } from '../utils/modelDisplay';
-import { useWebShellPortalRoot } from '../portalRoot';
 import { VoiceButton } from '../voice/VoiceButton';
 import { GitBranchIndicator } from './GitBranchIndicator';
 import { WorkspaceIndicator } from './WorkspaceIndicator';


### PR DESCRIPTION
## What this PR does

Deletes one line. `ChatEditor.tsx` imports `useWebShellPortalRoot` twice — once at line 21, and again at line 46, where #6872 added a second copy of an import the file already had.

## Why it's needed

**`main` does not install.** TypeScript answers the duplicate with `TS2300: Duplicate identifier 'useWebShellPortalRoot'`, which fails `tsc -p tsconfig.lib.json`, which fails `npm run build --workspace=packages/web-shell`, which runs in the `prepare` lifecycle — so **`npm ci` fails, and with it every job on every open pull request**, not only the ones that touch the web shell.

The two `const portalRoot = useWebShellPortalRoot()` call sites are in different components and are both correct. Only the second import is redundant.

## Reviewer Test Plan

### How to verify

On `main`:

```
$ npm run build --workspace=packages/web-shell
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
npm error Lifecycle script `build` failed
```

On this branch:

```
$ npm run build            # every workspace, in dependency order
   → rc=0, 0 TypeScript errors

$ npm run build --workspace=packages/web-shell
   → rc=0
```

The same failure is visible in CI on any recently-opened PR — e.g. #6892's `Test (ubuntu-latest, Node 22.x)` job fails at *Install dependencies* with exactly those two lines.

### Evidence (Before & After)

N/A — not user-visible. The before/after is the build output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: none. The symbol stays imported once and both of its call sites are unchanged.
- Not validated / out of scope: nothing else in the web shell is touched.
- Breaking changes / migration notes: none.

## Linked Issues

Regression from #6872.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

删一行。`ChatEditor.tsx` 把 `useWebShellPortalRoot` import 了**两次**——第 21 行一次，第 46 行又一次；后者是 #6872 加的，而这个文件本来就已经 import 过了。

## 为什么需要

**`main` 装不上。** TypeScript 报 `TS2300: Duplicate identifier`，于是 `tsc -p tsconfig.lib.json` 失败 → `npm run build --workspace=packages/web-shell` 失败 → 而这个 build 跑在 `prepare` 生命周期里 → **`npm ci` 失败**，于是**每一个开着的 PR 上的每一个 job 都跟着红**，不只是碰了 web shell 的那些。

文件里两处 `const portalRoot = useWebShellPortalRoot()` 分属不同组件，都是对的。多余的只有第二个 import。

## 验证

`main` 上：

```
$ npm run build --workspace=packages/web-shell
client/components/ChatEditor.tsx(21,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
client/components/ChatEditor.tsx(46,10): error TS2300: Duplicate identifier 'useWebShellPortalRoot'.
```

本分支上：`npm run build`（全 workspace，按依赖顺序）rc=0，零 TypeScript 错误。

同样的失败在任何新开的 PR 的 CI 上都能看到——例如 #6892 的 `Test (ubuntu-latest, Node 22.x)` 就是挂在 *Install dependencies*，报的正是那两行。

## 风险与范围

- 风险：无。符号仍然只 import 一次，两个调用点原封不动。
- 破坏性变更：无。

</details>
