### PR TITLE
ci: quarantine cron-interactive from push E2E to nightly-only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,9 +96,9 @@ jobs:
           VERBOSE: 'true'
         run: |-
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npm run test:integration:sandbox:docker
+            npm run test:integration:sandbox:docker -- --exclude '**/interactive/cron-interactive.test.ts'
           else
-            npm run test:integration:sandbox:none
+            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts'
           fi
 
   e2e-test-macos:
@@ -143,7 +143,56 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-        run: 'npm run test:e2e'
+        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts"'
+
+  cron-interactive-nightly:
+    name: 'cron-interactive E2E (nightly)'
+    runs-on: 'ubuntu-latest'
+    if: |-
+      ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    # This test is inherently timing-flaky (wall-clock cron fire + real model
+    # latency). Run it nightly only so flakes do not turn push CI red.
+    # continue-on-error prevents this job from marking the workflow as failed.
+    continue-on-error: true
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Configure npm for rate limiting'
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      - name: 'Install dependencies'
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+
+      - name: 'Build project'
+        run: |-
+          npm run build
+
+      - name: 'Bundle CLI for E2E tests'
+        run: |-
+          npm run bundle
+
+      - name: 'Run cron-interactive E2E tests'
+        env:
+          OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
+          OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
+          OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+          KEEP_OUTPUT: 'true'
+          VERBOSE: 'true'
+        run: 'npx cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests interactive/cron-interactive.test.ts'
 
   web-shell-browser-regression:
     name: 'web-shell Browser Regression'


### PR DESCRIPTION
## What this PR does

Quarantine the timing-flaky `cron-interactive.test.ts` from push-triggered E2E runs into a nightly-only isolated job. The test is excluded from both Linux and macOS push jobs via vitest `--exclude`, and a new `cron-interactive-nightly` job runs it on schedule/manual dispatch with `continue-on-error: true`.

## Why it's needed

`cron-interactive.test.ts` is inherently timing-flaky: it relies on wall-clock cron fire (`*/1` at minute boundary) + real model latency, with a 90s `waitForScreen` window. On slower macOS runners this occasionally exceeds the timeout, turning push CI red on `main` and triggering wasteful autofix attempts (~50min). This has been intermittently flaky for ~3.5 months (#2731 → #3402 → #3992 → #6016). Coverage is preserved: cron regressions are still caught by nightly runs within ~24h.

## Reviewer Test Plan

### How to verify

1. Check that the push-triggered E2E workflow excludes `cron-interactive.test.ts` — inspect the `Run E2E tests` step in the Linux and macOS jobs for the `--exclude` flag.
2. Verify the new `cron-interactive-nightly` job only runs on `schedule` or `workflow_dispatch` (same pattern as `web-shell-browser-regression`).
3. Confirm `continue-on-error: true` is set so flakes don't fail the workflow.
4. Trigger `workflow_dispatch` manually to verify the nightly job runs the cron-interactive tests correctly.

### Evidence (Before & After)

Before: push E2E runs all tests including cron-interactive → occasional timeout failures on macOS (e.g. [run 29424611412](https://github.com/QwenLM/qwen-code/actions/runs/29424611412)).
After: push E2E skips cron-interactive; nightly job runs it in isolation with `continue-on-error`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

CI-only change — verified by inspecting workflow YAML structure. Actual CI run will confirm on merge.

### Environment (optional)

N/A — pure CI configuration change.

## Risk & Scope

- Main risk or tradeoff: cron regressions are caught within ~24h (nightly) instead of immediately on push. This is an acceptable tradeoff given the test has been flaky for 3.5 months and never caught a real regression during that period.
- Not validated / out of scope: the root fix (deterministic test seam in CronScheduler) is in #6987.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #6982
Refs: #2731, #3402, #3992, #6016, #6987

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 timing-flaky 的 `cron-interactive.test.ts` 从 push 触发的 E2E 运行中隔离出来，移到仅 nightly 运行的独立 job。通过 vitest `--exclude` 从 Linux 和 macOS push job 中排除该测试，新增 `cron-interactive-nightly` job 在 schedule/manual dispatch 时运行，设置 `continue-on-error: true`。

## 为什么需要

`cron-interactive.test.ts` 存在固有的 timing-flakiness：依赖墙钟整分钟触发的 cron（`*/1`）+ 真实模型延迟，`waitForScreen` 窗口 90 秒。在较慢的 macOS runner 上偶尔超时，导致 main CI 变红并触发浪费的 autofix 尝试（~50 分钟）。这个问题已经间歇性存在约 3.5 个月。覆盖率不受影响：cron 回归仍然在 nightly 运行中被捕获（~24h 内）。

## 风险与范围

- 主要风险：cron 回归在 ~24h 内（nightly）被捕获，而不是 push 后立即。考虑到该测试已 flaky 3.5 个月且从未捕获过真实回归，这是可接受的折衷。
- 未验证/不在范围内：根改法（CronScheduler 确定性测试钩子）在 #6987。
- 破坏性变更/迁移说明：无。

</details>