### PR TITLE
docs(desktop): propose near-term product and UI directions

### DIFF
--- a/docs/design/2026-07-14-desktop-product-and-ui-proposal.md
+++ b/docs/design/2026-07-14-desktop-product-and-ui-proposal.md
@@ -1,0 +1,164 @@
+# Qwen Code Desktop: Near-Term Product and UI Directions
+
+Status: Draft for discussion and review
+
+Date: 2026-07-14
+Related issue: [#6896](https://github.com/QwenLM/qwen-code/issues/6896)
+
+## Background
+
+Qwen Code Desktop already provides multiple workspaces, multiple sessions, file previews, a dockable browser, background tasks, skills, automations, and settings. However, it still feels closer to a desktop container for CLI capabilities than a product with a clearly differentiated desktop value proposition.
+
+Desktop should do more than place a CLI conversation inside a window. It should use persistent visual surfaces, parallel information display, and interactive tools to provide a complete workspace experience that is difficult to achieve in a CLI.
+
+Based on the current Electron development environment, the existing code structure, and the ChatGPT/Codex Desktop reference interface, this proposal focuses on three near-term directions:
+
+1. Complete the core capabilities that demonstrate the value of Desktop, with an initial focus on the right sidebar;
+2. Clarify the sharing boundaries of the Desktop UI and the direction of ACP-based communication;
+3. Improve the overall information architecture and project-environment visibility while keeping near-term UI changes limited in scope.
+
+## Direction 1: Complete Desktop-Specific Capabilities
+
+### Goal
+
+Completing Desktop-specific capabilities is the primary goal of this proposal. Users should be able to continuously inspect information, operate tools, and track work within the same session workspace without frequently switching to other applications.
+
+Desktop differentiation includes many possible capabilities, but the near-term focus should be the right sidebar. It is the most direct surface for persistent information and tools, and therefore the clearest starting point for creating an experience that differs from the CLI. Other Desktop capabilities are outside the scope of this proposal.
+
+The right sidebar is more than a centralized set of feature entry points. Over time, it should become a shared context surface where the user and the Agent work together. The Agent should be able to act on and update panels for files, the browser, terminal sessions, tasks, and reviews, while also observing the context the user is currently viewing or selecting. The user should be able to inspect results, make decisions, and provide feedback within the same interface.
+
+For example, the Agent could present changes, diffs, and review findings in the sidebar, allowing the user to confirm them, comment on them, or request revisions against the same shared context. This two-way contextual collaboration is not simply a matter of grouping features together; it is a long-term problem that the Desktop experience needs to solve. This proposal establishes the direction, while detailed interactions and state-management mechanisms can be designed separately.
+
+### Near-Term Focus
+
+Using the right-hand work surface in ChatGPT/Codex Desktop as a reference, Qwen Code Desktop should first complete and unify the main right-sidebar entry points:
+
+- Review: inspect code changes, diffs, and related checks;
+- Terminal: inspect command execution, background shells, and runtime status;
+- Browser: view and verify web content alongside the session;
+- Files: inspect session artifacts, attachments, and workspace files;
+- Side tasks: continuously track background tasks and their status.
+
+The current codebase already contains foundational support for session files, file previews, browser docking, background tasks, terminal output, and diff rendering, but their entry points are fragmented. The near-term goal of Direction 1 is not to reimplement these capabilities, but to progressively organize them into a unified and stable right sidebar.
+
+The first step can prioritize the more mature file and browser capabilities, with other areas completed as their product definitions become clearer through actual use.
+
+[Issue #4885](https://github.com/QwenLM/qwen-code/issues/4885) proposed moving Desktop file content from a full-screen view into a sidebar or split-pane preview. Although the issue is closed, its goals of preserving conversation context and reducing view switching are aligned with this direction and provide useful background for the right-side file panel.
+
+## Direction 2: Clarify the Desktop UI and Communication Architecture
+
+### Goal
+
+Establish an application-level UI for the Desktop product that can serve both Electron and a future Desktop WebUI, while preserving a distinct product role for the repository's Web Shell.
+
+### UI Boundaries
+
+`@craft-agent/ui` already provides platform-independent components for chat rendering, Markdown, file previews, diffs, and terminal output. It should continue to serve as a shared presentation layer.
+
+[Issue #5883](https://github.com/QwenLM/qwen-code/issues/5883) proposes sharing a chat panel across Web Shell, the VS Code webview, and Desktop. Chat flows, message rendering, and composer components have clear cross-surface reuse value. This proposal supports continued evaluation and reuse in that direction, while leaving the exact component ownership and data-adaptation model to be confirmed against the current implementations.
+
+Sharing Chat components does not mean merging the entire Desktop UI with Web Shell. Desktop application-level UI such as workspace navigation, session layout, left and right sidebars, and tool panels may still require a separate component layer. That layer should be shared by Electron and a future Desktop WebUI, with platform adapters providing filesystem, browser, window, and notification capabilities.
+
+`packages/web-shell` serves as an embeddable daemon-backed session terminal. Its deployment model, host relationship, and product role differ from those of a Desktop WebUI, so its overall UI should not be merged with the Desktop application UI.
+
+The boundary can be summarized as follows:
+
+```text
+Electron ─────────┐
+                  ├─ Desktop application-level UI ── @craft-agent/ui
+Desktop WebUI ────┘
+
+Web Shell ── daemon SDK / HTTP / SSE
+```
+
+Whether this should become a dedicated application-level UI package or a clearly defined subpath of `@craft-agent/ui` can be decided during the first concrete extraction. The priority is to keep platform dependencies directional and prevent a future Desktop WebUI from depending directly on Electron renderer internals or global APIs.
+
+### ACP Communication
+
+Desktop sessions should continue to connect to the Qwen Code CLI through ACP, without introducing daemon as the default intermediary.
+
+The current path can be summarized as follows:
+
+```text
+Electron / Desktop WebUI
+  -> Desktop RPC and SessionManager
+  -> QwenAgent
+  -> Qwen Code CLI over ACP
+```
+
+For a single Desktop client, direct ACP communication avoids an additional process, protocol translation, and duplicated session state while remaining consistent with the current implementation. Daemon should continue to serve Web Shell, multi-client, and standalone service-deployment scenarios, keeping the two paths clearly separated.
+
+## Direction 3: Improve Information Architecture and Project Context
+
+### Goal
+
+Make a small set of information-architecture improvements so users can clearly distinguish global chats, workspaces, and tasks or sessions within a workspace; understand where existing capabilities such as file preview and the built-in browser belong; and quickly inspect the current project's Git context and change status.
+
+### Settings Placement
+
+Following the ChatGPT/Codex Desktop layout, move Settings from the primary navigation at the top to a fixed position at the bottom of the left sidebar.
+
+This step should only change the location of the Settings entry point. It should not reorganize settings categories or change existing settings content and storage.
+
+### Chats and Workspaces
+
+Chats and Workspaces should be top-level peers in both structure and visual hierarchy:
+
+- Chats: sessions that are not bound to a specific project workspace;
+- Workspaces: an explicit list of available workspaces, with the relevant tasks or sessions shown under each workspace.
+
+The proposed structure is:
+
+```text
+New chat
+Search
+Skills
+Skill marketplace
+Automations
+
+Chats
+Workspaces
+  workspace-a
+    Task / Session 1
+    Task / Session 2
+  workspace-b
+    Task / Session 3
+
+Settings
+```
+
+The current interface already displays workspaces and their sessions, but Chats can still be interpreted as another workspace. Near-term changes should focus on clearer top-level grouping, indentation, and selection states rather than expanding into a complete rewrite of the left sidebar.
+
+The final product terminology for Task and Session can remain open for discussion. The first step does not require a broad change to the internal `session` data model.
+
+### File Preview and Built-In Browser
+
+File preview and the dockable built-in browser already have foundational implementations, but their entry points and presentation are fragmented. The information architecture should unify their placement, entry points, and expansion behavior within the right sidebar, while clarifying how they relate to the current session and workspace context.
+
+Direction 1 concerns completing the right-sidebar capabilities themselves. Direction 3 concerns organizing and exposing those capabilities consistently. This phase does not require rewriting the underlying file-preview or browser implementations.
+
+### Project Git Context
+
+Using the environment-information area in the upper-right of the reference interface as a model, add a centralized and discoverable Git context entry point for the current project. It should summarize current changes, workspace location, branch, and common actions such as committing, pushing, and creating a pull request.
+
+Like the left-navigation adjustments, this is a small information-architecture improvement. The goal is to make it immediately clear which project and branch the user is working in, what has changed, and what actions are available next, without attempting to build a complete Git client or complex repository-management system in this phase.
+
+[Issue #4769](https://github.com/QwenLM/qwen-code/issues/4769) previously tracked displaying the Git branch directly in Desktop. [Issue #6699](https://github.com/QwenLM/qwen-code/issues/6699) discusses a unified presentation of workspace, execution context, and Git branch entry points in Web Shell. Although they target different surfaces, both reinforce the need for persistent and clear project context and provide useful references for this information-architecture work.
+
+## Near-Term Scope
+
+The near-term focus is to complete the core structure without broadly reorganizing existing UI and settings details:
+
+- Establish unified entry points for differentiated Desktop capabilities;
+- Clarify the shared UI boundary between Electron and a future Desktop WebUI;
+- Preserve direct ACP communication for Desktop;
+- Make the smallest necessary changes to Settings placement, left-sidebar hierarchy, file and browser entry points, and project Git context;
+- Refine details that are not yet clear through continued real-world use.
+
+## Open Questions
+
+1. Are these three directions appropriate as the main near-term focus areas for Desktop?
+2. Should the right-hand work surface host Review, Terminal, Browser, Files, and Side Tasks while also becoming a long-term shared context and collaboration surface for the user and the Agent?
+3. How should cross-surface reuse of Chat components align with Issue #5883, and does Desktop still need a separate application-level UI layer shared by Electron and a future Desktop WebUI?
+4. Should Desktop continue to connect directly to the Qwen Code CLI through ACP by default, without going through daemon?
+5. Should Settings move to the bottom, Chats and Workspaces become top-level peers, file preview and built-in browser entry points be unified, and project Git context be centralized in the upper-right area?


### PR DESCRIPTION
## What this PR does

This PR adds a discussion-oriented proposal for the near-term product and UI directions of Qwen Code Desktop. It groups the work into three areas: differentiated Desktop capabilities centered on the right-hand work surface; UI sharing boundaries and direct ACP communication; and focused information-architecture changes for chats, workspaces, settings, files, the built-in browser, and Git context.

The proposal connects the new discussion to existing issues #4885, #5883, #4769, and #6699. In particular, it treats the shared Chat components proposed in #5883 as compatible with a separate Desktop application-level UI layer shared by Electron and a future Desktop WebUI.

## Why it's needed

Qwen Code Desktop already has substantial foundational capabilities, but its value relative to the CLI is not yet expressed through a coherent Desktop-specific workspace experience. Before implementation is split into focused work items, the community needs a reviewable artifact that makes the intended product differentiation, UI reuse boundary, ACP communication direction, and near-term information-architecture scope explicit.

## Reviewer Test Plan

### How to verify

1. Confirm that the proposal clearly presents three near-term directions without positioning itself as a full product roadmap.
2. Confirm that the right-hand work surface is described both as a unified capability surface and as a longer-term shared context surface for user-Agent collaboration.
3. Confirm that the relationship with #5883 allows Chat component reuse while keeping open a separate Desktop application-level UI for Electron and a future Desktop WebUI.
4. Confirm that direct ACP remains the proposed default for Desktop and that the information-architecture changes remain intentionally small in scope.
5. Confirm that #4885, #5883, #4769, #6699, and the tracking issue #6896 are linked in the relevant context.

### Evidence (Before & After)

N/A — documentation-only change with no user-visible runtime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Documentation-only validation on macOS. Prettier and the staged diff whitespace check passed.

## Risk & Scope

- Main risk or tradeoff: The proposal records directions and open decisions rather than a finalized implementation architecture; reviewers may prefer different sharing boundaries or sequencing.
- Not validated / out of scope: Implementation, UI prototypes, interaction specifications, migrations, and runtime testing.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #6896.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 新增一份面向讨论的 Qwen Code Desktop 近期产品与 UI 方向提案。提案将近期工作归纳为三个方向：以右侧工作面为重点补齐桌面端差异化能力；明确 UI 复用边界并保持 Desktop 直连 ACP；以及针对对话、工作区、设置、文件、内置浏览器和 Git 上下文进行小范围的信息架构调整。

提案将本次讨论与已有的 #4885、#5883、#4769 和 #6699 关联起来。特别是，它认为 #5883 提议的 Chat 组件复用与单独建设 Desktop 应用级 UI 并不冲突；后者可以由 Electron 与未来的 Desktop WebUI 共同使用。

## 为什么需要

Qwen Code Desktop 已经具备较多基础能力，但相对于 CLI 的产品价值还没有通过连贯的桌面工作空间体验充分体现。在将后续实现拆分为聚焦的工作项之前，社区需要一份可评审的文档，明确桌面端的产品差异、UI 复用边界、ACP 通信方向和近期信息架构范围。

## Reviewer 测试计划

### 如何验证

1. 确认提案清晰呈现三个近期方向，并且没有将自身定义为完整的产品路线图。
2. 确认右侧工作面既被定义为统一的能力承载面，也被定义为用户与 Agent 长期共享上下文和协作的界面。
3. 确认提案与 #5883 的关系允许复用 Chat 组件，同时保留为 Electron 和未来 Desktop WebUI 建立单独 Desktop 应用级 UI 的可能性。
4. 确认 Desktop 默认直连 ACP 的方向保持不变，并且信息架构调整被有意限制在较小范围内。
5. 确认 #4885、#5883、#4769、#6699 和跟踪 Issue #6896 都在相关上下文中得到关联。

### 证据（修改前与修改后）

不适用——仅文档变更，没有用户可见的运行时行为变化。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

### 环境（可选）

在 macOS 上完成纯文档验证。Prettier 和暂存差异空白检查均已通过。

## 风险与范围

- 主要风险或权衡：提案记录的是方向和待确认问题，而不是已经最终确定的实现架构；评审者可能对复用边界或推进顺序有不同意见。
- 未验证或不在范围内：具体实现、UI 原型、交互规格、迁移和运行时测试。
- 破坏性变更或迁移说明：无。

## 关联 Issue

关联 #6896。

</details>
