### PR TITLE
fix(ui): keep SkillReviewDialog right border inside the dialog container

### DIFF
--- a/packages/cli/src/ui/components/SkillReviewDialog.test.tsx
+++ b/packages/cli/src/ui/components/SkillReviewDialog.test.tsx
@@ -5,6 +5,8 @@
  */
 
 import { render as inkRender } from 'ink-testing-library';
+import { Box } from 'ink';
+import stripAnsi from 'strip-ansi';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
@@ -176,6 +178,36 @@ describe('SkillReviewDialog', () => {
     expect(lastFrame()).toContain('auto-skill-alpha');
     expect(lastFrame()).toContain('does alpha');
     expect(lastFrame()).toContain('1/2');
+  });
+
+  // Regression for #7037: the outer Box used width="100%" PLUS marginLeft={1},
+  // making the dialog one column wider than the layout's dialog container
+  // (DefaultAppLayout caps it at mainAreaWidth with overflow hidden), so the
+  // right border was clipped off. Render inside an equivalent fixed-width,
+  // overflow-hidden container and require every border row to still end with
+  // its right-edge glyph.
+  it('does not overflow a width-constrained container (right border stays visible)', () => {
+    const { lastFrame } = render(
+      <Box width={60} flexDirection="column" overflow="hidden">
+        <SkillReviewDialog
+          skills={skills}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      </Box>,
+    );
+    const lines = lastFrame()!
+      .split('\n')
+      .map((line) => stripAnsi(line).trimEnd())
+      .filter((line) => line !== '');
+    expect(lines.length).toBeGreaterThan(2);
+    expect(lines[0]!.endsWith('╮')).toBe(true);
+    expect(lines[lines.length - 1]!.endsWith('╯')).toBe(true);
+    for (const line of lines.slice(1, -1)) {
+      expect(line.endsWith('│')).toBe(true);
+    }
   });
 
   it('offers keep / discard / bulk / turn-off options while several remain', () => {

--- a/packages/cli/src/ui/components/SkillReviewDialog.tsx
+++ b/packages/cli/src/ui/components/SkillReviewDialog.tsx
@@ -123,9 +123,9 @@ export const SkillReviewDialog = ({
   // container at min(terminalWidth − 4, 100) (mainAreaWidth in AppContainer;
   // DiffDialog applies the same clamp). MaxSizedBox wraps the preview at this
   // width, and its height cap counts the WRAPPED rows — so this must never
-  // exceed the dialog's actual inner text width (container − marginLeft 1 −
-  // border 2 − paddingX 2 = container − 5), or Ink would re-wrap at render
-  // time and push rows past the cap. −6 keeps one column of slack.
+  // exceed the dialog's actual inner text width (container − border 2 −
+  // paddingX 2 = container − 4), or Ink would re-wrap at render time and
+  // push rows past the cap. −6 keeps two columns of slack.
   const previewWidth = Math.max(20, Math.min(columns - 4, 100) - 6);
 
   const current = snapshot[index];
@@ -370,7 +370,6 @@ export const SkillReviewDialog = ({
       borderColor={theme.status.warning}
       paddingX={1}
       width="100%"
-      marginLeft={1}
     >
       <Text bold color={theme.text.primary}>
         {t('Auto-generated skill — keep it?')} ({index + 1}/{snapshot.length})


### PR DESCRIPTION
## What this PR does

Fixes the missing right border on the "Auto-generated skill — keep it?" modal. The dialog's outer box combined `width="100%"` with `marginLeft={1}`, which made the dialog one column wider than the dialog container it renders in (the layout caps that container at `mainAreaWidth` with `overflow="hidden"`), so the right edge — the `╮`, `│`, and `╯` glyphs — was clipped off. This PR drops the `marginLeft`, matching how `DiffDialog` and `MemoryDialog` size themselves, and updates the `previewWidth` comment arithmetic to match. A regression test renders the dialog inside an equivalent width-constrained, overflow-hidden container and asserts every border row keeps its right-edge glyph.

## Why it's needed

The modal renders with only three of its four borders (left, top, bottom), which looks broken and clipped. Reported in #7037.

Fixes #7037

## Reviewer Test Plan

### How to verify

1. Trigger the auto-generated skill review dialog (any pending skill-review task), or render `SkillReviewDialog` inside a width-constrained `overflow="hidden"` box.
2. Before this change: the top border runs to the container edge and is cut off — no `╮` corner, no right `│` rail, no `╯` corner. After: all four borders render.
3. `cd packages/cli && npx vitest run src/ui/components/SkillReviewDialog.test.tsx` — 33 tests pass. The new test `does not overflow a width-constrained container (right border stays visible)` fails on `main` (verified by temporarily re-adding `marginLeft={1}`) and passes with this fix.

### Evidence (Before & After)

Rendered the real `SkillReviewDialog` component with real ink inside the exact `DefaultAppLayout` dialog-container geometry (`marginX={2}`, `width = min(terminalWidth − 4, 100)`, `overflow="hidden"`) in a 100×30 tmux pane.

**Before** — right border clipped (matches the issue screenshot):

![before](https://raw.githubusercontent.com/zjunothing/qwen-code/assets-pr-screenshots/pr-7037/before.png)

**After** — all four borders render:

![after](https://raw.githubusercontent.com/zjunothing/qwen-code/assets-pr-screenshots/pr-7037/after.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |
