### PR TITLE
fix(vscode-companion): don't let a non-boundary @ suppress / completion

### DIFF
--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
@@ -8,6 +8,7 @@ import type { RefObject } from 'react';
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { CompletionItem } from '../../types/completionItemTypes.js';
 import { shouldAllowCompletionQuery } from '../utils/slashCommandUtils.js';
+import { resolveCompletionTrigger } from '../utils/completionUtils.js';
 import { stripZeroWidthSpaces } from '@qwen-code/webui';
 
 interface CompletionTriggerState {
@@ -311,49 +312,20 @@ export function useCompletionTrigger(
         cursorPosition = found ? offset : text.length;
       }
 
-      // Find trigger character before cursor.
+      // Find the trigger character before the cursor.
       // A cursorPosition of 0 is a valid position (cursor at the very start),
       // so it must not be rewritten to text.length. We still clamp to
       // text.length because the DOM cursor offset may exceed the stripped text
       // length (e.g. after removing a leading zero-width space).
       const clampedCursorPosition = Math.min(cursorPosition, text.length);
 
-      const textBeforeCursor = text.substring(0, clampedCursorPosition);
-      const lastAtMatch = textBeforeCursor.lastIndexOf('@');
-      const lastSlashMatch = textBeforeCursor.lastIndexOf('/');
-
-      // Check if we're in a trigger context
-      let triggerPos = -1;
-      let triggerChar: '@' | '/' | null = null;
-
-      // Priority: @ trigger takes precedence over / trigger
-      // This allows path-like queries (e.g., "src/components/Button") in @ mentions
-      // But skip if the trigger is inside a file tag
-      if (lastAtMatch >= 0) {
-        triggerPos = lastAtMatch;
-        triggerChar = '@';
-      } else if (lastSlashMatch >= 0) {
-        triggerPos = lastSlashMatch;
-        triggerChar = '/';
-      }
-
-      // Check if trigger is at word boundary (start of line or after space)
-      if (triggerPos >= 0 && triggerChar) {
-        const charBefore = triggerPos > 0 ? text[triggerPos - 1] : ' ';
-        const isValidTrigger =
-          charBefore === ' ' || charBefore === '\n' || triggerPos === 0;
-
-        if (isValidTrigger) {
-          const query = text.substring(triggerPos + 1, clampedCursorPosition);
-
-          if (shouldAllowCompletionQuery(triggerChar, query)) {
-            // Get precise cursor position for menu
-            const cursorPos = getCursorPosition();
-            if (cursorPos) {
-              await openCompletion(triggerChar, query, cursorPos);
-              return;
-            }
-          }
+      const trigger = resolveCompletionTrigger(text, clampedCursorPosition);
+      if (trigger && shouldAllowCompletionQuery(trigger.char, trigger.query)) {
+        // Get precise cursor position for menu
+        const cursorPos = getCursorPosition();
+        if (cursorPos) {
+          await openCompletion(trigger.char, trigger.query, cursorPos);
+          return;
         }
       }
 

--- a/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
@@ -82,12 +82,20 @@ describe('completionUtils', () => {
       expect(at('hello @wor')).toEqual({ char: '@', pos: 6, query: 'wor' });
     });
 
+    it('treats a newline as a word boundary for @', () => {
+      expect(at('hello\n@wor')).toEqual({ char: '@', pos: 6, query: 'wor' });
+    });
+
     it('resolves a / slash command at the start of input', () => {
       expect(at('/he')).toEqual({ char: '/', pos: 0, query: 'he' });
     });
 
     it('returns null when the only @ is inside a word and there is no /', () => {
       expect(at('email foo@bar.com')).toBeNull();
+    });
+
+    it('returns null when / is not at a word boundary and no valid @ exists', () => {
+      expect(at('foo/bar')).toBeNull();
     });
 
     it('returns null when neither trigger is present', () => {

--- a/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
@@ -110,5 +110,10 @@ describe('completionUtils', () => {
         query: 'he',
       });
     });
+
+    it('gives @ priority over / when both are at word boundaries', () => {
+      // Both triggers are valid (/ at pos 0, @ after a space); @ wins by design.
+      expect(at('/cmd @user')).toEqual({ char: '@', pos: 5, query: 'user' });
+    });
   });
 });

--- a/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/completionUtils.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import type { CompletionItem } from '../../types/completionItemTypes.js';
 import {
   isSkillsSecondaryQuery,
+  resolveCompletionTrigger,
   shouldOpenSkillsSecondaryPicker,
 } from './completionUtils.js';
 
@@ -54,6 +55,52 @@ describe('completionUtils', () => {
           ['review'],
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('resolveCompletionTrigger', () => {
+    const at = (text: string) => resolveCompletionTrigger(text, text.length);
+
+    it('falls back to a valid / when the last @ is inside a word (e.g. email)', () => {
+      // Regression: a non-boundary @ (inside "foo@bar.com") must not suppress
+      // the slash-command menu for a later, valid / trigger.
+      const text = 'contact foo@bar.com /he';
+      expect(at(text)).toEqual({ char: '/', pos: 20, query: 'he' });
+    });
+
+    it('keeps a / that is part of an @ mention path inside the mention', () => {
+      // The @ is at a word boundary, so it wins and the path-like / is not
+      // treated as a slash command.
+      expect(at('@src/components/Bu')).toEqual({
+        char: '@',
+        pos: 0,
+        query: 'src/components/Bu',
+      });
+    });
+
+    it('resolves an @ mention after a space', () => {
+      expect(at('hello @wor')).toEqual({ char: '@', pos: 6, query: 'wor' });
+    });
+
+    it('resolves a / slash command at the start of input', () => {
+      expect(at('/he')).toEqual({ char: '/', pos: 0, query: 'he' });
+    });
+
+    it('returns null when the only @ is inside a word and there is no /', () => {
+      expect(at('email foo@bar.com')).toBeNull();
+    });
+
+    it('returns null when neither trigger is present', () => {
+      expect(at('just some text')).toBeNull();
+    });
+
+    it('resolves the trigger relative to the cursor, ignoring text after it', () => {
+      // Cursor sits right after "/he" in "/help world".
+      expect(resolveCompletionTrigger('/help world', 3)).toEqual({
+        char: '/',
+        pos: 0,
+        query: 'he',
+      });
     });
   });
 });

--- a/packages/vscode-ide-companion/src/webview/utils/completionUtils.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/completionUtils.ts
@@ -44,3 +44,49 @@ export function shouldOpenSkillsSecondaryPicker(
     availableSkills.length > 0
   );
 }
+
+/**
+ * Resolve which completion trigger (`@` or `/`), if any, is active immediately
+ * before the cursor.
+ *
+ * A trigger only counts at a word boundary — the start of the input, or right
+ * after a space/newline. A valid `@` takes precedence over `/` so that
+ * path-like queries stay part of an `@` mention (e.g. `@src/components/Button`
+ * is a single mention, not a slash command). Crucially, an `@` that is NOT at
+ * a word boundary — for example inside an email like `foo@bar.com` — is not a
+ * trigger at all, so we fall through and still evaluate a later `/`. Without
+ * this, typing `foo@bar.com /he` would let the unrelated `@` suppress the
+ * slash-command menu entirely.
+ *
+ * @param text - The full input text
+ * @param cursorPosition - Cursor offset into `text` (already clamped to length)
+ * @returns The active trigger's character, position, and the query following
+ * it, or `null` when there is no valid trigger before the cursor.
+ */
+export function resolveCompletionTrigger(
+  text: string,
+  cursorPosition: number,
+): { char: '@' | '/'; pos: number; query: string } | null {
+  const textBeforeCursor = text.substring(0, cursorPosition);
+  const lastAtMatch = textBeforeCursor.lastIndexOf('@');
+  const lastSlashMatch = textBeforeCursor.lastIndexOf('/');
+
+  const isAtWordBoundary = (pos: number): boolean =>
+    pos === 0 || text[pos - 1] === ' ' || text[pos - 1] === '\n';
+
+  let pos = -1;
+  let char: '@' | '/' | null = null;
+  if (lastAtMatch >= 0 && isAtWordBoundary(lastAtMatch)) {
+    pos = lastAtMatch;
+    char = '@';
+  } else if (lastSlashMatch >= 0 && isAtWordBoundary(lastSlashMatch)) {
+    pos = lastSlashMatch;
+    char = '/';
+  }
+
+  if (pos < 0 || !char) {
+    return null;
+  }
+
+  return { char, pos, query: text.substring(pos + 1, cursorPosition) };
+}


### PR DESCRIPTION
## What this PR does

Fixes the VS Code chat input so that a stray `@` (for example inside an email address) no longer suppresses slash-command completion. Extracts the trigger-resolution logic into a small pure function and adds unit tests.

## Why it's needed

In `useCompletionTrigger`, the code that decides which trigger is active gave `@` unconditional priority over `/`:

```ts
if (lastAtMatch >= 0) {
  triggerPos = lastAtMatch;
  triggerChar = '@';
} else if (lastSlashMatch >= 0) {
  triggerPos = lastSlashMatch;
  triggerChar = '/';
}
```

When the last `@` before the cursor is not at a word boundary — e.g. inside `foo@bar.com` — it was still selected, then failed the boundary check below, and the function returned without ever evaluating the `/`. So typing `contact foo@bar.com /he` showed no slash-command menu, because the email's `@` short-circuited it.

The fix moves the resolution into a pure `resolveCompletionTrigger(text, cursorPosition)` that only treats an `@` as a trigger when it is at a word boundary; otherwise it falls through to a valid `/`. The `@`-over-`/` priority is preserved for real mentions, so path-like queries such as `@src/components/Button` still stay part of the `@` mention rather than being read as a slash command.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/webview/utils/completionUtils.test.ts` from `packages/vscode-ide-companion`. The new `resolveCompletionTrigger` suite covers the email fallback, the `@`-mention-with-path case, a plain `@` mention, a leading `/`, and the no-trigger cases. The email-fallback test fails against the previous unconditional-`@` logic (verified locally by reverting) and passes with the fix.

### Evidence (Before & After)

For input `contact foo@bar.com /he` with the cursor at the end:
Before: `@` (index 11, inside the email) is selected, fails the boundary check, and no completion opens — the `/he` slash command is never offered.
After: the non-boundary `@` is skipped and the valid `/` (index 20) resolves to `{ char: '/', query: 'he' }`, so slash-command completion opens.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `completionUtils` suite (11 pass, including 7 new; no existing test changed), confirmed the new email-fallback test fails against the pre-fix logic, and ran `prettier --check` + `eslint` on the changed files (clean). Windows/Linux: N/A — pure string logic with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/vscode-ide-companion` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note. The `@`-over-`/` priority is unchanged for valid mentions; the only behavior change is that an `@` which is not a real trigger no longer blocks a later `/`. Cases where the old code opened an `@` (or `/`) completion resolve identically.
- Not validated / out of scope: no change to `shouldAllowCompletionQuery` or the DOM cursor-offset calculation; those are untouched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 VS Code 聊天输入框：位于单词内部的 `@`（例如邮箱地址中的 `@`）不再抑制斜杠命令补全。将触发字符的判定逻辑抽取为一个纯函数，并补充单元测试。

## 为什么需要

在 `useCompletionTrigger` 中，判定当前激活触发符的代码让 `@` 无条件优先于 `/`：

```ts
if (lastAtMatch >= 0) {
  triggerPos = lastAtMatch;
  triggerChar = '@';
} else if (lastSlashMatch >= 0) {
  triggerPos = lastSlashMatch;
  triggerChar = '/';
}
```

当光标前最后一个 `@` 不在单词边界上（例如在 `foo@bar.com` 内部）时，它仍会被选中，随后未通过下方的边界校验，函数直接返回，`/` 从未被评估。因此输入 `contact foo@bar.com /he` 时不会弹出斜杠命令菜单——邮箱里的 `@` 把它短路了。

修复方式是把判定逻辑抽取为纯函数 `resolveCompletionTrigger(text, cursorPosition)`：仅当 `@` 位于单词边界时才将其视为触发符，否则回落到有效的 `/`。对真实的 `@` 提及仍保留 `@` 优先于 `/` 的规则，因此像 `@src/components/Button` 这样的路径查询仍属于 `@` 提及，而不会被当作斜杠命令。

## 复核测试计划

### 如何验证

在 `packages/vscode-ide-companion` 下运行 `npx vitest run src/webview/utils/completionUtils.test.ts`。新增的 `resolveCompletionTrigger` 用例覆盖了邮箱回落、`@` 提及含路径、普通 `@` 提及、开头的 `/`，以及无触发符的情形。邮箱回落用例在修复前的无条件 `@` 逻辑下会失败（已在本地通过回退验证），在修复下通过。

### 证据（修复前后对比）

对于输入 `contact foo@bar.com /he`（光标在末尾）：
修复前：选中邮箱中的 `@`（下标 11），边界校验失败，不弹出任何补全——`/he` 斜杠命令从未被提供。
修复后：跳过非边界的 `@`，有效的 `/`（下标 20）解析为 `{ char: '/', query: 'he' }`，弹出斜杠命令补全。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `completionUtils` 测试（11 个通过，含 7 个新增；未改动任何既有测试），确认新增的邮箱回落测试在修复前失败，并对改动文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯字符串逻辑，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/vscode-ide-companion` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有。对有效提及而言 `@` 优先于 `/` 的规则保持不变；唯一的行为变化是：不构成真正触发符的 `@` 不再阻挡后面的 `/`。此前会弹出 `@`（或 `/`）补全的情形，结果完全一致。
- 未验证 / 范围之外：未改动 `shouldAllowCompletionQuery`，也未改动 DOM 光标偏移的计算。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
