### PR TITLE
feat(web-shell): maximize a single split pane

### DIFF
--- a/packages/web-shell/client/components/ChatPane.module.css
+++ b/packages/web-shell/client/components/ChatPane.module.css
@@ -48,7 +48,8 @@
   color: var(--foreground);
 }
 
-.closeButton {
+.closeButton,
+.maximizeButton {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -62,9 +63,17 @@
   cursor: pointer;
 }
 
-.closeButton:hover {
+.closeButton:hover,
+.maximizeButton:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
+/* The maximized pane keeps its toggle visually "active" so it's clear which
+   control returns to the tiled layout. */
+.maximizeButton[aria-pressed='true'] {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--foreground) 10%, transparent);
 }
 
 /* The transcript takes the remaining height and scrolls independently per pane. */

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -534,6 +534,36 @@ describe('ChatPane', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('renders no maximize toggle without onToggleMaximize', () => {
+    render({ onClose: () => {} });
+    expect(container!.querySelector('[aria-label="Maximize pane"]')).toBeNull();
+    expect(container!.querySelector('[aria-label="Restore pane"]')).toBeNull();
+  });
+
+  it('invokes onToggleMaximize from the header maximize button', () => {
+    const onToggleMaximize = vi.fn();
+    render({ onToggleMaximize });
+    const maximizeBtn = container!.querySelector(
+      '[aria-label="Maximize pane"]',
+    );
+    expect(maximizeBtn).not.toBeNull();
+    // A toggle button always exposes its pressed state; not maximized here.
+    expect(maximizeBtn!.getAttribute('aria-pressed')).toBe('false');
+    act(() =>
+      maximizeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(onToggleMaximize).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the restore affordance while maximized', () => {
+    render({ onToggleMaximize: () => {}, isMaximized: true });
+    const restoreBtn = container!.querySelector('[aria-label="Restore pane"]');
+    expect(restoreBtn).not.toBeNull();
+    expect(restoreBtn!.getAttribute('aria-pressed')).toBe('true');
+    // The label flips to "restore" — no stale "maximize" affordance remains.
+    expect(container!.querySelector('[aria-label="Maximize pane"]')).toBeNull();
+  });
+
   it('cancels the active turn via the composer cancel action', () => {
     render();
     act(() =>

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -77,6 +77,14 @@ export interface ChatPaneProps {
    */
   workspaceCwd?: string;
   onClose?: () => void;
+  /**
+   * Toggle this pane between maximized (solo, filling the whole split) and the
+   * tiled layout. Omitted when only one pane is open — there's nothing to
+   * maximize against.
+   */
+  onToggleMaximize?: () => void;
+  /** Whether this pane is currently the maximized (solo) one. */
+  isMaximized?: boolean;
   onError?: (error: unknown, fallback: string) => void;
   onRightPanelOpen?: (request: TurnOutputOpenRequest) => void;
   onPaneArtifactsChange?: (
@@ -98,6 +106,8 @@ export function ChatPane({
   title,
   workspaceCwd,
   onClose,
+  onToggleMaximize,
+  isMaximized = false,
   onError,
   onRightPanelOpen,
   onPaneArtifactsChange,
@@ -397,6 +407,37 @@ export function ChatPane({
         <span className={styles.title} title={headerLabel}>
           {headerLabel}
         </span>
+        {onToggleMaximize && (
+          <button
+            type="button"
+            className={styles.maximizeButton}
+            onClick={onToggleMaximize}
+            aria-pressed={isMaximized}
+            aria-label={t(
+              isMaximized ? 'splitView.restorePane' : 'splitView.maximizePane',
+            )}
+            title={t(
+              isMaximized ? 'splitView.restorePane' : 'splitView.maximizePane',
+            )}
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path
+                // Maximize2 / Minimize2 (diagonal arrows), matching the dialog
+                // fullscreen toggle's icon vocabulary.
+                d={
+                  isMaximized
+                    ? 'M4 14h6v6M20 10h-6V4M14 10l7-7M3 21l7-7'
+                    : 'M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7'
+                }
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
         {onClose && (
           <button
             type="button"

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Maximize2Icon, Minimize2Icon } from 'lucide-react';
 import {
   useActions,
   useConnection,
@@ -420,22 +421,12 @@ export function ChatPane({
               isMaximized ? 'splitView.restorePane' : 'splitView.maximizePane',
             )}
           >
-            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-              <path
-                // Maximize2 / Minimize2 (diagonal arrows), matching the dialog
-                // fullscreen toggle's icon vocabulary.
-                d={
-                  isMaximized
-                    ? 'M4 14h6v6M20 10h-6V4M14 10l7-7M3 21l7-7'
-                    : 'M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7'
-                }
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            {/* Same icon vocabulary as the dialog fullscreen toggle. */}
+            {isMaximized ? (
+              <Minimize2Icon size={16} aria-hidden />
+            ) : (
+              <Maximize2Icon size={16} aria-hidden />
+            )}
           </button>
         )}
         {onClose && (

--- a/packages/web-shell/client/components/SplitView.module.css
+++ b/packages/web-shell/client/components/SplitView.module.css
@@ -144,6 +144,12 @@
   min-height: 0;
 }
 
+/* While one pane is maximized, its siblings are hidden (but stay mounted, so
+   their sessions keep streaming). The lone visible slot then fills the row. */
+.paneSlot[data-pane-hidden] {
+  display: none;
+}
+
 .empty {
   flex: 1 1 auto;
   display: flex;

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -480,6 +480,58 @@ describe('SplitView', () => {
     input.remove();
   });
 
+  it('moves maximize to another pane when its toggle is clicked', () => {
+    render({ sessionIds: ['s1', 's2', 's3'] });
+    // Maximize s1.
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    let maximized = container!.querySelector('[data-maximized="true"]');
+    expect(
+      maximized?.querySelector('[data-testid="pane-title"]')?.textContent,
+    ).toBe('One');
+    // Click s2's toggle while s1 is maximized — maximize MOVES to s2 (it does
+    // not restore to tiled). Guards the toggle's switch branch, which a
+    // "clear on any second click" regression would break.
+    act(() =>
+      maximizeButtons()[1].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    maximized = container!.querySelector('[data-maximized="true"]');
+    expect(
+      maximized?.querySelector('[data-testid="pane-title"]')?.textContent,
+    ).toBe('Two');
+    // Exactly one pane maximized, the other two hidden.
+    expect(container!.querySelectorAll('[data-maximized="true"]')).toHaveLength(
+      1,
+    );
+    expect(hiddenSlots()).toHaveLength(2);
+  });
+
+  it('closes the picker on Escape without un-maximizing', () => {
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // Open the add-session picker, then press Escape: it closes the picker but
+    // must NOT also un-maximize — Escape defers to the open picker first.
+    openPicker();
+    expect(container!.querySelector('[role="listbox"]')).not.toBeNull();
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      ),
+    );
+    expect(container!.querySelector('[role="listbox"]')).toBeNull();
+    expect(hiddenSlots()).toHaveLength(1);
+  });
+
   it('drops maximize when the maximized pane is closed', () => {
     // Uncontrolled so the close button removes the pane locally (a controlled
     // split only reports removals up via onPanesChange).

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -66,8 +66,17 @@ vi.mock('./ChatPane', () => ({
     // Let a test force a render crash to exercise the per-pane ErrorBoundary.
     if (props.title === 'BOOM') throw new Error('pane exploded');
     return (
-      <div data-testid="chat-pane" data-pane-workspace={props.workspaceCwd}>
+      <div
+        data-testid="chat-pane"
+        data-pane-workspace={props.workspaceCwd}
+        data-maximized={props.isMaximized ? 'true' : 'false'}
+      >
         <span data-testid="pane-title">{props.title}</span>
+        {props.onToggleMaximize && (
+          <button data-testid="pane-maximize" onClick={props.onToggleMaximize}>
+            max
+          </button>
+        )}
         {props.onClose && (
           <button data-testid="pane-close" onClick={props.onClose}>
             x
@@ -370,6 +379,206 @@ describe('SplitView', () => {
     expect(container!.textContent).toContain('This session pane hit an error');
     expect(panes()).toHaveLength(1);
     expect(titles()).toEqual(['Two']);
+  });
+
+  function maximizeButtons(): HTMLElement[] {
+    return Array.from(
+      container!.querySelectorAll('[data-testid="pane-maximize"]'),
+    );
+  }
+  function hiddenSlots(): HTMLElement[] {
+    return Array.from(container!.querySelectorAll('[data-pane-hidden]'));
+  }
+
+  it('offers a maximize toggle only when more than one pane is open', () => {
+    // A lone pane already fills the split — nothing to maximize against.
+    render();
+    expect(maximizeButtons()).toHaveLength(0);
+    // Adding a second pane makes the toggle available on both.
+    openPicker();
+    const options = container!.querySelectorAll('[role="option"] button');
+    act(() =>
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(maximizeButtons()).toHaveLength(2);
+  });
+
+  it('maximizing a pane hides the others but keeps them all mounted', () => {
+    render({ sessionIds: ['s1', 's2', 's3'] });
+    expect(panes()).toHaveLength(3);
+    expect(hiddenSlots()).toHaveLength(0);
+
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    // All three panes stay mounted (their sessions keep streaming)…
+    expect(panes()).toHaveLength(3);
+    // …but the two non-maximized slots are hidden, leaving one visible.
+    expect(hiddenSlots()).toHaveLength(2);
+    // The maximized pane reflects its state down to ChatPane.
+    const maximized = container!.querySelector('[data-maximized="true"]');
+    expect(
+      maximized?.querySelector('[data-testid="pane-title"]')?.textContent,
+    ).toBe('One');
+  });
+
+  it('toggles back to the tiled layout when the maximized pane’s button is clicked again', () => {
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // The still-mounted maximized pane's own toggle restores the split.
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(0);
+    expect(container!.querySelector('[data-maximized="true"]')).toBeNull();
+  });
+
+  it('restores the tiled layout on Escape', () => {
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // A plain Escape (not aimed at the composer or picker) restores all panes.
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(0);
+  });
+
+  it('keeps a pane maximized when Escape originates from an editable field', () => {
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // Escape from the composer cancels the turn / closes its menus — it must not
+    // also un-maximize. An <input> stands in for the CodeMirror editor here.
+    const input = document.createElement('input');
+    container!.appendChild(input);
+    act(() =>
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    input.remove();
+  });
+
+  it('drops maximize when the maximized pane is closed', () => {
+    // Uncontrolled so the close button removes the pane locally (a controlled
+    // split only reports removals up via onPanesChange).
+    render();
+    openPicker();
+    const options = container!.querySelectorAll('[role="option"] button');
+    act(() =>
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(panes()).toHaveLength(2); // seed 'Three' + added 'One'
+    // Maximize the seed pane, then close it via its (visible) close button.
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    const closes = container!.querySelectorAll('[data-testid="pane-close"]');
+    act(() =>
+      closes[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    // The lone survivor tiles normally — maximize was dropped with its pane.
+    expect(titles()).toEqual(['One']);
+    expect(hiddenSlots()).toHaveLength(0);
+  });
+
+  it('drops maximize when a controlled sync removes the maximized pane', () => {
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // The parent drops the maximized session (s1) from the split…
+    act(() =>
+      root!.render(
+        <I18nProvider language="en">
+          <SplitView onExit={() => {}} sessionIds={['s2']} />
+        </I18nProvider>,
+      ),
+    );
+    // …so nothing stays maximized — the lone survivor tiles normally.
+    expect(titles()).toEqual(['Two']);
+    expect(hiddenSlots()).toHaveLength(0);
+  });
+
+  it('clears a stale maximize when a controlled split shrinks to one pane then regrows', () => {
+    const rerender = (ids: string[]) =>
+      act(() =>
+        root!.render(
+          <I18nProvider language="en">
+            <SplitView onExit={() => {}} sessionIds={ids} />
+          </I18nProvider>,
+        ),
+      );
+    render({ sessionIds: ['s1', 's2'] });
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1); // s1 maximized, s2 hidden
+    // The parent drops the *other* pane, leaving the maximized one alone — the
+    // stale maximize must clear (it can't hold against a single pane)…
+    rerender(['s1']);
+    expect(titles()).toEqual(['One']);
+    expect(hiddenSlots()).toHaveLength(0);
+    // …so re-adding a pane shows a clean tiled split, not a silently re-hidden
+    // one from the earlier maximize.
+    rerender(['s1', 's2']);
+    expect(titles()).toEqual(['One', 'Two']);
+    expect(hiddenSlots()).toHaveLength(0);
+  });
+
+  it('reveals a newly added pane by exiting maximize', () => {
+    // Uncontrolled so the picker mounts the new pane locally.
+    render();
+    openPicker();
+    let options = container!.querySelectorAll('[role="option"] button');
+    act(() =>
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(panes()).toHaveLength(2);
+    act(() =>
+      maximizeButtons()[0].dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      ),
+    );
+    expect(hiddenSlots()).toHaveLength(1);
+    // Adding another session drops the maximize so the new pane isn't hidden
+    // behind a still-maximized one.
+    openPicker();
+    options = container!.querySelectorAll('[role="option"] button');
+    act(() =>
+      options[0].dispatchEvent(new MouseEvent('click', { bubbles: true })),
+    );
+    expect(panes()).toHaveLength(3);
+    expect(hiddenSlots()).toHaveLength(0);
   });
 
   it('reloads the session list when the picker opens (never a stale list)', () => {

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -31,6 +31,7 @@ import {
   mergeSessionsById,
   workspaceBasename,
 } from '../utils/workspace';
+import { isEditableTarget } from '../utils/dom';
 import styles from './SplitView.module.css';
 
 const MAX_PANES = MAX_SPLIT_PANES;
@@ -133,6 +134,10 @@ export function SplitView({
     return currentSessionId ? [currentSessionId] : [];
   });
   const [pickerOpen, setPickerOpen] = useState(false);
+  // Which pane, if any, is maximized to fill the whole split. Purely visual and
+  // ephemeral (not deep-linked via `?split=`, like the dialog fullscreen toggle
+  // it mirrors): the other panes stay mounted and streaming, just hidden.
+  const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null);
   const addWrapRef = useRef<HTMLDivElement | null>(null);
   // A per-tab/per-mount nonce: two browser tabs opening the same split must not
   // register the same daemon client id, or suppressOwnUserEcho would treat one
@@ -249,6 +254,9 @@ export function SplitView({
         return;
       }
       const next = [...currentPaneIds, sessionId];
+      // Reveal the freshly added pane rather than leaving it hidden behind a
+      // still-maximized one.
+      setMaximizedPaneId(null);
       if (sessionIdsControlled) {
         onPanesChange?.(next);
       } else {
@@ -292,11 +300,48 @@ export function SplitView({
     [onPanesChange, sessionIdsControlled],
   );
 
+  const toggleMaximize = useCallback((sessionId: string) => {
+    setMaximizedPaneId((current) => (current === sessionId ? null : sessionId));
+  }, []);
+
+  // Maximize only makes sense against another pane, so drop it whenever it no
+  // longer can hold: the maximized pane left the set (closed here, or removed by
+  // a controlled-mode sync), or the split shrank to a lone pane. Without the
+  // length guard a surviving maximized pane would keep a stale `maximizedPaneId`
+  // that silently re-hides the next pane a controlled parent adds back.
+  useEffect(() => {
+    if (
+      maximizedPaneId &&
+      (paneIds.length < 2 || !paneIds.includes(maximizedPaneId))
+    ) {
+      setMaximizedPaneId(null);
+    }
+  }, [paneIds, maximizedPaneId]);
+
+  // Escape restores the tiled layout, but only when the key is otherwise unused:
+  // defer to an open picker (its own Escape closes it first), and never steal
+  // Escape from the composer — it cancels the in-flight turn / closes its menus —
+  // or from an open dialog. `isEditableTarget` covers `.cm-editor` and dialog
+  // keyboard scopes, so a maximized pane's composer keeps its Escape.
+  useEffect(() => {
+    if (!maximizedPaneId) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (pickerOpen || isEditableTarget(event.target)) return;
+      setMaximizedPaneId(null);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [maximizedPaneId, pickerOpen]);
+
   const available = useMemo(
     () => allSessions.filter((session) => !paneIds.includes(session.sessionId)),
     [allSessions, paneIds],
   );
   const canAdd = paneIds.length < MAX_PANES && available.length > 0;
+  // Only offer per-pane maximize once there's another pane to maximize against —
+  // a lone pane already fills the split.
+  const canMaximize = paneIds.length > 1;
 
   return (
     <div className={styles.split} data-testid="split-view">
@@ -374,9 +419,14 @@ export function SplitView({
         ) : (
           paneIds.map((sessionId) => {
             const paneWorkspaceCwd = workspaceCwdById.get(sessionId);
+            const isMaximized = maximizedPaneId === sessionId;
+            // When one pane is maximized, the rest stay mounted (their sessions
+            // keep streaming) but are hidden via CSS — a purely visual solo.
+            const isHidden = maximizedPaneId !== null && !isMaximized;
             return (
               <div
                 className={styles.paneSlot}
+                data-pane-hidden={isHidden ? '' : undefined}
                 // Include the resolved workspace in the key on a multi-workspace
                 // daemon so a pane whose workspace resolves only after mount (e.g.
                 // a `?split=` deep link) remounts under the right workspace rather
@@ -433,6 +483,12 @@ export function SplitView({
                       title={titleById.get(sessionId)}
                       workspaceCwd={paneWorkspaceCwd}
                       onClose={() => removePane(sessionId)}
+                      onToggleMaximize={
+                        canMaximize
+                          ? () => toggleMaximize(sessionId)
+                          : undefined
+                      }
+                      isMaximized={isMaximized}
                       onError={onError}
                       onRightPanelOpen={onRightPanelOpen}
                       onPaneArtifactsChange={onPaneArtifactsChange}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1873,6 +1873,8 @@ const EN: Messages = {
   'splitView.count': (v) => `${v?.count ?? 0} panes`,
   'splitView.addPane': 'Add session',
   'splitView.closePane': 'Close pane',
+  'splitView.maximizePane': 'Maximize pane',
+  'splitView.restorePane': 'Restore pane',
   'splitView.paneError': 'This session pane hit an error',
   'splitView.paneConnectionError': 'Connection lost',
   'splitView.outerApprovalPending':
@@ -3740,6 +3742,8 @@ const ZH: Messages = {
   'splitView.count': (v) => `${v?.count ?? 0} 个窗格`,
   'splitView.addPane': '添加会话',
   'splitView.closePane': '关闭窗格',
+  'splitView.maximizePane': '最大化窗格',
+  'splitView.restorePane': '还原窗格',
   'splitView.paneError': '此会话窗格出错',
   'splitView.paneConnectionError': '连接已断开',
   'splitView.outerApprovalPending': '主会话正在等待审批。',


### PR DESCRIPTION
## What this PR does

Adds a per-pane **maximize / restore** toggle to the Web Shell split view. Each pane header gains a maximize button (⤢, left of the close button) that blows that pane up to fill the whole split and hides the others; clicking it again — or the header restore button, or `Escape` — returns to the tiled layout. The button only appears with 2+ panes. Hidden panes stay mounted (their SSE streams, streaming state, and approvals keep running), so maximize is a purely visual solo, not an unmount/reconnect. Adding a session exits maximize to reveal the new pane, and maximize is dropped automatically whenever its pane leaves the split or the split shrinks to a single pane.

## Why it's needed

The split view tiles N sessions at equal width with no way to focus one. When a single session's transcript is what you're actually working in — reading a long diff, following a tool run — the other panes just eat horizontal space and every line wraps early. Maximize lets you temporarily give one session the full width without tearing down the others (they keep streaming in the background) and snap back when you're done, so the split stays useful for both "watch several at once" and "dig into this one."

## Reviewer Test Plan

### How to verify

1. Open the Web Shell, enter the split view, and add a second session (so 2+ panes are shown).
2. Click the maximize button (⤢) in a pane header. Expected: that pane fills the split, the others disappear, and the button becomes a highlighted restore icon (⤡).
3. Press `Escape` with focus outside the composer. Expected: back to the tiled layout.
4. Maximize again, then focus the composer and press `Escape`. Expected: the composer handles Escape (cancels the turn / closes its menu) and the pane stays maximized.
5. Maximize a pane, then click a different pane's maximize button. Expected: maximize moves to that pane.
6. Maximize, then click "+ Add session". Expected: maximize exits so the new pane is visible.

Automated: `SplitView.test.tsx` (+11) and `ChatPane.test.tsx` (+3) cover toggle gating, hide-others-keep-mounted, toggle-back, switch-between-panes, Escape-restores, Escape-in-editable / picker-open do-not-restore, and close / controlled-sync / shrink-to-one clearing the maximize. Full web-shell suite: `1639 passing`. `typecheck` / `eslint` / `prettier` clean.

### Evidence (Before & After)

Rendered from a standalone repro of the real split-view DOM + `*.module.css` rules (verbatim), both themes. Programmatic checks confirmed all panes stay mounted with exactly one visible filling the row, and the maximized toggle shows the restore icon + `aria-pressed`.

Light — tiled (before) → maximized (after):

| Tiled (3 panes) | Maximized |
| --- | --- |
| <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/split-pane-maximize/split-pane-maximize/01-light-tiled.png" width="420"> | <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/split-pane-maximize/split-pane-maximize/02-light-maximized.png" width="420"> |

Dark — tiled (before) → maximized (after):

| Tiled (3 panes) | Maximized |
| --- | --- |
| <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/split-pane-maximize/split-pane-maximize/03-dark-tiled.png" width="420"> | <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/split-pane-maximize/split-pane-maximize/04-dark-maximized.png" width="420"> |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

macOS verified locally; Linux via CI (green); Windows not run.

### Environment (optional)

Unit tests + a standalone Playwright render of the real DOM/CSS. No daemon required.

## Risk & Scope

- Main risk or tradeoff: purely additive, ephemeral view state (`maximizedPaneId`). The two ways it could misbehave — a stale maximize hiding a pane, or `Escape` stealing a key from the composer / picker / dialog — are both guarded (auto-clear effect; `isEditableTarget` + `pickerOpen` deferral) and directly tested.
- Not validated / out of scope: resizable / draggable panes; persisting maximize in the `?split=` deep link (intentionally ephemeral, mirroring the dialog fullscreen toggle).
- Breaking changes / migration notes: none. Adds optional `ChatPane` props (`onToggleMaximize`, `isMaximized`); behavior is unchanged when they're absent.

## Linked Issues

N/A — direct feature request, no tracking issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 Web Shell 分屏加了单个窗格的**最大化 / 还原**开关。每个窗格标题栏新增一个最大化按钮（⤢，在关闭键左边），点击后该窗格放大占满整个分屏区、其它窗格隐藏；再次点击 —— 或标题栏的还原按钮，或 `Escape` —— 回到平铺。按钮仅在 ≥2 个窗格时出现。被隐藏的窗格仍然挂载（各自的 SSE 流、streaming 状态、审批都不中断），所以最大化是纯视觉的独占，而非卸载重连。点「+ 添加会话」会退出最大化以显现新窗格；当最大化的窗格离开分屏、或分屏缩到只剩一个时，自动清除最大化状态。

## 为什么需要

分屏把 N 个会话等宽平铺，无法聚焦其中某一个。当你实际在某一个会话里工作时（读长 diff、跟一次工具运行），其它窗格只是占着横向空间、每行很早就换行。最大化让你临时把整幅宽度给一个会话，又不拆掉其它窗格（它们在后台继续 streaming），用完再收回 —— 这样分屏对「同时看多个」和「深入看这一个」两种需求都好用。

## 审查者测试计划

### 如何验证

1. 打开 Web Shell，进入分屏，添加第二个会话（凑够 ≥2 个窗格）。
2. 点某个窗格标题栏的最大化按钮（⤢）。预期：该窗格占满分屏区、其它消失、按钮变成高亮的还原图标（⤡）。
3. 在焦点不在输入框时按 `Escape`。预期：回到平铺。
4. 再次最大化，然后聚焦输入框并按 `Escape`。预期：输入框处理 Escape（取消回合 / 关菜单），窗格保持最大化。
5. 最大化某个窗格，再点另一个窗格的最大化按钮。预期：最大化转移到那个窗格。
6. 最大化后点「+ 添加会话」。预期：退出最大化以显现新窗格。

自动化：`SplitView.test.tsx`（+11）与 `ChatPane.test.tsx`（+3）覆盖按钮门控、隐藏其它但保持挂载、再次点击还原、窗格间切换、Escape 还原、输入框内 / 选择器打开时 Escape 不还原、以及关闭 / 受控同步 / 缩到 1 个时清除最大化。web-shell 全套 `1639 通过`；`typecheck` / `eslint` / `prettier` 全过。

### 证据（Before & After）

以下由真实分屏 DOM + `*.module.css` 规则（逐字复刻）的独立 repro 渲染，明暗两套主题。程序化断言确认所有窗格保持挂载、恰好一个可见并占满整行，最大化开关显示还原图标 + `aria-pressed`。截图见上方英文 Evidence 部分。

### 测试平台

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

macOS 本地验证；Linux 经 CI（通过）；Windows 未运行。

### 运行环境（可选）

单元测试 + 独立 Playwright 渲染真实 DOM/CSS。无需 daemon。

## 风险与范围

- 主要风险 / 取舍：纯新增、临时的视图状态（`maximizedPaneId`）。它可能出错的两种方式 —— 残留的最大化误隐藏窗格、或 `Escape` 抢走 composer / 选择器 / 弹窗的按键 —— 都做了守卫（自动清除 effect；`isEditableTarget` + `pickerOpen` 避让）并有针对性测试。
- 未验证 / 范围之外：可拖拽调整大小的窗格；把最大化状态写进 `?split=` 深链（有意做成临时的，与弹窗全屏开关一致）。
- 破坏性变更 / 迁移说明：无。新增可选 `ChatPane` props（`onToggleMaximize`、`isMaximized`）；不传时行为不变。

## 关联 Issue

N/A —— 直接的功能请求，无跟踪 issue。

</details>
