### PR TITLE
fix(core): retry empty tool-result continuations

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1421,18 +1421,37 @@ describe('GeminiChat', async () => {
           },
         ]);
 
-        const responses: Part[][] = [
-          [{ thought: true, text: 'I should keep working.' }],
+        const responses: GenerateContentResponse[][] = [
+          [stopResponse([{ thought: true, text: 'I should keep working.' }])],
           [
-            { thought: true, text: 'I should still keep working.' },
-            { text: '(empty content)' },
+            stopResponse([
+              { thought: true, text: 'I should still keep working.' },
+              { text: '(empty content)' },
+            ]),
           ],
-          [{ text: 'Finished the analysis.' }],
+          [
+            {
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      { thought: true, text: 'One more attempt.' },
+                      { text: '(empty ' },
+                    ],
+                  },
+                },
+              ],
+            } as GenerateContentResponse,
+            stopResponse([{ text: 'content)' }]),
+          ],
+          [stopResponse([{ text: 'Finished the analysis.' }])],
         ];
         vi.mocked(
           mockContentGenerator.generateContentStream,
         ).mockImplementation(async () =>
-          streamResponse(stopResponse(responses.shift()!)),
+          (async function* () {
+            yield* responses.shift()!;
+          })(),
         );
 
         const stream = await chatWithRecording.sendMessageStream(
@@ -1450,11 +1469,11 @@ describe('GeminiChat', async () => {
           },
           'prompt-id-tool-result-empty-response',
         );
-        const events = await collectStreamWithFakeTimers(stream, 10_000);
+        const events = await collectStreamWithFakeTimers(stream, 15_000);
 
         expect(
           mockContentGenerator.generateContentStream,
-        ).toHaveBeenCalledTimes(3);
+        ).toHaveBeenCalledTimes(4);
         expect(
           events.some((event) => event.type === StreamEventType.RETRY),
         ).toBe(true);
@@ -1468,15 +1487,17 @@ describe('GeminiChat', async () => {
         );
         expect(finishIndex).toBeGreaterThan(lastRetryIndex);
         expect(
-          events.some(
-            (event) =>
-              event.type === StreamEventType.CHUNK &&
-              event.value.candidates?.[0]?.content?.parts?.some(
-                (part) => part.text === '(empty content)',
-              ),
-          ),
+          events
+            .slice(lastRetryIndex + 1)
+            .some(
+              (event) =>
+                event.type === StreamEventType.CHUNK &&
+                event.value.candidates?.[0]?.content?.parts?.some(
+                  (part) => part.text === '(empty content)',
+                ),
+            ),
         ).toBe(false);
-        expect(mockLogContentRetry).toHaveBeenCalledTimes(2);
+        expect(mockLogContentRetry).toHaveBeenCalledTimes(3);
         expect(mockLogContentRetry).toHaveBeenLastCalledWith(
           mockConfig,
           expect.objectContaining({
@@ -1569,6 +1590,79 @@ describe('GeminiChat', async () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('should escalate thought-only MAX_TOKENS responses after a tool result', async () => {
+      chat.setHistory([
+        { role: 'user', parts: [{ text: 'inspect the project' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_read_file',
+                name: 'read_file',
+                args: { path: '/tmp/example' },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const responses = [
+        streamResponse({
+          candidates: [
+            {
+              content: {
+                parts: [{ thought: true, text: 'I need more tokens.' }],
+              },
+              finishReason: 'MAX_TOKENS',
+            },
+          ],
+        } as GenerateContentResponse),
+        streamResponse(stopResponse([{ text: 'Finished the analysis.' }])),
+      ];
+      vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
+        async () => responses.shift()!,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'gemini-pro',
+        {
+          message: [
+            {
+              functionResponse: {
+                id: 'call_read_file',
+                name: 'read_file',
+                response: { output: 'file contents' },
+              },
+            },
+          ],
+        },
+        'prompt-id-tool-result-max-tokens',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
+
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+      const calls = vi.mocked(mockContentGenerator.generateContentStream).mock
+        .calls;
+      expect(calls[1]![0].config?.maxOutputTokens).toBeGreaterThan(
+        calls[0]![0].config?.maxOutputTokens ?? 0,
+      );
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.RETRY &&
+            event.maxOutputTokensEscalated !== undefined,
+        ),
+      ).toBe(true);
+      expect(chat.getHistory().at(-1)).toEqual({
+        role: 'model',
+        parts: [{ text: 'Finished the analysis.' }],
+      });
     });
 
     it('should succeed when there is finish reason and response text', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1480,7 +1480,7 @@ describe('GeminiChat', async () => {
         expect(mockLogContentRetry).toHaveBeenLastCalledWith(
           mockConfig,
           expect.objectContaining({
-            error_type: 'NO_RESPONSE_TEXT',
+            error_type: 'NO_TOOL_RESULT_PROGRESS',
             model: 'test-model',
           }),
         );
@@ -1496,6 +1496,76 @@ describe('GeminiChat', async () => {
           role: 'model',
           parts: [{ text: 'Finished the analysis.' }],
         });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should not retry tool result continuations that make another tool call', async () => {
+      vi.useFakeTimers();
+      try {
+        chat.setHistory([
+          { role: 'user', parts: [{ text: 'inspect the project' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  args: { path: '/tmp/example' },
+                },
+              },
+            ],
+          },
+        ]);
+
+        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+          streamResponse(
+            stopResponse([
+              {
+                functionCall: {
+                  id: 'call_list_files',
+                  name: 'list_files',
+                  args: { path: '/tmp' },
+                },
+              },
+            ]),
+          ),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          {
+            message: [
+              {
+                functionResponse: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  response: { output: 'file contents' },
+                },
+              },
+            ],
+          },
+          'prompt-id-tool-result-next-tool-call',
+        );
+        const events = await collectStreamWithFakeTimers(stream);
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          events.some((event) => event.type === StreamEventType.RETRY),
+        ).toBe(false);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.some(
+                (part) => part.functionCall?.id === 'call_list_files',
+              ),
+          ),
+        ).toBe(true);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1391,6 +1391,116 @@ describe('GeminiChat', async () => {
       });
     });
 
+    it('should retry semantically empty responses after a tool result', async () => {
+      vi.useFakeTimers();
+      try {
+        const recordAssistantTurn = vi.fn();
+        const chatWithRecording = new GeminiChat(
+          mockConfig,
+          config,
+          [],
+          {
+            recordAssistantTurn,
+            recordChatCompression: vi.fn(),
+          } as unknown as ConstructorParameters<typeof GeminiChat>[3],
+          uiTelemetryService,
+        );
+        chatWithRecording.setHistory([
+          { role: 'user', parts: [{ text: 'inspect the project' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  args: { path: '/tmp/example' },
+                },
+              },
+            ],
+          },
+        ]);
+
+        const responses: Part[][] = [
+          [{ thought: true, text: 'I should keep working.' }],
+          [
+            { thought: true, text: 'I should still keep working.' },
+            { text: '(empty content)' },
+          ],
+          [{ text: 'Finished the analysis.' }],
+        ];
+        vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mockImplementation(async () =>
+          streamResponse(stopResponse(responses.shift()!)),
+        );
+
+        const stream = await chatWithRecording.sendMessageStream(
+          'test-model',
+          {
+            message: [
+              {
+                functionResponse: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  response: { output: 'file contents' },
+                },
+              },
+            ],
+          },
+          'prompt-id-tool-result-empty-response',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 10_000);
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(3);
+        expect(
+          events.some((event) => event.type === StreamEventType.RETRY),
+        ).toBe(true);
+        const lastRetryIndex = events.findLastIndex(
+          (event) => event.type === StreamEventType.RETRY,
+        );
+        const finishIndex = events.findIndex(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            Boolean(event.value.candidates?.[0]?.finishReason),
+        );
+        expect(finishIndex).toBeGreaterThan(lastRetryIndex);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.CHUNK &&
+              event.value.candidates?.[0]?.content?.parts?.some(
+                (part) => part.text === '(empty content)',
+              ),
+          ),
+        ).toBe(false);
+        expect(mockLogContentRetry).toHaveBeenCalledTimes(2);
+        expect(mockLogContentRetry).toHaveBeenLastCalledWith(
+          mockConfig,
+          expect.objectContaining({
+            error_type: 'NO_RESPONSE_TEXT',
+            model: 'test-model',
+          }),
+        );
+        expect(recordAssistantTurn).toHaveBeenCalledOnce();
+        expect(recordAssistantTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: [{ text: 'Finished the analysis.' }],
+          }),
+        );
+        const history = chatWithRecording.getHistory();
+        expect(history).toHaveLength(4);
+        expect(history.at(-1)).toEqual({
+          role: 'model',
+          parts: [{ text: 'Finished the analysis.' }],
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should succeed when there is finish reason and response text', async () => {
       // Setup: Stream with both finish reason and text content
       const validStream = (async function* () {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1522,6 +1522,70 @@ describe('GeminiChat', async () => {
       }
     });
 
+    it('should surface the last empty tool result continuation after retry exhaustion', async () => {
+      vi.useFakeTimers();
+      try {
+        chat.setHistory([
+          { role: 'user', parts: [{ text: 'inspect the project' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  args: { path: '/tmp/example' },
+                },
+              },
+            ],
+          },
+        ]);
+        vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mockImplementation(async () =>
+          streamResponse(
+            stopResponse([{ thought: true, text: 'I should keep working.' }]),
+          ),
+        );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          {
+            message: [
+              {
+                functionResponse: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  response: { output: 'file contents' },
+                },
+              },
+            ],
+          },
+          'prompt-id-tool-result-empty-response-exhausted',
+        );
+        const collecting = (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })();
+        const resultPromise = expect(collecting).rejects.toMatchObject({
+          message:
+            'Model stream ended after a tool result without visible progress.',
+          type: 'NO_TOOL_RESULT_PROGRESS',
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(35_000);
+        await resultPromise;
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(5);
+        expect(mockLogContentRetry).toHaveBeenCalledTimes(4);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should not retry tool result continuations that make another tool call', async () => {
       chat.setHistory([
         { role: 'user', parts: [{ text: 'inspect the project' }] },
@@ -1659,6 +1723,90 @@ describe('GeminiChat', async () => {
         role: 'model',
         parts: [{ text: 'Finished the analysis.' }],
       });
+    });
+
+    it('should not escalate thought-only MAX_TOKENS responses when max tokens are user-set', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+          authType: 'gemini',
+          model: 'test-model',
+          samplingParams: { max_tokens: 1024 },
+        });
+        chat.setHistory([
+          { role: 'user', parts: [{ text: 'inspect the project' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  args: { path: '/tmp/example' },
+                },
+              },
+            ],
+          },
+        ]);
+
+        const responses = [
+          streamResponse({
+            candidates: [
+              {
+                content: {
+                  parts: [{ thought: true, text: 'I need more tokens.' }],
+                },
+                finishReason: 'MAX_TOKENS',
+              },
+            ],
+          } as GenerateContentResponse),
+          streamResponse(stopResponse([{ text: 'Finished the analysis.' }])),
+        ];
+        vi.mocked(
+          mockContentGenerator.generateContentStream,
+        ).mockImplementation(async () => responses.shift()!);
+
+        const stream = await chat.sendMessageStream(
+          'gemini-pro',
+          {
+            message: [
+              {
+                functionResponse: {
+                  id: 'call_read_file',
+                  name: 'read_file',
+                  response: { output: 'file contents' },
+                },
+              },
+            ],
+          },
+          'prompt-id-tool-result-user-max-tokens',
+        );
+        const events = await collectStreamWithFakeTimers(stream, 5_000);
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.some(
+            (event) =>
+              event.type === StreamEventType.RETRY &&
+              event.maxOutputTokensEscalated !== undefined,
+          ),
+        ).toBe(false);
+        expect(mockLogContentRetry).toHaveBeenCalledWith(
+          mockConfig,
+          expect.objectContaining({
+            error_type: 'NO_TOOL_RESULT_PROGRESS_MAX_TOKENS',
+            model: 'gemini-pro',
+          }),
+        );
+        expect(chat.getHistory().at(-1)).toEqual({
+          role: 'model',
+          parts: [{ text: 'Finished the analysis.' }],
+        });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should preserve (empty content) outside tool result continuations', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1729,7 +1729,7 @@ describe('GeminiChat', async () => {
       vi.useFakeTimers();
       try {
         vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
-          authType: 'gemini',
+          authType: AuthType.USE_GEMINI,
           model: 'test-model',
           samplingParams: { max_tokens: 1024 },
         });

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1568,11 +1568,18 @@ describe('GeminiChat', async () => {
             // consume stream
           }
         })();
-        const resultPromise = expect(collecting).rejects.toMatchObject({
-          message:
-            'Model stream ended after a tool result without visible progress.',
-          type: 'NO_TOOL_RESULT_PROGRESS',
-        });
+        const resultPromise = collecting.then(
+          () => {
+            throw new Error('Expected stream to reject');
+          },
+          (error: unknown) => {
+            expect(error).toMatchObject({
+              message:
+                'Model stream ended after a tool result without visible progress.',
+              type: 'NO_TOOL_RESULT_PROGRESS',
+            });
+          },
+        );
         await vi.advanceTimersByTimeAsync(0);
         await vi.advanceTimersByTimeAsync(35_000);
         await resultPromise;

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1523,73 +1523,69 @@ describe('GeminiChat', async () => {
     });
 
     it('should not retry tool result continuations that make another tool call', async () => {
-      vi.useFakeTimers();
-      try {
-        chat.setHistory([
-          { role: 'user', parts: [{ text: 'inspect the project' }] },
-          {
-            role: 'model',
-            parts: [
-              {
-                functionCall: {
-                  id: 'call_read_file',
-                  name: 'read_file',
-                  args: { path: '/tmp/example' },
-                },
+      chat.setHistory([
+        { role: 'user', parts: [{ text: 'inspect the project' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_read_file',
+                name: 'read_file',
+                args: { path: '/tmp/example' },
               },
-            ],
-          },
-        ]);
+            },
+          ],
+        },
+      ]);
 
-        vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-          streamResponse(
-            stopResponse([
-              {
-                functionCall: {
-                  id: 'call_list_files',
-                  name: 'list_files',
-                  args: { path: '/tmp' },
-                },
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamResponse(
+          stopResponse([
+            {
+              functionCall: {
+                id: 'call_list_files',
+                name: 'list_files',
+                args: { path: '/tmp' },
               },
-            ]),
-          ),
-        );
+            },
+          ]),
+        ),
+      );
 
-        const stream = await chat.sendMessageStream(
-          'test-model',
-          {
-            message: [
-              {
-                functionResponse: {
-                  id: 'call_read_file',
-                  name: 'read_file',
-                  response: { output: 'file contents' },
-                },
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        {
+          message: [
+            {
+              functionResponse: {
+                id: 'call_read_file',
+                name: 'read_file',
+                response: { output: 'file contents' },
               },
-            ],
-          },
-          'prompt-id-tool-result-next-tool-call',
-        );
-        const events = await collectStreamWithFakeTimers(stream);
+            },
+          ],
+        },
+        'prompt-id-tool-result-next-tool-call',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of stream) events.push(event);
 
-        expect(
-          mockContentGenerator.generateContentStream,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          events.some((event) => event.type === StreamEventType.RETRY),
-        ).toBe(false);
-        expect(
-          events.some(
-            (event) =>
-              event.type === StreamEventType.CHUNK &&
-              event.value.candidates?.[0]?.content?.parts?.some(
-                (part) => part.functionCall?.id === 'call_list_files',
-              ),
-          ),
-        ).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+        false,
+      );
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.candidates?.[0]?.content?.parts?.some(
+              (part) => part.functionCall?.id === 'call_list_files',
+            ),
+        ),
+      ).toBe(true);
     });
 
     it('should escalate thought-only MAX_TOKENS responses after a tool result', async () => {
@@ -1665,15 +1661,14 @@ describe('GeminiChat', async () => {
       });
     });
 
-    it('should succeed when there is finish reason and response text', async () => {
-      // Setup: Stream with both finish reason and text content
+    it('should preserve (empty content) outside tool result continuations', async () => {
       const validStream = (async function* () {
         yield {
           candidates: [
             {
               content: {
                 role: 'model',
-                parts: [{ text: 'valid response' }],
+                parts: [{ text: '(empty content)' }],
               },
               finishReason: 'STOP',
             },
@@ -1699,6 +1694,10 @@ describe('GeminiChat', async () => {
           }
         })(),
       ).resolves.not.toThrow();
+      expect(chat.getHistory().at(-1)).toEqual({
+        role: 'model',
+        parts: [{ text: '(empty content)' }],
+      });
     });
 
     it('should not lose finish reason when last chunk only has usage metadata', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2239,6 +2239,15 @@ export class GeminiChat {
           (cgConfig?.samplingParams?.max_tokens !== undefined &&
             cgConfig?.samplingParams?.max_tokens !== null) ||
           parsedEnvMaxTokens !== undefined;
+        const effectiveInitialMaxOutputTokens =
+          params.config?.maxOutputTokens ?? outputCeiling;
+        const escalatedLimit = clampOutputTokensToWindow(
+          OUTPUT_TOKEN_CEILING,
+          contextWindowForClamp,
+          promptTokensForClamp,
+        );
+        const shouldEscalateMaxOutputTokens =
+          effectiveInitialMaxOutputTokens < escalatedLimit;
 
         let lastFinishReason: string | undefined;
 
@@ -2492,6 +2501,18 @@ export class GeminiChat {
               break;
             }
 
+            if (
+              error instanceof InvalidStreamError &&
+              error.type === 'NO_TOOL_RESULT_PROGRESS_MAX_TOKENS' &&
+              !maxTokensEscalated &&
+              !hasUserMaxTokensOverride &&
+              shouldEscalateMaxOutputTokens
+            ) {
+              lastError = null;
+              lastFinishReason = FinishReason.MAX_TOKENS;
+              break;
+            }
+
             // Invalid stream responses use INVALID_STREAM_RETRY_CONFIG, which
             // is independent from HTTP retries handled by retryWithBackoff.
             const isInvalidStreamError = error instanceof InvalidStreamError;
@@ -2661,16 +2682,6 @@ export class GeminiChat {
         // params.config.maxOutputTokens is always set by the first-send clamp
         // above; the `?? outputCeiling` is a defensive fallback that never
         // fires in practice.
-        const effectiveInitialMaxOutputTokens =
-          params.config?.maxOutputTokens ?? outputCeiling;
-        const escalatedLimit = clampOutputTokensToWindow(
-          OUTPUT_TOKEN_CEILING,
-          contextWindowForClamp,
-          promptTokensForClamp,
-        );
-        const shouldEscalateMaxOutputTokens =
-          effectiveInitialMaxOutputTokens < escalatedLimit;
-
         if (
           lastError === null &&
           lastFinishReason === FinishReason.MAX_TOKENS &&
@@ -3829,7 +3840,8 @@ export class GeminiChat {
     // result, they do not advance the agent without text or another tool call.
     const hasAnyContent = contentText || thoughtText;
     const lacksVisibleToolResultProgress =
-      isToolResultContinuation && !contentText;
+      isToolResultContinuation &&
+      (!contentText || contentText === '(empty content)');
     if (
       streamError === null &&
       !hasToolCall &&
@@ -3844,7 +3856,9 @@ export class GeminiChat {
       if (lacksVisibleToolResultProgress) {
         throw new InvalidStreamError(
           'Model stream ended after a tool result without visible progress.',
-          'NO_TOOL_RESULT_PROGRESS',
+          deferredFinishReason === FinishReason.MAX_TOKENS
+            ? 'NO_TOOL_RESULT_PROGRESS_MAX_TOKENS'
+            : 'NO_TOOL_RESULT_PROGRESS',
         );
       }
       throw new InvalidStreamError(

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -3601,6 +3601,11 @@ export class GeminiChat {
     let hasFinishReason = false;
     const protocolTagDetector = new LeadingProtocolTagLeakDetector();
     let protocolTextWasSuppressed = false;
+    const currentUserTurn = this.history[this.history.length - 1];
+    const isToolResultContinuation =
+      currentUserTurn?.role === 'user' &&
+      currentUserTurn.parts?.some((part) => part.functionResponse) === true;
+    let deferredFinishReason: FinishReason | undefined;
     // Captured if the upstream stream throws mid-iteration (typical on weak
     // networks: SSE drops between `content_block_stop` of a tool_use and the
     // terminal `message_stop`). We still build / record / push a partial
@@ -3637,6 +3642,13 @@ export class GeminiChat {
           const content = candidate?.content;
           if (content?.parts) {
             content.parts = content.parts.flatMap((part) => {
+              if (
+                isToolResultContinuation &&
+                !part.thought &&
+                part.text?.trim() === '(empty content)'
+              ) {
+                return [];
+              }
               if (typeof part.text !== 'string' || part.thought) return [part];
               const text = protocolTagDetector.accept(part.text);
               if (text) return [{ ...part, text }];
@@ -3740,6 +3752,17 @@ export class GeminiChat {
           }
         }
 
+        if (isToolResultContinuation) {
+          // Do not let consumers commit Finished before post-stream validation
+          // can reject a semantically empty continuation.
+          for (const candidate of chunk.candidates ?? []) {
+            if (candidate.finishReason) {
+              deferredFinishReason ??= candidate.finishReason;
+              delete candidate.finishReason;
+            }
+          }
+        }
+
         if (!protocolTextWasSuppressed || !protocolTagDetector.blockingOutput) {
           yield chunk;
         }
@@ -3802,12 +3825,16 @@ export class GeminiChat {
     // 1. There's a tool call (tool calls can end without explicit finish reasons), OR
     // 2. There's a finish reason AND we have non-empty response text or thought text
     //
-    // Note: Thoughts-only responses are valid for models that use thinking modes.
+    // Thought-only responses remain valid for ordinary user turns. After a tool
+    // result, they do not advance the agent without text or another tool call.
     const hasAnyContent = contentText || thoughtText;
+    const lacksVisibleToolResultProgress =
+      isToolResultContinuation &&
+      (!contentText || contentText === '(empty content)');
     if (
       streamError === null &&
       !hasToolCall &&
-      (!hasFinishReason || !hasAnyContent)
+      (!hasFinishReason || !hasAnyContent || lacksVisibleToolResultProgress)
     ) {
       if (!hasFinishReason) {
         throw new InvalidStreamError(
@@ -3946,6 +3973,12 @@ export class GeminiChat {
         ...consolidatedHistoryParts,
       ],
     });
+    if (deferredFinishReason) {
+      yield {
+        candidates: [{ finishReason: deferredFinishReason }],
+        usageMetadata,
+      } as GenerateContentResponse;
+    }
   }
 
   /**

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -112,6 +112,9 @@ import { InvalidStreamError } from './invalid-stream-error.js';
 export { InvalidStreamError };
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
+// Gemini can emit this filler after tool results; filtering and validation
+// must stay in sync.
+const GEMINI_EMPTY_CONTENT_PLACEHOLDER = '(empty content)';
 
 function isToolCallPreparationOnly(response: GenerateContentResponse): boolean {
   if (getToolCallPreparations(response).length === 0) return false;
@@ -2239,6 +2242,8 @@ export class GeminiChat {
           (cgConfig?.samplingParams?.max_tokens !== undefined &&
             cgConfig?.samplingParams?.max_tokens !== null) ||
           parsedEnvMaxTokens !== undefined;
+        // params.config.maxOutputTokens is set by the first-send clamp; the
+        // outputCeiling fallback is defensive and should not fire in practice.
         const effectiveInitialMaxOutputTokens =
           params.config?.maxOutputTokens ?? outputCeiling;
         const escalatedLimit = clampOutputTokensToWindow(
@@ -2679,9 +2684,6 @@ export class GeminiChat {
             }
           }
         };
-        // params.config.maxOutputTokens is always set by the first-send clamp
-        // above; the `?? outputCeiling` is a defensive fallback that never
-        // fires in practice.
         if (
           lastError === null &&
           lastFinishReason === FinishReason.MAX_TOKENS &&
@@ -3656,7 +3658,7 @@ export class GeminiChat {
               if (
                 isToolResultContinuation &&
                 !part.thought &&
-                part.text?.trim() === '(empty content)'
+                part.text?.trim() === GEMINI_EMPTY_CONTENT_PLACEHOLDER
               ) {
                 return [];
               }
@@ -3841,7 +3843,7 @@ export class GeminiChat {
     const hasAnyContent = contentText || thoughtText;
     const lacksVisibleToolResultProgress =
       isToolResultContinuation &&
-      (!contentText || contentText === '(empty content)');
+      (!contentText || contentText === GEMINI_EMPTY_CONTENT_PLACEHOLDER);
     if (
       streamError === null &&
       !hasToolCall &&

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -3829,8 +3829,7 @@ export class GeminiChat {
     // result, they do not advance the agent without text or another tool call.
     const hasAnyContent = contentText || thoughtText;
     const lacksVisibleToolResultProgress =
-      isToolResultContinuation &&
-      (!contentText || contentText === '(empty content)');
+      isToolResultContinuation && !contentText;
     if (
       streamError === null &&
       !hasToolCall &&
@@ -3840,6 +3839,12 @@ export class GeminiChat {
         throw new InvalidStreamError(
           'Model stream ended without a finish reason.',
           'NO_FINISH_REASON',
+        );
+      }
+      if (lacksVisibleToolResultProgress) {
+        throw new InvalidStreamError(
+          'Model stream ended after a tool result without visible progress.',
+          'NO_TOOL_RESULT_PROGRESS',
         );
       }
       throw new InvalidStreamError(

--- a/packages/core/src/core/invalid-stream-error.ts
+++ b/packages/core/src/core/invalid-stream-error.ts
@@ -11,6 +11,7 @@ export class InvalidStreamError extends Error {
   readonly type:
     | 'NO_FINISH_REASON'
     | 'NO_RESPONSE_TEXT'
+    | 'NO_TOOL_RESULT_PROGRESS'
     | 'PROTOCOL_TAG_LEAK'
     | 'MALFORMED_TOOL_CALL';
 

--- a/packages/core/src/core/invalid-stream-error.ts
+++ b/packages/core/src/core/invalid-stream-error.ts
@@ -12,6 +12,7 @@ export class InvalidStreamError extends Error {
     | 'NO_FINISH_REASON'
     | 'NO_RESPONSE_TEXT'
     | 'NO_TOOL_RESULT_PROGRESS'
+    | 'NO_TOOL_RESULT_PROGRESS_MAX_TOKENS'
     | 'PROTOCOL_TAG_LEAK'
     | 'MALFORMED_TOOL_CALL';
 


### PR DESCRIPTION
## What this PR does

This change treats a semantically empty model continuation immediately after a tool result as a retryable invalid stream. A continuation that contains only thought text, or thought text plus the literal `(empty content)` placeholder, no longer reaches the agent as a successful terminal response when it also has no new tool call or visible answer.

The terminal finish signal is held until post-stream validation succeeds, so downstream consumers cannot commit a finished turn before the existing retry path has a chance to recover. A whole-part placeholder is suppressed immediately. If it arrives across multiple stream deltas, consolidated validation rejects the attempt so the existing retry signal clears those fragments. Neither form is persisted in history.

Ordinary thought-only responses remain valid for direct user turns, preserving the behavior established by #3251. A thought-only `MAX_TOKENS` tool continuation uses the existing output-token escalation only when a higher limit is available; otherwise it remains an invalid stream.

## Why it's needed

Some reasoning-model responses return HTTP 200 and a normal finish reason after a successful tool result but contain only internal thought text or an `(empty content)` placeholder. The previous general thought-only rule accepted that response, and the agent state machine interpreted it as normal completion even though the tool-driven workflow had not advanced. Users then had to send another message before execution resumed.

This differs from completely empty streams covered by earlier retry work: bytes and thought content are present here, so transport-level empty-response detection does not fire. Validation must consider the conversational boundary and require visible progress or another tool call specifically after a tool result.

## Reviewer Test Plan

### How to verify

Start a conversation whose model turn requests a tool, then send the successful tool result back to the model. Make the first continuation return thought text plus a stop reason, the second return thought text plus `(empty content)` in one part, the third split `(empty content)` across two stream deltas, and the fourth return a visible final answer.

Confirm that the first three attempts emit retry events, no failed attempt exposes a terminal finish event, retry clears any split placeholder fragments, only the fourth answer is persisted, and retry telemetry records `NO_TOOL_RESULT_PROGRESS`. Also confirm that a thought-only response to an ordinary user turn still succeeds, and that a thought-only `MAX_TOKENS` tool continuation escalates instead of consuming generic invalid-stream retries.

### Evidence (Before & After)

Before: a thought-only or placeholder continuation after a tool result could emit `Finished`, persist an empty-looking assistant turn, and stop the agent.

After: the same continuation is rejected through the existing invalid-stream retry path; `Finished` is emitted only after a continuation provides visible text or another tool call.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22, deterministic mocked streaming responses.

Local validation:

- Core chat suite: 233/233 passed.
- Build, typecheck, strict lint, formatting, and diff checks passed.
- Script tests: 510 passed, 9 platform-specific tests skipped.
- Serve fast-path bundle closure check passed.

The full workspace preflight was also attempted. Its build, lint, and typecheck stages passed; the test stage exposed unrelated failures in unchanged main-branch tests caused by local user configuration and a macOS `/var` versus `/private/var` realpath assumption. The changed suite and all directly related compatibility cases pass.

## Risk & Scope

- Main risk or tradeoff: a provider that intentionally returns only thought text after a tool result will now consume the existing invalid-stream retry budget instead of ending the turn.
- Not validated / out of scope: model fallback policy, frontend retry copy, and additional gateway telemetry are not changed here.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7034

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本改动会把“紧跟在工具结果之后、语义上没有推进流程”的模型续写视为可重试的无效流。如果续写只有 thought，或者只有 thought 加字面量 `(empty content)`，同时没有新的工具调用和可见答复，就不会再被 Agent 当作成功终态。

终止信号会延迟到流结束后的语义校验通过之后再发出，避免下游消费者在现有重试逻辑介入前先提交 `Finished`。完整占位文本会直接被抑制；如果它跨多个流分片到达，则在合并校验后拒绝本次尝试，并由现有重试信号清除这些片段。两种情况都不会写入历史。

普通用户轮次中的 thought-only 响应仍然合法，保留 #3251 确立的行为。工具结果后的 thought-only `MAX_TOKENS` 只有在输出上限确实可以提高时才进入现有升额流程，否则仍按无效流处理。

## 为什么需要

部分推理模型会在工具成功返回后，以 HTTP 200 和正常 finish reason 结束续写，但正文只有内部 thought，或者带有 `(empty content)` 占位文本。之前的通用 thought-only 规则会接受这类响应，Agent 状态机随即把它解释为正常完成，即使工具驱动流程实际没有继续推进。用户只能再追问一次才能恢复执行。

这与此前重试逻辑覆盖的“完全空流”不同：这里确实收到了数据和 thought，所以传输层的空响应检测不会触发。校验需要结合会话边界，仅在工具结果之后要求模型产生可见进展或下一次工具调用。

## Reviewer 验证计划

### 如何验证

构造一段模型先请求工具、随后收到成功工具结果的会话。第一次续写返回 thought 加 stop reason，第二次在一个 part 中返回 thought 和 `(empty content)`，第三次把 `(empty content)` 拆成两个流分片返回，第四次返回可见最终答复。

确认前三次都会产生重试事件，失败尝试不会暴露终止事件，分片占位文本会在重试时被清除；只有第四次答复会被写入历史；重试遥测记录 `NO_TOOL_RESULT_PROGRESS`。同时确认普通用户轮次中的 thought-only 响应仍能成功，并确认工具结果后的 thought-only `MAX_TOKENS` 会进入升额流程，而不是消耗普通无效流重试。

### 前后对比证据

修改前：工具结果后的 thought-only 或占位续写可能发出 `Finished`、写入看似空白的 Assistant 轮次，并让 Agent 停止。

修改后：相同续写会进入现有无效流重试路径；只有模型提供可见文本或新的工具调用后才会发出 `Finished`。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

Node.js 22，使用确定性的流式响应 mock。

本地验收：

- Core chat 测试：233/233 通过。
- Build、typecheck、严格 lint、格式和 diff 检查通过。
- 脚本测试：510 通过，9 个平台相关用例跳过。
- Serve fast-path bundle closure 检查通过。

也尝试执行了完整 workspace preflight。其 build、lint、typecheck 阶段均通过；测试阶段暴露了 main 分支未修改用例中的无关本地问题，来源包括用户配置注入，以及 macOS `/var` 与 `/private/var` 的 realpath 假设。此次修改对应的测试套件和直接兼容用例均通过。

## 风险与范围

- 主要风险或取舍：如果某个 Provider 有意在工具结果后只返回 thought，它现在会消耗现有的无效流重试预算，而不是直接结束本轮。
- 未验证或不在范围内：本 PR 不修改模型 fallback 策略、前端重试提示文案或额外的网关遥测。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #7034

</details>


