### PR TITLE
fix(web-shell): Harden non-primary session archive actions

### DIFF
--- a/docs/design/web-shell-non-primary-session-archive-hardening.md
+++ b/docs/design/web-shell-non-primary-session-archive-hardening.md
@@ -1,0 +1,37 @@
+# WebShell Non-Primary Session Archive Hardening
+
+## Summary
+
+WebShell already lists active and archived sessions from registered secondary
+workspaces, and the daemon already exposes workspace-qualified archive routes.
+This change completes the existing UI path without changing the archive API,
+SDK types, persistence format, or delete behavior.
+
+## Capability and Trust Boundaries
+
+Archive UI requires `session_archive`. A secondary workspace additionally
+requires `workspace_qualified_rest_core` and a trusted runtime. A trusted
+secondary active row exposes only Archive; its existing load-only treatment for
+pin, group, rename, export, and delete remains unchanged. Archived catalogs are
+not queried when the required capabilities are absent.
+
+## Identity and Reconciliation
+
+Merged WebShell collections and transient row state identify a session by
+`(workspaceCwd, sessionId)`. This applies to deduplication, React keys, current
+selection, busy state, unread completion, and export-in-flight state, so equal
+session ids in different workspaces remain independent.
+
+Workspace-qualified archive and unarchive responses may report per-session
+failures in a successful HTTP response. WebShell surfaces a matching
+`errors[]` entry and always reconciles the primary active and archived catalogs
+plus the selected workspace catalogs after the operation settles. Idempotent
+`alreadyArchived` and `alreadyActive` outcomes remain successful.
+
+## Verification
+
+WebShell tests cover successful and partial-failure responses, missing
+capabilities, untrusted workspaces, idempotency, equal-id current and busy-state
+isolation, and post-operation reconciliation. A daemon regression archives and
+unarchives an equal-id secondary session while verifying that the primary file
+and bridge remain untouched.

--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -4087,6 +4087,108 @@ describe('multi-workspace session dispatch', () => {
     });
   });
 
+  it('archives and unarchives only the selected workspace when session ids collide', async () => {
+    await withRuntimeDir(async () => {
+      const sessionId = '550e8400-e29b-41d4-a716-446655440122';
+      await writeStoredSession({
+        sessionId,
+        cwd: PRIMARY_CWD,
+        timestamp: '2026-07-08T00:12:00.000Z',
+        prompt: 'primary collision target',
+        mtime: new Date('2026-07-08T00:12:00.000Z'),
+      });
+      await writeStoredSession({
+        sessionId,
+        cwd: SECONDARY_CWD,
+        timestamp: '2026-07-08T00:13:00.000Z',
+        prompt: 'secondary collision target',
+        mtime: new Date('2026-07-08T00:13:00.000Z'),
+      });
+      const primaryChatsDir = path.join(
+        new Storage(PRIMARY_CWD).getProjectDir(),
+        'chats',
+      );
+      const secondaryChatsDir = path.join(
+        new Storage(SECONDARY_CWD).getProjectDir(),
+        'chats',
+      );
+      const primaryActivePath = path.join(
+        primaryChatsDir,
+        `${sessionId}.jsonl`,
+      );
+      const primaryArchivedPath = path.join(
+        primaryChatsDir,
+        'archive',
+        `${sessionId}.jsonl`,
+      );
+      const secondaryActivePath = path.join(
+        secondaryChatsDir,
+        `${sessionId}.jsonl`,
+      );
+      const secondaryArchivedPath = path.join(
+        secondaryChatsDir,
+        'archive',
+        `${sessionId}.jsonl`,
+      );
+      const { app, primaryBridge, secondaryBridge } = makeHarness({
+        primarySummaries: [],
+        secondarySummaries: [],
+      });
+
+      const archived = await request(app)
+        .post('/workspaces/secondary-id/sessions/archive')
+        .set('Host', host())
+        .send({ sessionIds: [sessionId] })
+        .expect(200);
+      expect(archived.body).toMatchObject({
+        archived: [sessionId],
+        alreadyArchived: [],
+        notFound: [],
+        errors: [],
+      });
+      await expect(fsp.readFile(primaryActivePath, 'utf8')).resolves.toContain(
+        'primary collision target',
+      );
+      await expect(fsp.stat(primaryArchivedPath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      await expect(
+        fsp.readFile(secondaryArchivedPath, 'utf8'),
+      ).resolves.toContain('secondary collision target');
+      await expect(fsp.stat(secondaryActivePath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      expect(primaryBridge.closeCalls).toEqual([]);
+      expect(secondaryBridge.closeCalls).toEqual([sessionId]);
+
+      const unarchived = await request(app)
+        .post('/workspaces/secondary-id/sessions/unarchive')
+        .set('Host', host())
+        .send({ sessionIds: [sessionId] })
+        .expect(200);
+      expect(unarchived.body).toMatchObject({
+        unarchived: [sessionId],
+        alreadyActive: [],
+        notFound: [],
+        errors: [],
+      });
+      await expect(fsp.readFile(primaryActivePath, 'utf8')).resolves.toContain(
+        'primary collision target',
+      );
+      await expect(fsp.stat(primaryArchivedPath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      await expect(
+        fsp.readFile(secondaryActivePath, 'utf8'),
+      ).resolves.toContain('secondary collision target');
+      await expect(fsp.stat(secondaryArchivedPath)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      expect(primaryBridge.closeCalls).toEqual([]);
+      expect(secondaryBridge.closeCalls).toEqual([sessionId]);
+    });
+  });
+
   it('routes plural session group CRUD to the selected workspace', async () => {
     await withRuntimeDir(async () => {
       const { app } = makeHarness();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -105,6 +105,13 @@ const GROUP_MENU_MARGIN = 8;
 const CUSTOM_GROUP_COLOR_OPTION = '__custom__';
 const DEFAULT_CUSTOM_GROUP_COLOR: DaemonSessionGroupHexColor = '#416ef5';
 
+function getSessionIdentity(
+  sessionId: string,
+  workspaceCwd: string | undefined,
+): string {
+  return `${workspaceCwd ?? ''}\0${sessionId}`;
+}
+
 export type WebShellSidebarFooterItem =
   | 'settings'
   | 'version'
@@ -426,12 +433,24 @@ export function WebShellSidebar({
   const organizationEnabled = Boolean(
     connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE),
   );
+  const sessionArchiveEnabled = Boolean(
+    connection.capabilities?.features?.includes('session_archive'),
+  );
+  const workspaceQualifiedRestCoreEnabled = Boolean(
+    connection.capabilities?.features?.includes(
+      'workspace_qualified_rest_core',
+    ),
+  );
   // Phase 4: registered workspaces on a multi-workspace daemon (absent or a
   // single entry otherwise). Drives the new-session workspace picker.
   const workspaces = useMemo(
     () => providedWorkspaces ?? workspace.capabilities?.workspaces ?? [],
     [providedWorkspaces, workspace.capabilities?.workspaces],
   );
+  const primaryWorkspaceCwd =
+    workspaces.find((entry) => entry.primary)?.cwd ??
+    workspace.capabilities?.workspaceCwd ??
+    connection.workspaceCwd;
   const lockedWorkspace = lockedWorkspaceCwd
     ? workspaces.find((entry) => entry.cwd === lockedWorkspaceCwd)
     : undefined;
@@ -477,7 +496,10 @@ export function WebShellSidebar({
     unarchiveSession,
   } = useSessions({
     autoLoad: true,
-    enabled: archivedExpanded && includePrimaryWorkspaceSessions,
+    enabled:
+      sessionArchiveEnabled &&
+      archivedExpanded &&
+      includePrimaryWorkspaceSessions,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'archived',
     ...(organizationEnabled
@@ -582,6 +604,9 @@ export function WebShellSidebar({
   );
   const canExportSessions =
     connection.capabilities?.features?.includes('session_export') ?? false;
+  const currentSessionIdentity = currentSessionId
+    ? getSessionIdentity(currentSessionId, connection.workspaceCwd)
+    : null;
   const projectName =
     getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
   const displayedWorkspaces = useMemo<DaemonWorkspaceCapability[]>(() => {
@@ -606,11 +631,18 @@ export function WebShellSidebar({
       ...(includePrimaryWorkspaceSessions ? primaryPinnedSessions : []),
       ...secondaryPinnedSessions,
     ]) {
-      byId.set(session.sessionId, session);
+      byId.set(
+        getSessionIdentity(
+          session.sessionId,
+          session.workspaceCwd || primaryWorkspaceCwd,
+        ),
+        session,
+      );
     }
     return [...byId.values()];
   }, [
     includePrimaryWorkspaceSessions,
+    primaryWorkspaceCwd,
     primaryPinnedSessions,
     secondaryPinnedSessions,
   ]);
@@ -631,6 +663,37 @@ export function WebShellSidebar({
       displayedWorkspaces.find((entry) => entry.cwd === workspaceCwd)
         ?.primary !== false,
     [displayedWorkspaces],
+  );
+  const getIdentityForSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      getSessionIdentity(
+        session.sessionId,
+        session.workspaceCwd || primaryWorkspaceCwd,
+      ),
+    [primaryWorkspaceCwd],
+  );
+  const isCurrentSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      currentSessionIdentity === getIdentityForSession(session),
+    [currentSessionIdentity, getIdentityForSession],
+  );
+  const canMutateSessionArchive = useCallback(
+    (session: DaemonSessionSummary) => {
+      const sessionWorkspace = displayedWorkspaces.find(
+        (entry) => entry.cwd === session.workspaceCwd,
+      );
+      if (sessionWorkspace?.trusted === false) return false;
+      return (
+        sessionArchiveEnabled &&
+        (sessionWorkspace?.primary !== false ||
+          workspaceQualifiedRestCoreEnabled)
+      );
+    },
+    [
+      displayedWorkspaces,
+      sessionArchiveEnabled,
+      workspaceQualifiedRestCoreEnabled,
+    ],
   );
 
   useEffect(() => {
@@ -674,17 +737,21 @@ export function WebShellSidebar({
     workspace.client,
     workspaceSessionsReloadToken,
   ]);
-  const allArchivedSessions = useMemo(
-    () => [
+  const allArchivedSessions = useMemo(() => {
+    const byIdentity = new Map<string, DaemonSessionSummary>();
+    for (const session of [
       ...(includePrimaryWorkspaceSessions ? archivedSessions : []),
       ...secondaryArchivedSessions,
-    ],
-    [
-      archivedSessions,
-      includePrimaryWorkspaceSessions,
-      secondaryArchivedSessions,
-    ],
-  );
+    ]) {
+      byIdentity.set(getIdentityForSession(session), session);
+    }
+    return [...byIdentity.values()];
+  }, [
+    archivedSessions,
+    getIdentityForSession,
+    includePrimaryWorkspaceSessions,
+    secondaryArchivedSessions,
+  ]);
   const effectiveArchivedLoading =
     (includePrimaryWorkspaceSessions && archivedLoading) ||
     secondaryArchivedLoading;
@@ -694,6 +761,12 @@ export function WebShellSidebar({
 
   useEffect(() => {
     if (!archivedExpanded) return;
+    if (!sessionArchiveEnabled || !workspaceQualifiedRestCoreEnabled) {
+      setSecondaryArchivedSessions([]);
+      setSecondaryArchivedLoading(false);
+      setSecondaryArchivedError(false);
+      return;
+    }
     const secondaryWorkspaces = displayedWorkspaces.filter(
       (entry) => !entry.primary && entry.trusted,
     );
@@ -751,7 +824,9 @@ export function WebShellSidebar({
     displayedWorkspaces,
     organizationEnabled,
     secondaryArchivedReloadToken,
+    sessionArchiveEnabled,
     workspace.client,
+    workspaceQualifiedRestCoreEnabled,
     workspaceSessionsReloadToken,
   ]);
   const qwenCodeVersion = connection.capabilities?.qwenCodeVersion || '';
@@ -822,16 +897,23 @@ export function WebShellSidebar({
     workspaces,
   ]);
 
-  const setSessionBusy = useCallback((sessionId: string, busy: boolean) => {
-    const next = new Set(busySessionIdsRef.current);
-    if (busy) {
-      next.add(sessionId);
-    } else {
-      next.delete(sessionId);
-    }
-    busySessionIdsRef.current = next;
-    setBusySessionIds(next);
-  }, []);
+  const setSessionBusy = useCallback(
+    (sessionId: string, busy: boolean, workspaceCwd?: string) => {
+      const identity = getSessionIdentity(
+        sessionId,
+        workspaceCwd || primaryWorkspaceCwd,
+      );
+      const next = new Set(busySessionIdsRef.current);
+      if (busy) {
+        next.add(identity);
+      } else {
+        next.delete(identity);
+      }
+      busySessionIdsRef.current = next;
+      setBusySessionIds(next);
+    },
+    [primaryWorkspaceCwd],
+  );
 
   const reloadGroups = useCallback(async () => {
     if (!organizationEnabled) {
@@ -981,7 +1063,7 @@ export function WebShellSidebar({
   useEffect(() => {
     const runningBySessionId = new Map(
       sessions.map((session) => [
-        session.sessionId,
+        getIdentityForSession(session),
         Boolean(session.hasActivePrompt),
       ]),
     );
@@ -993,33 +1075,33 @@ export function WebShellSidebar({
       const next = new Set(current);
       let changed = false;
 
-      for (const [sessionId, wasRunning] of previousRunningBySessionId) {
-        const isRunning = runningBySessionId.get(sessionId);
+      for (const [sessionIdentity, wasRunning] of previousRunningBySessionId) {
+        const isRunning = runningBySessionId.get(sessionIdentity);
         if (
           wasRunning &&
           isRunning === false &&
-          sessionId !== currentSessionId &&
-          !next.has(sessionId)
+          sessionIdentity !== currentSessionIdentity &&
+          !next.has(sessionIdentity)
         ) {
-          next.add(sessionId);
+          next.add(sessionIdentity);
           changed = true;
         }
       }
 
-      for (const sessionId of next) {
+      for (const sessionIdentity of next) {
         if (
-          sessionId === currentSessionId ||
-          !runningBySessionId.has(sessionId) ||
-          runningBySessionId.get(sessionId)
+          sessionIdentity === currentSessionIdentity ||
+          !runningBySessionId.has(sessionIdentity) ||
+          runningBySessionId.get(sessionIdentity)
         ) {
-          next.delete(sessionId);
+          next.delete(sessionIdentity);
           changed = true;
         }
       }
 
       return changed ? next : current;
     });
-  }, [currentSessionId, sessions]);
+  }, [currentSessionIdentity, getIdentityForSession, sessions]);
 
   const handleAddWorkspace = useCallback(
     async (cwd: string, persist: boolean) => {
@@ -1244,19 +1326,23 @@ export function WebShellSidebar({
 
   const handleLoadSession = useCallback(
     (sessionId: string, workspaceCwd?: string) => {
+      const sessionIdentity = getSessionIdentity(
+        sessionId,
+        workspaceCwd || primaryWorkspaceCwd,
+      );
       if (
-        sessionId === currentSessionId ||
-        busySessionIdsRef.current.has(sessionId)
+        sessionIdentity === currentSessionIdentity ||
+        busySessionIdsRef.current.has(sessionIdentity)
       ) {
         return;
       }
       setCompletedUnreadIds((current) => {
-        if (!current.has(sessionId)) return current;
+        if (!current.has(sessionIdentity)) return current;
         const next = new Set(current);
-        next.delete(sessionId);
+        next.delete(sessionIdentity);
         return next;
       });
-      setSessionBusy(sessionId, true);
+      setSessionBusy(sessionId, true, workspaceCwd);
       void (async () => {
         try {
           await onLoadSession(sessionId, workspaceCwd);
@@ -1265,11 +1351,18 @@ export function WebShellSidebar({
             onError(err, t('sidebar.switchFailed'));
           }
         } finally {
-          setSessionBusy(sessionId, false);
+          setSessionBusy(sessionId, false, workspaceCwd);
         }
       })();
     },
-    [currentSessionId, onError, onLoadSession, setSessionBusy, t],
+    [
+      currentSessionIdentity,
+      onError,
+      onLoadSession,
+      primaryWorkspaceCwd,
+      setSessionBusy,
+      t,
+    ],
   );
 
   const startRename = useCallback((session: DaemonSessionSummary) => {
@@ -1289,8 +1382,14 @@ export function WebShellSidebar({
       return;
     }
     const sessionId = editingSessionId;
-    if (busySessionIdsRef.current.has(sessionId)) return;
-    setSessionBusy(sessionId, true);
+    if (
+      busySessionIdsRef.current.has(
+        getSessionIdentity(sessionId, connection.workspaceCwd),
+      )
+    ) {
+      return;
+    }
+    setSessionBusy(sessionId, true, connection.workspaceCwd);
     actions
       .renameSession(nextName)
       .then(() => {
@@ -1303,12 +1402,13 @@ export function WebShellSidebar({
         cancelRename();
       })
       .finally(() => {
-        setSessionBusy(sessionId, false);
+        setSessionBusy(sessionId, false, connection.workspaceCwd);
       });
   }, [
     actions,
     bumpWorkspaceReload,
     cancelRename,
+    connection.workspaceCwd,
     currentSessionId,
     editingName,
     editingSessionId,
@@ -1320,33 +1420,41 @@ export function WebShellSidebar({
 
   const handleDeleteSession = useCallback(
     (session: DaemonSessionSummary) => {
-      if (session.sessionId === currentSessionId) return;
+      if (isCurrentSession(session)) return;
       setDeleteCandidate(session);
     },
-    [currentSessionId],
+    [isCurrentSession],
   );
 
   const setSessionExporting = useCallback(
-    (sessionId: string, exporting: boolean) => {
+    (sessionId: string, exporting: boolean, workspaceCwd?: string) => {
+      const identity = getSessionIdentity(
+        sessionId,
+        workspaceCwd || primaryWorkspaceCwd,
+      );
       const next = new Set(exportingSessionIdsRef.current);
       if (exporting) {
-        next.add(sessionId);
+        next.add(identity);
       } else {
-        next.delete(sessionId);
+        next.delete(identity);
       }
       exportingSessionIdsRef.current = next;
       setExportingSessionIds(next);
     },
-    [],
+    [primaryWorkspaceCwd],
   );
 
   const handleExportSession = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
-      if (!canExportSessions || exportingSessionIdsRef.current.has(sessionId)) {
+      const sessionIdentity = getIdentityForSession(session);
+      if (
+        !canExportSessions ||
+        exportingSessionIdsRef.current.has(sessionIdentity)
+      ) {
         return;
       }
-      setSessionExporting(sessionId, true);
+      setSessionExporting(sessionId, true, session.workspaceCwd);
       void (async () => {
         try {
           const result = await exportSession(sessionId, 'html');
@@ -1367,24 +1475,32 @@ export function WebShellSidebar({
         } catch (err) {
           onError(err, t('sidebar.exportFailed'));
         } finally {
-          setSessionExporting(sessionId, false);
+          setSessionExporting(sessionId, false, session.workspaceCwd);
         }
       })();
     },
-    [canExportSessions, exportSession, onError, setSessionExporting, t],
+    [
+      canExportSessions,
+      exportSession,
+      getIdentityForSession,
+      onError,
+      setSessionExporting,
+      t,
+    ],
   );
 
   const confirmDeleteSession = useCallback(() => {
     if (!deleteCandidate) return;
     const sessionId = deleteCandidate.sessionId;
-    if (sessionId === currentSessionId) {
+    const sessionIdentity = getIdentityForSession(deleteCandidate);
+    if (isCurrentSession(deleteCandidate)) {
       setDeleteCandidate(null);
       return;
     }
     const isArchived = Boolean(deleteCandidate.isArchived);
     setDeleteCandidate(null);
-    if (busySessionIdsRef.current.has(sessionId)) return;
-    setSessionBusy(sessionId, true);
+    if (busySessionIdsRef.current.has(sessionIdentity)) return;
+    setSessionBusy(sessionId, true, deleteCandidate.workspaceCwd);
     const removeSession = !isPrimaryWorkspaceCwd(deleteCandidate.workspaceCwd)
       ? (id: string) =>
           workspace.client
@@ -1403,14 +1519,15 @@ export function WebShellSidebar({
       })
       .catch((err: unknown) => onError(err, t('sidebar.deleteFailed')))
       .finally(() => {
-        setSessionBusy(sessionId, false);
+        setSessionBusy(sessionId, false, deleteCandidate.workspaceCwd);
       });
   }, [
     bumpWorkspaceReload,
-    currentSessionId,
     deleteArchivedSession,
     deleteCandidate,
     deleteSession,
+    getIdentityForSession,
+    isCurrentSession,
     isPrimaryWorkspaceCwd,
     onError,
     reload,
@@ -1422,10 +1539,10 @@ export function WebShellSidebar({
 
   const handleRenameFromMenu = useCallback(
     (session: DaemonSessionSummary) => {
-      if (session.sessionId !== currentSessionId) return;
+      if (!isCurrentSession(session)) return;
       startRename(session);
     },
-    [currentSessionId, startRename],
+    [isCurrentSession, startRename],
   );
 
   const handleCreateGroup = useCallback(() => {
@@ -1616,10 +1733,14 @@ export function WebShellSidebar({
   const handleTogglePin = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
-      if (!organizationEnabled || busySessionIdsRef.current.has(sessionId)) {
+      const sessionIdentity = getIdentityForSession(session);
+      if (
+        !organizationEnabled ||
+        busySessionIdsRef.current.has(sessionIdentity)
+      ) {
         return;
       }
-      setSessionBusy(sessionId, true);
+      setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
       sessionActions
         .updateSessionOrganization(sessionId, {
@@ -1632,11 +1753,12 @@ export function WebShellSidebar({
         })
         .catch((err: unknown) => onError(err, t('sidebar.organizationFailed')))
         .finally(() => {
-          setSessionBusy(sessionId, false);
+          setSessionBusy(sessionId, false, session.workspaceCwd);
         });
     },
     [
       bumpWorkspaceReload,
+      getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
       organizationEnabled,
@@ -1650,32 +1772,47 @@ export function WebShellSidebar({
   const handleArchive = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
+      const sessionIdentity = getIdentityForSession(session);
       // The daemon force-ends a live turn on archive; keep the current
       // session off-limits, mirroring the delete guard.
-      if (sessionId === currentSessionId) return;
-      if (busySessionIdsRef.current.has(sessionId)) return;
-      setSessionBusy(sessionId, true);
-      const archive = !isPrimaryWorkspaceCwd(session.workspaceCwd)
-        ? workspace.client
-            .workspaceByCwd(session.workspaceCwd)
-            .archiveSessionsData([sessionId])
-        : archiveSession(sessionId);
-      archive
-        .then(() => {
-          void reloadArchived();
+      if (!canMutateSessionArchive(session) || isCurrentSession(session))
+        return;
+      if (busySessionIdsRef.current.has(sessionIdentity)) return;
+      setSessionBusy(sessionId, true, session.workspaceCwd);
+      void (async () => {
+        try {
+          if (!isPrimaryWorkspaceCwd(session.workspaceCwd)) {
+            const result = await workspace.client
+              .workspaceByCwd(session.workspaceCwd)
+              .archiveSessionsData([sessionId]);
+            const itemError = result.errors.find(
+              (entry) => entry.sessionId === sessionId,
+            );
+            if (itemError) {
+              onError(new Error(itemError.error), t('sidebar.archiveFailed'));
+            }
+          } else {
+            await archiveSession(sessionId);
+          }
+        } catch (err) {
+          onError(err, t('sidebar.archiveFailed'));
+        } finally {
+          void reload().catch(() => undefined);
+          void reloadArchived().catch(() => undefined);
           bumpWorkspaceReload();
-        })
-        .catch((err: unknown) => onError(err, t('sidebar.archiveFailed')))
-        .finally(() => {
-          setSessionBusy(sessionId, false);
-        });
+          setSessionBusy(sessionId, false, session.workspaceCwd);
+        }
+      })();
     },
     [
       archiveSession,
       bumpWorkspaceReload,
-      currentSessionId,
+      canMutateSessionArchive,
+      getIdentityForSession,
       isPrimaryWorkspaceCwd,
+      isCurrentSession,
       onError,
+      reload,
       reloadArchived,
       setSessionBusy,
       t,
@@ -1686,28 +1823,43 @@ export function WebShellSidebar({
   const handleUnarchive = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
-      if (busySessionIdsRef.current.has(sessionId)) return;
-      setSessionBusy(sessionId, true);
-      const unarchive = !isPrimaryWorkspaceCwd(session.workspaceCwd)
-        ? workspace.client
-            .workspaceByCwd(session.workspaceCwd)
-            .unarchiveSessionsData([sessionId])
-        : unarchiveSession(sessionId);
-      unarchive
-        .then(() => {
-          void reload();
+      const sessionIdentity = getIdentityForSession(session);
+      if (!canMutateSessionArchive(session)) return;
+      if (busySessionIdsRef.current.has(sessionIdentity)) return;
+      setSessionBusy(sessionId, true, session.workspaceCwd);
+      void (async () => {
+        try {
+          if (!isPrimaryWorkspaceCwd(session.workspaceCwd)) {
+            const result = await workspace.client
+              .workspaceByCwd(session.workspaceCwd)
+              .unarchiveSessionsData([sessionId]);
+            const itemError = result.errors.find(
+              (entry) => entry.sessionId === sessionId,
+            );
+            if (itemError) {
+              onError(new Error(itemError.error), t('sidebar.unarchiveFailed'));
+            }
+          } else {
+            await unarchiveSession(sessionId);
+          }
+        } catch (err) {
+          onError(err, t('sidebar.unarchiveFailed'));
+        } finally {
+          void reload().catch(() => undefined);
+          void reloadArchived().catch(() => undefined);
           bumpWorkspaceReload();
-        })
-        .catch((err: unknown) => onError(err, t('sidebar.unarchiveFailed')))
-        .finally(() => {
-          setSessionBusy(sessionId, false);
-        });
+          setSessionBusy(sessionId, false, session.workspaceCwd);
+        }
+      })();
     },
     [
       bumpWorkspaceReload,
+      canMutateSessionArchive,
+      getIdentityForSession,
       isPrimaryWorkspaceCwd,
       onError,
       reload,
+      reloadArchived,
       setSessionBusy,
       t,
       unarchiveSession,
@@ -1766,11 +1918,15 @@ export function WebShellSidebar({
   const assignSessionGroup = useCallback(
     (session: DaemonSessionSummary, groupId: string | null) => {
       const sessionId = session.sessionId;
-      if (!organizationEnabled || busySessionIdsRef.current.has(sessionId)) {
+      const sessionIdentity = getIdentityForSession(session);
+      if (
+        !organizationEnabled ||
+        busySessionIdsRef.current.has(sessionIdentity)
+      ) {
         return;
       }
       setGroupMenu(null);
-      setSessionBusy(sessionId, true);
+      setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
       sessionActions
         // Group and color are a single choice in the UI: assigning a named
@@ -1782,11 +1938,12 @@ export function WebShellSidebar({
         })
         .catch((err: unknown) => onError(err, t('sidebar.organizationFailed')))
         .finally(() => {
-          setSessionBusy(sessionId, false);
+          setSessionBusy(sessionId, false, session.workspaceCwd);
         });
     },
     [
       bumpWorkspaceReload,
+      getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
       organizationEnabled,
@@ -1802,11 +1959,15 @@ export function WebShellSidebar({
       color: DaemonSessionGroupPresetColor | null,
     ) => {
       const sessionId = session.sessionId;
-      if (!organizationEnabled || busySessionIdsRef.current.has(sessionId)) {
+      const sessionIdentity = getIdentityForSession(session);
+      if (
+        !organizationEnabled ||
+        busySessionIdsRef.current.has(sessionIdentity)
+      ) {
         return;
       }
       setGroupMenu(null);
-      setSessionBusy(sessionId, true);
+      setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
       sessionActions
         // Picking a color clears any named-group assignment (single choice).
@@ -1817,11 +1978,12 @@ export function WebShellSidebar({
         })
         .catch((err: unknown) => onError(err, t('sidebar.organizationFailed')))
         .finally(() => {
-          setSessionBusy(sessionId, false);
+          setSessionBusy(sessionId, false, session.workspaceCwd);
         });
     },
     [
       bumpWorkspaceReload,
+      getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
       organizationEnabled,
@@ -2078,21 +2240,19 @@ export function WebShellSidebar({
       session: DaemonSessionSummary,
       options: {
         isArchived?: boolean;
-        // Suppress the per-session mutation actions (pin/group/archive/export/
-        // more). Used for non-primary workspace rows: the daemon is bound to the
-        // primary workspace, so those routes can't resolve another workspace's
-        // session (they 404 or silently no-op). Such rows stay load-only.
+        // Suppress per-session mutations other than an explicitly supported
+        // archive action. Secondary workspace rows remain otherwise load-only.
         readOnly?: boolean;
       } = {},
     ) => {
       const { isArchived = false, readOnly = false } = options;
+      const sessionIdentity = getIdentityForSession(session);
       const label = getSessionLabel(session);
       const stamp = session.updatedAt || session.createdAt;
       const time = stamp ? formatRelativeTime(stamp, t) : '';
-      const busy = busySessionIds.has(session.sessionId);
+      const busy = busySessionIds.has(sessionIdentity);
       const completedUnread =
-        session.sessionId !== currentSessionId &&
-        completedUnreadIds.has(session.sessionId);
+        !isCurrentSession(session) && completedUnreadIds.has(sessionIdentity);
       const details = (
         <div className={styles.tooltipContent}>
           <div className={styles.tooltipTitle}>{label}</div>
@@ -2117,7 +2277,7 @@ export function WebShellSidebar({
       if (isArchived) {
         return (
           <div
-            key={session.sessionId}
+            key={sessionIdentity}
             className={cx(
               styles.sessionRow,
               styles.archivedRow,
@@ -2165,12 +2325,14 @@ export function WebShellSidebar({
                           {details}
                         </DropdownMenuSubContent>
                       </DropdownMenuSub>
-                      <DropdownMenuItem
-                        onSelect={() => handleUnarchive(session)}
-                      >
-                        <ArchiveRestoreIcon />
-                        {t('sidebar.unarchive')}
-                      </DropdownMenuItem>
+                      {canMutateSessionArchive(session) && (
+                        <DropdownMenuItem
+                          onSelect={() => handleUnarchive(session)}
+                        >
+                          <ArchiveRestoreIcon />
+                          {t('sidebar.unarchive')}
+                        </DropdownMenuItem>
+                      )}
                       <DropdownMenuItem
                         variant="destructive"
                         onSelect={() => handleDeleteSession(session)}
@@ -2187,12 +2349,12 @@ export function WebShellSidebar({
         );
       }
 
-      const isCurrent = session.sessionId === currentSessionId;
-      const isEditing = editingSessionId === session.sessionId;
-      const exporting = exportingSessionIds.has(session.sessionId);
+      const isCurrent = isCurrentSession(session);
+      const isEditing = isCurrent && editingSessionId === session.sessionId;
+      const exporting = exportingSessionIds.has(sessionIdentity);
       return (
         <div
-          key={session.sessionId}
+          key={sessionIdentity}
           className={cx(
             styles.sessionRow,
             isCurrent && styles.currentSession,
@@ -2260,6 +2422,28 @@ export function WebShellSidebar({
                     ) : (
                       <span className={styles.sessionTime}>{time}</span>
                     )}
+                    {readOnly && canMutateSessionArchive(session) && (
+                      <div
+                        className={styles.sessionActions}
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => event.stopPropagation()}
+                      >
+                        <button
+                          className={styles.sessionActionButton}
+                          type="button"
+                          disabled={busy || isCurrent}
+                          aria-label={t('sidebar.archive')}
+                          title={
+                            isCurrent
+                              ? t('sidebar.archiveCurrentDisabled')
+                              : t('sidebar.archive')
+                          }
+                          onClick={() => handleArchive(session)}
+                        >
+                          <ArchiveIcon />
+                        </button>
+                      </div>
+                    )}
                     {!readOnly && (
                       <div
                         className={styles.sessionActions}
@@ -2290,20 +2474,22 @@ export function WebShellSidebar({
                             <PinIcon />
                           </button>
                         )}
-                        <button
-                          className={styles.sessionActionButton}
-                          type="button"
-                          disabled={busy || isCurrent}
-                          aria-label={t('sidebar.archive')}
-                          title={
-                            isCurrent
-                              ? t('sidebar.archiveCurrentDisabled')
-                              : t('sidebar.archive')
-                          }
-                          onClick={() => handleArchive(session)}
-                        >
-                          <ArchiveIcon />
-                        </button>
+                        {canMutateSessionArchive(session) && (
+                          <button
+                            className={styles.sessionActionButton}
+                            type="button"
+                            disabled={busy || isCurrent}
+                            aria-label={t('sidebar.archive')}
+                            title={
+                              isCurrent
+                                ? t('sidebar.archiveCurrentDisabled')
+                                : t('sidebar.archive')
+                            }
+                            onClick={() => handleArchive(session)}
+                          >
+                            <ArchiveIcon />
+                          </button>
+                        )}
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <button
@@ -2400,14 +2586,15 @@ export function WebShellSidebar({
     },
     [
       busySessionIds,
+      canMutateSessionArchive,
       canExportSessions,
       cancelRename,
       collapsed,
       completedUnreadIds,
-      currentSessionId,
       editingName,
       editingSessionId,
       exportingSessionIds,
+      getIdentityForSession,
       handleArchive,
       handleDeleteSession,
       handleExportSession,
@@ -2415,6 +2602,7 @@ export function WebShellSidebar({
       handleRenameFromMenu,
       handleTogglePin,
       handleUnarchive,
+      isCurrentSession,
       openGroupMenuFromAnchor,
       organizationEnabled,
       saveRename,
@@ -2500,7 +2688,7 @@ export function WebShellSidebar({
   ]);
 
   const archivedSection = useMemo(() => {
-    if (collapsed || searchQuery.trim()) return null;
+    if (!sessionArchiveEnabled || collapsed || searchQuery.trim()) return null;
 
     const header = (
       <button
@@ -2576,6 +2764,7 @@ export function WebShellSidebar({
     reloadArchived,
     renderSessionRow,
     searchQuery,
+    sessionArchiveEnabled,
     setSecondaryArchivedReloadToken,
     t,
   ]);
@@ -3174,10 +3363,13 @@ export function WebShellSidebar({
                             }
                             renderSessions={!ws.primary}
                             renderSession={(session) =>
-                              renderSessionRow({
-                                ...session,
-                                workspaceCwd: ws.cwd,
-                              })
+                              renderSessionRow(
+                                {
+                                  ...session,
+                                  workspaceCwd: ws.cwd,
+                                },
+                                { readOnly: !ws.primary },
+                              )
                             }
                             headerActions={(visible) => {
                               if (

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -9,56 +9,82 @@ import {
   type DaemonWorkspaceCapability,
 } from '@qwen-code/sdk/daemon';
 
-const { connection, workspace, workspaceActions, active, archived } =
-  vi.hoisted(() => {
-    const makeSessions = () => ({
-      sessions: [] as DaemonSessionSummary[],
-      loading: false,
-      error: null,
-      reload: vi.fn().mockResolvedValue(undefined),
-      deleteSession: vi.fn().mockResolvedValue(true),
-      archiveSession: vi.fn().mockResolvedValue(true),
-      unarchiveSession: vi.fn().mockResolvedValue(true),
-      exportSession: vi.fn(),
-    });
-    return {
-      connection: {
-        status: 'connected',
-        sessionId: null as string | null,
-        workspaceCwd: '/tmp/project',
-        capabilities: undefined as
-          | {
-              qwenCodeVersion: string;
-              features: string[];
-              workspaces: DaemonWorkspaceCapability[];
-            }
-          | undefined,
-      },
-      workspace: {
-        capabilities: undefined as
-          | {
-              qwenCodeVersion: string;
-              features: string[];
-              workspaces: DaemonWorkspaceCapability[];
-            }
-          | undefined,
-        client: {
-          workspaceByCwd: vi.fn(() => ({
-            listWorkspaceSessions: vi.fn().mockResolvedValue([]),
-            listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
-          })),
-        },
-        refreshCapabilities: vi.fn(),
-      },
-      workspaceActions: {
-        addWorkspace: vi.fn(),
-        removeWorkspace: vi.fn(),
-        listSessionGroups: vi.fn(),
-      },
-      active: makeSessions(),
-      archived: makeSessions(),
-    };
+const {
+  connection,
+  workspace,
+  workspaceActions,
+  active,
+  archived,
+  listWorkspaceSessions,
+  archiveSessionsData,
+  unarchiveSessionsData,
+} = vi.hoisted(() => {
+  const makeSessions = () => ({
+    sessions: [] as DaemonSessionSummary[],
+    loading: false,
+    error: null,
+    reload: vi.fn().mockResolvedValue(undefined),
+    deleteSession: vi.fn().mockResolvedValue(true),
+    archiveSession: vi.fn().mockResolvedValue(true),
+    unarchiveSession: vi.fn().mockResolvedValue(true),
+    exportSession: vi.fn(),
   });
+  const listWorkspaceSessions = vi.fn().mockResolvedValue([]);
+  const archiveSessionsData = vi.fn().mockResolvedValue({
+    archived: [],
+    alreadyArchived: [],
+    notFound: [],
+    errors: [],
+  });
+  const unarchiveSessionsData = vi.fn().mockResolvedValue({
+    unarchived: [],
+    alreadyActive: [],
+    notFound: [],
+    errors: [],
+  });
+  return {
+    connection: {
+      status: 'connected',
+      sessionId: null as string | null,
+      workspaceCwd: '/tmp/project',
+      capabilities: undefined as
+        | {
+            qwenCodeVersion: string;
+            features: string[];
+            workspaces: DaemonWorkspaceCapability[];
+          }
+        | undefined,
+    },
+    workspace: {
+      capabilities: undefined as
+        | {
+            qwenCodeVersion: string;
+            features: string[];
+            workspaces: DaemonWorkspaceCapability[];
+          }
+        | undefined,
+      client: {
+        workspaceByCwd: vi.fn(() => ({
+          listWorkspaceSessions,
+          listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+          archiveSessionsData,
+          unarchiveSessionsData,
+        })),
+      },
+      refreshCapabilities: vi.fn(),
+    },
+    workspaceActions: {
+      addWorkspace: vi.fn(),
+      removeWorkspace: vi.fn(),
+      listSessionGroups: vi.fn(),
+    },
+    active: makeSessions(),
+    archived: makeSessions(),
+    listWorkspaceSessions,
+    archiveSessionsData,
+    unarchiveSessionsData,
+  };
+});
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useConnection: () => connection,
@@ -91,7 +117,12 @@ if (!Element.prototype.scrollIntoView) {
 
 const capabilities = {
   qwenCodeVersion: '1.2.3',
-  features: ['multi_workspace_sessions', 'workspace_runtime_removal'],
+  features: [
+    'multi_workspace_sessions',
+    'workspace_runtime_removal',
+    'session_archive',
+    'workspace_qualified_rest_core',
+  ],
   workspaces: [
     {
       id: 'primary',
@@ -175,6 +206,60 @@ function click(element: HTMLElement): void {
   element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 }
 
+async function expandWorkspace(name: string): Promise<void> {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('button'),
+  ).find((candidate) => candidate.textContent?.includes(name));
+  expect(button).toBeDefined();
+  await act(async () => {
+    click(button!);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function archiveButtonFor(label: string): HTMLButtonElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Archive"]',
+    ),
+  ).find((button) =>
+    button.closest('[role="button"]')?.textContent?.includes(label),
+  );
+}
+
+async function expandArchived(): Promise<void> {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('button'),
+  ).find((candidate) => candidate.textContent?.includes('Archived'));
+  expect(button).toBeDefined();
+  await act(async () => {
+    click(button!);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function useWorkspaceSessionCatalog(
+  resolve: (
+    cwd: string,
+    options?: { archiveState?: string; group?: string },
+  ) => Promise<DaemonSessionSummary[]>,
+): void {
+  workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+    listWorkspaceSessions: (options?: {
+      archiveState?: string;
+      group?: string;
+    }) => {
+      void listWorkspaceSessions(cwd, options);
+      return resolve(cwd, options);
+    },
+    listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+    archiveSessionsData,
+    unarchiveSessionsData,
+  }));
+}
+
 function openRemoval(cwd: string): void {
   const trigger = workspaceAction(cwd);
   expect(trigger).toBeDefined();
@@ -205,14 +290,34 @@ beforeEach(() => {
   workspace.refreshCapabilities.mockReset();
   workspace.refreshCapabilities.mockResolvedValue(capabilities);
   workspace.client.workspaceByCwd.mockReset();
+  listWorkspaceSessions.mockReset();
+  listWorkspaceSessions.mockResolvedValue([]);
+  archiveSessionsData.mockReset();
+  archiveSessionsData.mockResolvedValue({
+    archived: [],
+    alreadyArchived: [],
+    notFound: [],
+    errors: [],
+  });
+  unarchiveSessionsData.mockReset();
+  unarchiveSessionsData.mockResolvedValue({
+    unarchived: [],
+    alreadyActive: [],
+    notFound: [],
+    errors: [],
+  });
   workspace.client.workspaceByCwd.mockImplementation(() => ({
-    listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+    listWorkspaceSessions,
     listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+    archiveSessionsData,
+    unarchiveSessionsData,
   }));
   workspaceActions.removeWorkspace.mockReset();
   workspaceActions.removeWorkspace.mockResolvedValue({ removed: true });
-  active.reload.mockClear();
-  archived.reload.mockClear();
+  active.reload.mockReset();
+  active.reload.mockResolvedValue(undefined);
+  archived.reload.mockReset();
+  archived.reload.mockResolvedValue(undefined);
   active.sessions.length = 0;
   archived.sessions.length = 0;
 });
@@ -446,5 +551,358 @@ describe('WebShellSidebar workspace removal', () => {
 
     expect(document.body.textContent).toContain('Voice sessions: 1');
     expect(dialogButton('Force remove').disabled).toBe(false);
+  });
+});
+
+describe('WebShellSidebar non-primary archive', () => {
+  it('archives a trusted secondary session and reconciles every catalog', async () => {
+    useWorkspaceSessionCatalog(async (cwd, options) => {
+      if (cwd === '/tmp/other' && options?.archiveState === 'active') {
+        return [
+          {
+            sessionId: 'secondary-active',
+            workspaceCwd: cwd,
+            displayName: 'Secondary active',
+          },
+        ];
+      }
+      return [];
+    });
+    archiveSessionsData.mockResolvedValue({
+      archived: ['secondary-active'],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [],
+    });
+
+    renderSidebar();
+    await expandWorkspace('other');
+    await expandArchived();
+    const archiveButton = archiveButtonFor('Secondary active');
+    expect(archiveButton).toBeDefined();
+    const secondaryRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((row) => row.textContent?.includes('Secondary active'));
+    expect(
+      secondaryRow?.querySelector('button[aria-label="More actions"]'),
+    ).toBeNull();
+
+    await act(async () => {
+      click(archiveButton!);
+      await archiveSessionsData.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(workspace.client.workspaceByCwd).toHaveBeenCalledWith('/tmp/other');
+    expect(archiveSessionsData).toHaveBeenCalledWith(['secondary-active']);
+    expect(active.reload).toHaveBeenCalled();
+    expect(archived.reload).toHaveBeenCalled();
+    expect(
+      listWorkspaceSessions.mock.calls.filter(
+        ([cwd, options]) =>
+          cwd === '/tmp/other' && options?.archiveState === 'active',
+      ).length,
+    ).toBeGreaterThan(1);
+    expect(
+      listWorkspaceSessions.mock.calls.some(
+        ([cwd, options]) =>
+          cwd === '/tmp/other' && options?.archiveState === 'archived',
+      ),
+    ).toBe(true);
+  });
+
+  it('surfaces a partial restore error and reconciles every catalog', async () => {
+    const onError = vi.fn();
+    useWorkspaceSessionCatalog(async (cwd, options) => {
+      if (cwd === '/tmp/other' && options?.archiveState === 'archived') {
+        return [
+          {
+            sessionId: 'secondary-archived',
+            workspaceCwd: cwd,
+            displayName: 'Secondary archived',
+            isArchived: true,
+          },
+        ];
+      }
+      return [];
+    });
+    unarchiveSessionsData.mockResolvedValue({
+      unarchived: ['secondary-archived'],
+      alreadyActive: [],
+      notFound: [],
+      errors: [
+        {
+          sessionId: 'secondary-archived',
+          error: 'scheduled task restore failed',
+        },
+      ],
+    });
+
+    renderSidebar({ onError });
+    await expandWorkspace('other');
+    await expandArchived();
+    const moreButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="More actions"]',
+      ),
+    ).find((button) =>
+      button
+        .closest<HTMLElement>('[class*="sessionRow"]')
+        ?.textContent?.includes('Secondary archived'),
+    );
+    expect(moreButton).toBeDefined();
+    act(() => click(moreButton!));
+    const restoreItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes('Restore'));
+    expect(restoreItem).toBeDefined();
+
+    await act(async () => {
+      click(restoreItem!);
+      await unarchiveSessionsData.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(unarchiveSessionsData).toHaveBeenCalledWith(['secondary-archived']);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'scheduled task restore failed' }),
+      'Failed to restore session',
+    );
+    expect(active.reload).toHaveBeenCalled();
+    expect(archived.reload).toHaveBeenCalled();
+    expect(
+      listWorkspaceSessions.mock.calls.filter(
+        ([cwd, options]) =>
+          cwd === '/tmp/other' && options?.archiveState === 'active',
+      ).length,
+    ).toBeGreaterThan(1);
+  });
+
+  it('surfaces secondary batch errors and still reconciles catalogs', async () => {
+    const onError = vi.fn();
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'secondary-error',
+              workspaceCwd: cwd,
+              displayName: 'Secondary error',
+            },
+          ]
+        : [],
+    );
+    archiveSessionsData.mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [
+        {
+          sessionId: 'secondary-error',
+          error: 'agent close failed',
+        },
+      ],
+    });
+
+    renderSidebar({ onError });
+    await expandWorkspace('other');
+    const archiveButton = archiveButtonFor('Secondary error');
+    expect(archiveButton).toBeDefined();
+    await act(async () => {
+      click(archiveButton!);
+      await archiveSessionsData.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'agent close failed' }),
+      'Failed to archive session',
+    );
+    expect(active.reload).toHaveBeenCalled();
+    expect(archived.reload).toHaveBeenCalled();
+    expect(
+      listWorkspaceSessions.mock.calls.filter(
+        ([cwd, options]) =>
+          cwd === '/tmp/other' && options?.archiveState === 'active',
+      ).length,
+    ).toBeGreaterThan(1);
+  });
+
+  it('allows primary archive but gates secondary archive without the plural capability', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: ['session_archive'],
+    };
+    active.sessions.push({
+      sessionId: 'primary-active',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Primary active',
+    });
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'secondary-active',
+              workspaceCwd: cwd,
+              displayName: 'Secondary active',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar();
+    await expandWorkspace('project');
+    await expandWorkspace('other');
+    expect(archiveButtonFor('Primary active')).toBeDefined();
+    expect(archiveButtonFor('Secondary active')).toBeUndefined();
+    await expandArchived();
+    expect(
+      listWorkspaceSessions.mock.calls.some(
+        ([, options]) => options?.archiveState === 'archived',
+      ),
+    ).toBe(false);
+  });
+
+  it('hides archive UI when session_archive is absent', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: ['workspace_qualified_rest_core'],
+    };
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'secondary-active',
+              workspaceCwd: cwd,
+              displayName: 'Secondary active',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar();
+    await expandWorkspace('other');
+    expect(archiveButtonFor('Secondary active')).toBeUndefined();
+    expect(container.textContent).not.toContain('Archived');
+  });
+
+  it('keeps untrusted secondary sessions read-only', async () => {
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/danger' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'untrusted-active',
+              workspaceCwd: cwd,
+              displayName: 'Untrusted active',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar();
+    await expandWorkspace('danger');
+    expect(container.textContent).toContain('Untrusted active');
+    expect(archiveButtonFor('Untrusted active')).toBeUndefined();
+    expect(archiveSessionsData).not.toHaveBeenCalled();
+  });
+
+  it('treats an idempotent secondary archive as success despite a matching current id', async () => {
+    const onError = vi.fn();
+    connection.sessionId = 'shared-session';
+    connection.workspaceCwd = '/tmp/project';
+    active.sessions.push({
+      sessionId: 'shared-session',
+      displayName: 'Legacy primary shared',
+    } as DaemonSessionSummary);
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'shared-session',
+              workspaceCwd: cwd,
+              displayName: 'Secondary shared',
+            },
+          ]
+        : [],
+    );
+    archiveSessionsData.mockResolvedValue({
+      archived: [],
+      alreadyArchived: ['shared-session'],
+      notFound: [],
+      errors: [],
+    });
+
+    renderSidebar({ onError });
+    await expandWorkspace('project');
+    await expandWorkspace('other');
+    const primaryArchiveButton = archiveButtonFor('Legacy primary shared');
+    const archiveButton = archiveButtonFor('Secondary shared');
+    expect(primaryArchiveButton).toBeDefined();
+    expect(primaryArchiveButton?.disabled).toBe(true);
+    expect(archiveButton).toBeDefined();
+    expect(archiveButton?.disabled).toBe(false);
+    await act(async () => {
+      click(archiveButton!);
+      await archiveSessionsData.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(archiveSessionsData).toHaveBeenCalledWith(['shared-session']);
+    expect(onError).not.toHaveBeenCalled();
+    expect(active.reload).toHaveBeenCalled();
+    expect(archived.reload).toHaveBeenCalled();
+  });
+
+  it('keeps equal-id archive busy state scoped to its workspace', async () => {
+    let finishArchive!: (result: {
+      archived: string[];
+      alreadyArchived: string[];
+      notFound: string[];
+      errors: [];
+    }) => void;
+    archiveSessionsData.mockReturnValue(
+      new Promise((resolve) => {
+        finishArchive = resolve;
+      }),
+    );
+    active.sessions.push({
+      sessionId: 'shared-pending',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Primary pending',
+    });
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'shared-pending',
+              workspaceCwd: cwd,
+              displayName: 'Secondary pending',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar();
+    await expandWorkspace('project');
+    await expandWorkspace('other');
+    const secondaryArchive = archiveButtonFor('Secondary pending');
+    expect(secondaryArchive).toBeDefined();
+
+    await act(async () => {
+      click(secondaryArchive!);
+      await Promise.resolve();
+    });
+
+    expect(archiveButtonFor('Secondary pending')?.disabled).toBe(true);
+    expect(archiveButtonFor('Primary pending')?.disabled).toBe(false);
+
+    await act(async () => {
+      finishArchive({
+        archived: ['shared-pending'],
+        alreadyArchived: [],
+        notFound: [],
+        errors: [],
+      });
+      await archiveSessionsData.mock.results.at(-1)?.value;
+    });
   });
 });


### PR DESCRIPTION
## What this PR does

This PR hardens the existing WebShell archive and restore flow for sessions in registered non-primary workspaces. Archive UI is gated by `session_archive`; secondary mutations additionally require `workspace_qualified_rest_core` and a trusted workspace. Secondary batch responses now surface matching `errors[]` entries, and every settled archive or restore reconciles primary active, primary archived, and workspace-qualified catalogs.

Merged sidebar collections and transient row state now identify sessions by `(workspaceCwd, sessionId)`, preventing equal ids in different workspaces from colliding in deduplication, React keys, current-session detection, busy state, unread completion, or export-in-flight state. A trusted secondary active row exposes only Archive, preserving its existing load-only treatment for other actions.

The daemon regression coverage verifies that archiving and restoring a secondary session with the same id as a primary session moves only the selected workspace file and touches only the selected workspace bridge.

## Why it's needed

The workspace-qualified archive API is already available, but WebShell could treat a partially failed HTTP 200 response as success, leave one or more catalogs stale, and confuse rows that shared a session id across workspaces. Capability and trust gates also need to reflect the exact server surface before exposing the mutation.

This makes the already-shipped archive path reliable without changing REST contracts, SDK types, persistence layout, active secondary delete behavior, or session export behavior.

## Reviewer Test Plan

### How to verify

1. Run the focused WebShell sidebar test and confirm all 16 scenarios pass, including success, partial archive/restore errors, missing capabilities, untrusted workspaces, idempotency, equal-id current isolation, equal-id pending-busy isolation, and catalog reconciliation.
2. Run the multi-workspace session test and confirm the equal-id archive/restore regression leaves the primary JSONL active, never creates a primary archived file, moves only the secondary JSONL, and closes only the secondary bridge.
3. With a daemon that registers two trusted workspaces, open a secondary active session row. Confirm Archive is available only when both required capabilities are advertised, while the secondary row still has no More/Delete/Export menu. Archive or restore it and confirm all sidebar catalogs refresh; inject a batch `errors[]` entry and confirm the error is shown.

### Evidence (Before & After)

Before: WebShell discarded secondary archive/restore `errors[]`, refreshed only part of the catalog set, and keyed cross-workspace row state by raw session id. A trusted secondary active row was otherwise load-only.

After: The focused jsdom regression suite passes 16/16 and directly verifies the capability/trust gates, error surfacing, complete reconciliation, equal-id current and busy isolation, and that trusted secondary active rows expose Archive without exposing More/Delete/Export. A global `qwen` 0.19.10 two-workspace daemon dry-run also passed the secondary active → archived → active filesystem lifecycle without ACP/model activity.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Node.js 22.22.3, npm 10.9.8, macOS, local workspace build, and global `qwen` 0.19.10 baseline daemon.

## Risk & Scope

- Main risk or tradeoff: Sidebar identity bookkeeping now uses a composite workspace/session key across several transient states; focused regressions cover the downstream consumers. The archive coordinator remains conservatively keyed by session id across workspaces.
- Not validated / out of scope: Full manual visual WebShell E2E was not executed; the documented plan and jsdom behavior matrix cover the changed paths. Delete, export, archive REST, SDK types, and disk format are out of scope.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #6378

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 加固了 WebShell 中已存在的注册非主 workspace 会话归档与恢复流程。归档 UI 由 `session_archive` 控制；secondary 变更还要求 `workspace_qualified_rest_core` 且 workspace 已受信任。Secondary 批量响应现在会展示匹配的 `errors[]`，每次归档或恢复结束后都会重新同步 primary active、primary archived 和 workspace-qualified 列表。

Sidebar 合并集合和临时行状态现在使用 `(workspaceCwd, sessionId)` 标识会话，避免不同 workspace 中相同 id 在去重、React key、当前会话判断、busy 状态、未读完成状态或导出中状态上发生冲突。受信任的 secondary active 行只开放 Archive，其他操作维持原有的仅加载行为。

Daemon 回归测试验证：当 secondary 会话与 primary 会话 id 相同时，归档和恢复只移动所选 workspace 的文件，并且只触达所选 workspace 的 bridge。

## 为什么需要

Workspace-qualified archive API 已经可用，但 WebShell 可能把带有部分失败的 HTTP 200 响应当作成功、让一个或多个列表保持陈旧，并混淆跨 workspace 共享 session id 的行。在展示变更入口前，能力与信任门禁也需要准确对应服务端实际表面。

这让已经发布的归档路径可靠闭环，同时不修改 REST 合同、SDK 类型、持久化布局、secondary active 的现有 delete 行为或 session export 行为。

## Reviewer 测试计划

### 如何验证

1. 运行聚焦的 WebShell sidebar 测试，确认 16 个场景全部通过，包括成功、archive/restore 部分错误、能力缺失、未受信任 workspace、幂等、相同 id 当前会话隔离、相同 id pending-busy 隔离和列表同步。
2. 运行 multi-workspace session 测试，确认相同 id 的 archive/restore 回归会让 primary JSONL 保持 active、不会创建 primary archived 文件、只移动 secondary JSONL，并且只关闭 secondary bridge。
3. 使用注册两个受信任 workspace 的 daemon，打开一个 secondary active session 行。确认只有在两个必需 capability 都存在时 Archive 才可用，同时该 secondary 行仍没有 More/Delete/Export 菜单。归档或恢复后确认所有 sidebar 列表都会刷新；注入批量 `errors[]` 并确认错误会显示。

### 证据（Before & After）

Before：WebShell 会丢弃 secondary archive/restore 的 `errors[]`，只刷新部分列表，并使用原始 session id 作为跨 workspace 行状态 key。受信任的 secondary active 行除此以外是仅加载的。

After：聚焦 jsdom 回归套件 16/16 通过，并直接验证能力/信任门禁、错误展示、完整同步、相同 id 的 current 与 busy 隔离，以及受信任 secondary active 行只开放 Archive 而不开放 More/Delete/Export。全局 `qwen` 0.19.10 双 workspace daemon dry-run 也完成了 secondary active → archived → active 文件系统生命周期，全程没有 ACP/model 活动。

### 已测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ⚠️ 未测试   |

### 环境（可选）

Node.js 22.22.3、npm 10.9.8、macOS、本地 workspace build，以及全局 `qwen` 0.19.10 baseline daemon。

## 风险与范围

- 主要风险或取舍：Sidebar 身份记录现在在多个临时状态中使用 workspace/session 复合 key；聚焦回归已覆盖所有下游消费者。Archive coordinator 仍按 session id 在跨 workspace 范围保守键控。
- 未验证 / 范围外：未执行完整的 WebShell 手工视觉 E2E；已记录的计划和 jsdom 行为矩阵覆盖了变更路径。Delete、export、archive REST、SDK 类型和磁盘格式均不在范围内。
- Breaking change / 迁移说明：无。

## 关联 Issue

Refs #6378

</details>
