### PR TITLE
test(web-shell): make visual-preview captures deterministic + add workspace-sidebar scenario

### DIFF
--- a/packages/web-shell/client/e2e/visuals/harness.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, test } from '@playwright/test';
+import { freezeLoopingAnimations } from './harness';
+
+// `freezeLoopingAnimations` is the load-bearing step that keeps spinner-bearing
+// captures deterministic (see its docstring). It runs only implicitly via
+// `captureScreenshot`, so pin its contract explicitly here: an infinite
+// animation must be paused and rewound to time 0, while a finite one must be
+// left alone for Playwright's own `animations: 'disabled'` to settle.
+test('freezeLoopingAnimations pins infinite animations to frame 0 and leaves finite ones', async ({
+  page,
+}) => {
+  await page.setContent(`
+    <style>
+      @keyframes spin { to { transform: rotate(360deg); } }
+      #loop { width: 10px; height: 10px; animation: spin 800ms linear infinite; }
+      #once { width: 10px; height: 10px; animation: spin 10s linear 1; }
+    </style>
+    <div id="loop"></div>
+    <div id="once"></div>
+  `);
+  // Advance both animations past frame 0 first, so a freeze that did nothing
+  // would leave a non-zero currentTime and fail the assertion below.
+  await page.waitForTimeout(100);
+
+  await freezeLoopingAnimations(page);
+
+  const state = await page.evaluate(
+    /* global document */
+    () => {
+      const animOf = (id: string) => {
+        const el = document.getElementById(id);
+        if (!el) throw new Error(`element #${id} not found`);
+        return el.getAnimations()[0];
+      };
+      const loop = animOf('loop');
+      return {
+        loopPlayState: loop.playState,
+        loopCurrentTime: Number(loop.currentTime),
+        oncePlayState: animOf('once').playState,
+      };
+    },
+  );
+
+  // The infinite loop is paused at its first frame…
+  expect(state.loopPlayState).toBe('paused');
+  expect(state.loopCurrentTime).toBe(0);
+  // …while the finite animation is untouched, still running toward completion.
+  expect(state.oncePlayState).toBe('running');
+});

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -158,8 +158,14 @@ export async function captureScreenshot(
  * a deterministic frame (verified: sidebar-attention drops from ~0.12% of pixels
  * differing between identical renders to 0); a two-frame wait lets the compositor
  * commit that frame before the capture reads it.
+ *
+ * Scope: this covers WAAPI and CSS `@keyframes` animations — everything
+ * `document.getAnimations()` reports. A spinner hand-rolled on a
+ * `requestAnimationFrame` loop instead would NOT be caught, and the flake would
+ * silently return; if a spinner reimplementation ever reintroduces it, this is
+ * the function to extend. `harness.spec.ts` pins the pause/rewind contract.
  */
-async function freezeLoopingAnimations(page: Page): Promise<void> {
+export async function freezeLoopingAnimations(page: Page): Promise<void> {
   await page.evaluate(
     /* global document, requestAnimationFrame */
     async () => {

--- a/packages/web-shell/client/e2e/visuals/harness.ts
+++ b/packages/web-shell/client/e2e/visuals/harness.ts
@@ -140,10 +140,40 @@ export async function captureScreenshot(
   name: string,
 ): Promise<void> {
   mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+  await freezeLoopingAnimations(page);
   await page.screenshot({
     path: join(SCREENSHOTS_DIR, `${name}.png`),
     animations: 'disabled',
   });
+}
+
+/**
+ * Pin looping animations to their first frame before a capture. Playwright's
+ * `animations: 'disabled'` settles finite animations and is meant to reset
+ * infinite ones, but a GPU-composited transform loop — e.g. the sidebar's
+ * rotating activity spinner — is still captured mid-rotation at a random angle.
+ * That angle differs between the base and head render passes, so the view reads
+ * as "changed" against the 0.02% before/after threshold even when nothing did.
+ * Pausing the infinite Web Animations and rewinding them to time 0 pins them to
+ * a deterministic frame (verified: sidebar-attention drops from ~0.12% of pixels
+ * differing between identical renders to 0); a two-frame wait lets the compositor
+ * commit that frame before the capture reads it.
+ */
+async function freezeLoopingAnimations(page: Page): Promise<void> {
+  await page.evaluate(
+    /* global document, requestAnimationFrame */
+    async () => {
+      for (const animation of document.getAnimations()) {
+        if (animation.effect?.getTiming().iterations === Infinity) {
+          animation.pause();
+          animation.currentTime = 0;
+        }
+      }
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+      );
+    },
+  );
 }
 
 /**

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -347,12 +347,22 @@ for (const theme of THEMES) {
       // Every other scenario here is single-workspace, where that tag never
       // renders (it is gated on more than one displayed workspace), so this is
       // the only scenario that can surface a change to the workspace labels.
+      //
+      // Pin the primary workspace cwd and its loaded session name explicitly,
+      // rather than leaning on createWebShellDaemonScenario's defaults: the
+      // basename ("qwen-web-shell-e2e") and the settle-wait below both depend on
+      // them, so a rename of those defaults in mockDaemon.ts would otherwise
+      // turn this into a cryptic "not visible" failure.
+      const primaryCwd = '/tmp/qwen-web-shell-e2e';
+      const primarySessionName = 'Run auth migration';
       const scenario = createWebShellDaemonScenario({
+        workspaceCwd: primaryCwd,
+        displayName: primarySessionName,
         capabilities: {
           workspaces: [
             {
               id: 'ws-primary',
-              cwd: '/tmp/qwen-web-shell-e2e',
+              cwd: primaryCwd,
               primary: true,
               trusted: true,
             },
@@ -384,11 +394,10 @@ for (const theme of THEMES) {
       ).toBeVisible();
       await expect(sidebar.getByText('Primary', { exact: true })).toBeVisible();
       // The primary workspace auto-expands and streams its session rows in via a
-      // per-workspace fetch. Wait for a row before capturing so the async load
-      // has settled — otherwise the row list races the screenshot and the
-      // capture is byte-nondeterministic between runs (the flake this scenario
-      // was added to replace).
-      await expect(sidebar.getByText('E2E Harness Session')).toBeVisible();
+      // per-workspace fetch. Wait for the loaded session's row before capturing
+      // so the async load has settled — otherwise the row list races the
+      // screenshot and the capture differs between runs.
+      await expect(sidebar.getByText(primarySessionName)).toBeVisible();
       await captureScreenshot(page, `workspace-sidebar-${theme}`);
     });
 

--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -266,12 +266,16 @@ for (const theme of THEMES) {
 
       // Restore the tiled layout (#6951): the solo pane returns to the split and
       // the hidden pane reappears — so the maximize control is back on both
-      // panes. Captures the restore path so a regression there is caught too.
+      // panes. Assert the restore path (behavioral coverage) but do NOT capture
+      // a screenshot: the restored layout is visually identical to the tiled
+      // `split view` shot above, and the reappearing pane re-renders its content
+      // just after this click, so the capture is byte-nondeterministic between
+      // identical runs — a flaky, redundant view that surfaces false-positive
+      // "changed" previews unrelated to the PR under review.
       await page.getByRole('button', { name: 'Restore pane' }).click();
       await expect(
         page.getByRole('button', { name: 'Maximize pane' }).first(),
       ).toBeVisible();
-      await captureScreenshot(page, `split-view-restored-${theme}`);
     });
 
     test(`sidebar attention`, async ({ page }, testInfo) => {
@@ -335,6 +339,57 @@ for (const theme of THEMES) {
       await expect(sidebar.getByText('Run test suite')).toBeVisible();
       await expect(sidebar.getByText('Draft release notes')).toBeVisible();
       await captureScreenshot(page, `sidebar-attention-${theme}`);
+    });
+
+    test(`workspace sidebar`, async ({ page }, testInfo) => {
+      // Two workspaces make the sidebar group sessions per workspace and tag the
+      // primary one — the surface the "primary workspace" label/badge lives on.
+      // Every other scenario here is single-workspace, where that tag never
+      // renders (it is gated on more than one displayed workspace), so this is
+      // the only scenario that can surface a change to the workspace labels.
+      const scenario = createWebShellDaemonScenario({
+        capabilities: {
+          workspaces: [
+            {
+              id: 'ws-primary',
+              cwd: '/tmp/qwen-web-shell-e2e',
+              primary: true,
+              trusted: true,
+            },
+            {
+              id: 'ws-api',
+              cwd: '/tmp/qwen-api-service',
+              primary: false,
+              trusted: true,
+            },
+          ],
+        },
+      });
+      const daemon = await installScenario(
+        page,
+        scenario,
+        resolveBaseURL(testInfo),
+      );
+      await gotoSession(page, scenario, daemon, theme);
+      // Each workspace renders a section headed by its basename; the primary one
+      // also carries a "Primary" tag. Assert both workspace names and the tag so
+      // a regression in the grouping or the (removable) primary label fails an
+      // assertion, not only the visually-reviewed screenshot.
+      const sidebar = page.getByRole('complementary');
+      await expect(
+        sidebar.getByText('qwen-web-shell-e2e', { exact: true }),
+      ).toBeVisible();
+      await expect(
+        sidebar.getByText('qwen-api-service', { exact: true }),
+      ).toBeVisible();
+      await expect(sidebar.getByText('Primary', { exact: true })).toBeVisible();
+      // The primary workspace auto-expands and streams its session rows in via a
+      // per-workspace fetch. Wait for a row before capturing so the async load
+      // has settled — otherwise the row list races the screenshot and the
+      // capture is byte-nondeterministic between runs (the flake this scenario
+      // was added to replace).
+      await expect(sidebar.getByText('E2E Harness Session')).toBeVisible();
+      await captureScreenshot(page, `workspace-sidebar-${theme}`);
     });
 
     test(`slash menu`, async ({ page }, testInfo) => {


### PR DESCRIPTION
## What this PR does

Makes the web-shell visual-preview captures deterministic and adds a scenario for a class of change the suite couldn't see. Three parts:

1. **Freeze looping animations before each capture.** The sidebar's activity spinner is a GPU-composited transform loop that Playwright's `animations: 'disabled'` captures mid-rotation at a random angle, so the `sidebar attention` view differed in ~0.12% of pixels between two identical renders — above the 0.02% before/after threshold, i.e. a false-positive "changed view" on any PR that renders it. `captureScreenshot` now pauses every infinite Web Animation and rewinds it to time 0 (a two-frame wait lets the compositor commit the frozen frame) before shooting.

2. **Drop the split-view "restored" screenshot.** It is visually identical to the tiled `split view` shot above it (restore returns to the same two-pane layout), so it adds no coverage that shot doesn't — and it was the specific view #7035's preview flagged. The restore click and the "both panes back" assertion stay, so the restore path keeps its behavioral coverage; only the redundant capture is removed.

3. **Add a `workspace sidebar` scenario** with two workspaces, so the sidebar groups sessions per workspace and tags the primary one. It is the only scenario that renders the primary-workspace label/badge (gated on more than one displayed workspace), so changes to those labels — which no single-workspace scenario can surface — now appear in the preview.

## Why it's needed

The before/after preview on #7035 flagged `split-view-restored-dark` as the only "changed" view, even though that PR (dropping a redundant primary-workspace label) touches neither split-view rendering nor anything else the suite captures. Root causes: animated content (spinners) is captured at a random frame and reads as changed between the base and head render passes, and the PR's real change was invisible because no scenario exercises multiple workspaces. This freezes the animations at the source, drops a redundant capture, and adds the missing scenario.

## Reviewer Test Plan

### How to verify

- **Determinism** — render the whole suite twice into two dirs and pixel-diff each view (a pixel differs when `|ΔR|+|ΔG|+|ΔB| > 30`, matching the bot):

```
cd packages/web-shell
WEB_SHELL_VISUALS_OUTPUT_DIR=/tmp/a npm run test:e2e:visuals
WEB_SHELL_VISUALS_OUTPUT_DIR=/tmp/b npm run test:e2e:visuals
# compare /tmp/a/screenshots vs /tmp/b/screenshots per view
```

Before this PR, `sidebar-attention-*` differs by ~0.12% of pixels (the spinner). With the freeze, every one of the 22 views is pixel-identical (worst 0.0001%, threshold 0.02%).

- **New scenario**: `npx playwright test --config playwright.visuals.config.ts -g "workspace sidebar" --project=chromium` → `2 passed`; the primary workspace (`qwen-web-shell-e2e`) carries a `Primary` badge, the other (`qwen-api-service`) does not.
- **Full suite**: `npm run test:e2e:visuals` → `23 passed` (was 21; +2 for the new scenario × 2 themes). No `split-view-restored-*.png` is emitted; `workspace-sidebar-*.png` is.

### Evidence (Before & After)

**Freeze — pixel-diff of two identical renders** (the number the 0.02% threshold actually measures; `cmp` byte-compare is misleading here because PNG encoding is non-deterministic even for pixel-identical frames):

```
                          before freeze      with freeze
sidebar-attention dark    0.1166% (1194px)   0.0000% (0px)   ✓
whole suite (22 views)    —                  worst 0.0001%   ✓ all deterministic
```

**New `workspace sidebar` scenario** — the surface the preview will now watch for primary-workspace-label changes (the `Primary` badge is exactly the node a "drop the primary label" change removes):

| Dark | Light |
| --- | --- |
| ![dark](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-visuals-splitview-multiworkspace/workspace-sidebar-dark.png) | ![light](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-visuals-splitview-multiworkspace/workspace-sidebar-light.png) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Verified locally on macOS; Windows/Linux left to CI (the visuals job runs on Linux).

### Environment (optional)

`npm run dev` web-shell dev server + Playwright (chromium), driven by `playwright.visuals.config.ts`.

## Risk & Scope

- Test-only change (everything is under `client/e2e/visuals/`).
- Main risk / tradeoff: `captureScreenshot` now runs a small `page.evaluate` before every shot. It only touches *infinite* Web Animations (pause + rewind to 0); finite animations are left to Playwright, so settled dialogs/transitions are unaffected. On this PR's own before/after preview, spinner-bearing views (e.g. `sidebar attention`) will read as "changed" once — base renders the spinner at a random angle, head freezes it — which is the fix demonstrating itself; it stabilizes afterwards.
- Not validated / out of scope: the `SplitView` session-picker and `SessionOverviewPanel` variants of the primary label (the sidebar badge is its highest-signal surface).
- Breaking changes / migration notes: none.

## Linked Issues

None. Follows the visual-preview suite (#6880), the before/after engine (#6963), and the scenario set (#6964, #6997). Motivated by the flaky preview observed on #7035.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell 视觉预览的截图具备确定性,并新增一个套件此前无法覆盖的改动类别的场景。三部分:

1. **每次截图前冻结循环动画。** 侧边栏的活动转圈图标是一个 GPU 合成的 transform 循环,Playwright 的 `animations: 'disabled'` 会在随机角度把它截下来,导致 `sidebar attention` 视图在两次相同渲染之间有约 0.12% 的像素不同——超过了 before/after 的 0.02% 阈值,也就是任何渲染到它的 PR 上都会出现的假"变更视图"。`captureScreenshot` 现在会在截图前暂停每一个无限 Web Animation 并把它回退到 time 0(等两帧让合成器提交冻结帧)。

2. **删掉 split-view "restored"(恢复)截图。** 它与上面那张平铺的 `split view` 截图视觉一致(恢复回到同样的双 pane 布局),不提供额外覆盖——而且它正是 #7035 预览标记的那张。恢复的点击与"两个 pane 都回来了"的断言保留(恢复路径的行为覆盖仍在),只删掉这张冗余截图。

3. **新增 `workspace sidebar`(工作区侧边栏)场景**,含两个工作区,使侧边栏按工作区分组会话并给主工作区打标。它是唯一会渲染主工作区标签/徽章的场景(仅在展示的工作区多于一个时才出现),因此对这些标签的改动——单工作区场景无法呈现的——现在会出现在预览里。

## 为什么需要它

#7035 的 before/after 预览把 `split-view-restored-dark` 标为唯一的变更视图,尽管那个 PR(删除一个冗余的主工作区标签)既没动 split-view 渲染,也没动套件截取的任何东西。根因:动画内容(转圈)被截在随机帧,于是在 base 与 head 两次渲染之间读作"变更";而该 PR 的真实改动不可见,因为没有任何场景用到多工作区。本 PR 从源头冻结动画、删掉一张冗余截图、并补上缺失的场景。

## 复现测试计划

### 如何验证

- **确定性**——把整个套件渲染两次到两个目录,对每个视图做像素级 diff(当 `|ΔR|+|ΔG|+|ΔB| > 30` 时算一个像素不同,与 bot 一致):

```
cd packages/web-shell
WEB_SHELL_VISUALS_OUTPUT_DIR=/tmp/a npm run test:e2e:visuals
WEB_SHELL_VISUALS_OUTPUT_DIR=/tmp/b npm run test:e2e:visuals
# 逐视图比较 /tmp/a/screenshots 与 /tmp/b/screenshots
```

本 PR 之前,`sidebar-attention-*` 有约 0.12% 的像素不同(转圈);加上冻结后,22 个视图每一个都逐像素一致(最差 0.0001%,阈值 0.02%)。

- **新场景**:`npx playwright test --config playwright.visuals.config.ts -g "workspace sidebar" --project=chromium` → `2 passed`;主工作区(`qwen-web-shell-e2e`)带 `Primary` 徽章,另一个(`qwen-api-service`)没有。
- **完整套件**:`npm run test:e2e:visuals` → `23 passed`(原为 21;新场景 × 2 主题 = +2)。不再产出 `split-view-restored-*.png`;产出 `workspace-sidebar-*.png`。

### 证据(Before & After)

**冻结——两次相同渲染的像素级 diff**(这才是 0.02% 阈值实际度量的数值;`cmp` 逐字节比较在这里会误导,因为 PNG 编码即便对逐像素一致的帧也非确定):

```
                          冻结前              冻结后
sidebar-attention dark    0.1166% (1194px)   0.0000% (0px)   ✓
整套件(22 个视图)        —                  最差 0.0001%    ✓ 全部确定
```

**新的 `workspace sidebar` 场景**——预览今后据此监视主工作区标签的改动(`Primary` 徽章正是"删主标签"类改动会移除的节点):见上方深色/浅色两图。

### 测试平台

仅在本地 macOS 验证;Windows/Linux 交由 CI(视觉任务在 Linux 上运行)。

## 风险与范围

- 仅测试改动(全部位于 `client/e2e/visuals/` 下)。
- 主要风险/取舍:`captureScreenshot` 现在每次截图前会跑一小段 `page.evaluate`。它只碰*无限*的 Web Animation(暂停 + 回退到 0);有限动画交给 Playwright,因此已稳定的弹窗/过渡不受影响。在本 PR 自己的 before/after 预览上,带转圈的视图(如 `sidebar attention`)会一次性读作"变更"——base 把转圈截在随机角度,head 冻结它——这正是修复本身的体现,之后即稳定。
- 未验证/不在范围内:同一主标签在 `SplitView` 会话选择器和 `SessionOverviewPanel` 里的变体(侧边栏徽章是它信号最强的一面)。
- 破坏性变更/迁移说明:无。

## 关联 Issue

无。延续视觉预览套件(#6880)、before/after 引擎(#6963)与场景集合(#6964、#6997)。由 #7035 上观察到的 flaky 预览触发。

</details>
