### PR TITLE
docs: make local PR verification optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ npm run lint:fix   # Auto-fix lint issues
 npm run format     # Prettier formatting
 npm run typecheck  # TypeScript type checking
 npm run preflight  # Legacy broad check; writes formatting and omits some PR CI checks
-npm run verify:pr  # Final clean PR gate after committing, before pushing
+npm run verify:pr  # Optional clean PR verification after committing
 ```
 
 ## Code Conventions
@@ -211,10 +211,10 @@ npm run verify:pr  # Final clean PR gate after committing, before pushing
    Here, `/review` means the Codex code-review workflow, not Qwen Review or
    the `qwen-review` plugin. Do not invoke Qwen Review unless the user
    explicitly requests it by name.
-6. **Final PR verification** — after the final changes are committed and the
-   working tree is clean, run `npm run verify:pr` before the first PR push and
-   before pushing updates. This is the final local deterministic gate; it does
-   not replace remote CI.
+6. **Optional PR verification** — after the final changes are committed and the
+   working tree is clean, ask whether to run `npm run verify:pr`. Run it only
+   when requested; it is not a required local step before pushing, and remote CI
+   remains authoritative.
 
 ### Feature development
 


### PR DESCRIPTION
## What this PR does

Updates the contributor-agent workflow so local PR verification is optional. The guidance now tells the agent to ask the user whether to run the verification command after committing, and explicitly states that it is not required before pushing.

## Why it's needed

The previous guidance made the local verification command a mandatory gate before every PR push. That command can be expensive, and the decision to run it should remain with the user while remote CI remains authoritative.

## Reviewer Test Plan

### How to verify

- Read the contributor-agent workflow and confirm the verification command is described as optional.
- Confirm the workflow requires asking the user before running the command and does not treat it as a prerequisite for pushing.
- Confirm no command implementation or other contributor documentation changes are included.

### Evidence (Before & After)

Before: the workflow required running local PR verification before the first push and every update.

After: the workflow asks the user whether to run it and proceeds without it unless requested.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Documentation-only change; validated with `git diff --check` and a local diff review.

## Risk & Scope

- Main risk or tradeoff: contributors may rely more often on remote CI when they skip the optional local verification.
- Not validated / out of scope: the verification command implementation, CI behavior, and other contributor documentation.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to https://github.com/QwenLM/qwen-code/pull/6873

<details>
<summary>中文说明</summary>

## 本 PR 的改动

更新贡献者 Agent 工作流，将本地 PR 验证改为可选步骤。现在的指引要求 Agent 在提交后先询问用户是否运行验证命令，并明确该命令不是推送前的必需步骤。

## 为什么需要

原有指引把本地验证命令设为每次 PR 推送前的强制门禁。该命令执行成本较高，是否运行应由用户决定，同时远端 CI 仍作为权威验证结果。

## Reviewer 测试计划

### 如何验证

- 阅读贡献者 Agent 工作流，确认验证命令被描述为可选步骤。
- 确认工作流要求运行前询问用户，并且不再把它作为推送前置条件。
- 确认本次不包含命令实现或其他贡献者文档的改动。

### 前后对比证据

改动前：工作流要求首次推送和后续更新前都必须运行本地 PR 验证。

改动后：工作流会询问用户是否运行；除非用户明确要求，否则可以不运行并继续流程。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

纯文档改动；已通过 `git diff --check` 和本地 diff 审查验证。

## 风险与范围

- 主要风险或权衡：跳过可选本地验证时，贡献者可能会更多依赖远端 CI。
- 未验证或范围外：验证命令实现、CI 行为和其他贡献者文档。
- 破坏性改动或迁移说明：无。

## 关联 Issue

作为 https://github.com/QwenLM/qwen-code/pull/6873 的后续调整。

</details>
