### PR TITLE
feat(cli): show active path in compact tool summaries

### DIFF
--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -162,6 +162,141 @@ describe('<CompactToolGroupDisplay /> — summary label', () => {
     expect(frame).not.toContain('…');
     expect(frame.replace(/\s/g, '')).toContain(`Read${description}`);
   });
+
+  it('shows the latest executing description while a batch is active', () => {
+    const tools = [
+      toolCall({
+        callId: 'c1',
+        name: 'ReadFile',
+        description: 'completed.ts',
+      }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: 'current.ts',
+        status: ToolCallStatus.Executing,
+      }),
+      toolCall({
+        callId: 'c3',
+        name: 'ReadFile',
+        description: 'queued.ts',
+        status: ToolCallStatus.Pending,
+      }),
+    ];
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame).toContain('Reading 3 files…');
+    expect(frame).toContain('⎿ current.ts');
+    expect(frame).not.toContain('queued.ts');
+  });
+
+  it('hides the description hint when a batch completes', () => {
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({ callId: 'c2', name: 'ReadFile', description: 'b.ts' }),
+    ];
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame).toContain('Read 2 files');
+    expect(frame).not.toContain('⎿');
+  });
+
+  it('does not expose JSON fallback arguments as an active hint', () => {
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: '{"file_path":"b.ts"}',
+        status: ToolCallStatus.Executing,
+      }),
+    ];
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame).toContain('Reading 2 files…');
+    expect(frame).not.toContain('⎿');
+    expect(frame).not.toContain('file_path');
+  });
+
+  it('does not repeat a description already shown for a single-tool category', () => {
+    const tools = [
+      toolCall({
+        callId: 'c1',
+        name: 'Grep',
+        description: 'needle',
+        status: ToolCallStatus.Executing,
+      }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: 'a.ts',
+      }),
+    ];
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame).toContain('Searching needle, reading a.ts…');
+    expect(frame).not.toContain('⎿');
+    expect(estimateCompactToolGroupHeight(tools, 80)).toBe(1);
+  });
+
+  it('keeps a 30-file active batch to two rows at 80 columns', () => {
+    const tools = Array.from({ length: 30 }, (_, index) =>
+      toolCall({
+        callId: `c${index + 1}`,
+        name: 'ReadFile',
+        description: `packages/cli/src/ui/components/example-${String(
+          index + 1,
+        ).padStart(2, '0')}.tsx`,
+        status:
+          index === 29 ? ToolCallStatus.Executing : ToolCallStatus.Success,
+      }),
+    );
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={80} />,
+    );
+    const frame = lastFrame()!;
+
+    expect(frame.split('\n')).toHaveLength(2);
+    expect(frame).toContain('Reading 30 files…');
+    expect(frame).toContain('⎿ packages/cli/src/ui/components/example-30.tsx');
+    expect(frame).not.toContain('example-01.tsx');
+  });
+
+  it('truncates a long active hint to one row', () => {
+    const currentPath =
+      'packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx';
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: currentPath,
+        status: ToolCallStatus.Executing,
+      }),
+    ];
+    const { lastFrame } = render(
+      <CompactToolGroupDisplay toolCalls={tools} contentWidth={30} />,
+    );
+    const frame = lastFrame()!;
+    const lines = frame.split('\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('⎿ packages/cli');
+    expect(lines[1]).toMatch(/…$/);
+    expect(frame).not.toContain(currentPath);
+  });
 });
 
 describe('buildToolSummary', () => {
@@ -189,13 +324,21 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary([make({})], true)).toBe('Reading a.ts');
   });
 
-  it('multiple same-type tools use count', () => {
+  it('multiple same-type tools use count format', () => {
     const tools = [
       make({ callId: 'c1', description: 'a.ts' }),
       make({ callId: 'c2', description: 'b.ts' }),
       make({ callId: 'c3', description: 'c.ts' }),
     ];
     expect(buildToolSummary(tools, false)).toBe('Read 3 files');
+  });
+
+  it('multiple same-type tools use progressive verb when active', () => {
+    const tools = [
+      make({ callId: 'c1', description: 'a.ts' }),
+      make({ callId: 'c2', description: 'b.ts' }),
+    ];
+    expect(buildToolSummary(tools, true)).toBe('Reading 2 files');
   });
 
   it('mixed types joined with comma and lowercase verbs', () => {
@@ -260,6 +403,15 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary(tools, false)).toBe('Ran 1 command');
   });
 
+  it('keeps file names that resemble JSON delimiters', () => {
+    expect(buildToolSummary([make({ description: '[id].tsx' })], false)).toBe(
+      'Read [id].tsx',
+    );
+    expect(buildToolSummary([make({ description: '{draft}.md' })], false)).toBe(
+      'Read {draft}.md',
+    );
+  });
+
   it('strips ANSI CSI escape sequences from description', () => {
     const tools = [
       make({
@@ -289,7 +441,7 @@ describe('buildToolSummary', () => {
     expect(buildToolSummary(tools, false)).toBe('Ran echo hello world');
   });
 
-  it('mixed group with count per category', () => {
+  it('mixed group uses count format per category', () => {
     const tools = [
       make({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
       make({ callId: 'c2', name: 'ReadFile', description: 'b.ts' }),
@@ -324,6 +476,43 @@ describe('estimateCompactToolGroupHeight', () => {
     const tool = toolCall({ name: 'ReadFile', description });
 
     expect(estimateCompactToolGroupHeight([tool], 30)).toBeGreaterThan(1);
+  });
+
+  it('adds one row for an active batch description hint', () => {
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: 'b.ts',
+        status: ToolCallStatus.Executing,
+      }),
+    ];
+
+    expect(estimateCompactToolGroupHeight(tools, 80)).toBe(2);
+  });
+
+  it('uses one row for a completed batch', () => {
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({ callId: 'c2', name: 'ReadFile', description: 'b.ts' }),
+    ];
+
+    expect(estimateCompactToolGroupHeight(tools, 80)).toBe(1);
+  });
+
+  it('does not reserve a hint row for unsafe fallback arguments', () => {
+    const tools = [
+      toolCall({ callId: 'c1', name: 'ReadFile', description: 'a.ts' }),
+      toolCall({
+        callId: 'c2',
+        name: 'ReadFile',
+        description: '["b.ts"]',
+        status: ToolCallStatus.Executing,
+      }),
+    ];
+
+    expect(estimateCompactToolGroupHeight(tools, 80)).toBe(1);
   });
 
   it('reserves additional width for active summary status', () => {

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -276,10 +276,46 @@ function safeDescription(raw: string | undefined): string | undefined {
   const cleaned = stripped.replace(/[\x00-\x1f\x7f]/g, ' ').trim();
   /* eslint-enable no-control-regex */
 
-  // Reject JSON-looking blobs (error fallback from args)
-  if (cleaned.startsWith('{') || cleaned.startsWith('[')) return undefined;
+  // Reject JSON blobs (error fallback from args) without rejecting legitimate
+  // paths such as "[id].tsx" or "{draft}.md".
+  if (cleaned.startsWith('{') || cleaned.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(cleaned) as unknown;
+      if (typeof parsed === 'object' && parsed !== null) return undefined;
+    } catch {
+      // The description only resembles JSON, so keep it.
+    }
+  }
 
   return cleaned || undefined;
+}
+
+function getActiveToolHint(
+  toolCalls: IndividualToolCallDisplay[],
+): string | undefined {
+  if (toolCalls.length < 2) return undefined;
+
+  const statuses = [
+    ToolCallStatus.Confirming,
+    ToolCallStatus.Executing,
+    ToolCallStatus.Pending,
+  ];
+  for (const status of statuses) {
+    for (let index = toolCalls.length - 1; index >= 0; index--) {
+      const tool = toolCalls[index];
+      if (tool.status === status) {
+        const category = getToolCategory(tool.name);
+        const usesCountSummary = toolCalls.some(
+          (candidate, candidateIndex) =>
+            candidateIndex !== index &&
+            getToolCategory(candidate.name) === category,
+        );
+        return usesCountSummary ? safeDescription(tool.description) : undefined;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -288,11 +324,11 @@ function safeDescription(raw: string | undefined): string | undefined {
  * Single tool (with description) → "Read a.ts" / "Ran ls -la"
  * Single tool (no description)   → "Read 1 file" / "Ran 1 command"
  * Multi  same                    → "Read 3 files"
- * Multi mixed                    → "Read a.ts, ran npm test, edited b.ts"
+ * Multi mixed                    → "Read 2 files, ran npm test"
  *
  * Uses past tense when all tools are done, present progressive when active.
- * Falls back to count format when description is empty, contains control
- * characters, or looks like a JSON blob (e.g. error fallback from args).
+ * Falls back to count format when description is missing, cleans to empty,
+ * or parses as a JSON object or array (e.g. error args).
  */
 export function buildToolSummary(
   toolCalls: IndividualToolCallDisplay[],
@@ -358,6 +394,7 @@ export function estimateCompactToolGroupHeight(
   const activeTool = getActiveTool(toolCalls);
   const isActive = isToolGroupActive(overallStatus);
   const summary = `${buildToolSummary(toolCalls, isActive)}${isActive ? '…' : ''}`;
+  const hint = getActiveToolHint(toolCalls);
   const summaryWidth = Math.max(
     1,
     contentWidth -
@@ -370,7 +407,7 @@ export function estimateCompactToolGroupHeight(
     trim: false,
   });
 
-  return Math.max(1, wrappedSummary.split('\n').length);
+  return Math.max(1, wrappedSummary.split('\n').length) + (hint ? 1 : 0);
 }
 
 export const CompactToolGroupDisplay: React.FC<
@@ -381,6 +418,7 @@ export const CompactToolGroupDisplay: React.FC<
   const overallStatus = getOverallStatus(toolCalls);
   const activeTool = getActiveTool(toolCalls);
   const isActive = isToolGroupActive(overallStatus);
+  const hint = getActiveToolHint(toolCalls);
 
   return (
     <Box flexDirection="column" width={contentWidth} paddingX={1} gap={0}>
@@ -398,6 +436,13 @@ export const CompactToolGroupDisplay: React.FC<
           timeoutMs={getShellTimeoutMs(activeTool)}
         />
       </Box>
+      {hint && (
+        <Box paddingLeft={STATUS_INDICATOR_WIDTH}>
+          <Text dimColor wrap="truncate-end">
+            ⎿ {hint}
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -1036,6 +1036,44 @@ describe('<ToolGroupMessage />', () => {
         .mock.calls.find((c) => c[0].callId === 'shell-result');
       expect(call?.[0].availableTerminalHeight).toBe(8);
     });
+
+    it('reserves an active compact hint row before sizing tool results', () => {
+      vi.mocked(ToolMessage).mockClear();
+      const toolCalls = [
+        createToolCall({
+          callId: 'read-complete',
+          name: 'ReadFile',
+          description: 'a.ts',
+          status: ToolCallStatus.Success,
+        }),
+        createToolCall({
+          callId: 'read-pending',
+          name: 'ReadFile',
+          description: 'b.ts',
+          status: ToolCallStatus.Pending,
+        }),
+        createToolCall({
+          callId: 'shell-result',
+          name: 'Shell',
+          description: 'npm test',
+          status: ToolCallStatus.Success,
+          resultDisplay: 'shell output',
+        }),
+      ];
+
+      renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={toolCalls}
+          availableTerminalHeight={12}
+        />,
+      );
+
+      const call = vi
+        .mocked(ToolMessage)
+        .mock.calls.find((c) => c[0].callId === 'shell-result');
+      expect(call?.[0].availableTerminalHeight).toBe(9);
+    });
   });
 
   describe('Confirmation Handling', () => {


### PR DESCRIPTION
## What this PR does

Compact multi-tool summaries keep their localized count-based labels at every batch size. While an active category is summarized by count, one dimmed hint line shows the most recent active description; the hint stays on one terminal row, safely truncates when needed, and disappears as soon as the batch completes. Single-tool summaries and mixed categories that already show the active description remain unchanged, and serialized fallback arguments are never exposed as hints.

## Why it's needed

Count-only summaries provide no live context, but listing every file name scales linearly and can turn a compact summary into dozens of terminal rows. A fixed-size summary plus one transient path gives users useful progress context without making completed history noisy.

## Reviewer Test Plan

### How to verify

Ask the CLI to read 20–30 known files in one parallel batch. While the reads are active, the summary should show a localized count plus one latest-path hint. After completion, the hint should disappear and only the count should remain. Repeat in a narrow terminal and confirm the hint truncates to one row. Toggle transcript detail mode with Ctrl+O to inspect individual tool details.

### Evidence (Before & After)

Before, the previous unbounded-name proposal measured 30 rows at 80 columns for a 30-file batch.

After, the active state is bounded to two rows and the completed state to one row:

![30-file active and completed compact summaries](https://raw.githubusercontent.com/zjunothing/qwen-code/ef1f4230e0042fb8493b646580c4190f5571852a/issue-6813/large-batch-evidence.png)

See the separate real-interactive verification comment for the preserved-session integrity check, exact 80/120-column measurements, automated checks, and evidence limitations.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 15.6 arm64, Node.js 22.23.1, tmux 3.6a, a 120×42 pane, and a real interactive source CLI session using `bailian/glm-5.1`.

## Risk & Scope

- Main risk or tradeoff: Active multi-tool groups use one additional terminal row; the height estimator accounts for it, and narrow hints truncate instead of wrapping.
- Not validated / out of scope: Manual Windows and Linux TUI testing. Existing transcript detail mode remains responsible for full per-tool details.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #6813

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

多工具紧凑摘要无论批次大小都保留本地化的计数文案。当执行中的类别按数量汇总时，下一行会以弱化样式显示最近一个活动描述；该提示始终限制在一行，必要时安全截断，并在批次完成后立即消失。单工具摘要以及首行已经显示活动描述的混合类别保持原样，序列化的回退参数也不会作为提示泄露。

## 为什么需要

仅显示数量的摘要缺少实时上下文，但列出全部文件名会随批次线性增长，可能让“紧凑”摘要占满几十行。固定大小的计数摘要加一条临时路径，既能提供进度上下文，又不会让完成后的历史记录变得嘈杂。

## 评审者测试计划

### 如何验证

让 CLI 在一个并行批次中读取 20–30 个已知文件。读取执行期间，摘要应显示本地化计数和一条最新路径提示；完成后提示应消失，只保留计数。再在窄终端中重复，确认提示只占一行并被安全截断。可用 Ctrl+O 切换 transcript 详情模式检查各工具的完整详情。

### 证据（修复前后）

旧的无限文件名方案在 80 列下实测一个 30 文件批次会占 30 行。

调整后，执行态固定为两行，完成态固定为一行：

![30 文件执行态与完成态紧凑摘要](https://raw.githubusercontent.com/zjunothing/qwen-code/ef1f4230e0042fb8493b646580c4190f5571852a/issue-6813/large-batch-evidence.png)

保留会话的完整性核验、80/120 列精确测量、自动化检查和证据限制见单独发布的真实交互验证评论。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 15.6 arm64、Node.js 22.23.1、tmux 3.6a、120×42 窗格，以及使用 `bailian/glm-5.1` 的真实交互式源码 CLI 会话。

## 风险与范围

- 主要风险或权衡：执行中的多工具组会额外占用一行；高度估算已计入该行，窄终端中的提示会截断而不是换行。
- 未验证 / 超出范围：未手工验证 Windows 和 Linux TUI。各工具的完整详情继续由现有 transcript 详情模式负责。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Closes #6813

</details>
