### PR TITLE
feat(review): build the Step 4 verifier and Step 5 reverse-audit prompts in code

### DIFF
--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -370,6 +370,31 @@ describe('agent-prompt (command boundary)', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('drives the verify role end-to-end through the handler', () => {
+    // verify is covered via buildRoleBrief / buildRoleLaunchPrompt directly; this is
+    // the one new role whose full handler path — brief write, record key, and the
+    // `output: 'verdicts'` branch of tail() — was not driven end-to-end.
+    const dir = mkdtempSync(join(tmpdir(), 'ap-verify-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      expect(() =>
+        (agentPromptCommand.handler as (a: unknown) => void)({
+          plan,
+          role: 'verify',
+        }),
+      ).not.toThrow();
+      const recorded = readRecordedPrompts(plan);
+      expect([...recorded.keys()]).toEqual(['verify']);
+      const briefText = readFileSync(briefPath(plan, 'verify'), 'utf8');
+      // The verdict branch: Exclusion Criteria yes, finding format no.
+      expect(briefText).toContain('What is NOT a finding');
+      expect(briefText).not.toContain('**Anchor:**');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // The half of the fan-out this command did not cover. Measured against one real
@@ -427,12 +452,25 @@ describe('buildWholeDiffBlock — the agents that walk the whole diff', () => {
     [
       'a non-reverse role + chunk',
       { chunk: 13, role: '2' },
-      /combines with --role only for reverse-audit/,
+      // The message names the set it read from `acceptsChunk`, not a hardcoded role.
+      /only for a per-chunk role \(reverse-audit\); role "2" does not take --chunk/,
     ],
     [
       'whole-diff + role',
       { 'whole-diff': true, role: '2' },
       /--whole-diff builds the diff-reading block alone/,
+    ],
+    [
+      'whole-diff + file',
+      { 'whole-diff': true, file: 'foo.ts' },
+      /--whole-diff builds the diff-reading block alone/,
+    ],
+    [
+      // A stray --file on a role that does not read a file would key its record by
+      // that file, colliding with — and masking — a real file-keyed record.
+      'reverse-audit + chunk + a stray file',
+      { role: 'reverse-audit', chunk: 14, file: 'foo.ts' },
+      /role "reverse-audit" does not take --file/,
     ],
     [
       'all three',

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -388,24 +388,51 @@ describe('buildWholeDiffBlock — the agents that walk the whole diff', () => {
   });
 
   it.each([
-    ['none of the three', {}],
-    ['chunk + whole-diff', { chunk: 13, 'whole-diff': true }],
-    ['chunk + role', { chunk: 13, role: '2' }],
-    ['whole-diff + role', { 'whole-diff': true, role: '2' }],
-    ['all three', { chunk: 13, 'whole-diff': true, role: '2' }],
-  ])('rejects a call that names %s', (_, extra) => {
-    // Three mutually exclusive modes: a territory chunk, a named role, or the
-    // bare whole-diff block. A run that named none used to fall through to the
-    // chunk builder with `undefined` and blame the plan for "no chunk undefined";
+    ['none of the three', {}, /exactly one of/],
+    [
+      'chunk + whole-diff',
+      { chunk: 13, 'whole-diff': true },
+      /--whole-diff builds the diff-reading block alone/,
+    ],
+    [
+      'a non-reverse role + chunk',
+      { chunk: 13, role: '2' },
+      /combines with --role only for reverse-audit/,
+    ],
+    [
+      'whole-diff + role',
+      { 'whole-diff': true, role: '2' },
+      /--whole-diff builds the diff-reading block alone/,
+    ],
+    [
+      'all three',
+      { chunk: 13, 'whole-diff': true, role: '2' },
+      /--whole-diff builds the diff-reading block alone/,
+    ],
+  ])('rejects a call that names %s', (_, extra, pattern) => {
+    // A territory chunk, a named role, or the bare whole-diff block — one primary
+    // mode. A run that named none used to blame the plan for "no chunk undefined";
     // a run that named two would silently pick one. The guard runs before the plan
-    // is read, so the message is about the call, and it covers every bad shape —
-    // not just the two the first version tested.
+    // is read, so the message is about the call, and it names the specific bad shape.
     expect(() =>
       (agentPromptCommand.handler as (a: unknown) => void)({
         plan: '/nonexistent/plan.json',
         ...extra,
       }),
-    ).toThrow(/exactly one of/);
+    ).toThrow(pattern as RegExp);
+  });
+
+  it('accepts --role reverse-audit --chunk N — the one legal role+chunk combo', () => {
+    // A Step 3B reverse-audit agent owns one chunk's territory. The guard lets that
+    // one through, and the launch prompt reads exactly that chunk's range — not the
+    // whole diff, which is what makes a large-PR reverse auditor context-starved.
+    const p = buildRoleLaunchPrompt(PLAN, 'reverse-audit', '/t/ra.brief.md', {
+      chunk: 14,
+    });
+    // Chunk 14 is lines 4025-4200 → offset 4024, limit 176.
+    expect(p).toContain('offset=4024, limit=176');
+    // and NOT chunk 13's or chunk 15's range.
+    expect(p).not.toContain('offset=3807');
   });
 });
 
@@ -844,5 +871,49 @@ describe('an invariant agent reads its file, not the whole review', () => {
     expect(p).toContain('offset=0, limit=400');
     expect(p).toContain('offset=400, limit=400');
     expect(p).toContain('offset=800, limit=400');
+  });
+});
+
+// Step 4 and Step 5 agents: their methodology now lives in code, not in prose the
+// orchestrator retypes each run. The rules pinned here are the ones a paraphrase
+// would have dropped — and one of them (the documented-intent gate) is the exact
+// rule a real run skipped when it auto-posted a false "leaks tokens" Critical.
+describe('verify and reverse-audit briefs — the Step 4/5 methodology, in code', () => {
+  it('the verify brief carries the reject-a-Critical high bar and the documented-intent gate', () => {
+    const p = buildRoleBrief(PLAN, 'verify');
+    // The verdict is a trace, not a vote.
+    expect(p).toMatch(/trac(e|ing) it through the real code/i);
+    // Rejecting a Critical needs quoted contradicting code, floors at low otherwise.
+    expect(p).toContain('quote the specific code that contradicts');
+    expect(p).toMatch(/floor is `confirmed \(low confidence\)`/);
+    // The documented-intent gate — the rule the token-leak false positive skipped.
+    expect(p).toContain('documented intent');
+    expect(p).toMatch(/documentation does not make a harm safe/);
+    // Agent 0 findings are not disproved by a green test.
+    expect(p).toMatch(/do not reject an issue-fidelity/i);
+  });
+
+  it('the verify brief is a verdict role: Exclusion Criteria yes, finding format no', () => {
+    const p = buildRoleBrief(PLAN, 'verify');
+    expect(p).toContain('What is NOT a finding'); // the Exclusion Criteria heading
+    // It rules on findings; it does not file them, so no finding-format block.
+    expect(p).not.toContain('**Anchor:**');
+  });
+
+  it('the reverse-audit brief hunts gaps and demands a substantive receipt', () => {
+    const p = buildRoleBrief(PLAN, 'reverse-audit');
+    expect(p).toMatch(/find the \*\*gaps\*\*/);
+    expect(p).toMatch(/Report only Critical or Suggestion/i);
+    expect(p).toContain('say what you examined'); // the substantive-return receipt
+    // It DOES file findings, so it keeps the finding format.
+    expect(p).toContain('**Anchor:**');
+  });
+
+  it('both point the agent at its brief file and give it diff reads', () => {
+    for (const role of ['verify', 'reverse-audit'] as const) {
+      const launch = buildRoleLaunchPrompt(PLAN, role, `/t/${role}.brief.md`);
+      expect(launch).toContain(`read_file(file_path="/t/${role}.brief.md")`);
+      expect(launch).toContain(PLAN.diffPathAbsolute);
+    }
   });
 });

--- a/packages/cli/src/commands/review/agent-prompt.test.ts
+++ b/packages/cli/src/commands/review/agent-prompt.test.ts
@@ -340,6 +340,36 @@ describe('agent-prompt (command boundary)', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('lets --role reverse-audit --chunk N through and keys the record by its chunk', () => {
+    // The unit tests build the launch prompt directly, bypassing the guard and the
+    // key derivation. This drives the real handler: the guard must let the one legal
+    // role+chunk combo through, the record key must carry the chunk — the delivery
+    // check finds the recorded prompt by that key — and the brief it points at must
+    // read that chunk alone, so brief and launch prompt agree on one chunk's range.
+    const dir = mkdtempSync(join(tmpdir(), 'ap-ra-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      expect(() =>
+        (agentPromptCommand.handler as (a: unknown) => void)({
+          plan,
+          role: 'reverse-audit',
+          chunk: 14,
+        }),
+      ).not.toThrow();
+      const recorded = readRecordedPrompts(plan);
+      expect([...recorded.keys()]).toEqual(['reverse-audit--chunk-14']);
+      const briefText = readFileSync(
+        briefPath(plan, 'reverse-audit--chunk-14'),
+        'utf8',
+      );
+      expect(briefText).toContain('offset=4024, limit=176'); // chunk 14 only
+      expect(briefText).not.toContain('offset=3807'); // not chunk 13
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // The half of the fan-out this command did not cover. Measured against one real
@@ -433,6 +463,31 @@ describe('buildWholeDiffBlock — the agents that walk the whole diff', () => {
     expect(p).toContain('offset=4024, limit=176');
     // and NOT chunk 13's or chunk 15's range.
     expect(p).not.toContain('offset=3807');
+  });
+
+  it('rejects --role reverse-audit --chunk N when the plan has no such chunk', () => {
+    // The happy path uses chunk 14, which the fixture has. A wrong chunk must name
+    // what the plan actually holds — not emit offset=NaN, and not credit an empty read.
+    expect(() =>
+      buildRoleLaunchPrompt(PLAN, 'reverse-audit', '/t/ra.brief.md', {
+        chunk: 999,
+      }),
+    ).toThrow(/the plan has no chunk 999/);
+    // Through the handler the brief is built first, and rejects it the same way.
+    const dir = mkdtempSync(join(tmpdir(), 'ap-ra-bad-'));
+    try {
+      const plan = join(dir, 'plan.json');
+      writeFileSync(plan, JSON.stringify(PLAN));
+      expect(() =>
+        (agentPromptCommand.handler as (a: unknown) => void)({
+          plan,
+          role: 'reverse-audit',
+          chunk: 999,
+        }),
+      ).toThrow(/the plan has no chunk 999/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -907,6 +962,24 @@ describe('verify and reverse-audit briefs — the Step 4/5 methodology, in code'
     expect(p).toContain('say what you examined'); // the substantive-return receipt
     // It DOES file findings, so it keeps the finding format.
     expect(p).toContain('**Anchor:**');
+  });
+
+  it('scopes a per-chunk reverse-audit brief to its one chunk, not the whole diff', () => {
+    // The brief is what the agent is told to obey. If it listed every chunk and said
+    // "walk it chunk by chunk", a `--chunk 14` auditor would read the whole diff the
+    // per-chunk design exists to spare it. Its brief reads chunk 14's range alone —
+    // the same range its launch prompt reads.
+    const scoped = buildRoleBrief(PLAN, 'reverse-audit', { chunk: 14 });
+    expect(scoped).toContain('offset=4024, limit=176'); // chunk 14
+    expect(scoped).not.toContain('offset=3807'); // not chunk 13
+    expect(scoped).not.toContain('offset=4200'); // not chunk 15
+    expect(scoped).toContain('chunk 14');
+    expect(scoped).not.toMatch(/Walk it chunk by chunk/);
+    // A whole-diff (3A) reverse audit, with no chunk, still walks every chunk.
+    const whole = buildRoleBrief(PLAN, 'reverse-audit');
+    expect(whole).toContain('offset=3807');
+    expect(whole).toContain('offset=4024, limit=176');
+    expect(whole).toMatch(/Walk it chunk by chunk/);
   });
 
   it('both point the agent at its brief file and give it diff reads', () => {

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -321,6 +321,19 @@ export function buildChunkAgentPrompt(
 }
 
 /**
+ * A diff line range as a `read_file` window. The `-1` / `+1` is the single place a
+ * 1-based inclusive `[startLine, endLine]` becomes a 0-based `offset` and a `limit`.
+ * It used to be spelled out at five sites; an off-by-one fix, or a change in how
+ * `read_file` windows, now lands here once instead of in five that could drift apart.
+ */
+function diffWindow(
+  startLine: number,
+  endLine: number,
+): { offset: number; limit: number } {
+  return { offset: startLine - 1, limit: endLine - startLine + 1 };
+}
+
+/**
  * The launch prompt for a territory agent: short, and it points at the brief.
  *
  * The same arithmetic that moved the dimension agents' briefs onto disk applies
@@ -342,8 +355,7 @@ export function buildChunkLaunchPrompt(
   briefFile: string,
 ): string {
   const { diffPath, chunk, total } = chunkFrom(report, id);
-  const offset = chunk.startLine - 1;
-  const limit = chunk.endLine - chunk.startLine + 1;
+  const { offset, limit } = diffWindow(chunk.startLine, chunk.endLine);
 
   return [
     `You are review agent \`chunk ${chunk.id} of ${total}\` — the territory agent for ` +
@@ -457,8 +469,7 @@ function diffReadingBlock(
             `(startLine=${c?.startLine}, endLine=${c?.endLine}).`,
         );
       }
-      const offset = c.startLine - 1;
-      const limit = c.endLine - c.startLine + 1;
+      const { offset, limit } = diffWindow(c.startLine, c.endLine);
       return `read_file(file_path="${diffPath}", offset=${offset}, limit=${limit})`;
     })
     .join('\n');
@@ -597,8 +608,10 @@ function invariantFileBlock(
       : '**This file records no added ranges.** Judge only what the diff below shows changed.',
   ];
   if (f.diffRange) {
-    const offset = f.diffRange.startLine - 1;
-    const limit = f.diffRange.endLine - f.diffRange.startLine + 1;
+    const { offset, limit } = diffWindow(
+      f.diffRange.startLine,
+      f.diffRange.endLine,
+    );
     parts.push(
       '',
       "**Then read this file's own slice of the diff** — it is the only place the removed " +
@@ -807,7 +820,7 @@ function invariantDiffRange(
   const f = files.find((x) => x?.path === file);
   const r = f?.diffRange;
   if (!r) return [];
-  return [{ offset: r.startLine - 1, limit: r.endLine - r.startLine + 1 }];
+  return [diffWindow(r.startLine, r.endLine)];
 }
 
 /**
@@ -860,10 +873,7 @@ export function buildRoleLaunchPrompt(
     const allChunks = (
       Array.isArray(report.chunks) ? report.chunks : []
     ) as DiffChunk[];
-    const rangeOf = (c: DiffChunk) => ({
-      offset: c.startLine - 1,
-      limit: c.endLine - c.startLine + 1,
-    });
+    const rangeOf = (c: DiffChunk) => diffWindow(c.startLine, c.endLine);
     let ranges: Array<{ offset: number; limit: number }>;
     if (role.startsWith('invariant-')) {
       ranges = invariantDiffRange(report, opts.file);
@@ -918,26 +928,42 @@ function runAgentPrompt(args: AgentPromptArgs): void {
   // — an error about the plan, for a mistake in the call.
   const hasChunk = typeof args.chunk === 'number';
   const hasRole = typeof args.role === 'string' && args.role.length > 0;
+  const hasFile = typeof args.file === 'string' && args.file.length > 0;
   const hasWhole = !!args.wholeDiff;
   const bad = (msg: string): never => {
     throw new Error(`agent-prompt: ${msg}`);
   };
   if (hasWhole) {
-    if (hasChunk || hasRole) {
+    if (hasChunk || hasRole || hasFile) {
       bad(
-        '--whole-diff builds the diff-reading block alone; it takes no --chunk or --role.',
+        '--whole-diff builds the diff-reading block alone; it takes no --chunk, --role or --file.',
       );
     }
   } else if (hasRole) {
+    const role = args.role as RoleId;
     // `--chunk` combines with a role only when that role owns one chunk's territory
     // — a Step 3B reverse auditor. Which roles those are is declared on the brief
     // (`acceptsChunk`), not hardcoded here, so a new per-chunk role is a data change
-    // in agent-briefs, not an edit to this guard. Any other role + chunk is a mistake
-    // (a dimension agent walks the whole diff; a chunk agent is `--chunk` alone).
-    if (hasChunk && !BRIEFS[args.role as RoleId]?.acceptsChunk) {
+    // in agent-briefs, not an edit to this guard — and the message names the set it
+    // read, so it can never claim "only reverse-audit" while allowing another role.
+    if (hasChunk && !BRIEFS[role]?.acceptsChunk) {
+      const chunkRoles = (Object.keys(BRIEFS) as RoleId[]).filter(
+        (r) => BRIEFS[r].acceptsChunk,
+      );
       bad(
-        `--chunk combines with --role only for reverse-audit (a Step 3B per-chunk ` +
-          `auditor); role "${args.role}" does not take --chunk.`,
+        `--chunk combines with --role only for a per-chunk role ` +
+          `(${chunkRoles.join(', ')}); role "${role}" does not take --chunk.`,
+      );
+    }
+    // `--file` is the invariant agent's one scoping input, and the record key is
+    // derived from it. A stray --file on any other role would key that role's record
+    // by a file it never reads — colliding with, and masking, a real file-keyed
+    // record. Invariant roles are the only ones that take a file; they require it,
+    // and `buildRoleBrief` throws if one is launched without it.
+    if (hasFile && !role.startsWith('invariant-')) {
+      bad(
+        `--file scopes an invariant agent to one heavily-rewritten file; ` +
+          `role "${role}" does not take --file.`,
       );
     }
   } else if (!hasChunk) {

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -481,8 +481,18 @@ function diffReadingBlock(report: PlanReport, diffPath: string): string[] {
 }
 
 /** The closing half every prompt shares: how to report, and what "nothing" means. */
-function tail(rules?: string): string[] {
-  const parts = ['', FINDING_FORMAT, '', SEVERITY, '', EXCLUSIONS];
+function tail(
+  rules?: string,
+  output: 'findings' | 'verdicts' = 'findings',
+): string[] {
+  // The verifier does not file findings, so it gets no finding format and no
+  // severity ladder — its output shape is the verdict, defined in its own brief. It
+  // does get the Exclusion Criteria, because a finding that matches one is a
+  // rejection. Every other role produces findings and gets the full tail.
+  const parts =
+    output === 'verdicts'
+      ? ['', EXCLUSIONS]
+      : ['', FINDING_FORMAT, '', SEVERITY, '', EXCLUSIONS];
   if (rules && rules.trim()) {
     parts.push('', '## Project rules', '', rules.trim());
   }
@@ -745,7 +755,7 @@ export function buildRoleBrief(
     if (pathRules) parts.push('', pathRules);
   }
 
-  parts.push(...tail(opts.rules));
+  parts.push(...tail(opts.rules, brief.output));
   return parts.join('\n');
 }
 
@@ -784,7 +794,7 @@ export function buildRoleLaunchPrompt(
   report: PlanReport,
   role: RoleId,
   briefFile: string,
-  opts: { file?: string } = {},
+  opts: { file?: string; chunk?: number } = {},
 ): string {
   const b = BRIEFS[role];
   if (!b) {
@@ -811,14 +821,32 @@ export function buildRoleLaunchPrompt(
     // thousand lines it was not asked about, and worse: coverage is computed from
     // the ranges in this prompt, so it would be credited with reading every chunk in
     // the review. One agent could then mask twenty missing ones.
-    const ranges = role.startsWith('invariant-')
-      ? invariantDiffRange(report, opts.file)
-      : (
-          (Array.isArray(report.chunks) ? report.chunks : []) as DiffChunk[]
-        ).map((c) => ({
-          offset: c.startLine - 1,
-          limit: c.endLine - c.startLine + 1,
-        }));
+    const allChunks = (
+      Array.isArray(report.chunks) ? report.chunks : []
+    ) as DiffChunk[];
+    const rangeOf = (c: DiffChunk) => ({
+      offset: c.startLine - 1,
+      limit: c.endLine - c.startLine + 1,
+    });
+    let ranges: Array<{ offset: number; limit: number }>;
+    if (role.startsWith('invariant-')) {
+      ranges = invariantDiffRange(report, opts.file);
+    } else if (opts.chunk !== undefined) {
+      // A Step 3B reverse-audit agent owns one chunk's territory, the same as its
+      // Step 3 counterpart. Give it that chunk's range, not the whole diff — a
+      // reverse auditor handed a 5 800-line diff is the most context-starved agent
+      // in the pipeline, on exactly the PRs where the reverse audit matters most.
+      const c = allChunks.find((x) => x.id === opts.chunk);
+      if (!c) {
+        throw new Error(
+          `agent-prompt: --role ${role} --chunk ${opts.chunk}: the plan has no ` +
+            `chunk ${opts.chunk} (it has ${allChunks.map((x) => x.id).join(', ')}).`,
+        );
+      }
+      ranges = [rangeOf(c)];
+    } else {
+      ranges = allChunks.map(rangeOf);
+    }
     const reads = ranges
       .map(
         (r) =>
@@ -848,19 +876,36 @@ export function buildRoleLaunchPrompt(
 }
 
 function runAgentPrompt(args: AgentPromptArgs): void {
-  // Exactly one mode. A call that named none used to fall through to the chunk
-  // builder with `undefined`, which then reported that the *plan* had no chunk
-  // `undefined` — an error about the plan, for a mistake in the call.
-  const modes = [
-    typeof args.chunk === 'number',
-    !!args.wholeDiff,
-    typeof args.role === 'string' && args.role.length > 0,
-  ].filter(Boolean).length;
-  if (modes !== 1) {
-    throw new Error(
-      'agent-prompt: pass exactly one of --chunk <id> (a Step 3B territory ' +
-        'agent), --role <role> (a named dimension agent), or --whole-diff (the ' +
-        'diff-reading block on its own).',
+  // Exactly one primary mode: a territory chunk, a named role, or the bare
+  // whole-diff block. A call that named none used to fall through to the chunk
+  // builder with `undefined`, which then blamed the *plan* for "no chunk undefined"
+  // — an error about the plan, for a mistake in the call.
+  const hasChunk = typeof args.chunk === 'number';
+  const hasRole = typeof args.role === 'string' && args.role.length > 0;
+  const hasWhole = !!args.wholeDiff;
+  const bad = (msg: string): never => {
+    throw new Error(`agent-prompt: ${msg}`);
+  };
+  if (hasWhole) {
+    if (hasChunk || hasRole) {
+      bad(
+        '--whole-diff builds the diff-reading block alone; it takes no --chunk or --role.',
+      );
+    }
+  } else if (hasRole) {
+    // `--chunk` combines with a role for exactly one case: a Step 3B reverse-audit
+    // agent, which owns one chunk's territory. Any other role + chunk is a mistake
+    // (a dimension agent walks the whole diff; a chunk agent is `--chunk` alone).
+    if (hasChunk && args.role !== 'reverse-audit') {
+      bad(
+        `--chunk combines with --role only for reverse-audit (a Step 3B per-chunk ` +
+          `auditor); role "${args.role}" does not take --chunk.`,
+      );
+    }
+  } else if (!hasChunk) {
+    bad(
+      'pass exactly one of --chunk <id> (a Step 3B territory agent), --role ' +
+        '<role> (a named agent), or --whole-diff (the diff-reading block on its own).',
     );
   }
 
@@ -907,7 +952,15 @@ function runAgentPrompt(args: AgentPromptArgs): void {
     key = 'whole-diff';
   } else if (args.role) {
     const role = args.role as RoleId;
-    key = args.file ? `${role}--${args.file}` : role;
+    // The record key must be unique per launch. An invariant agent is keyed by its
+    // file; a Step 3B reverse-audit agent by its chunk (its brief is identical
+    // across chunks, but its launch prompt reads a different range, and the delivery
+    // check compares launch prompts). Everything else is one per review.
+    key = args.file
+      ? `${role}--${args.file}`
+      : typeof args.chunk === 'number'
+        ? `${role}--chunk-${args.chunk}`
+        : role;
     // Two artifacts, both written here. The brief is what the agent reads; the
     // launch prompt is the short thing the orchestrator carries, and the only thing
     // it has to get right.
@@ -922,6 +975,7 @@ function runAgentPrompt(args: AgentPromptArgs): void {
     );
     prompt = buildRoleLaunchPrompt(report, role, briefFile, {
       file: args.file,
+      chunk: args.chunk,
     });
   } else {
     const id = args.chunk as number;

--- a/packages/cli/src/commands/review/agent-prompt.ts
+++ b/packages/cli/src/commands/review/agent-prompt.ts
@@ -413,13 +413,35 @@ function requireDiffPath(report: PlanReport): string {
 }
 
 /** How to walk the whole diff: one un-truncated read per chunk, and the paging rule. */
-function diffReadingBlock(report: PlanReport, diffPath: string): string[] {
+function diffReadingBlock(
+  report: PlanReport,
+  diffPath: string,
+  chunkId?: number,
+): string[] {
   if (!Array.isArray(report.chunks) || report.chunks.length === 0) {
     throw new Error('agent-prompt: the plan has no `chunks[]`.');
   }
   const chunks = report.chunks as DiffChunk[];
 
-  const reads = chunks
+  // A per-chunk agent — a Step 3B reverse auditor — owns one chunk's territory.
+  // Its brief must read that chunk alone, the same range its launch prompt reads.
+  // The brief is what the agent is told is authoritative; a brief that listed every
+  // chunk and said "walk it chunk by chunk" would send the auditor to read the whole
+  // diff the `--chunk` design exists to spare it — the defect this scoping removes.
+  const scoped = chunkId !== undefined;
+  let selected = chunks;
+  if (scoped) {
+    const c = chunks.find((x) => x.id === chunkId);
+    if (!c) {
+      throw new Error(
+        `agent-prompt: the plan has no chunk ${chunkId} ` +
+          `(it has ${chunks.map((x) => x.id).join(', ')}).`,
+      );
+    }
+    selected = [c];
+  }
+
+  const reads = selected
     .map((c) => {
       // Same guard `chunkFrom` applies element by element: a corrupted chunk with
       // a non-integer `startLine` would otherwise emit `offset=NaN, limit=NaN`
@@ -441,16 +463,25 @@ function diffReadingBlock(report: PlanReport, diffPath: string): string[] {
     })
     .join('\n');
 
-  const unreachable = chunks.filter((c) => c.maxLineChars > READ_FILE_CHAR_CAP);
+  const unreachable = selected.filter(
+    (c) => c.maxLineChars > READ_FILE_CHAR_CAP,
+  );
 
   const parts = [
     '## The diff',
     '',
-    '**Read the diff first. It is a file on disk — nothing in this prompt contains the code.**',
+    scoped
+      ? `Your territory is **chunk ${chunkId}** of the diff. It is a file on disk — ` +
+        'nothing in this prompt contains the code. Read your chunk:'
+      : '**Read the diff first. It is a file on disk — nothing in this prompt contains the code.**',
     '',
-    'Walk it chunk by chunk. Each of these reads fits inside one un-truncated ' +
-      '`read_file`; asking for the whole file in one call does not, and you would ' +
-      'silently receive its first screenful.',
+    scoped
+      ? 'This read fits inside one un-truncated `read_file`; if it comes back ' +
+        '`isTruncated`, page with a larger `offset` until it does not. Do not read the ' +
+        'other chunks — they belong to other agents; your gap is inside this one.'
+      : 'Walk it chunk by chunk. Each of these reads fits inside one un-truncated ' +
+        '`read_file`; asking for the whole file in one call does not, and you would ' +
+        'silently receive its first screenful.',
     '',
     '```',
     reads,
@@ -595,7 +626,12 @@ function invariantFileBlock(
 export function buildRoleBrief(
   report: PlanReport,
   role: RoleId,
-  opts: { rules?: string; file?: string; planPath?: string } = {},
+  opts: {
+    rules?: string;
+    file?: string;
+    planPath?: string;
+    chunk?: number;
+  } = {},
 ): string {
   const brief = BRIEFS[role];
   if (!brief) {
@@ -617,7 +653,7 @@ export function buildRoleBrief(
       }
       parts.push(...invariantFileBlock(report, diffPath, opts.file));
     } else {
-      parts.push(...diffReadingBlock(report, diffPath));
+      parts.push(...diffReadingBlock(report, diffPath, opts.chunk));
     }
     parts.push('');
   }
@@ -893,10 +929,12 @@ function runAgentPrompt(args: AgentPromptArgs): void {
       );
     }
   } else if (hasRole) {
-    // `--chunk` combines with a role for exactly one case: a Step 3B reverse-audit
-    // agent, which owns one chunk's territory. Any other role + chunk is a mistake
+    // `--chunk` combines with a role only when that role owns one chunk's territory
+    // — a Step 3B reverse auditor. Which roles those are is declared on the brief
+    // (`acceptsChunk`), not hardcoded here, so a new per-chunk role is a data change
+    // in agent-briefs, not an edit to this guard. Any other role + chunk is a mistake
     // (a dimension agent walks the whole diff; a chunk agent is `--chunk` alone).
-    if (hasChunk && args.role !== 'reverse-audit') {
+    if (hasChunk && !BRIEFS[args.role as RoleId]?.acceptsChunk) {
       bad(
         `--chunk combines with --role only for reverse-audit (a Step 3B per-chunk ` +
           `auditor); role "${args.role}" does not take --chunk.`,
@@ -971,6 +1009,7 @@ function runAgentPrompt(args: AgentPromptArgs): void {
         rules,
         file: args.file,
         planPath: args.plan,
+        chunk: args.chunk,
       }),
     );
     prompt = buildRoleLaunchPrompt(report, role, briefFile, {

--- a/packages/cli/src/commands/review/lib/agent-briefs.ts
+++ b/packages/cli/src/commands/review/lib/agent-briefs.ts
@@ -83,6 +83,18 @@ export interface Brief {
    * its output shape is the verdict, and its brief defines that.
    */
   output?: 'findings' | 'verdicts';
+  /**
+   * May this role be launched `--role <r> --chunk <id>` to own one chunk's
+   * territory, the way a Step 3B reverse auditor does?
+   *
+   * It is declarative for two readers. The command guard rejects `--chunk` on any
+   * role that does not set it, so a new per-chunk role is a data change here, not a
+   * name hardcoded in the guard. And the brief builder scopes such a role's diff
+   * reads to its one chunk — a per-chunk agent whose brief still said "walk it
+   * chunk by chunk" over all twenty chunks would read the whole diff the `--chunk`
+   * design exists to spare it, because the brief is what the agent is told to obey.
+   */
+  acceptsChunk?: boolean;
   /** The agent-facing text. */
   brief: string;
 }
@@ -409,6 +421,7 @@ Return, for each finding, one verdict:
 
   'reverse-audit': {
     reviewsCode: true,
+    acceptsChunk: true,
     label: 'Reverse audit agent',
     readsDiff: true,
     brief: `You are a **reverse audit agent**. Prior agents have already reviewed this diff and their confirmed findings are listed in the message that launched you. Your job is not to re-report them — it is to find the **gaps**: the important issues no prior agent or round caught.

--- a/packages/cli/src/commands/review/lib/agent-briefs.ts
+++ b/packages/cli/src/commands/review/lib/agent-briefs.ts
@@ -49,7 +49,9 @@ export type RoleId =
   | 'test-matrix'
   | 'invariant-a'
   | 'invariant-b'
-  | 'invariant-c';
+  | 'invariant-c'
+  | 'verify'
+  | 'reverse-audit';
 
 export interface Brief {
   /** How the role is named to a human reading a coverage failure. */
@@ -71,6 +73,16 @@ export interface Brief {
    * evidence is their output. Everyone else who does not read the diff is a bug.
    */
   readsDiff: boolean;
+  /**
+   * What the agent returns, which decides the shared tail of its prompt.
+   *
+   * `'findings'` (the default) gets the finding format, the severity definitions
+   * and the Exclusion Criteria. `'verdicts'` is the Step 4 verifier: it does not
+   * file findings, it rules on the ones it was handed, so it gets the Exclusion
+   * Criteria (a finding that matches one is rejected) but not the finding format —
+   * its output shape is the verdict, and its brief defines that.
+   */
+  output?: 'findings' | 'verdicts';
   /** The agent-facing text. */
   brief: string;
 }
@@ -365,6 +377,48 @@ This file is largely rewritten, and reviewing it as a diff is the wrong frame. T
 - **Early returns.** Does any early return skip a side effect a later path depends on — a cache populated, an id extracted and stored, a sequence number bumped? Pay particular attention to a blank/empty-input guard placed **before** a side effect rather than after it.
 
 Report a **Critical** for each violation, and give **both** locations that together make it a bug (\`<file>:<lineA>\` and \`<file>:<lineB>\`), not just one.`,
+  },
+
+  verify: {
+    reviewsCode: true,
+    output: 'verdicts',
+    label: 'Verification agent',
+    readsDiff: true,
+    brief: `You are a **verification agent**. You do not look for new problems — you rule on the findings you were handed, listed in the message that launched you, each with a file, a line, an issue, and a **failure scenario**. The failure scenario is the finding's testable claim, and your verdict is the **result of tracing it through the real code**, not a plausibility vote on how the finding reads.
+
+For each finding you were given:
+
+1. **Read the actual code** at the referenced file and line — in the worktree, not from the finding's quotation of it.
+2. **Check the surrounding context** — the callers, the type definitions, the tests, the related modules.
+3. **Trace the failure scenario.** Follow the claimed trigger through the code to the claimed wrong outcome. For a quality finding, trace the claimed *cost* instead: does the named helper exist **and do what the finding says** (right signature, right semantics for this call site); is the duplication real; does the quoted rule say what the finding claims **and apply to this code**?
+4. **Check the finding against the diff's own documented intent** — especially anything framed as a "regression", "removed protection", or "now allows X". Read the comments, JSDoc and rationale **inside the diff** for the changed lines. A behaviour the diff deliberately changes *and documents* (a comment saying \`X is intentionally preserved\`, a rationale block, a test asserting the new behaviour on purpose) is a design decision, not a defect — engage that rationale. This changes what you must do, **not** what confidence you may reach: a traced, concrete harm that survives the rationale keeps full confidence (if the author documents "unauthenticated access is intentional" and the trace still shows real data exposure, that is \`confirmed (high confidence)\` with the rebuttal stated — documentation does not make a harm safe). Use \`confirmed (low confidence)\` when engaging the rationale makes the harm genuinely uncertain. **Reject only** a finding that re-describes the documented change as a regression without naming a harm the rationale fails to answer. (A real run auto-posted a Critical claiming a secret-sanitization PR "now leaks AWS/GitHub tokens"; the file's own comment three lines up said those credentials **must remain available** to shell/MCP tools and the old broad denylist was the bug being fixed. The verifier had not read the rationale.)
+5. **Reject a false positive** — a finding that matches an item in the Exclusion Criteria below.
+
+Return, for each finding, one verdict:
+
+- **confirmed (high confidence)** — the trace works: you can restate the failure scenario against the real code, naming the triggering input/state and quoting the line(s) that produce the wrong outcome. Carry the severity (Critical | Suggestion | Nice to have).
+- **confirmed (low confidence)** — the mechanism is real but the trigger is uncertain (timing, environment, configuration). Say what would confirm it. Carry the severity.
+- **rejected** — the code does not do what the finding claims (**quote the contradicting code**), or it matches an Exclusion Criterion (one-line reason).
+
+**Rejecting a Critical carries a higher bar than anything else, and it is one-way.** A rejected Critical is gone — no later stage revisits it, it vanishes from both the pull request and the terminal. To reject one you must **quote the specific code that contradicts the claim**. A passing test, a plausible-looking guard, or "I could not reproduce the reasoning" is not enough — when you cannot quote the contradiction, the floor is \`confirmed (low confidence)\`, never rejection. Downgrading is reversible; a human still sees a low-confidence finding under "Needs Human Review". Rejection is not.
+
+**For anything non-Critical, when uncertain, downgrade to low confidence rather than rejecting.** Reserve outright rejection for a finding that clearly does not match the code (it describes behaviour the code does not have) or matches an Exclusion Criterion. Low confidence is for "likely real, needs human judgement", not for "I have no idea" — a vague suspicion with no concrete evidence in the code can still be rejected.
+
+**Do not reject an issue-fidelity / root-cause-ownership finding merely because the code compiles, runs, or has a passing test.** A working sanitizer with a green "malformed-shape" test does not disprove an issue-grounded claim that the root cause belongs upstream. Verify such a finding against the issue evidence quoted in the message that launched you; if that evidence is absent or genuinely inconclusive, downgrade rather than reject.`,
+  },
+
+  'reverse-audit': {
+    reviewsCode: true,
+    label: 'Reverse audit agent',
+    readsDiff: true,
+    brief: `You are a **reverse audit agent**. Prior agents have already reviewed this diff and their confirmed findings are listed in the message that launched you. Your job is not to re-report them — it is to find the **gaps**: the important issues no prior agent or round caught.
+
+- **Read your scope in full** with the diff reads the message gives you — page a truncated read rather than reasoning from its first screenful. A reverse audit that saw a fraction of its scope and returned "No issues found" is worse than none: it ends the loop on a lie.
+- **Focus exclusively on what is not already in the finding list.** Assume the obvious defects are found; look where a first pass does not: the interaction between two changes, the assumption that holds in the common case and breaks in the rare one, the removed guard whose replacement is three files away.
+- **Report only Critical or Suggestion.** Do not report Nice to have.
+- A found gap uses the standard finding format (with \`Source: [review]\`), including its failure scenario — your findings go through the same verification as any other, so they must carry the evidence a verifier can trace.
+
+If you find no new gap in your scope, say so **and name what you re-examined** — \`No issues found — re-walked the reconnect state machine and the two changed exports' call sites; every gap I checked was already in the list\`. A bare "No issues found." is indistinguishable from an agent that did nothing, and it is treated as one: it ends nothing, and it earns your scope a relaunch.`,
   },
 };
 

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -472,31 +472,16 @@ Launch verification agents that between them receive **all** non-pre-confirmed f
 
 A single verifier for every finding was cheaper, but on a large review it becomes the most context-starved agent in the pipeline: it must re-read code for each of 30-60 findings inside one context window, and its quality collapses on the tail of the list. Sharding keeps each verifier's job small; the cost is still far below one-agent-per-finding.
 
-Each verification agent receives:
+**Do not write the verifier's prompt. Ask for it:**
 
-- The complete list of findings to verify (with file, line, issue, and failure scenario for each — the scenario is the claim under test)
-- `diffPathAbsolute` from Step 1, to be read with `read_file` — never a `git diff` command, whose output is truncated to 30 000 chars
-- Access to read files and search the codebase
-- **For same-repo PR (worktree-mode) reviews, `working_dir: "<worktreePath>"`** — the verifier reads files and re-checks the diff, so it MUST be pinned to the PR worktree too (same rule as Step 3); otherwise it verifies against the user's main checkout
-- **For Agent 0 (Issue Fidelity) findings, the issue evidence those findings quoted** (issue body + comments) — a root-cause-ownership or issue-fidelity claim rests on linked-issue evidence the codebase alone does not contain, so the verifier must be handed that evidence to check it against
+```bash
+qwen review agent-prompt --plan <the plan report from Step 1> --role verify \
+  [--rules <the rules file from Step 2, if the project has any>]
+```
 
-Each verification agent must, for each finding it was given:
+Paste what it prints to each verifier **verbatim**, and add above it the one thing that changes per shard: **the findings this shard must rule on** — each with its file, line, issue and failure scenario (the scenario is the claim under test). For any **Agent 0 (Issue Fidelity)** finding in the shard, add the **issue evidence it quoted** (issue body + comments): a root-cause claim rests on linked-issue evidence the codebase does not contain, and the verifier must be handed it to check against. In worktree mode the verifier's `working_dir` is the PR worktree (same rule as Step 3), so its reads and re-checks resolve against the PR's code.
 
-1. Read the actual code at the referenced file and line
-2. Check surrounding context — callers, type definitions, tests, related modules
-3. **Trace the failure scenario**: follow the claimed trigger through the actual code to the claimed wrong outcome. The scenario is the finding's testable claim — the verdict is the result of that trace, not a plausibility vote on the finding's prose. (For quality findings, check the claimed cost instead: does the named helper exist **and actually do what the finding claims** — right signature, right semantics for this call site; is the duplication real; does the quoted rule say what the finding claims **and apply to this code**?)
-4. **Check the finding against the PR's own documented intent — especially any finding framed as a "regression", "removed protection", or "now allows X".** Read the comments, JSDoc, and design notes **inside the diff itself** for the changed lines. A behavior the diff deliberately changes _and documents_ (a comment saying `X is intentionally preserved`, a rationale block, a test that asserts the new behavior on purpose) is a design decision, not a defect — the finding must engage that rationale, not ignore it. The documented intent changes what the verifier must do, not what confidence it may reach: **a traced, concrete harm that survives the rationale keeps full confidence** — if the author documents "unauthenticated access is intentional" and the trace still shows real data exposure, that is `confirmed (high confidence)` with the rebuttal stated, because documentation does not make a harm safe. Use `confirmed (low confidence)` when engaging the rationale makes the harm genuinely uncertain (the rationale names a compensating control the verifier cannot rule out). **Reject** only a finding that simply re-describes the documented change as a regression without naming any harm the rationale fails to answer. This is the diff-local analogue of Agent 0's root-cause-ownership gate. (Dogfooding auto-posted a Critical claiming a secret-sanitization PR "now leaks AWS/GitHub tokens"; the file's own comment said those user credentials `must remain available` for shell/MCP tools and the old broad denylist was the bug being fixed — the verifier had not read the rationale three lines up.)
-5. Verify the issue is not a false positive — reject if it matches any item in the **Exclusion Criteria**
-6. Return a verdict with confidence level:
-   - **confirmed (high confidence)** — the trace works: you can restate the failure scenario against the real code, naming the triggering input/state and quoting the line(s) that produce the wrong outcome, with severity: Critical, Suggestion, or Nice to have
-   - **confirmed (low confidence)** — the mechanism is real but the trigger is uncertain (timing, environment, configuration); state what would confirm it, with severity
-   - **rejected** — the code does not do what the finding claims (cite the contradicting code), or the finding matches an Exclusion Criterion — one-line reason. For a **Critical**, this verdict is additionally constrained by the rule below: contradicting code must be quoted, and when it cannot be, downgrade instead of rejecting
-
-**Rejecting a Critical carries a higher bar than rejecting anything else.** To reject a Critical the verifier must quote the specific code that contradicts the claim — a passing test, a plausible-looking guard, or "I could not reproduce the reasoning" is not enough, and when the contradiction cannot be quoted, the floor verdict is `confirmed (low confidence)`, never rejection. Rejecting a Critical is irreversible and invisible: no later stage ever revisits it, and the finding disappears from both the PR and the terminal. Downgrading is reversible — a human still sees it under "Needs Human Review."
-
-**When uncertain about a non-Critical, downgrade to "confirmed (low confidence)" rather than rejecting outright.** Low-confidence findings stay in terminal output (under "Needs Human Review") but are filtered from PR inline comments — this preserves the "Silence is better than noise" principle for PR interactions while ensuring valid concerns are not silently swallowed. Reserve outright rejection for findings that clearly do not match the actual code (the finding describes behavior the code does not have, or it matches an Exclusion Criterion). Vague suspicions with no concrete evidence in the code can still be rejected — low-confidence is for "likely real but needs human judgment," not for "I have no idea."
-
-**Do NOT reject an Agent 0 issue-fidelity / root-cause-ownership finding merely because the code compiles, runs, or has a passing test** — a working sanitizer with a green "malformed-shape" test does not disprove an issue-grounded claim that the root cause belongs upstream. Verify such findings against the quoted issue evidence provided to you; if that evidence is absent or genuinely inconclusive, downgrade to low-confidence rather than rejecting outright.
+The brief holds the method the orchestrator used to spell out here and that a paraphrase kept dropping: trace the failure scenario through the real code rather than voting on the finding's prose; engage the diff's own documented intent before calling a documented change a regression (the rule a run skipped when it auto-posted a false "leaks tokens" Critical); and the one-way, quote-the-contradiction bar on **rejecting a Critical**. Read the brief to know what a verdict means; do not re-derive it here.
 
 **After verification:** remove all rejected findings. Separate confirmed findings into two groups: high-confidence and low-confidence. Low-confidence findings appear **only in terminal output** (under "Needs Human Review") and are **never posted as PR inline comments** — this preserves the "Silence is better than noise" principle for PR interactions.
 
@@ -532,21 +517,21 @@ After aggregation, run reverse audit **iteratively**. Each round receives the cu
 - **Small diffs (Step 3A path):** one reverse audit agent per round, reading the whole diff.
 - **Large diffs (Step 3B path):** one reverse audit agent **per chunk** per round, launched together in a single response. A single agent asked to re-read a 5 800-line diff with a growing finding list appended is the most context-starved agent in the pipeline — precisely on the PRs where the reverse audit matters most. Each per-chunk auditor gets the same territory as its Step 3B counterpart, plus the cumulative finding list for the **whole** diff (so it knows what is already covered elsewhere).
 
-Every reverse audit agent receives:
+**Do not write the reverse auditor's prompt. Ask for it:**
 
-- The cumulative list of all confirmed findings so far (from Steps 3-4 plus all prior reverse audit rounds — so it knows what's already covered)
-- `diffPathAbsolute` from Step 1, plus its chunk range (3B) or the whole `chunks[]` plan (3A). Never a `git diff` command (truncated to 30 000 chars), and never one whole-file `read_file` call (truncated to ~25 000 chars). A reverse audit that saw 14% of the diff is worse than none: it returns "No issues found." and terminates the loop.
-- Access to read files and search the codebase
-- **For same-repo PR (worktree-mode) reviews, `working_dir: "<worktreePath>"`** — same rule as Step 3, so the reverse audit reads the PR worktree, not the user's main checkout
+```bash
+# Step 3A (small diff): one auditor per round, the whole diff.
+qwen review agent-prompt --plan <the plan report from Step 1> --role reverse-audit \
+  [--rules <the rules file from Step 2>]
 
-Each reverse audit agent must:
+# Step 3B (large diff): one auditor PER CHUNK per round, launched together.
+qwen review agent-prompt --plan <the plan report from Step 1> --role reverse-audit --chunk <id> \
+  [--rules <the rules file from Step 2>]
+```
 
-1. Review its scope with full knowledge of what was already found
-2. Focus exclusively on **gaps** — important issues that no prior agent or round caught
-3. Only report **Critical** or **Suggestion** level findings — do not report Nice to have
-4. Apply the same **Exclusion Criteria** as other agents
-5. Return findings in the same structured format (with `Source: [review]`)
-6. If it finds no new gaps in its scope, say so with its receipt, like every agent: `No issues found — <one line naming what it re-examined>`. (A bare "No issues found." fails the substantive-return check below and triggers the one relaunch.)
+Paste what it prints **verbatim**, and add above it the one thing that changes per round: **the cumulative list of every confirmed finding so far** (Steps 3-4 plus all prior rounds), so the auditor hunts what is not already on it. The command gives each auditor its diff reads — the whole plan in 3A, one chunk's range in 3B (a Step 3B auditor handed the whole 5 800-line diff is the most context-starved agent in the pipeline, on exactly the PRs where the reverse audit matters most). In worktree mode its `working_dir` is the PR worktree.
+
+The brief holds what the auditor is for: hunt only the **gaps** no prior agent caught, report only Critical or Suggestion, apply the Exclusion Criteria, and end with a substantive receipt (`No issues found — <what it re-examined>`) — a bare "No issues found." fails the substantive-return check below and triggers the one relaunch.
 
 **Termination rules:**
 


### PR DESCRIPTION
## What this PR does

Follow-up to #6892. That PR moved the `/review` skill's Step 3 agent prompts into code — the diff path, the brief, the roster, the delivery check — so the orchestrator no longer retypes them. This PR does the same for Step 4 (verify) and Step 5 (reverse audit): both are now built by `qwen review agent-prompt --role verify` / `--role reverse-audit` and written to a brief file the agent reads, instead of being composed from prose in `SKILL.md`. The verifier is a new brief kind (`output: 'verdicts'`) that receives the Exclusion Criteria but not the finding format, because it rules on findings rather than files them. A Step 3B reverse auditor takes `--chunk <id>` so it reads one chunk's line range instead of the whole diff. `SKILL.md` Step 4/5 now call the commands and supply only the one input that changes per launch (the shard's findings for the verifier, the cumulative finding list for the auditor).

## Why it's needed

The verifier and reverse auditor are the two agents whose *method* — not just their target — decides whether the review is trustworthy, and it is the method most costly to drop under context pressure. The verifier carries a one-way bar on rejecting a Critical (quote the code that contradicts it, else downgrade rather than drop) and a documented-intent gate (a rationale in the diff does not make a real harm safe) — the exact rule a dogfood run skipped when it auto-posted a false *"this PR now leaks AWS/GitHub tokens"* Critical over a rationale sitting three lines up in the same diff. The reverse auditor carries a gaps-only focus and a substantive receipt requirement so it proves it read the code rather than restating the diff. When those rules live in prose the orchestrator paraphrases, they are the first thing to erode; in code they cannot be paraphrased away. The `--chunk` range for 3B fixes the auditor otherwise being the most context-starved agent in the pipeline (it was reading the whole 5 800-line diff).

## Reviewer Test Plan

### How to verify

Run the review unit suite and the CLI surface directly. `cd packages/cli && npx vitest run src/commands/review` → 586 passing across 29 files; `npx tsc --noEmit -p packages/cli/tsconfig.json` filtered to `commands/review` → clean. To exercise the new command surface: `qwen review agent-prompt --plan <plan.json> --role verify` emits a short launch prompt plus a `verify.brief.md` carrying the reject-Critical bar and Exclusion Criteria (no finding format); `--role reverse-audit --chunk <id>` restricts the auditor to that chunk's offset/limit range; the illegal combination `--role verify --chunk N` is rejected with `--chunk combines with --role only for reverse-audit`.

### Evidence (Before & After)

Non-UI change (a CLI subcommand and skill prose), so no before/after screenshots. Behavioral evidence from a dogfood on a real 3A review: the orchestrator adopted the commands (`--role verify` ×5, `--role reverse-audit` ×6 across rounds, with no fallback to hand-written prompts), and every launch that matched a written brief opened that brief in the harness transcript (verify + reverse auditor, 3/3). Before this PR the same two steps were prose in `SKILL.md` that the orchestrator paraphrased each run.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ not tested (CI)  |
| 🪟 Windows |  ⚠️ not tested (CI)  |
|  🐧 Linux  |  ✅ tested  |

### Environment (optional)

Linux dev box; repo-built CLI (`npm run build && npm run bundle`) driven under tmux against a live PR. Unit suite via `npx vitest`.

## Risk & Scope

- Main risk or tradeoff: the change is confined to the `/review` skill (one CLI subcommand's argument handling + brief content, and `SKILL.md` Step 4/5 text). No runtime path outside `qwen review` is touched. The verifier's stricter reject-Critical bar could in principle keep a genuinely-wrong Critical that a reviewer would otherwise have dropped — mitigated by the downgrade-not-drop rule and by this being the intended, documented policy.
- Not validated / out of scope: whether the verifier and auditor actually ran and read their briefs is not yet checked from the transcripts the way Step 3's agents are (these agents run after the Step 3D coverage gate, so the roster does not reach them). That check is the intended next step; it first needs a unique record key per verify shard / reverse-audit round (they currently share one), which reopens the "dynamic count not predictable from the plan" tension the roster already navigates.
- Breaking changes / migration notes: none. New CLI roles are additive; existing `agent-prompt` invocations are unchanged.

## Linked Issues

Follow-up to #6892 (no issue to close).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

#6892 的后续。那个 PR 把 `/review` skill 的 Step 3 agent prompt 搬进了代码——diff 路径、brief、roster、投递核对——让 orchestrator 不再手打它们。这个 PR 对 Step 4(verify)和 Step 5(reverse audit)做同样的事:两者现在都由 `qwen review agent-prompt --role verify` / `--role reverse-audit` 构建、写进一个 brief 文件让 agent 去读,而不再是 `SKILL.md` 里用散文拼出来的。verifier 是一种新的 brief 类型(`output: 'verdicts'`):它拿到 Exclusion Criteria,但不拿 finding format——因为它是裁决 finding,不是提交 finding。Step 3B 的 reverse auditor 接受 `--chunk <id>`,只读某个 chunk 的行范围,而不是整份 diff。`SKILL.md` Step 4/5 现在调用命令,只提供每次 launch 唯一变化的那份输入(verifier 拿本分片的 findings,auditor 拿累积的 finding 列表)。

## 为什么需要

verifier 和 reverse auditor 是两个「方法」决定 review 可不可信的 agent——不只是「看哪里」,而是「怎么看」,也是上下文压力下最不能丢的方法。verifier 携带推翻 Critical 的单向高门槛(必须引用与之矛盾的代码,否则降级而不是删掉)和一道 documented-intent gate(diff 里写了 rationale 不代表真实危害就安全了)——这正是某次 dogfood 跳过的规则:它自动发了一条假 Critical 说「这个 PR 现在会泄露 AWS/GitHub token」,而解释就在同一份 diff 往上三行。reverse auditor 携带「只找缺口」的聚焦和 substantive receipt 要求,以证明自己真读了代码、而非复述 diff。这些规则一旦活在「orchestrator 会转述」的散文里,就是第一个被磨掉的东西;放进代码,就无法被转述掉。3B 的 `--chunk` 范围修掉了 auditor 此前是整条流水线里上下文最匮乏的 agent 这个问题(它原本要读整份 5 800 行的 diff)。

## Reviewer 测试计划

### 如何验证

运行 review 单测套件并直接验证 CLI 表面。`cd packages/cli && npx vitest run src/commands/review` → 29 个文件 586 通过;`npx tsc --noEmit -p packages/cli/tsconfig.json` 过滤到 `commands/review` → 干净。验证新命令表面:`qwen review agent-prompt --plan <plan.json> --role verify` 输出一段简短的 launch prompt 外加一份 `verify.brief.md`,内含推翻 Critical 的门槛和 Exclusion Criteria(不含 finding format);`--role reverse-audit --chunk <id>` 把 auditor 限制在该 chunk 的 offset/limit 范围;非法组合 `--role verify --chunk N` 会被拒绝并提示 `--chunk combines with --role only for reverse-audit`。

### 证据(前后对比)

非 UI 改动(一个 CLI 子命令 + skill 散文),因此没有前后截图。来自真实 3A review dogfood 的行为证据:orchestrator 采用了这两个命令(`--role verify` ×5、`--role reverse-audit` ×6 多轮,没有回退到手写 prompt),且每一个能对上落盘 brief 的 launch,在 harness transcript 里都真的打开了那份 brief(verify + reverse auditor,3/3)。在这个 PR 之前,这两步是 `SKILL.md` 里的散文,orchestrator 每次运行都会转述。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ 未测试(CI)  |
| 🪟 Windows |  ⚠️ 未测试(CI)  |
|  🐧 Linux  |  ✅ 已测试  |

### 环境(可选)

Linux 开发机;仓库构建的 CLI(`npm run build && npm run bundle`)在 tmux 下针对真实 PR 运行。单测通过 `npx vitest`。

## 风险与范围

- 主要风险或取舍:改动局限于 `/review` skill(一个 CLI 子命令的参数处理 + brief 内容,以及 `SKILL.md` Step 4/5 文本)。不触及 `qwen review` 之外的任何运行时路径。verifier 更严的推翻-Critical 门槛,原则上可能保留一条 reviewer 本会删掉的、确实错误的 Critical——由「降级而非删除」规则缓解,且这本就是有意为之、有文档记录的策略。
- 未验证 / 不在范围内:verifier 和 auditor 到底有没有真跑、有没有真读 brief,还没有像 Step 3 的 agent 那样从 transcript 里核对(这两个 agent 在 Step 3D 覆盖率 gate 之后运行,roster 够不到它们)。这是紧接着的下一步;它需要先给每个 verify 分片 / 每轮 reverse-audit 一个唯一的 record key(现在它们共用一个),而这又撞上 roster 早已在应对的「动态数量无法从 plan 预测」那同一个张力。
- 破坏性变更 / 迁移说明:无。新增的 CLI role 是增量的;现有的 `agent-prompt` 调用不变。

## 关联 Issue

#6892 的后续(无需关闭的 issue)。

</details>
