### PR TITLE
feat(tools): add formatDisplayPath() and wire grep/glob/ripGrep descriptions

### DIFF
--- a/packages/core/src/tools/glob.test.ts
+++ b/packages/core/src/tools/glob.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+import { tildeifyPath } from '../utils/paths.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
 import type { Path as GlobResultPath } from 'glob';
@@ -954,6 +955,35 @@ describe('GlobTool', () => {
 
       // Should use plural "files" for multiple truncated files
       expect(result.llmContent).toContain('[5 files truncated] ...');
+    });
+  });
+
+  describe('getDescription', () => {
+    it('should generate correct description with pattern only', () => {
+      const params: GlobToolParams = { pattern: '*.ts' };
+      const invocation = globTool.build(params);
+      expect(invocation.getDescription()).toBe("'*.ts'");
+    });
+
+    it('should show project-internal paths relative to the project root', () => {
+      const params: GlobToolParams = { pattern: '*.ts', path: 'sub' };
+      const invocation = globTool.build(params);
+      expect(invocation.getDescription()).toBe("'*.ts' in sub");
+    });
+
+    it('should show . for the project root itself', () => {
+      const params: GlobToolParams = { pattern: '*.ts', path: '.' };
+      const invocation = globTool.build(params);
+      expect(invocation.getDescription()).toBe("'*.ts' in .");
+    });
+
+    it('should keep paths outside the project absolute (never project-relative)', () => {
+      const outside = path.resolve(os.tmpdir());
+      const params: GlobToolParams = { pattern: '*.ts', path: outside };
+      const invocation = globTool.build(params);
+      expect(invocation.getDescription()).toBe(
+        `'*.ts' in ${tildeifyPath(outside)}`,
+      );
     });
   });
 

--- a/packages/core/src/tools/glob.ts
+++ b/packages/core/src/tools/glob.ts
@@ -12,6 +12,7 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import {
   resolveAndValidatePath,
+  formatDisplayPath,
   resolvePath,
   isSubpath,
   unescapePath,
@@ -106,7 +107,11 @@ class GlobToolInvocation extends BaseToolInvocation<
   getDescription(): string {
     let description = `'${this.params.pattern}'`;
     if (this.params.path) {
-      description += ` in path '${this.params.path}'`;
+      const displayPath = formatDisplayPath(
+        this.params.path,
+        this.config.getTargetDir(),
+      );
+      description += ` in ${displayPath}`;
     }
 
     return description;

--- a/packages/core/src/tools/grep.test.ts
+++ b/packages/core/src/tools/grep.test.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+import { tildeifyPath } from '../utils/paths.js';
 import { ToolErrorType } from './tool-error.js';
 import * as glob from 'glob';
 import { FileReadCache } from '../services/fileReadCache.js';
@@ -859,7 +860,7 @@ describe('GrepTool', () => {
     it('should generate correct description with pattern only', () => {
       const params: GrepToolParams = { pattern: 'testPattern' };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toBe("'testPattern' in path './'");
+      expect(invocation.getDescription()).toBe("'testPattern' in .");
     });
 
     it('should generate correct description with pattern and glob', () => {
@@ -869,7 +870,7 @@ describe('GrepTool', () => {
       };
       const invocation = grepTool.build(params);
       expect(invocation.getDescription()).toBe(
-        "'testPattern' in path './' (filter: '*.ts')",
+        "'testPattern' in . (filter: '*.ts')",
       );
     });
 
@@ -881,16 +882,15 @@ describe('GrepTool', () => {
         path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toContain(
-        "'testPattern' in path 'src",
+      expect(invocation.getDescription()).toBe(
+        `'testPattern' in ${path.join('src', 'app')}`,
       );
-      expect(invocation.getDescription()).toContain("app'");
     });
 
     it('should indicate searching workspace directory when no path specified', () => {
       const params: GrepToolParams = { pattern: 'testPattern' };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toBe("'testPattern' in path './'");
+      expect(invocation.getDescription()).toBe("'testPattern' in .");
     });
 
     it('should generate correct description with pattern, glob, and path', async () => {
@@ -902,16 +902,23 @@ describe('GrepTool', () => {
         path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toContain(
-        "'testPattern' in path 'src",
+      expect(invocation.getDescription()).toBe(
+        `'testPattern' in ${path.join('src', 'app')} (filter: '*.ts')`,
       );
-      expect(invocation.getDescription()).toContain("(filter: '*.ts')");
     });
 
-    it('should use ./ for root path in description', () => {
+    it('should use . for root path in description', () => {
       const params: GrepToolParams = { pattern: 'testPattern', path: '.' };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toBe("'testPattern' in path '.'");
+      expect(invocation.getDescription()).toBe("'testPattern' in .");
+    });
+
+    it('should keep paths outside the project absolute (never project-relative)', () => {
+      const outside = path.resolve(os.tmpdir());
+      const params: GrepToolParams = { pattern: 'testPattern', path: outside };
+      const invocation = grepTool.build(params);
+      const description = invocation.getDescription();
+      expect(description).toBe(`'testPattern' in ${tildeifyPath(outside)}`);
     });
   });
 

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -14,6 +14,7 @@ import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
   resolveAndValidatePath,
+  formatDisplayPath,
   resolvePath,
   isSubpath,
   unescapePath,
@@ -407,7 +408,11 @@ class GrepToolInvocation extends BaseToolInvocation<
    * @returns A string describing the grep
    */
   getDescription(): string {
-    let description = `'${this.params.pattern}' in path '${this.params.path || './'}'`;
+    const displayPath = formatDisplayPath(
+      this.params.path || '.',
+      this.config.getTargetDir(),
+    );
+    let description = `'${this.params.pattern}' in ${displayPath}`;
     if (this.params.glob) {
       description += ` (filter: '${this.params.glob}')`;
     }

--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -21,6 +21,7 @@ import fs from 'node:fs/promises';
 import os, { EOL } from 'node:os';
 import type { Config } from '../config/config.js';
 import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+import { tildeifyPath } from '../utils/paths.js';
 import { spawn } from 'node:child_process';
 import { runRipgrep } from '../utils/ripgrepUtils.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
@@ -1458,10 +1459,9 @@ describe('RipGrepTool', () => {
         path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toContain(
-        "'testPattern' in path 'src",
+      expect(invocation.getDescription()).toBe(
+        `'testPattern' in ${path.join('src', 'app')}`,
       );
-      expect(invocation.getDescription()).toContain("app'");
     });
 
     it('should generate correct description with default search path', () => {
@@ -1479,16 +1479,27 @@ describe('RipGrepTool', () => {
         path: path.join('src', 'app'),
       };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toContain(
-        "'testPattern' in path 'src",
+      expect(invocation.getDescription()).toBe(
+        `'testPattern' in ${path.join('src', 'app')} (filter: '*.ts')`,
       );
-      expect(invocation.getDescription()).toContain("(filter: '*.ts')");
     });
 
     it('should use path when specified in description', () => {
       const params: RipGrepToolParams = { pattern: 'testPattern', path: '.' };
       const invocation = grepTool.build(params);
-      expect(invocation.getDescription()).toBe("'testPattern' in path '.'");
+      expect(invocation.getDescription()).toBe("'testPattern' in .");
+    });
+
+    it('should keep paths outside the project absolute (never project-relative)', () => {
+      const outside = path.resolve(os.tmpdir());
+      const params: RipGrepToolParams = {
+        pattern: 'testPattern',
+        path: outside,
+      };
+      const invocation = grepTool.build(params);
+      expect(invocation.getDescription()).toBe(
+        `'testPattern' in ${tildeifyPath(outside)}`,
+      );
     });
   });
 

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -11,6 +11,7 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolNames } from './tool-names.js';
 import {
   resolveAndValidatePath,
+  formatDisplayPath,
   resolvePath,
   unescapePath,
 } from '../utils/paths.js';
@@ -581,7 +582,11 @@ class GrepToolInvocation extends BaseToolInvocation<
   getDescription(): string {
     let description = `'${this.params.pattern}'`;
     if (this.params.path) {
-      description += ` in path '${this.params.path}'`;
+      const displayPath = formatDisplayPath(
+        this.params.path,
+        this.config.getTargetDir(),
+      );
+      description += ` in ${displayPath}`;
     }
     if (this.params.glob) {
       description += ` (filter: '${this.params.glob}')`;

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -18,6 +18,7 @@ import {
 } from 'vitest';
 import {
   escapePath,
+  formatDisplayPath,
   resolvePath,
   validatePath,
   resolveAndValidatePath,
@@ -708,6 +709,69 @@ describe('tildeifyPath', () => {
     const result = tildeifyPath(`/mnt/backup${homeDir}/data`);
     // Should not replace home dir in the middle
     expect(result).toBe(`/mnt/backup${homeDir}/data`);
+  });
+});
+
+describe('formatDisplayPath', () => {
+  const root = path.resolve(path.sep, 'projects', 'my-app');
+
+  it('renders project-internal paths relative to the root', () => {
+    const target = path.join(root, 'src', 'index.ts');
+    expect(formatDisplayPath(target, root)).toBe(path.join('src', 'index.ts'));
+  });
+
+  it('renders the project root itself as .', () => {
+    expect(formatDisplayPath(root, root)).toBe('.');
+  });
+
+  it('resolves relative input against the root before formatting', () => {
+    expect(formatDisplayPath(path.join('src', 'app'), root)).toBe(
+      path.join('src', 'app'),
+    );
+    expect(formatDisplayPath('.', root)).toBe('.');
+  });
+
+  it('keeps paths outside the project absolute', () => {
+    const outside = path.resolve(path.sep, 'other', 'place', 'file.txt');
+    expect(formatDisplayPath(outside, root)).toBe(outside);
+  });
+
+  it('shortens the home directory to ~ for paths outside the project', () => {
+    const homeDir = os.homedir();
+    const target = path.join(homeDir, 'elsewhere', 'file.txt');
+    expect(formatDisplayPath(target, root)).toBe(
+      `~${path.sep}elsewhere${path.sep}file.txt`,
+    );
+  });
+
+  it('does not tildeify project-internal paths when the project is under home', () => {
+    const homeRoot = path.join(os.homedir(), 'work', 'proj');
+    const target = path.join(homeRoot, 'src', 'main.ts');
+    expect(formatDisplayPath(target, homeRoot)).toBe(
+      path.join('src', 'main.ts'),
+    );
+  });
+
+  it('expands a tilde-prefixed input like other tool paths', () => {
+    expect(formatDisplayPath(path.join('~', 'data'), root)).toBe(
+      `~${path.sep}data`,
+    );
+  });
+
+  it('compresses overlong paths with shortenPath semantics', () => {
+    const target = path.join(
+      root,
+      'very',
+      'deeply',
+      'nested',
+      'directory',
+      'structure',
+      'file.ts',
+    );
+    const result = formatDisplayPath(target, root, 25);
+    expect(result.length).toBeLessThanOrEqual(25);
+    expect(result).toContain('...');
+    expect(result).toContain('file.ts');
   });
 });
 

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -270,6 +270,37 @@ export function makeRelative(
 }
 
 /**
+ * Formats a file path for terminal display.
+ *
+ * - Project-internal paths render relative to `rootDirectory` (the root
+ *   itself renders as '.').
+ * - Paths outside the project stay absolute, with the home directory
+ *   shortened to '~'.
+ * - Anything longer than `maxLen` is compressed by shortenPath(), which
+ *   drops middle segments rather than truncating the file name.
+ *
+ * Relative and '~'-prefixed inputs are resolved against `rootDirectory`
+ * first, so callers can pass raw user-supplied tool params verbatim.
+ *
+ * @param filePath The path to format (absolute, relative, or tilde-prefixed).
+ * @param rootDirectory The absolute path of the project root.
+ * @param maxLen Maximum display length before middle-segment compression.
+ * @returns The formatted path for display.
+ */
+export function formatDisplayPath(
+  filePath: string,
+  rootDirectory: string,
+  maxLen: number = 80,
+): string {
+  const resolved = resolvePath(rootDirectory, filePath);
+  const relative = makeRelative(resolved, rootDirectory);
+  // makeRelative returns the resolved absolute path when the target is
+  // outside rootDirectory — only then does the home-dir shorthand apply.
+  const display = path.isAbsolute(relative) ? tildeifyPath(relative) : relative;
+  return shortenPath(display, maxLen);
+}
+
+/**
  * Escapes special characters in a file path like macOS terminal does.
  * Escapes: spaces, parentheses, brackets, braces, semicolons, ampersands, pipes,
  * asterisks, question marks, dollar signs, backticks, quotes, hash, and other shell metacharacters.


### PR DESCRIPTION
## What this PR does

Adds a unified `formatDisplayPath()` helper to `packages/core/src/utils/paths.ts` and wires it into the `grep`, `ripGrep`, and `glob` tool summaries. Project-internal paths now render relative to the project root (the root itself renders as `.`), paths outside the project stay absolute with the home directory shortened to `~`, and overlong results are compressed through the existing `shortenPath()` middle-segment logic. The helper composes the existing `resolvePath` / `makeRelative` / `tildeifyPath` / `shortenPath` utilities rather than reimplementing them, exactly as proposed in the issue.

## Why it's needed

`read-file`, `edit`, `write-file`, `ls`, and `notebook-edit` already show short project-relative paths in their tool summaries, but the three search tools passed the raw user-supplied path straight through. The same session would show `Read packages/cli/src/ui/a.tsx` next to `'pattern' in path '/Users/me/git/project'` — and long absolute paths even got ellipsis-truncated in the TUI row, hiding the filter suffix. This is Phase 1 (high value, low risk) of the plan in #7004.

Fixes #7007

## Reviewer Test Plan

### How to verify

1. Run the CLI from source and ask the model to grep with an absolute project-internal path (e.g. `<project>/packages/cli/src/ui/hooks`).
2. Before: the summary row shows the raw absolute path (`'useKeypress' in path '/Users/…/packages/cli/src/ui/hooks' (filter: …` — truncated). After: `'useKeypress' in packages/cli/src/ui/hooks (filter: '*.ts')`.
3. `cd packages/core && npx vitest run src/utils/paths.test.ts src/tools/grep.test.ts src/tools/ripGrep.test.ts src/tools/glob.test.ts` — 322 passed. New coverage: 8 `formatDisplayPath` unit tests (relative/root/outside/home/tilde-input/shorten) plus description tests for all three tools including the outside-project-stays-absolute case.

### Evidence (Before & After)

Real end-to-end session (real CLI, real model call, same prompt, 110×32 tmux pane on macOS):

**Before** — released v0.19.10, raw absolute path, truncated:

![before](https://raw.githubusercontent.com/zjunothing/qwen-code/assets-pr-screenshots/pr-7007/before.png)

**After** — this branch built from source, project-relative path, fully visible:

![after](https://raw.githubusercontent.com/zjunothing/qwen-code/assets-pr-screenshots/pr-7007/after.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |
