### PR TITLE
feat(channels): tag daemon sessions with channel source

### DIFF
--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -304,7 +304,7 @@ function stubProcessSend(send: NodeJS.Process['send'] | undefined): () => void {
 }
 
 describe('createDaemonSessionFactory', () => {
-  it('creates and loads daemon sessions with thread session scope', async () => {
+  it('tags created channel sessions without changing loaded sessions', async () => {
     const sdk = createSdk();
     const factory = createDaemonSessionFactory({
       client: sdk.client,
@@ -325,6 +325,7 @@ describe('createDaemonSessionFactory', () => {
         workspaceCwd: '/workspace',
         modelServiceId: 'qwen-plus',
         sessionScope: 'thread',
+        sourceType: 'channel',
       },
       'qwen-channel-worker',
     );
@@ -364,6 +365,7 @@ describe('createDaemonSessionFactory', () => {
         workspaceCwd: '/workspace',
         approvalMode: 'yolo',
         sessionScope: 'thread',
+        sourceType: 'channel',
       },
       'qwen-channel-worker',
     );

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -85,6 +85,7 @@ interface DaemonSessionClientStaticLike {
       modelServiceId?: string;
       sessionScope: 'thread';
       approvalMode?: string;
+      sourceType?: string;
     },
     clientId?: string,
   ): Promise<DaemonChannelSessionClient>;
@@ -166,7 +167,7 @@ export function createDaemonSessionFactory({
     }
     return await DaemonSessionClient.createOrAttach(
       client,
-      daemonReq,
+      { ...daemonReq, sourceType: 'channel' },
       clientId,
     );
   };


### PR DESCRIPTION
## What this PR does

Marks every newly created daemon-backed channel session with immutable `sourceType: "channel"` metadata. Loading an existing session does not send source metadata, so the session's original creator attribution remains unchanged.

The metadata is added at the channel-only daemon session creation boundary shared by all daemon-backed channel adapters. This keeps the change local and avoids introducing an optional field through generic channel routing layers that do not otherwise need it.

## Why it's needed

Daemon JSONL transcripts, session APIs, and downstream log pipelines currently cannot distinguish a channel-created session from other daemon sessions. Persisting the existing source metadata lets consumers such as SLS ingestion and subscription services identify channel-originated sessions without adding a hook or inferring the source from message contents.

## Reviewer Test Plan

### How to verify

1. Build the bundled CLI, start a daemon with chat recording enabled under an isolated home directory, and connect the repository's mock channel.
2. Send `!true` from a private mock-channel chat so a real daemon-backed channel session is created without making a model request.
3. Confirm the session list and status both report `sourceType: "channel"`, and confirm the JSONL starts with exactly one `system` / `session_source` record whose payload contains that value.
4. Restart the daemon and send another message from the same chat. Confirm the same session ID is loaded, the source remains `channel`, and the JSONL still has exactly one source record.
5. Run the focused channel-worker test and confirm creation requests carry the source while load requests do not.

Local verification passed: focused tests (57/57), the full daemon server test file (722/722), script tests (582 passed, 9 skipped), no-AK integrations (43/43), Web Shell smoke tests (14/14), build, typecheck, bundle, formatting, and linting. The monolithic PR gate was exercised twice and surfaced changing unrelated Serve-test flakes; every failed test and the full affected server test file passed on focused rerun.

### Evidence (Before & After)

N/A — this changes persisted session metadata and has no UI output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Bundled CLI on macOS with an isolated `QWEN_HOME`, the local `plugin-example` mock channel, daemon chat recording, and no model request.

## Risk & Scope

- Main risk or tradeoff: Passing source metadata intentionally relies on the daemon SDK's existing `session_source_metadata` capability preflight, so the worker and daemon must agree on metadata support.
- Not validated / out of scope: Backfilling existing transcripts, per-message source attribution, `sourceId`, routing changes, and UI changes.
- Breaking changes / migration notes: None. Only newly created channel sessions receive the metadata; loaded sessions retain their original attribution.

## Linked Issues

Closes #6962

<details>
<summary>中文说明</summary>

## 本 PR 的改动

为每个新创建的 daemon-backed channel session 写入不可变的 `sourceType: "channel"` 元数据。加载已有 session 时不发送来源元数据，因此 session 原始创建者的归因保持不变。

该元数据在所有 daemon-backed channel adapter 共用、且仅供 channel 使用的 daemon session 创建边界上写入。这样可以把改动限制在局部，避免让不需要该字段的通用 channel 路由层逐层透传一个可选字段。

## 为什么需要

目前 daemon JSONL 会话记录、session API 和下游日志管道无法区分 channel 创建的 session 与其他 daemon session。持久化已有的来源元数据后，SLS 采集、订阅服务等消费者可以直接识别 channel 来源，无需增加 hook，也无需根据消息内容推断来源。

## Reviewer 测试计划

### 验证方法

1. 构建 bundled CLI，在隔离的 home 目录中启动启用了会话记录的 daemon，并连接仓库中的 mock channel。
2. 从 mock channel 私聊发送 `!true`，创建一个真实的 daemon-backed channel session，同时不发起模型请求。
3. 确认 session 列表和状态都返回 `sourceType: "channel"`；确认 JSONL 开头恰好有一条 `system` / `session_source` 记录，并且 payload 包含该值。
4. 重启 daemon，并从同一 chat 再发送一条消息。确认加载的是同一个 session ID，来源仍为 `channel`，JSONL 中仍然只有一条来源记录。
5. 运行 channel worker 的聚焦测试，确认创建请求带有来源字段，而加载请求不带该字段。

本地验证已通过：聚焦测试（57/57）、完整 daemon server 测试文件（722/722）、脚本测试（582 通过、9 跳过）、无 AK 集成测试（43/43）、Web Shell smoke 测试（14/14），以及 build、typecheck、bundle、格式和 lint 检查。整体 PR gate 运行了两次，出现了不同的、与本改动无关的 Serve 测试波动；所有失败用例以及受影响的完整 server 测试文件在聚焦重跑时均通过。

### 证据（改动前后）

N/A——本改动只影响持久化的 session 元数据，没有 UI 输出。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS 上的 bundled CLI，使用隔离的 `QWEN_HOME`、本地 `plugin-example` mock channel、daemon 会话记录，并且未发起模型请求。

## 风险与范围

- 主要风险或权衡：传递来源元数据会按设计依赖 daemon SDK 已有的 `session_source_metadata` 能力预检，因此 worker 与 daemon 需要对元数据能力达成一致。
- 未验证 / 不在范围内：回填已有会话记录、逐消息来源归因、`sourceId`、路由改动和 UI 改动。
- 破坏性变更 / 迁移说明：无。只有新创建的 channel session 会收到该元数据；加载已有 session 时会保留其原始归因。

## 关联 Issue

Closes #6962

</details>
