### PR TITLE
fix(mcp): require trust for read-only auto-approval

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -814,6 +814,54 @@ describe('DiscoveredMCPTool', () => {
       isTrustedFolder: () => isTrusted,
     });
 
+    it.each([
+      {
+        name: 'an untrusted server with readOnlyHint',
+        trust: undefined,
+        isTrustedFolder: true,
+        readOnlyHint: true,
+        expected: 'ask',
+      },
+      {
+        name: 'a trusted server with readOnlyHint in an untrusted folder',
+        trust: true,
+        isTrustedFolder: false,
+        readOnlyHint: true,
+        expected: 'ask',
+      },
+      {
+        name: 'a trusted server with readOnlyHint in a trusted folder',
+        trust: true,
+        isTrustedFolder: true,
+        readOnlyHint: true,
+        expected: 'allow',
+      },
+      {
+        name: 'an untrusted server with readOnlyHint disabled',
+        trust: undefined,
+        isTrustedFolder: true,
+        readOnlyHint: false,
+        expected: 'ask',
+      },
+    ])('should return $expected for $name', async (testCase) => {
+      const annotatedTool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        testCase.trust,
+        undefined,
+        mockConfig(testCase.isTrustedFolder) as any,
+        undefined,
+        undefined,
+        undefined,
+        { readOnlyHint: testCase.readOnlyHint },
+      );
+      const invocation = annotatedTool.build({ param: 'mock' });
+      expect(await invocation.getDefaultPermission()).toBe(testCase.expected);
+    });
+
     it('should return allow when trust is true and folder is trusted', async () => {
       const trustedTool = new DiscoveredMCPTool(
         mockCallableToolInstance,

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -144,19 +144,14 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   }
 
   /**
-   * MCP tool default permission based on trust and annotations:
+   * MCP tool default permission based on trust:
    * - trust: true in a trusted folder → 'allow' (server explicitly trusted by user config)
-   * - readOnlyHint → 'allow'
    * - All other MCP tools → 'ask'
    */
   override async getDefaultPermission(): Promise<PermissionDecision> {
     // MCP servers explicitly marked as trusted bypass confirmation,
     // but only when the workspace folder is also trusted (security gate).
     if (this.trust === true && this.cliConfig?.isTrustedFolder()) {
-      return 'allow';
-    }
-    // MCP tools annotated with readOnlyHint: true are safe
-    if (this.annotations?.readOnlyHint === true) {
       return 'allow';
     }
     return 'ask';


### PR DESCRIPTION
## What this PR does

Requires user-controlled MCP server trust before a tool can receive automatic default permission. A server-provided `readOnlyHint` continues to classify the tool as read-only for plan mode, but no longer grants permission by itself.

Adds regression coverage for annotated tools across untrusted servers, untrusted workspaces, trusted servers in trusted workspaces, and disabled annotations.

## Why it's needed

MCP tool annotations come from the server's discovery response. Previously, `readOnlyHint: true` changed the default permission from `ask` to `allow` even when the server was not configured as trusted, bypassing the normal confirmation prompt. Automatic permission should depend on the user's trust configuration, not the server's self-description.

## Reviewer Test Plan

### How to verify

Build an MCP tool invocation with `readOnlyHint: true` under each trust combination. Confirm that an untrusted server asks, a trusted server in an untrusted workspace asks, and a trusted server in a trusted workspace remains allowed. Confirm that an absent or false annotation retains the existing behavior and that annotated tools remain classified as read-only.

### Evidence (Before & After)

| Scenario | Before | After |
| --- | --- | --- |
| Untrusted server with `readOnlyHint: true` | `allow` | `ask` |
| Trusted server, untrusted workspace, with `readOnlyHint: true` | `allow` | `ask` |
| Trusted server, trusted workspace, with `readOnlyHint: true` | `allow` | `allow` |

The focused regression failed in the first two scenarios before the fix and passes after it. The complete MCP tool test file passes 61 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js 24; focused and complete MCP tool unit tests, repository build, typecheck, lint, Prettier, and targeted ESLint.

## Risk & Scope

- Main risk or tradeoff: Annotation-only MCP tools now prompt unless an explicit permission rule or trusted-server configuration allows them.
- Not validated / out of scope: MCP annotation transport, read-only classification, permission rule evaluation, and general confirmation-flow refactoring are unchanged.
- Breaking changes / migration notes: No API migration. Users who relied on annotation-only automatic permission can explicitly trust the server or configure a permission rule.

## Linked Issues

Fixes #6917

<details>
<summary>中文说明</summary>

## 此 PR 的作用

只有在用户明确将 MCP 服务器设为可信时，工具才能获得自动默认许可。服务器提供的 `readOnlyHint` 仍用于在计划模式中将工具分类为只读，但不再单独授予执行许可。

新增回归测试，覆盖不可信服务器、不可信工作区、可信工作区中的可信服务器，以及禁用注解的情况。

## 为什么需要此变更

MCP 工具注解来自服务器的发现响应。此前，即使服务器未配置为可信，`readOnlyHint: true` 也会将默认许可从 `ask` 改为 `allow`，从而跳过正常的确认提示。自动许可应由用户的信任配置决定，而不是由服务器的自我描述决定。

## 审阅者测试计划

### 如何验证

在每种信任组合下构建带有 `readOnlyHint: true` 的 MCP 工具调用。确认不可信服务器会询问，位于不可信工作区中的可信服务器会询问，而位于可信工作区中的可信服务器仍会被允许。确认缺少注解或注解为 false 时保留现有行为，并且带注解的工具仍被分类为只读。

### 证据（变更前后）

| 场景 | 变更前 | 变更后 |
| --- | --- | --- |
| 带有 `readOnlyHint: true` 的不可信服务器 | `allow` | `ask` |
| 位于不可信工作区且带有 `readOnlyHint: true` 的可信服务器 | `allow` | `ask` |
| 位于可信工作区且带有 `readOnlyHint: true` 的可信服务器 | `allow` | `allow` |

修复前，聚焦回归测试在前两个场景中失败；修复后通过。完整的 MCP 工具测试文件通过 61 项测试。

### 测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | N/A |
| 🪟 Windows | N/A |
| 🐧 Linux | ✅ 已测试 |

### 环境（可选）

Node.js 24；已运行聚焦及完整的 MCP 工具单元测试、仓库构建、类型检查、lint、Prettier 和针对性 ESLint。

## 风险与范围

- 主要风险或权衡：仅依赖注解的 MCP 工具现在会提示确认，除非显式权限规则或可信服务器配置允许执行。
- 未验证/范围外：MCP 注解传输、只读分类、权限规则求值和通用确认流程重构均未更改。
- 破坏性变更/迁移说明：无需 API 迁移。依赖仅凭注解自动许可的用户可以显式信任服务器或配置权限规则。

## 关联问题

修复 #6917

</details>
