### PR TITLE
fix(cron): add deterministic test seam for cron-interactive E2E

### DIFF
--- a/integration-tests/interactive/cron-interactive.test.ts
+++ b/integration-tests/interactive/cron-interactive.test.ts
@@ -31,6 +31,11 @@ function makeEnv(): NodeJS.ProcessEnv {
     QWEN_CODE_LANG: 'en',
     TERM: 'xterm-256color',
     NODE_NO_WARNINGS: '1',
+    // Enable the CronScheduler test seam: newly created session-only
+    // jobs auto-fire after 5s instead of waiting for the wall-clock
+    // minute boundary. Removes the timing-flakiness from these tests
+    // (see #6982).
+    QWEN_CODE_TEST_CRON_FAST: '1',
   };
 }
 
@@ -58,7 +63,7 @@ function makeEnv(): NodeJS.ProcessEnv {
     await session.waitForScreen(
       (scr) => scr.includes('Cron: PONG7742'),
       'cron notification "Cron: PONG7742"',
-      90_000,
+      30_000,
     );
 
     await session.idle(5000);
@@ -82,7 +87,7 @@ function makeEnv(): NodeJS.ProcessEnv {
     await session.waitForScreen(
       (scr) => scr.includes('Cron: CRONTICK99'),
       'first cron fire "Cron: CRONTICK99"',
-      90_000,
+      30_000,
     );
 
     await session.idle(5000);
@@ -113,7 +118,7 @@ function makeEnv(): NodeJS.ProcessEnv {
       await session.waitForScreen(
         (scr) => scr.includes('FILEERR88'),
         'model reporting FILEERR88 from cron prompt',
-        90_000,
+        30_000,
       );
 
       await session.idle(5000);

--- a/packages/core/src/services/cronScheduler.ts
+++ b/packages/core/src/services/cronScheduler.ts
@@ -307,6 +307,11 @@ export class CronScheduler {
   private fileWatcher: fsSync.FSWatcher | null = null;
   private lockProbeTimer: ReturnType<typeof setInterval> | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Test-only auto-fire timers (QWEN_CODE_TEST_CRON_FAST). Each timer
+  // fires its job via forceFireJob after a short delay so integration
+  // tests don't wait for the wall-clock minute boundary. Cleared on
+  // stop()/destroy() so a session teardown never leaks a pending fire.
+  private testFireTimers = new Map<string, ReturnType<typeof setTimeout>>();
   // Catch-up work detected before start() installed onFire — flushed
   // through onFire as soon as it exists.
   private pendingFires: PendingFire[] = [];
@@ -365,6 +370,26 @@ export class CronScheduler {
     };
 
     this.jobs.set(id, job);
+
+    // Test seam: when QWEN_CODE_TEST_CRON_FAST is set, schedule an
+    // auto-fire for newly created session-only jobs so integration tests
+    // don't wait up to 60s for the wall-clock minute boundary. The timer
+    // fires once after the configured delay (default 5s), then the normal
+    // tick takes over for subsequent fires of recurring jobs. Timers are
+    // tracked in testFireTimers and cleared on stop()/destroy().
+    if (process.env['QWEN_CODE_TEST_CRON_FAST'] === '1' && !job.durable) {
+      const delayMs = Number(process.env['QWEN_CODE_TEST_CRON_DELAY_MS']) || 5000;
+      const timer = setTimeout(() => {
+        this.testFireTimers.delete(id);
+        this.forceFireJob(id);
+      }, delayMs);
+      timer.unref();
+      this.testFireTimers.set(id, timer);
+      debugLogger.debug(
+        `Test seam: auto-fire scheduled for job ${id} in ${delayMs}ms`,
+      );
+    }
+
     return job;
   }
 
@@ -1149,6 +1174,22 @@ export class CronScheduler {
   }
 
   /**
+   * Immediately fires a job by ID, bypassing the cron schedule check.
+   * Sets lastFiredAt to prevent the normal tick from re-firing the same
+   * minute slot. Returns true if the job existed and was fired, false
+   * otherwise. Primarily a test seam (see QWEN_CODE_TEST_CRON_FAST in
+   * create()); also useful for manual debug triggers.
+   */
+  forceFireJob(id: string): boolean {
+    const job = this.jobs.get(id);
+    if (!job || !this.onFire) return false;
+    job.lastFiredAt = Date.now();
+    debugLogger.debug(`forceFireJob: firing ${id} (${job.cronExpr})`);
+    this.onFire(job);
+    return true;
+  }
+
+  /**
    * Starts the scheduler tick. Calls `onFire` when a job is due.
    * Only fires when called — does not auto-fire missed intervals.
    */
@@ -1194,6 +1235,10 @@ export class CronScheduler {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    // Clear any pending test-seam auto-fire timers so a torn-down
+    // scheduler never leaks a late forceFireJob call.
+    for (const timer of this.testFireTimers.values()) clearTimeout(timer);
+    this.testFireTimers.clear();
     if (this.wakeups.size > 0) {
       debugLogger.debug(`stop() discarding ${this.wakeups.size} wakeup(s)`);
       this.wakeups.clear();


### PR DESCRIPTION
## What this PR does

Add a deterministic test seam to `CronScheduler` so cron-interactive E2E tests no longer depend on wall-clock minute boundaries. A new `forceFireJob(id)` method fires a job immediately, and a `QWEN_CODE_TEST_CRON_FAST=1` environment variable triggers auto-fire 5s after job creation. The test file is updated to use this seam with reduced timeouts (90s → 30s).

## Why it's needed

`cron-interactive.test.ts` has been intermittently flaky for ~3.5 months because it waits up to 60s for a real wall-clock cron fire plus model round-trip, within a 90s budget. This is the root fix for #6982. Without it, even with quarantine (#6986), nightly runs still hit the same timing race. The test seam makes fires deterministic without changing any production scheduler logic.

## Reviewer Test Plan

### How to verify

1. Confirm `forceFireJob(id)` is additive — the normal `tick()` path is untouched, existing behavior preserved.
2. Confirm the `QWEN_CODE_TEST_CRON_FAST` seam is env-gated and inactive by default (no production impact).
3. Confirm test timers are cleaned up in `stop()` and `destroy()` — no leaked setTimeout handles.
4. Run cron-interactive E2E locally with `QWEN_CODE_TEST_CRON_FAST=1` and verify the cron notification appears within ~10s instead of up to 60s.
5. Run without the env var to confirm production behavior is unchanged.

### Evidence (Before & After)

Before: `cron_create` with `*/1 * * * *` → wait up to 60s for wall-clock minute boundary → occasional 90s timeout on slow runners.
After: with `QWEN_CODE_TEST_CRON_FAST=1` → auto-fire at ~5s → cron notification appears within ~10s total (5s delay + model round-trip).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Not locally tested (CI-only environment available). CI run on this PR will validate across all three platforms.

### Environment (optional)

Node.js v22.x, sandbox:none.

## Risk & Scope

- Main risk or tradeoff: the env-gated seam is a new code path in `CronScheduler.create()`, but it is strictly gated behind `QWEN_CODE_TEST_CRON_FAST=1` and has zero impact when unset. The `forceFireJob` method is additive and doesn't modify any existing fire logic.
- Not validated / out of scope: durable cron jobs are not affected by the test seam (guarded by `!job.durable` check). Full CronScheduler refactor with injectable clock is a larger effort not covered here.
- Breaking changes / migration notes: none. `forceFireJob` is a new public method, no existing API changed.

## Linked Issues

Closes #6982
Refs: #6986, #2731, #3402, #3992, #6016

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 `CronScheduler` 添加确定性测试钩子，使 cron-interactive E2E 测试不再依赖墙钟整分钟边界。新增 `forceFireJob(id)` 方法立即触发 job，以及 `QWEN_CODE_TEST_CRON_FAST=1` 环境变量在 job 创建后 5 秒自动触发。测试文件更新为使用该钩子并降低超时（90s → 30s）。

## 为什么需要

`cron-interactive.test.ts` 已经间歇性 flaky 约 3.5 个月，因为它需要等待最多 60 秒的真实墙钟 cron 触发加上模型往返，在 90 秒预算内。这是 #6982 的根改法。没有它，即使有隔离（#6986），nightly 运行仍然会遇到同样的 timing race。测试钩子使触发确定性化，不改变任何生产调度器逻辑。

## 风险与范围

- 主要风险：env 门控的钩子是 `CronScheduler.create()` 中的新代码路径，但严格门控在 `QWEN_CODE_TEST_CRON_FAST=1` 后面，不设置时零影响。`forceFireJob` 是增量方法，不修改任何现有触发逻辑。
- 未验证/不在范围内：durable cron jobs 不受测试钩子影响（由 `!job.durable` 检查保护）。带可注入时钟的完整 CronScheduler 重构是更大的工作，不在此 PR 范围内。
- 破坏性变更/迁移说明：无。`forceFireJob` 是新公开方法，没有现有 API 变更。

</details>