### PR TITLE
test(web-shell): add extensions-manager visual scenario

### DIFF
--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -601,7 +601,7 @@ async function handleDaemonRoute(
     return;
   }
   if (method === 'GET' && path === '/workspace/extensions') {
-    await json(route, workspaceExtensions(scenario));
+    await json(route, scenario.extensions);
     return;
   }
   if (method === 'GET' && path === '/workspace/extensions/operations') {
@@ -928,12 +928,6 @@ function workspaceTools(
     tools: [],
     errors: [],
   };
-}
-
-function workspaceExtensions(
-  scenario: WebShellDaemonScenario,
-): DaemonWorkspaceExtensionsStatus {
-  return scenario.extensions;
 }
 
 function workspaceVoice(

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -19,6 +19,8 @@ import {
   type DaemonWorkspaceSkillsStatus,
   type DaemonWorkspaceToolsStatus,
   type DaemonWorkspaceVoiceStatus,
+  type ExtensionActiveOperations,
+  type ExtensionUpdateCheckResponse,
   type PermissionResponse,
   type PromptRequest,
 } from '@qwen-code/sdk/daemon';
@@ -42,6 +44,7 @@ export interface WebShellDaemonScenario {
   providers: DaemonWorkspaceProvidersStatus;
   skills: DaemonWorkspaceSkillsStatus;
   settings: DaemonWorkspaceSettingsStatus;
+  extensions: DaemonWorkspaceExtensionsStatus;
   sessions: DaemonSessionSummary[];
   sessionGroups: DaemonSessionGroup[];
   events: DaemonEvent[];
@@ -66,6 +69,7 @@ type ScenarioOverrides = Partial<
     | 'providers'
     | 'skills'
     | 'settings'
+    | 'extensions'
     | 'sessions'
     | 'sessionGroups'
     | 'state'
@@ -75,6 +79,7 @@ type ScenarioOverrides = Partial<
   providers?: Partial<DaemonWorkspaceProvidersStatus>;
   skills?: Partial<DaemonWorkspaceSkillsStatus>;
   settings?: Partial<DaemonWorkspaceSettingsStatus>;
+  extensions?: Partial<DaemonWorkspaceExtensionsStatus>;
   sessions?: DaemonSessionSummary[];
   sessionGroups?: DaemonSessionGroup[];
   state?: Partial<DaemonSessionState>;
@@ -218,6 +223,15 @@ export function createWebShellDaemonScenario(
     ...(overrides.settings ?? {}),
   };
 
+  const extensions: DaemonWorkspaceExtensionsStatus = {
+    v: 1,
+    workspaceCwd,
+    initialized: true,
+    extensions: [],
+    errors: [],
+    ...(overrides.extensions ?? {}),
+  };
+
   const sessions = overrides.sessions ?? [
     {
       sessionId,
@@ -250,6 +264,7 @@ export function createWebShellDaemonScenario(
     providers,
     skills,
     settings,
+    extensions,
     sessions,
     sessionGroups: overrides.sessionGroups ?? [],
     events: overrides.events ?? [],
@@ -442,6 +457,8 @@ function isDaemonPath(path: string): boolean {
     path === '/workspace/skills' ||
     path === '/workspace/tools' ||
     path === '/workspace/extensions' ||
+    path === '/workspace/extensions/operations' ||
+    path === '/workspace/extensions/check-updates' ||
     path === '/workspace/mcp' ||
     path === '/workspace/voice' ||
     /^\/workspace\/mcp\/[^/]+\/tools\/?$/.test(path) ||
@@ -471,6 +488,12 @@ function isDaemonRoute(method: string, path: string): boolean {
   if (method === 'GET' && path === '/workspace/skills') return true;
   if (method === 'GET' && path === '/workspace/tools') return true;
   if (method === 'GET' && path === '/workspace/extensions') return true;
+  if (method === 'GET' && path === '/workspace/extensions/operations') {
+    return true;
+  }
+  if (method === 'POST' && path === '/workspace/extensions/check-updates') {
+    return true;
+  }
   if (method === 'GET' && path === '/workspace/mcp') return true;
   if (method === 'GET' && path === '/workspace/voice') return true;
   if (method === 'GET' && /^\/workspace\/mcp\/[^/]+\/tools\/?$/.test(path)) {
@@ -560,6 +583,22 @@ async function handleDaemonRoute(
   }
   if (method === 'GET' && path === '/workspace/extensions') {
     await json(route, workspaceExtensions(scenario));
+    return;
+  }
+  if (method === 'GET' && path === '/workspace/extensions/operations') {
+    // No install/update runs in the visual scenarios, so the manager polls an
+    // idle operations list (an empty poll) instead of hitting a 401 that would
+    // paint an error banner across the captured page.
+    await json(route, {
+      v: 1,
+      operations: [],
+    } satisfies ExtensionActiveOperations);
+    return;
+  }
+  if (method === 'POST' && path === '/workspace/extensions/check-updates') {
+    // The manager kicks off an update check on mount; report "no updates for
+    // any extension" so the visual doesn't paint an update-check error banner.
+    await json(route, { states: {} } satisfies ExtensionUpdateCheckResponse);
     return;
   }
   if (method === 'GET' && path === '/workspace/mcp') {
@@ -878,13 +917,7 @@ function workspaceTools(
 function workspaceExtensions(
   scenario: WebShellDaemonScenario,
 ): DaemonWorkspaceExtensionsStatus {
-  return {
-    v: 1,
-    workspaceCwd: scenario.workspaceCwd,
-    initialized: true,
-    extensions: [],
-    errors: [],
-  };
+  return scenario.extensions;
 }
 
 function workspaceVoice(

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -45,6 +45,8 @@ export interface WebShellDaemonScenario {
   skills: DaemonWorkspaceSkillsStatus;
   settings: DaemonWorkspaceSettingsStatus;
   extensions: DaemonWorkspaceExtensionsStatus;
+  extensionOperations: ExtensionActiveOperations;
+  extensionUpdateCheck: ExtensionUpdateCheckResponse;
   sessions: DaemonSessionSummary[];
   sessionGroups: DaemonSessionGroup[];
   events: DaemonEvent[];
@@ -70,6 +72,8 @@ type ScenarioOverrides = Partial<
     | 'skills'
     | 'settings'
     | 'extensions'
+    | 'extensionOperations'
+    | 'extensionUpdateCheck'
     | 'sessions'
     | 'sessionGroups'
     | 'state'
@@ -80,6 +84,8 @@ type ScenarioOverrides = Partial<
   skills?: Partial<DaemonWorkspaceSkillsStatus>;
   settings?: Partial<DaemonWorkspaceSettingsStatus>;
   extensions?: Partial<DaemonWorkspaceExtensionsStatus>;
+  extensionOperations?: Partial<ExtensionActiveOperations>;
+  extensionUpdateCheck?: Partial<ExtensionUpdateCheckResponse>;
   sessions?: DaemonSessionSummary[];
   sessionGroups?: DaemonSessionGroup[];
   state?: Partial<DaemonSessionState>;
@@ -232,6 +238,17 @@ export function createWebShellDaemonScenario(
     ...(overrides.extensions ?? {}),
   };
 
+  const extensionOperations: ExtensionActiveOperations = {
+    v: 1,
+    operations: [],
+    ...(overrides.extensionOperations ?? {}),
+  };
+
+  const extensionUpdateCheck: ExtensionUpdateCheckResponse = {
+    states: {},
+    ...(overrides.extensionUpdateCheck ?? {}),
+  };
+
   const sessions = overrides.sessions ?? [
     {
       sessionId,
@@ -265,6 +282,8 @@ export function createWebShellDaemonScenario(
     skills,
     settings,
     extensions,
+    extensionOperations,
+    extensionUpdateCheck,
     sessions,
     sessionGroups: overrides.sessionGroups ?? [],
     events: overrides.events ?? [],
@@ -586,19 +605,16 @@ async function handleDaemonRoute(
     return;
   }
   if (method === 'GET' && path === '/workspace/extensions/operations') {
-    // No install/update runs in the visual scenarios, so the manager polls an
-    // idle operations list (an empty poll) instead of hitting a 401 that would
-    // paint an error banner across the captured page.
-    await json(route, {
-      v: 1,
-      operations: [],
-    } satisfies ExtensionActiveOperations);
+    // The manager polls in-flight operations on mount. Defaults to an idle
+    // (empty) list so the capture has no error banner; a scenario can seed
+    // `extensionOperations` to preview an in-progress install/update.
+    await json(route, scenario.extensionOperations);
     return;
   }
   if (method === 'POST' && path === '/workspace/extensions/check-updates') {
-    // The manager kicks off an update check on mount; report "no updates for
-    // any extension" so the visual doesn't paint an update-check error banner.
-    await json(route, { states: {} } satisfies ExtensionUpdateCheckResponse);
+    // The manager kicks off an update check on mount. Defaults to "no updates
+    // available", overridable via the scenario's `extensionUpdateCheck`.
+    await json(route, scenario.extensionUpdateCheck);
     return;
   }
   if (method === 'GET' && path === '/workspace/mcp') {

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -145,13 +145,19 @@ for (const theme of THEMES) {
       // Gate on the page heading — a stable structural role, unlike card text a
       // refactor could reshape or that could also match a toast/sidebar — to
       // prove the manager PAGE (not a transcript/dialog) is reachable, then
-      // confirm a seeded card rendered via its button role.
+      // confirm seeded cards rendered via their button role — both an enabled
+      // marketplace one and the disabled, local-source one, so a regression
+      // that hides `isActive: false` or local rows fails an assertion rather
+      // than only differing in the (visually reviewed) screenshot.
       await submitLocalCommand(page, '/extensions');
       await expect(
         page.getByRole('heading', { name: 'Manage Extensions' }),
       ).toBeVisible();
       await expect(
         page.getByRole('button', { name: 'Context7' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Local Notes' }),
       ).toBeVisible();
       await captureScreenshot(page, `extensions-manager-${theme}`);
     });

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -141,11 +141,18 @@ for (const theme of THEMES) {
         resolveBaseURL(testInfo),
       );
       await gotoSession(page, scenario, daemon, theme);
-      // Open the full-page Extensions manager via the `/extensions` command,
-      // then wait for a mocked extension row to render (proves a full manager
-      // PAGE — not just a transcript/dialog — is reachable in this harness).
+      // Open the full-page Extensions manager via the `/extensions` command.
+      // Gate on the page heading — a stable structural role, unlike card text a
+      // refactor could reshape or that could also match a toast/sidebar — to
+      // prove the manager PAGE (not a transcript/dialog) is reachable, then
+      // confirm a seeded card rendered via its button role.
       await submitLocalCommand(page, '/extensions');
-      await expect(page.getByText('Context7')).toBeVisible();
+      await expect(
+        page.getByRole('heading', { name: 'Manage Extensions' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Context7' }),
+      ).toBeVisible();
       await captureScreenshot(page, `extensions-manager-${theme}`);
     });
 

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -61,6 +61,94 @@ for (const theme of THEMES) {
       await captureScreenshot(page, `session-transcript-${theme}`);
     });
 
+    test(`extensions manager`, async ({ page }, testInfo) => {
+      // Seed a few extensions so the full-page manager renders real cards —
+      // enabled + disabled, marketplace + local, with varied capability counts
+      // — instead of its empty state. `capabilities` is required on every entry.
+      const scenario = createWebShellDaemonScenario({
+        extensions: {
+          extensions: [
+            {
+              kind: 'extension',
+              id: 'context7',
+              name: 'context7',
+              displayName: 'Context7',
+              description:
+                'Up-to-date library docs injected into your prompts.',
+              version: '1.4.0',
+              isActive: true,
+              path: '/ext/context7',
+              source: 'marketplace',
+              capabilities: {
+                mcpServerCount: 1,
+                skillCount: 0,
+                agentCount: 0,
+                hookCount: 0,
+                commandCount: 0,
+                contextFileCount: 0,
+                channelCount: 0,
+                hasSettings: true,
+              },
+            },
+            {
+              kind: 'extension',
+              id: 'playwright',
+              name: 'playwright',
+              displayName: 'Playwright',
+              description: 'Drive a real browser for end-to-end checks.',
+              version: '0.9.2',
+              isActive: true,
+              path: '/ext/playwright',
+              source: 'marketplace',
+              capabilities: {
+                mcpServerCount: 1,
+                skillCount: 1,
+                agentCount: 0,
+                hookCount: 0,
+                commandCount: 2,
+                contextFileCount: 0,
+                channelCount: 0,
+                hasSettings: false,
+              },
+            },
+            {
+              kind: 'extension',
+              id: 'local-notes',
+              name: 'local-notes',
+              displayName: 'Local Notes',
+              description: 'A scratchpad extension loaded from disk.',
+              version: '0.1.0',
+              isActive: false,
+              path: '/ext/local-notes',
+              source: 'local',
+              capabilities: {
+                mcpServerCount: 0,
+                skillCount: 0,
+                agentCount: 0,
+                hookCount: 0,
+                commandCount: 1,
+                contextFileCount: 1,
+                channelCount: 0,
+                hasSettings: false,
+              },
+            },
+          ],
+        },
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+      // Open the full-page Extensions manager via the `/extensions` command,
+      // then wait for a mocked extension row to render (proves a full manager
+      // PAGE — not just a transcript/dialog — is reachable in this harness).
+      await submitLocalCommand(page, '/extensions');
+      await expect(page.getByText('Context7')).toBeVisible();
+      await captureScreenshot(page, `extensions-manager-${theme}`);
+    });
+
     test(`mermaid diagram`, async ({ page }, testInfo) => {
       const scenario = createWebShellDaemonScenario({
         events: [


### PR DESCRIPTION
## What this PR does

Adds a full-page **Extensions manager** scenario to the web-shell visual suite. The scenario opens the `/extensions` full-page manager in the mock-daemon harness, seeds a few extensions, and captures it in both dark and light themes — proving a manager *page* (not just a transcript or dialog) is reachable and renderable in the harness.

To make the captured page clean, it also fills two small gaps in the mock daemon: the manager fires `GET /workspace/extensions/operations` and `POST /workspace/extensions/check-updates` on mount, which the mock did not recognize, so they fell through to the (absent) real daemon and painted an error banner across the capture. The mock now serves both as idle / no-op responses, and the mocked extensions list is scenario-driven — empty by default (mirroring `skills`/`settings`/`tools`) so a scenario can seed sample rows without perturbing the other scenarios.

## Why it's needed

The visual-preview suite so far captured transcripts, dialogs, and the sidebar, but no full-page manager view — the surface most likely to regress silently on layout or data-shape changes. This adds the first manager-page scenario, so the before/after preview bot surfaces changes to the Extensions manager (cards, badges, empty/populated states) on any PR that touches it. It also hardens the mock daemon's extensions surface so future manager scenarios (MCP, tools, providers) can be added the same way.

## Reviewer Test Plan

### How to verify

```
cd packages/web-shell
npx playwright test --config playwright.visuals.config.ts -g "extensions manager" --project=chromium
```

Expected: `2 passed` (dark + light). The captured `extensions-manager-<theme>.png` shows the "Manage Extensions" page with three cards (Context7 / Playwright enabled, Local Notes disabled) and **no** error banner.

- Typecheck: the e2e files are excluded from the package `tsconfig.json`, so scope a `tsc --noEmit` to `client/e2e/**` — clean.
- `npx eslint` on the two changed files — clean.
- Full visuals suite (`npm run test:e2e:visuals`): `21 passed`, no regression in the other scenarios (the mock's default extensions list stays empty, matching `main`).

### Evidence (Before & After)

New scenario — there is no "before" capture (the view did not exist). After:

| Dark | Light |
| --- | --- |
| ![dark](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-visuals-extensions-scenario/extensions-manager-dark.png) | ![light](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-visuals-extensions-scenario/extensions-manager-light.png) |

The web-shell visuals bot also triggers on this PR (it touches `packages/web-shell/client/**`) and will post a live preview of the same scenario as a NEW view.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Verified locally on macOS; Windows/Linux left to CI (the visuals job runs on Linux).

### Environment (optional)

`npm run dev` web-shell dev server + Playwright (chromium), driven by `playwright.visuals.config.ts`.

## Risk & Scope

- Main risk or tradeoff: test-only change (everything is under `client/e2e/`). The one shared edit is the mock daemon adding a required `extensions` field to the scenario type — safe because the factory is the only constructor (no direct literal construction anywhere) and it defaults to an empty list, so existing scenarios are unchanged.
- Not validated / out of scope: the manager's *interactive* flows (install / enable / disable / update / delete). Those mutations are user-action-only and the scenario never triggers them, so their mock routes are intentionally not added here.
- Breaking changes / migration notes: none.

## Linked Issues

None. Follows the visual-preview suite (#6880) and the before/after engine (#6963); extends the feature-scenario set added in #6964.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 web-shell 视觉套件新增一个整页的 **扩展管理器（Extensions manager）** 场景。该场景在 mock-daemon 测试环境中打开 `/extensions` 整页管理器，注入若干扩展，并在深色与浅色两种主题下截图——证明在该测试环境中可以到达并渲染一个管理器*页面*（而不仅仅是对话记录或弹窗）。

为了让截图干净，本 PR 还补齐了 mock daemon 的两个缺口：管理器在挂载时会请求 `GET /workspace/extensions/operations` 和 `POST /workspace/extensions/check-updates`，而 mock 未识别这两个路径，导致请求穿透到（并不存在的）真实 daemon 并在截图上渲染出一条错误条。现在 mock 将两者作为空闲 / 无操作响应返回；同时把 mock 的扩展列表改为由场景驱动——默认为空（与 `skills`/`settings`/`tools` 一致），使场景可以注入示例行而不影响其他场景。

## 为什么需要它

到目前为止，视觉预览套件覆盖了对话记录、弹窗和侧边栏，但没有任何整页管理器视图——而这恰恰是最容易在布局或数据结构变更中悄悄回归的界面。本 PR 新增第一个管理器页面场景，这样 before/after 预览机器人就能在任何改动扩展管理器的 PR 上呈现其变化（卡片、徽章、空/非空状态）。它同时加固了 mock daemon 的扩展接口面，便于后续以相同方式新增管理器场景（MCP、工具、供应商）。

## 复现测试计划

### 如何验证

```
cd packages/web-shell
npx playwright test --config playwright.visuals.config.ts -g "extensions manager" --project=chromium
```

预期：`2 passed`（深色 + 浅色）。截图 `extensions-manager-<theme>.png` 显示 "Manage Extensions" 页面，含三张卡片（Context7 / Playwright 启用，Local Notes 停用），且**没有**错误条。

- 类型检查：e2e 文件被包内 `tsconfig.json` 排除，因此需将 `tsc --noEmit` 单独限定到 `client/e2e/**`——通过。
- 对两个改动文件运行 `npx eslint`——通过。
- 完整视觉套件（`npm run test:e2e:visuals`）：`21 passed`，其他场景无回归（mock 的默认扩展列表保持为空，与 `main` 一致）。

### 证据（Before & After）

新场景——没有 "before" 截图（该视图此前不存在）。After：见上方深色 / 浅色两图。

web-shell 视觉机器人也会在本 PR 上触发（因为改动了 `packages/web-shell/client/**`），并会将同一场景作为 NEW 视图发布实时预览。

### 测试平台

仅在本地 macOS 验证；Windows/Linux 交由 CI（视觉任务在 Linux 上运行）。

## 风险与范围

- 主要风险/取舍：仅测试改动（全部位于 `client/e2e/` 下）。唯一的共享改动是 mock daemon 在场景类型上新增了必填的 `extensions` 字段——安全，因为工厂函数是唯一构造入口（代码中没有任何直接的字面量构造），且默认为空列表，因此现有场景不受影响。
- 未验证 / 不在范围内：管理器的*交互*流程（安装 / 启用 / 停用 / 更新 / 删除）。这些变更仅由用户操作触发，场景不会触发它们，因此这里刻意不添加它们的 mock 路由。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。延续视觉预览套件（#6880）与 before/after 引擎（#6963）；扩展了 #6964 新增的功能场景集合。

</details>
