### PR TITLE
fix(core): respect enableManagedAutoMemory in memory availability

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -4301,6 +4301,28 @@ describe('Server Config (config.ts)', () => {
     expect(config.getUserMemory()).toContain('MEMORY.md is currently empty');
   });
 
+  it('refreshHierarchicalMemory should omit managed auto-memory prompt when disabled', async () => {
+    const config = new Config({
+      ...baseParams,
+      enableManagedAutoMemory: false,
+    });
+
+    vi.mocked(loadServerHierarchicalMemory).mockResolvedValue({
+      memoryContent: '--- Context from: QWEN.md ---\nProject rules',
+      fileCount: 1,
+      ruleCount: 0,
+      conditionalRules: [],
+      projectRoot: '/tmp',
+    });
+    vi.mocked(readAutoMemoryIndex).mockResolvedValue(null);
+
+    await config.refreshHierarchicalMemory();
+
+    expect(config.getUserMemory()).toContain('Project rules');
+    expect(config.getUserMemory()).not.toContain('# auto memory');
+    expect(readAutoMemoryIndex).not.toHaveBeenCalled();
+  });
+
   it('refreshHierarchicalMemory should only use explicit inputs in bare mode', async () => {
     const config = new Config({
       ...baseParams,
@@ -4336,13 +4358,13 @@ describe('Server Config (config.ts)', () => {
       expect(config.isManagedMemoryAvailable()).toBe(false);
     });
 
-    it('returns true even when enableManagedAutoMemory is false', () => {
+    it('returns false when enableManagedAutoMemory is false', () => {
       const config = new Config({
         ...baseParams,
         enableManagedAutoMemory: false,
         bareMode: false,
       });
-      expect(config.isManagedMemoryAvailable()).toBe(true);
+      expect(config.isManagedMemoryAvailable()).toBe(false);
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -5687,7 +5687,7 @@ export class Config {
   }
 
   isManagedMemoryAvailable(): boolean {
-    return !this.getBareMode();
+    return this.enableManagedAutoMemory && !this.getBareMode();
   }
 
   getManagedAutoDreamEnabled(): boolean {


### PR DESCRIPTION
## What this PR does

Makes managed-memory availability respect the existing `memory.enableManagedAutoMemory` setting. When managed auto-memory is disabled, `isManagedMemoryAvailable()` now returns `false`, so the `# auto memory` system-prompt block and related managed-memory surfaces stay aligned with the user's setting.

## Why it's needed

Fixes #6936. Before this change, `enableManagedAutoMemory: false` disabled managed-memory operations but still allowed the 7-9 KB `# auto memory` instruction block to be injected into the system prompt. That meant users who explicitly disabled auto-memory to save context still paid the prompt cost for capabilities the model could not use.

## Reviewer Test Plan

### How to verify

Review the updated `isManagedMemoryAvailable()` gate and the config regression coverage. The focused test now verifies both that `isManagedMemoryAvailable()` returns `false` when `enableManagedAutoMemory` is disabled and that `refreshHierarchicalMemory()` still keeps project memory while omitting the `# auto memory` block without reading the auto-memory index.

### Evidence (Before & After)

N/A — non-UI config behavior covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npm --workspace @qwen-code/qwen-code-core test -- src/config/config.test.ts` → 1 file passed, 396 tests passed. `npm --workspace @qwen-code/qwen-code-core run typecheck` → passed.

## Risk & Scope

- Main risk or tradeoff: `isManagedMemoryAvailable()` also gates managed-memory commands and surfaces, so disabling `memory.enableManagedAutoMemory` now hides those surfaces consistently with the operation gate.
- Not validated / out of scope: No new setting is introduced; this does not add a separate prompt-only strip option.
- Breaking changes / migration notes: No migration required. This intentionally preserves the existing bare-mode behavior and avoids broadening safe-mode semantics by not replacing the gate with `getManagedAutoMemoryEnabled()`.

## Linked Issues

Fixes #6936

<details>
<summary>中文说明</summary>

## What this PR does

让 managed memory 的可用性判断尊重现有的 `memory.enableManagedAutoMemory` 设置。当 managed auto-memory 被关闭时，`isManagedMemoryAvailable()` 现在会返回 `false`，因此 `# auto memory` system prompt 块以及相关 managed-memory 入口会和用户设置保持一致。

## Why it's needed

修复 #6936。此前 `enableManagedAutoMemory: false` 会禁用 managed-memory 操作，但仍允许 7-9 KB 的 `# auto memory` 指令块注入 system prompt。这意味着用户即使明确关闭 auto-memory 来节省上下文，仍然要为模型无法使用的能力支付 prompt 成本。

## Reviewer Test Plan

### How to verify

检查更新后的 `isManagedMemoryAvailable()` 门控和 config 回归测试。聚焦测试现在同时验证：当 `enableManagedAutoMemory` 被关闭时，`isManagedMemoryAvailable()` 返回 `false`；并且 `refreshHierarchicalMemory()` 仍保留项目 memory，但不会注入 `# auto memory` 块，也不会读取 auto-memory index。

### Evidence (Before & After)

N/A — 这是非 UI 配置行为，由单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npm --workspace @qwen-code/qwen-code-core test -- src/config/config.test.ts` → 1 个测试文件通过，396 个测试通过。`npm --workspace @qwen-code/qwen-code-core run typecheck` → 通过。

## Risk & Scope

- Main risk or tradeoff: `isManagedMemoryAvailable()` 也会门控 managed-memory 命令和界面入口，因此关闭 `memory.enableManagedAutoMemory` 后这些入口会与操作门控保持一致地隐藏。
- Not validated / out of scope: 没有新增设置；本 PR 不提供单独的 prompt-only strip 选项。
- Breaking changes / migration notes: 不需要迁移。本 PR 有意保留现有 bare mode 行为，并且没有直接替换为 `getManagedAutoMemoryEnabled()`，避免顺手扩大 safe mode 语义。

## Linked Issues

Fixes #6936

</details>