### PR TITLE
test(web-shell): add mermaid, split-view + sidebar visual scenarios

### DIFF
--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -108,6 +108,18 @@ for (const theme of THEMES) {
           turnCompleteEvent('prompt-split', { id: 3 }),
         ],
       });
+      // Derive the second pane's session from the scenario's OWN sessions list
+      // rather than hardcoding an id: a rename/removal of the default entry
+      // would otherwise surface here as a confusing SSE connection timeout
+      // instead of a clear, self-explaining error.
+      const secondSessionId = scenario.sessions.find(
+        (s) => s.sessionId !== scenario.sessionId,
+      )?.sessionId;
+      if (!secondSessionId) {
+        throw new Error(
+          'split view scenario expects a second session in the list',
+        );
+      }
       const daemon = await installScenario(
         page,
         scenario,
@@ -118,7 +130,7 @@ for (const theme of THEMES) {
       await gotoSession(page, scenario, daemon, theme);
       await page.goto(
         `/session/${encodeURIComponent(scenario.sessionId)}` +
-          `?split=${encodeURIComponent(scenario.sessionId)},previous-session` +
+          `?split=${encodeURIComponent(scenario.sessionId)},${encodeURIComponent(secondSessionId)}` +
           `&theme=${theme}`,
       );
       await expect(page.locator('[data-testid="split-view"]')).toBeVisible();
@@ -130,7 +142,7 @@ for (const theme of THEMES) {
         scenario.sessionId,
         scenario.events.length,
       );
-      await completeReplay(page, daemon, 'previous-session', 0);
+      await completeReplay(page, daemon, secondSessionId, 0);
       // The maximize control only appears with 2+ panes (#6951); waiting on it
       // confirms the split actually rendered both panes.
       await expect(

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -147,6 +147,62 @@ for (const theme of THEMES) {
       await captureScreenshot(page, `split-view-maximized-${theme}`);
     });
 
+    test(`sidebar attention`, async ({ page }, testInfo) => {
+      const stamp = '2026-07-03T00:00:00.000Z';
+      const base = {
+        workspaceCwd: '/tmp/qwen-web-shell-e2e',
+        createdAt: stamp,
+        updatedAt: stamp,
+        clientCount: 1,
+      };
+      const scenario = createWebShellDaemonScenario({
+        sessionId: 'sess-running',
+        displayName: 'Run test suite',
+        sessions: [
+          {
+            ...base,
+            sessionId: 'sess-approval',
+            displayName: 'Deploy to staging',
+            hasActivePrompt: true,
+            isWaitingForPermission: true,
+          },
+          {
+            ...base,
+            sessionId: 'sess-question',
+            displayName: 'Refactor auth module',
+            hasActivePrompt: true,
+            isWaitingForUserQuestion: true,
+          },
+          {
+            ...base,
+            sessionId: 'sess-running',
+            displayName: 'Run test suite',
+            hasActivePrompt: true,
+          },
+          {
+            ...base,
+            sessionId: 'sess-idle',
+            displayName: 'Draft release notes',
+            clientCount: 0,
+            hasActivePrompt: false,
+          },
+        ],
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+      // The sidebar lists every session; #6956 adds an attention pill to the
+      // ones waiting on the user. Assert on session names (present on both
+      // `main` and the PR) so the frame is the same shape either way — the pill
+      // itself is the PR's diff that the before/after preview surfaces.
+      await expect(page.getByText('Deploy to staging')).toBeVisible();
+      await expect(page.getByText('Refactor auth module')).toBeVisible();
+      await captureScreenshot(page, `sidebar-attention-${theme}`);
+    });
+
     test(`slash menu`, async ({ page }, testInfo) => {
       const scenario = createWebShellDaemonScenario();
       const daemon = await installScenario(

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -162,6 +162,15 @@ for (const theme of THEMES) {
         page.getByRole('button', { name: 'Restore pane' }),
       ).toBeVisible();
       await captureScreenshot(page, `split-view-maximized-${theme}`);
+
+      // Restore the tiled layout (#6951): the solo pane returns to the split and
+      // the hidden pane reappears — so the maximize control is back on both
+      // panes. Captures the restore path so a regression there is caught too.
+      await page.getByRole('button', { name: 'Restore pane' }).click();
+      await expect(
+        page.getByRole('button', { name: 'Maximize pane' }).first(),
+      ).toBeVisible();
+      await captureScreenshot(page, `split-view-restored-${theme}`);
     });
 
     test(`sidebar attention`, async ({ page }, testInfo) => {
@@ -217,6 +226,13 @@ for (const theme of THEMES) {
       // itself is the PR's diff that the before/after preview surfaces.
       await expect(page.getByText('Deploy to staging')).toBeVisible();
       await expect(page.getByText('Refactor auth module')).toBeVisible();
+      // Assert all four sessions render (not just the two waiting ones), so a
+      // regression that truncates the running or idle session is caught. The
+      // running session is also the loaded one, so its name shows in the main
+      // view too — scope to the sidebar landmark to keep the match unambiguous.
+      const sidebar = page.getByRole('complementary');
+      await expect(sidebar.getByText('Run test suite')).toBeVisible();
+      await expect(sidebar.getByText('Draft release notes')).toBeVisible();
       await captureScreenshot(page, `sidebar-attention-${theme}`);
     });
 

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -60,6 +60,45 @@ for (const theme of THEMES) {
       await captureScreenshot(page, `session-transcript-${theme}`);
     });
 
+    test(`mermaid diagram`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario({
+        events: [
+          userTextEvent('Diagram the tool-approval flow so I can review it.', {
+            id: 1,
+          }),
+          assistantTextEvent(
+            'Here is the tool-approval flow:\n\n' +
+              '```mermaid\n' +
+              'flowchart LR\n' +
+              '  A[Tool call] --> B{Folder trusted?}\n' +
+              '  B -->|Yes| C[Run immediately]\n' +
+              '  B -->|No| D{Ask approval}\n' +
+              '  D -->|Approve| C\n' +
+              '  D -->|Reject| E[Cancel turn]\n' +
+              '  C --> F[Return result]\n' +
+              '```',
+            { id: 2 },
+          ),
+          turnCompleteEvent('prompt-mermaid', { id: 3 }),
+        ],
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+
+      // MermaidBlock lazy-imports `mermaid` and renders asynchronously (behind a
+      // ~150ms timer), swapping a "rendering…" placeholder for the injected
+      // `<svg id="mermaid-N">`. Wait for that SVG so the diagram is captured
+      // rendered — not the placeholder — on every run.
+      await expect(
+        page.locator('[data-web-shell-message-list] svg[id^="mermaid-"]'),
+      ).toBeVisible();
+      await captureScreenshot(page, `mermaid-diagram-${theme}`);
+    });
+
     test(`slash menu`, async ({ page }, testInfo) => {
       const scenario = createWebShellDaemonScenario();
       const daemon = await installScenario(

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/mockDaemon';
 import {
   captureScreenshot,
+  completeReplay,
   fillComposer,
   gotoSession,
   installScenario,
@@ -97,6 +98,53 @@ for (const theme of THEMES) {
         page.locator('[data-web-shell-message-list] svg[id^="mermaid-"]'),
       ).toBeVisible();
       await captureScreenshot(page, `mermaid-diagram-${theme}`);
+    });
+
+    test(`split view`, async ({ page }, testInfo) => {
+      const scenario = createWebShellDaemonScenario({
+        events: [
+          userTextEvent('Review two sessions side by side.', { id: 1 }),
+          assistantTextEvent('Here is the first pane of the split.', { id: 2 }),
+          turnCompleteEvent('prompt-split', { id: 3 }),
+        ],
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      // Load the primary session (this also primes the theme), then enter the
+      // split via the `?split=a,b` deep link so two panes render side by side.
+      await gotoSession(page, scenario, daemon, theme);
+      await page.goto(
+        `/session/${encodeURIComponent(scenario.sessionId)}` +
+          `?split=${encodeURIComponent(scenario.sessionId)},previous-session` +
+          `&theme=${theme}`,
+      );
+      await expect(page.locator('[data-testid="split-view"]')).toBeVisible();
+      // Both panes reconnect on the split navigation; settle each replay so
+      // neither pane is stuck on the loading state.
+      await completeReplay(
+        page,
+        daemon,
+        scenario.sessionId,
+        scenario.events.length,
+      );
+      await completeReplay(page, daemon, 'previous-session', 0);
+      // The maximize control only appears with 2+ panes (#6951); waiting on it
+      // confirms the split actually rendered both panes.
+      await expect(
+        page.getByRole('button', { name: 'Maximize pane' }).first(),
+      ).toBeVisible();
+      await captureScreenshot(page, `split-view-${theme}`);
+
+      // Maximize the first pane (#6951): it fills the split and the other pane
+      // hides; the button flips to "Restore pane".
+      await page.getByRole('button', { name: 'Maximize pane' }).first().click();
+      await expect(
+        page.getByRole('button', { name: 'Restore pane' }),
+      ).toBeVisible();
+      await captureScreenshot(page, `split-view-maximized-${theme}`);
     });
 
     test(`slash menu`, async ({ page }, testInfo) => {

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -71,12 +71,12 @@ for (const theme of THEMES) {
             'Here is the tool-approval flow:\n\n' +
               '```mermaid\n' +
               'flowchart LR\n' +
-              '  A[Tool call] --> B{Folder trusted?}\n' +
-              '  B -->|Yes| C[Run immediately]\n' +
-              '  B -->|No| D{Ask approval}\n' +
-              '  D -->|Approve| C\n' +
-              '  D -->|Reject| E[Cancel turn]\n' +
-              '  C --> F[Return result]\n' +
+              '  A[Tool call] --> B{Trusted?}\n' +
+              '  B -->|Yes| C[Run]\n' +
+              '  B -->|No| D{Approve?}\n' +
+              '  D -->|Yes| C\n' +
+              '  D -->|No| E[Cancel]\n' +
+              '  C --> F[Result]\n' +
               '```',
             { id: 2 },
           ),
@@ -104,7 +104,12 @@ for (const theme of THEMES) {
       const scenario = createWebShellDaemonScenario({
         events: [
           userTextEvent('Review two sessions side by side.', { id: 1 }),
-          assistantTextEvent('Here is the first pane of the split.', { id: 2 }),
+          // Pane-neutral copy: the mock replays these same events into *both*
+          // panes, so wording that names "the first pane" would read wrong in
+          // the second one.
+          assistantTextEvent('Here are the two sessions, side by side.', {
+            id: 2,
+          }),
           turnCompleteEvent('prompt-split', { id: 3 }),
         ],
       });


### PR DESCRIPTION
## What this PR does

Adds three scenarios to the web-shell visuals suite, covering surfaces it had no coverage for:

- **`mermaid diagram`** — an assistant message with a mermaid fenced flowchart, rendering the real `MermaidBlock` (async `mermaid`, injected `<svg>`).
- **`split view`** — enters the two-pane split via `?split=a,b`, then maximizes one pane, capturing the **tiled** state (both panes + maximize controls) and the **maximized** state (one pane filling, restore control).
- **`sidebar attention`** — four sessions in distinct states (waiting-on-permission, waiting-on-user-question, running, idle), so the sidebar renders the "Waiting for approval" / "User input needed" attention pills.

Each renders in light and dark.

## Why it's needed

The suite only had the five original canned views, so the surfaces enriched by #6881 (mermaid zoom), #6951 (split-pane maximize), and #6956 (sidebar attention pills) never appeared in any preview. These scenarios give those surfaces a stable render, so once #6963 (before/after, show-only-changed) is active they become real before/after targets — a PR touching any of them shows exactly that view, diffed against `main`.

## Reviewer Test Plan

### How to verify

- `WEB_SHELL_VISUALS_OUTPUT_DIR=<dir> PLAYWRIGHT_PORT=<port> npx playwright test --config playwright.visuals.config.ts -g "mermaid diagram|split view|sidebar attention" --project=chromium` renders the six PNGs (`mermaid-diagram-*`, `split-view-*`, `split-view-maximized-*`, `sidebar-attention-*`).
- Each waits on a settled signal (mermaid `<svg id="mermaid-N">`; split settles both panes' replays then clicks **Maximize pane** → waits **Restore pane**; sidebar asserts session names) so every capture is deterministic, never a loading placeholder.
- The sidebar/split/mermaid tests assert only on state that exists on **both** `main` and the feature PRs (session names, the split layout), so they render fine either way — the new pill / zoom control / maximize is the PR's diff that #6963 surfaces.

### Evidence (Before & After)

Rendered locally in light and dark. The sidebar shot is run through #6963's compositor against `main` — the exact before/after the bot will auto-post (green/blue pills appear only on the right):

| mermaid | split (tiled) | split (maximized) |
| :---: | :---: | :---: |
| <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-scenarios/wsv-mermaid-scenario-light.png" width="250"> | <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-scenarios/wsv-split-tiled-light.png" width="250"> | <img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-scenarios/wsv-split-max-light.png" width="250"> |

**sidebar attention — before/after composite (auto-generated by #6963's compositor):**

<img src="https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-scenarios/wsv-sidebar-ba-light.png" width="900">

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Playwright/Chromium render of the web-shell visuals suite (vite dev server). The sidebar before/after was produced by overlaying #6956's real component changes for the "after" arm (the feature isn't on `main` yet), then diffing with `web-shell-visuals-compose.mjs` (#6963).

## Risk & Scope

- Main risk or tradeoff: depends on #6963 (before/after, show-only-changed). Merged before #6963, these add three always-shown canned views to every web-shell preview.
- Not validated / out of scope: the split scenario relies on the mock daemon serving two sessions; the sidebar scenario relies on the session-summary `isWaitingForPermission` / `isWaitingForUserQuestion` flags (already on `main`'s type). Content is intentionally minimal — the point is each surface's state, not rich transcripts.
- Breaking changes / migration notes: none — adds scenarios only; the rest of the suite is untouched.

## Linked Issues

Depends on #6963. Gives #6881, #6951, and #6956 a before/after surface. No closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 web-shell 视觉套件加三个场景,覆盖此前没覆盖的界面:

- **`mermaid diagram`** —— 带 mermaid 代码块的助手消息,渲染真实 `MermaidBlock`(异步 `mermaid`、注入 `<svg>`)。
- **`split view`** —— 通过 `?split=a,b` 进双窗格分屏,再最大化一个窗格,捕获**平铺**态(两窗格 + 最大化控件)和**最大化**态(单窗格占满、还原控件)。
- **`sidebar attention`** —— 四个不同状态的 session(等审批、等用户输入、运行中、空闲),让侧栏渲染出"Waiting for approval" / "User input needed"注意力徽章。

每个都渲染明暗两套。

## 为什么需要

套件此前只有最初五个罐头视图,所以 #6881(mermaid 缩放)、#6951(分屏最大化)、#6956(侧栏徽章)增强的界面在任何预览里都看不到。这三个场景给它们稳定渲染,等 #6963(before/after、只显示变化)生效后,它们就成了真正的 before/after 目标 —— 碰其中任何一个的 PR 会精确显示对应视图与 `main` 的 diff。

## Reviewer Test Plan

### 如何验证

- `WEB_SHELL_VISUALS_OUTPUT_DIR=<dir> PLAYWRIGHT_PORT=<port> npx playwright test --config playwright.visuals.config.ts -g "mermaid diagram|split view|sidebar attention" --project=chromium` 渲染六张 PNG。
- 每个都等待 settle 信号(mermaid `<svg id="mermaid-N">`;split settle 两窗格 replay 再点 **Maximize pane** → 等 **Restore pane**;sidebar 断言 session 名),所以每张截图都确定,绝非加载占位符。
- 这些测试只断言 `main` 和功能 PR **都存在**的状态(session 名、分屏布局),两边都能正常渲染 —— 新徽章/缩放控件/最大化态是 PR 的 diff,由 #6963 呈现。

### 证据(Before & After)

本地明暗两套渲染。侧栏那张用 #6963 的 compositor 对着 `main` 跑出来 —— 就是 bot 将自动发的 before/after(绿/蓝徽章只在右侧出现):见上方英文表格三张 render + 侧栏 before/after 拼接图。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境(可选)

本地 Playwright/Chromium 渲染视觉套件(vite dev)。侧栏 before/after 的"after"臂是叠加 #6956 真实组件改动渲染的(功能还没进 main),再用 `web-shell-visuals-compose.mjs`(#6963)做 diff。

## 风险与范围

- 主要风险/取舍:依赖 #6963。若在 #6963 之前合入,会给每个 web-shell 预览多三个常驻视图。
- 未验证/范围外:split 依赖 mock daemon 供两 session;sidebar 依赖 session summary 的 `isWaitingForPermission`/`isWaitingForUserQuestion` 标志(main 的类型上已有)。内容刻意做简 —— 重点是每个界面的状态,不是 transcript。
- 破坏性变更:无 —— 只加场景。

## 关联 Issue

依赖 #6963。给 #6881、#6951、#6956 提供 before/after 展示面。无关闭关键字。

</details>
