### PR TITLE
fix(test): isolate WeCom temporary files across concurrent CI jobs

### DIFF
--- a/packages/channels/wecom/src/WeComAdapter.test.ts
+++ b/packages/channels/wecom/src/WeComAdapter.test.ts
@@ -377,7 +377,9 @@ function channelFileDirs(): string[] {
   return readdirSync(parent).map((entry) => join(parent, entry));
 }
 
-const suiteTmpDir = mkdtempSync(join(tmpdir(), 'qwen-wecom-test-'));
+// Capture before tests stub TMPDIR; one assertion checks the host temp root.
+const realTmpDir = tmpdir();
+const suiteTmpDir = mkdtempSync(join(realTmpDir, 'qwen-wecom-test-'));
 
 describe('WeComChannel', () => {
   beforeAll(() => {
@@ -4411,7 +4413,7 @@ describe('WeComChannel', () => {
   });
 
   it('does not allow a hardcoded /tmp channel-files fallback', async () => {
-    if (tmpdir() === '/tmp') return;
+    if (realTmpDir === '/tmp') return;
 
     const stderr = vi
       .spyOn(process.stderr, 'write')

--- a/packages/channels/wecom/src/WeComAdapter.test.ts
+++ b/packages/channels/wecom/src/WeComAdapter.test.ts
@@ -11,7 +11,16 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import type {
   ChannelAgentBridge,
   ChannelConfig,
@@ -368,7 +377,20 @@ function channelFileDirs(): string[] {
   return readdirSync(parent).map((entry) => join(parent, entry));
 }
 
+const suiteTmpDir = mkdtempSync(join(tmpdir(), 'qwen-wecom-test-'));
+
 describe('WeComChannel', () => {
+  beforeAll(() => {
+    vi.stubEnv('TMPDIR', suiteTmpDir);
+    vi.stubEnv('TMP', suiteTmpDir);
+    vi.stubEnv('TEMP', suiteTmpDir);
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    rmSync(suiteTmpDir, { recursive: true, force: true });
+  });
+
   beforeEach(() => {
     mocks.instances.length = 0;
     mocks.httpCalls.length = 0;


### PR DESCRIPTION
## What this PR does

This PR gives each WeCom test process a private temporary root for the duration of the suite. It sets `TMPDIR`, `TMP`, and `TEMP` before the tests run, then restores the environment and removes the private directory afterward.

## Why it's needed

The self-hosted runner jobs behind #6893 and #6866 started their WeCom suites eight milliseconds apart on the same physical host. Both processes previously enumerated and recursively deleted the shared `/tmp/channel-files` directory, allowing one process to count or remove files owned by the other.

## Reviewer Test Plan

### How to verify

Start two complete WeCom test processes concurrently. Both processes should pass all 136 tests, and attachment directory creation, counting, and cleanup should remain isolated without changing any `waitFor` timeout.

### Evidence (Before & After)

Before this change, two concurrent processes failed 7 and 9 tests respectively, including missing attachment directories and unstable directory counts such as `0 → 2`, `3 → 2`, and `3 → 0`. After this change, both concurrent processes pass 136/136 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 and Vitest 3.2.4.

## Risk & Scope

- Main risk or tradeoff: `os.tmpdir()` points to a suite-private directory while the WeCom tests run; the original environment is restored afterward.
- Not validated / out of scope: Windows and Linux are left to PR CI. This PR does not address the unrelated 5000ms core test timeouts observed in the same CI runs.
- Breaking changes / migration notes: None. Production behavior is unchanged.

## Linked Issues

Related to the WeCom failures in #6893 and #6866.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为每个 WeCom 测试进程创建独占的临时目录，并在套件运行期间通过 `TMPDIR`、`TMP` 和 `TEMP` 让 `os.tmpdir()` 指向该目录。测试结束后恢复环境变量并清理临时目录。

## 为什么需要这个改动

#6893 和 #6866 的两个 self-hosted runner job 在同一物理机上几乎同时启动 WeCom 测试。两个进程此前都会枚举并递归删除共享的 `/tmp/channel-files`，因此一个进程可能删除另一个进程正在使用的附件，也可能在目录数量断言中误计入另一个进程的数据。

## Reviewer Test Plan

### 如何验证

同时启动两个完整的 WeCom 测试进程，确认两边均通过全部 136 个测试，并且附件目录的创建、计数与清理互不影响。

### 修复前后证据

修复前，两个并发进程分别失败 7 个和 9 个测试，包含目录意外消失以及 `0 → 2`、`3 → 2`、`3 → 0` 等目录数量错误。修复后，两个并发进程均通过 136/136，未修改任何 `waitFor` 超时。

### 测试环境

本地在 macOS、Node.js 22 和 Vitest 3.2.4 上验证。Windows 和 Linux 交由 PR CI 验证。

## 风险与范围

- 只影响 WeCom 测试环境，不修改生产行为。
- 本地尚未验证 Windows 和 Linux。
- 不处理这两个 CI run 中独立出现的 core 5000ms timeout。
- 不包含破坏性变更或迁移要求。

## 关联

关联 #6893 和 #6866 中的 WeCom 测试失败。

</details>
