### PR TITLE
feat(cli): add general.notificationMode to silence per-approval notifications (#6898)

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -556,6 +556,7 @@ type QwenCoreSettingKey =
   | 'general.showSessionRecap'
   | 'general.sessionRecapAwayThresholdMinutes'
   | 'general.terminalBell'
+  | 'general.notificationMode'
   | 'general.gitCoAuthor.commit'
   | 'general.gitCoAuthor.pr'
   | 'general.defaultFileEncoding'
@@ -623,6 +624,10 @@ const QWEN_CORE_SETTING_DEFINITIONS = {
   'general.showSessionRecap': { type: 'boolean' },
   'general.sessionRecapAwayThresholdMinutes': { type: 'number', min: 1 },
   'general.terminalBell': { type: 'boolean' },
+  'general.notificationMode': {
+    type: 'enum',
+    values: ['all', 'task-complete'],
+  },
   'general.gitCoAuthor.commit': { type: 'boolean' },
   'general.gitCoAuthor.pr': { type: 'boolean' },
   'general.defaultFileEncoding': {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -603,6 +603,23 @@ const SETTINGS_SCHEMA = {
           'Play terminal bell sound when response completes or needs approval.',
         showInDialog: true,
       },
+      notificationMode: {
+        type: 'enum',
+        label: 'Notification Mode',
+        category: 'General',
+        requiresRestart: false,
+        default: 'all',
+        description:
+          'Which unfocused-terminal events fire a bell/OS notification. ' +
+          '"all" fires on every tool approval prompt AND on task completion (current behavior). ' +
+          '"task-complete" suppresses the per-approval notification and only fires when a long task returns to idle. ' +
+          'Requires `terminalBell` to be enabled; otherwise no notifications fire regardless of mode.',
+        showInDialog: true,
+        options: [
+          { value: 'all', label: 'All (approvals + task completion)' },
+          { value: 'task-complete', label: 'Task completion only' },
+        ],
+      },
       preventSystemSleep: {
         type: 'boolean',
         label: 'Prevent System Sleep While Running',

--- a/packages/cli/src/serve/routes/workspace-settings.ts
+++ b/packages/cli/src/serve/routes/workspace-settings.ts
@@ -28,6 +28,7 @@ import type { WorkspaceRegistry } from '../workspace-registry.js';
 const TUI_ONLY_SETTINGS = new Set([
   'general.vimMode',
   'general.terminalBell',
+  'general.notificationMode',
   'general.preferredEditor',
   'general.outputLanguage',
   'ide.enabled',

--- a/packages/cli/src/ui/hooks/useAttentionNotifications.test.ts
+++ b/packages/cli/src/ui/hooks/useAttentionNotifications.test.ts
@@ -47,6 +47,37 @@ const mockSettingsDisabled: LoadedSettings = {
   },
 } as LoadedSettings;
 
+// Approval notifications suppressed; task-completion notifications preserved.
+const mockSettingsTaskCompleteOnly: LoadedSettings = {
+  merged: {
+    general: {
+      terminalBell: true,
+      notificationMode: 'task-complete',
+    },
+  },
+} as LoadedSettings;
+
+// Explicit 'all' — same behavior as an unset notificationMode.
+const mockSettingsAllMode: LoadedSettings = {
+  merged: {
+    general: {
+      terminalBell: true,
+      notificationMode: 'all',
+    },
+  },
+} as LoadedSettings;
+
+// Unknown value must fall back to 'all' rather than silently disabling
+// approval notifications (defensive parse in the hook).
+const mockSettingsUnknownMode: LoadedSettings = {
+  merged: {
+    general: {
+      terminalBell: true,
+      notificationMode: 'garbage-value',
+    },
+  },
+} as unknown as LoadedSettings;
+
 describe('useAttentionNotifications', () => {
   beforeEach(() => {
     vi.mocked(mockedSendNotification).mockReset();
@@ -283,5 +314,100 @@ describe('useAttentionNotifications', () => {
     });
 
     expect(mockedSendNotification).not.toHaveBeenCalled();
+  });
+
+  describe('notificationMode (#6898)', () => {
+    it('suppresses approval notification when mode is task-complete', () => {
+      // The whole point of the task-complete mode: users driving many tool
+      // approvals in a single task no longer get an OS notification for every
+      // one. The WaitingForConfirmation transition must NOT fire sendNotification.
+      const { rerender } = render({ settings: mockSettingsTaskCompleteOnly });
+
+      rerender({
+        hookProps: {
+          isFocused: false,
+          streamingState: StreamingState.WaitingForConfirmation,
+          elapsedTime: 0,
+          settings: mockSettingsTaskCompleteOnly,
+          terminal: mockTerminal,
+        },
+      });
+
+      expect(mockedSendNotification).not.toHaveBeenCalled();
+    });
+
+    it('still fires task-completion notification when mode is task-complete', () => {
+      // task-complete only silences approvals — the long-task idle notification
+      // is the one the user WANTS to keep. Guards against widening the gate.
+      const { rerender } = render({ settings: mockSettingsTaskCompleteOnly });
+
+      // Simulate a long streaming task followed by return to Idle while
+      // unfocused, matching the LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS path.
+      rerender({
+        hookProps: {
+          isFocused: false,
+          streamingState: StreamingState.Responding,
+          elapsedTime: LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 1,
+          settings: mockSettingsTaskCompleteOnly,
+          terminal: mockTerminal,
+        },
+      });
+      rerender({
+        hookProps: {
+          isFocused: false,
+          streamingState: StreamingState.Idle,
+          elapsedTime: LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 1,
+          settings: mockSettingsTaskCompleteOnly,
+          terminal: mockTerminal,
+        },
+      });
+
+      expect(mockedSendNotification).toHaveBeenCalledTimes(1);
+      expect(mockedSendNotification).toHaveBeenCalledWith(
+        {
+          message: 'Qwen Code is waiting for your input',
+          title: 'Qwen Code',
+        },
+        mockTerminal,
+        true,
+      );
+    });
+
+    it('preserves current behavior when mode is explicitly "all"', () => {
+      // Setting notificationMode: 'all' must be a no-op compared to leaving
+      // it unset — same firing pattern as the pre-#6898 default.
+      const { rerender } = render({ settings: mockSettingsAllMode });
+
+      rerender({
+        hookProps: {
+          isFocused: false,
+          streamingState: StreamingState.WaitingForConfirmation,
+          elapsedTime: 0,
+          settings: mockSettingsAllMode,
+          terminal: mockTerminal,
+        },
+      });
+
+      expect(mockedSendNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to "all" when notificationMode is an unrecognized value', () => {
+      // A legacy settings file with a typo or a future value we don't know
+      // yet must not silently disable approval notifications — the user's
+      // intent is unclear, so we preserve the visible (louder) behavior.
+      const { rerender } = render({ settings: mockSettingsUnknownMode });
+
+      rerender({
+        hookProps: {
+          isFocused: false,
+          streamingState: StreamingState.WaitingForConfirmation,
+          elapsedTime: 0,
+          settings: mockSettingsUnknownMode,
+          terminal: mockTerminal,
+        },
+      });
+
+      expect(mockedSendNotification).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/cli/src/ui/hooks/useAttentionNotifications.ts
+++ b/packages/cli/src/ui/hooks/useAttentionNotifications.ts
@@ -20,6 +20,17 @@ export const LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS = 20;
 
 const NOTIFICATION_TITLE = 'Qwen Code';
 
+// The two accepted values for `general.notificationMode`:
+//   - 'all' (default, historical behavior) — fire on every WaitingForConfirmation
+//     transition AND on long-task idle.
+//   - 'task-complete' — suppress per-approval notifications; only fire on
+//     long-task idle. Requested in #6898: users driving many tool approvals
+//     otherwise get "几十次弹窗" per task.
+// The value read from settings is defensively narrowed at the call site — an
+// unknown value falls back to 'all' rather than silently disabling approval
+// notifications.
+export type NotificationMode = 'all' | 'task-complete';
+
 interface UseAttentionNotificationsOptions {
   isFocused: boolean;
   streamingState: StreamingState;
@@ -41,6 +52,15 @@ export const useAttentionNotifications = ({
 }: UseAttentionNotificationsOptions) => {
   const terminalBellEnabled: boolean =
     (settings?.merged?.general?.terminalBell as boolean) ?? true;
+  // Only 'task-complete' suppresses the per-approval notification; any other
+  // value (including missing / legacy configs) preserves the historical "all"
+  // behavior. See #6898.
+  const notificationMode: NotificationMode =
+    (settings?.merged?.general as { notificationMode?: unknown } | undefined)
+      ?.notificationMode === 'task-complete'
+      ? 'task-complete'
+      : 'all';
+  const approvalNotificationsEnabled = notificationMode === 'all';
 
   const awaitingNotificationSentRef = useRef(false);
   const respondingElapsedRef = useRef(0);
@@ -60,7 +80,8 @@ export const useAttentionNotifications = ({
       streamingState === StreamingState.WaitingForConfirmation &&
       !isFocused &&
       !awaitingNotificationSentRef.current &&
-      terminalBellEnabled
+      terminalBellEnabled &&
+      approvalNotificationsEnabled
     ) {
       const message = awaitingToolName
         ? `Qwen Code needs your permission to use ${awaitingToolName}`
@@ -81,6 +102,7 @@ export const useAttentionNotifications = ({
     isFocused,
     streamingState,
     terminalBellEnabled,
+    approvalNotificationsEnabled,
     terminal,
     awaitingToolName,
   ]);

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -168,6 +168,14 @@
           "type": "boolean",
           "default": true
         },
+        "notificationMode": {
+          "description": "Which unfocused-terminal events fire a bell/OS notification. \"all\" fires on every tool approval prompt AND on task completion (current behavior). \"task-complete\" suppresses the per-approval notification and only fires when a long task returns to idle. Requires `terminalBell` to be enabled; otherwise no notifications fire regardless of mode. Options: all, task-complete",
+          "enum": [
+            "all",
+            "task-complete"
+          ],
+          "default": "all"
+        },
         "preventSystemSleep": {
           "description": "Prevent the system from sleeping while Qwen Code is streaming a model response or executing tools. Idle prompt time and permission prompts do not inhibit sleep.",
           "type": "boolean",


### PR DESCRIPTION
## What this PR does

Adds a new `general.notificationMode` enum setting so users can choose between the existing behavior (`"all"` — fire on every approval prompt AND on task completion) and a task-complete-only mode (`"task-complete"` — suppress per-approval notifications, only fire when a long task returns to idle).

## Why it's needed

`general.terminalBell` is currently binary. With approval mode enabled and a task that drives many tool calls, `useAttentionNotifications` fires an OS/bell notification on every `WaitingForConfirmation` transition — the reporter on #6898 describes getting "几十次弹窗" per session (dozens of popups) and just wants to be told **when the task is done, then go confirm**. The triage on #6898 accepted this for exploration and outlined the exact three-step direction (schema, hook gate, i18n / plumbing).

The change is deliberately minimal:

- New enum setting `general.notificationMode` with two values (`"all"` and `"task-complete"`), default `"all"` so no existing user's notifications change on upgrade.
- `useAttentionNotifications` reads the mode defensively — anything that isn't the literal string `"task-complete"` falls back to `"all"`. That means a legacy settings file, a typo, or a future value we don't know yet keeps the visible (louder) behavior rather than silently going quiet.
- The `WaitingForConfirmation` branch of the hook is gated on the mode; the long-task idle branch and the notification hook are untouched, so `"task-complete"` really does still notify when the task finishes.
- Register the new key in the two places `general.terminalBell` is already listed: the acpAgent typed setting metadata (`acpAgent.ts`) and the TUI-only allowlist in `workspace-settings.ts`. Without this the setting can't be read/written over ACP or the serve `/workspace/settings` route.

Not doing (out of scope):

- Per-tool notification granularity (`shell-only`, `edit-only`, etc.). #6898 phrases the ask in terms of shell but the underlying signal is "don't fire per approval" regardless of tool; a finer knob is easy to add later without breaking the enum.
- Any behavior change when `general.terminalBell` is off. It still short-circuits everything; `notificationMode` is a no-op in that case.
- No i18n string changes required — new labels/descriptions live in `settingsSchema.ts` and the existing settings dialog picks them up via the same key-lookup pattern as `terminalBell`. `check-i18n` passes as a result.

## Reviewer Test Plan

### How to verify

Unit coverage lives in `useAttentionNotifications.test.ts` (four new cases, all under a `notificationMode (#6898)` describe):

- `suppresses approval notification when mode is task-complete` — the main fix: WaitingForConfirmation + unfocused + terminalBell on → `sendNotification` is NOT called.
- `still fires task-completion notification when mode is task-complete` — the guard against widening the gate: `Responding` for `LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 1`, then `Idle`, still notifies once.
- `preserves current behavior when mode is explicitly "all"` — no regression when the setting is explicitly set to its default.
- `falls back to "all" when notificationMode is an unrecognized value` — legacy / typo / unknown-future value keeps the historical loud behavior.

Full suites confirmed locally with `npx vitest run`:

- `useAttentionNotifications.test.ts` — 13/13 pass (9 pre-existing + 4 new)
- `acpAgent.test.ts` — 242/242 pass
- `config/settings.test.ts` — passing
- `serve/routes/workspace-settings.test.ts` — passing
- `scripts/check-i18n.ts` — all checks passed (new labels/descriptions do not affect i18n locale parity)

Manual smoke on a real session: enter approval mode, ask the model to do something that calls a handful of tools, unfocus the terminal — with `notificationMode = "task-complete"`, no bell/notification during the approvals; with `= "all"` (or unset), each approval fires one.

### Evidence (Before & After)

N/A — non-user-visible change until the setting is toggled. The default preserves the existing behavior byte-for-byte.

### Tested on

|     OS     |  Status  |
| :--------: | :------: |
|  🍏 macOS  |    ⚠️    |
| 🪟 Windows |    ✅    |
|  🐧 Linux  |    ⚠️    |

### Environment (optional)

`npx vitest run` for the affected suites and `npx tsx scripts/check-i18n.ts`. No `npm run dev` end-to-end drive.

## Risk & Scope

- Main risk or tradeoff: forgetting to gate a future notification site on `notificationMode`. The current implementation gates exactly the WaitingForConfirmation branch — that's the site the user actually complained about. Documented in the type comment on `NotificationMode` and in the setting's `description` so a future contributor adding another OS-notification firing site knows to consider the gate.
- Not validated / out of scope: the deeper "per-tool notification granularity" ask (see above) and any equivalent behavior on the desktop `@qwen-code/desktop` notification path — that lives outside `packages/cli` and can be a separate PR if maintainers want it aligned.
- Breaking changes / migration notes: none. Default is `"all"`, matching pre-#6898 behavior.

## Linked Issues

Closes #6898

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增枚举设置 `general.notificationMode`，让用户在现有行为（`"all"` —— 每次审批弹窗 + 任务结束提醒）与仅任务结束提醒（`"task-complete"`）之间选择。

## 为什么需要

`general.terminalBell` 目前是二进制开关。开启审批模式且一次任务触发大量工具调用时，`useAttentionNotifications` 会在每次 `WaitingForConfirmation` 状态变化时都弹一次系统通知——#6898 的报告者描述每次任务收到"几十次弹窗"，只想在**任务结束时被告知一次然后去确认**。#6898 的 triage 已接受该方向，并给出了三步实现路径（schema、hook 门控、i18n / 接线）。

改动刻意保持最小：

- 新增枚举设置 `general.notificationMode`，取值 `"all"` 和 `"task-complete"`，默认 `"all"`，因此现有用户升级后行为不变。
- `useAttentionNotifications` 防御性读取模式——凡不是字面量 `"task-complete"` 的一律回退到 `"all"`。这样 legacy 配置、拼写错误、未来新增值都保留可见（更响亮）的行为，而不是静默变哑。
- Hook 中 `WaitingForConfirmation` 分支按模式门控；长任务空闲分支和 notification hook 保持不变，因此 `"task-complete"` 确实还会在任务结束时提醒。
- 在 `general.terminalBell` 已注册的两个位置也注册新 key：acpAgent 的类型化设置元数据（`acpAgent.ts`）与 TUI 白名单（`workspace-settings.ts`），否则该设置无法经 ACP 或 serve `/workspace/settings` 读写。

不做（范围之外）：

- 按工具粒度分类（`shell-only`、`edit-only` 等）。#6898 措辞聚焦 shell 但真正的信号是"别每次审批都弹"，与工具无关；未来若需要细粒度旋钮，加在 enum 上不会破坏兼容。
- `general.terminalBell` 关闭时的任何行为变更——它仍短路一切，此时 `notificationMode` 无效。
- 无需 i18n 字符串更新，新 label/description 生活在 `settingsSchema.ts`，设置对话框沿现有 key 查找模式取值。`check-i18n` 通过。

## 复审测试计划

### 如何验证

单元覆盖在 `useAttentionNotifications.test.ts`（4 个新用例，位于 `notificationMode (#6898)` describe 下）：

- `suppresses approval notification when mode is task-complete` — 核心修复：WaitingForConfirmation + 未聚焦 + terminalBell 开启 → 不调用 `sendNotification`。
- `still fires task-completion notification when mode is task-complete` — 防止门控扩大：`Responding` 满 `LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 1` 后回到 `Idle`，仍触发一次通知。
- `preserves current behavior when mode is explicitly "all"` — 显式设为默认值时无回归。
- `falls back to "all" when notificationMode is an unrecognized value` — legacy / 拼写错误 / 未知未来值保留历史（响亮）行为。

`npx vitest run` 本地全绿：

- `useAttentionNotifications.test.ts` 13/13（原 9 + 新 4）
- `acpAgent.test.ts` 242/242
- `config/settings.test.ts`、`serve/routes/workspace-settings.test.ts` 通过
- `scripts/check-i18n.ts` 全部检查通过

手工冒烟：进入审批模式，让模型执行调用若干工具的任务，取消终端焦点。`notificationMode = "task-complete"` 时审批过程无提示；`= "all"`（或未设）时每次审批各触发一次。

### 证据（Before & After）

N/A——除非用户切换设置，否则无用户可见行为。默认与之前行为逐字节一致。

### 测试环境

|     系统     |  状态  |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

对相关测试集运行 `npx vitest run`，以及 `npx tsx scripts/check-i18n.ts`。未做 `npm run dev` 端到端验证。

## 风险与范围

- 主要风险 / 取舍：将来新增通知触发点时忘记按 `notificationMode` 门控。目前门控仅在 WaitingForConfirmation 分支——即用户实际抱怨的位置。`NotificationMode` 类型注释和设置 `description` 已记录，方便未来添加其他系统通知触发点的贡献者考虑门控。
- 未验证 / 范围之外：更深层的"按工具粒度"请求（见上），以及桌面端 `@qwen-code/desktop` 通知路径的相应对齐——它位于 `packages/cli` 之外，若维护者希望统一可作为独立 PR。
- 破坏性变更 / 迁移说明：无。默认 `"all"`，与 #6898 之前行为一致。

## 关联 Issue

Closes #6898

</details>
