### PR TITLE
fix(core): preserve MCP OAuth challenges from HTTP handshakes

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -786,6 +786,67 @@ describe('mcp-client', () => {
       expect(mcpServerRequiresOAuth.has(serverName)).toBe(false);
     });
 
+    it('preserves a captured OAuth challenge when the SDK error only reports 401', async () => {
+      const serverName = 'status-only-http-oauth-server';
+      const serverConfig = { httpUrl: 'https://example.com/mcp' };
+      const resourceMetadataUrl =
+        'https://example.com/.well-known/oauth-protected-resource';
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(null, {
+          status: 401,
+          headers: {
+            'www-authenticate': `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        }),
+      );
+      vi.mocked(ClientLib.Client).mockReturnValue({
+        connect: vi.fn().mockImplementation(async (transport: unknown) => {
+          const transportFetch = (transport as { _fetch: typeof fetch })._fetch;
+          await transportFetch(serverConfig.httpUrl, { method: 'POST' });
+          throw new Error('Streamable HTTP error: HTTP 401 Unauthorized');
+        }),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        getInstructions: vi.fn(),
+      } as unknown as ClientLib.Client);
+      vi.mocked(MCPOAuthTokenStorage).mockImplementation(
+        () =>
+          ({
+            getCredentials: vi.fn().mockResolvedValue(null),
+          }) as unknown as MCPOAuthTokenStorage,
+      );
+      const authenticate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(MCPOAuthProvider).mockImplementation(
+        () => ({ authenticate }) as unknown as MCPOAuthProvider,
+      );
+      const discoverOAuthConfig = vi
+        .spyOn(OAuthUtils, 'discoverOAuthConfig')
+        .mockResolvedValue({
+          authorizationUrl: 'https://auth.example/authorize',
+          tokenUrl: 'https://auth.example/token',
+          scopes: [],
+        });
+      const client = new McpClient(
+        serverName,
+        serverConfig,
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {
+          getDirectories: vi.fn().mockReturnValue([]),
+        } as unknown as WorkspaceContext,
+        false,
+      );
+
+      await expect(client.connect()).rejects.toThrow('HTTP 401 Unauthorized');
+      await expect(
+        attemptAutomaticMcpOAuth(serverName, serverConfig, true),
+      ).resolves.toBe(true);
+
+      expect(discoverOAuthConfig).toHaveBeenCalledWith(resourceMetadataUrl);
+      expect(authenticate).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+
     it('does not classify a non-401 HTTP failure as OAuth', async () => {
       vi.mocked(ClientLib.Client).mockReturnValue({
         connect: vi

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2038,6 +2038,39 @@ describe('mcp-client', () => {
         expect((transport as any)._fetch).toEqual(expect.any(Function));
       });
 
+      it('captures OAuth challenges from the initial HTTP handshake', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+          new Response(null, {
+            status: 401,
+            headers: {
+              'www-authenticate':
+                'Bearer resource_metadata="https://test-server/.well-known/oauth-protected-resource"',
+            },
+          }),
+        );
+        const serverName = 'handshake-oauth-server';
+        const serverConfig = { httpUrl: 'https://test-server/mcp' };
+        const transport = await createTransport(
+          serverName,
+          serverConfig,
+          false,
+        );
+        const transportFetch = (
+          transport as unknown as { _fetch: typeof fetch }
+        )._fetch;
+
+        const response = await transportFetch(serverConfig.httpUrl, {
+          method: 'POST',
+        });
+
+        expect(response.status).toBe(401);
+        expect(mcpServerRequiresOAuth.get(serverName)).toBe(true);
+        await expect(
+          probeMcpServerForOAuth(serverName, serverConfig),
+        ).resolves.toBe(true);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+
       it('treats 400 from optional GET SSE stream as unsupported', async () => {
         const fetchFn = vi
           .fn<typeof fetch>()

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -767,7 +767,10 @@ function setMcpOAuthRequirement(
   const key = oauthRecoveryKey(mcpServerName, mcpServerConfig);
   mcpServerOAuthProbeCandidates.delete(key);
   mcpServerOAuthRequirements.add(key);
-  mcpServerOAuthChallenges.set(key, wwwAuthenticate);
+  mcpServerOAuthChallenges.set(
+    key,
+    wwwAuthenticate || mcpServerOAuthChallenges.get(key) || '',
+  );
   mcpServerRequiresOAuth.set(mcpServerName, true);
 }
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -199,7 +199,8 @@ function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
 }
 
 /**
- * Wraps fetch to normalize Spring AI-style 400 responses to the SDK's
+ * Wraps fetch to preserve OAuth challenges before the SDK discards response
+ * metadata and to normalize Spring AI-style 400 responses to the SDK's
  * unsupported sentinel for the optional Streamable HTTP GET SSE request.
  *
  * SDK coupling: `StreamableHTTPClientTransport._startOrAuthSse()` treats a
@@ -209,9 +210,21 @@ function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
 export function createStreamableHttpCompatibilityFetch(
   mcpServerName: string,
   fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),
+  mcpServerConfig?: MCPServerConfig,
 ): typeof fetch {
   return async (input, init) => {
     const response = await fetchFn(input, init);
+    if (
+      response.status === 401 &&
+      mcpServerConfig &&
+      supportsMcpOAuth(mcpServerConfig)
+    ) {
+      setMcpOAuthRequirement(
+        mcpServerName,
+        mcpServerConfig,
+        response.headers.get('www-authenticate') ?? '',
+      );
+    }
     if (
       !isStreamableHttpGetSseRequest(init) ||
       !STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES.has(response.status)
@@ -235,6 +248,17 @@ export function createStreamableHttpCompatibilityFetch(
       statusText: 'Method Not Allowed',
     });
   };
+}
+
+function createMcpStreamableHttpFetch(
+  mcpServerName: string,
+  mcpServerConfig: MCPServerConfig,
+): typeof fetch {
+  return createStreamableHttpCompatibilityFetch(
+    mcpServerName,
+    globalThis.fetch.bind(globalThis),
+    mcpServerConfig,
+  );
 }
 
 export type DiscoveredMCPPrompt = Prompt & {
@@ -1014,7 +1038,7 @@ async function createTransportWithOAuth(
     if (mcpServerConfig.httpUrl) {
       // Create HTTP transport with OAuth token
       const oauthTransportOptions: StreamableHTTPClientTransportOptions = {
-        fetch: createStreamableHttpCompatibilityFetch(mcpServerName),
+        fetch: createMcpStreamableHttpFetch(mcpServerName, mcpServerConfig),
         requestInit: {
           headers: {
             ...mcpServerConfig.headers,
@@ -1972,7 +1996,7 @@ export async function createTransport(
 
     if (mcpServerConfig.httpUrl) {
       (transportOptions as StreamableHTTPClientTransportOptions).fetch =
-        createStreamableHttpCompatibilityFetch(mcpServerName);
+        createMcpStreamableHttpFetch(mcpServerName, mcpServerConfig);
       return new StreamableHTTPClientTransport(
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
@@ -2000,7 +2024,7 @@ export async function createTransport(
     };
     if (mcpServerConfig.httpUrl) {
       (transportOptions as StreamableHTTPClientTransportOptions).fetch =
-        createStreamableHttpCompatibilityFetch(mcpServerName);
+        createMcpStreamableHttpFetch(mcpServerName, mcpServerConfig);
       return new StreamableHTTPClientTransport(
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
@@ -2063,7 +2087,7 @@ export async function createTransport(
 
   if (mcpServerConfig.httpUrl) {
     const transportOptions: StreamableHTTPClientTransportOptions = {
-      fetch: createStreamableHttpCompatibilityFetch(mcpServerName),
+      fetch: createMcpStreamableHttpFetch(mcpServerName, mcpServerConfig),
     };
 
     // Set up headers with OAuth token if available


### PR DESCRIPTION
## What this PR does

Preserves OAuth authorization challenges from Streamable HTTP MCP handshake responses before the MCP SDK converts those responses into errors. When an unauthenticated remote MCP server returns `401 Unauthorized` with `WWW-Authenticate`, the workspace status now records that authentication is required, allowing the Web Shell to offer Authenticate instead of treating the server as an ordinary disconnected server.

The change applies to Streamable HTTP transports while retaining the existing provider guard, so Google credentials and service-account authentication are not reclassified as dynamic MCP OAuth. The original HTTP response is returned unchanged to the SDK.

## Why it's needed

Some MCP SDK errors omit both the HTTP status and response headers. For the affected server, the real initialize request returned a standards-compliant `401` and `WWW-Authenticate` challenge, but the SDK surfaced only an Unauthorized JSON body. The fallback authorization probe used `HEAD`; the endpoint correctly allowed only `POST` and returned `405 Method Not Allowed`, so Qwen Code never set `requiresAuth`.

Without `requiresAuth`, the Web Shell displayed Reconnect. Restarting repeated the unauthenticated handshake, left the server disconnected, and failed with “did not reach a connected state after restart.” Capturing the challenge from the real initial handshake follows the MCP authorization flow and removes the dependency on whether an endpoint supports `HEAD`.

## Reviewer Test Plan

### How to verify

Configure a Streamable HTTP MCP server that returns `401 Unauthorized` with a `WWW-Authenticate: Bearer resource_metadata="..."` challenge for an unauthenticated initialize request and does not support `HEAD`. Start MCP discovery without stored credentials. Confirm that workspace MCP status contains `requiresAuth: true`, the management UI offers Authenticate rather than Reconnect, and the authorization action begins OAuth discovery. Also confirm that non-401 HTTP failures remain ordinary connection failures.

### Evidence (Before & After)

Before: the tested endpoint returned `405` for `HEAD` and a valid OAuth challenge for initialize `POST`; workspace status reported `mcpStatus: disconnected` and `hasOAuthTokens: false` without `requiresAuth`, so Reconnect was shown and restart failed.

After: a real connection attempt to the same endpoint still receives the expected unauthenticated error, while the preserved handshake response sets the OAuth requirement; the resulting status path produces `requiresAuth: true` and selects Authenticate.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, local non-sandboxed development environment, unit tests plus a live unauthenticated handshake against the reported Streamable HTTP MCP endpoint.

## Risk & Scope

- Main risk or tradeoff: every Streamable HTTP response passes through the existing compatibility wrapper; the new behavior only records a challenge for `401` responses on providers that support dynamic MCP OAuth and does not consume or rewrite the response.
- Not validated / out of scope: completing the browser login and callback against the internal authorization service, and runtime validation on Windows or Linux.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的修改

在 MCP SDK 将 Streamable HTTP 握手响应转换为错误之前保留 OAuth 认证挑战。当未认证的远程 MCP server 返回带有 `WWW-Authenticate` 的 `401 Unauthorized` 时，workspace 状态现在会记录需要认证，使 Web Shell 展示“认证”，而不是把该服务当作普通断连服务处理。

该修改覆盖 Streamable HTTP transport，同时保留现有 provider 限制，因此 Google credentials 和 service account 认证不会被误判为动态 MCP OAuth。原始 HTTP 响应仍会不经修改地返回给 SDK。

## 修改原因

部分 MCP SDK 错误不会保留 HTTP 状态码和响应头。对于本次涉及的服务，真实 initialize 请求返回了符合规范的 `401` 和 `WWW-Authenticate`，但 SDK 只暴露了 Unauthorized JSON 正文。后续认证探测使用 `HEAD`；该端点仅允许 `POST` 并正确返回 `405 Method Not Allowed`，因此 Qwen Code 始终没有设置 `requiresAuth`。

缺少 `requiresAuth` 时，Web Shell 会展示“重新连接”。重启只会重复未认证握手，使服务继续处于 disconnected，最终报错“did not reach a connected state after restart”。从真实初始握手中捕获认证挑战符合 MCP Authorization 流程，也不再依赖端点是否支持 `HEAD`。

## Reviewer 测试计划

### 验证方法

配置一个 Streamable HTTP MCP server：未认证 initialize 请求返回带有 `WWW-Authenticate: Bearer resource_metadata="..."` 的 `401 Unauthorized`，且不支持 `HEAD`。在没有已保存凭据的情况下启动 MCP discovery。确认 workspace MCP 状态包含 `requiresAuth: true`，管理页面展示“认证”而非“重新连接”，且认证操作会启动 OAuth discovery。同时确认非 401 HTTP 错误仍作为普通连接错误处理。

### 前后证据

修改前：测试端点对 `HEAD` 返回 `405`，对 initialize `POST` 返回有效 OAuth challenge；workspace 状态包含 `mcpStatus: disconnected` 和 `hasOAuthTokens: false`，但缺少 `requiresAuth`，因此页面展示“重新连接”，且重启失败。

修改后：对同一端点的真实连接仍会收到预期的未认证错误，但握手响应中保留的认证挑战会设置 OAuth requirement；最终状态链路生成 `requiresAuth: true` 并选择“认证”。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22，本地非 sandbox 开发环境；执行单元测试，并对报告中的 Streamable HTTP MCP 端点进行了真实未认证握手。

## 风险与范围

- 主要风险或取舍：所有 Streamable HTTP 响应都会经过现有 compatibility wrapper；新增行为仅针对支持动态 MCP OAuth 的 provider 的 `401` 响应记录认证挑战，不会读取正文、消费或改写响应。
- 未验证或不在范围内：在内部认证服务上完成浏览器登录和 callback，以及 Windows、Linux 运行时验证。
- 破坏性修改或迁移说明：无。

## 关联 Issue

N/A

</details>
