### PR TITLE
feat(daemon): add immutable session source metadata

### DIFF
--- a/docs/design/2026-07-15-daemon-session-source-metadata.md
+++ b/docs/design/2026-07-15-daemon-session-source-metadata.md
@@ -1,0 +1,72 @@
+# Daemon session source metadata
+
+## Motivation
+
+Daemon clients need to identify which integration created a session after the
+daemon restarts. Live-only bridge metadata is insufficient because live entries
+are rebuilt from the persisted transcript on load or resume.
+
+## API
+
+`POST /session` accepts two optional immutable fields:
+
+- `sourceType`: a lowercase source token (`[a-z][a-z0-9_-]{0,63}`).
+- `sourceId`: a non-empty identifier of at most 256 characters. It is valid
+  only when `sourceType` is present.
+
+The fields are returned by session creation, status, and workspace session-list
+responses. Existing sessions omit both fields. Under `sessionScope: single`, an
+attach returns the existing session's source and never adopts the attaching
+request's source.
+
+Workspace session lists accept `sourceType` and optional `sourceId` query
+parameters. `sourceId` requires `sourceType`; when both are present they are
+matched together. Source filters are not combined with the organized view.
+
+Daemon scheduled tasks tag their dedicated session with
+`sourceType: "scheduled_task"` and the durable task id as `sourceId`.
+
+## Persistence
+
+A fresh session stores one `session_source` system record near the head of its
+JSONL transcript:
+
+```json
+{
+  "type": "system",
+  "subtype": "session_source",
+  "systemPayload": {
+    "sourceType": "web_shell",
+    "sourceId": "window-1"
+  }
+}
+```
+
+The bridge asks the session child to append this record through an awaited ACP
+control method, matching the existing `parent_session` persistence boundary.
+The create response exposes `sourcePersisted` so a caller can detect a degraded
+live-only source if recording fails.
+
+`SessionService` reads the record while scanning the transcript head for list
+responses and before load/resume so restored live summaries retain the source.
+
+## Branching
+
+Forked transcripts must not copy `session_source`; otherwise a new branch would
+claim the original session's creator. A branch has no source until its creation
+path explicitly assigns one.
+
+## Compatibility
+
+Both fields are optional. Older transcripts and clients remain valid. REST,
+ACP-over-HTTP, and the TypeScript SDK forward creation and list-filter fields.
+Daemons that implement the fields advertise `session_source_metadata`; the SDK
+checks this capability before sending source metadata or source filters so an
+older daemon cannot silently ignore them and return unfiltered results.
+Values are attribution only and must not be used as an authorization signal
+because clients can supply them.
+
+If a client disconnects before receiving a newly-created session, the daemon
+removes both the live session and its newly-written transcript. A concurrent
+attach prevents both operations, preserving the session for the attached
+client.

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -306,6 +306,7 @@ describe('qwen serve — capabilities envelope', () => {
       'session_resume',
       'unstable_session_resume',
       'session_list',
+      'session_source_metadata',
       'session_prompt',
       'session_cancel',
       'session_events',

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -8002,6 +8002,80 @@ describe('createAcpSessionBridge', () => {
     });
   });
 
+  describe('session source metadata', () => {
+    it('persists and returns source metadata in status and list summaries', async () => {
+      const handles: ChannelHandle[] = [];
+      const bridge = makeBridge({
+        channelFactory: async () => {
+          const handle = makeChannel({
+            extMethodImpl: async (method) =>
+              method === SERVE_CONTROL_EXT_METHODS.sessionSource
+                ? { persisted: true }
+                : {},
+          });
+          handles.push(handle);
+          return handle.channel;
+        },
+      });
+
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+
+      expect(session).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+        sourcePersisted: true,
+      });
+      expect(bridge.getSessionSummary(session.sessionId)).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+      expect(bridge.listWorkspaceSessions(WS_A)[0]).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+      expect(handles[0]?.agent.extMethodCalls).toContainEqual({
+        method: SERVE_CONTROL_EXT_METHODS.sessionSource,
+        params: {
+          sessionId: session.sessionId,
+          sourceType: 'scheduled_task',
+          sourceId: 'task-123',
+        },
+      });
+
+      await bridge.shutdown();
+    });
+
+    it('does not replace the source when single scope attaches', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const first = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sourceType: 'scheduled_task',
+        sourceId: 'task-1',
+      });
+      const attached = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sourceType: 'api',
+        sourceId: 'request-2',
+      });
+
+      expect(attached).toMatchObject({
+        sessionId: first.sessionId,
+        attached: true,
+        sourceType: 'scheduled_task',
+        sourceId: 'task-1',
+      });
+
+      await bridge.shutdown();
+    });
+  });
+
   describe('parentSessionId', () => {
     it('carries parentSessionId from a spawn into the session summary', async () => {
       const bridge = makeBridge({
@@ -11175,7 +11249,9 @@ describe('createAcpSessionBridge', () => {
       const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       expect(b.attached).toBe(true);
       // Client A's disconnect-reaper fires now.
-      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      await expect(
+        bridge.killSession(a.sessionId, { requireZeroAttaches: true }),
+      ).resolves.toBe(false);
       // Session must SURVIVE — client B is still using it.
       const c = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       expect(c.attached).toBe(true);
@@ -11317,8 +11393,11 @@ describe('createAcpSessionBridge', () => {
       expect(a.attached).toBe(false);
       expect(bridge.sessionCount).toBe(1);
       // No second attach. Reaper fires.
-      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      await expect(
+        bridge.killSession(a.sessionId, { requireZeroAttaches: true }),
+      ).resolves.toBe(true);
       expect(bridge.sessionCount).toBe(0);
+      await expect(bridge.killSession(a.sessionId)).resolves.toBe(false);
       await bridge.shutdown();
     });
 

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -80,6 +80,7 @@ import {
   InvalidRewindTargetError,
 } from './bridgeErrors.js';
 import { canonicalizeWorkspace } from './workspacePaths.js';
+import { parseSessionSource } from './session-source.js';
 import {
   LOAD_REPLAY_BULK_MODE,
   LOAD_REPLAY_META_KEY,
@@ -394,6 +395,9 @@ interface SessionEntry {
    * Immutable — written once at creation, never on attach. Absent for a
    * top-level session. */
   parentSessionId?: string;
+  /** Immutable creator attribution, persisted in the transcript when present. */
+  sourceType?: string;
+  sourceId?: string;
   channel: AcpChannel;
   connection: ClientSideConnection;
   /** Per-session event bus drives `GET /session/:id/events`. */
@@ -1541,6 +1545,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       ...(entry.parentSessionId
         ? { parentSessionId: entry.parentSessionId }
         : {}),
+      ...(entry.sourceType ? { sourceType: entry.sourceType } : {}),
+      ...(entry.sourceId !== undefined ? { sourceId: entry.sourceId } : {}),
       clientCount: entry.clientIds.size,
       hasActivePrompt: entry.promptActive,
       isWaitingForPermission,
@@ -2052,6 +2058,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     requestedClientId?: string,
     onSessionRegistered?: () => void,
     parentSessionId?: string,
+    sourceType?: string,
+    sourceId?: string,
   ): Promise<BridgeSession> {
     // Get-or-create the daemon's single channel, then call
     // `connection.newSession()` on it. Sessions share the child's
@@ -2131,7 +2139,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         newSessionResp.sessionId,
         boundWorkspace,
         undefined,
-        { parentSessionId },
+        { parentSessionId, sourceType, sourceId },
       );
       initializedSessionId = entry.sessionId;
       sessionRegistered = true;
@@ -2224,6 +2232,39 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         }
       }
 
+      let sourcePersisted: boolean | undefined;
+      if (entry.sourceType) {
+        try {
+          const sourceResult = await Promise.race([
+            withTimeout(
+              entry.connection.extMethod(
+                SERVE_CONTROL_EXT_METHODS.sessionSource,
+                {
+                  sessionId: entry.sessionId,
+                  sourceType: entry.sourceType,
+                  ...(entry.sourceId !== undefined
+                    ? { sourceId: entry.sourceId }
+                    : {}),
+                },
+              ),
+              initTimeoutMs,
+              'sessionSource',
+            ),
+            getTransportClosedReject(entry),
+          ]);
+          sourcePersisted =
+            (sourceResult as { persisted?: boolean } | undefined)?.persisted ===
+            true;
+        } catch (err) {
+          sourcePersisted = false;
+          writeStderrLine(
+            `qwen serve: source metadata for ${entry.sessionId} was not persisted ` +
+              `(${err instanceof Error ? err.message : String(err)}) — the source is live-only ` +
+              `until restart (reported to the caller via sourcePersisted=false)`,
+          );
+        }
+      }
+
       // ACP `newSession` doesn't take a model id; honor the caller's
       // `modelServiceId` via `unstable_setSessionModel`. See
       // `applyModelServiceId` for rationale (race against
@@ -2281,6 +2322,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         attached: false,
         clientId,
         createdAt: entry.createdAt,
+        ...(entry.sourceType ? { sourceType: entry.sourceType } : {}),
+        ...(entry.sourceId !== undefined ? { sourceId: entry.sourceId } : {}),
+        ...(entry.sourceType
+          ? { sourcePersisted: sourcePersisted === true }
+          : {}),
         ...(entry.parentSessionId
           ? { parentSessionPersisted: parentSessionPersisted === true }
           : {}),
@@ -3050,6 +3096,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       drainEarlyEvents?: boolean;
       lifecycleReason?: string;
       parentSessionId?: string;
+      sourceType?: string;
+      sourceId?: string;
     } = {},
   ): SessionEntry => {
     const entry: SessionEntry = {
@@ -3059,6 +3107,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       ...(options.parentSessionId
         ? { parentSessionId: options.parentSessionId }
         : {}),
+      ...(options.sourceType ? { sourceType: options.sourceType } : {}),
+      ...(options.sourceId !== undefined ? { sourceId: options.sourceId } : {}),
       channel: ci.channel,
       connection: ci.connection,
       events,
@@ -3397,6 +3447,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         attached: true,
         clientId,
         createdAt: existing.createdAt,
+        ...(existing.sourceType ? { sourceType: existing.sourceType } : {}),
+        ...(existing.sourceId !== undefined
+          ? { sourceId: existing.sourceId }
+          : {}),
         // Late attachers get the same ACP state the original restore
         // caller saw; spawn-only sessions don't carry a state payload.
         state: existing.restoreState ?? {},
@@ -3632,6 +3686,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           attached: true,
           clientId,
           createdAt: racedEntry.createdAt,
+          ...(racedEntry.sourceType
+            ? { sourceType: racedEntry.sourceType }
+            : {}),
+          ...(racedEntry.sourceId !== undefined
+            ? { sourceId: racedEntry.sourceId }
+            : {}),
           state: racedEntry.restoreState ?? {},
           hasActivePrompt: racedEntry.promptActive,
           ...replayFieldsFor(racedEntry, action),
@@ -3651,6 +3711,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           ...(req.parentSessionId
             ? { parentSessionId: req.parentSessionId }
             : {}),
+          ...(req.sourceType ? { sourceType: req.sourceType } : {}),
+          ...(req.sourceId !== undefined ? { sourceId: req.sourceId } : {}),
         },
       );
       releaseAdmissionOnce();
@@ -3709,6 +3771,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         attached: false,
         clientId,
         createdAt: entry.createdAt,
+        ...(entry.sourceType ? { sourceType: entry.sourceType } : {}),
+        ...(entry.sourceId !== undefined ? { sourceId: entry.sourceId } : {}),
         state: publicState,
         ...(artifactRestoreWarnings.length > 0
           ? { artifactWarnings: artifactRestoreWarnings }
@@ -4027,6 +4091,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         throw new InvalidSessionScopeError(req.sessionScope);
       }
       const effectiveScope = req.sessionScope ?? defaultSessionScope;
+      const source = parseSessionSource(req.sourceType, req.sourceId);
+      if ('error' in source) {
+        throw new InvalidSessionMetadataError('sourceType', source.error);
+      }
       if (
         req.approvalMode !== undefined &&
         !KNOWN_APPROVAL_MODES.has(req.approvalMode)
@@ -4094,6 +4162,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             attached: true,
             clientId,
             createdAt: existing.createdAt,
+            ...(existing.sourceType ? { sourceType: existing.sourceType } : {}),
+            ...(existing.sourceId !== undefined
+              ? { sourceId: existing.sourceId }
+              : {}),
             hasActivePrompt: existing.promptActive,
           };
         }
@@ -4187,6 +4259,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         req.clientId,
         releaseAdmissionOnce,
         req.parentSessionId,
+        source.sourceType,
+        source.sourceId,
       );
       // Track in-flight spawns regardless of scope. Under `single`
       // this also serves the coalescing path above (a parallel
@@ -6717,7 +6791,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
 
     async killSession(sessionId, opts) {
       const entry = byId.get(sessionId);
-      if (!entry) return;
+      if (!entry) return false;
       // BQ9tV race guard: skip the reap if any other client already
       // attached to this entry. The disconnect-reaper in server.ts
       // sets `requireZeroAttaches: true` because it only wants to
@@ -6733,7 +6807,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // detach does nothing structural).
       if (opts?.requireZeroAttaches && entry.attachCount > 0) {
         entry.spawnOwnerWantedKill = true;
-        return;
+        return false;
       }
       // Mediator-driven cancel cascade. Must run BEFORE byId.delete so
       // the mediator's emit callback can still reach entry.events via
@@ -6815,6 +6889,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           await startIdleTimer(ci, `killSession "${sessionId}"`);
         }
       }
+      return true;
     },
 
     async detachClient(sessionId, clientId) {

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -89,6 +89,10 @@ export interface BridgeSpawnRequest {
    * top-level session that no other session spawned.
    */
   parentSessionId?: string;
+  /** Immutable attribution supplied by the creator of a fresh session. */
+  sourceType?: string;
+  /** Optional source-specific identifier. Valid only with `sourceType`. */
+  sourceId?: string;
   approvalMode?: ApprovalMode;
 }
 
@@ -116,6 +120,12 @@ export interface BridgeSession {
    * treating every spawn as an equally successful link.
    */
   parentSessionPersisted?: boolean;
+  /** Immutable creator attribution for this session, when supplied. */
+  sourceType?: string;
+  /** Optional source-specific identifier paired with `sourceType`. */
+  sourceId?: string;
+  /** True iff the source metadata was durably written to the transcript. */
+  sourcePersisted?: boolean;
 }
 
 export interface BridgeRestoreSessionRequest {
@@ -136,6 +146,10 @@ export interface BridgeRestoreSessionRequest {
    * for a top-level session.
    */
   parentSessionId?: string;
+  /** Persisted creator attribution recovered from the transcript. */
+  sourceType?: string;
+  /** Optional persisted identifier paired with `sourceType`. */
+  sourceId?: string;
 }
 
 export const LOAD_REPLAY_MODE_META_KEY = 'qwen.session.loadReplayMode';
@@ -319,6 +333,10 @@ export interface BridgeSessionSummary {
    * absent for a top-level session. Lets a UI link a sub-session back to its
    * parent. Immutable — set when the session is created. */
   parentSessionId?: string;
+  /** Immutable creator attribution, absent on legacy/unattributed sessions. */
+  sourceType?: string;
+  /** Optional source-specific identifier paired with `sourceType`. */
+  sourceId?: string;
   clientCount: number;
   hasActivePrompt: boolean;
   /** True while a non-question permission request awaits a response. */
@@ -1169,11 +1187,13 @@ export interface AcpSessionBridge {
    * `requireZeroAttaches: true` makes the call a no-op when at
    * least one other client has called `spawnOrAttach` for this
    * entry and got `attached: true`.
+   *
+   * Returns true only when this call removed the live session.
    */
   killSession(
     sessionId: string,
     opts?: { requireZeroAttaches?: boolean },
-  ): Promise<void>;
+  ): Promise<boolean>;
 
   /**
    * Roll back a prior attach: decrement `attachCount` and reap if the

--- a/packages/acp-bridge/src/index.ts
+++ b/packages/acp-bridge/src/index.ts
@@ -14,6 +14,7 @@ export * from './status.js';
 export * from './bridgeErrors.js';
 export * from './sessionArtifacts.js';
 export * from './bridgeTypes.js';
+export * from './session-source.js';
 export * from './bridgeOptions.js';
 export * from './replayWindowLimits.js';
 export * from './spawnChannel.js';

--- a/packages/acp-bridge/src/session-source.test.ts
+++ b/packages/acp-bridge/src/session-source.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSessionSource } from './session-source.js';
+
+describe('parseSessionSource', () => {
+  it('accepts an absent source or a valid source pair', () => {
+    expect(parseSessionSource(undefined, undefined)).toEqual({});
+    expect(parseSessionSource('scheduled_task', 'task-123')).toEqual({
+      sourceType: 'scheduled_task',
+      sourceId: 'task-123',
+    });
+  });
+
+  it('requires sourceType when sourceId is provided', () => {
+    expect(parseSessionSource(undefined, 'task-123')).toEqual({
+      error: expect.stringContaining('sourceType'),
+    });
+  });
+
+  it.each(['ScheduledTask', 'scheduled task', '', 'a'.repeat(65)])(
+    'rejects invalid sourceType %j',
+    (sourceType) => {
+      expect(parseSessionSource(sourceType, undefined)).toEqual({
+        error: expect.stringContaining('sourceType'),
+      });
+    },
+  );
+
+  it.each(['', 'bad\nvalue', 'a'.repeat(257)])(
+    'rejects invalid sourceId %j',
+    (sourceId) => {
+      expect(parseSessionSource('scheduled_task', sourceId)).toEqual({
+        error: expect.stringContaining('sourceId'),
+      });
+    },
+  );
+});

--- a/packages/acp-bridge/src/session-source.ts
+++ b/packages/acp-bridge/src/session-source.ts
@@ -1,0 +1,37 @@
+export interface SessionSourceMetadata {
+  sourceType?: string;
+  sourceId?: string;
+}
+
+export const SESSION_SOURCE_TYPE_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+export const MAX_SESSION_SOURCE_ID_LENGTH = 256;
+
+export function parseSessionSource(
+  sourceType: unknown,
+  sourceId: unknown,
+): SessionSourceMetadata | { error: string } {
+  if (sourceType === undefined && sourceId === undefined) return {};
+  if (
+    typeof sourceType !== 'string' ||
+    !SESSION_SOURCE_TYPE_PATTERN.test(sourceType)
+  ) {
+    return {
+      error: '`sourceType` must match [a-z][a-z0-9_-]{0,63} when provided',
+    };
+  }
+  if (sourceId === undefined) return { sourceType };
+  if (
+    typeof sourceId !== 'string' ||
+    sourceId.length === 0 ||
+    sourceId.length > MAX_SESSION_SOURCE_ID_LENGTH ||
+    [...sourceId].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || code === 127;
+    })
+  ) {
+    return {
+      error: `\`sourceId\` must be a non-empty string of at most ${MAX_SESSION_SOURCE_ID_LENGTH} characters without control characters`,
+    };
+  }
+  return { sourceType, sourceId };
+}

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -140,6 +140,7 @@ export const SERVE_CONTROL_EXT_METHODS = {
   sessionContinue: 'qwen/control/session/continue',
   sessionTitle: 'qwen/control/session/title',
   sessionParent: 'qwen/control/session/parent',
+  sessionSource: 'qwen/control/session/source',
   sessionArtifactsPersist: 'qwen/control/session/artifacts/persist',
   workspaceMcpRestart: 'qwen/control/workspace/mcp/restart',
   workspaceMcpManage: 'qwen/control/workspace/mcp/manage',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -264,6 +264,7 @@ import {
   type ServeWorkspaceExtensionsStatus,
   IDLE_HOOK_EVENTS,
 } from '@qwen-code/acp-bridge/status';
+import { parseSessionSource } from '@qwen-code/acp-bridge';
 import {
   CLIENT_MCP_OVER_WS_CONFIG_FLAG,
   LOAD_REPLAY_BULK_MODE,
@@ -6724,6 +6725,41 @@ class QwenAgent implements Agent {
           ok = await recording.recordParentSession(parentSessionId);
         }
         return { sessionId, parentSessionId, persisted: ok };
+      }
+      case SERVE_CONTROL_EXT_METHODS.sessionSource: {
+        const sessionId = params['sessionId'];
+        const sourceType = params['sourceType'];
+        const sourceId = params['sourceId'];
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid or missing sessionId',
+          );
+        }
+        const source = parseSessionSource(sourceType, sourceId);
+        if ('error' in source || source.sourceType === undefined) {
+          throw RequestError.invalidParams(
+            undefined,
+            'error' in source ? source.error : 'Invalid or missing sourceType',
+          );
+        }
+        const session = this.sessionOrThrow(sessionId);
+        const recording = session.getConfig().getChatRecordingService();
+        let ok = false;
+        if (recording) {
+          ok = await recording.recordSessionSource(
+            source.sourceType,
+            source.sourceId,
+          );
+        }
+        return {
+          sessionId,
+          sourceType: source.sourceType,
+          ...(source.sourceId !== undefined
+            ? { sourceId: source.sourceId }
+            : {}),
+          persisted: ok,
+        };
       }
       case SERVE_CONTROL_EXT_METHODS.sessionClose: {
         const sessionId = params['sessionId'];

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -41,6 +41,7 @@ import {
   UpstreamDeviceFlowError,
 } from '../auth/device-flow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
+import { parseSessionSource } from '@qwen-code/acp-bridge';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {
   SessionShellClientRequiredError,
@@ -677,9 +678,19 @@ export class AcpDispatcher {
     this.agentManager = createDaemonSubagentManager(boundWorkspace);
   }
 
-  private killOrphanSession(sessionId: string): void {
+  private killOrphanSession(
+    sessionId: string,
+    removePersistedSession = false,
+  ): void {
     void this.bridge
       .killSession(sessionId, { requireZeroAttaches: true })
+      .then(async (killed) => {
+        if (killed && removePersistedSession) {
+          await new SessionService(this.boundWorkspace).removeSession(
+            sessionId,
+          );
+        }
+      })
       .catch((err) =>
         writeStderrLine(
           `qwen serve: /acp orphan killSession(${logSafe(sessionId)}) failed: ${logSafe(errMsg(err))}`,
@@ -1076,6 +1087,16 @@ export class AcpDispatcher {
 
         case 'session/new': {
           const cwd = parseOptionalWorkspaceCwd(params, this.boundWorkspace);
+          const source = parseSessionSource(
+            params['sourceType'],
+            params['sourceId'],
+          );
+          if ('error' in source) {
+            if (id !== undefined) {
+              conn.sendConn(error(id, RPC.INVALID_PARAMS, source.error));
+            }
+            return;
+          }
           // ACP standard: session/new MUST create a new isolated session.
           // Always use sessionScope 'thread' regardless of client params.
           // The REST surface (POST /session) supports 'single' for
@@ -1084,12 +1105,13 @@ export class AcpDispatcher {
             workspaceCwd: cwd,
             clientId: conn.clientId,
             sessionScope: 'thread',
+            ...source,
           });
           // Teardown raced the spawn: the connection was destroyed while the
           // bridge call was in flight, so nothing will tear this session down.
           // Kill the orphan (no other client could have attached yet).
           if (conn.destroyed) {
-            this.killOrphanSession(session.sessionId);
+            this.killOrphanSession(session.sessionId, true);
             return;
           }
           conn.getOrCreateSession(session.sessionId).clientId =
@@ -1097,7 +1119,7 @@ export class AcpDispatcher {
           conn.ownSession(session.sessionId);
           const configOptions = await this.configOptionsFor(session.sessionId);
           if (conn.destroyed) {
-            this.killOrphanSession(session.sessionId);
+            this.killOrphanSession(session.sessionId, true);
             return;
           }
           // Build ACP-standard models/modes from configOptions.
@@ -1107,6 +1129,13 @@ export class AcpDispatcher {
           const modes = this.extractModeState(configOptions);
           this.replyConn(conn, id, {
             sessionId: session.sessionId,
+            ...(session.sourceType ? { sourceType: session.sourceType } : {}),
+            ...(session.sourceId !== undefined
+              ? { sourceId: session.sourceId }
+              : {}),
+            ...(session.sourcePersisted !== undefined
+              ? { sourcePersisted: session.sourcePersisted }
+              : {}),
             ...(configOptions ? { configOptions } : {}),
             ...(models ? { models } : {}),
             ...(modes ? { modes } : {}),
@@ -1152,26 +1181,22 @@ export class AcpDispatcher {
               // Re-seed the persisted parent lineage so a restored sub-session
               // still reports its parent over the ACP transport (parity with the
               // REST restore handler); the bridge creates the entry without it.
-              const parentSessionId = await new SessionService(
+              const metadata = await new SessionService(
                 cwd,
-              ).readParentSessionId(sessionId);
+              ).readCreationMetadata(sessionId);
               return method === 'session/load'
                 ? await this.bridge.loadSession({
                     sessionId,
                     workspaceCwd: cwd,
                     clientId: conn.clientId,
                     historyReplay: 'response',
-                    ...(parentSessionId !== undefined
-                      ? { parentSessionId }
-                      : {}),
+                    ...metadata,
                   })
                 : await this.bridge.resumeSession({
                     sessionId,
                     workspaceCwd: cwd,
                     clientId: conn.clientId,
-                    ...(parentSessionId !== undefined
-                      ? { parentSessionId }
-                      : {}),
+                    ...metadata,
                   });
             },
           );
@@ -1315,6 +1340,18 @@ export class AcpDispatcher {
               );
             }
           }
+          const parsedSource = parseSessionSource(
+            params['sourceType'],
+            params['sourceId'],
+          );
+          if ('error' in parsedSource) {
+            throw new AcpParamError(parsedSource.error);
+          }
+          if (parsedSource.sourceType !== undefined && view === 'organized') {
+            throw new AcpParamError(
+              '`sourceType` is not supported with `view` "organized"',
+            );
+          }
           const result = await listWorkspaceSessionsForResponse(
             this.bridge,
             workspaceCwd,
@@ -1325,6 +1362,7 @@ export class AcpDispatcher {
               view,
               group,
               parentSessionId,
+              ...parsedSource,
             },
           );
           this.replyConn(conn, id, {
@@ -1339,6 +1377,10 @@ export class AcpDispatcher {
               ...(s.parentSessionId !== undefined
                 ? { parentSessionId: s.parentSessionId }
                 : {}),
+              ...(s.sourceType !== undefined
+                ? { sourceType: s.sourceType }
+                : {}),
+              ...(s.sourceId !== undefined ? { sourceId: s.sourceId } : {}),
               clientCount: s.clientCount,
               hasActivePrompt: s.hasActivePrompt,
               isArchived: s.isArchived === true,

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -188,6 +188,7 @@ class FakeBridge {
   }
   async killSession(sessionId: string) {
     this.killed.push(sessionId);
+    return true;
   }
 
   loadShouldThrow = false;
@@ -4623,7 +4624,10 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     for (const f of frames) expect(f.error?.code).toBe(-32602);
   });
 
-  it('session/new orphan: DELETE before spawn resolves → bridge.killSession', async () => {
+  it('session/new orphan: DELETE before spawn resolves removes the persisted session', async () => {
+    const removeSession = vi
+      .spyOn(SessionService.prototype, 'removeSession')
+      .mockResolvedValue(true);
     let release: () => void = () => {};
     bridge.gate = new Promise<void>((r) => (release = r));
     const connId = await initialize();
@@ -4641,6 +4645,8 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     release(); // spawn resolves AFTER destroy
     await new Promise((r) => setTimeout(r, 40));
     expect(bridge.killed).toContain('sess-1');
+    expect(removeSession).toHaveBeenCalledWith('sess-1');
+    removeSession.mockRestore();
   });
 
   it('session/load orphan (attached:false) → killSession, not detach', async () => {

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -41,6 +41,7 @@ export const SERVE_CAPABILITY_REGISTRY = {
   // the underlying ACP method from unstable_resumeSession to resumeSession.
   unstable_session_resume: { since: 'v1' },
   session_list: { since: 'v1' },
+  session_source_metadata: { since: 'v1' },
   session_prompt: { since: 'v1' },
   session_cancel: { since: 'v1' },
   session_events: { since: 'v1' },

--- a/packages/cli/src/serve/routes/scheduled-tasks.test.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.test.ts
@@ -38,6 +38,8 @@ interface StubBridge {
   spawnOrAttach(req: {
     workspaceCwd: string;
     sessionScope?: 'single' | 'thread';
+    sourceType?: string;
+    sourceId?: string;
   }): Promise<{ sessionId: string }>;
   closeSession(sessionId: string): Promise<unknown>;
   updateSessionMetadata(
@@ -46,6 +48,7 @@ interface StubBridge {
   ): unknown;
   spawned: string[];
   spawnScopes: Array<'single' | 'thread' | undefined>;
+  spawnSources: Array<{ sourceType?: string; sourceId?: string }>;
   closed: string[];
   named: Array<{ sessionId: string; displayName?: string }>;
   failNext: boolean;
@@ -56,6 +59,7 @@ function makeStubBridge(): StubBridge {
   const bridge: StubBridge = {
     spawned: [],
     spawnScopes: [],
+    spawnSources: [],
     closed: [],
     named: [],
     failNext: false,
@@ -67,6 +71,10 @@ function makeStubBridge(): StubBridge {
       const sessionId = `sess-${++seq}`;
       bridge.spawned.push(sessionId);
       bridge.spawnScopes.push(req.sessionScope);
+      bridge.spawnSources.push({
+        ...(req.sourceType !== undefined ? { sourceType: req.sourceType } : {}),
+        ...(req.sourceId !== undefined ? { sourceId: req.sourceId } : {}),
+      });
       return { sessionId };
     },
     async closeSession(sessionId: string) {
@@ -161,6 +169,9 @@ describe('scheduled-tasks routes', () => {
     // The task carries the id of the session the bridge minted for it.
     expect(h.bridge.spawned).toHaveLength(1);
     expect(res.body.sessionId).toBe(h.bridge.spawned[0]);
+    expect(h.bridge.spawnSources).toEqual([
+      { sourceType: 'scheduled_task', sourceId: res.body.id },
+    ]);
     // And it's persisted on disk, not just in the response.
     const list = await request(h.app).get('/scheduled-tasks');
     expect(list.body.tasks[0].sessionId).toBe(h.bridge.spawned[0]);

--- a/packages/cli/src/serve/routes/scheduled-tasks.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.ts
@@ -71,6 +71,8 @@ export interface ScheduledTasksSessionBridge {
   spawnOrAttach(req: {
     workspaceCwd: string;
     sessionScope?: 'single' | 'thread';
+    sourceType?: string;
+    sourceId?: string;
   }): Promise<{ sessionId: string }>;
   closeSession(sessionId: string): Promise<unknown>;
   /** Give the task's session a readable name so it's recognizable in the
@@ -374,6 +376,7 @@ function registerScheduledTaskCrudRoutes(
     }
     const recurring = body['recurring'] !== false;
     const enabled = body['enabled'] !== false;
+    const taskId = generateCronTaskId();
 
     // Mint the task's dedicated session up front. The task is BOUND to it and
     // fires only inside it — its transcript becomes the task's run history, and
@@ -409,6 +412,8 @@ function registerScheduledTaskCrudRoutes(
         const session = await bridge.spawnOrAttach({
           workspaceCwd,
           sessionScope: 'thread',
+          sourceType: 'scheduled_task',
+          sourceId: taskId,
         });
         boundSessionId = session.sessionId;
         // Name the session after the task so it's recognizable in the session
@@ -434,7 +439,7 @@ function registerScheduledTaskCrudRoutes(
 
     const now = Date.now();
     const task: DurableCronTask = {
-      id: generateCronTaskId(),
+      id: taskId,
       cron,
       prompt,
       recurring,

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -25,6 +25,7 @@ import {
   type SessionArchiveState,
 } from '@qwen-code/qwen-code-core';
 import type { SessionArtifactInput } from '@qwen-code/acp-bridge/sessionArtifacts';
+import { parseSessionSource } from '@qwen-code/acp-bridge';
 import type { Application, Request, RequestHandler, Response } from 'express';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import {
@@ -1056,6 +1057,14 @@ export function registerSessionRoutes(
     }
     const approvalMode = parseOptionalApprovalMode(body, res);
     if (approvalMode === null) return;
+    const source = parseSessionSource(body['sourceType'], body['sourceId']);
+    if ('error' in source) {
+      res.status(400).json({
+        error: source.error,
+        code: 'invalid_session_source',
+      });
+      return;
+    }
     const clientId = parseClientIdHeader(req, res);
     if (clientId === null) return;
     try {
@@ -1065,6 +1074,10 @@ export function registerSessionRoutes(
         ...(clientId !== undefined ? { clientId } : {}),
         ...(sessionScope !== undefined ? { sessionScope } : {}),
         ...(approvalMode !== undefined ? { approvalMode } : {}),
+        ...(source.sourceType !== undefined
+          ? { sourceType: source.sourceType }
+          : {}),
+        ...(source.sourceId !== undefined ? { sourceId: source.sourceId } : {}),
       });
       // Client may have disconnected during the 1–3s spawn window. If
       // so, the response can't be delivered. The session is otherwise
@@ -1111,11 +1124,18 @@ export function registerSessionRoutes(
           // dispatching, the bridge will see `attachCount > 0` and
           // skip the kill. Without the flag, that second client's
           // session would die mid-prompt.
-          runtime.bridge
-            .killSession(session.sessionId, { requireZeroAttaches: true })
-            .catch(() => {
-              // Best-effort cleanup; channel.exited will eventually reap.
+          try {
+            const killed = await runtime.bridge.killSession(session.sessionId, {
+              requireZeroAttaches: true,
             });
+            if (killed) {
+              await new SessionService(runtime.workspaceCwd).removeSession(
+                session.sessionId,
+              );
+            }
+          } catch {
+            // Best-effort cleanup; channel.exited will eventually reap.
+          }
         } else {
           // When an attaching client disconnects
           // before its 200 response can be written, the
@@ -1187,9 +1207,9 @@ export function registerSessionRoutes(
             // Recover the persisted parent lineage so the restored live entry
             // reports it (the bridge otherwise creates the entry without it, and
             // status calls would show a restored sub-session as top-level).
-            const parentSessionId = await new SessionService(
+            const metadata = await new SessionService(
               workspaceCwd,
-            ).readParentSessionId(sessionId);
+            ).readCreationMetadata(sessionId);
             return action === 'load'
               ? await runtime.bridge.loadSession({
                   sessionId,
@@ -1197,14 +1217,14 @@ export function registerSessionRoutes(
                   historyReplay: 'response',
                   ...(clientId !== undefined ? { clientId } : {}),
                   ...(approvalMode !== undefined ? { approvalMode } : {}),
-                  ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+                  ...metadata,
                 })
               : await runtime.bridge.resumeSession({
                   sessionId,
                   workspaceCwd,
                   ...(clientId !== undefined ? { clientId } : {}),
                   ...(approvalMode !== undefined ? { approvalMode } : {}),
-                  ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+                  ...metadata,
                 });
           },
         );
@@ -2618,6 +2638,24 @@ export function registerSessionRoutes(
           }
           parentSessionId = rawParentSessionId;
         }
+        const parsedSource = parseSessionSource(
+          req.query['sourceType'],
+          req.query['sourceId'],
+        );
+        if ('error' in parsedSource) {
+          res.status(400).json({
+            error: parsedSource.error,
+            code: 'invalid_session_source',
+          });
+          return;
+        }
+        if (parsedSource.sourceType !== undefined && view === 'organized') {
+          res.status(400).json({
+            error: '`sourceType` is not supported with `view=organized`',
+            code: 'invalid_session_source_filter',
+          });
+          return;
+        }
         const options = {
           ...(cursor !== undefined ? { cursor } : {}),
           ...(size !== undefined ? { size } : {}),
@@ -2625,11 +2663,12 @@ export function registerSessionRoutes(
           ...(view !== undefined ? { view } : {}),
           ...(group !== undefined ? { group } : {}),
           ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+          ...parsedSource,
         };
         // Organized/archived views always need the persisted store: organized
         // cursors are opaque (non-numeric) and archived-only workspaces have no
         // active persisted sessions, so the live-only fallback would drop them.
-        // A parentSessionId filter joins them: it gathers the whole workspace
+        // Metadata filters gather the whole workspace
         // (persisted + live) to filter completely and paginates with an opaque
         // activity cursor, so the numeric-cursor live fallback can't serve it.
         const usePersisted =
@@ -2638,6 +2677,7 @@ export function registerSessionRoutes(
           view === 'organized' ||
           archiveState === 'archived' ||
           parentSessionId !== undefined ||
+          parsedSource.sourceType !== undefined ||
           (cursor !== undefined && cursor !== ''
             ? isNumericSessionCursor(cursor)
             : await hasActivePersistedSessions(key));
@@ -2647,7 +2687,10 @@ export function registerSessionRoutes(
         // a future option added to validation but not to that gate fails loudly.
         if (
           !usePersisted &&
-          (view !== undefined || archiveState === 'archived')
+          (view !== undefined ||
+            archiveState === 'archived' ||
+            parentSessionId !== undefined ||
+            parsedSource.sourceType !== undefined)
         ) {
           throw new Error(
             'session list live path received persisted-only options',

--- a/packages/cli/src/serve/scheduled-task-keepalive.test.ts
+++ b/packages/cli/src/serve/scheduled-task-keepalive.test.ts
@@ -251,6 +251,13 @@ describe('scheduled-task keepalive', () => {
       task({ id: 'a', sessionId: 'sess-1' }),
       task({ id: 'b', sessionId: 'sess-2' }),
     ]);
+    const readMetadata = vi
+      .spyOn(SessionService.prototype, 'readCreationMetadata')
+      .mockResolvedValue({
+        sourceType: 'scheduled_task',
+        sourceId: 'a',
+      });
+    const loadRequests: unknown[] = [];
     const reviving = {
       recordHeartbeat: (id: string) => {
         if (id === 'sess-1') throw new Error('not resident');
@@ -258,6 +265,7 @@ describe('scheduled-task keepalive', () => {
       },
       loadSession: async (req: { sessionId: string }) => {
         loads.push(req.sessionId);
+        loadRequests.push(req);
       },
       spawnOrAttach: async () => {
         throw new Error('not mocked');
@@ -278,6 +286,16 @@ describe('scheduled-task keepalive', () => {
     // scheduler; sess-2 was resident and still got its heartbeat.
     expect(loads).toEqual(['sess-1']);
     expect(beats).toEqual(['sess-2']);
+    expect(loadRequests).toEqual([
+      {
+        sessionId: 'sess-1',
+        workspaceCwd: workspace,
+        historyReplay: 'response',
+        sourceType: 'scheduled_task',
+        sourceId: 'a',
+      },
+    ]);
+    readMetadata.mockRestore();
   });
 
   it('a failed revive is swallowed and does not block siblings', async () => {
@@ -399,18 +417,42 @@ describe('scheduled-task keepalive', () => {
       task({ id: 'c', sessionId: 'sess-1' }), // same session as 'a'
       task({ id: 'd' }), // unbound
     ]);
-    const loaded: string[] = [];
+    const readMetadata = vi
+      .spyOn(SessionService.prototype, 'readCreationMetadata')
+      .mockImplementation(async (sessionId) => ({
+        sourceType: 'scheduled_task',
+        sourceId: `task-for-${sessionId}`,
+      }));
+    const loaded: Array<{
+      sessionId: string;
+      sourceType?: string;
+      sourceId?: string;
+    }> = [];
     const res = await rehydrateScheduledTaskSessions({
       bridge: {
         loadSession: async (req) => {
-          loaded.push(req.sessionId);
+          loaded.push(req);
         },
       },
       boundWorkspace: workspace,
     });
-    expect(loaded.sort()).toEqual(['sess-1', 'sess-2']);
+    expect(loaded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: 'sess-1',
+          sourceType: 'scheduled_task',
+          sourceId: 'task-for-sess-1',
+        }),
+        expect.objectContaining({
+          sessionId: 'sess-2',
+          sourceType: 'scheduled_task',
+          sourceId: 'task-for-sess-2',
+        }),
+      ]),
+    );
     expect(res.loaded.sort()).toEqual(['sess-1', 'sess-2']);
     expect(res.failed).toEqual([]);
+    readMetadata.mockRestore();
   });
 
   it('rehydrate records a gone session as failed but keeps loading siblings', async () => {
@@ -527,6 +569,8 @@ describe('scheduled-task keepalive', () => {
     expect(spawns[0]).toEqual({
       workspaceCwd: workspace,
       sessionScope: 'thread',
+      sourceType: 'scheduled_task',
+      sourceId: 'unbound-1',
     });
     expect(names).toHaveLength(1);
     expect(names[0]![0]).toBe('new-sess-1');

--- a/packages/cli/src/serve/scheduled-task-keepalive.ts
+++ b/packages/cli/src/serve/scheduled-task-keepalive.ts
@@ -80,10 +80,14 @@ export interface KeepaliveBridge {
     sessionId: string;
     workspaceCwd: string;
     historyReplay?: 'stream' | 'response';
+    sourceType?: string;
+    sourceId?: string;
   }): Promise<unknown>;
   spawnOrAttach(req: {
     workspaceCwd: string;
     sessionScope?: 'single' | 'thread';
+    sourceType?: string;
+    sourceId?: string;
   }): Promise<{ sessionId: string }>;
   closeSession(sessionId: string): Promise<unknown>;
   updateSessionMetadata(
@@ -145,6 +149,8 @@ async function bindAndNameSessions(
       const rawSpawn = bridge.spawnOrAttach({
         workspaceCwd: boundWorkspace,
         sessionScope: 'thread',
+        sourceType: 'scheduled_task',
+        sourceId: task.id,
       });
       // spawnOrAttach is not abortable — if the timeout fires first, the
       // raw promise may still resolve later with a live session. Attach a
@@ -316,12 +322,16 @@ export function startScheduledTaskKeepalive(
           continue; // still backing off from prior revive failures
         }
         log.debug('keepalive: recordHeartbeat failed for', sessionId, err);
+        reviving.add(sessionId);
+        const metadata = await new SessionService(
+          boundWorkspace,
+        ).readCreationMetadata(sessionId);
         const load = bridge.loadSession({
           sessionId,
           workspaceCwd: boundWorkspace,
           historyReplay: 'response',
+          ...metadata,
         });
-        reviving.add(sessionId);
         // Clear the in-flight guard on the load's TRUE settlement (not the
         // timeout below) so a still-running load keeps blocking a duplicate.
         void load
@@ -444,6 +454,8 @@ export interface RehydrateBridge {
     sessionId: string;
     workspaceCwd: string;
     historyReplay?: 'stream' | 'response';
+    sourceType?: string;
+    sourceId?: string;
   }): Promise<unknown>;
 }
 
@@ -493,10 +505,14 @@ export async function rehydrateScheduledTaskSessions(deps: {
   const loaded: string[] = [];
   const failed: string[] = [];
   const loadOne = async (sessionId: string) => {
+    const metadata = await new SessionService(
+      boundWorkspace,
+    ).readCreationMetadata(sessionId);
     const load = bridge.loadSession({
       sessionId,
       workspaceCwd: boundWorkspace,
       historyReplay: 'response',
+      ...metadata,
     });
     // loadSession isn't abortable, so a timed-out load keeps forking/replaying
     // in the background. Swallow its eventual settlement up front so it can't

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -232,6 +232,7 @@ const EXPECTED_STAGE1_FEATURES = [
   'session_resume',
   'unstable_session_resume',
   'session_list',
+  'session_source_metadata',
   'session_prompt',
   'session_cancel',
   'session_events',
@@ -1840,6 +1841,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     },
     async killSession(sessionId, opts) {
       killCalls.push({ sessionId, opts });
+      return true;
     },
     async detachClient(sessionId, clientId) {
       detachCalls.push({
@@ -7589,6 +7591,42 @@ describe('createServeApp', () => {
       expect(bridge.calls[0]?.workspaceCwd).toBe(WS_BOUND);
     });
 
+    it('forwards valid session source metadata to the bridge', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge },
+      );
+      const res = await request(app)
+        .post('/session')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ sourceType: 'scheduled_task', sourceId: 'task-123' });
+
+      expect(res.status).toBe(200);
+      expect(bridge.calls[0]).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+    });
+
+    it('rejects sourceId without sourceType', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge },
+      );
+      const res = await request(app)
+        .post('/session')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ sourceId: 'task-123' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('invalid_session_source');
+      expect(bridge.calls).toHaveLength(0);
+    });
+
     it('400 when cwd is relative', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(
@@ -8664,6 +8702,8 @@ describe('createServeApp', () => {
       mtime: Date;
       state?: 'active' | 'archived';
       parentSessionId?: string;
+      sourceType?: string;
+      sourceId?: string;
     }): Promise<void> {
       const chatsDir = path.join(
         new Storage(input.cwd).getProjectDir(),
@@ -8697,6 +8737,27 @@ describe('createServeApp', () => {
           cwd: input.cwd,
         };
         lines.push(JSON.stringify(parentRecord));
+      }
+      if (input.sourceType !== undefined) {
+        const sourceRecord = {
+          uuid: `${input.sessionId}-source-1`,
+          parentUuid:
+            input.parentSessionId === undefined
+              ? `${input.sessionId}-user-1`
+              : `${input.sessionId}-parent-1`,
+          sessionId: input.sessionId,
+          timestamp: input.timestamp,
+          type: 'system',
+          subtype: 'session_source',
+          systemPayload: {
+            sourceType: input.sourceType,
+            ...(input.sourceId !== undefined
+              ? { sourceId: input.sourceId }
+              : {}),
+          },
+          cwd: input.cwd,
+        };
+        lines.push(JSON.stringify(sourceRecord));
       }
       await fsp.writeFile(filePath, `${lines.join('\n')}\n`, 'utf8');
       await fsp.utimes(filePath, input.mtime, input.mtime);
@@ -8978,6 +9039,46 @@ describe('createServeApp', () => {
           hasActivePrompt: false,
         }),
       ]);
+    });
+
+    it('keeps persisted source metadata paired during a live merge', async () => {
+      const sessionId = 'f47ac10b-58cc-4372-a567-0e02b2c3d480';
+      await writeStoredSession({
+        sessionId,
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T12:01:00.000Z',
+        prompt: 'stored source',
+        mtime: new Date('2026-05-17T12:11:00.000Z'),
+        sourceType: 'scheduled_task',
+      });
+      const bridge = fakeBridge({
+        listImpl: () => [
+          {
+            sessionId,
+            workspaceCwd: WS_BOUND,
+            createdAt: '2026-05-17T12:30:00.000Z',
+            sourceType: 'api',
+            sourceId: 'request-456',
+            clientCount: 1,
+            hasActivePrompt: false,
+          },
+        ],
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+
+      const res = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.sessions[0]).toMatchObject({
+        sourceType: 'scheduled_task',
+      });
+      expect(res.body.sessions[0]).not.toHaveProperty('sourceId');
     });
 
     it('returns an empty array when no sessions exist for the workspace', async () => {
@@ -10296,6 +10397,65 @@ describe('createServeApp', () => {
         expect(res.body.code).toBe('invalid_parent_session_id');
       });
     });
+
+    describe('session source filter', () => {
+      it('returns persisted sessions matching sourceType and sourceId', async () => {
+        await writeStoredSession({
+          sessionId: '550e8400-e29b-41d4-a716-446655440101',
+          cwd: WS_BOUND,
+          timestamp: '2026-05-17T12:00:00.000Z',
+          prompt: 'matching source',
+          mtime: new Date('2026-05-17T12:00:00.000Z'),
+          sourceType: 'scheduled_task',
+          sourceId: 'task-123',
+        });
+        await writeStoredSession({
+          sessionId: '550e8400-e29b-41d4-a716-446655440102',
+          cwd: WS_BOUND,
+          timestamp: '2026-05-17T12:01:00.000Z',
+          prompt: 'different source',
+          mtime: new Date('2026-05-17T12:01:00.000Z'),
+          sourceType: 'scheduled_task',
+          sourceId: 'task-456',
+        });
+        const app = createServeApp(
+          { ...baseOpts, workspace: WS_BOUND },
+          undefined,
+          { bridge: fakeBridge(), boundWorkspace: WS_BOUND },
+        );
+
+        const res = await request(app)
+          .get(
+            `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?sourceType=scheduled_task&sourceId=task-123`,
+          )
+          .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.sessions).toEqual([
+          expect.objectContaining({
+            sessionId: '550e8400-e29b-41d4-a716-446655440101',
+            sourceType: 'scheduled_task',
+            sourceId: 'task-123',
+          }),
+        ]);
+      });
+
+      it('rejects sourceId without sourceType', async () => {
+        const app = createServeApp(
+          { ...baseOpts, workspace: WS_BOUND },
+          undefined,
+          { bridge: fakeBridge(), boundWorkspace: WS_BOUND },
+        );
+        const res = await request(app)
+          .get(
+            `/workspace/${encodeURIComponent(WS_BOUND)}/sessions?sourceId=task-123`,
+          )
+          .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('invalid_session_source');
+      });
+    });
   });
 
   describe('GET /session/:id/status', () => {
@@ -10305,6 +10465,8 @@ describe('createServeApp', () => {
         workspaceCwd: WS_BOUND,
         createdAt: '2026-05-17T12:00:00.000Z',
         displayName: 'demo',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
         clientCount: 2,
         hasActivePrompt: true,
       };

--- a/packages/cli/src/serve/server/session-list.ts
+++ b/packages/cli/src/serve/server/session-list.ts
@@ -36,6 +36,10 @@ export interface ListWorkspaceSessionsOptions {
    * (not the numeric storage cursor). Absent = no parent filter.
    */
   parentSessionId?: string;
+  /** Restrict results to sessions created by this source type. */
+  sourceType?: string;
+  /** Further restrict `sourceType` matches to this source identifier. */
+  sourceId?: string;
 }
 
 export interface ListWorkspaceSessionsResult {
@@ -53,7 +57,7 @@ export interface ListWorkspaceSessionsReadOptions {
 export class InvalidCursorError extends Error {
   constructor(
     cursor: string,
-    kind: 'numeric' | 'organized' | 'live' | 'parent' = 'numeric',
+    kind: 'numeric' | 'organized' | 'live' | 'parent' | 'metadata' = 'numeric',
   ) {
     super(`Invalid cursor: "${cursor}" is not a valid ${kind} cursor`);
     this.name = 'InvalidCursorError';
@@ -164,18 +168,16 @@ function encodeLiveSessionCursor(last: LiveSessionCursorKey): string {
   return Buffer.from(JSON.stringify(last), 'utf8').toString('base64url');
 }
 
-/**
- * Decodes a `?parentSessionId=` page cursor, binding it to the query that
- * produced it. The cursor carries the `parentSessionId` and `archiveState` it
- * was minted for, and decode REJECTS a cursor whose scope differs from the
- * current request — otherwise a cursor from parent A (or from the active set)
- * replayed against parent B (or the archived set) would be accepted and
- * silently skip every session newer than that unrelated key. Same
- * bind-and-validate contract as {@link parseOrganizedCursor}.
- */
-function parseParentSessionCursor(
+/** Binds an opaque cursor to the metadata filter that produced it. */
+interface SessionMetadataFilter {
+  parentSessionId?: string;
+  sourceType?: string;
+  sourceId?: string;
+}
+
+function parseMetadataSessionCursor(
   cursor: string,
-  expected: { parentSessionId: string; archiveState: SessionArchiveState },
+  expected: SessionMetadataFilter & { archiveState: SessionArchiveState },
 ): LiveSessionCursorKey | undefined {
   if (cursor === '') return undefined;
   try {
@@ -196,24 +198,29 @@ function parseParentSessionCursor(
       last.sessionId.length === 0 ||
       (parsed as { parentSessionId?: unknown }).parentSessionId !==
         expected.parentSessionId ||
+      (parsed as { sourceType?: unknown }).sourceType !== expected.sourceType ||
+      (parsed as { sourceId?: unknown }).sourceId !== expected.sourceId ||
       (parsed as { archiveState?: unknown }).archiveState !==
         expected.archiveState
     ) {
-      throw new Error('invalid parent cursor');
+      throw new Error('invalid metadata cursor');
     }
     return { activityTime: last.activityTime, sessionId: last.sessionId };
   } catch {
-    throw new InvalidCursorError(cursor, 'parent');
+    throw new InvalidCursorError(
+      cursor,
+      expected.sourceType === undefined ? 'parent' : 'metadata',
+    );
   }
 }
 
-function encodeParentSessionCursor(
+function encodeMetadataSessionCursor(
   last: LiveSessionCursorKey,
-  parentSessionId: string,
+  filter: SessionMetadataFilter,
   archiveState: SessionArchiveState,
 ): string {
   return Buffer.from(
-    JSON.stringify({ parentSessionId, archiveState, last }),
+    JSON.stringify({ ...filter, archiveState, last }),
     'utf8',
   ).toString('base64url');
 }
@@ -226,6 +233,8 @@ function toSummary(item: {
   prompt: string;
   customTitle?: string;
   parentSessionId?: string;
+  sourceType?: string;
+  sourceId?: string;
   isArchived?: boolean;
 }): BridgeSessionSummary {
   return {
@@ -235,6 +244,8 @@ function toSummary(item: {
     updatedAt: new Date(item.mtime).toISOString(),
     displayName: item.customTitle || item.prompt,
     ...(item.parentSessionId ? { parentSessionId: item.parentSessionId } : {}),
+    ...(item.sourceType ? { sourceType: item.sourceType } : {}),
+    ...(item.sourceId !== undefined ? { sourceId: item.sourceId } : {}),
     clientCount: 0,
     hasActivePrompt: false,
     isArchived: item.isArchived === true,
@@ -246,7 +257,7 @@ function toSummary(item: {
  * that exists in both. The persisted record owns identity/immutable facts
  * (`createdAt`, `parentSessionId` lineage) while the live entry owns volatile
  * state (`clientCount`, `hasActivePrompt`, a fresher `displayName`/`updatedAt`).
- * Shared by all three list paths (default, organized, by-parent) so the merge
+ * Shared by all three list paths (default, organized, metadata-filtered) so the merge
  * rule lives in one place.
  */
 function mergeLiveSessionSummary(
@@ -261,6 +272,9 @@ function mergeLiveSessionSummary(
     // Immutable lineage; the persisted transcript is authoritative, and a live
     // entry only carries it when spawned this run.
     parentSessionId: existing.parentSessionId ?? live.parentSessionId,
+    sourceType: existing.sourceType ?? live.sourceType,
+    sourceId:
+      existing.sourceType !== undefined ? existing.sourceId : live.sourceId,
     updatedAt: live.updatedAt ?? existing.updatedAt,
     clientCount: live.clientCount,
     hasActivePrompt: live.hasActivePrompt,
@@ -515,19 +529,15 @@ async function listOrganizedWorkspaceSessionsForResponse(
 }
 
 /**
- * Lists only the sessions spawned by `parentSessionId`. Unlike the default
- * storage-paginated path, this gathers the whole workspace (capped, like the
- * organized view) and filters before paginating, so a page is never short of
- * matches and the client can page to completion without wading through empty
- * pages. Sorted newest-activity-first and paginated with the same opaque
- * activity cursor as the live-only path.
+ * Applies persisted metadata filters before pagination so pages are not
+ * silently short of matches.
  */
-async function listWorkspaceSessionsByParentForResponse(
+async function listWorkspaceSessionsByMetadataForResponse(
   bridge: AcpSessionBridge,
   workspaceCwd: string,
   options: ListWorkspaceSessionsOptions,
   pageSize: number,
-  parentSessionId: string,
+  filter: SessionMetadataFilter,
   readOptions: ListWorkspaceSessionsReadOptions,
 ): Promise<ListWorkspaceSessionsResult> {
   const archiveState = options.archiveState ?? 'active';
@@ -564,7 +574,7 @@ async function listWorkspaceSessionsByParentForResponse(
     } catch (error) {
       liveMergeFailed = true;
       writeStderrLine(
-        `qwen serve: session-by-parent live merge failed; using persisted sessions only: ${
+        `qwen serve: session metadata filter live merge failed; using persisted sessions only: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -572,7 +582,14 @@ async function listWorkspaceSessionsByParentForResponse(
   }
 
   const matches = [...bySessionId.values()]
-    .filter((session) => session.parentSessionId === parentSessionId)
+    .filter(
+      (session) =>
+        (filter.parentSessionId === undefined ||
+          session.parentSessionId === filter.parentSessionId) &&
+        (filter.sourceType === undefined ||
+          session.sourceType === filter.sourceType) &&
+        (filter.sourceId === undefined || session.sourceId === filter.sourceId),
+    )
     .sort((a, b) =>
       compareLiveSessionCursorKeys(
         getLiveSessionCursorKey(a),
@@ -581,8 +598,8 @@ async function listWorkspaceSessionsByParentForResponse(
     );
   const cursorKey =
     options.cursor !== undefined && options.cursor !== ''
-      ? parseParentSessionCursor(options.cursor, {
-          parentSessionId,
+      ? parseMetadataSessionCursor(options.cursor, {
+          ...filter,
           archiveState,
         })
       : undefined;
@@ -599,9 +616,9 @@ async function listWorkspaceSessionsByParentForResponse(
   const page = afterCursor.slice(0, pageSize);
   const nextCursor =
     page.length < afterCursor.length
-      ? encodeParentSessionCursor(
+      ? encodeMetadataSessionCursor(
           getLiveSessionCursorKey(page[page.length - 1]!),
-          parentSessionId,
+          filter,
           archiveState,
         )
       : undefined;
@@ -636,13 +653,26 @@ export async function listWorkspaceSessionsForResponse(
     );
   }
 
-  if (options?.parentSessionId !== undefined) {
-    return listWorkspaceSessionsByParentForResponse(
+  if (
+    options?.parentSessionId !== undefined ||
+    options?.sourceType !== undefined
+  ) {
+    return listWorkspaceSessionsByMetadataForResponse(
       bridge,
       workspaceCwd,
       options,
       pageSize,
-      options.parentSessionId,
+      {
+        ...(options.parentSessionId !== undefined
+          ? { parentSessionId: options.parentSessionId }
+          : {}),
+        ...(options.sourceType !== undefined
+          ? { sourceType: options.sourceType }
+          : {}),
+        ...(options.sourceId !== undefined
+          ? { sourceId: options.sourceId }
+          : {}),
+      },
       readOptions,
     );
   }

--- a/packages/cli/src/serve/workspace-agents.test.ts
+++ b/packages/cli/src/serve/workspace-agents.test.ts
@@ -96,7 +96,7 @@ function buildBridgeStub(
     setSessionModel: async () => {
       throw new Error('not implemented');
     },
-    killSession: async () => {},
+    killSession: async () => true,
     detachClient: async () => {},
     sessionCount: 0,
     pendingPermissionCount: 0,

--- a/packages/cli/src/serve/workspace-memory.test.ts
+++ b/packages/cli/src/serve/workspace-memory.test.ts
@@ -106,7 +106,7 @@ function buildBridgeStub(
     setSessionModel: async () => {
       throw new Error('not implemented');
     },
-    killSession: async () => {},
+    killSession: async () => true,
     detachClient: async () => {},
     sessionCount: 0,
     pendingPermissionCount: 0,

--- a/packages/cli/src/serve/workspace-remember.test.ts
+++ b/packages/cli/src/serve/workspace-remember.test.ts
@@ -204,7 +204,7 @@ function buildBridgeStub(opts: {
     invokeWorkspaceCommand: async () => {
       throw new Error('not implemented');
     },
-    killSession: async () => {},
+    killSession: async () => true,
     detachClient: async () => {},
     sessionCount: 0,
     pendingPermissionCount: 0,

--- a/packages/cli/src/serve/workspace-service/__tests__/integration.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/integration.test.ts
@@ -112,7 +112,7 @@ function minimalBridge(
       .fn()
       .mockImplementation((_method: string, idle: () => unknown) => idle()),
     invokeWorkspaceCommand: vi.fn().mockResolvedValue({}),
-    killSession: vi.fn().mockResolvedValue(undefined),
+    killSession: vi.fn().mockResolvedValue(true),
     detachClient: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
     killAllSync: vi.fn(),

--- a/packages/core/src/services/chatRecordingService.parentSession.test.ts
+++ b/packages/core/src/services/chatRecordingService.parentSession.test.ts
@@ -105,6 +105,56 @@ describe('ChatRecordingService - recordParentSession', () => {
     expect(writtenRecord.sessionId).toBe('test-session-id');
   });
 
+  it('records immutable session source metadata', async () => {
+    const first = await chatRecordingService.recordSessionSource(
+      'scheduled_task',
+      'task-123',
+    );
+    const second = await chatRecordingService.recordSessionSource(
+      'scheduled_task',
+      'task-123',
+    );
+    await chatRecordingService.flush();
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(jsonl.writeLine).toHaveBeenCalledOnce();
+    const writtenRecord = vi.mocked(jsonl.writeLine).mock
+      .calls[0][1] as ChatRecord;
+    expect(writtenRecord).toMatchObject({
+      type: 'system',
+      subtype: 'session_source',
+      systemPayload: {
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      },
+    });
+  });
+
+  it('rejects a different session source after the first write', async () => {
+    await expect(
+      chatRecordingService.recordSessionSource('scheduled_task', 'task-123'),
+    ).resolves.toBe(true);
+    await expect(
+      chatRecordingService.recordSessionSource('web_shell', 'window-1'),
+    ).resolves.toBe(false);
+    await chatRecordingService.flush();
+
+    expect(jsonl.writeLine).toHaveBeenCalledOnce();
+  });
+
+  it('reports a session source write failure', async () => {
+    const writeError = new Error('disk full');
+    vi.mocked(jsonl.writeLine).mockRejectedValueOnce(writeError);
+
+    await expect(
+      chatRecordingService.recordSessionSource('scheduled_task', 'task-123'),
+    ).resolves.toBe(false);
+    await expect(chatRecordingService.flush()).rejects.toBe(writeError);
+
+    expect(jsonl.writeLine).toHaveBeenCalledOnce();
+  });
+
   it('includes the standard record metadata', async () => {
     await chatRecordingService.recordParentSession('parent-abc');
     await chatRecordingService.flush();

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -253,6 +253,7 @@ export interface ChatRecord {
     | 'mid_turn_user_message'
     | 'custom_title'
     | 'parent_session'
+    | 'session_source'
     | 'rewind'
     | 'agent_bootstrap'
     | 'agent_launch_prompt'
@@ -303,6 +304,7 @@ export interface ChatRecord {
     | AttributionSnapshotPayload
     | CustomTitleRecordPayload
     | ParentSessionRecordPayload
+    | SessionSourceRecordPayload
     | NotificationRecordPayload
     | RewindRecordPayload
     | AgentBootstrapRecordPayload
@@ -443,6 +445,12 @@ export interface ParentSessionRecordPayload {
   parentSessionId: string;
 }
 
+/** Immutable attribution describing which integration created the session. */
+export interface SessionSourceRecordPayload {
+  sourceType: string;
+  sourceId?: string;
+}
+
 /**
  * Stored payload for UI telemetry replay.
  */
@@ -551,6 +559,9 @@ export class ChatRecordingService {
    * idempotent — a bridge retry (after a failed response) must not append a
    * second `parent_session` record for the same immutable lineage. */
   private currentParentSessionId: string | undefined;
+  /** Immutable creator attribution once recorded. */
+  private currentSourceType: string | undefined;
+  private currentSourceId: string | undefined;
   /**
    * How many auto-title attempts have been made this process.
    *
@@ -1496,6 +1507,39 @@ export class ChatRecordingService {
     } catch (error) {
       if (error !== this.writeFailure) {
         debugLogger.error('Error saving parent session record:', error);
+      }
+      return false;
+    }
+  }
+
+  /** Persist immutable creator attribution near the start of the transcript. */
+  async recordSessionSource(
+    sourceType: string,
+    sourceId?: string,
+  ): Promise<boolean> {
+    if (this.currentSourceType !== undefined) {
+      return (
+        this.currentSourceType === sourceType &&
+        this.currentSourceId === sourceId
+      );
+    }
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'session_source',
+        systemPayload: {
+          sourceType,
+          ...(sourceId !== undefined ? { sourceId } : {}),
+        },
+      };
+      await this.appendRecordStrict(record);
+      this.currentSourceType = sourceType;
+      this.currentSourceId = sourceId;
+      return true;
+    } catch (error) {
+      if (error !== this.writeFailure) {
+        debugLogger.error('Error saving session source:', error);
       }
       return false;
     }

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -2810,7 +2810,7 @@ describe('SessionService', () => {
       );
       fs.mkdirSync(chatsDir, { recursive: true });
       const file = realPath.join(chatsDir, `${sessionId}.jsonl`);
-      const lines = [
+      const lines: Array<Record<string, unknown>> = [
         {
           uuid: 'u1',
           parentUuid: null,
@@ -3450,7 +3450,7 @@ describe('SessionService', () => {
       );
     });
 
-    it('drops the source parent_session record so the fork inherits no lineage', async () => {
+    it('drops creation metadata so the fork inherits no lineage or source', async () => {
       // A fork is a fresh top-level session, not a sub-session. Copying the
       // source's parent_session record would make the fork report the original's
       // parent as its own. Seed the parent_session record on the active branch
@@ -3463,7 +3463,7 @@ describe('SessionService', () => {
       );
       fs.mkdirSync(chatsDir, { recursive: true });
       const srcFile = realPath.join(chatsDir, `${oldId}.jsonl`);
-      const lines = [
+      const lines: Array<Record<string, unknown>> = [
         {
           uuid: 'u1',
           parentUuid: null,
@@ -3487,7 +3487,7 @@ describe('SessionService', () => {
         },
         {
           uuid: 'u2',
-          parentUuid: 'up',
+          parentUuid: 'us',
           sessionId: oldId,
           type: 'assistant',
           timestamp: '2026-04-22T00:00:01.000Z',
@@ -3496,6 +3496,20 @@ describe('SessionService', () => {
           message: { role: 'model', parts: [{ text: 'hi' }] },
         },
       ];
+      lines.splice(2, 0, {
+        uuid: 'us',
+        parentUuid: 'up',
+        sessionId: oldId,
+        type: 'system',
+        subtype: 'session_source',
+        timestamp: '2026-04-22T00:00:00.750Z',
+        cwd,
+        version: 'test',
+        systemPayload: {
+          sourceType: 'scheduled_task',
+          sourceId: 'task-123',
+        },
+      });
       fs.writeFileSync(
         srcFile,
         lines.map((l) => JSON.stringify(l)).join('\n') + '\n',
@@ -3513,10 +3527,20 @@ describe('SessionService', () => {
           (r) => r.type === 'system' && r.subtype === 'parent_session',
         ),
       ).toBe(false);
+      expect(
+        written.some(
+          (r) => r.type === 'system' && r.subtype === 'session_source',
+        ),
+      ).toBe(false);
 
       // The source keeps its lineage; the fork carries none of it.
       expect(await service.readParentSessionId(oldId)).toBe('P');
       expect(await service.readParentSessionId(newId)).toBeUndefined();
+      expect(await service.readCreationMetadata(oldId)).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+      expect(await service.readCreationMetadata(newId)).toEqual({});
     });
   });
 
@@ -3789,6 +3813,21 @@ describe('SessionService', () => {
       systemPayload: { parentSessionId },
     });
 
+    const sessionSourceLine = (sessionId: string) => ({
+      uuid: 'u3',
+      parentUuid: 'u2',
+      sessionId,
+      type: 'system',
+      subtype: 'session_source',
+      timestamp: '2026-04-22T00:00:02.000Z',
+      cwd,
+      version: 'test',
+      systemPayload: {
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      },
+    });
+
     const writeSession = (
       sessionId: string,
       lines: Array<Record<string, unknown>>,
@@ -3802,7 +3841,12 @@ describe('SessionService', () => {
     };
 
     const findItem = (
-      items: Array<{ sessionId: string; parentSessionId?: string }>,
+      items: Array<{
+        sessionId: string;
+        parentSessionId?: string;
+        sourceType?: string;
+        sourceId?: string;
+      }>,
       sessionId: string,
     ) => items.find((item) => item.sessionId === sessionId);
 
@@ -3818,6 +3862,46 @@ describe('SessionService', () => {
       const item = findItem(result.items, sessionId);
       expect(item).toBeDefined();
       expect(item?.parentSessionId).toBe('parent-abc');
+    });
+
+    it('rehydrates source metadata for lists and direct restore lookup', async () => {
+      const sessionId = '77777777-7777-7777-7777-777777777777';
+      writeSession(sessionId, [
+        userLine(sessionId, 'hello'),
+        parentSessionLine(sessionId, 'parent-abc'),
+        sessionSourceLine(sessionId),
+      ]);
+
+      const result = await service.listSessions();
+
+      expect(findItem(result.items, sessionId)).toMatchObject({
+        parentSessionId: 'parent-abc',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+      expect(await service.readCreationMetadata(sessionId)).toEqual({
+        parentSessionId: 'parent-abc',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+    });
+
+    it('keeps the first immutable source record', async () => {
+      const sessionId = '88888888-8888-8888-8888-888888888888';
+      writeSession(sessionId, [
+        userLine(sessionId, 'hello'),
+        sessionSourceLine(sessionId),
+        {
+          ...sessionSourceLine(sessionId),
+          uuid: 'u4',
+          systemPayload: { sourceType: 'api', sourceId: 'request-456' },
+        },
+      ]);
+
+      expect(await service.readCreationMetadata(sessionId)).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
     });
 
     it('leaves parentSessionId undefined when no parent_session record exists', async () => {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -90,6 +90,10 @@ export interface SessionListItem {
    * any. Read from the transcript's `parent_session` record. Absent for a
    * top-level session. */
   parentSessionId?: string;
+  /** Immutable creator attribution read from `session_source`. */
+  sourceType?: string;
+  /** Optional source-specific identifier paired with `sourceType`. */
+  sourceId?: string;
   /** True when the item was read from the archive directory. */
   isArchived?: boolean;
 }
@@ -408,6 +412,15 @@ export class SessionService {
    * undefined rather than throwing — a missing link must never fail a restore.
    */
   async readParentSessionId(sessionId: string): Promise<string | undefined> {
+    return (await this.readCreationMetadata(sessionId)).parentSessionId;
+  }
+
+  /** Reads immutable creation metadata for an active or archived session. */
+  async readCreationMetadata(sessionId: string): Promise<{
+    parentSessionId?: string;
+    sourceType?: string;
+    sourceId?: string;
+  }> {
     for (const state of ['active', 'archived'] as const) {
       const filePath = this.getSessionFilePath(sessionId, state);
       try {
@@ -424,14 +437,15 @@ export class SessionService {
         ) {
           continue;
         }
-        const parent = this.extractParentSessionIdFromRecords(records);
-        if (parent) return parent;
+        return this.extractCreationMetadataFromRecords(records);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
-        this.warn(`readParentSessionId: failed to read ${sessionId}: ${error}`);
+        this.warn(
+          `readCreationMetadata: failed to read ${sessionId}: ${error}`,
+        );
       }
     }
-    return undefined;
+    return {};
   }
 
   async getSessionLocation(sessionId: string): Promise<SessionLocation> {
@@ -599,20 +613,45 @@ export class SessionService {
    * within that window. No extra file open, unlike the title (which re-anchors
    * at EOF and needs its own tail-then-head scan).
    */
-  private extractParentSessionIdFromRecords(
-    records: ChatRecord[],
-  ): string | undefined {
+  private extractCreationMetadataFromRecords(records: ChatRecord[]): {
+    parentSessionId?: string;
+    sourceType?: string;
+    sourceId?: string;
+  } {
+    let parentSessionId: string | undefined;
+    let sourceType: string | undefined;
+    let sourceId: string | undefined;
     for (const record of records) {
       if (record.type === 'system' && record.subtype === 'parent_session') {
         const payload = record.systemPayload as
           | { parentSessionId?: unknown }
           | undefined;
-        if (typeof payload?.parentSessionId === 'string') {
-          return payload.parentSessionId;
+        if (
+          parentSessionId === undefined &&
+          typeof payload?.parentSessionId === 'string'
+        ) {
+          parentSessionId = payload.parentSessionId;
+        }
+      }
+      if (record.type === 'system' && record.subtype === 'session_source') {
+        const payload = record.systemPayload as
+          | { sourceType?: unknown; sourceId?: unknown }
+          | undefined;
+        if (
+          sourceType === undefined &&
+          typeof payload?.sourceType === 'string'
+        ) {
+          sourceType = payload.sourceType;
+          sourceId =
+            typeof payload.sourceId === 'string' ? payload.sourceId : undefined;
         }
       }
     }
-    return undefined;
+    return {
+      ...(parentSessionId ? { parentSessionId } : {}),
+      ...(sourceType ? { sourceType } : {}),
+      ...(sourceId !== undefined ? { sourceId } : {}),
+    };
   }
 
   /**
@@ -920,7 +959,7 @@ export class SessionService {
       const prompt = this.extractFirstPromptFromRecords(records);
 
       const titleInfo = this.readSessionTitleInfoFromFile(filePath, tailBuffer);
-      const parentSessionId = this.extractParentSessionIdFromRecords(records);
+      const source = this.extractCreationMetadataFromRecords(records);
       items.push({
         sessionId: firstRecord.sessionId,
         cwd: firstRecord.cwd,
@@ -933,7 +972,11 @@ export class SessionService {
         // and `countSessionMessages` for the rationale.
         customTitle: titleInfo.title,
         titleSource: titleInfo.source,
-        ...(parentSessionId ? { parentSessionId } : {}),
+        ...(source.parentSessionId
+          ? { parentSessionId: source.parentSessionId }
+          : {}),
+        ...(source.sourceType ? { sourceType: source.sourceType } : {}),
+        ...(source.sourceId !== undefined ? { sourceId: source.sourceId } : {}),
         isArchived,
       });
     }
@@ -1550,12 +1593,15 @@ export class SessionService {
       records,
       activeMessages,
     ).filter(
-      // A fork is a fresh top-level session, NOT a `create_sub_session` child.
-      // Copying the source's `parent_session` record would make the fork report
-      // the original's parent as its own, so `?parentSessionId=` lists the fork
-      // as a direct child of a session that never spawned it. Drop the lineage.
+      // A fork is a fresh top-level session with its own creation metadata.
+      // Inheriting either record would falsely attribute the fork to the
+      // source session's parent or creator.
       (record) =>
-        !(record.type === 'system' && record.subtype === 'parent_session'),
+        !(
+          record.type === 'system' &&
+          (record.subtype === 'parent_session' ||
+            record.subtype === 'session_source')
+        ),
     );
     if (sourceRecords.length === 0) {
       throw new Error(`Source session not found or empty: ${sourceSessionId}`);

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -13,6 +13,7 @@ import { DaemonAuthFlow } from './DaemonAuthFlow.js';
 import { DaemonHttpError } from './DaemonHttpError.js';
 import type { DaemonTransport } from './DaemonTransport.js';
 import { RestSseTransport } from './RestSseTransport.js';
+import { DaemonCapabilityMissingError } from './types.js';
 import type {
   DaemonAgentMutationResult,
   DaemonAuthProviderId,
@@ -375,6 +376,10 @@ export interface CreateSessionRequest {
    */
   sessionScope?: 'single' | 'thread';
   approvalMode?: string;
+  /** Immutable creator attribution stored with a newly created session. */
+  sourceType?: string;
+  /** Optional source-specific identifier. Requires `sourceType`. */
+  sourceId?: string;
 }
 
 export interface RestoreSessionRequest {
@@ -828,6 +833,16 @@ export class DaemonClient {
         return (await res.json()) as DaemonCapabilities;
       },
     );
+  }
+
+  async requireCapability(capability: string): Promise<void> {
+    const caps = await this.capabilities();
+    if (!caps.features.includes(capability)) {
+      throw new DaemonCapabilityMissingError(
+        capability,
+        `daemon does not advertise the ${capability} feature`,
+      );
+    }
   }
 
   /**
@@ -1783,6 +1798,9 @@ export class DaemonClient {
     req: CreateSessionRequest,
     clientId?: string,
   ): Promise<DaemonSession> {
+    if (req.sourceType !== undefined || req.sourceId !== undefined) {
+      await this.requireCapability('session_source_metadata');
+    }
     // Omitting `cwd` lets the daemon fall back to its
     // primary workspace. JSON.stringify strips `undefined` values, so
     // `cwd: undefined` becomes "no `cwd` key" on the wire — and the
@@ -1815,6 +1833,10 @@ export class DaemonClient {
           ...(req.approvalMode !== undefined
             ? { approvalMode: req.approvalMode }
             : {}),
+          ...(req.sourceType !== undefined
+            ? { sourceType: req.sourceType }
+            : {}),
+          ...(req.sourceId !== undefined ? { sourceId: req.sourceId } : {}),
         }),
       },
       async (res) => {
@@ -1834,6 +1856,8 @@ export class DaemonClient {
       pageSize?: number;
       archiveState?: DaemonSessionArchiveState;
       parentSessionId?: string;
+      sourceType?: string;
+      sourceId?: string;
     },
   ): Promise<DaemonSessionSummary[]> {
     const page = await this.listWorkspaceSessionsPage(workspaceCwd, options);
@@ -1844,6 +1868,9 @@ export class DaemonClient {
     workspaceCwd: string,
     options?: DaemonSessionListPageOptions,
   ): Promise<DaemonSessionListPage> {
+    if (options?.sourceType !== undefined || options?.sourceId !== undefined) {
+      await this.requireCapability('session_source_metadata');
+    }
     const requestedPageSize =
       options?.pageSize ?? DEFAULT_SESSION_LIST_PAGE_SIZE;
     const pageSize = Math.max(
@@ -1872,6 +1899,12 @@ export class DaemonClient {
     }
     if (options?.parentSessionId !== undefined) {
       query.set('parentSessionId', options.parentSessionId);
+    }
+    if (options?.sourceType !== undefined) {
+      query.set('sourceType', options.sourceType);
+    }
+    if (options?.sourceId !== undefined) {
+      query.set('sourceId', options.sourceId);
     }
     return await this.jsonRequest<DaemonSessionListPage>(
       `/workspace/${urlEncode(workspaceCwd)}/sessions?${query.toString()}`,
@@ -4061,9 +4094,12 @@ export class WorkspaceDaemonClient {
     );
   }
 
-  listWorkspaceSessionsPage(
+  async listWorkspaceSessionsPage(
     options?: DaemonSessionListPageOptions,
   ): Promise<DaemonSessionListPage> {
+    if (options?.sourceType !== undefined || options?.sourceId !== undefined) {
+      await this.client.requireCapability('session_source_metadata');
+    }
     const requestedPageSize =
       options?.pageSize ?? DEFAULT_SESSION_LIST_PAGE_SIZE;
     const pageSize = Math.max(
@@ -4087,7 +4123,13 @@ export class WorkspaceDaemonClient {
     if (options?.parentSessionId !== undefined) {
       query.set('parentSessionId', options.parentSessionId);
     }
-    return this.get(
+    if (options?.sourceType !== undefined) {
+      query.set('sourceType', options.sourceType);
+    }
+    if (options?.sourceId !== undefined) {
+      query.set('sourceId', options.sourceId);
+    }
+    return await this.get(
       `/sessions?${query.toString()}`,
       'GET /workspaces/:workspace/sessions',
     );

--- a/packages/sdk-typescript/src/daemon/acpRouteTable.ts
+++ b/packages/sdk-typescript/src/daemon/acpRouteTable.ts
@@ -761,6 +761,8 @@ export const ROUTE_TABLE: readonly RouteEntry[] = [
           ...strParam(query, 'view'),
           ...strParam(query, 'group'),
           ...strParam(query, 'parentSessionId'),
+          ...strParam(query, 'sourceType'),
+          ...strParam(query, 'sourceId'),
           ...(size == null || size === ''
             ? {}
             : { _meta: { size: Number(size) } }),

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -456,6 +456,12 @@ export interface DaemonSession {
   createdAt?: string;
   /** True while the live session has an in-flight prompt. */
   hasActivePrompt?: boolean;
+  /** Immutable creator attribution, absent on legacy/unattributed sessions. */
+  sourceType?: string;
+  /** Optional source-specific identifier paired with `sourceType`. */
+  sourceId?: string;
+  /** True iff supplied source metadata was durably written to the transcript. */
+  sourcePersisted?: boolean;
 }
 
 /**
@@ -573,6 +579,10 @@ export interface DaemonSessionSummary {
    * absent for a top-level session. Lets a UI link a sub-session back to its
    * parent. */
   parentSessionId?: string;
+  /** Immutable creator attribution, absent on legacy/unattributed sessions. */
+  sourceType?: string;
+  /** Optional source-specific identifier paired with `sourceType`. */
+  sourceId?: string;
   clientCount?: number;
   hasActivePrompt?: boolean;
   isWaitingForPermission?: boolean;
@@ -701,6 +711,10 @@ export interface DaemonSessionListPageOptions {
    * opaque and activity-based.
    */
   parentSessionId?: string;
+  /** Restrict the page to sessions attributed to this source type. */
+  sourceType?: string;
+  /** Restrict the page to this source identifier. Requires `sourceType`. */
+  sourceId?: string;
 }
 
 export interface DaemonSessionListPage {

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1501,6 +1501,65 @@ describe('DaemonClient', () => {
       });
     });
 
+    it('forwards session source metadata when supplied', async () => {
+      const { fetch, calls } = recordingFetch((request) =>
+        request.url.endsWith('/capabilities')
+          ? jsonResponse(200, {
+              v: 1,
+              mode: 'http-bridge',
+              features: ['session_source_metadata'],
+              modelServices: [],
+            })
+          : jsonResponse(200, {
+              sessionId: 's-1',
+              workspaceCwd: '/work/a',
+              attached: false,
+              sourceType: 'scheduled_task',
+              sourceId: 'task-123',
+            }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      const session = await client.createOrAttachSession({
+        workspaceCwd: '/work/a',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+
+      expect(session).toMatchObject({
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+      expect(calls[0]?.url).toBe('http://daemon/capabilities');
+      expect(JSON.parse(calls[1]!.body!)).toEqual({
+        cwd: '/work/a',
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      });
+    });
+
+    it('rejects source metadata before creating against an old daemon', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          v: 1,
+          mode: 'http-bridge',
+          features: ['session_create'],
+          modelServices: [],
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await expect(
+        client.createOrAttachSession({ sourceType: 'scheduled_task' }),
+      ).rejects.toMatchObject({
+        name: 'DaemonCapabilityMissingError',
+        capability: 'session_source_metadata',
+      });
+      expect(calls.map((call) => call.url)).toEqual([
+        'http://daemon/capabilities',
+      ]);
+    });
+
     it('sends client identity in a header, not the request body', async () => {
       const { fetch, calls } = recordingFetch(() =>
         jsonResponse(200, {
@@ -2712,6 +2771,67 @@ describe('DaemonClient', () => {
       expect(calls[0]?.url).toBe(
         'http://daemon/workspaces/%2Fwork%2Fa/sessions?size=20&parentSessionId=P',
       );
+    });
+
+    it('serializes source filters into both workspace session-list clients', async () => {
+      const { fetch, calls } = recordingFetch((request) =>
+        request.url.endsWith('/capabilities')
+          ? jsonResponse(200, {
+              v: 1,
+              mode: 'http-bridge',
+              features: ['session_source_metadata'],
+              modelServices: [],
+            })
+          : jsonResponse(200, {
+              sessions: [
+                {
+                  sessionId: 's-source',
+                  workspaceCwd: '/work/a',
+                  sourceType: 'scheduled_task',
+                  sourceId: 'task-123',
+                },
+              ],
+            }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      const options = {
+        sourceType: 'scheduled_task',
+        sourceId: 'task-123',
+      };
+
+      await client.listWorkspaceSessionsPage('/work/a', options);
+      await client.workspaceByCwd('/work/a').listWorkspaceSessionsPage(options);
+
+      expect(calls.map((call) => call.url)).toEqual([
+        'http://daemon/capabilities',
+        'http://daemon/workspace/%2Fwork%2Fa/sessions?size=20&sourceType=scheduled_task&sourceId=task-123',
+        'http://daemon/capabilities',
+        'http://daemon/workspaces/%2Fwork%2Fa/sessions?size=20&sourceType=scheduled_task&sourceId=task-123',
+      ]);
+    });
+
+    it('rejects source filtering before listing against an old daemon', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          v: 1,
+          mode: 'http-bridge',
+          features: ['session_list'],
+          modelServices: [],
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await expect(
+        client.listWorkspaceSessionsPage('/work/a', {
+          sourceType: 'scheduled_task',
+        }),
+      ).rejects.toMatchObject({
+        name: 'DaemonCapabilityMissingError',
+        capability: 'session_source_metadata',
+      });
+      expect(calls.map((call) => call.url)).toEqual([
+        'http://daemon/capabilities',
+      ]);
     });
 
     it('manages session groups and session organization', async () => {


### PR DESCRIPTION
## What this PR does

This PR adds immutable `sourceType` and `sourceId` attribution metadata to daemon sessions. Callers can provide the metadata when creating a session, session status and workspace session-list responses expose it, and workspace session lists can be filtered by source. The metadata is persisted in session recordings, restored after daemon restarts, validated consistently across REST, ACP, bridge, CLI, and SDK boundaries, and deliberately removed when a session is forked.

Scheduled tasks now tag their dedicated sessions with `sourceType: scheduled_task` and the task ID as `sourceId`, including sessions created by keepalive recovery. Restoring those sessions after a daemon restart preserves the attribution.

The SDK checks the daemon capability before using source-aware creation or filtering so an older daemon cannot silently ignore the requested semantics. Session cleanup also only removes a newly persisted recording after the bridge confirms that the disconnected session was actually reaped.

## Why it's needed

Daemon clients currently cannot reliably identify which subsystem created a session. Parent-session metadata does not solve this for top-level sessions such as scheduled-task sessions, and inference from prompts or runtime state is not durable. Explicit persisted attribution lets callers count, query, and audit sessions created by a task or another source without including unrelated child sessions.

## Reviewer Test Plan

### How to verify

1. Create a daemon session with a valid `sourceType` and optional `sourceId`; confirm both fields appear in the individual session status and workspace session-list responses after restarting the daemon.
2. Query the workspace session list with `sourceType`, and with `sourceType` plus `sourceId`; confirm only matching sessions are returned and cursors cannot be replayed with different filters.
3. Create a scheduled task; confirm its bound session reports `sourceType: scheduled_task` and `sourceId` equal to the task ID. Confirm the same attribution remains after keepalive recovery or daemon restart.
4. Confirm invalid values are rejected, `sourceId` without `sourceType` is rejected, an existing session's attribution cannot be changed, and forks do not inherit source attribution.
5. Use the TypeScript SDK against a daemon without the new capability; confirm source-aware creation and filtering fail explicitly instead of being silently ignored.

Automated verification completed locally: full build and typecheck; 117 Core tests; 404 ACP bridge tests; 267 SDK tests; 85 scheduled-task route/keepalive tests; and targeted CLI tests covering source metadata, filtering, and orphan cleanup. The large CLI server test file was also exercised, but unrelated existing tests showed non-deterministic failures across runs; all tests on paths changed by this PR passed in isolation.

### Evidence (Before & After)

N/A — daemon API, persistence, and SDK behavior only; no UI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node.js workspace build and package-scoped Vitest runs, without a sandbox.

## Risk & Scope

- Main risk or tradeoff: This is a cross-package protocol addition. Capability negotiation prevents new SDK calls from silently degrading against older daemons, while existing callers and sessions remain compatible because the metadata is optional.
- Not validated / out of scope: Windows and Linux were not tested locally. This does not backfill attribution for existing sessions that never recorded source metadata.
- Breaking changes / migration notes: None. Existing session creation and listing calls continue to work without source fields.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为 daemon Session 增加不可变的 `sourceType` 和 `sourceId` 归因元数据。调用方可以在创建 Session 时传入这些字段；单个 Session 状态和工作区 Session 列表响应会返回这些字段；工作区 Session 列表也支持按来源过滤。元数据会持久化到 Session 录制文件，在 daemon 重启后恢复，并在 REST、ACP、bridge、CLI 和 SDK 各层进行一致校验。Fork Session 时会明确移除来源归因，避免错误继承。

调度任务现在会给其专用 Session 写入 `sourceType: scheduled_task`，并以任务 ID 作为 `sourceId`，包括 keepalive 恢复过程中补建的 Session。daemon 重启后恢复这些 Session 时，来源归因也会保留。

SDK 在执行带来源的创建或过滤前会检查 daemon capability，避免旧 daemon 静默忽略所请求的语义。Session 清理逻辑也只会在 bridge 确认断连 Session 确实已被回收后，才删除刚创建的持久化录制文件。

## 为什么需要

目前 daemon 客户端无法可靠识别某个 Session 是由哪个子系统创建的。父 Session 元数据无法解决调度任务等顶层 Session 的来源问题，通过 prompt 或运行时状态推断也无法持久保存。显式且持久化的归因信息可以让调用方统计、查询和审计某个任务或其他来源创建的 Session，同时不包含无关的子 Session。

## Reviewer Test Plan

### 如何验证

1. 使用有效的 `sourceType` 和可选的 `sourceId` 创建 daemon Session；重启 daemon 后，确认单个 Session 状态和工作区 Session 列表响应仍包含这两个字段。
2. 分别使用 `sourceType`、`sourceType` 加 `sourceId` 查询工作区 Session 列表；确认只返回匹配的 Session，并且游标不能在不同过滤条件间复用。
3. 创建调度任务；确认其绑定 Session 的 `sourceType` 为 `scheduled_task`，`sourceId` 等于任务 ID。确认 keepalive 恢复或 daemon 重启后归因保持不变。
4. 确认非法值会被拒绝，只有 `sourceId` 而没有 `sourceType` 会被拒绝，已有 Session 的归因不能更改，Fork 不会继承来源归因。
5. 使用 TypeScript SDK 连接不支持新 capability 的 daemon；确认带来源的创建和过滤会明确失败，而不是被静默忽略。

本地已完成自动验证：完整 build 和 typecheck；117 个 Core 测试；404 个 ACP bridge 测试；267 个 SDK 测试；85 个调度任务 route/keepalive 测试；以及覆盖来源元数据、过滤和孤儿 Session 清理的 CLI 定向测试。也运行了大型 CLI server 测试文件，但其中与本 PR 无关的既有测试在不同轮次出现非确定性失败；本 PR 修改路径上的测试均已隔离通过。

### 证据（Before & After）

N/A——仅涉及 daemon API、持久化和 SDK 行为，没有 UI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node.js 工作区构建及按 package 运行的 Vitest 测试，未使用 sandbox。

## 风险与范围

- 主要风险或权衡：这是一个跨 package 的协议扩展。Capability 协商可以阻止新版 SDK 调用在旧 daemon 上静默降级；由于元数据为可选字段，现有调用方和已有 Session 保持兼容。
- 未验证或不在范围内：未在本地测试 Windows 和 Linux；不会为从未记录来源元数据的已有 Session 回填归因。
- 破坏性变更或迁移说明：无。不传来源字段的现有 Session 创建和列表调用继续正常工作。

## 关联 Issue

N/A

</details>
