### PR TITLE
ci(serve): daemon A/B before/after preview on response-surface PRs

### DIFF
--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -25,7 +25,7 @@ import { pathToFileURL } from 'node:url';
 // noise. Masked paths are ignored. Extend per scenario as richer endpoints are
 // added (session ids, createdAt, …).
 export const DEFAULT_VOLATILE = [
-  /(^|[.\]])(uptime|uptimeMs|startedAt|timestamp|now|pid|port|elapsed|durationMs|latencyMs|memory|rss|heap)([.[]|$)/i,
+  /(^|[.\]])(uptime|uptimeMs|startedAt|createdAt|updatedAt|expiresAt|lastActivityAt|idleSince|idleSinceMs|sessionId|clientId|workspaceCwd|workspaceRoot|cwd|timestamp|now|pid|port|elapsed|durationMs|latencyMs|memory|rss|heap)([.[]|$)/i,
 ];
 
 export function maskPath(path, patterns = DEFAULT_VOLATILE) {

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -21,6 +21,18 @@ import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+// Read + parse a capture file, turning malformed JSON into a CLEAR error (a raw
+// SyntaxError doesn't say which capture is bad). Used for both the base and head
+// sides so neither can crash opaquely on a truncated/garbage capture.
+function readJson(path) {
+  const text = readFileSync(path, 'utf8');
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new Error(`invalid JSON capture at ${path}: ${e.message}`);
+  }
+}
+
 // Leaf keys whose VALUES vary run-to-run (not base→head), so a diff on them is
 // noise. Masked paths are ignored. Extend per scenario as richer endpoints are
 // added (session ids, createdAt, …).
@@ -203,10 +215,10 @@ export function diffCaptureDirs(beforeDir, afterDir) {
     .sort();
   const sections = afterFiles.map((f) => {
     const scenario = f.replace(/\.json$/, '');
-    const after = JSON.parse(readFileSync(join(afterDir, f), 'utf8'));
+    const after = readJson(join(afterDir, f));
     let before = {};
     try {
-      before = JSON.parse(readFileSync(join(beforeDir, f), 'utf8'));
+      before = readJson(join(beforeDir, f));
     } catch {
       // no baseline for this individual scenario
     }
@@ -235,8 +247,8 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   } else {
     // Single scenario: `serve-ab-diff.mjs <scenario> <beforeJson> <afterJson>`.
     const [beforePath, afterPath] = rest;
-    const before = JSON.parse(readFileSync(beforePath, 'utf8'));
-    const after = JSON.parse(readFileSync(afterPath, 'utf8'));
+    const before = readJson(beforePath);
+    const after = readJson(afterPath);
     const changes = diffJson(before, after);
     process.stdout.write(renderTable(cmd, changes) + '\n');
     process.stderr.write(`${changes.length}\n`);

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -17,7 +17,7 @@
  *   node serve-ab-diff.mjs <scenario> <beforeJson> <afterJson>
  */
 
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -133,7 +133,7 @@ export function renderTable(scenario, changes) {
   for (const c of changes) {
     const before = c.kind === 'added' ? '—' : fmt(c.before);
     const after = c.kind === 'removed' ? '—' : fmt(c.after);
-    const path = c.path || '(root)';
+    const path = (c.path || '(root)').replace(/`/g, '&#96;');
     out.push(`| \`${path}\` | ${before} | ${after} |`);
   }
   out.push('');
@@ -216,12 +216,11 @@ export function diffCaptureDirs(beforeDir, afterDir) {
   const sections = afterFiles.map((f) => {
     const scenario = f.replace(/\.json$/, '');
     const after = readJson(join(afterDir, f));
-    let before = {};
-    try {
-      before = readJson(join(beforeDir, f));
-    } catch {
-      // no baseline for this individual scenario
-    }
+    // A missing base file → no baseline for this scenario (fine); but an
+    // EXISTING but malformed base must surface (readJson throws) rather than be
+    // silently treated as {}, which would report every field as "added".
+    const beforePath = join(beforeDir, f);
+    const before = existsSync(beforePath) ? readJson(beforePath) : {};
     return { scenario, changes: diffJson(before, after) };
   });
   return { sections, baselineMissing, removed };
@@ -242,8 +241,9 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
     const total = baselineMissing
       ? 0
       : sections.reduce((n, s) => n + s.changes.length, 0);
-    // stdout = total changed fields (workflow reads it to decide whether to post).
-    process.stdout.write(`${total}\n`);
+    // Log only — nothing gates on this (the publisher posts whenever body.md
+    // exists); kept for the CI run log.
+    process.stderr.write(`serve-ab: ${total} changed field(s)\n`);
   } else {
     // Single scenario: `serve-ab-diff.mjs <scenario> <beforeJson> <afterJson>`.
     const [beforePath, afterPath] = rest;

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Backend A/B: structural diff of two daemon JSON captures (base = `main`,
+ * head = PR) into a before/after field table — the daemon analog of the
+ * web-shell before/after compositor. A scenario drives a fixed endpoint
+ * (e.g. GET /capabilities) against both builds; this diffs the responses and
+ * shows only the fields that CHANGED. A PR with no response impact → empty
+ * diff → "no change".
+ *
+ * Pure helpers (`typeOf`, `isPrimitiveArray`, `diffJson`, `maskPath`,
+ * `renderTable`) are unit-tested. CLI:
+ *   node serve-ab-diff.mjs <scenario> <beforeJson> <afterJson>
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Leaf keys whose VALUES vary run-to-run (not base→head), so a diff on them is
+// noise. Masked paths are ignored. Extend per scenario as richer endpoints are
+// added (session ids, createdAt, …).
+export const DEFAULT_VOLATILE = [
+  /(^|[.\]])(uptime|uptimeMs|startedAt|timestamp|now|pid|port|elapsed|durationMs|latencyMs|memory|rss|heap)([.[]|$)/i,
+];
+
+export function maskPath(path, patterns = DEFAULT_VOLATILE) {
+  return patterns.some((re) => re.test(path));
+}
+
+export function typeOf(v) {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}
+
+export function isPrimitiveArray(a) {
+  return (
+    Array.isArray(a) && a.every((v) => v === null || typeof v !== 'object')
+  );
+}
+
+/**
+ * Recursive structural diff → flat list of `{ path, kind, before?, after? }`.
+ * Objects compared by key; primitive arrays as SETS (added/removed elements, so
+ * an appended capability reads as one add, not an index shuffle); object arrays
+ * by index. Volatile leaf paths are skipped.
+ */
+export function diffJson(before, after, path = '', out = [], opts = {}) {
+  const patterns = opts.volatile ?? DEFAULT_VOLATILE;
+  if (path && maskPath(path, patterns)) return out;
+
+  if (before === undefined && after !== undefined) {
+    out.push({ path, kind: 'added', after });
+    return out;
+  }
+  if (after === undefined && before !== undefined) {
+    out.push({ path, kind: 'removed', before });
+    return out;
+  }
+
+  const tb = typeOf(before);
+  const ta = typeOf(after);
+  if (tb !== ta) {
+    out.push({ path, kind: 'changed', before, after });
+    return out;
+  }
+
+  if (tb === 'object') {
+    const keys = [...new Set([...Object.keys(before), ...Object.keys(after)])];
+    for (const k of keys.sort()) {
+      const p = path ? `${path}.${k}` : k;
+      diffJson(before[k], after[k], p, out, opts);
+    }
+  } else if (tb === 'array') {
+    if (isPrimitiveArray(before) && isPrimitiveArray(after)) {
+      const bset = new Set(before);
+      const aset = new Set(after);
+      for (const v of after)
+        if (!bset.has(v))
+          out.push({ path: `${path}[]`, kind: 'added', after: v });
+      for (const v of before)
+        if (!aset.has(v))
+          out.push({ path: `${path}[]`, kind: 'removed', before: v });
+    } else {
+      const n = Math.max(before.length, after.length);
+      for (let i = 0; i < n; i++) {
+        diffJson(before[i], after[i], `${path}[${i}]`, out, opts);
+      }
+    }
+  } else if (before !== after) {
+    out.push({ path, kind: 'changed', before, after });
+  }
+  return out;
+}
+
+const fmt = (v) => (v === undefined ? '—' : '`' + JSON.stringify(v) + '`');
+
+/** Markdown before/after table for one scenario's diff (or a no-change note). */
+export function renderTable(scenario, changes) {
+  const out = [];
+  out.push(`#### \`${scenario}\``);
+  out.push('');
+  if (changes.length === 0) {
+    out.push('_No response change vs `main`._');
+    out.push('');
+    return out.join('\n');
+  }
+  out.push('| field | main (before) | this PR (after) |');
+  out.push('| --- | --- | --- |');
+  for (const c of changes) {
+    const before = c.kind === 'added' ? '—' : fmt(c.before);
+    const after = c.kind === 'removed' ? '—' : fmt(c.after);
+    const path = c.path || '(root)';
+    out.push(`| \`${path}\` | ${before} | ${after} |`);
+  }
+  out.push('');
+  return out.join('\n');
+}
+
+/**
+ * Assemble the full PR comment from per-scenario diffs. `sections` is
+ * `[{ scenario, changes }]`. Only scenarios that changed get a table; if none
+ * changed, a single "no change" line (the common backend-PR case).
+ */
+export function buildComment(sections, ctx = {}) {
+  const shortSha = String(ctx.shortSha ?? '').replace(/[^\w.-]/g, '');
+  const changed = sections.filter((s) => s.changes.length > 0);
+  const out = [];
+  out.push('<!-- qwen:serve-ab -->');
+  out.push('### 🩺 serve daemon A/B');
+  out.push(
+    `Built \`main\` vs this PR head \`${shortSha}\`, drove a fixed endpoint set against each, and diffed the JSON responses. Only fields that changed are shown.`,
+  );
+  out.push('');
+  if (changed.length === 0) {
+    out.push(
+      `✅ _No response changes against \`main\` across ${sections.length} scenario(s)._`,
+    );
+    out.push('');
+  } else {
+    for (const s of changed) out.push(renderTable(s.scenario, s.changes));
+  }
+  out.push('— _Qwen Code · serve A/B_');
+  return out.join('\n') + '\n';
+}
+
+// Read a capture dir's `<scenario>.json` files → `[{ scenario, changes }]`,
+// diffing each against the same-named file in the base dir (missing base → all
+// fields read as added).
+function diffCaptureDirs(beforeDir, afterDir) {
+  let names = [];
+  try {
+    names = readdirSync(afterDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    // no captures → empty
+  }
+  return names.sort().map((f) => {
+    const scenario = f.replace(/\.json$/, '');
+    const after = JSON.parse(readFileSync(join(afterDir, f), 'utf8'));
+    let before = {};
+    try {
+      before = JSON.parse(readFileSync(join(beforeDir, f), 'utf8'));
+    } catch {
+      // no baseline for this scenario
+    }
+    return { scenario, changes: diffJson(before, after) };
+  });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd === 'comment') {
+    const [beforeDir, afterDir, shortSha, bodyFile] = rest;
+    const sections = diffCaptureDirs(beforeDir, afterDir);
+    writeFileSync(bodyFile, buildComment(sections, { shortSha }));
+    const total = sections.reduce((n, s) => n + s.changes.length, 0);
+    // stdout = total changed fields (workflow reads it to decide whether to post).
+    process.stdout.write(`${total}\n`);
+  } else {
+    // Single scenario: `serve-ab-diff.mjs <scenario> <beforeJson> <afterJson>`.
+    const [beforePath, afterPath] = rest;
+    const before = JSON.parse(readFileSync(beforePath, 'utf8'));
+    const after = JSON.parse(readFileSync(afterPath, 'utf8'));
+    const changes = diffJson(before, after);
+    process.stdout.write(renderTable(cmd, changes) + '\n');
+    process.stderr.write(`${changes.length}\n`);
+  }
+}

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -129,17 +129,28 @@ export function renderTable(scenario, changes) {
  */
 export function buildComment(sections, ctx = {}) {
   const shortSha = String(ctx.shortSha ?? '').replace(/[^\w.-]/g, '');
-  const changed = sections.filter((s) => s.changes.length > 0);
   const out = [];
   out.push('<!-- qwen:serve-ab -->');
   out.push('### 🩺 serve daemon A/B');
   out.push(
-    `Built \`main\` vs this PR head \`${shortSha}\`, drove a fixed endpoint set against each, and diffed the JSON responses. Only fields that changed are shown.`,
+    `Built the PR base vs this PR head \`${shortSha}\`, drove a fixed endpoint set against each, and diffed the JSON responses. Only fields that changed are shown.`,
   );
   out.push('');
+  // Degraded run: head captures exist but the PR-base build/drive produced
+  // none. Say so explicitly instead of misreporting every field as "added"
+  // (which a `{}` baseline would) — the diff was never actually performed.
+  if (ctx.baselineMissing) {
+    out.push(
+      '⚠️ _The PR-base baseline could not be built this run, so the before/after diff was skipped. Re-run to compare._',
+    );
+    out.push('');
+    out.push('— _Qwen Code · serve A/B_');
+    return out.join('\n') + '\n';
+  }
+  const changed = sections.filter((s) => s.changes.length > 0);
   if (changed.length === 0) {
     out.push(
-      `✅ _No response changes against \`main\` across ${sections.length} scenario(s)._`,
+      `✅ _No response changes against the PR base across ${sections.length} scenario(s)._`,
     );
     out.push('');
   } else {
@@ -149,36 +160,51 @@ export function buildComment(sections, ctx = {}) {
   return out.join('\n') + '\n';
 }
 
-// Read a capture dir's `<scenario>.json` files → `[{ scenario, changes }]`,
-// diffing each against the same-named file in the base dir (missing base → all
-// fields read as added).
-function diffCaptureDirs(beforeDir, afterDir) {
-  let names = [];
-  try {
-    names = readdirSync(afterDir).filter((f) => f.endsWith('.json'));
-  } catch {
-    // no captures → empty
-  }
-  return names.sort().map((f) => {
+/**
+ * Read a capture dir's `<scenario>.json` files → `{ sections, baselineMissing }`.
+ * Each section diffs an after-capture against the same-named base file. When the
+ * base captures are ENTIRELY absent (a failed base build/drive) but head
+ * captures exist, `baselineMissing` is set so the caller reports "diff skipped"
+ * rather than misreporting every field as added. This is the function the CI
+ * `comment` subcommand actually invokes, so it is exported + covered.
+ */
+export function diffCaptureDirs(beforeDir, afterDir) {
+  const jsonFiles = (dir) => {
+    try {
+      return readdirSync(dir).filter((f) => f.endsWith('.json'));
+    } catch {
+      return [];
+    }
+  };
+  const afterFiles = jsonFiles(afterDir).sort();
+  const baselineMissing =
+    afterFiles.length > 0 && jsonFiles(beforeDir).length === 0;
+  const sections = afterFiles.map((f) => {
     const scenario = f.replace(/\.json$/, '');
     const after = JSON.parse(readFileSync(join(afterDir, f), 'utf8'));
     let before = {};
     try {
       before = JSON.parse(readFileSync(join(beforeDir, f), 'utf8'));
     } catch {
-      // no baseline for this scenario
+      // no baseline for this individual scenario
     }
     return { scenario, changes: diffJson(before, after) };
   });
+  return { sections, baselineMissing };
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const [cmd, ...rest] = process.argv.slice(2);
   if (cmd === 'comment') {
     const [beforeDir, afterDir, shortSha, bodyFile] = rest;
-    const sections = diffCaptureDirs(beforeDir, afterDir);
-    writeFileSync(bodyFile, buildComment(sections, { shortSha }));
-    const total = sections.reduce((n, s) => n + s.changes.length, 0);
+    const { sections, baselineMissing } = diffCaptureDirs(beforeDir, afterDir);
+    writeFileSync(
+      bodyFile,
+      buildComment(sections, { shortSha, baselineMissing }),
+    );
+    const total = baselineMissing
+      ? 0
+      : sections.reduce((n, s) => n + s.changes.length, 0);
     // stdout = total changed fields (workflow reads it to decide whether to post).
     process.stdout.write(`${total}\n`);
   } else {

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -124,11 +124,11 @@ export function renderTable(scenario, changes) {
   out.push(`#### \`${scenario}\``);
   out.push('');
   if (changes.length === 0) {
-    out.push('_No response change vs `main`._');
+    out.push('_No response change vs the PR base._');
     out.push('');
     return out.join('\n');
   }
-  out.push('| field | main (before) | this PR (after) |');
+  out.push('| field | PR base (before) | this PR (after) |');
   out.push('| --- | --- | --- |');
   for (const c of changes) {
     const before = c.kind === 'added' ? '—' : fmt(c.before);

--- a/.github/scripts/serve-ab-diff.mjs
+++ b/.github/scripts/serve-ab-diff.mjs
@@ -98,7 +98,13 @@ export function diffJson(before, after, path = '', out = [], opts = {}) {
   return out;
 }
 
-const fmt = (v) => (v === undefined ? '—' : '`' + JSON.stringify(v) + '`');
+const fmt = (v) => {
+  if (v === undefined) return '—';
+  // Escape pipes (which split a GFM table cell) and backticks (which close the
+  // code span) so an arbitrary daemon value can't break the table layout.
+  const s = JSON.stringify(v).replace(/\|/g, '\\|').replace(/`/g, '&#96;');
+  return '`' + s + '`';
+};
 
 /** Markdown before/after table for one scenario's diff (or a no-change note). */
 export function renderTable(scenario, changes) {
@@ -147,6 +153,14 @@ export function buildComment(sections, ctx = {}) {
     out.push('— _Qwen Code · serve A/B_');
     return out.join('\n') + '\n';
   }
+  if (ctx.removed?.length) {
+    out.push(
+      `⚠️ _Present in the base but absent from this PR: ${ctx.removed
+        .map((s) => '`' + s + '`')
+        .join(', ')} (removed or failed to capture)._`,
+    );
+    out.push('');
+  }
   const changed = sections.filter((s) => s.changes.length > 0);
   if (changed.length === 0) {
     out.push(
@@ -177,8 +191,16 @@ export function diffCaptureDirs(beforeDir, afterDir) {
     }
   };
   const afterFiles = jsonFiles(afterDir).sort();
-  const baselineMissing =
-    afterFiles.length > 0 && jsonFiles(beforeDir).length === 0;
+  const beforeFiles = jsonFiles(beforeDir);
+  const baselineMissing = afterFiles.length > 0 && beforeFiles.length === 0;
+  const afterSet = new Set(afterFiles);
+  // Scenarios present in the base but gone from the head — a removed or broken
+  // scenario would otherwise vanish silently and lower the "across N" count,
+  // masking the regression.
+  const removed = beforeFiles
+    .filter((f) => !afterSet.has(f))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort();
   const sections = afterFiles.map((f) => {
     const scenario = f.replace(/\.json$/, '');
     const after = JSON.parse(readFileSync(join(afterDir, f), 'utf8'));
@@ -190,17 +212,20 @@ export function diffCaptureDirs(beforeDir, afterDir) {
     }
     return { scenario, changes: diffJson(before, after) };
   });
-  return { sections, baselineMissing };
+  return { sections, baselineMissing, removed };
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   const [cmd, ...rest] = process.argv.slice(2);
   if (cmd === 'comment') {
     const [beforeDir, afterDir, shortSha, bodyFile] = rest;
-    const { sections, baselineMissing } = diffCaptureDirs(beforeDir, afterDir);
+    const { sections, baselineMissing, removed } = diffCaptureDirs(
+      beforeDir,
+      afterDir,
+    );
     writeFileSync(
       bodyFile,
-      buildComment(sections, { shortSha, baselineMissing }),
+      buildComment(sections, { shortSha, baselineMissing, removed }),
     );
     const total = baselineMissing
       ? 0

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -118,10 +118,7 @@ test('renderTable: change table has a row per field, escapes paths in code spans
 
 test('renderTable: empty diff → explicit no-change note (not a blank table)', () => {
   const md = renderTable('health', []);
-  assert.match(
-    md,
-    /No response change against `main`|No response change vs `main`/,
-  );
+  assert.match(md, /No response change vs the PR base/);
   assert.doesNotMatch(md, /\| field \|/);
 });
 

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildComment,
+  diffJson,
+  isPrimitiveArray,
+  maskPath,
+  renderTable,
+  typeOf,
+} from './serve-ab-diff.mjs';
+
+test('typeOf distinguishes null, array, object, primitive', () => {
+  assert.equal(typeOf(null), 'null');
+  assert.equal(typeOf([1]), 'array');
+  assert.equal(typeOf({}), 'object');
+  assert.equal(typeOf('x'), 'string');
+  assert.equal(typeOf(3), 'number');
+});
+
+test('isPrimitiveArray is true only for arrays of non-objects', () => {
+  assert.equal(isPrimitiveArray(['a', 'b']), true);
+  assert.equal(isPrimitiveArray([1, null, 'x']), true);
+  assert.equal(isPrimitiveArray([{ a: 1 }]), false);
+  assert.equal(isPrimitiveArray('nope'), false);
+});
+
+test('diffJson: identical objects → no changes (backend PR with no impact)', () => {
+  const o = { status: 'ok', features: ['a', 'b'], v: 1 };
+  assert.deepEqual(diffJson(o, JSON.parse(JSON.stringify(o))), []);
+});
+
+test('diffJson: added / removed / changed leaf fields', () => {
+  const changes = diffJson({ a: 1, gone: true }, { a: 2, added: 'x' });
+  assert.deepEqual(
+    changes.sort((x, y) => x.path.localeCompare(y.path)),
+    [
+      { path: 'a', kind: 'changed', before: 1, after: 2 },
+      { path: 'added', kind: 'added', after: 'x' },
+      { path: 'gone', kind: 'removed', before: true },
+    ],
+  );
+});
+
+test('diffJson: primitive arrays diff as SETS (one add, not an index shuffle)', () => {
+  const changes = diffJson(
+    { features: ['a', 'b'] },
+    { features: ['a', 'b', 'c'] },
+  );
+  assert.deepEqual(changes, [
+    { path: 'features[]', kind: 'added', after: 'c' },
+  ]);
+  // A removal:
+  assert.deepEqual(diffJson({ f: ['a', 'b'] }, { f: ['a'] }), [
+    { path: 'f[]', kind: 'removed', before: 'b' },
+  ]);
+});
+
+test('diffJson: object arrays diff by index; nested paths are dotted', () => {
+  const changes = diffJson(
+    { items: [{ id: 1, n: 'a' }] },
+    { items: [{ id: 1, n: 'b' }] },
+  );
+  assert.deepEqual(changes, [
+    { path: 'items[0].n', kind: 'changed', before: 'a', after: 'b' },
+  ]);
+});
+
+test('diffJson: a type change (array → object) is one "changed"', () => {
+  assert.deepEqual(diffJson({ x: [] }, { x: {} }), [
+    { path: 'x', kind: 'changed', before: [], after: {} },
+  ]);
+});
+
+test('maskPath / diffJson skips volatile fields (timestamps, pid, uptime …)', () => {
+  assert.equal(maskPath('daemon.uptimeMs'), true);
+  assert.equal(maskPath('startedAt'), true);
+  assert.equal(maskPath('features'), false);
+  // A change only in a volatile field yields no diff.
+  assert.deepEqual(
+    diffJson({ status: 'ok', uptimeMs: 10 }, { status: 'ok', uptimeMs: 999 }),
+    [],
+  );
+});
+
+test('renderTable: change table has a row per field, escapes paths in code spans', () => {
+  const md = renderTable('capabilities', [
+    { path: 'features[]', kind: 'added', after: 'sse' },
+    {
+      path: 'qwenCodeVersion',
+      kind: 'changed',
+      before: '0.19.9',
+      after: '0.19.10',
+    },
+  ]);
+  assert.match(md, /#### `capabilities`/);
+  assert.match(md, /\| `features\[\]` \| — \| `"sse"` \|/);
+  assert.match(md, /\| `qwenCodeVersion` \| `"0.19.9"` \| `"0.19.10"` \|/);
+});
+
+test('renderTable: empty diff → explicit no-change note (not a blank table)', () => {
+  const md = renderTable('health', []);
+  assert.match(
+    md,
+    /No response change against `main`|No response change vs `main`/,
+  );
+  assert.doesNotMatch(md, /\| field \|/);
+});
+
+test('buildComment: only changed scenarios get a table; unchanged omitted', () => {
+  const body = buildComment(
+    [
+      {
+        scenario: 'capabilities',
+        changes: [{ path: 'features[]', kind: 'added', after: 'sse' }],
+      },
+      { scenario: 'health', changes: [] },
+    ],
+    { shortSha: 'abc1234' },
+  );
+  assert.match(body, /<!-- qwen:serve-ab -->/);
+  assert.match(body, /serve daemon A\/B/);
+  assert.match(body, /abc1234/);
+  assert.match(body, /#### `capabilities`/);
+  assert.doesNotMatch(body, /#### `health`/); // unchanged scenario omitted
+});
+
+test('buildComment: all unchanged → one no-change note, no tables', () => {
+  const body = buildComment(
+    [
+      { scenario: 'health', changes: [] },
+      { scenario: 'capabilities', changes: [] },
+    ],
+    { shortSha: 'deadbee' },
+  );
+  assert.match(body, /No response changes against `main` across 2 scenario/);
+  assert.doesNotMatch(body, /\| field \|/);
+});

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -5,10 +5,14 @@
  */
 
 import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 
 import {
   buildComment,
+  diffCaptureDirs,
   diffJson,
   isPrimitiveArray,
   maskPath,
@@ -147,6 +151,46 @@ test('buildComment: all unchanged → one no-change note, no tables', () => {
     ],
     { shortSha: 'deadbee' },
   );
-  assert.match(body, /No response changes against `main` across 2 scenario/);
+  assert.match(
+    body,
+    /No response changes against the PR base across 2 scenario/,
+  );
   assert.doesNotMatch(body, /\| field \|/);
+});
+
+test('diffCaptureDirs: diffs each scenario against its same-named base file', () => {
+  const before = mkdtempSync(join(tmpdir(), 'sa-before-'));
+  const after = mkdtempSync(join(tmpdir(), 'sa-after-'));
+  writeFileSync(
+    join(before, 'capabilities.json'),
+    JSON.stringify({ v: 1, features: ['a'] }),
+  );
+  writeFileSync(
+    join(after, 'capabilities.json'),
+    JSON.stringify({ v: 1, features: ['a', 'b'] }),
+  );
+  writeFileSync(join(before, 'health.json'), JSON.stringify({ status: 'ok' }));
+  writeFileSync(join(after, 'health.json'), JSON.stringify({ status: 'ok' }));
+  const { sections, baselineMissing } = diffCaptureDirs(before, after);
+  assert.equal(baselineMissing, false);
+  assert.deepEqual(sections.map((s) => s.scenario).sort(), [
+    'capabilities',
+    'health',
+  ]);
+  assert.deepEqual(
+    sections.find((s) => s.scenario === 'capabilities').changes,
+    [{ path: 'features[]', kind: 'added', after: 'b' }],
+  );
+  assert.deepEqual(sections.find((s) => s.scenario === 'health').changes, []);
+});
+
+test('diffCaptureDirs: absent base + present head → baselineMissing (not "no change")', () => {
+  const before = mkdtempSync(join(tmpdir(), 'sa-before-')); // left empty
+  const after = mkdtempSync(join(tmpdir(), 'sa-after-'));
+  writeFileSync(join(after, 'capabilities.json'), JSON.stringify({ v: 1 }));
+  const { baselineMissing } = diffCaptureDirs(before, after);
+  assert.equal(baselineMissing, true);
+  const body = buildComment([], { shortSha: 'x', baselineMissing: true });
+  assert.match(body, /baseline could not be built/);
+  assert.doesNotMatch(body, /No response changes/);
 });

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -194,3 +194,29 @@ test('diffCaptureDirs: absent base + present head → baselineMissing (not "no c
   assert.match(body, /baseline could not be built/);
   assert.doesNotMatch(body, /No response changes/);
 });
+
+test('renderTable: escapes pipes + backticks so a value cannot break the table', () => {
+  const md = renderTable('x', [
+    { path: 'note', kind: 'changed', before: 'a|b', after: '`c`' },
+  ]);
+  assert.match(md, /a\\\|b/); // pipe backslash-escaped
+  assert.match(md, /&#96;c&#96;/); // backtick entity-encoded
+  const row = md.split('\n').find((l) => l.includes('`note`'));
+  // Exactly the 4 cell separators — the escaped `\|` is not counted.
+  assert.equal((row.match(/(?<!\\)\|/g) || []).length, 4);
+});
+
+test('diffCaptureDirs: a base-only (removed) scenario is surfaced, not dropped', () => {
+  const before = mkdtempSync(join(tmpdir(), 'sa-before-'));
+  const after = mkdtempSync(join(tmpdir(), 'sa-after-'));
+  writeFileSync(join(before, 'health.json'), JSON.stringify({ status: 'ok' }));
+  writeFileSync(join(after, 'health.json'), JSON.stringify({ status: 'ok' }));
+  writeFileSync(join(before, 'capabilities.json'), JSON.stringify({ v: 1 })); // gone in head
+  const { removed } = diffCaptureDirs(before, after);
+  assert.deepEqual(removed, ['capabilities']);
+  const body = buildComment([], { shortSha: 'x', removed });
+  assert.match(
+    body,
+    /Present in the base but absent from this PR: `capabilities`/,
+  );
+});

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -206,6 +206,19 @@ test('renderTable: escapes pipes + backticks so a value cannot break the table',
   assert.equal((row.match(/(?<!\\)\|/g) || []).length, 4);
 });
 
+test('diffCaptureDirs: a malformed capture surfaces a clear error (not silent {})', () => {
+  const before = mkdtempSync(join(tmpdir(), 'sa-before-'));
+  const after = mkdtempSync(join(tmpdir(), 'sa-after-'));
+  // Malformed HEAD capture → clear error, not a raw SyntaxError.
+  writeFileSync(join(after, 'health.json'), '{ not valid json');
+  assert.throws(() => diffCaptureDirs(before, after), /invalid JSON capture/);
+  // Existing-but-malformed BASE capture → also surfaces (not silently {} →
+  // "everything added").
+  writeFileSync(join(after, 'health.json'), JSON.stringify({ status: 'ok' }));
+  writeFileSync(join(before, 'health.json'), 'garbage');
+  assert.throws(() => diffCaptureDirs(before, after), /invalid JSON capture/);
+});
+
 test('diffCaptureDirs: a base-only (removed) scenario is surfaced, not dropped', () => {
   const before = mkdtempSync(join(tmpdir(), 'sa-before-'));
   const after = mkdtempSync(join(tmpdir(), 'sa-after-'));

--- a/.github/scripts/serve-ab-diff.test.mjs
+++ b/.github/scripts/serve-ab-diff.test.mjs
@@ -81,6 +81,14 @@ test('diffJson: a type change (array → object) is one "changed"', () => {
 test('maskPath / diffJson skips volatile fields (timestamps, pid, uptime …)', () => {
   assert.equal(maskPath('daemon.uptimeMs'), true);
   assert.equal(maskPath('startedAt'), true);
+  // Session-lifecycle volatiles (from the create-session scenario).
+  assert.equal(maskPath('lastActivityAt'), true);
+  assert.equal(maskPath('idleSinceMs'), true);
+  assert.equal(maskPath('sessionId'), true);
+  assert.equal(maskPath('workspaceCwd'), true);
+  // …but the meaningful counts next to them are NOT masked.
+  assert.equal(maskPath('sessions'), false); // not `sessionId`
+  assert.equal(maskPath('activePrompts'), false);
   assert.equal(maskPath('features'), false);
   // A change only in a volatile field yields no diff.
   assert.deepEqual(

--- a/.github/scripts/serve-ab-drive.mjs
+++ b/.github/scripts/serve-ab-drive.mjs
@@ -32,6 +32,26 @@ export const SCENARIOS = [
   { name: 'health', method: 'GET', path: '/health', auth: false },
   { name: 'health-deep', method: 'GET', path: '/health?deep=1', auth: false },
   { name: 'capabilities', method: 'GET', path: '/capabilities', auth: true },
+  {
+    // Create one session, THEN probe deep health — exercises the session
+    // lifecycle and the cross-workspace session aggregation (#6961's exact
+    // case). Runs last so the earlier probes see the idle daemon. The volatile
+    // `lastActivityAt` / `idleSinceMs` in the response are masked by
+    // serve-ab-diff.mjs; the meaningful counts (sessions, pendingPermissions,
+    // activePrompts, connectedClients, channelAlive) are stable.
+    name: 'health-deep-with-session',
+    setup: [
+      {
+        method: 'POST',
+        path: '/session',
+        auth: true,
+        body: ({ home }) => ({ clientId: 'serve-ab', workspaceCwd: home }),
+      },
+    ],
+    method: 'GET',
+    path: '/health?deep=1',
+    auth: true,
+  },
 ];
 
 function freePort() {
@@ -96,12 +116,25 @@ export async function driveCli(cliEntry, outDir) {
   const base = `http://127.0.0.1:${port}`;
   try {
     await waitForHealth(base);
-    for (const s of SCENARIOS) {
-      const headers = s.auth ? { Authorization: `Bearer ${token}` } : {};
-      const res = await fetch(`${base}${s.path}`, {
-        method: s.method,
+    const doRequest = (spec) => {
+      const headers = spec.auth ? { Authorization: `Bearer ${token}` } : {};
+      let body;
+      if (spec.body) {
+        headers['Content-Type'] = 'application/json';
+        const b =
+          typeof spec.body === 'function' ? spec.body({ home }) : spec.body;
+        body = JSON.stringify(b);
+      }
+      return fetch(`${base}${spec.path}`, {
+        method: spec.method,
         headers,
+        body,
       });
+    };
+    for (const s of SCENARIOS) {
+      // Run any setup requests (e.g. create a session) before the capture.
+      for (const step of s.setup ?? []) await doRequest(step);
+      const res = await doRequest(s);
       const text = await res.text();
       let json;
       try {

--- a/.github/scripts/serve-ab-drive.mjs
+++ b/.github/scripts/serve-ab-drive.mjs
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Drive a built `qwen serve` daemon through a fixed scenario set and capture
+ * each endpoint's JSON response to `<outDir>/<scenario>.json`. Run once against
+ * the PR-base build and once against the PR-head build; serve-ab-diff.mjs then
+ * diffs the two capture dirs per scenario.
+ *
+ * Deterministic + credential-free: `/health` needs no auth; `/capabilities`
+ * uses the local `--token`. No model is contacted (dummy OpenAI creds), so the
+ * responses are stable and safe to diff. Scenarios that mutate state (create a
+ * session, etc.) can be added here later — mask their volatile fields in
+ * serve-ab-diff.mjs.
+ *
+ *   node serve-ab-drive.mjs <cliEntry> <outDir>
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// The fixed scenarios. `auth` sends the bearer token; anything mutating the
+// daemon would push requests here in order.
+export const SCENARIOS = [
+  { name: 'health', method: 'GET', path: '/health', auth: false },
+  { name: 'health-deep', method: 'GET', path: '/health?deep=1', auth: false },
+  { name: 'capabilities', method: 'GET', path: '/capabilities', auth: true },
+];
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.on('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const { port } = s.address();
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHealth(base, timeoutMs = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${base}/health`);
+      if (r.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`daemon did not become healthy within ${timeoutMs}ms`);
+}
+
+export async function driveCli(cliEntry, outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const home = mkdtempSync(join(tmpdir(), 'serve-ab-home-'));
+  const token = 'serve-ab-token';
+  const port = await freePort();
+  const daemon = spawn(
+    'node',
+    [
+      cliEntry,
+      'serve',
+      '--port',
+      String(port),
+      '--token',
+      token,
+      '--hostname',
+      '127.0.0.1',
+      '--workspace',
+      home,
+    ],
+    {
+      // No real model: dummy OpenAI creds so session auth never contacts a
+      // backend. HOME/QWEN_HOME isolate any on-disk state per run.
+      env: {
+        ...process.env,
+        HOME: home,
+        QWEN_HOME: join(home, '.qwen'),
+        OPENAI_API_KEY: 'fake-key',
+        OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
+        OPENAI_MODEL: 'fake-model',
+        QWEN_MODEL: 'fake-model',
+      },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    },
+  );
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitForHealth(base);
+    for (const s of SCENARIOS) {
+      const headers = s.auth ? { Authorization: `Bearer ${token}` } : {};
+      const res = await fetch(`${base}${s.path}`, {
+        method: s.method,
+        headers,
+      });
+      const text = await res.text();
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch {
+        json = { _status: res.status, _nonJson: text.slice(0, 500) };
+      }
+      writeFileSync(
+        join(outDir, `${s.name}.json`),
+        JSON.stringify(json, null, 2) + '\n',
+      );
+      process.stderr.write(`  captured ${s.name} (HTTP ${res.status})\n`);
+    }
+  } finally {
+    daemon.kill('SIGTERM');
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const [cliEntry, outDir] = process.argv.slice(2);
+  if (!cliEntry || !outDir) {
+    process.stderr.write('usage: serve-ab-drive.mjs <cliEntry> <outDir>\n');
+    process.exit(2);
+  }
+  driveCli(cliEntry, outDir).catch((e) => {
+    process.stderr.write(`${e?.stack ?? e}\n`);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/serve-ab-drive.mjs
+++ b/.github/scripts/serve-ab-drive.mjs
@@ -133,7 +133,18 @@ export async function driveCli(cliEntry, outDir) {
     };
     for (const s of SCENARIOS) {
       // Run any setup requests (e.g. create a session) before the capture.
-      for (const step of s.setup ?? []) await doRequest(step);
+      for (const step of s.setup ?? []) {
+        const r = await doRequest(step);
+        // A failed setup (e.g. POST /session non-2xx) would let the capture
+        // reflect wrong state (0 sessions) and silently mask or fake a diff —
+        // fail loudly instead.
+        if (!r.ok) {
+          const body = await r.text().catch(() => '');
+          throw new Error(
+            `setup ${step.method} ${step.path} failed (HTTP ${r.status}) for "${s.name}": ${body.slice(0, 200)}`,
+          );
+        }
+      }
       const res = await doRequest(s);
       const text = await res.text();
       let json;
@@ -150,6 +161,15 @@ export async function driveCli(cliEntry, outDir) {
     }
   } finally {
     daemon.kill('SIGTERM');
+    // Await exit so a hung daemon (pending async / open WebSockets) can't
+    // linger; escalate to SIGKILL if it doesn't stop promptly.
+    await new Promise((resolve) => {
+      daemon.on('exit', resolve);
+      setTimeout(() => {
+        daemon.kill('SIGKILL');
+        resolve();
+      }, 5000);
+    });
   }
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
           node scripts/lint.js --setup
           node scripts/lint.js --actionlint
           node scripts/lint.js --yamllint
-          node --test .github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs
+          node --test .github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/serve-ab-diff.test.mjs
 
       # Self-hosted can't reach nodejs.org reliably; reuse the machine's Node.
       - name: 'Set up Node.js 22.x (hosted)'

--- a/.github/workflows/serve-ab-publish.yml
+++ b/.github/workflows/serve-ab-publish.yml
@@ -1,0 +1,124 @@
+name: 'Serve A/B Publish'
+
+# Privileged companion to `serve-ab.yml`. Runs AFTER it via workflow_run, in the
+# base-repo context with a write token, but NEVER checks out or runs PR code —
+# it only downloads the text artifact (a markdown body the capture job produced
+# + a PR number) and posts/updates one PR comment. Same GitHub-recommended split
+# as web-shell-visuals-publish.yml for commenting on fork PRs with the results
+# of untrusted-code execution.
+on:
+  workflow_run:
+    workflows:
+      - 'Serve A/B'
+    types:
+      - 'completed'
+
+permissions:
+  actions: 'read'
+
+concurrency:
+  group: >-
+    serve-ab-publish-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  publish:
+    name: 'Publish serve A/B to the PR'
+    if: >-
+      github.repository == 'QwenLM/qwen-code' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    steps:
+      - name: 'Download serve-ab artifact'
+        id: 'download'
+        continue-on-error: true
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' # v5.0.0
+        with:
+          name: 'serve-ab'
+          run-id: '${{ github.event.workflow_run.id }}'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          path: 'serve-ab'
+
+      - name: 'Publish serve A/B comment'
+        env:
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          RUN_HEAD_SHA: '${{ github.event.workflow_run.head_sha }}'
+          RUN_HEAD_REPO: '${{ github.event.workflow_run.head_repository.full_name }}'
+          RUN_HEAD_BRANCH: '${{ github.event.workflow_run.head_branch }}'
+        run: |-
+          set -euo pipefail
+
+          ART='serve-ab'
+          if [ ! -f "${ART}/body.md" ] || [ ! -f "${ART}/pr.txt" ]; then
+            echo "::notice::No serve-ab artifact; nothing to publish."
+            exit 0
+          fi
+
+          # pr.txt is UNTRUSTED (written by a job that ran PR code): sanitize to
+          # digits, then BIND it to this run — require the PR's current head SHA
+          # (and repo+branch) to equal this run's authenticated values, so a
+          # malicious PR can't redirect the comment at a victim PR.
+          PR="$(tr -dc '0-9' < "${ART}/pr.txt" 2>/dev/null | head -c 12 || true)"
+          [ -n "${PR}" ] || { echo "::warning::Artifact has no valid PR number; aborting."; exit 0; }
+
+          BOT_LOGIN="$(gh api user --jq '.login' 2>/dev/null || true)"
+          [ -n "${BOT_LOGIN}" ] || { echo "::warning::Could not resolve bot identity; skipping."; exit 0; }
+
+          # 0 = valid, 1 = genuinely invalid (closed / mismatch), 2 = transient.
+          validate_pr() {
+            local j st hd rr rf attempt; j=''
+            for attempt in 1 2 3; do
+              j="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" 2>/dev/null || true)"
+              [ -n "${j}" ] && break; sleep 2
+            done
+            [ -n "${j}" ] || { echo "::warning::Could not fetch PR #${PR}."; return 2; }
+            st="$(jq -r '.state // empty' <<< "${j}")"
+            hd="$(jq -r '.head.sha // empty' <<< "${j}")"
+            rr="$(jq -r '.head.repo.full_name // empty' <<< "${j}")"
+            rf="$(jq -r '.head.ref // empty' <<< "${j}")"
+            [ "${st}" = "open" ] || { echo "::notice::PR #${PR} not open (${st:-unknown})."; return 1; }
+            { [ -n "${RUN_HEAD_SHA}" ] && [ "${hd}" = "${RUN_HEAD_SHA}" ]; } || { echo "::warning::PR #${PR} head != run head; refusing."; return 1; }
+            { [ -n "${RUN_HEAD_REPO}" ] && [ "${rr}" = "${RUN_HEAD_REPO}" ] && [ "${rf}" = "${RUN_HEAD_BRANCH}" ]; } || { echo "::warning::PR #${PR} repo/branch != run; refusing."; return 1; }
+            return 0
+          }
+          gate() {
+            local rc; if validate_pr; then rc=0; else rc=$?; fi
+            [ "${rc}" -eq 0 ] && return 0
+            [ "${rc}" -eq 2 ] && { echo "::error::Transient API failure; failing so it can be re-triggered."; exit 1; }
+            echo "::notice::PR #${PR} no longer valid; skipping."; exit 0
+          }
+          gate
+
+          BODY_FILE="${ART}/body.md"
+          MARKER='<!-- qwen:serve-ab -->'
+
+          # Dedup only against OUR prior comment (bot author + marker), and only
+          # after a SUCCESSFUL listing (a failed list must not read as "none" and
+          # post a duplicate).
+          EXISTING=''; listed=0
+          for attempt in 1 2 3; do
+            if resp="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --method GET --paginate -F per_page=100 2>/dev/null)"; then
+              EXISTING="$(jq -sr --arg m "${MARKER}" --arg u "${BOT_LOGIN}" \
+                '[.[][] | select((.user.login == $u) and (.body | contains($m)))] | last | .id // empty' <<< "${resp}")"
+              listed=1; break
+            fi
+            echo "::notice::comment lookup attempt ${attempt} failed; retrying."; sleep 2
+          done
+          [ "${listed}" -eq 1 ] || { echo "::error::Could not list PR comments; not posting (avoids duplicates)."; exit 1; }
+
+          # Final TOCTOU gate immediately before the write.
+          gate
+
+          if [ -n "${EXISTING}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -F body=@"${BODY_FILE}" >/dev/null
+            echo "Updated serve-ab comment on PR #${PR}."
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -F body=@"${BODY_FILE}" >/dev/null
+            echo "Posted serve-ab comment on PR #${PR}."
+          fi

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -52,10 +52,27 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: 'Checkout PR base'
+      # Diff against the MERGE-BASE, not the base-branch tip: a PR branch behind
+      # `main` would otherwise show others' already-landed daemon changes,
+      # reversed, as this PR's diff. Best-effort — a base failure degrades the
+      # diff to after-only (every field reads as added).
+      - name: 'Resolve the merge-base'
+        id: 'mergebase'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          BASE_SHA: '${{ github.event.pull_request.base.sha }}'
+          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          set -euo pipefail
+          MB="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" --jq '.merge_base_commit.sha' 2>/dev/null || true)"
+          echo "sha=${MB:-$BASE_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "before (merge-base) = ${MB:-$BASE_SHA}; base tip = ${BASE_SHA}"
+
+      - name: 'Checkout the merge-base'
+        continue-on-error: true
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
-          ref: '${{ github.event.pull_request.base.sha }}'
+          ref: '${{ steps.mergebase.outputs.sha }}'
           path: 'base'
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -1,0 +1,121 @@
+name: 'Serve A/B'
+
+# For PRs that touch the `qwen serve` daemon's response surface, build the CLI
+# from BOTH the PR base (`main`) and the PR head, drive a fixed set of endpoints
+# against each daemon, and diff the JSON responses into a before/after field
+# table posted on the PR. A PR with no response change → "no change". This is
+# the daemon analog of the web-shell visual before/after preview.
+#
+# Security model: this workflow BUILDS AND RUNS untrusted PR code, so it runs on
+# the `pull_request` trigger (fork PRs get a read-only token and NO secrets), on
+# an ephemeral runner, with `contents: read`. It produces only JSON captures +
+# a markdown body as an artifact. The privileged step that needs a write token —
+# posting the comment — lives in the separate workflow_run publisher, which
+# never checks out PR code. The daemon is driven with dummy OpenAI creds, so no
+# model is contacted and the responses are deterministic + safe to diff.
+on:
+  pull_request:
+    branches:
+      - 'main'
+      - 'release/**'
+    # The daemon's HTTP response surface. Doc/UI-only PRs don't need an A/B.
+    paths:
+      - 'packages/cli/src/serve/**'
+      - 'packages/core/src/**'
+      - '.github/workflows/serve-ab.yml'
+      - '.github/scripts/serve-ab-diff.mjs'
+      - '.github/scripts/serve-ab-drive.mjs'
+
+permissions:
+  contents: 'read'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  ab:
+    name: 'Serve A/B (ubuntu-latest, Node 22.x)'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
+    steps:
+      - name: 'Checkout PR head'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+          path: 'head'
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: 'Checkout PR base'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          ref: '${{ github.event.pull_request.base.sha }}'
+          path: 'base'
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: 'Set up Node.js 22.x'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: 'head/package-lock.json'
+
+      - name: 'Build + drive the PR head'
+        working-directory: 'head'
+        run: |-
+          set -euo pipefail
+          npm ci --prefer-offline --no-audit --progress=false
+          npm run build
+          node .github/scripts/serve-ab-drive.mjs \
+            packages/cli/dist/index.js "${RUNNER_TEMP}/after"
+
+      # Best-effort: if the base fails to build/drive, the diff treats every
+      # after-field as new rather than sinking the whole preview.
+      - name: 'Build + drive the PR base'
+        continue-on-error: true
+        working-directory: 'base'
+        run: |-
+          set -euo pipefail
+          npm ci --prefer-offline --no-audit --progress=false
+          npm run build
+          node ../head/.github/scripts/serve-ab-drive.mjs \
+            packages/cli/dist/index.js "${RUNNER_TEMP}/before"
+
+      - name: 'Diff before/after → comment body'
+        env:
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+          SHORT_SHA: '${{ github.event.pull_request.head.sha }}'
+        run: |-
+          set -euo pipefail
+          OUT="${RUNNER_TEMP}/serve-ab"
+          mkdir -p "${OUT}"
+          node head/.github/scripts/serve-ab-diff.mjs comment \
+            "${RUNNER_TEMP}/before" "${RUNNER_TEMP}/after" \
+            "${SHORT_SHA:0:7}" "${OUT}/body.md"
+          # PR number for the workflow_run publisher (which validates it). The
+          # head SHA is NOT shipped — the publisher binds to the authenticated
+          # workflow_run.head_sha.
+          printf '%s\n' "${PR_NUMBER}" > "${OUT}/pr.txt"
+          # Bound the untrusted body the privileged publisher will post.
+          if [ "$(wc -c < "${OUT}/body.md")" -gt 65536 ]; then
+            echo "::warning::serve-ab body exceeds 64KB; truncating."
+            head -c 65536 "${OUT}/body.md" > "${OUT}/body.trunc" && mv "${OUT}/body.trunc" "${OUT}/body.md"
+          fi
+          echo "Comment body: $(wc -l < "${OUT}/body.md") lines."
+
+      - name: 'Upload serve-ab artifact (published)'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' # v7.0.1
+        with:
+          name: 'serve-ab'
+          path: |-
+            ${{ runner.temp }}/serve-ab/body.md
+            ${{ runner.temp }}/serve-ab/pr.txt
+          if-no-files-found: 'warn'
+          retention-days: 7

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -67,11 +67,25 @@ jobs:
           HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
         run: |-
           set -euo pipefail
-          MB="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" --jq '.merge_base_commit.sha' 2>/dev/null || true)"
-          echo "sha=${MB:-$BASE_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "before (merge-base) = ${MB:-$BASE_SHA}; base tip = ${BASE_SHA}"
+          # Retry, then emit an EMPTY sha and skip the before build (after-only)
+          # rather than falling back to the base-branch tip — the tip would show
+          # already-landed changes reversed, the exact bug the merge-base avoids.
+          MB=''
+          for attempt in 1 2 3; do
+            MB="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" --jq '.merge_base_commit.sha' 2>/dev/null || true)"
+            [ -n "${MB}" ] && break
+            sleep 2
+          done
+          echo "sha=${MB}" >> "${GITHUB_OUTPUT}"
+          if [ -n "${MB}" ]; then
+            echo "before (merge-base) = ${MB}"
+          else
+            echo "::warning::could not resolve the merge-base; skipping the before build (after-only)."
+          fi
 
       - name: 'Checkout the merge-base'
+        id: 'base_checkout'
+        if: "${{ steps.mergebase.outputs.sha != '' }}"
         continue-on-error: true
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
@@ -99,6 +113,7 @@ jobs:
       # Best-effort: if the base fails to build/drive, the diff treats every
       # after-field as new rather than sinking the whole preview.
       - name: 'Build + drive the PR base'
+        if: "${{ steps.base_checkout.outcome == 'success' }}"
         continue-on-error: true
         working-directory: 'base'
         run: |-

--- a/.github/workflows/serve-ab.yml
+++ b/.github/workflows/serve-ab.yml
@@ -18,10 +18,13 @@ on:
     branches:
       - 'main'
       - 'release/**'
-    # The daemon's HTTP response surface. Doc/UI-only PRs don't need an A/B.
+    # The daemon's HTTP response surface lives entirely under serve/. `core` has
+    # no serve/health subtree, and firing on all ~1100 packages/core/src files
+    # (tools, prompts, models, …) would trigger the expensive 2x-build A/B on
+    # most core PRs for nothing — a rare core-only response change is an
+    # acceptable best-effort miss. Doc/UI-only PRs don't need an A/B either.
     paths:
       - 'packages/cli/src/serve/**'
-      - 'packages/core/src/**'
       - '.github/workflows/serve-ab.yml'
       - '.github/scripts/serve-ab-diff.mjs'
       - '.github/scripts/serve-ab-drive.mjs'


### PR DESCRIPTION
## What this PR does

Extends the before/after preview idea to the **backend**. For PRs that touch the `qwen serve` response surface, it builds the CLI from **both** the PR base (`main`) and the PR head, drives a fixed set of endpoints against each daemon, and diffs the JSON responses into a **before/after field table** posted on the PR. A PR with no response change → "no change". It's the daemon analog of the web-shell visual before/after bot.

## Why it's needed

Backend PRs (health aggregation, capabilities, session routes) get no automatic before/after — reviewers hand-build A/B tables (e.g. the deep-health verification's `sessions 0→1`, `workspaceCount absent→2`). This does that automatically, on the same "diff against merge-base, show only what changed" principle the web-shell bot already uses — just on structured JSON instead of pixels.

## Reviewer Test Plan

### How to verify

- `node --test .github/scripts/serve-ab-diff.test.mjs` → **12/12** (structural diff: set-aware arrays, volatile-field masking, added/removed/changed, `buildComment` assembly, no-change).
- Drive the real daemon end-to-end: `node .github/scripts/serve-ab-drive.mjs packages/cli/dist/index.js /tmp/caps` boots the built `qwen serve` (dummy OpenAI creds — no model) and captures `health.json` / `health-deep.json` / `capabilities.json`.
- Diff two capture dirs: `node .github/scripts/serve-ab-diff.mjs comment <beforeDir> <afterDir> <sha> body.md`.

### Evidence (Before & After)

Driving the **real** daemon (captured `/capabilities`), then diffing against a head that adds a feature + bumps the version — exactly what the bot posts:

#### `capabilities`

| field | main (before) | this PR (after) |
| --- | --- | --- |
| `features[]` | — | `"stateless_generation_sse"` |
| `qwenCodeVersion` | `"0.19.9"` | `"0.19.10"` |

…and unchanged endpoints (`health`) render `_No response change vs main._` and are omitted from the comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local: `node --test` + a real `node packages/cli/dist/index.js serve` boot driven over HTTP. The workflow builds + drives on Linux in CI.

## Risk & Scope

- Main risk or tradeoff: the workflow wiring (two checkouts, `npm ci` + `npm run build` + drive per arm) can only be exercised by a real CI run — as with the web-shell publish path, its **first real run is the next serve PR**. It fails safe: the base build/drive is `continue-on-error` (a broken base → after-only), and the untrusted body is size-capped before the privileged publisher posts it.
- Not validated / out of scope: the base-build step under real GitHub Actions; only three read-only endpoints are driven so far (`/health`, `/health?deep=1`, `/capabilities`) — mutating scenarios (create a session, etc.) can be added to `serve-ab-drive.mjs` with their volatile fields masked in `serve-ab-diff.mjs`.
- Breaking changes / migration notes: none — new workflows + scripts only; nothing else is touched.

## Linked Issues

Companion to the web-shell before/after work (#6963). No closing keyword.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 before/after 预览推广到**后端**。对碰 `qwen serve` 响应面的 PR:从 PR base(`main`)和 head **两边**各构建 CLI,对各自的 daemon 驱动一组固定 endpoint,把 JSON 响应 diff 成一张 **before/after 字段表**发到 PR 上。无响应变化的 PR → "no change"。是 web-shell 视觉 before/after bot 的 daemon 版。

## 为什么需要

后端 PR(health 聚合、capabilities、session 路由)没有自动 before/after —— 维护者手工搭 A/B 表(如 deep-health 验证里的 `sessions 0→1`、`workspaceCount absent→2`)。这个自动化了它,用的是 web-shell bot 已经在用的同一套"对 merge-base 做 diff、只显示变化"原理 —— 只不过对象是结构化 JSON 而非像素。

## Reviewer Test Plan

### 如何验证

- `node --test .github/scripts/serve-ab-diff.test.mjs` → **12/12**(结构化 diff:集合式数组、volatile 字段屏蔽、增/删/改、`buildComment` 组装、no-change)。
- 端到端驱动真实 daemon:`node .github/scripts/serve-ab-drive.mjs packages/cli/dist/index.js /tmp/caps` 启动构建好的 `qwen serve`(dummy OpenAI creds、不打模型),捕获 `health.json` / `health-deep.json` / `capabilities.json`。
- diff 两个捕获目录:`node .github/scripts/serve-ab-diff.mjs comment <beforeDir> <afterDir> <sha> body.md`。

### 证据(Before & After)

驱动**真实** daemon(捕获 `/capabilities`),再对一个"加了 feature + 升了版本"的 head 做 diff —— 就是 bot 会发的表(见上方英文表格)。未变的 endpoint(`health`)渲染 `_No response change vs main._` 并从评论里省略。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境(可选)

本地:`node --test` + 真实 `node packages/cli/dist/index.js serve` 启动并通过 HTTP 驱动。workflow 在 CI 的 Linux 上构建 + 驱动。

## 风险与范围

- 主要风险/取舍:workflow 接线(两次 checkout、每臂 `npm ci` + `npm run build` + 驱动)只能靠真实 CI 运行验证 —— 和 web-shell 发布路径一样,**首次真实运行是下一个 serve PR**。已做 fail-safe:base 构建/驱动是 `continue-on-error`(base 坏了 → 只出 after),不可信 body 在特权发布前已限大小。
- 未验证/范围外:真实 GitHub Actions 下的 base 构建;目前只驱动三个只读 endpoint(`/health`、`/health?deep=1`、`/capabilities`)—— 会改状态的场景(建 session 等)可以加进 `serve-ab-drive.mjs`,并在 `serve-ab-diff.mjs` 里屏蔽其 volatile 字段。
- 破坏性变更:无 —— 只加 workflow + 脚本。

## 关联 Issue

web-shell before/after 工作(#6963)的姊妹件。无关闭关键字。

</details>
