### PR TITLE
fix(core): canonicalize restrictive permission paths

### DIFF
--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -677,6 +677,26 @@ describe('matchesPathPattern', () => {
     });
   });
 
+  it('canonicalizes through a file that causes ENOTDIR', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(protectedDir);
+      fs.writeFileSync(path.join(protectedDir, 'config.json'), '{}');
+      fs.symlinkSync(protectedDir, link, 'dir');
+
+      expect(
+        matchesPathPattern(
+          '/protected/**',
+          path.join(link, 'config.json', 'nested.txt'),
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(true);
+    });
+  });
+
   it('canonicalizes a symlinked project root in restrictive rules', () => {
     withTempRoot((root) => {
       const realRoot = path.join(root, 'real');

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -3218,6 +3218,42 @@ describe('PermissionManager — compound shell write attribution', () => {
     ).toBe(false);
   });
 
+  it('does not treat canonical-only allow matches as relevant', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-permission-'));
+    try {
+      const allowedDir = path.join(root, 'allowed');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(allowedDir);
+      fs.writeFileSync(path.join(allowedDir, 'file.txt'), 'allowed');
+      fs.symlinkSync(allowedDir, link, 'dir');
+
+      const pm = new PermissionManager(
+        makeConfig({
+          permissionsAllow: ['Edit(/allowed/**)'],
+          cwd: root,
+          projectRoot: root,
+        }),
+      );
+      pm.initialize();
+
+      expect(
+        pm.hasRelevantRules({
+          toolName: 'edit',
+          filePath: path.join(link, 'file.txt'),
+        }),
+      ).toBe(false);
+      expect(
+        pm.hasRelevantRules({
+          toolName: 'run_shell_command',
+          command: `echo allowed > ${path.join(link, 'file.txt')}`,
+          cwd: root,
+        }),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('hasRelevantRules sees protected writes after sibling shell-wrapper segments', () => {
     const pm = new PermissionManager(
       makeConfig({

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 import {
   parseRule,
   parseRules,
@@ -539,6 +541,14 @@ describe('resolvePathPattern', () => {
 describe('matchesPathPattern', () => {
   const projectRoot = '/project';
   const cwd = '/project';
+  const withTempRoot = (run: (root: string) => void): void => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-permission-'));
+    try {
+      run(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
 
   it('matches dotfiles (e.g. .env)', async () => {
     expect(matchesPathPattern('.env', '/project/.env', projectRoot, cwd)).toBe(
@@ -618,6 +628,183 @@ describe('matchesPathPattern', () => {
         cwd,
       ),
     ).toBe(false);
+  });
+
+  it('matches a path after resolving parent-directory traversal', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const nestedDir = path.join(root, 'workspace', 'nested');
+      fs.mkdirSync(protectedDir);
+      fs.mkdirSync(nestedDir, { recursive: true });
+
+      expect(
+        matchesPathPattern(
+          `/${path.basename(protectedDir)}/**`,
+          `${nestedDir}${path.sep}..${path.sep}..${path.sep}protected${path.sep}new.txt`,
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('matches the canonical target of a symlinked path', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(protectedDir);
+      fs.writeFileSync(path.join(protectedDir, 'existing.txt'), 'protected');
+      fs.symlinkSync(protectedDir, link, 'dir');
+
+      expect(
+        matchesPathPattern(
+          '/protected/**',
+          path.join(link, 'existing.txt'),
+          root,
+          root,
+        ),
+      ).toBe(false);
+      expect(
+        matchesPathPattern(
+          '/protected/**',
+          path.join(link, 'existing.txt'),
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('canonicalizes a symlinked project root in restrictive rules', () => {
+    withTempRoot((root) => {
+      const realRoot = path.join(root, 'real');
+      const linkedRoot = path.join(root, 'linked');
+      const protectedDir = path.join(realRoot, 'protected');
+      fs.mkdirSync(protectedDir, { recursive: true });
+      fs.writeFileSync(path.join(protectedDir, 'file.txt'), 'protected');
+      fs.symlinkSync(realRoot, linkedRoot, 'dir');
+
+      expect(
+        matchesPathPattern(
+          '/protected/**',
+          path.join(protectedDir, 'file.txt'),
+          linkedRoot,
+          linkedRoot,
+          'canonical',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('canonicalizes the nearest existing ancestor for a new path', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(protectedDir);
+      fs.symlinkSync(protectedDir, link, 'dir');
+
+      expect(
+        matchesPathPattern(
+          '/protected/**',
+          path.join(link, 'new', 'file.txt'),
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('matches the target of a dangling symlink', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const target = path.join(protectedDir, 'new.txt');
+      const link = path.join(root, 'link.txt');
+      fs.mkdirSync(protectedDir);
+      fs.symlinkSync(target, link, 'file');
+
+      expect(
+        matchesPathPattern('/protected/**', link, root, root, 'canonical'),
+      ).toBe(true);
+    });
+  });
+
+  it('preserves traversal semantics in a dangling symlink target', () => {
+    withTempRoot((root) => {
+      const projectDir = path.join(root, 'project');
+      const outsideDir = path.join(root, 'outside');
+      fs.mkdirSync(projectDir);
+      fs.mkdirSync(path.join(outsideDir, 'dir'), { recursive: true });
+      fs.mkdirSync(path.join(outsideDir, 'safe'));
+
+      fs.symlinkSync(
+        path.join(outsideDir, 'dir'),
+        path.join(projectDir, 'inner'),
+        'dir',
+      );
+      const link = path.join(projectDir, 'link.txt');
+      fs.symlinkSync(
+        `inner${path.sep}..${path.sep}safe${path.sep}new.txt`,
+        link,
+      );
+
+      expect(
+        matchesPathPattern('/outside/safe/**', link, root, root, 'canonical'),
+      ).toBe(true);
+      expect(
+        matchesPathPattern('/project/safe/**', link, root, root, 'canonical'),
+      ).toBe(false);
+    });
+  });
+
+  it('resolves parent traversal after following a directory symlink', () => {
+    withTempRoot((root) => {
+      const projectDir = path.join(root, 'project');
+      const outsideDir = path.join(root, 'outside');
+      const outsideSafeDir = path.join(outsideDir, 'safe');
+      fs.mkdirSync(path.join(projectDir, 'safe'), { recursive: true });
+      fs.mkdirSync(path.join(outsideDir, 'dir'), { recursive: true });
+      fs.mkdirSync(outsideSafeDir);
+      fs.writeFileSync(path.join(outsideSafeDir, 'file.txt'), 'outside');
+
+      const link = path.join(projectDir, 'link');
+      fs.symlinkSync(path.join(outsideDir, 'dir'), link, 'dir');
+      const filePath = `${link}${path.sep}..${path.sep}safe${path.sep}file.txt`;
+
+      expect(
+        matchesPathPattern(
+          '/outside/safe/**',
+          filePath,
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(true);
+      expect(
+        matchesPathPattern(
+          '/project/safe/**',
+          filePath,
+          root,
+          root,
+          'canonical',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it('preserves matching against the lexical symlink path', () => {
+    withTempRoot((root) => {
+      const protectedDir = path.join(root, 'protected');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(protectedDir);
+      fs.symlinkSync(protectedDir, link, 'dir');
+
+      expect(
+        matchesPathPattern('/link/**', path.join(link, 'new.txt'), root, root),
+      ).toBe(true);
+    });
   });
 });
 
@@ -1854,6 +2041,53 @@ describe('PermissionManager', () => {
           filePath: '/project/src/generated/code.ts',
         }),
       ).toBe('deny');
+    });
+
+    it('denies an equivalent path containing parent traversal', async () => {
+      expect(
+        await pm.evaluate({
+          toolName: 'edit',
+          filePath: '/project/work/../src/generated/code.ts',
+        }),
+      ).toBe('deny');
+    });
+
+    it('canonicalizes restrictive rules without widening allow rules', async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-permission-'));
+      try {
+        const protectedDir = path.join(root, 'protected');
+        const link = path.join(root, 'link');
+        fs.mkdirSync(protectedDir);
+        fs.writeFileSync(path.join(protectedDir, 'file.txt'), 'protected');
+        fs.symlinkSync(protectedDir, link, 'dir');
+        const filePath = path.join(link, 'file.txt');
+
+        const denyManager = new PermissionManager(
+          makeConfig({
+            permissionsDeny: ['Edit(/protected/**)'],
+            projectRoot: root,
+            cwd: root,
+          }),
+        );
+        denyManager.initialize();
+        expect(await denyManager.evaluate({ toolName: 'edit', filePath })).toBe(
+          'deny',
+        );
+
+        const allowManager = new PermissionManager(
+          makeConfig({
+            permissionsAllow: ['Edit(/protected/**)'],
+            projectRoot: root,
+            cwd: root,
+          }),
+        );
+        allowManager.initialize();
+        expect(
+          await allowManager.evaluate({ toolName: 'edit', filePath }),
+        ).toBe('default');
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
     });
 
     it('allows reading in an allowed directory', async () => {

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -2456,6 +2456,33 @@ describe('PermissionManager', () => {
         }),
       ).toBe(true);
     });
+
+    it('matches an ask rule through a symlinked path', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-permission-'));
+      try {
+        const protectedDir = path.join(root, 'protected');
+        const link = path.join(root, 'link');
+        fs.mkdirSync(protectedDir);
+        fs.symlinkSync(protectedDir, link, 'dir');
+        pm = new PermissionManager(
+          makeConfig({
+            permissionsAsk: ['Edit(/protected/**)'],
+            projectRoot: root,
+            cwd: root,
+          }),
+        );
+        pm.initialize();
+
+        expect(
+          pm.hasMatchingAskRule({
+            toolName: 'edit',
+            filePath: path.join(link, 'file.txt'),
+          }),
+        ).toBe(true);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
   });
 });
 
@@ -2979,6 +3006,33 @@ describe('PermissionManager.findMatchingDenyRule', () => {
     });
     // rule.raw preserves the original rule string as written in config
     expect(result).toBe('ShellTool');
+  });
+
+  it('matches a deny rule through a symlinked path', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-permission-'));
+    try {
+      const protectedDir = path.join(root, 'protected');
+      const link = path.join(root, 'link');
+      fs.mkdirSync(protectedDir);
+      fs.symlinkSync(protectedDir, link, 'dir');
+      const pm = new PermissionManager(
+        makeConfig({
+          permissionsDeny: ['Edit(/protected/**)'],
+          projectRoot: root,
+          cwd: root,
+        }),
+      );
+      pm.initialize();
+
+      expect(
+        pm.findMatchingDenyRule({
+          toolName: 'edit',
+          filePath: path.join(link, 'file.txt'),
+        }),
+      ).toBe('Edit(/protected/**)');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -290,6 +290,8 @@ export class PermissionManager {
     // Compute the base decision from explicit Bash/file/domain rules.
     // Using an IIFE to keep the priority-cascade logic clean.
     const baseDecision: PermissionDecision = (() => {
+      // Restrictive rules follow canonical destinations; allow rules stay
+      // lexical so a symlink cannot widen what the user explicitly allowed.
       // Priority 1: deny rules (session first, then persistent)
       for (const rule of [
         ...this.sessionRules.deny,

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -712,9 +712,11 @@ export class PermissionManager {
           }
         : undefined;
 
-    const allRules = [
+    const allowRules = [
       ...this.sessionRules.allow,
       ...this.persistentRules.allow,
+    ];
+    const restrictiveRules = [
       ...this.sessionRules.ask,
       ...this.persistentRules.ask,
       ...this.sessionRules.deny,
@@ -747,8 +749,13 @@ export class PermissionManager {
             pathCtx,
             undefined,
           ] as const;
-          return allRules.some((rule) =>
-            matchesRule(rule, ...opMatchArgs, undefined, 'canonical'),
+          return (
+            restrictiveRules.some((rule) =>
+              matchesRule(rule, ...opMatchArgs, undefined, 'canonical'),
+            ) ||
+            allowRules.some((rule) =>
+              matchesRule(rule, ...opMatchArgs, undefined),
+            )
           );
         })
       ) {
@@ -775,8 +782,10 @@ export class PermissionManager {
       toolParams,
     ] as const;
 
-    return allRules.some((rule) =>
-      matchesRule(rule, ...matchArgs, 'canonical'),
+    return (
+      restrictiveRules.some((rule) =>
+        matchesRule(rule, ...matchArgs, 'canonical'),
+      ) || allowRules.some((rule) => matchesRule(rule, ...matchArgs))
     );
   }
 

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -295,14 +295,14 @@ export class PermissionManager {
         ...this.sessionRules.deny,
         ...this.persistentRules.deny,
       ]) {
-        if (matchesRule(rule, ...matchArgs)) return 'deny';
+        if (matchesRule(rule, ...matchArgs, 'canonical')) return 'deny';
       }
       // Priority 2: ask rules
       for (const rule of [
         ...this.sessionRules.ask,
         ...this.persistentRules.ask,
       ]) {
-        if (matchesRule(rule, ...matchArgs)) return 'ask';
+        if (matchesRule(rule, ...matchArgs, 'canonical')) return 'ask';
       }
       // Priority 3: allow rules
       for (const rule of [
@@ -646,7 +646,7 @@ export class PermissionManager {
       ...this.sessionRules.deny,
       ...this.persistentRules.deny,
     ]) {
-      if (matchesRule(rule, ...matchArgs)) {
+      if (matchesRule(rule, ...matchArgs, 'canonical')) {
         return rule.raw;
       }
     }
@@ -747,7 +747,9 @@ export class PermissionManager {
             pathCtx,
             undefined,
           ] as const;
-          return allRules.some((rule) => matchesRule(rule, ...opMatchArgs));
+          return allRules.some((rule) =>
+            matchesRule(rule, ...opMatchArgs, undefined, 'canonical'),
+          );
         })
       ) {
         return true;
@@ -773,7 +775,9 @@ export class PermissionManager {
       toolParams,
     ] as const;
 
-    return allRules.some((rule) => matchesRule(rule, ...matchArgs));
+    return allRules.some((rule) =>
+      matchesRule(rule, ...matchArgs, 'canonical'),
+    );
   }
 
   /**
@@ -824,7 +828,9 @@ export class PermissionManager {
             pathCtx,
             undefined,
           ] as const;
-          return askRules.some((rule) => matchesRule(rule, ...opMatchArgs));
+          return askRules.some((rule) =>
+            matchesRule(rule, ...opMatchArgs, undefined, 'canonical'),
+          );
         })
       ) {
         return true;
@@ -850,7 +856,9 @@ export class PermissionManager {
       toolParams,
     ] as const;
 
-    return askRules.some((rule) => matchesRule(rule, ...matchArgs));
+    return askRules.some((rule) =>
+      matchesRule(rule, ...matchArgs, 'canonical'),
+    );
   }
 
   private hasAskRuleForTool(toolName: string): boolean {

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -1076,6 +1076,7 @@ function getCanonicalPathMatchCandidates(
 }
 
 function resolveWithoutNormalizing(base: string, filePath: string): string {
+  // Preserve `..` until realpathNearestExisting resolves symlinks on disk.
   return path.isAbsolute(filePath)
     ? filePath
     : `${base}${/[\\/]$/.test(base) ? '' : path.sep}${filePath}`;
@@ -1089,6 +1090,7 @@ function realpathNearestExisting(filePath: string): string | undefined {
 
   while (true) {
     try {
+      // Joining deliberately normalizes traversal in the unresolved suffix.
       return path.join(fs.realpathSync.native(current), ...missingSegments);
     } catch (error: unknown) {
       if (

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -1011,8 +1011,9 @@ export function resolvePathPattern(
  * Uses picomatch for the actual glob matching, following gitignore semantics:
  *   - `*` matches files in a single directory (does not cross `/`)
  *   - `**` matches recursively across directories
- * Both the lexical absolute path and its canonical filesystem destination are
- * considered. For new files, the closest existing ancestor is canonicalized.
+ * When `matchMode` is `'canonical'`, both the lexical absolute path and its
+ * canonical filesystem destination are considered. For new files, the closest
+ * existing ancestor is canonicalized.
  *
  * @param specifier - The raw specifier from the rule (e.g. "./secrets/**")
  * @param filePath - The absolute path of the file being accessed

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -5,10 +5,12 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs';
 import os from 'node:os';
 import picomatch from 'picomatch';
 import { parse } from 'shell-quote';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { isNodeError } from '../utils/errors.js';
 
 const debugLogger = createDebugLogger('PERMISSIONS');
 
@@ -1009,11 +1011,14 @@ export function resolvePathPattern(
  * Uses picomatch for the actual glob matching, following gitignore semantics:
  *   - `*` matches files in a single directory (does not cross `/`)
  *   - `**` matches recursively across directories
+ * Both the lexical absolute path and its canonical filesystem destination are
+ * considered. For new files, the closest existing ancestor is canonicalized.
  *
  * @param specifier - The raw specifier from the rule (e.g. "./secrets/**")
  * @param filePath - The absolute path of the file being accessed
  * @param projectRoot - The project root directory (absolute)
  * @param cwd - The current working directory (absolute)
+ * @param matchMode - Whether to also match the canonical filesystem destination
  * @returns True if the file path matches the pattern
  */
 export function matchesPathPattern(
@@ -1021,22 +1026,104 @@ export function matchesPathPattern(
   filePath: string,
   projectRoot: string,
   cwd: string,
+  matchMode: 'lexical' | 'canonical' = 'lexical',
 ): boolean {
   const resolvedPattern = resolvePathPattern(specifier, projectRoot, cwd);
+  const patterns =
+    matchMode === 'canonical'
+      ? getCanonicalPatternCandidates(resolvedPattern)
+      : [resolvedPattern];
+  const matchers = patterns.map((pattern) =>
+    picomatch(pattern, {
+      dot: true,
+      nocase: false,
+    }),
+  );
+  const paths =
+    matchMode === 'canonical'
+      ? getCanonicalPathMatchCandidates(filePath, cwd)
+      : [toPosixPath(filePath)];
 
-  // Normalize filePath to forward slashes for cross-platform picomatch compatibility.
-  // On Windows, incoming paths may use backslashes; picomatch expects forward slashes.
-  const normalizedFilePath = toPosixPath(filePath);
+  return paths.some((candidate) =>
+    matchers.some((isMatch) => isMatch(candidate)),
+  );
+}
 
-  // Use picomatch for gitignore-style matching
-  const isMatch = picomatch(resolvedPattern, {
-    dot: true, // Match dotfiles (e.g. .env)
-    nocase: false, // Case-sensitive (filesystem convention)
-    // Note: do NOT set bash: true — it makes `*` match across directories.
-    // Default picomatch behavior is gitignore-style: `*` = single dir, `**` = recursive.
-  });
+function getCanonicalPatternCandidates(resolvedPattern: string): string[] {
+  const candidates = new Set([resolvedPattern]);
+  const { base } = picomatch.scan(resolvedPattern);
+  const canonicalBase = realpathNearestExisting(base);
+  if (canonicalBase !== undefined) {
+    candidates.add(
+      `${toPosixPath(canonicalBase)}${resolvedPattern.slice(base.length)}`,
+    );
+  }
+  return [...candidates];
+}
 
-  return isMatch(normalizedFilePath);
+function getCanonicalPathMatchCandidates(
+  filePath: string,
+  cwd: string,
+): string[] {
+  const candidates = new Set([toPosixPath(filePath)]);
+  const absolutePath = resolveWithoutNormalizing(cwd, filePath);
+  const canonicalPath = realpathNearestExisting(absolutePath);
+  if (canonicalPath !== undefined) {
+    candidates.add(toPosixPath(canonicalPath));
+  }
+  return [...candidates];
+}
+
+function resolveWithoutNormalizing(base: string, filePath: string): string {
+  return path.isAbsolute(filePath)
+    ? filePath
+    : `${base}${/[\\/]$/.test(base) ? '' : path.sep}${filePath}`;
+}
+
+function realpathNearestExisting(filePath: string): string | undefined {
+  let current = filePath;
+  const missingSegments: string[] = [];
+  let symlinkHops = 0;
+  const maxSymlinkHops = 40;
+
+  while (true) {
+    try {
+      return path.join(fs.realpathSync.native(current), ...missingSegments);
+    } catch (error: unknown) {
+      if (
+        !isNodeError(error) ||
+        (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
+      ) {
+        return undefined;
+      }
+    }
+
+    try {
+      if (fs.lstatSync(current).isSymbolicLink()) {
+        if (symlinkHops++ >= maxSymlinkHops) {
+          return undefined;
+        }
+        const target = fs.readlinkSync(current);
+        const parent = fs.realpathSync.native(path.dirname(current));
+        current = resolveWithoutNormalizing(parent, target);
+        continue;
+      }
+    } catch (error: unknown) {
+      if (
+        !isNodeError(error) ||
+        (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
+      ) {
+        return undefined;
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    missingSegments.unshift(path.basename(current));
+    current = parent;
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1163,6 +1250,7 @@ export interface PathMatchContext {
  * @param filePath - Absolute file path (for Read/Edit rules)
  * @param domain - Domain (for WebFetch rules)
  * @param pathContext - Project root and cwd for resolving relative path patterns
+ * @param pathMatchMode - Whether path rules also match canonical destinations
  */
 export function matchesRule(
   rule: PermissionRule,
@@ -1173,6 +1261,7 @@ export function matchesRule(
   pathContext?: PathMatchContext,
   specifier?: string,
   toolParams?: Record<string, unknown>,
+  pathMatchMode: 'lexical' | 'canonical' = 'lexical',
 ): boolean {
   const canonicalCtxToolName = resolveToolName(toolName);
 
@@ -1250,6 +1339,7 @@ export function matchesRule(
           filePath,
           ctx.projectRoot,
           ctx.cwd,
+          pathMatchMode,
         );
         break;
       }

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -1097,9 +1097,13 @@ function realpathNearestExisting(filePath: string): string | undefined {
         !isNodeError(error) ||
         (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
       ) {
+      if (
+        !isNodeError(error) ||
+        (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
+      ) {
+        debugLogger.debug(`realpathNearestExisting: abandoning "${current}" due to ${isNodeError(error) ? error.code : 'non-Node error'}`);
         return undefined;
       }
-    }
 
     try {
       if (fs.lstatSync(current).isSymbolicLink()) {

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -1097,13 +1097,9 @@ function realpathNearestExisting(filePath: string): string | undefined {
         !isNodeError(error) ||
         (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
       ) {
-      if (
-        !isNodeError(error) ||
-        (error.code !== 'ENOENT' && error.code !== 'ENOTDIR')
-      ) {
-        debugLogger.debug(`realpathNearestExisting: abandoning "${current}" due to ${isNodeError(error) ? error.code : 'non-Node error'}`);
         return undefined;
       }
+    }
 
     try {
       if (fs.lstatSync(current).isSymbolicLink()) {


### PR DESCRIPTION
## What this PR does

Restrictive file permission rules now compare both the path spelling supplied by a tool and the path's canonical filesystem destination. The canonicalization follows existing symlinks, resolves dangling symlink targets, and realpaths the nearest existing ancestor when a write target has not been created yet.

Allow rules retain lexical matching. This preserves existing rules written against symlink aliases and prevents an allow rule for a symlink target from authorizing an operation that mutates a link located somewhere else. Permission-rule relevance checks use the same distinction, so a canonical-only allow match does not trigger redundant evaluation.

## Why it's needed

File rules previously matched only the raw path string. A deny or ask rule could therefore be missed when the same destination was expressed with `..`, through a directory symlink, through a dangling symlink, or through the real path of a symlinked project root.

## Reviewer Test Plan

### How to verify

Confirm that a restrictive rule matches an existing symlink target, a new file below a symlinked directory, a dangling symlink target, parent traversal, and the real path beneath a symlinked project root. Also confirm that parent traversal is resolved after following a directory symlink, and that an allow rule for a canonical target neither authorizes a link entry outside that allowed path nor makes a canonical-only match relevant.

### Evidence (Before & After)

N/A — this changes internal permission evaluation and has no visual UI.

Before: equivalent traversal and symlink paths could miss restrictive file rules.

After: deny and ask rules inspect lexical and canonical forms, while allow rules preserve their previous lexical behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Linux 6.8.0 x86_64, Node.js 24.18.0. Focused permission tests: 294 passed. Core build, core typecheck, focused ESLint, Prettier, and structured autoreview passed.

## Risk & Scope

- Main risk or tradeoff: Restrictive path rules perform synchronous filesystem metadata lookups when they are evaluated. Matching remains lexical when canonicalization cannot be completed.
- Not validated / out of scope: macOS and Windows runtime validation; atomic protection against a symlink being retargeted between permission evaluation and the later filesystem operation. A full monorepo build progressed through the core package but could not complete because the isolated worktree reused workspace dependencies that resolve the channel packages from the primary checkout; the directly affected core package build passed.
- Breaking changes / migration notes: None. Allow rules keep their previous lexical path semantics.

## Linked Issues

Fixes #6915

## AI Assistance Disclosure

Codex was used for investigation, implementation, test development, and structured review. The final review found no actionable issues.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

限制性文件权限规则现在会同时比较工具提供的路径写法和该路径在文件系统中的规范目标。规范化会跟随现有符号链接、解析悬空符号链接的目标，并在写入目标尚未创建时对最近的现有祖先目录执行 realpath。

允许规则仍然采用词法匹配。这样既保留了针对符号链接别名编写的现有规则，也避免了针对链接目标的允许规则意外授权修改位于其他位置的链接项。权限规则相关性检查采用相同的区分，因此仅规范路径匹配的允许规则不会触发多余的权限评估。

## 为什么需要

文件规则此前只匹配原始路径字符串。因此，当同一目标通过 `..`、目录符号链接、悬空符号链接或符号链接项目根目录的真实路径表示时，拒绝或询问规则可能无法命中。

## Reviewer Test Plan

### 如何验证

确认限制性规则能够匹配现有符号链接目标、符号链接目录下的新文件、悬空符号链接目标、父目录遍历以及符号链接项目根目录下的真实路径。还应确认父目录遍历发生在跟随目录符号链接之后，并且针对规范目标的允许规则既不会授权修改允许路径之外的链接项，也不会仅因规范路径匹配而被判定为相关规则。

### 证据（修改前与修改后）

N/A — 这是内部权限评估变更，没有可视化 UI。

修改前：等价的遍历和符号链接路径可能绕过限制性文件规则的匹配。

修改后：拒绝和询问规则会检查词法形式和规范形式，而允许规则保留原有的词法行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

Linux 6.8.0 x86_64，Node.js 24.18.0。聚焦权限测试 294 项通过。Core 构建、Core 类型检查、聚焦 ESLint、Prettier 和结构化自动审查均通过。

## 风险与范围

- 主要风险或取舍：限制性路径规则在评估时会执行同步文件系统元数据查询。当规范化无法完成时，匹配仍会回退到词法形式。
- 未验证 / 范围外：未在 macOS 和 Windows 上进行运行时验证；未提供从权限评估到后续文件系统操作之间防止符号链接被重新指向的原子保证。完整 monorepo 构建已通过 Core 包阶段，但由于隔离 worktree 复用了会将 channel 包解析到主 checkout 的 workspace 依赖，无法完成；直接受影响的 Core 包构建已通过。
- 破坏性变更 / 迁移说明：无。允许规则保持原有的词法路径语义。

## 关联 Issue

Fixes #6915

## AI 辅助披露

Codex 用于调查、实现、测试开发和结构化审查。最终审查未发现可操作问题。

</details>