### PR TITLE
fix(web-shell): filter sessions by source

### DIFF
--- a/docs/design/web-shell-session-source-filter.md
+++ b/docs/design/web-shell-session-source-filter.md
@@ -1,0 +1,28 @@
+# Web Shell session source filtering
+
+## Problem
+
+Web Shell sessions are currently created without source metadata, and every
+session-list request is unfiltered. This lets sessions created by other
+features, such as scheduled tasks, appear in Web Shell. Existing Web Shell
+sessions also have no source metadata, so an exact source filter would hide
+historical data.
+
+## Design
+
+- Create every new Web Shell session with `sourceType: 'default'`.
+- Add `sourceType: 'default'` to filtered Web Shell session-list requests. The
+  Sidebar remains unfiltered because it is the all-session catalog.
+- Treat `sourceType=default` as a compatibility filter that matches both
+  `sourceType: 'default'` and sessions without `sourceType`. Other source
+  filters remain exact matches.
+- Support the source filter with organized session views so filtering does not
+  disable grouping, pinning, or archived-session behavior.
+- Bind organized pagination cursors to the source filter that produced them.
+
+## Compatibility
+
+Older sessions remain visible in Web Shell because missing source metadata is
+included only for the `default` filter. Sessions attributed to another source
+remain excluded. Callers that omit `sourceType` retain the current unfiltered
+behavior.

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -1347,11 +1347,6 @@ export class AcpDispatcher {
           if ('error' in parsedSource) {
             throw new AcpParamError(parsedSource.error);
           }
-          if (parsedSource.sourceType !== undefined && view === 'organized') {
-            throw new AcpParamError(
-              '`sourceType` is not supported with `view` "organized"',
-            );
-          }
           const result = await listWorkspaceSessionsForResponse(
             this.bridge,
             workspaceCwd,

--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -988,6 +988,8 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     sessionId: string,
     state: 'active' | 'archived' = 'active',
     parentSessionId?: string,
+    sourceType?: string,
+    sourceId?: string,
   ): Promise<void> {
     const chatsDir = path.join(
       new Storage('/ws').getProjectDir(),
@@ -1019,6 +1021,23 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
           type: 'system',
           subtype: 'parent_session',
           systemPayload: { parentSessionId },
+          cwd: '/ws',
+        }),
+      );
+    }
+    if (sourceType !== undefined) {
+      lines.push(
+        JSON.stringify({
+          uuid: `${sessionId}-source-1`,
+          parentUuid: `${sessionId}-user-1`,
+          sessionId,
+          timestamp: '2026-06-30T00:00:00.000Z',
+          type: 'system',
+          subtype: 'session_source',
+          systemPayload: {
+            sourceType,
+            ...(sourceId !== undefined ? { sourceId } : {}),
+          },
           cwd: '/ws',
         }),
       );
@@ -6665,6 +6684,50 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
             sessions: [{ sessionId, color: 'purple', groupId: null }],
           },
         });
+        reader.close();
+      });
+    });
+
+    it('session/list organized default source includes legacy sessions', async () => {
+      await withRuntimeDir(async () => {
+        const legacyId = '550e8400-e29b-41d4-a716-446655440014';
+        const defaultId = '550e8400-e29b-41d4-a716-446655440015';
+        const scheduledId = '550e8400-e29b-41d4-a716-446655440016';
+        await writeStoredSession(legacyId);
+        await writeStoredSession(defaultId, 'active', undefined, 'default');
+        await writeStoredSession(
+          scheduledId,
+          'active',
+          undefined,
+          'scheduled_task',
+          'task-1',
+        );
+        const connId = await initialize();
+        const streamRes = openStream(connId);
+        await new Promise((r) => setTimeout(r, 30));
+        const reader = frameReader(await streamRes);
+
+        await post(connId, {
+          jsonrpc: '2.0',
+          id: 87,
+          method: 'session/list',
+          params: {
+            workspaceCwd: '/ws',
+            view: 'organized',
+            group: 'all',
+            sourceType: 'default',
+            _meta: { size: 20 },
+          },
+        });
+        const frame = (await reader.next()) as {
+          result: { sessions: Array<{ sessionId: string }> };
+        };
+        expect(
+          frame.result.sessions.map((session) => session.sessionId),
+        ).toEqual(expect.arrayContaining([legacyId, defaultId]));
+        expect(
+          frame.result.sessions.map((session) => session.sessionId),
+        ).not.toContain(scheduledId);
         reader.close();
       });
     });

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2809,13 +2809,6 @@ export function registerSessionRoutes(
           });
           return;
         }
-        if (parsedSource.sourceType !== undefined && view === 'organized') {
-          res.status(400).json({
-            error: '`sourceType` is not supported with `view=organized`',
-            code: 'invalid_session_source_filter',
-          });
-          return;
-        }
         const options = {
           ...(cursor !== undefined ? { cursor } : {}),
           ...(size !== undefined ? { size } : {}),

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -10482,6 +10482,100 @@ describe('createServeApp', () => {
     });
 
     describe('session source filter', () => {
+      it('includes legacy sessions in the default source filter', async () => {
+        const legacyId = '550e8400-e29b-41d4-a716-446655440201';
+        const defaultId = '550e8400-e29b-41d4-a716-446655440202';
+        const scheduledId = '550e8400-e29b-41d4-a716-446655440203';
+        await writeStoredSession({
+          sessionId: legacyId,
+          cwd: WS_BOUND,
+          timestamp: '2026-05-17T12:00:00.000Z',
+          prompt: 'legacy web shell session',
+          mtime: new Date('2026-05-17T12:00:00.000Z'),
+        });
+        await writeStoredSession({
+          sessionId: defaultId,
+          cwd: WS_BOUND,
+          timestamp: '2026-05-17T12:01:00.000Z',
+          prompt: 'default web shell session',
+          mtime: new Date('2026-05-17T12:01:00.000Z'),
+          sourceType: 'default',
+          sourceId: 'web-1',
+        });
+        await writeStoredSession({
+          sessionId: scheduledId,
+          cwd: WS_BOUND,
+          timestamp: '2026-05-17T12:02:00.000Z',
+          prompt: 'scheduled session',
+          mtime: new Date('2026-05-17T12:02:00.000Z'),
+          sourceType: 'scheduled_task',
+          sourceId: 'task-1',
+        });
+        const app = createServeApp(
+          { ...baseOpts, workspace: WS_BOUND },
+          undefined,
+          { bridge: fakeBridge(), boundWorkspace: WS_BOUND },
+        );
+        const get = (query: string) =>
+          request(app)
+            .get(`/workspace/${encodeURIComponent(WS_BOUND)}/sessions?${query}`)
+            .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+        const defaultResult = await get('sourceType=default');
+        expect(defaultResult.status).toBe(200);
+        expect(
+          defaultResult.body.sessions.map(
+            (session: { sessionId: string }) => session.sessionId,
+          ),
+        ).toEqual([defaultId, legacyId]);
+
+        const organizedFirstPage = await get(
+          'view=organized&group=all&sourceType=default&size=1',
+        );
+        expect(organizedFirstPage.status).toBe(200);
+        expect(
+          organizedFirstPage.body.sessions.map(
+            (session: { sessionId: string }) => session.sessionId,
+          ),
+        ).toEqual([defaultId]);
+        const organizedSecondPage = await get(
+          `view=organized&group=all&sourceType=default&size=1&cursor=${encodeURIComponent(
+            organizedFirstPage.body.nextCursor,
+          )}`,
+        );
+        expect(organizedSecondPage.status).toBe(200);
+        expect(
+          organizedSecondPage.body.sessions.map(
+            (session: { sessionId: string }) => session.sessionId,
+          ),
+        ).toEqual([legacyId]);
+        const mismatchedCursor = await get(
+          `view=organized&group=all&sourceType=scheduled_task&size=1&cursor=${encodeURIComponent(
+            organizedFirstPage.body.nextCursor,
+          )}`,
+        );
+        expect(mismatchedCursor.status).toBe(400);
+        expect(mismatchedCursor.body.code).toBe('invalid_cursor');
+
+        const sourceIdResult = await get('sourceType=default&sourceId=web-1');
+        expect(sourceIdResult.status).toBe(200);
+        expect(
+          sourceIdResult.body.sessions.map(
+            (session: { sessionId: string }) => session.sessionId,
+          ),
+        ).toEqual([defaultId]);
+
+        const organizedSourceIdResult = await get(
+          'view=organized&group=all&sourceType=default&sourceId=web-1',
+        );
+        expect(organizedSourceIdResult.status).toBe(200);
+        expect(
+          organizedSourceIdResult.body.sessions.map(
+            (session: { sessionId: string }) => session.sessionId,
+          ),
+        ).toEqual([defaultId]);
+      });
+
       it('returns persisted sessions matching sourceType and sourceId', async () => {
         await writeStoredSession({
           sessionId: '550e8400-e29b-41d4-a716-446655440101',

--- a/packages/cli/src/serve/server/session-list.ts
+++ b/packages/cli/src/serve/server/session-list.ts
@@ -82,6 +82,8 @@ function parseSessionCursor(cursor: string): number | undefined {
 interface OrganizedCursor {
   group: string;
   archiveState: SessionArchiveState;
+  sourceType?: string;
+  sourceId?: string;
   last: OrganizedCursorKey;
 }
 
@@ -98,7 +100,12 @@ interface LiveSessionCursorKey {
 
 function parseOrganizedCursor(
   cursor: string,
-  expected: { group: string; archiveState: SessionArchiveState },
+  expected: {
+    group: string;
+    archiveState: SessionArchiveState;
+    sourceType?: string;
+    sourceId?: string;
+  },
 ): OrganizedCursorKey | undefined {
   if (cursor === '') return undefined;
   try {
@@ -118,7 +125,9 @@ function parseOrganizedCursor(
       typeof last.sessionId !== 'string' ||
       last.sessionId.length === 0 ||
       (parsed as OrganizedCursor).group !== expected.group ||
-      (parsed as OrganizedCursor).archiveState !== expected.archiveState
+      (parsed as OrganizedCursor).archiveState !== expected.archiveState ||
+      (parsed as OrganizedCursor).sourceType !== expected.sourceType ||
+      (parsed as OrganizedCursor).sourceId !== expected.sourceId
     ) {
       throw new Error('invalid organized cursor');
     }
@@ -132,9 +141,11 @@ function encodeOrganizedCursor(
   last: OrganizedCursorKey,
   group: string,
   archiveState: SessionArchiveState,
+  sourceType?: string,
+  sourceId?: string,
 ): string {
   return Buffer.from(
-    JSON.stringify({ group, archiveState, last }),
+    JSON.stringify({ group, archiveState, sourceType, sourceId, last }),
     'utf8',
   ).toString('base64url');
 }
@@ -173,6 +184,22 @@ interface SessionMetadataFilter {
   parentSessionId?: string;
   sourceType?: string;
   sourceId?: string;
+}
+
+function matchesSessionMetadataSource(
+  session: BridgeSessionSummary,
+  filter: Pick<SessionMetadataFilter, 'sourceType' | 'sourceId'>,
+): boolean {
+  const sourceTypeMatches =
+    filter.sourceType === undefined ||
+    session.sourceType === filter.sourceType ||
+    // Legacy sessions without source metadata belong to the default catalog.
+    (filter.sourceType === 'default' && session.sourceType === undefined);
+  return (
+    sourceTypeMatches &&
+    // sourceId remains exact; only the default source type has legacy fallback.
+    (filter.sourceId === undefined || session.sourceId === filter.sourceId)
+  );
 }
 
 function parseMetadataSessionCursor(
@@ -422,7 +449,12 @@ async function listOrganizedWorkspaceSessionsForResponse(
   }
   const cursorKey =
     options.cursor !== undefined
-      ? parseOrganizedCursor(options.cursor, { group, archiveState })
+      ? parseOrganizedCursor(options.cursor, {
+          group,
+          archiveState,
+          sourceType: options.sourceType,
+          sourceId: options.sourceId,
+        })
       : undefined;
   const isFirstPage = cursorKey === undefined;
   let liveMergeFailed = false;
@@ -484,6 +516,7 @@ async function listOrganizedWorkspaceSessionsForResponse(
   }
 
   const filtered = [...bySessionId.values()].filter((session) => {
+    if (!matchesSessionMetadataSource(session, options)) return false;
     if (group === 'all') return true;
     if (group === 'pinned') return session.isPinned === true;
     if (group === 'ungrouped')
@@ -518,6 +551,8 @@ async function listOrganizedWorkspaceSessionsForResponse(
           getOrganizedCursorKey(activityTimeById, page[page.length - 1]!),
           group,
           archiveState,
+          options.sourceType,
+          options.sourceId,
         )
       : undefined;
   return {
@@ -586,9 +621,7 @@ async function listWorkspaceSessionsByMetadataForResponse(
       (session) =>
         (filter.parentSessionId === undefined ||
           session.parentSessionId === filter.parentSessionId) &&
-        (filter.sourceType === undefined ||
-          session.sourceType === filter.sourceType) &&
-        (filter.sourceId === undefined || session.sourceId === filter.sourceId),
+        matchesSessionMetadataSource(session, filter),
     )
     .sort((a, b) =>
       compareLiveSessionCursorKeys(

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -603,6 +603,7 @@ type SessionActionsWithCreate = {
   createSession: (options?: {
     workspaceCwd?: string;
     approvalMode?: string;
+    sourceType?: string;
   }) => Promise<{ sessionId: string }>;
   attachSession: () => Promise<void>;
   clearSession: () => Promise<void>;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -15,6 +15,7 @@ const {
   workspaceActions,
   active,
   archived,
+  useSessions,
   listWorkspaceSessions,
   archiveSessionsData,
   unarchiveSessionsData,
@@ -42,6 +43,11 @@ const {
     notFound: [],
     errors: [],
   });
+  const active = makeSessions();
+  const archived = makeSessions();
+  const useSessions = vi.fn((options?: { archiveState?: string }) =>
+    options?.archiveState === 'archived' ? archived : active,
+  );
   return {
     connection: {
       status: 'connected',
@@ -78,8 +84,9 @@ const {
       removeWorkspace: vi.fn(),
       listSessionGroups: vi.fn(),
     },
-    active: makeSessions(),
-    archived: makeSessions(),
+    active,
+    archived,
+    useSessions,
     listWorkspaceSessions,
     archiveSessionsData,
     unarchiveSessionsData,
@@ -91,8 +98,7 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useActions: () => ({ renameSession: vi.fn() }),
   useWorkspace: () => workspace,
   useWorkspaceActions: () => workspaceActions,
-  useSessions: (options?: { archiveState?: string }) =>
-    options?.archiveState === 'archived' ? archived : active,
+  useSessions,
 }));
 
 const { I18nProvider } = await import('../../i18n');
@@ -318,6 +324,7 @@ beforeEach(() => {
   active.reload.mockResolvedValue(undefined);
   archived.reload.mockReset();
   archived.reload.mockResolvedValue(undefined);
+  useSessions.mockClear();
   active.sessions.length = 0;
   archived.sessions.length = 0;
 });
@@ -401,6 +408,16 @@ describe('WebShellSidebar workspace removal', () => {
 
     expect(container.textContent).toContain('Secondary archived');
     expect(container.textContent).not.toContain('Primary archived');
+    expect(
+      useSessions.mock.calls.every(
+        ([options]) => !Object.hasOwn(options ?? {}, 'sourceType'),
+      ),
+    ).toBe(true);
+    expect(
+      listSecondarySessions.mock.calls.every(
+        ([options]) => !Object.hasOwn(options ?? {}, 'sourceType'),
+      ),
+    ).toBe(true);
   });
 
   it('shows only the locked workspace without registration controls', () => {

--- a/packages/web-shell/client/constants/sessions.ts
+++ b/packages/web-shell/client/constants/sessions.ts
@@ -11,3 +11,4 @@
  */
 export const SESSION_LIST_PAGE_SIZE = 1000;
 export const SESSION_ORGANIZATION_FEATURE = 'session_organization';
+export const WEB_SHELL_SESSION_SOURCE_TYPE = 'default';

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -154,6 +154,7 @@ export function createWebShellDaemonScenario(
       'permission_vote',
       'session_permission_vote',
       'session_scope_override',
+      'session_source_metadata',
       'workspace_settings',
       'workspace_voice',
     ],

--- a/packages/web-shell/client/hooks/useOtherWorkspaceSessions.test.tsx
+++ b/packages/web-shell/client/hooks/useOtherWorkspaceSessions.test.tsx
@@ -121,6 +121,7 @@ describe('useOtherWorkspaceSessions', () => {
     expect(listWorkspaceSessions).toHaveBeenCalledWith('/b', {
       pageSize: SESSION_LIST_PAGE_SIZE,
       archiveState: 'active',
+      sourceType: 'default',
     });
     expect(latest.sessions.map((s) => s.sessionId)).toEqual(['b1']);
   });

--- a/packages/web-shell/client/hooks/useOtherWorkspaceSessions.ts
+++ b/packages/web-shell/client/hooks/useOtherWorkspaceSessions.ts
@@ -7,7 +7,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useWorkspace } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionSummary } from '@qwen-code/sdk/daemon';
-import { SESSION_LIST_PAGE_SIZE } from '../constants/sessions';
+import {
+  SESSION_LIST_PAGE_SIZE,
+  WEB_SHELL_SESSION_SOURCE_TYPE,
+} from '../constants/sessions';
 
 export interface OtherWorkspaceSessionsResult {
   /**
@@ -73,6 +76,7 @@ export function useOtherWorkspaceSessions(
         client.listWorkspaceSessions(cwd, {
           pageSize: SESSION_LIST_PAGE_SIZE,
           archiveState: 'active',
+          sourceType: WEB_SHELL_SESSION_SOURCE_TYPE,
         }),
       ),
     );

--- a/packages/web-shell/client/hooks/useScopedSessions.test.tsx
+++ b/packages/web-shell/client/hooks/useScopedSessions.test.tsx
@@ -98,6 +98,7 @@ describe('useScopedSessions', () => {
       archiveState: undefined,
       view: undefined,
       group: undefined,
+      sourceType: 'default',
     });
 
     await act(async () => {

--- a/packages/web-shell/client/hooks/useScopedSessions.ts
+++ b/packages/web-shell/client/hooks/useScopedSessions.ts
@@ -4,6 +4,7 @@ import type {
   DaemonSessionArchiveState,
   DaemonSessionSummary,
 } from '@qwen-code/sdk/daemon';
+import { WEB_SHELL_SESSION_SOURCE_TYPE } from '../constants/sessions';
 
 interface ScopedSessionsOptions {
   autoLoad?: boolean;
@@ -40,6 +41,7 @@ export function useScopedSessions(
     archiveState,
     view,
     group,
+    sourceType: WEB_SHELL_SESSION_SOURCE_TYPE,
   });
   const {
     reload: reloadPrimary,
@@ -64,7 +66,13 @@ export function useScopedSessions(
     try {
       const sessions = await workspace.client
         .workspaceByCwd(workspaceCwd)
-        .listWorkspaceSessions({ pageSize, archiveState, view, group });
+        .listWorkspaceSessions({
+          pageSize,
+          archiveState,
+          view,
+          group,
+          sourceType: WEB_SHELL_SESSION_SOURCE_TYPE,
+        });
       const scopedSessions = sessions.map((session) => ({
         ...session,
         workspaceCwd,

--- a/packages/web-shell/client/utils/sessionPreparation.test.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.test.ts
@@ -58,6 +58,7 @@ describe('createAndAttachSessionForPrompt', () => {
     expect(actions.createSession).toHaveBeenCalledWith({
       workspaceCwd: '/ws/secondary',
       approvalMode: 'yolo',
+      sourceType: 'default',
     });
     // Model is still a post-create call, sequenced after attach.
     expect(order).toEqual(['create', 'attach', 'model']);
@@ -74,6 +75,7 @@ describe('createAndAttachSessionForPrompt', () => {
 
     expect(actions.createSession).toHaveBeenCalledWith({
       workspaceCwd: undefined,
+      sourceType: 'default',
     });
   });
 
@@ -88,6 +90,7 @@ describe('createAndAttachSessionForPrompt', () => {
     expect(actions.createSession).toHaveBeenCalledWith({
       workspaceCwd: undefined,
       approvalMode: 'plan',
+      sourceType: 'default',
     });
     expect(actions.setModel).not.toHaveBeenCalled();
   });
@@ -162,6 +165,7 @@ describe('createAndAttachSessionForPrompt', () => {
     expect(actions.createSession).toHaveBeenCalledWith({
       workspaceCwd: undefined,
       approvalMode: 'yolo',
+      sourceType: 'default',
     });
     expect(actions.attachSession).not.toHaveBeenCalled();
     expect(actions.setModel).not.toHaveBeenCalled();
@@ -249,6 +253,7 @@ describe('createAndAttachSessionForPrompt', () => {
     });
     expect(actions.createSession).toHaveBeenCalledWith({
       workspaceCwd: '/ws/secondary',
+      sourceType: 'default',
     });
   });
 

--- a/packages/web-shell/client/utils/sessionPreparation.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.ts
@@ -2,6 +2,7 @@ import {
   DAEMON_APPROVAL_MODES,
   type DaemonApprovalMode,
 } from '@qwen-code/webui/daemon-react-sdk';
+import { WEB_SHELL_SESSION_SOURCE_TYPE } from '../constants/sessions';
 
 const SESSION_CREATED_CALLBACK_TIMEOUT_MS = 30_000;
 
@@ -9,6 +10,7 @@ type PromptSessionActions = {
   createSession: (options?: {
     workspaceCwd?: string;
     approvalMode?: DaemonApprovalMode;
+    sourceType?: string;
   }) => Promise<{ sessionId: string }>;
   attachSession: () => Promise<void>;
   clearSession: () => Promise<void>;
@@ -49,6 +51,7 @@ export async function createAndAttachSessionForPrompt({
     modeId && isDaemonApprovalMode(modeId) ? modeId : undefined;
   const { sessionId } = await sessionActions.createSession({
     workspaceCwd,
+    sourceType: WEB_SHELL_SESSION_SOURCE_TYPE,
     ...(approvalMode ? { approvalMode } : {}),
   });
   onSessionAllocated?.(sessionId);

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1728,7 +1728,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         }),
         createDetachedSession: (
           workspaceCwd?: string,
-          overrides?: Pick<CreateSessionRequest, 'approvalMode'>,
+          overrides?: Pick<CreateSessionRequest, 'approvalMode' | 'sourceType'>,
         ) => {
           const client =
             workspaceClientRef.current ??
@@ -1745,6 +1745,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               sessionRef.current?.workspaceCwd,
             ...(overrides?.approvalMode !== undefined
               ? { approvalMode: overrides.approvalMode }
+              : {}),
+            ...(overrides?.sourceType !== undefined
+              ? { sourceType: overrides.sourceType }
               : {}),
           };
           const requestClientId = clientId

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -195,6 +195,21 @@ describe('createDaemonSessionActions', () => {
     });
   });
 
+  it('forwards options.sourceType to the detached create branch', async () => {
+    const nextSession = createMockSession('session-b');
+    const createDetachedSession = vi.fn(async () => nextSession);
+    const { actions } = createActionsHarness({
+      connection: { status: 'connected' },
+      createDetachedSession,
+    });
+
+    await actions.createSession({ sourceType: 'default' });
+
+    expect(createDetachedSession).toHaveBeenCalledWith(undefined, {
+      sourceType: 'default',
+    });
+  });
+
   it('merges options.workspaceCwd into the active session request', async () => {
     const existingSession = createMockSession('session-a');
     const nextSession = createMockSession('session-b');
@@ -224,6 +239,22 @@ describe('createDaemonSessionActions', () => {
 
     expect(existingSession.client.createOrAttachSession).toHaveBeenCalledWith(
       expect.objectContaining({ approvalMode: 'yolo' }),
+    );
+  });
+
+  it('folds options.sourceType into the active session request', async () => {
+    const existingSession = createMockSession('session-a');
+    const nextSession = createMockSession('session-b');
+    existingSession.client.createOrAttachSession.mockResolvedValue(nextSession);
+    const { actions } = createActionsHarness({
+      connection: { status: 'connected', sessionId: 'session-a' },
+      session: existingSession,
+    });
+
+    await actions.createSession({ sourceType: 'default' });
+
+    expect(existingSession.client.createOrAttachSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceType: 'default' }),
     );
   });
 

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -61,7 +61,7 @@ export interface CreateDaemonSessionActionsArgs {
   getCreateSessionRequest: () => CreateSessionRequest;
   createDetachedSession: (
     workspaceCwd?: string,
-    overrides?: Pick<CreateSessionRequest, 'approvalMode'>,
+    overrides?: Pick<CreateSessionRequest, 'approvalMode' | 'sourceType'>,
   ) => Promise<DaemonSessionClient>;
   getConnection: () => DaemonConnectionState;
   hasSessionActivePrompt: () => boolean;
@@ -613,6 +613,7 @@ export function createDaemonSessionActions({
     async createSession(options?: {
       workspaceCwd?: string;
       approvalMode?: DaemonApprovalMode;
+      sourceType?: string;
     }) {
       try {
         manualSessionClearRef.current = false;
@@ -622,10 +623,14 @@ export function createDaemonSessionActions({
         // `setApprovalMode` round-trip. Approval mode is fail-closed at spawn:
         // an application failure aborts creation (this call rejects) rather than
         // leaving the session in a different mode than the caller requested.
-        const approvalOverride =
-          options?.approvalMode !== undefined
+        const requestOverrides = {
+          ...(options?.approvalMode !== undefined
             ? { approvalMode: options.approvalMode }
-            : {};
+            : {}),
+          ...(options?.sourceType !== undefined
+            ? { sourceType: options.sourceType }
+            : {}),
+        };
         const session = sessionRef.current;
         const activeSession =
           session && getConnection().sessionId === session.sessionId
@@ -638,7 +643,7 @@ export function createDaemonSessionActions({
               ...(options?.workspaceCwd !== undefined
                 ? { workspaceCwd: options.workspaceCwd }
                 : {}),
-              ...approvalOverride,
+              ...requestOverrides,
             }),
             'Create session timed out',
           );
@@ -647,7 +652,7 @@ export function createDaemonSessionActions({
         }
 
         const nextSession = await withActionTimeout(
-          createDetachedSession(options?.workspaceCwd, approvalOverride),
+          createDetachedSession(options?.workspaceCwd, requestOverrides),
           'Create session timed out',
         );
         if (manualSessionClearRef.current) {

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -350,10 +350,13 @@ export interface DaemonSessionActions {
    * `options.approvalMode` seeds the session's approval mode in the create
    * request itself, so the daemon applies it atomically at spawn instead of
    * requiring a follow-up `setApprovalMode` call.
+   *
+   * `options.sourceType` records immutable creator attribution.
    */
   createSession(options?: {
     workspaceCwd?: string;
     approvalMode?: DaemonApprovalMode;
+    sourceType?: string;
   }): Promise<DaemonSession>;
   attachSession(): Promise<void>;
   clearSession(): Promise<void>;

--- a/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.test.tsx
+++ b/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.test.tsx
@@ -731,6 +731,7 @@ describe('DaemonWorkspaceProvider', () => {
         group: 'all',
         cursor: 'cursor-1',
         pageSize: 10,
+        sourceType: 'default',
       });
       return null;
     }
@@ -747,6 +748,7 @@ describe('DaemonWorkspaceProvider', () => {
         cursor: 'cursor-1',
         view: 'organized',
         group: 'all',
+        sourceType: 'default',
       },
     );
     expect(result?.data).toEqual([session]);

--- a/packages/webui/src/daemon/workspace/hooks/useDaemonSessions.ts
+++ b/packages/webui/src/daemon/workspace/hooks/useDaemonSessions.ts
@@ -21,11 +21,19 @@ export interface DaemonSessionsOptions extends DaemonResourceOptions {
   archiveState?: DaemonSessionArchiveState;
   view?: 'organized';
   group?: string;
+  sourceType?: string;
 }
 
 export function useDaemonSessions(options: DaemonSessionsOptions = {}) {
-  const { pageSize, cursor, archiveState, view, group, ...resourceOptions } =
-    options;
+  const {
+    pageSize,
+    cursor,
+    archiveState,
+    view,
+    group,
+    sourceType,
+    ...resourceOptions
+  } = options;
   const workspace = useDaemonWorkspace();
   const sessionActions = useOptionalDaemonActions();
   const load = useCallback(() => {
@@ -35,9 +43,18 @@ export function useDaemonSessions(options: DaemonSessionsOptions = {}) {
       ...(archiveState !== undefined ? { archiveState } : {}),
       ...(view !== undefined ? { view } : {}),
       ...(group !== undefined ? { group } : {}),
+      ...(sourceType !== undefined ? { sourceType } : {}),
     };
     return workspace.actions.listSessionsPage(listOptions);
-  }, [archiveState, cursor, group, pageSize, view, workspace.actions]);
+  }, [
+    archiveState,
+    cursor,
+    group,
+    pageSize,
+    sourceType,
+    view,
+    workspace.actions,
+  ]);
   const workspaceReady = !!workspace.workspaceCwd;
   const result = useDaemonResource(load, {
     ...resourceOptions,


### PR DESCRIPTION
## What this PR does

Web Shell now attributes newly created sessions with `sourceType: default`. Session catalog requests that explicitly filter by `sourceType=default` include both newly attributed sessions and legacy sessions that have no source metadata, while other source filters remain exact. Source filtering now composes with organized views, groups, archive state, and opaque pagination cursors. The Sidebar remains an unfiltered all-session catalog.

## Why it's needed

Web Shell sessions previously had no creator attribution, so filtered session surfaces could not distinguish them from sessions created by scheduled tasks or other integrations. An exact default-source filter would also hide historical Web Shell sessions, so the compatibility behavior must include records whose source metadata is absent.

## Reviewer Test Plan

### How to verify

Create a session from Web Shell and confirm the create request contains `sourceType: default`. Query the session catalog with `sourceType=default` and confirm it returns both that session and a legacy session without source metadata while excluding a session attributed to another source. Repeat with `view=organized`, a group filter, archive state, and pagination. Confirm Sidebar catalog requests omit `sourceType` and continue to show all sessions.

### Evidence (Before & After)

Before: Web Shell creation omitted source metadata, and exact source filtering excluded legacy sessions. Organized views rejected source filters. After: Web Shell creation records the default source, default-source queries preserve legacy sessions, organized queries support the same filter, and Sidebar remains unfiltered. Automated REST, ACP HTTP, WebUI action, hook, and Sidebar regression tests cover these behaviors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node.js workspace. Verified with targeted Vitest suites, `npm run build`, `npm run typecheck`, and `npm run lint`.

## Risk & Scope

- Main risk or tradeoff: `sourceType=default` intentionally has compatibility semantics rather than strict equality because it also matches sessions without source metadata.
- Not validated / out of scope: Windows and Linux runtime verification; migration or backfill of existing session files.
- Breaking changes / migration notes: None. Requests without `sourceType` remain unfiltered, and non-default source filters remain exact.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 新创建的 session 现在会携带 `sourceType: default`。当 session 列表显式使用 `sourceType=default` 过滤时，会同时返回新写入来源的 session 和没有来源元数据的历史 session；其他来源类型仍保持精确匹配。来源过滤现在可以与 organized 视图、分组、归档状态及不透明分页 cursor 组合使用。左侧 Sidebar 仍然是不加来源过滤的全量 session 目录。

## 为什么需要

此前 Web Shell 创建的 session 没有创建来源标识，因此需要过滤的 session 展示面无法将其与定时任务或其他集成创建的 session 区分开。若直接采用严格的 default 来源过滤，又会隐藏历史 Web Shell session，因此兼容逻辑需要包含来源元数据缺失的记录。

## Reviewer 测试计划

### 如何验证

从 Web Shell 创建 session，确认创建请求包含 `sourceType: default`。使用 `sourceType=default` 查询 session 列表，确认结果同时包含该 session 和一个没有来源元数据的历史 session，并排除其他来源创建的 session。随后结合 `view=organized`、分组过滤、归档状态和分页重复验证。确认 Sidebar 的列表请求不传 `sourceType`，并继续展示全部 session。

### 证据（修改前后）

修改前：Web Shell 创建不写入来源元数据，精确来源过滤会漏掉历史 session，organized 视图也会拒绝来源过滤。修改后：Web Shell 创建会记录 default 来源，default 来源查询兼容历史 session，organized 查询支持同样的过滤，同时 Sidebar 保持全量。REST、ACP HTTP、WebUI action、hook 和 Sidebar 的自动化回归测试覆盖了这些行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node.js workspace。已通过定向 Vitest、`npm run build`、`npm run typecheck` 和 `npm run lint` 验证。

## 风险与范围

- 主要风险或权衡：`sourceType=default` 为兼容历史数据而有意采用非严格相等语义，也会匹配没有来源元数据的 session。
- 未验证或超出范围：Windows 和 Linux 运行时验证；对现有 session 文件执行迁移或回填。
- 破坏性变更或迁移说明：无。不传 `sourceType` 的请求仍返回全部 session，非 default 的来源过滤仍保持精确匹配。

## 关联 Issue

N/A

</details>
