### PR TITLE
fix(cua-driver): harden MCP tool reliability

### DIFF
--- a/.github/workflows/cd-cua-driver.yml
+++ b/.github/workflows/cd-cua-driver.yml
@@ -25,7 +25,7 @@ on:
       version:
         description: 'Version to release (without v prefix)'
         required: true
-        default: '0.7.1'
+        default: '0.7.2'
       notarize:
         description: 'Codesign + notarize the macOS artifacts (false to skip during
           iteration)'
@@ -41,12 +41,33 @@ on:
 permissions:
   contents: 'write'
 jobs:
+  validate-version:
+    name: 'validate-release-version'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v4'
+      - name: 'Validate release version'
+        shell: 'bash'
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/cua-driver-rs-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/cua-driver-rs-v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+
+          CARGO_VERSION=$(sed -nE 's/^version = "([^"]+)"$/\1/p' packages/cua-driver/rust/Cargo.toml | head -1)
+          if [[ "$CARGO_VERSION" != "$VERSION" ]]; then
+            echo "::error::Release version $VERSION does not match Cargo version $CARGO_VERSION"
+            exit 1
+          fi
+
   # ── Linux (x86_64 + arm64) ───────────────────────────────────────────────
   # Built inside debian:11 (glibc 2.31) so binaries run on Debian 11+,
   # Ubuntu 20.04+, RHEL/Rocky 8+. arm64 builds natively on a hosted ARM
   # runner to avoid hand-wiring a cross linker for the X11/Wayland C deps.
   build-linux:
     name: 'linux-${{ matrix.arch }}'
+    needs: ['validate-version']
     runs-on: '${{ matrix.runner }}'
     strategy:
       fail-fast: false
@@ -93,7 +114,7 @@ jobs:
             cua-driver-linux-${{ matrix.arch }}-
       - name: 'Build (release)'
         working-directory: 'packages/cua-driver/rust'
-        run: 'cargo build -p cua-driver --release --target ${{ matrix.target }}'
+        run: 'cargo build -p cua-driver --release --locked --target ${{ matrix.target }}'
       - name: 'Package'
         working-directory: 'packages/cua-driver/rust'
         run: |
@@ -115,6 +136,7 @@ jobs:
   # ── Windows (x86_64 + arm64) — UNSIGNED ──────────────────────────────────
   build-windows:
     name: 'windows-${{ matrix.arch }}'
+    needs: ['validate-version']
     runs-on: 'windows-latest'
     strategy:
       fail-fast: false
@@ -151,7 +173,7 @@ jobs:
             cua-driver-windows-${{ matrix.arch }}-
       - name: 'Build (release, unsigned)'
         working-directory: 'packages/cua-driver/rust'
-        run: 'cargo build -p cua-driver -p cua-driver-uia --release --target ${{ matrix.target }}'
+        run: 'cargo build -p cua-driver -p cua-driver-uia --release --locked --target ${{ matrix.target }}'
       - name: 'Package'
         working-directory: 'packages/cua-driver/rust'
         shell: 'pwsh'
@@ -174,6 +196,7 @@ jobs:
   # ── macOS (universal: lipo arm64 + x86_64) — SIGNED + NOTARIZED ──────────
   build-macos:
     name: 'macos-universal'
+    needs: ['validate-version']
     runs-on: 'macos-latest'
     env:
       # Sign+notarize on tag push (real release); on manual dispatch honor the
@@ -205,10 +228,10 @@ jobs:
             cua-driver-darwin-universal-
       - name: 'Build arm64'
         working-directory: 'packages/cua-driver/rust'
-        run: 'cargo build -p cua-driver --release --target aarch64-apple-darwin'
+        run: 'cargo build -p cua-driver --release --locked --target aarch64-apple-darwin'
       - name: 'Build x86_64'
         working-directory: 'packages/cua-driver/rust'
-        run: 'cargo build -p cua-driver --release --target x86_64-apple-darwin'
+        run: 'cargo build -p cua-driver --release --locked --target x86_64-apple-darwin'
       - name: 'Create universal binary (lipo)'
         working-directory: 'packages/cua-driver/rust'
         run: |
@@ -318,6 +341,8 @@ jobs:
     name: 'Create GitHub Release'
     needs: ['build-linux', 'build-windows', 'build-macos']
     runs-on: 'ubuntu-latest'
+    outputs:
+      version: '${{ steps.version.outputs.version }}'
     if: 'startsWith(github.ref, ''refs/tags/cua-driver-rs-v'') || (github.event_name
       == ''workflow_dispatch'' && inputs.dry_run == false)'
     steps:
@@ -356,3 +381,62 @@ jobs:
 
             Enable relative coordinates: `CUA_DRIVER_RS_COORDINATE_SPACE=1`
             (default `0` = off; optional `CUA_DRIVER_RS_COORDINATE_SCALE=1000`).
+
+  sync-installer-version:
+    name: 'Sync installer version to main'
+    needs: ['release']
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+    steps:
+      - name: 'Require CI bot token'
+        env:
+          CI_BOT_PAT_SECRET: '${{ secrets.CI_BOT_PAT }}'
+        run: |
+          if [[ -z "$CI_BOT_PAT_SECRET" ]]; then
+            echo "::error::CI_BOT_PAT is required to create the installer version sync PR"
+            exit 1
+          fi
+      - uses: 'actions/checkout@v4'
+        with:
+          token: '${{ secrets.CI_BOT_PAT }}'
+          ref: 'main'
+          fetch-depth: 0
+      - name: 'Create installer version sync PR'
+        env:
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          VERSION: '${{ needs.release.outputs.version }}'
+        run: |
+          sed -E -i.bak "s/^CUA_DRIVER_RS_BAKED_VERSION=\"[^\"]+\"$/CUA_DRIVER_RS_BAKED_VERSION=\"${VERSION}\"/" packages/cua-driver/scripts/_install-rust.sh
+          sed -E -i.bak "s/^\\\$Script:CuaDriverRsBakedVersion = \"[^\"]+\"$/\\\$Script:CuaDriverRsBakedVersion = \"${VERSION}\"/" packages/cua-driver/scripts/install.ps1
+          sed -E -i.bak "s/(CUA_DRIVER_RS_VERSION=)[0-9]+\\.[0-9]+\\.[0-9]+/\\1${VERSION}/" packages/cua-driver/README.md
+          sed -E -i.bak "s/(\\\$env:CuaDriverRsVersion = \"|\\\$env:CUA_DRIVER_RS_VERSION = \"|Expected: cua-driver )[0-9]+\\.[0-9]+\\.[0-9]+/\\1${VERSION}/" packages/cua-driver/README.md
+          rm -f packages/cua-driver/README.md.bak packages/cua-driver/scripts/_install-rust.sh.bak packages/cua-driver/scripts/install.ps1.bak
+
+          grep -Fqx "CUA_DRIVER_RS_BAKED_VERSION=\"${VERSION}\"" packages/cua-driver/scripts/_install-rust.sh
+          grep -Fqx "\$Script:CuaDriverRsBakedVersion = \"${VERSION}\"" packages/cua-driver/scripts/install.ps1
+          grep -Fq "CUA_DRIVER_RS_VERSION=${VERSION} " packages/cua-driver/README.md
+          grep -Fq "\$env:CUA_DRIVER_RS_VERSION = \"${VERSION}\"" packages/cua-driver/README.md
+          grep -Fq "Expected: cua-driver ${VERSION}" packages/cua-driver/README.md
+
+          if git diff --quiet; then
+            echo "Installer references already point to ${VERSION}"
+            exit 0
+          fi
+
+          BRANCH="chore/cua-driver-v${VERSION}-installers"
+          PR_URL=$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url')
+          if [[ -z "$PR_URL" ]]; then
+            if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null; then
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git switch -c "$BRANCH"
+              git add packages/cua-driver/README.md packages/cua-driver/scripts/_install-rust.sh packages/cua-driver/scripts/install.ps1
+              git commit -m "chore(cua-driver): bake v${VERSION} into installers"
+              git push --set-upstream origin "$BRANCH"
+            fi
+            PR_URL=$(gh pr create --base main --head "$BRANCH" --label skip-changelog --title "chore(cua-driver): bake v${VERSION} into installers" --body "Syncs the default installers and documentation to the published cua-driver-rs v${VERSION} release.")
+          fi
+
+          gh pr merge "$PR_URL" --squash --auto --subject "chore(cua-driver): bake v${VERSION} into installers [skip ci]"

--- a/docs/design/cua-driver-mcp-reliability.md
+++ b/docs/design/cua-driver-mcp-reliability.md
@@ -1,0 +1,78 @@
+# cua-driver MCP reliability hardening
+
+## Problem
+
+The MCP proxy waits up to 120 seconds for a daemon response. Several macOS tool
+paths can block longer than that in synchronous OS calls. The proxy then emits a
+generic JSON-RPC `-32603`, while the abandoned operation and child process keep
+running. Separately, capture scope is read from both memory and disk, so one MCP
+session can observe contradictory values after `set_config` reports success.
+
+## Design
+
+### One effective configuration per session
+
+Treat `capture_scope` like the existing session-scoped image-size override.
+MCP calls resolve it from the caller's `_session_id`; anonymous CLI calls use the
+global persisted default. `set_config`, `get_config`, and `get_desktop_state`
+must all resolve through the same `ToolState`. Anonymous persistence happens
+before the in-memory value is committed, and a write failure is returned to the
+caller.
+
+### Remove subprocesses from app enumeration
+
+Use `NSWorkspace.runningApplications` for live apps and Core Foundation bundle
+metadata for installed apps. This removes `osascript` and `plutil` from the
+`list_apps`, `get_accessibility_tree`, and `launch_app` discovery paths rather
+than attempting to guess a safe timeout for each installed bundle.
+
+### Bound and terminate screenshot capture
+
+Keep the existing `screencapture` backend, but spawn it through one bounded
+helper. On deadline, kill and reap the process before returning a tool error.
+Use a unique temporary pathname per capture and an RAII cleanup guard so
+concurrent calls cannot collide and failures do not leave files behind.
+
+### Bound AX and daemon work below the proxy deadline
+
+Set the native AX messaging timeout before tree walks and element actions. Add a
+daemon-side tool deadline shorter than the proxy's 120-second transport deadline
+as a final backstop. Internal bounds should normally win; the daemon deadline
+ensures an unforeseen tool stall becomes a tool-level error instead of
+`-32603`.
+
+### Isolate the fork's daemon endpoint
+
+Use a Qwen-specific default Unix socket and PID directory. An old upstream
+daemon may continue running on the upstream default, but the Qwen proxy will no
+longer silently reuse it and execute a different implementation/version than
+the binary the user launched. Explicit `--socket` overrides remain unchanged.
+
+### Preserve lifecycle diagnosis
+
+Retain why a session was tombstoned (explicit end, idle expiry, or connection
+end) and include that reason in rejection text. Keep explicit `start_session`
+revival. Increase the default idle TTL so a normal long agent turn does not lose
+its session after only five minutes; the environment override remains available
+for tests and deployments.
+
+### Make E2E tests execute the fork binary
+
+Resolve `qwen-cua-driver` in the shared testkit. A missing binary must no longer
+turn an intended E2E assertion into a zero-second passing skip when the fork's
+binary is present under its actual name.
+
+## Non-goals
+
+- Changing the MCP JSON-RPC protocol or retrying destructive actions.
+- Making Tokio able to cancel arbitrary foreign blocking calls; OS subprocesses
+  are killed directly and AX receives its native messaging timeout.
+- Changing coordinate normalization behavior.
+
+## Verification
+
+Run the same isolated proxy/daemon black-box cases used for the pre-fix
+reproduction: failed config persistence, hung app-enumeration shim, hung
+screenshot shim, and short session TTL/revival. The two hang cases must return
+before the 120-second proxy deadline, leave no child process, and allow an
+immediate follow-up call.

--- a/packages/cua-driver/rust/Cargo.lock
+++ b/packages/cua-driver/rust/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-testkit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "windows 0.61.3",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "image",
@@ -939,7 +939,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1892,7 +1892,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1946,7 +1946,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/packages/cua-driver/rust/Cargo.lock
+++ b/packages/cua-driver/rust/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-testkit"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde_json",
  "windows 0.61.3",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "image",
@@ -939,7 +939,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1892,7 +1892,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1946,7 +1946,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/packages/cua-driver/rust/Cargo.toml
+++ b/packages/cua-driver/rust/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["trycua"]
 license = "MIT"

--- a/packages/cua-driver/rust/PARITY.md
+++ b/packages/cua-driver/rust/PARITY.md
@@ -2184,8 +2184,8 @@ resolve the release tag in the same priority order as the Swift
    `CUA_DRIVER_RS_VERSION` (`$env:CUA_DRIVER_RS_VERSION` on Windows).
 2. **Baked-in default** —
    a sentinel-block-wrapped constant carried in the install script
-   itself, updated by the CD `Bake version into install scripts` step
-   after each `cua-driver-rs-v*` tag push. Matches the Swift driver's
+   itself, updated by the CD `sync-installer-version` job after each
+   successful `cua-driver-rs-v*` release. Matches the Swift driver's
    `CUA_DRIVER_BAKED_VERSION` shape.
 3. **GitHub Releases API fallback** —
    only consulted when the env override is absent *and* the baked
@@ -2230,27 +2230,17 @@ line, not the markers, so the markers are a human cue only.
 
 #### CD wiring
 
-`.github/workflows/cd-rust-cua-driver.yml` runs a `Bake version into
-install scripts` step at the end of the `release` job after each
-`cua-driver-rs-v*` tag push. It runs on `ubuntu-latest` (GNU sed)
-and the equivalent Swift step runs on `macos-15` (BSD sed), so the
-two workflows use slightly different `sed -i` syntax:
+`.github/workflows/cd-cua-driver.yml` first validates that the manual
+input or `cua-driver-rs-v*` tag matches the Cargo workspace version.
+Release builds use `--locked`, so a stale lockfile stops the workflow.
 
-| Workflow | Runner | `sed -i` form |
-|---|---|---|
-| `cd-rust-cua-driver.yml` (this) | `ubuntu-latest` | `sed -i 's/.../.../`  (GNU) |
-| `cd-swift-cua-driver.yml` | `macos-15` | `sed -i '' 's/.../.../`  (BSD) |
-
-Both push the rewritten files back to `main` using a GitHub App
-token (`RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`) so the push
-bypasses the "Changes must be made through a pull request" ruleset
-on `main` — the default `GITHUB_TOKEN` (github-actions[bot]) is
-rejected by that ruleset.
-
-The commit author is `trycua-release[bot]` and the message is
-`chore(cua-driver-rs): bake version <V> into install scripts [skip ci]`
-(the `[skip ci]` suppresses the recursive CD trigger from the
-bake-push hitting `main`).
+The installers deliberately keep pointing at the last published
+release while the new artifacts build. Only after the GitHub Release
+has been created successfully does `sync-installer-version` update the
+Bash and PowerShell baked constants plus the README examples. It opens
+a small follow-up PR with `CI_BOT_PAT` and enables auto-merge, preserving
+the main-branch ruleset and avoiding a window where default installs
+refer to assets that do not exist yet.
 
 ### Per-version release-dir GC (`CUA_DRIVER_RS_KEEP_VERSIONS`)
 

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/session.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/session.rs
@@ -18,7 +18,7 @@
 //! `recording.rs` — a registry-free, platform-pluggable hook set with no
 //! reverse coupling from core into the platform crates.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -51,14 +51,33 @@ fn is_trackable(id: &str) -> bool {
 /// be idempotent because the overlay Remove + recording stop must run exactly
 /// once. Growth is bounded (one short string per ended session over the
 /// daemon's lifetime); eviction is a deliberate non-blocking follow-up.
-static ENDED_SESSIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+static ENDED_SESSIONS: OnceLock<Mutex<HashMap<String, SessionEndReason>>> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionEndReason {
+    Explicit,
+    IdleTimeout,
+    ConnectionClosed,
+    Unknown,
+}
+
+impl SessionEndReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit_end",
+            Self::IdleTimeout => "idle_timeout",
+            Self::ConnectionClosed => "connection_closed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
 
 fn hooks() -> &'static Mutex<Vec<SessionEndHook>> {
     SESSION_END_HOOKS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
-fn ended_sessions() -> &'static Mutex<HashSet<String>> {
-    ENDED_SESSIONS.get_or_init(|| Mutex::new(HashSet::new()))
+fn ended_sessions() -> &'static Mutex<HashMap<String, SessionEndReason>> {
+    ENDED_SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Register a callback invoked with the disconnecting `session_id` whenever a
@@ -78,14 +97,19 @@ pub fn register_session_end_hook(hook: impl Fn(&str) + Send + Sync + 'static) {
 /// stray legacy `session_end` (mixed-version rollout) so cursor-remove +
 /// recording-stop run exactly once. No-op when no hooks are registered.
 pub fn fire_session_end(session_id: &str) {
+    fire_session_end_with_reason(session_id, SessionEndReason::Unknown);
+}
+
+pub fn fire_session_end_with_reason(session_id: &str, reason: SessionEndReason) {
     // Mark-then-fan-out under a short critical section, releasing the lock
     // before running hooks (hooks may be slow / re-entrant and must not hold
     // the dedupe lock).
     {
         let mut ended = ended_sessions().lock().unwrap();
-        if !ended.insert(session_id.to_owned()) {
+        if ended.contains_key(session_id) {
             return; // already ended — idempotent no-op.
         }
+        ended.insert(session_id.to_owned(), reason);
     }
     for hook in hooks().lock().unwrap().iter() {
         hook(session_id);
@@ -96,7 +120,11 @@ pub fn fire_session_end(session_id: &str) {
 /// daemon-side authority for "this session is permanently gone"; the macOS
 /// overlay keeps its own render-side tombstone keyed on the same id.
 pub fn is_session_ended(session_id: &str) -> bool {
-    ended_sessions().lock().unwrap().contains(session_id)
+    ended_sessions().lock().unwrap().contains_key(session_id)
+}
+
+pub fn session_end_reason(session_id: &str) -> Option<SessionEndReason> {
+    ended_sessions().lock().unwrap().get(session_id).copied()
 }
 
 /// Revive a previously-ended session id by clearing its tombstone, so a fresh
@@ -113,7 +141,7 @@ pub fn revive_session(session_id: &str) -> bool {
     if !is_trackable(session_id) {
         return false;
     }
-    ended_sessions().lock().unwrap().remove(session_id)
+    ended_sessions().lock().unwrap().remove(session_id).is_some()
 }
 
 /// Record activity for an explicit session id, resetting its idle-TTL clock.
@@ -140,7 +168,7 @@ pub fn end_session(session_id: &str) {
         return;
     }
     activity().lock().unwrap().remove(session_id);
-    fire_session_end(session_id);
+    fire_session_end_with_reason(session_id, SessionEndReason::Explicit);
 }
 
 /// End every session whose last activity is older than `ttl`, returning the ids
@@ -159,7 +187,8 @@ pub fn evict_idle(ttl: Duration) -> Vec<String> {
             .collect()
     };
     for id in &stale {
-        end_session(id);
+        activity().lock().unwrap().remove(id);
+        fire_session_end_with_reason(id, SessionEndReason::IdleTimeout);
     }
     stale
 }
@@ -192,6 +221,7 @@ mod tests {
         assert!(!is_session_ended(sid));
         fire_session_end(sid);
         assert!(is_session_ended(sid));
+        assert_eq!(session_end_reason(sid), Some(SessionEndReason::Unknown));
         // Second + third fire for the same id must be no-ops.
         fire_session_end(sid);
         fire_session_end(sid);
@@ -212,6 +242,7 @@ mod tests {
         let evicted = evict_idle(Duration::ZERO);
         assert!(evicted.iter().any(|s| s == sid), "zero-TTL must evict a touched session");
         assert!(is_session_ended(sid), "evicted session is ended");
+        assert_eq!(session_end_reason(sid), Some(SessionEndReason::IdleTimeout));
     }
 
     #[test]
@@ -229,6 +260,7 @@ mod tests {
         touch_session(sid);
         end_session(sid);
         assert!(is_session_ended(sid));
+        assert_eq!(session_end_reason(sid), Some(SessionEndReason::Explicit));
         // Its TTL entry is gone, so a later sweep doesn't re-fire for it.
         assert!(!evict_idle(Duration::ZERO).iter().any(|s| s == sid));
     }

--- a/packages/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-testkit/src/paths.rs
@@ -23,9 +23,9 @@ pub fn workspace_root() -> PathBuf {
 /// copy-pasted across the test files.
 pub fn driver_binary() -> PathBuf {
     let name = if cfg!(target_os = "windows") {
-        "cua-driver.exe"
+        "qwen-cua-driver.exe"
     } else {
-        "cua-driver"
+        "qwen-cua-driver"
     };
     let root = workspace_root();
     let release = root.join("target/release").join(name);

--- a/packages/cua-driver/rust/crates/cua-driver/src/cli.rs
+++ b/packages/cua-driver/rust/crates/cua-driver/src/cli.rs
@@ -2501,7 +2501,7 @@ fn diagnose_config_paths_section() -> String {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
     let paths: &[(&str, String)] = &[
         ("user data dir",   format!("{home}/.cua-driver")),
-        ("config cache",    format!("{home}/Library/Caches/cua-driver")),
+        ("config cache",    format!("{home}/Library/Caches/qwen-cua-driver")),
         ("telemetry id",    format!("{home}/.cua-driver/.telemetry_id")),
         ("updater plist",   format!("{home}/Library/LaunchAgents/com.trycua.cua_driver_updater.plist")),
         ("daemon plist",    format!("{home}/Library/LaunchAgents/com.trycua.cua_driver_daemon.plist")),

--- a/packages/cua-driver/rust/crates/cua-driver/src/proxy.rs
+++ b/packages/cua-driver/rust/crates/cua-driver/src/proxy.rs
@@ -29,7 +29,7 @@ use cua_driver_core::protocol::{initialize_result, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
 
-use crate::serve::{is_daemon_listening, send_request, DaemonRequest};
+use crate::serve::{is_daemon_listening, send_request, DaemonRequest, DaemonResponse};
 
 /// Run the MCP stdio proxy. Reads JSON-RPC lines from stdin, forwards
 /// the body of each `tools/list` / `tools/call` to the daemon at
@@ -494,14 +494,7 @@ async fn forward_tool_call(
         // it as `Response::ok` with `isError: true`. Mirror that
         // shape here so MCP clients see identical envelopes either
         // way — CodeRabbit #2.
-        let msg = resp.error.unwrap_or_else(|| "daemon reported failure".into());
-        let exit_code = resp.exit_code.unwrap_or(1);
-        let result = serde_json::json!({
-            "content": [{ "type": "text", "text": msg }],
-            "isError": true,
-            "structuredContent": { "exit_code": exit_code }
-        });
-        return Response::ok(id, result);
+        return Response::ok(id, tool_error_result(resp));
     }
 
     let result = resp.result.unwrap_or_else(|| {
@@ -511,6 +504,25 @@ async fn forward_tool_call(
         })
     });
     Response::ok(id, result)
+}
+
+fn tool_error_result(resp: DaemonResponse) -> serde_json::Value {
+    let msg = resp.error.unwrap_or_else(|| "daemon reported failure".into());
+    let exit_code = resp.exit_code.unwrap_or(1);
+    let mut structured = match resp.error_data {
+        Some(serde_json::Value::Object(map)) => serde_json::Value::Object(map),
+        Some(data) => serde_json::json!({ "details": data }),
+        None => serde_json::json!({}),
+    };
+    structured
+        .as_object_mut()
+        .expect("structured tool error is always an object")
+        .insert("exit_code".into(), serde_json::json!(exit_code));
+    serde_json::json!({
+        "content": [{ "type": "text", "text": msg }],
+        "isError": true,
+        "structuredContent": structured,
+    })
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -534,14 +546,7 @@ mod tests {
         id: serde_json::Value,
         resp: DaemonResponse,
     ) -> Response {
-        let msg = resp.error.unwrap_or_else(|| "daemon reported failure".into());
-        let exit_code = resp.exit_code.unwrap_or(1);
-        let result = serde_json::json!({
-            "content": [{ "type": "text", "text": msg }],
-            "isError": true,
-            "structuredContent": { "exit_code": exit_code }
-        });
-        Response::ok(id, result)
+        Response::ok(id, tool_error_result(resp))
     }
 
     #[test]
@@ -551,6 +556,7 @@ mod tests {
             result: None,
             error: Some("missing required field `pid`".into()),
             exit_code: Some(64),
+            error_data: None,
         };
         let resp = build_tool_error_response(serde_json::json!(7), daemon_resp);
         let value = serde_json::to_value(&resp).expect("serialize");
@@ -578,11 +584,34 @@ mod tests {
             result: None,
             error: None,
             exit_code: None,
+            error_data: None,
         };
         let resp = build_tool_error_response(serde_json::json!("abc"), daemon_resp);
         let value = serde_json::to_value(&resp).expect("serialize");
         assert_eq!(value["result"]["isError"], serde_json::json!(true));
         assert_eq!(value["result"]["content"][0]["text"], "daemon reported failure");
         assert_eq!(value["result"]["structuredContent"]["exit_code"], 1);
+    }
+
+    #[test]
+    fn daemon_error_data_is_preserved_in_structured_content() {
+        let daemon_resp = DaemonResponse {
+            ok: false,
+            result: None,
+            error: Some("timed out".into()),
+            exit_code: Some(1),
+            error_data: Some(serde_json::json!({
+                "code": "tool_timeout",
+                "tool": "get_window_state",
+                "timeout_seconds": 90,
+            })),
+        };
+        let resp = build_tool_error_response(serde_json::json!(9), daemon_resp);
+        let value = serde_json::to_value(&resp).expect("serialize");
+        let structured = &value["result"]["structuredContent"];
+        assert_eq!(structured["code"], "tool_timeout");
+        assert_eq!(structured["tool"], "get_window_state");
+        assert_eq!(structured["timeout_seconds"], 90);
+        assert_eq!(structured["exit_code"], 1);
     }
 }

--- a/packages/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/packages/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -13,8 +13,8 @@
 //!   {"ok":false,"error":"...","exit_code":1}
 //!
 //! The socket file is at:
-//!   macOS  — ~/Library/Caches/cua-driver/cua-driver.sock
-//!   Linux  — ~/.cache/cua-driver/cua-driver.sock
+//!   macOS  — ~/Library/Caches/qwen-cua-driver/qwen-cua-driver.sock
+//!   Linux  — ~/.cache/qwen-cua-driver/qwen-cua-driver.sock
 //!   Windows — \\.\pipe\cua-driver  (TODO: use named pipe; stubs only for now)
 
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 /// `CUA_DRIVER_RS_RECORDING_IDLE_TTL_SECS` env var (used by the #1764 verify
 /// harness to exercise the backstop quickly).
 const RECORDING_IDLE_TTL_SECS_DEFAULT: u64 = 300;
+const TOOL_CALL_TIMEOUT_SECS_DEFAULT: u64 = 90;
 
 /// Wall-clock seconds since the Unix epoch. Same idiom `recording.rs` uses for
 /// `now_ms`.
@@ -83,6 +84,54 @@ fn apply_session_identity(
 /// would be wrongly rejected if the guard gated them on an already-ended id.
 fn is_session_lifecycle_tool(tool_name: &str) -> bool {
     matches!(tool_name, "start_session" | "end_session")
+}
+
+fn tool_call_timeout_secs() -> u64 {
+    std::env::var("CUA_DRIVER_RS_TOOL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0 && *value < 120)
+        .unwrap_or(TOOL_CALL_TIMEOUT_SECS_DEFAULT)
+}
+
+async fn invoke_with_deadline(
+    registry: &cua_driver_core::tool::ToolRegistry,
+    tool_name: &str,
+    args: serde_json::Value,
+) -> cua_driver_core::protocol::ToolResult {
+    let timeout_secs = tool_call_timeout_secs();
+    invoke_with_timeout(
+        registry,
+        tool_name,
+        args,
+        std::time::Duration::from_secs(timeout_secs),
+        timeout_secs,
+    )
+    .await
+}
+
+async fn invoke_with_timeout(
+    registry: &cua_driver_core::tool::ToolRegistry,
+    tool_name: &str,
+    args: serde_json::Value,
+    timeout: std::time::Duration,
+    timeout_secs: u64,
+) -> cua_driver_core::protocol::ToolResult {
+    match tokio::time::timeout(timeout, registry.invoke(tool_name, args))
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => cua_driver_core::protocol::ToolResult::error(format!(
+            "tool '{tool_name}' exceeded the daemon response deadline after {timeout_secs}s; \
+             returning before the 120s MCP transport deadline. Any underlying \
+             blocking OS work remains governed by its native deadline"
+        ))
+        .with_structured(serde_json::json!({
+            "code": "tool_timeout",
+            "tool": tool_name,
+            "timeout_seconds": timeout_secs,
+        })),
+    }
 }
 
 /// Resolve the recording idle TTL, honoring the env override.
@@ -151,7 +200,7 @@ fn spawn_recording_idle_backstop(
 /// isn't touched (no tool call carrying its `session`) for this long is reclaimed
 /// by [`spawn_session_idle_sweep`] — its cursor removed, recording stopped,
 /// config cleared. Overridable via `CUA_DRIVER_RS_SESSION_IDLE_TTL_SECS`.
-const SESSION_IDLE_TTL_SECS_DEFAULT: u64 = 300;
+const SESSION_IDLE_TTL_SECS_DEFAULT: u64 = 1800;
 
 fn session_idle_ttl_secs() -> u64 {
     std::env::var("CUA_DRIVER_RS_SESSION_IDLE_TTL_SECS")
@@ -214,12 +263,12 @@ pub fn default_socket_path() -> String {
     #[cfg(target_os = "macos")]
     {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        format!("{home}/Library/Caches/cua-driver/cua-driver.sock")
+        format!("{home}/Library/Caches/qwen-cua-driver/qwen-cua-driver.sock")
     }
     #[cfg(target_os = "linux")]
     {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        format!("{home}/.cache/cua-driver/cua-driver.sock")
+        format!("{home}/.cache/qwen-cua-driver/qwen-cua-driver.sock")
     }
     #[cfg(target_os = "windows")]
     {
@@ -249,12 +298,12 @@ pub fn default_pid_file_path() -> String {
     #[cfg(target_os = "macos")]
     {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        format!("{home}/Library/Caches/cua-driver/cua-driver.pid")
+        format!("{home}/Library/Caches/qwen-cua-driver/qwen-cua-driver.pid")
     }
     #[cfg(target_os = "linux")]
     {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-        format!("{home}/.cache/cua-driver/cua-driver.pid")
+        format!("{home}/.cache/qwen-cua-driver/qwen-cua-driver.pid")
     }
     #[cfg(target_os = "windows")]
     {
@@ -297,14 +346,25 @@ pub struct DaemonResponse {
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_data: Option<serde_json::Value>,
 }
 
 impl DaemonResponse {
     pub fn ok(result: serde_json::Value) -> Self {
-        Self { ok: true, result: Some(result), error: None, exit_code: None }
+        Self { ok: true, result: Some(result), error: None, exit_code: None, error_data: None }
     }
     pub fn err(msg: impl Into<String>, code: i32) -> Self {
-        Self { ok: false, result: None, error: Some(msg.into()), exit_code: Some(code) }
+        Self { ok: false, result: None, error: Some(msg.into()), exit_code: Some(code), error_data: None }
+    }
+    pub fn err_with_data(msg: impl Into<String>, code: i32, error_data: serde_json::Value) -> Self {
+        Self {
+            ok: false,
+            result: None,
+            error: Some(msg.into()),
+            exit_code: Some(code),
+            error_data: Some(error_data),
+        }
     }
 }
 
@@ -683,13 +743,21 @@ pub async fn run_serve(
                                     if !is_session_lifecycle_tool(&tool_name)
                                         && cua_driver_core::session::is_session_ended(sid)
                                     {
-                                        let resp = DaemonResponse::err(
+                                        let reason = cua_driver_core::session::session_end_reason(sid)
+                                            .map(|reason| reason.as_str())
+                                            .unwrap_or("unknown");
+                                        let resp = DaemonResponse::err_with_data(
                                             format!(
-                                                "session '{sid}' has ended; tool call '{tool_name}' was \
+                                                "session '{sid}' has ended (reason={reason}); tool call '{tool_name}' was \
                                                  rejected. Call start_session with this id to revive it \
                                                  before issuing further actions, or use a new session id."
                                             ),
                                             1,
+                                            serde_json::json!({
+                                                "code": "session_ended",
+                                                "reason": reason,
+                                                "session": sid,
+                                            }),
                                         );
                                         let _ = writer.write_all(
                                             (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -706,8 +774,9 @@ pub async fn run_serve(
                                     ).await;
                                     continue;
                                 }
-                                let result = reg.invoke(&tool_name, args).await;
+                                let result = invoke_with_deadline(&reg, &tool_name, args).await;
                                 let is_err = result.is_error.unwrap_or(false);
+                                let error_data = result.structured_content.clone();
                                 let content: Vec<serde_json::Value> = result.content.iter().map(|c| {
                                     match c {
                                         cua_driver_core::protocol::Content::Text { text, .. } =>
@@ -724,13 +793,15 @@ pub async fn run_serve(
                                     result_obj["structuredContent"] = sc;
                                 }
                                 let resp = if is_err {
-                                    DaemonResponse::err(
+                                    let message =
                                         result.content.iter()
                                             .filter_map(|c| if let cua_driver_core::protocol::Content::Text { text, .. } = c { Some(text.as_str()) } else { None })
                                             .collect::<Vec<_>>()
-                                            .join("\n"),
-                                        1
-                                    )
+                                            .join("\n");
+                                    match error_data {
+                                        Some(data) => DaemonResponse::err_with_data(message, 1, data),
+                                        None => DaemonResponse::err(message, 1),
+                                    }
                                 } else {
                                     DaemonResponse::ok(result_obj)
                                 };
@@ -776,7 +847,10 @@ pub async fn run_serve(
                                     // fire_session_end, after the mark). stop_owner does
                                     // not consult is_session_ended, so reaping after the
                                     // mark is safe.
-                                    cua_driver_core::session::fire_session_end(sid);
+                                    cua_driver_core::session::fire_session_end_with_reason(
+                                        sid,
+                                        cua_driver_core::session::SessionEndReason::ConnectionClosed,
+                                    );
                                     let reg2 = reg.clone();
                                     let sid_for_stop = sid.to_owned();
                                     let _ = tokio::task::spawn_blocking(move || {
@@ -822,7 +896,10 @@ pub async fn run_serve(
                         // sees ended=true and bails (mark-before-reap; the cursor/config
                         // hooks already reap inside fire_session_end after the mark).
                         // stop_owner ignores is_session_ended, so reaping after is safe.
-                        cua_driver_core::session::fire_session_end(&sid);
+                        cua_driver_core::session::fire_session_end_with_reason(
+                            &sid,
+                            cua_driver_core::session::SessionEndReason::ConnectionClosed,
+                        );
                         let reg2 = reg.clone();
                         let sid_for_stop = sid.clone();
                         let _ = tokio::task::spawn_blocking(move || {
@@ -1214,13 +1291,21 @@ pub async fn run_serve(
                                     if !is_session_lifecycle_tool(&tool_name)
                                         && cua_driver_core::session::is_session_ended(sid)
                                     {
-                                        let resp = DaemonResponse::err(
+                                        let reason = cua_driver_core::session::session_end_reason(sid)
+                                            .map(|reason| reason.as_str())
+                                            .unwrap_or("unknown");
+                                        let resp = DaemonResponse::err_with_data(
                                             format!(
-                                                "session '{sid}' has ended; tool call '{tool_name}' was \
+                                                "session '{sid}' has ended (reason={reason}); tool call '{tool_name}' was \
                                                  rejected. Call start_session with this id to revive it \
                                                  before issuing further actions, or use a new session id."
                                             ),
                                             1,
+                                            serde_json::json!({
+                                                "code": "session_ended",
+                                                "reason": reason,
+                                                "session": sid,
+                                            }),
                                         );
                                         let _ = writer.write_all(
                                             (serde_json::to_string(&resp).unwrap() + "\n").as_bytes()
@@ -1235,8 +1320,9 @@ pub async fn run_serve(
                                     ).await;
                                     continue;
                                 }
-                                let result = reg.invoke(&tool_name, args).await;
+                                let result = invoke_with_deadline(&reg, &tool_name, args).await;
                                 let is_err = result.is_error.unwrap_or(false);
+                                let error_data = result.structured_content.clone();
                                 let content: Vec<serde_json::Value> = result.content.iter().map(|c| match c {
                                     cua_driver_core::protocol::Content::Text { text, .. } =>
                                         serde_json::json!({"type":"text","text":text}),
@@ -1248,12 +1334,14 @@ pub async fn run_serve(
                                     result_obj["structuredContent"] = sc;
                                 }
                                 let resp = if is_err {
-                                    DaemonResponse::err(
+                                    let message =
                                         result.content.iter()
                                             .filter_map(|c| if let cua_driver_core::protocol::Content::Text { text, .. } = c { Some(text.as_str()) } else { None })
-                                            .collect::<Vec<_>>().join("\n"),
-                                        1
-                                    )
+                                            .collect::<Vec<_>>().join("\n");
+                                    match error_data {
+                                        Some(data) => DaemonResponse::err_with_data(message, 1, data),
+                                        None => DaemonResponse::err(message, 1),
+                                    }
                                 } else {
                                     DaemonResponse::ok(result_obj)
                                 };
@@ -1292,7 +1380,10 @@ pub async fn run_serve(
                                     // fire_session_end, after the mark). stop_owner does
                                     // not consult is_session_ended, so reaping after the
                                     // mark is safe.
-                                    cua_driver_core::session::fire_session_end(sid);
+                                    cua_driver_core::session::fire_session_end_with_reason(
+                                        sid,
+                                        cua_driver_core::session::SessionEndReason::ConnectionClosed,
+                                    );
                                     let reg2 = reg.clone();
                                     let sid_for_stop = sid.to_owned();
                                     let _ = tokio::task::spawn_blocking(move || {
@@ -1329,7 +1420,10 @@ pub async fn run_serve(
                         // sees ended=true and bails (mark-before-reap; the cursor/config
                         // hooks already reap inside fire_session_end after the mark).
                         // stop_owner ignores is_session_ended, so reaping after is safe.
-                        cua_driver_core::session::fire_session_end(&sid);
+                        cua_driver_core::session::fire_session_end_with_reason(
+                            &sid,
+                            cua_driver_core::session::SessionEndReason::ConnectionClosed,
+                        );
                         let reg2 = reg.clone();
                         let sid_for_stop = sid.clone();
                         let _ = tokio::task::spawn_blocking(move || {
@@ -1480,6 +1574,61 @@ pub fn run_status_cmd(socket_path: &str, pid_file_path: &str) {
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod deadline_tests {
+    use super::invoke_with_timeout;
+    use async_trait::async_trait;
+    use cua_driver_core::{
+        protocol::ToolResult,
+        tool::{Tool, ToolDef, ToolRegistry},
+    };
+    use serde_json::Value;
+
+    struct SlowTool {
+        def: ToolDef,
+    }
+
+    #[async_trait]
+    impl Tool for SlowTool {
+        fn def(&self) -> &ToolDef { &self.def }
+
+        async fn invoke(&self, _args: Value) -> ToolResult {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            ToolResult::text("finished")
+        }
+    }
+
+    #[tokio::test]
+    async fn daemon_deadline_returns_structured_tool_error() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(SlowTool {
+            def: ToolDef {
+                name: "slow".into(),
+                description: "test".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+                read_only: true,
+                destructive: false,
+                idempotent: true,
+                open_world: false,
+            },
+        }));
+
+        let result = invoke_with_timeout(
+            &registry,
+            "slow",
+            serde_json::json!({}),
+            std::time::Duration::from_millis(10),
+            90,
+        )
+        .await;
+        assert_eq!(result.is_error, Some(true));
+        let structured = result.structured_content.expect("structured timeout");
+        assert_eq!(structured["code"], "tool_timeout");
+        assert_eq!(structured["tool"], "slow");
+        assert_eq!(structured["timeout_seconds"], 90);
+    }
+}
 
 #[cfg(all(test, unix))]
 mod gate_tests {

--- a/packages/cua-driver/rust/crates/cua-driver/tests/transport_config_persistence_test.rs
+++ b/packages/cua-driver/rust/crates/cua-driver/tests/transport_config_persistence_test.rs
@@ -10,10 +10,9 @@
 //!   - **MCP** (`McpDriver`) is one long-lived connection — a `set_config` is
 //!     visible to later calls on the SAME driver within the session.
 //!
-//! Uses `max_image_dimension` as the persisted key. `capture_mode` /
-//! `capture_scope` are NO LONGER settings (they are per-call params now —
-//! the modality-ladder refactor), so `max_image_dimension` is the remaining
-//! disk-persisted config field and the right probe for this transport behavior.
+//! Uses `max_image_dimension` as the persisted key. `capture_mode` is per-call;
+//! `capture_scope` is session-scoped over a persisted default. The numeric field
+//! remains the simplest probe for this transport behavior.
 //!
 //! Both tests are `#[ignore]`: they mutate the real on-disk config, so they
 //! save the prior value and restore it. Run explicitly:

--- a/packages/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -45,7 +45,7 @@ fn list_running_apps_native() -> Vec<AppInfo> {
             .filter_map(|app| {
                 let pid = app.processIdentifier();
                 let name = app.localizedName()?.to_string();
-                if pid == 0 || name.is_empty() {
+                if pid <= 0 || name.is_empty() {
                     return None;
                 }
                 let launch_path = app

--- a/packages/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/apps/mod.rs
@@ -2,7 +2,6 @@
 
 pub mod nsworkspace;
 
-use std::process::Command;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,76 +30,43 @@ pub struct AppInfo {
 }
 
 /// Enumerate running apps with NSApplicationActivationPolicyRegular.
-/// Uses `osascript` to query System Events — no Accessibility permission needed.
 pub fn list_running_apps() -> Vec<AppInfo> {
-    // Use `ps` + NSWorkspace via a brief Swift one-liner via swift-sh is heavy;
-    // instead use the Obj-C bridge via `osascript`.
-    // Fallback: parse `ps -axo pid,command` and cross-reference with bundle IDs.
-    // Better: use a native call via core-foundation bindings.
     list_running_apps_native()
 }
 
 fn list_running_apps_native() -> Vec<AppInfo> {
-    // Use `lsappinfo list` which is a macOS system tool available on all versions.
-    // Alternatively we can use NSWorkspace via objc2 — but for simplicity and
-    // to match the Swift reference, we use a subprocess call to `osascript`.
-    let script = r#"
-set output to ""
-tell application "System Events"
-    set appList to every application process whose background only is false
-    repeat with proc in appList
-        set procName to name of proc
-        set procPid to unix id of proc
-        set bundleId to bundle identifier of proc
-        if bundleId is missing value then set bundleId to ""
-        set isFront to "0"
-        if frontmost of proc then set isFront to "1"
-        set output to output & procName & "|" & procPid & "|" & bundleId & "|" & isFront & linefeed
-    end repeat
-end tell
-return output
-"#;
+    use objc2_app_kit::{NSApplicationActivationPolicy, NSWorkspace};
 
-    let out = Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .output();
-
-    match out {
-        Err(_) => vec![],
-        Ok(o) => {
-            let text = String::from_utf8_lossy(&o.stdout);
-            parse_osascript_app_list(&text)
-        }
+    unsafe {
+        let apps = NSWorkspace::sharedWorkspace().runningApplications();
+        (0..apps.len())
+            .filter_map(|index| apps.get(index))
+            .filter(|app| app.activationPolicy() == NSApplicationActivationPolicy::Regular)
+            .filter_map(|app| {
+                let pid = app.processIdentifier();
+                let name = app.localizedName()?.to_string();
+                if pid == 0 || name.is_empty() {
+                    return None;
+                }
+                let launch_path = app
+                    .bundleURL()
+                    .and_then(|url| url.path())
+                    .map(|path| path.to_string());
+                Some(AppInfo {
+                    name,
+                    pid,
+                    bundle_id: app.bundleIdentifier().map(|id| id.to_string()),
+                    running: true,
+                    active: app.isActive(),
+                    last_used: launch_path
+                        .as_deref()
+                        .and_then(|path| fs_last_used(std::path::Path::new(path))),
+                    launch_path,
+                    kind: Some("desktop".to_owned()),
+                })
+            })
+            .collect()
     }
-}
-
-fn parse_osascript_app_list(text: &str) -> Vec<AppInfo> {
-    let mut apps = Vec::new();
-    for line in text.lines() {
-        let parts: Vec<&str> = line.splitn(4, '|').collect();
-        if parts.len() < 2 { continue; }
-        let name = parts[0].trim().to_owned();
-        let pid: i32 = parts[1].trim().parse().unwrap_or(0);
-        let bundle_id = if parts.len() > 2 && !parts[2].trim().is_empty() {
-            Some(parts[2].trim().to_owned())
-        } else {
-            None
-        };
-        let active = parts.get(3).map(|s| s.trim() == "1").unwrap_or(false);
-        if name.is_empty() || pid == 0 { continue; }
-        apps.push(AppInfo {
-            name,
-            pid,
-            bundle_id,
-            running: true,
-            active,
-            launch_path: None,
-            kind: Some("desktop".to_owned()),
-            last_used: None,
-        });
-    }
-    apps
 }
 
 /// Launch an app by bundle ID via NSWorkspace, background only (no focus
@@ -329,24 +295,9 @@ pub(crate) fn locate_by_name(name: &str) -> Option<AppLocator> {
     resolve_bundle_id_to_locator(name)
 }
 
-/// Read `CFBundleIdentifier` from an `.app` bundle's `Info.plist`.
-/// Falls back to shelling out to `plutil` (already used elsewhere in
-/// this file) to avoid pulling in a plist crate just for this.
+/// Read `CFBundleIdentifier` from an `.app` bundle via Core Foundation.
 fn bundle_id_for_app_path(app_path: &str) -> Option<String> {
-    let plist = format!("{app_path}/Contents/Info.plist");
-    let out = Command::new("plutil")
-        .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-", &plist])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let bid = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if bid.is_empty() {
-        None
-    } else {
-        Some(bid)
-    }
+    bundle_string(std::path::Path::new(app_path), "CFBundleIdentifier")
 }
 
 /// Return all apps: running apps merged with installed-but-not-running apps.
@@ -463,39 +414,15 @@ pub(crate) fn unix_secs_to_rfc3339(secs: i64) -> String {
 }
 
 fn read_app_plist(plist_path: &std::path::Path) -> Option<AppInfo> {
-    let bundle_id_out = Command::new("plutil")
-        .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-",
-               plist_path.to_str()?])
-        .output().ok()?;
-    if !bundle_id_out.status.success() { return None; }
-    let bundle_id = String::from_utf8_lossy(&bundle_id_out.stdout).trim().to_string();
-    if bundle_id.is_empty() { return None; }
-
-    let name_out = Command::new("plutil")
-        .args(["-extract", "CFBundleDisplayName", "raw", "-o", "-",
-               plist_path.to_str()?])
-        .output().ok();
-    let name = name_out
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .filter(|s| !s.is_empty())
+    let app_path = plist_path.parent()?.parent()?;
+    let bundle_id = bundle_string(app_path, "CFBundleIdentifier")?;
+    let name = bundle_string(app_path, "CFBundleDisplayName")
+        .or_else(|| bundle_string(app_path, "CFBundleName"))
         .unwrap_or_else(|| {
-            // Fallback: CFBundleName.
-            Command::new("plutil")
-                .args(["-extract", "CFBundleName", "raw", "-o", "-",
-                       plist_path.to_str().unwrap_or("")])
-                .output().ok()
-                .filter(|o| o.status.success())
-                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| {
-                    plist_path.parent()
-                        .and_then(|p| p.parent())
-                        .and_then(|p| p.file_stem())
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("")
-                        .to_string()
-                })
+            app_path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_owned()
         });
 
     if name.is_empty() { return None; }
@@ -510,6 +437,18 @@ fn read_app_plist(plist_path: &std::path::Path) -> Option<AppInfo> {
         kind: None,
         last_used: None,
     })
+}
+
+fn bundle_string(app_path: &std::path::Path, key: &str) -> Option<String> {
+    use core_foundation::{bundle::CFBundle, string::CFString, url::CFURL};
+
+    let url = CFURL::from_path(app_path, true)?;
+    let bundle = CFBundle::new(url)?;
+    let info = bundle.info_dictionary();
+    let key = CFString::new(key);
+    let value = info.find(&key)?;
+    let value = value.downcast::<CFString>()?.to_string();
+    (!value.is_empty()).then_some(value)
 }
 
 /// Return the pid of the current frontmost application via
@@ -561,25 +500,13 @@ pub fn bundle_id_for_pid(pid: i32) -> Option<String> {
 }
 
 /// Return the localized application name for a running process by PID.
-/// Uses `ps -p {pid} -o comm=` which gives the command name without path.
-/// Returns `None` if the PID is unknown or the command fails.
 pub fn get_app_name_for_pid(pid: i32) -> Option<String> {
-    let out = Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "comm="])
-        .output()
-        .ok()?;
-    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if raw.is_empty() {
-        return None;
+    use objc2_app_kit::NSRunningApplication;
+    unsafe {
+        NSRunningApplication::runningApplicationWithProcessIdentifier(pid)?
+            .localizedName()
+            .map(|name| name.to_string())
     }
-    // Strip path prefix: "/Applications/Safari.app/Contents/MacOS/Safari" → "Safari"
-    Some(
-        std::path::Path::new(&raw)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&raw)
-            .to_string(),
-    )
 }
 
 /// Format the app list in the same text style as libs/cua-driver.

--- a/packages/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -21,8 +21,10 @@ pub type AXUIElementRef = *mut __AXUIElement;
 // ── AXError ──────────────────────────────────────────────────────────────────
 
 pub type AXError = c_int;
+pub const AX_MESSAGING_TIMEOUT_SECS: u64 = 5;
 pub const kAXErrorSuccess: AXError = 0;
 pub const kAXErrorFailure: AXError = -25200;
+pub const kAXErrorIllegalArgument: AXError = -25201;
 pub const kAXErrorInvalidUIElement: AXError = -25202;
 pub const kAXErrorAttributeUnsupported: AXError = -25205;
 pub const kAXErrorNoValue: AXError = -25212;
@@ -44,6 +46,7 @@ pub const kAXValueIllegalType: AXValueType = 1_000;
 // ── Link to AXUIElement functions ────────────────────────────────────────────
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
+    pub fn AXUIElementCreateSystemWide() -> AXUIElementRef;
     pub fn AXUIElementCreateApplication(pid: i32) -> AXUIElementRef;
     pub fn AXUIElementCopyAttributeValue(
         element: AXUIElementRef,
@@ -301,6 +304,24 @@ pub unsafe fn set_messaging_timeout(element: AXUIElementRef, timeout_in_seconds:
     AXUIElementSetMessagingTimeout(element, timeout_in_seconds)
 }
 
+/// Apply the native AX messaging timeout to every accessibility object used by
+/// this process. Apple documents object-level timeouts as non-inheriting, so
+/// setting only an application element does not protect its descendants.
+pub fn set_global_messaging_timeout(timeout_in_seconds: f32) -> Result<(), AXError> {
+    if !timeout_in_seconds.is_finite() || timeout_in_seconds <= 0.0 {
+        return Err(kAXErrorIllegalArgument);
+    }
+    unsafe {
+        let system_wide = AXUIElementCreateSystemWide();
+        if system_wide.is_null() {
+            return Err(kAXErrorFailure);
+        }
+        let status = AXUIElementSetMessagingTimeout(system_wide, timeout_in_seconds);
+        CFRelease(system_wide as CFTypeRef);
+        if status == kAXErrorSuccess { Ok(()) } else { Err(status) }
+    }
+}
+
 /// Set an AX attribute to a CFString value.
 pub unsafe fn set_string_attr(element: AXUIElementRef, attr_name: &str, value: &str) -> AXError {
     let attr = CFStr::new(attr_name);
@@ -391,4 +412,23 @@ pub unsafe fn copy_ax_windows(element: AXUIElementRef) -> Vec<AXUIElementRef> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_messaging_timeout_accepts_production_value() {
+        assert_eq!(
+            set_global_messaging_timeout(AX_MESSAGING_TIMEOUT_SECS as f32),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn global_messaging_timeout_rejects_invalid_values() {
+        assert_eq!(set_global_messaging_timeout(0.0), Err(kAXErrorIllegalArgument));
+        assert_eq!(set_global_messaging_timeout(f32::NAN), Err(kAXErrorIllegalArgument));
+    }
 }

--- a/packages/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/ax/bindings.rs
@@ -67,6 +67,10 @@ extern "C" {
         attribute: CFStringRef,
         value: CFTypeRef,
     ) -> AXError;
+    pub fn AXUIElementSetMessagingTimeout(
+        element: AXUIElementRef,
+        timeout_in_seconds: f32,
+    ) -> AXError;
     pub fn AXUIElementGetTypeID() -> CFTypeID;
     pub fn AXIsProcessTrusted() -> bool;
     /// `AXIsProcessTrustedWithOptions(options)` — when called with
@@ -291,6 +295,10 @@ pub unsafe fn copy_children(element: AXUIElementRef) -> Vec<AXUIElementRef> {
 pub unsafe fn perform_action(element: AXUIElementRef, action_name: &str) -> AXError {
     let action = CFStr::new(action_name);
     AXUIElementPerformAction(element, action.as_concrete_TypeRef())
+}
+
+pub unsafe fn set_messaging_timeout(element: AXUIElementRef, timeout_in_seconds: f32) -> AXError {
+    AXUIElementSetMessagingTimeout(element, timeout_in_seconds)
 }
 
 /// Set an AX attribute to a CFString value.

--- a/packages/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -13,7 +13,10 @@
 use super::bindings::*;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeRef};
 use std::collections::HashSet;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Mutex, OnceLock,
+};
 
 /// Default maximum depth for AX tree walks. Deep menus and complex web views
 /// can nest deeply; 25 covers realistic app chrome without exploding on
@@ -88,6 +91,19 @@ pub struct TreeWalkResult {
     pub truncated: bool,
 }
 
+impl TreeWalkResult {
+    /// Release the retains that a completed walk would otherwise transfer to
+    /// the element cache. Used when a cancelled background walk finishes after
+    /// its caller has already returned a timeout response.
+    pub(crate) fn release_retained_elements(self) {
+        for node in self.nodes {
+            if node.element_index.is_some() && node.element_ptr != 0 {
+                unsafe { CFRelease(node.element_ptr as AXUIElementRef as CFTypeRef) };
+            }
+        }
+    }
+}
+
 /// Walk the AX tree of `pid`, optionally filtered to a specific window.
 ///
 /// `window_id` — when Some, only the AXWindow matching that CGWindowID is
@@ -121,6 +137,42 @@ pub fn walk_tree_bounded(
     max_elements: usize,
     max_depth: usize,
 ) -> TreeWalkResult {
+    walk_tree_bounded_impl(
+        pid,
+        window_id,
+        query,
+        max_elements,
+        max_depth,
+        None,
+    )
+}
+
+pub(crate) fn walk_tree_bounded_cancellable(
+    pid: i32,
+    window_id: Option<u32>,
+    query: Option<&str>,
+    max_elements: usize,
+    max_depth: usize,
+    cancelled: &AtomicBool,
+) -> TreeWalkResult {
+    walk_tree_bounded_impl(
+        pid,
+        window_id,
+        query,
+        max_elements,
+        max_depth,
+        Some(cancelled),
+    )
+}
+
+fn walk_tree_bounded_impl(
+    pid: i32,
+    window_id: Option<u32>,
+    query: Option<&str>,
+    max_elements: usize,
+    max_depth: usize,
+    cancelled: Option<&AtomicBool>,
+) -> TreeWalkResult {
     let mut nodes: Vec<AXNode> = Vec::new();
     let mut lines: Vec<(usize, String)> = Vec::new(); // (depth, line)
     let mut index_counter = 0usize;
@@ -135,8 +187,6 @@ pub fn walk_tree_bounded(
         if app_elem.is_null() {
             return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
         }
-        let _ = set_messaging_timeout(app_elem, 5.0);
-
         // Chromium/Electron apps (Arc, VS Code, Electron shells) ship their
         // web-content AX tree OFF and only build it once an assistive client
         // asks for it. Without this, the first walk of such an app returns an
@@ -157,8 +207,30 @@ pub fn walk_tree_bounded(
         // Union AXChildren + AXWindows — the only way to see background windows.
         // AXChildren omits windows when the app isn't frontmost (AppKit limitation).
         // AXWindows returns the window list regardless of activation state.
+        if is_cancelled(cancelled) {
+            CFRelease(app_elem as CFTypeRef);
+            return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
+        }
         let from_children = copy_children(app_elem);
+        if is_cancelled(cancelled) {
+            for child in from_children {
+                CFRelease(child as CFTypeRef);
+            }
+            CFRelease(app_elem as CFTypeRef);
+            return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
+        }
         let from_windows = copy_ax_windows(app_elem);
+        if is_cancelled(cancelled) {
+            for child in from_children.into_iter().chain(from_windows) {
+                CFRelease(child as CFTypeRef);
+            }
+            CFRelease(app_elem as CFTypeRef);
+            return TreeWalkResult {
+                tree_markdown: String::new(),
+                nodes,
+                truncated: false,
+            };
+        }
 
         let mut top_level = from_children;
         for w in from_windows {
@@ -174,7 +246,13 @@ pub fn walk_tree_bounded(
         // Filter: keep non-window children (menu bar) + the target window.
         let walk_these: Vec<AXUIElementRef> = if let Some(wid) = window_id {
             top_level.iter().copied().filter(|&child| {
+                if is_cancelled(cancelled) {
+                    return false;
+                }
                 let role = copy_string_attr(child, "AXRole").unwrap_or_default();
+                if is_cancelled(cancelled) {
+                    return false;
+                }
                 if role != "AXWindow" {
                     return true; // always keep menu bar and other non-window items
                 }
@@ -187,6 +265,9 @@ pub fn walk_tree_bounded(
 
         // Walk each top-level child at depth 0.
         for child in walk_these {
+            if is_cancelled(cancelled) {
+                break;
+            }
             walk_element(
                 child,
                 0,
@@ -198,6 +279,7 @@ pub fn walk_tree_bounded(
                 &mut truncated,
                 max_elements,
                 max_depth,
+                cancelled,
             );
         }
 
@@ -241,7 +323,9 @@ unsafe fn walk_element(
     truncated: &mut bool,
     max_elements: usize,
     max_depth: usize,
+    cancelled: Option<&AtomicBool>,
 ) {
+    if is_cancelled(cancelled) { return; }
     if depth > max_depth { return; }
     // Enforce total-node cap — mirrors Swift's maxElements guard.
     // Set the truncated flag only when we actually stop early.
@@ -253,6 +337,7 @@ unsafe fn walk_element(
 
     let role = copy_string_attr(element, "AXRole")
         .unwrap_or_else(|| "AXUnknown".into());
+    if is_cancelled(cancelled) { return; }
 
     // Skip pure layout containers that have no interesting content.
     if role == "AXScrollArea" || role == "AXGroup" {
@@ -272,6 +357,7 @@ unsafe fn walk_element(
                 truncated,
                 max_elements,
                 max_depth,
+                cancelled,
             );
             CFRelease(child as CFTypeRef);
         }
@@ -284,14 +370,21 @@ unsafe fn walk_element(
     // (digit buttons). Merging them would produce "2" (quoted) instead of (2)
     // (parens), breaking _find_calc_button which searches for "(2)".
     let title = copy_string_attr(element, "AXTitle");
+    if is_cancelled(cancelled) { return; }
     let value = copy_string_attr(element, "AXValue");
+    if is_cancelled(cancelled) { return; }
     // AXPlaceholderValue as fallback for empty text fields.
     let value = value.filter(|v| !v.trim().is_empty())
         .or_else(|| copy_string_attr(element, "AXPlaceholderValue"));
+    if is_cancelled(cancelled) { return; }
     let description = copy_string_attr(element, "AXDescription");
+    if is_cancelled(cancelled) { return; }
     let identifier = copy_string_attr(element, "AXIdentifier");
+    if is_cancelled(cancelled) { return; }
     let help = copy_string_attr(element, "AXHelp").filter(|h| !h.trim().is_empty());
+    if is_cancelled(cancelled) { return; }
     let actions = copy_action_names(element);
+    if is_cancelled(cancelled) { return; }
 
     let visible_title = title.as_deref().unwrap_or("").trim().to_owned();
     let visible_description = description.as_deref().unwrap_or("").trim().to_owned();
@@ -316,6 +409,7 @@ unsafe fn walk_element(
                 truncated,
                 max_elements,
                 max_depth,
+                cancelled,
             );
             CFRelease(child as CFTypeRef);
         }
@@ -324,6 +418,7 @@ unsafe fn walk_element(
 
     let element_ptr = element as usize;
     let frame = element_screen_rect(element);
+    if is_cancelled(cancelled) { return; }
     let node = if is_actionable {
         let idx = *counter;
         *counter += 1;
@@ -383,9 +478,14 @@ unsafe fn walk_element(
             truncated,
             max_elements,
             max_depth,
+            cancelled,
         );
         CFRelease(child as CFTypeRef);
     }
+}
+
+fn is_cancelled(cancelled: Option<&AtomicBool>) -> bool {
+    cancelled.is_some_and(|flag| flag.load(Ordering::Relaxed))
 }
 
 fn format_node_line(node: &AXNode) -> String {
@@ -448,6 +548,43 @@ fn render_lines(lines: &[(usize, String)]) -> String {
         out.push('\n');
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_foundation::base::{CFGetRetainCount, CFRetain, TCFType};
+    use core_foundation::string::CFString;
+
+    #[test]
+    fn cancelled_result_releases_untransferred_element_retains() {
+        let value = CFString::new("cua-driver-cancelled-tree-retain-test");
+        let ptr = value.as_concrete_TypeRef() as usize;
+        let base = unsafe { CFGetRetainCount(ptr as CFTypeRef) };
+        unsafe { CFRetain(ptr as CFTypeRef) };
+
+        TreeWalkResult {
+            tree_markdown: String::new(),
+            nodes: vec![AXNode {
+                element_index: Some(0),
+                role: "AXButton".into(),
+                title: None,
+                value: None,
+                description: None,
+                identifier: None,
+                help: None,
+                actions: vec!["press".into()],
+                element_ptr: ptr,
+                depth: 0,
+                parent_element_index: None,
+                frame: None,
+            }],
+            truncated: false,
+        }
+        .release_retained_elements();
+
+        assert_eq!(unsafe { CFGetRetainCount(ptr as CFTypeRef) }, base);
+    }
 }
 
 /// Filter the tree markdown to lines matching `query` plus their ancestor chain.

--- a/packages/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/ax/tree.rs
@@ -135,6 +135,7 @@ pub fn walk_tree_bounded(
         if app_elem.is_null() {
             return TreeWalkResult { tree_markdown: String::new(), nodes, truncated: false };
         }
+        let _ = set_messaging_timeout(app_elem, 5.0);
 
         // Chromium/Electron apps (Arc, VS Code, Electron shells) ship their
         // web-content AX tree OFF and only build it once an assistive client

--- a/packages/cua-driver/rust/crates/platform-macos/src/capture.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/capture.rs
@@ -17,14 +17,37 @@ use std::{
 };
 
 const SCREENSHOT_TIMEOUT_SECS_DEFAULT: u64 = 15;
+const TOOL_TIMEOUT_SECS_DEFAULT: u64 = 90;
+const TOOL_DEADLINE_MARGIN: Duration = Duration::from_millis(250);
+
+fn tool_timeout() -> Duration {
+    let seconds = std::env::var("CUA_DRIVER_RS_TOOL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0 && *value < 120)
+        .unwrap_or(TOOL_TIMEOUT_SECS_DEFAULT);
+    Duration::from_secs(seconds)
+}
+
+pub(crate) fn remaining_tool_budget(started: Instant) -> Duration {
+    tool_timeout()
+        .saturating_sub(started.elapsed())
+        .saturating_sub(TOOL_DEADLINE_MARGIN)
+}
 
 fn screenshot_timeout() -> Duration {
-    let seconds = std::env::var("CUA_DRIVER_RS_SCREENSHOT_TIMEOUT_SECS")
+    let requested = std::env::var("CUA_DRIVER_RS_SCREENSHOT_TIMEOUT_SECS")
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(SCREENSHOT_TIMEOUT_SECS_DEFAULT);
-    Duration::from_secs(seconds)
+    bounded_screenshot_timeout(requested, tool_timeout().as_secs())
+}
+
+fn bounded_screenshot_timeout(requested_seconds: u64, tool_timeout_seconds: u64) -> Duration {
+    let native_budget =
+        Duration::from_secs(tool_timeout_seconds).saturating_sub(TOOL_DEADLINE_MARGIN);
+    Duration::from_secs(requested_seconds).min(native_budget)
 }
 
 struct CaptureFile(PathBuf);
@@ -47,21 +70,34 @@ impl Drop for CaptureFile {
     }
 }
 
-fn run_screencapture(args: &[String], target: &str) -> anyhow::Result<()> {
+fn run_screencapture(args: &[String], target: &str, timeout: Duration) -> anyhow::Result<()> {
+    if timeout.is_zero() {
+        anyhow::bail!("no tool deadline remains for screencapture of {target}");
+    }
     let mut child = Command::new("screencapture").args(args).spawn()?;
-    let timeout = screenshot_timeout();
-    let deadline = Instant::now() + timeout;
+    let Some(deadline) = Instant::now().checked_add(timeout) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        anyhow::bail!("invalid screencapture timeout for {target}");
+    };
     let status = loop {
-        match child.try_wait()? {
-            Some(status) => break status,
-            None if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(20)),
-            None => {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Ok(None) => {
                 let _ = child.kill();
                 let _ = child.wait();
                 anyhow::bail!(
-                    "screencapture timed out after {}s for {target}; process terminated",
-                    timeout.as_secs()
+                    "screencapture timed out after {} ms for {target}; process terminated",
+                    timeout.as_millis()
                 );
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error.into());
             }
         }
     };
@@ -74,13 +110,24 @@ fn run_screencapture(args: &[String], target: &str) -> anyhow::Result<()> {
 /// Capture a window by its `window_id` (CGWindowID).
 /// Returns raw PNG bytes or an error.
 pub fn screenshot_window_bytes(window_id: u32) -> anyhow::Result<Vec<u8>> {
+    screenshot_window_bytes_with_budget(window_id, screenshot_timeout())
+}
+
+pub(crate) fn screenshot_window_bytes_with_budget(
+    window_id: u32,
+    remaining_budget: Duration,
+) -> anyhow::Result<Vec<u8>> {
     let capture = CaptureFile::new(&format!("window-{window_id}"));
     let args = vec![
         "-l".to_owned(), window_id.to_string(),
         "-x".to_owned(), "-o".to_owned(),
         capture.path().to_string_lossy().into_owned(),
     ];
-    run_screencapture(&args, &format!("window {window_id}"))?;
+    run_screencapture(
+        &args,
+        &format!("window {window_id}"),
+        screenshot_timeout().min(remaining_budget),
+    )?;
     let bytes = std::fs::read(capture.path())?;
 
     if bytes.is_empty() {
@@ -103,7 +150,7 @@ pub fn screenshot_window(window_id: u32) -> anyhow::Result<(String, u32, u32)> {
 pub fn screenshot_display_bytes() -> anyhow::Result<Vec<u8>> {
     let capture = CaptureFile::new("display");
     let args = vec!["-x".to_owned(), capture.path().to_string_lossy().into_owned()];
-    run_screencapture(&args, "main display")?;
+    run_screencapture(&args, "main display", screenshot_timeout())?;
     let bytes = std::fs::read(capture.path())?;
 
     if bytes.is_empty() {
@@ -161,4 +208,21 @@ pub fn crosshair_png_bytes(png_bytes: &[u8], cx: f64, cy: f64) -> anyhow::Result
 /// Parse width and height from a PNG file's IHDR chunk.
 pub fn png_dimensions(data: &[u8]) -> anyhow::Result<(u32, u32)> {
     cua_driver_core::image_utils::png_dimensions(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn screenshot_timeout_stays_inside_tool_deadline() {
+        assert_eq!(
+            bounded_screenshot_timeout(u64::MAX, 90),
+            Duration::from_millis(89_750),
+        );
+        assert_eq!(
+            bounded_screenshot_timeout(15, 5),
+            Duration::from_millis(4_750),
+        );
+    }
 }

--- a/packages/cua-driver/rust/crates/platform-macos/src/capture.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/capture.rs
@@ -10,28 +10,78 @@
 //! approach is simpler to implement correctly and is reliable across OS versions.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    time::{Duration, Instant},
+};
+
+const SCREENSHOT_TIMEOUT_SECS_DEFAULT: u64 = 15;
+
+fn screenshot_timeout() -> Duration {
+    let seconds = std::env::var("CUA_DRIVER_RS_SCREENSHOT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(SCREENSHOT_TIMEOUT_SECS_DEFAULT);
+    Duration::from_secs(seconds)
+}
+
+struct CaptureFile(PathBuf);
+
+impl CaptureFile {
+    fn new(kind: &str) -> Self {
+        Self(std::env::temp_dir().join(format!(
+            "qwen-cua-driver-{kind}-{}-{}.png",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        )))
+    }
+
+    fn path(&self) -> &Path { &self.0 }
+}
+
+impl Drop for CaptureFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn run_screencapture(args: &[String], target: &str) -> anyhow::Result<()> {
+    let mut child = Command::new("screencapture").args(args).spawn()?;
+    let timeout = screenshot_timeout();
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait()? {
+            Some(status) => break status,
+            None if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(20)),
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                anyhow::bail!(
+                    "screencapture timed out after {}s for {target}; process terminated",
+                    timeout.as_secs()
+                );
+            }
+        }
+    };
+    if !status.success() {
+        anyhow::bail!("screencapture failed for {target} (status {status})");
+    }
+    Ok(())
+}
 
 /// Capture a window by its `window_id` (CGWindowID).
 /// Returns raw PNG bytes or an error.
 pub fn screenshot_window_bytes(window_id: u32) -> anyhow::Result<Vec<u8>> {
-    let tmp_path = format!("/tmp/cua-driver-rs-capture-{}.png", window_id);
-
-    let status = Command::new("screencapture")
-        .args([
-            "-l", &window_id.to_string(),
-            "-x",  // no sound
-            "-o",  // no shadow
-            &tmp_path,
-        ])
-        .status()?;
-
-    if !status.success() {
-        anyhow::bail!("screencapture failed for window {window_id}");
-    }
-
-    let bytes = std::fs::read(&tmp_path)?;
-    let _ = std::fs::remove_file(&tmp_path);
+    let capture = CaptureFile::new(&format!("window-{window_id}"));
+    let args = vec![
+        "-l".to_owned(), window_id.to_string(),
+        "-x".to_owned(), "-o".to_owned(),
+        capture.path().to_string_lossy().into_owned(),
+    ];
+    run_screencapture(&args, &format!("window {window_id}"))?;
+    let bytes = std::fs::read(capture.path())?;
 
     if bytes.is_empty() {
         anyhow::bail!("screencapture produced empty output for window {window_id}");
@@ -51,19 +101,10 @@ pub fn screenshot_window(window_id: u32) -> anyhow::Result<(String, u32, u32)> {
 /// Capture the full main display.
 /// Returns raw PNG bytes or an error.
 pub fn screenshot_display_bytes() -> anyhow::Result<Vec<u8>> {
-    // Use a pid-unique path so concurrent cua-driver processes don't step on each other.
-    let tmp_path = format!("/tmp/cua-driver-rs-display-{}.png", std::process::id());
-
-    let status = Command::new("screencapture")
-        .args(["-x", &*tmp_path])
-        .status()?;
-
-    if !status.success() {
-        anyhow::bail!("screencapture failed for main display");
-    }
-
-    let bytes = std::fs::read(&tmp_path)?;
-    let _ = std::fs::remove_file(&tmp_path);
+    let capture = CaptureFile::new("display");
+    let args = vec!["-x".to_owned(), capture.path().to_string_lossy().into_owned()];
+    run_screencapture(&args, "main display")?;
+    let bytes = std::fs::read(capture.path())?;
 
     if bytes.is_empty() {
         anyhow::bail!("screencapture produced empty output for main display");

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -747,6 +747,7 @@ fn perform_ax_click(
 ) -> anyhow::Result<(String, bool, bool)> {
     let ax_action = map_action(action_str);
     let element = element_ptr as AXUIElementRef;
+    let _ = unsafe { crate::ax::bindings::set_messaging_timeout(element, 5.0) };
 
     // Capture advertised actions BEFORE dispatching so we can detect silent no-ops
     // (AX returns success even when the element doesn't advertise the action).

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/click.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/click.rs
@@ -747,7 +747,6 @@ fn perform_ax_click(
 ) -> anyhow::Result<(String, bool, bool)> {
     let ax_action = map_action(action_str);
     let element = element_ptr as AXUIElementRef;
-    let _ = unsafe { crate::ax::bindings::set_messaging_timeout(element, 5.0) };
 
     // Capture advertised actions BEFORE dispatching so we can detect silent no-ops
     // (AX returns success even when the element doesn't advertise the action).
@@ -767,18 +766,20 @@ fn perform_ax_click(
     if role == "AXPopUpButton" {
         let children = unsafe { copy_children(element) };
         if !children.is_empty() {
-            let options: Vec<String> = children.iter()
-                .filter_map(|&child| {
-                    let t = unsafe { copy_string_attr(child, "AXTitle") }.unwrap_or_default();
-                    let v = unsafe { copy_string_attr(child, "AXValue") }.unwrap_or_default();
-                    if t.is_empty() && v.is_empty() { return None; }
-                    Some(if v.is_empty() || v == t {
-                        format!("\"{t}\"")
-                    } else {
-                        format!("\"{t}\" (value: {v})")
-                    })
-                })
-                .collect();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let mut options = Vec::new();
+            for &child in children.iter().take(100) {
+                if std::time::Instant::now() >= deadline { break; }
+                let t = unsafe { copy_string_attr(child, "AXTitle") }.unwrap_or_default();
+                if std::time::Instant::now() >= deadline { break; }
+                let v = unsafe { copy_string_attr(child, "AXValue") }.unwrap_or_default();
+                if t.is_empty() && v.is_empty() { continue; }
+                options.push(if v.is_empty() || v == t {
+                    format!("\"{t}\"")
+                } else {
+                    format!("\"{t}\" (value: {v})")
+                });
+            }
             for &child in &children { unsafe { CFRelease(child as _); } }
 
             if !options.is_empty() {

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_accessibility_tree.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_accessibility_tree.rs
@@ -50,8 +50,12 @@ impl Tool for GetAccessibilityTreeTool {
     async fn invoke(&self, _args: Value) -> ToolResult {
         let _ = &self.state; // state not needed for this tool
 
-        let apps    = crate::apps::list_running_apps();
-        let windows = crate::windows::visible_windows();
+        let (apps, windows) = match tokio::task::spawn_blocking(|| {
+            (crate::apps::list_running_apps(), crate::windows::visible_windows())
+        }).await {
+            Ok(result) => result,
+            Err(e) => return ToolResult::error(format!("desktop discovery task failed: {e}")),
+        };
 
         let mut lines = vec![format!(
             "{} running app(s), {} visible window(s)",

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
@@ -37,12 +37,27 @@ impl Tool for GetConfigTool {
         // sees its own override layered over the global; the anonymous session
         // (absent `_session_id`) sees the raw global — today's behavior.
         let session_id = args.opt_str("_session_id");
-        let (max_image_dimension, capture_scope) = {
+        let snapshot = super::with_driver_config_commit_lock(|| {
             let cfg = self.state.config.read().unwrap();
-            (
-                self.state.session_config.effective_max_image_dimension(session_id.as_deref(), &cfg),
-                self.state.session_config.effective_capture_scope(session_id.as_deref(), &cfg),
-            )
+            let (max_image_dimension, capture_scope) = self
+                .state
+                .session_config
+                .effective_config(session_id.as_deref(), &cfg);
+            let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
+            Ok((
+                max_image_dimension,
+                capture_scope,
+                pip_enabled,
+                pip_geometry,
+            ))
+        });
+        let (max_image_dimension, capture_scope, pip_enabled, pip_geometry) = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return ToolResult::error(format!(
+                    "failed to read cua-driver configuration: {error}"
+                ));
+            }
         };
         // Report the CALLING session's own cursor enabled-state, not a
         // nondeterministic HashMap.first(). Resolve the same key the click /
@@ -54,11 +69,6 @@ impl Tool for GetConfigTool {
             .or_else(|| self.state.cursor_registry.get("default"))
             .map(|s| s.config.enabled)
             .unwrap_or(true);
-        // PiP values aren't in DriverConfig — they're file-only since the
-        // backend is initialised once at startup. Read fresh so the
-        // response reflects whatever set_config (or a direct JSON edit)
-        // last wrote.
-        let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
         ToolResult::text("cua-driver-rs configuration")
             .with_structured(serde_json::json!({
                 "version": env!("CARGO_PKG_VERSION"),

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_config.rs
@@ -37,9 +37,12 @@ impl Tool for GetConfigTool {
         // sees its own override layered over the global; the anonymous session
         // (absent `_session_id`) sees the raw global — today's behavior.
         let session_id = args.opt_str("_session_id");
-        let max_image_dimension = {
+        let (max_image_dimension, capture_scope) = {
             let cfg = self.state.config.read().unwrap();
-            self.state.session_config.effective_max_image_dimension(session_id.as_deref(), &cfg)
+            (
+                self.state.session_config.effective_max_image_dimension(session_id.as_deref(), &cfg),
+                self.state.session_config.effective_capture_scope(session_id.as_deref(), &cfg),
+            )
         };
         // Report the CALLING session's own cursor enabled-state, not a
         // nondeterministic HashMap.first(). Resolve the same key the click /
@@ -56,13 +59,12 @@ impl Tool for GetConfigTool {
         // response reflects whatever set_config (or a direct JSON edit)
         // last wrote.
         let (pip_enabled, pip_geometry) = pip_preview::read_pip_keys_from_file();
-        let capture_scope = self.state.config.read().unwrap().capture_scope.clone();
         ToolResult::text("cua-driver-rs configuration")
             .with_structured(serde_json::json!({
                 "version": env!("CARGO_PKG_VERSION"),
                 "platform": "macos",
-                // capture_mode is a per-call param; capture_scope is a global
-                // setting that gates get_desktop_state.
+                // capture_mode is per-call; capture_scope is the effective
+                // session value that gates get_desktop_state.
                 "max_image_dimension": max_image_dimension,
                 "capture_scope": capture_scope,
                 "agent_cursor": {

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
@@ -14,10 +14,17 @@
 use async_trait::async_trait;
 use cua_driver_core::{protocol::{ToolResult, Content}, tool::{Tool, ToolDef}};
 use serde_json::Value;
+use std::sync::Arc;
 
-use super::get_screen_size::main_screen_size;
+use super::{get_screen_size::main_screen_size, ToolState};
 
-pub struct GetDesktopStateTool;
+pub struct GetDesktopStateTool {
+    state: Arc<ToolState>,
+}
+
+impl GetDesktopStateTool {
+    pub fn new(state: Arc<ToolState>) -> Self { Self { state } }
+}
 
 static DEF: std::sync::OnceLock<ToolDef> = std::sync::OnceLock::new();
 
@@ -52,10 +59,11 @@ impl Tool for GetDesktopStateTool {
     async fn invoke(&self, args: Value) -> ToolResult {
         use cua_driver_core::tool_args::ArgsExt;
 
-        // Gate on the global capture_scope (re-read from the persisted config,
-        // the same value set_config writes): a full-display capture is a
-        // desktop-scope operation, available only under capture_scope="desktop".
-        let scope = super::load_driver_config().capture_scope;
+        let session_id = args.opt_str("_session_id");
+        let scope = {
+            let cfg = self.state.config.read().unwrap();
+            self.state.session_config.effective_capture_scope(session_id.as_deref(), &cfg)
+        };
         if scope != "desktop" {
             return ToolResult::error(format!(
                 "get_desktop_state requires capture_scope=\"desktop\" (current scope is \

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_desktop_state.rs
@@ -68,8 +68,9 @@ impl Tool for GetDesktopStateTool {
             return ToolResult::error(format!(
                 "get_desktop_state requires capture_scope=\"desktop\" (current scope is \
                  \"{scope}\"). Full-display capture is a desktop-scope operation; call \
-                 set_config with capture_scope=desktop first (it also enables window-less \
-                 screen-absolute click/scroll). For a single window, use \
+                 set_config with capture_scope=desktop first. Window-less screen-absolute \
+                 click additionally requires per-call scope=desktop; scroll remains \
+                 window-targeted. For a single window, use \
                  get_window_state(pid, window_id) instead."
             ))
             .with_structured(serde_json::json!({

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -433,7 +433,12 @@ impl Tool for GetWindowStateTool {
 }
 
 fn has_ax_content(result: &crate::ax::tree::TreeWalkResult) -> bool {
-    !result.nodes.is_empty() || !result.tree_markdown.trim().is_empty()
+    result.nodes.iter().any(|node| {
+        node.element_index.is_some()
+            || node.title.as_deref().is_some_and(|value| !value.trim().is_empty())
+            || node.value.as_deref().is_some_and(|value| !value.trim().is_empty())
+            || node.description.as_deref().is_some_and(|value| !value.trim().is_empty())
+    })
 }
 
 /// Render the actionable nodes from the AX walk into the
@@ -571,6 +576,19 @@ mod tests {
         };
         assert!(has_ax_content(&result));
         assert_eq!(result.nodes.iter().filter(|node| node.element_index.is_some()).count(), 0);
+    }
+
+    #[test]
+    fn role_only_window_or_sheet_is_not_usable_perception() {
+        let result = crate::ax::tree::TreeWalkResult {
+            tree_markdown: "- AXWindow\n  - AXSheet\n".into(),
+            nodes: vec![
+                node(None, "AXWindow", None, 0, None, None),
+                node(None, "AXSheet", None, 1, None, None),
+            ],
+            truncated: false,
+        };
+        assert!(!has_ax_content(&result));
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -93,6 +93,7 @@ impl Tool for GetWindowStateTool {
 
     async fn invoke(&self, args: Value) -> ToolResult {
         use cua_driver_core::tool_args::ArgsExt;
+        let operation_started = std::time::Instant::now();
         let pid = match args.require_i32("pid") { Ok(v) => v, Err(e) => return e };
         let window_id = match args.require_u32("window_id") { Ok(v) => v, Err(e) => return e };
         let query = args.opt_str("query");
@@ -142,33 +143,60 @@ impl Tool for GetWindowStateTool {
             .unwrap_or(crate::ax::tree::DEFAULT_MAX_DEPTH);
 
         // Always walk the AX tree (perception returns both tree + screenshot).
-        let tree_result = {
-            let q = query.clone();
-            // Wrap the blocking AX walk in a 30-second timeout. Heavy webview apps
-            // (Arc, Safari with many tabs, Electron) can block
-            // AXUIElementCopyAttributeValue indefinitely via XPC — without a
-            // deadline the MCP server hangs forever (issue #1537).
-            let walk_future = tokio::task::spawn_blocking(move || {
-                crate::ax::tree::walk_tree_bounded(
-                    pid,
-                    Some(window_id),
-                    q.as_deref(),
-                    max_elements,
-                    max_depth,
+        let (tree_result, ax_error) = {
+            const AX_WALK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+            const AX_NATIVE_CALL_RESERVE: std::time::Duration = std::time::Duration::from_secs(
+                crate::ax::bindings::AX_MESSAGING_TIMEOUT_SECS,
+            );
+            let ax_budget = crate::capture::remaining_tool_budget(operation_started)
+                .saturating_sub(AX_NATIVE_CALL_RESERVE)
+                .min(AX_WALK_TIMEOUT);
+            if ax_budget.is_zero() {
+                (
+                    None,
+                    Some(
+                        "AX tree walk skipped because the daemon response deadline is too close"
+                            .into(),
+                    ),
                 )
-            });
-            match tokio::time::timeout(std::time::Duration::from_secs(30), walk_future).await {
-                Ok(Ok(r)) => Some(r),
-                Ok(Err(e)) => return ToolResult::error(format!("AX tree walk failed: {e}")),
-                Err(_elapsed) => {
-                    return ToolResult::error(format!(
-                        "AX tree walk for pid={pid} timed out after 30 s. \
-                         The app (likely Arc, Electron, or Safari with many tabs) has a \
-                         pathologically large accessibility tree. \
-                         Workaround: re-call with a depth-limited scan \
-                         (max_elements / max_depth), then act by pixel (x,y) off \
-                         the screenshot if the tree stays unusable."
-                    ));
+            } else {
+                let q = query.clone();
+                let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let worker_cancelled = cancelled.clone();
+                // Stop before the daemon deadline and reserve one native AX timeout
+                // for the cancelled worker to leave its current call and clean up.
+                let mut walk_task = tokio::task::spawn_blocking(move || {
+                    crate::ax::tree::walk_tree_bounded_cancellable(
+                        pid,
+                        Some(window_id),
+                        q.as_deref(),
+                        max_elements,
+                        max_depth,
+                        &worker_cancelled,
+                    )
+                });
+                match tokio::time::timeout(ax_budget, &mut walk_task).await {
+                    Ok(Ok(r)) => (Some(r), None),
+                    Ok(Err(e)) => (None, Some(format!("AX tree task failed: {e}"))),
+                    Err(_elapsed) => {
+                        cancelled.store(true, std::sync::atomic::Ordering::Relaxed);
+                        tokio::spawn(async move {
+                            match walk_task.await {
+                                Ok(result) => result.release_retained_elements(),
+                                Err(error) => {
+                                    tracing::warn!(%error, "cancelled AX tree task failed during cleanup");
+                                }
+                            }
+                        });
+                        (None, Some(format!(
+                            "AX tree walk for pid={pid} timed out after {} ms. \
+                             The app (likely Arc, Electron, or Safari with many tabs) has a \
+                             pathologically large accessibility tree. \
+                             The screenshot path was still attempted; re-call with lower \
+                             max_elements / max_depth if the AX tree remains unavailable.",
+                            ax_budget.as_millis()
+                        )))
+                    }
                 }
             }
         };
@@ -176,6 +204,8 @@ impl Tool for GetWindowStateTool {
         // Update element cache.
         if let Some(ref r) = tree_result {
             self.state.element_cache.update(pid, window_id, &r.nodes);
+        } else {
+            self.state.element_cache.update(pid, window_id, &[]);
         }
 
         // Capture the screenshot and deliver it alongside the tree — the
@@ -187,9 +217,13 @@ impl Tool for GetWindowStateTool {
         // Returns (b64_or_path, final_w, final_h, Option<original_w>, is_file_path)
         let (screenshot, screenshot_error) = if should_capture {
             let out_file = screenshot_out_file.clone();
+            let screenshot_budget = crate::capture::remaining_tool_budget(operation_started);
             let res = tokio::task::spawn_blocking(move || -> anyhow::Result<(Option<String>, Option<String>, u32, u32, Option<u32>)> {
                 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-                let raw = crate::capture::screenshot_window_bytes(window_id)?;
+                let raw = crate::capture::screenshot_window_bytes_with_budget(
+                    window_id,
+                    screenshot_budget,
+                )?;
                 let (orig_w, _orig_h) = crate::capture::png_dimensions(&raw)?;
                 let png = crate::capture::resize_png_if_needed(&raw, max_dim)?;
                 let (w, h) = crate::capture::png_dimensions(&png)?;
@@ -226,13 +260,18 @@ impl Tool for GetWindowStateTool {
             (None, None)
         };
 
-        let element_count = self.state.element_cache.element_count(pid, window_id);
-        if should_capture && screenshot.is_none() && element_count == 0 {
+        let element_count = tree_result
+            .as_ref()
+            .map(|result| result.nodes.iter().filter(|node| node.element_index.is_some()).count())
+            .unwrap_or(0);
+        let has_ax_perception = tree_result.as_ref().is_some_and(has_ax_content);
+        if should_capture && screenshot.is_none() && !has_ax_perception {
             let error = screenshot_error.as_deref().unwrap_or("unknown screenshot failure");
             return ToolResult::error(format!(
                 "get_window_state could not produce usable perception for pid={pid} \
                  window_id={window_id}: screenshot failed ({error}) and the AX tree \
-                 had no actionable elements"
+                 produced no content{}",
+                ax_error.as_deref().map(|error| format!(" ({error})")).unwrap_or_default()
             ))
             .with_structured(serde_json::json!({
                 "code": "perception_unavailable",
@@ -240,6 +279,7 @@ impl Tool for GetWindowStateTool {
                 "window_id": window_id,
                 "element_count": element_count,
                 "screenshot_error": error,
+                "ax_error": ax_error,
             }));
         }
 
@@ -256,18 +296,20 @@ impl Tool for GetWindowStateTool {
             }
 
             // Summary text line (matching Swift reference format).
-            let element_count = self.state.element_cache.element_count(pid, window_id);
             let summary = if let Some(ref r) = tree_result {
                 format!(
                     "window_id={window_id} pid={pid} size={}x{} elements={element_count}\n\n{}",
                     w, h, r.tree_markdown
                 )
             } else {
-                format!("window_id={window_id} pid={pid} size={}x{}", w, h)
+                let ax_note = ax_error
+                    .as_deref()
+                    .map(|error| format!(" ax_error={error}"))
+                    .unwrap_or_default();
+                format!("window_id={window_id} pid={pid} size={}x{}{ax_note}", w, h)
             };
             content.push(Content::text(summary));
         } else if let Some(ref r) = tree_result {
-            let element_count = self.state.element_cache.element_count(pid, window_id);
             let screenshot_note = screenshot_error
                 .as_deref()
                 .map(|error| format!(" screenshot_error={error}"))
@@ -279,7 +321,10 @@ impl Tool for GetWindowStateTool {
         }
 
         if content.is_empty() {
-            return ToolResult::error("No content produced (neither AX tree nor screenshot succeeded)");
+            let detail = ax_error
+                .as_deref()
+                .unwrap_or("neither AX tree nor screenshot produced content");
+            return ToolResult::error(format!("No content produced: {detail}"));
         }
 
         let tree_md = tree_result.as_ref().map(|r| r.tree_markdown.clone()).unwrap_or_default();
@@ -327,17 +372,15 @@ impl Tool for GetWindowStateTool {
                 Issue #22865: use `max_elements` / `max_depth` to bound the \
                 AX walk on apps with very large trees."
         });
-        // Best-effort-background ladder, rung (2): an AX walk that ran but found
-        // zero actionable elements is NOT a clean snapshot — the window may be a
-        // non-AX surface (canvas/WebGL) or its tree wasn't ready (Chromium needs
-        // an enable+settle). Mark it degraded so callers don't read `elements: []`
-        // as "this window has no controls". Only applies when a walk was actually
-        // attempted (tree_result is None in capture_mode=vision, where empty is
-        // expected, not degraded).
-        if tree_result.is_some() && element_count == 0 {
+        // Best-effort-background ladder, rung (2): an AX walk that produced no
+        // content is NOT a clean snapshot — the window may be a non-AX surface
+        // (canvas/WebGL) or its tree wasn't ready (Chromium needs an
+        // enable+settle). Mark it degraded so callers don't read `elements: []`
+        // as "this window has no controls".
+        if tree_result.is_some() && !has_ax_perception {
             structured["degraded"] = serde_json::json!(true);
             structured["degraded_reason"] = serde_json::json!(
-                "ax_tree_empty: the AX walk returned no actionable elements. The \
+                "ax_tree_empty: the AX walk returned no content. The \
                  window may be a non-AX surface (canvas/WebGL/custom-drawn) or its \
                  accessibility tree was not ready (Chromium/Electron require an \
                  AX-enable + settle). Do not treat element data as authoritative — \
@@ -377,8 +420,20 @@ impl Tool for GetWindowStateTool {
             );
             structured["screenshot_error"] = serde_json::json!(error);
         }
+        if let Some(error) = ax_error {
+            structured["degraded"] = serde_json::json!(true);
+            structured["degraded_reason"] = serde_json::json!(
+                "ax_tree_unavailable: the screenshot remains usable, but element-indexed \
+                 actions are unavailable for this response."
+            );
+            structured["ax_error"] = serde_json::json!(error);
+        }
         ToolResult { content, is_error: None, structured_content: Some(structured) }
     }
+}
+
+fn has_ax_content(result: &crate::ax::tree::TreeWalkResult) -> bool {
+    !result.nodes.is_empty() || !result.tree_markdown.trim().is_empty()
 }
 
 /// Render the actionable nodes from the AX walk into the
@@ -505,6 +560,17 @@ mod tests {
             .map(|e| e["element_index"].as_u64().unwrap())
             .collect();
         assert_eq!(indices, vec![0, 1, 2], "ordering must match DFS / element_index assignment");
+    }
+
+    #[test]
+    fn static_ax_text_is_still_usable_perception() {
+        let result = crate::ax::tree::TreeWalkResult {
+            tree_markdown: "- AXStaticText = \"read only\"".into(),
+            nodes: vec![node(None, "AXStaticText", Some("read only"), 0, None, None)],
+            truncated: false,
+        };
+        assert!(has_ax_content(&result));
+        assert_eq!(result.nodes.iter().filter(|node| node.element_index.is_some()).count(), 0);
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/get_window_state.rs
@@ -185,7 +185,7 @@ impl Tool for GetWindowStateTool {
         // surface the path instead of embedding base64; otherwise embed base64.
         let max_dim = effective_max_dim;
         // Returns (b64_or_path, final_w, final_h, Option<original_w>, is_file_path)
-        let screenshot = if should_capture {
+        let (screenshot, screenshot_error) = if should_capture {
             let out_file = screenshot_out_file.clone();
             let res = tokio::task::spawn_blocking(move || -> anyhow::Result<(Option<String>, Option<String>, u32, u32, Option<u32>)> {
                 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -211,20 +211,37 @@ impl Tool for GetWindowStateTool {
                     } else {
                         self.state.resize_registry.clear_ratio(pid);
                     }
-                    Some((b64, file_path, w, h))
+                    (Some((b64, file_path, w, h)), None)
                 }
                 Ok(Err(e)) => {
                     tracing::warn!("Screenshot failed for window {window_id}: {e}");
-                    None
+                    (None, Some(e.to_string()))
                 }
                 Err(e) => {
                     tracing::warn!("Screenshot task error for window {window_id}: {e}");
-                    None
+                    (None, Some(format!("screenshot task failed: {e}")))
                 }
             }
         } else {
-            None
+            (None, None)
         };
+
+        let element_count = self.state.element_cache.element_count(pid, window_id);
+        if should_capture && screenshot.is_none() && element_count == 0 {
+            let error = screenshot_error.as_deref().unwrap_or("unknown screenshot failure");
+            return ToolResult::error(format!(
+                "get_window_state could not produce usable perception for pid={pid} \
+                 window_id={window_id}: screenshot failed ({error}) and the AX tree \
+                 had no actionable elements"
+            ))
+            .with_structured(serde_json::json!({
+                "code": "perception_unavailable",
+                "pid": pid,
+                "window_id": window_id,
+                "element_count": element_count,
+                "screenshot_error": error,
+            }));
+        }
 
         // Capture screenshot dimensions before consuming.
         let screenshot_dims = screenshot.as_ref().map(|(_, _, w, h)| (*w, *h));
@@ -251,8 +268,12 @@ impl Tool for GetWindowStateTool {
             content.push(Content::text(summary));
         } else if let Some(ref r) = tree_result {
             let element_count = self.state.element_cache.element_count(pid, window_id);
+            let screenshot_note = screenshot_error
+                .as_deref()
+                .map(|error| format!(" screenshot_error={error}"))
+                .unwrap_or_default();
             content.push(Content::text(format!(
-                "window_id={window_id} pid={pid} elements={element_count}\n\n{}",
+                "window_id={window_id} pid={pid} elements={element_count}{screenshot_note}\n\n{}",
                 r.tree_markdown
             )));
         }
@@ -261,7 +282,6 @@ impl Tool for GetWindowStateTool {
             return ToolResult::error("No content produced (neither AX tree nor screenshot succeeded)");
         }
 
-        let element_count = self.state.element_cache.element_count(pid, window_id);
         let tree_md = tree_result.as_ref().map(|r| r.tree_markdown.clone()).unwrap_or_default();
 
         // Surface 6: register a snapshot in the global token registry so
@@ -348,6 +368,14 @@ impl Tool for GetWindowStateTool {
         }
         if let Some(ref fp) = screenshot_file_path {
             structured["screenshot_file_path"] = serde_json::json!(fp);
+        }
+        if let Some(error) = screenshot_error {
+            structured["degraded"] = serde_json::json!(true);
+            structured["degraded_reason"] = serde_json::json!(
+                "screenshot_unavailable: the AX elements remain usable, but visual \
+                 cross-checking is unavailable for this response."
+            );
+            structured["screenshot_error"] = serde_json::json!(error);
         }
         ToolResult { content, is_error: None, structured_content: Some(structured) }
     }

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -180,13 +180,9 @@ impl ResizeRegistry {
 
 /// Runtime-mutable driver configuration persisted across calls within a session.
 ///
-/// `capture_mode` is per-call now (the `capture_mode` param). `capture_scope` is
-/// re-introduced here as a GLOBAL setting: it gates `get_desktop_state` (a
-/// full-display capture has no pid/window_id and therefore no per-call scope to
-/// key on — the only coherent gate is a global one), matching the Windows/Linux
-/// `DriverConfig.capture_scope`. Per-call tools (`click`/`scroll`) still accept a
-/// per-call `scope`; this global is the baseline the no-args desktop-capture
-/// tool reads. Default `"window"`.
+/// `capture_mode` is per-call. `capture_scope` is the persisted default layered
+/// beneath per-MCP-session overrides; `get_desktop_state`, `get_config`, and
+/// `set_config` all resolve the same effective session value. Default `"window"`.
 pub struct DriverConfig {
     /// Max screenshot dimension (0 = no limit). Applied during screenshot/zoom.
     /// Default 1568 matches Swift's `CuaDriverConfig.defaultMaxImageDimension` —
@@ -228,8 +224,8 @@ pub fn load_driver_config() -> DriverConfig {
         Err(_) => return cfg,  // malformed file — use defaults
     };
     // `capture_mode` is per-call now; an old on-disk `capture_mode` key is
-    // silently ignored. `capture_scope` IS a global setting again (gates
-    // get_desktop_state) — load it, accepting only window|desktop.
+    // silently ignored. Load the persisted capture_scope default, accepting
+    // only window|desktop; named sessions may override it in memory.
     if let Some(v) = json.get("max_image_dimension").and_then(|v| v.as_u64()) {
         if let Ok(v32) = u32::try_from(v) {
             cfg.max_image_dimension = v32;
@@ -243,10 +239,15 @@ pub fn load_driver_config() -> DriverConfig {
     cfg
 }
 
-/// Persist a single key/value pair to `~/.cua-driver/config.json`.
+/// Persist config updates to `~/.cua-driver/config.json`.
 /// Merges with any existing file contents so other keys are preserved.
 /// Returns `Err` if the directory cannot be created or the file cannot be written.
-pub fn write_driver_config_key(key: &str, value: &serde_json::Value) -> Result<(), String> {
+pub fn write_driver_config_updates(updates: &[(&str, serde_json::Value)]) -> Result<(), String> {
+    static WRITE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    let _guard = WRITE_LOCK
+        .get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .map_err(|e| e.to_string())?;
     let path = config_file_path();
     let mut json: serde_json::Value = path
         .exists()
@@ -254,12 +255,19 @@ pub fn write_driver_config_key(key: &str, value: &serde_json::Value) -> Result<(
         .flatten()
         .and_then(|t| serde_json::from_str(&t).ok())
         .unwrap_or_else(|| serde_json::json!({}));
-    json[key] = value.clone();
+    for (key, value) in updates {
+        json[*key] = value.clone();
+    }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let body = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
-    std::fs::write(&path, body).map_err(|e| e.to_string())?;
+    let temp_path = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    std::fs::write(&temp_path, body).map_err(|e| e.to_string())?;
+    if let Err(e) = std::fs::rename(&temp_path, &path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(e.to_string());
+    }
     Ok(())
 }
 
@@ -268,14 +276,15 @@ pub fn write_driver_config_key(key: &str, value: &serde_json::Value) -> Result<(
 /// The cua-driver daemon is one shared process: every `cua-driver mcp` proxy
 /// connects to it and shares its `ToolState`. `DriverConfig` is therefore
 /// multi-tenant AND persisted to disk — so without session scoping, session A's
-/// `set_config capture_mode=vision` clobbers session B's value and flips the
-/// on-disk default under everyone. These overrides fix that: a named MCP session
+/// `set_config` clobbers session B's value and flips the on-disk default under
+/// everyone. These overrides fix that: a named MCP session
 /// gets an in-memory, non-persisted override keyed by its `_session_id`; the
 /// anonymous session (CLI / one-shot `call`) still writes the shared global +
 /// disk. `None` fields mean "fall through to the global layer".
 #[derive(Clone, Default)]
 pub struct ConfigOverrides {
     pub max_image_dimension: Option<u32>,
+    pub capture_scope: Option<String>,
 }
 
 /// Thread-safe map of `session_id` → `ConfigOverrides`, mirroring
@@ -304,6 +313,9 @@ impl SessionConfigRegistry {
         if delta.max_image_dimension.is_some() {
             entry.max_image_dimension = delta.max_image_dimension;
         }
+        if delta.capture_scope.is_some() {
+            entry.capture_scope = delta.capture_scope;
+        }
     }
 
     /// Resolve the effective `max_image_dimension` for `session`, layering its
@@ -315,6 +327,12 @@ impl SessionConfigRegistry {
             Some(ov) => ov.max_image_dimension.unwrap_or(global.max_image_dimension),
             None => global.max_image_dimension,
         }
+    }
+
+    pub fn effective_capture_scope(&self, session: Option<&str>, global: &DriverConfig) -> String {
+        let ov = session.and_then(|s| self.inner.lock().unwrap().get(s).cloned());
+        ov.and_then(|o| o.capture_scope)
+            .unwrap_or_else(|| global.capture_scope.clone())
     }
 
     /// Drop `session`'s overrides. No-op for an unknown id (so `session_end`
@@ -416,7 +434,7 @@ pub fn register_all(registry: &mut ToolRegistry, compat: bool) {
     // triggers Claude Code's computer-use beta-tool injection (see cli.rs).
     let _ = compat;
     registry.register(Box::new(get_screen_size::GetScreenSizeTool));
-    registry.register(Box::new(get_desktop_state::GetDesktopStateTool));
+    registry.register(Box::new(get_desktop_state::GetDesktopStateTool::new(state.clone())));
     registry.register(Box::new(get_cursor_position::GetCursorPositionTool));
     registry.register(Box::new(move_cursor::MoveCursorTool::new(state.clone())));
     registry.register(Box::new(cursor_tools::SetAgentCursorEnabledTool::new(state.clone())));
@@ -461,7 +479,7 @@ mod session_config_guard_tests {
     use cua_driver_core::session::fire_session_end;
 
     fn overrides(max_dim: u32) -> ConfigOverrides {
-        ConfigOverrides { max_image_dimension: Some(max_dim) }
+        ConfigOverrides { max_image_dimension: Some(max_dim), capture_scope: None }
     }
 
     #[test]
@@ -489,6 +507,26 @@ mod session_config_guard_tests {
         reg.set(sid, overrides(800));
         let dim = reg.effective_max_image_dimension(Some(sid), &global);
         assert_eq!(dim, 800, "live session override must apply");
+    }
+
+    #[test]
+    fn capture_scope_is_isolated_per_session() {
+        let reg = SessionConfigRegistry::new();
+        let global = DriverConfig::default();
+        let desktop = "wb-scope-desktop-B1C2D3";
+        let window = "wb-scope-window-E4F5G6";
+        reg.set(desktop, ConfigOverrides {
+            max_image_dimension: None,
+            capture_scope: Some("desktop".to_owned()),
+        });
+        reg.set(window, ConfigOverrides {
+            max_image_dimension: None,
+            capture_scope: Some("window".to_owned()),
+        });
+
+        assert_eq!(reg.effective_capture_scope(Some(desktop), &global), "desktop");
+        assert_eq!(reg.effective_capture_scope(Some(window), &global), "window");
+        assert_eq!(reg.effective_capture_scope(None, &global), "window");
     }
 }
 

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -242,15 +242,15 @@ pub fn load_driver_config() -> DriverConfig {
 /// Persist config updates to `~/.cua-driver/config.json`.
 /// Merges with any existing file contents so other keys are preserved.
 /// Runs `apply_in_memory` after the atomic rename but before releasing the
-/// process-wide write lock, keeping concurrent disk and memory commits ordered.
+/// process-wide commit lock, keeping concurrent disk and memory commits ordered.
 /// Returns `Err` if the directory cannot be created or the file cannot be written.
-static DRIVER_CONFIG_WRITE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+static DRIVER_CONFIG_COMMIT_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
     std::sync::OnceLock::new();
 
-fn with_driver_config_write_lock<T>(
+pub(super) fn with_driver_config_commit_lock<T>(
     operation: impl FnOnce() -> Result<T, String>,
 ) -> Result<T, String> {
-    let _guard = DRIVER_CONFIG_WRITE_LOCK
+    let _guard = DRIVER_CONFIG_COMMIT_LOCK
         .get_or_init(|| std::sync::Mutex::new(()))
         .lock()
         .map_err(|e| e.to_string())?;
@@ -261,11 +261,18 @@ pub fn write_driver_config_updates<T>(
     updates: &[(&str, serde_json::Value)],
     apply_in_memory: impl FnOnce() -> T,
 ) -> Result<T, String> {
-    with_driver_config_write_lock(|| {
-        let path = config_file_path();
+    write_driver_config_updates_at_path(&config_file_path(), updates, apply_in_memory)
+}
+
+fn write_driver_config_updates_at_path<T>(
+    path: &std::path::Path,
+    updates: &[(&str, serde_json::Value)],
+    apply_in_memory: impl FnOnce() -> T,
+) -> Result<T, String> {
+    with_driver_config_commit_lock(|| {
         let mut json: serde_json::Value = path
             .exists()
-            .then(|| std::fs::read_to_string(&path).ok())
+            .then(|| std::fs::read_to_string(path).ok())
             .flatten()
             .and_then(|t| serde_json::from_str(&t).ok())
             .unwrap_or_else(|| serde_json::json!({}));
@@ -278,7 +285,7 @@ pub fn write_driver_config_updates<T>(
         let body = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
         let temp_path = path.with_extension(format!("json.tmp-{}", std::process::id()));
         std::fs::write(&temp_path, body).map_err(|e| e.to_string())?;
-        if let Err(e) = std::fs::rename(&temp_path, &path) {
+        if let Err(e) = std::fs::rename(&temp_path, path) {
             let _ = std::fs::remove_file(&temp_path);
             return Err(e.to_string());
         }
@@ -348,6 +355,21 @@ impl SessionConfigRegistry {
         let ov = session.and_then(|s| self.inner.lock().unwrap().get(s).cloned());
         ov.and_then(|o| o.capture_scope)
             .unwrap_or_else(|| global.capture_scope.clone())
+    }
+
+    pub fn effective_config(
+        &self,
+        session: Option<&str>,
+        global: &DriverConfig,
+    ) -> (u32, String) {
+        let ov = session.and_then(|s| self.inner.lock().unwrap().get(s).cloned());
+        match ov {
+            Some(ov) => (
+                ov.max_image_dimension.unwrap_or(global.max_image_dimension),
+                ov.capture_scope.unwrap_or_else(|| global.capture_scope.clone()),
+            ),
+            None => (global.max_image_dimension, global.capture_scope.clone()),
+        }
     }
 
     /// Drop `session`'s overrides. No-op for an unknown id (so `session_end`
@@ -497,7 +519,7 @@ pub fn register_all(registry: &mut ToolRegistry, compat: bool) {
 mod session_config_guard_tests {
     use super::*;
     use cua_driver_core::session::fire_session_end;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Mutex};
 
     fn overrides(max_dim: u32) -> ConfigOverrides {
         ConfigOverrides { max_image_dimension: Some(max_dim), capture_scope: None }
@@ -551,32 +573,61 @@ mod session_config_guard_tests {
     }
 
     #[test]
-    fn config_commit_callbacks_are_serialized_with_disk_writes() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let max_active = Arc::new(AtomicUsize::new(0));
-        let barrier = Arc::new(std::sync::Barrier::new(4));
-        let handles: Vec<_> = (0..4)
-            .map(|_| {
-                let active = active.clone();
-                let max_active = max_active.clone();
-                let barrier = barrier.clone();
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    with_driver_config_write_lock(|| {
-                        let now = active.fetch_add(1, Ordering::SeqCst) + 1;
-                        max_active.fetch_max(now, Ordering::SeqCst);
-                        std::thread::sleep(std::time::Duration::from_millis(20));
-                        active.fetch_sub(1, Ordering::SeqCst);
-                        Ok(())
-                    })
-                    .unwrap();
-                })
-            })
-            .collect();
-        for handle in handles {
-            handle.join().unwrap();
-        }
-        assert_eq!(max_active.load(Ordering::SeqCst), 1);
+    fn disk_and_memory_config_commits_keep_the_same_order() {
+        let dir = std::env::temp_dir().join(format!(
+            "qwen-cua-driver-config-order-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let path = dir.join("config.json");
+        let memory = Arc::new(Mutex::new(String::new()));
+        let (a_started_tx, a_started_rx) = mpsc::channel();
+        let (release_a_tx, release_a_rx) = mpsc::channel();
+        let (b_done_tx, b_done_rx) = mpsc::channel();
+
+        let path_a = path.clone();
+        let memory_a = memory.clone();
+        let writer_a = std::thread::spawn(move || {
+            write_driver_config_updates_at_path(
+                &path_a,
+                &[("capture_scope", serde_json::json!("window"))],
+                || {
+                    a_started_tx.send(()).unwrap();
+                    release_a_rx.recv().unwrap();
+                    *memory_a.lock().unwrap() = "window".to_owned();
+                },
+            )
+            .unwrap();
+        });
+        a_started_rx.recv().unwrap();
+
+        let path_b = path.clone();
+        let memory_b = memory.clone();
+        let writer_b = std::thread::spawn(move || {
+            write_driver_config_updates_at_path(
+                &path_b,
+                &[("capture_scope", serde_json::json!("desktop"))],
+                || {
+                    *memory_b.lock().unwrap() = "desktop".to_owned();
+                    b_done_tx.send(()).unwrap();
+                },
+            )
+            .unwrap();
+        });
+
+        let b_overtook_a = b_done_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .is_ok();
+        release_a_tx.send(()).unwrap();
+        writer_a.join().unwrap();
+        writer_b.join().unwrap();
+
+        let disk: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let memory = memory.lock().unwrap().clone();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(!b_overtook_a, "a later disk write must wait for the earlier memory commit");
+        assert_eq!(disk["capture_scope"], memory);
     }
 }
 

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/mod.rs
@@ -241,34 +241,49 @@ pub fn load_driver_config() -> DriverConfig {
 
 /// Persist config updates to `~/.cua-driver/config.json`.
 /// Merges with any existing file contents so other keys are preserved.
+/// Runs `apply_in_memory` after the atomic rename but before releasing the
+/// process-wide write lock, keeping concurrent disk and memory commits ordered.
 /// Returns `Err` if the directory cannot be created or the file cannot be written.
-pub fn write_driver_config_updates(updates: &[(&str, serde_json::Value)]) -> Result<(), String> {
-    static WRITE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    let _guard = WRITE_LOCK
+static DRIVER_CONFIG_WRITE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
+
+fn with_driver_config_write_lock<T>(
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let _guard = DRIVER_CONFIG_WRITE_LOCK
         .get_or_init(|| std::sync::Mutex::new(()))
         .lock()
         .map_err(|e| e.to_string())?;
-    let path = config_file_path();
-    let mut json: serde_json::Value = path
-        .exists()
-        .then(|| std::fs::read_to_string(&path).ok())
-        .flatten()
-        .and_then(|t| serde_json::from_str(&t).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
-    for (key, value) in updates {
-        json[*key] = value.clone();
-    }
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
-    let body = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
-    let temp_path = path.with_extension(format!("json.tmp-{}", std::process::id()));
-    std::fs::write(&temp_path, body).map_err(|e| e.to_string())?;
-    if let Err(e) = std::fs::rename(&temp_path, &path) {
-        let _ = std::fs::remove_file(&temp_path);
-        return Err(e.to_string());
-    }
-    Ok(())
+    operation()
+}
+
+pub fn write_driver_config_updates<T>(
+    updates: &[(&str, serde_json::Value)],
+    apply_in_memory: impl FnOnce() -> T,
+) -> Result<T, String> {
+    with_driver_config_write_lock(|| {
+        let path = config_file_path();
+        let mut json: serde_json::Value = path
+            .exists()
+            .then(|| std::fs::read_to_string(&path).ok())
+            .flatten()
+            .and_then(|t| serde_json::from_str(&t).ok())
+            .unwrap_or_else(|| serde_json::json!({}));
+        for (key, value) in updates {
+            json[*key] = value.clone();
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let body = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+        let temp_path = path.with_extension(format!("json.tmp-{}", std::process::id()));
+        std::fs::write(&temp_path, body).map_err(|e| e.to_string())?;
+        if let Err(e) = std::fs::rename(&temp_path, &path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(e.to_string());
+        }
+        Ok(apply_in_memory())
+    })
 }
 
 /// Per-session config overrides layered over the global persisted `DriverConfig`.
@@ -385,6 +400,11 @@ impl Default for ToolState {
 /// variant — same name, stricter args, window-scoped JPEG @ 85% + a text
 /// note telling the caller to use pixel-addressed tools.
 pub fn register_all(registry: &mut ToolRegistry, compat: bool) {
+    if let Err(error) = crate::ax::bindings::set_global_messaging_timeout(
+        crate::ax::bindings::AX_MESSAGING_TIMEOUT_SECS as f32,
+    ) {
+        tracing::warn!(error, "failed to configure process-wide AX messaging timeout");
+    }
     let state = Arc::new(ToolState::default());
     // Share the element cache with the recording-hook layer so it can
     // resolve element_index → window-local screenshot coords for click.png.
@@ -477,6 +497,7 @@ pub fn register_all(registry: &mut ToolRegistry, compat: bool) {
 mod session_config_guard_tests {
     use super::*;
     use cua_driver_core::session::fire_session_end;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn overrides(max_dim: u32) -> ConfigOverrides {
         ConfigOverrides { max_image_dimension: Some(max_dim), capture_scope: None }
@@ -527,6 +548,35 @@ mod session_config_guard_tests {
         assert_eq!(reg.effective_capture_scope(Some(desktop), &global), "desktop");
         assert_eq!(reg.effective_capture_scope(Some(window), &global), "window");
         assert_eq!(reg.effective_capture_scope(None, &global), "window");
+    }
+
+    #[test]
+    fn config_commit_callbacks_are_serialized_with_disk_writes() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let active = active.clone();
+                let max_active = max_active.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    with_driver_config_write_lock(|| {
+                        let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(now, Ordering::SeqCst);
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(max_active.load(Ordering::SeqCst), 1);
     }
 }
 

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -145,7 +145,11 @@ impl Tool for SetConfigTool {
         }
         let persisted_global = if !updates.is_empty() {
             match write_driver_config_updates(&updates, || {
-                if session_id.is_some() {
+                if let Some(sid) = session_id.as_deref() {
+                    self.state.session_config.set(sid, ConfigOverrides {
+                        max_image_dimension: max_dim,
+                        capture_scope: scope_arg.clone(),
+                    });
                     return None;
                 }
                 let mut cfg = self.state.config.write().unwrap();
@@ -171,15 +175,17 @@ impl Tool for SetConfigTool {
         let (effective_dim, effective_scope) = if let Some(sid) = session_id.as_deref() {
             // These session-scoped fields are in-memory only; PiP settings above
             // remain global because the backend reads them once at daemon startup.
-            self.state.session_config.set(sid, ConfigOverrides {
-                max_image_dimension: max_dim,
-                capture_scope: scope_arg.clone(),
-            });
+            // When PiP persistence was part of this call, the override committed
+            // inside the same config transaction above; otherwise no disk state
+            // changed and this single registry write is already atomic.
+            if updates.is_empty() {
+                self.state.session_config.set(sid, ConfigOverrides {
+                    max_image_dimension: max_dim,
+                    capture_scope: scope_arg.clone(),
+                });
+            }
             let cfg = self.state.config.read().unwrap();
-            (
-                self.state.session_config.effective_max_image_dimension(Some(sid), &cfg),
-                self.state.session_config.effective_capture_scope(Some(sid), &cfg),
-            )
+            self.state.session_config.effective_config(Some(sid), &cfg)
         } else if let Some(applied) = persisted_global {
             applied
         } else {

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -3,7 +3,7 @@ use cua_driver_core::{protocol::ToolResult, tool::{Tool, ToolDef}};
 use serde_json::Value;
 use std::sync::Arc;
 
-use super::{write_driver_config_key, ConfigOverrides, ToolState};
+use super::{write_driver_config_updates, ConfigOverrides, ToolState};
 
 pub struct SetConfigTool {
     state: Arc<ToolState>,
@@ -24,8 +24,8 @@ fn def() -> &'static ToolDef {
             take effect on the next daemon restart (the PiP backend is \
             initialised once at startup).\n\nNote: capture_mode is a per-call \
             param (on get_window_state / click), not a stored setting. \
-            capture_scope IS a global setting: it gates get_desktop_state \
-            (full-display capture requires capture_scope=desktop).".into(),
+            capture_scope gates get_desktop_state (full-display capture requires \
+            capture_scope=desktop) and is isolated per named MCP session.".into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
@@ -47,7 +47,7 @@ fn def() -> &'static ToolDef {
                     "enum": ["window", "desktop"],
                     "description": "Capture scope: \"window\" (default) or \"desktop\". Desktop \
                         scope enables get_desktop_state (full-display capture) and window-less \
-                        screen-absolute click/scroll. Global setting; takes effect immediately."
+                        screen-absolute click/scroll. Session-scoped for MCP; takes effect immediately."
                 },
                 "experimental_pip": {
                     "type": "boolean",
@@ -104,68 +104,89 @@ impl Tool for SetConfigTool {
             None => None,
         };
 
-        let effective_dim = if let Some(sid) = session_id.as_deref() {
-            // Session-scoped override: in-memory only, no global write, no disk.
-            self.state.session_config.set(sid, ConfigOverrides {
-                max_image_dimension: max_dim,
-            });
-            self.state.session_config.effective_max_image_dimension(Some(sid), &self.state.config.read().unwrap())
-        } else {
-            // Anonymous/global session: write the shared global + persist.
-            let mut cfg = self.state.config.write().unwrap();
-            if let Some(dim32) = max_dim {
-                cfg.max_image_dimension = dim32;
-                if let Err(e) = write_driver_config_key("max_image_dimension", &Value::Number(u64::from(dim32).into())) {
-                    tracing::warn!("set_config: failed to persist max_image_dimension: {e}");
-                }
-            }
-            cfg.max_image_dimension
-        };
-        // PiP keys persist to the same config.json but take effect only on
-        // next daemon restart — the backend is initialised once at startup.
-        let mut pip_note = String::new();
-        if let Some(enabled) = args.get("experimental_pip").and_then(|v| v.as_bool()) {
-            if let Err(e) = pip_preview::write_config_key("experimental_pip", Value::Bool(enabled)) {
-                return ToolResult::error(format!("failed to persist experimental_pip: {e}"));
-            }
-            pip_note = format!(" — restart cua-driver for experimental_pip={enabled} to take effect");
-        }
-        if let Some(geom) = args.opt_str("experimental_pip_geometry") {
-            // Validate before persisting so the user gets an immediate error.
-            if pip_preview::PipGeometry::parse(&geom).is_none() {
-                return ToolResult::error(format!(
-                    "experimental_pip_geometry `{geom}` is not a valid WxH or WxH+X+Y string"
-                ));
-            }
-            if let Err(e) = pip_preview::write_config_key("experimental_pip_geometry", Value::String(geom.clone())) {
-                return ToolResult::error(format!("failed to persist experimental_pip_geometry: {e}"));
-            }
-            if pip_note.is_empty() {
-                pip_note = format!(" — restart cua-driver for experimental_pip_geometry={geom} to take effect");
-            }
-        }
-        // capture_scope: GLOBAL setting (gates get_desktop_state). Accept the
-        // direct field or {key,value} shape; validate window|desktop; write the
-        // shared global config + persist (matches Windows/Linux — not
-        // session-scoped, since it's the baseline a no-args capture tool reads).
         let scope_arg = args.opt_str("capture_scope").or_else(|| {
             kv.as_ref()
                 .filter(|(k, _)| k == "capture_scope")
                 .and_then(|(_, v)| v.as_str().map(str::to_owned))
         });
-        let mut capture_scope_note = String::new();
-        if let Some(sc) = scope_arg {
-            if sc != "window" && sc != "desktop" {
+        if let Some(ref scope) = scope_arg {
+            if scope != "window" && scope != "desktop" {
                 return ToolResult::error(format!(
-                    "`capture_scope` must be \"window\" or \"desktop\", got \"{sc}\"."
+                    "`capture_scope` must be \"window\" or \"desktop\", got \"{scope}\"."
                 ));
             }
-            self.state.config.write().unwrap().capture_scope = sc.clone();
-            if let Err(e) = write_driver_config_key("capture_scope", &Value::String(sc.clone())) {
-                tracing::warn!("set_config: failed to persist capture_scope: {e}");
-            }
-            capture_scope_note = format!(", capture_scope={sc}");
         }
+
+        let pip_enabled = args.get("experimental_pip").and_then(|v| v.as_bool());
+        let pip_geometry = args.opt_str("experimental_pip_geometry");
+        if let Some(ref geometry) = pip_geometry {
+            if pip_preview::PipGeometry::parse(geometry).is_none() {
+                return ToolResult::error(format!(
+                    "experimental_pip_geometry `{geometry}` is not a valid WxH or WxH+X+Y string"
+                ));
+            }
+        }
+
+        let mut updates = Vec::new();
+        if session_id.is_none() {
+            if let Some(dim32) = max_dim {
+                updates.push(("max_image_dimension", Value::Number(u64::from(dim32).into())));
+            }
+            if let Some(ref scope) = scope_arg {
+                updates.push(("capture_scope", Value::String(scope.clone())));
+            }
+        }
+        if let Some(enabled) = pip_enabled {
+            updates.push(("experimental_pip", Value::Bool(enabled)));
+        }
+        if let Some(ref geometry) = pip_geometry {
+            updates.push(("experimental_pip_geometry", Value::String(geometry.clone())));
+        }
+        if !updates.is_empty() {
+            if let Err(e) = write_driver_config_updates(&updates) {
+                return ToolResult::error(format!(
+                    "failed to persist cua-driver configuration: {e}"
+                ));
+            }
+        }
+
+        let (effective_dim, effective_scope) = if let Some(sid) = session_id.as_deref() {
+            // These session-scoped fields are in-memory only; PiP settings above
+            // remain global because the backend reads them once at daemon startup.
+            self.state.session_config.set(sid, ConfigOverrides {
+                max_image_dimension: max_dim,
+                capture_scope: scope_arg.clone(),
+            });
+            let cfg = self.state.config.read().unwrap();
+            (
+                self.state.session_config.effective_max_image_dimension(Some(sid), &cfg),
+                self.state.session_config.effective_capture_scope(Some(sid), &cfg),
+            )
+        } else {
+            let mut cfg = self.state.config.write().unwrap();
+            if let Some(dim32) = max_dim {
+                cfg.max_image_dimension = dim32;
+            }
+            if let Some(ref scope) = scope_arg {
+                cfg.capture_scope = scope.clone();
+            }
+            (cfg.max_image_dimension, cfg.capture_scope.clone())
+        };
+        // PiP keys persist to the same config.json but take effect only on
+        // next daemon restart — the backend is initialised once at startup.
+        let mut pip_note = String::new();
+        if let Some(enabled) = pip_enabled {
+            pip_note = format!(" — restart cua-driver for experimental_pip={enabled} to take effect");
+        }
+        if let Some(geom) = pip_geometry {
+            if pip_note.is_empty() {
+                pip_note = format!(" — restart cua-driver for experimental_pip_geometry={geom} to take effect");
+            }
+        }
+        let capture_scope_note = scope_arg
+            .as_ref()
+            .map(|scope| format!(", capture_scope={scope}"))
+            .unwrap_or_default();
 
         let scope_note = if session_id.is_some() {
             " (session-scoped; persisted default unchanged)"
@@ -174,7 +195,6 @@ impl Tool for SetConfigTool {
         };
         // Echo the config back in structured content (matches Windows/Linux
         // set_config, which callers/tests read for the applied capture_scope).
-        let capture_scope = self.state.config.read().unwrap().capture_scope.clone();
         ToolResult::text(format!(
             "Config updated: max_image_dimension={}{}{}{}",
             effective_dim, capture_scope_note, scope_note, pip_note
@@ -183,7 +203,34 @@ impl Tool for SetConfigTool {
             "version": env!("CARGO_PKG_VERSION"),
             "platform": "macos",
             "max_image_dimension": effective_dim,
-            "capture_scope": capture_scope,
+            "capture_scope": effective_scope,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_pip_geometry_does_not_apply_session_overrides() {
+        let state = Arc::new(ToolState::default());
+        let global_scope = state.config.read().unwrap().capture_scope.clone();
+        let requested_scope = if global_scope == "window" { "desktop" } else { "window" };
+        let tool = SetConfigTool::new(state.clone());
+        let session = "set-config-validation-test";
+
+        let result = tool.invoke(serde_json::json!({
+            "_session_id": session,
+            "capture_scope": requested_scope,
+            "experimental_pip_geometry": "bad",
+        })).await;
+
+        assert_eq!(result.is_error, Some(true));
+        let cfg = state.config.read().unwrap();
+        assert_eq!(
+            state.session_config.effective_capture_scope(Some(session), &cfg),
+            global_scope,
+        );
     }
 }

--- a/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
+++ b/packages/cua-driver/rust/crates/platform-macos/src/tools/set_config.rs
@@ -46,8 +46,9 @@ fn def() -> &'static ToolDef {
                     "type": "string",
                     "enum": ["window", "desktop"],
                     "description": "Capture scope: \"window\" (default) or \"desktop\". Desktop \
-                        scope enables get_desktop_state (full-display capture) and window-less \
-                        screen-absolute click/scroll. Session-scoped for MCP; takes effect immediately."
+                        scope enables get_desktop_state (full-display capture). A window-less \
+                        screen-absolute click still requires per-call scope=desktop; scroll remains \
+                        window-targeted. Session-scoped for MCP; takes effect immediately."
                 },
                 "experimental_pip": {
                     "type": "boolean",
@@ -142,13 +143,30 @@ impl Tool for SetConfigTool {
         if let Some(ref geometry) = pip_geometry {
             updates.push(("experimental_pip_geometry", Value::String(geometry.clone())));
         }
-        if !updates.is_empty() {
-            if let Err(e) = write_driver_config_updates(&updates) {
-                return ToolResult::error(format!(
-                    "failed to persist cua-driver configuration: {e}"
-                ));
+        let persisted_global = if !updates.is_empty() {
+            match write_driver_config_updates(&updates, || {
+                if session_id.is_some() {
+                    return None;
+                }
+                let mut cfg = self.state.config.write().unwrap();
+                if let Some(dim32) = max_dim {
+                    cfg.max_image_dimension = dim32;
+                }
+                if let Some(ref scope) = scope_arg {
+                    cfg.capture_scope = scope.clone();
+                }
+                Some((cfg.max_image_dimension, cfg.capture_scope.clone()))
+            }) {
+                Ok(applied) => applied,
+                Err(e) => {
+                    return ToolResult::error(format!(
+                        "failed to persist cua-driver configuration: {e}"
+                    ));
+                }
             }
-        }
+        } else {
+            None
+        };
 
         let (effective_dim, effective_scope) = if let Some(sid) = session_id.as_deref() {
             // These session-scoped fields are in-memory only; PiP settings above
@@ -162,14 +180,10 @@ impl Tool for SetConfigTool {
                 self.state.session_config.effective_max_image_dimension(Some(sid), &cfg),
                 self.state.session_config.effective_capture_scope(Some(sid), &cfg),
             )
+        } else if let Some(applied) = persisted_global {
+            applied
         } else {
-            let mut cfg = self.state.config.write().unwrap();
-            if let Some(dim32) = max_dim {
-                cfg.max_image_dimension = dim32;
-            }
-            if let Some(ref scope) = scope_arg {
-                cfg.capture_scope = scope.clone();
-            }
+            let cfg = self.state.config.read().unwrap();
             (cfg.max_image_dimension, cfg.capture_scope.clone())
         };
         // PiP keys persist to the same config.json but take effect only on

--- a/packages/cua-driver/scripts/_install-rust.sh
+++ b/packages/cua-driver/scripts/_install-rust.sh
@@ -471,7 +471,7 @@ if [[ "$OS" == "Darwin" && "$ARCH_RAW" == "x86_64" ]]; then
     fi
 fi
 
-# LABEL  = the release-asset tarball label (matches what cd-rust-cua-driver.yml
+# LABEL  = the release-asset tarball label (matches what cd-cua-driver.yml
 #          publishes; user-facing).
 # TARGET = the Rust target triple, used in the on-disk per-version dir name so
 #          a multi-arch dev can keep e.g. aarch64-apple-darwin and

--- a/packages/cua-driver/scripts/install.ps1
+++ b/packages/cua-driver/scripts/install.ps1
@@ -103,7 +103,7 @@ $BinaryName = "qwen-cua-driver.exe"
 
 # Baked-version constant — kept in lock-step with the latest published
 # cua-driver-rs-v* release tag by the CD workflow's bake-version step
-# (see .github/workflows/cd-rust-cua-driver.yml). The sentinel-block
+# (see .github/workflows/cd-cua-driver.yml). The sentinel-block
 # markers must stay byte-identical to the matching block in install.sh
 # so the CD `sed` command can update both files with one pattern.
 #

--- a/packages/cua-driver/test-harness/linux-container/calc.sh
+++ b/packages/cua-driver/test-harness/linux-container/calc.sh
@@ -118,7 +118,7 @@ PY
     # a11y, restart, launch. Use when list_windows comes back empty (a zombie
     # unreaped child of the daemon pollutes pgrep).
     pkill -9 -f 'cua-driver serve' 2>/dev/null; pkill -9 -f galculator 2>/dev/null; sleep 3
-    rm -f /home/cua/.cache/cua-driver/cua-driver.sock
+    rm -f /home/cua/.cache/qwen-cua-driver/qwen-cua-driver.sock
     gsettings set org.gnome.desktop.interface toolkit-accessibility true 2>/dev/null
     pgrep -f at-spi-bus-launcher >/dev/null || (setsid /usr/libexec/at-spi-bus-launcher --launch-immediately >/tmp/atspi.log 2>&1 &)
     sleep 1

--- a/packages/cua-driver/test-harness/linux-container/derec.sh
+++ b/packages/cua-driver/test-harness/linux-container/derec.sh
@@ -72,7 +72,7 @@ case "$1" in
  env) echo "lane=$([ -n "$WAYLAND" ] && echo wayland || echo x11) DISPLAY=${DISPLAY:-<unset>} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-<unset>} XAUTHORITY=$XAUTHORITY dbus=${DBUS_SESSION_BUS_ADDRESS:+set} CUA=$CUA APP=$APP DE_PID=$DE_PID";;
  setup)
   pkill -f 'cua-driver serve' 2>/dev/null; pkill -f "$APP" 2>/dev/null; sleep 2
-  rm -f ~/.cache/cua-driver/cua-driver.sock
+  rm -f ~/.cache/qwen-cua-driver/qwen-cua-driver.sock
   (setsid "$CUA" serve >$W/cuad.log 2>&1 &); sleep 2
   "$CUA" call launch_app "{\"name\":\"$APP\"}" >$W/launch.json 2>&1; sleep 4
   PID=$(resolve_pid); echo "$PID" >$W/pid

--- a/packages/cua-driver/test-harness/linux-container/modality_matrix.sh
+++ b/packages/cua-driver/test-harness/linux-container/modality_matrix.sh
@@ -54,7 +54,7 @@ PY
 case "${1:-help}" in
   setup)
     pkill -9 -f 'cua-driver serve' 2>/dev/null; pkill -9 -f galculator 2>/dev/null; sleep 2
-    rm -f /home/cua/.cache/cua-driver/cua-driver.sock
+    rm -f /home/cua/.cache/qwen-cua-driver/qwen-cua-driver.sock
     gsettings set org.gnome.desktop.interface toolkit-accessibility true 2>/dev/null
     pgrep -f at-spi-bus-launcher >/dev/null || (setsid /usr/libexec/at-spi-bus-launcher --launch-immediately >/tmp/atspi.log 2>&1 &)
     sleep 1


### PR DESCRIPTION
## What this PR does

This hardens cua-driver MCP reliability on macOS by bounding screenshot and Accessibility calls, returning structured tool errors before the outer MCP transport deadline, and preserving machine-readable failure details through the daemon proxy. It replaces script-based application discovery with native APIs, keeps capture configuration consistent within each MCP session, records why sessions ended, isolates the Qwen fork's Unix daemon endpoint, and makes the existing integration harness execute the fork binary instead of silently skipping.

## Why it's needed

Workspace benchmark trajectories showed `list_apps` and `get_window_state` waiting for the full 120-second proxy deadline and then surfacing generic JSON-RPC `-32603` errors. The underlying synchronous macOS operations could remain alive after the proxy returned. Capture scope also had two authorities: configuration updates changed in-memory state while desktop capture reloaded disk state, so a failed persistence attempt could be reported as success and immediately contradicted by the next tool call. The fork could additionally reuse an upstream daemon at the shared default socket, making the executing implementation differ from the launched binary.

Users now receive prompt, structured, recoverable tool errors for the confirmed failure paths, and the same daemon remains responsive to follow-up calls. This does not claim that arbitrary foreign blocking work can always be cancelled; the daemon response deadline is a final diagnostic backstop, while the confirmed screenshot and Accessibility paths have their own native bounds.

## Reviewer Test Plan

### How to verify

1. Start an isolated daemon and MCP proxy with a non-returning `osascript` earlier in `PATH`, then call `list_apps`. Confirm that a real application list returns promptly and the shim is never invoked.
2. Repeat with a non-returning `screencapture`, first for desktop capture and then for a real visible window. Confirm that both calls return a tool-level error before the MCP deadline, the screenshot child is gone when the response arrives, and an immediate `get_config` succeeds.
3. Make the persisted configuration directory unwritable, set the named MCP session's capture scope to desktop, and call both configuration read and desktop capture. Confirm that all calls resolve the session value. Also submit a valid capture scope together with invalid PiP geometry and confirm that the failed call does not partially apply or persist either value.
4. Run with a short session idle TTL, wait through the production sweep, and confirm that the rejected call reports `session_ended` with `reason=idle_timeout`. Start the same session ID again and confirm that it reports `revived=true` and accepts subsequent calls.
5. Run the ignored MCP configuration integration case and confirm that it executes assertions against `qwen-cua-driver` rather than printing a missing-binary skip.

### Evidence (Before & After)

Before: injected application-discovery and screenshot hangs returned after approximately 120.010 seconds as JSON-RPC `-32603`; the fault-injection child remained alive, and capture configuration could report desktop from one tool and window from the next.

After: native application discovery returned 109 applications in 0.136 seconds with zero `osascript` invocations. Desktop and real ChatGPT-window screenshot hangs returned structured errors in approximately 2.04 and 2.02 seconds, respectively; both injected children were reaped, and follow-up configuration calls completed in under 0.001 seconds. Idle expiry returned structured `session_ended / idle_timeout`, and restarting the same ID returned `revived=true`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, isolated temporary `HOME`, dedicated Unix socket, real stdio MCP proxy to daemon transport, fault-injected external commands, and a real visible ChatGPT window. The user's default daemon and configuration were not touched.

## Risk & Scope

- Main risk or tradeoff: the daemon-wide response deadline can cancel the async request but cannot forcibly terminate arbitrary work already running in a blocking thread; confirmed subprocess and Accessibility paths therefore have their own termination bounds.
- Not validated / out of scope: Windows and Linux end-to-end behavior, retries of destructive actions, and changes to coordinate normalization.
- Breaking changes / migration notes: the Qwen fork now uses a Qwen-specific default Unix socket and PID path so it cannot silently reuse an upstream daemon. Explicit socket overrides are unchanged, and an existing upstream daemon may continue running independently at its old path.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 加固了 macOS 上 cua-driver MCP 的可靠性：为截图和 Accessibility 调用增加边界，在 MCP 外层传输超时之前返回结构化工具错误，并通过 daemon proxy 保留可机器读取的失败详情。同时使用原生 API 替代脚本式应用发现，使 capture 配置在每个 MCP session 内保持一致，记录 session 结束原因，为 Qwen fork 使用独立 Unix daemon endpoint，并修正现有 integration harness，使其真正执行 fork binary 而不是静默跳过。

## 为什么需要

Workspace benchmark 轨迹显示，`list_apps` 和 `get_window_state` 会等待完整的 120 秒 proxy deadline，随后暴露通用 JSON-RPC `-32603`。底层同步 macOS 操作在 proxy 返回后仍可能存活。Capture scope 还存在两个配置权威：更新修改内存状态，而桌面截图重新读取磁盘，因此持久化失败可能被报告为成功，并立即被下一次工具调用否定。Fork 还可能复用共享默认 socket 上的上游 daemon，导致实际执行的实现与用户启动的 binary 不一致。

对于已经确认的失败路径，用户现在会及时收到结构化、可恢复的工具错误，并且同一 daemon 仍能响应后续调用。本 PR 不声称可以始终取消任意外部阻塞工作；daemon response deadline 是最终诊断兜底，而已确认的截图和 Accessibility 路径拥有各自的原生边界。

## Reviewer 测试计划

### 如何验证

1. 启动隔离 daemon 和 MCP proxy，在 `PATH` 前面放置不会返回的 `osascript`，然后调用 `list_apps`。确认真实应用列表及时返回，并且 shim 从未被调用。
2. 使用不会返回的 `screencapture` 重复测试，分别执行桌面截图和真实可见窗口截图。确认两次调用均在 MCP deadline 前返回工具级错误，响应到达时截图子进程已经消失，并且紧随其后的 `get_config` 成功。
3. 将持久化配置目录设为不可写，在命名 MCP session 中把 capture scope 设置为 desktop，然后读取配置并执行桌面截图。确认所有调用都解析为该 session 值。再同时提交合法 capture scope 与非法 PiP geometry，确认失败调用不会部分应用或持久化任何值。
4. 使用较短的 session idle TTL 运行，等待生产 sweep，确认被拒绝的调用报告 `session_ended` 且 `reason=idle_timeout`。重新启动同一个 session ID，确认返回 `revived=true` 并接受后续调用。
5. 执行 ignored MCP 配置 integration case，确认它针对 `qwen-cua-driver` 真正执行断言，而不是打印缺少 binary 的跳过信息。

### 修复前后证据

修复前：注入的应用发现和截图挂起会在约 120.010 秒后以 JSON-RPC `-32603` 返回；故障注入子进程仍然存活，并且 capture 配置可能在一个工具中报告 desktop、在下一个工具中报告 window。

修复后：原生应用发现于 0.136 秒返回 109 个应用，`osascript` 调用数为零。桌面截图和真实 ChatGPT 窗口截图挂起分别在约 2.04 秒和 2.02 秒返回结构化错误；两个注入子进程均已回收，后续配置调用在 0.001 秒内完成。Idle expiry 返回结构化 `session_ended / idle_timeout`，重新启动同一个 ID 返回 `revived=true`。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境

macOS、隔离的临时 `HOME`、专用 Unix socket、真实 stdio MCP proxy 到 daemon transport、故障注入外部命令，以及一个真实可见的 ChatGPT 窗口。没有触碰用户的默认 daemon 和配置。

## 风险与范围

- 主要风险或权衡：daemon 全局 response deadline 可以取消 async request，但无法强制终止已经运行在 blocking thread 中的任意工作；因此已确认的 subprocess 和 Accessibility 路径拥有各自的终止边界。
- 未验证或范围外：Windows 和 Linux 端到端行为、破坏性动作重试，以及 coordinate normalization 修改。
- 破坏性变更或迁移说明：Qwen fork 现在使用 Qwen 专属的默认 Unix socket 和 PID 路径，因此不会静默复用上游 daemon。显式 socket override 保持不变，已有上游 daemon 可能继续在旧路径独立运行。

## 关联 Issue

N/A

</details>
