### PR TITLE
fix(web-shell): restore portal root hook import

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -17,6 +17,7 @@ import type { UseDaemonFollowupSuggestionReturn } from '@qwen-code/webui/daemon-
 import type { CommandDisplayCategoryOrder } from '../utils/commandDisplay';
 import type { SkillInfo } from '../completions/slashCompletion';
 import { useI18n } from '../i18n';
+import { useWebShellPortalRoot } from '../portalRoot';
 import {
   useWebShellCustomization,
   type WebShellComposerInput,


### PR DESCRIPTION
## What this PR does

Restores the portal-root hook import used by composer tag tooltips.

## Why it's needed

A recent composer popover refactor removed the import while the composer tag tooltip path still calls the hook. This causes the Web Shell TypeScript build to fail with `TS2304: Cannot find name useWebShellPortalRoot`, blocking main-branch E2E jobs before tests start.

## Reviewer Test Plan

### How to verify

Run the repository build and confirm the Web Shell completes its application build, library build, and TypeScript declaration check without the previous `TS2304` error.

### Evidence (Before & After)

Before: main fails in the Web Shell TypeScript build because the portal-root hook name is unresolved.

After: `npm run build` completes successfully, including `tsc -p tsconfig.lib.json` for the Web Shell.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS workspace with Node.js 22 and locked npm dependencies.

## Risk & Scope

- Main risk or tradeoff: Minimal; this restores the import for an existing call site.
- Not validated / out of scope: Interactive browser behavior was not manually retested.
- Breaking changes / migration notes: None.

## Linked Issues

Resolves #6933

<details>
<summary>中文说明</summary>

## 本 PR 的修改

恢复 composer 标签 tooltip 所使用的 portal root hook import。

## 修改原因

最近的 composer popover 重构删除了该 import，但 composer 标签 tooltip 路径仍然调用这个 hook，导致 Web Shell TypeScript 构建报 `TS2304: Cannot find name useWebShellPortalRoot`，main 分支的 E2E 任务在测试开始前就被阻断。

## Reviewer Test Plan

### 验证方式

运行仓库构建，确认 Web Shell 的应用构建、library 构建和 TypeScript declaration 检查均完成，并且不再出现之前的 `TS2304` 错误。

### 修改前后证据

修改前：main 在 Web Shell TypeScript 构建阶段因为无法解析 portal root hook 名称而失败。

修改后：`npm run build` 成功完成，包括 Web Shell 的 `tsc -p tsconfig.lib.json`。

### 测试环境

macOS：已测试；Windows、Linux：未测试。使用 Node.js 22 和锁定的 npm 依赖。

## 风险与范围

- 主要风险或权衡：极低；仅恢复现有调用点所需的 import。
- 未验证/范围外：未手动重测浏览器交互。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Resolves #6933

</details>