### PR TITLE
fix(cli): don't mutate cached trusted-folders config on preview trust check

### DIFF
--- a/packages/cli/src/config/trustedFolders.test.ts
+++ b/packages/cli/src/config/trustedFolders.test.ts
@@ -664,6 +664,28 @@ describe('getWorkspaceTrustStatus', () => {
       explicitTrustLevel: null,
     });
   });
+
+  it('does not mutate the cached config when a preview override is passed', () => {
+    mockRules['/home/user/projectA'] = TrustLevel.TRUST_FOLDER;
+
+    // Prime the module cache from disk, then snapshot the loaded config.
+    const before = { ...loadTrustedFolders().user.config };
+
+    // A read-only "preview" check with a tentative override config that adds a
+    // folder not present on disk.
+    const overrideConfig = {
+      ...before,
+      '/home/user/preview': TrustLevel.DO_NOT_TRUST,
+    };
+    getWorkspaceTrustStatus(mockSettings, '/home/user/preview', overrideConfig);
+
+    // The cached config must be unchanged — the tentative preview must not leak
+    // into subsequent reads.
+    expect(loadTrustedFolders().user.config).toEqual(before);
+    expect(
+      loadTrustedFolders().user.config['/home/user/preview'],
+    ).toBeUndefined();
+  });
 });
 
 describe('isWorkspaceTrusted with IDE override', () => {

--- a/packages/cli/src/config/trustedFolders.ts
+++ b/packages/cli/src/config/trustedFolders.ts
@@ -323,10 +323,6 @@ function loadTrustedFoldersWithOverrides(
 ): LoadedTrustedFolders {
   const folders = loadTrustedFolders();
 
-  if (trustConfig) {
-    folders.user.config = trustConfig;
-  }
-
   if (folders.errors.length > 0) {
     const errorMessages = folders.errors.map(
       (error) => `Error in ${error.path}: ${error.message}`,
@@ -335,6 +331,20 @@ function loadTrustedFoldersWithOverrides(
       `${errorMessages.join('\n')}\nPlease fix the configuration file and try again.`,
     );
   }
+
+  if (trustConfig) {
+    // Return a fresh instance instead of mutating the cached singleton. Callers
+    // pass an override to *preview* trust status for a tentative config (e.g.
+    // useTrustModify's updateTrustLevel, which builds the config "to check the
+    // new trust status without writing"). Mutating the cached singleton here
+    // would leak that unconfirmed config into every later loadTrustedFolders()
+    // read and persist it on the next setValue().
+    return new LoadedTrustedFolders(
+      { ...folders.user, config: trustConfig },
+      folders.errors,
+    );
+  }
+
   return folders;
 }
 


### PR DESCRIPTION
Fixes #6831

## Problem

`loadTrustedFoldersWithOverrides()` in `packages/cli/src/config/trustedFolders.ts` mutates the module-level cached `LoadedTrustedFolders` singleton when given an override:

```ts
const folders = loadTrustedFolders();   // cached singleton
if (trustConfig) {
  folders.user.config = trustConfig;    // mutates the cache in place
}
```

But callers pass an override to **preview** trust status for a tentative config without persisting it — e.g. `useTrustModify.ts`'s `updateTrustLevel`, which explicitly builds the config "to check the new trust status without writing":

```ts
const currentConfig = loadTrustedFolders().user.config;
const newConfig = { ...currentConfig, [cwd]: trustLevel };
const { isTrusted, source } = isWorkspaceTrusted(settings.merged, newConfig);
```

So the tentative preview leaks into the cache:

1. **Read pollution** — every later `isWorkspaceTrusted(settings)` / `loadTrustedFolders().user.config` sees the preview instead of the real config.
2. **Write pollution** — `LoadedTrustedFolders.setValue()` does `this.user.config[path] = trustLevel; saveTrustedFolders(this.user)`, and `this.user` is the same polluted singleton, so a later confirmed change persists the unconfirmed preview to disk.

Since this governs folder-trust decisions, an unconfirmed preview making a folder report as trusted (or untrusted) is a correctness/security concern.

## Fix

Return a fresh `LoadedTrustedFolders` (with a spread-copied config) for the override case instead of mutating the cached singleton. The error check is moved ahead of the override branch and is behavior-preserving.

## Testing

- Added a regression test asserting `loadTrustedFolders().user.config` is unchanged after a preview override check (and the preview key never leaks in).
- Verified red/green: the test fails without the fix and passes with it.
- `trustedFolders.test.ts`: 37/37 pass. eslint + prettier clean.