### PR TITLE
fix: surface underlying .cause of OpenAI-compatible connection errors in debug log and API error message

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/errorHandler.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/errorHandler.test.ts
@@ -182,6 +182,10 @@ describe('EnhancedErrorHandler', () => {
       expect(() => {
         errorHandler.handle(stringError, mockContext, mockRequest);
       }).toThrow(stringError);
+      expect(debugLoggerSpy.error).toHaveBeenCalledWith(
+        'OpenAI API Error:',
+        stringError,
+      );
     });
 
     it('should redact proxy credentials before throwing request-time errors', () => {
@@ -327,6 +331,25 @@ describe('EnhancedErrorHandler', () => {
       expect(() => {
         errorHandler.handle(originalError, mockContext, mockRequest);
       }).toThrow('Original error message');
+      expect(debugLoggerSpy.error).toHaveBeenCalledWith(
+        'OpenAI API Error:',
+        'Original error message',
+      );
+    });
+
+    it('should include the underlying cause for non-timeout errors', () => {
+      const cause = Object.assign(new Error('fetch failed'), {
+        code: 'ECONNREFUSED',
+      });
+      const connectionError = new Error('Connection error.', { cause });
+
+      expect(() => {
+        errorHandler.handle(connectionError, mockContext, mockRequest);
+      }).toThrow(connectionError);
+      expect(debugLoggerSpy.error).toHaveBeenCalledWith(
+        'OpenAI API Error:',
+        'Connection error. (cause: ECONNREFUSED: fetch failed)',
+      );
     });
 
     it('should handle non-Error objects', () => {

--- a/packages/core/src/core/openaiContentGenerator/errorHandler.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/errorHandler.test.ts
@@ -185,6 +185,7 @@ describe('EnhancedErrorHandler', () => {
       expect(debugLoggerSpy.error).toHaveBeenCalledWith(
         'OpenAI API Error:',
         stringError,
+        expect.objectContaining({ model: 'test-model' }),
       );
     });
 
@@ -334,6 +335,7 @@ describe('EnhancedErrorHandler', () => {
       expect(debugLoggerSpy.error).toHaveBeenCalledWith(
         'OpenAI API Error:',
         'Original error message',
+        expect.objectContaining({ model: 'test-model' }),
       );
     });
 
@@ -349,6 +351,7 @@ describe('EnhancedErrorHandler', () => {
       expect(debugLoggerSpy.error).toHaveBeenCalledWith(
         'OpenAI API Error:',
         'Connection error. (cause: ECONNREFUSED: fetch failed)',
+        expect.objectContaining({ model: 'test-model' }),
       );
     });
 

--- a/packages/core/src/core/openaiContentGenerator/errorHandler.ts
+++ b/packages/core/src/core/openaiContentGenerator/errorHandler.ts
@@ -6,7 +6,11 @@
 
 import type { GenerateContentParameters } from '@google/genai';
 import { createDebugLogger } from '../../utils/debugLogger.js';
-import { getErrorStatus, getErrorType } from '../../utils/errors.js';
+import {
+  getErrorMessage,
+  getErrorStatus,
+  getErrorType,
+} from '../../utils/errors.js';
 import { getRateLimitErrorDetails } from '../../utils/rateLimit.js';
 import { redactProxyError } from '../../utils/runtimeFetchOptions.js';
 import type { ErrorHandler, RequestContext } from './types.js';
@@ -112,7 +116,7 @@ export class EnhancedErrorHandler implements ErrorHandler {
       return `Request timeout after ${durationSeconds}s. Try reducing input length or increasing timeout in config.`;
     }
 
-    return error instanceof Error ? error.message : String(error);
+    return error instanceof Error ? getErrorMessage(error) : String(error);
   }
 
   private buildDiagnostics(

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -100,6 +100,34 @@ describe('parseAndFormatApiError', () => {
     expect(parseAndFormatApiError(error)).toBe(expected);
   });
 
+  it('should include the underlying cause of an Error', () => {
+    const cause = Object.assign(new Error('fetch failed'), {
+      code: 'ECONNREFUSED',
+    });
+    const error = new Error('Connection error.', { cause });
+
+    expect(parseAndFormatApiError(error)).toBe(
+      '[API Error: Connection error. (cause: ECONNREFUSED: fetch failed)]',
+    );
+  });
+
+  it('should preserve a plain Error message when there is no cause', () => {
+    expect(parseAndFormatApiError(new Error('Connection error.'))).toBe(
+      '[API Error: Connection error.]',
+    );
+  });
+
+  it('should include details from an AggregateError cause', () => {
+    const cause = Object.assign(new Error('connect failed'), {
+      code: 'ECONNREFUSED',
+    });
+    const error = new Error('Connection error.', {
+      cause: new AggregateError([cause]),
+    });
+
+    expect(parseAndFormatApiError(error)).toContain('ECONNREFUSED');
+  });
+
   it('should format a 429 StructuredError with the vertex message', () => {
     const error: StructuredError = {
       message: 'Rate limit exceeded',
@@ -114,6 +142,15 @@ describe('parseAndFormatApiError', () => {
     const error = 12345;
     const expected = '[API Error: An unknown error occurred.]';
     expect(parseAndFormatApiError(error)).toBe(expected);
+  });
+
+  it.each([
+    'Qwen OAuth quota exceeded: retry after 12:00 UTC',
+    'Qwen OAuth free tier has been discontinued for this model',
+  ])('should return Qwen quota messages unchanged: %s', (message) => {
+    const error: StructuredError = { message, status: 429 };
+
+    expect(parseAndFormatApiError(error)).toBe(message);
   });
 
   // Idempotency — added after a customer report where a 4xx in non-interactive

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -6,6 +6,7 @@
 
 import { isApiError, isStructuredError } from './quotaErrorDetection.js';
 import { AuthType } from '../core/contentGenerator.js';
+import { getErrorMessage } from './errors.js';
 
 const RATE_LIMIT_MESSAGE_BY_AUTH = {
   [AuthType.USE_GEMINI]:
@@ -80,7 +81,9 @@ export function parseAndFormatApiError(
       return error.message;
     }
 
-    let text = `[API Error: ${error.message}]`;
+    const message =
+      error instanceof Error ? getErrorMessage(error) : error.message;
+    let text = `[API Error: ${message}]`;
     if (error.status === 429) {
       text += getRateLimitMessage(authType);
     }

--- a/packages/core/src/utils/errors.test.ts
+++ b/packages/core/src/utils/errors.test.ts
@@ -12,25 +12,62 @@ describe('getErrorMessage cause unwrapping', () => {
     expect(getErrorMessage(new Error('boom'))).toBe('boom');
   });
 
-  it('surfaces an undici-style fetch-failed AggregateError cause (ECONNREFUSED)', () => {
-    // undici "TypeError: fetch failed" wraps an AggregateError whose own
-    // message is empty; the useful detail lives in `.errors[].code`.
-    const inner = Object.assign(
+  it('surfaces ECONNREFUSED from the real OpenAI and undici error chain', () => {
+    const syscall = Object.assign(
       new Error('connect ECONNREFUSED 127.0.0.1:29900'),
       { code: 'ECONNREFUSED' },
     );
-    const agg = new AggregateError([inner]); // message === ''
-    const err = new TypeError('fetch failed', { cause: agg });
+    const fetchFailed = new TypeError('fetch failed', { cause: syscall });
+    const err = new Error('Connection error.', { cause: fetchFailed });
 
     const msg = getErrorMessage(err);
-    expect(msg).toContain('fetch failed');
     expect(msg).toContain('ECONNREFUSED');
+  });
+
+  it('surfaces ENOTFOUND from the real OpenAI and undici error chain', () => {
+    const syscall = Object.assign(
+      new Error('getaddrinfo ENOTFOUND nonexistent.example'),
+      { code: 'ENOTFOUND' },
+    );
+    const fetchFailed = new TypeError('fetch failed', { cause: syscall });
+    const err = new Error('Connection error.', { cause: fetchFailed });
+
+    expect(getErrorMessage(err)).toContain('ENOTFOUND');
+  });
+
+  it('surfaces coded causes from an undici AggregateError', () => {
+    const refused = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('connect ECONNREFUSED ::1:29900'), {
+        code: 'ECONNREFUSED',
+      }),
+    });
+    const timedOut = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('connect ETIMEDOUT 127.0.0.1:29900'), {
+        code: 'ETIMEDOUT',
+      }),
+    });
+    const aggregate = new AggregateError([refused, timedOut]);
+    const fetchFailed = new TypeError('fetch failed', { cause: aggregate });
+    const err = new Error('Connection error.', { cause: fetchFailed });
+
+    const msg = getErrorMessage(err);
+    expect(msg).toContain('ECONNREFUSED');
+    expect(msg).toContain('ETIMEDOUT');
   });
 
   it('surfaces a single Error cause that has a code but empty message', () => {
     const cause = Object.assign(new Error(''), { code: 'ECONNREFUSED' });
     const err = new TypeError('fetch failed', { cause });
     expect(getErrorMessage(err)).toBe('fetch failed (cause: ECONNREFUSED)');
+  });
+
+  it('does not loop on a cyclic cause chain', () => {
+    const cause = new TypeError('fetch failed');
+    Object.defineProperty(cause, 'cause', { value: cause });
+
+    expect(getErrorMessage(new Error('Connection error.', { cause }))).toBe(
+      'Connection error. (cause: fetch failed)',
+    );
   });
 
   it('keeps the existing behavior for a cause with a meaningful message', () => {

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -49,19 +49,67 @@ export function isAbortError(error: unknown): boolean {
  *     IPv4 `127.0.0.1`): its own `message` is empty, so unwrap `.errors[]`.
  *   - a plain `Error` with a Node `code` (e.g. `ECONNREFUSED`) but possibly an
  *     empty message — prefer `code`, combine with message when both add signal.
+ *   - nested `.cause` chains: walk through opaque wrappers to the deepest code.
  *   - any other value — stringify.
  */
 function describeErrorCause(cause: unknown): string | undefined {
   if (cause == null) return undefined;
+  return (
+    describeCodedCause(cause, 0, new Set<object>()) ??
+    describeCauseFallback(cause)
+  );
+}
+
+function describeCauseFallback(cause: unknown): string | undefined {
   if (cause instanceof AggregateError && Array.isArray(cause.errors)) {
     const inner = cause.errors
-      .map((e) => describeSingleError(e))
-      .filter((s): s is string => Boolean(s));
+      .map((error) => describeSingleError(error))
+      .filter((detail): detail is string => Boolean(detail));
     if (inner.length > 0) {
       return [...new Set(inner)].join('; ');
     }
   }
   return describeSingleError(cause);
+}
+
+function describeCodedCause(
+  cause: unknown,
+  depth: number,
+  visited: Set<object>,
+): string | undefined {
+  if (
+    cause == null ||
+    depth >= 8 ||
+    typeof cause !== 'object' ||
+    visited.has(cause)
+  ) {
+    return undefined;
+  }
+
+  visited.add(cause);
+
+  if (cause instanceof AggregateError && Array.isArray(cause.errors)) {
+    const inner = cause.errors
+      .map((error) => describeCodedCause(error, depth + 1, visited))
+      .filter((detail): detail is string => Boolean(detail));
+    if (inner.length > 0) {
+      return [...new Set(inner)].join('; ');
+    }
+  }
+
+  const nested = describeCodedCause(
+    (cause as { cause?: unknown }).cause,
+    depth + 1,
+    visited,
+  );
+  if (nested) {
+    return nested;
+  }
+
+  const code = (cause as { code?: unknown }).code;
+  return typeof code === 'string' && code
+    ? describeSingleError(cause)
+    : undefined;
 }
 
 function describeSingleError(err: unknown): string | undefined {


### PR DESCRIPTION
## What this PR does

Route both discarding call sites through the existing `getErrorMessage(error)` helper in `packages/core/src/utils/errors.ts`, which already unwraps `error.cause` via `describeErrorCause()` (including undici `AggregateError`) and formats it as `${error.message} (cause: ${detail})`. Change 1: in `errorHandler.ts`, `buildErrorMessage()` currently returns `error instanceof Error ? error.message : String(error)` (~line 115) for the debug-log path; replace the `error.message` branch with `getErrorMessage(error)`.

## Why it's needed

When qwen-code is pointed at a custom OpenAI-compatible provider (via `modelProviders.openai[]` in `settings.json` or plain `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` env vars), every request fails with a generic `[API Error: Connection error. (cause: fetch failed)]`. The real underlying cause (e.g. `ECONNREFUSED`, TLS mismatch, timeout) is discarded before it reaches the user or the debug log, so the failure is undiagnosable even with `--debug --openai-logging`.

## Reviewer Test Plan

### How to verify

- happy path: an `Error("Connection error.")` whose `.cause` is `Error("fetch failed", { cause: { code: "ECONNREFUSED" } })` is formatted by `parseAndFormatApiError` into a string that contains the underlying cause (e.g. `ECONNREFUSED`), not just `Connection error.`.
- happy path: `buildErrorMessage()` in `errorHandler.ts` includes the unwrapped cause in the debug-log message for the same nested-cause error.
- edge case: a plain `Error` with no `.cause` still formats to exactly its `message` (no trailing `(cause: ...)`), preserving existing output.
- edge case: an undici `AggregateError` (multiple nested causes) surfaces a non-empty cause description rather than an empty string.
- edge case: existing early-return paths remain byte-identical — quota-exceeded messages (`Qwen OAuth quota exceeded:` / free-tier discontinued) and already-formatted `[API Error: ...]` strings are returned verbatim.
- error path: a non-Error value (e.g. a string thrown) still degrades to `String(error)` without throwing.

### Evidence (Before & After)

N/A - non-UI change (error message plumbing).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: routes error surfacing through the existing `getErrorMessage()` helper; scope limited to error plumbing.
- Not validated / out of scope: unrelated provider paths.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6996

AI was used for assistance.
