### PR TITLE
fix(core): route id-less continuation chunks to a colliding tool-call opener's slot

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -1033,6 +1033,33 @@ describe('StreamingToolCallParser', () => {
         args: { b: 2 },
         index: 1,
       });
+      // call_1's arguments must survive the collision intact.
+      expect(parser.getCompletedToolCalls()).toContainEqual({
+        id: 'call_1',
+        name: 'function1',
+        args: { a: 1 },
+        index: 0,
+      });
+    });
+
+    it('routes id-less continuations after a content-bearing colliding opener', () => {
+      parser.addChunk(0, '{"a":1}', 'call_1', 'function1');
+
+      // Same collision as above, but call_2's opener already carries a partial
+      // arguments fragment alongside its id and name — the line-239 remap-record
+      // path, as opposed to the empty-opener early return.
+      const opener = parser.addChunk(0, '{"b":', 'call_2', 'function2');
+      expect(opener.actualIndex).toBe(1);
+
+      const continuation = parser.addChunk(0, '2}');
+      expect(continuation.actualIndex).toBe(1);
+
+      expect(parser.getCompletedToolCalls()).toContainEqual({
+        id: 'call_2',
+        name: 'function2',
+        args: { b: 2 },
+        index: 1,
+      });
     });
 
     it('does not let a brand-new tool-call id adopt a remap slot that already has an id', () => {

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -1012,6 +1012,29 @@ describe('StreamingToolCallParser', () => {
       });
     });
 
+    it('routes id-less continuation chunks to a slot claimed by a colliding opener delta', () => {
+      parser.addChunk(0, '{"a":1}', 'call_1', 'function1');
+
+      // The provider reuses index 0 for a second tool call whose id and name
+      // arrive together on an empty opener delta (the standard OpenAI streaming
+      // shape: function: { name, arguments: '' }).
+      const opener = parser.addChunk(0, '', 'call_2', 'function2');
+      expect(opener.actualIndex).toBe(1);
+
+      // The following id-less argument chunk must land on call_2's slot, not on
+      // a fresh orphan slot that would drop the arguments and get the call
+      // flagged as malformed.
+      const continuation = parser.addChunk(0, '{"b":2}');
+      expect(continuation.actualIndex).toBe(1);
+
+      expect(parser.getCompletedToolCalls()).toContainEqual({
+        id: 'call_2',
+        name: 'function2',
+        args: { b: 2 },
+        index: 1,
+      });
+    });
+
     it('should handle rapid tool call switching at same index', () => {
       // Rapid switching between different tool calls at index 0
       parser.addChunk(0, '{"step1":', 'call_1', 'function1');

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -1035,6 +1035,26 @@ describe('StreamingToolCallParser', () => {
       });
     });
 
+    it('does not let a brand-new tool-call id adopt a remap slot that already has an id', () => {
+      // Exercises the added `!toolCallMeta.get(remap)?.id` guard on pending-remap
+      // adoption: after call_2 claims the 0->1 remap (with its own id), a third
+      // tool call that reuses index 0 with a fresh id must NOT hijack call_2's
+      // slot via that remap — it has to fall through to collision handling and
+      // get its own slot.
+      parser.addChunk(0, '{"a":1}', 'call_1', 'function1');
+      parser.addChunk(0, '', 'call_2', 'function2');
+      parser.addChunk(0, '{"b":2}');
+
+      const third = parser.addChunk(0, '{"c":3}', 'call_3', 'function3');
+      expect(third.actualIndex).not.toBe(1);
+
+      const completed = parser.getCompletedToolCalls();
+      const call2 = completed.find((tc) => tc.id === 'call_2');
+      const call3 = completed.find((tc) => tc.id === 'call_3');
+      expect(call2?.args).toEqual({ b: 2 });
+      expect(call3?.args).toEqual({ c: 3 });
+    });
+
     it('should handle rapid tool call switching at same index', () => {
       // Rapid switching between different tool calls at index 0
       parser.addChunk(0, '{"step1":', 'call_1', 'function1');

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -1082,6 +1082,29 @@ describe('StreamingToolCallParser', () => {
       expect(call3?.args).toEqual({ c: 3 });
     });
 
+    it('routes an id-less continuation to the newest of three colliding openers', () => {
+      // Three tool calls reuse provider index 0 in sequence, each opener remapping
+      // to a fresh slot. An id-less continuation after the third opener must land on
+      // the third call's slot. Guarding the remap overwrite to keep the *first*
+      // mapping would pin the remap at call_2's slot and misroute this chunk.
+      parser.addChunk(0, '{"a":1}', 'call_1', 'function1'); // slot 0
+      parser.addChunk(0, '', 'call_2', 'function2'); // opener -> slot 1
+      parser.addChunk(0, '{"b":2}'); // call_2 args -> slot 1
+      const opener3 = parser.addChunk(0, '', 'call_3', 'function3'); // opener -> slot 2
+      expect(opener3.actualIndex).toBe(2);
+
+      const continuation = parser.addChunk(0, '{"c":3}'); // id-less -> must be call_3's slot
+      expect(continuation.actualIndex).toBe(2);
+
+      const completed = parser.getCompletedToolCalls();
+      expect(completed.find((tc) => tc.id === 'call_3')?.args).toEqual({
+        c: 3,
+      });
+      expect(completed.find((tc) => tc.id === 'call_2')?.args).toEqual({
+        b: 2,
+      });
+    });
+
     it('should handle rapid tool call switching at same index', () => {
       // Rapid switching between different tool calls at index 0
       parser.addChunk(0, '{"step1":', 'call_1', 'function1');

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -110,8 +110,14 @@ export class StreamingToolCallParser {
       if (this.idToIndexMap.has(id)) {
         // We've seen this ID before, use the existing mapped index
         actualIndex = this.idToIndexMap.get(id)!;
-      } else if (this.pendingIndexRemaps.has(index)) {
-        // Some providers stream name or arguments before the stable ID.
+      } else if (
+        this.pendingIndexRemaps.has(index) &&
+        !this.toolCallMeta.get(this.pendingIndexRemaps.get(index)!)?.id
+      ) {
+        // Some providers stream name or arguments before the stable ID. Only
+        // adopt the remapped slot while it has not yet been claimed by an id:
+        // once it has one, the remap only exists to route later id-less
+        // continuation chunks, so a brand-new id must not hijack that slot.
         actualIndex = this.pendingIndexRemaps.get(index)!;
         this.pendingIndexRemaps.delete(index);
         this.idToIndexMap.set(id, actualIndex);
@@ -206,7 +212,7 @@ export class StreamingToolCallParser {
       } else {
         this.namelessToolCallIndices.delete(actualIndex);
       }
-      if (!meta.id && actualIndex !== index) {
+      if (actualIndex !== index) {
         this.pendingIndexRemaps.set(index, actualIndex);
       }
       return { actualIndex, complete: false };
@@ -236,7 +242,7 @@ export class StreamingToolCallParser {
         meta.name = validName;
       }
     }
-    if (!meta.id && actualIndex !== index) {
+    if (actualIndex !== index) {
       this.pendingIndexRemaps.set(index, actualIndex);
     }
 

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -123,8 +123,10 @@ export class StreamingToolCallParser {
         // adopt the remapped slot while it has not yet been claimed by an id:
         // once it has one, the remap only exists to route later id-less
         // continuation chunks, so a brand-new id must not hijack that slot.
+        // The remap is deliberately left in place — the re-registration on the
+        // common path below keeps `index -> actualIndex` alive so subsequent
+        // id-less continuation chunks at this provider index still resolve here.
         actualIndex = this.pendingIndexRemaps.get(index)!;
-        this.pendingIndexRemaps.delete(index);
         this.idToIndexMap.set(id, actualIndex);
       } else {
         // New tool call ID

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -49,7 +49,12 @@ export class StreamingToolCallParser {
   private namelessToolCallIndices = new Set<number>();
   /** Map from tool call ID to actual index used for storage */
   private idToIndexMap: Map<string, number> = new Map();
-  /** Remapped slots awaiting a stable ID from a later chunk. */
+  /**
+   * Maps a provider index to the actual slot it was remapped to on collision.
+   * Two readers consume it: an id that arrives after its name/args adopts the
+   * slot, and later id-less continuation chunks at the same provider index are
+   * routed to it.
+   */
   private pendingIndexRemaps: Map<number, number> = new Map();
   /** Counter for generating new indices when collisions occur */
   private nextAvailableIndex: number = 0;


### PR DESCRIPTION
## What this PR does

Fixes a silent tool-call argument-loss bug in `StreamingToolCallParser`. When a provider reuses the same streaming `index` for a second tool call whose `id` and `name` arrive together on an empty opener delta (the standard OpenAI streaming shape `function: { name, arguments: "" }`), the `index -> slot` remap was never recorded — it was guarded by `!meta.id`, and the id was already set. The subsequent id-less argument chunks then failed to find the remapped slot and were routed to a fresh orphan slot: the tool call was emitted with empty `args {}`, the real arguments (in a nameless slot) were dropped by `getCompletedToolCalls`, and the nameless slot made `converter.ts` raise `InvalidStreamError('MALFORMED_TOOL_CALL')`, forcing up to four wasted retries of an otherwise valid response.

The fix records the remap whenever the actual slot differs from the provider index, and guards pending-remap adoption so a brand-new id cannot hijack a slot that already has an id. A follow-up commit also removes the now-dead `pendingIndexRemaps.delete` in the adoption branch (the common-path re-registration immediately re-creates it), which a reviewer flagged, and documents why the remap is intentionally kept alive.

## Why it's needed

Under the standard OpenAI streaming protocol, argument continuation chunks carry neither `id` nor `name`. When a provider recycles an index, these continuations were misrouted, so any tool call in that shape silently lost its arguments and burned the retry budget. This is a real provider-stream shape, not a synthetic edge case, and the existing collision tests only covered the id-arrives-late variant.

## Reviewer Test Plan

### How to verify

```
cd packages/core
npx vitest run src/core/openaiContentGenerator/streamingToolCallParser.test.ts
```

Three tests are added: `routes id-less continuation chunks to a slot claimed by a colliding opener delta`, `routes id-less continuations after a content-bearing colliding opener`, and `does not let a brand-new tool-call id adopt a remap slot that already has an id` (the block direction of the adoption guard).

### Evidence (Before & After)

Non-user-visible core parser change, so the evidence is the test suite rather than a screenshot.

- Before: reverting the fix fails `routes id-less continuation chunks...` — `continuation.actualIndex` is an orphan slot and the call is emitted with `args: {}`. Reverting the added guard fails `does not let a brand-new tool-call id adopt...` — `third.actualIndex` is `1`, hijacking the prior call's slot.
- After: `Test Files 1 passed`, `Tests 88 passed`. The full `openaiContentGenerator` suite stays green.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS verified locally (parser suite 88/88, `prettier`/`eslint` clean); Windows and Linux are exercised by CI.

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: confined to `StreamingToolCallParser`'s index-remap bookkeeping; the id-arrives-late path and public API are untouched.
- Not validated / out of scope: real-provider live streams (the failing shape is reproduced deterministically in the unit tests instead).
- Breaking changes / migration notes: none.

## Linked Issues

None — a self-contained streaming-parser correctness fix found while reading the collision/remap code introduced in #6819.
