### PR TITLE
fix(core): roll back failed max-token continuation attempts

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -10289,26 +10289,11 @@ describe('GeminiChat', async () => {
       expect(mergedText).toBe('BCD');
     });
 
-    it('flushes the JSONL record when escalated stream throws mid-tool_use', async () => {
-      // Critical regression for the max-tokens escalation path:
-      // 1) initial stream succeeds with text + MAX_TOKENS → triggers
-      //    escalation, no partial set, deferred record clean.
-      // 2) escalated stream throws AFTER yielding a functionCall chunk
-      //    → processStreamResponse pushes a partial model[fc] into
-      //    `this.history` and stashes a NEW `pendingPartialAssistantRecord`.
-      // 3) The throw escapes through the for-await on the escalated
-      //    stream, propagates past the (now-passed) retry loop, and
-      //    lands in the outer `finally` block.
-      //
-      // BEFORE the fix: the flush only ran BEFORE the escalation block,
-      // so the new record set in step 2 was never appended to JSONL —
-      // live history disagreed with disk; `--resume` rehydrated a
-      // truncated transcript and `repairOrphanedToolUseTurnsInHistory`
-      // had nothing to repair, leaving the React scheduler's late real
-      // result as a permanent orphan.
-      //
-      // AFTER the fix: the flush is in `finally`, so the record lands
-      // on disk regardless of which stream raised.
+    it('rolls back an escalated partial tool call when the stream fails', async () => {
+      // The escalated attempt pushes a partial model[functionCall] and
+      // stages its recording before the stream failure surfaces. Both must
+      // be rolled back so later sends and resumed sessions do not repair an
+      // incomplete call with a synthetic result.
       const recordAssistantTurn = vi.fn();
       const chatWithRecording = new GeminiChat(
         mockConfig,
@@ -10368,20 +10353,10 @@ describe('GeminiChat', async () => {
         })(),
       ).rejects.toThrow(/synthetic mid-tool_use cut/);
 
-      // In-memory: the partial functionCall pushed by the escalated
-      // processStreamResponse must be in history.
-      const history = chatWithRecording.getHistory();
-      const partialModel = history.findLast((h) => h.role === 'model');
-      expect(
-        partialModel?.parts?.some(
-          (p) => p.functionCall?.id === 'call_escalation_throw',
-        ),
-      ).toBe(true);
+      expect(chatWithRecording.getHistory()).toEqual([
+        { role: 'user', parts: [{ text: 'kick off' }] },
+      ]);
 
-      // JSONL: at least one record must mention the partial functionCall
-      // (the escalation throw flushed it). Without the finally-block
-      // flush, this assertion would fail and the durable transcript
-      // would silently lose a tool_use that's still live in memory.
       const recordedHasPartial = recordAssistantTurn.mock.calls.some((call) => {
         const message = (
           call[0] as {
@@ -10392,7 +10367,7 @@ describe('GeminiChat', async () => {
           (p) => p.functionCall?.id === 'call_escalation_throw',
         );
       });
-      expect(recordedHasPartial).toBe(true);
+      expect(recordedHasPartial).toBe(false);
     });
   });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2596,9 +2596,9 @@ export class GeminiChat {
               }
               return;
             } catch (error) {
+              attemptState.rollback();
               if (!(error instanceof InvalidStreamError)) throw error;
 
-              attemptState.rollback();
               const maxContinuationRetries =
                 error.type === 'PROTOCOL_TAG_LEAK'
                   ? INVALID_STREAM_RETRY_CONFIG.protocolTagLeakMaxRetries


### PR DESCRIPTION
## What this PR does

Failed max-output-token escalation and continuation attempts now run their attempt-specific rollback before the error is either retried or propagated. This removes partial assistant tool calls from live history and discards their deferred recording when a follow-up stream fails with an error outside the invalid-stream retry class.

The existing invalid-stream retry behavior is unchanged: eligible invalid streams still roll back and retry with their current budgets, while other failures still propagate after cleanup.

## Why it's needed

A follow-up stream can emit a tool call before a socket failure. That partial call was kept in history because rollback only ran for errors eligible for invalid-stream retry. The next send then treated the incomplete call as an orphan and synthesized a generic failure result; resumed sessions could restore the same incomplete call from the recording.

## Reviewer Test Plan

### How to verify

Use a model stream where the first response ends at the output-token limit, the escalated response emits a function call, and that response then throws. Confirm that the original transport error still reaches the caller, history contains only the user turn, and no recording contains the failed function call. Also confirm that ordinary invalid-stream continuation retries retain their existing retry budgets and recovery behavior.

### Evidence (Before & After)

Before: the deterministic regression ended with `user -> model[functionCall]`, and the partial function call was staged for recording.

After: the same regression ends with only the user turn, and the failed function call is absent from recording.

Validation run on Linux:

- `cd packages/core && npx vitest run src/core/geminiChat.test.ts` — 226 passed
- `npm run build` — passed
- `npm run typecheck` — passed
- changed-file Prettier and ESLint checks — passed
- structured autoreview against `origin/main` — clean, no actionable findings

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node.js 24.18.0 with the repository Vitest configuration and deterministic content-generator streams.

## Risk & Scope

- Main risk or tradeoff: follow-up stream failures now discard any partial tool call from that failed attempt before propagating the error; each caller already supplies rollback scoped to that attempt.
- Not validated / out of scope: provider-specific live traffic, changes to transport retry eligibility, and replaying output after a chunk has reached the caller.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6919

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 max-output-token escalation 或 continuation 尝试失败时，现在会先执行该尝试对应的回滚，再决定重试或向上抛出错误。如果后续流因不属于 invalid-stream 重试类别的错误而失败，回滚会从实时历史中移除不完整的 assistant tool call，并丢弃其待写入的记录。

现有 invalid-stream 重试行为保持不变：符合条件的 invalid stream 仍会按照当前预算回滚并重试，其他失败仍会在清理后向上抛出。

## 为什么需要它

后续流可能先输出一个 tool call，然后发生 socket 故障。此前只有符合 invalid-stream 重试条件的错误才会执行回滚，因此这个不完整的调用会留在历史中。下一次发送会将它视为孤立调用并合成一个通用失败结果；恢复会话时，也可能从记录中重新载入同一个不完整调用。

## Reviewer Test Plan

### 如何验证

构造如下模型流：第一次响应因输出 token 上限结束，escalated 响应输出一个 function call 后抛出错误。确认原始 transport error 仍会传给调用方，历史中只保留 user turn，且记录中不包含失败的 function call。同时确认普通 invalid-stream continuation 重试仍保留现有重试预算和恢复行为。

### 证据（修改前后）

修改前：确定性回归场景结束时历史为 `user -> model[functionCall]`，不完整的 function call 也进入待记录状态。

修改后：同一回归场景结束时只剩 user turn，记录中也不存在失败的 function call。

在 Linux 上执行的验证：

- `cd packages/core && npx vitest run src/core/geminiChat.test.ts` — 226 个测试通过
- `npm run build` — 通过
- `npm run typecheck` — 通过
- 变更文件的 Prettier 和 ESLint 检查 — 通过
- 针对 `origin/main` 的结构化 autoreview — 无可执行问题

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Node.js 24.18.0，使用仓库 Vitest 配置和确定性的 content-generator 流。

## 风险与范围

- 主要风险或权衡：后续流失败时，会在错误向上抛出前丢弃该失败尝试产生的不完整 tool call；每个调用方已经提供只作用于该尝试的回滚。
- 未验证或范围外：特定 provider 的真实流量、transport retry 条件的改变，以及在 chunk 已传给调用方后重放输出。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #6919

</details>
