### PR TITLE
ci(web-shell): stop visual previews firing on SDK-only PRs

### DIFF
--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -23,11 +23,21 @@ on:
       - 'packages/web-shell/package.json'
       - 'packages/web-shell/vite.config.ts'
       - 'packages/web-shell/playwright.visuals.config.ts'
-      # The visuals dev server aliases these runtime sources (see the `resolve.
-      # alias` block in packages/web-shell/vite.config.ts), so UI-affecting
-      # changes there must also refresh the preview.
+      # The visuals dev server aliases the shared web UI library into the
+      # rendered bundle (see the `resolve.alias` block in
+      # packages/web-shell/vite.config.ts), so a change to its components/hooks
+      # must also refresh the preview.
       - 'packages/webui/src/**'
-      - 'packages/sdk-typescript/src/**'
+      # NOTE: packages/sdk-typescript/src/** is deliberately NOT a trigger.
+      # It is aliased in too, but the visuals render against a *mock* daemon, so
+      # the SDK's transport/client layer is stubbed at the network boundary and
+      # its changes don't alter the canned scenarios — e.g. #6911 only added a
+      # DaemonClient data-layer method yet still re-posted identical screenshots
+      # on a pure-backend PR. The web-shell client imports no runtime code from
+      # the SDK root and only type-imports DaemonClient, so leaving the SDK out
+      # avoids spamming backend PRs. If an SDK-only, render-shaping change ever
+      # needs a preview, add the specific file (e.g. daemon/events.ts) here
+      # rather than the whole tree.
       # The capture pipeline itself, so a workflow-only change is exercised.
       - '.github/workflows/web-shell-visuals.yml'
 


### PR DESCRIPTION
## Summary

The web-shell **visual-preview** workflow (`web-shell-visuals.yml`) triggered on `packages/sdk-typescript/src/**`. But the previews render against a **mock daemon**, so the SDK's transport/client layer is stubbed at the network boundary and its changes can't alter any of the rendered scenarios.

The result was false-positive previews on pure-backend PRs. Concretely, **#6911** (archived-session export) only added a `DaemonClient` data-layer method, yet the bot re-posted the same five canned screenshots — pure noise on a PR with zero UI surface.

## Change

Drop `packages/sdk-typescript/src/**` from the trigger `paths`, and document why it is intentionally excluded.

This loses **no** real UI coverage:

- The web-shell client imports **no runtime code** from the SDK root (`@qwen-code/sdk`); every runtime import is from `@qwen-code/sdk/daemon`, and even `DaemonClient` is imported **type-only** (erased at build).
- Genuine web-shell UI PRs still trigger via the retained `packages/web-shell/client/**` and `packages/webui/src/**` paths.

If an SDK-only, render-shaping change ever needs a preview, add that specific file (e.g. `daemon/events.ts`) rather than the whole tree.

## Verification

Simulated GitHub's path-glob predicate against each PR's real changed-file list:

| PR | Type | Before | After |
|---|---|---|---|
| #6911 | pure-backend (SDK/daemon) | ❌ triggered (noise) | ✅ **no longer triggers** |
| #6951 | web-shell UI (split-pane) | ✅ triggers | ✅ still triggers (`client/**`) |
| #6881 | web-shell UI (mermaid) | ✅ triggers | ✅ still triggers (`client/**`) |

YAML parse clean.

<details>
<summary>中文说明（点击展开）</summary>

## 概述

web-shell **视觉预览** workflow（`web-shell-visuals.yml`）的触发路径里包含 `packages/sdk-typescript/src/**`。但预览是对着 **mock daemon** 渲染的，SDK 的传输/客户端层在网络边界就被打桩了，改它动不了任何一个渲染场景的像素。

结果就是纯后端 PR 被误触发发图：**#6911**（归档会话导出）只加了一个 `DaemonClient` 的数据层方法，机器人却照样把那 5 张固定罐头图重发了一遍 —— 一个没有任何 UI 改动的 PR 上纯噪音。

## 改动

从触发 `paths` 里删掉 `packages/sdk-typescript/src/**`，并在注释里说明为什么故意排除。

这**不会**丢失任何真实 UI 覆盖：

- web-shell client 对 SDK 根（`@qwen-code/sdk`）**零运行时 import**，全部运行时导入都走 `@qwen-code/sdk/daemon`，连 `DaemonClient` 都只是 `import type`（编译期擦除）。
- 真·web-shell UI 的 PR 仍通过保留的 `packages/web-shell/client/**` 和 `packages/webui/src/**` 触发。

如果将来某个 SDK-only 且真会改变渲染的改动需要预览，单独把那个文件（如 `daemon/events.ts`）加回来即可，而不是整棵树。

## 验证

用 GitHub 的 path-glob 语义对三个 PR 的真实文件清单跑了触发判定：

| PR | 类型 | 改前 | 改后 |
|---|---|---|---|
| #6911 | 纯后端（SDK/daemon） | ❌ 误触发 | ✅ **不再触发** |
| #6951 | web-shell UI（分屏） | ✅ 触发 | ✅ 仍触发（`client/**`） |
| #6881 | web-shell UI（mermaid） | ✅ 触发 | ✅ 仍触发（`client/**`） |

YAML 解析通过。

</details>
