### PR TITLE
fix(tui): pin MaxSizedBox rows and gate the pending backstop for show-more diff (#6809)

### DIFF
--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '../contexts/UIActionsContext.js';
 import { AppContext } from '../contexts/AppContext.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
-import { ToolCallStatus } from '../types.js';
+import { ToolCallStatus, StreamingState } from '../types.js';
 
 // Global compact mode was removed (#5666); type-based tool rendering no longer
 // consumes a compact-mode context.
@@ -26,12 +26,20 @@ const staticItemsSpy = vi.fn();
 const historyItemDisplayPropsSpy = vi.fn();
 const appHeaderSpy = vi.fn();
 const scrollableListPropsSpy = vi.fn();
+// Records every <Box> render's props so tests can assert layout props
+// (e.g. the pending-region maxHeight backstop) without coupling to ink's
+// Yoga internals.
+const boxPropsSpy = vi.fn();
 
 vi.mock('ink', async () => {
   const actual = await vi.importActual<typeof import('ink')>('ink');
 
   return {
     ...actual,
+    Box: (props: React.ComponentProps<typeof actual.Box>) => {
+      boxPropsSpy(props);
+      return <actual.Box {...props} />;
+    },
     Static: ({
       children,
       items,
@@ -877,5 +885,47 @@ describe('<MainContent />', () => {
       // The ref-based read keeps identity stable.
       expect(secondRenderItem).toBe(firstRenderItem);
     });
+  });
+
+  // #6809: the pending-region maxHeight backstop must stay ON while streaming
+  // (Responding) so streaming tables don't yank the viewport to the top
+  // (#6421), but drop in show-more mode once streaming has settled to a static
+  // confirmation (WaitingForConfirmation) so a tall diff renders every row.
+  it('gates the pending-region maxHeight backstop on streamingState (#6809)', () => {
+    const wrapperProps = () =>
+      boxPropsSpy.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (p: { flexShrink?: number; overflow?: string }) =>
+            p.flexShrink === 0 && p.overflow === 'hidden',
+        );
+
+    boxPropsSpy.mockClear();
+    renderMainContent(
+      createUIState({
+        pendingHistoryItems: [{ type: 'gemini_content', text: 'x' }],
+        availableTerminalHeight: 5,
+        constrainHeight: false,
+        streamingState: StreamingState.Responding,
+      }),
+    );
+    expect(
+      wrapperProps().some((p: { maxHeight?: number }) => p.maxHeight === 5),
+    ).toBe(true);
+
+    boxPropsSpy.mockClear();
+    renderMainContent(
+      createUIState({
+        pendingHistoryItems: [{ type: 'gemini_content', text: 'x' }],
+        availableTerminalHeight: 5,
+        constrainHeight: false,
+        streamingState: StreamingState.WaitingForConfirmation,
+      }),
+    );
+    expect(
+      wrapperProps().some(
+        (p: { maxHeight?: number }) => p.maxHeight === undefined,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -927,5 +927,21 @@ describe('<MainContent />', () => {
         (p: { maxHeight?: number }) => p.maxHeight === undefined,
       ),
     ).toBe(true);
+
+    // Constrained mode (#6421): constrainHeight alone must engage the
+    // backstop even when not streaming, so streaming tables don't yank
+    // the viewport to the top.
+    boxPropsSpy.mockClear();
+    renderMainContent(
+      createUIState({
+        pendingHistoryItems: [{ type: 'gemini_content', text: 'x' }],
+        availableTerminalHeight: 5,
+        constrainHeight: true,
+        streamingState: StreamingState.Idle,
+      }),
+    );
+    expect(
+      wrapperProps().some((p: { maxHeight?: number }) => p.maxHeight === 5),
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -7,13 +7,14 @@
 import { Box, Static } from 'ink';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
-import { isHistoryItemVisibleAfterRestore } from '../types.js';
+import { isHistoryItemVisibleAfterRestore, StreamingState } from '../types.js';
 import { HistoryItemDisplay } from './HistoryItemDisplay.js';
 import { ShowMoreLines } from './ShowMoreLines.js';
 import { Notifications } from './Notifications.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useAppContext } from '../contexts/AppContext.js';
+import { useStreamingContext } from '../contexts/StreamingContext.js';
 import { AppHeader } from './AppHeader.js';
 import { DebugModeNotification } from './DebugModeNotification.js';
 import {
@@ -107,6 +108,7 @@ const virtualIsStaticItem = (item: VpItem) =>
 export const MainContent = () => {
   const { version } = useAppContext();
   const uiState = useUIState();
+  const streamingState = useStreamingContext();
   const showScrollbar = uiState.showScrollbar ?? true;
   const {
     pendingHistoryItems,
@@ -476,11 +478,26 @@ export const MainContent = () => {
             so the clamp is a no-op there and only engages on residual overflow.
             ShowMoreLines stays OUTSIDE the clamp; it only renders while
             constrained (so the clamp is inert) and must not be clipped.
+
+            The clamp engages while constrained OR while the model is actively
+            streaming (Responding) — i.e. the case that trips the scroll-to-top
+            lock. It is deliberately dropped in "show more lines" mode
+            (constrainHeight off) once streaming has settled to a static
+            confirmation (WaitingForConfirmation): a tall edit/write_file diff
+            preview must render every row so the user can scroll the terminal
+            scrollback and review the full change before approving (#6809). A
+            static confirmation is a single render, so it does not trip Ink's
+            from-top full-redraw path the way a streaming table does.
           */}
           <Box
             flexDirection="column"
             flexShrink={0}
-            maxHeight={availableTerminalHeight || undefined}
+            maxHeight={
+              uiState.constrainHeight ||
+              streamingState === StreamingState.Responding
+                ? availableTerminalHeight
+                : undefined
+            }
             overflow="hidden"
           >
             {pendingHistoryItemsWithSourceCopyOffsets.map(

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -14,7 +14,6 @@ import { Notifications } from './Notifications.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useAppContext } from '../contexts/AppContext.js';
-import { useStreamingContext } from '../contexts/StreamingContext.js';
 import { AppHeader } from './AppHeader.js';
 import { DebugModeNotification } from './DebugModeNotification.js';
 import {
@@ -108,7 +107,7 @@ const virtualIsStaticItem = (item: VpItem) =>
 export const MainContent = () => {
   const { version } = useAppContext();
   const uiState = useUIState();
-  const streamingState = useStreamingContext();
+  const streamingState = uiState.streamingState;
   const showScrollbar = uiState.showScrollbar ?? true;
   const {
     pendingHistoryItems,
@@ -495,7 +494,7 @@ export const MainContent = () => {
             maxHeight={
               uiState.constrainHeight ||
               streamingState === StreamingState.Responding
-                ? availableTerminalHeight
+                ? availableTerminalHeight || undefined
                 : undefined
             }
             overflow="hidden"

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx
@@ -422,4 +422,50 @@ Line 3 direct child`);
 
     expect(lastFrame()).equals(expected);
   });
+
+  // Regression for #6809: when MaxSizedBox renders all its rows (maxHeight
+  // undefined — the "show more lines" mode) while a pending-region ancestor
+  // clamps the column height, Ink's default flexShrink=1 compresses the rows
+  // and stacks several at the same Y, leaving only every Nth line visible.
+  // The ancestor chain mirrors the live confirmation dialog: a maxHeight
+  // backstop wrapping a padded content box with a flexGrow/overflow body.
+  it('keeps rows sequential when an ancestor clamps the column height (#6809)', () => {
+    const rows = Array.from({ length: 60 }, (_, i) => (
+      <Box key={i}>
+        <Text>{`line ${i + 1}`}</Text>
+      </Box>
+    ));
+
+    const { lastFrame } = render(
+      <OverflowProvider>
+        <Box
+          flexDirection="column"
+          flexShrink={0}
+          maxHeight={24}
+          overflow="hidden"
+        >
+          <Box flexDirection="column" padding={1} width={80}>
+            <Box flexGrow={1} flexShrink={1} overflow="hidden" marginBottom={1}>
+              <MaxSizedBox maxWidth={80} maxHeight={undefined}>
+                {rows}
+              </MaxSizedBox>
+            </Box>
+          </Box>
+        </Box>
+      </OverflowProvider>,
+    );
+
+    const frame = lastFrame()!;
+    const gutters: number[] = [];
+    for (const line of frame.split('\n')) {
+      const match = line.match(/^\s*line (\d+)/);
+      if (match) gutters.push(Number(match[1]));
+    }
+    // Without the flexShrink={0} pin, the gutters are sparse (e.g. 1, 4, 7…)
+    // because the rows are compressed onto shared lines. With the pin they
+    // remain a contiguous prefix.
+    expect(gutters).toEqual(
+      Array.from({ length: gutters.length }, (_, i) => i + 1),
+    );
+  });
 });

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -174,8 +174,13 @@ export const MaxSizedBox: React.FC<MaxSizedBoxProps> = ({
         : laidOutStyledText.slice(0, visibleContentHeight)
       : laidOutStyledText;
 
+  // Pin each rendered row to its natural height. Ink's default flexShrink is
+  // 1, so when an ancestor clamps this column's height (e.g. the pending-
+  // region maxHeight backstop) Yoga compresses the rows and stacks several at
+  // the same Y, leaving only every Nth line visible (#6809). flexShrink={0}
+  // keeps rows full-height and sequential under a clamped ancestor.
   const visibleLines = visibleStyledText.map((line, index) => (
-    <Box key={index}>
+    <Box key={index} flexShrink={0}>
       {line.length > 0 ? (
         line.map((segment, segIndex) => (
           <Text key={segIndex} {...segment.props}>


### PR DESCRIPTION
## What this PR does

Pins each rendered preview/code row to its natural height (so rows stay sequential under a clamped ancestor), and gates the pending-region height backstop so that in "show more lines" mode a static edit/write_file diff confirmation renders every row and flows into the terminal scrollback instead of being clipped.

## Why it's needed

In the "show more lines" view of an edit/write_file confirmation, the diff/code preview renders every row. The pending region is wrapped in a hard maxHeight backstop (added to stop streaming tables from yanking the viewport to the top). Under that clamped column the per-row containers default to `flexShrink: 1`, so the layout engine compresses them and stacks several rows at the same vertical position — only every Nth line survives, line numbers skip (e.g. 6, 16, 26, 37, 47, 57), and changed lines vanish from the preview. Worse, the backstop's `maxHeight` also clips the show-more preview to the viewport, so the user cannot see the full change before approving — which is the whole point of the preview. Both defects are exactly #6809.

This PR addresses both: pin the rows to `flexShrink: 0` (fixes the garbling), and drop the backstop in show-more mode once streaming has settled to a static confirmation (WaitingForConfirmation), so the diff renders every row and the user can scroll the terminal scrollback to review the full change. The backstop still engages while constrained OR while the model is actively streaming (Responding), so the streaming-table scroll-to-top protection it was added for (#6421) is unaffected.

## Reviewer Test Plan

### How to verify

1. Trigger an edit or write_file that opens a multi-line (>~30 lines) diff/code confirmation.
2. Press Ctrl+S to enter "show more lines".
3. Confirm the preview shows line numbers in sequence (1, 2, 3, …) with no lines dropped or glued together, and that scrolling the terminal scrollback reveals the entire file — for both a multi-line edit and a new-file write.
4. Streaming tables: stream a tall wide table (the #6421 repro) in normal (constrained) mode and confirm the viewport is still not yanked to the top (the backstop is unchanged there).

### Evidence (Before & After)

Real-PTY capture at 100×60 (terminal-capture harness: xterm.js + Playwright + node-pty; default OpenAI-compatible fake server driving a write_file tool call that creates a 60-line file). See the attached screenshots for the visible before/after of the Ctrl+S diff preview.

- Before: show-more diff gutters = `6, 16, 26, 37, 47, 57` (sparse, every ~10th line; lines dropped) and only the viewport slice visible (the rest clipped away, not scrollable).
- After: show-more diff gutters = `1, 2, 3, …, 60` (contiguous, full file; the tail is reachable by scrolling the terminal scrollback).
- #6421 streaming-table regression ratchet (constrained): still `pass=true`, `clearTerminalTriples=0`.
- Table in show-more mode (Ctrl+S mid-stream, Responding): `clearsAfterToggle=0` — no scroll-to-top regression.
- MaxSizedBox suite (22 tests, incl. a new regression case for this): all pass.

<img width="1726" height="1196" alt="compare" src="https://github.com/user-attachments/assets/771a3f34-9021-4d56-b255-58b9c9585ddd" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment

macOS (Node 22.23.1): the 59 directly-relevant tests pass — MaxSizedBox (22, incl. the new #6809 regression case), DiffRenderer (16), ToolConfirmationMessage (21). A full `npm run preflight` on macOS hits pre-existing, unrelated failures that do not reproduce under CI's English locale and standard network: Chinese-locale CLI error messages vs. English assertions (i18n), serve/network 5s timeouts, 403 / socket-hang-up, and VSCode-extension spies; these appear identically on a clean main checkout. Linux (Node 20.18): the three behaviors above were verified end-to-end with the real-PTY terminal-capture harness (diff shows 1..60; #6421 ratchet pass; table show-more 0 clears) plus vitest; full preflight was blocked here only by environment quirks (`npm ci` postinstall PATH, `NODE_ENV=production` default → browser test env, no clipboard in the headless container) — none code-related.

## Risk & Scope

- Main risk or tradeoff: two small changes. (1) `flexShrink={0}` on the preview rows only changes layout when an ancestor actually clamps the column — when it doesn't, rows were already full-height. (2) The backstop is dropped only in show-more mode AND only after streaming has settled to a static confirmation (WaitingForConfirmation); it stays on while constrained or while streaming (Responding), so streaming-table protection is unchanged. The show-more toggle of a tall diff emits a brief repaint burst as the layout grows, then settles (a single static render does not trip Ink's from-top full-redraw path the way a streaming table does).
- Not validated / out of scope: Windows TUI not run locally. The garbling and the clip were only reproducible through the full confirmation-dialog box chain (a component-only render does not reproduce it), so the regression test mirrors that chain.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6809

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把预览/代码块的每一行固定为本身自然高度（在被夹住的祖先下仍顺序排列），并按状态门控待处理区域的 maxHeight 兜底：在「显示更多行」模式下，当流式输出已落定为静态确认框（WaitingForConfirmation）时，不再裁剪，让 edit/write_file 的 diff 渲染出全部行、流入终端 scrollback。

## 为什么需要它

在 edit/write_file 确认框的「显示更多行」视图里，diff/代码预览会渲染每一行。待处理区域被一个硬性 maxHeight 兜底包裹（它是为了防止流式表格把视口拽回顶部而加的）。在这个被夹住高度的列里，每一行的容器默认是 `flexShrink: 1`，布局引擎把它们压缩、让多行堆到同一个垂直位置——只有每 N 行能留下来，行号跳号（例如 6, 16, 26, 37, 47, 57），改动的行从预览里消失。更糟的是，这个兜底的 `maxHeight` 还把显示更多行后的预览裁到视口内，用户看不到完整改动就没法判断是否允许——而这正是预览的用途。两者都是 #6809。

本 PR 同时解决：把行固定为 `flexShrink: 0`（修乱码），并在「显示更多行」模式下、流式已落定为静态确认框时去掉兜底（让 diff 渲染全部行、用户可滚动终端 scrollback 看全）。兜底在约束模式或模型正在流式输出（Responding）时仍然生效，所以它当初为流式表格提供的「跳顶」保护（#6421）不受影响。

## 评审测试计划

### 如何验证

1. 触发一个 edit 或 write_file，弹出一个多行（>~30 行）的 diff/代码确认框。
2. 按 Ctrl+S 进入「显示更多行」。
3. 确认预览行号连续（1, 2, 3, …）、不丢行不粘行，且滚动终端 scrollback 能看到整个文件——多行 edit 和新文件 write_file 都要试。
4. 流式表格：在正常（约束）模式下流一个又高又宽的表格（#6421 复现），确认视口仍不被拽回顶部（约束模式下兜底未变）。

### 证据（前后对比）

100×60 真实 PTY 捕获（terminal-capture harness：xterm.js + Playwright + node-pty；默认 OpenAI 兼容假服务器驱动一个创建 60 行文件的 write_file 工具调用）。前后截图见 PR 附件。

- 之前：显示更多行 diff 行号 = `6, 16, 26, 37, 47, 57`（稀疏，约每 10 行一行；行被丢），且只看到视口那一截（其余被裁，无法滚动）。
- 之后：行号 = `1, 2, 3, …, 60`（连续，全文；尾部可通过滚动终端 scrollback 看到）。
- #6421 流式表格回归 ratchet（约束模式）：仍 `pass=true`，`clearTerminalTriples=0`。
- 表格在显示更多行模式（流式中按 Ctrl+S，Responding）：`clearsAfterToggle=0`——无「跳顶」回归。
- MaxSizedBox 套件（22 个测试，含为此新增的一个回归用例）：全过。

### 测试过的平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测 |
| 🪟 Windows | ⚠️ 未测 |
|  🐧 Linux  | ✅ 已测 |

### 环境

macOS（Node 22.23.1）：59 个直接相关测试全过——MaxSizedBox（22，含新增 #6809 回归用例）、DiffRenderer（16）、ToolConfirmationMessage（21）。macOS 上完整 `npm run preflight` 会出现一些预存的、与本次改动无关的失败，CI 的英文 locale + 标准网络环境下不会复现：中文 locale 下 CLI 报错为中文而断言写死英文（i18n）、serve/网络 5 秒超时、403 / socket hang up、VSCode 扩展 spy；在干净的 main 上同样出现。Linux（Node 20.18）：上述三个行为用真实 PTY terminal-capture harness 端到端验证（diff 显示 1..60；#6421 ratchet pass；表格显示更多行 0 clears）+ vitest；这里完整 preflight 只被环境问题挡住（`npm ci` postinstall 的 PATH、默认 `NODE_ENV=production` → 浏览器测试环境、无头容器无剪贴板），都与代码无关。

## 风险与范围

- 主要风险或取舍：两处小改动。(1) 预览行的 `flexShrink={0}` 只有在祖先真的夹住列高度时才改变布局——不夹时行本来就已本身高度。(2) 兜底只在「显示更多行」且流式已落定为静态确认框（WaitingForConfirmation）时去掉；约束模式或流式（Responding）时仍开，所以流式表格保护不变。显示更多行切换一个高 diff 时会有短暂的布局增长重绘 burst，随后稳定（静态单次渲染不会像流式表格那样触发 Ink 的从顶全屏重绘）。
- 未验证 / 范围外：Windows 的 TUI 没在本地跑。乱码与裁剪只有在完整的确认对话框 box 链路里才能复现（仅组件级渲染复现不出来），所以回归测试镜像的是这条链路。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6809

</details>
