### PR TITLE
fix(shell): handle command-specific exit codes

### DIFF
--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -857,6 +857,20 @@ describe('HistoryReplayer', () => {
       );
     });
 
+    it('should preserve a stored error status without an error object', async () => {
+      const record = createToolResultRecord('run_shell_command');
+      record.toolCallResult!.status = 'error';
+
+      await replayer.replay([record]);
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionUpdate: 'tool_call_update',
+          status: 'failed',
+        }),
+      );
+    });
+
     it('should emit plan update for TodoWriteTool results', async () => {
       const todoDisplay: TodoResultDisplay = {
         type: 'todo_list',

--- a/packages/cli/src/acp-integration/session/history-replayer.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.ts
@@ -328,7 +328,10 @@ export class HistoryReplayer {
     await this.toolCallEmitter.emitResult({
       toolName,
       callId,
-      success: !result?.error,
+      success:
+        result?.status === undefined
+          ? !result?.error
+          : result.status === 'success' && !result.error,
       message: record.message.parts,
       resultDisplay: result?.resultDisplay,
       artifacts: result?.artifacts,

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -289,7 +289,7 @@ export interface ChatRecord {
    * Tool call metadata for UI recovery.
    * Contains enriched info (displayName, status, result, etc.) not in API format.
    */
-  toolCallResult?: Partial<ToolCallResponseInfo>;
+  toolCallResult?: Partial<ToolCallResponseInfo> & { status?: Status };
 
   /**
    * Payload for records that need non-API metadata. For chat compression, this

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2636,7 +2636,8 @@ describe('ShellTool', () => {
       'diff before after',
       'test -f missing',
       '[ -f missing ]',
-      'find protected-directory',
+      '[[ -f missing ]]',
+      '"C:\\\\tools\\\\grep.exe" pattern file',
     ])('does not report exit 1 from %s as a tool error', async (command) => {
       const invocation = shellTool.build({
         command,
@@ -2655,9 +2656,44 @@ describe('ShellTool', () => {
       expect(result.llmContent).toContain('Exit Code: 1');
     });
 
-    it('does not exempt exit 1 from a compound command', async () => {
+    it('does not report exit 1 from a pipeline ending in grep as a tool error', async () => {
       const invocation = shellTool.build({
-        command: 'false && grep pattern file',
+        command: 'ps aux | grep missing-process',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: '',
+        exitCode: 1,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Exit Code: 1');
+    });
+
+    it('reports exit 1 from find as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'find missing-directory',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: 'find: missing-directory: No such file or directory',
+        exitCode: 1,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.error?.type).toBe(ToolErrorType.SHELL_EXECUTE_ERROR);
+    });
+
+    it('does not exempt exit 1 from a mixed compound command', async () => {
+      const invocation = shellTool.build({
+        command: 'false && ps aux | grep pattern',
         is_background: false,
       });
       const promise = invocation.execute(mockAbortSignal);

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2608,6 +2608,87 @@ describe('ShellTool', () => {
       });
     });
 
+    it('reports a foreground non-zero exit as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'failing-command',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: 'failed output',
+        exitCode: 3,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.returnDisplay).toContain('failed output');
+      expect(result.error).toEqual({
+        message: expect.stringContaining('Exit Code: 3'),
+        type: ToolErrorType.SHELL_EXECUTE_ERROR,
+      });
+      expect(result.error?.message).toContain('failed output');
+    });
+
+    it.each([
+      'grep pattern file',
+      'rg pattern file',
+      'diff before after',
+      'test -f missing',
+      '[ -f missing ]',
+      'find protected-directory',
+    ])('does not report exit 1 from %s as a tool error', async (command) => {
+      const invocation = shellTool.build({
+        command,
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: 'negative result',
+        exitCode: 1,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Exit Code: 1');
+    });
+
+    it('does not exempt exit 1 from a compound command', async () => {
+      const invocation = shellTool.build({
+        command: 'false && grep pattern file',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: '',
+        exitCode: 1,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.error?.type).toBe(ToolErrorType.SHELL_EXECUTE_ERROR);
+    });
+
+    it('reports exit 2 from an allowlisted command as a tool error', async () => {
+      const invocation = shellTool.build({
+        command: 'grep pattern file',
+        is_background: false,
+      });
+      const promise = invocation.execute(mockAbortSignal);
+      resolveShellExecution({
+        output: 'grep failed',
+        exitCode: 2,
+        error: null,
+      });
+
+      const result = await promise;
+
+      expect(result.error?.type).toBe(ToolErrorType.SHELL_EXECUTE_ERROR);
+    });
+
     describe('long-running foreground hint', () => {
       // Auto-bg advisory. Threshold = effectiveTimeout / 2 — for the
       // default 120s timeout that's 60_000ms, which the tests below

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -346,6 +346,30 @@ function tokeniseSegment(segment: string): string[] | null {
   return tokens.slice(i);
 }
 
+const EXIT_ONE_IS_NOT_ERROR_COMMANDS = new Set([
+  'grep',
+  'rg',
+  'diff',
+  'test',
+  '[',
+  'find',
+]);
+
+function isShellExitError(command: string, exitCode: number | null) {
+  if (exitCode === null || exitCode === 0) return false;
+  if (exitCode >= 2) return true;
+
+  const segments = splitCommands(command);
+  if (segments.length !== 1) return true;
+
+  const tokens = tokeniseSegment(segments[0]!);
+  const executable = tokens?.[0];
+  if (!executable) return true;
+
+  const commandName = path.basename(path.win32.basename(executable));
+  return !EXIT_ONE_IS_NOT_ERROR_COMMANDS.has(commandName);
+}
+
 const SUDO_FLAGS_WITH_VALUE = new Set([
   '-u',
   '-g',
@@ -2865,11 +2889,22 @@ export class ShellToolInvocation extends BaseToolInvocation<
             error: {
               message:
                 result.error.message +
-                  (longRunHint ? `\n\n---\n${longRunHint}` : ''),
+                (longRunHint ? `\n\n---\n${longRunHint}` : ''),
               type: ToolErrorType.SHELL_EXECUTE_ERROR,
             },
           }
-        : {};
+        : isShellExitError(this.params.command, result.exitCode)
+          ? {
+              error: {
+                // Schedulers use error.message as the model-facing response.
+                message:
+                  typeof llmContent === 'string'
+                    ? llmContent
+                    : returnDisplayMessage,
+                type: ToolErrorType.SHELL_EXECUTE_ERROR,
+              },
+            }
+          : {};
 
     return {
       llmContent,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -65,7 +65,7 @@ import {
   splitCommands,
   stripShellWrapper,
 } from '../utils/shell-utils.js';
-import { parse } from 'shell-quote';
+import { parse, type ControlOperator } from 'shell-quote';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { checkPriorRead, StructuredToolError } from './priorReadEnforcement.js';
 import {
@@ -352,21 +352,56 @@ const EXIT_ONE_IS_NOT_ERROR_COMMANDS = new Set([
   'diff',
   'test',
   '[',
-  'find',
+  '[[',
 ]);
+
+const PIPELINE_ALLOWED_OPERATORS = new Set<ControlOperator['op']>([
+  '|',
+  '|&',
+  '<<<',
+  '>>',
+  '>&',
+  '<&',
+  '<',
+  '>',
+]);
+
+function getExitStatusSegment(command: string): string | null {
+  const segments = splitCommands(command);
+  if (segments.length === 1) return segments[0]!;
+
+  try {
+    const operators = parse(command, (key) => '$' + key).filter(
+      (token): token is ControlOperator =>
+        typeof token === 'object' && token !== null && 'op' in token,
+    );
+    if (
+      !operators.some(({ op }) => op === '|' || op === '|&') ||
+      operators.some(({ op }) => !PIPELINE_ALLOWED_OPERATORS.has(op))
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return segments.at(-1) ?? null;
+}
 
 function isShellExitError(command: string, exitCode: number | null) {
   if (exitCode === null || exitCode === 0) return false;
   if (exitCode >= 2) return true;
 
-  const segments = splitCommands(command);
-  if (segments.length !== 1) return true;
+  const exitStatusSegment = getExitStatusSegment(command);
+  if (!exitStatusSegment) return true;
 
-  const tokens = tokeniseSegment(segments[0]!);
+  const tokens = tokeniseSegment(exitStatusSegment);
   const executable = tokens?.[0];
   if (!executable) return true;
 
-  const commandName = path.basename(path.win32.basename(executable));
+  const commandName = path
+    .basename(path.win32.basename(executable))
+    .replace(/\.(?:exe|cmd|bat)$/i, '');
   return !EXIT_ONE_IS_NOT_ERROR_COMMANDS.has(commandName);
 }
 

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -453,6 +453,14 @@ describe('tool kind logic', () => {
 });
 
 describe('tool row rendering', () => {
+  it('shows failed status in the collapsed chat summary', () => {
+    const container = renderToolGroup([
+      makeTool({ toolName: 'Shell', status: 'failed' }),
+    ]);
+
+    expect(container.querySelector('button')?.textContent).toContain('Failed');
+  });
+
   it('renders ANSI shell output as styled spans instead of escape text', () => {
     const container = renderToolLine(
       makeTool({

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1394,6 +1394,7 @@ export const ToolGroup = memo(function ToolGroup({
   const compactMode = useContext(CompactModeContext);
   const [chatExpanded, setChatExpanded] = useState(false);
   const hasRunningTool = hasActiveTool(tools);
+  const hasFailedTool = tools.some((tool) => tool.status === 'failed');
   const activeTool = tools.length > 0 ? getActiveTool(tools) : undefined;
   const singleTool = tools.length === 1 ? tools[0] : undefined;
   const summaryIconTool = tools[0] ?? activeTool;
@@ -1439,6 +1440,7 @@ export const ToolGroup = memo(function ToolGroup({
               <ToolGroupIcon />
             )}
           </span>
+          {hasFailedTool && <StatusIcon status="failed" />}
           <span
             className={
               hasRunningTool

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -215,6 +215,7 @@
 
 .iconError {
   color: var(--error-color);
+  font-size: 13px;
 }
 
 .lineName {


### PR DESCRIPTION
## What this PR does

Foreground shell commands that exit unsuccessfully are now reported as failed tool calls, so telemetry, ACP history replay, and the Web Shell summary agree with the process result. Exit code 1 remains a non-error for standalone `grep`/`rg`, `diff`, and `test`/`[`/`[[` commands because those commands use it for expected negative results; pure pipelines use the final command's semantics, and Windows executable suffixes are normalized. Exit code 2 or higher remains an error.

## Why it's needed

#6869 fixed non-zero exits being recorded as success, but it was reverted by #6875 because treating every non-zero exit as an error caused false failures for common probing and comparison commands. This follow-up keeps the original status propagation while adding the command-semantics allowlist requested in the review discussion.

## Reviewer Test Plan

### How to verify

- Run a foreground shell command that exits with code 3 and confirm the tool call, telemetry, replayed history, and collapsed Web Shell summary report failure while preserving the command output and exit code for the model.
- Run standalone `grep`/`rg` with no match, `diff` with different inputs, and false `test`/`[`/`[[` conditions; confirm the exit code remains visible but the tool call is not classified as an error. Verify the same behavior for a pure pipeline ending in an allowlisted command and for an allowlisted Windows executable path.
- Confirm an allowlisted command exiting with code 2, `find` exiting with code 1, an ordinary command exiting with code 1, and a mixed compound command exiting with code 1 are still classified as failures.

### Evidence (Before & After)

Before: a foreground command with exit code 3 was persisted as `status: "success"`, emitted telemetry with `success: true`, and replayed as successful. After: the same result is persisted as `status: "error"`, emits `success: false` with `shell_execute_error`, replays as failed, and shows the failed indicator in Web Shell. Standalone allowlisted exit-1 cases keep `Exit Code: 1` in model-visible output without producing a tool error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local source build with Node.js 22; affected unit suites, full workspace build, and workspace typecheck passed.

## Risk & Scope

- Main risk or tradeoff: shell syntax can be complex, so the exit-1 exemption is intentionally limited to a single recognized command or the final command of a pure pipeline; mixed compound or unparseable commands retain the default non-zero-is-error behavior.
- Not validated / out of scope: manual Windows and Linux verification; background task status behavior is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #6869 and #6875.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

前台 shell 命令以失败状态退出时，现在会被报告为失败的工具调用，使遥测、ACP 历史回放和 Web Shell 摘要与进程结果保持一致。对于独立执行的 `grep`/`rg`、`diff` 和 `test`/`[`/`[[` 命令，退出码 1 仍不算错误，因为这些命令会用它表示预期的否定结果；纯管道按最后一个命令的语义判断，并会规范化 Windows 可执行文件后缀。退出码 2 或更高仍算错误。

## 为什么需要

#6869 修复了非零退出被记录为成功的问题，但由于将所有非零退出都视为错误会让常见的探测和比较命令产生误报，该改动被 #6875 回滚。本次后续修改保留原有的状态传播，同时加入评审讨论中要求的命令语义白名单。

## 审阅者测试计划

### 如何验证

- 运行一个以退出码 3 结束的前台 shell 命令，确认工具调用、遥测、回放历史和折叠的 Web Shell 摘要都报告失败，同时模型仍能看到命令输出和退出码。
- 分别运行无匹配的独立 `grep`/`rg`、输入存在差异的 `diff` 和条件为假的 `test`/`[`/`[[`；确认退出码仍然可见，但工具调用不会被归类为错误。对末尾为白名单命令的纯管道以及带 Windows 可执行文件路径的白名单命令验证相同行为。
- 确认白名单命令返回退出码 2、`find` 返回退出码 1、普通命令返回退出码 1，以及混合复合命令返回退出码 1 时仍会被归类为失败。

### 证据（修改前后）

修改前：退出码为 3 的前台命令会以 `status: "success"` 持久化，遥测发出 `success: true`，历史回放也显示成功。修改后：相同结果以 `status: "error"` 持久化，遥测发出带有 `shell_execute_error` 的 `success: false`，历史回放显示失败，并在 Web Shell 中展示失败标识。独立执行的白名单命令在退出码为 1 时仍会把 `Exit Code: 1` 保留在模型可见输出中，但不会产生工具错误。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 本地源码构建；受影响的单元测试、完整 workspace 构建和 workspace 类型检查均通过。

## 风险与范围

- 主要风险或权衡：shell 语法可能很复杂，因此退出码 1 的豁免被有意限制为单个可识别命令或纯管道的最后一个命令；混合复合命令或无法解析的命令继续使用默认的“非零即错误”行为。
- 未验证或范围外：未在 Windows 和 Linux 上手动验证；后台任务状态行为保持不变。
- 破坏性变更或迁移说明：无。

## 关联事项

#6869 和 #6875 的后续改进。

</details>
