### PR TITLE
fix(web-shell): land on the split's first pane when a shrink folds the split

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -3201,6 +3201,105 @@ describe('App session callbacks', () => {
     }
   });
 
+  it('lands on the first pane, not an empty new chat, when a shrink closes a URL-driven split', async () => {
+    let large = true;
+    let changeHandler: ((event: { matches: boolean }) => void) | undefined;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        get matches() {
+          return query.includes('min-width') ? large : false;
+        },
+        media: query,
+        addEventListener: (
+          _type: string,
+          cb: (event: { matches: boolean }) => void,
+        ) => {
+          // Capture the isLargeScreen (1024px) query specifically — not the
+          // separate 1200px split-sidebar query — so flipping it drives the fold.
+          if (query.includes('1024')) changeHandler = cb;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    });
+    // The single chat has no session of its own — the split was entered from a
+    // `?split=` deep link — so a naive close would strand on an empty new chat.
+    mockConnection.sessionId = undefined;
+    window.history.replaceState(null, '', '/?split=s1,s2');
+
+    try {
+      const { container } = renderApp();
+      await flush();
+      expect(
+        container.querySelector('[data-testid="split-view-page"]'),
+      ).not.toBeNull();
+
+      await act(async () => {
+        large = false;
+        changeHandler?.({ matches: false });
+        await Promise.resolve();
+      });
+
+      // The split folds back to chat and re-attaches to the first pane's
+      // session instead of stranding the user on an empty new chat.
+      expect(
+        container.querySelector('[data-testid="split-view-page"]'),
+      ).toBeNull();
+      expect(mockSessionActions.loadSession).toHaveBeenCalledWith('s1');
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
+
+  it('keeps the chat on its own session (does not re-point to the first pane) when a shrink closes the split', async () => {
+    let large = true;
+    let changeHandler: ((event: { matches: boolean }) => void) | undefined;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        get matches() {
+          return query.includes('min-width') ? large : false;
+        },
+        media: query,
+        addEventListener: (
+          _type: string,
+          cb: (event: { matches: boolean }) => void,
+        ) => {
+          if (query.includes('1024')) changeHandler = cb;
+        },
+        removeEventListener: vi.fn(),
+      })),
+    });
+    // This chat HAS a session of its own — folding must leave it (and its git
+    // branch / URL) untouched rather than re-pointing at the split's first pane.
+    mockConnection.sessionId = 'own-session';
+    window.history.replaceState(null, '', '/?split=s1,s2');
+
+    try {
+      const { container } = renderApp();
+      await flush();
+      expect(
+        container.querySelector('[data-testid="split-view-page"]'),
+      ).not.toBeNull();
+      mockSessionActions.loadSession.mockClear();
+
+      await act(async () => {
+        large = false;
+        changeHandler?.({ matches: false });
+        await Promise.resolve();
+      });
+
+      // Folded back to chat, but the guard kept the existing session — no
+      // re-point to the first pane.
+      expect(
+        container.querySelector('[data-testid="split-view-page"]'),
+      ).toBeNull();
+      expect(mockSessionActions.loadSession).not.toHaveBeenCalled();
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
+
   it('auto-closes the Session Overview when the screen shrinks below the breakpoint', async () => {
     // Drive isLargeScreen through a controllable media query: open the panel on
     // a large screen, then flip below the breakpoint and confirm it closes.

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2290,6 +2290,18 @@ export function App({
       // split, or dropping back to that chat, is exactly what it was before.
       if (!externalSplitControlled) {
         splitFoldedByShrinkRef.current = true;
+        // …except when the chat has no session of its own — the common case
+        // when the split was entered from the Session Overview or a `?split=a,b`
+        // link. A bare fold would then strand the user on an empty "new chat",
+        // so land on the split's first (leftmost) pane instead. Guarded on the
+        // *empty* chat so it never re-points a chat that already has a session
+        // (which would wipe its git branch / change the session+URL it drops
+        // back to). Best-effort: a load failure (e.g. a non-primary-workspace
+        // pane the single connection can't own) just leaves the empty chat.
+        const firstPane = splitSessionIdsRef.current[0];
+        if (firstPane && !currentSessionIdRef.current) {
+          void sessionActions.loadSession(firstPane).catch(() => undefined);
+        }
       }
     }
   }, [
@@ -2298,6 +2310,7 @@ export function App({
     mainView,
     notifyControlledSplitClose,
     externalSplitControlled,
+    sessionActions,
   ]);
   // Land focus on the composer after a shrink-driven split close so keyboard
   // users aren't dropped onto <body> — but not when the chat now shows an


### PR DESCRIPTION
## What this PR does

Restores the behavior where narrowing the browser past the large-screen breakpoint — which folds the split view back to a single chat — lands on the split's first (leftmost) pane instead of an empty "new chat", when the chat being folded to has no session of its own. A chat that already has its own session is left untouched, exactly as before.

## Why it's needed

When the viewport shrinks below the large-screen breakpoint, the split view auto-folds to the single chat. If the split was entered straight from the Session Overview or a `?split=a,b` link, the underlying chat has no session of its own, so a bare fold strands the user on an empty "new chat" instead of the sessions they were just looking at.

This exact fallback was implemented once and then deliberately superseded during #6746: re-pointing the chat to the first pane on fold wiped the git branch and changed the session+URL of a chat that *did* have a session, so that PR shipped "fold without touching the connection" — which reintroduced the empty-new-chat symptom. The right reconciliation is to re-point **only when the chat is empty** (`!currentSessionId`): an empty chat has no git branch or session/URL to preserve, so it fixes the empty-new-chat case without regressing the branch-preservation case that motivated dropping it.

## Reviewer Test Plan

### How to verify

1. On a large screen, open a split view of two sessions from the Session Overview (or open a `?split=a,b` link in a fresh tab) so the underlying single chat has no session of its own.
2. Narrow the browser window past the large-screen breakpoint (below 1024px) so the split folds back to the single chat.
3. Expected: the chat shows the split's first (leftmost) pane's session — not a blank "new chat". Grow the window back and the full split restores as before.
4. Repeat starting from a chat that already has its own session (open a session normally, then enter split): folding must leave that chat on its own session (its git branch / URL unchanged), i.e. it must NOT jump to the first pane.

Automated (from `packages/web-shell`): `npm test` is green (105 files / 1672 tests). Two new tests in `App.test.tsx` drive the real `App` component: one asserts `loadSession(firstPane)` fires when the folded chat is empty, the other asserts it does NOT fire when the chat already has a session. Controlled revert (below) shows the empty-chat test fails on `main` and passes with the fix. `npm run typecheck` / `lint` / `format:check` clean.

### Evidence (Before & After)

Controlled revert — same test, same `App` component, only the one-block fix toggled. Without it the shrink never re-attaches a session (stranding a blank new-chat); with it the folded chat lands on the split's first pane, while the guard leaves a chat that already has its own session untouched:

![Controlled revert: before strands on empty new chat, after lands on first pane](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/split-fold-first-pane/split-fold-first-pane-before-after.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Local: `npm test` / `npm run typecheck` / `npm run lint` / `npm run format:check` in `packages/web-shell`, plus a controlled-revert experiment (`git stash push App.tsx` → run the empty-chat test → it fails → `git stash pop` → it passes).

## Risk & Scope

- Main risk or tradeoff: purely client-side and standalone-split-only (a controlled host still owns its split lifecycle). The fallback is best-effort — a `loadSession` failure (e.g. a non-primary-workspace first pane the single connection can't own) simply leaves the empty chat, i.e. today's behavior.
- Not validated / out of scope: the git-branch-preservation case is what motivated dropping the original fallback; it is preserved here by the `!currentSessionId` guard and covered by a dedicated test, but only in the standalone (uncontrolled) split path.
- Breaking changes / migration notes: none. A chat that already has a session behaves exactly as before.

## Linked Issues

N/A — reported regression: the narrow-fold shows a new-session window instead of the leftmost pane.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复这样的行为：当浏览器拉窄、越过大屏断点导致分屏折叠回单个 chat 时，如果被折叠到的那个 chat 自己没有会话，就落到分屏的第一个（最左侧）pane，而不是一个空的「新建会话」。如果那个 chat 本来就有自己的会话，则保持不变，和之前完全一样。

## 为什么需要

当视口缩小到大屏断点以下时，分屏会自动折叠回单个 chat。如果分屏是从 Session Overview 或 `?split=a,b` 链接进来的，底层 chat 并没有自己的会话，于是折叠后就把用户丢在一个空的「新建会话」上，而不是他们刚才在看的会话。

这个 fallback 其实实现过一次，但在 #6746 里被有意替换掉了：折叠时把 chat 重新指向第一个 pane 会抹掉一个「本来有会话」的 chat 的 git branch、并改变它掉回去的 session+URL，所以那个 PR 最终改成了「折叠时不动连接」——空会话的症状也就回来了。正确的调和方式是：**仅当 chat 为空时**（`!currentSessionId`）才重新指向第一个 pane——空 chat 没有 git branch、也没有要保留的 session/URL，因此既修好空会话的情况，又不回归当初促使去掉它的「保留 branch」情况。

## 复现验证方式

1. 在大屏下，从 Session Overview 打开两个会话的分屏（或在新标签页打开 `?split=a,b` 链接），使底层单 chat 没有自己的会话。
2. 把浏览器窗口拉窄到大屏断点以下（1024px 以下），使分屏折叠回单 chat。
3. 预期：chat 显示分屏第一个（最左侧）pane 的会话，而不是空白「新建会话」。把窗口放大回去，完整分屏照旧恢复。
4. 换成「chat 本来就有自己的会话」再试一次（正常打开一个会话，再进分屏）：折叠必须保留该 chat 自己的会话（git branch / URL 不变），即绝不跳到第一个 pane。

自动化（在 `packages/web-shell` 下）：`npm test` 全绿（105 文件 / 1672 测试）。`App.test.tsx` 里新增两个测试，驱动真实 `App` 组件：一个断言空 chat 折叠时会触发 `loadSession(firstPane)`，另一个断言 chat 已有会话时不会触发。下方的「controlled revert」显示空会话测试在 `main` 上失败、加了修复后通过。`typecheck` / `lint` / `format:check` 均干净。

## 证据（Before & After）

Controlled revert——同一个测试、同一个 `App` 组件，只切换这一处修复。没有它时，缩窄从不重新挂上会话（把用户丢在空白新 chat）；有了它，折叠后的 chat 落到分屏第一个 pane，而守卫让「已有自己会话」的 chat 保持不动（上图）。

## 风险与范围

- 主要风险 / 取舍：纯客户端，且仅作用于独立（standalone）分屏（受控 host 仍自己管理分屏生命周期）。fallback 是尽力而为——`loadSession` 失败（例如单连接无法拥有的非主 workspace 第一个 pane）就保持空 chat，即今天的行为。
- 未验证 / 范围之外：git branch 保留的情况正是当初去掉该 fallback 的原因；这里用 `!currentSessionId` 守卫保住了它，并有专门测试覆盖，但仅在独立分屏路径上。
- 破坏性变更 / 迁移说明：无。已有会话的 chat 行为与之前完全一致。

## 关联 Issue

N/A —— 回归上报：窄屏折叠显示了新建会话窗口，而不是最左侧 pane。

</details>
