### PR TITLE
fix(core): preserve display output for malformed tool results

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1226,6 +1226,60 @@ describe('CoreToolScheduler', () => {
     expect(outputOfFirstCall(onAllToolCallsComplete)).toBe('small output');
   });
 
+  it('preserves display output when a tool omits model-facing content', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: undefined,
+      returnDisplay: 'completed',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        'malformedTool',
+        new MockTool({
+          name: 'malformedTool',
+          // SAFETY: This deliberately violates ToolResult to exercise the
+          // runtime boundary used by untyped custom tool adapters.
+          execute: execute as (
+            params: Record<string, unknown>,
+          ) => Promise<ToolResult>,
+        }),
+      ],
+    ]);
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({ toolsByName });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'c-malformed',
+          name: 'malformedTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'p-malformed',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    const completedCall = (
+      onAllToolCallsComplete.mock.calls[0][0] as ToolCall[]
+    )[0];
+    expect(completedCall.status).toBe('success');
+    if (completedCall.status === 'success') {
+      expect(completedCall.response.responseParts).toEqual([
+        {
+          functionResponse: {
+            id: 'c-malformed',
+            name: 'malformedTool',
+            response: {
+              output: '(malformedTool completed with no output)',
+            },
+          },
+        },
+      ]);
+      expect(completedCall.response.resultDisplay).toBe('completed');
+    }
+  });
+
   it('applies the per-tool budget for a tool invoked via a legacy alias', async () => {
     // Regression (C1): limitsTool read getTool(request.name) with the raw alias
     // ('task'), which the registry stores only under the canonical name

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -3835,7 +3835,7 @@ export class CoreToolScheduler {
       }
 
       if (toolResult.error === undefined) {
-        let content = toolResult.llmContent;
+        let content = toolResult.llmContent ?? '';
         let contentLength: number | undefined =
           typeof content === 'string' ? content.length : undefined;
 


### PR DESCRIPTION
## What this PR does

This change treats missing or null model-facing content from a runtime tool as empty output at the scheduler boundary. The existing no-output marker is then sent to the model, while the tool's valid display result remains available to the user.

## Why it's needed

The TypeScript tool contract requires model-facing content, but custom JavaScript tools and runtime adapters can still return malformed values. When that content is `undefined`, output truncation throws; the fallback response conversion throws again; and the outer execution handler replaces the successful display result with a generic error. Normalizing the malformed field as soon as the scheduler receives a successful result prevents both failures without changing correctly typed results.

## Reviewer Test Plan

### How to verify

- Run a custom tool that returns `{ llmContent: undefined, returnDisplay: "completed" }` and confirm the scheduler reports success, sends the standard no-output marker to the model, and retains `completed` as the display result.
- Confirm ordinary strings, content parts, media, and valid empty outputs retain their existing behavior.

### Evidence (Before & After)

N/A — this is non-UI scheduler behavior. Before the fix, the focused scheduler regression failed because the completed call had `error` status. After the fix, the scheduler and truncation suites pass all 287 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node.js 24.18.0 on Linux 6.8.0 x86_64.

## Risk & Scope

- Main risk or tradeoff: Missing or null model-facing content is represented by the existing no-output marker rather than failing the completed tool call.
- Not validated / out of scope: Other malformed non-null values remain governed by the existing runtime behavior; macOS and Windows were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #6916

<details>
<summary>中文说明</summary>

## 此 PR 的改动

此改动在调度器边界将运行时工具返回的缺失或空模型内容视为空输出。随后，现有的无输出标记会发送给模型，同时工具的有效显示结果仍会保留给用户。

## 改动原因

TypeScript 工具契约要求提供模型内容，但自定义 JavaScript 工具和运行时适配器仍可能返回不符合契约的值。当该内容为 `undefined` 时，输出截断会抛出异常；回退的响应转换会再次抛出异常；最外层执行处理器最终会用通用错误替换原本成功的显示结果。调度器收到成功结果后立即规范化该异常字段，可以避免这两次失败，同时不改变类型正确的结果。

## 审阅者测试计划

### 验证方法

- 运行一个返回 `{ llmContent: undefined, returnDisplay: "completed" }` 的自定义工具，确认调度器报告成功、向模型发送标准无输出标记，并保留 `completed` 作为显示结果。
- 确认普通字符串、内容部件、媒体和有效空输出维持现有行为。

### 修改前后证据

不适用——这是非 UI 的调度器行为。修复前，聚焦的调度器回归测试失败，因为完成的调用状态为 `error`。修复后，调度器和截断测试套件的 287 个测试全部通过。

### 测试平台

|      OS      | 状态 |
| :----------: | :--: |
|  🍏 macOS   | N/A  |
| 🪟 Windows  | N/A  |
|  🐧 Linux   |  ✅  |

### 环境（可选）

Linux 6.8.0 x86_64，Node.js 24.18.0。

## 风险与范围

- 主要风险或权衡：缺失或空模型内容会使用现有无输出标记表示，而不会让已完成的工具调用失败。
- 未验证 / 范围外：其他非空异常值仍遵循现有运行时行为；未在本地测试 macOS 和 Windows。
- 破坏性改动 / 迁移说明：无。

## 关联 Issue

Fixes #6916

</details>
