### PR TITLE
fix(web-shell): show workspace chip tooltip on narrow composer

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -232,7 +232,12 @@ describe('ChatEditor workspace toolbar integration', () => {
     });
     const chip = container.querySelector('[aria-label="Workspace: api"]');
     expect(chip).not.toBeNull();
-    expect(chip?.getAttribute('title')).toBe('/work/api');
+    // The full cwd is surfaced via the hover tooltip (mirroring the git branch
+    // chip), not a native `title` attribute.
+    expect(chip?.getAttribute('data-web-shell-workspace-title')).toBe(
+      '/work/api',
+    );
+    expect(chip?.getAttribute('title')).toBeNull();
     expect(
       container.querySelector('[data-web-shell-workspace]'),
     ).not.toBeNull();
@@ -247,7 +252,7 @@ describe('ChatEditor workspace toolbar integration', () => {
     expect(
       container
         .querySelector('[data-web-shell-workspace]')
-        ?.getAttribute('title'),
+        ?.getAttribute('data-web-shell-workspace-title'),
     ).toBe('api');
   });
 

--- a/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
+import { getTranslator } from '../i18n';
+import { WorkspaceIndicator } from './WorkspaceIndicator';
+
+describe('WorkspaceIndicator', () => {
+  it('renders a read-only workspace chip with the name and full cwd tooltip', () => {
+    const name = 'api';
+    const title = '/work/services/a-very-long-web-shell-workspace-path/api';
+    const ariaLabel = `Workspace: ${name}`;
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <WorkspaceIndicator name={name} title={title} ariaLabel={ariaLabel} />,
+      );
+    });
+
+    const chip = container.querySelector(`[aria-label="${ariaLabel}"]`);
+    if (!chip) throw new Error('workspace chip was not rendered');
+    expect(chip.tagName).toBe('OUTPUT');
+    expect(chip.textContent).toContain(name);
+    // It's a non-interactive chip — no button, no native `title` (the full cwd
+    // rides in the Radix hover tooltip, matching the git branch chip).
+    expect(container.querySelector('button')).toBeNull();
+    expect(chip.getAttribute('title')).toBeNull();
+    expect(chip.getAttribute('data-web-shell-workspace-title')).toBe(title);
+
+    act(() => root.unmount());
+  });
+
+  it('keeps the full cwd discoverable when the name collapses in compact mode', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <WorkspaceIndicator
+          name="api"
+          title="/work/api"
+          ariaLabel="Workspace: api"
+          compact
+        />,
+      );
+    });
+
+    // Even icon-only (compact) the tooltip source stays present so a narrow /
+    // mobile composer can still reveal which workspace the pane targets.
+    const chip = container.querySelector('[data-web-shell-workspace]');
+    expect(chip?.getAttribute('data-web-shell-workspace-title')).toBe(
+      '/work/api',
+    );
+
+    act(() => root.unmount());
+  });
+
+  it('localizes the accessible workspace label', () => {
+    expect(getTranslator('en')('workspace.paneLabel', { name: 'api' })).toBe(
+      'Workspace: api',
+    );
+    expect(getTranslator('zh-CN')('workspace.paneLabel', { name: 'api' })).toBe(
+      '工作区：api',
+    );
+  });
+});

--- a/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
@@ -2,16 +2,29 @@
 
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { getTranslator } from '../i18n';
 import { WorkspaceIndicator } from './WorkspaceIndicator';
 
+// Radix Tooltip only mounts its content while open, and opens on a mouse
+// `pointermove` over the trigger after `delayDuration`. jsdom has no
+// `PointerEvent`, so a plain bubbling `pointermove` Event stands in (Radix reads
+// `event.pointerType`, which is `undefined` here → treated as non-touch).
+function openTooltip(chip: HTMLElement) {
+  act(() => {
+    chip.dispatchEvent(new Event('pointermove', { bubbles: true }));
+    vi.advanceTimersByTime(300);
+  });
+}
+
 describe('WorkspaceIndicator', () => {
-  it('renders a read-only workspace chip with the name and full cwd tooltip', () => {
+  it('reveals the full cwd via a hover tooltip, not a native title', () => {
+    vi.useFakeTimers();
     const name = 'api';
     const title = '/work/services/a-very-long-web-shell-workspace-path/api';
     const ariaLabel = `Workspace: ${name}`;
     const container = document.createElement('div');
+    document.body.appendChild(container);
     const root = createRoot(container);
 
     act(() => {
@@ -20,21 +33,35 @@ describe('WorkspaceIndicator', () => {
       );
     });
 
-    const chip = container.querySelector(`[aria-label="${ariaLabel}"]`);
+    const chip = container.querySelector<HTMLElement>(
+      `[aria-label="${ariaLabel}"]`,
+    );
     if (!chip) throw new Error('workspace chip was not rendered');
     expect(chip.tagName).toBe('OUTPUT');
     expect(chip.textContent).toContain(name);
-    // It's a non-interactive chip — no button, no native `title` (the full cwd
-    // rides in the Radix hover tooltip, matching the git branch chip).
+    // Non-interactive chip: no button, and no native `title` — the full cwd
+    // rides in the Radix hover tooltip, matching the git branch chip.
     expect(container.querySelector('button')).toBeNull();
     expect(chip.getAttribute('title')).toBeNull();
     expect(chip.getAttribute('data-web-shell-workspace-title')).toBe(title);
 
+    // The headline behaviour: hovering renders the Radix tooltip with the full
+    // cwd (guards against it rendering the short `name` or nothing at all).
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    openTooltip(chip);
+    const tooltip = document.querySelector('[role="tooltip"]');
+    expect(tooltip?.textContent).toBe(title);
+    expect(tooltip?.textContent).not.toBe(name);
+
     act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
   });
 
   it('keeps the full cwd discoverable when the name collapses in compact mode', () => {
+    vi.useFakeTimers();
     const container = document.createElement('div');
+    document.body.appendChild(container);
     const root = createRoot(container);
 
     act(() => {
@@ -48,14 +75,26 @@ describe('WorkspaceIndicator', () => {
       );
     });
 
-    // Even icon-only (compact) the tooltip source stays present so a narrow /
-    // mobile composer can still reveal which workspace the pane targets.
-    const chip = container.querySelector('[data-web-shell-workspace]');
+    const chip = container.querySelector<HTMLElement>(
+      '[data-web-shell-workspace]',
+    );
+    // Compact must actually apply the icon-only class...
+    expect(chip?.className).toContain('workspaceChipCompact');
     expect(chip?.getAttribute('data-web-shell-workspace-title')).toBe(
       '/work/api',
     );
 
+    // ...and the tooltip must still reveal the cwd once the name is hidden, so a
+    // narrow / mobile composer can tell which workspace the pane targets.
+    if (!chip) throw new Error('workspace chip was not rendered');
+    openTooltip(chip);
+    expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(
+      '/work/api',
+    );
+
     act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
   });
 
   it('localizes the accessible workspace label', () => {

--- a/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceIndicator.test.tsx
@@ -78,15 +78,15 @@ describe('WorkspaceIndicator', () => {
     const chip = container.querySelector<HTMLElement>(
       '[data-web-shell-workspace]',
     );
+    if (!chip) throw new Error('workspace chip was not rendered');
     // Compact must actually apply the icon-only class...
-    expect(chip?.className).toContain('workspaceChipCompact');
-    expect(chip?.getAttribute('data-web-shell-workspace-title')).toBe(
+    expect(chip.className).toContain('workspaceChipCompact');
+    expect(chip.getAttribute('data-web-shell-workspace-title')).toBe(
       '/work/api',
     );
 
     // ...and the tooltip must still reveal the cwd once the name is hidden, so a
     // narrow / mobile composer can tell which workspace the pane targets.
-    if (!chip) throw new Error('workspace chip was not rendered');
     openTooltip(chip);
     expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(
       '/work/api',

--- a/packages/web-shell/client/components/WorkspaceIndicator.tsx
+++ b/packages/web-shell/client/components/WorkspaceIndicator.tsx
@@ -5,6 +5,12 @@
  */
 
 import styles from './ChatEditor.module.css';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
 
 function WorkspaceFolderIcon() {
   return (
@@ -24,7 +30,9 @@ function WorkspaceFolderIcon() {
  * session belongs to. Mirrors {@link GitBranchIndicator}; both sit in the
  * composer toolbar. Shown only on a multi-workspace daemon (the pane composer
  * opts into the `workspace` toolbar action) so it's clear which workspace a
- * message goes to.
+ * message goes to. The full cwd stays in a hover tooltip — matching the git
+ * branch chip — so it's still discoverable once the name ellipsizes or
+ * collapses to an icon on a narrow (split-screen / mobile) composer.
  */
 export function WorkspaceIndicator({
   name,
@@ -38,18 +46,25 @@ export function WorkspaceIndicator({
   compact?: boolean;
 }) {
   return (
-    <output
-      className={`${styles.workspaceChip} ${
-        compact ? styles.workspaceChipCompact : ''
-      }`}
-      title={title}
-      aria-label={ariaLabel}
-      data-web-shell-workspace
-    >
-      <span className={styles.workspaceChipIcon}>
-        <WorkspaceFolderIcon />
-      </span>
-      <span className={styles.workspaceChipText}>{name}</span>
-    </output>
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <output
+            className={`${styles.workspaceChip} ${
+              compact ? styles.workspaceChipCompact : ''
+            }`}
+            aria-label={ariaLabel}
+            data-web-shell-workspace
+            data-web-shell-workspace-title={title}
+          >
+            <span className={styles.workspaceChipIcon}>
+              <WorkspaceFolderIcon />
+            </span>
+            <span className={styles.workspaceChipText}>{name}</span>
+          </output>
+        </TooltipTrigger>
+        <TooltipContent side="top">{title}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## Summary

In the Web Shell composer toolbar, the **workspace** chip surfaced its full working directory only through a native HTML `title` attribute, while its siblings — the **git branch** and **model** chips — use a styled Radix tooltip.

On a narrow composer (split‑screen or mobile), the chips ellipsize their text or collapse to an icon, so the full value is discoverable **only on hover**. There the native `title` falls short: it is inconsistent, unstyled, and **never fires on touch devices** — so on a phone or a split pane the workspace name simply had no reachable tooltip, even though git branch and model did.

`WorkspaceIndicator`'s own doc comment already says it *"Mirrors `GitBranchIndicator`"*, but the mirror was incomplete: when compact/icon‑only mode was added (#6877), the git‑branch chip kept its Radix tooltip and the workspace chip was left with the native `title`.

## Fix

Give `WorkspaceIndicator` the same Radix `Tooltip` wrapper `GitBranchIndicator` uses, with the full cwd as the tooltip content:

- Removed the native `title` attribute (avoids a double / OS tooltip).
- Added a `data-web-shell-workspace-title` hook so the resolved cwd stays observable to tests/e2e.
- Radix renders a visually‑hidden `role="tooltip"` mirror, so the cwd is now announced to screen readers too — which the native `title` did not do reliably.

Behavior now matches the git‑branch and model chips exactly, including when the chip collapses to an icon on a narrow composer.

## Before / After

Narrow (split‑screen / mobile) composer, workspace chip collapsed to an icon — hovering it:

| Before (native `title`) | After (Radix tooltip) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-workspace-tooltip/workspace-tooltip-before.png) | ![after](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-workspace-tooltip/workspace-tooltip-after.png) |

*Before:* hovering the workspace icon renders no in‑page tooltip (native `title` only, which never appears on touch).
*After:* hovering shows the styled tooltip with the full path `/work/services/payments-service-frontend/really/deep/path`.

## Testing

Real test runs — 20 unit tests (Vitest) + 2 behavioral checks in a real Chromium (Playwright) asserting the old chip renders no in‑page tooltip and the new chip's Radix tooltip shows the full cwd on hover:

![tests](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-workspace-tooltip/workspace-tooltip-tests.png)

- `WorkspaceIndicator.test.tsx` (new) — mirrors the git‑branch test: renders a read‑only chip, no native `title`, keeps the cwd discoverable in compact mode, localized aria label.
- `ChatEditor.test.tsx` — updated the two workspace assertions from the native `title` to the `data-web-shell-workspace-title` hook.
- `packages/web-shell` typecheck, ESLint, and Prettier are clean.

<details>
<summary>中文说明（点击展开）</summary>

## 概述

在 Web Shell 输入框（composer）工具栏中，**workspace** 芯片只通过原生 HTML `title` 属性来展示完整的工作目录，而相邻的 **git 分支**、**模型** 芯片都使用了带样式的 Radix tooltip。

在窄屏（分屏或手机）下，工具栏芯片的文字会被省略号截断、或直接收起为图标，因此只有 **hover 时**才能看到完整内容。而原生 `title` 在这种场景下并不可靠：样式不统一，而且 **在触屏设备上根本不会触发** —— 所以在手机或分屏里，workspace 名称的 hover 提示完全无法显示，尽管 git 分支和模型都能正常显示。

`WorkspaceIndicator` 自己的文档注释里就写着 *“Mirrors `GitBranchIndicator`”*，但这个“镜像”并不完整：在加入紧凑/纯图标模式（#6877）时，git 分支芯片保留了 Radix tooltip，而 workspace 芯片仍然只有原生 `title`。

## 修复

让 `WorkspaceIndicator` 使用与 `GitBranchIndicator` 相同的 Radix `Tooltip`，并以完整 cwd 作为 tooltip 内容：

- 移除原生 `title` 属性（避免出现双重 / 系统级 tooltip）。
- 新增 `data-web-shell-workspace-title` 属性，方便测试 / e2e 观测解析后的 cwd。
- Radix 会额外渲染一个视觉隐藏的 `role="tooltip"` 镜像，因此完整路径现在也会被读屏软件朗读 —— 这是原生 `title` 无法可靠做到的。

修复后，其行为与 git 分支、模型芯片完全一致，包括窄屏下芯片收起为图标时。

## 测试

真实测试运行 —— 20 个单元测试（Vitest）+ 2 个真实 Chromium 行为测试（Playwright），分别断言：旧芯片 hover 时不渲染任何页面内 tooltip；新芯片的 Radix tooltip 在 hover 时展示完整 cwd。

- `WorkspaceIndicator.test.tsx`（新增）—— 对齐 git 分支的测试：渲染只读芯片、无原生 `title`、紧凑模式下仍可获取 cwd、本地化 aria label。
- `ChatEditor.test.tsx` —— 将两处 workspace 断言从原生 `title` 改为 `data-web-shell-workspace-title`。
- `packages/web-shell` 的 typecheck、ESLint、Prettier 均通过。

</details>
