### PR TITLE
fix(mcp): terminate descendants after discovery timeout

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -2060,6 +2060,22 @@ describe('McpClientManager', () => {
       expect(mockedMcpClient.disconnect).toHaveBeenCalledOnce();
     });
 
+    it('skips signaling when a stdio transport has no descendants', async () => {
+      const mockedMcpClient = makeTimedOutClient(101);
+      vi.mocked(listDescendantPids).mockClear();
+      vi.mocked(sigtermPids).mockClear();
+
+      await runTimedOutDiscovery(mockedMcpClient, {
+        command: 'node',
+        args: [],
+        discoveryTimeoutMs: 100,
+      });
+
+      expect(listDescendantPids).toHaveBeenCalledWith(101);
+      expect(sigtermPids).not.toHaveBeenCalled();
+      expect(mockedMcpClient.disconnect).toHaveBeenCalledOnce();
+    });
+
     it('still disconnects when descendant enumeration fails', async () => {
       const mockedMcpClient = makeTimedOutClient(101);
       vi.mocked(listDescendantPids).mockClear();

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -15,6 +15,7 @@ import { MCPServerConfig, type Config } from '../config/config.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import { connectionIdOf } from './mcp-pool-key.js';
+import { listDescendantPids, sigtermPids } from './pid-descendants.js';
 
 vi.mock('./mcp-client.js', async () => {
   const originalModule = await vi.importActual('./mcp-client.js');
@@ -25,6 +26,11 @@ vi.mock('./mcp-client.js', async () => {
     populateMcpServerCommand: vi.fn((servers) => servers),
   };
 });
+
+vi.mock('./pid-descendants.js', () => ({
+  listDescendantPids: vi.fn().mockResolvedValue([]),
+  sigtermPids: vi.fn().mockReturnValue(0),
+}));
 
 /**
  * F2 (#4175 commit 6 review fix — wenshao R9 / PR A): test factory
@@ -1978,6 +1984,100 @@ describe('McpClientManager', () => {
 
     expect(calls).toContain(5_000);
     expect(calls).not.toContain(30_000);
+  });
+
+  describe('discovery timeout process cleanup', () => {
+    function makeTimedOutClient(rootPid?: number) {
+      return {
+        connect: vi.fn(() => new Promise<void>(() => {})),
+        discover: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn(),
+        getTransportPid: vi.fn(() => rootPid),
+      };
+    }
+
+    async function runTimedOutDiscovery(
+      mockedMcpClient: ReturnType<typeof makeTimedOutClient>,
+      serverConfig: MCPServerConfig,
+    ): Promise<void> {
+      vi.mocked(McpClient).mockReturnValue(
+        mockedMcpClient as unknown as McpClient,
+      );
+      const config = {
+        isTrustedFolder: () => true,
+        getMcpServers: () => ({ slow: serverConfig }),
+        getMcpServerCommand: () => undefined,
+        getPromptRegistry: () =>
+          ({ removePromptsByServer: vi.fn() }) as unknown as PromptRegistry,
+        getResourceRegistry: () => ({ removeResourcesByServer: vi.fn() }),
+        getWorkspaceContext: () => ({}) as WorkspaceContext,
+        getDebugMode: () => false,
+        isMcpServerDisabled: () => false,
+      } as unknown as Config;
+      const manager = mkManager({ config });
+
+      await manager.discoverAllMcpToolsIncremental(config);
+    }
+
+    it('signals stdio wrapper descendants before disconnecting after timeout', async () => {
+      const events: string[] = [];
+      const mockedMcpClient = makeTimedOutClient(101);
+      mockedMcpClient.disconnect.mockImplementationOnce(async () => {
+        events.push('disconnect');
+      });
+      vi.mocked(listDescendantPids).mockClear();
+      vi.mocked(sigtermPids).mockClear();
+      vi.mocked(listDescendantPids).mockResolvedValueOnce([201, 301]);
+      vi.mocked(sigtermPids).mockImplementationOnce(() => {
+        events.push('signal');
+        return 2;
+      });
+
+      await runTimedOutDiscovery(mockedMcpClient, {
+        command: 'node',
+        args: [],
+        discoveryTimeoutMs: 100,
+      });
+
+      expect(listDescendantPids).toHaveBeenCalledWith(101);
+      expect(sigtermPids).toHaveBeenCalledWith([201, 301]);
+      expect(events).toEqual(['signal', 'disconnect']);
+    });
+
+    it('disconnects remote transports without enumerating pids', async () => {
+      const mockedMcpClient = makeTimedOutClient();
+      vi.mocked(listDescendantPids).mockClear();
+      vi.mocked(sigtermPids).mockClear();
+
+      await runTimedOutDiscovery(mockedMcpClient, {
+        httpUrl: 'https://example.test/mcp',
+        discoveryTimeoutMs: 100,
+      });
+
+      expect(listDescendantPids).not.toHaveBeenCalled();
+      expect(sigtermPids).not.toHaveBeenCalled();
+      expect(mockedMcpClient.disconnect).toHaveBeenCalledOnce();
+    });
+
+    it('still disconnects when descendant enumeration fails', async () => {
+      const mockedMcpClient = makeTimedOutClient(101);
+      vi.mocked(listDescendantPids).mockClear();
+      vi.mocked(sigtermPids).mockClear();
+      vi.mocked(listDescendantPids).mockRejectedValueOnce(
+        new Error('process table unavailable'),
+      );
+
+      await runTimedOutDiscovery(mockedMcpClient, {
+        command: 'node',
+        args: [],
+        discoveryTimeoutMs: 100,
+      });
+
+      expect(listDescendantPids).toHaveBeenCalledWith(101);
+      expect(sigtermPids).not.toHaveBeenCalled();
+      expect(mockedMcpClient.disconnect).toHaveBeenCalledOnce();
+    });
   });
 
   it('runWithDiscoveryTimeout disconnects the client AND drops registered tools on timeout', async () => {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2387,11 +2387,15 @@ export class McpClientManager {
             if (rootPid !== undefined) {
               const descendants = await listDescendantPids(rootPid);
               if (descendants.length > 0) {
-                sigtermPids(descendants);
+                const signaled = sigtermPids(descendants);
+                debugLogger.debug(
+                  `Sent SIGTERM to ${signaled}/${descendants.length} descendants ` +
+                    `of pid ${rootPid} for timed-out server '${serverName}'`,
+                );
               }
             }
           } catch (err) {
-            debugLogger.debug(
+            debugLogger.warn(
               `Descendant pid sweep for timed-out server '${serverName}' threw: ${getErrorMessage(err)}. Proceeding with disconnect.`,
             );
           }

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2393,6 +2393,10 @@ export class McpClientManager {
                     `of pid ${rootPid} for timed-out server '${serverName}'`,
                 );
               }
+            } else {
+              debugLogger.debug(
+                `Skipping descendant pid sweep for timed-out server '${serverName}': transport pid unavailable`,
+              );
             }
           } catch (err) {
             debugLogger.warn(

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -40,6 +40,7 @@ import {
   McpServerSpawnFailedError,
   InvalidMcpConfigError,
 } from './mcp-errors.js';
+import { listDescendantPids, sigtermPids } from './pid-descendants.js';
 
 const debugLogger = createDebugLogger('MCP');
 export const RUNTIME_MCP_IF_ABSENT_CONFIG_FLAG = '__qwenRuntimeMcpIfAbsent';
@@ -2381,6 +2382,19 @@ export class McpClientManager {
         // vector" — `await` plus `removeMcpToolsByServer` closes it.
         const client = this.clients.get(serverName);
         if (client) {
+          try {
+            const rootPid = client.getTransportPid?.();
+            if (rootPid !== undefined) {
+              const descendants = await listDescendantPids(rootPid);
+              if (descendants.length > 0) {
+                sigtermPids(descendants);
+              }
+            }
+          } catch (err) {
+            debugLogger.debug(
+              `Descendant pid sweep for timed-out server '${serverName}' threw: ${getErrorMessage(err)}. Proceeding with disconnect.`,
+            );
+          }
           try {
             await client.disconnect();
           } catch (err) {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2399,11 +2399,6 @@ export class McpClientManager {
                       'Remaining processes may leak.',
                   );
                 }
-                    `Partial signal for timed-out server '${serverName}': ` +
-                      `${signaled}/${descendants.length} descendants of pid ${rootPid} signaled. ` +
-                      'Remaining processes may leak.',
-                  );
-                }
               }
             } else {
               debugLogger.debug(

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2392,6 +2392,13 @@ export class McpClientManager {
                   `Sent SIGTERM to ${signaled}/${descendants.length} descendants ` +
                     `of pid ${rootPid} for timed-out server '${serverName}'`,
                 );
+                if (signaled < descendants.length) {
+                  debugLogger.warn(
+                    `Partial signal for timed-out server '${serverName}': ` +
+                      `${signaled}/${descendants.length} descendants of pid ${rootPid} signaled. ` +
+                      'Remaining processes may leak.',
+                  );
+                }
               }
             } else {
               debugLogger.debug(

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2399,6 +2399,11 @@ export class McpClientManager {
                       'Remaining processes may leak.',
                   );
                 }
+                    `Partial signal for timed-out server '${serverName}': ` +
+                      `${signaled}/${descendants.length} descendants of pid ${rootPid} signaled. ` +
+                      'Remaining processes may leak.',
+                  );
+                }
               }
             } else {
               debugLogger.debug(


### PR DESCRIPTION
## What this PR does

When non-pooled MCP discovery times out for a stdio server, terminate processes below the transport wrapper before disconnecting the wrapper. The sweep is best-effort and reuses the existing bounded, cross-platform descendant-PID utilities. Remote transports continue directly to disconnect because they expose no process ID.

## Why it's needed

Stdio launchers such as `npx` and `uvx` can run the MCP server as a grandchild. The SDK closes its direct child on timeout, but that does not terminate the grandchild, so a timed-out discovery can leave the actual server running.

## Reviewer Test Plan

### How to verify

- Trigger a discovery timeout with a stdio client that exposes a wrapper PID and two descendants. Both descendants should receive SIGTERM before the wrapper disconnect begins.
- Trigger the same timeout with a remote client that exposes no PID. PID enumeration and signaling should be skipped, while disconnect still runs.
- Make descendant enumeration fail. Disconnect should still run because process-tree cleanup is best-effort.

Regression proof on the base branch: the two stdio cases failed because descendant enumeration was never called, while the remote/no-PID control passed. With this change, all three cases pass. An independent SDK fallback also confirmed that direct-child close is bounded: it returned in 2017 ms, stopped the wrapper, and left the wrapper's grandchild alive.

### Evidence (Before & After)

N/A — internal process-lifecycle change with no UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Linux, Node.js 24.18.0. Focused timeout tests: 4/4 passed. Full MCP client manager tests: 116/116 passed. Core build, typecheck, formatting, and ESLint passed.

## Risk & Scope

- Main risk or tradeoff: discovery timeout cleanup now sends SIGTERM to descendants of the stdio wrapper before closing the wrapper; PID enumeration and signaling remain bounded and best-effort.
- Not validated / out of scope: no changes to pooled lifecycle cleanup or the existing descendant-PID implementation; macOS and Windows were not run locally.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6918

<details>
<summary>中文说明</summary>

## 此 PR 的作用

当非池化 MCP 的 stdio 服务器发现过程超时时，在断开包装进程之前终止其下层进程。该清理为尽力而为，并复用现有的、有界且跨平台的后代 PID 工具。远程传输不提供进程 ID，因此仍直接执行断开连接。

## 为什么需要此更改

`npx` 和 `uvx` 等 stdio 启动器可能将 MCP 服务器作为孙进程运行。SDK 会在超时时关闭直接子进程，但不会终止孙进程，因此发现超时后实际服务器可能仍在运行。

## 审阅者测试计划

### 验证方法

- 使用一个提供包装进程 PID 和两个后代进程的 stdio 客户端触发发现超时。两个后代进程应在包装进程开始断开连接之前收到 SIGTERM。
- 使用不提供 PID 的远程客户端触发相同超时。应跳过 PID 枚举和信号发送，同时仍执行断开连接。
- 让后代进程枚举失败。由于进程树清理是尽力而为，仍应执行断开连接。

基线分支上的回归证明：两个 stdio 用例因从未调用后代进程枚举而失败，远程无 PID 对照用例通过。应用此更改后，三个用例全部通过。独立 SDK 回退验证还确认直接子进程关闭是有界的：关闭在 2017 毫秒内返回，包装进程退出，但其孙进程仍然存活。

### 证据（更改前与更改后）

不适用——内部进程生命周期更改，无 UI。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|      🍏 macOS     | ⚠️ 未测试 |
|     🪟 Windows    | ⚠️ 未测试 |
|      🐧 Linux     | ✅ 已测试 |

### 环境（可选）

Linux，Node.js 24.18.0。聚焦超时测试 4/4 通过；完整 MCP 客户端管理器测试 116/116 通过；核心包构建、类型检查、格式检查和 ESLint 均通过。

## 风险与范围

- 主要风险或权衡：发现超时清理现在会在关闭 stdio 包装进程之前向其后代发送 SIGTERM；PID 枚举和信号发送仍然有界且为尽力而为。
- 未验证或范围外：未更改池化生命周期清理和现有后代 PID 实现；未在本地运行 macOS 和 Windows 测试。
- 破坏性更改或迁移说明：无。

## 关联问题

Fixes #6918

</details>