### PR TITLE
fix(dingtalk): refresh token for inbound media

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -843,6 +843,96 @@ describe('DingtalkChannel prompt reactions', () => {
   });
 });
 
+describe('DingtalkChannel inbound media', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function attachImage(
+    channel: DingtalkChannelInstance,
+    envelope: Envelope,
+    downloadCode: string,
+  ): Promise<void> {
+    return (
+      channel as unknown as {
+        attachMedia(
+          envelope: Envelope,
+          downloadCode: string,
+          mediaType: 'image',
+        ): Promise<void>;
+      }
+    ).attachMedia(envelope, downloadCode, 'image');
+  }
+
+  it('refreshes the app access token after its TTL while the stream stays connected', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T00:00:00Z'));
+    const channel = createChannel();
+    let tokenCall = 0;
+    const mediaTokens: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith('https://oapi.dingtalk.com/gettoken')) {
+          tokenCall++;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                errcode: 0,
+                access_token: `app-token-${tokenCall}`,
+                expires_in: 60,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (
+          url === 'https://api.dingtalk.com/v1.0/robot/messageFiles/download'
+        ) {
+          mediaTokens.push(
+            (init?.headers as Record<string, string>)[
+              'x-acs-dingtalk-access-token'
+            ],
+          );
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ downloadUrl: 'https://example.com/image' }),
+              { status: 200 },
+            ),
+          );
+        }
+        return Promise.resolve(
+          new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+          }),
+        );
+      },
+    );
+    const firstEnvelope = {} as Envelope;
+    const secondEnvelope = {} as Envelope;
+    await attachImage(channel, firstEnvelope, 'download-code-1');
+    vi.advanceTimersByTime(61_000);
+    await attachImage(channel, secondEnvelope, 'download-code-2');
+
+    expect(tokenCall).toBe(2);
+    expect(mediaTokens).toEqual(['app-token-1', 'app-token-2']);
+    expect(firstEnvelope.attachments).toHaveLength(1);
+    expect(secondEnvelope.attachments).toHaveLength(1);
+  });
+
+  it('keeps media attachment best-effort when app token refresh fails', async () => {
+    const channel = createChannel();
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(
+      attachImage(channel, {} as Envelope, 'download-code'),
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe('DingtalkChannel.isUnroutableGroupMessage', () => {
   it('drops group messages with no conversationId', () => {
     expect(DingtalkChannel.isUnroutableGroupMessage(true, undefined)).toBe(

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -924,7 +924,11 @@ describe('DingtalkChannel inbound media', () => {
 
   it('keeps media attachment best-effort when app token refresh fails', async () => {
     const channel = createChannel();
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error(
+        'request failed for https://oapi.dingtalk.com/gettoken?appkey=client-id&appsecret=client-secret',
+      ),
+    );
     const stderrSpy = vi
       .spyOn(process.stderr, 'write')
       .mockImplementation(() => true);
@@ -935,6 +939,11 @@ describe('DingtalkChannel inbound media', () => {
     expect(stderrSpy).toHaveBeenCalledWith(
       '[DingTalk:test-dingtalk] Cannot download media: access token refresh failed.\n',
     );
+    const logged = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(logged).toContain(
+      '[DingTalk:test-dingtalk] access token fetch failed.\n',
+    );
+    expect(logged).not.toContain('client-secret');
   });
 });
 

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -925,11 +925,16 @@ describe('DingtalkChannel inbound media', () => {
   it('keeps media attachment best-effort when app token refresh fails', async () => {
     const channel = createChannel();
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
 
     await expect(
       attachImage(channel, {} as Envelope, 'download-code'),
     ).resolves.toBeUndefined();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      '[DingTalk:test-dingtalk] Cannot download media: access token refresh failed.\n',
+    );
   });
 });
 

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -1090,7 +1090,14 @@ export class DingtalkChannel extends ChannelBase {
     mediaType: 'image' | 'file' | 'audio' | 'video',
     fileName?: string,
   ): Promise<void> {
-    const token = this.getAccessToken();
+    let token: string | undefined;
+    try {
+      token = this.config.clientSecret
+        ? await this.getProactiveToken()
+        : this.getAccessToken();
+    } catch {
+      return;
+    }
     const robotCode = this.config.clientId;
     if (!token || !robotCode) {
       process.stderr.write(

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -530,21 +530,19 @@ export class DingtalkChannel extends ChannelBase {
         signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
       });
       data = (await resp.json()) as DingTalkTokenResponse;
-    } catch (err) {
+    } catch {
       process.stderr.write(
-        `[DingTalk:${this.name}] proactive send failed: token fetch error ${err}\n`,
+        `[DingTalk:${this.name}] access token fetch failed.\n`,
       );
-      throw new Error(
-        'DingTalk proactive send failed: could not fetch access token',
-      );
+      throw new Error('DingTalk access token fetch failed');
     }
     if (!data.access_token) {
       const errmsg = sanitizeLogText(String(data.errmsg ?? ''), 200);
       process.stderr.write(
-        `[DingTalk:${this.name}] proactive send failed: gettoken errcode=${data.errcode} ${errmsg}\n`,
+        `[DingTalk:${this.name}] access token request failed: gettoken errcode=${data.errcode} ${errmsg}\n`,
       );
       throw new Error(
-        `DingTalk proactive send failed: gettoken errcode=${data.errcode}${errmsg ? ` ${errmsg}` : ''}`,
+        `DingTalk access token request failed: gettoken errcode=${data.errcode}${errmsg ? ` ${errmsg}` : ''}`,
       );
     }
     this.proactiveToken = {
@@ -1090,7 +1088,7 @@ export class DingtalkChannel extends ChannelBase {
     mediaType: 'image' | 'file' | 'audio' | 'video',
     fileName?: string,
   ): Promise<void> {
-    let token: string | undefined;
+    let token: string;
     try {
       token = await this.getProactiveToken();
     } catch {
@@ -1100,9 +1098,9 @@ export class DingtalkChannel extends ChannelBase {
       return;
     }
     const robotCode = this.config.clientId;
-    if (!token || !robotCode) {
+    if (!robotCode) {
       process.stderr.write(
-        `[DingTalk:${this.name}] Cannot download media: missing token or robotCode.\n`,
+        `[DingTalk:${this.name}] Cannot download media: missing robotCode.\n`,
       );
       return;
     }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -1092,10 +1092,11 @@ export class DingtalkChannel extends ChannelBase {
   ): Promise<void> {
     let token: string | undefined;
     try {
-      token = this.config.clientSecret
-        ? await this.getProactiveToken()
-        : this.getAccessToken();
+      token = await this.getProactiveToken();
     } catch {
+      process.stderr.write(
+        `[DingTalk:${this.name}] Cannot download media: access token refresh failed.\n`,
+      );
       return;
     }
     const robotCode = this.config.clientId;


### PR DESCRIPTION
## What this PR does

Inbound DingTalk media downloads now use the app access-token cache that refreshes before expiry instead of the Stream connection's startup-time token. Token refresh failures remain best-effort so the text portion of an inbound message can still be delivered.

Regression coverage keeps the Stream client connected across a token TTL boundary, verifies that media requests use newly fetched tokens, and covers token-endpoint failure behavior.

## Why it's needed

A healthy long-running DingTalk Stream socket can outlive the access token captured when it connected. Image and file callbacks continue arriving, but media downloads eventually fail with the stale token until the channel restarts.

## Reviewer Test Plan

### How to verify

Run the DingTalk adapter test file and confirm that media downloads fetch a new app token after the cached token expires while the mocked Stream token remains unchanged. Also confirm that a token refresh failure does not make media attachment throw and block the inbound message path.

### Evidence (Before & After)

Before: the TTL regression reported zero app-token requests and both media downloads used the fixed Stream token. After: the test observes two app-token requests, media download headers use `app-token-1` and `app-token-2`, and both image attachments are created. The DingTalk adapter suite passes 64/64 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 local workspace; credential-free deterministic adapter tests.

## Risk & Scope

- Main risk or tradeoff: media downloads now depend on the app-token endpoint when a client secret is configured; failures are contained at the existing best-effort media boundary.
- Not validated / out of scope: live DingTalk verification across a real two-hour TTL requires app credentials, a bot conversation, and a valid download code; explicit retry after an unexpected media API 401 is not included because normal expiry is handled by the existing early-refresh cache.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6886

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

钉钉入站媒体下载现在复用会在过期前刷新的应用 access token 缓存，不再使用 Stream 连接建立时保存的 token。token 刷新失败仍保持 best-effort 语义，因此入站消息的文本部分仍可继续交付。

回归测试保持 Stream 客户端跨越 token TTL 持续连接，验证媒体请求使用新获取的 token，并覆盖 token 接口失败时的行为。

## 为什么需要

健康的钉钉 Stream 长连接可能比建连时获取的 access token 存活更久。图片和文件回调仍会到达，但媒体下载会因旧 token 失败，直到重启通道。

## Reviewer Test Plan

### 验证方式

运行钉钉适配器测试，确认在模拟的 Stream token 保持不变时，媒体下载会在缓存 token 过期后获取新的应用 token。同时确认 token 刷新失败不会让媒体附件流程抛错并阻断入站消息路径。

### 前后证据

修复前：TTL 回归测试观察到应用 token 请求为零，两次媒体下载都使用固定的 Stream token。修复后：测试观察到两次应用 token 请求，媒体下载请求头分别使用 `app-token-1` 和 `app-token-2`，且两次图片附件都成功创建。钉钉适配器测试 64/64 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

Node.js 22 本地工作区；无需凭证的确定性适配器测试。

## 风险与范围

- 主要风险或权衡：配置 client secret 时，媒体下载会依赖应用 token 接口；失败会被限制在原有的 best-effort 媒体边界内。
- 未验证 / 范围外：真实跨越两小时 TTL 的钉钉验证需要应用凭证、机器人会话和有效 download code；没有加入媒体 API 意外返回 401 后的显式重试，因为正常过期已由现有的提前刷新缓存处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6886

</details>
