### PR TITLE
fix(wecom): prevent requireMention from disabling group chat

### DIFF
--- a/docs/users/features/channels/wecom.md
+++ b/docs/users/features/channels/wecom.md
@@ -39,10 +39,7 @@ Add the channel to `~/.qwen/settings.json`:
       "sessionScope": "user",
       "cwd": "/path/to/your/project",
       "instructions": "You are a concise coding assistant responding via WeCom.",
-      "groupPolicy": "open",
-      "groups": {
-        "*": { "requireMention": true }
-      }
+      "groupPolicy": "open"
     }
   }
 }
@@ -82,9 +79,13 @@ Open WeCom and send a message to the intelligent robot.
 - `pairing`: users must pair before using the bot.
 - `open`: anyone who can message the robot can use it.
 
-For groups, set `groupPolicy` to `"allowlist"` or `"open"`. By default, group messages require a mention through `"requireMention": true`.
+For groups, set `groupPolicy` to `"allowlist"` or `"open"`. WeCom only delivers group messages that mention the intelligent robot, so every delivered group callback is treated as mentioned. The `requireMention` setting cannot enable responses to unmentioned group messages because those messages are not delivered to the bot.
 
-When the WeCom SDK includes explicit mention metadata, Qwen Code uses it for this gate. If no mention metadata is present, the channel treats delivered group messages as unmentioned. Set `"requireMention": false` only if you want to rely on WeCom-side delivery scoping instead.
+### Group Mention Compatibility
+
+Earlier Qwen Code versions also applied the generic `requireMention` gate after WeCom delivered a group callback. Because the callback does not include separate mention metadata, `requireMention: true`—including the default value—could reject every delivered group message and make group chat appear nonfunctional.
+
+Qwen Code now relies on WeCom's mention-scoped delivery and does not apply a second mention decision. Existing WeCom configurations containing either `requireMention: true` or `requireMention: false` remain valid and do not produce configuration errors. Both values have the same behavior for WeCom, so the field can be removed. Other settings in the same group entry, such as `dispatchMode` and `groupHistoryLimit`, continue to apply.
 
 ## Images and Files
 
@@ -109,7 +110,7 @@ For safety, local image paths must be inside the channel file directory under th
 ### Bot does not respond in groups
 
 - Check `groupPolicy`.
-- Mention the bot unless the group config sets `"requireMention": false`.
+- Mention the bot in the group.
 - Confirm the robot has been added to the group.
 
 ### Self-built application credentials do not work

--- a/docs/users/features/channels/wecom.md
+++ b/docs/users/features/channels/wecom.md
@@ -85,7 +85,7 @@ For groups, set `groupPolicy` to `"allowlist"` or `"open"`. WeCom only delivers 
 
 Earlier Qwen Code versions also applied the generic `requireMention` gate after WeCom delivered a group callback. Because the callback does not include separate mention metadata, `requireMention: true`—including the default value—could reject every delivered group message and make group chat appear nonfunctional.
 
-Qwen Code now relies on WeCom's mention-scoped delivery and does not apply a second mention decision. Existing WeCom configurations containing either `requireMention: true` or `requireMention: false` remain valid and do not produce configuration errors. Both values have the same behavior for WeCom, so the field can be removed. Other settings in the same group entry, such as `dispatchMode` and `groupHistoryLimit`, continue to apply.
+Qwen Code now relies on WeCom's mention-scoped delivery and does not apply a second mention decision. Existing WeCom configurations containing either `requireMention: true` or `requireMention: false` remain valid and do not produce configuration errors. Both values have the same behavior for WeCom, so the field can be removed. Other settings in the same group entry, such as `dispatchMode`, continue to apply. `groupHistoryLimit` remains accepted but cannot collect new WeCom history because unmentioned group messages are not delivered.
 
 ## Images and Files
 

--- a/packages/channels/wecom/src/WeComAdapter.test.ts
+++ b/packages/channels/wecom/src/WeComAdapter.test.ts
@@ -1484,7 +1484,7 @@ describe('WeComChannel', () => {
       'bot',
       makeConfig({
         groupPolicy: 'open',
-        groups: { '*': { requireMention: false } },
+        groups: { '*': {} },
       }),
       makeBridge(),
     );
@@ -1544,6 +1544,7 @@ describe('WeComChannel', () => {
     const mixed = channel.envelopes[0]!;
     expect(mixed.chatId).toBe('group-1');
     expect(mixed.isGroup).toBe(true);
+    expect(mixed.isMentioned).toBe(true);
     expect(mixed.text).toBe('@bot inspect this\nvoice transcript');
     expect(mixed.referencedText).toBe('previous voice text');
     expect(mixed.attachments?.[0]).toMatchObject({
@@ -1600,7 +1601,7 @@ describe('WeComChannel', () => {
     ).toBe(2);
   });
 
-  it('allows group replies to the bot without an explicit mention', async () => {
+  it('normalizes replies to the bot in group callbacks', async () => {
     const channel = new TestWeComChannel(
       'bot',
       makeConfig({
@@ -1617,7 +1618,6 @@ describe('WeComChannel', () => {
       chattype: 'group',
       chatid: 'group-1',
       from: { userid: 'alice' },
-      mentions: [],
       text: { content: 'follow up' },
       quote: {
         msgtype: 'text',
@@ -1629,7 +1629,7 @@ describe('WeComChannel', () => {
     await vi.waitFor(() => expect(channel.envelopes).toHaveLength(1));
     expect(channel.envelopes[0]).toMatchObject({
       isGroup: true,
-      isMentioned: false,
+      isMentioned: true,
       isReplyToBot: true,
       referencedText: 'bot response',
     });
@@ -1653,78 +1653,6 @@ describe('WeComChannel', () => {
 
     await vi.waitFor(() => expect(channel.envelopes).toHaveLength(1));
     expect(channel.envelopes[0]?.attachments?.[0]?.fileName).toBe('secret.png');
-  });
-
-  it('honors explicit group mention metadata when present', async () => {
-    const channel = new TestWeComChannel(
-      'bot',
-      makeConfig({
-        groupPolicy: 'open',
-        groups: { '*': { requireMention: false } },
-      }),
-      makeBridge(),
-    );
-    await channel.connect();
-    const client = lastClient();
-
-    client.emit('message.text', {
-      msgid: 'msg-unmentioned',
-      msgtype: 'text',
-      chattype: 'group',
-      chatid: 'group-1',
-      from: { userid: 'bob' },
-      text: { content: 'background' },
-      mentions: [{ userid: 'other-bot' }],
-    });
-    client.emit('message.text', {
-      msgid: 'msg-mentioned',
-      msgtype: 'text',
-      chattype: 'group',
-      chatid: 'group-1',
-      from: { userid: 'bob' },
-      text: { content: '@bot inspect' },
-      mentions: [{ userid: 'bot-id' }],
-    });
-    client.emit('message.text', {
-      msgid: 'msg-other-mentioned',
-      msgtype: 'text',
-      chattype: 'group',
-      chatid: 'group-1',
-      from: { userid: 'bob' },
-      text: { content: '@someone else' },
-      isMentioned: true,
-      isInAtList: false,
-    });
-
-    await vi.waitFor(() => expect(channel.envelopes).toHaveLength(3));
-    expect(channel.envelopes.map((envelope) => envelope.isMentioned)).toEqual([
-      false,
-      true,
-      false,
-    ]);
-  });
-
-  it('treats empty mention metadata as explicitly unmentioned', async () => {
-    const channel = new TestWeComChannel(
-      'bot',
-      makeConfig({ groupPolicy: 'open', groups: { '*': {} } }),
-      makeBridge(),
-    );
-    await channel.connect();
-    const client = lastClient();
-
-    client.emit('message.text', {
-      msgid: 'msg-empty-mentions',
-      msgtype: 'text',
-      chattype: 'group',
-      chatid: 'group-1',
-      from: { userid: 'bob' },
-      text: { content: 'background' },
-      mentions: [],
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(channel.envelopes).toHaveLength(0);
   });
 
   it('logs sanitized payloads only when debug payload logging is enabled', async () => {
@@ -1774,7 +1702,7 @@ describe('WeComChannel', () => {
     expect(logged).not.toContain('media-key');
   });
 
-  it('treats missing group mention metadata as unmentioned', async () => {
+  it('accepts delivered group messages without mention metadata', async () => {
     const channel = new TestWeComChannel(
       'bot',
       makeConfig({ groupPolicy: 'open', groups: { '*': {} } }),
@@ -1784,22 +1712,30 @@ describe('WeComChannel', () => {
     const client = lastClient();
 
     client.emit('message.text', {
-      msgid: 'msg-missing-mention-metadata',
-      msgtype: 'text',
-      chattype: 'group',
-      chatid: 'group-1',
-      from: { userid: 'bob' },
-      text: { content: 'background' },
+      cmd: 'aibot_msg_callback',
+      headers: { req_id: 'req-group-mention' },
+      body: {
+        msgid: 'msg-missing-mention-metadata',
+        aibotid: 'bot-id',
+        msgtype: 'text',
+        chattype: 'group',
+        chatid: 'group-1',
+        from: { userid: 'bob' },
+        text: { content: 'inspect this' },
+      },
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(channel.envelopes).toHaveLength(0);
+    await vi.waitFor(() => expect(channel.envelopes).toHaveLength(1));
+    expect(channel.envelopes[0]).toMatchObject({
+      isGroup: true,
+      isMentioned: true,
+    });
   });
 
-  it('does not download attachments for messages rejected by mention gate', async () => {
+  it('does not download attachments for messages rejected by group policy', async () => {
     const channel = new TestWeComChannel(
       'bot',
-      makeConfig({ groupPolicy: 'open', groups: { '*': {} } }),
+      makeConfig({ groupPolicy: 'disabled' }),
       makeBridge(),
     );
     await channel.connect();
@@ -1811,7 +1747,6 @@ describe('WeComChannel', () => {
       chattype: 'group',
       chatid: 'group-1',
       from: { userid: 'bob' },
-      mentions: [],
       image: { url: 'https://example.invalid/private-image', aeskey: 'k1' },
     });
 
@@ -1839,7 +1774,6 @@ describe('WeComChannel', () => {
       chattype: 'group',
       from: { userid: 'bob' },
       text: { content: '@bot inspect' },
-      mentions: [{ userid: 'bot-id' }],
     });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -1894,7 +1828,6 @@ describe('WeComChannel', () => {
       chatid: 'group-1',
       from: { userid: 'alice' },
       text: { content: '!pwd' },
-      mentions: [{ userid: 'bot-id' }],
     });
 
     await vi.waitFor(() => expect(client.sendMessage).toHaveBeenCalled());

--- a/packages/channels/wecom/src/WeComAdapter.ts
+++ b/packages/channels/wecom/src/WeComAdapter.ts
@@ -419,6 +419,8 @@ export class WeComChannel extends ChannelBase {
       text,
       messageId: rawMessageId ?? messageId,
       isGroup,
+      // WeCom only delivers group callbacks when the intelligent robot is
+      // mentioned, so each delivered group message is already mention-scoped.
       isMentioned: true,
       isReplyToBot:
         getString(getRecord(quote, 'from'), 'userid') === this.wecom.botId,

--- a/packages/channels/wecom/src/WeComAdapter.ts
+++ b/packages/channels/wecom/src/WeComAdapter.ts
@@ -410,7 +410,6 @@ export class WeComChannel extends ChannelBase {
     }
 
     const text = extractText(body);
-    const explicitMention = getExplicitMention(body, this.wecom.botId);
     const quote = getRecord(body, 'quote');
     const envelope: Envelope = {
       channelName: this.name,
@@ -420,7 +419,7 @@ export class WeComChannel extends ChannelBase {
       text,
       messageId: rawMessageId ?? messageId,
       isGroup,
-      isMentioned: !isGroup || (explicitMention ?? false),
+      isMentioned: true,
       isReplyToBot:
         getString(getRecord(quote, 'from'), 'userid') === this.wecom.botId,
       referencedText: extractQuoteText(quote),
@@ -2091,62 +2090,4 @@ function getString(
 ): string {
   const raw = value?.[key];
   return typeof raw === 'string' ? raw : '';
-}
-
-function getBoolean(
-  value: Record<string, unknown> | undefined,
-  key: string,
-): boolean | undefined {
-  const raw = value?.[key];
-  return typeof raw === 'boolean' ? raw : undefined;
-}
-
-function getExplicitMention(
-  body: Record<string, unknown>,
-  botId: string,
-): boolean | undefined {
-  const botSpecificMention =
-    getBoolean(body, 'isInAtList') ?? getBoolean(body, 'is_in_at_list');
-  if (botSpecificMention !== undefined) return botSpecificMention;
-
-  const mentions = collectMentionValues(body);
-  if (!mentions.present) return getBoolean(body, 'isMentioned');
-
-  return mentions.values.some(
-    (mention) => mention === botId || mention === '@all' || mention === 'all',
-  );
-}
-
-function collectMentionValues(body: Record<string, unknown>): {
-  present: boolean;
-  values: string[];
-} {
-  const values: string[] = [];
-  let present = false;
-  for (const key of [
-    'mentions',
-    'mentioned_list',
-    'mentionedList',
-    'at_list',
-    'atList',
-    'at_userids',
-    'atUserIds',
-  ]) {
-    if (Object.prototype.hasOwnProperty.call(body, key)) {
-      present = true;
-    }
-    for (const item of getArray(body, key)) {
-      if (typeof item === 'string') {
-        values.push(item);
-        continue;
-      }
-      const record = asRecord(item);
-      if (!record) continue;
-      for (const itemKey of ['userid', 'userId', 'id', 'open_id', 'openId']) {
-        const value = getString(record, itemKey);
-        if (value) values.push(value);
-      }
-    }
-  }
-  return { present, values };
 }


### PR DESCRIPTION
## What this PR does

Aligns WeCom group-message handling with the intelligent robot delivery contract. Every delivered group callback is treated as already mention-scoped, speculative parsing of undocumented mention fields is removed, and the user guide now explains the behavior and compatibility of existing `requireMention` settings.

## Why it's needed

WeCom only delivers a group callback after the intelligent robot is mentioned, but the callback does not contain a separate mention flag or mention-target list. The generic channel gate defaulted `requireMention` to `true`, interpreted the missing metadata as unmentioned, and rejected every delivered group message. As a result, explicitly setting `requireMention: true`—or relying on its default—could make an otherwise correctly configured WeCom group chat completely nonfunctional.

The fix removes this ambiguous second decision. It does not enable unmentioned group traffic because WeCom still controls which messages are delivered.

## Reviewer Test Plan

### How to verify

Configure a WeCom intelligent robot with group access enabled and either omit `requireMention` or set it to `true`. Mention the robot in an allowed group and confirm the delivered callback reaches the agent instead of being rejected as `mention_required`. Confirm an existing configuration containing either `requireMention: true` or `requireMention: false` still starts without a configuration error. Confirm `groupPolicy`, group allowlisting, and sender access controls still reject disallowed traffic.

### Evidence (Before & After)

Before: a protocol-shaped group callback with no mention metadata was rejected by the default mention gate, leaving the group with no responses even after the robot was mentioned.

After: the same callback is accepted as mention-scoped, while a callback from a disabled group is still rejected before attachments are downloaded. The complete WeCom unit suite passes with 134 tests. A live WeCom group test with explicit `requireMention: true` delivered the mentioned message to the agent and returned `WECOM_E2E_OK` to the group.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v24.13.0 on macOS. Local validation included the complete WeCom unit suite, formatting, lint, build, type checking, and an independent code review. Full PR verification passed steps 1–20 of 22 and was stopped on request while downloading the Playwright browser for the remaining checks. The live WeCom test used a deterministic local OpenAI-compatible response backend so it validated the real WeCom receive-and-reply path without depending on an external model credential.

## Risk & Scope

- Main risk or tradeoff: WeCom mention gating now relies on the platform's documented mention-scoped delivery contract; the shared mention gate and other channels are unchanged.
- Not validated / out of scope: Windows and Linux were not tested. Outbound replies that explicitly mention a group member are unrelated to this change.
- Breaking changes / migration notes: None. Existing WeCom `requireMention: true` and `requireMention: false` settings remain valid but have the same behavior and can be removed; other per-group settings continue to apply.

## Linked Issues

Fixes #6939

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 让企业微信群消息处理与智能机器人平台的投递契约保持一致。所有已投递的群回调都会被视为已经过 @机器人 的平台筛选，同时删除对协议未定义的 mention 字段的推测解析，并在用户文档中说明现有 `requireMention` 配置的行为与兼容性。

## Why it's needed

企业微信只会在群内 @智能机器人后投递群回调，但回调中没有独立的 mention 标志或被 @对象列表。通用 channel 门禁默认将 `requireMention` 设为 `true`，又把缺少 mention 元数据解释为未 @，从而拒绝所有已经投递的群消息。因此，显式配置 `requireMention: true` 或使用其默认值，都会让其他配置完全正确的企业微信群聊表现为彻底不可用。

本修复移除了这层有歧义的二次判断。它不会让机器人收到未 @ 的群消息，因为消息是否投递仍由企业微信控制。

## Reviewer Test Plan

### How to verify

启用企业微信智能机器人的群访问，并省略 `requireMention` 或将其设为 `true`。在允许的群内 @机器人，确认已投递回调能够到达 agent，而不是以 `mention_required` 被拒绝。确认包含 `requireMention: true` 或 `requireMention: false` 的已有配置仍可正常启动且不会出现配置错误。确认 `groupPolicy`、群白名单和发送者访问控制仍会拒绝无权限流量。

### Evidence (Before & After)

修复前：不含 mention 元数据的协议形状群回调会被默认 mention 门禁拒绝，即使用户已经 @机器人，群里仍然没有任何响应。

修复后：相同回调会被视为已经过平台 @筛选并正常接收；禁用群的回调仍会在下载附件之前被拒绝。企业微信完整单测共 134 项，全部通过。真实企业微信群中显式配置 `requireMention: true` 后，@机器人消息已进入 agent，并在群内成功收到 `WECOM_E2E_OK` 回复。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS，Node.js v24.13.0。本地已完成企业微信完整单测、格式检查、lint、构建、类型检查以及独立代码审查。完整 PR 验证共 22 步，前 20 步通过，随后按要求在下载 Playwright 浏览器时停止。真实企业微信验证使用本地确定性 OpenAI 兼容响应服务，因此在不依赖外部模型凭据的情况下验证了真实企业微信收发链路。

## Risk & Scope

- 主要风险或权衡：企业微信 mention 门禁改为依赖平台文档定义的 @机器人后投递契约；共享 mention 门禁和其他 channel 均未改动。
- 未验证或范围外：未测试 Windows 和 Linux；机器人回复时显式 @某个群成员不属于本次改动。
- 破坏性变更或迁移说明：无。已有企业微信 `requireMention: true` 和 `requireMention: false` 配置仍然有效，但两者行为相同，可以删除该字段；同一群配置中的其他字段继续生效。

## Linked Issues

Fixes #6939

</details>
