### PR TITLE
fix(headless): run concurrency-safe tool calls in parallel

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1379,6 +1379,56 @@ describe('runNonInteractive', () => {
         }
       }
     });
+
+    it('canonicalizes legacy tool aliases so they partition like the interactive path', async () => {
+      setupMetricsMock();
+      // `search_file_content` is a legacy alias for `grep_search`
+      // (Kind.Search, concurrency-safe). The registry only knows the canonical
+      // name, so the partitioner must canonicalize before the kind lookup —
+      // otherwise these classify unsafe → sequential here while the TUI runs
+      // them in parallel.
+      vi.mocked(mockToolRegistry.getTool).mockImplementation(
+        (name: string) =>
+          (name === 'grep_search'
+            ? { kind: Kind.Search }
+            : undefined) as unknown as ReturnType<
+            typeof mockToolRegistry.getTool
+          >,
+      );
+
+      const total = 2;
+      const startOrder: string[] = [];
+      let started = 0;
+      let openGate!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        openGate = resolve;
+      });
+      mockCoreExecuteToolCall.mockImplementation(
+        async (_config: unknown, req: { callId: string }) => {
+          startOrder.push(req.callId);
+          started += 1;
+          if (started === total) openGate();
+          await gate;
+          return { responseParts: [{ text: `resp-${req.callId}` }] };
+        },
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents(
+            toolCallEvents(['s1', 's2'], 'search_file_content', 'p-alias'),
+          ),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      await runNonInteractive(mockConfig, mockSettings, 'go', 'p-alias');
+
+      // Both alias calls run in parallel (the gate opens only once both have
+      // started); a raw-name lookup would classify them sequential and this
+      // would deadlock.
+      expect(started).toBe(total);
+      expect(startOrder).toEqual(['s1', 's2']);
+    });
   });
 
   it('should ignore duplicate provider tool-call ids across rounds', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -17,6 +17,7 @@ import {
   ToolErrorType,
   shutdownTelemetry,
   GeminiEventType,
+  Kind,
   OutputFormat,
   uiTelemetryService,
   FatalInputError,
@@ -1046,6 +1047,217 @@ describe('runNonInteractive', () => {
     expect(
       mockGeminiClient.consumePendingMemoryTaskPromises,
     ).toHaveBeenCalled();
+  });
+
+  describe('parallel tool execution', () => {
+    const finishTurn: ServerGeminiStreamEvent[] = [
+      { type: GeminiEventType.Content, value: 'done' },
+      {
+        type: GeminiEventType.Finished,
+        value: { reason: undefined, usageMetadata: { totalTokenCount: 1 } },
+      },
+    ];
+
+    function toolCallEvents(
+      ids: string[],
+      name: string,
+      promptId: string,
+    ): ServerGeminiStreamEvent[] {
+      return ids.map((callId) => ({
+        type: GeminiEventType.ToolCallRequest,
+        value: {
+          callId,
+          name,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: promptId,
+        },
+      }));
+    }
+
+    it('runs a batch of concurrency-safe tool calls concurrently', async () => {
+      setupMetricsMock();
+      // Kind.Read is concurrency-safe, so the whole batch is one parallel
+      // partition (mirrors the interactive scheduler).
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Read,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+
+      const total = 3;
+      const startOrder: string[] = [];
+      let started = 0;
+      let openGate!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        openGate = resolve;
+      });
+      // Each call blocks on `gate`, which only opens once EVERY call in the
+      // batch has started. Under the old one-at-a-time loop, call #2 never
+      // starts until call #1 resolves — but call #1 is parked on the gate, so
+      // the gate never opens and the run deadlocks (the test then times out).
+      // Reaching `started === total` therefore proves the batch ran in
+      // parallel.
+      mockCoreExecuteToolCall.mockImplementation(
+        async (_config: unknown, req: { callId: string }) => {
+          startOrder.push(req.callId);
+          started += 1;
+          if (started === total) openGate();
+          await gate;
+          return { responseParts: [{ text: `resp-${req.callId}` }] };
+        },
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents(
+            toolCallEvents(
+              ['tool-1', 'tool-2', 'tool-3'],
+              'read',
+              'p-parallel',
+            ),
+          ),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      await runNonInteractive(mockConfig, mockSettings, 'go', 'p-parallel');
+
+      expect(started).toBe(total);
+      expect(startOrder).toEqual(['tool-1', 'tool-2', 'tool-3']);
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(total);
+    });
+
+    it('finalizes concurrent results in request order despite out-of-order completion', async () => {
+      setupMetricsMock();
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Read,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+
+      const resolvers: Record<string, () => void> = {};
+      mockCoreExecuteToolCall.mockImplementation(
+        (_config: unknown, req: { callId: string }) =>
+          new Promise((resolve) => {
+            resolvers[req.callId] = () =>
+              resolve({
+                responseParts: [
+                  {
+                    functionResponse: {
+                      id: req.callId,
+                      name: req.callId,
+                      response: { output: `r-${req.callId}` },
+                    },
+                  },
+                ],
+              });
+          }),
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents(
+            toolCallEvents(['a', 'b', 'c'], 'read', 'p-order'),
+          ),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      const run = runNonInteractive(mockConfig, mockSettings, 'go', 'p-order');
+      // Wait for all three to launch, then resolve them out of order.
+      await vi.waitFor(() =>
+        expect(Object.keys(resolvers).sort()).toEqual(['a', 'b', 'c']),
+      );
+      resolvers['c']();
+      resolvers['a']();
+      resolvers['b']();
+      await run;
+
+      // The next model turn must receive the tool responses in the original
+      // request order a, b, c — not the completion order c, a, b.
+      const nextTurnParts = mockGeminiClient.sendMessageStream.mock
+        .calls[1][0] as Part[];
+      const ids = nextTurnParts
+        .map((part) => part.functionResponse?.id)
+        .filter((id): id is string => id === 'a' || id === 'b' || id === 'c');
+      expect(ids).toEqual(['a', 'b', 'c']);
+    });
+
+    it('runs side-effecting (unsafe) tool calls sequentially', async () => {
+      setupMetricsMock();
+      // Kind.Edit is a mutator: each unsafe call forms its own sequential
+      // batch, so call #2 must not start until call #1 has settled.
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Edit,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+
+      const startOrder: string[] = [];
+      const resolvers: Array<() => void> = [];
+      mockCoreExecuteToolCall.mockImplementation(
+        (_config: unknown, req: { callId: string }) =>
+          new Promise((resolve) => {
+            startOrder.push(req.callId);
+            resolvers.push(() =>
+              resolve({ responseParts: [{ text: `resp-${req.callId}` }] }),
+            );
+          }),
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents(toolCallEvents(['e1', 'e2'], 'edit', 'p-seq')),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      const run = runNonInteractive(mockConfig, mockSettings, 'go', 'p-seq');
+      await vi.waitFor(() => expect(startOrder).toEqual(['e1']));
+      // Flush pending microtasks; the second call must still not have started
+      // while the first is unresolved.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(startOrder).toEqual(['e1']);
+      resolvers[0]();
+      await vi.waitFor(() => expect(startOrder).toEqual(['e1', 'e2']));
+      resolvers[1]();
+      await run;
+
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(2);
+    });
+
+    it('caps a parallel batch at exactly --max-tool-calls', async () => {
+      setupMetricsMock();
+      vi.mocked(mockConfig.getMaxToolCalls).mockReturnValue(2);
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Read,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+      mockCoreExecuteToolCall.mockResolvedValue({
+        responseParts: [{ text: 'r' }],
+      });
+
+      mockGeminiClient.sendMessageStream.mockReturnValueOnce(
+        createStreamFromEvents(
+          toolCallEvents(['t1', 't2', 't3'], 'read', 'p-budget'),
+        ),
+      );
+
+      // Budget = 2, so the 3rd tick trips the budget and stops the launch
+      // loop before the 3rd call runs. The run then unwinds through the
+      // budget-abort path; assert on the cap rather than the terminal exit
+      // (which routes through the mocked process.exit / cleanup machinery and
+      // never settles under these mocks — the same routeAbort the serial path
+      // takes).
+      const run = runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'go',
+        'p-budget',
+      ).catch(() => undefined);
+
+      await vi.waitFor(() =>
+        expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(2),
+      );
+      // A would-be 3rd launch happens synchronously with the first two, so a
+      // couple of extra event-loop turns confirm it never fires.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(2);
+
+      void run;
+    });
   });
 
   it('should ignore duplicate provider tool-call ids across rounds', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1258,6 +1258,127 @@ describe('runNonInteractive', () => {
 
       void run;
     });
+
+    it('partitions a mixed batch: parallel reads, sequential edit, parallel reads', async () => {
+      setupMetricsMock();
+      // read → Kind.Read (safe), edit → Kind.Edit (unsafe). The batch
+      // [r1,r2,e1,r3,r4] partitions to [r1,r2](parallel), [e1](sequential),
+      // [r3,r4](parallel).
+      vi.mocked(mockToolRegistry.getTool).mockImplementation(
+        (name: string) =>
+          ({
+            kind: name.startsWith('read') ? Kind.Read : Kind.Edit,
+          }) as unknown as ReturnType<typeof mockToolRegistry.getTool>,
+      );
+
+      const startOrder: string[] = [];
+      const resolvers: Record<string, () => void> = {};
+      mockCoreExecuteToolCall.mockImplementation(
+        (_config: unknown, req: { callId: string }) =>
+          new Promise((resolve) => {
+            startOrder.push(req.callId);
+            resolvers[req.callId] = () =>
+              resolve({ responseParts: [{ text: `resp-${req.callId}` }] });
+          }),
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents([
+            ...toolCallEvents(['r1', 'r2'], 'read', 'p-mixed'),
+            ...toolCallEvents(['e1'], 'edit', 'p-mixed'),
+            ...toolCallEvents(['r3', 'r4'], 'read', 'p-mixed'),
+          ]),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      const run = runNonInteractive(mockConfig, mockSettings, 'go', 'p-mixed');
+
+      // Batch 1: r1 and r2 launch together; the edit and later reads wait.
+      await vi.waitFor(() => expect(startOrder).toEqual(['r1', 'r2']));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(startOrder).toEqual(['r1', 'r2']);
+      resolvers['r1']();
+      resolvers['r2']();
+
+      // Batch 2: the edit runs alone; r3/r4 must not start until it settles.
+      await vi.waitFor(() => expect(startOrder).toEqual(['r1', 'r2', 'e1']));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(startOrder).toEqual(['r1', 'r2', 'e1']);
+      resolvers['e1']();
+
+      // Batch 3: r3 and r4 launch together.
+      await vi.waitFor(() =>
+        expect(startOrder).toEqual(['r1', 'r2', 'e1', 'r3', 'r4']),
+      );
+      resolvers['r3']();
+      resolvers['r4']();
+      await run;
+
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(5);
+    });
+
+    it('throttles a parallel batch to QWEN_CODE_MAX_TOOL_CONCURRENCY in flight', async () => {
+      setupMetricsMock();
+      const prev = process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'];
+      process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] = '2';
+      try {
+        vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+          kind: Kind.Read,
+        } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+
+        let active = 0;
+        let maxActive = 0;
+        const startOrder: string[] = [];
+        const resolvers: Record<string, () => void> = {};
+        mockCoreExecuteToolCall.mockImplementation(
+          (_config: unknown, req: { callId: string }) =>
+            new Promise((resolve) => {
+              startOrder.push(req.callId);
+              active += 1;
+              maxActive = Math.max(maxActive, active);
+              resolvers[req.callId] = () => {
+                active -= 1;
+                resolve({ responseParts: [{ text: `resp-${req.callId}` }] });
+              };
+            }),
+        );
+
+        mockGeminiClient.sendMessageStream
+          .mockReturnValueOnce(
+            createStreamFromEvents(
+              toolCallEvents(['c1', 'c2', 'c3', 'c4'], 'read', 'p-cap'),
+            ),
+          )
+          .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+        const run = runNonInteractive(mockConfig, mockSettings, 'go', 'p-cap');
+
+        // Cap = 2: only c1 and c2 start; c3 waits on Promise.race(inFlight).
+        await vi.waitFor(() => expect(startOrder).toEqual(['c1', 'c2']));
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(startOrder).toEqual(['c1', 'c2']);
+        // Freeing one slot admits the next call, one at a time.
+        resolvers['c1']();
+        await vi.waitFor(() => expect(startOrder).toEqual(['c1', 'c2', 'c3']));
+        resolvers['c2']();
+        await vi.waitFor(() =>
+          expect(startOrder).toEqual(['c1', 'c2', 'c3', 'c4']),
+        );
+        resolvers['c3']();
+        resolvers['c4']();
+        await run;
+
+        expect(maxActive).toBe(2);
+        expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(4);
+      } finally {
+        if (prev === undefined) {
+          delete process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'];
+        } else {
+          process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'] = prev;
+        }
+      }
+    });
   });
 
   it('should ignore duplicate provider tool-call ids across rounds', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -6,6 +6,7 @@
 
 import type {
   BackgroundTaskStatus,
+  ConcurrencyBatch,
   Config,
   CronJob,
   CronScheduler,
@@ -43,6 +44,7 @@ import {
   findRepeatedDuplicateProviderToolCall,
   isToolCallConcurrencySafe,
   parsePositiveIntegerEnv,
+  partitionByConcurrencySafety,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -302,39 +304,32 @@ export interface RunNonInteractiveOptions {
   continueInterrupted?: boolean;
 }
 
-interface HeadlessToolBatch {
-  /** When true, the calls in this batch may execute concurrently. */
-  concurrent: boolean;
-  calls: ToolCallRequestInfo[];
-}
-
 /**
  * Partition headless tool-call requests into consecutive batches by
- * concurrency safety, mirroring the interactive scheduler's
- * `partitionToolCalls` (CoreToolScheduler). Consecutive concurrency-safe
- * calls (independent sub-agents, read-only shells, pure reads) merge into a
- * single parallel batch; every unsafe call (edits, writes, mutating shells)
- * forms its own sequential batch. Request order is preserved.
+ * concurrency safety, mirroring the interactive scheduler
+ * (CoreToolScheduler). Consecutive concurrency-safe calls (independent
+ * sub-agents, read-only shells, pure reads) merge into a single parallel
+ * batch; every unsafe call (edits, writes, mutating shells) forms its own
+ * sequential batch. Request order is preserved.
  *
- * Kinds are resolved from the tool registry; an unregistered tool resolves to
- * `undefined`, which {@link isToolCallConcurrencySafe} treats as unsafe.
+ * Reuses core's `partitionByConcurrencySafety` so the headless and
+ * interactive runtimes share one partition algorithm and can't diverge on
+ * which tool sets they parallelize. Kinds are resolved from the tool
+ * registry; an unregistered tool resolves to `undefined`, which
+ * {@link isToolCallConcurrencySafe} treats as unsafe.
  */
 function partitionHeadlessToolCalls(
   requests: ToolCallRequestInfo[],
   config: Config,
-): HeadlessToolBatch[] {
+): Array<ConcurrencyBatch<ToolCallRequestInfo>> {
   const registry = config.getToolRegistry();
-  return requests.reduce<HeadlessToolBatch[]>((batches, request) => {
-    const kind = registry.getTool(request.name)?.kind;
-    const safe = isToolCallConcurrencySafe(request.name, kind, request.args);
-    const last = batches[batches.length - 1];
-    if (safe && last?.concurrent) {
-      last.calls.push(request);
-    } else {
-      batches.push({ concurrent: safe, calls: [request] });
-    }
-    return batches;
-  }, []);
+  return partitionByConcurrencySafety(requests, (request) =>
+    isToolCallConcurrencySafe(
+      request.name,
+      registry.getTool(request.name)?.kind,
+      request.args,
+    ),
+  );
 }
 
 /**
@@ -1215,10 +1210,19 @@ export async function runNonInteractive(
         // returning the in-flight promise. Budget ticking and abort
         // checks are the caller's responsibility (sequenced before the
         // launch) so --max-tool-calls stays exact even in a parallel
-        // batch.
-        const launchToolCall = (
+        // batch. `async` so a synchronous throw while building the
+        // callbacks (e.g. getInputFormat / getToolCallUpdateCallback)
+        // surfaces as a rejected promise that Promise.allSettled collects
+        // below, instead of aborting the launch loop and leaving the
+        // already-launched siblings as unawaited fire-and-forget. The
+        // launch/settle debug lines identify which call in a parallel batch
+        // is slow or stuck (the serial path made that obvious for free).
+        const launchToolCall = async (
           requestInfo: ToolCallRequestInfo,
         ): Promise<ToolCallResponseInfo> => {
+          debugLogger.debug(
+            `[runNonInteractive] launching tool call ${requestInfo.callId} (${requestInfo.name})`,
+          );
           const inputFormat =
             typeof config.getInputFormat === 'function'
               ? config.getInputFormat()
@@ -1241,12 +1245,23 @@ export async function runNonInteractive(
               )
             : createToolProgressHandler(requestInfo, adapter);
 
-          return executeToolCall(config, requestInfo, abortController.signal, {
-            outputUpdateHandler,
-            ...(toolCallUpdateCallback && {
-              onToolCallsUpdate: toolCallUpdateCallback,
-            }),
-          });
+          const response = await executeToolCall(
+            config,
+            requestInfo,
+            abortController.signal,
+            {
+              outputUpdateHandler,
+              ...(toolCallUpdateCallback && {
+                onToolCallsUpdate: toolCallUpdateCallback,
+              }),
+            },
+          );
+          debugLogger.debug(
+            `[runNonInteractive] tool call ${requestInfo.callId} (${requestInfo.name}) settled${
+              response.error ? ' with error' : ''
+            }`,
+          );
+          return response;
         };
 
         // Emit + record a completed tool call in the caller's order.
@@ -1330,14 +1345,19 @@ export async function runNonInteractive(
             }> = [];
             const inFlight = new Set<Promise<void>>();
             for (const requestInfo of batch.calls) {
-              executedRequests.add(requestInfo);
               if (!isBudgetExempt(requestInfo)) {
                 budgetEnforcer.tickToolCall();
               }
               // A tick that trips the budget (or an external SIGINT) aborts
               // here; stop launching and route the abort after the
-              // already-launched calls settle.
+              // already-launched calls settle. Mark the request executed
+              // only once it is actually launched, so a
+              // budget-tripped-but-unlaunched call still lands in
+              // unexecutedCalls and gets a synthetic skipped-output response
+              // (matters only if routeAbort ever becomes resumable — today it
+              // throws before that synthesis runs).
               if (abortController.signal.aborted) break;
+              executedRequests.add(requestInfo);
               const promise = launchToolCall(requestInfo);
               launched.push({ requestInfo, promise });
               // Track a never-rejecting settle marker for the in-flight
@@ -1384,11 +1404,11 @@ export async function runNonInteractive(
             // Sequential batch (a single tool, or a side-effecting tool):
             // identical to the pre-parallelisation behaviour.
             for (const requestInfo of batch.calls) {
-              executedRequests.add(requestInfo);
               if (!isBudgetExempt(requestInfo)) {
                 budgetEnforcer.tickToolCall();
               }
               if (abortController.signal.aborted) await routeAbort();
+              executedRequests.add(requestInfo);
               const toolResponse = await launchToolCall(requestInfo);
               if (finalizeToolCall(requestInfo, toolResponse)) {
                 sessionEnded = true;

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -43,6 +43,7 @@ import {
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
   isToolCallConcurrencySafe,
+  canonicalToolName,
   parsePositiveIntegerEnv,
   partitionByConcurrencySafety,
 } from '@qwen-code/qwen-code-core';
@@ -314,9 +315,12 @@ export interface RunNonInteractiveOptions {
  *
  * Reuses core's `partitionByConcurrencySafety` so the headless and
  * interactive runtimes share one partition algorithm and can't diverge on
- * which tool sets they parallelize. Kinds are resolved from the tool
- * registry; an unregistered tool resolves to `undefined`, which
- * {@link isToolCallConcurrencySafe} treats as unsafe.
+ * which tool sets they parallelize. Kinds are resolved from the registry
+ * under the tool's canonical name (via `canonicalToolName`, as execution and
+ * the interactive scheduler do) so a legacy alias — e.g. `search_file_content`
+ * for `grep` — classifies with the same safety and doesn't parallelize
+ * differently from the TUI. An unregistered tool resolves to `undefined`,
+ * which {@link isToolCallConcurrencySafe} treats as unsafe.
  */
 function partitionHeadlessToolCalls(
   requests: ToolCallRequestInfo[],
@@ -326,7 +330,7 @@ function partitionHeadlessToolCalls(
   return partitionByConcurrencySafety(requests, (request) =>
     isToolCallConcurrencySafe(
       request.name,
-      registry.getTool(request.name)?.kind,
+      registry.getTool(canonicalToolName(request.name))?.kind,
       request.args,
     ),
   );
@@ -1395,9 +1399,15 @@ export async function runNonInteractive(
             }
 
             if (!sessionEnded && abortController.signal.aborted) {
-              // Finalised the in-budget calls above; now unwind exactly as
-              // the serial path's per-iteration abort check would (budget
-              // overrun → exit 55, SIGINT → exit 130; routeAbort discerns).
+              // A budget overrun (or SIGINT) tripped mid-launch; finalise the
+              // launched calls above, then unwind. Note this is not fully
+              // equivalent to the serial path: serial awaits each in-budget
+              // call to completion before the tick that trips, whereas here
+              // the in-budget siblings were launched before the aborting tick,
+              // so when their execution reaches the scheduler's abort re-check
+              // they resolve as cancelled rather than completing. The run still
+              // exits identically (budget overrun → 55, SIGINT → 130;
+              // routeAbort discerns) and sends nothing to the model.
               await routeAbort();
             }
           } else {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -10,6 +10,7 @@ import type {
   CronJob,
   CronScheduler,
   ToolCallRequestInfo,
+  ToolCallResponseInfo,
 } from '@qwen-code/qwen-code-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import { isInlineModelOverrideAllowed } from './utils/acpModelUtils.js';
@@ -40,6 +41,8 @@ import {
   isSystemReminderContent,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
+  isToolCallConcurrencySafe,
+  parsePositiveIntegerEnv,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -297,6 +300,41 @@ export interface RunNonInteractiveOptions {
    * cleanly the run emits a no-op result and exits 0.
    */
   continueInterrupted?: boolean;
+}
+
+interface HeadlessToolBatch {
+  /** When true, the calls in this batch may execute concurrently. */
+  concurrent: boolean;
+  calls: ToolCallRequestInfo[];
+}
+
+/**
+ * Partition headless tool-call requests into consecutive batches by
+ * concurrency safety, mirroring the interactive scheduler's
+ * `partitionToolCalls` (CoreToolScheduler). Consecutive concurrency-safe
+ * calls (independent sub-agents, read-only shells, pure reads) merge into a
+ * single parallel batch; every unsafe call (edits, writes, mutating shells)
+ * forms its own sequential batch. Request order is preserved.
+ *
+ * Kinds are resolved from the tool registry; an unregistered tool resolves to
+ * `undefined`, which {@link isToolCallConcurrencySafe} treats as unsafe.
+ */
+function partitionHeadlessToolCalls(
+  requests: ToolCallRequestInfo[],
+  config: Config,
+): HeadlessToolBatch[] {
+  const registry = config.getToolRegistry();
+  return requests.reduce<HeadlessToolBatch[]>((batches, request) => {
+    const kind = registry.getTool(request.name)?.kind;
+    const safe = isToolCallConcurrencySafe(request.name, kind, request.args);
+    const last = batches[batches.length - 1];
+    if (safe && last?.concurrent) {
+      last.calls.push(request);
+    } else {
+      batches.push({ concurrent: safe, calls: [request] });
+    }
+    return batches;
+  }, []);
 }
 
 /**
@@ -1128,9 +1166,59 @@ export async function runNonInteractive(
           respondedRequests,
         );
 
-        for (const requestInfo of requestsToExecute) {
-          executedRequests.add(requestInfo);
+        // Partition this batch by concurrency safety, then run each
+        // partition. Tools that are safe to run concurrently (agent
+        // sub-agents, read-only shell, pure reads) run in parallel;
+        // everything with side effects (edits, writes, mutating shell)
+        // runs sequentially in original order. This mirrors the
+        // interactive CoreToolScheduler (partitionToolCalls /
+        // runConcurrently) via the shared isToolCallConcurrencySafe rule,
+        // so `qwen -p` and the TUI agree on which tools parallelise — a
+        // model turn that emits N parallel agent calls no longer executes
+        // them one-at-a-time. Regardless of execution order, results are
+        // finalised (emitted, recorded, appended to `toolResponseParts`)
+        // strictly in original request order, so the model and the event
+        // log always see a deterministic sequence.
+        const toolBatches = partitionHeadlessToolCalls(
+          requestsToExecute,
+          config,
+        );
 
+        // Tick BEFORE the call so that --max-tool-calls=N caps the run
+        // at exactly N executions: the (N+1)th tick aborts before the
+        // tool runs. Ticking after would let the (N+1)th tool execute
+        // and only then abort. See issue #4103. In a parallel batch the
+        // tick still runs serially and in order before each launch, so
+        // the cap fires on the same call it would serially.
+        //
+        // Exempt `structured_output` ONLY when `--json-schema` is
+        // active: under --json-schema this is the terminal "I'm done"
+        // contract tool, not real work, and counting it would abort
+        // an otherwise-valid completion at the budget edge (budget=3,
+        // model used 3 tools then emits structured_output as call #4
+        // → exit 55 instead of success). Guarding on
+        // `getJsonSchema()` keeps the exemption tied to the feature
+        // that owns the tool name — an MCP server that registers an
+        // unrelated tool literally named `structured_output` would
+        // otherwise inherit a free pass.
+        //
+        // Caveat: failed structured_output calls (Ajv validation
+        // failure) also skip the tick, so a model stuck in a
+        // validation-retry loop is not bounded by --max-tool-calls.
+        // Documented in docs/users/features/headless.md → "Scope".
+        // Combine with --max-session-turns or --max-wall-time.
+        const isBudgetExempt = (requestInfo: ToolCallRequestInfo): boolean =>
+          requestInfo.name === ToolNames.STRUCTURED_OUTPUT &&
+          config.getJsonSchema?.() !== undefined;
+
+        // Build the progress/permission callbacks and START a tool call,
+        // returning the in-flight promise. Budget ticking and abort
+        // checks are the caller's responsibility (sequenced before the
+        // launch) so --max-tool-calls stays exact even in a parallel
+        // batch.
+        const launchToolCall = (
+          requestInfo: ToolCallRequestInfo,
+        ): Promise<ToolCallResponseInfo> => {
           const inputFormat =
             typeof config.getInputFormat === 'function'
               ? config.getInputFormat()
@@ -1153,46 +1241,21 @@ export async function runNonInteractive(
               )
             : createToolProgressHandler(requestInfo, adapter);
 
-          // Tick BEFORE the call so that --max-tool-calls=N caps the run
-          // at exactly N executions: the (N+1)th tick aborts before the
-          // tool runs. Ticking after would let the (N+1)th tool execute
-          // and only then abort. See issue #4103.
-          //
-          // Exempt `structured_output` ONLY when `--json-schema` is
-          // active: under --json-schema this is the terminal "I'm done"
-          // contract tool, not real work, and counting it would abort
-          // an otherwise-valid completion at the budget edge (budget=3,
-          // model used 3 tools then emits structured_output as call #4
-          // → exit 55 instead of success). Guarding on
-          // `getJsonSchema()` keeps the exemption tied to the feature
-          // that owns the tool name — an MCP server that registers an
-          // unrelated tool literally named `structured_output` would
-          // otherwise inherit a free pass.
-          //
-          // Caveat: failed structured_output calls (Ajv validation
-          // failure) also skip the tick, so a model stuck in a
-          // validation-retry loop is not bounded by --max-tool-calls.
-          // Documented in docs/users/features/headless.md → "Scope".
-          // Combine with --max-session-turns or --max-wall-time.
-          const isStructuredOutputExempt =
-            requestInfo.name === ToolNames.STRUCTURED_OUTPUT &&
-            config.getJsonSchema?.() !== undefined;
-          if (!isStructuredOutputExempt) {
-            budgetEnforcer.tickToolCall();
-          }
-          if (abortController.signal.aborted) await routeAbort();
-          const toolResponse = await executeToolCall(
-            config,
-            requestInfo,
-            abortController.signal,
-            {
-              outputUpdateHandler,
-              ...(toolCallUpdateCallback && {
-                onToolCallsUpdate: toolCallUpdateCallback,
-              }),
-            },
-          );
+          return executeToolCall(config, requestInfo, abortController.signal, {
+            outputUpdateHandler,
+            ...(toolCallUpdateCallback && {
+              onToolCallsUpdate: toolCallUpdateCallback,
+            }),
+          });
+        };
 
+        // Emit + record a completed tool call in the caller's order.
+        // Returns true when this was the terminal structured_output
+        // success (the "first valid call ends the session" contract).
+        const finalizeToolCall = (
+          requestInfo: ToolCallRequestInfo,
+          toolResponse: ToolCallResponseInfo,
+        ): boolean => {
           if (toolResponse.error) {
             // In JSON/STREAM_JSON mode, tool errors are tolerated and
             // formatted as tool_result blocks. handleToolError detects
@@ -1235,12 +1298,103 @@ export async function runNonInteractive(
             !toolResponse.error
           ) {
             // Honour the "first valid call ends the session" contract.
-            // The break is after the responseParts/modelOverride capture
+            // Captured after the responseParts/modelOverride handling
             // above so future changes to SyntheticOutputTool can't
             // silently drop those signals. structuredSubmission is the
             // session-scoped binding from the enclosing scope.
             structuredSubmission = requestInfo.args;
-            break;
+            return true;
+          }
+          return false;
+        };
+
+        const maxToolConcurrency = parsePositiveIntegerEnv(
+          process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'],
+          10,
+        );
+
+        let sessionEnded = false;
+        for (const batch of toolBatches) {
+          if (sessionEnded) break;
+
+          if (batch.concurrent && batch.calls.length > 1) {
+            // Parallel batch. Tick the budget for each call serially and
+            // in order (so --max-tool-calls caps at exactly N and the
+            // abort fires on the same call it would serially), launch only
+            // the calls that fit the budget — capped at
+            // QWEN_CODE_MAX_TOOL_CONCURRENCY in flight — then finalise in
+            // request order once all launched calls have settled.
+            const launched: Array<{
+              requestInfo: ToolCallRequestInfo;
+              promise: Promise<ToolCallResponseInfo>;
+            }> = [];
+            const inFlight = new Set<Promise<void>>();
+            for (const requestInfo of batch.calls) {
+              executedRequests.add(requestInfo);
+              if (!isBudgetExempt(requestInfo)) {
+                budgetEnforcer.tickToolCall();
+              }
+              // A tick that trips the budget (or an external SIGINT) aborts
+              // here; stop launching and route the abort after the
+              // already-launched calls settle.
+              if (abortController.signal.aborted) break;
+              const promise = launchToolCall(requestInfo);
+              launched.push({ requestInfo, promise });
+              // Track a never-rejecting settle marker for the in-flight
+              // cap so Promise.race can't throw mid-launch and abandon
+              // siblings. The real outcome is read from `promise` below.
+              const marker = promise
+                .then(
+                  () => {},
+                  () => {},
+                )
+                .finally(() => {
+                  inFlight.delete(marker);
+                });
+              inFlight.add(marker);
+              if (inFlight.size >= maxToolConcurrency) {
+                await Promise.race(inFlight);
+              }
+            }
+
+            const settled = await Promise.allSettled(
+              launched.map((l) => l.promise),
+            );
+            for (let i = 0; i < launched.length; i++) {
+              const outcome = settled[i];
+              if (outcome.status === 'rejected') {
+                // Preserve the serial contract: an unexpected rejection
+                // (a scheduling failure, not a tool-level error, which
+                // surfaces as toolResponse.error) aborts the turn.
+                throw outcome.reason;
+              }
+              if (finalizeToolCall(launched[i].requestInfo, outcome.value)) {
+                sessionEnded = true;
+                break;
+              }
+            }
+
+            if (!sessionEnded && abortController.signal.aborted) {
+              // Finalised the in-budget calls above; now unwind exactly as
+              // the serial path's per-iteration abort check would (budget
+              // overrun → exit 55, SIGINT → exit 130; routeAbort discerns).
+              await routeAbort();
+            }
+          } else {
+            // Sequential batch (a single tool, or a side-effecting tool):
+            // identical to the pre-parallelisation behaviour.
+            for (const requestInfo of batch.calls) {
+              executedRequests.add(requestInfo);
+              if (!isBudgetExempt(requestInfo)) {
+                budgetEnforcer.tickToolCall();
+              }
+              if (abortController.signal.aborted) await routeAbort();
+              const toolResponse = await launchToolCall(requestInfo);
+              if (finalizeToolCall(requestInfo, toolResponse)) {
+                sessionEnded = true;
+                break;
+              }
+            }
           }
         }
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -44,6 +44,7 @@ import {
   convertToFunctionErrorResponse,
   convertToFunctionResponse,
   extractToolFilePaths,
+  isToolCallConcurrencySafe,
 } from './coreToolScheduler.js';
 import type { Part, PartListUnion } from '@google/genai';
 import {
@@ -11409,6 +11410,60 @@ describe('Fire hook functions integration', () => {
         release();
         await schedulePromise;
       }
+    });
+
+    describe('isToolCallConcurrencySafe', () => {
+      it('treats agent tools as safe regardless of resolved kind', () => {
+        expect(isToolCallConcurrencySafe(ToolNames.AGENT, undefined, {})).toBe(
+          true,
+        );
+        expect(isToolCallConcurrencySafe(ToolNames.AGENT, Kind.Other, {})).toBe(
+          true,
+        );
+      });
+
+      it('treats pure-read kinds as safe', () => {
+        expect(isToolCallConcurrencySafe('read_file', Kind.Read, {})).toBe(
+          true,
+        );
+        expect(isToolCallConcurrencySafe('grep', Kind.Search, {})).toBe(true);
+        expect(isToolCallConcurrencySafe('fetch', Kind.Fetch, {})).toBe(true);
+      });
+
+      it('treats mutating kinds as unsafe', () => {
+        expect(isToolCallConcurrencySafe('edit', Kind.Edit, {})).toBe(false);
+        expect(isToolCallConcurrencySafe('rm', Kind.Delete, {})).toBe(false);
+        expect(isToolCallConcurrencySafe('mv', Kind.Move, {})).toBe(false);
+        expect(isToolCallConcurrencySafe('think', Kind.Think, {})).toBe(false);
+      });
+
+      it('treats a read-only shell command as safe and a mutating one as unsafe', () => {
+        expect(
+          isToolCallConcurrencySafe('shell', Kind.Execute, {
+            command: 'git status',
+          }),
+        ).toBe(true);
+        expect(
+          isToolCallConcurrencySafe('shell', Kind.Execute, {
+            command: 'rm -rf build',
+          }),
+        ).toBe(false);
+      });
+
+      it('treats a shell call with a non-string command as unsafe (fail-closed)', () => {
+        expect(isToolCallConcurrencySafe('shell', Kind.Execute, {})).toBe(
+          false,
+        );
+        expect(
+          isToolCallConcurrencySafe('shell', Kind.Execute, { command: 42 }),
+        ).toBe(false);
+      });
+
+      it('treats an unresolved (undefined) kind on a non-agent tool as unsafe', () => {
+        expect(isToolCallConcurrencySafe('mystery_tool', undefined, {})).toBe(
+          false,
+        );
+      });
     });
 
     it('should run concurrency-safe tools in parallel and unsafe tools sequentially', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -475,7 +475,14 @@ const FS_PATH_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   ToolNames.NOTEBOOK_EDIT,
 ]);
 
-function canonicalToolName(toolName: string): string {
+/**
+ * Resolve a tool name through the legacy-alias migration map (e.g.
+ * `search_file_content` → `grep`) to its canonical form. Exported so callers
+ * that classify tools by name/kind — the headless partitioner in
+ * nonInteractiveCli — resolve the same registry entry the interactive
+ * scheduler and executor do, instead of missing on an alias.
+ */
+export function canonicalToolName(toolName: string): string {
   return (ToolNamesMigration as Record<string, string>)[toolName] ?? toolName;
 }
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1165,19 +1165,30 @@ interface BatchAbortState {
 }
 
 /**
- * Returns true if a scheduled tool call can safely execute concurrently
- * with other safe tools (no side effects, no shared mutable state).
+ * Returns true if a tool call can safely execute concurrently with other
+ * safe tools (no side effects, no shared mutable state), decided from its
+ * raw name/kind/args alone. Shared by the interactive scheduler's batch
+ * partitioning and the headless runner (`runNonInteractive`) so both
+ * runtimes parallelize exactly the same set of tools.
+ *
+ * `kind` is the resolved tool's {@link Kind}; pass `undefined` when the tool
+ * cannot be resolved from the registry, which is treated as unsafe (the call
+ * runs sequentially).
  */
-function isConcurrencySafe(call: ScheduledToolCall): boolean {
+export function isToolCallConcurrencySafe(
+  name: string,
+  kind: Kind | undefined,
+  args: unknown,
+): boolean {
   // Agent tools spawn independent sub-agents with no shared state.
-  if (canonicalToolName(call.request.name) === ToolNames.AGENT) return true;
+  if (canonicalToolName(name) === ToolNames.AGENT) return true;
   // Shell commands: check if the command is read-only (e.g., git log, cat).
   // Uses the synchronous regex+shell-quote checker (not the async AST-based
   // one) because partitioning runs synchronously. The sync checker covers
   // the same command whitelist and is fail-closed — unknown commands remain
   // sequential. The AST version is used separately for permission decisions.
-  if (call.tool.kind === Kind.Execute) {
-    const command = (call.request.args as { command?: string }).command;
+  if (kind === Kind.Execute) {
+    const command = (args as { command?: string } | undefined)?.command;
     if (typeof command !== 'string') return false;
     try {
       return isShellCommandReadOnly(stripShellWrapper(command));
@@ -1185,7 +1196,20 @@ function isConcurrencySafe(call: ScheduledToolCall): boolean {
       return false; // fail-closed
     }
   }
-  return CONCURRENCY_SAFE_KINDS.has(call.tool.kind);
+  if (kind === undefined) return false;
+  return CONCURRENCY_SAFE_KINDS.has(kind);
+}
+
+/**
+ * Returns true if a scheduled tool call can safely execute concurrently
+ * with other safe tools (no side effects, no shared mutable state).
+ */
+function isConcurrencySafe(call: ScheduledToolCall): boolean {
+  return isToolCallConcurrencySafe(
+    call.request.name,
+    call.tool.kind,
+    call.request.args,
+  );
 }
 
 /**

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1146,10 +1146,16 @@ interface CoreToolSchedulerOptions {
 
 // ─── Tool Concurrency Helpers ────────────────────────────────
 
-interface ToolBatch {
+/**
+ * A batch of items grouped by concurrency safety: `concurrent` batches may run
+ * their `calls` in parallel; non-concurrent batches run one at a time.
+ */
+export interface ConcurrencyBatch<T> {
   concurrent: boolean;
-  calls: ScheduledToolCall[];
+  calls: T[];
 }
+
+type ToolBatch = ConcurrencyBatch<ScheduledToolCall>;
 
 /**
  * State for the per-batch signal.abort listener registered in
@@ -1213,24 +1219,35 @@ function isConcurrencySafe(call: ScheduledToolCall): boolean {
 }
 
 /**
- * Partition tool calls into consecutive batches by concurrency safety.
+ * Partition items into consecutive batches by concurrency safety: consecutive
+ * safe items are merged into a single parallel batch, and each unsafe item
+ * forms its own sequential batch. Order is preserved.
  *
- * Consecutive safe tools are merged into a single parallel batch.
- * Each unsafe tool forms its own sequential batch.
+ * Shared by the interactive scheduler ({@link partitionToolCalls}) and the
+ * headless runner (`partitionHeadlessToolCalls` in nonInteractiveCli) via the
+ * {@link isToolCallConcurrencySafe} predicate, so the two runtimes partition
+ * using one algorithm and can't silently diverge.
  *
  * Example: [Read, Read, Edit, Read] → [[Read,Read](parallel), [Edit](seq), [Read](seq)]
  */
-function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
-  return calls.reduce<ToolBatch[]>((batches, call) => {
-    const safe = isConcurrencySafe(call);
+export function partitionByConcurrencySafety<T>(
+  items: T[],
+  isSafe: (item: T) => boolean,
+): Array<ConcurrencyBatch<T>> {
+  return items.reduce<Array<ConcurrencyBatch<T>>>((batches, item) => {
+    const safe = isSafe(item);
     const lastBatch = batches[batches.length - 1];
     if (safe && lastBatch?.concurrent) {
-      lastBatch.calls.push(call);
+      lastBatch.calls.push(item);
     } else {
-      batches.push({ concurrent: safe, calls: [call] });
+      batches.push({ concurrent: safe, calls: [item] });
     }
     return batches;
   }, []);
+}
+
+function partitionToolCalls(calls: ScheduledToolCall[]): ToolBatch[] {
+  return partitionByConcurrencySafety(calls, isConcurrencySafe);
 }
 
 export class CoreToolScheduler {


### PR DESCRIPTION
## What this PR does

Makes headless (`qwen -p`) run a batch of concurrency-safe tool calls in parallel instead of one at a time, matching what the interactive TUI already does. `runNonInteractive` previously executed every tool call in a model turn through a plain `await`-loop, so N parallel tool calls ran strictly sequentially, whereas the interactive path runs the same batch concurrently through `CoreToolScheduler`. This PR partitions each headless batch by concurrency safety — consecutive safe calls (independent sub-agents, read-only shells, pure reads) run in parallel while every unsafe call (edits, writes, mutating shells) stays sequential in request order — mirroring the interactive scheduler's `partitionToolCalls` / `runConcurrently`. The safe/unsafe decision is extracted into an exported `isToolCallConcurrencySafe(name, kind, args)` in `coreToolScheduler.ts`, and the interactive `isConcurrencySafe(call)` now delegates to it so both runtimes parallelize exactly the same set of tools.

## Why it's needed

Headless serialization dominated wall-clock on any turn that fans out parallel tool calls — most visibly the `/review` agent fan-out, where an 11-agent wave queued for ~16 min. First-agent start offsets (ms) for the same wave show the gap clearly:

- TUI (parallel): `0 0 0 0 0 0 0 0 0 0 0`
- headless (before): `0 78 157 259 295 379 425 485 582 634 749`

It affects any headless / ACP / daemon run with parallel tool calls, not just `/review`.

## Reviewer Test Plan

### How to verify

Run the affected suites and confirm the new parallel-execution tests pass:

```
npx vitest run packages/cli/src/nonInteractiveCli.test.ts packages/core/src/core/coreToolScheduler.test.ts
```

The key correctness proof is a gate-barrier test: a parallel batch of 3 tool calls each blocks on a shared gate that only opens once all 3 have started — under the old serial loop call #2 never starts, so the test would deadlock; reaching `started === 3` proves the batch runs in parallel. Other tests assert request-order finalization under out-of-order completion, sequential execution of side-effecting (`Kind.Edit`) tools, and that `--max-tool-calls=N` caps a parallel batch at exactly N.

### Evidence (Before & After)

Internal timing change; output is unchanged for a given prompt, so there is no user-visible before/after screenshot. The timing offsets for an 11-agent wave are above. All existing `nonInteractiveCli` (76, 1 skipped) and `coreToolScheduler` (275) suites pass, plus 10 new tests (4 CLI + 6 core). Typecheck and lint are clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Vitest unit tests + `npm run typecheck` + `eslint` on Linux (Node 22). macOS/Windows covered by CI.

## Risk & Scope

- Main risk or tradeoff: this is core headless infrastructure used by every `qwen -p`, ACP, and daemon child. Mitigated by mirroring the exact concurrency-safety model the interactive TUI already ships (the same `isToolCallConcurrencySafe` predicate) and preserving every observable contract — the budget tick stays serial and in request order (`--max-tool-calls=N` still caps at exactly N), results finalize in request order regardless of completion order, `structured_output` stays sequential (the terminal "first valid call ends the session" contract is unchanged), and abort (budget overrun or SIGINT) routes through the same `routeAbort` after launched calls settle.
- Not validated / out of scope: parallelism is capped by `QWEN_CODE_MAX_TOOL_CONCURRENCY` (default 10); setting it to `1` restores fully serial execution as an escape hatch. macOS/Windows behavior is expected identical and is CI-covered.
- Breaking changes / migration notes: none. Default behavior is faster with identical results.

## Linked Issues

No filed issue — follow-up to #6955 (the `/review` latency effort), where this headless serialization was surfaced.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 headless(`qwen -p`)把一批并发安全的 tool call 并行执行,而不是逐个执行,与交互式 TUI 的行为对齐。`runNonInteractive` 之前用一个普通的 `await` 循环逐个执行模型一轮里的每个 tool call,所以 N 个并行 tool call 是严格串行执行的,而交互路径通过 `CoreToolScheduler` 把同一批并发执行。本 PR 按并发安全性对每个 headless 批次分组——连续的安全 call(独立子 agent、只读 shell、纯读)并行执行,而每个不安全 call(edit、write、有副作用的 shell)按请求顺序串行——镜像交互式调度器的 `partitionToolCalls` / `runConcurrently`。安全/不安全的判定被抽取为 `coreToolScheduler.ts` 中导出的 `isToolCallConcurrencySafe(name, kind, args)`,交互式的 `isConcurrencySafe(call)` 现在委托它,因此两条运行路径并行的工具集合完全一致。

## 为什么需要

headless 串行化主导了任何 fan-out 并行 tool call 的一轮的整体耗时——最明显的是 `/review` 的 agent fan-out,11 个 agent 排队约 16 分钟。同一批 agent 的首个启动偏移(ms)清楚地显示了差距:

- TUI(并行):`0 0 0 0 0 0 0 0 0 0 0`
- headless(改前):`0 78 157 259 295 379 425 485 582 634 749`

它影响任何带并行 tool call 的 headless / ACP / daemon 运行,不只是 `/review`。

## Reviewer 验证方案

### 如何验证

运行受影响的测试套件,确认新增的并行执行测试通过:

```
npx vitest run packages/cli/src/nonInteractiveCli.test.ts packages/core/src/core/coreToolScheduler.test.ts
```

核心的正确性证明是一个 gate 屏障测试:一批 3 个并行 tool call,每个都阻塞在一个共享 gate 上,该 gate 只有在全部 3 个都启动后才打开——在旧的串行循环下 call #2 永远不会启动,测试会死锁;能达到 `started === 3` 就证明这批是并行执行的。其他测试断言:乱序完成时仍按请求顺序 finalize、有副作用的(`Kind.Edit`)工具串行执行、以及 `--max-tool-calls=N` 把并行批精确封顶在 N。

### 证据(Before & After)

内部时序改动;对给定 prompt 的输出不变,因此没有用户可见的前后截图。11 个 agent 的时序偏移见上文。现有 `nonInteractiveCli`(76,1 skipped)和 `coreToolScheduler`(275)全部套件通过,另加 10 个新测试(4 CLI + 6 core)。typecheck 与 lint 干净。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境(可选)

Linux(Node 22)上的 Vitest 单元测试 + `npm run typecheck` + `eslint`。macOS/Windows 由 CI 覆盖。

## 风险与范围

- 主要风险/取舍:这是被每个 `qwen -p`、ACP 和 daemon child 使用的核心 headless 基础设施。通过镜像交互式 TUI 已发布的完全相同的并发安全模型(相同的 `isToolCallConcurrencySafe` 谓词)并保持每一个可观测契约来缓解——预算 tick 保持串行且按请求顺序(`--max-tool-calls=N` 仍精确封顶在 N)、结果按请求顺序 finalize(与完成顺序无关)、`structured_output` 保持串行(终止契约"首个有效调用结束会话"不变)、中止(预算超限或 SIGINT)在已启动的 call settle 后经相同的 `routeAbort` 收敛。
- 未验证/范围外:并行度由 `QWEN_CODE_MAX_TOOL_CONCURRENCY`(默认 10)封顶;设为 `1` 可作为退路恢复完全串行。macOS/Windows 行为预期一致,由 CI 覆盖。
- 破坏性改动/迁移说明:无。默认行为更快,结果相同。

## 关联 Issue

无已建 issue——是 #6955(`/review` 延迟优化)的后续,该串行化问题即在其中被发现。

</details>
