### PR TITLE
fix(vscode-companion): accurate image-size messages and formatFileSize units

### DIFF
--- a/packages/vscode-ide-companion/src/webview/hooks/useImage.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useImage.test.ts
@@ -7,8 +7,8 @@
 import { build } from 'esbuild';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { escapePath } from '../../utils/imageSupport.js';
-import { splitMessageContentForImages } from './useImage.js';
+import { escapePath, MAX_IMAGE_SIZE } from '../../utils/imageSupport.js';
+import { formatFileSize, splitMessageContentForImages } from './useImage.js';
 
 describe('splitMessageContentForImages', () => {
   it('restores escaped image paths with spaces back to their original file path', () => {
@@ -21,6 +21,32 @@ describe('splitMessageContentForImages', () => {
 
     expect(result.text).toBe('Please inspect this screenshot.');
     expect(result.imagePaths).toEqual([imagePath]);
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats small sizes with the right unit', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+    expect(formatFileSize(512)).toBe('512 B');
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1536)).toBe('1.5 KB');
+    expect(formatFileSize(1024 * 1024)).toBe('1 MB');
+  });
+
+  it('describes the image size limit consistently with the constant', () => {
+    // The "too large" paste error interpolates this value, so it must read as
+    // a real size (and track MAX_IMAGE_SIZE) rather than a hardcoded string.
+    expect(formatFileSize(MAX_IMAGE_SIZE)).toBe('10 MB');
+  });
+
+  it('handles terabyte-scale sizes without emitting "undefined"', () => {
+    // Regression: the previous ['B','KB','MB','GB'] list had no slot for
+    // index 4, so a >= 1 TB value rendered "… undefined".
+    expect(formatFileSize(2 * 1024 ** 4)).toBe('2 TB');
+  });
+
+  it('clamps beyond the largest known unit instead of going out of bounds', () => {
+    expect(formatFileSize(1024 ** 5)).toBe('1024 TB');
   });
 });
 

--- a/packages/vscode-ide-companion/src/webview/hooks/useImage.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useImage.ts
@@ -245,9 +245,6 @@ export function formatFileSize(bytes: number): string {
   }
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-  // Clamp the unit index so a very large (or sub-1-byte) value never reads a
-  // slot past the array — otherwise sizes[i] is undefined and we render
-  // "… undefined" (e.g. for ≥ 1 TB with the previous ['B'..'GB'] list).
   const i = Math.max(
     0,
     Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1),

--- a/packages/vscode-ide-companion/src/webview/hooks/useImage.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useImage.ts
@@ -239,13 +239,19 @@ function isWithinSizeLimit(file: File): boolean {
   return file.size <= MAX_IMAGE_SIZE;
 }
 
-function formatFileSize(bytes: number): string {
+export function formatFileSize(bytes: number): string {
   if (bytes === 0) {
     return '0 B';
   }
   const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  // Clamp the unit index so a very large (or sub-1-byte) value never reads a
+  // slot past the array — otherwise sizes[i] is undefined and we render
+  // "… undefined" (e.g. for ≥ 1 TB with the previous ['B'..'GB'] list).
+  const i = Math.max(
+    0,
+    Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1),
+  );
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 }
 
@@ -332,7 +338,7 @@ export function useImagePaste({
 
           if (!isWithinSizeLimit(file)) {
             errors.push(
-              `Image "${file.name || 'pasted image'}" is too large (${formatFileSize(file.size)}). Maximum size is 10MB.`,
+              `Image "${file.name || 'pasted image'}" is too large (${formatFileSize(file.size)}). Maximum size is ${formatFileSize(MAX_IMAGE_SIZE)}.`,
             );
             continue;
           }


### PR DESCRIPTION
## What this PR does

Fixes two small correctness issues in the VS Code paste-image flow (`useImage.ts`) and adds unit tests for `formatFileSize`.

## Why it's needed

1. **The "too large" error hardcoded the limit.** When a pasted image exceeds the size cap, the message read `Maximum size is 10MB.` while the actual check uses the `MAX_IMAGE_SIZE` constant. If that constant ever changes, the message silently lies. The fix interpolates `formatFileSize(MAX_IMAGE_SIZE)` so the message always matches the real limit.

2. **`formatFileSize` could emit `"… undefined"`.** It used `['B', 'KB', 'MB', 'GB']` with an unclamped unit index:

   ```ts
   const sizes = ['B', 'KB', 'MB', 'GB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   ```

   For a value ≥ 1 TB, `i` is 4 or more, so `sizes[i]` is `undefined` and the result is e.g. `"2 undefined"`. The fix adds `'TB'` and clamps the index to the array bounds so it degrades gracefully instead of going out of range. (Low impact in practice, since individual images are capped well below 1 TB — but `formatFileSize` is a general helper and the total-size message uses it too.)

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/webview/hooks/useImage.test.ts` from `packages/vscode-ide-companion`. The new `formatFileSize` suite covers small sizes, the size-limit message value, the terabyte case, and the clamp beyond the largest unit. The terabyte and clamp tests fail against the previous `['B'..'GB']` implementation (verified locally by reverting) and pass with the fix.

### Evidence (Before & After)

`formatFileSize(2 * 1024 ** 4)` (2 TB):
Before: `"2 undefined"` (index 4 has no entry in `['B','KB','MB','GB']`).
After: `"2 TB"`.

Paste-image "too large" message:
Before: `… Maximum size is 10MB.` (literal string, independent of `MAX_IMAGE_SIZE`).
After: `… Maximum size is 10 MB.` derived from `formatFileSize(MAX_IMAGE_SIZE)`, so it tracks the constant.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: ran the `useImage` suite (6 pass, including 4 new; no existing test changed), confirmed the TB/clamp tests fail against the pre-fix implementation, and ran `prettier --check` + `eslint` on the changed files (clean). Windows/Linux: N/A — pure numeric/string formatting with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/vscode-ide-companion` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note. `formatFileSize` output is unchanged for all previously-in-range sizes; only ≥ 1 TB (previously broken) and the message string change. `formatFileSize` is now exported for testing.
- Not validated / out of scope: the size limits themselves (`MAX_IMAGE_SIZE`, `MAX_TOTAL_IMAGE_SIZE`) are unchanged; the paste flow's behavior is otherwise untouched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 VS Code 粘贴图片流程（`useImage.ts`）中的两个小的正确性问题，并为 `formatFileSize` 补充单元测试。

## 为什么需要

1. **"图片过大"的提示把上限写死了。** 当粘贴的图片超过大小上限时，提示显示 `Maximum size is 10MB.`，而实际校验用的是 `MAX_IMAGE_SIZE` 常量。若该常量改变，提示会悄悄失真。修复方式是插入 `formatFileSize(MAX_IMAGE_SIZE)`，使提示始终与真实上限一致。

2. **`formatFileSize` 可能输出 `"… undefined"`。** 它使用 `['B', 'KB', 'MB', 'GB']` 且单位下标未做上界钳制：对 ≥ 1 TB 的值，`i` ≥ 4，`sizes[i]` 为 `undefined`，结果形如 `"2 undefined"`。修复方式是加入 `'TB'` 并将下标钳制在数组范围内。（实际影响很小，因为单张图片远低于 1 TB；但 `formatFileSize` 是通用工具函数，总大小提示也在用它。）

## 复核测试计划

### 如何验证

在 `packages/vscode-ide-companion` 下运行 `npx vitest run src/webview/hooks/useImage.test.ts`。新增的 `formatFileSize` 用例覆盖小尺寸、大小上限提示值、TB 情形，以及超出最大单位后的钳制。TB 与钳制用例在修复前的 `['B'..'GB']` 实现下会失败（已在本地通过回退验证），在修复下通过。

### 证据（修复前后对比）

`formatFileSize(2 * 1024 ** 4)`（2 TB）：
修复前：`"2 undefined"`（`['B','KB','MB','GB']` 中下标 4 无对应项）。
修复后：`"2 TB"`。

粘贴图片"过大"提示：
修复前：`… Maximum size is 10MB.`（字面字符串，与 `MAX_IMAGE_SIZE` 无关）。
修复后：`… Maximum size is 10 MB.`，由 `formatFileSize(MAX_IMAGE_SIZE)` 推导，随常量变化。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：运行了 `useImage` 测试（6 个通过，含 4 个新增；未改动任何既有测试），确认 TB/钳制测试在修复前失败，并对改动文件运行 `prettier --check` 与 `eslint`（均无问题）。Windows/Linux：N/A——纯数值/字符串格式化，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/vscode-ide-companion` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有。对此前处于范围内的所有尺寸，`formatFileSize` 输出不变；仅 ≥ 1 TB（此前是坏的）与提示字符串发生变化。`formatFileSize` 现导出以便测试。
- 未验证 / 范围之外：大小上限本身（`MAX_IMAGE_SIZE`、`MAX_TOTAL_IMAGE_SIZE`）不变；粘贴流程的其他行为未动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
