### PR TITLE
feat: support full-turn multimodal routing for image prompts

### DIFF
--- a/docs/design/2026-07-16-full-turn-multimodal-routing.md
+++ b/docs/design/2026-07-16-full-turn-multimodal-routing.md
@@ -1,0 +1,122 @@
+# Full-turn multimodal routing
+
+## Context
+
+When the primary model is text-only, Vision Bridge sends an image to a vision
+model for transcription and then returns the transcription to the primary
+model. That remains the safe default. Some configured vision models can also
+run the complete agent loop; reducing those models to transcription loses
+visual detail and prevents them from inspecting image-producing tool results.
+
+Phase 1 adds a turn-scoped route for that explicit case. A logical turn starts
+with an image-bearing user prompt and includes model retries, tool calls, tool
+results, and the final assistant response. It does not include the next user
+prompt.
+
+## Routing contract
+
+| Primary model | Selected vision model                      | Route                               | Image handling                                                  |
+| ------------- | ------------------------------------------ | ----------------------------------- | --------------------------------------------------------------- |
+| Image-capable | Any                                        | Existing primary route              | Send the original image directly                                |
+| Text-only     | Image-capable and explicitly agent-capable | Full-turn vision route              | Send the original image and keep the logical turn on that model |
+| Text-only     | Agent capability absent or false           | Existing Vision Bridge route        | Transcribe the image, then continue on the primary model        |
+| Text-only     | No usable vision model                     | Existing unsupported-image behavior | Do not silently send the image to another model                 |
+
+Direct primary routing wins over every fallback. Full-turn routing is considered
+only when the current user input contains an image; plain-text turns continue
+to use the primary model.
+
+## Positive capability declaration
+
+A model is eligible only when existing image-capability resolution succeeds and
+its configuration explicitly declares:
+
+```json
+{
+  "capabilities": {
+    "vision": true,
+    "agent": true
+  }
+}
+```
+
+`agent: true` is an operator promise that the selected endpoint accepts normal
+agent system instructions, tool declarations, tool calls, tool results, and
+multi-request continuations. It is positive-only: a missing or false value
+keeps Vision Bridge behavior. Model names and provider defaults must not infer
+agent capability.
+
+## Route lifecycle
+
+1. Resolve image support and the configured vision model before Vision Bridge
+   replaces any image.
+2. If the positive capability contract matches, create a request-scoped route
+   containing the exact model selection and an effective configuration with
+   image input enabled. This explicit projection also covers custom model names
+   whose image support came from `capabilities.vision` rather than name-based
+   inference.
+3. Resolve that exact provider, model, and endpoint fail-closed. Provider
+   identity is retained even when two providers expose the same bare model id.
+   Do not fall back to the primary model or another configured model after raw
+   image data is retained.
+4. Use the route for the initial request, transport retries, tool-result
+   continuations, and a retry of the same logical turn.
+5. Keep stop hooks and blocking hook continuations on the same runtime route.
+6. On successful completion or explicit abandonment, persist a media-settled
+   checkpoint and release the active route. On cancellation or failure, scrub
+   the live in-memory history but retain the persisted raw turn plus its exact
+   route identity so retry or process restart can continue safely. A later
+   independent turn settles that interrupted route before using the primary.
+7. At the completed-turn boundary, replace canonical inline images with
+   existing in-session
+   `Image #…` references and other inline media with text placeholders. This is
+   delayed until no tool continuation remains, so the routed model keeps visual
+   context throughout its logical turn. Later primary models, model switches,
+   follow-up suggestions, hooks, forks, summaries, and background agents never
+   receive the route-scoped raw payload as historical context.
+
+The user-facing routing notice identifies the selected model and makes clear
+that the current image turn, rather than transcription alone, is handled by
+that model. Routing changes only the destination and duration; it does not add
+unrelated session data to the request.
+
+## Tool runtime context
+
+The turn route is request-scoped; it must not mutate global model configuration.
+Model continuations read the locked model selection, while file and media tools
+read the route's effective input modalities. Consequently, an image produced
+by a tool during a full-turn vision route stays as image data for the same
+model instead of being downgraded according to the text-only primary model.
+
+Tool execution outside such a route continues to use the primary model's
+runtime modalities. Phase 1 does not promote an already-running text-only turn
+merely because a tool later produces an image.
+
+## Entry-point behavior
+
+| Entry point         | Phase 1 behavior                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TUI                 | Acquire the route for an image submit; retain it for tool results and retry; release it before the next independent user prompt.                                   |
+| ACP                 | Scope the route to one `session/prompt` execution and its internal tool loop; persist exact affinity across an interrupted retry/resume.                           |
+| Non-interactive CLI | Apply the same selection before the first send, retain the exact route through its tool loop and stop-hook continuations, and fail closed before any primary send. |
+
+All entry points use the shared exact-model resolution path so a model override
+cannot accidentally reuse the primary model's generator or base URL.
+
+## Failure behavior
+
+If the selected full-turn model cannot be resolved or its endpoint fails, the
+turn reports that failure without replaying raw image content to the primary or
+another fallback. A capability declaration that is absent, false, or
+incompatible is not an error; it selects the existing Vision Bridge path.
+
+## Deferred work
+
+- **Phase 2:** persist structured, durable visual context after the routed turn
+  so later text-only turns can reason from more than ordinary transcript data.
+- **Phase 3:** preserve durable attachment/reference relationships across
+  resume and compaction, then support explicit, on-demand reinspection of
+  earlier images.
+
+Phase 1 does not define a visual-context schema, backfill old sessions, promise
+stable image identifiers, or retain raw images beyond existing history policy.

--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -6,6 +6,8 @@ Qwen Code allows you to configure multiple model providers through the `modelPro
 
 Use `modelProviders` to declare models per provider id that the `/model` picker can switch between. Each key is a provider id and its value is **an array of model definitions** (`ModelConfig[]`). For built-in providers the key must be a valid auth type (`openai`, `anthropic`, `gemini`, `vertex-ai`); a custom provider id (e.g. `idealab`) is allowed as long as you map it to a protocol via the top-level [`providerProtocol`](#custom-provider-ids-providerprotocol) setting. Each model entry requires an `id`; `envKey` is **optional and recommended** (when omitted, it falls back to the auth type's default env key, e.g. `OPENAI_API_KEY` for `openai`), with optional `name`, `description`, `baseUrl`, and `generationConfig`. Credentials are never persisted in settings; the runtime reads them from `process.env[envKey]`. Qwen OAuth models remain hard-coded and cannot be overridden.
 
+`capabilities.vision` declares that a model accepts image input. `capabilities.agent` opts an image-capable vision model into full-turn routing when it is selected as `visionModel`, so the same model handles tool calls and continuations for that turn. Full-turn routing requires `capabilities.agent` to be explicitly `true`; `false` or an omitted value keeps the existing Vision Bridge transcription flow.
+
 > [!note]
 >
 > Earlier previews wrapped each provider's models in a `{ "protocol": ..., "models": [...] }` object. That shape has been reverted — the current value is the bare `ModelConfig[]` array shown throughout this page. A wrapped entry in an already-migrated (`$version: 4`) settings file is silently skipped, so update any old configs to the array form.
@@ -217,7 +219,8 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
         "envKey": "GEMINI_API_KEY",
         "baseUrl": "https://generativelanguage.googleapis.com",
         "capabilities": {
-          "vision": true
+          "vision": true,
+          "agent": true
         },
         "generationConfig": {
           "timeout": 60000,

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -26,6 +26,8 @@ import type {
   Config,
   Extension,
   GeminiChat,
+  FullTurnModelRoute,
+  FullTurnModelRouteIdentity,
 } from '@qwen-code/qwen-code-core';
 import {
   ApprovalMode,
@@ -48,6 +50,7 @@ import { MessageType } from '../../ui/types.js';
 const debugLoggerWarnSpy = vi.hoisted(() => vi.fn());
 const debugLoggerDebugSpy = vi.hoisted(() => vi.fn());
 const runVisionBridgeSpy = vi.hoisted(() => vi.fn());
+const resolveFullTurnVisionRouteSpy = vi.hoisted(() => vi.fn());
 const refreshMemoryAfterManagedWriteSpy = vi.hoisted(() => vi.fn());
 const transcribeVoiceAudioSpy = vi.hoisted(() => vi.fn());
 // Records every LoopTickResolver construction's deps so a test can assert what
@@ -68,6 +71,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     generatePromptSuggestion: vi.fn(),
     logPromptSuggestion: vi.fn(),
     runVisionBridge: runVisionBridgeSpy,
+    resolveFullTurnVisionRoute: resolveFullTurnVisionRouteSpy,
     refreshMemoryAfterManagedWrite: refreshMemoryAfterManagedWriteSpy,
     // Transparent recording wrapper: records the constructor deps, then behaves
     // exactly like the real resolver (subclass → instanceof + methods preserved).
@@ -281,6 +285,8 @@ describe('Session', () => {
     recordFileHistorySnapshot: ReturnType<typeof vi.fn>;
     rewindRecording: ReturnType<typeof vi.fn>;
     setTitleRecordedCallback: ReturnType<typeof vi.fn>;
+    recordFullTurnRoute: ReturnType<typeof vi.fn>;
+    recordMediaScrubCheckpoint: ReturnType<typeof vi.fn>;
   };
   let mockFileHistoryService: {
     makeSnapshot: ReturnType<typeof vi.fn>;
@@ -292,6 +298,7 @@ describe('Session', () => {
     getChat: ReturnType<typeof vi.fn>;
     isInitialized: ReturnType<typeof vi.fn>;
     tryCompressChat: ReturnType<typeof vi.fn>;
+    setHistory: ReturnType<typeof vi.fn>;
   };
   let mockBackgroundTaskRegistry: {
     setNotificationCallback: ReturnType<typeof vi.fn>;
@@ -376,6 +383,19 @@ describe('Session', () => {
     return request?.message ?? [];
   }
 
+  function makeVisionAgentRoute(): FullTurnModelRoute {
+    return {
+      model: 'vision-agent',
+      contentGenerator: {},
+      contentGeneratorConfig: {
+        model: 'vision-agent',
+        authType: AuthType.USE_OPENAI,
+        contextWindowSize: 123_456,
+        modalities: { image: true },
+      },
+    } as FullTurnModelRoute;
+  }
+
   function textParts(parts: Part[]): string[] {
     return parts.flatMap((part) =>
       typeof part.text === 'string' ? [part.text] : [],
@@ -395,6 +415,9 @@ describe('Session', () => {
 
   beforeEach(() => {
     runVisionBridgeSpy.mockReset();
+    resolveFullTurnVisionRouteSpy
+      .mockReset()
+      .mockResolvedValue({ status: 'not-eligible' });
     refreshMemoryAfterManagedWriteSpy.mockReset();
     refreshMemoryAfterManagedWriteSpy.mockResolvedValue(false);
     transcribeVoiceAudioSpy.mockReset();
@@ -408,6 +431,8 @@ describe('Session', () => {
       });
 
     const getHistoryMock = vi.fn().mockReturnValue([]);
+    let pendingFullTurnRouteIdentity: FullTurnModelRouteIdentity | undefined;
+    let pendingFullTurnRoute: FullTurnModelRoute | undefined;
     mockChat = {
       sendMessageStream: vi.fn(),
       addHistory: vi.fn(),
@@ -423,6 +448,20 @@ describe('Session', () => {
       truncateHistory: vi.fn(),
       stripThoughtsFromHistory: vi.fn(),
       stripOrphanedUserEntriesFromHistory: vi.fn().mockReturnValue([]),
+      replaceHistoricalMediaWithReferences: vi.fn(),
+      prepareHistoricalMediaForContinuation: vi.fn((parts) => parts),
+      setPendingFullTurnRoute: vi.fn((identity, route) => {
+        pendingFullTurnRouteIdentity = identity;
+        pendingFullTurnRoute = route;
+      }),
+      getPendingFullTurnRouteIdentity: vi.fn(
+        () => pendingFullTurnRouteIdentity,
+      ),
+      getPendingFullTurnRoute: vi.fn(() => pendingFullTurnRoute),
+      clearPendingFullTurnRoute: vi.fn(() => {
+        pendingFullTurnRouteIdentity = undefined;
+        pendingFullTurnRoute = undefined;
+      }),
     } as unknown as GeminiChat;
     mockGeminiClient = {
       getChat: vi.fn().mockReturnValue(mockChat),
@@ -432,6 +471,7 @@ describe('Session', () => {
         newTokenCount: 0,
         compressionStatus: core.CompressionStatus.NOOP,
       }),
+      setHistory: vi.fn(),
     };
     mockBackgroundTaskRegistry = {
       setNotificationCallback: vi.fn(),
@@ -454,6 +494,8 @@ describe('Session', () => {
       recordFileHistorySnapshot: vi.fn(),
       rewindRecording: vi.fn(),
       setTitleRecordedCallback: vi.fn(),
+      recordFullTurnRoute: vi.fn(),
+      recordMediaScrubCheckpoint: vi.fn(),
     };
     mockFileHistoryService = {
       makeSnapshot: vi.fn().mockResolvedValue(undefined),
@@ -651,6 +693,172 @@ describe('Session', () => {
       // fire its own internal prompt() here.
       await Promise.resolve();
       expect(promptSpy).not.toHaveBeenCalled();
+    });
+
+    it('reacquires an exact vision route before continuing an orphaned image prompt', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue([
+        {
+          role: 'user',
+          parts: [
+            { text: 'inspect this' },
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: 'private-image',
+              },
+            },
+          ],
+        },
+      ]);
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      mockChat.getPendingFullTurnRoute = vi.fn().mockReturnValue(route);
+      mockChat.getPendingFullTurnRouteIdentity = vi.fn().mockReturnValue({
+        model: route.model,
+        authType: AuthType.USE_OPENAI,
+      });
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.continueLastTurn': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(firstSentMessage()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            inlineData: expect.objectContaining({ data: 'private-image' }),
+          }),
+        ]),
+      );
+      expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+        'vision-agent',
+        expect.any(Object),
+        expect.any(String),
+        { modelRoute: route },
+      );
+    });
+
+    it('keeps the persisted exact route when retrying a plain image prompt', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      const route = makeVisionAgentRoute();
+      mockChat.getPendingFullTurnRoute = vi.fn().mockReturnValue(route);
+      mockChat.getPendingFullTurnRouteIdentity = vi.fn().mockReturnValue({
+        model: route.model,
+        authType: AuthType.USE_OPENAI,
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [
+          { type: 'text', text: 'retry this image' },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'retry-image',
+          },
+        ],
+        retry: true,
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(resolveFullTurnVisionRouteSpy).not.toHaveBeenCalled();
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(firstSentMessage()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            inlineData: expect.objectContaining({ data: 'retry-image' }),
+          }),
+        ]),
+      );
+      expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+        route.model,
+        expect.any(Object),
+        expect.any(String),
+        { modelRoute: route },
+      );
+    });
+
+    it('reacquires the image route when continuing an interrupted tool turn', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue([
+        {
+          role: 'user',
+          parts: [
+            { text: 'inspect this' },
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: 'private-image',
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-1',
+                name: 'read_file',
+                args: { path: '/tmp/example.png' },
+              },
+            },
+          ],
+        },
+      ]);
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      mockChat.getPendingFullTurnRoute = vi.fn().mockReturnValue(route);
+      mockChat.getPendingFullTurnRouteIdentity = vi.fn().mockReturnValue({
+        model: route.model,
+        authType: AuthType.USE_OPENAI,
+      });
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.continueLastTurn': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+        'vision-agent',
+        expect.objectContaining({
+          message: expect.arrayContaining([
+            expect.objectContaining({
+              functionResponse: expect.objectContaining({ id: 'call-1' }),
+            }),
+          ]),
+        }),
+        expect.any(String),
+        { modelRoute: route },
+      );
     });
 
     it('classifies a turn with dangling tool calls as interrupted_turn', async () => {
@@ -1085,7 +1293,7 @@ describe('Session', () => {
       session.restoreHistory(snapshot);
 
       expect(snapshot).toEqual(history);
-      expect(mockChat.setHistory).toHaveBeenCalledWith(history);
+      expect(mockGeminiClient.setHistory).toHaveBeenCalledWith(history);
       expect(mockChat.getHistory).not.toHaveBeenCalled();
     });
 
@@ -3162,6 +3370,372 @@ describe('Session', () => {
       const sent = firstSentMessage();
       expect(textParts(sent)).toContain('[transcribed image]');
       expect(sent.some((part) => 'inlineData' in part)).toBe(false);
+    });
+
+    it('routes slash-command image prompts through the vision bridge', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'qwen3.7-plus',
+      });
+      vi.mocked(
+        nonInteractiveCliCommands.handleSlashCommand,
+      ).mockResolvedValueOnce({
+        type: 'submit_prompt',
+        content: [
+          { text: 'look at this' },
+          {
+            inlineData: {
+              mimeType: 'image/png',
+              data: 'iVBORw0KGgo=',
+            },
+          },
+        ],
+      });
+      runVisionBridgeSpy.mockResolvedValue({
+        applied: true,
+        status: 'ok',
+        parts: [{ text: 'look at this' }, { text: '[slash image]' }],
+        transcript: '[slash image]',
+        convertedCount: 1,
+        omittedCount: 0,
+        modelId: 'qwen3.7-plus',
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: '/vision' }],
+      });
+
+      expect(resolveFullTurnVisionRouteSpy).toHaveBeenCalledOnce();
+      expect(runVisionBridgeSpy).toHaveBeenCalledOnce();
+      expect(textParts(firstSentMessage())).toContain('[slash image]');
+      expect(firstSentMessage().some((part) => 'inlineData' in part)).toBe(
+        false,
+      );
+    });
+
+    it('routes slash-command image prompts through the exact agent model', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      vi.mocked(
+        nonInteractiveCliCommands.handleSlashCommand,
+      ).mockResolvedValueOnce({
+        type: 'submit_prompt',
+        content: [
+          { text: 'look at this' },
+          {
+            inlineData: {
+              mimeType: 'image/png',
+              data: 'iVBORw0KGgo=',
+            },
+          },
+        ],
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+      mockChat.replaceHistoricalMediaWithReferences = vi
+        .fn()
+        .mockReturnValueOnce(true);
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: '/vision' }],
+      });
+
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(firstSentMessage().some((part) => 'inlineData' in part)).toBe(
+        true,
+      );
+      expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+        'vision-agent',
+        expect.any(Object),
+        expect.any(String),
+        { modelRoute: route },
+      );
+      expect(
+        mockChatRecordingService.recordMediaScrubCheckpoint.mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(
+        mockChatRecordingService.recordFullTurnRoute.mock
+          .invocationCallOrder[0]!,
+      );
+      expect(
+        mockChatRecordingService.recordFullTurnRoute.mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(
+        mockChatRecordingService.recordUserMessage.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it('routes unknown slash image prompts through the exact agent model', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      vi.mocked(
+        nonInteractiveCliCommands.handleSlashCommand,
+      ).mockResolvedValueOnce({ type: 'no_command' });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [
+          { type: 'text', text: '/unknown' },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'iVBORw0KGgo=',
+          },
+        ],
+      });
+
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(firstSentMessage().some((part) => 'inlineData' in part)).toBe(
+        true,
+      );
+      expect(mockChat.sendMessageStream).toHaveBeenCalledWith(
+        'vision-agent',
+        expect.any(Object),
+        expect.any(String),
+        { modelRoute: route },
+      );
+    });
+
+    it('routes an agent-capable image prompt exactly for that ACP prompt only', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      const messageBus = {
+        request: vi.fn().mockResolvedValue({ success: true, output: {} }),
+      };
+      mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+      mockConfig.hasHooksForEvent = vi
+        .fn()
+        .mockImplementation((eventName: string) => eventName === 'Stop');
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+      mockToolRegistry.getTool.mockReturnValue({
+        name: 'read_file',
+        kind: core.Kind.Read,
+        build: vi.fn().mockReturnValue({
+          params: { path: '/tmp/test.txt' },
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue('Read file'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'file contents',
+            returnDisplay: 'file contents',
+          }),
+        }),
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValueOnce(
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                usageMetadata: {
+                  promptTokenCount: 42,
+                  totalTokenCount: 42,
+                },
+                functionCalls: [
+                  {
+                    id: 'call-1',
+                    name: 'read_file',
+                    args: { path: '/tmp/test.txt' },
+                  },
+                ],
+              },
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(createEmptyStream())
+        .mockResolvedValueOnce(createEmptyStream());
+      mockClient.extMethod = vi.fn().mockResolvedValue({
+        items: [
+          {
+            content: [
+              { type: 'text', text: 'also inspect this' },
+              {
+                type: 'image',
+                mimeType: 'image/png',
+                data: 'mid-turn-image',
+              },
+            ],
+            displayText: 'also inspect this',
+          },
+        ],
+      });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [
+          { type: 'text', text: 'look at this' },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'iVBORw0KGgo=',
+          },
+        ],
+      });
+
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(firstSentMessage().some((part) => 'inlineData' in part)).toBe(
+        true,
+      );
+      const sendMessageStream = vi.mocked(mockChat.sendMessageStream);
+      expect(sendMessageStream.mock.calls[0]?.[3]).toEqual({
+        modelRoute: route,
+      });
+      expect(sendMessageStream.mock.calls[1]?.[0]).toBe('vision-agent');
+      expect(sendMessageStream.mock.calls[1]?.[3]).toEqual({
+        modelRoute: route,
+      });
+      expect(mockGeminiClient.tryCompressChat).not.toHaveBeenCalled();
+      expect(
+        (sendMessageStream.mock.calls[1]?.[1] as { message: Part[] }).message,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            functionResponse: expect.objectContaining({ name: 'read_file' }),
+          }),
+          expect.objectContaining({
+            inlineData: expect.objectContaining({ data: 'mid-turn-image' }),
+          }),
+        ]),
+      );
+      expect(agentMessageChunks()).toContainEqual(
+        expect.stringContaining('current image turn'),
+      );
+      expect(
+        mockChat.replaceHistoricalMediaWithReferences,
+      ).toHaveBeenCalledTimes(2);
+      expect(messageBus.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventName: 'Stop',
+          input: expect.objectContaining({ context_limit: 123_456 }),
+        }),
+        expect.anything(),
+      );
+
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'not-eligible',
+      });
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'next text turn' }],
+      });
+      expect(sendMessageStream.mock.calls[2]?.[3]).toBeUndefined();
+      expect(mockGeminiClient.tryCompressChat).toHaveBeenCalledOnce();
+    });
+
+    it('fails an ACP image prompt closed when the exact route cannot resolve', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'failed',
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      await expect(
+        session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [
+            { type: 'text', text: 'look at this' },
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'iVBORw0KGgo=',
+            },
+          ],
+        }),
+      ).rejects.toThrow('not sent to the primary model');
+
+      expect(runVisionBridgeSpy).not.toHaveBeenCalled();
+      expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
+    });
+
+    it('scrubs live routed media but keeps retry affinity after a stream failure', async () => {
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'vision-agent',
+        agentCapable: true,
+      });
+      const route = makeVisionAgentRoute();
+      resolveFullTurnVisionRouteSpy.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockChat.getPendingFullTurnRouteIdentity = vi
+        .fn()
+        .mockReturnValue(undefined);
+      mockChat.setPendingFullTurnRoute = vi.fn();
+      mockChat.clearPendingFullTurnRoute = vi.fn();
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        (async function* () {
+          throw new Error('route stream failed');
+        })(),
+      );
+
+      await expect(
+        session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [
+            { type: 'text', text: 'look at this' },
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'private-image',
+            },
+          ],
+        }),
+      ).rejects.toThrow('route stream failed');
+
+      expect(
+        mockChat.replaceHistoricalMediaWithReferences,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockChatRecordingService.recordMediaScrubCheckpoint,
+      ).not.toHaveBeenCalled();
+      expect(mockChat.clearPendingFullTurnRoute).not.toHaveBeenCalled();
     });
 
     it('strips image parts when the vision bridge is cancelled before applying', async () => {
@@ -10358,6 +10932,68 @@ describe('Session', () => {
 
           expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
           expect(result.stopReason).toBe('end_turn');
+        });
+
+        it('does not persist a blocked routed image as resumable input', async () => {
+          const messageBus = {
+            request: vi.fn().mockResolvedValue({
+              success: true,
+              output: { decision: 'block', reason: 'Blocked by hook' },
+            }),
+          };
+          mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
+          mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+          mockConfig.hasHooksForEvent = vi.fn().mockReturnValue(true);
+          mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+          const route = makeVisionAgentRoute();
+          mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+            id: route.model,
+            agentCapable: true,
+          });
+          resolveFullTurnVisionRouteSpy.mockResolvedValue({
+            status: 'ready',
+            route,
+            selection: { id: route.model, agentCapable: true },
+          });
+          let pendingIdentity:
+            | { model: string; authType: AuthType }
+            | undefined;
+          mockChat.getPendingFullTurnRouteIdentity = vi.fn(
+            () => pendingIdentity,
+          );
+          mockChat.setPendingFullTurnRoute = vi.fn((identity) => {
+            pendingIdentity = identity;
+          });
+          mockChat.clearPendingFullTurnRoute = vi.fn(() => {
+            pendingIdentity = undefined;
+          });
+          mockChat.sendMessageStream = vi.fn();
+
+          const result = await session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [
+              { type: 'text', text: 'blocked image prompt' },
+              {
+                type: 'image',
+                mimeType: 'image/png',
+                data: 'blocked-image',
+              },
+            ],
+          });
+
+          expect(result.stopReason).toBe('end_turn');
+          expect(mockChat.sendMessageStream).not.toHaveBeenCalled();
+          expect(
+            mockChatRecordingService.recordUserMessage,
+          ).not.toHaveBeenCalled();
+          expect(
+            mockChatRecordingService.recordMediaScrubCheckpoint,
+          ).toHaveBeenCalledOnce();
+          expect(mockChat.clearPendingFullTurnRoute).toHaveBeenCalledOnce();
+          expect(await session.continueLastTurn()).toEqual({
+            accepted: false,
+            interruption: 'none',
+          });
         });
       });
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3711,7 +3711,7 @@ describe('Session', () => {
       mockChat.clearPendingFullTurnRoute = vi.fn();
       mockChat.sendMessageStream = vi.fn().mockResolvedValue(
         (async function* () {
-          throw new Error('route stream failed');
+          yield Promise.reject(new Error('route stream failed'));
         })(),
       );
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2662,14 +2662,6 @@ export class Session implements SessionContext {
   }
 
   /**
-   * Mirrors the core send path for ACP model sends.
-   *
-   * Attempts automatic chat compression first, checks the session token limit,
-   * emits an ACP-visible notice when compression succeeds, and returns the ACP
-   * stop reason when the provider send should be skipped because the request
-   * was cancelled or the session token limit was exceeded.
-   */
-  /**
    * Create the MessageDisplay hook dispatcher for one model call's streamed
    * reply, or null when the hook isn't registered (the common case — keeps
    * the streaming loops zero-cost). The ACP surface consumes GeminiChat's

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -38,8 +38,10 @@ import type {
   ToolArtifact,
   VisionBridgeResult,
   MemoryWriteCandidate,
+  FullTurnModelRoute,
 } from '@qwen-code/qwen-code-core';
 import {
+  getFullTurnModelRouteIdentity,
   AuthType,
   ApprovalMode,
   CompressionStatus,
@@ -133,6 +135,10 @@ import {
   runVisionBridge,
   shouldRunVisionBridge,
   formatVisionBridgeNotice,
+  formatFullTurnVisionNotice,
+  formatFullTurnVisionFailureNotice,
+  resolveFullTurnVisionRoute,
+  runWithRuntimeContentGenerator,
   splitImageParts,
   approxBase64Bytes,
 } from '@qwen-code/qwen-code-core';
@@ -1334,10 +1340,7 @@ export class Session implements SessionContext {
       );
     }
 
-    this.config
-      .getGeminiClient()!
-      .getChat()
-      .setHistory(structuredClone(history));
+    this.config.getGeminiClient()!.setHistory(structuredClone(history));
   }
 
   #computeApiTruncationIndexForUserTurn(
@@ -1754,6 +1757,20 @@ export class Session implements SessionContext {
                 DAEMON_CONTINUE_META_KEY
               ] === true;
             let continuationParts: Part[] | null = null;
+            const chat = this.#getCurrentChat();
+            let modelRoute: FullTurnModelRoute | undefined;
+            const pendingRouteIdentity =
+              chat.getPendingFullTurnRouteIdentity?.();
+            if (isContinue || isRetry) {
+              modelRoute = chat.getPendingFullTurnRoute?.();
+              if (pendingRouteIdentity && !modelRoute) {
+                throw new Error(
+                  `Cannot safely continue the interrupted image turn because its exact route (${pendingRouteIdentity.model}) is unavailable.`,
+                );
+              }
+            } else if (pendingRouteIdentity) {
+              this.#settlePendingFullTurnRoute();
+            }
             // For an `interrupted_prompt` continuation we strip the orphaned
             // user run from history before re-sending it. If the send then
             // throws before re-pushing it, the orphan would be permanently lost
@@ -1794,6 +1811,25 @@ export class Session implements SessionContext {
               } else {
                 continuationParts = recoveryPlan.continuation.parts;
               }
+              const sourceHasImages =
+                recoveryPlan.continuation.sourceHistory.some((content) =>
+                  hasImageParts(content.parts ?? []),
+                );
+              if (
+                !pendingRouteIdentity &&
+                sourceHasImages &&
+                this.config.getEffectiveInputModalities?.().image !== true
+              ) {
+                throw new Error(
+                  'Cannot safely continue an interrupted image turn without its original exact route identity.',
+                );
+              }
+              if (modelRoute) {
+                continuationParts = chat.prepareHistoricalMediaForContinuation(
+                  continuationParts,
+                  recoveryPlan.continuation.sourceHistory,
+                );
+              }
             }
 
             if (isContinue) {
@@ -1801,11 +1837,6 @@ export class Session implements SessionContext {
               // message would duplicate the turn in the transcript.
             } else if (isRetry) {
               this.#getCurrentChat().stripOrphanedUserEntriesFromHistory();
-            } else {
-              // record user message for session management
-              this.config
-                .getChatRecordingService()
-                ?.recordUserMessage(promptText);
             }
 
             // Check if the input contains a slash command
@@ -1816,11 +1847,37 @@ export class Session implements SessionContext {
             const inputText = firstTextBlock?.text || '';
 
             let parts: Part[] | null;
+            const onModelRoute = (route: FullTurnModelRoute) => {
+              const identity = getFullTurnModelRouteIdentity(route);
+              const currentIdentity = chat.getPendingFullTurnRouteIdentity?.();
+              if (
+                !currentIdentity ||
+                currentIdentity.model !== identity.model ||
+                currentIdentity.baseUrl !== identity.baseUrl ||
+                currentIdentity.authType !== identity.authType
+              ) {
+                if (chat.replaceHistoricalMediaWithReferences()) {
+                  this.config
+                    .getChatRecordingService()
+                    ?.recordMediaScrubCheckpoint();
+                }
+                this.config
+                  .getChatRecordingService()
+                  ?.recordFullTurnRoute(identity);
+              }
+              chat.setPendingFullTurnRoute?.(identity, route);
+              modelRoute = route;
+            };
 
             if (isContinue) {
               // Non-null here: the `none` case returned early above, and both
               // interruption branches assign a concrete part list.
-              parts = continuationParts!;
+              parts = await this.#applyBridgeConversionsIfNeeded(
+                continuationParts!,
+                pendingSend.signal,
+                onModelRoute,
+                modelRoute,
+              );
             } else if (isSlashCommand(inputText)) {
               // Handle slash command in ACP mode using capability-based filtering
               const slashCommandResult = await handleSlashCommand(
@@ -1833,11 +1890,19 @@ export class Session implements SessionContext {
               parts = await this.#processSlashCommandResult(
                 slashCommandResult,
                 params.prompt,
+                pendingSend.signal,
+                onModelRoute,
+                isRetry ? modelRoute : undefined,
               );
 
               // If parts is null, the command was fully handled (e.g., /summary completed)
               // Return early without sending to the model
               if (parts === null) {
+                if (!isContinue && !isRetry) {
+                  this.config
+                    .getChatRecordingService()
+                    ?.recordUserMessage(promptText);
+                }
                 return { stopReason: 'end_turn' };
               }
             } else {
@@ -1847,7 +1912,11 @@ export class Session implements SessionContext {
               parts = await this.#resolvePrompt(
                 params.prompt,
                 pendingSend.signal,
-                { promptLast: true },
+                {
+                  promptLast: true,
+                  onModelRoute,
+                  preselectedRoute: isRetry ? modelRoute : undefined,
+                },
               );
             }
 
@@ -1888,6 +1957,7 @@ export class Session implements SessionContext {
                 await this.messageEmitter.emitAgentMessage(
                   `✗ **UserPromptSubmit blocked**: ${blockReason}`,
                 );
+                this.#settlePendingFullTurnRoute();
                 return { stopReason: 'end_turn' };
               }
 
@@ -1896,6 +1966,12 @@ export class Session implements SessionContext {
               if (additionalContext) {
                 parts = [...parts, { text: additionalContext }];
               }
+            }
+
+            if (!isContinue && !isRetry) {
+              this.config
+                .getChatRecordingService()
+                ?.recordUserMessage(modelRoute ? parts : promptText);
             }
 
             // Snapshot file state before this turn (mirrors the makeSnapshot
@@ -1966,6 +2042,7 @@ export class Session implements SessionContext {
 
             let nextMessage: Content | null = { role: 'user', parts };
             let turnCount = 0;
+            let completedRoutedTurn = false;
             const toolLoopState = createDaemonToolLoopState();
 
             // conversation_finished must fire on every terminal path of the
@@ -2001,6 +2078,7 @@ export class Session implements SessionContext {
                       promptId,
                       nextMessage?.parts ?? [],
                       pendingSend.signal,
+                      { modelRoute },
                     );
                   if (!sendResult.responseStream) {
                     // Preserve the full message (not just functionResponse
@@ -2012,6 +2090,7 @@ export class Session implements SessionContext {
                       nextMessage,
                       isContinue || sendResult.stopReason === 'cancelled',
                     );
+                    completedRoutedTurn = sendResult.stopReason === 'end_turn';
                     return { stopReason: sendResult.stopReason };
                   }
                   const responseStream = sendResult.responseStream;
@@ -2168,28 +2247,37 @@ export class Session implements SessionContext {
                 }
 
                 if (functionCalls.length > 0) {
-                  const toolRun = await this.runToolCalls(
-                    pendingSend.signal,
-                    promptId,
-                    functionCalls,
-                    toolLoopState,
-                  );
+                  const runTools = () =>
+                    this.runToolCalls(
+                      pendingSend.signal,
+                      promptId,
+                      functionCalls,
+                      toolLoopState,
+                    );
+                  const toolRun = modelRoute
+                    ? await runWithRuntimeContentGenerator(modelRoute, runTools)
+                    : await runTools();
                   if (toolRun.stopAfterPermissionCancel) {
                     await this.#preserveStoppedToolRun(
                       toolRun,
                       pendingSend.signal,
+                      modelRoute,
                     );
+                    completedRoutedTurn = true;
                     return { stopReason: 'end_turn' };
                   }
                   nextMessage = await this.#buildNextMessageAfterToolRun(
                     toolRun,
                     pendingSend.signal,
+                    modelRoute,
                   );
                   if (toolRun.loopDetected) {
                     await this.#preserveStoppedToolRun(
                       toolRun,
                       pendingSend.signal,
+                      modelRoute,
                     );
+                    completedRoutedTurn = true;
                     return { stopReason: 'end_turn' };
                   }
                 }
@@ -2202,12 +2290,19 @@ export class Session implements SessionContext {
 
               // Fire Stop hook loop (aligned with core path in client.ts)
               // This is triggered after model response completes with no pending tool calls
-              return await this.#handleStopHookLoop(
-                pendingSend,
-                promptId,
-                hooksEnabled,
-                messageBus,
-              );
+              const runStopHooks = () =>
+                this.#handleStopHookLoop(
+                  pendingSend,
+                  promptId,
+                  hooksEnabled,
+                  messageBus,
+                  modelRoute,
+                );
+              const stopResult = modelRoute
+                ? await runWithRuntimeContentGenerator(modelRoute, runStopHooks)
+                : await runStopHooks();
+              completedRoutedTurn = stopResult.stopReason === 'end_turn';
+              return stopResult;
             } finally {
               logConversationFinishedEvent(
                 this.config,
@@ -2216,6 +2311,13 @@ export class Session implements SessionContext {
                   turnCount,
                 ),
               );
+              if (modelRoute) {
+                if (completedRoutedTurn) {
+                  this.#settlePendingFullTurnRoute();
+                } else {
+                  this.#getCurrentChat().replaceHistoricalMediaWithReferences();
+                }
+              }
             }
           },
           (result: { stopReason: PromptResponse['stopReason'] }) =>
@@ -2242,16 +2344,19 @@ export class Session implements SessionContext {
     promptId: string,
     hooksEnabled: boolean,
     messageBus: MessageBus | undefined,
+    modelRoute?: FullTurnModelRoute,
   ): Promise<{ stopReason: PromptResponse['stopReason'] }> {
     const stopHookBlockingCap = this.config.getStopHookBlockingCap();
     let stopHookIterationCount = 0;
     let stopHookReasons: string[] = [];
 
     while (stopHookIterationCount < stopHookBlockingCap) {
+      if (pendingSend.signal.aborted) {
+        return { stopReason: 'cancelled' };
+      }
       if (
         !hooksEnabled ||
         !messageBus ||
-        pendingSend.signal.aborted ||
         !this.config.hasHooksForEvent?.('Stop')
       ) {
         return { stopReason: 'end_turn' };
@@ -2263,7 +2368,8 @@ export class Session implements SessionContext {
         '[no response text]';
 
       const contextUsage = buildContextUsage(
-        this.config.getContentGeneratorConfig()?.contextWindowSize ??
+        modelRoute?.contentGeneratorConfig.contextWindowSize ??
+          this.config.getContentGeneratorConfig()?.contextWindowSize ??
           DEFAULT_TOKEN_LIMIT,
         this.lastPromptTokenCount,
       );
@@ -2365,7 +2471,10 @@ export class Session implements SessionContext {
                 promptId + '_stop_hook_' + stopHookIterationCount,
                 nextMessage?.parts ?? [],
                 pendingSend.signal,
-                { skipCompression: stopHookIterationCount > 1 },
+                {
+                  skipCompression: stopHookIterationCount > 1,
+                  modelRoute,
+                },
               );
             if (!continueSendResult.responseStream) {
               this.#preserveUnsentMessageHistory(
@@ -2497,15 +2606,24 @@ export class Session implements SessionContext {
               toolLoopState,
             );
             if (toolRun.stopAfterPermissionCancel) {
-              await this.#preserveStoppedToolRun(toolRun, pendingSend.signal);
+              await this.#preserveStoppedToolRun(
+                toolRun,
+                pendingSend.signal,
+                modelRoute,
+              );
               return { stopReason: 'end_turn' };
             }
             nextMessage = await this.#buildNextMessageAfterToolRun(
               toolRun,
               pendingSend.signal,
+              modelRoute,
             );
             if (toolRun.loopDetected) {
-              await this.#preserveStoppedToolRun(toolRun, pendingSend.signal);
+              await this.#preserveStoppedToolRun(
+                toolRun,
+                pendingSend.signal,
+                modelRoute,
+              );
               return { stopReason: 'end_turn' };
             }
           }
@@ -2533,6 +2651,14 @@ export class Session implements SessionContext {
 
   #getCurrentChat(): GeminiChat {
     return this.config.getGeminiClient()!.getChat();
+  }
+
+  #settlePendingFullTurnRoute(): void {
+    const chat = this.#getCurrentChat();
+    if (!chat.getPendingFullTurnRouteIdentity?.()) return;
+    chat.replaceHistoricalMediaWithReferences();
+    this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+    chat.clearPendingFullTurnRoute?.();
   }
 
   /**
@@ -2576,12 +2702,15 @@ export class Session implements SessionContext {
     promptId: string,
     message: Part[],
     abortSignal: AbortSignal,
-    options: { skipCompression?: boolean } = {},
+    options: {
+      skipCompression?: boolean;
+      modelRoute?: FullTurnModelRoute;
+    } = {},
   ): Promise<AutoCompressionSendResult> {
     const geminiClient = this.config.getGeminiClient()!;
     let compressionDiagnostic: string | null = null;
     let compressionInfo: ChatCompressionInfo | null = null;
-    if (!options.skipCompression) {
+    if (!options.skipCompression && !options.modelRoute) {
       try {
         const compressed = await geminiClient.tryCompressChat(
           promptId,
@@ -2658,16 +2787,21 @@ export class Session implements SessionContext {
       return { responseStream: null, stopReason: 'cancelled' };
     }
 
-    const responseStream = await this.#getCurrentChat().sendMessageStream(
-      this.config.getModel(),
-      {
-        message,
-        config: {
-          abortSignal,
-        },
+    const model = options.modelRoute?.model ?? this.config.getModel();
+    const params = {
+      message,
+      config: {
+        abortSignal,
       },
-      promptId,
-    );
+    };
+    const responseStream = options.modelRoute
+      ? await this.#getCurrentChat().sendMessageStream(
+          model,
+          params,
+          promptId,
+          { modelRoute: options.modelRoute },
+        )
+      : await this.#getCurrentChat().sendMessageStream(model, params, promptId);
     return { responseStream };
   }
 
@@ -2704,6 +2838,7 @@ export class Session implements SessionContext {
   async #preserveStoppedToolRun(
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
+    modelRoute?: FullTurnModelRoute,
   ): Promise<void> {
     this.#preserveUnsentMessageHistory(
       {
@@ -2713,7 +2848,7 @@ export class Session implements SessionContext {
           ...(toolRun.loopDetected
             ? [{ text: LOOP_DETECTED_CONTEXT_MESSAGE }]
             : []),
-          ...(await this.#drainMidTurnUserMessages(abortSignal)),
+          ...(await this.#drainMidTurnUserMessages(abortSignal, modelRoute)),
         ],
       },
       true,
@@ -2724,6 +2859,7 @@ export class Session implements SessionContext {
   async #buildNextMessageAfterToolRun(
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
+    modelRoute?: FullTurnModelRoute,
   ): Promise<Content | null> {
     if (toolRun.loopDetected) {
       debugLogger.debug('Stopping ACP turn after daemon loop detection.');
@@ -2737,7 +2873,7 @@ export class Session implements SessionContext {
     }
     const parts = [
       ...toolRun.parts,
-      ...(await this.#drainMidTurnUserMessages(abortSignal)),
+      ...(await this.#drainMidTurnUserMessages(abortSignal, modelRoute)),
     ];
     return { role: 'user', parts };
   }
@@ -2848,7 +2984,10 @@ export class Session implements SessionContext {
     });
   }
 
-  async #drainMidTurnUserMessages(abortSignal: AbortSignal): Promise<Part[]> {
+  async #drainMidTurnUserMessages(
+    abortSignal: AbortSignal,
+    modelRoute?: FullTurnModelRoute,
+  ): Promise<Part[]> {
     // Flush anything recovered from a PRIOR timed-out drain first: the daemon
     // splices + SSE-publishes synchronously, so on a timeout the browser has
     // already deduped those messages — discarding the late response would lose
@@ -2857,7 +2996,7 @@ export class Session implements SessionContext {
     const recovered = this.#takeRecoveredMidTurnMessages();
 
     if (this.midTurnDrainUnavailable) {
-      return this.#buildMidTurnParts(recovered, abortSignal);
+      return this.#buildMidTurnParts(recovered, abortSignal, modelRoute);
     }
 
     let drainPromise: ReturnType<AgentSideConnection['extMethod']> | undefined;
@@ -2882,6 +3021,7 @@ export class Session implements SessionContext {
       return this.#buildMidTurnParts(
         [...recovered, ...parseMidTurnDrainResponse(response)],
         abortSignal,
+        modelRoute,
       );
     } catch (error) {
       // The ACP SDK rejects with the raw JSON-RPC error object
@@ -2932,7 +3072,7 @@ export class Session implements SessionContext {
       );
       // Even on a failed/timed-out drain, still inject anything recovered from
       // an EARLIER timeout so a transient stall never strands those messages.
-      return this.#buildMidTurnParts(recovered, abortSignal);
+      return this.#buildMidTurnParts(recovered, abortSignal, modelRoute);
     }
   }
 
@@ -2998,6 +3138,7 @@ export class Session implements SessionContext {
   async #buildMidTurnParts(
     messages: DrainedMidTurnMessage[],
     abortSignal: AbortSignal,
+    modelRoute?: FullTurnModelRoute,
   ): Promise<Part[]> {
     const parts: Part[] = [];
     for (const message of messages) {
@@ -3011,7 +3152,10 @@ export class Session implements SessionContext {
             : await withTimeoutSignal(
                 abortSignal,
                 MID_TURN_QUEUE_RESOLVE_TIMEOUT_MS,
-                (signal) => this.#resolvePrompt(message.content, signal),
+                (signal) =>
+                  this.#resolvePrompt(message.content, signal, {
+                    preselectedRoute: modelRoute,
+                  }),
               );
       } catch (messageError) {
         if (abortSignal.aborted) return parts;
@@ -3181,6 +3325,7 @@ export class Session implements SessionContext {
           async () => {
             let turnCount = 0;
             try {
+              this.#settlePendingFullTurnRoute();
               // A `<<loop.md>>` / `<<loop.md-dynamic>>` sentinel is expanded at
               // fire time into the loop.md task block — full on the first or a
               // changed fire, a short reminder when unchanged. Non-sentinel
@@ -3663,6 +3808,7 @@ export class Session implements SessionContext {
           this.config.getSessionId() + '########notification' + Date.now();
 
         try {
+          this.#settlePendingFullTurnRoute();
           await this.#emitBackgroundNotificationDisplay(item);
 
           const notificationParts: Part[] = [{ text: item.modelText }];
@@ -5804,11 +5950,16 @@ export class Session implements SessionContext {
    *
    * @param result The result from handleSlashCommand
    * @param originalPrompt The original prompt blocks
+   * @param abortSignal The current prompt's cancellation signal
+   * @param onModelRoute Records an exact model route selected for this prompt
    * @returns Parts to use for the prompt, or null if command was handled without needing model interaction
    */
   async #processSlashCommandResult(
     result: NonInteractiveSlashCommandResult,
     originalPrompt: ContentBlock[],
+    abortSignal: AbortSignal,
+    onModelRoute: (route: FullTurnModelRoute) => void,
+    preselectedRoute?: FullTurnModelRoute,
   ): Promise<Part[] | null> {
     this.#emitGoalStatusItems(result);
 
@@ -5816,7 +5967,12 @@ export class Session implements SessionContext {
       case 'submit_prompt':
         // Command wants to submit a prompt to the model
         // Convert PartListUnion to Part[]
-        return normalizePartList(result.content);
+        return this.#applyBridgeConversionsIfNeeded(
+          normalizePartList(result.content),
+          abortSignal,
+          onModelRoute,
+          preselectedRoute,
+        );
 
       case 'message': {
         if (result.messageType === 'error') {
@@ -5888,11 +6044,11 @@ export class Session implements SessionContext {
         // No command was found or executed, resolve the original prompt
         // through the standard path that handles all block types. promptLast
         // keeps the user's instruction prominent (matches the normal path).
-        return this.#resolvePrompt(
-          originalPrompt,
-          new AbortController().signal,
-          { promptLast: true },
-        );
+        return this.#resolvePrompt(originalPrompt, abortSignal, {
+          promptLast: true,
+          onModelRoute,
+          preselectedRoute,
+        });
 
       default: {
         // Exhaustiveness check
@@ -5911,7 +6067,11 @@ export class Session implements SessionContext {
     // (see the assembly comment below). Only genuine user prompts pass this;
     // the mid-turn drain path leaves it false so its synthetic `@uri` marker
     // stays first and keeps carrying the "[User message received...]" prefix.
-    options: { promptLast?: boolean } = {},
+    options: {
+      promptLast?: boolean;
+      onModelRoute?: (route: FullTurnModelRoute) => void;
+      preselectedRoute?: FullTurnModelRoute;
+    } = {},
   ): Promise<Part[]> {
     const FILE_URI_SCHEME = 'file://';
 
@@ -5988,13 +6148,20 @@ export class Session implements SessionContext {
       extensionParts.length === 0 &&
       mcpServerParts.length === 0
     ) {
-      return this.#applyBridgeConversionsIfNeeded(parts, abortSignal);
+      return this.#applyBridgeConversionsIfNeeded(
+        parts,
+        abortSignal,
+        options.onModelRoute,
+        options.preselectedRoute,
+      );
     }
 
     if (atPathCommandParts.length === 0 && embeddedContext.length === 0) {
       return this.#applyBridgeConversionsIfNeeded(
         [...parts, ...extensionParts, ...mcpServerParts],
         abortSignal,
+        options.onModelRoute,
+        options.preselectedRoute,
       );
     }
 
@@ -6103,12 +6270,16 @@ export class Session implements SessionContext {
     return this.#applyBridgeConversionsIfNeeded(
       processedQueryParts,
       abortSignal,
+      options.onModelRoute,
+      options.preselectedRoute,
     );
   }
 
   async #applyBridgeConversionsIfNeeded(
     originalParts: Part[],
     abortSignal: AbortSignal,
+    onModelRoute?: (route: FullTurnModelRoute) => void,
+    preselectedRoute?: FullTurnModelRoute,
   ): Promise<Part[]> {
     const parts = await this.#applyVoiceBridgeIfNeeded(
       originalParts,
@@ -6116,6 +6287,29 @@ export class Session implements SessionContext {
     );
     if (!hasImageParts(parts) || !shouldRunVisionBridge(this.config)) {
       return parts;
+    }
+
+    if (preselectedRoute) {
+      onModelRoute?.(preselectedRoute);
+      return parts;
+    }
+
+    if (onModelRoute) {
+      const routeResult = await resolveFullTurnVisionRoute(this.config);
+      if (routeResult.status === 'ready') {
+        onModelRoute(routeResult.route);
+        await this.messageEmitter.emitAgentMessage(
+          formatFullTurnVisionNotice(routeResult.selection),
+        );
+        return parts;
+      }
+      if (routeResult.status === 'failed') {
+        const message = formatFullTurnVisionFailureNotice(
+          routeResult.selection,
+        );
+        await this.messageEmitter.emitAgentMessage(message);
+        throw new Error(message);
+      }
     }
 
     let bridgeResult: VisionBridgeResult;

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1294,7 +1294,7 @@ const SETTINGS_SCHEMA = {
     requiresRestart: false,
     default: '',
     description:
-      'Image-capable model used as the vision bridge: when a text-only main model receives an image, it is transcribed by this model first. Set with /model --vision. Leave empty to auto-pick a same-provider vision model.',
+      'Image-capable model used when a text-only main model receives an image. Only an image-capable model that explicitly declares capabilities.agent: true handles the full agent turn; all others use Vision Bridge transcription. Set with /model --vision. Leave empty to auto-pick a same-provider vision model.',
     showInDialog: true,
   },
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -51,6 +51,13 @@ import {
 } from './utils/errors.js';
 
 // Mock core modules
+const visionRouteMocks = vi.hoisted(() => ({
+  resolve: vi.fn(),
+  runBridge: vi.fn(),
+  runWithRuntime: vi.fn(
+    async <T>(_route: unknown, fn: () => Promise<T>): Promise<T> => fn(),
+  ),
+}));
 vi.mock('./ui/hooks/atCommandProcessor.js');
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const original =
@@ -73,6 +80,9 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
       getMetrics: vi.fn(),
       getMetricsForSession: vi.fn(),
     },
+    resolveFullTurnVisionRoute: visionRouteMocks.resolve,
+    runVisionBridge: visionRouteMocks.runBridge,
+    runWithRuntimeContentGenerator: visionRouteMocks.runWithRuntime,
   };
 });
 
@@ -212,6 +222,15 @@ describe('runNonInteractive', () => {
     // handleError tests in the never-resolving promise (5s vitest timeout).
     _resetCleanupFunctionsForTest();
     _resetExitLatchForTest();
+    visionRouteMocks.resolve.mockReset().mockResolvedValue({
+      status: 'not-eligible',
+    });
+    visionRouteMocks.runBridge.mockReset();
+    visionRouteMocks.runWithRuntime
+      .mockReset()
+      .mockImplementation(
+        async <T>(_route: unknown, fn: () => Promise<T>): Promise<T> => fn(),
+      );
 
     mockCoreExecuteToolCall = vi.mocked(executeToolCall);
     mockShutdownTelemetry = vi.mocked(shutdownTelemetry);
@@ -291,6 +310,8 @@ describe('runNonInteractive', () => {
       getIdeMode: vi.fn().mockReturnValue(false),
       getFullContext: vi.fn().mockReturnValue(false),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getEffectiveInputModalities: vi.fn().mockReturnValue({ image: false }),
+      getDefaultVisionBridgeModel: vi.fn().mockReturnValue(undefined),
       getDebugMode: vi.fn().mockReturnValue(false),
       getOutputFormat: vi.fn().mockReturnValue('text'),
       getJsonSchema: vi.fn().mockReturnValue(undefined),
@@ -1947,6 +1968,183 @@ describe('runNonInteractive', () => {
 
     // 6. Assert the final output is correct
     expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.\n');
+  });
+
+  it('keeps an agent-capable image turn on the exact route through tool continuation', async () => {
+    setupMetricsMock();
+    const imagePart: Part = {
+      inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' },
+    };
+    const route = {
+      model: 'vision-agent',
+      contentGenerator: {},
+      contentGeneratorConfig: { model: 'vision-agent' },
+    };
+    const { handleAtCommand } = await import(
+      './ui/hooks/atCommandProcessor.js'
+    );
+    vi.mocked(handleAtCommand).mockResolvedValue({
+      processedQuery: [{ text: 'inspect this' }, imagePart],
+      shouldProceed: true,
+    });
+    vi.mocked(mockConfig.getDefaultVisionBridgeModel).mockReturnValue({
+      id: 'vision-agent',
+      agentCapable: true,
+    });
+    visionRouteMocks.resolve.mockResolvedValue({
+      status: 'ready',
+      selection: { id: 'vision-agent', agentCapable: true },
+      route,
+    });
+    mockCoreExecuteToolCall.mockResolvedValue({
+      responseParts: [{ text: 'tool result' }],
+    });
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'tool-vision',
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'prompt-vision-route',
+            },
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'done' },
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 1 },
+            },
+          },
+        ]),
+      );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'inspect @image.png',
+      'prompt-vision-route',
+    );
+
+    expect(visionRouteMocks.runBridge).not.toHaveBeenCalled();
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
+      1,
+      [{ text: 'inspect this' }, imagePart],
+      expect.any(AbortSignal),
+      'prompt-vision-route',
+      expect.objectContaining({
+        type: SendMessageType.UserQuery,
+        modelRoute: route,
+      }),
+    );
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
+      2,
+      [{ text: 'tool result' }],
+      expect.any(AbortSignal),
+      'prompt-vision-route',
+      expect.objectContaining({
+        type: SendMessageType.ToolResult,
+        modelRoute: route,
+      }),
+    );
+    expect(visionRouteMocks.runWithRuntime).toHaveBeenCalledWith(
+      route,
+      expect.any(Function),
+    );
+  });
+
+  it('uses Vision Bridge for an image model without agent capability', async () => {
+    setupMetricsMock();
+    const imagePart: Part = {
+      inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' },
+    };
+    const { handleAtCommand } = await import(
+      './ui/hooks/atCommandProcessor.js'
+    );
+    vi.mocked(handleAtCommand).mockResolvedValue({
+      processedQuery: [{ text: 'inspect this' }, imagePart],
+      shouldProceed: true,
+    });
+    vi.mocked(mockConfig.getDefaultVisionBridgeModel).mockReturnValue({
+      id: 'vision-only',
+    });
+    visionRouteMocks.runBridge.mockResolvedValue({
+      applied: true,
+      status: 'ok',
+      parts: [{ text: 'inspect this' }, { text: 'image transcription' }],
+      convertedCount: 1,
+      omittedCount: 0,
+      modelId: 'vision-only',
+      egressOccurred: true,
+    });
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents([
+        {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 1 },
+          },
+        },
+      ]),
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'inspect @image.png',
+      'prompt-vision-bridge',
+    );
+
+    expect(visionRouteMocks.runBridge).toHaveBeenCalledOnce();
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledWith(
+      [{ text: 'inspect this' }, { text: 'image transcription' }],
+      expect.any(AbortSignal),
+      'prompt-vision-bridge',
+      expect.not.objectContaining({ modelRoute: expect.anything() }),
+    );
+  });
+
+  it('fails closed before sending an image when the full-turn route cannot resolve', async () => {
+    setupMetricsMock();
+    const { handleAtCommand } = await import(
+      './ui/hooks/atCommandProcessor.js'
+    );
+    vi.mocked(handleAtCommand).mockResolvedValue({
+      processedQuery: [
+        { text: 'inspect this' },
+        { inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' } },
+      ],
+      shouldProceed: true,
+    });
+    vi.mocked(mockConfig.getDefaultVisionBridgeModel).mockReturnValue({
+      id: 'vision-agent',
+      agentCapable: true,
+    });
+    visionRouteMocks.resolve.mockResolvedValue({
+      status: 'failed',
+      selection: { id: 'vision-agent', agentCapable: true },
+    });
+
+    await expect(
+      runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'inspect @image.png',
+        'prompt-vision-failed',
+      ),
+    ).rejects.toThrow('not sent to the primary model');
+
+    expect(mockGeminiClient.sendMessageStream).not.toHaveBeenCalled();
+    expect(visionRouteMocks.runBridge).not.toHaveBeenCalled();
   });
 
   it('should process input and write JSON output with stats', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -10,6 +10,7 @@ import type {
   ToolRegistry,
   ServerGeminiStreamEvent,
   SessionMetrics,
+  TeamManager,
 } from '@qwen-code/qwen-code-core';
 import type { CLIUserMessage } from './nonInteractive/types.js';
 import {
@@ -437,6 +438,42 @@ describe('runNonInteractive', () => {
     for (const event of events) {
       yield event;
     }
+  }
+
+  function createMockTeamManager(initiallyActive = false) {
+    let active = initiallyActive;
+    let leaderMessageCallback: Parameters<
+      TeamManager['setLeaderMessageCallback']
+    >[0] = null;
+    const waitForTeammateActivity =
+      vi.fn<TeamManager['waitForTeammateActivity']>();
+    const manager = {
+      setLeaderMessageCallback: vi.fn(
+        (callback: Parameters<TeamManager['setLeaderMessageCallback']>[0]) => {
+          leaderMessageCallback = callback;
+        },
+      ),
+      getEventEmitter: vi.fn(() => ({
+        on: vi.fn(),
+        off: vi.fn(),
+      })),
+      hasActiveTeammates: vi.fn(() => active),
+      allRemainingStalled: vi.fn(() => false),
+      abortStalledTeammates: vi.fn(),
+      buildTeamStatusSummary: vi.fn(() => 'team status'),
+      waitForTeammateActivity,
+      drainLeaderInbox: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TeamManager;
+    return {
+      manager,
+      waitForTeammateActivity,
+      setActive(value: boolean) {
+        active = value;
+      },
+      deliver(message: string) {
+        leaderMessageCallback?.(message, message);
+      },
+    };
   }
 
   it('should process input and write text output', async () => {
@@ -1996,13 +2033,15 @@ describe('runNonInteractive', () => {
       selection: { id: 'vision-agent', agentCapable: true },
       route,
     });
+    const team = createMockTeamManager();
+    vi.mocked(mockConfig.getTeamManager).mockReturnValue(team.manager);
     mockCoreExecuteToolCall.mockResolvedValue({
       responseParts: [{ text: 'tool result' }],
     });
     mockGeminiClient.sendMessageStream
       .mockReturnValueOnce(
-        createStreamFromEvents([
-          {
+        (async function* () {
+          yield {
             type: GeminiEventType.ToolCallRequest,
             value: {
               callId: 'tool-vision',
@@ -2011,8 +2050,9 @@ describe('runNonInteractive', () => {
               isClientInitiated: false,
               prompt_id: 'prompt-vision-route',
             },
-          },
-        ]),
+          } satisfies ServerGeminiStreamEvent;
+          team.deliver('teammate result');
+        })(),
       )
       .mockReturnValueOnce(
         createStreamFromEvents([
@@ -2047,17 +2087,89 @@ describe('runNonInteractive', () => {
     );
     expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
       2,
-      [{ text: 'tool result' }],
+      [{ text: 'tool result' }, { text: 'teammate result' }],
       expect.any(AbortSignal),
       'prompt-vision-route',
       expect.objectContaining({
-        type: SendMessageType.ToolResult,
+        type: SendMessageType.Teammate,
         modelRoute: route,
+        continuesToolTurn: true,
       }),
     );
     expect(visionRouteMocks.runWithRuntime).toHaveBeenCalledWith(
       route,
       expect.any(Function),
+    );
+  });
+
+  it('returns a standalone teammate message to the primary after a routed image turn', async () => {
+    setupMetricsMock();
+    const imagePart: Part = {
+      inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' },
+    };
+    const route = {
+      model: 'vision-agent',
+      contentGenerator: {},
+      contentGeneratorConfig: { model: 'vision-agent' },
+    };
+    const { handleAtCommand } = await import(
+      './ui/hooks/atCommandProcessor.js'
+    );
+    vi.mocked(handleAtCommand).mockResolvedValue({
+      processedQuery: [{ text: 'inspect this' }, imagePart],
+      shouldProceed: true,
+    });
+    vi.mocked(mockConfig.getDefaultVisionBridgeModel).mockReturnValue({
+      id: 'vision-agent',
+      agentCapable: true,
+    });
+    visionRouteMocks.resolve.mockResolvedValue({
+      status: 'ready',
+      selection: { id: 'vision-agent', agentCapable: true },
+      route,
+    });
+    const team = createMockTeamManager(true);
+    vi.mocked(mockConfig.getTeamManager).mockReturnValue(team.manager);
+    team.waitForTeammateActivity.mockImplementation(async () => {
+      team.deliver('independent teammate update');
+      team.setActive(false);
+      return 'message';
+    });
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'image turn done' },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'primary handled update' },
+        ]),
+      );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'inspect @image.png',
+      'prompt-vision-teammate',
+    );
+
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
+      1,
+      [{ text: 'inspect this' }, imagePart],
+      expect.any(AbortSignal),
+      'prompt-vision-teammate',
+      expect.objectContaining({
+        type: SendMessageType.UserQuery,
+        modelRoute: route,
+      }),
+    );
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
+      2,
+      [{ text: 'independent teammate update' }],
+      expect.any(AbortSignal),
+      'prompt-vision-teammate',
+      expect.not.objectContaining({ modelRoute: expect.anything() }),
     );
   });
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -1602,6 +1602,7 @@ export async function runNonInteractive(
         // initial query — early teammate messages will be picked
         // up on the next iteration.
         let isTeammateTurn = false;
+        let teammateContinuesToolTurn = false;
         if (!isFirstTurn && pendingTeammateMessages.length > 0) {
           const batch = pendingTeammateMessages.splice(0);
           const teammatePart = { text: batch.join('\n\n') };
@@ -1610,18 +1611,10 @@ export async function runNonInteractive(
               ...(currentMessages[0].parts || []),
               teammatePart,
             ];
+            teammateContinuesToolTurn = true;
           } else {
             currentMessages = [{ role: 'user', parts: [teammatePart] }];
           }
-          // Treat BOTH the standalone and the merged-into-tool-response
-          // cases as a teammate turn. Teammate text is fresh external
-          // input, so the loop detector must reset — otherwise a leader
-          // that polls task_list while teammate messages keep merging
-          // into its tool-response turns climbs the identical-tool-call
-          // counter and trips a false LoopDetected. The Teammate send
-          // path prepends nothing to the request, so a merged turn's
-          // leading functionResponse parts stay paired with their
-          // functionCall.
           isTeammateTurn = true;
         }
         hasUnsentToolResponse = false;
@@ -1657,6 +1650,7 @@ export async function runNonInteractive(
             type: sendType,
             modelOverride,
             ...(modelRoute && { modelRoute }),
+            ...(teammateContinuesToolTurn && { continuesToolTurn: true }),
             ...(isFirstTurn &&
               options.notificationDisplayText && {
                 notificationDisplayText: options.notificationDisplayText,
@@ -1773,6 +1767,11 @@ export async function runNonInteractive(
           currentMessages = [{ role: 'user', parts: toolResponseParts }];
           hasUnsentToolResponse = true;
         } else {
+          // Core settles an exact route once the response has no pending
+          // tools. Do not carry the wrapper's stale copy into an independent
+          // teammate turn.
+          modelRoute = undefined;
+
           // No more tool calls — check if teammates are active.
           const teamManager = config.getTeamManager();
           if (teamManager?.hasActiveTeammates()) {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -10,6 +10,7 @@ import type {
   Config,
   CronJob,
   CronScheduler,
+  FullTurnModelRoute,
   ToolCallRequestInfo,
   ToolCallResponseInfo,
 } from '@qwen-code/qwen-code-core';
@@ -46,6 +47,15 @@ import {
   canonicalToolName,
   parsePositiveIntegerEnv,
   partitionByConcurrencySafety,
+  formatFullTurnVisionFailureNotice,
+  formatFullTurnVisionNotice,
+  formatVisionBridgeNotice,
+  hasImageParts,
+  resolveFullTurnVisionRoute,
+  runVisionBridge,
+  runWithRuntimeContentGenerator,
+  shouldRunVisionBridge,
+  splitImageParts,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -603,6 +613,7 @@ export async function runNonInteractive(
     // First-turn SendMessageType override for continuation turns; null means
     // the regular options.sendMessageType / UserQuery selection applies.
     let continueSendType: SendMessageType | null = null;
+    let restoredContinuationRoute: FullTurnModelRoute | undefined;
 
     try {
       process.stdout.on('error', stdoutErrorHandler);
@@ -662,7 +673,32 @@ export async function runNonInteractive(
           return 0;
         }
 
-        initialPartList = recoveryPlan.continuation.parts;
+        const chat = geminiClient.getChat();
+        const pendingRouteIdentity = chat.getPendingFullTurnRouteIdentity?.();
+        restoredContinuationRoute = chat.getPendingFullTurnRoute?.();
+        if (pendingRouteIdentity && !restoredContinuationRoute) {
+          throw new FatalInputError(
+            `Cannot safely continue the interrupted image turn because its exact route (${pendingRouteIdentity.model}) is unavailable.`,
+          );
+        }
+        const sourceHasImages = recoveryPlan.continuation.sourceHistory.some(
+          (content) => hasImageParts(content.parts ?? []),
+        );
+        if (
+          !pendingRouteIdentity &&
+          sourceHasImages &&
+          config.getEffectiveInputModalities?.().image !== true
+        ) {
+          throw new FatalInputError(
+            'Cannot safely continue an interrupted image turn without its original exact route identity.',
+          );
+        }
+        initialPartList = restoredContinuationRoute
+          ? chat.prepareHistoricalMediaForContinuation(
+              recoveryPlan.continuation.parts,
+              recoveryPlan.continuation.sourceHistory,
+            )
+          : recoveryPlan.continuation.parts;
         if (recoveryPlan.continuation.mode === 'retry_user_parts') {
           continueSendType = SendMessageType.Retry;
         } else {
@@ -837,6 +873,66 @@ export async function runNonInteractive(
         }
       }
 
+      let modelRoute = restoredContinuationRoute;
+      const initialPromptHasImages = hasImageParts(initialPartList);
+      if (
+        !modelRoute &&
+        initialPromptHasImages &&
+        shouldRunVisionBridge(config)
+      ) {
+        const routeResult = await resolveFullTurnVisionRoute(config);
+        if (routeResult.status === 'ready') {
+          modelRoute = routeResult.route;
+          const notice = formatFullTurnVisionNotice(routeResult.selection);
+          if (outputFormat === OutputFormat.TEXT) {
+            process.stderr.write(`${notice}\n`);
+          } else {
+            adapter.emitSystemMessage('full_turn_vision_route', { notice });
+          }
+        } else if (routeResult.status === 'failed') {
+          const message = formatFullTurnVisionFailureNotice(
+            routeResult.selection,
+          );
+          if (outputFormat !== OutputFormat.TEXT) {
+            adapter.emitSystemMessage('full_turn_vision_route_failed', {
+              message,
+            });
+          }
+          throw new FatalInputError(message);
+        } else {
+          const originalParts = initialPartList;
+          try {
+            const bridgeResult = await runVisionBridge({
+              config,
+              parts: originalParts,
+              signal: abortController.signal,
+            });
+            if (
+              bridgeResult.status !== 'skipped' ||
+              bridgeResult.egressOccurred
+            ) {
+              const notice = formatVisionBridgeNotice(bridgeResult);
+              if (outputFormat === OutputFormat.TEXT) {
+                process.stderr.write(`${notice}\n`);
+              } else {
+                adapter.emitSystemMessage('vision_bridge', { notice });
+              }
+            }
+            initialPartList =
+              bridgeResult.applied && bridgeResult.parts != null
+                ? bridgeResult.parts
+                : splitImageParts(originalParts).nonImageParts;
+          } catch (error) {
+            debugLogger.warn(
+              `vision bridge failed before image replacement: ${String(
+                error instanceof Error ? error.message : error,
+              )}`,
+            );
+            initialPartList = splitImageParts(originalParts).nonImageParts;
+          }
+        }
+      }
+
       const initialParts = normalizePartList(initialPartList);
       let currentMessages: Content[] = [{ role: 'user', parts: initialParts }];
 
@@ -952,6 +1048,16 @@ export async function runNonInteractive(
       let loopDetected = false;
       let loopDetectedMessage = formatLoopDetectedMessage(undefined);
 
+      const settleFullTurnRoute = () => {
+        if (!modelRoute) return;
+        const chat = geminiClient.getChat();
+        const changed = chat.replaceHistoricalMediaWithReferences();
+        if (changed || chat.getPendingFullTurnRouteIdentity?.()) {
+          config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+        }
+        chat.clearPendingFullTurnRoute?.();
+      };
+
       // Shared terminal block for the structured-output success
       // contract. Both the main-turn loop and the drain-turn post-loop
       // previously reproduced this block verbatim
@@ -963,6 +1069,7 @@ export async function runNonInteractive(
       // no-op), so unconditional invocation is safe even when the drain
       // path already finalized monitors before reaching here.
       const emitStructuredSuccess = async (): Promise<0> => {
+        settleFullTurnRoute();
         registry.abortAll();
         // `abortAll()` marks each task `cancelled` synchronously, but
         // the matching `task_notification` is emitted later by the
@@ -999,6 +1106,7 @@ export async function runNonInteractive(
       };
 
       const emitLoopDetectedResult = async (): Promise<1> => {
+        settleFullTurnRoute();
         registry.abortAll();
         flushQueuedNotificationsToSdk(localQueue);
         finalizeOneShotMonitors();
@@ -1061,6 +1169,7 @@ export async function runNonInteractive(
       const processToolCallBatch = async (
         batchRequests: ToolCallRequestInfo[],
         setModelOverride: (override: string | undefined) => void,
+        toolRoute?: FullTurnModelRoute,
       ): Promise<ToolCallBatchResult> => {
         const toolResponseParts: Part[] = [];
         const structuredOutputActive =
@@ -1249,17 +1358,16 @@ export async function runNonInteractive(
               )
             : createToolProgressHandler(requestInfo, adapter);
 
-          const response = await executeToolCall(
-            config,
-            requestInfo,
-            abortController.signal,
-            {
+          const execute = () =>
+            executeToolCall(config, requestInfo, abortController.signal, {
               outputUpdateHandler,
               ...(toolCallUpdateCallback && {
                 onToolCallsUpdate: toolCallUpdateCallback,
               }),
-            },
-          );
+            });
+          const response = toolRoute
+            ? await runWithRuntimeContentGenerator(toolRoute, execute)
+            : await execute();
           debugLogger.debug(
             `[runNonInteractive] tool call ${requestInfo.callId} (${requestInfo.name}) settled${
               response.error ? ' with error' : ''
@@ -1548,6 +1656,7 @@ export async function runNonInteractive(
           {
             type: sendType,
             modelOverride,
+            ...(modelRoute && { modelRoute }),
             ...(isFirstTurn &&
               options.notificationDisplayText && {
                 notificationDisplayText: options.notificationDisplayText,
@@ -1633,11 +1742,15 @@ export async function runNonInteractive(
           const {
             responseParts: toolResponseParts,
             repeatedDuplicateProviderToolCall,
-          } = await processToolCallBatch(toolCallRequests, (override) => {
-            if (!inlineModelOverrideActive) {
-              modelOverride = override;
-            }
-          });
+          } = await processToolCallBatch(
+            toolCallRequests,
+            (override) => {
+              if (!inlineModelOverrideActive && !modelRoute) {
+                modelOverride = override;
+              }
+            },
+            modelRoute,
+          );
 
           if (structuredSubmission !== undefined) {
             // Single-shot terminal contract; aborts in-flight background

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -188,6 +188,7 @@ describe('AppContainer State Management', () => {
   let mockConfig: Config;
   let mockSettings: LoadedSettings;
   let mockInitResult: InitializationResult;
+  let mockClearRetryState: Mock;
 
   // Create typed mocks for all hooks
   const mockedUseHistory = useHistory as Mock;
@@ -302,6 +303,7 @@ describe('AppContainer State Management', () => {
       shellConfirmationRequest: null,
       confirmationRequest: null,
     });
+    mockClearRetryState = vi.fn();
     mockedUseGeminiStream.mockReturnValue({
       streamingState: 'idle',
       submitQuery: vi.fn(),
@@ -310,6 +312,7 @@ describe('AppContainer State Management', () => {
       thought: null,
       cancelOngoingRequest: vi.fn(),
       retryLastPrompt: vi.fn(),
+      clearRetryState: mockClearRetryState,
       streamingResponseLengthRef: { current: 0 },
       isReceivingContent: false,
     });
@@ -560,6 +563,7 @@ describe('AppContainer State Management', () => {
       rewind,
       getHistoryShallow,
       truncateHistory,
+      clearRetryState: mockClearRetryState,
       rewindRecording,
       snapshots,
     };
@@ -3998,6 +4002,7 @@ describe('AppContainer State Management', () => {
 
       expect(harness.rewind).toHaveBeenCalledWith('prompt-2', true);
       expect(harness.truncateHistory).toHaveBeenCalledWith(2);
+      expect(harness.clearRetryState).toHaveBeenCalledOnce();
       expect(harness.loadHistory).toHaveBeenCalledWith([
         rewindUserItem(1, 'first prompt', 'prompt-1'),
         { id: 2, type: 'gemini', text: 'first response' },

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1868,6 +1868,7 @@ export const AppContainer = (props: AppContainerProps) => {
     thought,
     cancelOngoingRequest,
     retryLastPrompt,
+    clearRetryState,
     handleApprovalModeChange,
     activePtyId,
     loopDetectionConfirmationRequest,
@@ -3241,6 +3242,7 @@ export const AppContainer = (props: AppContainerProps) => {
           }
 
           geminiClient.truncateHistory(apiTruncateIndex);
+          clearRetryState();
 
           // Strip suppressOnRestore flags and filter out collapse-summary items
           // so rewound items remain visible without stale summary text
@@ -3316,7 +3318,7 @@ export const AppContainer = (props: AppContainerProps) => {
         setIsRewindSelectorOpen(false);
       }
     },
-    [config, historyManager, refreshStatic, buffer],
+    [config, historyManager, refreshStatic, buffer, clearRetryState],
   );
 
   const handleDoubleEscRewind = useDoublePress(openRewindSelector, (pending) =>

--- a/packages/cli/src/ui/commands/arenaCommand.ts
+++ b/packages/cli/src/ui/commands/arenaCommand.ts
@@ -21,6 +21,7 @@ import {
   ArenaSessionStatus,
   AuthType,
   createDebugLogger,
+  slimCompactionInput,
   stripStartupContext,
   type Config,
   type ArenaModelConfig,
@@ -195,7 +196,9 @@ function executeArenaCommand(
   let chatHistory;
   try {
     const fullHistory = config.getGeminiClient().getChat().getHistoryShallow();
-    chatHistory = stripStartupContext(fullHistory);
+    chatHistory = slimCompactionInput(
+      stripStartupContext(fullHistory),
+    ).slimmedHistory;
   } catch {
     debugLogger.debug('Could not retrieve chat history for arena agents');
   }

--- a/packages/cli/src/ui/commands/restoreCommand.test.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.test.ts
@@ -202,6 +202,37 @@ describe('restoreCommand', () => {
       expect(mockSetHistory).not.toHaveBeenCalled();
       expect(mockRewind).not.toHaveBeenCalled();
     });
+
+    it('restores media preserved by a native multimodal checkpoint', async () => {
+      const toolCallData = {
+        clientHistory: [
+          {
+            role: 'user',
+            parts: [
+              { text: 'inspect this' },
+              {
+                inlineData: {
+                  mimeType: 'image/png',
+                  data: 'private-checkpoint-image',
+                },
+              },
+            ],
+          },
+        ],
+        toolCall: { name: 'run_shell_command', args: 'ls' },
+      };
+      await fs.writeFile(
+        path.join(checkpointsDir, 'legacy-image.json'),
+        JSON.stringify(toolCallData),
+      );
+
+      await restoreCommand(mockConfig)?.action?.(mockContext, 'legacy-image');
+
+      expect(mockSetHistory).toHaveBeenCalledOnce();
+      expect(JSON.stringify(mockSetHistory.mock.calls[0]?.[0])).toContain(
+        'private-checkpoint-image',
+      );
+    });
   });
 
   it('should reject legacy checkpoint format with commitHash', async () => {

--- a/packages/cli/src/ui/commands/restoreCommand.ts
+++ b/packages/cli/src/ui/commands/restoreCommand.ts
@@ -148,7 +148,9 @@ async function restoreAction(
     }
 
     if (toolCallData.clientHistory) {
-      await config?.getGeminiClient()?.setHistory(toolCallData.clientHistory);
+      await config
+        ?.getGeminiClient()
+        ?.setHistory(toolCallData.clientHistory);
     }
 
     return {

--- a/packages/cli/src/ui/commands/summaryCommand.ts
+++ b/packages/cli/src/ui/commands/summaryCommand.ts
@@ -14,6 +14,7 @@ import {
 import {
   getProjectSummaryPrompt,
   runSideQuery,
+  slimCompactionInput,
 } from '@qwen-code/qwen-code-core';
 import type { HistoryItemSummary } from '../types.js';
 import { t } from '../../i18n/index.js';
@@ -87,10 +88,7 @@ export const summaryCommand: SlashCommand = {
       history: ReturnType<typeof getChatHistory>,
     ): Promise<string> => {
       // Build the conversation context for summary generation
-      const conversationContext = history.map((message) => ({
-        role: message.role,
-        parts: message.parts,
-      }));
+      const conversationContext = slimCompactionInput(history).slimmedHistory;
 
       // Carry over the main session's system instruction. Without this the
       // model sees only chat history + the summary prompt, losing the coding-

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -578,6 +578,54 @@ describe('useGeminiStream', () => {
       );
     });
 
+    it('clears the routed retry snapshot after a conversation rewind', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield* [];
+          throw new Error('vision route failed');
+        })(),
+      );
+
+      const { result } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('@img.png describe');
+      });
+      await waitFor(() =>
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(1),
+      );
+
+      act(() => {
+        result.current.clearRetryState();
+      });
+      await act(async () => {
+        await result.current.retryLastPrompt();
+      });
+
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'No failed request to retry.',
+        }),
+        expect.any(Number),
+      );
+    });
+
     it('schedules tools with the active full-turn route', async () => {
       enableBridge();
       const route = {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -23,6 +23,7 @@ import type {
   EditorType,
   GeminiClient,
   AnyToolInvocation,
+  FullTurnModelRoute,
 } from '@qwen-code/qwen-code-core';
 import {
   ApprovalMode,
@@ -46,6 +47,7 @@ const mockSendMessageStream = vi
   .mockReturnValue((async function* () {})());
 const mockStartChat = vi.fn();
 const mockRunVisionBridge = vi.hoisted(() => vi.fn());
+const mockResolveFullTurnVisionRoute = vi.hoisted(() => vi.fn());
 
 const MockedGeminiClientClass = vi.hoisted(() =>
   vi.fn().mockImplementation(function (this: any, _config: any) {
@@ -53,6 +55,9 @@ const MockedGeminiClientClass = vi.hoisted(() =>
     this.startChat = mockStartChat;
     this.sendMessageStream = mockSendMessageStream;
     this.addHistory = vi.fn();
+    this.getChat = vi.fn().mockReturnValue({
+      replaceHistoricalMediaWithReferences: vi.fn(),
+    });
     this.consumePendingMemoryTaskPromises = vi.fn().mockReturnValue([]);
     this.recordCompletedToolCall = vi.fn();
     // Default to the fast-path accessor returning an empty Set so the
@@ -110,6 +115,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     setActiveGoal: mockSetActiveGoal,
     clearActiveGoal: mockClearActiveGoal,
     runVisionBridge: mockRunVisionBridge,
+    resolveFullTurnVisionRoute: mockResolveFullTurnVisionRoute,
     refreshMemoryAfterManagedWrite: mockRefreshMemoryAfterManagedWrite,
   };
 });
@@ -283,6 +289,9 @@ describe('useGeminiStream', () => {
       .mockReturnValue((async function* () {})());
     handleAtCommandSpy = vi.spyOn(atCommandProcessor, 'handleAtCommand');
     mockRunVisionBridge.mockReset();
+    mockResolveFullTurnVisionRoute
+      .mockReset()
+      .mockResolvedValue({ status: 'not-eligible' });
   });
 
   afterEach(() => {
@@ -451,7 +460,7 @@ describe('useGeminiStream', () => {
         modelId: 'vm',
         egressOccurred: true,
       });
-      const { result, mockSendMessageStream } = renderTestHook();
+      const { result } = renderTestHook();
       await act(async () => {
         await result.current.submitQuery('@img.png describe');
       });
@@ -486,6 +495,406 @@ describe('useGeminiStream', () => {
       );
       expect(String(visionNotice?.[0]?.text)).not.toContain(
         '[transcribed image]',
+      );
+    });
+
+    it('keeps an exact full-turn route for retry, then clears it on the next user turn', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: {
+          id: 'vision-agent',
+          baseUrl: 'https://vision.example.com/v1',
+          agentCapable: true,
+        },
+      });
+      mockSendMessageStream
+        .mockReturnValueOnce(
+          (async function* () {
+            yield* [];
+            throw new Error('vision route failed');
+          })(),
+        )
+        .mockReturnValueOnce((async function* () {})())
+        .mockReturnValueOnce((async function* () {})());
+
+      const { result } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('@img.png describe');
+      });
+      await waitFor(() =>
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(1),
+      );
+
+      expect(mockRunVisionBridge).not.toHaveBeenCalled();
+      expect(
+        JSON.stringify(mockSendMessageStream.mock.calls[0]?.[0]),
+      ).toContain('inlineData');
+      expect(mockSendMessageStream.mock.calls[0]?.[3]).toEqual(
+        expect.objectContaining({ modelRoute: route }),
+      );
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.VISION_NOTICE,
+          text: expect.stringContaining('current image turn'),
+        }),
+        expect.any(Number),
+      );
+
+      mockHandleSlashCommand.mockResolvedValueOnce({ type: 'handled' });
+      await act(async () => {
+        await result.current.submitQuery('/help');
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await result.current.retryLastPrompt();
+      });
+      expect(mockSendMessageStream.mock.calls[1]?.[3]).toEqual(
+        expect.objectContaining({ modelRoute: route }),
+      );
+
+      handleAtCommandSpy.mockResolvedValue({
+        processedQuery: [{ text: 'next text turn' }],
+        shouldProceed: true,
+      } as unknown as Awaited<
+        ReturnType<typeof atCommandProcessor.handleAtCommand>
+      >);
+      await act(async () => {
+        await result.current.submitQuery('next text turn');
+      });
+      expect(mockSendMessageStream.mock.calls[2]?.[3]).not.toHaveProperty(
+        'modelRoute',
+      );
+    });
+
+    it('schedules tools with the active full-turn route', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: { model: 'vision-agent' },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'route-tool',
+              name: 'read_file',
+              args: { path: '/tmp/file' },
+              isClientInitiated: false,
+              prompt_id: 'route-prompt',
+            },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('@img.png inspect');
+      });
+
+      expect(mockScheduleToolCalls).toHaveBeenCalledWith(
+        [expect.objectContaining({ callId: 'route-tool' })],
+        expect.any(AbortSignal),
+        route,
+      );
+    });
+
+    it('keeps mid-turn images on the active full-turn route', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: { model: 'vision-agent' },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockSendMessageStream
+        .mockReturnValueOnce(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'route-tool',
+                name: 'read_file',
+                args: { path: '/tmp/file' },
+                isClientInitiated: false,
+                prompt_id: 'route-prompt',
+              },
+            };
+          })(),
+        )
+        .mockReturnValueOnce((async function* () {})());
+      const midTurnImage: Part = {
+        inlineData: { mimeType: 'image/png', data: 'mid-turn-image' },
+      };
+      const resolveAtCommandQuerySpy = vi
+        .spyOn(atCommandProcessor, 'resolveAtCommandQuery')
+        .mockResolvedValue({
+          processedQuery: [{ text: 'inspect second image' }, midTurnImage],
+          shouldProceed: true,
+        });
+      const midTurnDrainRef = {
+        current: vi.fn().mockReturnValue(['inspect @/tmp/second.png']),
+      };
+      let completeTools:
+        | ((tools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      mockUseReactToolScheduler.mockImplementation((onComplete) => {
+        completeTools = onComplete;
+        return [
+          [],
+          mockScheduleToolCalls,
+          mockCancelAllToolCalls,
+          mockMarkToolsAsSubmitted,
+        ];
+      });
+      const client = new MockedGeminiClientClass(mockConfig);
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          client,
+          [],
+          mockAddItem,
+          mockConfig,
+          true,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+          midTurnDrainRef,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('@img.png inspect');
+      });
+      await act(async () => {
+        await completeTools?.([
+          {
+            request: {
+              callId: 'route-tool',
+              name: 'read_file',
+              args: { path: '/tmp/file' },
+              isClientInitiated: false,
+              prompt_id: 'route-prompt',
+            },
+            status: 'success',
+            response: {
+              callId: 'route-tool',
+              responseParts: [
+                {
+                  functionResponse: {
+                    id: 'route-tool',
+                    name: 'read_file',
+                    response: { output: 'ok' },
+                  },
+                },
+              ],
+              errorType: undefined,
+            },
+            responseSubmittedToGemini: false,
+            tool: { displayName: 'Read File' },
+            invocation: {
+              getDescription: () => 'Read file',
+            } as unknown as AnyToolInvocation,
+          } as TrackedCompletedToolCall,
+        ]);
+      });
+
+      expect(mockRunVisionBridge).not.toHaveBeenCalled();
+      expect(mockResolveFullTurnVisionRoute).toHaveBeenCalledOnce();
+      expect(resolveAtCommandQuerySpy).toHaveBeenCalledOnce();
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+      expect(mockSendMessageStream.mock.calls[1]?.[0]).toEqual(
+        expect.arrayContaining([midTurnImage]),
+      );
+      expect(mockSendMessageStream.mock.calls[1]?.[3]).toEqual(
+        expect.objectContaining({ modelRoute: route }),
+      );
+    });
+
+    it('scrubs routed media when every pending tool is cancelled', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: { model: 'vision-agent' },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'route-tool',
+              name: 'read_file',
+              args: { path: '/tmp/file' },
+              isClientInitiated: false,
+              prompt_id: 'route-prompt',
+            },
+          };
+        })(),
+      );
+      let completedTools:
+        | ((tools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      mockUseReactToolScheduler.mockImplementation((onComplete) => {
+        completedTools = onComplete;
+        return [
+          [],
+          mockScheduleToolCalls,
+          mockCancelAllToolCalls,
+          mockMarkToolsAsSubmitted,
+        ];
+      });
+      const client = new MockedGeminiClientClass(mockConfig);
+      const replaceHistoricalMediaWithReferences = client.getChat()
+        .replaceHistoricalMediaWithReferences as Mock;
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          client,
+          [],
+          mockAddItem,
+          mockConfig,
+          true,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('@img.png inspect');
+      });
+      await act(async () => {
+        await completedTools?.([
+          {
+            request: {
+              callId: 'route-tool',
+              name: 'read_file',
+              args: { path: '/tmp/file' },
+              isClientInitiated: false,
+              prompt_id: 'route-prompt',
+            },
+            status: 'cancelled',
+            response: {
+              callId: 'route-tool',
+              responseParts: [{ text: 'cancelled' }],
+              errorType: undefined,
+            },
+            responseSubmittedToGemini: false,
+            tool: { displayName: 'Read File' },
+            invocation: {
+              getDescription: () => 'Read file',
+            } as unknown as AnyToolInvocation,
+          } as TrackedCancelledToolCall,
+        ]);
+      });
+
+      expect(replaceHistoricalMediaWithReferences).toHaveBeenCalledOnce();
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes image content produced by a slash command through the full-turn gate', async () => {
+      enableBridge();
+      const route = {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          modalities: { image: true },
+        },
+      } as FullTurnModelRoute;
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'ready',
+        route,
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+      mockHandleSlashCommand.mockResolvedValueOnce({
+        type: 'submit_prompt',
+        content: [{ text: 'inspect' }, imagePart],
+      });
+
+      const { result } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('/inspect-image');
+      });
+
+      expect(mockRunVisionBridge).not.toHaveBeenCalled();
+      expect(mockSendMessageStream.mock.calls[0]?.[0]).toEqual([
+        { text: 'inspect' },
+        imagePart,
+      ]);
+      expect(mockSendMessageStream.mock.calls[0]?.[3]).toEqual(
+        expect.objectContaining({ modelRoute: route }),
+      );
+    });
+
+    it('stops before sending when an eligible exact route cannot resolve', async () => {
+      enableBridge();
+      mockResolveFullTurnVisionRoute.mockResolvedValue({
+        status: 'failed',
+        selection: { id: 'vision-agent', agentCapable: true },
+      });
+
+      const { result, mockSendMessageStream } = renderTestHook();
+      await act(async () => {
+        await result.current.submitQuery('@img.png describe');
+      });
+
+      expect(mockRunVisionBridge).not.toHaveBeenCalled();
+      expect(mockSendMessageStream).not.toHaveBeenCalled();
+      expect(mockAddItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.ERROR,
+          text: expect.stringContaining('not sent to the primary model'),
+        }),
+        expect.any(Number),
       );
     });
 
@@ -1206,6 +1615,15 @@ describe('useGeminiStream', () => {
         recordMidTurnUserMessage: vi.fn(),
       })),
     });
+    mockResolveFullTurnVisionRoute.mockResolvedValue({
+      status: 'ready',
+      route: {
+        model: 'vision-agent',
+        contentGenerator: {},
+        contentGeneratorConfig: { model: 'vision-agent' },
+      },
+      selection: { id: 'vision-agent', agentCapable: true },
+    });
     mockRunVisionBridge.mockResolvedValue({
       applied: true,
       status: 'ok',
@@ -1320,6 +1738,7 @@ describe('useGeminiStream', () => {
       parts: [resolvedTextPart, resolvedImagePart],
       signal: expect.any(AbortSignal),
     });
+    expect(mockResolveFullTurnVisionRoute).not.toHaveBeenCalled();
     expect(mockAddItem).toHaveBeenCalledWith(
       expect.objectContaining({
         type: MessageType.VISION_NOTICE,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2814,6 +2814,14 @@ export const useGeminiStream = (
     await submitQuery(lastPrompt, SendMessageType.Retry);
   }, [streamingState, addItem, clearRetryCountdown, submitQuery]);
 
+  const clearRetryState = useCallback(() => {
+    clearRetryCountdown();
+    lastPromptRef.current = null;
+    lastPromptModelRouteRef.current = undefined;
+    lastPromptErroredRef.current = false;
+    modelRouteRef.current = undefined;
+  }, [clearRetryCountdown]);
+
   const handleApprovalModeChange = useCallback(
     async (newApprovalMode: ApprovalMode) => {
       // Auto-approve pending tool calls when switching to auto-approval modes
@@ -3825,6 +3833,7 @@ export const useGeminiStream = (
     thought,
     cancelOngoingRequest,
     retryLastPrompt,
+    clearRetryState,
     pendingToolCalls: toolCalls,
     handleApprovalModeChange,
     activePtyId,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -27,6 +27,7 @@ import {
   type GeminiErrorEventValue,
   type StopFailureErrorType,
   type ActiveGoal,
+  type FullTurnModelRoute,
   GeminiEventType as ServerGeminiEventType,
   SendMessageType,
   createDebugLogger,
@@ -53,6 +54,9 @@ import {
   runVisionBridge,
   shouldRunVisionBridge,
   formatVisionBridgeNotice,
+  formatFullTurnVisionNotice,
+  formatFullTurnVisionFailureNotice,
+  resolveFullTurnVisionRoute,
   hasImageParts,
   splitImageParts,
   generateToolUseSummary,
@@ -65,6 +69,7 @@ import {
   findRepeatedDuplicateProviderToolCall,
   AutonomousLoopTickResolver,
   refreshMemoryAfterManagedWrite,
+  slimCompactionInput,
 } from '@qwen-code/qwen-code-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -451,6 +456,9 @@ export const useGeminiStream = (
   const turnCancelledRef = useRef(false);
   const isSubmittingQueryRef = useRef(false);
   const lastPromptRef = useRef<PartListUnion | null>(null);
+  const lastPromptModelRouteRef = useRef<FullTurnModelRoute | undefined>(
+    undefined,
+  );
   // Records the USER history item that THIS turn's prepareQueryForGemini
   // added (if any). Reset to null at the start of every turn (including
   // Retry, which bypasses prepareQueryForGemini). Cron / Notification /
@@ -532,6 +540,7 @@ export const useGeminiStream = (
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
   const submitPromptOnCompleteRef = useRef<(() => Promise<void>) | null>(null);
   const modelOverrideRef = useRef<string | undefined>(undefined);
+  const modelRouteRef = useRef<FullTurnModelRoute | undefined>(undefined);
   // True when the current turn's model override came from an explicit inline
   // `/model <id> <prompt>`. Skill-tool overrides must not clobber a user's
   // explicit choice mid-turn, so this takes precedence until the next user turn.
@@ -777,6 +786,21 @@ export const useGeminiStream = (
     }
   }, [streamingState, config, history]);
 
+  const replaceCompletedRoutedMedia = useCallback(
+    (persist = true) => {
+      if (!modelRouteRef.current) return;
+      const chat = geminiClient.getChat();
+      const changed = chat.replaceHistoricalMediaWithReferences();
+      if (persist) {
+        if (changed || chat.getPendingFullTurnRouteIdentity?.()) {
+          config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+        }
+        chat.clearPendingFullTurnRoute?.();
+      }
+    },
+    [config, geminiClient],
+  );
+
   const cancelOngoingRequest = useCallback(() => {
     if (streamingState !== StreamingState.Responding) {
       return;
@@ -804,6 +828,12 @@ export const useGeminiStream = (
     turnCancelledRef.current = true;
     isSubmittingQueryRef.current = false;
     abortControllerRef.current?.abort();
+    // During an active model request GeminiClient's abort cleanup owns this
+    // boundary. Once it has yielded tool calls, no generator remains to remove
+    // the route-scoped media when the user cancels the tool phase.
+    if (activeModelStreamsRef.current === 0) {
+      replaceCompletedRoutedMedia(false);
+    }
     // Aborting a tick-in-flight ends any self-paced /loop: drop pending loop
     // wakeups so the loop doesn't resume after the cancelled tick. Only clears
     // session wakeups (never cron jobs); lazily-creating an empty scheduler
@@ -889,6 +919,7 @@ export const useGeminiStream = (
     pendingHistoryItemRef,
     setShellInputFocused,
     clearRetryCountdown,
+    replaceCompletedRoutedMedia,
     config,
     getPromptCount,
   ]);
@@ -898,16 +929,49 @@ export const useGeminiStream = (
       parts: PartListUnion | null,
       timestamp: number,
       signal: AbortSignal,
+      allowFullTurnRoute = true,
     ): Promise<{ parts: PartListUnion | null; shouldProceed: boolean }> => {
-      if (
-        parts === null ||
-        !hasImageParts(parts) ||
-        !shouldRunVisionBridge(config)
-      ) {
+      if (parts === null || !hasImageParts(parts)) {
+        return { parts, shouldProceed: true };
+      }
+
+      // A full-turn route is already locked for this logical turn. Preserve
+      // newly arriving media so the same exact model receives it with the
+      // next ToolResult instead of leaking it through a one-shot bridge.
+      if (modelRouteRef.current) {
+        return { parts, shouldProceed: true };
+      }
+
+      if (!shouldRunVisionBridge(config)) {
         return { parts, shouldProceed: true };
       }
 
       debugLogger.debug('vision bridge: gate matched, running conversion');
+      if (allowFullTurnRoute) {
+        const routeResult = await resolveFullTurnVisionRoute(config);
+        if (routeResult.status === 'ready') {
+          modelRouteRef.current = routeResult.route;
+          addItem(
+            {
+              type: MessageType.VISION_NOTICE,
+              text: formatFullTurnVisionNotice(routeResult.selection),
+            },
+            timestamp,
+          );
+          return { parts, shouldProceed: true };
+        }
+        if (routeResult.status === 'failed') {
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: formatFullTurnVisionFailureNotice(routeResult.selection),
+            },
+            timestamp,
+          );
+          return { parts: null, shouldProceed: false };
+        }
+      }
+
       const bridgeResult = await runVisionBridge({ config, parts, signal });
       debugLogger.debug(
         `vision bridge: status=${bridgeResult.status} applied=${bridgeResult.applied} model=${bridgeResult.modelId ?? '(none)'}`,
@@ -1021,7 +1085,15 @@ export const useGeminiStream = (
               return { queryToSend: null, shouldProceed: false };
             }
             case 'submit_prompt': {
-              localQueryToSendToGemini = slashCommandResult.content;
+              const bridgeResult = await applyVisionBridgeIfNeeded(
+                slashCommandResult.content,
+                userMessageTimestamp,
+                abortSignal,
+              );
+              if (!bridgeResult.shouldProceed) {
+                return { queryToSend: null, shouldProceed: false };
+              }
+              localQueryToSendToGemini = bridgeResult.parts;
               submitPromptOnCompleteRef.current =
                 slashCommandResult.onComplete ?? null;
               // Per-turn model override (e.g. inline `/model <id> <prompt>`).
@@ -2255,7 +2327,15 @@ export const useGeminiStream = (
         }
 
         if (executableToolCallRequests.length > 0) {
-          scheduleToolCalls(executableToolCallRequests, signal);
+          if (modelRouteRef.current) {
+            scheduleToolCalls(
+              executableToolCallRequests,
+              signal,
+              modelRouteRef.current,
+            );
+          } else {
+            scheduleToolCalls(executableToolCallRequests, signal);
+          }
         }
       }
       return StreamProcessingStatus.Completed;
@@ -2395,6 +2475,9 @@ export const useGeminiStream = (
           }
           clearModelOverride(modelOverrideRef, inlineModelOverrideActiveRef);
         }
+        if (submitType !== SendMessageType.Retry) {
+          modelRouteRef.current = undefined;
+        }
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn.
         // Clear both countdown-based errors AND static errors (those without
@@ -2463,7 +2546,11 @@ export const useGeminiStream = (
         }
 
         const finalQueryToSend = queryToSend;
-        lastPromptRef.current = finalQueryToSend;
+        // History owns and later scrubs nested functionResponse media in place.
+        // Keep retry input detached so a failed routed ToolResult can resend
+        // the original image bytes to the same exact route.
+        lastPromptRef.current = structuredClone(finalQueryToSend);
+        lastPromptModelRouteRef.current = modelRouteRef.current;
         lastPromptErroredRef.current = false;
 
         if (
@@ -2483,7 +2570,9 @@ export const useGeminiStream = (
                 prompt_id,
                 config.getContentGeneratorConfig()?.authType,
                 queryToSend,
-                modelOverrideRef.current ?? config.getModel(),
+                modelRouteRef.current?.model ??
+                  modelOverrideRef.current ??
+                  config.getModel(),
               ),
             );
           }
@@ -2533,6 +2622,9 @@ export const useGeminiStream = (
               type: submitType,
               notificationDisplayText: metadata?.notificationDisplayText,
               modelOverride: modelOverrideRef.current,
+              ...(modelRouteRef.current && {
+                modelRoute: modelRouteRef.current,
+              }),
             },
           );
 
@@ -2718,6 +2810,7 @@ export const useGeminiStream = (
 
     clearRetryCountdown();
 
+    modelRouteRef.current = lastPromptModelRouteRef.current;
     await submitQuery(lastPrompt, SendMessageType.Retry);
   }, [streamingState, addItem, clearRetryCountdown, submitQuery]);
 
@@ -2946,6 +3039,7 @@ export const useGeminiStream = (
         geminiTools.length === 0 &&
         pendingDuplicateResponseParts.length === 0
       ) {
+        replaceCompletedRoutedMedia();
         return;
       }
 
@@ -2956,6 +3050,7 @@ export const useGeminiStream = (
         markToolsAsSubmitted(
           geminiTools.map((toolCall) => toolCall.request.callId),
         );
+        replaceCompletedRoutedMedia(false);
         return;
       }
 
@@ -2984,6 +3079,7 @@ export const useGeminiStream = (
           (toolCall) => toolCall.request.callId,
         );
         markToolsAsSubmitted(callIdsToMarkAsSubmitted);
+        replaceCompletedRoutedMedia();
         return;
       }
 
@@ -3126,6 +3222,7 @@ export const useGeminiStream = (
 
       // Don't continue if model was switched due to quota error
       if (modelSwitchedFromQuotaError) {
+        replaceCompletedRoutedMedia(false);
         return;
       }
 
@@ -3228,6 +3325,7 @@ export const useGeminiStream = (
               resolvedMidTurnQuery,
               midTurnTimestamp + index,
               midTurnAbort.signal,
+              false,
             );
             if (!bridgeResult.shouldProceed) {
               if (midTurnAbort.signal.aborted) {
@@ -3271,6 +3369,7 @@ export const useGeminiStream = (
         turnCancelledRef.current ||
         abortControllerRef.current?.signal.aborted
       ) {
+        replaceCompletedRoutedMedia(false);
         return;
       }
 
@@ -3288,6 +3387,7 @@ export const useGeminiStream = (
       dualOutput,
       onDebugMessage,
       applyVisionBridgeIfNeeded,
+      replaceCompletedRoutedMedia,
     ],
   );
 
@@ -3359,7 +3459,11 @@ export const useGeminiStream = (
             const toolName = toolCall.request.name;
             const fileName = path.basename(filePath);
             const toolCallWithSnapshotFileName = `${timestamp}-${fileName}-${toolName}.json`;
-            const clientHistory = geminiClient?.getHistoryShallow();
+            const rawClientHistory = geminiClient?.getHistoryShallow();
+            const clientHistory =
+              rawClientHistory && modelRouteRef.current
+                ? slimCompactionInput(rawClientHistory).slimmedHistory
+                : rawClientHistory;
             const toolCallWithSnapshotFilePath = path.join(
               checkpointDir,
               toolCallWithSnapshotFileName,

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -19,6 +19,7 @@ import type {
   ToolCall,
   Status as CoreStatus,
   EditorType,
+  FullTurnModelRoute,
 } from '@qwen-code/qwen-code-core';
 import {
   CoreToolScheduler,
@@ -42,6 +43,7 @@ const debugLogger = createDebugLogger('REACT_TOOL_SCHEDULER');
 export type ScheduleFn = (
   request: ToolCallRequestInfo | ToolCallRequestInfo[],
   signal: AbortSignal,
+  modelRoute?: FullTurnModelRoute,
 ) => void;
 export type MarkToolsAsSubmittedFn = (callIds: string[]) => void;
 
@@ -217,8 +219,9 @@ export function useReactToolScheduler(
     (
       request: ToolCallRequestInfo | ToolCallRequestInfo[],
       signal: AbortSignal,
+      modelRoute?: FullTurnModelRoute,
     ) => {
-      void scheduler.schedule(request, signal);
+      void scheduler.schedule(request, signal, modelRoute);
     },
     [scheduler],
   );

--- a/packages/core/src/agents/runtime/agent-context.test.ts
+++ b/packages/core/src/agents/runtime/agent-context.test.ts
@@ -14,6 +14,7 @@ import {
   isTopLevelSession,
   runWithAgentContext,
   runWithRuntimeContentGenerator,
+  wrapAsyncGeneratorWithRuntimeContentGenerator,
   spawnBlockReason,
   type RuntimeContentGeneratorView,
 } from './agent-context.js';
@@ -139,6 +140,36 @@ describe('agent-context (runtimeView)', () => {
       return getRuntimeContentGenerator();
     });
     expect(outerAgain).toBe(outer);
+  });
+
+  it('restores the view for every async-generator step and cleanup', async () => {
+    const view = makeView('vision-route');
+    const seen: Array<RuntimeContentGeneratorView | undefined> = [];
+    async function* source() {
+      try {
+        seen.push(getRuntimeContentGenerator());
+        yield 1;
+        seen.push(getRuntimeContentGenerator());
+        await Promise.resolve();
+        seen.push(getRuntimeContentGenerator());
+        yield 2;
+      } finally {
+        seen.push(getRuntimeContentGenerator());
+      }
+    }
+
+    const wrapped = wrapAsyncGeneratorWithRuntimeContentGenerator(
+      view,
+      source(),
+    );
+    expect(await wrapped.next()).toEqual({ done: false, value: 1 });
+    expect(getRuntimeContentGenerator()).toBeUndefined();
+    expect(await wrapped.next()).toEqual({ done: false, value: 2 });
+    expect(getRuntimeContentGenerator()).toBeUndefined();
+    expect(await wrapped.next()).toEqual({ done: true, value: undefined });
+
+    expect(seen).toEqual([view, view, view, view]);
+    expect(getRuntimeContentGenerator()).toBeUndefined();
   });
 });
 

--- a/packages/core/src/agents/runtime/agent-context.ts
+++ b/packages/core/src/agents/runtime/agent-context.ts
@@ -71,6 +71,35 @@ export function runWithRuntimeContentGenerator<T>(
   return storage.run({ ...current, runtimeView: view }, fn);
 }
 
+/** Consume an async generator with the runtime model view restored per step. */
+export async function* wrapAsyncGeneratorWithRuntimeContentGenerator<
+  TYield,
+  TReturn = void,
+>(
+  view: RuntimeContentGeneratorView,
+  generator: AsyncGenerator<TYield, TReturn>,
+): AsyncGenerator<TYield, TReturn> {
+  let completed = false;
+  try {
+    while (true) {
+      const next = await runWithRuntimeContentGenerator(view, () =>
+        generator.next(),
+      );
+      if (next.done) {
+        completed = true;
+        return next.value;
+      }
+      yield next.value;
+    }
+  } finally {
+    if (!completed) {
+      await runWithRuntimeContentGenerator(view, () =>
+        generator.return(undefined as TReturn),
+      );
+    }
+  }
+}
+
 export function getCurrentAgentId(): string | null {
   return storage.getStore()?.agentId ?? null;
 }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1029,9 +1029,74 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-anthropic',
+        authType: AuthType.USE_ANTHROPIC,
         baseUrl: 'https://api.anthropic.com',
       });
     });
+
+    it('retains provider identity for a bare cross-provider namesake', () => {
+      const config = new Config({ ...baseParams, visionModel: 'shared-model' });
+      stubProvider(config, [
+        {
+          id: 'shared-model',
+          authType: AuthType.USE_ANTHROPIC,
+          isVision: true,
+          capabilities: { agent: true },
+        },
+      ]);
+
+      expect(config.getDefaultVisionBridgeModel()).toEqual({
+        id: 'shared-model',
+        authType: AuthType.USE_ANTHROPIC,
+        agentCapable: true,
+      });
+    });
+
+    it('propagates full-turn capability from an explicit image-capable agent model', () => {
+      const config = new Config({ ...baseParams, visionModel: 'vl-agent' });
+      stubProvider(config, [
+        {
+          id: 'vl-agent',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://primary.example.com',
+          isVision: true,
+          capabilities: { agent: true },
+        },
+      ]);
+
+      expect(config.getDefaultVisionBridgeModel()).toEqual({
+        id: 'vl-agent',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://primary.example.com',
+        agentCapable: true,
+      });
+    });
+
+    it.each([
+      ['agent capability is false', true, false],
+      ['agent capability is omitted', true, undefined],
+      ['the agent model is not image-capable', false, true],
+    ])(
+      'does not enable full-turn routing when %s',
+      (_label, isVision, agent) => {
+        const config = new Config({ ...baseParams, visionModel: 'vl-bridge' });
+        stubProvider(config, [
+          {
+            id: 'vl-bridge',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://primary.example.com',
+            isVision,
+            capabilities: { agent },
+          },
+        ]);
+
+        expect(config.getDefaultVisionBridgeModel()).toEqual({
+          id: 'vl-bridge',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://primary.example.com',
+        });
+      },
+    );
 
     it('falls back to same-provider auto-select when the explicit model is not configured', () => {
       const config = new Config({ ...baseParams, visionModel: 'ghost-model' });
@@ -1047,6 +1112,7 @@ describe('Server Config (config.ts)', () => {
       // same-provider candidate is auto-picked instead.
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
     });
@@ -1063,7 +1129,28 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
+      });
+    });
+
+    it('propagates full-turn capability from an auto-selected agent model', () => {
+      const config = new Config({ ...baseParams });
+      stubProvider(config, [
+        {
+          id: 'vl-agent',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://primary.example.com',
+          isVision: true,
+          capabilities: { agent: true },
+        },
+      ]);
+
+      expect(config.getDefaultVisionBridgeModel()).toEqual({
+        id: 'vl-agent',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://primary.example.com',
+        agentCapable: true,
       });
     });
 
@@ -1090,6 +1177,7 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'anthropic:vl-shared',
+        authType: AuthType.USE_ANTHROPIC,
         baseUrl: 'https://api.anthropic.com',
       });
     });
@@ -1115,6 +1203,7 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'openai:qwen3.7-plus',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://token-plan.example.com/v1',
       });
     });
@@ -1146,6 +1235,7 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
     });
@@ -1165,6 +1255,7 @@ describe('Server Config (config.ts)', () => {
       expect(() => config.getDefaultVisionBridgeModel()).not.toThrow();
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
     });
@@ -1186,6 +1277,7 @@ describe('Server Config (config.ts)', () => {
 
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
       expect(warn).toHaveBeenCalledWith(
@@ -1216,6 +1308,7 @@ describe('Server Config (config.ts)', () => {
       ]);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
     });
@@ -1239,12 +1332,14 @@ describe('Server Config (config.ts)', () => {
       // Pinned first.
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-anthropic',
+        authType: AuthType.USE_ANTHROPIC,
         baseUrl: 'https://api.anthropic.com',
       });
       // Cleared with '' — JSDoc promises a fall back to auto-select.
       config.setVisionModel('');
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
       // undefined clears too.
@@ -1252,6 +1347,7 @@ describe('Server Config (config.ts)', () => {
       config.setVisionModel(undefined);
       expect(config.getDefaultVisionBridgeModel()).toEqual({
         id: 'vl-same-provider',
+        authType: AuthType.USE_OPENAI,
         baseUrl: 'https://primary.example.com',
       });
     });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -25,7 +25,10 @@ import type { ReasoningEffort } from '../core/reasoning-effort.js';
 import type { MCPOAuthConfig } from '../mcp/oauth-provider.js';
 import type { ShellExecutionConfig } from '../services/shellExecutionService.js';
 import type { VisionBridgeModelSelection } from '../services/visionBridge/vision-bridge-service.js';
-import { selectVisionBridgeModel } from '../services/visionBridge/vision-bridge-service.js';
+import {
+  isImageCapable,
+  selectVisionBridgeModel,
+} from '../services/visionBridge/vision-bridge-service.js';
 import type { AnyToolInvocation } from '../tools/tools.js';
 import type { ArenaManager } from '../agents/arena/ArenaManager.js';
 import { ArenaAgentClient } from '../agents/arena/ArenaAgentClient.js';
@@ -3610,9 +3613,12 @@ export class Config {
     }
     return {
       id: parsedSetting.selector,
+      ...(match.authType && { authType: match.authType }),
       ...((parsedSetting.baseUrl ?? match.baseUrl) && {
         baseUrl: parsedSetting.baseUrl ?? match.baseUrl,
       }),
+      ...(isImageCapable(match) &&
+        match.capabilities?.agent === true && { agentCapable: true }),
     };
   }
 

--- a/packages/core/src/core/baseLlmClient.test.ts
+++ b/packages/core/src/core/baseLlmClient.test.ts
@@ -842,7 +842,7 @@ describe('BaseLlmClient', () => {
       expect(mockCreateContentGenerator).not.toHaveBeenCalled();
     });
 
-    it('builds a per-model generator when model differs and is registered under another authType', async () => {
+    it('returns the exact target config with a cross-provider generator', async () => {
       // Main authType is QWEN_OAUTH; fast model only resolves under USE_ANTHROPIC.
       getResolvedModel.mockImplementation((authType: string, model: string) => {
         if (authType === AuthType.QWEN_OAUTH) return undefined;
@@ -855,12 +855,19 @@ describe('BaseLlmClient', () => {
         }
         return undefined;
       });
+      const targetConfig = {
+        model: fastModel,
+        authType: AuthType.USE_ANTHROPIC,
+        baseUrl: 'https://api.anthropic.com',
+      };
+      mockBuildAgentContentGeneratorConfig.mockReturnValue(targetConfig);
 
       const c = new BaseLlmClient(mockContentGenerator, crossProviderConfig);
 
       const resolved = await c.resolveForModel(fastModel);
 
       expect(resolved.contentGenerator).toBe(fastContentGenerator);
+      expect(resolved.contentGeneratorConfig).toBe(targetConfig);
       expect(resolved.retryAuthType).toBe(AuthType.USE_ANTHROPIC);
       expect(mockBuildAgentContentGeneratorConfig).toHaveBeenCalledWith(
         crossProviderConfig,
@@ -870,7 +877,10 @@ describe('BaseLlmClient', () => {
           baseUrl: 'https://api.anthropic.com',
         }),
       );
-      expect(mockCreateContentGenerator).toHaveBeenCalledTimes(1);
+      expect(mockCreateContentGenerator).toHaveBeenCalledWith(
+        targetConfig,
+        crossProviderConfig,
+      );
     });
 
     it('resolves same-id model selectors by baseUrl when provided', async () => {
@@ -1027,6 +1037,41 @@ describe('BaseLlmClient', () => {
       await expect(
         c.resolveForModel(fastModel, { failClosed: true }),
       ).rejects.toThrow(/missing credential/i);
+    });
+
+    it('isolates concurrent fail-open and fail-closed generator creation failures', async () => {
+      getResolvedModel.mockImplementation((authType: string, model: string) =>
+        authType === AuthType.USE_ANTHROPIC && model === fastModel
+          ? {
+              authType: AuthType.USE_ANTHROPIC,
+              envKey: 'ANTHROPIC_API_KEY',
+              baseUrl: 'https://api.anthropic.com',
+            }
+          : undefined,
+      );
+      let rejectCreation!: (error: Error) => void;
+      const creation = new Promise<ContentGenerator>((_resolve, reject) => {
+        rejectCreation = reject;
+      });
+      mockCreateContentGenerator.mockReturnValue(creation);
+      const c = new BaseLlmClient(mockContentGenerator, crossProviderConfig);
+
+      const failOpen = c.resolveForModel(fastModel);
+      const failClosedOutcome = c
+        .resolveForModel(fastModel, { failClosed: true })
+        .then(
+          (value) => ({ value }),
+          (error: unknown) => ({ error }),
+        );
+
+      expect(mockCreateContentGenerator).toHaveBeenCalledTimes(2);
+      rejectCreation(new Error('missing credential'));
+      await expect(failOpen).resolves.toMatchObject({
+        contentGenerator: mockContentGenerator,
+      });
+      await expect(failClosedOutcome).resolves.toMatchObject({
+        error: expect.objectContaining({ message: 'missing credential' }),
+      });
     });
 
     it('falls back to the main generator for an unregistered model when failClosed is not set', async () => {

--- a/packages/core/src/core/baseLlmClient.ts
+++ b/packages/core/src/core/baseLlmClient.ts
@@ -15,7 +15,10 @@ import type {
   Schema,
 } from '@google/genai';
 import type { Config } from '../config/config.js';
-import type { ContentGenerator } from './contentGenerator.js';
+import type {
+  ContentGenerator,
+  ContentGeneratorConfig,
+} from './contentGenerator.js';
 import { AuthType, createContentGenerator } from './contentGenerator.js';
 import type { ResolvedModelConfig } from '../models/types.js';
 import { buildAgentContentGeneratorConfig } from '../models/content-generator-config.js';
@@ -33,6 +36,7 @@ import { logApiRetry } from '../telemetry/loggers.js';
 import { getFunctionCalls } from '../utils/generateContentResponseUtilities.js';
 import { getResponseText } from '../utils/partUtils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import type { RuntimeContentGeneratorView } from '../agents/runtime/agent-context.js';
 
 const DEFAULT_MAX_ATTEMPTS = 7;
 
@@ -49,16 +53,38 @@ function splitModelBaseUrl(model: string): { model: string; baseUrl?: string } {
   };
 }
 
+/** Exact provider/runtime route for one complete agent turn. */
+export interface FullTurnModelRoute extends RuntimeContentGeneratorView {
+  model: string;
+}
+
+export interface FullTurnModelRouteIdentity {
+  model: string;
+  baseUrl?: string;
+  authType?: string;
+}
+
+export function getFullTurnModelRouteIdentity(
+  route: FullTurnModelRoute,
+): FullTurnModelRouteIdentity {
+  return {
+    model: route.model,
+    ...(route.contentGeneratorConfig.baseUrl
+      ? { baseUrl: route.contentGeneratorConfig.baseUrl }
+      : {}),
+    ...(route.contentGeneratorConfig.authType
+      ? { authType: route.contentGeneratorConfig.authType }
+      : {}),
+  };
+}
+
 /**
- * The pair of generator and retry-authType to use for a request targeting
- * a specific model. When the requested model differs from the main session
- * model, both fields are resolved against that model's provider so that
- * per-model `extra_body` / `samplingParams` / reasoning settings — and
- * provider-specific retry/quota behaviour — do not leak from the main
- * session.
+ * The generator, config, and retry metadata resolved for a requested model.
+ * This may represent a fail-open fallback and is not an exact full-turn route.
  */
 export interface ResolvedGeneratorForModel {
   contentGenerator: ContentGenerator;
+  contentGeneratorConfig: ContentGeneratorConfig;
   retryAuthType: string | undefined;
   retryErrorCodes?: readonly number[];
   model: string;
@@ -200,7 +226,7 @@ export class BaseLlmClient {
    */
   private readonly perModelGeneratorCache = new Map<
     string,
-    Promise<ContentGenerator>
+    Promise<RuntimeContentGeneratorView>
   >();
 
   constructor(
@@ -534,18 +560,20 @@ export class BaseLlmClient {
     ) {
       return {
         contentGenerator: this.getCurrentContentGenerator(),
+        contentGeneratorConfig: mainGeneratorConfig,
         retryAuthType: mainAuthType,
         retryErrorCodes: mainRetryErrorCodes,
         model: requestModel,
       };
     }
 
-    const contentGenerator = await this.createContentGeneratorForModel(
-      requested.model,
-      selector,
-      opts?.failClosed ?? false,
-      requested.baseUrl,
-    );
+    const { contentGenerator, contentGeneratorConfig } =
+      await this.createRuntimeViewForModel(
+        requested.model,
+        selector,
+        opts?.failClosed ?? false,
+        requested.baseUrl,
+      );
     const resolvedModel = this.resolveModelAcrossAuthTypes(
       requested.model,
       selector,
@@ -558,6 +586,7 @@ export class BaseLlmClient {
 
     return {
       contentGenerator,
+      contentGeneratorConfig,
       retryAuthType,
       retryErrorCodes,
       model: resolvedModel?.id ?? requestModel,
@@ -618,17 +647,18 @@ export class BaseLlmClient {
     return undefined;
   }
 
-  private async createContentGeneratorForModel(
+  private async createRuntimeViewForModel(
     model: string,
     selector: ResolvedModelId | undefined,
     failClosed = false,
     modelBaseUrl?: string,
-  ): Promise<ContentGenerator> {
-    const cacheKey = selector
+  ): Promise<RuntimeContentGeneratorView> {
+    const routeKey = selector
       ? modelBaseUrl === undefined
         ? `${selector.authType ?? ''}:${selector.modelId}`
         : `${selector.authType ?? ''}:${selector.modelId}\0${modelBaseUrl}`
       : model;
+    const cacheKey = `${routeKey}:${failClosed ? 'closed' : 'open'}`;
     const cached = this.perModelGeneratorCache.get(cacheKey);
     if (cached) return cached;
 
@@ -656,7 +686,10 @@ export class BaseLlmClient {
       // runtime view from AsyncLocalStorage, which can differ between calls
       // (e.g. inside a subagent vs. on the main session). Caching here would
       // pin the first-call view's generator under this selector key.
-      return this.getCurrentContentGenerator();
+      return {
+        contentGenerator: this.getCurrentContentGenerator(),
+        contentGeneratorConfig: this.config.getContentGeneratorConfig(),
+      };
     }
 
     const generatorPromise = (async () => {
@@ -674,7 +707,13 @@ export class BaseLlmClient {
           },
         );
 
-        return await createContentGenerator(targetConfig, this.config);
+        return {
+          contentGenerator: await createContentGenerator(
+            targetConfig,
+            this.config,
+          ),
+          contentGeneratorConfig: targetConfig,
+        };
       } catch (err: unknown) {
         this.perModelGeneratorCache.delete(cacheKey);
         if (failClosed) {
@@ -690,7 +729,10 @@ export class BaseLlmClient {
           `Failed to create content generator for model "${model}", falling back to main generator.`,
           err instanceof Error ? err.message : String(err),
         );
-        return this.getCurrentContentGenerator();
+        return {
+          contentGenerator: this.getCurrentContentGenerator(),
+          contentGeneratorConfig: this.config.getContentGeneratorConfig(),
+        };
       }
     })();
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -31,7 +31,7 @@ import {
   type ContentGenerator,
   type ContentGeneratorConfig,
 } from './contentGenerator.js';
-import { BaseLlmClient } from './baseLlmClient.js';
+import { BaseLlmClient, type FullTurnModelRoute } from './baseLlmClient.js';
 import { buildAgentContentGeneratorConfig } from '../models/content-generator-config.js';
 import { GeminiChat } from './geminiChat.js';
 import type { Config } from '../config/config.js';
@@ -98,7 +98,10 @@ import {
   setActiveGoal,
 } from '../goals/activeGoalStore.js';
 import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
-import { runWithAgentContext } from '../agents/runtime/agent-context.js';
+import {
+  getRuntimeContentGenerator,
+  runWithAgentContext,
+} from '../agents/runtime/agent-context.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -706,6 +709,214 @@ describe('Gemini Client (client.ts)', () => {
 
       expect(resumedClient.getChat().getLastPromptTokenCount()).toBe(200);
       expect(seedResumeTokenCountsSpy).toHaveBeenCalledWith(200, 80);
+    });
+
+    it.each([
+      [
+        'eligible',
+        {
+          capabilities: { agent: true, vision: true },
+          modalities: { image: true },
+        },
+        true,
+      ],
+      [
+        'agent-disabled',
+        {
+          capabilities: { agent: false, vision: true },
+          modalities: { image: true },
+        },
+        false,
+      ],
+      [
+        'image-disabled',
+        {
+          capabilities: { agent: true, vision: false },
+          modalities: { image: false },
+        },
+        false,
+      ],
+      [
+        'fast-only',
+        {
+          capabilities: { agent: true, vision: true },
+          modalities: { image: true },
+          fastOnly: true,
+        },
+        false,
+      ],
+    ])(
+      'restores a persisted full-turn route only when the model remains %s',
+      async (_case, modelFlags, eligible) => {
+        const identity = {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://vision.example/v1',
+        };
+        vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+          conversation: {
+            sessionId: 'resumed-session-id',
+            projectHash: 'project-hash',
+            startTime: new Date(0).toISOString(),
+            lastUpdated: new Date(0).toISOString(),
+            messages: [
+              {
+                uuid: 'route-marker',
+                parentUuid: null,
+                sessionId: 'resumed-session-id',
+                timestamp: new Date(0).toISOString(),
+                type: 'system',
+                subtype: 'full_turn_route',
+                systemPayload: identity,
+              },
+            ],
+          },
+          filePath: '/test/session.jsonl',
+          lastCompletedUuid: null,
+        } as unknown as ReturnType<Config['getResumedSessionData']>);
+        vi.mocked(mockConfig.getAllConfiguredModels).mockReturnValue([
+          {
+            id: identity.model,
+            label: identity.model,
+            authType: AuthType.USE_OPENAI,
+            baseUrl: identity.baseUrl,
+            ...modelFlags,
+          },
+        ]);
+        const resolveForModel = vi
+          .spyOn(mockConfig.getBaseLlmClient(), 'resolveForModel')
+          .mockResolvedValue({
+            model: identity.model,
+            contentGenerator: mockContentGenerator,
+            contentGeneratorConfig: {
+              model: identity.model,
+              authType: AuthType.USE_OPENAI,
+              baseUrl: identity.baseUrl,
+              modalities: { image: true },
+            },
+            retryAuthType: AuthType.USE_OPENAI,
+          });
+
+        const resumedClient = new GeminiClient(mockConfig);
+        await resumedClient.initialize();
+
+        expect(
+          resumedClient.getChat().getPendingFullTurnRouteIdentity(),
+        ).toEqual(identity);
+        expect(Boolean(resumedClient.getChat().getPendingFullTurnRoute())).toBe(
+          eligible,
+        );
+        expect(resolveForModel).toHaveBeenCalledTimes(eligible ? 1 : 0);
+      },
+    );
+
+    it('keeps resumed pending images retryable after another failure scrub', async () => {
+      const identity = {
+        model: 'vision-agent',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://vision.example/v1',
+      };
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        conversation: {
+          sessionId: 'resumed-session-id',
+          projectHash: 'project-hash',
+          startTime: new Date(0).toISOString(),
+          lastUpdated: new Date(0).toISOString(),
+          messages: [
+            {
+              uuid: 'settled-user',
+              parentUuid: null,
+              sessionId: 'resumed-session-id',
+              timestamp: new Date(0).toISOString(),
+              type: 'user',
+              message: {
+                role: 'user',
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: 'image/png',
+                      data: 'settled-image',
+                    },
+                  },
+                ],
+              },
+            },
+            {
+              uuid: 'settled-model',
+              parentUuid: 'settled-user',
+              sessionId: 'resumed-session-id',
+              timestamp: new Date(1).toISOString(),
+              type: 'assistant',
+              message: { role: 'model', parts: [{ text: 'settled' }] },
+            },
+            {
+              uuid: 'route-marker',
+              parentUuid: 'settled-model',
+              sessionId: 'resumed-session-id',
+              timestamp: new Date(2).toISOString(),
+              type: 'system',
+              subtype: 'full_turn_route',
+              systemPayload: identity,
+            },
+            {
+              uuid: 'pending-user',
+              parentUuid: 'route-marker',
+              sessionId: 'resumed-session-id',
+              timestamp: new Date(3).toISOString(),
+              type: 'user',
+              message: {
+                role: 'user',
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: 'image/png',
+                      data: 'pending-image',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        filePath: '/test/session.jsonl',
+        lastCompletedUuid: null,
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+      vi.mocked(mockConfig.getAllConfiguredModels).mockReturnValue([
+        {
+          id: identity.model,
+          label: identity.model,
+          authType: identity.authType,
+          baseUrl: identity.baseUrl,
+          capabilities: { agent: true, vision: true },
+          modalities: { image: true },
+        },
+      ]);
+      vi.spyOn(
+        mockConfig.getBaseLlmClient(),
+        'resolveForModel',
+      ).mockResolvedValue({
+        model: identity.model,
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: identity.model,
+          authType: identity.authType,
+          baseUrl: identity.baseUrl,
+          modalities: { image: true },
+        },
+        retryAuthType: identity.authType,
+      });
+
+      const resumedClient = new GeminiClient(mockConfig);
+      await resumedClient.initialize();
+      const chat = resumedClient.getChat();
+
+      chat.replaceHistoricalMediaWithReferences();
+      const secondRetry = chat.preparePendingFullTurnMediaForContinuation([
+        { text: 'retry again' },
+      ]);
+
+      expect(JSON.stringify(secondRetry)).toContain('pending-image');
+      expect(JSON.stringify(secondRetry)).not.toContain('settled-image');
     });
 
     it('seeds recently completed tools from resumed history', async () => {
@@ -2207,6 +2418,48 @@ describe('Gemini Client (client.ts)', () => {
       client.setHistory([{ role: 'user', parts: [{ text: 'replaced' }] }]);
 
       expect(cacheClear).toHaveBeenCalled();
+    });
+
+    it('setHistory closes a pending full-turn route before installing restored history', () => {
+      const clearPendingFullTurnRoute = vi.fn();
+      const setHistory = vi.fn();
+      client['chat'] = {
+        getPendingFullTurnRouteIdentity: vi.fn().mockReturnValue({
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+        }),
+        clearPendingFullTurnRoute,
+        setHistory,
+      } as unknown as GeminiChat;
+      const recordMediaScrubCheckpoint = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordMediaScrubCheckpoint,
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      const restoredHistory: Content[] = [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: 'restored-checkpoint-image',
+              },
+            },
+          ],
+        },
+      ];
+
+      client.setHistory(restoredHistory);
+
+      expect(clearPendingFullTurnRoute).toHaveBeenCalledOnce();
+      expect(recordMediaScrubCheckpoint).toHaveBeenCalledOnce();
+      expect(setHistory).toHaveBeenCalledWith(restoredHistory);
+      expect(JSON.stringify(setHistory.mock.calls[0]?.[0])).toContain(
+        'restored-checkpoint-image',
+      );
+      expect(
+        clearPendingFullTurnRoute.mock.invocationCallOrder[0],
+      ).toBeLessThan(setHistory.mock.invocationCallOrder[0]!);
     });
 
     /**
@@ -4061,6 +4314,365 @@ describe('Gemini Client (client.ts)', () => {
   });
 
   describe('sendMessageStream', () => {
+    it('passes an exact full-turn route to Turn ahead of model overrides', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      mockTurnRunFn.mockReturnValue((async function* () {})());
+      const signal = new AbortController().signal;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'inspect image' }],
+        signal,
+        'prompt-exact-route',
+        {
+          type: SendMessageType.UserQuery,
+          modelOverride: 'skill-model',
+          modelRoute: route,
+        },
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'vision-agent',
+        expect.any(Array),
+        signal,
+        route,
+      );
+    });
+
+    it('scrubs historical media before opening a new full-turn route', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setHistory([
+        {
+          role: 'user',
+          parts: [{ inlineData: { mimeType: 'image/png', data: 'old-image' } }],
+        },
+        { role: 'model', parts: [{ text: 'old response' }] },
+      ]);
+      const recordMediaScrubCheckpoint = vi.fn();
+      const recordFullTurnRoute = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordUserMessage: vi.fn(),
+        recordMediaScrubCheckpoint,
+        recordFullTurnRoute,
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      let historyAtRun: Content[] | undefined;
+      let requestAtRun: unknown;
+      mockTurnRunFn.mockImplementation((_model, request) => {
+        historyAtRun = chat.getHistory();
+        requestAtRun = request;
+        return (async function* () {})();
+      });
+
+      await fromAsync(
+        client.sendMessageStream(
+          [
+            { text: 'inspect current image' },
+            { inlineData: { mimeType: 'image/png', data: 'current-image' } },
+          ],
+          new AbortController().signal,
+          'prompt-new-route-boundary',
+          { type: SendMessageType.UserQuery, modelRoute: route },
+        ),
+      );
+
+      expect(JSON.stringify(historyAtRun)).not.toContain('old-image');
+      expect(JSON.stringify(historyAtRun)).toMatch(
+        /\[Image #[a-f0-9]{12}: image\/png, \d+ bytes\]/,
+      );
+      expect(JSON.stringify(requestAtRun)).toContain('current-image');
+      expect(
+        recordMediaScrubCheckpoint.mock.invocationCallOrder[0],
+      ).toBeLessThan(recordFullTurnRoute.mock.invocationCallOrder[0]!);
+    });
+
+    it.each([SendMessageType.ToolResult, SendMessageType.Hook])(
+      'does not microcompact an active full-turn route on %s',
+      async (type) => {
+        const route: FullTurnModelRoute = {
+          model: 'vision-agent',
+          contentGenerator: mockContentGenerator,
+          contentGeneratorConfig: {
+            model: 'vision-agent',
+            authType: AuthType.USE_OPENAI,
+            modalities: { image: true },
+          },
+        };
+        const microcompact = vi.spyOn(
+          client as unknown as {
+            microcompactHistoryBeforeSend: (
+              timestamp: number | null,
+              options?: { sizeOnly?: boolean },
+            ) => Promise<boolean>;
+          },
+          'microcompactHistoryBeforeSend',
+        );
+        mockTurnRunFn.mockReturnValue((async function* () {})());
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'continue routed turn' }],
+            new AbortController().signal,
+            `prompt-${type}`,
+            { type, modelRoute: route },
+          ),
+        );
+
+        expect(microcompact).not.toHaveBeenCalled();
+      },
+    );
+
+    it('fails closed before an un-routed image Retry can reach the primary', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+      const replaceMedia = vi.spyOn(
+        chat,
+        'replaceHistoricalMediaWithReferences',
+      );
+      const recordMediaScrubCheckpoint = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordMediaScrubCheckpoint,
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      await expect(
+        fromAsync(
+          client.sendMessageStream(
+            [
+              { text: 'retry image without route' },
+              {
+                inlineData: { mimeType: 'image/png', data: 'private-image' },
+              },
+            ],
+            new AbortController().signal,
+            'prompt-unrouted-retry',
+            { type: SendMessageType.Retry },
+          ),
+        ),
+      ).rejects.toThrow(/exact route/);
+
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+      expect(replaceMedia).not.toHaveBeenCalled();
+      expect(recordMediaScrubCheckpoint).not.toHaveBeenCalled();
+      expect(chat.getPendingFullTurnRouteIdentity()).toBeDefined();
+    });
+
+    it('reattaches only the pending turn images for an exact-route Retry', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setHistory([
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: { mimeType: 'image/png', data: 'settled-image' },
+            },
+          ],
+        },
+        { role: 'model', parts: [{ text: 'settled' }] },
+      ]);
+      chat.replaceHistoricalMediaWithReferences();
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+      chat.addHistory({
+        role: 'user',
+        parts: [
+          { text: 'inspect' },
+          { inlineData: { mimeType: 'image/png', data: 'pending-image' } },
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://pending.example/shot.png',
+            },
+          },
+        ],
+      });
+      chat.addHistory({
+        role: 'model',
+        parts: [{ functionCall: { id: 'call-1', name: 'screenshot' } }],
+      });
+      chat.replaceHistoricalMediaWithReferences();
+
+      const recordMediaScrubCheckpoint = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordMediaScrubCheckpoint,
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      mockTurnRunFn.mockReturnValue((async function* () {})());
+
+      await fromAsync(
+        client.sendMessageStream(
+          [
+            {
+              functionResponse: {
+                id: 'call-1',
+                name: 'screenshot',
+                response: { output: 'done' },
+              },
+            },
+            {
+              inlineData: { mimeType: 'image/png', data: 'pending-image' },
+            },
+          ],
+          new AbortController().signal,
+          'prompt-routed-retry',
+          { type: SendMessageType.Retry, modelRoute: route },
+        ),
+      );
+
+      const request = mockTurnRunFn.mock.calls.at(-1)?.[1];
+      const serializedRequest = JSON.stringify(request);
+      expect(serializedRequest.match(/pending-image/g)).toHaveLength(1);
+      expect(serializedRequest).toContain('https://pending.example/shot.png');
+      expect(serializedRequest).not.toContain('settled-image');
+      expect(JSON.stringify(chat.getHistory())).not.toContain('pending-image');
+      expect(JSON.stringify(chat.getHistory())).not.toContain(
+        'https://pending.example/shot.png',
+      );
+      expect(chat.getPendingFullTurnRouteIdentity()).toBeUndefined();
+      expect(recordMediaScrubCheckpoint).toHaveBeenCalledOnce();
+    });
+
+    it('resets the media boundary for a fresh UserQuery on the same route', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+      chat.addHistory({
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType: 'image/png', data: 'previous-turn' } },
+        ],
+      });
+      chat.replaceHistoricalMediaWithReferences();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordUserMessage: vi.fn(),
+        recordFullTurnRoute: vi.fn(),
+        recordMediaScrubCheckpoint: vi.fn(),
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          throw new Error('new turn failed');
+        })(),
+      );
+
+      await expect(
+        fromAsync(
+          client.sendMessageStream(
+            [
+              { text: 'new turn' },
+              { inlineData: { mimeType: 'image/png', data: 'current-turn' } },
+            ],
+            new AbortController().signal,
+            'prompt-new-same-route',
+            { type: SendMessageType.UserQuery, modelRoute: route },
+          ),
+        ),
+      ).rejects.toThrow('new turn failed');
+
+      const retry = chat.preparePendingFullTurnMediaForContinuation([
+        { inlineData: { mimeType: 'image/png', data: 'current-turn' } },
+      ]);
+      expect(JSON.stringify(retry)).not.toContain('previous-turn');
+      expect(JSON.stringify(retry).match(/current-turn/g)).toHaveLength(1);
+    });
+
+    it('settles the previous route before a matching teammate turn', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+      const replaceMedia = vi.spyOn(
+        chat,
+        'replaceHistoricalMediaWithReferences',
+      );
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordNotification: vi.fn(),
+        recordFullTurnRoute: vi.fn(),
+        recordMediaScrubCheckpoint: vi.fn(),
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      mockTurnRunFn.mockReturnValue((async function* () {})());
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'teammate update' }],
+          new AbortController().signal,
+          'prompt-routed-teammate',
+          { type: SendMessageType.Teammate, modelRoute: route },
+        ),
+      );
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        route.model,
+        expect.any(Array),
+        expect.any(AbortSignal),
+        route,
+      );
+      expect(replaceMedia).toHaveBeenCalled();
+    });
+
     it('should merge editor context into the user request when ideMode is enabled', async () => {
       // Arrange
       vi.mocked(ideContextStore.get).mockReturnValue({
@@ -5434,6 +6046,51 @@ hello
             config: mockConfig,
           }),
         );
+      });
+
+      it('removes media before passing live history to skill review', async () => {
+        mockMemoryManager.scheduleSkillReview.mockReturnValue({
+          status: 'skipped',
+          skippedReason: 'below_threshold',
+        });
+        vi.mocked(mockChat.getHistory!).mockReturnValue([
+          {
+            role: 'user',
+            parts: [
+              { inlineData: { mimeType: 'image/png', data: 'raw-image' } },
+              {
+                functionResponse: {
+                  name: 'read_file',
+                  response: { output: 'loaded' },
+                  parts: [
+                    {
+                      fileData: {
+                        mimeType: 'image/jpeg',
+                        fileUri: 'https://private.example/image.jpg',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          } as unknown as Content,
+          { role: 'model', parts: [{ text: 'Done' }] },
+        ]);
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'a query' }],
+            new AbortController().signal,
+            'prompt-id-autoskill-media',
+          ),
+        );
+
+        const call = mockMemoryManager.scheduleSkillReview.mock.calls[0]?.[0];
+        const serialized = JSON.stringify(call?.history);
+        expect(serialized).toContain('[image: image/png]');
+        expect(serialized).toContain('[image: image/jpeg]');
+        expect(serialized).not.toContain('raw-image');
+        expect(serialized).not.toContain('https://private.example/image.jpg');
       });
 
       it('should reset toolCallCount and push promise when review is scheduled', async () => {
@@ -7492,6 +8149,95 @@ Other open files:
             type: GeminiEventType.StopHookLoop,
           }),
         );
+      });
+
+      it('keeps Stop hooks and their blocking continuation on the exact model route', async () => {
+        const route: FullTurnModelRoute = {
+          model: 'vision-agent',
+          contentGenerator: mockContentGenerator,
+          contentGeneratorConfig: {
+            model: 'vision-agent',
+            authType: AuthType.USE_OPENAI,
+            contextWindowSize: 2_000,
+            modalities: { image: true },
+          },
+        };
+        const seenRuntimeViews: Array<
+          ReturnType<typeof getRuntimeContentGenerator>
+        > = [];
+        const mockMessageBus = {
+          request: vi
+            .fn()
+            .mockImplementationOnce(async () => {
+              seenRuntimeViews.push(getRuntimeContentGenerator());
+              return {
+                output: { decision: 'block', reason: 'Keep working' },
+                stopHookCount: 1,
+              };
+            })
+            .mockImplementationOnce(async () => {
+              seenRuntimeViews.push(getRuntimeContentGenerator());
+              return {};
+            }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        vi.mocked(mockConfig.getSkipNextSpeakerCheck).mockReturnValue(true);
+        vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+          500,
+        );
+        const replaceHistoricalMediaWithReferences = vi.fn();
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi
+            .fn()
+            .mockReturnValue([
+              { role: 'model', parts: [{ text: 'not done' }] },
+            ]),
+          replaceHistoricalMediaWithReferences,
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockImplementation(() =>
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'not done' };
+          })(),
+        );
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Inspect this image' }],
+            new AbortController().signal,
+            'prompt-routed-stop-hook',
+            { type: SendMessageType.UserQuery, modelRoute: route },
+          ),
+        );
+
+        expect(seenRuntimeViews).toEqual([route, route]);
+        expect(mockMessageBus.request).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            eventName: 'Stop',
+            input: expect.objectContaining({
+              context_usage: 0.25,
+              context_limit: 2_000,
+              input_tokens: 500,
+            }),
+          }),
+          expect.anything(),
+        );
+        expect(mockTurnRunFn).toHaveBeenNthCalledWith(
+          2,
+          'vision-agent',
+          expect.any(Array),
+          expect.any(AbortSignal),
+          route,
+        );
+        expect(replaceHistoricalMediaWithReferences).toHaveBeenCalled();
       });
 
       it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -2487,6 +2487,24 @@ describe('Gemini Client (client.ts)', () => {
       expect(cacheClear).toHaveBeenCalled();
     });
 
+    it('truncateHistory records settlement for a pending full-turn route', () => {
+      mockFileReadCacheClear();
+      const recordMediaScrubCheckpoint = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordMediaScrubCheckpoint,
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      client['chat'] = {
+        ...mockChatWithLengths(3, 2),
+        getPendingFullTurnRouteIdentity: vi.fn(() => ({
+          model: 'vision-agent',
+        })),
+      } as unknown as GeminiChat;
+
+      client.truncateHistory(2);
+
+      expect(recordMediaScrubCheckpoint).toHaveBeenCalledOnce();
+    });
+
     it('truncateHistory does NOT clear the cache when nothing was removed (keepCount >= history length)', () => {
       const cacheClear = mockFileReadCacheClear();
 
@@ -4671,6 +4689,57 @@ describe('Gemini Client (client.ts)', () => {
         route,
       );
       expect(replaceMedia).toHaveBeenCalled();
+    });
+
+    it('keeps a teammate message merged with tool results on the pending route', async () => {
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: mockContentGenerator,
+        contentGeneratorConfig: {
+          model: 'vision-agent',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+        },
+      };
+      const chat = client.getChat();
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+      const replaceMedia = vi.spyOn(
+        chat,
+        'replaceHistoricalMediaWithReferences',
+      );
+      const recordFullTurnRoute = vi.fn();
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        recordNotification: vi.fn(),
+        recordFullTurnRoute,
+        recordMediaScrubCheckpoint: vi.fn(),
+        recordAttributionSnapshot: vi.fn(),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      mockTurnRunFn.mockReturnValue((async function* () {})());
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'tool result plus teammate update' }],
+          new AbortController().signal,
+          'prompt-routed-tool-teammate',
+          {
+            type: SendMessageType.Teammate,
+            modelRoute: route,
+            continuesToolTurn: true,
+          },
+        ),
+      );
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        route.model,
+        expect.any(Array),
+        expect.any(AbortSignal),
+        route,
+      );
+      expect(replaceMedia).toHaveBeenCalledOnce();
+      expect(recordFullTurnRoute).not.toHaveBeenCalled();
     });
 
     it('should merge editor context into the user request when ideMode is enabled', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4603,7 +4603,7 @@ describe('Gemini Client (client.ts)', () => {
       } as unknown as ReturnType<Config['getChatRecordingService']>);
       mockTurnRunFn.mockReturnValue(
         (async function* () {
-          throw new Error('new turn failed');
+          yield Promise.reject(new Error('new turn failed'));
         })(),
       );
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -178,6 +178,8 @@ export interface SendMessageOptions {
   modelOverride?: string;
   /** Exact provider/runtime route for the current logical turn. */
   modelRoute?: FullTurnModelRoute;
+  /** A teammate message appended to an unsent tool result stays on that turn. */
+  continuesToolTurn?: boolean;
 }
 
 const EMPTY_RELEVANT_AUTO_MEMORY_RESULT: RelevantAutoMemoryPromptResult = {
@@ -672,8 +674,11 @@ export class GeminiClient {
     // Use the O(1) length getter rather than getHistory() — the latter
     // structuredClone's the entire history just to read .length, which
     // gets expensive in long-running sessions.
-    const prevLen = this.getChat().getHistoryLength();
-    this.getChat().truncateHistory(keepCount);
+    const chat = this.getChat();
+    const prevLen = chat.getHistoryLength();
+    const hadPendingFullTurnRoute =
+      chat.getPendingFullTurnRouteIdentity?.() !== undefined;
+    chat.truncateHistory(keepCount);
     // Decide whether to invalidate based on the *actual* post-truncate
     // length, not on the keepCount argument. Comparing keepCount alone
     // misses pathological inputs (e.g. NaN: slice(0, NaN) returns [],
@@ -681,6 +686,9 @@ export class GeminiClient {
     // the clear, reintroducing the file_unchanged placeholder bug).
     const newLen = this.getChat().getHistoryLength();
     if (newLen < prevLen) {
+      if (hadPendingFullTurnRoute) {
+        this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+      }
       debugLogger.debug(
         `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount}, prev=${prevLen}, new=${newLen})`,
       );
@@ -1910,20 +1918,22 @@ export class GeminiClient {
       messageType === SendMessageType.Cron ||
       messageType === SendMessageType.Notification ||
       messageType === SendMessageType.Teammate;
+    const startsIndependentRoute =
+      startsIndependentTurn && options?.continuesToolTurn !== true;
     const chat = this.getChat();
     const pendingRouteIdentity = chat.getPendingFullTurnRouteIdentity?.();
     const incomingRouteIdentity = options?.modelRoute
       ? getFullTurnModelRouteIdentity(options.modelRoute)
       : undefined;
     const continuesPendingRoute =
-      !startsIndependentTurn &&
+      !startsIndependentRoute &&
       pendingRouteIdentity &&
       incomingRouteIdentity &&
       pendingRouteIdentity.model === incomingRouteIdentity.model &&
       pendingRouteIdentity.baseUrl === incomingRouteIdentity.baseUrl &&
       pendingRouteIdentity.authType === incomingRouteIdentity.authType;
     if (pendingRouteIdentity && !continuesPendingRoute) {
-      if (startsIndependentTurn) {
+      if (startsIndependentRoute) {
         chat.replaceHistoricalMediaWithReferences?.();
         this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
         chat.clearPendingFullTurnRoute?.();

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -36,6 +36,10 @@ import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 import { buildContextUsage } from '../hooks/context-usage.js';
 import { DEFAULT_TOKEN_LIMIT } from './tokenLimits.js';
 import { createSessionStartProfiler } from './session-start-profiler.js';
+import {
+  getFullTurnModelRouteIdentity,
+  type FullTurnModelRoute,
+} from './baseLlmClient.js';
 
 const debugLogger = createDebugLogger('CLIENT');
 
@@ -59,6 +63,8 @@ import {
 // Services
 import { LoopDetectionService } from '../services/loopDetectionService.js';
 import { CommitAttributionService } from '../services/commitAttribution.js';
+import { slimCompactionInput } from '../services/compactionInputSlimming.js';
+import { isFullTurnVisionCapable } from '../services/visionBridge/vision-bridge-service.js';
 
 // Tools
 import type { RelevantAutoMemoryPromptResult } from '../memory/manager.js';
@@ -103,6 +109,7 @@ import {
 import type { DeferredToolSummary } from '../tools/tool-registry.js';
 import {
   buildApiHistoryFromConversation,
+  getPendingFullTurnRouteState,
   replayUiTelemetryFromConversation,
 } from '../services/sessionService.js';
 import { reportError } from '../utils/errorReporting.js';
@@ -119,6 +126,7 @@ import { escapeSystemReminderTags } from '../utils/xml.js';
 import { ApiRetryEvent } from '../telemetry/types.js';
 import { logApiRetry } from '../telemetry/loggers.js';
 import { shouldUsePlanOnlyReminderInSubagentContext } from '../agents/runtime/subagent-plan-tool-policy.js';
+import { runWithRuntimeContentGenerator } from '../agents/runtime/agent-context.js';
 
 // Hook types and utilities
 import {
@@ -168,6 +176,8 @@ export interface SendMessageOptions {
   notificationDisplayText?: string;
   /** Model override from skill execution. When present, overrides the session model for this turn. */
   modelOverride?: string;
+  /** Exact provider/runtime route for the current logical turn. */
+  modelRoute?: FullTurnModelRoute;
 }
 
 const EMPTY_RELEVANT_AUTO_MEMORY_RESULT: RelevantAutoMemoryPromptResult = {
@@ -334,6 +344,73 @@ export class GeminiClient {
         sessionStartSource ?? SessionStartSource.Resume,
       );
       const chat = this.getChat();
+      const pendingRouteState = getPendingFullTurnRouteState(
+        resumedSessionData.conversation,
+      );
+      const pendingRouteIdentity = pendingRouteState?.identity;
+      if (pendingRouteIdentity) {
+        const historyStartContent =
+          resumedHistory[pendingRouteState.historyStart];
+        const configuredRoute = this.config
+          .getAllConfiguredModels()
+          .find(
+            (model) =>
+              model.id === pendingRouteIdentity.model &&
+              (!pendingRouteIdentity.authType ||
+                model.authType === pendingRouteIdentity.authType) &&
+              (!pendingRouteIdentity.baseUrl ||
+                model.baseUrl === pendingRouteIdentity.baseUrl),
+          );
+        const qualifiedModel =
+          pendingRouteIdentity.authType &&
+          !pendingRouteIdentity.model.startsWith(
+            `${pendingRouteIdentity.authType}:`,
+          )
+            ? `${pendingRouteIdentity.authType}:${pendingRouteIdentity.model}`
+            : pendingRouteIdentity.model;
+        const selector = pendingRouteIdentity.baseUrl
+          ? `${qualifiedModel}\0${pendingRouteIdentity.baseUrl}`
+          : qualifiedModel;
+        try {
+          if (!configuredRoute || !isFullTurnVisionCapable(configuredRoute)) {
+            throw new Error('model is no longer eligible for full-turn vision');
+          }
+          const resolved = await this.config
+            .getBaseLlmClient()
+            .resolveForModel(selector, { failClosed: true });
+          if (
+            pendingRouteIdentity.authType &&
+            resolved.contentGeneratorConfig.authType !==
+              pendingRouteIdentity.authType
+          ) {
+            throw new Error('auth type changed');
+          }
+          chat.setPendingFullTurnRoute(
+            pendingRouteIdentity,
+            {
+              model: resolved.model,
+              contentGenerator: resolved.contentGenerator,
+              contentGeneratorConfig: {
+                ...resolved.contentGeneratorConfig,
+                modalities: {
+                  ...resolved.contentGeneratorConfig.modalities,
+                  image: true,
+                },
+              },
+            },
+            historyStartContent,
+          );
+        } catch (error) {
+          debugLogger.warn(
+            `Could not restore exact full-turn route ${pendingRouteIdentity.model}: ${getErrorMessage(error)}`,
+          );
+          chat.setPendingFullTurnRoute(
+            pendingRouteIdentity,
+            undefined,
+            historyStartContent,
+          );
+        }
+      }
       if (resumeTokenCounts) {
         chat.seedResumeTokenCounts(
           resumeTokenCounts.promptTokenCount,
@@ -575,7 +652,12 @@ export class GeminiClient {
   }
 
   setHistory(history: Content[]) {
-    this.getChat().setHistory(history);
+    const chat = this.getChat();
+    if (chat.getPendingFullTurnRouteIdentity?.()) {
+      chat.clearPendingFullTurnRoute?.();
+      this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+    }
+    chat.setHistory(history);
     // Replacing history wholesale drops any prior read_file tool
     // results the FileReadCache still believes the model has seen.
     // Without clearing, a follow-up Read of an unchanged file would
@@ -1573,7 +1655,9 @@ export class GeminiClient {
     ) {
       const projectRoot = this.config.getProjectRoot();
       const sessionId = this.config.getSessionId();
-      const history = this.getHistoryShallow();
+      const history = slimCompactionInput(
+        this.getHistoryShallow(),
+      ).slimmedHistory;
       const mgr = this.config.getMemoryManager();
       const autoSkillEnabled = this.config.getAutoSkillEnabled();
 
@@ -1637,7 +1721,9 @@ export class GeminiClient {
 
     const projectRoot = this.config.getProjectRoot();
     const sessionId = this.config.getSessionId();
-    const history = this.getHistoryShallow();
+    const history = slimCompactionInput(
+      this.getHistoryShallow(),
+    ).slimmedHistory;
     const mgr = this.config.getMemoryManager();
 
     if (!this.config.getManagedAutoMemoryEnabled()) {
@@ -1819,6 +1905,50 @@ export class GeminiClient {
     turns: number = MAX_TURNS,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     const messageType = options?.type ?? SendMessageType.UserQuery;
+    const startsIndependentTurn =
+      messageType === SendMessageType.UserQuery ||
+      messageType === SendMessageType.Cron ||
+      messageType === SendMessageType.Notification ||
+      messageType === SendMessageType.Teammate;
+    const chat = this.getChat();
+    const pendingRouteIdentity = chat.getPendingFullTurnRouteIdentity?.();
+    const incomingRouteIdentity = options?.modelRoute
+      ? getFullTurnModelRouteIdentity(options.modelRoute)
+      : undefined;
+    const continuesPendingRoute =
+      !startsIndependentTurn &&
+      pendingRouteIdentity &&
+      incomingRouteIdentity &&
+      pendingRouteIdentity.model === incomingRouteIdentity.model &&
+      pendingRouteIdentity.baseUrl === incomingRouteIdentity.baseUrl &&
+      pendingRouteIdentity.authType === incomingRouteIdentity.authType;
+    if (pendingRouteIdentity && !continuesPendingRoute) {
+      if (startsIndependentTurn) {
+        chat.replaceHistoricalMediaWithReferences?.();
+        this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+        chat.clearPendingFullTurnRoute?.();
+      } else {
+        throw new Error(
+          `Cannot safely continue the interrupted image turn because its exact route (${pendingRouteIdentity.model}) was not provided.`,
+        );
+      }
+    }
+    if (options?.modelRoute) {
+      const identity = incomingRouteIdentity!;
+      const pendingIdentity = chat.getPendingFullTurnRouteIdentity?.();
+      if (
+        !pendingIdentity ||
+        pendingIdentity.model !== identity.model ||
+        pendingIdentity.baseUrl !== identity.baseUrl ||
+        pendingIdentity.authType !== identity.authType
+      ) {
+        if (chat.replaceHistoricalMediaWithReferences?.()) {
+          this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+        }
+        this.config.getChatRecordingService()?.recordFullTurnRoute(identity);
+      }
+      chat.setPendingFullTurnRoute?.(identity, options.modelRoute);
+    }
     let strippedRetryEntries: Content[] = [];
     // Snapshot of GeminiChat's user-content push counter, taken right after the
     // strip. The Retry's re-submitted content is the first thing the send
@@ -1860,6 +1990,11 @@ export class GeminiClient {
     };
 
     if (messageType === SendMessageType.Retry) {
+      if (continuesPendingRoute) {
+        request = chat.preparePendingFullTurnMediaForContinuation(
+          createUserContent(request).parts ?? [],
+        );
+      }
       strippedRetryEntries = this.stripOrphanedUserEntriesFromHistory() ?? [];
       pushCountAfterStrip = currentPushCount();
       // The matching dangling-`functionCall` repair runs inside
@@ -1916,7 +2051,9 @@ export class GeminiClient {
             originalPrompt: promptText,
           },
         };
-        return new Turn(this.getChat(), prompt_id);
+        const blockedTurn = new Turn(this.getChat(), prompt_id);
+        this.replaceCompletedFullTurnMedia(options?.modelRoute, blockedTurn);
+        return blockedTurn;
       }
 
       // Add additional context from hooks to the request
@@ -1944,11 +2081,7 @@ export class GeminiClient {
     // Notifications start a fresh Turn with a new prompt_id, so the loop
     // detector must reset — otherwise a prior turn's count can trip
     // LoopDetected early on the notification turn.
-    const isTopLevelInteraction =
-      messageType === SendMessageType.UserQuery ||
-      messageType === SendMessageType.Cron ||
-      messageType === SendMessageType.Notification ||
-      messageType === SendMessageType.Teammate;
+    const isTopLevelInteraction = startsIndependentTurn;
     if (isTopLevelInteraction) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
@@ -1983,6 +2116,7 @@ export class GeminiClient {
     // uncaught-exception exits too; created (when the hook is registered)
     // right before the turn's streaming loop below.
     let messageDisplay: MessageDisplayDispatcher | null = null;
+    let activeTurn: Turn | undefined;
     try {
       if (
         messageType === SendMessageType.UserQuery ||
@@ -2086,7 +2220,7 @@ export class GeminiClient {
         if (messageType === SendMessageType.UserQuery || compacted) {
           this.lastHookMicrocompactionTimestamp = Date.now();
         }
-      } else if (messageType === SendMessageType.Hook) {
+      } else if (messageType === SendMessageType.Hook && !options?.modelRoute) {
         this.lastHookMicrocompactionTimestamp ??=
           this.lastApiCompletionTimestamp ?? Date.now();
         const checkpoint = this.lastHookMicrocompactionTimestamp;
@@ -2248,9 +2382,13 @@ export class GeminiClient {
       }
 
       const turn = new Turn(this.getChat(), prompt_id);
+      activeTurn = turn;
 
       // Determine the model to use for this turn
-      const model = options?.modelOverride ?? this.config.getModel();
+      const model =
+        options?.modelRoute?.model ??
+        options?.modelOverride ??
+        this.config.getModel();
 
       // Assemble the outgoing request. IDE context is merged into the
       // user prompt's first text part, then on UserQuery / Cron turns
@@ -2341,10 +2479,12 @@ export class GeminiClient {
           // text as a separate user message after the tool messages.
           requestToSend = [...requestToSend, toolResultMemory.prompt];
         }
-        await this.microcompactHistoryBeforeSend(null, {
-          sizeOnly: true,
-          pendingContent: createUserContent(requestToSend),
-        });
+        if (!options?.modelRoute) {
+          await this.microcompactHistoryBeforeSend(null, {
+            sizeOnly: true,
+            pendingContent: createUserContent(requestToSend),
+          });
+        }
       }
 
       const activeGoalAtTurnStart = getActiveGoal(this.config.getSessionId());
@@ -2394,7 +2534,9 @@ export class GeminiClient {
             )
           : null;
 
-      const resultStream = turn.run(model, requestToSend, signal);
+      const resultStream = options?.modelRoute
+        ? turn.run(model, requestToSend, signal, options.modelRoute)
+        : turn.run(model, requestToSend, signal);
       let didUpdateIdeContextState = false;
       try {
         for await (const event of resultStream) {
@@ -2559,27 +2701,32 @@ export class GeminiClient {
           this.getLastModelMessageText() || '[no response text]';
 
         const contextUsage = buildContextUsage(
-          this.config.getContentGeneratorConfig()?.contextWindowSize ??
+          options?.modelRoute?.contentGeneratorConfig.contextWindowSize ??
+            this.config.getContentGeneratorConfig()?.contextWindowSize ??
             DEFAULT_TOKEN_LIMIT,
           uiTelemetryService.getLastPromptTokenCount(),
         );
 
-        const response = await messageBus.request<
-          HookExecutionRequest,
-          HookExecutionResponse
-        >(
-          {
-            type: MessageBusType.HOOK_EXECUTION_REQUEST,
-            eventName: 'Stop',
-            input: {
-              stop_hook_active: true,
-              last_assistant_message: responseText,
-              ...contextUsage,
+        const requestStopHook = () =>
+          messageBus.request<HookExecutionRequest, HookExecutionResponse>(
+            {
+              type: MessageBusType.HOOK_EXECUTION_REQUEST,
+              eventName: 'Stop',
+              input: {
+                stop_hook_active: true,
+                last_assistant_message: responseText,
+                ...contextUsage,
+              },
+              signal,
             },
-            signal,
-          },
-          MessageBusType.HOOK_EXECUTION_RESPONSE,
-        );
+            MessageBusType.HOOK_EXECUTION_RESPONSE,
+          );
+        const response = options?.modelRoute
+          ? await runWithRuntimeContentGenerator(
+              options.modelRoute,
+              requestStopHook,
+            )
+          : await requestStopHook();
 
         // Stop hook callbacks can mutate active goal state during request().
         // Capture it before cancellation returns so clear events are not lost.
@@ -2668,7 +2815,9 @@ export class GeminiClient {
               value: warning,
             };
             debugLogger.warn(warning);
+            this.replaceCompletedFullTurnMedia(options?.modelRoute, turn);
             if (isTopLevelInteraction) endInteractionSpan('ok');
+            normalCompletion = true;
             return turn;
           }
 
@@ -2710,6 +2859,7 @@ export class GeminiClient {
             {
               type: SendMessageType.Hook,
               modelOverride: options?.modelOverride,
+              modelRoute: options?.modelRoute,
               stopHookState: {
                 iterationCount: currentIterationCount,
                 reasons: currentReasons,
@@ -2717,6 +2867,7 @@ export class GeminiClient {
             },
             hookTurnBudget,
           );
+          this.replaceCompletedFullTurnMedia(options?.modelRoute, hookTurn);
           if (isTopLevelInteraction)
             endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           // Preserve the pending prefetch: the inner Hook turn we just
@@ -2741,10 +2892,9 @@ export class GeminiClient {
         try {
           const chat = this.getChat();
           const maxHistoryForCache = 40;
-          const cachedHistory = this.getHistoryTailShallow(
-            maxHistoryForCache,
-            true,
-          );
+          const cachedHistory = slimCompactionInput(
+            this.getHistoryTailShallow(maxHistoryForCache, true),
+          ).slimmedHistory;
           saveCacheSafeParams(
             chat.getGenerationConfig(),
             cachedHistory,
@@ -2755,6 +2905,7 @@ export class GeminiClient {
         }
 
         if (this.config.getSkipNextSpeakerCheck()) {
+          this.replaceCompletedFullTurnMedia(options?.modelRoute, turn);
           this.runManagedAutoMemoryBackgroundTasks(messageType);
           if (arenaAgentClient) {
             await arenaAgentClient.reportCompleted();
@@ -2786,6 +2937,7 @@ export class GeminiClient {
             { ...options, type: SendMessageType.Hook },
             boundedTurns - 1,
           );
+          this.replaceCompletedFullTurnMedia(options?.modelRoute, continueTurn);
           if (isTopLevelInteraction)
             endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           // Preserve the pending prefetch: same reasoning as the
@@ -2796,6 +2948,7 @@ export class GeminiClient {
           return continueTurn;
         }
 
+        this.replaceCompletedFullTurnMedia(options?.modelRoute, turn);
         this.runManagedAutoMemoryBackgroundTasks(messageType);
 
         if (arenaAgentClient) {
@@ -2811,6 +2964,9 @@ export class GeminiClient {
 
       if (isTopLevelInteraction) {
         endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
+      }
+      if (signal?.aborted) {
+        this.replaceCompletedFullTurnMedia(options?.modelRoute, turn, true);
       }
       // Reached the bottom of the try — this turn ended cleanly. Preserve
       // any still-pending memory prefetch so the next ToolResult turn can
@@ -2829,6 +2985,13 @@ export class GeminiClient {
       // `return turn`. Catches uncaught exceptions and guards against
       // future early-return sites that forget to call cancel.
       if (!normalCompletion) {
+        if (activeTurn) {
+          this.replaceCompletedFullTurnMedia(
+            options?.modelRoute,
+            activeTurn,
+            true,
+          );
+        }
         this.cancelPendingMemoryPrefetch();
       }
       if (isTopLevelInteraction) {
@@ -2836,6 +2999,22 @@ export class GeminiClient {
           errorMessage: 'unexpected exit',
         });
       }
+    }
+  }
+
+  private replaceCompletedFullTurnMedia(
+    modelRoute: FullTurnModelRoute | undefined,
+    turn: Turn,
+    force = false,
+  ): void {
+    if (!modelRoute || (!force && turn.pendingToolCalls.length > 0)) return;
+    const chat = this.getChat();
+    const changed = chat.replaceHistoricalMediaWithReferences();
+    if (!force) {
+      if (changed || chat.getPendingFullTurnRouteIdentity?.()) {
+        this.config.getChatRecordingService()?.recordMediaScrubCheckpoint();
+      }
+      chat.clearPendingFullTurnRoute?.();
     }
   }
 

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -64,7 +64,11 @@ import { WriteFileTool } from '../tools/write-file.js';
 import { ShellTool, ShellToolInvocation } from '../tools/shell.js';
 import type { ShellToolParams } from '../tools/shell.js';
 import type { ShellExecutionConfig } from '../services/shellExecutionService.js';
-import { runWithAgentContext } from '../agents/runtime/agent-context.js';
+import {
+  getRuntimeContentGenerator,
+  runWithAgentContext,
+  type RuntimeContentGeneratorView,
+} from '../agents/runtime/agent-context.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
 
 type ToolSpanRecord = {
@@ -794,6 +798,41 @@ describe('CoreToolScheduler', () => {
       onToolCallsUpdate,
     };
   }
+
+  it('executes scheduled tools inside the supplied runtime route', async () => {
+    const runtimeView: RuntimeContentGeneratorView = {
+      contentGenerator: {} as RuntimeContentGeneratorView['contentGenerator'],
+      contentGeneratorConfig: { model: 'vision-agent' },
+    };
+    const seen: Array<RuntimeContentGeneratorView | undefined> = [];
+    const execute = vi.fn(async () => {
+      await Promise.resolve();
+      seen.push(getRuntimeContentGenerator());
+      return { llmContent: 'done', returnDisplay: 'done' };
+    });
+    const { scheduler } = createSchedulerForLegacyToolTests({
+      toolsByName: new Map([
+        ['routedTool', new MockTool({ name: 'routedTool', execute })],
+      ]),
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'routed-call',
+          name: 'routedTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'routed-prompt',
+        },
+      ],
+      new AbortController().signal,
+      runtimeView,
+    );
+
+    expect(seen).toEqual([runtimeView]);
+    expect(getRuntimeContentGenerator()).toBeUndefined();
+  });
 
   it('dispatches legacy tool names through their canonical registered tools', async () => {
     const canonicalNamesByLegacyName = new Map(
@@ -8329,6 +8368,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     args?: Record<string, unknown>;
     abortController?: AbortController;
     tools?: MockTool[];
+    runtimeView?: RuntimeContentGeneratorView;
   }): Promise<{
     scheduler: CoreToolScheduler;
     onAllToolCallsComplete: ReturnType<typeof vi.fn>;
@@ -8349,6 +8389,7 @@ describe('CoreToolScheduler telemetry spans', () => {
         },
       ],
       abortController.signal,
+      options.runtimeView,
     );
     return { ...built, abortController };
   }
@@ -8428,6 +8469,40 @@ describe('CoreToolScheduler telemetry spans', () => {
     const blocked = getBlockedSpans();
     expect(blocked).toHaveLength(1);
     expect(blocked[0].ended).toBe(true);
+  });
+
+  it('restores the runtime route when an ask is approved outside its async context', async () => {
+    const runtimeView: RuntimeContentGeneratorView = {
+      contentGenerator: {} as RuntimeContentGeneratorView['contentGenerator'],
+      contentGeneratorConfig: { model: 'vision-agent' },
+    };
+    const seen: Array<RuntimeContentGeneratorView | undefined> = [];
+    const execute = vi.fn(async () => {
+      await Promise.resolve();
+      seen.push(getRuntimeContentGenerator());
+      return { llmContent: 'ok', returnDisplay: 'ok' };
+    });
+    const { onToolCallsUpdate, onAllToolCallsComplete } = await scheduleWithAsk(
+      {
+        messageBus: askMessageBus(),
+        execute,
+        runtimeView,
+      },
+    );
+
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    expect(getRuntimeContentGenerator()).toBeUndefined();
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    expect(seen).toEqual([runtimeView]);
   });
 
   it('cancels the tool without executing when the user declines an ask', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -142,6 +142,11 @@ import {
 } from '../telemetry/index.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
+import {
+  getRuntimeContentGenerator,
+  runWithRuntimeContentGenerator,
+  type RuntimeContentGeneratorView,
+} from '../agents/runtime/agent-context.js';
 
 const debugLogger = createDebugLogger('TOOL_SCHEDULER');
 
@@ -1314,6 +1319,7 @@ export class CoreToolScheduler {
   private requestQueue: Array<{
     request: ToolCallRequestInfo | ToolCallRequestInfo[];
     signal: AbortSignal;
+    runtimeView?: RuntimeContentGeneratorView;
     resolve: () => void;
     reject: (reason?: Error) => void;
   }> = [];
@@ -1966,6 +1972,7 @@ export class CoreToolScheduler {
   schedule(
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
     signal: AbortSignal,
+    runtimeView?: RuntimeContentGeneratorView,
   ): Promise<void> {
     if (this.isRunning() || this.isScheduling) {
       return new Promise((resolve, reject) => {
@@ -1985,6 +1992,7 @@ export class CoreToolScheduler {
         this.requestQueue.push({
           request,
           signal,
+          runtimeView,
           resolve: () => {
             signal.removeEventListener('abort', abortHandler);
             resolve();
@@ -1996,7 +2004,18 @@ export class CoreToolScheduler {
         });
       });
     }
-    return this._schedule(request, signal);
+    return this.scheduleWithRuntimeView(request, signal, runtimeView);
+  }
+
+  private scheduleWithRuntimeView(
+    request: ToolCallRequestInfo | ToolCallRequestInfo[],
+    signal: AbortSignal,
+    runtimeView?: RuntimeContentGeneratorView,
+  ): Promise<void> {
+    const run = () => this._schedule(request, signal, runtimeView);
+    return runtimeView
+      ? runWithRuntimeContentGenerator(runtimeView, run)
+      : run();
   }
 
   /**
@@ -2038,6 +2057,7 @@ export class CoreToolScheduler {
   private async _schedule(
     request: ToolCallRequestInfo | ToolCallRequestInfo[],
     signal: AbortSignal,
+    runtimeView?: RuntimeContentGeneratorView,
   ): Promise<void> {
     this.isScheduling = true;
     try {
@@ -2755,14 +2775,19 @@ export class CoreToolScheduler {
               onConfirm: (
                 outcome: ToolConfirmationOutcome,
                 payload?: ToolConfirmationPayload,
-              ) =>
-                this.handleConfirmationResponse(
-                  reqInfo.callId,
-                  originalOnConfirm,
-                  outcome,
-                  signal,
-                  payload,
-                ),
+              ) => {
+                const confirm = () =>
+                  this.handleConfirmationResponse(
+                    reqInfo.callId,
+                    originalOnConfirm,
+                    outcome,
+                    signal,
+                    payload,
+                  );
+                return runtimeView
+                  ? runWithRuntimeContentGenerator(runtimeView, confirm)
+                  : confirm();
+              },
             };
             this.setStatusInternal(
               reqInfo.callId,
@@ -3472,6 +3497,7 @@ export class CoreToolScheduler {
   ): void {
     const { callId, name: toolName } = scheduledCall.request;
     const canonicalName = canonicalToolName(toolName);
+    const runtimeView = getRuntimeContentGenerator();
 
     this.bouncedAwaitingApproval.add(callId);
 
@@ -3482,16 +3508,21 @@ export class CoreToolScheduler {
         reason ||
         `A PreToolUse hook requested confirmation before running ${toolName}.`,
       hideAlwaysAllow: true,
-      onConfirm: (outcome, payload) =>
-        this.handleConfirmationResponse(
-          callId,
-          // No real tool onConfirm — for this synthetic prompt all of the
-          // approve/deny handling lives in handleConfirmationResponse.
-          async () => {},
-          outcome,
-          signal,
-          payload,
-        ),
+      onConfirm: (outcome, payload) => {
+        const confirm = () =>
+          this.handleConfirmationResponse(
+            callId,
+            // No real tool onConfirm — for this synthetic prompt all of the
+            // approve/deny handling lives in handleConfirmationResponse.
+            async () => {},
+            outcome,
+            signal,
+            payload,
+          );
+        return runtimeView
+          ? runWithRuntimeContentGenerator(runtimeView, confirm)
+          : confirm();
+      },
     };
 
     this.setStatusInternal(callId, 'awaiting_approval', confirmationDetails);
@@ -4672,7 +4703,11 @@ export class CoreToolScheduler {
           // Always drain the queue, even if completion callbacks throw.
           if (this.requestQueue.length > 0) {
             const next = this.requestQueue.shift()!;
-            this._schedule(next.request, next.signal)
+            this.scheduleWithRuntimeView(
+              next.request,
+              next.signal,
+              next.runtimeView,
+            )
               .then(next.resolve)
               .catch(next.reject);
           }

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -8773,6 +8773,7 @@ describe('GeminiChat', async () => {
           parts: [{ functionCall: { id: 'x', name: 't', args: {} } }],
         },
       ]);
+      chat.setPendingFullTurnRoute({ model: 'vision-agent' });
       plantMarkers(chat);
       expect(markers(chat).idx).toBe(0);
 
@@ -8780,6 +8781,7 @@ describe('GeminiChat', async () => {
 
       expect(markers(chat).idx).toBeNull();
       expect(markers(chat).record).toBeNull();
+      expect(chat.getPendingFullTurnRouteIdentity()).toBeUndefined();
     });
 
     it('stripThoughtsFromHistory() clears the partial-push markers', () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -44,6 +44,8 @@ import {
   getToolCallPreparations,
   setToolCallPreparations,
 } from './tool-call-preparation.js';
+import { getRuntimeContentGenerator } from '../agents/runtime/agent-context.js';
+import type { FullTurnModelRoute } from './baseLlmClient.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -168,10 +170,13 @@ describe('GeminiChat', async () => {
       getTelemetryLogPromptsEnabled: () => true,
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
-      getContentGeneratorConfig: vi.fn().mockReturnValue({
-        authType: 'gemini', // Ensure this is set for fallback tests
-        model: 'test-model',
-      }),
+      getContentGeneratorConfig: vi.fn().mockImplementation(
+        () =>
+          getRuntimeContentGenerator()?.contentGeneratorConfig ?? {
+            authType: 'gemini', // Ensure this is set for fallback tests
+            model: 'test-model',
+          },
+      ),
       getModel: vi.fn().mockReturnValue('gemini-pro'),
       setModel: vi.fn(),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),
@@ -183,7 +188,13 @@ describe('GeminiChat', async () => {
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn(),
       }),
-      getContentGenerator: vi.fn().mockReturnValue(mockContentGenerator),
+      getContentGenerator: vi
+        .fn()
+        .mockImplementation(
+          () =>
+            getRuntimeContentGenerator()?.contentGenerator ??
+            mockContentGenerator,
+        ),
       getBaseLlmClient: vi.fn().mockReturnValue(undefined),
       getModelFallbacks: vi.fn().mockReturnValue([]),
       getChatCompression: vi.fn().mockReturnValue(undefined),
@@ -1638,6 +1649,11 @@ describe('GeminiChat', async () => {
     });
 
     it('keeps historical image refs stable and reattaches only recent image bytes', async () => {
+      vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+        authType: AuthType.USE_GEMINI,
+        model: 'test-model',
+        modalities: { image: true },
+      });
       vi.mocked(mockConfig.getChatCompression).mockReturnValue({
         maxRecentImagesToRetain: 1,
         imagePayloadThreshold: 1,
@@ -5334,6 +5350,500 @@ describe('GeminiChat', async () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('uses the exact model route generator and preserves raw images', async () => {
+      const routeGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi
+          .fn()
+          .mockResolvedValue(streamResponse(stopResponse([{ text: 'seen' }]))),
+      } as unknown as ContentGenerator;
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: routeGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          baseUrl: 'https://vision.example.com/v1',
+          modalities: { image: true },
+        },
+      };
+      const imagePart: Part = {
+        inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' },
+      };
+
+      const stream = await chat.sendMessageStream(
+        route.model,
+        { message: [{ text: 'inspect' }, imagePart] },
+        'prompt-exact-vision-route',
+        { modelRoute: route },
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      expect(mockContentGenerator.generateContentStream).not.toHaveBeenCalled();
+      expect(routeGenerator.generateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'vision-agent',
+          contents: expect.arrayContaining([
+            expect.objectContaining({
+              parts: expect.arrayContaining([imagePart]),
+            }),
+          ]),
+        }),
+        'prompt-exact-vision-route',
+      );
+    });
+
+    it('preserves all pending-route images instead of applying the retention threshold', async () => {
+      vi.mocked(mockConfig.getChatCompression).mockReturnValue({
+        maxRecentImagesToRetain: 1,
+        imagePayloadThreshold: 1,
+      });
+      const compress = vi.spyOn(ChatCompressionService.prototype, 'compress');
+      const routeGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi
+          .fn()
+          .mockResolvedValue(streamResponse(stopResponse([{ text: 'seen' }]))),
+      } as unknown as ContentGenerator;
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: routeGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          modalities: { image: true },
+        },
+      };
+      chat.setHistory([
+        {
+          role: 'user',
+          parts: [{ inlineData: { mimeType: 'image/png', data: 'first' } }],
+        },
+        { role: 'model', parts: [{ text: 'first seen' }] },
+        {
+          role: 'user',
+          parts: [{ inlineData: { mimeType: 'image/png', data: 'second' } }],
+        },
+        { role: 'model', parts: [{ text: 'second seen' }] },
+      ]);
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+
+      const stream = await chat.sendMessageStream(
+        route.model,
+        { message: 'continue' },
+        'prompt-preserve-route-images',
+        { modelRoute: route },
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      const contents = vi.mocked(routeGenerator.generateContentStream).mock
+        .calls[0]?.[0].contents;
+      expect(JSON.stringify(contents)).toContain('"data":"first"');
+      expect(JSON.stringify(contents)).toContain('"data":"second"');
+      expect(compress).not.toHaveBeenCalled();
+    });
+
+    it('surfaces exact-route context overflow without reactive compression', async () => {
+      const overflow = new Error(
+        'prompt is too long: 135000 tokens > 128000 maximum',
+      );
+      const compress = vi.spyOn(ChatCompressionService.prototype, 'compress');
+      const routeGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi.fn().mockRejectedValue(overflow),
+      } as unknown as ContentGenerator;
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: routeGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          modalities: { image: true },
+        },
+      };
+      chat.setPendingFullTurnRoute(
+        { model: route.model, authType: AuthType.USE_OPENAI },
+        route,
+      );
+
+      const stream = await chat.sendMessageStream(
+        route.model,
+        { message: 'continue' },
+        'prompt-exact-route-overflow',
+        { modelRoute: route },
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toThrow(overflow);
+      expect(compress).not.toHaveBeenCalled();
+      expect(routeGenerator.generateContentStream).toHaveBeenCalledOnce();
+    });
+
+    it('does not replay routed image bytes to the text-only primary on the next turn', async () => {
+      const routeGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi
+          .fn()
+          .mockResolvedValue(streamResponse(stopResponse([{ text: 'seen' }]))),
+      } as unknown as ContentGenerator;
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: routeGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          modalities: { image: true },
+        },
+      };
+
+      const imageStream = await chat.sendMessageStream(
+        route.model,
+        {
+          message: [
+            { text: 'inspect' },
+            { inlineData: { mimeType: 'image/png', data: 'private-image' } },
+            {
+              fileData: {
+                mimeType: 'image/jpeg',
+                fileUri: 'https://private.example/image.jpg',
+              },
+            },
+          ],
+        },
+        'prompt-routed-image',
+        { modelRoute: route },
+      );
+      for await (const _ of imageStream) {
+        /* consume */
+      }
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamResponse(stopResponse([{ text: 'continued' }])),
+      );
+      const textStream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'continue' },
+        'prompt-primary-text',
+      );
+      for await (const _ of textStream) {
+        /* consume */
+      }
+
+      const routedRequest = vi.mocked(routeGenerator.generateContentStream).mock
+        .calls[0]?.[0];
+      expect(JSON.stringify(routedRequest?.contents)).toContain(
+        '"data":"private-image"',
+      );
+      expect(JSON.stringify(routedRequest?.contents)).toContain(
+        'https://private.example/image.jpg',
+      );
+
+      const primaryRequest = vi.mocked(
+        mockContentGenerator.generateContentStream,
+      ).mock.calls[0]?.[0];
+      const serializedPrimary = JSON.stringify(primaryRequest?.contents);
+      expect(serializedPrimary).not.toContain('private-image');
+      expect(serializedPrimary).not.toContain(
+        'https://private.example/image.jpg',
+      );
+      expect(serializedPrimary).not.toContain('inlineData');
+      expect(serializedPrimary).not.toContain('fileData');
+      expect(serializedPrimary).toMatch(
+        /\[Image #[a-f0-9]{12}: image\/png, \d+ bytes\]/,
+      );
+      expect(serializedPrimary).toMatch(
+        /\[Image #[a-f0-9]{12}: image\/jpeg, file URI\]/,
+      );
+    });
+
+    it('scrubs an orphaned image user entry before merging a new text prompt', async () => {
+      chat.setHistory([
+        {
+          role: 'user',
+          parts: [
+            { text: 'interrupted image prompt' },
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: 'orphaned-private-image',
+              },
+            },
+          ],
+        },
+      ]);
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamResponse(stopResponse([{ text: 'continued' }])),
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'new text prompt' },
+        'prompt-after-orphaned-image',
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      const request = vi.mocked(mockContentGenerator.generateContentStream).mock
+        .calls[0]?.[0];
+      const serialized = JSON.stringify(request?.contents);
+      expect(serialized).toContain('new text prompt');
+      expect(serialized).not.toContain('orphaned-private-image');
+      expect(serialized).not.toContain('inlineData');
+    });
+
+    it('does not replay route-scoped media after switching to another image provider', async () => {
+      const firstGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi
+          .fn()
+          .mockResolvedValue(streamResponse(stopResponse([{ text: 'seen' }]))),
+      } as unknown as ContentGenerator;
+      const firstRoute: FullTurnModelRoute = {
+        model: 'first-vision-agent',
+        contentGenerator: firstGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'first-vision-agent',
+          baseUrl: 'https://first.example.com/v1',
+          modalities: { image: true },
+        },
+      };
+      const firstStream = await chat.sendMessageStream(
+        firstRoute.model,
+        {
+          message: [
+            { inlineData: { mimeType: 'image/png', data: 'private-image' } },
+            {
+              fileData: {
+                mimeType: 'image/jpeg',
+                fileUri: 'https://private.example/image.jpg',
+              },
+            },
+          ],
+        },
+        'prompt-first-provider',
+        { modelRoute: firstRoute },
+      );
+      for await (const _ of firstStream) {
+        /* consume */
+      }
+
+      chat.replaceHistoricalMediaWithReferences();
+
+      const secondGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi
+          .fn()
+          .mockResolvedValue(
+            streamResponse(stopResponse([{ text: 'continued' }])),
+          ),
+      } as unknown as ContentGenerator;
+      const secondRoute: FullTurnModelRoute = {
+        model: 'second-vision-agent',
+        contentGenerator: secondGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'second-vision-agent',
+          baseUrl: 'https://second.example.com/v1',
+          modalities: { image: true },
+        },
+      };
+      const secondStream = await chat.sendMessageStream(
+        secondRoute.model,
+        { message: 'continue' },
+        'prompt-second-provider',
+        { modelRoute: secondRoute },
+      );
+      for await (const _ of secondStream) {
+        /* consume */
+      }
+
+      const secondRequest = vi.mocked(secondGenerator.generateContentStream)
+        .mock.calls[0]?.[0];
+      const serialized = JSON.stringify(secondRequest?.contents);
+      expect(serialized).not.toContain('private-image');
+      expect(serialized).not.toContain('https://private.example/image.jpg');
+      expect(serialized).not.toContain('inlineData');
+      expect(serialized).not.toContain('fileData');
+      expect(serialized).toMatch(
+        /\[Image #[a-f0-9]{12}: image\/png, \d+ bytes\]/,
+      );
+      expect(serialized).toMatch(
+        /\[Image #[a-f0-9]{12}: image\/jpeg, file URI\]/,
+      );
+    });
+
+    it('preserves raw continuation images after an exact route is restored', () => {
+      const image: Part = {
+        inlineData: { mimeType: 'image/png', data: 'persisted-image' },
+      };
+
+      const prepared = chat.prepareHistoricalMediaForContinuation(
+        [{ text: 'retry' }, image],
+        [{ role: 'user', parts: [{ text: 'retry' }, image] }],
+      );
+
+      expect(prepared).toContainEqual(image);
+    });
+
+    it('does not reattach an older settled image to an unrelated continuation', () => {
+      chat.setHistory([
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'image/png',
+                data: 'older-settled-image',
+              },
+            },
+          ],
+        },
+      ]);
+      chat.replaceHistoricalMediaWithReferences();
+      const settledId = JSON.stringify(chat.getHistory()).match(
+        /Image #([a-f0-9]{12})/,
+      )?.[1];
+      expect(settledId).toBeDefined();
+
+      const prepared = chat.prepareHistoricalMediaForContinuation(
+        [
+          { text: `inspect Image #${settledId}` },
+          { functionResponse: { id: 'new-call', name: 'read_file' } },
+        ],
+        [
+          {
+            role: 'user',
+            parts: [{ text: `inspect Image #${settledId}` }],
+          },
+          {
+            role: 'model',
+            parts: [{ functionCall: { id: 'new-call', name: 'read_file' } }],
+          },
+        ],
+      );
+
+      expect(JSON.stringify(prepared)).not.toContain('older-settled-image');
+      expect(prepared.some((part) => part.inlineData)).toBe(false);
+    });
+
+    it('keeps ordinary retries on the exact model route', async () => {
+      const capacityError = Object.assign(
+        new Error('temporarily unavailable'),
+        {
+          status: 503,
+        },
+      );
+      const routeGenerateContentStream = vi
+        .fn()
+        .mockRejectedValueOnce(capacityError)
+        .mockResolvedValueOnce(
+          streamResponse(stopResponse([{ text: 'recovered' }])),
+        );
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: {
+          ...mockContentGenerator,
+          generateContentStream: routeGenerateContentStream,
+        } as unknown as ContentGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          modalities: { image: true },
+        },
+      };
+      const resolveForModel = vi.fn();
+      vi.mocked(mockConfig.getModelFallbacks).mockReturnValue([
+        'ordinary-fallback',
+      ]);
+      vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
+        resolveForModel,
+      } as unknown as ReturnType<typeof mockConfig.getBaseLlmClient>);
+      mockRetryWithBackoff.mockImplementation(async (apiCall, options) => {
+        try {
+          return await apiCall();
+        } catch (error) {
+          expect(options?.shouldRetryOnError?.(error)).toBe(true);
+          return apiCall();
+        }
+      });
+
+      const stream = await chat.sendMessageStream(
+        route.model,
+        { message: [{ inlineData: { mimeType: 'image/png', data: 'raw' } }] },
+        'prompt-exact-vision-retry',
+        { modelRoute: route },
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      expect(routeGenerateContentStream).toHaveBeenCalledTimes(2);
+      expect(mockContentGenerator.generateContentStream).not.toHaveBeenCalled();
+      expect(resolveForModel).not.toHaveBeenCalled();
+      expect(mockRetryWithBackoff).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ authType: AuthType.USE_OPENAI }),
+      );
+    });
+
+    it('does not enter the configured fallback chain from an exact model route', async () => {
+      const capacityError = Object.assign(new Error('vision unavailable'), {
+        status: 503,
+      });
+      const routeGenerator = {
+        ...mockContentGenerator,
+        generateContentStream: vi.fn().mockRejectedValue(capacityError),
+      } as unknown as ContentGenerator;
+      const route: FullTurnModelRoute = {
+        model: 'vision-agent',
+        contentGenerator: routeGenerator,
+        contentGeneratorConfig: {
+          authType: AuthType.USE_OPENAI,
+          model: 'vision-agent',
+          maxRetries: 0,
+          modalities: { image: true },
+        },
+      };
+      const resolveForModel = vi.fn();
+      vi.mocked(mockConfig.getModelFallbacks).mockReturnValue([
+        'ordinary-fallback',
+      ]);
+      vi.mocked(mockConfig.getBaseLlmClient).mockReturnValue({
+        resolveForModel,
+      } as unknown as ReturnType<typeof mockConfig.getBaseLlmClient>);
+
+      const stream = await chat.sendMessageStream(
+        route.model,
+        { message: [{ inlineData: { mimeType: 'image/png', data: 'raw' } }] },
+        'prompt-exact-vision-failure',
+        { modelRoute: route },
+      );
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toBe(capacityError);
+
+      expect(resolveForModel).not.toHaveBeenCalled();
+      expect(mockContentGenerator.generateContentStream).not.toHaveBeenCalled();
     });
 
     it('does not enter the fallback chain in unattended retry mode', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -3425,6 +3425,8 @@ export class GeminiChat {
       current.baseUrl !== identity.baseUrl ||
       current.authType !== identity.authType
     ) {
+      // Resume may prepend startup context or repair history before restoring
+      // the route, so resolve the recorded boundary against the live array.
       const historyStart = historyStartContent
         ? this.history.indexOf(historyStartContent)
         : this.history.length;
@@ -3638,7 +3640,11 @@ export class GeminiChat {
   }
 
   truncateHistory(keepCount: number): void {
+    const previousLength = this.history.length;
     this.history = this.history.slice(0, keepCount);
+    if (this.history.length < previousLength) {
+      this.clearPendingFullTurnRoute();
+    }
     // Truncation can drop the entry the partial-push marker points at,
     // or leave it valid but shift the meaning of nearby indices. Reset
     // both fields rather than try to fix them up — they're per-send and

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -69,11 +69,13 @@ import { acquireSleepInhibitor } from '../services/sleepInhibitor.js';
 import {
   resolveCompactionTuning,
   resolveSlimmingConfig,
+  slimCompactionInput,
 } from '../services/compactionInputSlimming.js';
 import {
   InMemoryImagePayloadStore,
   buildReattachParts,
   countAllInlineImages,
+  prepareImagePayloadsForRequest,
   replaceImagePayloadsInPlace,
 } from '../services/image-payload-references.js';
 import {
@@ -108,8 +110,22 @@ import {
   setToolCallPreparations,
 } from './tool-call-preparation.js';
 import { InvalidStreamError } from './invalid-stream-error.js';
+import type {
+  FullTurnModelRoute,
+  FullTurnModelRouteIdentity,
+} from './baseLlmClient.js';
+import {
+  runWithRuntimeContentGenerator,
+  wrapAsyncGeneratorWithRuntimeContentGenerator,
+} from '../agents/runtime/agent-context.js';
 
 export { InvalidStreamError };
+
+export interface GeminiChatSendOptions {
+  modelRoute?: FullTurnModelRoute;
+  /** Internal marker: exact routes must never enter the configured fallback chain. */
+  exactRoute?: boolean;
+}
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
@@ -972,7 +988,10 @@ function validateHistory(history: Content[]) {
  * filters or recitation). Extracting valid turns from the history
  * ensures that subsequent requests could be accepted by the model.
  */
-function extractCuratedHistory(comprehensiveHistory: Content[]): Content[] {
+function extractCuratedHistory(
+  comprehensiveHistory: Content[],
+  preserveUserBoundary?: Content,
+): Content[] {
   if (comprehensiveHistory === undefined || comprehensiveHistory.length === 0) {
     return [];
   }
@@ -981,7 +1000,11 @@ function extractCuratedHistory(comprehensiveHistory: Content[]): Content[] {
   let i = 0;
   while (i < length) {
     if (comprehensiveHistory[i].role === 'user') {
-      appendCuratedContent(curatedHistory, comprehensiveHistory[i]);
+      if (comprehensiveHistory[i] === preserveUserBoundary) {
+        curatedHistory.push(comprehensiveHistory[i]);
+      } else {
+        appendCuratedContent(curatedHistory, comprehensiveHistory[i]);
+      }
       i++;
     } else {
       const modelOutput: Content[] = [];
@@ -999,6 +1022,18 @@ function extractCuratedHistory(comprehensiveHistory: Content[]): Content[] {
     }
   }
   return curatedHistory;
+}
+
+function mergeAdjacentUserContents(contents: Content[]): Content[] {
+  const merged: Content[] = [];
+  for (const content of contents) {
+    if (content.role === 'user') {
+      appendCuratedContent(merged, content);
+    } else {
+      merged.push(content);
+    }
+  }
+  return merged;
 }
 
 function appendCuratedContent(
@@ -1528,6 +1563,10 @@ export class GeminiChat {
     | null = null;
 
   private readonly imagePayloadStore = new InMemoryImagePayloadStore();
+  private pendingFullTurnRouteIdentity?: FullTurnModelRouteIdentity;
+  private pendingFullTurnRoute?: FullTurnModelRoute;
+  private pendingFullTurnRouteHistoryStart?: number;
+  private readonly pendingFullTurnImageIds = new Set<string>();
 
   /**
    * Monotonically counts user-content pushes that survived into history.
@@ -1607,25 +1646,56 @@ export class GeminiChat {
    * defensive deep copy for caller mutation safety.
    */
   private getRequestHistory(currentUserContent?: Content): Content[] {
-    const curatedHistory = extractCuratedHistory(this.history);
+    const curatedHistory = extractCuratedHistory(
+      this.history,
+      currentUserContent,
+    );
+    if (this.pendingFullTurnRouteIdentity) {
+      return mergeAdjacentUserContents(
+        curatedHistory.map(copyContentContainer),
+      );
+    }
     const { maxRecentImages, imagePayloadThreshold } = resolveCompactionTuning(
       this.config.getChatCompression(),
     );
-    if (countAllInlineImages(curatedHistory) >= imagePayloadThreshold) {
-      const skipEntry = currentUserContent
-        ? curatedHistory.find(
-            (c) =>
-              c === currentUserContent ||
-              (c.role === 'user' &&
-                currentUserContent.parts?.some((p) => c.parts?.includes(p))),
-          )
-        : undefined;
+    const inlineImageCount = countAllInlineImages(curatedHistory);
+    const currentModelAcceptsImages =
+      this.config.getContentGeneratorConfig()?.modalities?.image === true;
+    const skipEntry = currentUserContent
+      ? curatedHistory.find(
+          (c) =>
+            c === currentUserContent ||
+            (c.role === 'user' &&
+              currentUserContent.parts?.some((p) => c.parts?.includes(p))),
+        )
+      : undefined;
+
+    if (!currentModelAcceptsImages) {
+      replaceImagePayloadsInPlace(
+        curatedHistory,
+        this.imagePayloadStore,
+        skipEntry,
+      );
+      return mergeAdjacentUserContents(
+        curatedHistory.map((content) =>
+          copyContentContainer(
+            content === skipEntry
+              ? content
+              : (slimCompactionInput([content]).slimmedHistory[0] ?? content),
+          ),
+        ),
+      );
+    }
+
+    if (inlineImageCount >= imagePayloadThreshold) {
       const replaced = replaceImagePayloadsInPlace(
         curatedHistory,
         this.imagePayloadStore,
         skipEntry,
       );
-      const requestHistory = curatedHistory.map(copyContentContainer);
+      const requestHistory = mergeAdjacentUserContents(
+        curatedHistory.map(copyContentContainer),
+      );
       const reattachParts = buildReattachParts(replaced, maxRecentImages);
       if (reattachParts.length > 0) {
         const last = requestHistory.at(-1);
@@ -1637,7 +1707,7 @@ export class GeminiChat {
       }
       return requestHistory;
     }
-    return curatedHistory.map(copyContentContainer);
+    return mergeAdjacentUserContents(curatedHistory.map(copyContentContainer));
   }
 
   /**
@@ -1691,6 +1761,13 @@ export class GeminiChat {
     signal?: AbortSignal,
     options?: TryCompressOptions,
   ): Promise<ChatCompressionInfo> {
+    if (this.pendingFullTurnRouteIdentity) {
+      return {
+        originalTokenCount: this.lastPromptTokenCount,
+        newTokenCount: this.lastPromptTokenCount,
+        compressionStatus: CompressionStatus.NOOP,
+      };
+    }
     const service = new ChatCompressionService();
     const { newHistory, info } = await service.compress(this, {
       promptId,
@@ -1882,7 +1959,18 @@ export class GeminiChat {
     model: string,
     params: SendMessageParameters,
     prompt_id: string,
+    options?: GeminiChatSendOptions,
   ): Promise<AsyncGenerator<StreamEvent>> {
+    if (options?.modelRoute) {
+      const route = options.modelRoute;
+      const stream = await runWithRuntimeContentGenerator(route, () =>
+        this.sendMessageStream(route.model, params, prompt_id, {
+          exactRoute: true,
+        }),
+      );
+      return wrapAsyncGeneratorWithRuntimeContentGenerator(route, stream);
+    }
+
     await this.sendPromise;
 
     let streamDoneResolver: () => void;
@@ -2921,6 +3009,7 @@ export class GeminiChat {
 
           if (
             fallbackModels.length > 0 &&
+            !options?.exactRoute &&
             !isUnattendedMode() &&
             !streamYieldedAnyChunk
           ) {
@@ -3113,6 +3202,7 @@ export class GeminiChat {
             }
           } else if (
             fallbackModels.length > 0 &&
+            !options?.exactRoute &&
             !isUnattendedMode() &&
             streamYieldedAnyChunk
           ) {
@@ -3296,6 +3386,94 @@ export class GeminiChat {
     // Deep copy the history to avoid mutating the history outside of the
     // chat session.
     return structuredClone(history);
+  }
+
+  /** Remove route-scoped media bytes once their logical turn has ended. */
+  replaceHistoricalMediaWithReferences(): boolean {
+    const start = this.pendingFullTurnRouteHistoryStart;
+    const replaced =
+      start === undefined
+        ? replaceImagePayloadsInPlace(this.history, this.imagePayloadStore)
+        : [
+            ...replaceImagePayloadsInPlace(
+              this.history.slice(0, start),
+              this.imagePayloadStore,
+            ),
+            ...replaceImagePayloadsInPlace(
+              this.history.slice(start),
+              this.imagePayloadStore,
+            ).map((image) => {
+              this.pendingFullTurnImageIds.add(image.id);
+              return image;
+            }),
+          ];
+    const slimmed = slimCompactionInput(this.history).slimmedHistory;
+    const changed = replaced.length > 0 || slimmed !== this.history;
+    this.setHistory(slimmed);
+    return changed;
+  }
+
+  setPendingFullTurnRoute(
+    identity: FullTurnModelRouteIdentity,
+    route?: FullTurnModelRoute,
+    historyStartContent?: Content,
+  ): void {
+    const current = this.pendingFullTurnRouteIdentity;
+    if (
+      !current ||
+      current.model !== identity.model ||
+      current.baseUrl !== identity.baseUrl ||
+      current.authType !== identity.authType
+    ) {
+      const historyStart = historyStartContent
+        ? this.history.indexOf(historyStartContent)
+        : this.history.length;
+      this.pendingFullTurnRouteHistoryStart =
+        historyStart < 0 ? this.history.length : historyStart;
+      this.pendingFullTurnImageIds.clear();
+    }
+    this.pendingFullTurnRouteIdentity = identity;
+    this.pendingFullTurnRoute = route;
+  }
+
+  getPendingFullTurnRoute(): FullTurnModelRoute | undefined {
+    return this.pendingFullTurnRoute;
+  }
+
+  getPendingFullTurnRouteIdentity(): FullTurnModelRouteIdentity | undefined {
+    return this.pendingFullTurnRouteIdentity;
+  }
+
+  clearPendingFullTurnRoute(): void {
+    this.pendingFullTurnRouteIdentity = undefined;
+    this.pendingFullTurnRoute = undefined;
+    this.pendingFullTurnRouteHistoryStart = undefined;
+    this.pendingFullTurnImageIds.clear();
+  }
+
+  preparePendingFullTurnMediaForContinuation(parts: Part[]): Part[] {
+    return this.prepareHistoricalMediaForContinuation(
+      parts,
+      this.history.slice(
+        this.pendingFullTurnRouteHistoryStart ?? this.history.length,
+      ),
+    );
+  }
+
+  /** Reattach in-memory image references when retrying an interrupted turn. */
+  prepareHistoricalMediaForContinuation(
+    parts: Part[],
+    sourceHistory: Content[],
+  ): Part[] {
+    const current: Content = { role: 'user', parts };
+    const prepared = prepareImagePayloadsForRequest([current], {
+      maxRecentImages: 0,
+      preserveImagePartsForContentIndex: 0,
+      referenceContents: [...sourceHistory, current],
+      allowedReferencedImageIds: this.pendingFullTurnImageIds,
+      store: this.imagePayloadStore,
+    });
+    return prepared[0]?.parts ?? parts;
   }
 
   /**

--- a/packages/core/src/core/session-recovery.ts
+++ b/packages/core/src/core/session-recovery.ts
@@ -34,6 +34,8 @@ export interface SessionRecoveryContinuation {
   mode: 'retry_user_parts' | 'tool_result_parts';
   parts: Part[];
   displayText: string;
+  /** History belonging to this unfinished logical turn only. */
+  sourceHistory: Content[];
 }
 
 export interface SessionRecoveryPlan {
@@ -104,6 +106,37 @@ function buildVisibleNotice(
   }
 
   return 'Previous session appears to have stopped during tool execution.';
+}
+
+function getInterruptedTurnSourceHistory(
+  history: Content[],
+  kind: 'interrupted_prompt' | 'interrupted_turn',
+): Content[] {
+  if (kind === 'interrupted_prompt') {
+    let start = history.length - 1;
+    while (start > 0 && history[start - 1]?.role === 'user') start--;
+    const trailingUsers = history.slice(start);
+    if (
+      !trailingUsers.some((content) =>
+        (content.parts ?? []).some((part) => part.functionResponse),
+      )
+    ) {
+      return structuredClone(trailingUsers);
+    }
+  }
+
+  let start = history.length - 1;
+  for (let index = history.length - 2; index >= 0; index--) {
+    const content = history[index];
+    if (
+      content?.role === 'model' &&
+      !(content.parts ?? []).some((part) => part.functionCall)
+    ) {
+      break;
+    }
+    start = index;
+  }
+  return structuredClone(history.slice(start));
 }
 
 export function buildSessionRecoveryPlan({
@@ -185,6 +218,10 @@ export function buildSessionRecoveryPlanFromApiHistory({
       mode: 'retry_user_parts',
       parts: interruption.parts,
       displayText: 'Continue interrupted user prompt',
+      sourceHistory: getInterruptedTurnSourceHistory(
+        originalApiHistory,
+        'interrupted_prompt',
+      ),
     };
     return {
       planId,
@@ -208,6 +245,10 @@ export function buildSessionRecoveryPlanFromApiHistory({
       ORPHAN_TOOL_USE_REPAIR_REASON,
     ),
     displayText: 'Continue interrupted tool turn',
+    sourceHistory: getInterruptedTurnSourceHistory(
+      originalApiHistory,
+      'interrupted_turn',
+    ),
   };
 
   return {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -37,6 +37,7 @@ import {
 import type { LoopType } from '../telemetry/types.js';
 import type { ActiveGoal } from '../goals/activeGoalStore.js';
 import { getProviderToolCallId } from './toolCallIdUtils.js';
+import type { FullTurnModelRoute } from './baseLlmClient.js';
 
 const ERROR_REPORT_HISTORY_TAIL_COUNT = 8;
 const ERROR_REPORT_TEXT_PREVIEW_CHARS = 200;
@@ -447,20 +448,22 @@ export class Turn {
     model: string,
     req: PartListUnion,
     signal: AbortSignal,
+    modelRoute?: FullTurnModelRoute,
   ): AsyncGenerator<ServerGeminiStreamEvent> {
     try {
       // Note: This assumes `sendMessageStream` yields events like
       // { type: StreamEventType.RETRY } or { type: StreamEventType.CHUNK, value: GenerateContentResponse }
-      const responseStream = await this.chat.sendMessageStream(
-        model,
-        {
-          message: req,
-          config: {
-            abortSignal: signal,
-          },
+      const params = {
+        message: req,
+        config: {
+          abortSignal: signal,
         },
-        this.prompt_id,
-      );
+      };
+      const responseStream = modelRoute
+        ? await this.chat.sendMessageStream(model, params, this.prompt_id, {
+            modelRoute,
+          })
+        : await this.chat.sendMessageStream(model, params, this.prompt_id);
 
       for await (const streamEvent of responseStream) {
         if (signal?.aborted) {

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -8,10 +8,12 @@ import type { Content } from '@google/genai';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 
-const { mockGetCacheSafeParams, mockRunForkedAgent } = vi.hoisted(() => ({
-  mockGetCacheSafeParams: vi.fn(),
-  mockRunForkedAgent: vi.fn(),
-}));
+const { mockGetCacheSafeParams, mockRunForkedAgent, mockRunSideQuery } =
+  vi.hoisted(() => ({
+    mockGetCacheSafeParams: vi.fn(),
+    mockRunForkedAgent: vi.fn(),
+    mockRunSideQuery: vi.fn(),
+  }));
 
 vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
   const actual =
@@ -22,6 +24,10 @@ vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
     runForkedAgent: mockRunForkedAgent,
   };
 });
+
+vi.mock('../utils/sideQuery.js', () => ({
+  runSideQuery: mockRunSideQuery,
+}));
 
 import {
   generatePromptSuggestion,
@@ -40,6 +46,114 @@ describe('generatePromptSuggestion', () => {
   beforeEach(() => {
     mockGetCacheSafeParams.mockReset();
     mockRunForkedAgent.mockReset();
+    mockRunSideQuery.mockReset();
+  });
+
+  it('removes top-level and tool-nested media before a side query', async () => {
+    const historyWithMedia: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { text: 'inspect these' },
+          { inlineData: { mimeType: 'image/png', data: 'raw-image' } },
+          {
+            fileData: {
+              mimeType: 'application/pdf',
+              fileUri: 'file:///private/report.pdf',
+            },
+          },
+        ],
+      },
+      { role: 'model', parts: [{ text: 'I inspected them.' }] },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: 'image loaded' },
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'raw-tool-image',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { role: 'model', parts: [{ text: 'Done.' }] },
+    ];
+    mockRunSideQuery.mockResolvedValue({ text: 'run tests' });
+    const config = {
+      getFastModel: vi.fn(() => 'fast-model'),
+      getModel: vi.fn(() => 'main-model'),
+    } as unknown as Config;
+
+    await generatePromptSuggestion(
+      config,
+      historyWithMedia,
+      new AbortController().signal,
+    );
+
+    const options = mockRunSideQuery.mock.calls[0]?.[1] as {
+      contents: Content[];
+    };
+    const serialized = JSON.stringify(options.contents);
+    expect(serialized).toContain('[image: image/png]');
+    expect(serialized).toContain('[image: image/jpeg]');
+    expect(serialized).toContain('[document: application/pdf]');
+    expect(serialized).not.toContain('raw-image');
+    expect(serialized).not.toContain('raw-tool-image');
+    expect(serialized).not.toContain('file:///private/report.pdf');
+    expect(JSON.stringify(historyWithMedia)).toContain('raw-tool-image');
+  });
+
+  it('removes media from cache-shared history without mutating the snapshot', async () => {
+    const cacheHistory: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType: 'image/png', data: 'cached-image' } },
+        ],
+      },
+      { role: 'model', parts: [{ text: 'Looked.' }] },
+      { role: 'user', parts: [{ text: 'continue' }] },
+      { role: 'model', parts: [{ text: 'Finished.' }] },
+    ];
+    const cacheSafe = {
+      generationConfig: {},
+      history: cacheHistory,
+      model: 'main-model',
+      version: 1,
+    };
+    mockGetCacheSafeParams.mockReturnValue(cacheSafe);
+    mockRunForkedAgent.mockResolvedValue({
+      text: null,
+      jsonResult: { suggestion: 'run tests' },
+      usage: { inputTokens: 10, outputTokens: 3, cacheHitTokens: 0 },
+    });
+    const config = {
+      getFastModel: vi.fn(() => undefined),
+      getModel: vi.fn(() => 'main-model'),
+    } as unknown as Config;
+
+    await generatePromptSuggestion(
+      config,
+      conversationHistory,
+      new AbortController().signal,
+      { enableCacheSharing: true },
+    );
+
+    const call = mockRunForkedAgent.mock.calls[0]?.[0] as {
+      cacheSafeParams: { history: Content[] };
+    };
+    const serialized = JSON.stringify(call.cacheSafeParams.history);
+    expect(serialized).toContain('[image: image/png]');
+    expect(serialized).not.toContain('cached-image');
+    expect(JSON.stringify(cacheSafe.history)).toContain('cached-image');
   });
 
   it('passes cache-safe model in cache mode when no explicit or fast model exists', async () => {

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -11,9 +11,14 @@
 
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
-import { getCacheSafeParams, runForkedAgent } from '../utils/forkedAgent.js';
+import {
+  getCacheSafeParams,
+  runForkedAgent,
+  type CacheSafeParams,
+} from '../utils/forkedAgent.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { slimCompactionInput } from '../services/compactionInputSlimming.js';
 
 const debugLogger = createDebugLogger('FOLLOWUP');
 
@@ -107,10 +112,18 @@ export async function generatePromptSuggestion(
       `Generating suggestion: cacheSharing=${!!cacheSafe}, model=${modelOverride || '(default)'}`,
     );
     const raw = cacheSafe
-      ? await generateViaForkedQuery(config, abortSignal, modelOverride)
+      ? await generateViaForkedQuery(
+          config,
+          {
+            ...cacheSafe,
+            history: slimCompactionInput(cacheSafe.history).slimmedHistory,
+          },
+          abortSignal,
+          modelOverride,
+        )
       : await generateViaBaseLlm(
           config,
-          conversationHistory,
+          slimCompactionInput(conversationHistory).slimmedHistory,
           abortSignal,
           modelOverride,
         );
@@ -144,11 +157,10 @@ export async function generatePromptSuggestion(
 /** Generate suggestion via cache-aware forked query */
 async function generateViaForkedQuery(
   config: Config,
+  cacheSafeParams: CacheSafeParams,
   abortSignal: AbortSignal,
   modelOverride?: string,
 ): Promise<string | null> {
-  const cacheSafeParams = getCacheSafeParams();
-  if (!cacheSafeParams) return null;
   const model = modelOverride ?? config.getFastModel() ?? cacheSafeParams.model;
   const result = await runForkedAgent({
     config,

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -450,6 +450,48 @@ describe('judgeGoal', () => {
     expect(contents.slice(0, tail.length)).toEqual(tail);
   });
 
+  it('removes top-level and tool-nested media from the judge transcript', async () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType: 'image/png', data: 'raw-image' } },
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: 'loaded' },
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'raw-tool-image',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      } as unknown as Content,
+      { role: 'model', parts: [{ text: 'done' }] },
+    ];
+    const client = makeMockClient({ history });
+    const config = makeConfig({ client, fastModel: 'text-judge' });
+
+    await judgeGoal(config, {
+      condition: 'finish',
+      lastAssistantText: 'done',
+      signal: new AbortController().signal,
+    });
+
+    const [contents] = client.generateContent.mock.calls[0] as [Content[]];
+    const serialized = JSON.stringify(contents);
+    expect(serialized).toContain('[image: image/png]');
+    expect(serialized).toContain('[image: image/jpeg]');
+    expect(serialized).not.toContain('raw-image');
+    expect(serialized).not.toContain('raw-tool-image');
+    expect(JSON.stringify(history)).toContain('raw-tool-image');
+  });
+
   it('appends lastAssistantText as a model turn when history does not contain it', async () => {
     const history: Content[] = [
       { role: 'user', parts: [{ text: 'go' }] },

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -8,6 +8,7 @@ import type { Content, Part, Schema } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { reportError } from '../utils/errorReporting.js';
+import { slimCompactionInput } from '../services/compactionInputSlimming.js';
 
 const debugLogger = createDebugLogger('GOAL_JUDGE');
 
@@ -239,7 +240,7 @@ function collectTranscript(
     const client = config.getGeminiClient();
     if (!client.isInitialized()) return fallbackTranscript(lastAssistantText);
     const full = client.getHistoryTail(TRANSCRIPT_TAIL_MESSAGES);
-    const tail = full.map(capContent);
+    const tail = slimCompactionInput(full.map(capContent)).slimmedHistory;
     if (tail.length === 0) return fallbackTranscript(lastAssistantText);
     // If the live history's last assistant text doesn't include the supplied
     // `lastAssistantText`, splice it in — the Stop hook can fire before the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,15 @@ export * from './output/types.js';
 // ============================================================================
 
 export * from './core/client.js';
+export {
+  getFullTurnModelRouteIdentity,
+  type FullTurnModelRoute,
+  type FullTurnModelRouteIdentity,
+} from './core/baseLlmClient.js';
+export {
+  runWithRuntimeContentGenerator,
+  type RuntimeContentGeneratorView,
+} from './agents/runtime/agent-context.js';
 export * from './core/contentGenerator.js';
 export * from './core/reasoning-effort.js';
 export * from './core/coreToolScheduler.js';
@@ -208,6 +217,7 @@ export {
   computeThresholds,
   type CompactionThresholds,
 } from './services/chatCompressionService.js';
+export { slimCompactionInput } from './services/compactionInputSlimming.js';
 export * from './services/chatRecordingService.js';
 export * from './services/cronScheduler.js';
 export type { DurableCronTask, CronTaskRun } from './services/cronTasksFile.js';

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -226,6 +226,32 @@ describe('ModelRegistry', () => {
       expect(model?.generationConfig.modalities).toEqual(explicitModalities);
     });
 
+    it('projects an explicit vision capability into generator modalities', () => {
+      const registry = new ModelRegistry({
+        openai: [
+          {
+            id: 'custom-vision-agent',
+            name: 'Custom Vision Agent',
+            baseUrl: 'https://example.invalid',
+            generationConfig: { modalities: { image: false } },
+            capabilities: { vision: true, agent: true },
+          },
+        ],
+      });
+
+      const model = registry.getModel(
+        AuthType.USE_OPENAI,
+        'custom-vision-agent',
+      );
+      expect(model?.generationConfig.modalities).toEqual({ image: true });
+      expect(
+        registry
+          .getModelsForAuthType(AuthType.USE_OPENAI)
+          .find((candidate) => candidate.id === 'custom-vision-agent')
+          ?.modalities,
+      ).toEqual({ image: true });
+    });
+
     it('returns text-only ({}) for models with no multimodal default', () => {
       const registry = new ModelRegistry({
         openai: [
@@ -542,6 +568,18 @@ describe('ModelRegistry', () => {
         'https://proxy.example.com/v1',
       );
       expect(proxy?.name).toBe('GPT-4 Proxy');
+    });
+
+    it('retrieves an implicit provider URL by its resolved exact baseUrl', () => {
+      const registry = new ModelRegistry({
+        openai: [{ id: 'gpt-4o', name: 'GPT-4o Default' }],
+      });
+
+      const resolved = registry.getModel(AuthType.USE_OPENAI, 'gpt-4o');
+      expect(resolved?.baseUrl).toBe('https://api.openai.com/v1');
+      expect(
+        registry.getModel(AuthType.USE_OPENAI, 'gpt-4o', resolved?.baseUrl),
+      ).toBe(resolved);
     });
 
     it('should return first match when getModel is called without baseUrl', () => {

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -250,7 +250,17 @@ export class ModelRegistry {
     if (!models) return undefined;
 
     if (baseUrl) {
-      return models.get(modelRegistryKey(modelId, baseUrl));
+      const exact = models.get(modelRegistryKey(modelId, baseUrl));
+      if (exact) return exact;
+
+      // Models registered without an explicit baseUrl use the plain id as
+      // their storage key, but resolution fills the provider default URL.
+      // Exact runtime-route restoration addresses the resolved URL, so match
+      // that canonical value as well.
+      for (const model of models.values()) {
+        if (model.id === modelId && model.baseUrl === baseUrl) return model;
+      }
+      return undefined;
     }
 
     // Try plain id key first (models registered without explicit baseUrl)
@@ -308,6 +318,12 @@ export class ModelRegistry {
       shouldUseCanonicalModalities(config.id)
     ) {
       generationConfig.modalities = defaultModalities(config.id);
+    }
+    if (config.capabilities?.vision === true) {
+      generationConfig.modalities = {
+        ...generationConfig.modalities,
+        image: true,
+      };
     }
 
     return {

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -17,6 +17,8 @@ import type { ConfigSources } from '../utils/configResolver.js';
 export interface ModelCapabilities {
   /** Supports image/vision inputs */
   vision?: boolean;
+  /** Can run the normal agent tool loop, not only transcription requests. */
+  agent?: boolean;
 }
 
 /**
@@ -57,7 +59,7 @@ export interface ModelConfig {
   envKey?: string;
   /** API endpoint override */
   baseUrl?: string;
-  /** Model capabilities, reserve for future use. Now we do not read this to determine multi-modal support or other capabilities. */
+  /** Explicit model capabilities used for safe feature routing. */
   capabilities?: ModelCapabilities;
   /** Generation configuration (sampling parameters) */
   generationConfig?: ModelGenerationConfig;

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -143,6 +143,23 @@ describe('ChatRecordingService', () => {
       expect(user2.parentUuid).toBe('00000000-0000-0000-0000-000000000002');
     });
 
+    it('keeps a media scrub checkpoint on the active record chain', async () => {
+      chatRecordingService.recordUserMessage([{ text: 'image turn' }]);
+      chatRecordingService.recordMediaScrubCheckpoint();
+      chatRecordingService.recordUserMessage([{ text: 'next turn' }]);
+      await chatRecordingService.flush();
+
+      const calls = vi.mocked(jsonl.writeLine).mock.calls;
+      const marker = calls[1][1] as ChatRecord;
+      const nextUser = calls[2][1] as ChatRecord;
+      expect(marker).toMatchObject({
+        type: 'system',
+        subtype: 'media_scrub',
+        parentUuid: '00000000-0000-0000-0000-000000000001',
+      });
+      expect(nextUser.parentUuid).toBe(marker.uuid);
+    });
+
     it('should record mid-turn user messages with a mergeable subtype', async () => {
       const modelFacingParts: Part[] = [
         {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -38,6 +38,7 @@ import type {
   SessionArtifactEventRecordPayload,
   SessionArtifactSnapshotRecordPayload,
 } from './session-artifact-persistence.js';
+import type { FullTurnModelRouteIdentity } from '../core/baseLlmClient.js';
 
 const debugLogger = createDebugLogger('CHAT_RECORDING');
 
@@ -244,6 +245,8 @@ export interface ChatRecord {
   /** Optional subtype for distinguishing non-standard records */
   subtype?:
     | 'chat_compression'
+    | 'media_scrub'
+    | 'full_turn_route'
     | 'slash_command'
     | 'ui_telemetry'
     | 'at_command'
@@ -298,6 +301,7 @@ export interface ChatRecord {
    */
   systemPayload?:
     | ChatCompressionRecordPayload
+    | FullTurnRouteRecordPayload
     | SlashCommandRecordPayload
     | UiTelemetryRecordPayload
     | AtCommandRecordPayload
@@ -381,6 +385,8 @@ export interface ChatCompressionRecordPayload {
    */
   compressedHistory: Content[];
 }
+
+export type FullTurnRouteRecordPayload = FullTurnModelRouteIdentity;
 
 export interface SlashCommandRecordPayload {
   /** Whether this record represents the invocation or the resulting output. */
@@ -1270,6 +1276,41 @@ export class ChatRecordingService {
       this.appendRecord(record);
     } catch (error) {
       debugLogger.error('Error saving chat compression record:', error);
+    }
+  }
+
+  /**
+   * Marks all model-facing media recorded before this point as settled. Resume
+   * reconstruction replaces those payloads with placeholders while preserving
+   * any later, interrupted turn for exact-route recovery.
+   */
+  recordMediaScrubCheckpoint(): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'media_scrub',
+      };
+
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving media scrub checkpoint:', error);
+    }
+  }
+
+  /** Persists exact retry affinity before a routed image turn is recorded. */
+  recordFullTurnRoute(payload: FullTurnRouteRecordPayload): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'full_turn_route',
+        systemPayload: payload,
+      };
+
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving full-turn route:', error);
     }
   }
 

--- a/packages/core/src/services/image-payload-references.test.ts
+++ b/packages/core/src/services/image-payload-references.test.ts
@@ -184,6 +184,99 @@ describe('prepareImagePayloadsForRequest', () => {
     ]);
   });
 
+  it('does not reattach an image already present in the preserved request', () => {
+    const store = new InMemoryImagePayloadStore();
+    const source: Content[] = [
+      {
+        role: 'user',
+        parts: [{ inlineData: { mimeType: 'image/png', data: 'same-shot' } }],
+      },
+    ];
+    const [stored] = replaceImagePayloadsInPlace(source, store);
+
+    const prepared = prepareImagePayloadsForRequest(
+      [
+        {
+          role: 'user',
+          parts: [{ inlineData: { mimeType: 'image/png', data: 'same-shot' } }],
+        },
+      ],
+      {
+        maxRecentImages: 0,
+        preserveImagePartsForContentIndex: 0,
+        referenceContents: source,
+        allowedReferencedImageIds: new Set([stored!.id]),
+        store,
+      },
+    );
+
+    expect(imageParts(prepared).map((part) => part.inlineData?.data)).toEqual([
+      'same-shot',
+    ]);
+  });
+
+  it('limits reference reattachment to the pending-turn allowlist', () => {
+    const store = new InMemoryImagePayloadStore();
+    const settled: Content[] = [toolImageTurn('settled-shot')];
+    const pending: Content[] = [toolImageTurn('pending-shot')];
+    const [settledImage] = replaceImagePayloadsInPlace(settled, store);
+    const [pendingImage] = replaceImagePayloadsInPlace(pending, store);
+    const references: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          {
+            text: `retry Image #${settledImage!.id} and Image #${pendingImage!.id}`,
+          },
+        ],
+      },
+    ];
+
+    const prepared = prepareImagePayloadsForRequest(references, {
+      maxRecentImages: 0,
+      referenceContents: references,
+      allowedReferencedImageIds: new Set([pendingImage!.id]),
+      store,
+    });
+
+    expect(imageParts(prepared).map((part) => part.inlineData?.data)).toEqual([
+      'pending-shot',
+    ]);
+  });
+
+  it('stores and reattaches image fileData for an interrupted route', () => {
+    const store = new InMemoryImagePayloadStore();
+    const source: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          {
+            fileData: {
+              mimeType: 'image/png',
+              fileUri: 'https://files.example/shot.png',
+            },
+          },
+        ],
+      },
+    ];
+    const [stored] = replaceImagePayloadsInPlace(source, store);
+
+    const prepared = prepareImagePayloadsForRequest(
+      [{ role: 'user', parts: [{ text: 'retry' }] }],
+      {
+        maxRecentImages: 0,
+        referenceContents: source,
+        allowedReferencedImageIds: new Set([stored!.id]),
+        store,
+      },
+    );
+
+    expect(JSON.stringify(source)).not.toContain('files.example');
+    expect(
+      prepared.at(-1)?.parts?.find((part) => part.fileData)?.fileData?.fileUri,
+    ).toBe('https://files.example/shot.png');
+  });
+
   it('does not echo tool-controlled image metadata into text references', () => {
     const store = new InMemoryImagePayloadStore();
     const prepared = prepareImagePayloadsForRequest(
@@ -269,6 +362,20 @@ describe('replaceImagePayloadsInPlace', () => {
     expect(countAllInlineImages(contents)).toBe(1);
     expect(JSON.stringify(contents)).toContain('"data":"current-shot"');
     expect(JSON.stringify(contents)).not.toContain('"data":"old-shot"');
+  });
+
+  it('does not mutate a shared nested function-response payload', () => {
+    const store = new InMemoryImagePayloadStore();
+    const recorded = toolImageTurn('queued-shot');
+    const historyCopy: Content = {
+      ...recorded,
+      parts: [...(recorded.parts ?? [])],
+    };
+
+    replaceImagePayloadsInPlace([historyCopy], store);
+
+    expect(JSON.stringify(historyCopy)).not.toContain('"data":"queued-shot"');
+    expect(JSON.stringify(recorded)).toContain('"data":"queued-shot"');
   });
 });
 

--- a/packages/core/src/services/image-payload-references.ts
+++ b/packages/core/src/services/image-payload-references.ts
@@ -20,6 +20,7 @@ export interface StoredImagePayload {
   id: string;
   mimeType: string;
   data: string;
+  fileUri?: string;
   bytes: number;
   displayName?: string;
 }
@@ -81,10 +82,7 @@ export function replaceImagePayloadsInPlace(
     if (!content.parts) continue;
     for (let i = 0; i < content.parts.length; i++) {
       const part = content.parts[i]!;
-      if (
-        part.inlineData?.mimeType?.startsWith('image/') &&
-        part.inlineData.data
-      ) {
+      if (isStorableImagePart(part)) {
         const stored = store.put(part);
         replaced.push(stored);
         content.parts[i] = { text: imageReferenceText(stored) };
@@ -92,16 +90,24 @@ export function replaceImagePayloadsInPlace(
       }
       const nested = getFunctionResponseParts(part);
       if (!nested) continue;
+      let updatedNested: Part[] | undefined;
       for (let j = 0; j < nested.length; j++) {
         const inner = nested[j]!;
-        if (
-          inner.inlineData?.mimeType?.startsWith('image/') &&
-          inner.inlineData.data
-        ) {
+        if (isStorableImagePart(inner)) {
           const stored = store.put(inner);
           replaced.push(stored);
-          nested[j] = { text: imageReferenceText(stored) };
+          updatedNested ??= [...nested];
+          updatedNested[j] = { text: imageReferenceText(stored) };
         }
+      }
+      if (updatedNested) {
+        content.parts[i] = {
+          ...part,
+          functionResponse: {
+            ...part.functionResponse,
+            parts: updatedNested,
+          },
+        } as Part;
       }
     }
   }
@@ -144,10 +150,20 @@ export function prepareImagePayloadsForRequest(
     maxRecentImages: number;
     preserveImagePartsForContentIndex?: number;
     preserveLastUserImagePartCount?: number;
+    referenceContents?: Content[];
+    allowedReferencedImageIds?: ReadonlySet<string>;
     store: ImagePayloadStore;
   },
 ): Content[] {
-  const referencedIds = collectReferencedImageIds(contents.at(-1));
+  const referencedIds = new Set<string>();
+  for (const content of options.referenceContents ?? [contents.at(-1)]) {
+    collectReferencedImageIds(content, referencedIds);
+  }
+  if (options.allowedReferencedImageIds) {
+    for (const id of referencedIds) {
+      if (!options.allowedReferencedImageIds.has(id)) referencedIds.delete(id);
+    }
+  }
   const collected: CollectedImage[] = [];
   const transformed = contents.map((content, index) => {
     if (index === options.preserveImagePartsForContentIndex) {
@@ -192,6 +208,9 @@ export function prepareImagePayloadsForRequest(
       reattachById.set(stored.id, stored);
     }
   }
+  for (const content of transformed) {
+    removeAlreadyAttachedImages(content.parts ?? [], reattachById);
+  }
 
   if (reattachById.size === 0) {
     return transformed;
@@ -220,7 +239,7 @@ function transformPart(
   store: ImagePayloadStore,
   collected: CollectedImage[],
 ): Part {
-  if (part.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) {
+  if (isStorableImagePart(part)) {
     const stored = store.put(part);
     collected.push({ stored });
     return { text: imageReferenceText(stored) };
@@ -243,17 +262,30 @@ function transformPart(
   return part;
 }
 
-function collectReferencedImageIds(content: Content | undefined): Set<string> {
-  const ids = new Set<string>();
-  for (const part of content?.parts ?? []) {
+function collectReferencedImageIds(
+  content: Content | undefined,
+  ids: Set<string>,
+): void {
+  collectReferencedImageIdsFromParts(content?.parts ?? [], ids);
+}
+
+function collectReferencedImageIdsFromParts(
+  parts: Part[],
+  ids: Set<string>,
+): void {
+  for (const part of parts) {
     const text = part.text;
-    if (!text) continue;
-    for (const match of text.matchAll(IMAGE_REFERENCE_PATTERN)) {
-      const id = match[1];
-      if (id) ids.add(id.toLowerCase());
+    if (text) {
+      for (const match of text.matchAll(IMAGE_REFERENCE_PATTERN)) {
+        const id = match[1];
+        if (id) ids.add(id.toLowerCase());
+      }
+    }
+    const nested = getFunctionResponseParts(part);
+    if (nested) {
+      collectReferencedImageIdsFromParts(nested, ids);
     }
   }
-  return ids;
 }
 
 function recentUniqueImages(
@@ -275,25 +307,53 @@ function recentUniqueImages(
   return recent.reverse();
 }
 
+function isStorableImagePart(part: Part): boolean {
+  return Boolean(
+    (part.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) ||
+      (part.fileData?.mimeType?.startsWith('image/') && part.fileData.fileUri),
+  );
+}
+
+function removeAlreadyAttachedImages(
+  parts: Part[],
+  images: Map<string, StoredImagePayload>,
+): void {
+  for (const part of parts) {
+    if (isStorableImagePart(part)) {
+      images.delete(imagePartToStoredPayload(part).id);
+    }
+    const nested = getFunctionResponseParts(part);
+    if (nested) removeAlreadyAttachedImages(nested, images);
+  }
+}
+
 function imagePartToStoredPayload(part: Part): StoredImagePayload {
   const data = part.inlineData?.data ?? '';
-  const mimeType = part.inlineData?.mimeType ?? 'application/octet-stream';
+  const fileUri = part.fileData?.fileUri;
+  const mimeType =
+    part.inlineData?.mimeType ??
+    part.fileData?.mimeType ??
+    'application/octet-stream';
   const hash = createHash('sha256')
+    .update(fileUri ? 'file' : 'inline')
+    .update('\0')
     .update(mimeType)
     .update('\0')
-    .update(data)
+    .update(fileUri ?? data)
     .digest('hex');
   return {
     id: hash.slice(0, IMAGE_ID_LENGTH),
     mimeType,
     data,
-    bytes: approxBase64Bytes(data),
-    displayName: part.inlineData?.displayName,
+    ...(fileUri && { fileUri }),
+    bytes: fileUri ? 0 : approxBase64Bytes(data),
+    displayName: part.inlineData?.displayName ?? part.fileData?.displayName,
   };
 }
 
 function imageReferenceText(stored: StoredImagePayload): string {
-  return `[Image #${stored.id}: ${safeImageMimeType(stored.mimeType)}, ${stored.bytes} bytes]`;
+  const size = stored.fileUri ? 'file URI' : `${stored.bytes} bytes`;
+  return `[Image #${stored.id}: ${safeImageMimeType(stored.mimeType)}, ${size}]`;
 }
 
 function safeImageMimeType(mimeType: string): string {
@@ -303,6 +363,15 @@ function safeImageMimeType(mimeType: string): string {
 }
 
 function storedImageToPart(stored: StoredImagePayload): Part {
+  if (stored.fileUri) {
+    return {
+      fileData: {
+        mimeType: stored.mimeType,
+        fileUri: stored.fileUri,
+        displayName: stored.displayName,
+      },
+    };
+  }
   return {
     inlineData: {
       mimeType: stored.mimeType,

--- a/packages/core/src/services/memoryPressureMonitor.test.ts
+++ b/packages/core/src/services/memoryPressureMonitor.test.ts
@@ -1292,6 +1292,35 @@ describe('MemoryPressureMonitor', () => {
       expect(monitor.getConsecutiveFailures()).toBe(0);
     });
 
+    it('skips compaction while a full-turn media route is active', async () => {
+      const getHistoryShallow = vi.fn(() => [
+        { role: 'user', parts: [{ text: 'keep routed history intact' }] },
+      ]);
+      const setHistory = vi.fn();
+      const monitor = new MemoryPressureMonitor(
+        createMockConfig({
+          geminiClient: {
+            isInitialized: () => true,
+            getChat: () => ({
+              getPendingFullTurnRouteIdentity: () => ({
+                model: 'vision-agent',
+              }),
+              getHistoryShallow,
+              setHistory,
+            }),
+          },
+        }),
+        { ...DEFAULT_PRESSURE_CONFIG, cleanupCooldownMs: 0 },
+      );
+
+      setMemUsage(10 * 1024 * 1024 * 1024);
+      monitor.performCheck();
+      await drainCleanupMeasurement();
+
+      expect(getHistoryShallow).not.toHaveBeenCalled();
+      expect(setHistory).not.toHaveBeenCalled();
+    });
+
     it('handles empty history without errors', async () => {
       const setHistory = vi.fn();
       const monitor = new MemoryPressureMonitor(

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -715,6 +715,12 @@ export class MemoryPressureMonitor extends EventEmitter {
             break;
           }
           const chat = client.getChat();
+          if (chat.getPendingFullTurnRouteIdentity?.()) {
+            debugLogger.debug(
+              '[COMPACT_HISTORY] skipped: full-turn media route is active',
+            );
+            break;
+          }
           const history = chat.getHistoryShallow?.() ?? chat.getHistory();
           const settings = this.coreConfig.getClearContextOnIdle();
           const projectRoot = this.coreConfig.getProjectRoot();

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -21,6 +21,7 @@ import { readRuntimeStatus } from '../utils/runtimeStatus.js';
 import {
   SessionService,
   buildApiHistoryFromConversation,
+  getPendingFullTurnRouteState,
   getResumePromptTokenCount,
   getResumeTokenCounts,
   type ConversationRecord,
@@ -2366,6 +2367,81 @@ describe('SessionService', () => {
     });
   });
 
+  describe('getPendingFullTurnRouteState', () => {
+    it('returns the API-history boundary at the pending route marker', () => {
+      const assistant: ChatRecord = {
+        ...recordB2,
+        sessionId: sessionIdA,
+        parentUuid: recordA1.uuid,
+      };
+      const routeMarker: ChatRecord = {
+        ...recordA1,
+        uuid: 'route-marker',
+        parentUuid: assistant.uuid,
+        type: 'system',
+        subtype: 'full_turn_route',
+        message: undefined,
+        systemPayload: {
+          model: 'vision-agent',
+          authType: 'openai',
+        },
+      };
+      const pendingUser: ChatRecord = {
+        ...recordA1,
+        uuid: 'pending-user',
+        parentUuid: routeMarker.uuid,
+        message: {
+          role: 'user',
+          parts: [{ text: 'inspect the image' }],
+        },
+      };
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: recordA1.timestamp,
+        lastUpdated: pendingUser.timestamp,
+        messages: [recordA1, assistant, routeMarker, pendingUser],
+      };
+
+      expect(getPendingFullTurnRouteState(conversation)).toEqual({
+        identity: routeMarker.systemPayload,
+        historyStart: 2,
+      });
+    });
+
+    it('clears a route marker when the active branch is rewound', () => {
+      const routeMarker: ChatRecord = {
+        ...recordA1,
+        uuid: 'route-marker',
+        type: 'system',
+        subtype: 'full_turn_route',
+        message: undefined,
+        systemPayload: {
+          model: 'vision-agent',
+          authType: 'openai',
+          baseUrl: 'https://vision.example/v1',
+        },
+      };
+      const rewind: ChatRecord = {
+        ...recordA1,
+        uuid: 'rewind-route',
+        parentUuid: routeMarker.uuid,
+        type: 'system',
+        subtype: 'rewind',
+        message: undefined,
+      };
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: routeMarker.timestamp,
+        lastUpdated: rewind.timestamp,
+        messages: [routeMarker, rewind],
+      };
+
+      expect(getPendingFullTurnRouteState(conversation)).toBeUndefined();
+    });
+  });
+
   describe('buildApiHistoryFromConversation', () => {
     it('should return linear messages when no compression checkpoint exists', () => {
       const assistantA1: ChatRecord = {
@@ -2385,6 +2461,115 @@ describe('SessionService', () => {
       const history = buildApiHistoryFromConversation(conversation);
 
       expect(history).toEqual([recordA1.message, assistantA1.message]);
+    });
+
+    it('scrubs media before a checkpoint but preserves a later interrupted turn', () => {
+      const before: ChatRecord = {
+        ...recordA1,
+        message: {
+          role: 'user',
+          parts: [
+            {
+              inlineData: { mimeType: 'image/png', data: 'settled-image' },
+            },
+            {
+              functionResponse: {
+                id: 'call-1',
+                name: 'read_file',
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: 'image/png',
+                      data: 'settled-tool-image',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      const marker: ChatRecord = {
+        ...recordB2,
+        uuid: 'media-scrub',
+        parentUuid: before.uuid,
+        type: 'system',
+        subtype: 'media_scrub',
+        message: undefined,
+      };
+      const after: ChatRecord = {
+        ...recordA1,
+        uuid: 'after-image',
+        parentUuid: marker.uuid,
+        message: {
+          role: 'user',
+          parts: [
+            {
+              inlineData: { mimeType: 'image/png', data: 'pending-image' },
+            },
+          ],
+        },
+      };
+
+      const history = buildApiHistoryFromConversation({
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: before.timestamp,
+        lastUpdated: after.timestamp,
+        messages: [before, marker, after],
+      });
+      const serialized = JSON.stringify(history);
+      expect(serialized).not.toContain('settled-image');
+      expect(serialized).not.toContain('settled-tool-image');
+      expect(serialized).toContain('pending-image');
+    });
+
+    it('applies a media scrub checkpoint after a compression snapshot', () => {
+      const compressionRecord: ChatRecord = {
+        ...recordB2,
+        uuid: 'compression-with-image',
+        type: 'system',
+        subtype: 'chat_compression',
+        systemPayload: {
+          info: {
+            originalTokenCount: 100,
+            newTokenCount: 50,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+          compressedHistory: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  fileData: {
+                    mimeType: 'image/png',
+                    fileUri: 'file:///private/image.png',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+      const marker: ChatRecord = {
+        ...recordB2,
+        uuid: 'media-scrub-after-compression',
+        parentUuid: compressionRecord.uuid,
+        type: 'system',
+        subtype: 'media_scrub',
+        message: undefined,
+      };
+
+      const history = buildApiHistoryFromConversation({
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: compressionRecord.timestamp,
+        lastUpdated: marker.timestamp,
+        messages: [compressionRecord, marker],
+      });
+      expect(JSON.stringify(history)).not.toContain(
+        'file:///private/image.png',
+      );
     });
 
     it('does not deep-clone stored messages when rebuilding resume API history', () => {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -20,6 +20,7 @@ import type {
   ChatCompressionRecordPayload,
   ChatRecord,
   FileHistorySnapshotRecordPayload,
+  FullTurnRouteRecordPayload,
   TitleSource,
   UiTelemetryRecordPayload,
 } from './chatRecordingService.js';
@@ -47,6 +48,7 @@ import {
 } from './session-artifact-persistence.js';
 import { SessionOrganizationService } from './session-organization-service.js';
 import { SessionTranscriptTooLargeError } from './session-transcript-reader.js';
+import { slimCompactionInput } from './compactionInputSlimming.js';
 
 const debugLogger = createDebugLogger('SESSION');
 
@@ -207,6 +209,34 @@ export interface ResumedSessionData {
    * when the chain was intact.
    */
   historyGaps?: HistoryGap[];
+}
+
+export function getPendingFullTurnRouteState(
+  conversation: ConversationRecord,
+): { identity: FullTurnRouteRecordPayload; historyStart: number } | undefined {
+  let pending:
+    | { identity: FullTurnRouteRecordPayload; recordIndex: number }
+    | undefined;
+  for (const [recordIndex, record] of conversation.messages.entries()) {
+    if (record.type !== 'system') continue;
+    if (record.subtype === 'media_scrub' || record.subtype === 'rewind') {
+      pending = undefined;
+      continue;
+    }
+    if (record.subtype !== 'full_turn_route') continue;
+    const payload = record.systemPayload as
+      | FullTurnRouteRecordPayload
+      | undefined;
+    if (payload && typeof payload.model === 'string' && payload.model) {
+      pending = { identity: payload, recordIndex };
+    }
+  }
+  if (!pending) return undefined;
+  const historyStart = buildApiHistoryFromConversation({
+    ...conversation,
+    messages: conversation.messages.slice(0, pending.recordIndex + 1),
+  }).length;
+  return { identity: pending.identity, historyStart };
 }
 
 /**
@@ -2100,29 +2130,19 @@ export function buildApiHistoryFromConversation(
     }
   });
 
-  if (compressedHistory && lastCompressionIndex >= 0) {
-    const baseHistory: Content[] = compressedHistory.map(
-      copyContentForApiHistory,
-    );
+  let result: Content[] =
+    compressedHistory && lastCompressionIndex >= 0
+      ? compressedHistory.map(copyContentForApiHistory)
+      : [];
+  const startIndex = lastCompressionIndex >= 0 ? lastCompressionIndex + 1 : 0;
 
-    // Append everything after the compression record (newer turns)
-    for (let i = lastCompressionIndex + 1; i < messages.length; i++) {
-      const record = messages[i];
-      if (record.type === 'system') continue;
-      appendApiHistoryRecord(baseHistory, record);
+  for (let i = startIndex; i < messages.length; i++) {
+    const record = messages[i];
+    if (record.type === 'system' && record.subtype === 'media_scrub') {
+      result = slimCompactionInput(result).slimmedHistory;
+      continue;
     }
-
-    if (stripThoughtsFromHistory) {
-      return baseHistory
-        .map(stripThoughtsFromContent)
-        .filter((content): content is Content => content !== null);
-    }
-    return baseHistory;
-  }
-
-  // Fallback: return linear messages as Content[]
-  const result: Content[] = [];
-  for (const record of messages) {
+    if (record.type === 'system') continue;
     appendApiHistoryRecord(result, record);
   }
 

--- a/packages/core/src/services/visionBridge/vision-bridge-service.test.ts
+++ b/packages/core/src/services/visionBridge/vision-bridge-service.test.ts
@@ -9,7 +9,9 @@ import type { Part } from '@google/genai';
 import {
   formatVisionBridgeNoticeDisplay,
   formatVisionBridgeNotice,
+  formatFullTurnVisionNotice,
   isVisionBridgeNoticeDisplay,
+  resolveFullTurnVisionRoute,
   runVisionBridge,
   selectVisionBridgeModel,
   isImageCapable,
@@ -892,7 +894,11 @@ describe('selectVisionBridgeModel (same-provider only)', () => {
     // dashscope endpoint and must win.
     expect(
       selectVisionBridgeModel('qwen-text-max', models, { baseUrl: dashscope }),
-    ).toEqual({ id: 'qwen3.7-plus', baseUrl: dashscope });
+    ).toEqual({
+      id: 'qwen3.7-plus',
+      authType: 'openai',
+      baseUrl: dashscope,
+    });
   });
 
   it('never reaches across providers: undefined when the only vision model is on a different endpoint', () => {
@@ -947,6 +953,204 @@ describe('selectVisionBridgeModel (same-provider only)', () => {
       { baseUrl: dashscope },
     );
     expect(picked?.id).toBe('custom-text-name');
+  });
+
+  it('marks only explicitly agent-capable image models for full-turn routing', () => {
+    expect(
+      selectVisionBridgeModel(
+        'primary',
+        [
+          { id: 'primary', baseUrl: dashscope },
+          {
+            id: 'vision-agent',
+            baseUrl: dashscope,
+            modalities: { image: true },
+            capabilities: { agent: true },
+          },
+        ],
+        { baseUrl: dashscope },
+      ),
+    ).toEqual({
+      id: 'vision-agent',
+      baseUrl: dashscope,
+      agentCapable: true,
+    });
+
+    expect(
+      selectVisionBridgeModel(
+        'primary',
+        [
+          { id: 'primary', baseUrl: dashscope },
+          {
+            id: 'vision-only',
+            baseUrl: dashscope,
+            modalities: { image: true },
+            capabilities: { agent: false },
+          },
+        ],
+        { baseUrl: dashscope },
+      ),
+    ).toEqual({ id: 'vision-only', baseUrl: dashscope });
+  });
+});
+
+describe('resolveFullTurnVisionRoute', () => {
+  const routeConfig = (
+    image: boolean,
+    selection: {
+      id: string;
+      authType?: string;
+      baseUrl?: string;
+      agentCapable?: true;
+    },
+    resolveForModel = vi.fn(),
+  ) =>
+    ({
+      getEffectiveInputModalities: () => ({ image }),
+      getDefaultVisionBridgeModel: () => selection,
+      getBaseLlmClient: () => ({ resolveForModel }),
+    }) as unknown as Config;
+
+  it('marks a custom capability-selected route image-capable for tool continuations', async () => {
+    const baseUrl = 'https://vision.example.com/v1';
+    const contentGenerator = {};
+    const contentGeneratorConfig = {
+      model: 'custom-vision-agent',
+      authType: 'openai',
+      baseUrl,
+      // Unknown custom names resolve to text-only defaults even when the model
+      // was selected through capabilities.vision + capabilities.agent.
+      modalities: {},
+    };
+    const resolveForModel = vi.fn().mockResolvedValue({
+      contentGenerator,
+      contentGeneratorConfig,
+      retryAuthType: 'openai',
+      model: 'custom-vision-agent',
+    });
+    const selection = selectVisionBridgeModel(
+      'primary',
+      [
+        { id: 'primary', baseUrl },
+        {
+          id: 'openai:custom-vision-agent',
+          baseUrl,
+          isVision: true,
+          modalities: {},
+          capabilities: { agent: true },
+        },
+      ],
+      { baseUrl },
+    );
+    expect(selection).toEqual({
+      id: 'openai:custom-vision-agent',
+      baseUrl,
+      agentCapable: true,
+    });
+    if (!selection) throw new Error('expected a full-turn vision selection');
+
+    const result = await resolveFullTurnVisionRoute(
+      routeConfig(false, selection, resolveForModel),
+    );
+
+    expect(resolveForModel).toHaveBeenCalledWith(
+      'openai:custom-vision-agent\0https://vision.example.com/v1',
+      { failClosed: true },
+    );
+    expect(result).toEqual({
+      status: 'ready',
+      selection,
+      route: {
+        model: 'custom-vision-agent',
+        contentGenerator,
+        contentGeneratorConfig: {
+          ...contentGeneratorConfig,
+          modalities: { image: true },
+        },
+      },
+    });
+    expect(contentGeneratorConfig.modalities).toEqual({});
+  });
+
+  it('keeps the bridge path without an explicit agent capability', async () => {
+    const resolveForModel = vi.fn();
+    const result = await resolveFullTurnVisionRoute(
+      routeConfig(false, { id: 'vision-only' }, resolveForModel),
+    );
+
+    expect(result).toEqual({ status: 'not-eligible' });
+    expect(resolveForModel).not.toHaveBeenCalled();
+  });
+
+  it('qualifies a bare exact route with its selected provider', async () => {
+    const resolveForModel = vi.fn().mockResolvedValue({
+      model: 'shared-model',
+      contentGenerator: {},
+      contentGeneratorConfig: {
+        model: 'shared-model',
+        authType: 'anthropic',
+        modalities: { image: true },
+      },
+    });
+
+    await resolveFullTurnVisionRoute(
+      routeConfig(
+        false,
+        {
+          id: 'shared-model',
+          authType: 'anthropic',
+          agentCapable: true,
+        },
+        resolveForModel,
+      ),
+    );
+
+    expect(resolveForModel).toHaveBeenCalledWith('anthropic:shared-model', {
+      failClosed: true,
+    });
+  });
+
+  it('leaves an image-capable primary on its direct route', async () => {
+    const resolveForModel = vi.fn();
+    const result = await resolveFullTurnVisionRoute(
+      routeConfig(
+        true,
+        { id: 'vision-agent', agentCapable: true },
+        resolveForModel,
+      ),
+    );
+
+    expect(result).toEqual({ status: 'not-eligible' });
+    expect(resolveForModel).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the exact route cannot be resolved', async () => {
+    const selection = {
+      id: 'vision-agent',
+      agentCapable: true as const,
+    };
+    const result = await resolveFullTurnVisionRoute(
+      routeConfig(
+        false,
+        selection,
+        vi.fn().mockRejectedValue(new Error('secret provider failure')),
+      ),
+    );
+
+    expect(result).toEqual({ status: 'failed', selection });
+  });
+
+  it('formats a full-turn disclosure without claiming transcription', () => {
+    const notice = formatFullTurnVisionNotice({
+      id: 'vision-agent',
+      baseUrl: 'https://vision.example.com/v1',
+      agentCapable: true,
+    });
+
+    expect(notice).toContain('vision-agent (vision.example.com)');
+    expect(notice).toMatch(/current image turn/i);
+    expect(notice).toMatch(/tool continuation/i);
+    expect(notice).not.toMatch(/transcrib/i);
   });
 });
 

--- a/packages/core/src/services/visionBridge/vision-bridge-service.ts
+++ b/packages/core/src/services/visionBridge/vision-bridge-service.ts
@@ -7,6 +7,7 @@
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { Config } from '../../config/config.js';
 import type { InputModalities } from '../../core/contentGenerator.js';
+import type { FullTurnModelRoute } from '../../core/baseLlmClient.js';
 import { defaultModalities } from '../../core/modalityDefaults.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { runSideQuery } from '../../utils/sideQuery.js';
@@ -34,12 +35,17 @@ export interface VisionModelCandidate {
   baseUrl?: string;
   modalities?: InputModalities;
   isVision?: boolean;
+  capabilities?: { agent?: boolean };
+  fastOnly?: boolean;
+  voiceOnly?: boolean;
 }
 
 /** The model/endpoint selected for a vision bridge call. */
 export interface VisionBridgeModelSelection {
   id: string;
+  authType?: string;
   baseUrl?: string;
+  agentCapable?: true;
 }
 
 /**
@@ -55,8 +61,34 @@ export function isImageCapable(model: VisionModelCandidate): boolean {
   );
 }
 
+export function isFullTurnVisionCapable(
+  model: VisionModelCandidate,
+): boolean {
+  return (
+    !model.fastOnly &&
+    !model.voiceOnly &&
+    model.capabilities?.agent === true &&
+    isImageCapable(model)
+  );
+}
+
 function toSelection(model: VisionModelCandidate): VisionBridgeModelSelection {
-  return { id: model.id, ...(model.baseUrl && { baseUrl: model.baseUrl }) };
+  return {
+    id: model.id,
+    ...(model.authType && { authType: model.authType }),
+    ...(model.baseUrl && { baseUrl: model.baseUrl }),
+    ...(isFullTurnVisionCapable(model) && { agentCapable: true }),
+  };
+}
+
+function selectionModelSelector(selection: VisionBridgeModelSelection): string {
+  const qualifiedId =
+    selection.authType && !selection.id.startsWith(`${selection.authType}:`)
+      ? `${selection.authType}:${selection.id}`
+      : selection.id;
+  return selection.baseUrl
+    ? `${qualifiedId}\0${selection.baseUrl}`
+    : qualifiedId;
 }
 
 /**
@@ -79,7 +111,11 @@ export function selectVisionBridgeModel(
   primaryProvider: { authType?: string; baseUrl?: string } = {},
 ): VisionBridgeModelSelection | undefined {
   const candidates = models.filter(
-    (m) => m.id !== primaryModelId && isImageCapable(m),
+    (m) =>
+      m.id !== primaryModelId &&
+      !m.fastOnly &&
+      !m.voiceOnly &&
+      isImageCapable(m),
   );
   if (candidates.length === 0) return undefined;
   // Match the primary's endpoint when it has one; otherwise fall back to the
@@ -114,6 +150,80 @@ export function shouldRunVisionBridge(
     config.getEffectiveInputModalities?.()?.image !== true &&
     config.getDefaultVisionBridgeModel?.() !== undefined
   );
+}
+
+export type FullTurnVisionRouteResolution =
+  | { status: 'not-eligible' }
+  | {
+      status: 'ready';
+      selection: VisionBridgeModelSelection;
+      route: FullTurnModelRoute;
+    }
+  | { status: 'failed'; selection: VisionBridgeModelSelection };
+
+/** Resolve a full-turn route only for an explicitly agent-capable image model. */
+export async function resolveFullTurnVisionRoute(
+  config: Pick<
+    Config,
+    | 'getEffectiveInputModalities'
+    | 'getDefaultVisionBridgeModel'
+    | 'getBaseLlmClient'
+  >,
+): Promise<FullTurnVisionRouteResolution> {
+  if (config.getEffectiveInputModalities()?.image === true) {
+    return { status: 'not-eligible' };
+  }
+  const selection = config.getDefaultVisionBridgeModel();
+  if (selection?.agentCapable !== true) {
+    return { status: 'not-eligible' };
+  }
+
+  const selector = selectionModelSelector(selection);
+  try {
+    const resolved = await config
+      .getBaseLlmClient()
+      .resolveForModel(selector, { failClosed: true });
+    return {
+      status: 'ready',
+      selection,
+      route: {
+        model: resolved.model,
+        contentGenerator: resolved.contentGenerator,
+        contentGeneratorConfig: {
+          ...resolved.contentGeneratorConfig,
+          modalities: {
+            ...resolved.contentGeneratorConfig.modalities,
+            image: true,
+          },
+        },
+      },
+    };
+  } catch (error) {
+    debugLogger.warn(
+      `full-turn vision route resolution failed for ${selection.id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { status: 'failed', selection };
+  }
+}
+
+/** User-facing disclosure for an exact full-turn image route. */
+export function formatFullTurnVisionNotice(
+  selection: VisionBridgeModelSelection,
+): string {
+  const endpoint = hostOf(selection.baseUrl);
+  const target = endpoint ? `${selection.id} (${endpoint})` : selection.id;
+  return `Routing the current image turn to ${target}. Your image and prompt/context will be sent to that model, and tool continuations will stay there until the turn ends.`;
+}
+
+/** Safe failure text that never exposes provider errors or forwards the image. */
+export function formatFullTurnVisionFailureNotice(
+  selection: VisionBridgeModelSelection,
+): string {
+  const endpoint = hostOf(selection.baseUrl);
+  const target = endpoint ? `${selection.id} (${endpoint})` : selection.id;
+  return `Full-turn vision routing via ${target} could not start. The image was not sent to the primary model.`;
 }
 
 /**
@@ -430,7 +540,7 @@ export async function runVisionBridge(params: {
   const selection = config.getDefaultVisionBridgeModel?.();
   const modelId = selection?.id;
   const baseUrl = selection?.baseUrl;
-  const modelForApi = baseUrl && modelId ? `${modelId}\0${baseUrl}` : modelId;
+  const modelForApi = selection ? selectionModelSelector(selection) : undefined;
   if (!modelForApi || !modelId) {
     return failure(
       'no image-capable model is available for the vision bridge',

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -2538,6 +2538,56 @@ describe('AgentTool', () => {
       );
     });
 
+    it('removes media before seeding a fork with parent history', async () => {
+      vi.mocked(config.getGeminiClient).mockReturnValue({
+        getHistory: vi.fn().mockReturnValue([
+          {
+            role: 'user',
+            parts: [
+              { inlineData: { mimeType: 'image/png', data: 'raw-image' } },
+              {
+                functionResponse: {
+                  name: 'read_file',
+                  response: { output: 'loaded' },
+                  parts: [
+                    {
+                      inlineData: {
+                        mimeType: 'image/jpeg',
+                        data: 'raw-tool-image',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          { role: 'model', parts: [{ text: 'done' }] },
+        ]),
+        getChat: vi.fn().mockReturnValue({
+          getGenerationConfig: vi
+            .fn()
+            .mockReturnValue({ systemInstruction: 'parent' }),
+        }),
+      } as unknown as ReturnType<Config['getGeminiClient']>);
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation({
+        description: 'fork task',
+        prompt: 'continue',
+        subagent_type: 'fork',
+      });
+      await invocation.execute();
+
+      const promptConfig = vi.mocked(AgentHeadless.create).mock.calls[0]?.[2];
+      const serialized = JSON.stringify(promptConfig?.initialMessages);
+      expect(serialized).toContain('[image: image/png]');
+      expect(serialized).toContain('[image: image/jpeg]');
+      expect(serialized).not.toContain('raw-image');
+      expect(serialized).not.toContain('raw-tool-image');
+      await vi.runAllTimersAsync();
+    });
+
     it('stops the per-subagent ToolRegistry after the fork body finishes', async () => {
       // Regression: foreground-fork fires the body via
       // `void runInForkContext(...)` and returns a placeholder

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -53,6 +53,7 @@ import {
   writeWorktreeSessionMarker,
 } from '../../services/gitWorktreeService.js';
 import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
+import { slimCompactionInput } from '../../services/compactionInputSlimming.js';
 import { WorkspaceContext } from '../../utils/workspaceContext.js';
 import {
   childLaunchDepth,
@@ -1482,10 +1483,12 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     toolConfig: ToolConfig;
   }> {
     const geminiClient = this.config.getGeminiClient();
-    const rawHistory = geminiClient
-      ? (geminiClient.getHistoryShallow?.(true) ??
-        geminiClient.getHistory(true))
-      : [];
+    const rawHistory = slimCompactionInput(
+      geminiClient
+        ? (geminiClient.getHistoryShallow?.(true) ??
+            geminiClient.getHistory(true))
+        : [],
+    ).slimmedHistory;
 
     // Build the history that will seed the fork's chat. Must end with a
     // model message so agent-headless can send the task_prompt as a user

--- a/packages/core/src/utils/btwUtils.test.ts
+++ b/packages/core/src/utils/btwUtils.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content } from '@google/genai';
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '../config/config.js';
+import { buildBtwCacheSafeParams } from './btwUtils.js';
+
+describe('buildBtwCacheSafeParams', () => {
+  it('replaces media before handing live history to a forked model', () => {
+    const history: Content[] = [
+      {
+        role: 'user',
+        parts: [
+          { inlineData: { mimeType: 'image/png', data: 'raw-image' } },
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: 'loaded' },
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/jpeg',
+                    data: 'raw-tool-image',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      } as unknown as Content,
+      { role: 'model', parts: [{ text: 'done' }] },
+    ];
+    const config = {
+      getGeminiClient: vi.fn(() => ({
+        getChat: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({ temperature: 0 })),
+        })),
+        getHistoryTail: vi.fn(() => history),
+      })),
+      getModel: vi.fn(() => 'text-primary'),
+    } as unknown as Config;
+
+    const result = buildBtwCacheSafeParams(config);
+
+    const serialized = JSON.stringify(result?.history);
+    expect(serialized).toContain('[image: image/png]');
+    expect(serialized).toContain('[image: image/jpeg]');
+    expect(serialized).not.toContain('raw-image');
+    expect(serialized).not.toContain('raw-tool-image');
+    expect(JSON.stringify(history)).toContain('raw-tool-image');
+  });
+});

--- a/packages/core/src/utils/btwUtils.ts
+++ b/packages/core/src/utils/btwUtils.ts
@@ -7,6 +7,7 @@
 import type { CacheSafeParams } from './forkedAgent.js';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from './debugLogger.js';
+import { slimCompactionInput } from '../services/compactionInputSlimming.js';
 
 const logger = createDebugLogger('btw');
 
@@ -39,7 +40,9 @@ export function buildBtwCacheSafeParams(
     const generationConfig = chat.getGenerationConfig();
     if (!generationConfig) return null;
     const maxHistoryEntries = 40;
-    const history = geminiClient.getHistoryTail(maxHistoryEntries, true);
+    const history = slimCompactionInput(
+      geminiClient.getHistoryTail(maxHistoryEntries, true),
+    ).slimmedHistory;
     return {
       generationConfig: structuredClone(generationConfig),
       history,

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -554,7 +554,7 @@
       "default": ""
     },
     "visionModel": {
-      "description": "Image-capable model used as the vision bridge: when a text-only main model receives an image, it is transcribed by this model first. Set with /model --vision. Leave empty to auto-pick a same-provider vision model.",
+      "description": "Image-capable model used when a text-only main model receives an image. Only an image-capable model that explicitly declares capabilities.agent: true handles the full agent turn; all others use Vision Bridge transcription. Set with /model --vision. Leave empty to auto-pick a same-provider vision model.",
       "type": "string",
       "default": ""
     },


### PR DESCRIPTION
## What this PR does

When the primary model is text-only and the configured vision model explicitly declares both `capabilities.vision: true` and `capabilities.agent: true`, this change routes the complete image-bearing logical turn through that model's exact provider, model, and endpoint.

The route remains locked across transport retries, tool calls, tool results, and blocking Stop Hook continuations in TUI, ACP, and non-interactive CLI flows. The next independent user prompt returns to the primary model.

If agent capability is absent or disabled, the existing Vision Bridge transcription flow remains unchanged. If the exact route can no longer be resolved, the turn fails closed instead of sending raw image data to the text-only primary model or another fallback.

Interrupted turns retain their exact route identity for safe retry and resume. At completed or abandoned turn boundaries, raw historical media is replaced with existing in-session references or text placeholders so later primary-model requests and side-channel consumers do not replay the route-scoped payload.

## Why it's needed

Vision Bridge currently sends images to a vision model for transcription and asks the primary model to produce the final response. For multimodal models that can run the complete agent loop, reducing them to transcription loses visual detail, prevents them from inspecting image-producing tool results, and adds an extra generation step.

Positive capability gating lets eligible models own the full image turn while preserving the existing transcription path as the safe default.

## Reviewer Test Plan

### How to verify

1. Configure a text-only primary model and an image-capable vision model with `capabilities.agent: true`, then submit an image prompt and confirm the complete logical turn uses the selected exact vision route.
2. Exercise a tool call, tool result, retry, and blocking Stop Hook continuation, and confirm each continuation retains the same provider, model, and endpoint.
3. Complete the image turn, submit a new text-only prompt, and confirm it returns to the primary model without replaying prior raw image data or URLs.
4. Interrupt an image turn and retry or resume it, confirming only media from the pending turn is reattached. If the original exact model can no longer be resolved, confirm continuation fails closed.
5. Remove `capabilities.agent` or set it to `false`, and confirm the existing Vision Bridge transcription path is used.
6. Confirm equivalent routing behavior across TUI, ACP, and non-interactive CLI entry points.

Validation completed locally:

- `npm run lint` passed.
- `npm run build` passed.
- Core focused regression group: 636 tests passed.
- CLI focused regression group: 541 tests passed and 1 skipped.
- Post-lint-fix focused regressions: Core 262 tests passed; CLI 276 tests passed.
- Core and CLI TypeScript checks passed.

### Evidence (Before & After)

Before: the vision fallback only transcribes the image, and the text-only primary model generates the final response.

After: an explicitly opted-in agent-capable multimodal model owns the complete logical image turn, while the next independent text turn returns to the primary model. Models without the opt-in keep the existing behavior.

No real TUI screenshots or recordings have been captured yet, so this PR is opened as a draft.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.22.0 in a local workspace, using package-level Vitest and TypeScript checks.

## Risk & Scope

- Main risk or tradeoff: route lifetime, media cleanup, and interrupted-turn recovery must remain consistent across entry points. Active routed turns skip compaction, so unusually long image or tool turns may reach the context limit directly.
- Not validated / out of scope: durable structured visual summaries, on-demand reinspection of completed historical images, and permanently stable image references across long-term compaction and restore.
- Breaking changes / migration notes: none. Full-turn routing requires explicit `capabilities.agent: true`; existing configurations retain Vision Bridge behavior.

## Linked Issues

Related to #6988. Implements Phase 1 of the proposed behavior.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

当主模型不支持图片，且配置的视觉模型明确声明 `capabilities.vision: true` 和 `capabilities.agent: true` 时，本改动会将包含图片的完整逻辑回合路由到该模型的精确 provider、model 和 endpoint。

该路由会在 TUI、ACP 和非交互 CLI 流程中持续覆盖传输重试、工具调用、工具结果以及阻塞式 Stop Hook 续传。下一个独立用户请求会恢复使用主模型。

如果 agent capability 缺失或关闭，现有 Vision Bridge 转写流程保持不变。如果精确路由无法重新解析，该回合会安全失败，不会将原始图片数据发送给文本主模型或其他 fallback。

中断回合会保留精确路由身份，以安全支持重试和恢复。在回合完成或明确放弃的边界，历史中的原始媒体会替换为现有会话内引用或文本占位符，避免后续主模型请求及侧路消费者重放该回合的媒体数据。

## 为什么需要它

Vision Bridge 当前会把图片发送给视觉模型转写，再由主模型生成最终回答。对于能够执行完整 agent loop 的多模态模型，仅用于转写会损失视觉细节，使其无法检查工具产生的图片结果，并额外增加一次生成。

显式能力门控允许符合条件的模型处理完整图片回合，同时保留现有转写路径作为安全默认行为。

## Reviewer Test Plan

### 如何验证

1. 配置文本主模型以及声明 `capabilities.agent: true` 的图片模型，提交图片请求，确认完整逻辑回合使用所选的精确视觉路由。
2. 触发工具调用、工具结果、重试及阻塞式 Stop Hook 续传，确认每次续传都保留相同的 provider、model 和 endpoint。
3. 完成图片回合后提交新的纯文本请求，确认恢复主模型，且不会重放先前的原始图片数据或 URL。
4. 中断图片回合后进行重试或恢复，确认只重新附加未完成回合的媒体。如果原精确模型无法重新解析，确认续传会安全失败。
5. 删除 `capabilities.agent` 或将其设为 `false`，确认继续使用现有 Vision Bridge 转写路径。
6. 确认 TUI、ACP 和非交互 CLI 入口具有一致的路由行为。

已完成的本地验证：

- `npm run lint` 通过。
- `npm run build` 通过。
- Core 定向回归组：636 项测试通过。
- CLI 定向回归组：541 项测试通过，1 项跳过。
- lint 修复后的定向回归：Core 262 项测试通过；CLI 276 项测试通过。
- Core 和 CLI TypeScript 检查通过。

### 证据（Before & After）

Before：视觉 fallback 只转写图片，最终回答由文本主模型生成。

After：显式 opt-in 的 agent-capable 多模态模型处理完整逻辑图片回合，后续独立文本回合恢复主模型。未 opt-in 的模型行为保持不变。

尚未采集真实 TUI 截图或录屏，因此本 PR 先以 Draft 形式创建。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Node.js v22.22.0，本地 workspace，使用 package-level Vitest 和 TypeScript 检查。

## 风险与范围

- 主要风险或权衡：路由生命周期、媒体清理和中断恢复需要在多个入口保持一致。活动路由回合会跳过压缩，因此异常长的图片或工具回合可能直接触及上下文限制。
- 未验证或不在范围内：持久结构化视觉摘要、已完成历史图片的按需重新检查，以及跨长期压缩与恢复永久稳定的图片引用。
- 破坏性变更或迁移说明：无。完整回合路由要求显式配置 `capabilities.agent: true`；现有配置继续使用 Vision Bridge。

## 关联 Issue

关联 #6988，实现提议行为的 Phase 1。

</details>
