### PR TITLE
fix(acp): disambiguate model routes

### DIFF
--- a/docs/design/acp-model-route-identity.md
+++ b/docs/design/acp-model-route-identity.md
@@ -11,8 +11,8 @@ Core already treats `(authType, modelId, configured baseUrl)` as the registry id
 Build ACP model options from the existing configured-model list:
 
 - Keep `modelId(authType)` when it is unique. This preserves existing IDs for the normal case.
-- When multiple options would share that ID, replace each with a deterministic `qwen-route:v1:<digest>` selector derived from non-secret model metadata and its occurrence within otherwise identical entries.
-- Never include or hash `baseUrl` in the wire selector. Endpoint URLs may contain credentials, and an unkeyed digest would still allow offline guessing.
+- When multiple options would share that ID, replace each with a deterministic `qwen-route:v1:<digest>` selector derived from non-secret model metadata and the public endpoint identity (credentials, query, and fragment removed).
+- Reject routes that remain indistinguishable after sanitization instead of using array order, which could remap an old selector after configuration reordering.
 - Continue using `ModelInfo.name` and provider metadata for display. The route ID is an opaque machine selector.
 
 Core exposes the original optional registry `baseUrl` alongside the resolved display endpoint. The same option builder supplies ACP session models, config options, live provider status, and daemon workspace provider status so every client sees the same ID while the server retains the exact registry discriminator.

--- a/docs/design/acp-model-route-identity.md
+++ b/docs/design/acp-model-route-identity.md
@@ -1,0 +1,43 @@
+# ACP Model Route Identity
+
+## Problem
+
+Qwen Code currently exposes ACP model IDs as `modelId(authType)`. Two configured models with the same model ID and auth type but different `baseUrl` values therefore collapse to one ACP selector. Clients cannot identify the active row or round-trip a selection to the intended endpoint.
+
+Core already treats `(authType, modelId, configured baseUrl)` as the registry identity. The loss happens only when that identity crosses the ACP boundary. The configured value must remain separate from the resolved endpoint because provider defaults can fill `baseUrl` after registration.
+
+## Design
+
+Build ACP model options from the existing configured-model list:
+
+- Keep `modelId(authType)` when it is unique. This preserves existing IDs for the normal case.
+- When multiple options would share that ID, replace each with a deterministic `qwen-route:v1:<digest>` selector derived from non-secret model metadata and its occurrence within otherwise identical entries.
+- Never include or hash `baseUrl` in the wire selector. Endpoint URLs may contain credentials, and an unkeyed digest would still allow offline guessing.
+- Continue using `ModelInfo.name` and provider metadata for display. The route ID is an opaque machine selector.
+
+Core exposes the original optional registry `baseUrl` alongside the resolved display endpoint. The same option builder supplies ACP session models, config options, live provider status, and daemon workspace provider status so every client sees the same ID while the server retains the exact registry discriminator.
+
+On `session/set_model`, Qwen Code resolves the selector against the current configured-model list before switching. It passes the resolved `baseUrl` to Core, then persists only the canonical settings values:
+
+- `model.name`: actual model ID
+- `model.baseUrl`: configured registry endpoint, or an empty tombstone for an implicit default
+- `security.auth.selectedType`: actual auth type
+
+The opaque selector is never written to `settings.json`.
+
+## Compatibility
+
+- ACP schema is unchanged; `modelId` remains a string.
+- Unique existing model IDs retain the current wire representation.
+- Legacy `modelId(authType)` requests remain accepted. If such an ID is ambiguous, existing first-match behavior is preserved for compatibility; newly advertised selectors are exact.
+- Unknown or stale opaque selectors are rejected instead of being treated as literal model IDs.
+- Generic ACP clients, including Zed, only need to echo the opaque selector.
+- CLI TUI settings and selection behavior are unchanged.
+
+## Verification
+
+- Duplicate routes receive distinct, stable selectors without leaking their URLs.
+- Session model state and config options publish the same selectors and exact current route.
+- Selecting the second route switches with its `baseUrl`, persists canonical settings, and notifies clients with its opaque selector.
+- Daemon provider status identifies the exact current route for Web Shell.
+- Unique and legacy model selections keep working.

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -7416,12 +7416,12 @@ describe('createAcpSessionBridge', () => {
       });
       const session = await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
-        modelServiceId: 'qwen3-coder',
+        modelServiceId: 'qwen-route:v1:abcdefghijklmnop',
       });
       expect(session.attached).toBe(false);
       expect(setModelCalls).toHaveLength(1);
       expect(setModelCalls[0]?.sessionId).toBe(session.sessionId);
-      expect(setModelCalls[0]?.modelId).toBe('qwen3-coder');
+      expect(setModelCalls[0]?.modelId).toBe('qwen-route:v1:abcdefghijklmnop');
       const abort = new AbortController();
       const iter = bridge.subscribeEvents(session.sessionId, {
         signal: abort.signal,
@@ -7430,6 +7430,10 @@ describe('createAcpSessionBridge', () => {
       const it = iter[Symbol.asyncIterator]();
       const switched = await it.next();
       expect(switched.value?.type).toBe('model_switched');
+      expect(switched.value?.data).toEqual({
+        sessionId: session.sessionId,
+        modelId: 'qwen-route:v1:abcdefghijklmnop',
+      });
       const settingsChanged = await it.next();
       expect(settingsChanged.value?.type).toBe('settings_changed');
       expect(settingsChanged.value?.originatorClientId).toBe(session.clientId);

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -7367,7 +7367,12 @@ describe('createAcpSessionBridge', () => {
 
   describe('modelServiceId honored at session create', () => {
     /** Build a channel that records `unstable_setSessionModel` calls. */
-    function setup(opts: { setModelImpl?: () => Promise<unknown> } = {}) {
+    function setup(
+      opts: {
+        setModelImpl?: () => Promise<unknown>;
+        setModelResult?: Record<string, unknown>;
+      } = {},
+    ) {
       const setModelCalls: Array<{ sessionId: string; modelId: string }> = [];
       const factory: ChannelFactory = async () => {
         const { clientStream, agentStream } = createInMemoryChannel();
@@ -7381,7 +7386,7 @@ describe('createAcpSessionBridge', () => {
                   modelId: req.modelId,
                 });
                 if (opts.setModelImpl) await opts.setModelImpl();
-                return {};
+                return opts.setModelResult ?? {};
               };
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -7404,7 +7409,11 @@ describe('createAcpSessionBridge', () => {
     }
 
     it('applies modelServiceId via unstable_setSessionModel after newSession', async () => {
-      const { bridge, setModelCalls } = setup();
+      const { bridge, setModelCalls } = setup({
+        setModelResult: {
+          _meta: { qwenModelSwitch: { modelId: 'qwen3-coder-canonical' } },
+        },
+      });
       const session = await bridge.spawnOrAttach({
         workspaceCwd: WS_A,
         modelServiceId: 'qwen3-coder',
@@ -7426,7 +7435,7 @@ describe('createAcpSessionBridge', () => {
       expect(settingsChanged.value?.originatorClientId).toBe(session.clientId);
       expect(settingsChanged.value?.data).toEqual({
         key: 'model.name',
-        value: 'qwen3-coder',
+        value: 'qwen3-coder-canonical',
       });
       abort.abort();
       await bridge.shutdown();
@@ -8930,7 +8939,7 @@ describe('createAcpSessionBridge', () => {
 
   describe('setSessionModel', () => {
     /** Set up a channel where the agent records setSessionModel calls. */
-    async function setup() {
+    async function setup(response: Record<string, unknown> = {}) {
       const setModelCalls: Array<{ sessionId: string; modelId: string }> = [];
       const factory: ChannelFactory = async () => {
         const { clientStream, agentStream } = createInMemoryChannel();
@@ -8945,7 +8954,7 @@ describe('createAcpSessionBridge', () => {
                   sessionId: req.sessionId,
                   modelId: req.modelId,
                 });
-                return {};
+                return response;
               };
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8981,21 +8990,23 @@ describe('createAcpSessionBridge', () => {
     });
 
     it('publishes a model_switched event on success', async () => {
-      const { bridge, session } = await setup();
+      const { bridge, session } = await setup({
+        _meta: { qwenModelSwitch: { modelId: 'qwen3-coder' } },
+      });
       const abort = new AbortController();
       const iter = bridge.subscribeEvents(session.sessionId, {
         signal: abort.signal,
       });
       await bridge.setSessionModel(session.sessionId, {
         sessionId: session.sessionId,
-        modelId: 'qwen3-coder',
+        modelId: 'qwen-route:v1:opaque',
       });
       const it = iter[Symbol.asyncIterator]();
       const next = await it.next();
       expect(next.value?.type).toBe('model_switched');
       expect(next.value?.data).toEqual({
         sessionId: session.sessionId,
-        modelId: 'qwen3-coder',
+        modelId: 'qwen-route:v1:opaque',
       });
       const settingsChanged = await it.next();
       expect(settingsChanged.value?.type).toBe('settings_changed');

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3542,10 +3542,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
   // `{ currentModelId: null, currentApprovalMode: null }` and the SDK reducer's
   // `!= null` guard would leave the client unseeded — defeating A5's primary
   // (initial-attach) use case. The agent's `currentModelId` is already the
-  // canonical `model(authType)` form (acpAgent `formatAcpModelId`), matching
-  // what `reconcileAfterRoundtrip` reads back, so seeding it keeps the model
-  // comparison format-stable. Mode ids pass the same `KNOWN_APPROVAL_MODES`
-  // backstop the demux/reconcile paths use.
+  // advertised selector (legacy or opaque), matching what
+  // `reconcileAfterRoundtrip` reads back, so seeding it keeps the comparison
+  // format-stable. Mode ids pass the same `KNOWN_APPROVAL_MODES` backstop the
+  // demux/reconcile paths use.
   const seedSnapshotCaches = (
     entry: SessionEntry,
     resp: {
@@ -6276,14 +6276,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             ),
             transportClosed,
           ]);
-          // Cache the model id as received from the caller. The bridge
-          // layer does not have access to the CLI's `formatAcpModelId`
-          // (which requires `authType`), so it cannot canonicalize here.
-          // In practice callers always send canonical ids (from
-          // `buildAvailableModels`); any residual raw→canonical drift is
-          // corrected by the `reconcileAfterRoundtrip` below, which reads
-          // the agent's authoritative canonical id and re-publishes if it
-          // differs.
+          // Cache the advertised selector as received from the caller. Any
+          // drift is corrected by `reconcileAfterRoundtrip`, which reads the
+          // agent's authoritative selector and re-publishes if it differs.
           publishModelSwitched(entry, req.modelId, originatorClientId);
           broadcastWorkspaceEvent({
             type: 'settings_changed',

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -191,6 +191,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function getCanonicalModelId(response: unknown, fallback: string): string {
+  if (!isRecord(response) || !isRecord(response['_meta'])) return fallback;
+  const modelSwitch = response['_meta']['qwenModelSwitch'];
+  if (!isRecord(modelSwitch)) return fallback;
+  const modelId = modelSwitch['modelId'];
+  return typeof modelId === 'string' ? modelId : fallback;
+}
+
 function isBulkReplayUpdate(value: unknown): value is SessionUpdate {
   if (!isRecord(value)) return false;
   const updateType = value['sessionUpdate'];
@@ -2488,7 +2496,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // model_switched right beside the model_switch_failed below.
       let succeeded = false;
       try {
-        await Promise.race([
+        const result = await Promise.race([
           withTimeout(
             conn.unstable_setSessionModel({
               sessionId: entry.sessionId,
@@ -2504,7 +2512,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           type: 'settings_changed',
           data: {
             key: 'model.name',
-            value: modelId,
+            value: getCanonicalModelId(result, modelId),
           },
           ...(originatorClientId ? { originatorClientId } : {}),
         });
@@ -6281,7 +6289,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             type: 'settings_changed',
             data: {
               key: 'model.name',
-              value: req.modelId,
+              value: getCanonicalModelId(result, req.modelId),
             },
             ...(originatorClientId ? { originatorClientId } : {}),
           });

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3633,6 +3633,98 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('session model selectors distinguish the same model id on different endpoints', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const innerConfig = await setupSessionMocks(sessionId);
+    Object.assign(innerConfig, {
+      getModel: vi.fn().mockReturnValue('shared-model'),
+      getAuthType: vi.fn().mockReturnValue('api-key'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        authType: 'api-key',
+        model: 'shared-model',
+        baseUrl: 'https://two.example/v1',
+      }),
+      getAllConfiguredModels: vi.fn().mockReturnValue([
+        {
+          id: 'shared-model',
+          label: 'Provider One',
+          authType: 'api-key',
+          baseUrl: 'https://one.example/v1',
+          registryBaseUrl: 'https://one.example/v1',
+        },
+        {
+          id: 'shared-model',
+          label: 'Provider Two',
+          authType: 'api-key',
+          baseUrl: 'https://two.example/v1',
+          registryBaseUrl: 'https://two.example/v1',
+        },
+      ]),
+    });
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const session = (await agent.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    })) as {
+      models: {
+        currentModelId: string;
+        availableModels: Array<{ modelId: string }>;
+      };
+      configOptions: Array<{
+        id: string;
+        currentValue: string;
+        options: Array<{ value: string }>;
+      }>;
+    };
+    const context = (await agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.sessionContext,
+      { sessionId },
+    )) as {
+      state: {
+        models: {
+          currentModelId: string;
+          availableModels: Array<{ modelId: string }>;
+        };
+      };
+    };
+    const modelIds = session.models.availableModels.map(
+      (model) => model.modelId,
+    );
+    const modelOption = session.configOptions.find(
+      (option) => option.id === 'model',
+    );
+
+    expect(new Set(modelIds)).toHaveLength(2);
+    expect(modelIds).toEqual([
+      expect.stringMatching(/^qwen-route:v1:/),
+      expect.stringMatching(/^qwen-route:v1:/),
+    ]);
+    expect(modelOption?.options.map((option) => option.value)).toEqual(
+      modelIds,
+    );
+    expect(session.models.currentModelId).toBe(modelIds[1]);
+    expect(modelOption?.currentValue).toBe(modelIds[1]);
+    expect(
+      context.state.models.availableModels.map((model) => model.modelId),
+    ).toEqual(modelIds);
+    expect(context.state.models.currentModelId).toBe(modelIds[1]);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('status ext methods expose live session context and supported commands', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
     const innerConfig = await setupSessionMocks(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3496,6 +3496,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         id: 'runtime-qwen-plus',
         authType: 'qwen',
       }),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://stale.example/v1'),
       getModel: vi.fn().mockReturnValue('qwen-plus'),
       getAllConfiguredModels: vi.fn().mockReturnValue([
         {
@@ -3542,6 +3545,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ],
     });
     expect(vi.mocked(tokenLimit)).toHaveBeenCalledWith('runtime-qwen-plus');
+    expect(mockConfig.getCurrentModelRegistryBaseUrl).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -650,19 +650,6 @@ vi.mock('./session/Session.js', () => ({
     availableSkills: [],
   }),
 }));
-vi.mock('../utils/acpModelUtils.js', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../utils/acpModelUtils.js')>();
-  return {
-    ...actual,
-    formatAcpModelId: vi.fn(
-      (modelId: string, authType: string) => `${modelId}(${authType})`,
-    ),
-    parseAcpBaseModelId: vi.fn((modelId: string) =>
-      modelId.replace(/\([^)]+\)$/, ''),
-    ),
-  };
-});
 vi.mock('../utils/languageUtils.js', () => ({
   updateOutputLanguageFile: vi.fn(),
   writeOutputLanguageAndRegisterPath: vi.fn(
@@ -3644,6 +3631,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         model: 'shared-model',
         baseUrl: 'https://two.example/v1',
       }),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://two.example/v1'),
       getAllConfiguredModels: vi.fn().mockReturnValue([
         {
           id: 'shared-model',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4635,7 +4635,7 @@ class QwenAgent implements Agent {
             modelOptions,
             currentModelId,
             currentAuth,
-            config.getContentGeneratorConfig?.()?.baseUrl,
+            config.getCurrentModelRegistryBaseUrl?.(),
           )
         : undefined;
       const providers = new Map<string, ServeWorkspaceProviderStatus>();
@@ -9361,8 +9361,9 @@ class QwenAgent implements Agent {
       modelOptions,
       activeRuntimeSnapshot?.id ?? rawCurrentModelId,
       activeRuntimeSnapshot?.authType ?? currentAuthType,
-      activeRuntimeSnapshot?.baseUrl ??
-        config.getContentGeneratorConfig?.()?.baseUrl,
+      activeRuntimeSnapshot
+        ? undefined
+        : config.getCurrentModelRegistryBaseUrl?.(),
     );
 
     const mappedAvailableModels = modelOptions.map(({ model, modelId }) => ({
@@ -9406,8 +9407,9 @@ class QwenAgent implements Agent {
       modelOptions,
       activeRuntimeSnapshot?.id ?? rawCurrentModelId,
       activeRuntimeSnapshot?.authType ?? currentAuthType,
-      activeRuntimeSnapshot?.baseUrl ??
-        config.getContentGeneratorConfig?.()?.baseUrl,
+      activeRuntimeSnapshot
+        ? undefined
+        : config.getCurrentModelRegistryBaseUrl?.(),
     );
 
     const modeOptions = APPROVAL_MODES.map((mode) => ({

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4635,7 +4635,9 @@ class QwenAgent implements Agent {
             modelOptions,
             currentModelId,
             currentAuth,
-            config.getCurrentModelRegistryBaseUrl?.(),
+            activeRuntimeSnapshot
+              ? undefined
+              : config.getCurrentModelRegistryBaseUrl?.(),
           )
         : undefined;
       const providers = new Map<string, ServeWorkspaceProviderStatus>();

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -204,7 +204,8 @@ import {
   replayTranscriptRecordPage,
 } from './session/history-replay-page.js';
 import {
-  formatAcpModelId,
+  buildAcpModelOptions,
+  getCurrentAcpModelId,
   parseAcpBaseModelId,
   sanitizeProviderBaseUrl,
 } from '../utils/acpModelUtils.js';
@@ -4626,15 +4627,21 @@ class QwenAgent implements Agent {
         : (config.getModel() || '').trim();
       const hasCurrentModel = currentModelId.length > 0;
       const currentAuth = activeRuntimeSnapshot?.authType ?? currentAuthType;
-      const currentAcpModelId =
-        hasCurrentModel && currentAuth
-          ? formatAcpModelId(currentModelId, currentAuth)
-          : currentModelId || undefined;
+      const modelOptions = buildAcpModelOptions(
+        config.getAllConfiguredModels(),
+      );
+      const currentAcpModelId = hasCurrentModel
+        ? getCurrentAcpModelId(
+            modelOptions,
+            currentModelId,
+            currentAuth,
+            config.getContentGeneratorConfig?.()?.baseUrl,
+          )
+        : undefined;
       const providers = new Map<string, ServeWorkspaceProviderStatus>();
 
-      for (const model of config
-        .getAllConfiguredModels()
-        .filter(isMainSelectableModel)) {
+      for (const option of modelOptions) {
+        const { model, effectiveModelId, modelId } = option;
         const authType = String(model.authType);
         let provider = providers.get(authType);
         if (!provider) {
@@ -4648,17 +4655,8 @@ class QwenAgent implements Agent {
           providers.set(authType, provider);
         }
 
-        const effectiveModelId =
-          model.isRuntimeModel && model.runtimeSnapshotId
-            ? model.runtimeSnapshotId
-            : model.id;
-        const modelId = formatAcpModelId(effectiveModelId, model.authType);
         const isCurrent =
-          currentAuth === model.authType &&
-          hasCurrentModel &&
-          (currentModelId === effectiveModelId ||
-            currentModelId === model.id ||
-            currentAcpModelId === modelId);
+          currentAuth === model.authType && currentAcpModelId === modelId;
         const providerModel: ServeWorkspaceProviderModel = {
           modelId,
           baseModelId: parseAcpBaseModelId(effectiveModelId),
@@ -9356,33 +9354,25 @@ class QwenAgent implements Agent {
       ''
     ).trim();
     const currentAuthType = config.getAuthType();
-    const allConfiguredModels = config
-      .getAllConfiguredModels()
-      .filter(isMainSelectableModel);
+    const modelOptions = buildAcpModelOptions(config.getAllConfiguredModels());
 
     const activeRuntimeSnapshot = config.getActiveRuntimeModelSnapshot?.();
-    const currentModelId = activeRuntimeSnapshot
-      ? formatAcpModelId(
-          activeRuntimeSnapshot.id,
-          activeRuntimeSnapshot.authType,
-        )
-      : this.formatCurrentModelId(rawCurrentModelId, currentAuthType);
+    const currentModelId = getCurrentAcpModelId(
+      modelOptions,
+      activeRuntimeSnapshot?.id ?? rawCurrentModelId,
+      activeRuntimeSnapshot?.authType ?? currentAuthType,
+      activeRuntimeSnapshot?.baseUrl ??
+        config.getContentGeneratorConfig?.()?.baseUrl,
+    );
 
-    const mappedAvailableModels = allConfiguredModels.map((model) => {
-      const effectiveModelId =
-        model.isRuntimeModel && model.runtimeSnapshotId
-          ? model.runtimeSnapshotId
-          : model.id;
-
-      return {
-        modelId: formatAcpModelId(effectiveModelId, model.authType),
-        name: model.label,
-        description: model.description ?? null,
-        _meta: {
-          contextLimit: model.contextWindowSize ?? tokenLimit(model.id),
-        },
-      };
-    });
+    const mappedAvailableModels = modelOptions.map(({ model, modelId }) => ({
+      modelId,
+      name: model.label,
+      description: model.description ?? null,
+      _meta: {
+        contextLimit: model.contextWindowSize ?? tokenLimit(model.id),
+      },
+    }));
 
     return {
       currentModelId,
@@ -9407,19 +9397,18 @@ class QwenAgent implements Agent {
 
   private buildConfigOptions(config: Config): SessionConfigOption[] {
     const currentApprovalMode = config.getApprovalMode();
-    const allConfiguredModels = config
-      .getAllConfiguredModels()
-      .filter(isMainSelectableModel);
+    const modelOptions = buildAcpModelOptions(config.getAllConfiguredModels());
     const rawCurrentModelId = (config.getModel() || '').trim();
     const currentAuthType = config.getAuthType?.();
 
     const activeRuntimeSnapshot = config.getActiveRuntimeModelSnapshot?.();
-    const currentModelId = activeRuntimeSnapshot
-      ? formatAcpModelId(
-          activeRuntimeSnapshot.id,
-          activeRuntimeSnapshot.authType,
-        )
-      : this.formatCurrentModelId(rawCurrentModelId, currentAuthType);
+    const currentModelId = getCurrentAcpModelId(
+      modelOptions,
+      activeRuntimeSnapshot?.id ?? rawCurrentModelId,
+      activeRuntimeSnapshot?.authType ?? currentAuthType,
+      activeRuntimeSnapshot?.baseUrl ??
+        config.getContentGeneratorConfig?.()?.baseUrl,
+    );
 
     const modeOptions = APPROVAL_MODES.map((mode) => ({
       value: mode,
@@ -9437,17 +9426,11 @@ class QwenAgent implements Agent {
       options: modeOptions,
     };
 
-    const modelOptions = allConfiguredModels.map((model) => {
-      const effectiveModelId =
-        model.isRuntimeModel && model.runtimeSnapshotId
-          ? model.runtimeSnapshotId
-          : model.id;
-      return {
-        value: formatAcpModelId(effectiveModelId, model.authType),
-        name: model.label,
-        description: model.description ?? '',
-      };
-    });
+    const configModelOptions = modelOptions.map(({ model, modelId }) => ({
+      value: modelId,
+      name: model.label,
+      description: model.description ?? '',
+    }));
 
     const modelConfigOption: SessionConfigOption = {
       id: 'model',
@@ -9456,26 +9439,11 @@ class QwenAgent implements Agent {
       category: 'model',
       type: 'select' as const,
       currentValue: currentModelId,
-      options: modelOptions,
+      options: configModelOptions,
     };
 
     return [modeConfigOption, modelConfigOption];
   }
-
-  private formatCurrentModelId(
-    baseModelId: string,
-    authType?: AuthType,
-  ): string {
-    if (!baseModelId) return baseModelId;
-    return authType ? formatAcpModelId(baseModelId, authType) : baseModelId;
-  }
-}
-
-function isMainSelectableModel(model: {
-  fastOnly?: boolean;
-  voiceOnly?: boolean;
-}): boolean {
-  return model.fastOnly !== true && model.voiceOnly !== true;
 }
 
 function diffSettingsKeys(

--- a/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
@@ -246,10 +246,6 @@ vi.mock('../config/config.js', () => ({
   buildDisabledSkillNamesProvider: vi.fn(() => () => new Set<string>()),
 }));
 vi.mock('./session/Session.js', () => ({ Session: vi.fn() }));
-vi.mock('../utils/acpModelUtils.js', () => ({
-  formatAcpModelId: vi.fn(),
-}));
-
 // ---------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -44,6 +44,7 @@ import type { LoadedSettings } from '../../config/settings.js';
 import * as nonInteractiveCliCommands from '../../nonInteractiveCliCommands.js';
 import { CommandKind } from '../../ui/commands/types.js';
 import { MessageType } from '../../ui/types.js';
+import { buildAcpModelOptions } from '../../utils/acpModelUtils.js';
 
 const debugLoggerWarnSpy = vi.hoisted(() => vi.fn());
 const debugLoggerDebugSpy = vi.hoisted(() => vi.fn());
@@ -495,6 +496,7 @@ describe('Session', () => {
       getTargetDir: vi.fn().mockReturnValue(process.cwd()),
       getDebugMode: vi.fn().mockReturnValue(false),
       getAuthType: vi.fn().mockImplementation(() => currentAuthType),
+      getAllConfiguredModels: vi.fn().mockReturnValue([]),
       isCronEnabled: vi.fn().mockReturnValue(false),
       getSessionTokenLimit: vi.fn().mockReturnValue(0),
       getStopHookBlockingCap: vi.fn().mockReturnValue(8),
@@ -1145,6 +1147,14 @@ describe('Session', () => {
   describe('setModel', () => {
     it('sets model via config and returns current model', async () => {
       const requested = `qwen3-coder-plus(${AuthType.USE_OPENAI})`;
+      vi.mocked(mockConfig.getAllConfiguredModels).mockReturnValue([
+        {
+          id: 'qwen3-coder-plus',
+          label: 'Qwen3 Coder Plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://default.example/v1',
+        },
+      ]);
       await session.setModel({
         sessionId: 'test-session-id',
         modelId: `  ${requested}  `,
@@ -1184,9 +1194,135 @@ describe('Session', () => {
         expect.objectContaining({
           v: 1,
           sessionId: 'test-session-id',
-          currentModelId: 'qwen3-coder-plus',
+          currentModelId: `qwen3-coder-plus(${AuthType.USE_OPENAI})`,
         }),
       );
+    });
+
+    it('resolves an opaque ACP route and persists the canonical model identity', async () => {
+      const models = [
+        {
+          id: 'shared-model',
+          label: 'Provider One',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://one.example/v1',
+          registryBaseUrl: 'https://one.example/v1',
+        },
+        {
+          id: 'shared-model',
+          label: 'Provider Two',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://two.example/v1',
+          registryBaseUrl: 'https://two.example/v1',
+        },
+      ];
+      let activeBaseUrl = 'https://one.example/v1';
+      vi.mocked(mockConfig.getAllConfiguredModels).mockReturnValue(models);
+      vi.mocked(mockConfig.getContentGeneratorConfig).mockImplementation(
+        () =>
+          ({
+            authType: currentAuthType,
+            model: currentModel,
+            baseUrl: activeBaseUrl,
+          }) as ReturnType<Config['getContentGeneratorConfig']>,
+      );
+      switchModelSpy.mockImplementation(
+        async (
+          authType: AuthType,
+          modelId: string,
+          options?: { baseUrl?: string },
+        ) => {
+          currentAuthType = authType;
+          currentModel = modelId;
+          activeBaseUrl = options?.baseUrl ?? activeBaseUrl;
+        },
+      );
+      const routeId = buildAcpModelOptions(models)[1]!.modelId;
+
+      const response = await session.setModel({
+        sessionId: 'test-session-id',
+        modelId: routeId,
+      });
+
+      expect(mockConfig.switchModel).toHaveBeenCalledWith(
+        AuthType.USE_OPENAI,
+        'shared-model',
+        { baseUrl: 'https://two.example/v1' },
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'shared-model',
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.baseUrl',
+        'https://two.example/v1',
+      );
+      expect(mockClient.extNotification).toHaveBeenCalledWith(
+        'qwen/notify/session/model-update',
+        expect.objectContaining({ currentModelId: routeId }),
+      );
+      expect(response).toMatchObject({
+        _meta: {
+          qwenModelSwitch: {
+            modelId: 'shared-model',
+            baseUrl: 'https://two.example/v1',
+          },
+        },
+      });
+    });
+
+    it('switches an implicit route without using its resolved default as a registry key', async () => {
+      const models = [
+        {
+          id: 'shared-model',
+          label: 'Implicit Default',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://default.example/v1',
+        },
+        {
+          id: 'shared-model',
+          label: 'Explicit Route',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://default.example/v1',
+          registryBaseUrl: 'https://default.example/v1',
+        },
+      ];
+      vi.mocked(mockConfig.getAllConfiguredModels).mockReturnValue(models);
+      const routeId = buildAcpModelOptions(models)[0]!.modelId;
+
+      const response = await session.setModel({
+        sessionId: 'test-session-id',
+        modelId: routeId,
+      });
+
+      expect(mockConfig.switchModel).toHaveBeenCalledWith(
+        AuthType.USE_OPENAI,
+        'shared-model',
+        undefined,
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'shared-model',
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.baseUrl',
+        '',
+      );
+      expect(mockClient.extNotification).toHaveBeenCalledWith(
+        'qwen/notify/session/model-update',
+        expect.objectContaining({ currentModelId: routeId }),
+      );
+      expect(response).toMatchObject({
+        _meta: {
+          qwenModelSwitch: {
+            modelId: 'shared-model',
+          },
+        },
+      });
     });
 
     it('does NOT emit the model-update notification when the switch fails (A1)', async () => {
@@ -1210,6 +1346,18 @@ describe('Session', () => {
           modelId: '   ',
         }),
       ).rejects.toThrow('Invalid params');
+
+      expect(mockConfig.switchModel).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+    });
+
+    it('rejects an opaque route that is no longer advertised', async () => {
+      await expect(
+        session.setModel({
+          sessionId: 'test-session-id',
+          modelId: 'qwen-route:v1:abcdefghijklmnop',
+        }),
+      ).rejects.toThrow('Unknown or stale model route');
 
       expect(mockConfig.switchModel).not.toHaveBeenCalled();
       expect(mockSettings.setValue).not.toHaveBeenCalled();

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -191,6 +191,7 @@ import {
   type HistoryItemGoalStatus,
 } from '../../ui/types.js';
 import {
+  ACP_ROUTE_ID_PREFIX,
   buildAcpModelOptions,
   getCurrentAcpModelId,
   parseAcpModelOption,
@@ -4064,10 +4065,7 @@ export class Session implements SessionContext {
       rawModelId,
       this.config.getAllConfiguredModels(),
     );
-    if (
-      !resolvedRoute &&
-      /^qwen-route:v1:[A-Za-z0-9_-]{16}$/.test(rawModelId)
-    ) {
+    if (!resolvedRoute && rawModelId.startsWith(ACP_ROUTE_ID_PREFIX)) {
       throw RequestError.invalidParams(
         undefined,
         `Unknown or stale model route: "${rawModelId}"`,
@@ -4113,10 +4111,10 @@ export class Session implements SessionContext {
       activeRuntimeSnapshot?.id ?? effectiveModelId,
       activeRuntimeSnapshot?.authType ?? effectiveAuthType,
       activeRuntimeSnapshot
-        ? activeRuntimeSnapshot.baseUrl
+        ? undefined
         : resolvedRoute
-          ? resolvedRoute.baseUrl
-          : after?.baseUrl,
+          ? resolvedRoute.registryBaseUrl
+          : this.config.getCurrentModelRegistryBaseUrl?.(),
     );
 
     // Notify attached clients of an in-session model switch so a

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -190,7 +190,12 @@ import {
   MessageType,
   type HistoryItemGoalStatus,
 } from '../../ui/types.js';
-import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
+import {
+  buildAcpModelOptions,
+  getCurrentAcpModelId,
+  parseAcpModelOption,
+  resolveAcpModelOption,
+} from '../../utils/acpModelUtils.js';
 import { classifyApiError } from '../../ui/hooks/useGeminiStream.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
@@ -4055,7 +4060,20 @@ export class Session implements SessionContext {
       throw RequestError.invalidParams(undefined, 'modelId cannot be empty');
     }
 
-    const parsed = parseAcpModelOption(rawModelId);
+    const resolvedRoute = resolveAcpModelOption(
+      rawModelId,
+      this.config.getAllConfiguredModels(),
+    );
+    if (
+      !resolvedRoute &&
+      /^qwen-route:v1:[A-Za-z0-9_-]{16}$/.test(rawModelId)
+    ) {
+      throw RequestError.invalidParams(
+        undefined,
+        `Unknown or stale model route: "${rawModelId}"`,
+      );
+    }
+    const parsed = resolvedRoute ?? parseAcpModelOption(rawModelId);
     const previousAuthType = this.config.getAuthType?.();
     const selectedAuthType = parsed.authType ?? previousAuthType;
 
@@ -4066,18 +4084,40 @@ export class Session implements SessionContext {
       );
     }
 
+    const requireCachedCredentials =
+      selectedAuthType !== previousAuthType &&
+      selectedAuthType === AuthType.QWEN_OAUTH;
+    const switchOptions =
+      resolvedRoute?.baseUrl !== undefined || requireCachedCredentials
+        ? {
+            ...(resolvedRoute?.baseUrl !== undefined
+              ? { baseUrl: resolvedRoute.baseUrl }
+              : {}),
+            ...(requireCachedCredentials
+              ? { requireCachedCredentials: true }
+              : {}),
+          }
+        : undefined;
     await this.config.switchModel(
       selectedAuthType,
       parsed.modelId,
-      selectedAuthType !== previousAuthType &&
-        selectedAuthType === AuthType.QWEN_OAUTH
-        ? { requireCachedCredentials: true }
-        : undefined,
+      switchOptions,
     );
 
     const after = this.config.getContentGeneratorConfig?.();
     const effectiveAuthType = after?.authType ?? selectedAuthType;
     const effectiveModelId = after?.model ?? parsed.modelId;
+    const activeRuntimeSnapshot = this.config.getActiveRuntimeModelSnapshot?.();
+    const currentAcpModelId = getCurrentAcpModelId(
+      buildAcpModelOptions(this.config.getAllConfiguredModels()),
+      activeRuntimeSnapshot?.id ?? effectiveModelId,
+      activeRuntimeSnapshot?.authType ?? effectiveAuthType,
+      activeRuntimeSnapshot
+        ? activeRuntimeSnapshot.baseUrl
+        : resolvedRoute
+          ? resolvedRoute.baseUrl
+          : after?.baseUrl,
+    );
 
     // Notify attached clients of an in-session model switch so a
     // `/model` slash command or plan-mode change reaches the bus (today only
@@ -4093,7 +4133,7 @@ export class Session implements SessionContext {
       .extNotification('qwen/notify/session/model-update', {
         v: 1,
         sessionId: this.sessionId,
-        currentModelId: effectiveModelId,
+        currentModelId: currentAcpModelId,
       })
       .catch((error) => {
         // Advisory only; a failed notification must not fail the model switch.
@@ -4102,17 +4142,22 @@ export class Session implements SessionContext {
 
     if (options.persistDefault ?? true) {
       const persistScope = getPersistScopeForModelSelection(this.settings);
-      this.settings.setValue(persistScope, 'model.name', parsed.modelId);
-      // Id-only switch: clear any baseUrl disambiguator left by a previous
-      // model-picker selection so the next launch resolves to this provider,
-      // not a stale one sharing the same model id. Empty-string tombstone so
-      // the clear overrides a lower-scope value on merge (undefined is dropped
-      // from JSON and would not override).
-      this.settings.setValue(persistScope, 'model.baseUrl', '');
+      this.settings.setValue(
+        persistScope,
+        'model.name',
+        resolvedRoute?.isRuntime ? resolvedRoute.modelId : effectiveModelId,
+      );
+      this.settings.setValue(
+        persistScope,
+        'model.baseUrl',
+        resolvedRoute && !resolvedRoute.isRuntime
+          ? (resolvedRoute.baseUrl ?? '')
+          : '',
+      );
       this.settings.setValue(
         persistScope,
         'security.auth.selectedType',
-        selectedAuthType,
+        effectiveAuthType,
       );
     }
 
@@ -4123,7 +4168,8 @@ export class Session implements SessionContext {
           modelId: effectiveModelId,
           baseUrl: after?.baseUrl ?? '(default)',
           apiKey: maskApiKeyForDisplay(after?.apiKey),
-          isRuntime: rawModelId.startsWith('$runtime|'),
+          isRuntime:
+            resolvedRoute?.isRuntime ?? rawModelId.startsWith('$runtime|'),
         },
       },
     };

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2152,6 +2152,7 @@ export async function loadCliConfig(
     providerProtocolConfig,
     generationConfigSources: resolvedCliConfig.sources,
     generationConfig: resolvedCliConfig.generationConfig,
+    initialModelRegistryBaseUrl: resolvedCliConfig.registryBaseUrl,
     warnings: resolvedCliConfig.warnings,
     bareMode,
     safeMode,

--- a/packages/cli/src/serve/workspace-providers-status.test.ts
+++ b/packages/cli/src/serve/workspace-providers-status.test.ts
@@ -202,14 +202,51 @@ describe('createWorkspaceProvidersStatusProvider', () => {
 
     const result = await provider(workspace, false);
     const models = result.providers.flatMap((p) => p.models);
+    const first = models.find(
+      (m) => m.baseUrl === 'https://api-one.example/v1',
+    );
+    const second = models.find(
+      (m) => m.baseUrl === 'https://api-two.example/v1',
+    );
 
-    expect(result.current?.modelId).toBe('shared-model(openai)');
-    expect(
-      models.find((m) => m.baseUrl === 'https://api-one.example/v1')?.isCurrent,
-    ).toBe(false);
-    expect(
-      models.find((m) => m.baseUrl === 'https://api-two.example/v1')?.isCurrent,
-    ).toBe(true);
+    expect(first?.modelId).toMatch(/^qwen-route:v1:/);
+    expect(second?.modelId).toMatch(/^qwen-route:v1:/);
+    expect(first?.modelId).not.toBe(second?.modelId);
+    expect(result.current?.modelId).toBe(second?.modelId);
+    expect(first?.isCurrent).toBe(false);
+    expect(second?.isCurrent).toBe(true);
+  });
+
+  it('does not mark a configured route for an unmatched explicit endpoint', async () => {
+    const provider = createWorkspaceProvidersStatusProvider({ env: {} });
+    await writeUserSettings({
+      security: { auth: { selectedType: 'openai' } },
+      model: {
+        name: 'shared-model',
+        baseUrl: 'https://outside.example/v1',
+      },
+      modelProviders: {
+        openai: [
+          {
+            id: 'shared-model',
+            name: 'Shared One',
+            baseUrl: 'https://api-one.example/v1',
+          },
+          {
+            id: 'shared-model',
+            name: 'Shared Two',
+            baseUrl: 'https://api-two.example/v1',
+          },
+        ],
+      },
+    });
+
+    const result = await provider(workspace, false);
+    const models = result.providers.flatMap((entry) => entry.models);
+
+    expect(result.current?.modelId).toBe('shared-model');
+    expect(result.current?.baseUrl).toBe('https://outside.example/v1');
+    expect(models.every((model) => model.isCurrent === false)).toBe(true);
   });
 
   it('filters fastOnly and voiceOnly models from the workspace provider catalog', async () => {
@@ -331,11 +368,10 @@ describe('createWorkspaceProvidersStatusProvider', () => {
 
     const result = await provider(workspace, false);
     const models = result.providers.flatMap((p) => p.models);
+    const defaultModel = models.find((m) => m.name === 'Shared Default');
 
-    expect(result.current?.modelId).toBe('shared-model(openai)');
-    expect(models.find((m) => m.name === 'Shared Default')?.isCurrent).toBe(
-      true,
-    );
+    expect(result.current?.modelId).toBe(defaultModel?.modelId);
+    expect(defaultModel?.isCurrent).toBe(true);
     expect(
       models.find((m) => m.baseUrl === 'https://proxy.example/v1')?.isCurrent,
     ).toBe(false);

--- a/packages/cli/src/serve/workspace-providers-status.ts
+++ b/packages/cli/src/serve/workspace-providers-status.ts
@@ -9,7 +9,6 @@ import {
   APPROVAL_MODES,
   createDebugLogger,
   ModelsConfig,
-  resolveProviderProtocol,
   tokenLimit,
 } from '@qwen-code/qwen-code-core';
 import type { AuthType } from '@qwen-code/qwen-code-core';
@@ -28,7 +27,8 @@ import {
 } from '../utils/modelConfigUtils.js';
 import type { CliGenerationConfigInputs } from '../utils/modelConfigUtils.js';
 import {
-  formatAcpModelId,
+  buildAcpModelOptions,
+  getCurrentAcpModelId,
   parseAcpBaseModelId,
   sanitizeProviderBaseUrl,
 } from '../utils/acpModelUtils.js';
@@ -94,12 +94,24 @@ function buildWorkspaceProvidersStatus(
       ''
     ).trim();
     const hasCurrentModel = currentModelId.length > 0;
-    const currentAcpModelId =
-      hasCurrentModel && currentAuth
-        ? formatAcpModelId(currentModelId, currentAuth)
-        : currentModelId || undefined;
-    const currentBaseUrl = resolvedCliConfig.sources['baseUrl']
-      ? resolvedCliConfig.baseUrl || undefined
+    const modelCameFromSettings =
+      !argv.model && settings.model?.name?.trim() === currentModelId;
+    const currentBaseUrl =
+      modelCameFromSettings && settings.model?.baseUrl !== undefined
+        ? settings.model.baseUrl || undefined
+        : resolvedCliConfig.sources['baseUrl']
+          ? resolvedCliConfig.baseUrl || undefined
+          : undefined;
+    const modelOptions = buildAcpModelOptions(
+      modelsConfig.getAllConfiguredModels(),
+    );
+    const currentAcpModelId = hasCurrentModel
+      ? getCurrentAcpModelId(
+          modelOptions,
+          currentModelId,
+          currentAuth,
+          currentBaseUrl,
+        )
       : undefined;
     const fastModelId =
       typeof settings.fastModel === 'string' && settings.fastModel.length > 0
@@ -112,14 +124,8 @@ function buildWorkspaceProvidersStatus(
         : undefined;
     const approvalMode = resolveApprovalMode(settings);
     const providers = new Map<string, ServeWorkspaceProviderStatus>();
-    const explicitModelBaseUrls = buildExplicitModelBaseUrls(
-      settings.modelProviders,
-      settings.providerProtocol,
-    );
-
-    for (const model of modelsConfig
-      .getAllConfiguredModels()
-      .filter(isMainSelectableModel)) {
+    for (const option of modelOptions) {
+      const { model, effectiveModelId, modelId } = option;
       if (model.isRuntimeModel) continue;
       const authType = String(model.authType);
       let provider = providers.get(authType);
@@ -134,20 +140,8 @@ function buildWorkspaceProvidersStatus(
         providers.set(authType, provider);
       }
 
-      const effectiveModelId = model.id;
-      const modelId = formatAcpModelId(effectiveModelId, model.authType);
       const isCurrent =
-        currentAuth === model.authType &&
-        hasCurrentModel &&
-        matchesCurrentModel(currentModelId, effectiveModelId, modelId) &&
-        matchesCurrentBaseUrl(
-          currentBaseUrl,
-          model.baseUrl,
-          model.baseUrl !== undefined &&
-            explicitModelBaseUrls.has(
-              modelBaseUrlKey(authType, effectiveModelId, model.baseUrl),
-            ),
-        );
+        currentAuth === model.authType && currentAcpModelId === modelId;
       const providerModel: ServeWorkspaceProviderModel = {
         modelId,
         baseModelId: parseAcpBaseModelId(effectiveModelId),
@@ -232,89 +226,6 @@ function resolveApprovalMode(settings: Settings): ApprovalMode {
     );
   }
   return ApprovalMode.AUTO;
-}
-
-function isMainSelectableModel(model: {
-  fastOnly?: boolean;
-  voiceOnly?: boolean;
-}): boolean {
-  return model.fastOnly !== true && model.voiceOnly !== true;
-}
-
-function matchesCurrentModel(
-  currentModelId: string,
-  baseModelId: string,
-  acpModelId: string,
-): boolean {
-  return currentModelId === baseModelId || currentModelId === acpModelId;
-}
-
-function matchesCurrentBaseUrl(
-  currentBaseUrl: string | undefined,
-  modelBaseUrl: string | undefined,
-  modelHasExplicitBaseUrl: boolean,
-): boolean {
-  if (!currentBaseUrl) return !modelHasExplicitBaseUrl;
-  return currentBaseUrl === modelBaseUrl;
-}
-
-function buildExplicitModelBaseUrls(
-  modelProviders: Settings['modelProviders'],
-  providerProtocol: Settings['providerProtocol'],
-): Set<string> {
-  const baseUrls = new Set<string>();
-  if (!modelProviders) return baseUrls;
-
-  for (const [providerId, providerConfig] of Object.entries(modelProviders)) {
-    const authType = resolveProviderProtocol(providerId, providerProtocol);
-    if (!authType) continue;
-    const models = readProviderModels(providerConfig);
-    for (const model of models) {
-      if (
-        typeof model.id === 'string' &&
-        typeof model.baseUrl === 'string' &&
-        model.baseUrl.length > 0
-      ) {
-        baseUrls.add(modelBaseUrlKey(authType, model.id, model.baseUrl));
-      }
-    }
-  }
-  return baseUrls;
-}
-
-type ProviderModelBaseUrlConfig = {
-  id?: unknown;
-  baseUrl?: unknown;
-};
-
-function readProviderModels(
-  providerConfig: unknown,
-): ProviderModelBaseUrlConfig[] {
-  if (Array.isArray(providerConfig)) {
-    return providerConfig.filter(isProviderModelBaseUrlConfig);
-  }
-  if (typeof providerConfig !== 'object' || providerConfig === null) {
-    return [];
-  }
-
-  const { models } = providerConfig as { models?: unknown };
-  return Array.isArray(models)
-    ? models.filter(isProviderModelBaseUrlConfig)
-    : [];
-}
-
-function isProviderModelBaseUrlConfig(
-  value: unknown,
-): value is ProviderModelBaseUrlConfig {
-  return typeof value === 'object' && value !== null;
-}
-
-function modelBaseUrlKey(
-  authType: string,
-  modelId: string,
-  baseUrl: string,
-): string {
-  return `${authType}\0${modelId}\0${baseUrl}`;
 }
 
 const URL_LIKE_PATTERN = /\b[A-Za-z][A-Za-z\d+.-]*:\/\/[^\s'"`<>]+/g;

--- a/packages/cli/src/serve/workspace-providers-status.ts
+++ b/packages/cli/src/serve/workspace-providers-status.ts
@@ -102,6 +102,13 @@ function buildWorkspaceProvidersStatus(
         : resolvedCliConfig.sources['baseUrl']
           ? resolvedCliConfig.baseUrl || undefined
           : undefined;
+    const currentRegistryBaseUrl =
+      modelCameFromSettings && currentAuth
+        ? settings.model?.baseUrl !== undefined
+          ? settings.model.baseUrl || null
+          : (modelsConfig.getResolvedModel(currentAuth, currentModelId)
+              ?.registryBaseUrl ?? null)
+        : undefined;
     const modelOptions = buildAcpModelOptions(
       modelsConfig.getAllConfiguredModels(),
     );
@@ -110,7 +117,7 @@ function buildWorkspaceProvidersStatus(
           modelOptions,
           currentModelId,
           currentAuth,
-          currentBaseUrl,
+          currentRegistryBaseUrl,
         )
       : undefined;
     const fastModelId =

--- a/packages/cli/src/utils/acpModelUtils.test.ts
+++ b/packages/cli/src/utils/acpModelUtils.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect } from 'vitest';
 import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import {
   buildAcpModelOptions,
-  formatAcpModelId,
   getCurrentAcpModelId,
   isInlineModelOverrideAllowed,
   parseAcpBaseModelId,
@@ -18,12 +17,6 @@ import {
 } from './acpModelUtils.js';
 
 describe('acpModelUtils', () => {
-  it('formats modelId(authType)', () => {
-    expect(formatAcpModelId('qwen3', AuthType.QWEN_OAUTH)).toBe(
-      `qwen3(${AuthType.QWEN_OAUTH})`,
-    );
-  });
-
   it('uses opaque ids only to disambiguate colliding model routes', () => {
     const models = [
       {
@@ -55,9 +48,7 @@ describe('acpModelUtils', () => {
     expect(first?.modelId).toMatch(/^qwen-route:v1:/);
     expect(second?.modelId).toMatch(/^qwen-route:v1:/);
     expect(first?.modelId).not.toBe(second?.modelId);
-    expect(unique?.modelId).toBe(
-      formatAcpModelId('unique-model', AuthType.USE_OPENAI),
-    );
+    expect(unique?.modelId).toBe(`unique-model(${AuthType.USE_OPENAI})`);
     expect(options.map((option) => option.modelId).join(' ')).not.toContain(
       'secret',
     );
@@ -110,9 +101,15 @@ describe('acpModelUtils', () => {
     expect(resolveAcpModelOption(options[1]!.modelId, models)?.baseUrl).toBe(
       'https://two.example/v1',
     );
+    const reversed = buildAcpModelOptions([...models].reverse());
+    expect(
+      reversed.find(
+        (option) => option.model.baseUrl === 'https://one.example/v1',
+      )?.modelId,
+    ).toBe(options[0]?.modelId);
   });
 
-  it('does not derive opaque ids from provider endpoints', () => {
+  it('binds opaque ids to credential-free endpoint identity', () => {
     const makeModels = (suffix: string) => [
       {
         id: 'shared-model',
@@ -132,10 +129,40 @@ describe('acpModelUtils', () => {
 
     expect(
       buildAcpModelOptions(makeModels('first')).map((option) => option.modelId),
-    ).toEqual(
+    ).not.toEqual(
       buildAcpModelOptions(makeModels('changed')).map(
         (option) => option.modelId,
       ),
+    );
+
+    const withSecrets = makeModels('first').map((model, index) => ({
+      ...model,
+      baseUrl: model.baseUrl
+        .replace('https://', `https://user:secret-${index}@`)
+        .concat(`?token=${index}`),
+      registryBaseUrl: model.registryBaseUrl
+        .replace('https://', `https://user:secret-${index}@`)
+        .concat(`?token=${index}`),
+    }));
+    expect(
+      buildAcpModelOptions(withSecrets).map((option) => option.modelId),
+    ).toEqual(
+      buildAcpModelOptions(makeModels('first')).map((option) => option.modelId),
+    );
+  });
+
+  it('rejects colliding routes that differ only by secret URL parts', () => {
+    const models = ['one', 'two'].map((token) => ({
+      id: 'shared-model',
+      label: 'Shared',
+      authType: AuthType.USE_OPENAI,
+      envKey: 'SHARED_KEY',
+      baseUrl: `https://user:${token}@api.example/v1?token=${token}`,
+      registryBaseUrl: `https://user:${token}@api.example/v1?token=${token}`,
+    }));
+
+    expect(() => buildAcpModelOptions(models)).toThrow(
+      'need distinct names, envKey values, or public endpoints',
     );
   });
 
@@ -162,7 +189,7 @@ describe('acpModelUtils', () => {
       resolveAcpModelOption(options[0]!.modelId, models),
     ).not.toHaveProperty('baseUrl');
     expect(
-      getCurrentAcpModelId(options, 'shared-model', AuthType.USE_OPENAI),
+      getCurrentAcpModelId(options, 'shared-model', AuthType.USE_OPENAI, null),
     ).toBe(options[0]?.modelId);
     expect(
       getCurrentAcpModelId(

--- a/packages/cli/src/utils/acpModelUtils.test.ts
+++ b/packages/cli/src/utils/acpModelUtils.test.ts
@@ -7,10 +7,13 @@
 import { describe, it, expect } from 'vitest';
 import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import {
+  buildAcpModelOptions,
   formatAcpModelId,
+  getCurrentAcpModelId,
   isInlineModelOverrideAllowed,
   parseAcpBaseModelId,
   parseAcpModelOption,
+  resolveAcpModelOption,
   sanitizeProviderBaseUrl,
 } from './acpModelUtils.js';
 
@@ -19,6 +22,164 @@ describe('acpModelUtils', () => {
     expect(formatAcpModelId('qwen3', AuthType.QWEN_OAUTH)).toBe(
       `qwen3(${AuthType.QWEN_OAUTH})`,
     );
+  });
+
+  it('uses opaque ids only to disambiguate colliding model routes', () => {
+    const models = [
+      {
+        id: 'shared-model',
+        label: 'Provider One',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://one.example/v1',
+        registryBaseUrl: 'https://one.example/v1',
+      },
+      {
+        id: 'shared-model',
+        label: 'Provider Two',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://user:secret@two.example/v1?token=value',
+        registryBaseUrl: 'https://user:secret@two.example/v1?token=value',
+      },
+      {
+        id: 'unique-model',
+        label: 'Unique',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://three.example/v1',
+        registryBaseUrl: 'https://three.example/v1',
+      },
+    ];
+
+    const options = buildAcpModelOptions(models);
+    const [first, second, unique] = options;
+
+    expect(first?.modelId).toMatch(/^qwen-route:v1:/);
+    expect(second?.modelId).toMatch(/^qwen-route:v1:/);
+    expect(first?.modelId).not.toBe(second?.modelId);
+    expect(unique?.modelId).toBe(
+      formatAcpModelId('unique-model', AuthType.USE_OPENAI),
+    );
+    expect(options.map((option) => option.modelId).join(' ')).not.toContain(
+      'secret',
+    );
+    expect(resolveAcpModelOption(second!.modelId, models)).toMatchObject({
+      modelId: 'shared-model',
+      authType: AuthType.USE_OPENAI,
+      baseUrl: 'https://user:secret@two.example/v1?token=value',
+    });
+    expect(
+      getCurrentAcpModelId(
+        options,
+        'shared-model',
+        AuthType.USE_OPENAI,
+        'https://user:secret@two.example/v1?token=value',
+      ),
+    ).toBe(second?.modelId);
+    expect(
+      buildAcpModelOptions([...models].reverse()).find(
+        (option) =>
+          option.model.baseUrl ===
+          'https://user:secret@two.example/v1?token=value',
+      )?.modelId,
+    ).toBe(second?.modelId);
+  });
+
+  it('keeps opaque ids unique when colliding routes have identical metadata', () => {
+    const models = [
+      {
+        id: 'shared-model',
+        label: 'shared-model',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://one.example/v1',
+        registryBaseUrl: 'https://one.example/v1',
+      },
+      {
+        id: 'shared-model',
+        label: 'shared-model',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://two.example/v1',
+        registryBaseUrl: 'https://two.example/v1',
+      },
+    ];
+
+    const options = buildAcpModelOptions(models);
+
+    expect(new Set(options.map((option) => option.modelId))).toHaveLength(2);
+    expect(resolveAcpModelOption(options[0]!.modelId, models)?.baseUrl).toBe(
+      'https://one.example/v1',
+    );
+    expect(resolveAcpModelOption(options[1]!.modelId, models)?.baseUrl).toBe(
+      'https://two.example/v1',
+    );
+  });
+
+  it('does not derive opaque ids from provider endpoints', () => {
+    const makeModels = (suffix: string) => [
+      {
+        id: 'shared-model',
+        label: 'Provider One',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: `https://one.example/${suffix}`,
+        registryBaseUrl: `https://one.example/${suffix}`,
+      },
+      {
+        id: 'shared-model',
+        label: 'Provider Two',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: `https://two.example/${suffix}`,
+        registryBaseUrl: `https://two.example/${suffix}`,
+      },
+    ];
+
+    expect(
+      buildAcpModelOptions(makeModels('first')).map((option) => option.modelId),
+    ).toEqual(
+      buildAcpModelOptions(makeModels('changed')).map(
+        (option) => option.modelId,
+      ),
+    );
+  });
+
+  it('keeps resolved defaults separate from the registry route key', () => {
+    const models = [
+      {
+        id: 'shared-model',
+        label: 'Default Route',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://default.example/v1',
+      },
+      {
+        id: 'shared-model',
+        label: 'Explicit Route',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://default.example/v1',
+        registryBaseUrl: 'https://default.example/v1',
+      },
+    ];
+    const options = buildAcpModelOptions(models);
+
+    expect(options[0]?.modelId).not.toBe(options[1]?.modelId);
+    expect(
+      resolveAcpModelOption(options[0]!.modelId, models),
+    ).not.toHaveProperty('baseUrl');
+    expect(
+      getCurrentAcpModelId(options, 'shared-model', AuthType.USE_OPENAI),
+    ).toBe(options[0]?.modelId);
+    expect(
+      getCurrentAcpModelId(
+        options,
+        'shared-model',
+        AuthType.USE_OPENAI,
+        'https://default.example/v1',
+      ),
+    ).toBe(options[1]?.modelId);
+    expect(
+      getCurrentAcpModelId(
+        options,
+        'shared-model',
+        AuthType.USE_OPENAI,
+        'https://outside.example/v1',
+      ),
+    ).toBe('shared-model');
   });
 
   it('extracts base model id when string ends with parentheses', () => {

--- a/packages/cli/src/utils/acpModelUtils.ts
+++ b/packages/cli/src/utils/acpModelUtils.ts
@@ -4,11 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType, type Config } from '@qwen-code/qwen-code-core';
+import { createHash } from 'node:crypto';
+import {
+  AuthType,
+  type AvailableModel,
+  type Config,
+} from '@qwen-code/qwen-code-core';
 import { z } from 'zod';
 
 /**
- * ACP model IDs are represented as `${modelId}(${authType})` in the ACP protocol.
+ * ACP model IDs use `${modelId}(${authType})` when that route is unique.
+ * Colliding routes receive an opaque selector from `buildAcpModelOptions`.
  *
  * NOTE: The VSCode webview side mirrors this encoding contract in
  * `packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts` to
@@ -18,6 +24,111 @@ import { z } from 'zod';
  */
 export function formatAcpModelId(modelId: string, authType: AuthType): string {
   return `${modelId}(${authType})`;
+}
+
+export interface AcpModelOption {
+  model: AvailableModel;
+  modelId: string;
+  effectiveModelId: string;
+}
+
+export function buildAcpModelOptions(
+  models: readonly AvailableModel[],
+): AcpModelOption[] {
+  const candidates = models
+    .filter((model) => model.fastOnly !== true && model.voiceOnly !== true)
+    .map((model) => {
+      const effectiveModelId =
+        model.isRuntimeModel && model.runtimeSnapshotId
+          ? model.runtimeSnapshotId
+          : model.id;
+      return {
+        model,
+        effectiveModelId,
+        legacyModelId: formatAcpModelId(effectiveModelId, model.authType),
+      };
+    });
+  const counts = new Map<string, number>();
+  for (const candidate of candidates) {
+    counts.set(
+      candidate.legacyModelId,
+      (counts.get(candidate.legacyModelId) ?? 0) + 1,
+    );
+  }
+  const discriminatorCounts = new Map<string, number>();
+
+  return candidates.map(({ model, effectiveModelId, legacyModelId }) => {
+    const discriminator = [
+      legacyModelId,
+      model.label,
+      model.envKey ?? null,
+    ] as const;
+    const discriminatorKey = JSON.stringify(discriminator);
+    const occurrence = discriminatorCounts.get(discriminatorKey) ?? 0;
+    discriminatorCounts.set(discriminatorKey, occurrence + 1);
+
+    return {
+      model,
+      effectiveModelId,
+      modelId:
+        counts.get(legacyModelId) === 1
+          ? legacyModelId
+          : `qwen-route:v1:${createHash('sha256')
+              .update(JSON.stringify([...discriminator, occurrence]))
+              .digest('base64url')
+              .slice(0, 16)}`,
+    };
+  });
+}
+
+export function resolveAcpModelOption(
+  input: string,
+  models: readonly AvailableModel[],
+): {
+  modelId: string;
+  authType: AuthType;
+  baseUrl?: string;
+  isRuntime: boolean;
+} | null {
+  const matched = buildAcpModelOptions(models).find(
+    (option) => option.modelId === input.trim(),
+  );
+  if (!matched) return null;
+  return {
+    modelId: matched.effectiveModelId,
+    authType: matched.model.authType,
+    ...(matched.model.registryBaseUrl !== undefined
+      ? { baseUrl: matched.model.registryBaseUrl }
+      : {}),
+    isRuntime: matched.model.isRuntimeModel === true,
+  };
+}
+
+export function getCurrentAcpModelId(
+  options: readonly AcpModelOption[],
+  modelId: string,
+  authType?: AuthType,
+  baseUrl?: string,
+): string {
+  if (!modelId || !authType) return modelId;
+  const matching = options.filter(
+    (option) =>
+      option.effectiveModelId === modelId && option.model.authType === authType,
+  );
+  const exact = matching.find(
+    (option) => option.model.registryBaseUrl === baseUrl,
+  );
+  if (exact) return exact.modelId;
+  if (matching[0]?.model.isRuntimeModel) return matching[0].modelId;
+  if (baseUrl !== undefined) {
+    const implicit = matching.find(
+      (option) =>
+        option.model.registryBaseUrl === undefined &&
+        option.model.baseUrl === baseUrl,
+    );
+    return implicit?.modelId ?? modelId;
+  }
+  return matching[0]?.modelId ?? formatAcpModelId(modelId, authType);
 }
 
 export function sanitizeProviderBaseUrl(baseUrl: string): string {

--- a/packages/cli/src/utils/acpModelUtils.ts
+++ b/packages/cli/src/utils/acpModelUtils.ts
@@ -12,6 +12,22 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { z } from 'zod';
 
+export const ACP_ROUTE_ID_PREFIX = 'qwen-route:v1:';
+
+function getRouteEndpointIdentity(baseUrl: string | undefined): string | null {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.href;
+  } catch {
+    return sanitizeProviderBaseUrl(baseUrl).split(/[?#]/, 1)[0] ?? null;
+  }
+}
+
 /**
  * ACP model IDs use `${modelId}(${authType})` when that route is unique.
  * Colliding routes receive an opaque selector from `buildAcpModelOptions`.
@@ -22,11 +38,11 @@ import { z } from 'zod';
  * format. If the encoding here evolves (new authTypes, runtime prefix changes,
  * etc.), update that file too.
  */
-export function formatAcpModelId(modelId: string, authType: AuthType): string {
+function formatAcpModelId(modelId: string, authType: AuthType): string {
   return `${modelId}(${authType})`;
 }
 
-export interface AcpModelOption {
+interface AcpModelOption {
   model: AvailableModel;
   modelId: string;
   effectiveModelId: string;
@@ -55,17 +71,26 @@ export function buildAcpModelOptions(
       (counts.get(candidate.legacyModelId) ?? 0) + 1,
     );
   }
-  const discriminatorCounts = new Map<string, number>();
+  const discriminators = new Set<string>();
 
   return candidates.map(({ model, effectiveModelId, legacyModelId }) => {
     const discriminator = [
       legacyModelId,
       model.label,
       model.envKey ?? null,
+      model.registryBaseUrl === undefined,
+      getRouteEndpointIdentity(model.registryBaseUrl ?? model.baseUrl),
     ] as const;
     const discriminatorKey = JSON.stringify(discriminator);
-    const occurrence = discriminatorCounts.get(discriminatorKey) ?? 0;
-    discriminatorCounts.set(discriminatorKey, occurrence + 1);
+    if (
+      counts.get(legacyModelId) !== 1 &&
+      discriminators.has(discriminatorKey)
+    ) {
+      throw new Error(
+        `ACP model routes for "${legacyModelId}" need distinct names, envKey values, or public endpoints.`,
+      );
+    }
+    discriminators.add(discriminatorKey);
 
     return {
       model,
@@ -73,8 +98,8 @@ export function buildAcpModelOptions(
       modelId:
         counts.get(legacyModelId) === 1
           ? legacyModelId
-          : `qwen-route:v1:${createHash('sha256')
-              .update(JSON.stringify([...discriminator, occurrence]))
+          : `${ACP_ROUTE_ID_PREFIX}${createHash('sha256')
+              .update(discriminatorKey)
               .digest('base64url')
               .slice(0, 16)}`,
     };
@@ -88,6 +113,7 @@ export function resolveAcpModelOption(
   modelId: string;
   authType: AuthType;
   baseUrl?: string;
+  registryBaseUrl?: string | null;
   isRuntime: boolean;
 } | null {
   const matched = buildAcpModelOptions(models).find(
@@ -100,6 +126,9 @@ export function resolveAcpModelOption(
     ...(matched.model.registryBaseUrl !== undefined
       ? { baseUrl: matched.model.registryBaseUrl }
       : {}),
+    ...(!matched.model.isRuntimeModel
+      ? { registryBaseUrl: matched.model.registryBaseUrl ?? null }
+      : {}),
     isRuntime: matched.model.isRuntimeModel === true,
   };
 }
@@ -108,27 +137,23 @@ export function getCurrentAcpModelId(
   options: readonly AcpModelOption[],
   modelId: string,
   authType?: AuthType,
-  baseUrl?: string,
+  registryBaseUrl?: string | null,
 ): string {
   if (!modelId || !authType) return modelId;
   const matching = options.filter(
     (option) =>
       option.effectiveModelId === modelId && option.model.authType === authType,
   );
-  const exact = matching.find(
-    (option) => option.model.registryBaseUrl === baseUrl,
-  );
-  if (exact) return exact.modelId;
   if (matching[0]?.model.isRuntimeModel) return matching[0].modelId;
-  if (baseUrl !== undefined) {
-    const implicit = matching.find(
-      (option) =>
-        option.model.registryBaseUrl === undefined &&
-        option.model.baseUrl === baseUrl,
+  if (registryBaseUrl !== undefined) {
+    const exact = matching.find(
+      (option) => (option.model.registryBaseUrl ?? null) === registryBaseUrl,
     );
-    return implicit?.modelId ?? modelId;
+    return exact?.modelId ?? modelId;
   }
-  return matching[0]?.modelId ?? formatAcpModelId(modelId, authType);
+  return matching.length === 1
+    ? matching[0]!.modelId
+    : formatAcpModelId(modelId, authType);
 }
 
 export function sanitizeProviderBaseUrl(baseUrl: string): string {

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -631,7 +631,7 @@ describe('modelConfigUtils', () => {
           },
         });
 
-        resolveCliGenerationConfig({
+        const result = resolveCliGenerationConfig({
           argv: {},
           settings,
           selectedAuthType: AuthType.USE_OPENAI,
@@ -643,6 +643,7 @@ describe('modelConfigUtils', () => {
         expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
           expect.objectContaining({ modelProvider: ideaLab }),
         );
+        expect(result.registryBaseUrl).toBe(ideaLab.baseUrl);
       });
 
       it('falls back to the first id match when no baseUrl is persisted (backward compat)', () => {

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -191,6 +191,8 @@ export interface ResolvedCliGenerationConfig {
   baseUrl: string;
   /** The full generation config to pass to core Config */
   generationConfig: Partial<ContentGeneratorConfig>;
+  /** Exact selected modelProviders baseUrl; null selects an implicit route. */
+  registryBaseUrl?: string | null;
   /** Source attribution for each resolved field */
   sources: ContentGeneratorConfigSources;
   /** Warnings generated during resolution */
@@ -445,6 +447,9 @@ export function resolveCliGenerationConfig(
     apiKey: resolved.config.apiKey || '',
     baseUrl: resolved.config.baseUrl || '',
     generationConfig,
+    ...(modelProvider
+      ? { registryBaseUrl: modelProvider.baseUrl ?? null }
+      : {}),
     sources: resolved.sources,
     warnings: [
       ...resolved.warnings,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1057,6 +1057,8 @@ export interface ConfigParameters {
   ideMode?: boolean;
   authType?: AuthType;
   generationConfig?: Partial<ContentGeneratorConfig>;
+  /** Exact initial model registry baseUrl; null selects an implicit route. */
+  initialModelRegistryBaseUrl?: string | null;
   /**
    * Optional source map for generationConfig fields (e.g. CLI/env/settings attribution).
    * This is used to produce per-field source badges in the UI.
@@ -2159,6 +2161,7 @@ export class Config {
         baseUrl: params.generationConfig?.baseUrl,
       },
       generationConfigSources: params.generationConfigSources,
+      initialRegistryBaseUrl: params.initialModelRegistryBaseUrl,
       onModelChange: this.handleModelChange.bind(this),
     });
 
@@ -3350,6 +3353,10 @@ export class Config {
     return (
       this.getContentGeneratorConfig()?.model || this.modelsConfig.getModel()
     );
+  }
+
+  getCurrentModelRegistryBaseUrl(): string | null | undefined {
+    return this.modelsConfig.getCurrentRegistryBaseUrl();
   }
 
   /**

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -132,6 +132,10 @@ describe('ModelRegistry', () => {
       expect(gpt4?.description).toBe('Most capable GPT-4');
       expect(gpt4?.isVision).toBe(true);
       expect(gpt4?.authType).toBe(AuthType.USE_OPENAI);
+      expect(gpt4?.registryBaseUrl).toBe('https://api.openai.com/v1');
+      expect(
+        models.find((m) => m.id === 'gpt-3.5-turbo')?.registryBaseUrl,
+      ).toBeUndefined();
     });
   });
 
@@ -511,6 +515,10 @@ describe('ModelRegistry', () => {
       expect(models.length).toBe(2);
       expect(models[0].label).toBe('GPT-4 Direct');
       expect(models[1].label).toBe('GPT-4 Proxy');
+      expect(models.map((model) => model.registryBaseUrl)).toEqual([
+        'https://api.openai.com/v1',
+        'https://proxy.example.com/v1',
+      ]);
     });
 
     it('should retrieve model by id and baseUrl precisely', () => {

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -216,7 +216,7 @@ export class ModelRegistry {
     const models = this.modelsByAuthType.get(authType);
     if (!models) return [];
 
-    return Array.from(models.values()).map((model) => ({
+    return Array.from(models.entries()).map(([key, model]) => ({
       id: model.id,
       label: model.name,
       description: model.description,
@@ -229,6 +229,9 @@ export class ModelRegistry {
       // always defined on `ResolvedModelConfig` — no fallback needed here.
       modalities: model.generationConfig.modalities,
       baseUrl: model.baseUrl,
+      ...(key === model.id
+        ? {}
+        : { registryBaseUrl: key.slice(model.id.length + 1) }),
       envKey: model.envKey,
       fastOnly: model.fastOnly,
       voiceOnly: model.voiceOnly,

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -216,7 +216,7 @@ export class ModelRegistry {
     const models = this.modelsByAuthType.get(authType);
     if (!models) return [];
 
-    return Array.from(models.entries()).map(([key, model]) => ({
+    return Array.from(models.values()).map((model) => ({
       id: model.id,
       label: model.name,
       description: model.description,
@@ -229,9 +229,9 @@ export class ModelRegistry {
       // always defined on `ResolvedModelConfig` — no fallback needed here.
       modalities: model.generationConfig.modalities,
       baseUrl: model.baseUrl,
-      ...(key === model.id
-        ? {}
-        : { registryBaseUrl: key.slice(model.id.length + 1) }),
+      ...(model.registryBaseUrl !== undefined
+        ? { registryBaseUrl: model.registryBaseUrl }
+        : {}),
       envKey: model.envKey,
       fastOnly: model.fastOnly,
       voiceOnly: model.voiceOnly,
@@ -247,13 +247,13 @@ export class ModelRegistry {
   getModel(
     authType: AuthType,
     modelId: string,
-    baseUrl?: string,
+    baseUrl?: string | null,
   ): ResolvedModelConfig | undefined {
     const models = this.modelsByAuthType.get(authType);
     if (!models) return undefined;
 
-    if (baseUrl) {
-      return models.get(modelRegistryKey(modelId, baseUrl));
+    if (baseUrl !== undefined) {
+      return models.get(modelRegistryKey(modelId, baseUrl ?? undefined));
     }
 
     // Try plain id key first (models registered without explicit baseUrl)
@@ -318,6 +318,7 @@ export class ModelRegistry {
       authType,
       name: config.name || config.id,
       baseUrl: config.baseUrl || this.getDefaultBaseUrl(authType),
+      ...(config.baseUrl ? { registryBaseUrl: config.baseUrl } : {}),
       generationConfig,
       capabilities: config.capabilities || {},
     };

--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -2658,6 +2658,47 @@ describe('ModelsConfig', () => {
       expect(modelsConfig.getModelDisplayName('qwen3.7-max')).toBe(
         '[Idealab] qwen3.7-max',
       );
+      expect(modelsConfig.getCurrentRegistryBaseUrl()).toBe(idealabBaseUrl);
+    });
+
+    it('tracks implicit and explicit registry routes with the same effective URL', async () => {
+      const defaultBaseUrl = 'https://api.openai.com/v1';
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          { id: 'shared', name: 'Implicit', envKey: 'IMPLICIT_KEY' },
+          {
+            id: 'shared',
+            name: 'Explicit',
+            baseUrl: defaultBaseUrl,
+            envKey: 'EXPLICIT_KEY',
+          },
+        ],
+      };
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+      });
+
+      await modelsConfig.switchModel(AuthType.USE_OPENAI, 'shared');
+      expect(modelsConfig.getCurrentRegistryBaseUrl()).toBeNull();
+      modelsConfig.syncAfterAuthRefresh(AuthType.USE_OPENAI, 'shared');
+      expect(modelsConfig.getGenerationConfig().apiKeyEnvKey).toBe(
+        'IMPLICIT_KEY',
+      );
+
+      await modelsConfig.switchModel(AuthType.USE_OPENAI, 'shared', {
+        baseUrl: defaultBaseUrl,
+      });
+      expect(modelsConfig.getCurrentRegistryBaseUrl()).toBe(defaultBaseUrl);
+
+      const restored = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        initialRegistryBaseUrl: defaultBaseUrl,
+        modelProvidersConfig,
+        generationConfig: { model: 'shared' },
+      });
+      restored.syncAfterAuthRefresh(AuthType.USE_OPENAI, 'shared');
+      expect(restored.getGenerationConfig().apiKeyEnvKey).toBe('EXPLICIT_KEY');
     });
 
     it('should return raw modelId when currentAuthType is falsy', () => {

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -61,6 +61,8 @@ export interface ModelsConfigOptions {
   generationConfig?: Partial<ContentGeneratorConfig>;
   /** Source tracking for generation config */
   generationConfigSources?: ContentGeneratorConfigSources;
+  /** Exact initial registry baseUrl; null selects an implicit route. */
+  initialRegistryBaseUrl?: string | null;
   /** Callback when model changes require refresh */
   onModelChange?: OnModelChangeCallback;
 }
@@ -81,6 +83,7 @@ export class ModelsConfig {
 
   // Current selection state
   private currentAuthType: AuthType | undefined;
+  private currentRegistryBaseUrl: string | null | undefined;
 
   // Generation config state
   private _generationConfig: Partial<ContentGeneratorConfig>;
@@ -169,6 +172,17 @@ export class ModelsConfig {
 
     // Initialize selection state
     this.currentAuthType = options.initialAuthType;
+    const initialModelId = this._generationConfig.model;
+    if (this.currentAuthType && initialModelId) {
+      const initialModel = this.modelRegistry.getModel(
+        this.currentAuthType,
+        initialModelId,
+        options.initialRegistryBaseUrl,
+      );
+      if (initialModel) {
+        this.currentRegistryBaseUrl = initialModel.registryBaseUrl ?? null;
+      }
+    }
   }
 
   /**
@@ -185,6 +199,7 @@ export class ModelsConfig {
     requireCachedQwenCredentialsOnce: boolean;
     hasManualCredentials: boolean;
     activeRuntimeModelSnapshotId: string | undefined;
+    currentRegistryBaseUrl: string | null | undefined;
   } {
     return {
       currentAuthType: this.currentAuthType,
@@ -196,6 +211,7 @@ export class ModelsConfig {
       requireCachedQwenCredentialsOnce: this.requireCachedQwenCredentialsOnce,
       hasManualCredentials: this.hasManualCredentials,
       activeRuntimeModelSnapshotId: this.activeRuntimeModelSnapshotId,
+      currentRegistryBaseUrl: this.currentRegistryBaseUrl,
     };
   }
 
@@ -216,6 +232,7 @@ export class ModelsConfig {
       snapshot.requireCachedQwenCredentialsOnce;
     this.hasManualCredentials = snapshot.hasManualCredentials;
     this.activeRuntimeModelSnapshotId = snapshot.activeRuntimeModelSnapshotId;
+    this.currentRegistryBaseUrl = snapshot.currentRegistryBaseUrl;
   }
 
   /**
@@ -230,6 +247,10 @@ export class ModelsConfig {
    */
   getCurrentAuthType(): AuthType | undefined {
     return this.currentAuthType;
+  }
+
+  getCurrentRegistryBaseUrl(): string | null | undefined {
+    return this.currentRegistryBaseUrl;
   }
 
   /**
@@ -332,11 +353,14 @@ export class ModelsConfig {
   getModelDisplayName(modelId: string): string {
     if (!this.currentAuthType) return modelId;
     const resolved =
-      this.modelRegistry.getModel(
-        this.currentAuthType,
-        modelId,
-        this._generationConfig.baseUrl || undefined,
-      ) ?? this.modelRegistry.getModel(this.currentAuthType, modelId);
+      (this.currentRegistryBaseUrl !== undefined
+        ? this.modelRegistry.getModel(
+            this.currentAuthType,
+            modelId,
+            this.currentRegistryBaseUrl,
+          )
+        : undefined) ??
+      this.modelRegistry.getModel(this.currentAuthType, modelId);
     return resolved?.name ?? modelId;
   }
 
@@ -355,6 +379,7 @@ export class ModelsConfig {
       newModel === DEFAULT_QWEN_MODEL
     ) {
       this.strictModelProviderSelection = false;
+      this.currentRegistryBaseUrl = undefined;
       this._generationConfig.model = newModel;
       this.generationConfigSources['model'] = {
         kind: 'programmatic',
@@ -385,6 +410,7 @@ export class ModelsConfig {
     const rollbackSnapshot = this.createStateSnapshotForRollback();
     try {
       this.strictModelProviderSelection = false;
+      this.currentRegistryBaseUrl = undefined;
       this._generationConfig.model = newModel;
       this.generationConfigSources['model'] = {
         kind: 'programmatic',
@@ -488,7 +514,7 @@ export class ModelsConfig {
           ? (this.modelRegistry.getModel(
               authType,
               previousModelId,
-              rollbackSnapshot.generationConfig.baseUrl,
+              rollbackSnapshot.currentRegistryBaseUrl,
             ) ?? this.modelRegistry.getModel(authType, previousModelId))
           : undefined;
       const canReusePreviousApiKey =
@@ -658,6 +684,7 @@ export class ModelsConfig {
      */
     if (credentials.apiKey || credentials.baseUrl || credentials.model) {
       this.hasManualCredentials = true;
+      this.currentRegistryBaseUrl = undefined;
       this.clearProviderSourcedConfig();
     }
 
@@ -801,6 +828,7 @@ export class ModelsConfig {
    */
   private applyResolvedModelDefaults(model: ResolvedModelConfig): void {
     this.strictModelProviderSelection = true;
+    this.currentRegistryBaseUrl = model.registryBaseUrl ?? null;
     // We're explicitly applying modelProvider defaults now, so manual overrides
     // should no longer block syncAfterAuthRefresh from applying provider defaults.
     this.hasManualCredentials = false;
@@ -997,9 +1025,12 @@ export class ModelsConfig {
     // model provider switch; fall back to any model with the same id.
     const providerBaseUrl =
       providerBaseUrlOverride ??
-      (this.generationConfigSources['baseUrl']?.kind === 'modelProviders'
-        ? this._generationConfig.baseUrl
-        : undefined);
+      (previousAuthType === authType &&
+      this.currentRegistryBaseUrl !== undefined
+        ? this.currentRegistryBaseUrl
+        : this.generationConfigSources['baseUrl']?.kind === 'modelProviders'
+          ? this._generationConfig.baseUrl
+          : undefined);
     const resolved = modelId
       ? (this.modelRegistry.getModel(authType, modelId, providerBaseUrl) ??
         this.modelRegistry.getModel(authType, modelId))
@@ -1101,6 +1132,7 @@ export class ModelsConfig {
       (this.hasManualCredentials || hasExistingCredentials);
 
     if (shouldPreserveCredentials) {
+      this.currentRegistryBaseUrl = undefined;
       // Preserve existing credentials, just update authType and modelId if provided
       if (modelId) {
         this._generationConfig.model = modelId;
@@ -1127,6 +1159,7 @@ export class ModelsConfig {
     // Step 4: No default available - leave generationConfig incomplete
     // resolveContentGeneratorConfigWithSources will throw exceptions as expected
     if (modelId) {
+      this.currentRegistryBaseUrl = undefined;
       this._generationConfig.model = modelId;
       if (!this.generationConfigSources['model']) {
         this.generationConfigSources['model'] = {
@@ -1202,6 +1235,7 @@ export class ModelsConfig {
 
     this.runtimeModelSnapshots.set(snapshotId, snapshot);
     this.activeRuntimeModelSnapshotId = snapshotId;
+    this.currentRegistryBaseUrl = undefined;
 
     // Enforce per-authType limit
     this.cleanupOldRuntimeModelSnapshots();
@@ -1252,6 +1286,7 @@ export class ModelsConfig {
         runtimeModelSnapshot.authType !== this.currentAuthType;
       this.currentAuthType = runtimeModelSnapshot.authType;
       this.activeRuntimeModelSnapshotId = snapshotId;
+      this.currentRegistryBaseUrl = undefined;
 
       // Apply runtime configuration
       this.strictModelProviderSelection = false;

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -121,6 +121,8 @@ export interface AvailableModel {
   contextWindowSize?: number;
   modalities?: InputModalities;
   baseUrl?: string;
+  /** Exact optional baseUrl used in the model registry key, before defaults. */
+  registryBaseUrl?: string;
   envKey?: string;
 
   /** When true, this model only appears in the fast model selector */

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -102,6 +102,8 @@ export interface ResolvedModelConfig extends ModelConfig {
   envKey?: string;
   /** API base URL (always present, has default per authType) */
   baseUrl: string;
+  /** Exact optional baseUrl used in the registry key, before defaults. */
+  registryBaseUrl?: string;
   /** Generation config (always present, merged with defaults) */
   generationConfig: ModelGenerationConfig;
   /** Capabilities (always present, defaults to {}) */

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -549,6 +549,21 @@ describe('ChatEditor toolbar popovers', () => {
     expect(onSelectModel).toHaveBeenCalledWith('qwen-max');
   });
 
+  it('displays the model label instead of an opaque route id', () => {
+    const routeId = 'qwen-route:v1:abcdefghijklmnop';
+    const container = renderChatEditor({
+      visibleToolbarActions: ['model'],
+      currentModel: routeId,
+      availableModels: [{ id: routeId, label: 'Provider One' }],
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      '[data-web-shell-model-button]',
+    );
+    expect(button?.textContent).toContain('Provider One');
+    expect(button?.textContent).not.toContain(routeId);
+  });
+
   it('switches between sibling toolbar popovers without dismissing the target', async () => {
     const container = renderChatEditor({
       visibleToolbarActions: ['approvalMode', 'model'],

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1576,7 +1576,10 @@ export const ChatEditor = memo(
     const modeLabel = getModeLabel(currentMode, t);
 
     const currentModelLabel = currentModel
-      ? getModelDisplayName(currentModel)
+      ? (availableModels.find((model) => model.id === currentModel)?.label ??
+        (currentModel.startsWith('qwen-route:')
+          ? ''
+          : getModelDisplayName(currentModel)))
       : '';
     const { modelLabel, modelLabelReady } = resolveToolbarModelLabel({
       currentModelLabel,

--- a/packages/web-shell/client/components/SessionOverviewPanel.test.tsx
+++ b/packages/web-shell/client/components/SessionOverviewPanel.test.tsx
@@ -244,6 +244,20 @@ describe('deriveSessionCards', () => {
     expect(cards[0].model).toBe('qwen-max');
     expect(cards[0].clientCount).toBe(2);
   });
+
+  it('does not expose opaque route ids as model names', () => {
+    const cards = deriveSessionCards(
+      [session('s')],
+      [
+        statusSession('s', {
+          currentModelId: 'qwen-route:v1:abcdefghijklmnop',
+        }),
+      ],
+      undefined,
+    );
+
+    expect(cards[0].model).toBeUndefined();
+  });
 });
 
 describe('SessionOverviewPanel', () => {

--- a/packages/web-shell/client/components/SessionOverviewPanel.tsx
+++ b/packages/web-shell/client/components/SessionOverviewPanel.tsx
@@ -31,6 +31,7 @@ import {
   SESSION_ORGANIZATION_FEATURE,
 } from '../constants/sessions';
 import { ErrorBoundary } from './ErrorBoundary';
+import { getModelDisplayName } from '../utils/modelDisplay';
 import styles from './SessionOverviewPanel.module.css';
 
 // The list is cheap to poll (it's the same endpoint the sidebar already hits),
@@ -95,7 +96,11 @@ export function deriveSessionCards(
       label: session.displayName?.trim() || session.sessionId.slice(0, 8),
       status: needsApproval ? 'needsApproval' : running ? 'running' : 'idle',
       clientCount: session.clientCount ?? status?.clientCount ?? 0,
-      model: status?.currentModelId,
+      model: status?.currentModelId?.startsWith('qwen-route:')
+        ? undefined
+        : status?.currentModelId
+          ? getModelDisplayName(status.currentModelId)
+          : undefined,
       updatedAt: session.updatedAt || session.createdAt,
       color: session.color,
       isCurrent: session.sessionId === currentSessionId,

--- a/packages/web-shell/client/components/messages/ModelManagementSection.dom.test.tsx
+++ b/packages/web-shell/client/components/messages/ModelManagementSection.dom.test.tsx
@@ -270,9 +270,7 @@ describe('ModelManagementSection', () => {
     expect(setButtons).toHaveLength(1);
   });
 
-  it('marks only one row current for a bare current id shared by variants', () => {
-    // A bare current id matches several variants' base id; only the first wins,
-    // so the list never shows multiple "Current" badges.
+  it('does not guess a current row for a bare id shared by variants', () => {
     const dupProviders: DaemonWorkspaceProviderStatus[] = [
       {
         kind: 'model_provider',
@@ -306,7 +304,7 @@ describe('ModelManagementSection', () => {
     const currentBadges = Array.from(
       container.querySelectorAll<HTMLSpanElement>('span'),
     ).filter((s) => s.textContent?.trim() === 'Current');
-    expect(currentBadges).toHaveLength(1);
+    expect(currentBadges).toHaveLength(0);
   });
 
   it('labels each row action with the model identity for screen readers', () => {

--- a/packages/web-shell/client/components/messages/ModelManagementSection.tsx
+++ b/packages/web-shell/client/components/messages/ModelManagementSection.tsx
@@ -34,11 +34,9 @@ function rowKeyFor(
 
 /**
  * Resolves the single row that is "current", returning its row key. Preferring a
- * provider-qualified `modelId` match means a bare `currentModelId` (which can
- * equal several endpoint variants' `baseModelId`) marks only ONE row current
- * instead of every same-base-id variant. Falls back to the persisted `isCurrent`
- * flag when no live current id is available yet (the live id is updated
- * optimistically on select, so it's authoritative while present).
+ * provider-qualified `modelId` match identifies an endpoint variant precisely.
+ * A bare id is used only when it has one possible row; ambiguous ids defer to
+ * the server's `isCurrent` flag instead of guessing the first endpoint.
  */
 function findCurrentRowKey(
   providers: DaemonWorkspaceProviderStatus[],
@@ -50,10 +48,12 @@ function findCurrentRowKey(
   if (currentModelId) {
     const exact = all.find(({ model }) => model.modelId === currentModelId);
     if (exact) return rowKeyFor(exact.provider, exact.model);
-    const byBase = all.find(
+    const byBase = all.filter(
       ({ model }) => model.baseModelId === currentModelId,
     );
-    return byBase ? rowKeyFor(byBase.provider, byBase.model) : undefined;
+    if (byBase.length === 1) {
+      return rowKeyFor(byBase[0]!.provider, byBase[0]!.model);
+    }
   }
   const flagged = all.find(({ model }) => model.isCurrent);
   return flagged ? rowKeyFor(flagged.provider, flagged.model) : undefined;


### PR DESCRIPTION
## What this PR does

This PR preserves the existing `modelId(authType)` ACP selector for unique models and assigns deterministic opaque selectors only when multiple configured routes share the same model ID and protocol. The agent resolves an opaque selector back to the exact registry route, switches with the original configured endpoint, and persists the canonical model ID, endpoint, and auth type rather than the wire selector.

The same route identity is now used by session model catalogs, config options, live session context, daemon workspace status, and bridge events. Opaque selectors are derived only from non-secret display metadata and ordering; endpoint URLs are neither embedded nor hashed. Unknown or stale opaque selectors are rejected.

## Why it's needed

ACP previously represented a model only as `modelId(authType)`. When two providers used the same model ID and protocol with different base URLs, clients received duplicate selectors, could render both rows as current, and could not round-trip a selection to the intended provider. This affected the ACP product matrix, including the VS Code extension, daemon-backed Web Shell, and generic ACP clients such as Zed, rather than only Desktop.

## Reviewer Test Plan

### How to verify

- Configure two providers under the same protocol with the same model ID and different names, base URLs, and credential environment keys.
- Open an ACP client and confirm both rows have distinct selectors while exactly one row is current.
- Select the second row and confirm the client echoes its opaque selector, the agent switches to the second endpoint, and settings persist the real model ID and configured base URL.
- Restart the session and confirm the same route remains selected. Then change the persisted endpoint to one that is no longer configured and confirm no configured row is incorrectly marked current.
- Confirm a model without a collision still uses the existing `modelId(authType)` selector.

### Evidence (Before & After)

Before: two same-ID providers produced the same ACP selector, VS Code could report duplicate keys and multiple current rows, and Web Shell or a generic client could not identify the intended endpoint.

After: VS Code and Web Shell product-matrix DOM checks each showed exactly one current row and returned the exact selected opaque selector. Generic ACP bridge checks preserved the opaque selector in `model_switched` while publishing the canonical model ID in `settings_changed`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Validated in an isolated worktree with focused Core, CLI, session, daemon status, bridge, VS Code selector, and Web Shell dialog tests. Full lint, typecheck, and build also passed. Local `verify:pr` was intentionally skipped; remote CI remains authoritative.

## Risk & Scope

- Main risk or tradeoff: colliding routes now expose opaque ACP selectors, so clients must treat `modelId` as an opaque value and echo it unchanged; unique routes remain backward compatible.
- Not validated / out of scope: the Zed application was not launched directly; the generic ACP list/current/switch contract used by clients such as Zed was covered. Windows and Linux behavior is left to CI.
- Breaking changes / migration notes: no ACP or settings schema change is required. Existing canonical settings remain valid, and opaque selectors are never written to disk.

## Linked Issues

Resolves #4877

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 对唯一模型继续保留现有的 `modelId(authType)` ACP selector，仅在多个配置路由共享相同 model ID 和协议时生成确定性的 opaque selector。Agent 会将 opaque selector 解析回精确的 registry route，使用原始配置的 endpoint 完成切换，并持久化真实的 model ID、endpoint 和 auth type，而不是把 wire selector 写入设置。

Session model catalog、config options、live session context、daemon workspace status 和 bridge events 现在统一使用同一套路由身份。Opaque selector 只基于非敏感的展示元数据和顺序生成，不会包含或哈希 endpoint URL。未知或过期的 opaque selector 会被拒绝。

## 为什么需要

ACP 之前只用 `modelId(authType)` 表示模型。当两个 provider 使用相同的 model ID 和协议、但 base URL 不同时，client 会收到重复 selector，可能同时把两行显示为 current，也无法把选择精确回传到目标 provider。这个问题影响整个 ACP 产品矩阵，包括 VS Code 插件、daemon 支持的 Web Shell，以及 Zed 之类的通用 ACP client，并非 Desktop 独有。

## Reviewer 测试计划

### 如何验证

- 在同一个协议下配置两个 provider，使用相同的 model ID，但配置不同的名称、base URL 和凭证环境变量名。
- 打开 ACP client，确认两行具有不同的 selector，并且只有一行是 current。
- 选择第二行，确认 client 原样回传它的 opaque selector，Agent 切换到第二个 endpoint，并且 settings 持久化真实 model ID 和配置的 base URL。
- 重启 session，确认仍然选中同一路由。随后把已持久化的 endpoint 改成一个不再存在于配置中的值，确认不会错误地把任意配置路由标记为 current。
- 确认没有冲突的模型仍然使用现有的 `modelId(authType)` selector。

### 前后对比证据

改动前：两个同 ID provider 会产生相同的 ACP selector，VS Code 可能报告重复 key 并同时显示多个 current 行，Web Shell 或通用 client 也无法识别目标 endpoint。

改动后：VS Code 和 Web Shell 的产品矩阵 DOM 检查都只显示一个 current 行，并精确返回选中的 opaque selector。通用 ACP bridge 检查在 `model_switched` 中保留 opaque selector，同时在 `settings_changed` 中发布真实 model ID。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在独立 worktree 中验证了 Core、CLI、session、daemon status、bridge、VS Code selector 和 Web Shell dialog 的相关测试。完整 lint、typecheck 和 build 也已通过。按要求明确跳过了本地 `verify:pr`，远端 CI 仍作为权威结果。

## 风险与范围

- 主要风险或权衡：冲突路由现在会暴露 opaque ACP selector，因此 client 必须把 `modelId` 当作 opaque 值并原样回传；唯一模型保持向后兼容。
- 未验证或范围外：没有直接启动 Zed 应用；Zed 等 client 使用的通用 ACP list/current/switch 契约已覆盖。Windows 和 Linux 行为交由 CI 验证。
- 破坏性改动或迁移说明：不需要修改 ACP 或 settings schema。现有 canonical settings 仍然有效，opaque selector 永远不会写入磁盘。

## 关联 Issue

Resolves #4877

</details>
