### PR TITLE
feat(web-shell): expose session controls to hosts

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -169,6 +169,37 @@
   display: none;
 }
 
+/* Hosts can embed WebShell in a narrow side pane while the browser viewport
+ * remains wide. The public drawer API must still show a usable overlay inside
+ * that container instead of relying exclusively on the viewport media query. */
+.mobileDrawerForced {
+  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  pointer-events: auto;
+  visibility: visible;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+
+.mobileDrawerForced .mobileBackdrop {
+  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 49;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mobileDrawerForced > aside {
+  position: relative;
+  z-index: 50;
+}
+
 .hamburgerButton {
   display: none;
   align-items: center;

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2058,6 +2058,121 @@ describe('App session callbacks', () => {
     expect(drawer?.className).toContain('mobileDrawerForced');
   });
 
+  it('does not open or lock scrolling when the sidebar is disabled', async () => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'auto';
+
+    try {
+      const shellRef = createRef<WebShellApi>();
+      const { container } = renderApp({ sidebar: false, shellRef });
+      await flush();
+
+      await act(async () => {
+        shellRef.current?.openSessionDrawer();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-sidebar-shell]')).toBeNull();
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.body.style.overflow).toBe('auto');
+    } finally {
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it('closes a forced compact drawer when the sidebar becomes disabled', async () => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'auto';
+    const shellRef = createRef<WebShellApi>();
+    const { container, rerender, unmount } = renderApp({
+      sidebar: true,
+      shellRef,
+    });
+
+    try {
+      await flush();
+      await act(async () => {
+        shellRef.current?.openSessionDrawer();
+        await Promise.resolve();
+      });
+
+      expect(
+        container.querySelector('[data-sidebar-shell][role="dialog"]'),
+      ).not.toBeNull();
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender({ sidebar: false, shellRef });
+      await flush();
+
+      expect(container.querySelector('[data-sidebar-shell]')).toBeNull();
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.body.style.overflow).toBe('auto');
+    } finally {
+      unmount();
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it('dismisses a forced compact drawer before opening split view', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      shellRef.current?.openSplitView();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).not.toContain('mobileDrawerForced');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('dismisses a forced compact drawer before opening the Session Overview', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      shellRef.current?.openSessionOverview();
+      await Promise.resolve();
+    });
+
+    const panel = container.querySelector('[data-testid="inline-panel"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute('aria-label')).toBe('Session Overview');
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).not.toContain('mobileDrawerForced');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
   it('returns a forced compact drawer to viewport control when dismissed', async () => {
     const shellRef = createRef<WebShellApi>();
     const { container } = renderApp({ sidebar: true, shellRef });

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2041,6 +2041,184 @@ describe('App session callbacks', () => {
     expect(panel?.getAttribute('aria-label')).toBe('Session Overview');
   });
 
+  it('forces the compact session drawer from the external shell ref', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+
+    const drawer = container.querySelector(
+      '[data-sidebar-shell][role="dialog"]',
+    );
+    expect(drawer).not.toBeNull();
+    expect(drawer?.className).toContain('mobileDrawerForced');
+  });
+
+  it('returns a forced compact drawer to viewport control when dismissed', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).toContain('mobileDrawerForced');
+
+    await act(async () => {
+      container
+        .querySelector<HTMLElement>(
+          '[data-sidebar-shell] > div[aria-hidden="true"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).not.toContain('mobileDrawerForced');
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).toBeNull();
+  });
+
+  it('returns to chat and clears the current page when opening the compact drawer', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionOverview();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
+
+    await act(async () => {
+      shellRef.current?.openSplitView();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).not.toBeNull();
+  });
+
+  it('clears a forced compact drawer after crossing to a wide viewport', async () => {
+    let mobileChangeHandler:
+      | ((event: { matches: boolean }) => void)
+      | undefined;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('min-width'),
+        media: query,
+        addEventListener: (
+          _type: string,
+          handler: (event: { matches: boolean }) => void,
+        ) => {
+          if (query.includes('max-width')) mobileChangeHandler = handler;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    });
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).toContain('mobileDrawerForced');
+
+    await act(async () => {
+      mobileChangeHandler?.({ matches: false });
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).not.toContain('mobileDrawerForced');
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).toBeNull();
+  });
+
+  it('starts a new session from the external shell ref and returns to chat', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSplitView();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).not.toBeNull();
+
+    vi.useFakeTimers();
+    let created: boolean | undefined;
+    await act(async () => {
+      created = await shellRef.current?.createNewSession();
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(created).toBe(true);
+    expect(mockSessionActions.clearSession).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+  });
+
+  it('reports a failed external new-session attempt through its boolean result', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockSessionActions.clearSession.mockRejectedValueOnce(new Error('boom'));
+    const shellRef = createRef<WebShellApi>();
+    renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    vi.useFakeTimers();
+    let created: boolean | undefined;
+    await act(async () => {
+      created = await shellRef.current?.createNewSession();
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(created).toBe(false);
+    expect(mockSessionActions.clearSession).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[web-shell]',
+      'boom',
+      expect.any(Error),
+    );
+  });
+
   it('returns to the Session Overview when leaving the split view', async () => {
     const { container } = renderApp();
     await flush();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -435,6 +435,10 @@ export interface WebShellApi {
   openSplitView: () => void;
   /** Open the Session Overview panel, matching the built-in sidebar button. */
   openSessionOverview: () => void;
+  /** Open the compact session drawer, matching the hamburger control. */
+  openSessionDrawer: () => void;
+  /** Start a new session using the same lifecycle as the built-in New Chat action. */
+  createNewSession: () => Promise<boolean>;
 }
 
 export type WebShellComposerPlaceholderState = ComposerPlaceholderState;
@@ -1052,8 +1056,10 @@ export function App({
     string | null
   >(null);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [forceMobileDrawer, setForceMobileDrawer] = useState(false);
   const closeMobileDrawer = useCallback(() => {
     setMobileDrawerOpen(false);
+    setForceMobileDrawer(false);
   }, []);
   // The Session Overview panel (mission control for managing many sessions at
   // once) is only offered on large screens; below that there is no room for it
@@ -1068,11 +1074,11 @@ export function App({
   useEffect(() => {
     const mql = window.matchMedia('(max-width: 760px)');
     const handler = (e: MediaQueryListEvent) => {
-      if (!e.matches) setMobileDrawerOpen(false);
+      if (!e.matches) closeMobileDrawer();
     };
     mql.addEventListener('change', handler);
     return () => mql.removeEventListener('change', handler);
-  }, []);
+  }, [closeMobileDrawer]);
 
   useEffect(() => {
     if (!mobileDrawerOpen) return;
@@ -2116,6 +2122,12 @@ export function App({
     setActivePanel(null);
     setMainView('scheduledTasks');
   }, []);
+  const openSessionDrawer = useCallback(() => {
+    setActivePanel(null);
+    setMainView('chat');
+    setForceMobileDrawer(true);
+    setMobileDrawerOpen(true);
+  }, []);
   // Open the in-window split view showing 2+ sessions side by side. `splitSessionIds`
   // is the live pane set — SplitView mirrors add/remove back into it via
   // onPanesChange — so it must be preserved across entries, not blindly reset.
@@ -2166,22 +2178,6 @@ export function App({
     openSplitView,
     splitSessionIds,
   ]);
-  const shellApi = useMemo<WebShellApi>(
-    () => ({
-      openSplitView: () => requestOpenSplitView(),
-      openSessionOverview: () => openPanel('sessions'),
-    }),
-    [openPanel, requestOpenSplitView],
-  );
-  useEffect(() => {
-    assignShellRef(shellRef, shellApi);
-  }, [shellApi, shellRef]);
-  useEffect(
-    () => () => {
-      assignShellRef(shellRef, null);
-    },
-    [shellRef],
-  );
   useEffect(() => {
     if (!externalSplitControlled) return;
     const requested = externalSplitSignature
@@ -3621,6 +3617,7 @@ export function App({
       // Starting a new chat means the user wants to see it — leave any open
       // Settings/Status panel so the fresh chat is visible (no-op when closed).
       closePanel();
+      setMainView('chat');
       let focusRequest: number | undefined;
       try {
         const clearPromise = (
@@ -3645,6 +3642,24 @@ export function App({
       scheduleComposerFocus,
       sessionActions,
     ],
+  );
+  const shellApi = useMemo<WebShellApi>(
+    () => ({
+      openSplitView: () => requestOpenSplitView(),
+      openSessionOverview: () => openPanel('sessions'),
+      openSessionDrawer,
+      createNewSession: () => createNewSession(),
+    }),
+    [createNewSession, openPanel, openSessionDrawer, requestOpenSplitView],
+  );
+  useEffect(() => {
+    assignShellRef(shellRef, shellApi);
+  }, [shellApi, shellRef]);
+  useEffect(
+    () => () => {
+      assignShellRef(shellRef, null);
+    },
+    [shellRef],
   );
   const handleMissingSessionNewSession = useCallback(async () => {
     if (creatingMissingSessionRef.current) return;
@@ -5921,6 +5936,7 @@ export function App({
                 className={[
                   styles.mobileDrawer,
                   mobileDrawerOpen ? styles.mobileDrawerOpen : undefined,
+                  forceMobileDrawer ? styles.mobileDrawerForced : undefined,
                 ]
                   .filter(Boolean)
                   .join(' ')}
@@ -6016,6 +6032,7 @@ export function App({
                       .filter(Boolean)
                       .join(' ')}
                     onClick={() => {
+                      setForceMobileDrawer(false);
                       setMobileDrawerOpen((open) => !open);
                     }}
                     aria-label={t('sidebar.toggleMenu')}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1072,6 +1072,10 @@ export function App({
   const splitSidebarHasRoom = useIsLargeScreen('(min-width: 1200px)');
 
   useEffect(() => {
+    if (!sidebarOptions.enabled) closeMobileDrawer();
+  }, [closeMobileDrawer, sidebarOptions.enabled]);
+
+  useEffect(() => {
     const mql = window.matchMedia('(max-width: 760px)');
     const handler = (e: MediaQueryListEvent) => {
       if (!e.matches) closeMobileDrawer();
@@ -2123,11 +2127,12 @@ export function App({
     setMainView('scheduledTasks');
   }, []);
   const openSessionDrawer = useCallback(() => {
+    if (!sidebarOptions.enabled) return;
     setActivePanel(null);
     setMainView('chat');
     setForceMobileDrawer(true);
     setMobileDrawerOpen(true);
-  }, []);
+  }, [sidebarOptions.enabled]);
   // Open the in-window split view showing 2+ sessions side by side. `splitSessionIds`
   // is the live pane set — SplitView mirrors add/remove back into it via
   // onPanesChange — so it must be preserved across entries, not blindly reset.
@@ -3645,12 +3650,24 @@ export function App({
   );
   const shellApi = useMemo<WebShellApi>(
     () => ({
-      openSplitView: () => requestOpenSplitView(),
-      openSessionOverview: () => openPanel('sessions'),
+      openSplitView: () => {
+        closeMobileDrawer();
+        requestOpenSplitView();
+      },
+      openSessionOverview: () => {
+        closeMobileDrawer();
+        openPanel('sessions');
+      },
       openSessionDrawer,
       createNewSession: () => createNewSession(),
     }),
-    [createNewSession, openPanel, openSessionDrawer, requestOpenSplitView],
+    [
+      closeMobileDrawer,
+      createNewSession,
+      openPanel,
+      openSessionDrawer,
+      requestOpenSplitView,
+    ],
   );
   useEffect(() => {
     assignShellRef(shellRef, shellApi);
@@ -3665,7 +3682,6 @@ export function App({
     if (creatingMissingSessionRef.current) return;
     creatingMissingSessionRef.current = true;
     setIsCreatingMissingSession(true);
-    setMainView('chat');
     try {
       const success = await createNewSession();
       if (success) {
@@ -5985,7 +6001,6 @@ export function App({
                     );
                   }}
                   onNewSession={(workspaceCwd) => {
-                    setMainView('chat');
                     return createNewSession(workspaceCwd);
                   }}
                   onLoadSession={(sessionId, workspaceCwd) => {
@@ -6235,7 +6250,6 @@ export function App({
                         // describe the task in natural language; the agent
                         // creates it via its cron_create tool. Focus is deferred
                         // so the new session's composer is mounted/visible first.
-                        setMainView('chat');
                         void createNewSession().then((created) => {
                           // If the new session couldn't be started,
                           // createNewSession already surfaced the error — do NOT


### PR DESCRIPTION
## What this PR does

This PR adds two imperative session controls to the embedded WebShell API. Hosts can open the session-history drawer even when the workspace sidebar is otherwise visible, and they can start a new session through the same lifecycle used by the built-in UI. The forced drawer state is cleared when the drawer is dismissed or the responsive breakpoint changes.

## Why it's needed

The multi-workspace sidebar refactor removed the supported host entry point for opening session history, so embedded header actions could no longer surface past sessions. Hosts also had no public command for starting a new session without reaching into WebShell internals or simulating a UI click.

## Reviewer Test Plan

### How to verify

1. Mount WebShell with a ref in a wide embedded layout and call `openSessionDrawer()`. Confirm that the history drawer and backdrop appear, the main view returns to chat, and any open auxiliary panel is closed.
2. Dismiss the drawer, then open it again and cross the responsive breakpoint. Confirm that the forced drawer state is cleared and the normal sidebar layout resumes.
3. Call `createNewSession()`. Confirm that it follows the existing new-session lifecycle, returns `true` when creation succeeds, and returns `false` without switching sessions when creation fails.
4. Automated verification: `npm run test --workspace=packages/web-shell` (101 files, 1596 tests passed), `npm run test:ci --workspace=packages/web-shell` (1596 tests passed with coverage), `npm run typecheck --workspace=packages/web-shell`, `npm run build --workspace=packages/web-shell`, changed-file Prettier check, and `npm run pre-commit` all passed.
5. `npm run preflight` passed clean/install/format/lint/build/typecheck, then stopped in full-repository tests on unrelated baseline failures: 8 CLI locale/auth interaction tests and 4 core managed-memory refresh tests. The WebShell package remained green.

### Evidence (Before & After)

Before: an embedded host header had no supported API to open session history after the sidebar refactor, and no public API to create a session. After: the host can invoke both actions through `WebShellApi`; the downstream pre-DW integration was manually verified on macOS.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS; WebShell package tests/build plus manual verification in the downstream pre-DW embedded host.

## Risk & Scope

- Main risk or tradeoff: `openSessionDrawer()` temporarily overrides the wide-layout sidebar presentation; cleanup is covered for explicit dismissal and responsive breakpoint changes. `createNewSession()` delegates to the existing lifecycle and reports failure to the caller.
- Not validated / out of scope: responsive composer labels are intentionally excluded because PR #6877 already covers them; downstream plugin code is excluded; Windows and Linux were not manually tested. The local Qwen `/review` run produced no final report before its 20-minute timeout, while an independent review found no issues.
- Breaking changes / migration notes: None. Both API methods are additive.

## Linked Issues

N/A — no issue was provided for this contribution.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为嵌入式 WebShell API 增加两个命令式会话控制能力。宿主即使在工作区侧边栏原本可见的宽屏布局下，也可以打开历史会话抽屉；宿主还可以通过与内置 UI 相同的生命周期创建新会话。强制打开的抽屉状态会在抽屉关闭或响应式断点变化时清理。

## 为什么需要

多工作区侧边栏重构移除了宿主打开历史会话的受支持入口，导致嵌入式 header 操作无法再展示历史会话。同时，宿主也缺少一个无需访问 WebShell 内部实现或模拟 UI 点击即可创建新会话的公开命令。

## 评审测试计划

### 验证方式

1. 在宽屏嵌入式布局中通过 ref 挂载 WebShell，并调用 `openSessionDrawer()`。确认历史会话抽屉和遮罩出现，主视图返回聊天页，并关闭已打开的辅助面板。
2. 关闭抽屉后再次打开，并跨越响应式断点。确认强制抽屉状态被清理，恢复正常侧边栏布局。
3. 调用 `createNewSession()`。确认它复用现有的新会话生命周期，创建成功时返回 `true`，创建失败时返回 `false` 且不会切换会话。
4. 自动化验证：`npm run test --workspace=packages/web-shell`（101 个文件、1596 个测试通过）、`npm run test:ci --workspace=packages/web-shell`（1596 个测试及覆盖率检查通过）、`npm run typecheck --workspace=packages/web-shell`、`npm run build --workspace=packages/web-shell`、改动文件 Prettier 检查以及 `npm run pre-commit` 均通过。
5. `npm run preflight` 的 clean/install/format/lint/build/typecheck 阶段通过，随后在全仓测试中因与本改动无关的基线失败而停止：8 个 CLI locale/auth 交互测试和 4 个 core managed-memory refresh 测试。WebShell 包测试仍全部通过。

### 证据（修改前后）

修改前：侧边栏重构后，嵌入式宿主 header 没有受支持的 API 打开历史会话，也没有创建新会话的公开 API。修改后：宿主可以通过 `WebShellApi` 调用这两个操作；下游 pre-DW 集成已在 macOS 上完成人工验证。

### 测试平台

|    操作系统    | 状态 |
| :------------: | :--: |
|   🍏 macOS     |  ✅  |
|  🪟 Windows    |  ⚠️  |
|   🐧 Linux     |  ⚠️  |

### 环境（可选）

macOS；完成 WebShell 包测试和构建，并在下游 pre-DW 嵌入式宿主中进行人工验证。

## 风险与范围

- 主要风险或取舍：`openSessionDrawer()` 会临时覆盖宽屏布局下的侧边栏展示方式；显式关闭和响应式断点变化时的清理均有测试覆盖。`createNewSession()` 委托给现有生命周期，并向调用方返回失败结果。
- 未验证或不在范围内：响应式输入框标签被明确排除，因为 PR #6877 已覆盖该问题；下游插件代码不在本 PR 中；未在 Windows 和 Linux 上进行人工测试。本地 Qwen `/review` 在 20 分钟超时前没有产出最终报告，独立代码评审未发现问题。
- 破坏性变更或迁移说明：无。两个 API 方法均为新增能力。

## 关联 Issue

N/A — 本次贡献没有提供关联 Issue。

</details>
