### PR TITLE
fix(cli): keep streaming code blocks intact when split across commits

### DIFF
--- a/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.test.tsx
@@ -54,9 +54,7 @@ index 0000000..e69de29
       'python',
       undefined,
       80,
-      undefined,
-      mockSettings,
-      4,
+      { settings: mockSettings, tabWidth: 4 },
     );
   });
 
@@ -85,9 +83,7 @@ index 0000000..e69de29
       null,
       undefined,
       80,
-      undefined,
-      mockSettings,
-      4,
+      { settings: mockSettings, tabWidth: 4 },
     );
   });
 
@@ -115,9 +111,7 @@ index 0000000..e69de29
       null,
       undefined,
       80,
-      undefined,
-      mockSettings,
-      4,
+      { settings: mockSettings, tabWidth: 4 },
     );
   });
 

--- a/packages/cli/src/ui/components/messages/DiffRenderer.tsx
+++ b/packages/cli/src/ui/components/messages/DiffRenderer.tsx
@@ -159,9 +159,7 @@ export const DiffRenderer: React.FC<DiffRendererProps> = ({
       language,
       availableTerminalHeight,
       contentWidth,
-      theme,
-      settings,
-      tabWidth,
+      { theme, settings, tabWidth },
     );
   } else {
     renderedOutput = renderDiffContent(

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -4393,6 +4393,76 @@ describe('useGeminiStream', () => {
       });
     });
 
+    it('repairs the fence when an oversized thought is split inside a code block', async () => {
+      vi.useFakeTimers();
+
+      const splitLimit = 16_384;
+      vi.mocked(findLastSafeSplitPoint).mockImplementation(
+        (s: string, max?: number) =>
+          max !== undefined && s.length > max ? max : s.length,
+      );
+
+      // A reasoning stream whose fenced code block spans the char-cap boundary.
+      const codeBody = Array.from(
+        { length: 2000 },
+        (_, i) => `const x${i} = ${i};`,
+      ).join('\n');
+      const longThought = '```ts\n' + codeBody;
+      expect(longThought.length).toBeGreaterThan(splitLimit);
+
+      let releaseStream!: () => void;
+      const holdStream = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      const mockStream = (async function* () {
+        yield {
+          type: ServerGeminiEventType.Thought,
+          value: { description: longThought },
+        };
+        await holdStream;
+      })();
+      mockSendMessageStream.mockReturnValue(mockStream);
+
+      const { result } = renderTestHook();
+      act(() => {
+        void result.current.submitQuery('test query');
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(60);
+      });
+
+      const thoughtItems = mockAddItem.mock.calls
+        .map(([item]) => item as HistoryItem)
+        .filter(
+          (item) =>
+            item.type === 'gemini_thought' ||
+            item.type === 'gemini_thought_content',
+        );
+      // The committed head is a self-contained fenced block (opening fence +
+      // synthetic closing fence), not an unterminated one.
+      expect(thoughtItems.length).toBeGreaterThanOrEqual(1);
+      const head = thoughtItems[0]!;
+      expect(head.text.startsWith('```ts')).toBe(true);
+      expect(head.text.trimEnd().endsWith('```')).toBe(true);
+      // The pending tail re-opens the fence (with a continued gutter directive)
+      // instead of leaking code as prose.
+      const pendingText = result.current.pendingHistoryItems[0]?.text ?? '';
+      expect(pendingText.startsWith('```ts')).toBe(true);
+      expect(pendingText).toContain('qwen-code:start-line=');
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      await act(async () => {
+        releaseStream();
+      });
+    });
+
     it('splits oversized streamed content by rendered height so the pending item stays bounded', async () => {
       vi.useFakeTimers();
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -131,9 +131,17 @@ vi.mock('./shellCommandProcessor.js', () => ({
 
 vi.mock('./atCommandProcessor.js');
 
-vi.mock('../utils/markdownUtilities.js', () => ({
-  findLastSafeSplitPoint: vi.fn((s: string) => s.length),
-}));
+vi.mock('../utils/markdownUtilities.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../utils/markdownUtilities.js')>();
+  return {
+    ...actual,
+    // Only the split-point chooser is mocked so tests can drive commit
+    // boundaries per-case. The real splitFencedMarkdown / getEnclosingFenceInfo
+    // run, so fence detection and repair match production.
+    findLastSafeSplitPoint: vi.fn((s: string) => s.length),
+  };
+});
 
 vi.mock('./useLogger.js', () => ({
   useLogger: vi.fn().mockReturnValue({
@@ -4668,6 +4676,102 @@ describe('useGeminiStream', () => {
       const pendingLines =
         pendingText.length === 0 ? 0 : pendingText.split('\n').length;
       expect(pendingLines).toBeLessThanOrEqual(12);
+
+      act(() => result.current.cancelOngoingRequest());
+      await act(async () => {
+        releaseStream();
+      });
+    });
+
+    it('commits a code block taller than the viewport incrementally (no stall-then-dump)', async () => {
+      vi.useFakeTimers();
+      vi.mocked(findLastSafeSplitPoint).mockImplementation(
+        (s: string, cap?: number) =>
+          cap === undefined ? s.length : Math.min(cap, s.length),
+      );
+
+      // Intro + blank, then a fenced code block far taller than the budget
+      // (terminalHeight 24 → budget 7) whose lines carry NO blank-line boundary,
+      // then a trailing paragraph. Before the fence-aware mid-block commit, the
+      // whole block had no safe split point and stayed pending — frozen on its
+      // head — until finalize dumped it at once. It must now commit in chunks.
+      const codeLines = Array.from(
+        { length: 40 },
+        (_, i) => `int v${i} = ${i};`,
+      );
+      const content = [
+        'Here is some C++:',
+        '',
+        '```cpp',
+        ...codeLines,
+        '```',
+        '',
+        'And a normal paragraph after the code.',
+      ].join('\n');
+
+      const { result } = renderTestHook();
+      const releaseStream = await streamContent(result, content);
+
+      // Committed BEFORE finalize (streamContent holds the stream open): early
+      // code lines already landed in <Static> rather than waiting to dump.
+      const committed = geminiContentItems();
+      expect(committed.length).toBeGreaterThanOrEqual(2);
+      expect(committed.some((item) => item.text.includes('int v0 = 0;'))).toBe(
+        true,
+      );
+      // Every committed chunk that carries code lines is a self-contained fenced
+      // block (the split closed/re-opened the fence — no orphaned prose tail).
+      for (const item of committed) {
+        if (item.text.includes('int v')) {
+          expect(item.text).toContain('```');
+        }
+      }
+      // The live pending frame is bounded, not the whole 40+ line block.
+      const pendingText = result.current.pendingHistoryItems[0]?.text ?? '';
+      const pendingLines =
+        pendingText.length === 0 ? 0 : pendingText.split('\n').length;
+      expect(pendingLines).toBeLessThanOrEqual(12);
+
+      act(() => result.current.cancelOngoingRequest());
+      await act(async () => {
+        releaseStream();
+      });
+    });
+
+    it('keeps a tall mermaid block whole (never splits it mid-diagram)', async () => {
+      vi.useFakeTimers();
+      vi.mocked(findLastSafeSplitPoint).mockImplementation(
+        (s: string, cap?: number) =>
+          cap === undefined ? s.length : Math.min(cap, s.length),
+      );
+
+      // A mermaid block far taller than the budget with no blank lines. Unlike a
+      // plain code block, mermaid needs its whole source to render a diagram, so
+      // it must NOT be hard-split — it stays pending until it completes.
+      const nodes = Array.from(
+        { length: 40 },
+        (_, i) => `  A${i} --> A${i + 1}`,
+      );
+      const content = [
+        'Here is a diagram:',
+        '',
+        '```mermaid',
+        'graph TD',
+        ...nodes,
+      ].join('\n');
+
+      const { result } = renderTestHook();
+      const releaseStream = await streamContent(result, content);
+
+      // Nothing containing mermaid edges was committed mid-block: no committed
+      // chunk carries a partial diagram.
+      for (const item of geminiContentItems()) {
+        expect(item.text.includes('-->')).toBe(false);
+      }
+      // The whole diagram source sits in the (bounded-by-render) pending item.
+      const pendingText = result.current.pendingHistoryItems[0]?.text ?? '';
+      expect(pendingText).toContain('```mermaid');
+      expect(pendingText).toContain('graph TD');
 
       act(() => result.current.cancelOngoingRequest());
       await act(async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -86,7 +86,11 @@ import {
   handleAtCommand,
   resolveAtCommandQuery,
 } from './atCommandProcessor.js';
-import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
+import {
+  findLastSafeSplitPoint,
+  splitFencedMarkdown,
+  getEnclosingFenceInfo,
+} from '../utils/markdownUtilities.js';
 import { fitPendingSlice } from '../utils/pending-rendered-height.js';
 import { useStateAndRef } from './useStateAndRef.js';
 import { prefixMidTurnUserMessageParts } from '../../utils/midTurnUserMessage.js';
@@ -1225,8 +1229,12 @@ export const useGeminiStream = (
         // multiple times per-second (as streaming occurs). Prior to this change you'd
         // see heavy flickering of the terminal. This ensures that larger messages get
         // broken up so that there are more "statically" rendered.
-        const beforeText = newGeminiMessageBuffer.substring(0, safeSplitPoint);
-        const afterText = newGeminiMessageBuffer.substring(safeSplitPoint);
+        // Repair fences when the split lands inside a code block so the tail
+        // does not render as prose (see splitFencedMarkdown).
+        const { before: beforeText, after: afterText } = splitFencedMarkdown(
+          newGeminiMessageBuffer,
+          safeSplitPoint,
+        );
         commitItem(
           {
             type: nextPendingType,
@@ -1297,12 +1305,37 @@ export const useGeminiStream = (
             break;
           }
         }
-        if (boundaryLine < 0) break; // no block boundary yet → keep pending
-        const target = charIndexAfterLine(
-          newGeminiMessageBuffer,
-          boundaryLine + 1,
-        );
-        if (target <= 0) break;
+        let target: number;
+        if (boundaryLine < 0) {
+          // No blank-line boundary at/before the kept prefix. A fenced code
+          // block taller than the viewport never provides one mid-block, so the
+          // whole block would stay pending — frozen on its head — and only land
+          // in scrollback when it finally closes (the "stall then dump" seen on
+          // a 100-line code block). Hard-splitting inside a fence is now safe
+          // (splitFencedMarkdown closes/re-opens the fence and continues the
+          // gutter), so commit the budget-fit prefix and keep streaming. Restrict
+          // this to code blocks: other tall blocks (tables/lists) must stay whole
+          // and are still kept pending.
+          const capIndex = charIndexAfterLine(
+            newGeminiMessageBuffer,
+            keptLines,
+          );
+          const fenceInfo =
+            capIndex > 0
+              ? getEnclosingFenceInfo(newGeminiMessageBuffer, capIndex)
+              : null;
+          // Only hard-split a real code block. Other tall blocks (tables/lists)
+          // must stay whole, and mermaid needs its whole source to render a
+          // diagram — splitting it mid-block would break the render — so both
+          // stay pending until they complete.
+          if (!fenceInfo || fenceInfo.lang?.toLowerCase() === 'mermaid') {
+            break; // no safe boundary yet → keep pending
+          }
+          target = capIndex;
+        } else {
+          target = charIndexAfterLine(newGeminiMessageBuffer, boundaryLine + 1);
+          if (target <= 0) break;
+        }
         const splitPoint = findLastSafeSplitPoint(
           newGeminiMessageBuffer,
           target,
@@ -1310,8 +1343,12 @@ export const useGeminiStream = (
         if (splitPoint <= 0 || splitPoint >= newGeminiMessageBuffer.length) {
           break;
         }
-        const beforeText = newGeminiMessageBuffer.substring(0, splitPoint);
-        const afterText = newGeminiMessageBuffer.substring(splitPoint);
+        // Repair fences when the split lands inside a code block so the tail
+        // does not render as prose (see splitFencedMarkdown).
+        const { before: beforeText, after: afterText } = splitFencedMarkdown(
+          newGeminiMessageBuffer,
+          splitPoint,
+        );
         commitItem(
           {
             type: nextPendingType,
@@ -1459,8 +1496,12 @@ export const useGeminiStream = (
           splitPoint > 0 && splitPoint < newThoughtBuffer.length
             ? splitPoint
             : STREAM_PENDING_ITEM_MAX_CHARS;
-        const beforeText = newThoughtBuffer.substring(0, safeSplitPoint);
-        const afterText = newThoughtBuffer.substring(safeSplitPoint);
+        // Repair fences when the split lands inside a code block so the tail
+        // does not render as prose (see splitFencedMarkdown).
+        const { before: beforeText, after: afterText } = splitFencedMarkdown(
+          newThoughtBuffer,
+          safeSplitPoint,
+        );
         addItem(
           buildThoughtItem(pendingThoughtType, beforeText),
           userMessageTimestamp,

--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -220,22 +220,32 @@ export function colorizeLine(
  *
  * @param code The code string to highlight.
  * @param language The language identifier (e.g., 'javascript', 'css', 'html')
- * @param tabWidth The number of spaces to replace each tab character with, default is 4
- * @param startLineNumber The number shown for the first line, default 1. Lets a
- *   code block that was split across streaming commits (see splitFencedMarkdown)
- *   continue its gutter numbering instead of restarting at 1.
+ * @param availableHeight Optional cap on rendered rows (older lines are clipped).
+ * @param maxWidth Optional cap on rendered width.
+ * @param options Presentation overrides:
+ *   - `theme` — theme to use (defaults to the active theme)
+ *   - `settings` — loaded settings (drives showLineNumbers)
+ *   - `tabWidth` — spaces per tab, default 4
+ *   - `startLineNumber` — the number shown for the first line, default 1. Lets a
+ *     code block that was split across streaming commits (see splitFencedMarkdown)
+ *     continue its gutter numbering instead of restarting at 1.
  * @returns A React.ReactNode containing Ink <Text> elements for the highlighted code.
  */
+export interface ColorizeCodeOptions {
+  theme?: Theme;
+  settings?: LoadedSettings;
+  tabWidth?: number;
+  startLineNumber?: number;
+}
+
 export function colorizeCode(
   code: string,
   language: string | null,
   availableHeight?: number,
   maxWidth?: number,
-  theme?: Theme,
-  settings?: LoadedSettings,
-  tabWidth = 4,
-  startLineNumber = 1,
+  options: ColorizeCodeOptions = {},
 ): React.ReactNode {
+  const { theme, settings, tabWidth = 4, startLineNumber = 1 } = options;
   const firstLineNumber = Math.max(1, Math.trunc(startLineNumber));
   const codeToHighlight = code
     .replace(/\n$/, '')

--- a/packages/cli/src/ui/utils/CodeColorizer.tsx
+++ b/packages/cli/src/ui/utils/CodeColorizer.tsx
@@ -221,6 +221,9 @@ export function colorizeLine(
  * @param code The code string to highlight.
  * @param language The language identifier (e.g., 'javascript', 'css', 'html')
  * @param tabWidth The number of spaces to replace each tab character with, default is 4
+ * @param startLineNumber The number shown for the first line, default 1. Lets a
+ *   code block that was split across streaming commits (see splitFencedMarkdown)
+ *   continue its gutter numbering instead of restarting at 1.
  * @returns A React.ReactNode containing Ink <Text> elements for the highlighted code.
  */
 export function colorizeCode(
@@ -231,7 +234,9 @@ export function colorizeCode(
   theme?: Theme,
   settings?: LoadedSettings,
   tabWidth = 4,
+  startLineNumber = 1,
 ): React.ReactNode {
+  const firstLineNumber = Math.max(1, Math.trunc(startLineNumber));
   const codeToHighlight = code
     .replace(/\n$/, '')
     .replace(/\t/g, ' '.repeat(tabWidth));
@@ -247,7 +252,8 @@ export function colorizeCode(
     // Render the HAST tree using the adapted theme
     // Apply the theme's default foreground color to the top-level Text element
     let lines = codeToHighlight.split('\n');
-    const padWidth = String(lines.length).length; // Calculate padding width based on number of lines
+    // Pad to the widest gutter number, accounting for a non-1 start offset.
+    const padWidth = String(lines.length + firstLineNumber - 1).length;
 
     let hiddenLinesCount = 0;
 
@@ -280,10 +286,9 @@ export function colorizeCode(
             <Box key={index}>
               {showLineNumbers && (
                 <Text color={activeTheme.colors.Gray}>
-                  {`${String(index + 1 + hiddenLinesCount).padStart(
-                    padWidth,
-                    ' ',
-                  )} `}
+                  {`${String(
+                    index + firstLineNumber + hiddenLinesCount,
+                  ).padStart(padWidth, ' ')} `}
                 </Text>
               )}
               <Text color={activeTheme.defaultColor} wrap="wrap">
@@ -302,7 +307,7 @@ export function colorizeCode(
     // Fall back to plain text with default color on error
     // Also display line numbers in fallback
     const lines = codeToHighlight.split('\n');
-    const padWidth = String(lines.length).length; // Calculate padding width based on number of lines
+    const padWidth = String(lines.length + firstLineNumber - 1).length;
     return (
       <MaxSizedBox
         maxHeight={availableHeight}
@@ -313,7 +318,7 @@ export function colorizeCode(
           <Box key={index}>
             {showLineNumbers && (
               <Text color={activeTheme.defaultColor}>
-                {`${String(index + 1).padStart(padWidth, ' ')} `}
+                {`${String(index + firstLineNumber).padStart(padWidth, ' ')} `}
               </Text>
             )}
             <Text color={activeTheme.colors.Gray}>{line}</Text>

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -76,6 +76,25 @@ describe('<MarkdownDisplay />', () => {
       expect(lastFrame()).toMatchSnapshot();
     });
 
+    it('continues gutter numbering for a fence carrying the start-line directive', () => {
+      // A tail produced by splitFencedMarkdown after 16 lines were committed.
+      const text =
+        '```javascript qwen-code:start-line=17\nconst a = 1;\nconst b = 2;\n```'.replace(
+          /\n/g,
+          eol,
+        );
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame() ?? '';
+      // Gutter continues at 17/18 instead of restarting at 1/2.
+      expect(frame).toContain('17');
+      expect(frame).toContain('18');
+      // The internal directive lives on the (unrendered) fence line, so it must
+      // never surface on screen.
+      expect(frame).not.toContain('qwen-code');
+    });
+
     it('handles unclosed (pending) code blocks', () => {
       const text = '```typescript\nlet y = 2;'.replace(/\n/g, eol);
       const { lastFrame } = renderWithProviders(

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -904,10 +904,7 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
         lang,
         availableTerminalHeight,
         contentWidth - CODE_BLOCK_PREFIX_PADDING,
-        undefined,
-        settings,
-        undefined,
-        startLineNumber,
+        { settings, startLineNumber },
       );
       return (
         <Box paddingLeft={CODE_BLOCK_PREFIX_PADDING} flexDirection="column">
@@ -922,10 +919,7 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
     lang,
     availableTerminalHeight,
     contentWidth - CODE_BLOCK_PREFIX_PADDING,
-    undefined,
-    settings,
-    undefined,
-    startLineNumber,
+    { settings, startLineNumber },
   );
 
   return (

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -14,6 +14,7 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import { MermaidDiagram } from './MermaidDiagram.js';
 import { renderInlineLatex } from './latexRenderer.js';
 import { useRenderMode } from '../contexts/RenderModeContext.js';
+import { parseCodeFenceInfo } from './markdownUtilities.js';
 import {
   fitPendingSlice,
   splitMarkdownTableRow,
@@ -99,8 +100,7 @@ export function countMarkdownSourceBlocks(
 
     if (codeFenceMatch) {
       activeCodeFence = codeFenceMatch[1];
-      const lang =
-        codeFenceMatch[2]?.trim().split(/\s+/)[0]?.toLowerCase() || null;
+      const lang = parseCodeFenceInfo(codeFenceMatch[2]).lang?.toLowerCase();
       if (lang) {
         codeBlockLanguageCounts.set(
           lang,
@@ -381,6 +381,9 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   let codeBlockIndex = 0;
   let currentCodeBlockIndex = 0;
   let currentCodeBlockLangIndex = 0;
+  // Gutter start line for the current block: >1 when it continues a block that
+  // streaming split across commits (see splitFencedMarkdown).
+  let currentCodeBlockStartLine = 1;
   const codeBlockLanguageCounts = new Map<string, number>(
     sourceCopyIndexOffsets?.codeBlockLanguageCounts,
   );
@@ -424,6 +427,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
             isPending={isPending}
             availableTerminalHeight={availableTerminalHeight}
             contentWidth={contentWidth}
+            startLineNumber={currentCodeBlockStartLine}
           />,
         );
         inCodeBlock = false;
@@ -474,7 +478,9 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       codeBlockIndex += 1;
       currentCodeBlockIndex = codeBlockIndex;
       codeBlockFence = codeFenceMatch[1];
-      codeBlockLang = codeFenceMatch[2]?.trim().split(/\s+/)[0] || null;
+      const fenceInfo = parseCodeFenceInfo(codeFenceMatch[2]);
+      codeBlockLang = fenceInfo.lang;
+      currentCodeBlockStartLine = fenceInfo.startLine;
       if (codeBlockLang) {
         const normalizedLang = codeBlockLang.toLowerCase();
         const nextLangIndex =
@@ -735,6 +741,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         isPending={isPending}
         availableTerminalHeight={availableTerminalHeight}
         contentWidth={contentWidth}
+        startLineNumber={currentCodeBlockStartLine}
       />,
     );
   }
@@ -825,6 +832,9 @@ interface RenderCodeBlockProps {
   isPending: boolean;
   availableTerminalHeight?: number;
   contentWidth: number;
+  /** Gutter number for the first line; >1 when the block continues a block
+   * that streaming split across commits (see splitFencedMarkdown). */
+  startLineNumber?: number;
 }
 
 const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
@@ -835,6 +845,7 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
   isPending,
   availableTerminalHeight,
   contentWidth,
+  startLineNumber = 1,
 }) => {
   const settings = useSettings();
   const { renderMode } = useRenderMode();
@@ -895,6 +906,8 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
         contentWidth - CODE_BLOCK_PREFIX_PADDING,
         undefined,
         settings,
+        undefined,
+        startLineNumber,
       );
       return (
         <Box paddingLeft={CODE_BLOCK_PREFIX_PADDING} flexDirection="column">
@@ -911,6 +924,8 @@ const RenderCodeBlockInternal: React.FC<RenderCodeBlockProps> = ({
     contentWidth - CODE_BLOCK_PREFIX_PADDING,
     undefined,
     settings,
+    undefined,
+    startLineNumber,
   );
 
   return (

--- a/packages/cli/src/ui/utils/markdownUtilities.test.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.test.ts
@@ -9,6 +9,7 @@ import {
   findLastSafeSplitPoint,
   splitFencedMarkdown,
   parseCodeFenceInfo,
+  getEnclosingFenceInfo,
 } from './markdownUtilities.js';
 
 describe('markdownUtilities', () => {
@@ -198,6 +199,38 @@ describe('markdownUtilities', () => {
       expect(parseCodeFenceInfo(undefined)).toEqual({
         lang: null,
         startLine: 1,
+      });
+    });
+  });
+
+  describe('getEnclosingFenceInfo', () => {
+    it('returns null when the index is not inside a fence', () => {
+      const content = 'plain intro\n\n```ts\ncode\n```\n\nafter';
+      expect(getEnclosingFenceInfo(content, 3)).toBeNull(); // in the intro
+      expect(getEnclosingFenceInfo(content, content.length - 2)).toBeNull(); // after the closed block
+    });
+
+    it('reports the language and start line of the enclosing code block', () => {
+      const content = '```python\nline1\nline2\n';
+      const idx = content.indexOf('line2');
+      expect(getEnclosingFenceInfo(content, idx)).toEqual({
+        lang: 'python',
+        startLine: 1,
+      });
+    });
+
+    it('surfaces the mermaid language so the caller can keep the block whole', () => {
+      const content = '```mermaid\ngraph TD\nA-->B\n';
+      const idx = content.indexOf('A-->B');
+      expect(getEnclosingFenceInfo(content, idx)?.lang).toBe('mermaid');
+    });
+
+    it('carries the accumulated start-line directive from a re-opened fence', () => {
+      const content = '```ts qwen-code:start-line=7\nline7\nline8\n';
+      const idx = content.indexOf('line8');
+      expect(getEnclosingFenceInfo(content, idx)).toEqual({
+        lang: 'ts',
+        startLine: 7,
       });
     });
   });

--- a/packages/cli/src/ui/utils/markdownUtilities.test.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.test.ts
@@ -150,6 +150,22 @@ describe('markdownUtilities', () => {
       expect(after.match(/qwen-code:start-line=/g)).toHaveLength(1);
     });
 
+    it('handles a language-less fence without a stray leading space', () => {
+      const content = '```\nline1\nline2\nline3\n';
+      const splitPoint = content.indexOf('line3');
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      // Head closes with a bare fence; tail re-opens with the directive only,
+      // no language and no leading space.
+      expect(before).toBe('```\nline1\nline2\n```\n');
+      expect(after).toBe('```qwen-code:start-line=3\nline3\n');
+      expect(after).toMatch(/^```qwen-code:start-line=\d+\n/);
+      // The directive still parses back to no language and the right start line.
+      expect(parseCodeFenceInfo('qwen-code:start-line=3')).toEqual({
+        lang: null,
+        startLine: 3,
+      });
+    });
+
     it('does not touch a split that closes exactly at the fence boundary', () => {
       // Point sits right after a fully closed block → not inside a fence.
       const content = '```ts\ncode\n```\n\nprose after';

--- a/packages/cli/src/ui/utils/markdownUtilities.test.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { findLastSafeSplitPoint } from './markdownUtilities.js';
+import {
+  findLastSafeSplitPoint,
+  splitFencedMarkdown,
+  parseCodeFenceInfo,
+} from './markdownUtilities.js';
 
 describe('markdownUtilities', () => {
   describe('findLastSafeSplitPoint', () => {
@@ -85,6 +89,116 @@ describe('markdownUtilities', () => {
     it('should hard split an oversized leading code block with a max length', () => {
       const content = '```ts\n' + 'a'.repeat(100);
       expect(findLastSafeSplitPoint(content, 40)).toBe(40);
+    });
+  });
+
+  describe('splitFencedMarkdown', () => {
+    it('splits plainly when the point is not inside a code block', () => {
+      const content = 'Intro paragraph.\n\nSecond paragraph.';
+      const splitPoint = 18; // start of "Second paragraph."
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      expect(before).toBe(content.slice(0, splitPoint));
+      expect(after).toBe(content.slice(splitPoint));
+    });
+
+    it('closes the head fence and re-opens it on the tail when split inside a fence', () => {
+      const content = '```python\nline1\nline2\n\nline3\nline4\n';
+      const splitPoint = content.indexOf('line3'); // inside the still-open fence
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      // Head shows line1,line2,blank (3 lines), so the tail continues at line 4.
+      expect(before).toBe('```python\nline1\nline2\n\n```\n');
+      expect(after).toBe('```python qwen-code:start-line=4\nline3\nline4\n');
+      // Each half is now a self-contained, valid fenced block.
+      expect(before.match(/```/g)).toHaveLength(2);
+      expect(after.startsWith('```python ')).toBe(true);
+      // The directive parses back to the right language and start line.
+      expect(parseCodeFenceInfo('python qwen-code:start-line=4')).toEqual({
+        lang: 'python',
+        startLine: 4,
+      });
+    });
+
+    it('preserves the exact delimiter run and info string', () => {
+      const content = '~~~~ts extra\naaaa\nbbbb\n';
+      const splitPoint = content.indexOf('bbbb');
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      expect(before.endsWith('~~~~\n')).toBe(true); // closing carries no info string
+      // Re-open keeps the delimiter run and full info string, plus the directive.
+      expect(after.startsWith('~~~~ts extra qwen-code:start-line=2\n')).toBe(
+        true,
+      );
+    });
+
+    it('inserts a newline before the closing fence when the head does not end with one', () => {
+      const content = '```ts\n' + 'a'.repeat(100);
+      const splitPoint = 40; // mid-line hard split inside the fence
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      expect(before).toBe(content.slice(0, 40) + '\n```\n');
+      expect(after).toBe('```ts qwen-code:start-line=2\n' + content.slice(40));
+    });
+
+    it('accumulates the start line when a re-opened tail is split again', () => {
+      // Simulate the tail produced by a prior split (already carries a directive).
+      const tail =
+        '```python qwen-code:start-line=4\nline4\nline5\n\nline6\nline7\n';
+      const splitPoint = tail.indexOf('line6');
+      const { after } = splitFencedMarkdown(tail, splitPoint);
+      // Head of this tail shows line4,line5,blank (3 lines) from start 4 → next 7.
+      expect(after.startsWith('```python qwen-code:start-line=7\n')).toBe(true);
+      // No duplicated directive on the re-opened fence.
+      expect(after.match(/qwen-code:start-line=/g)).toHaveLength(1);
+    });
+
+    it('does not touch a split that closes exactly at the fence boundary', () => {
+      // Point sits right after a fully closed block → not inside a fence.
+      const content = '```ts\ncode\n```\n\nprose after';
+      const splitPoint = content.indexOf('prose after');
+      const { before, after } = splitFencedMarkdown(content, splitPoint);
+      expect(before).toBe(content.slice(0, splitPoint));
+      expect(after).toBe(content.slice(splitPoint));
+    });
+
+    it('returns the whole content unchanged at the string boundaries', () => {
+      const content = '```ts\ncode';
+      expect(splitFencedMarkdown(content, 0)).toEqual({
+        before: '',
+        after: content,
+      });
+      expect(splitFencedMarkdown(content, content.length)).toEqual({
+        before: content,
+        after: '',
+      });
+    });
+  });
+
+  describe('parseCodeFenceInfo', () => {
+    it('parses a plain language with no directive as start line 1', () => {
+      expect(parseCodeFenceInfo('python')).toEqual({
+        lang: 'python',
+        startLine: 1,
+      });
+    });
+
+    it('extracts the start line and strips the directive from the language', () => {
+      expect(parseCodeFenceInfo('ts qwen-code:start-line=17')).toEqual({
+        lang: 'ts',
+        startLine: 17,
+      });
+    });
+
+    it('handles a language-less fence that only carries the directive', () => {
+      expect(parseCodeFenceInfo('qwen-code:start-line=5')).toEqual({
+        lang: null,
+        startLine: 5,
+      });
+    });
+
+    it('returns null language and start line 1 for empty/undefined info', () => {
+      expect(parseCodeFenceInfo('')).toEqual({ lang: null, startLine: 1 });
+      expect(parseCodeFenceInfo(undefined)).toEqual({
+        lang: null,
+        startLine: 1,
+      });
     });
   });
 });

--- a/packages/cli/src/ui/utils/markdownUtilities.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.ts
@@ -96,32 +96,60 @@ const isIndexInsideCodeBlock = (
 };
 
 /**
- * Finds the starting index of the code block (``` or ~~~) that encloses the
- * given index. Returns -1 if the index is not inside a code block.
+ * Returns the fenced code block (``` or ~~~) that encloses `indexToTest`, or
+ * null when the index is not inside one. Reports the fence's start index, its
+ * exact opening delimiter run (e.g. "```" or "~~~~") and the info string that
+ * followed it on the same line (e.g. "python", "ts"), so a split can re-open an
+ * identical fence. Open/close matching mirrors findLastSafeSplitPoint's rules:
+ * a fence only closes a block opened with the SAME character AND a run at least
+ * as long.
  */
-const findEnclosingCodeBlockStart = (
+const getEnclosingFence = (
   content: string,
-  index: number,
-): number => {
-  let openChar: '`' | '~' | '' = '';
-  let openLen = 0;
-  let openIndex = -1;
+  indexToTest: number,
+): { startIndex: number; delimiter: string; infoString: string } | null => {
+  let open: { char: '`' | '~'; len: number; index: number } | null = null;
   let searchPos = 0;
   while (searchPos < content.length) {
     const fence = findNextFence(content, searchPos);
-    if (!fence || fence.index >= index) break;
-    if (openChar === '') {
-      openChar = fence.char;
-      openLen = fence.length;
-      openIndex = fence.index;
-    } else if (fence.char === openChar && fence.length >= openLen) {
-      openChar = '';
-      openLen = 0;
-      openIndex = -1;
+    if (!fence || fence.index >= indexToTest) break;
+    if (!open) {
+      open = { char: fence.char, len: fence.length, index: fence.index };
+    } else if (fence.char === open.char && fence.length >= open.len) {
+      open = null;
     }
     searchPos = fence.index + fence.length;
   }
-  return openChar !== '' ? openIndex : -1;
+  if (!open) return null;
+  const newlineIndex = content.indexOf('\n', open.index);
+  const fenceLineEnd = newlineIndex === -1 ? content.length : newlineIndex;
+  return {
+    startIndex: open.index,
+    delimiter: content.slice(open.index, open.index + open.len),
+    infoString: content.slice(open.index + open.len, fenceLineEnd),
+  };
+};
+
+/**
+ * Finds the starting index of the code block (``` or ~~~) that encloses the
+ * given index. Returns -1 if the index is not inside a code block.
+ */
+const findEnclosingCodeBlockStart = (content: string, index: number): number =>
+  getEnclosingFence(content, index)?.startIndex ?? -1;
+
+/**
+ * When `index` sits inside an open fenced code block, returns that block's
+ * language and gutter start line; otherwise null. Lets the streaming commit
+ * loop tell a tall code block (safe to hard-split via splitFencedMarkdown) apart
+ * from other tall blocks like tables/lists (which must stay whole), and from
+ * whole-source blocks like mermaid (which must not be split mid-diagram).
+ */
+export const getEnclosingFenceInfo = (
+  content: string,
+  index: number,
+): { lang: string | null; startLine: number } | null => {
+  const fence = getEnclosingFence(content, index);
+  return fence ? parseCodeFenceInfo(fence.infoString) : null;
 };
 
 export const findLastSafeSplitPoint = (
@@ -191,4 +219,96 @@ export const findLastSafeSplitPoint = (
   // block boundary. With a cap, fall back to the cap so a single long line
   // cannot remain one ever-growing pending render item forever.
   return hasLengthCap ? searchEnd : content.length;
+};
+
+/**
+ * Internal fence info-string directive carrying the gutter start line for a
+ * code block that streaming split across commits. It rides on the re-opened
+ * fence's info line — which is a delimiter line, never rendered as content — so
+ * it never shows on screen; it only lets `parseCodeFenceInfo` restore
+ * continuous line numbering. Namespaced to avoid colliding with real info
+ * strings.
+ */
+const START_LINE_DIRECTIVE_RE = /\s*\bqwen-code:start-line=(\d+)\b/;
+
+/**
+ * Parses a fenced code block's info string into its language (first token, with
+ * the internal start-line directive removed) and the gutter start line (1 when
+ * no directive is present). Shared by MarkdownDisplay so the directive never
+ * leaks into language detection.
+ */
+export const parseCodeFenceInfo = (
+  info: string | undefined | null,
+): { lang: string | null; startLine: number } => {
+  const raw = info ?? '';
+  const directive = raw.match(START_LINE_DIRECTIVE_RE);
+  const startLine = directive ? Math.max(1, Number(directive[1])) : 1;
+  const lang = raw.replace(START_LINE_DIRECTIVE_RE, '').trim().split(/\s+/)[0];
+  return { lang: lang || null, startLine };
+};
+
+/** Counts code lines shown in the committed head of a fenced block, i.e. the
+ * lines after the opening fence line up to `splitPoint`. Used to advance the
+ * re-opened tail's start line so its gutter continues instead of resetting. */
+const countHeadContentLines = (
+  content: string,
+  fenceStartIndex: number,
+  splitPoint: number,
+): number => {
+  const headFromFence = content.slice(fenceStartIndex, splitPoint);
+  const newlineCount = (headFromFence.match(/\n/g) || []).length;
+  // The opening fence line owns the first newline; the rest are content lines.
+  // A head not ending in a newline has one trailing partial content line.
+  return headFromFence.endsWith('\n') ? newlineCount - 1 : newlineCount;
+};
+
+/**
+ * Splits `content` at `splitPoint` into a head (committed to <Static>) and a
+ * tail (kept pending) for streaming render.
+ *
+ * `findLastSafeSplitPoint` prefers block boundaries, but with a length cap it
+ * may deliberately hard-split INSIDE a fenced code block to bound an oversized
+ * leading block (so the live pending frame stays within the viewport). A naive
+ * substring split there breaks rendering: the head becomes an unterminated
+ * fence and the tail, now missing its opening fence, renders as plain prose —
+ * losing syntax highlighting and line numbers.
+ *
+ * This helper makes both halves valid standalone markdown: when the split lands
+ * strictly inside a fence, it closes the fence at the end of the head and
+ * re-opens an identical fence (same delimiter run and info string) at the start
+ * of the tail. When the split is not inside a fence it is a plain substring
+ * split, identical to the previous behavior.
+ */
+export const splitFencedMarkdown = (
+  content: string,
+  splitPoint: number,
+): { before: string; after: string } => {
+  const before = content.slice(0, splitPoint);
+  const after = content.slice(splitPoint);
+  if (splitPoint <= 0 || splitPoint >= content.length) {
+    return { before, after };
+  }
+
+  const fence = getEnclosingFence(content, splitPoint);
+  if (!fence) {
+    return { before, after };
+  }
+
+  // A closing fence must carry no info string; the re-opened fence restores the
+  // original delimiter run and language so the tail keeps its highlighting, and
+  // advances the start-line directive so the tail's gutter continues instead of
+  // resetting to 1.
+  const closingFence = fence.delimiter;
+  const { startLine: headStart } = parseCodeFenceInfo(fence.infoString);
+  const tailStart =
+    headStart + countHeadContentLines(content, fence.startIndex, splitPoint);
+  const baseInfo = fence.infoString
+    .replace(START_LINE_DIRECTIVE_RE, '')
+    .replace(/\s+$/, '');
+  const reopeningFence = `${fence.delimiter}${baseInfo} qwen-code:start-line=${tailStart}`;
+  const beforeWithClose = before.endsWith('\n')
+    ? `${before}${closingFence}\n`
+    : `${before}\n${closingFence}\n`;
+  const afterWithReopen = `${reopeningFence}\n${after}`;
+  return { before: beforeWithClose, after: afterWithReopen };
 };

--- a/packages/cli/src/ui/utils/markdownUtilities.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.ts
@@ -68,41 +68,14 @@ const findNextFence = (
 };
 
 /**
- * Checks if a given character index is inside a fenced code block (``` or ~~~).
- * A fence only closes a block opened with the SAME character AND a run at least
- * as long (mirroring CommonMark / MarkdownDisplay), so a ``` inside a ~~~ block
- * — or a shorter run inside a longer fence — does not toggle the state.
- */
-const isIndexInsideCodeBlock = (
-  content: string,
-  indexToTest: number,
-): boolean => {
-  let openChar: '`' | '~' | '' = '';
-  let openLen = 0;
-  let searchPos = 0;
-  while (searchPos < content.length) {
-    const fence = findNextFence(content, searchPos);
-    if (!fence || fence.index >= indexToTest) break;
-    if (openChar === '') {
-      openChar = fence.char;
-      openLen = fence.length;
-    } else if (fence.char === openChar && fence.length >= openLen) {
-      openChar = '';
-      openLen = 0;
-    }
-    searchPos = fence.index + fence.length;
-  }
-  return openChar !== '';
-};
-
-/**
  * Returns the fenced code block (``` or ~~~) that encloses `indexToTest`, or
  * null when the index is not inside one. Reports the fence's start index, its
  * exact opening delimiter run (e.g. "```" or "~~~~") and the info string that
  * followed it on the same line (e.g. "python", "ts"), so a split can re-open an
- * identical fence. Open/close matching mirrors findLastSafeSplitPoint's rules:
- * a fence only closes a block opened with the SAME character AND a run at least
- * as long.
+ * identical fence. Open/close matching mirrors CommonMark / MarkdownDisplay: a
+ * fence only closes a block opened with the SAME character AND a run at least as
+ * long, so a ``` inside a ~~~ block — or a shorter run inside a longer fence —
+ * does not toggle the state.
  */
 const getEnclosingFence = (
   content: string,
@@ -129,6 +102,13 @@ const getEnclosingFence = (
     infoString: content.slice(open.index + open.len, fenceLineEnd),
   };
 };
+
+/**
+ * Checks if a given character index is inside a fenced code block (``` or ~~~).
+ * Shares its fence-matching rules with {@link getEnclosingFence}.
+ */
+const isIndexInsideCodeBlock = (content: string, index: number): boolean =>
+  getEnclosingFence(content, index) !== null;
 
 /**
  * Finds the starting index of the code block (``` or ~~~) that encloses the

--- a/packages/cli/src/ui/utils/markdownUtilities.ts
+++ b/packages/cli/src/ui/utils/markdownUtilities.ts
@@ -285,7 +285,12 @@ export const splitFencedMarkdown = (
   const baseInfo = fence.infoString
     .replace(START_LINE_DIRECTIVE_RE, '')
     .replace(/\s+$/, '');
-  const reopeningFence = `${fence.delimiter}${baseInfo} qwen-code:start-line=${tailStart}`;
+  const directive = `qwen-code:start-line=${tailStart}`;
+  // A language-less fence has no base info, so omit the separating space to
+  // avoid a stray leading space in the re-opened fence's info string.
+  const reopeningFence = `${fence.delimiter}${
+    baseInfo ? `${baseInfo} ${directive}` : directive
+  }`;
   const beforeWithClose = before.endsWith('\n')
     ? `${before}${closingFence}\n`
     : `${before}\n${closingFence}\n`;


### PR DESCRIPTION
## What this PR does

Makes the streaming renderer keep a fenced code block intact when the incremental commit-to-scrollback logic has to cut it across chunks. When a cut lands inside a fence, the committed head now gets a synthetic closing fence and the pending tail gets an identical re-opened fence (same delimiter run and language), carrying an internal start-line hint so the gutter numbering continues instead of restarting at 1. A code block taller than the viewport that has no blank line inside the visible window is now committed by cutting inside the fence rather than being held back, so it scrolls smoothly into scrollback while streaming. Mermaid blocks are excluded from mid-block cutting because a diagram needs its complete source to render, so they stay whole until they finish.

## Why it's needed

Streaming a code block taller than the terminal viewport was visibly broken in three ways: past the first screenful the block lost its code styling and rendered as ordinary Markdown (so a `//` or `---` line turned into a heading or a horizontal rule), the gutter line numbers restarted at 1 on every committed chunk, and a block with no blank line inside the window never committed while streaming — it froze on its first screenful and dumped the rest all at once when it finished. All three come from the same place: the commit path only cut at a blank line and refused to cut inside a fence, so a tall fenced block either had no safe cut point (stall) or was cut into an unterminated head plus a fence-less tail that rendered as prose (mangled code, reset numbers).

## Reviewer Test Plan

### How to verify

Ask the model to output roughly 100–120 lines of C++ with no blank lines, followed by a short paragraph of normal prose (a prompt such as "output about 120 lines of C++ with no blank lines, then a short paragraph"). Keep the terminal at a normal height so the block is taller than the viewport.

Expected after this change: the code scrolls smoothly into scrollback as it streams (no freeze-then-dump), keeps syntax highlighting and code styling throughout, shows one continuous set of gutter line numbers across the whole listing, never misparses its own lines as Markdown, and the trailing prose renders normally right after the fence. A language-less block (` ``` ` with no language) behaves the same, minus highlighting. A tall Markdown table and a tall Mermaid diagram still stay whole (they are not cut mid-block).

Unit coverage was added for the split helper (close/re-open fence, delimiter and language preservation, start-line accumulation across repeated splits, language directive parsing), for continued gutter numbering, for incremental commit of an over-tall code block, and for keeping a tall Mermaid block whole.

### Evidence (Before & After)

Before: a long code block loses its line-number gutter and code styling partway down; the remaining lines render as prose (`//` comments and `---` show up as a horizontal rule, `#` lines as headings); with a taller block the pane freezes on its first screenful and the rest appears in one jump when the block completes.

After: the same block streams line by line into scrollback with continuous gutter numbers (for example 1→120) and unbroken highlighting, and the trailing paragraph follows immediately.

Screenshots of the before/after behavior can be attached on request.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Local `npm run dev` interactive TUI (v0.19.10), Linux, OpenAI-compatible local model. `npm run verify:pr` (full profile) passed on a clean Node 22 checkout.

## Risk & Scope

- Main risk or tradeoff: the split now injects a synthetic close/re-open fence pair and an internal start-line hint into the committed and pending render items. The hint rides on the fence's info line, which is a delimiter line that is never rendered as content, so it stays invisible; copy and export read the model's recorded parts rather than these render chunks, so they are unaffected.
- Not validated / out of scope: a Mermaid diagram (or any whole-source block) taller than the viewport still appears all at once when its source completes — that is inherent to diagram rendering and is intentionally left as-is rather than cut mid-block. A pathological single code line with no newline at all that is hard-split mid-line has its second half counted as a new gutter line; normal line-boundary splits are exact. Not tested on macOS or Windows.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7006

<details>
<summary>中文说明</summary>

## 這個 PR 做了什麼

讓串流渲染器在「增量提交到 scrollback」需要把一個圍欄程式碼區塊切成多段時，仍能保持它完整。當切點落在圍欄內時，已提交的前段會補上一個合成的結尾圍欄，待渲染的後段會補回一個相同的開頭圍欄（相同的圍欄符號與語言），並帶一個內部的起始行號提示，讓行號接續而不是每段重設為 1。一個比視窗高、且可見範圍內沒有空行的程式碼區塊，現在會透過在圍欄內切割來提交，而不是被整塊卡住，因此串流時能順順地捲進 scrollback。Mermaid 區塊被排除在中途切割之外，因為圖表需要完整源碼才能渲染，所以會保持完整直到結束。

## 為什麼需要

串流一個比終端視窗高的程式碼區塊時，會明顯壞成三種樣子：超過第一個畫面後區塊失去程式碼樣式、被當成普通 Markdown 渲染（`//` 或 `---` 變成標題或水平線），行號在每個提交分段都從 1 重新開始，而一個可見範圍內沒有空行的區塊在串流時根本不會提交——它凍在第一個畫面、等結束才一次刷出剩下的內容。三者同源：提交路徑只在空行切割、且拒絕在圍欄內切，所以一個高的圍欄區塊要嘛找不到安全切點（卡住），要嘛被切成沒有結尾的前段加上失去開頭圍欄、被當普通文字渲染的後段（程式碼變形、行號重置）。

## 審查者驗證方式

請模型輸出約 100–120 行、無空行的 C++，後面接一小段一般對話（例如「輸出約 120 行無空行的 C++，之後接一小段文字」）。終端維持一般高度，讓區塊高過視窗。

預期（本 PR 後）：程式碼會隨串流順順捲進 scrollback（沒有凍住後一次刷出），全程保持語法高亮與程式碼樣式，整份清單顯示一組連續行號，不會把自己的行誤判成 Markdown，且圍欄後的一般文字緊接著正常渲染。無語言區塊（純 ` ``` `）行為相同，只是沒有高亮。高的 Markdown 表格與高的 Mermaid 圖仍保持完整（不被中途切割）。

已為切割輔助函式（補結尾/重開圍欄、保留圍欄符號與語言、跨多次切割累加起始行號、語言指示解析）、行號連續、過高程式碼區塊的增量提交、以及保持高 Mermaid 區塊完整補上單元測試。

## 風險與範圍

- 主要風險/取捨：切割會在提交與待渲染項目中注入一組合成的結尾/重開圍欄與一個內部起始行號提示。該提示位於圍欄的資訊行（分隔行，永不當作內容渲染），因此不可見；複製與匯出讀取的是模型記錄的內容片段，而非這些渲染分段，所以不受影響。
- 未驗證/範圍外：一個比視窗高的 Mermaid 圖（或任何需完整源碼的區塊）在源碼完成時仍會一次出現——這是圖表渲染的本質，刻意保持原狀而不中途切割。一個完全沒有換行的病態單行程式碼若被中途硬切，其後半會被算成新的一行號；正常的行邊界切割則精確。未在 macOS 或 Windows 上測試。
- 破壞性變更/遷移說明：無。

## 連結的 Issue

Fixes #7006

</details>
