### PR TITLE
refactor(core): Classify shell safety as read-only, write, or unknown

### DIFF
--- a/docs/design/shell-safety-classification.md
+++ b/docs/design/shell-safety-classification.md
@@ -1,0 +1,47 @@
+# Shell safety classification
+
+## Context and scope
+
+Issue [#6949](https://github.com/QwenLM/qwen-code/issues/6949) requires Plan mode to distinguish commands that are proven read-only from commands whose behavior cannot be established statically. A boolean cannot retain that distinction, so this change introduces a three-state fact layer in `shellAstParser.ts` without changing permission routing.
+
+This change does not modify routing or call-site logic in Shell, Monitor, PermissionManager, speculation, memory-scoped agents, ACP, Plan-mode prompts, or Plan exit behavior. Existing boolean consumers can become more conservative where the classifier is hardened. A follow-up change can route `unknown` commands to one-off approval using the new fact without changing this classifier.
+
+## Contract
+
+`classifyShellCommandSafety(command)` is an internal module API with these results:
+
+| Result      | Meaning                                                                                                                          |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `read-only` | Every executable path is proven by the current rules not to modify persistent or external state.                                 |
+| `write`     | The syntax contains positive evidence of a file, Git, process, or other state mutation. The command need not ultimately succeed. |
+| `unknown`   | The command cannot be proved safe or mutating by the supported static rules.                                                     |
+
+For a valid AST, results combine in the order `write > unknown > read-only`. A tree containing `ERROR` is classified as `unknown` before evaluating partial syntax. Command and process substitutions impose an `unknown` floor while their executable contents are scanned, so a nested known writer promotes the result to `write`. Redirect analysis owns substitutions inside redirect nodes while command and statement evaluators exclude those nodes from their substitution scans, preventing repeated traversal of nested substitutions. Control flow uses the same unknown floor and scans possible branches. A function definition is not execution and therefore remains `unknown` without classifying its body as an executed write.
+
+A standalone pure assignment and `cd` preserve the existing compatibility behavior. An assignment that prefixes a command or shares a compound sequence with another statement imposes an `unknown` floor because variables such as `LD_PRELOAD`, `PATH`, `PAGER`, or tool-specific configuration can change behavior; explicit write evidence still wins. Subshells and command groups aggregate their executed contents. The API analyzes only the supplied source string; it does not unwrap `sudo` or interpreters, resolve PATH or aliases, or load shell configuration.
+
+## Parser failure and compatibility API
+
+The private classifier may throw while loading or running tree-sitter. The public three-state API maps those failures to `unknown` and never substitutes regex certainty. A parser that throws while parsing is discarded and rebuilt from the already loaded Bash language, because the failed instance may remain poisoned; this does not reload the runtime or language. The existing `isShellCommandReadOnlyAST()` compatibility API returns `true` only for `read-only`, but retains the existing regex fallback when tree-sitter cannot load or throws at runtime. A syntactically invalid tree is a normal `unknown` result, not a parser failure, so it never enters that fallback. Every successfully returned tree is released once in a `finally` block.
+
+This asymmetry is intentional: new consumers need an honest uncertainty fact, while existing boolean consumers keep their parser-availability behavior until they migrate explicitly.
+
+## Supported evidence
+
+The classifier recognizes a bounded, case-sensitive set of direct filesystem writers, process signaling commands, output redirections, Git mutation families, and explicit write modes in `find`, `sed`, `awk`, `sort`, `tree`, `uniq`, `tee`, and `dd`. Sed and AWK use shared linear scanners that distinguish inline programs from option values and file arguments, so escaped, malformed, or highly repetitive input cannot trigger regex backtracking or fabricate write evidence from a filename. Git output files for `diff`, `log`, and `show` are writes. Stateful `printf -v` forms are unknown. Explicit Git helpers and signature verification, including pager/config environment options, diff/text-conversion helpers, grep's external pager, and signature placeholders, are unknown; unsupported Git global options and subcommand help paths also fail closed because help may launch an external viewer. Dynamic execution, external scripts, ambiguous output targets, interpreters and wrappers, `sort --compress-program`, ripgrep preprocessors, hostname helpers, and archive search (`--pre`, `--hostname-bin`, `--search-zip`, and `-z`), and ordinary pager commands remain `unknown`. Option terminators and the supported options' value arity are interpreted so a filename or message literally named `--help` is not mistaken for a help invocation. Differently-cased command names, unlisted package managers, services, and custom executables also remain `unknown`; the classifier is not a sandbox.
+
+The deprecated synchronous checker mirrors every newly rejected pattern needed by synchronous scheduling. It preserves parameter expansions with sentinels instead of allowing `shell-quote` to erase them, rejects malformed trailing pipelines and assignment-bearing compounds, and evaluates wrappers from the original command. It intentionally remains boolean and is more conservative than the AST classifier: `printf`, option-heavy `sort`, `tree`, `uniq`, `rg`, and `ripgrep` commands, and Git branch forms beyond the simplest listing modes, run sequentially.
+
+## Consumers and migration boundary
+
+Current boolean consumers are Shell, Monitor, PermissionManager, the speculation gate, and memory-scoped agent configuration; their call sites do not change in this refactor. The synchronous checker is also used by the core tool scheduler and the legacy shell permission utility. The scheduler now passes the original command to the checker so wrappers remain unknown instead of being unwrapped into an apparently read-only command. `extractCommandRules()` remains independent of safety classification.
+
+The follow-up `fix(core): Route unknown Plan shell commands to one-off approval` should consume `classifyShellCommandSafety()` only at the Plan permission boundary. It must separately define approval provenance, lifetime, ACP behavior, and the interaction with Plan exit; those policies do not belong in the fact layer.
+
+## Claude Code reference
+
+Claude Code's Bash analysis is useful as evidence for two design principles: parsing uncertainty must be represented explicitly, and permission decisions must fail closed when parsing is unavailable or too complex. Its larger Bash parser and policy engine are not copied because Qwen Code needs only a small classifier at the current boundary.
+
+## Verification
+
+Unit coverage uses table-driven matrices for all three states, compound precedence, substitutions, syntax errors, parser initialization and runtime failures, bounded behavior for adversarial nested and escaped input, and compatibility monotonicity. The synchronous checker and scheduler tests prevent newly known unsafe commands from joining concurrent Shell batches.

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -12020,8 +12020,8 @@ describe('Fire hook functions integration', () => {
         onToolCallsUpdate,
       );
 
-      // "git log" and "ls" are read-only → concurrent
-      // "npm install" is not read-only → sequential, breaks the batch
+      // "git log" and "ls" are read-only → concurrent.
+      // Wrappers, output-writing sort, and npm install are sequential.
       const requests = [
         {
           callId: '1',
@@ -12039,6 +12039,20 @@ describe('Fire hook functions integration', () => {
         },
         {
           callId: '3',
+          name: 'run_shell_command',
+          args: { command: "bash -c 'git status'" },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+        {
+          callId: '4',
+          name: 'run_shell_command',
+          args: { command: 'sort -o output input' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+        {
+          callId: '5',
           name: 'run_shell_command',
           args: { command: 'npm install' },
           isClientInitiated: false,
@@ -12063,14 +12077,32 @@ describe('Fire hook functions integration', () => {
       expect(gitStart).toBeLessThan(firstReadOnlyEnd);
       expect(lsStart).toBeLessThan(firstReadOnlyEnd);
 
-      // "npm install" should start after both read-only commands complete
+      // The unknown wrapper should start after both reads complete.
       const lastReadOnlyEnd = Math.max(
         executionLog.indexOf('shell:end:git log'),
         executionLog.indexOf('shell:end:ls'),
       );
+      const wrapperStart = executionLog.indexOf(
+        "shell:start:bash -c 'git status'",
+      );
+      expect(wrapperStart).not.toBe(-1);
+      expect(wrapperStart).toBeGreaterThan(lastReadOnlyEnd);
+
+      // The output-writing sort should not overlap the wrapper batch.
+      const wrapperEnd = executionLog.indexOf("shell:end:bash -c 'git status'");
+      const sortStart = executionLog.indexOf(
+        'shell:start:sort -o output input',
+      );
+      expect(wrapperEnd).not.toBe(-1);
+      expect(sortStart).not.toBe(-1);
+      expect(sortStart).toBeGreaterThan(wrapperEnd);
+
+      // npm install should not overlap the sequential sort batch.
+      const sortEnd = executionLog.indexOf('shell:end:sort -o output input');
       const npmStart = executionLog.indexOf('shell:start:npm install');
+      expect(sortEnd).not.toBe(-1);
       expect(npmStart).not.toBe(-1);
-      expect(npmStart).toBeGreaterThan(lastReadOnlyEnd);
+      expect(npmStart).toBeGreaterThan(sortEnd);
     });
   });
 });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -66,7 +66,6 @@ import { unescapePath, PATH_ARG_KEYS } from '../utils/paths.js';
 import type { MemoryPressureMonitor } from '../services/memoryPressureMonitor.js';
 import { CONCURRENCY_SAFE_KINDS, isShellProgressData } from '../tools/tools.js';
 import { isShellCommandReadOnly } from '../utils/shellReadOnlyChecker.js';
-import { stripShellWrapper } from '../utils/shell-utils.js';
 import { parsePositiveIntegerEnv } from '../utils/env.js';
 import {
   isAlreadyTruncated,
@@ -1197,14 +1196,13 @@ export function isToolCallConcurrencySafe(
   if (canonicalToolName(name) === ToolNames.AGENT) return true;
   // Shell commands: check if the command is read-only (e.g., git log, cat).
   // Uses the synchronous regex+shell-quote checker (not the async AST-based
-  // one) because partitioning runs synchronously. The sync checker covers
-  // the same command whitelist and is fail-closed — unknown commands remain
-  // sequential. The AST version is used separately for permission decisions.
+  // one) because partitioning runs synchronously. It is deliberately more
+  // conservative than the AST version used for permission decisions.
   if (kind === Kind.Execute) {
     const command = (args as { command?: string } | undefined)?.command;
     if (typeof command !== 'string') return false;
     try {
-      return isShellCommandReadOnly(stripShellWrapper(command));
+      return isShellCommandReadOnly(command);
     } catch {
       return false; // fail-closed
     }

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -1486,19 +1486,15 @@ describe('PermissionManager', () => {
       ).toBe('allow');
     });
 
-    it('exact Monitor(...) allow rule matches wrapped fallback commands', async () => {
-      const pm2 = new PermissionManager(
-        makeConfig({
-          permissionsAllow: ['Monitor(FOO="bar baz" tail -f /var/log/app.log)'],
-        }),
-      );
+    it('asks by default for wrapped commands with environment prefixes', async () => {
+      const pm2 = new PermissionManager(makeConfig({}));
       pm2.initialize();
       expect(
         await pm2.evaluate({
           toolName: 'monitor',
           command: String.raw`FOO="bar baz" /bin/bash --noprofile -c 'tail -f /var/log/app.log &'`,
         }),
-      ).toBe('allow');
+      ).toBe('ask');
     });
 
     it('Monitor(...) deny rule sees shell wrapper suffix commands', async () => {

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -485,14 +485,6 @@ export class PermissionManager {
   private async resolveDefaultPermission(
     command: string,
   ): Promise<'allow' | 'ask'> {
-    // AST-based read-only detection. Commands containing command
-    // substitution are never read-only — `evaluateStatementReadOnly`
-    // (shellAstParser.ts) guards on `containsCommandSubstitutionAST` at
-    // the top so every node type inherits the check, including
-    // `variable_assignment` (`FOO=$(curl ...)`) and `redirected_statement`
-    // (`cat < $(curl ...)`) where earlier versions had blind spots. See
-    // PR #4386 round 4. So substitution-bearing commands fall through
-    // to 'ask' on the line below.
     try {
       const isReadOnly = await isShellCommandReadOnlyAST(command);
       if (isReadOnly) {

--- a/packages/core/src/utils/shell-ast-parser-lazy.test.ts
+++ b/packages/core/src/utils/shell-ast-parser-lazy.test.ts
@@ -86,10 +86,23 @@ describe('shellAstParser lazy runtime', () => {
   it('loads web-tree-sitter on first use and deduplicates initialization', async () => {
     const runtimeLoaded = vi.fn();
     const init = vi.fn(async () => undefined);
+    let releaseLanguage!: () => void;
+    const languageReady = new Promise<void>((resolve) => {
+      releaseLanguage = resolve;
+    });
+    const constructed = vi.fn();
+    const loadLanguage = vi.fn(async () => {
+      await languageReady;
+      return {};
+    });
 
     class ParserMock {
       static init = init;
-      static Language = { load: vi.fn(async () => ({})) };
+      static Language = { load: loadLanguage };
+
+      constructor() {
+        constructed();
+      }
 
       setLanguage = vi.fn();
     }
@@ -101,27 +114,129 @@ describe('shellAstParser lazy runtime', () => {
 
     const parser = await import('./shellAstParser.js');
     expect(runtimeLoaded).not.toHaveBeenCalled();
+    const first = parser.initParser();
+    await vi.waitFor(() => expect(loadLanguage).toHaveBeenCalledTimes(1));
+    expect(constructed).not.toHaveBeenCalled();
 
-    await Promise.all([parser.initParser(), parser.initParser()]);
+    let secondResolved = false;
+    const second = parser.initParser().then(() => {
+      secondResolved = true;
+    });
+    await Promise.resolve();
+    expect(secondResolved).toBe(false);
 
+    releaseLanguage();
+    await Promise.all([first, second]);
     expect(runtimeLoaded).toHaveBeenCalledTimes(1);
     expect(init).toHaveBeenCalledTimes(1);
+    expect(loadLanguage).toHaveBeenCalledTimes(1);
+    expect(constructed).toHaveBeenCalledTimes(1);
   });
 
-  it('latches a runtime import failure and falls back without retrying', async () => {
-    const runtimeLoads = vi.fn();
-    vi.doMock('web-tree-sitter', () => {
-      runtimeLoads();
-      throw new Error('runtime chunk unavailable');
+  it('latches a language load failure', async () => {
+    const languageLoads = vi.fn(async () => {
+      throw new Error('bash language unavailable');
     });
 
+    class ParserMock {
+      static init = vi.fn(async () => undefined);
+      static Language = { load: languageLoads };
+
+      setLanguage = vi.fn();
+    }
+
+    vi.doMock('web-tree-sitter', () => ({ default: ParserMock }));
     const parser = await import('./shellAstParser.js');
+
+    expect(await parser.classifyShellCommandSafety('git status')).toBe(
+      'unknown',
+    );
     expect(await parser.isShellCommandReadOnlyAST('git status')).toBe(true);
     expect(await parser.isShellCommandReadOnlyAST('rm -rf temp')).toBe(false);
     await expect(parser.initParser()).rejects.toThrow(
       'tree-sitter WASM failed to initialise',
     );
-    expect(runtimeLoads).toHaveBeenCalledTimes(1);
+    expect(languageLoads).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps parser runtime exceptions without changing the legacy fallback', async () => {
+    const init = vi.fn(async () => undefined);
+    const deleteParser = vi.fn();
+    const parse = vi.fn(() => {
+      throw new Error('parser runtime failure');
+    });
+    const setLanguage = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('cannot configure replacement');
+      });
+    const constructed = vi.fn();
+
+    class ParserMock {
+      static init = init;
+      static Language = { load: vi.fn(async () => ({})) };
+
+      constructor() {
+        constructed();
+      }
+
+      delete = deleteParser;
+      parse = parse;
+      setLanguage = setLanguage;
+    }
+
+    vi.doMock('web-tree-sitter', () => ({ default: ParserMock }));
+    const parser = await import('./shellAstParser.js');
+
+    expect(await parser.classifyShellCommandSafety('git status')).toBe(
+      'unknown',
+    );
+    expect(await parser.isShellCommandReadOnlyAST('git status')).toBe(true);
+    await expect(parser.initParser()).rejects.toThrow(
+      'tree-sitter WASM failed to initialise',
+    );
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(parse).toHaveBeenCalledTimes(2);
+    expect(constructed).toHaveBeenCalledTimes(3);
+    expect(setLanguage).toHaveBeenCalledTimes(3);
+    expect(deleteParser).toHaveBeenCalledTimes(3);
+  });
+
+  it('releases each parsed tree exactly once', async () => {
+    const deleteTree = vi.fn();
+    const parse = vi
+      .fn()
+      .mockReturnValueOnce({
+        rootNode: { namedChildCount: 0, hasError: false, namedChildren: [] },
+        delete: deleteTree,
+      })
+      .mockReturnValueOnce({
+        get rootNode() {
+          throw new Error('tree evaluation failure');
+        },
+        delete: deleteTree,
+      });
+
+    class ParserMock {
+      static init = vi.fn(async () => undefined);
+      static Language = { load: vi.fn(async () => ({})) };
+
+      parse = parse;
+      setLanguage = vi.fn();
+    }
+
+    vi.doMock('web-tree-sitter', () => ({ default: ParserMock }));
+    const parser = await import('./shellAstParser.js');
+
+    expect(await parser.classifyShellCommandSafety('git status')).toBe(
+      'unknown',
+    );
+    expect(await parser.classifyShellCommandSafety('git status')).toBe(
+      'unknown',
+    );
+    expect(deleteTree).toHaveBeenCalledTimes(2);
   });
 
   it('keeps the packaged runtime deferred and parses from emitted chunks', async () => {
@@ -130,7 +245,7 @@ describe('shellAstParser lazy runtime', () => {
     const entryPath = path.join(tempDir, 'entry.ts');
     writeFileSync(
       entryPath,
-      `export { _resetParser, isShellCommandReadOnlyAST, parseShellCommand } from ${JSON.stringify(
+      `export { _resetParser, classifyShellCommandSafety, isShellCommandReadOnlyAST, parseShellCommand } from ${JSON.stringify(
         path.join(repoRoot, 'packages/core/src/utils/shellAstParser.ts'),
       )};\n`,
     );
@@ -176,6 +291,9 @@ describe('shellAstParser lazy runtime', () => {
       }?test=${Date.now()}`
     )) as {
       _resetParser(): void;
+      classifyShellCommandSafety(
+        command: string,
+      ): Promise<'read-only' | 'write' | 'unknown'>;
       isShellCommandReadOnlyAST(command: string): Promise<boolean>;
       parseShellCommand(command: string): Promise<{
         rootNode: { type: string };
@@ -195,6 +313,15 @@ describe('shellAstParser lazy runtime', () => {
     );
     expect(await packagedParser.isShellCommandReadOnlyAST('rm -rf temp')).toBe(
       false,
+    );
+    expect(await packagedParser.classifyShellCommandSafety('rm -rf temp')).toBe(
+      'write',
+    );
+    await packagedParser.classifyShellCommandSafety(
+      'case x in x) rm target;; esac',
+    );
+    expect(await packagedParser.classifyShellCommandSafety('git status')).toBe(
+      'read-only',
     );
 
     packagedParser._resetParser();

--- a/packages/core/src/utils/shell-safety-rules.ts
+++ b/packages/core/src/utils/shell-safety-rules.ts
@@ -20,8 +20,7 @@ const SED_VALUE_OPTIONS = '-f --file -e --expression -l --line-length'.split(
 );
 const AWK_STATIC_WRITE =
   /^\s*(?:print|printf)\b(?!\s*\()(?:(?:"(?:\\[\s\S]|[^"\\])*")|[^">|])*>>?\s*"[^"]*"\s*$/;
-const AWK_UNKNOWN_OPERATION =
-  /(?:system|close)\s*\(|getline\b|@(?:include|load)\b/;
+const AWK_UNKNOWN_OPERATION = /(?:system|close)\s*\(|getline\b/;
 const AWK_PRINT = /\b(?:print|printf)\b/;
 
 function scanDelimitedSection(
@@ -213,9 +212,11 @@ export function classifySedCommandSafety(args: string[]): SedScriptSafety {
 function splitAwkStatements(script: string): {
   statements: string[];
   ambiguousSlash: boolean;
+  unsupportedAt: boolean;
 } {
   const statements: string[] = [];
   let ambiguousSlash = false;
+  let unsupportedAt = false;
   let start = 0;
   let escaped = false;
   let inString = false;
@@ -252,10 +253,11 @@ function splitAwkStatements(script: string): {
       continue;
     }
     if (char === '/') ambiguousSlash = true;
+    if (char === '@') unsupportedAt = true;
     if (char === '#') {
       statements.push(script.slice(start, i));
       const newline = script.indexOf('\n', i + 1);
-      if (newline < 0) return { statements, ambiguousSlash };
+      if (newline < 0) return { statements, ambiguousSlash, unsupportedAt };
       start = newline + 1;
       i = newline;
       previousSignificant = '\n';
@@ -270,17 +272,18 @@ function splitAwkStatements(script: string): {
     if (!/\s/.test(char)) previousSignificant = char;
   }
   statements.push(script.slice(start));
-  return { statements, ambiguousSlash };
+  return { statements, ambiguousSlash, unsupportedAt };
 }
 
 export function classifyAwkScriptSafety(script: string): AwkScriptSafety {
-  const { statements, ambiguousSlash } = splitAwkStatements(script);
+  const { statements, ambiguousSlash, unsupportedAt } =
+    splitAwkStatements(script);
   if (
     !ambiguousSlash &&
     statements.some((statement) => AWK_STATIC_WRITE.test(statement))
   )
     return 'write';
-  if (AWK_UNKNOWN_OPERATION.test(script)) return 'unknown';
+  if (unsupportedAt || AWK_UNKNOWN_OPERATION.test(script)) return 'unknown';
   return AWK_PRINT.test(script) && /[>|]/.test(script)
     ? 'unknown'
     : 'read-only';

--- a/packages/core/src/utils/shell-safety-rules.ts
+++ b/packages/core/src/utils/shell-safety-rules.ts
@@ -1,0 +1,336 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type SedScriptSafety = 'read-only' | 'write' | 'unknown';
+export type AwkScriptSafety = SedScriptSafety;
+
+const SED_ADDRESS =
+  /^\s*(?:(?:\d+|\$)(?:\s*,\s*(?:\d+|\$))?|\/(?:\\[\s\S]|[^/\\])*\/)?\s*/;
+const SED_ADDRESS_AT =
+  /\s*(?:(?:\d+|\$)(?:\s*,\s*(?:\d+|\$))?|\/(?:\\[\s\S]|[^/\\])*\/)?\s*/y;
+const SAFE_SED_COMMAND = /^[dDgGhHlnNpPqQxz=]$/;
+const SAFE_SUBSTITUTION_FLAGS = /^[0-9gIpM]*$/;
+const SAFE_SED_OPTION =
+  /^(?:-[nElrsuz]|--(?:quiet|silent|line-length(?:=.*)?))$/;
+const SED_VALUE_OPTIONS = '-f --file -e --expression -l --line-length'.split(
+  ' ',
+);
+const AWK_STATIC_WRITE =
+  /^\s*(?:print|printf)\b(?!\s*\()(?:(?:"(?:\\[\s\S]|[^"\\])*")|[^">|])*>>?\s*"[^"]*"\s*$/;
+const AWK_UNKNOWN_OPERATION =
+  /(?:system|close)\s*\(|getline\b|@(?:include|load)\b/;
+const AWK_PRINT = /\b(?:print|printf)\b/;
+
+function scanDelimitedSection(
+  script: string,
+  start: number,
+  delimiter: string,
+): number {
+  let escaped = false;
+  for (let i = start; i < script.length; i++) {
+    const char = script[i]!;
+    if (escaped) {
+      escaped = false;
+    } else if (char === '\\') {
+      escaped = true;
+    } else if (char === delimiter) {
+      return i + 1;
+    }
+  }
+  return -1;
+}
+
+function classifySingleSedCommandSafety(script: string): SedScriptSafety {
+  const compatibilityUnknown = /(?:^|[^\\])[ewr]\s/.test(script);
+  const commandOffset = SED_ADDRESS.exec(script)?.[0].length ?? 0;
+  if (commandOffset === script.length) return 'read-only';
+
+  const command = script[commandOffset]!;
+  if (command === 'w' || command === 'W')
+    return script.slice(commandOffset + 1).trim() ? 'write' : 'unknown';
+  if (/[eErR]/.test(command)) return 'unknown';
+
+  if (command === 's') {
+    const delimiter = script[commandOffset + 1];
+    if (!delimiter || delimiter === '\\' || /\s/.test(delimiter))
+      return 'unknown';
+    const replacementStart = scanDelimitedSection(
+      script,
+      commandOffset + 2,
+      delimiter,
+    );
+    if (replacementStart < 0) return 'unknown';
+    const flagsStart = scanDelimitedSection(
+      script,
+      replacementStart,
+      delimiter,
+    );
+    if (flagsStart < 0) return 'unknown';
+
+    const flags = script.slice(flagsStart).trim();
+    if (/[;\n{}]/.test(flags)) return 'unknown';
+    const writeFlag = flags.indexOf('w');
+    if (writeFlag >= 0)
+      return flags.slice(writeFlag + 1).trim() ? 'write' : 'unknown';
+    if (/[eErRwW]/.test(flags)) return 'unknown';
+    if (!SAFE_SUBSTITUTION_FLAGS.test(flags)) return 'unknown';
+    return compatibilityUnknown ? 'unknown' : 'read-only';
+  }
+
+  if (/[;\n{}]/.test(script.slice(commandOffset + 1))) return 'unknown';
+  if (!SAFE_SED_COMMAND.test(command)) return 'unknown';
+  return compatibilityUnknown ? 'unknown' : 'read-only';
+}
+
+function nextSedSeparator(script: string, start: number): number {
+  for (let i = start; i < script.length; i++) {
+    if (script[i] === ';' || script[i] === '\n') return i;
+  }
+  return script.length;
+}
+
+export function classifySedScriptSafety(script: string): SedScriptSafety {
+  let result: SedScriptSafety = 'read-only';
+  let start = 0;
+  while (start < script.length) {
+    SED_ADDRESS_AT.lastIndex = start;
+    const address = SED_ADDRESS_AT.exec(script);
+    if (!address) return 'unknown';
+    const commandOffset = SED_ADDRESS_AT.lastIndex;
+    if (commandOffset === script.length) return result;
+    const command = script[commandOffset]!;
+
+    if (command === 'w' || command === 'W') {
+      const writer = classifySingleSedCommandSafety(script.slice(start));
+      return writer === 'write' ? 'write' : 'unknown';
+    }
+    if (/[eErR]/.test(command)) return 'unknown';
+    if (command !== 's' && !SAFE_SED_COMMAND.test(command)) return 'unknown';
+
+    let separator: number;
+    if (command === 's') {
+      const delimiter = script[commandOffset + 1];
+      if (!delimiter || delimiter === '\\' || /\s/.test(delimiter))
+        return 'unknown';
+      const replacementStart = scanDelimitedSection(
+        script,
+        commandOffset + 2,
+        delimiter,
+      );
+      if (replacementStart < 0) return 'unknown';
+      const flagsStart = scanDelimitedSection(
+        script,
+        replacementStart,
+        delimiter,
+      );
+      if (flagsStart < 0) return 'unknown';
+      separator = nextSedSeparator(script, flagsStart);
+    } else {
+      separator = nextSedSeparator(script, commandOffset + 1);
+    }
+
+    const current = classifySingleSedCommandSafety(
+      script.slice(start, separator),
+    );
+    if (current === 'write') return 'write';
+    if (current === 'unknown') result = 'unknown';
+    if (separator === script.length) return result;
+    start = separator + 1;
+  }
+  return result;
+}
+
+export function classifySedCommandSafety(args: string[]): SedScriptSafety {
+  const terminator = args.indexOf('--');
+  const options = args.slice(0, terminator < 0 ? args.length : terminator);
+  if (
+    options.some(
+      (arg, index) =>
+        /^(?:--help|--version)$/i.test(arg) &&
+        !SED_VALUE_OPTIONS.includes(options[index - 1]!),
+    )
+  )
+    return 'unknown';
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === '--') break;
+    if (SED_VALUE_OPTIONS.includes(arg)) i++;
+    else if (/^-[nErsuz]*e.+/.test(arg)) continue;
+    else if (/^(?:-[nErsuz]*[iI]|--in-place(?:=|$))/.test(arg)) return 'write';
+  }
+
+  const scripts: string[] = [];
+  const scriptArguments = new Set<number>();
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === '--') {
+      if (scripts.length === 0) {
+        const script = args[i + 1];
+        if (script === undefined || script.startsWith('-')) return 'unknown';
+        scripts.push(script);
+        scriptArguments.add(i + 1);
+      }
+      break;
+    }
+    if (/^(?:-l|--line-length)$/.test(arg) && !args[++i]) return 'unknown';
+    if (/^(?:-f|--file(?:=|$))/.test(arg)) return 'unknown';
+    if (arg === '-e' || arg === '--expression') {
+      const script = args[++i];
+      if (!script || script.startsWith('-')) return 'unknown';
+      scripts.push(script);
+      scriptArguments.add(i);
+    } else if (/^(?:-e.+|--expression=)/.test(arg)) {
+      const script = arg.slice(arg.startsWith('-e') ? 2 : 13);
+      if (script.startsWith('-')) return 'unknown';
+      scripts.push(script);
+      scriptArguments.add(i);
+    } else if (/^--(?!line-length(?:=|$))/.test(arg)) {
+      return 'unknown';
+    } else if (arg.startsWith('-') && !SAFE_SED_OPTION.test(arg)) {
+      return 'unknown';
+    } else if (!arg.startsWith('-') && scripts.length === 0) {
+      scripts.push(arg);
+      scriptArguments.add(i);
+    }
+  }
+
+  let result: SedScriptSafety = 'read-only';
+  for (const script of scripts) {
+    const current = classifySedScriptSafety(script);
+    if (current === 'write') return 'write';
+    if (current === 'unknown') result = 'unknown';
+  }
+  const remainingArgs = args.filter((_, index) => !scriptArguments.has(index));
+  return /(?:^|[^\\])[ewr]\s/.test(remainingArgs.join(' '))
+    ? 'unknown'
+    : result;
+}
+
+function splitAwkStatements(script: string): {
+  statements: string[];
+  ambiguousSlash: boolean;
+} {
+  const statements: string[] = [];
+  let ambiguousSlash = false;
+  let start = 0;
+  let escaped = false;
+  let inString = false;
+  let inRegex = false;
+  let previousSignificant = '';
+
+  for (let i = 0; i < script.length; i++) {
+    const char = script[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if ((inString || inRegex) && char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (inString) {
+      if (char === '"') inString = false;
+      continue;
+    }
+    if (inRegex) {
+      if (char === '/') inRegex = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (
+      char === '/' &&
+      (!previousSignificant || '({[=,:;!~?&|'.includes(previousSignificant))
+    ) {
+      inRegex = true;
+      continue;
+    }
+    if (char === '/') ambiguousSlash = true;
+    if (char === '#') {
+      statements.push(script.slice(start, i));
+      const newline = script.indexOf('\n', i + 1);
+      if (newline < 0) return { statements, ambiguousSlash };
+      start = newline + 1;
+      i = newline;
+      previousSignificant = '\n';
+      continue;
+    }
+    if (/[;{}\n]/.test(char)) {
+      statements.push(script.slice(start, i));
+      start = i + 1;
+      previousSignificant = char;
+      continue;
+    }
+    if (!/\s/.test(char)) previousSignificant = char;
+  }
+  statements.push(script.slice(start));
+  return { statements, ambiguousSlash };
+}
+
+export function classifyAwkScriptSafety(script: string): AwkScriptSafety {
+  const { statements, ambiguousSlash } = splitAwkStatements(script);
+  if (
+    !ambiguousSlash &&
+    statements.some((statement) => AWK_STATIC_WRITE.test(statement))
+  )
+    return 'write';
+  if (AWK_UNKNOWN_OPERATION.test(script)) return 'unknown';
+  return AWK_PRINT.test(script) && /[>|]/.test(script)
+    ? 'unknown'
+    : 'read-only';
+}
+
+export function classifyAwkCommandSafety(args: string[]): AwkScriptSafety {
+  let programIndex = -1;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === '--') {
+      programIndex = i + 1;
+      break;
+    }
+    if (arg === '-F' || arg === '-v') {
+      if (!args[++i]) return 'unknown';
+      continue;
+    }
+    if (/^-[Fv].+/.test(arg)) continue;
+    if (arg.startsWith('-')) return 'unknown';
+    programIndex = i;
+    break;
+  }
+  if (programIndex < 0) return 'read-only';
+  const program = args[programIndex];
+  if (program === undefined) return 'unknown';
+  const result = classifyAwkScriptSafety(program);
+  if (result !== 'read-only') return result;
+  return classifyAwkScriptSafety(args.join(' ')) === 'read-only'
+    ? 'read-only'
+    : 'unknown';
+}
+
+export function hasShellBraceExpansion(text: string): boolean {
+  let braceDepth = 0;
+  let previousDot = false;
+  for (const char of text) {
+    if (char === '{') {
+      braceDepth++;
+      previousDot = false;
+    } else if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+      previousDot = false;
+    } else if (braceDepth > 0) {
+      if (char === ',' || (char === '.' && previousDot)) return true;
+      previousDot = char === '.';
+    }
+  }
+  return false;
+}
+
+export function hasShellPatternExpansion(text: string): boolean {
+  return /[[*?]/.test(text) || hasShellBraceExpansion(text);
+}

--- a/packages/core/src/utils/shellAstParser.test.ts
+++ b/packages/core/src/utils/shellAstParser.test.ts
@@ -201,6 +201,15 @@ describe('isShellCommandReadOnlyAST', () => {
       ).toBe(false);
     });
 
+    it('rejects gawk indirect function calls', async () => {
+      for (const command of [
+        'awk \'BEGIN { fn = "system"; @fn("touch /tmp/pwned") }\'',
+        'awk \'BEGIN { fn = "system"; @ fn("touch /tmp/pwned") }\'',
+      ]) {
+        expect(await isShellCommandReadOnlyAST(command)).toBe(false);
+      }
+    });
+
     it('rejects awk with file output redirection', async () => {
       expect(
         await isShellCommandReadOnlyAST(
@@ -438,6 +447,7 @@ describe('classifyShellCommandSafety', () => {
     "awk '{ print*2 }' file",
     "awk -- '{ print }' input",
     "awk -F : '{ print $1 }' input",
+    'awk \'BEGIN { print "user@example.com" }\'',
     "printf '%s' value",
   ])('classifies %j as read-only', async (command) => {
     expect(await classifyShellCommandSafety(command)).toBe('read-only');
@@ -725,6 +735,9 @@ describe('classifyShellCommandSafety', () => {
     'awk -Wexec=script.awk file',
     'awk "$PROGRAM" file',
     'awk \'@include "library.awk"\' file',
+    'awk \'@namespace "safe"\' file',
+    'awk \'BEGIN { fn = "system"; @fn("touch /tmp/pwned") }\'',
+    'awk \'BEGIN { fn = "system"; @ fn("touch /tmp/pwned") }\'',
     "awk -e '{ print }' file",
     "awk --load extension '{ print }' file",
     "awk --profile=report '{ print }' file",

--- a/packages/core/src/utils/shellAstParser.test.ts
+++ b/packages/core/src/utils/shellAstParser.test.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
+  classifyShellCommandSafety,
   initParser,
   isShellCommandReadOnlyAST,
   extractCommandRules,
@@ -100,8 +101,8 @@ describe('isShellCommandReadOnlyAST', () => {
     expect(await isShellCommandReadOnlyAST('   ')).toBe(false);
   });
 
-  it('respects environment prefix followed by allowed command', async () => {
-    expect(await isShellCommandReadOnlyAST('FOO=bar ls')).toBe(true);
+  it('rejects environment prefix followed by allowed command', async () => {
+    expect(await isShellCommandReadOnlyAST('FOO=bar ls')).toBe(false);
   });
 
   describe('multi-command security', () => {
@@ -248,9 +249,6 @@ describe('isShellCommandReadOnlyAST', () => {
       expect(await isShellCommandReadOnlyAST("sed -n '1,5p' file.txt")).toBe(
         true,
       );
-      expect(await isShellCommandReadOnlyAST("sed '/pattern/d' file.txt")).toBe(
-        true,
-      );
     });
 
     it('rejects sed with execute command', async () => {
@@ -303,8 +301,8 @@ describe('isShellCommandReadOnlyAST', () => {
       expect(await isShellCommandReadOnlyAST('FOO=bar')).toBe(true);
     });
 
-    it('allows multiple env vars before command', async () => {
-      expect(await isShellCommandReadOnlyAST('A=1 B=2 ls -la')).toBe(true);
+    it('rejects multiple env vars before command', async () => {
+      expect(await isShellCommandReadOnlyAST('A=1 B=2 ls -la')).toBe(false);
     });
 
     it('rejects function definitions', async () => {
@@ -392,6 +390,447 @@ describe('isShellCommandReadOnlyAST', () => {
         false,
       );
     });
+  });
+});
+
+// =========================================================================
+// classifyShellCommandSafety
+// =========================================================================
+
+describe('classifyShellCommandSafety', () => {
+  it.each([
+    'ls -la',
+    'git status --short',
+    'ls | cat && pwd',
+    'FOO=bar',
+    'cd /tmp',
+    '(git status)',
+    '{ ls; pwd; }',
+    'cat < input.txt',
+    'cat <<EOF\nhello\nEOF',
+    'echo 2>&1',
+    'echo >&-',
+    'uniq input.txt',
+    'uniq -- -f',
+    'git branch --list --color=always topic',
+    'git diff -o patch',
+    'git diff -Oorderfile',
+    'git log -p',
+    'git show -p HEAD',
+    'git blame -p file',
+    'git log -- --output=log.out',
+    'sort -- -o output',
+    'tree -- -o output',
+    'rg -- -z file',
+    'sort -- -roout input',
+    'sort -- --output=out',
+    "sed -- 's/a/b/' input",
+    "sed 's/a/*/' file",
+    "sed 's/old/new/' file",
+    "sed 's/hello/world/' file",
+    "sed 's/error/warning/g' file",
+    "sed -n '/needle/p' file",
+    "sed '/pattern/d' file",
+    "sed 's/a/woutput/' file",
+    "sed 's#x#s/a/b/woutput#' file",
+    "sed 's#x#foo;woutput#' file",
+    "sed 'p;d' file",
+    "awk '{ print*2 }' file",
+    "awk -- '{ print }' input",
+    "awk -F : '{ print $1 }' input",
+    "printf '%s' value",
+  ])('classifies %j as read-only', async (command) => {
+    expect(await classifyShellCommandSafety(command)).toBe('read-only');
+  });
+
+  it.each([
+    ...[
+      'chgrp',
+      'chmod',
+      'chown',
+      'cp',
+      'install',
+      'ln',
+      'mkdir',
+      'mkfifo',
+      'mknod',
+      'mv',
+      'rename',
+      'rm',
+      'rmdir',
+      'shred',
+      'touch',
+      'truncate',
+      'unlink',
+    ].map((root) => `${root} target`),
+    ...'add am checkout cherry-pick clean clone commit fetch gc init merge mv pull push rebase reset restore revert rm stash switch'
+      .split(' ')
+      .map((subcommand) => `git ${subcommand} target`),
+    'kill 123',
+    'kill -- -0',
+    'kill "$PID"',
+    'pkill -n 0',
+    'pkill -n0 process',
+    'pkill -s0 process',
+    'pkill -s 0 process',
+    'pkill -s "$SESSION" process',
+    'killall -n0 process',
+    'echo > out',
+    '> out',
+    'export FOO=bar > out',
+    'echo >> out',
+    'echo >| out',
+    'echo &> out',
+    'echo &>> out',
+    'echo >& out',
+    '> out echo',
+    'git commit -m message',
+    'git commit -m --help',
+    'git commit -F --help',
+    'git commit -C --help',
+    'git commit -c --help',
+    'git commit --reuse-message --help',
+    'git commit --fixup --help',
+    'git commit -m --dry-run',
+    'git commit -n -m message',
+    "git commit -m '%G?'",
+    'git add -- --help',
+    'git add -- --dry-run',
+    'touch -- --help',
+    'git fetch -n origin',
+    'git branch topic',
+    'git branch -- topic',
+    'git branch --color=always color-topic',
+    'git branch --column column-topic',
+    'git branch --sort=refname sort-topic',
+    "git branch --format='%(refname)' format-topic",
+    'git branch -v verbose-topic',
+    'git branch --delete topic',
+    'git branch -uorigin/main topic',
+    'git branch --format --help -d topic',
+    'git branch --sort --version --delete topic',
+    'git remote set-url origin url',
+    'git remote rm origin',
+    'git remote prune origin',
+    'git diff --output=patch',
+    'git log --output=log.out',
+    'git show --output=show.out HEAD',
+    'git log --output --help',
+    'find . -delete',
+    'find . -fprint matches',
+    'find . -fprint --help',
+    'find . -fls --help',
+    'find . -fprintf --help format',
+    'find . -exec rm {} \\;',
+    'find . -exec echo --help {} \\; -delete',
+    'find . -exec echo --version {} \\; -delete',
+    "sed -i 's/a/b/' file",
+    'sed -f script.sed -i file',
+    'sed --file=script.sed --in-place=.bak file',
+    "sed -- 'wout' input",
+    "sed -- 's/a/b/wout' input",
+    "sed -I .bak 's/a/b/' file",
+    "sed -I.bak 's/a/b/' file",
+    "sed -ni.bak 's/a/b/' file",
+    "sed -nI.bak 's/a/b/' file",
+    "sed 's/a/b/w output' file",
+    "sed -e 's/a/b/' -e 'woutput' file",
+    "sed 's/a/b/woutput' file",
+    "sed 'woutput' file",
+    "sed '1woutput' file",
+    "sed '/pattern/woutput' file",
+    "sed 'W output' file",
+    "sed '1W output' file",
+    "sed 'p;w output' file",
+    "sed 's/a/b/;w output' file",
+    "sed 's/a/;/;w output' file",
+    "sed -l 80 'w output' file",
+    "sed --line-length 80 'w output' file",
+    'awk \'{ print > "output" }\' file',
+    'awk -- \'BEGIN { print > "out" }\'',
+    'awk \'BEGIN { print "x" > "out" }\'',
+    'awk \'BEGIN { printf "%s", "x" > "out" }\'',
+    'awk \'BEGIN { print a[x] > "out" }\'',
+    'awk \'{ print>"output" }\' file',
+    'awk -v mode=1 \'BEGIN { print > "out" }\' input',
+    'awk \'/pattern/ { print > "out" }\' input',
+    'sort -o output input',
+    'sort -o --help input',
+    'tree -o tree.txt',
+    'tree -o --help .',
+    'uniq input output',
+    'uniq - output',
+    'uniq -- -f output',
+    'uniq input -- -f',
+    'tee output',
+    'tee -- -output',
+    'tee -a -- -output',
+    'dd if=input of=output',
+    'echo $(rm target)',
+    'FOO=$(rm target)',
+    'cat <(rm target)',
+    'cat < <(rm target)',
+    '< <(rm target) cat',
+    '! rm target',
+    'cat <<EOF\n$(rm target)\nEOF',
+    'FOO=bar rm target',
+    'python -c pass; touch target',
+    'if true; then rm target; fi',
+    'while false; do rm target; done',
+    'for item in value; do rm target; done',
+  ])('classifies %j as write', async (command) => {
+    expect(await classifyShellCommandSafety(command)).toBe('write');
+  });
+
+  it.each([
+    '',
+    'python -c pass',
+    'node -e pass',
+    'LS -la',
+    'printf -v PATH /tmp',
+    'printf -xv PATH /tmp',
+    'printf "$OPTIONS" value',
+    'printf -v PATH /tmp; ls',
+    'sudo ls',
+    'bash -c ls',
+    '/bin/rm target',
+    'rm --help',
+    'kill -0 123',
+    'kill -n 0 123',
+    'kill -n 00 123',
+    'kill -n0 123',
+    'kill -s0 123',
+    'kill --signal 0 123',
+    'kill -SIG0 123',
+    'kill -s SIG0 123',
+    'kill --signal=SIG0 123',
+    'kill -l',
+    'kill --list=TERM',
+    'kill --table',
+    'kill -V',
+    'killall -help',
+    'killall -s0 process',
+    'killall -sSIG0 process',
+    'pkill -0 process',
+    'pkill -SIG0 process',
+    'pkill --signal 0 process',
+    'pkill --signal SIG0 process',
+    'kill -s "$SIGNAL" 123',
+    'kill -n "$SIGNAL" 123',
+    'kill --signal="$SIGNAL" 123',
+    'git clean --dry-run',
+    'git commit -m -F --help',
+    'git commit -m -F --dry-run',
+    'git commit --message --file --help',
+    'git commit --untracked-files --help',
+    'git --config-env=diff.external=HELPER diff',
+    'git --paginate log',
+    'git -p log',
+    'git --unknown-option status',
+    'git -- status',
+    'git --help commit',
+    'git status --help',
+    'git log --help',
+    'git diff --help',
+    'git log --show-signature -1',
+    'git show --format=%G? HEAD',
+    'GIT_EXTERNAL_DIFF=/tmp/helper git diff',
+    'FOO=bar GIT_EXTERNAL_DIFF=/tmp/helper git diff',
+    "GIT_EXTERNAL_DIFF='touch /tmp/pwned'; git diff",
+    'FOO=bar; ls',
+    'FOO=bar ls',
+    'LD_PRELOAD=/tmp/evil.so ls',
+    'RIPGREP_CONFIG_PATH=/tmp/config rg pattern',
+    'PAGER=helper git log',
+    'git add -n target',
+    'git branch -d topic --help',
+    'git branch --list -- -d',
+    'git branch -- --list',
+    'git branch --sort refname',
+    "git branch --format '%(refname)'",
+    'git branch --sort refname topic',
+    'git branch --format --delete',
+    'git branch --sort -d',
+    'git diff --output=',
+    'git blame --output=blame.out file',
+    'git diff --ext-diff',
+    'git show --textconv HEAD:file',
+    'git grep --open-files-in-pager=less needle',
+    'git grep -Ovim needle',
+    'git cat-file --filters HEAD:file',
+    'git remote prune --dry-run origin',
+    'git remote prune -n origin',
+    'git remote show remove',
+    'git remote get-url prune',
+    'find . -exec echo {} \\;',
+    'find . -exec echo -delete \\;',
+    'find . -fprint --help --help',
+    'find . -name -delete',
+    'find . -printf -delete',
+    'find . -newermt -delete',
+    'find . -samefile -delete',
+    'find . -mtime -delete',
+    'find . -used -delete',
+    'find . -- -delete',
+    'find . -exec rm --help \\;',
+    'sed -f script.sed file',
+    'sed -fscript.sed file',
+    "sed --in-pl=.bak 's/a/b/' file",
+    'sed --f script.sed file',
+    'sed -newout input',
+    'sed -nEewout input',
+    'sed "$SCRIPT" file',
+    'sed -e "$SCRIPT" file',
+    'sed s/a/*/ file',
+    'sed \'s/a/b/\' "$FILE"',
+    "sed -i 's/a/b/' --help",
+    'sed -e -i file',
+    'sed -einstall file',
+    'sed -neinstall file',
+    "sed -e '' file",
+    'sed -f -i file',
+    'sed -e-i file',
+    'sed -- -i file',
+    "sed 's/a/b/e' file",
+    "sed 's/a/printf hacked > marker/ep' file",
+    "sed 's#a#printf hacked > marker#pe' file",
+    "sed 'etouch marker' file",
+    "sed '1etouch marker' file",
+    "sed 's/a/b/w' file",
+    "sed 'w' file",
+    "sed '1w' file",
+    "sed 'R input' file",
+    "sed 's/a/b/' 'w file'",
+    "sed 's/a/new value/' file",
+    "sed 's/a/blue sky/' file",
+    "sed 's/a/car value/' file",
+    "sed 's/w /x/' file",
+    "sed '/p;w output/p' file",
+    "sed 's/a/;w output/' file",
+    'awk \'{ system("date") }\'',
+    "awk '{ print > output }' file",
+    'awk \'BEGIN { print("x")|"cat > output" }\'',
+    'awk \'BEGIN { print(1 > "0") }\'',
+    'awk \'BEGIN { printf("%d", 1 > "0") }\'',
+    'awk \'BEGIN { print "print > " "output" }\'',
+    'awk \'BEGIN { print (x) > "out" }\'',
+    'awk \'BEGIN { print +(x > "0") }\'',
+    'awk \'BEGIN { print a[x > "0"] }\'',
+    'awk \'BEGIN { # print > "out"\nprint }\'',
+    'awk \'BEGIN { print /x; print y > "out";/ }\'',
+    'awk \'BEGIN { print x / 2 > "out" }\'',
+    "awk '{ print }' 'print > \"out\"'",
+    'awk -fscript.awk file',
+    'awk -W exec=script.awk file',
+    'awk -Wexec=script.awk file',
+    'awk "$PROGRAM" file',
+    'awk \'@include "library.awk"\' file',
+    "awk -e '{ print }' file",
+    "awk --load extension '{ print }' file",
+    "awk --profile=report '{ print }' file",
+    'awk {print*2} file',
+    'awk -v x="$VALUE" \'{ print x }\' file',
+    'awk \'{ print $NF }\' "$FILE"',
+    'uniq *',
+    'uniq "$FILES"',
+    'sort "$OPTIONS" input',
+    'sort {-o,output} input',
+    'sort --out=output input',
+    'sort -roout input',
+    'tree -Cofile .',
+    'sort --co=cat input',
+    'tree --output=tree.txt',
+    'find . "$EXPRESSION"',
+    'rg "$OPTIONS" pattern',
+    'git status "$OPTIONS"',
+    'sort --compress-program gzip input',
+    'sort --output=',
+    'sort -o output --help',
+    'rg --pre cat pattern',
+    'rg --hostname-bin=hostname pattern',
+    'rg -z pattern archive.gz',
+    'ripgrep -iz pattern archive.gz',
+    'rg --search-zip pattern archive.gz',
+    'less file',
+    'more file',
+    'tee',
+    'dd if=input',
+    'echo >& "$target"',
+    'cat <> file',
+    'echo >',
+    'FOO=bar > out',
+    'echo $(git status)',
+    'FOO=$(git status)',
+    'cat <(git status)',
+    'if true; then git status; fi',
+    'fn() { rm target; }',
+  ])('classifies %j as unknown', async (command) => {
+    expect(await classifyShellCommandSafety(command)).toBe('unknown');
+  });
+
+  it.each([
+    'rm target',
+    'python -c pass',
+    'echo $(git status)',
+    'if true; then git status; fi',
+    'fn() { rm target; }',
+    'git push origin main',
+    'git branch --list -- -d',
+    'find . -exec echo {} \\;',
+    "sed 's/a/b/e' file",
+    "sed 's/a/b/' 'w file'",
+    "sed 's/w /x/' file",
+    'awk \'{ system("date") }\'',
+    'git remote show remove',
+  ])('does not widen the compatibility boolean for %j', async (command) => {
+    expect(await isShellCommandReadOnlyAST(command)).toBe(false);
+  });
+
+  it('classifies deeply nested substitutions without repeated traversal', async () => {
+    let command = 'git status';
+    for (let depth = 0; depth < 30; depth++) command = `echo $(${command})`;
+    expect(await classifyShellCommandSafety(command)).toBe('unknown');
+  });
+
+  it('classifies deeply nested redirected substitutions without repeated traversal', async () => {
+    const commands = ['git status', 'git status'];
+    for (let depth = 0; depth < 20; depth++) {
+      commands[0] = `echo $(${commands[0]}) < /dev/null`;
+      commands[1] = `< <(${commands[1]}) cat`;
+    }
+    const startedAt = performance.now();
+    await expect(
+      Promise.all(commands.map(classifyShellCommandSafety)),
+    ).resolves.toEqual(['unknown', 'unknown']);
+    expect(performance.now() - startedAt).toBeLessThan(1000);
+  });
+
+  it('classifies adversarial rule inputs in bounded time', async () => {
+    const backslashes = '\\'.repeat(10_000);
+    const repeatedSed = 'p;'.repeat(10_000);
+    const repeatedPrint = 'print value; '.repeat(10_000);
+    const repeatedFindExec = '-exec echo \\; '.repeat(10_000);
+    const unmatchedBraces = '\\{'.repeat(10_000);
+    const commands = [
+      `sed 's/${backslashes}a' file`,
+      `sed '${repeatedSed}' file`,
+      `awk 'BEGIN { print "${backslashes} > output }'`,
+      `awk 'BEGIN { ${repeatedPrint} }'`,
+      `find . ${repeatedFindExec}`,
+      `git status ${unmatchedBraces}`,
+    ];
+    const startedAt = performance.now();
+    await expect(
+      Promise.all(commands.map(classifyShellCommandSafety)),
+    ).resolves.toEqual([
+      'unknown',
+      'read-only',
+      'unknown',
+      'read-only',
+      'unknown',
+      'read-only',
+    ]);
+    expect(performance.now() - startedAt).toBeLessThan(1000);
   });
 });
 
@@ -561,6 +1000,18 @@ describe('isShellCommandReadOnlyAST fallback to regex-based checker', () => {
     expect(await isShellCommandReadOnlyAST('ls -la')).toBe(true);
   });
 
+  it('maps parser unavailability to unknown in the classification API', async () => {
+    _setParserFailedForTesting();
+    expect(await classifyShellCommandSafety('git status')).toBe('unknown');
+    expect(await isShellCommandReadOnlyAST('git status')).toBe(true);
+  });
+
+  it('treats syntax errors as unknown without widening the boolean API', async () => {
+    expect(isShellCommandReadOnly('ls |')).toBe(false);
+    expect(await classifyShellCommandSafety('ls |')).toBe('unknown');
+    expect(await isShellCommandReadOnlyAST('ls |')).toBe(false);
+  });
+
   it('returns the regex-based result for a mutating command when parser is marked failed', async () => {
     _setParserFailedForTesting();
     expect(await isShellCommandReadOnlyAST('rm -rf /')).toBe(false);
@@ -689,8 +1140,8 @@ describe('consistency: isShellCommandReadOnly (regex) vs isShellCommandReadOnlyA
     ['ls\n\ngrep foo', true, 'consecutive newlines, all read-only'],
 
     // --- env prefix ---
-    ['FOO=bar ls', true],
-    ['A=1 B=2 ls -la', true],
+    ['FOO=bar ls', false],
+    ['A=1 B=2 ls -la', false],
 
     // --- whitespace ---
     ['   ', false, 'whitespace-only returns false'],

--- a/packages/core/src/utils/shellAstParser.ts
+++ b/packages/core/src/utils/shellAstParser.ts
@@ -20,7 +20,14 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isShellCommandReadOnly } from './shellReadOnlyChecker.js';
+import {
+  classifyAwkCommandSafety,
+  classifySedCommandSafety,
+  hasShellPatternExpansion,
+} from './shell-safety-rules.js';
 
+export type ShellCommandSafety = 'read-only' | 'write' | 'unknown';
+type Safety = ShellCommandSafety;
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -108,6 +115,8 @@ const READ_ONLY_ROOT_COMMANDS = new Set([
   'whoami',
 ]);
 
+const WRITE_ROOT_COMMAND =
+  /^(chgrp|chmod|chown|cp|install|ln|mkdir|mkfifo|mknod|mv|rename|rm|rmdir|shred|touch|truncate|unlink)$/;
 /** Git sub-commands considered read-only. */
 const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   'blame',
@@ -123,64 +132,28 @@ const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   'status',
   'describe',
 ]);
-
+const WRITE_GIT_SUBCOMMAND =
+  /^(add|am|checkout|cherry-pick|clean|clone|commit|fetch|gc|init|merge|mv|pull|push|rebase|reset|restore|revert|rm|stash|switch)$/;
 /** git remote actions that mutate state. */
-const BLOCKED_GIT_REMOTE_ACTIONS = new Set([
-  'add',
-  'remove',
-  'rename',
-  'set-url',
-  'prune',
-  'update',
-]);
-
+const WRITE_GIT_REMOTE_ACTION =
+  /^(add|remove|rm|rename|set-branches|set-head|set-url|update)$/;
+const GIT_EXTERNAL_HELPER_OPTION =
+  /^--(?:ext-diff|filters|show-signature|textconv|open-files-in-pager)(?:=|$)/;
+const GIT_COMMIT_VALUE_OPTION =
+  /^(?:-[CcFmt]|--(?:author|cleanup|date|file|fixup|message|pathspec-from-file|reedit-message|reuse-message|squash|template|trailer))$/;
 /** git branch flags that mutate state. */
-const BLOCKED_GIT_BRANCH_FLAGS = new Set([
-  '-d',
-  '-D',
-  '--delete',
-  '--move',
-  '-m',
-]);
+const WRITE_GIT_BRANCH_FLAG =
+  /^(?:-[cCdDmMu](?:.|$)|--(?:delete|move|copy|set-upstream(?:-to)?|unset-upstream|create-reflog|edit-description)(?:=|$))/;
+const GIT_BRANCH_LIST_FLAG =
+  /^(?:-[alr]|--(?:all|list|remotes|show-current|contains|no-contains|merged|no-merged|points-at))(?:=|$)/;
 
-/** find flags that have side-effects. */
-const BLOCKED_FIND_FLAGS = new Set([
-  '-delete',
-  '-exec',
-  '-execdir',
-  '-ok',
-  '-okdir',
-]);
+const BLOCKED_FIND_PREFIXES = ['-fls', '-fprint', '-fprintf'];
+const FIND_VALUE_PREDICATE =
+  /^-(?:[ac]?newer|newer[a-z]{2}|[acm](?:min|time)|context|fstype|gid|group|i?(?:lname|name|path|regex)|inum|links|maxdepth|mindepth|path|perm|printf|regextype|samefile|size|type|uid|used|user|wholename|xtype)$/;
 
-const BLOCKED_FIND_PREFIXES = ['-fprint', '-fprintf'];
-
-/** sed flags that cause in-place editing. */
-const BLOCKED_SED_PREFIXES = ['-i'];
-
-/** AWK side-effect patterns that can execute commands or write files. */
-const AWK_SIDE_EFFECT_PATTERNS = [
-  /system\s*\(/,
-  /print\s+[^>|]*>\s*"[^"]*"/,
-  /printf\s+[^>|]*>\s*"[^"]*"/,
-  /print\s+[^>|]*>>\s*"[^"]*"/,
-  /printf\s+[^>|]*>>\s*"[^"]*"/,
-  /print\s+[^|]*\|\s*"[^"]*"/,
-  /printf\s+[^|]*\|\s*"[^"]*"/,
-  /getline\s*<\s*"[^"]*"/,
-  /"[^"]*"\s*\|\s*getline/,
-  /close\s*\(/,
-];
-
-/** SED side-effect patterns. */
-const SED_SIDE_EFFECT_PATTERNS = [
-  /[^\\]e\s/,
-  /^e\s/,
-  /[^\\]w\s/,
-  /^w\s/,
-  /[^\\]r\s/,
-  /^r\s/,
-];
-
+const UNIQ_VALUE_OPTIONS = new Set(
+  '-f --skip-fields -s --skip-chars -w --check-chars'.split(' '),
+);
 /**
  * Write-redirection operators in file_redirect nodes.
  * Input-only redirections (`<`, `<<`, `<<<`) are safe.
@@ -601,6 +574,7 @@ const DOCKER_COMPOSE_SUBCOMMANDS = new Set([
 
 let parserInstance: Parser | null = null;
 let bashLanguage: Parser.Language | null = null;
+let parserClass: typeof Parser;
 let initPromise: Promise<void> | null = null;
 /** Set to true permanently once WASM initialisation fails. */
 let parserInitFailed = false;
@@ -629,19 +603,28 @@ export async function initParser(): Promise<void> {
       'web-tree-sitter/tree-sitter.wasm',
     );
     await ParserClass.init({ wasmBinary: treeSitterWasm });
-    parserInstance = new ParserClass();
     const bashWasm = await loadWasmBinary(
       () =>
         import('tree-sitter-wasms/out/tree-sitter-bash.wasm?binary' as string),
       'tree-sitter-wasms/out/tree-sitter-bash.wasm',
     );
     bashLanguage = await ParserClass.Language.load(bashWasm);
+    parserClass = ParserClass;
+    parserInstance = new ParserClass();
     parserInstance.setLanguage(bashLanguage);
   })().catch((err: unknown) => {
+    const failedParser = parserInstance;
+    parserInstance = null;
+    bashLanguage = null;
     // Mark as permanently failed so callers can use the regex fallback
     // instead of retrying (which could cause the agent to hang).
     parserInitFailed = true;
     initPromise = null;
+    try {
+      failedParser?.delete();
+    } catch {
+      // Preserve the initialization error.
+    }
     throw err;
   });
 
@@ -654,7 +637,30 @@ export async function initParser(): Promise<void> {
  */
 export async function parseShellCommand(command: string): Promise<Parser.Tree> {
   await initParser();
-  return parserInstance!.parse(command);
+  const parser = parserInstance!;
+  try {
+    return parser.parse(command);
+  } catch (error) {
+    parserInstance = null;
+    let replacement: Parser | null = null;
+    try {
+      replacement = new parserClass();
+      replacement.setLanguage(bashLanguage);
+      parserInstance = replacement;
+    } catch {
+      try {
+        replacement?.delete();
+      } catch {
+        // Preserve the parse error.
+      }
+      bashLanguage = null;
+      parserInitFailed = true;
+      initPromise = null;
+    } finally {
+      parser.delete();
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -663,10 +669,16 @@ export async function parseShellCommand(command: string): Promise<Parser.Tree> {
 
 type SyntaxNode = Parser.SyntaxNode;
 
+const SHELL_EXPANSION_TYPES = new Set(
+  'simple_expansion expansion arithmetic_expansion'.split(' '),
+);
+const CHILD_STATEMENT =
+  /^(?:pipeline|list|subshell|compound_statement|negated_command)$/;
 /** Collect all descendant nodes of given types. */
 function collectDescendants(
   node: SyntaxNode,
   types: Set<string>,
+  outermostOnly = false,
 ): SyntaxNode[] {
   const result: SyntaxNode[] = [];
   const stack: SyntaxNode[] = [node];
@@ -674,41 +686,13 @@ function collectDescendants(
     const current = stack.pop()!;
     if (types.has(current.type)) {
       result.push(current);
+      if (outermostOnly) continue;
     }
     for (let i = current.childCount - 1; i >= 0; i--) {
       stack.push(current.child(i)!);
     }
   }
   return result;
-}
-
-/** Check if a tree contains any command_substitution or process_substitution node. */
-function containsCommandSubstitutionAST(node: SyntaxNode): boolean {
-  return (
-    collectDescendants(
-      node,
-      new Set(['command_substitution', 'process_substitution']),
-    ).length > 0
-  );
-}
-
-/** Check if a redirected_statement contains a write-redirection. */
-function hasWriteRedirection(node: SyntaxNode): boolean {
-  if (node.type !== 'redirected_statement') return false;
-  for (let i = 0; i < node.childCount; i++) {
-    const child = node.child(i)!;
-    if (child.type === 'file_redirect') {
-      // The operator is the first non-descriptor child
-      for (let j = 0; j < child.childCount; j++) {
-        const op = child.child(j)!;
-        if (op.type === 'file_descriptor') continue;
-        // operator token
-        if (WRITE_REDIRECT_OPERATORS.has(op.type)) return true;
-        break; // only check the operator position
-      }
-    }
-  }
-  return false;
 }
 
 /**
@@ -752,180 +736,384 @@ function stripOuterQuotes(text: string): string {
   return text;
 }
 
-// ---------------------------------------------------------------------------
-// Read-Only Analysis (per-command)
-// ---------------------------------------------------------------------------
-
-/**
- * Evaluate whether a single `command` node (simple command) is read-only.
- */
-function evaluateCommandReadOnly(commandNode: SyntaxNode): boolean {
-  const root = getCommandName(commandNode);
-  if (!root) return true; // pure variable assignment
-  const argNodes = getArgumentNodes(commandNode);
-  const argTexts = argNodes.map((n) => stripOuterQuotes(n.text));
-
-  if (!READ_ONLY_ROOT_COMMANDS.has(root)) return false;
-
-  // Command-specific analysis
-  if (root === 'git') return evaluateGitReadOnly(argTexts);
-  if (root === 'find') return evaluateFindReadOnly(argTexts);
-  if (root === 'sed') return evaluateSedReadOnly(argTexts);
-  if (root === 'awk') return evaluateAwkReadOnly(argTexts);
-
-  return true;
+function hasShellExpansion(node: SyntaxNode): boolean {
+  return (
+    collectDescendants(node, SHELL_EXPANSION_TYPES).length > 0 ||
+    (['word', 'concatenation'].includes(node.type) &&
+      hasShellPatternExpansion(node.text))
+  );
 }
 
-function evaluateGitReadOnly(args: string[]): boolean {
-  // Skip global flags to find subcommand
-  let idx = 0;
-  while (idx < args.length && args[idx]!.startsWith('-')) {
-    const flag = args[idx]!.toLowerCase();
-    if (flag === '--version' || flag === '--help') return true;
-    idx++;
+function mergeSafety(...results: ShellCommandSafety[]): ShellCommandSafety {
+  if (results.includes('write')) return 'write';
+  if (results.includes('unknown')) return 'unknown';
+  return 'read-only';
+}
+
+function beforeTerminator(args: string[]): string[] {
+  const end = args.indexOf('--');
+  return args.slice(0, end < 0 ? args.length : end);
+}
+
+function hasHelp(args: string[], valueOptions: string[] = []): boolean {
+  return beforeTerminator(args).some(
+    (arg, index, options) =>
+      /^(?:--help|--version)$/i.test(arg) &&
+      !valueOptions.includes(options[index - 1]!),
+  );
+}
+
+function withoutOptionValues(args: string[], valueOption: RegExp): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    result.push(args[i]!);
+    if (valueOption.test(args[i]!)) i++;
   }
-  if (idx >= args.length) return true; // `git` with only flags
+  return result;
+}
 
-  const subcommand = args[idx]!.toLowerCase();
-  if (!READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) return false;
+function evaluateOutputOption(args: string[], long = true, short = true) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === '--') break;
+    if ((short && arg === '-o') || (long && arg === '--output')) {
+      return args[i + 1] ? 'write' : 'unknown';
+    }
+    if (short && arg.startsWith('-o') && arg.length > 2) return 'write';
+    if (long && arg.startsWith('--output=')) {
+      return arg.length > 9 ? 'write' : 'unknown';
+    }
+  }
+  return null;
+}
 
-  const rest = args.slice(idx + 1);
+function evaluateGitSafety(args: string[]): ShellCommandSafety {
+  const first = args[0];
+  if (!first || first === '--version') return 'read-only';
+  if (first === '--help') return args.length === 1 ? 'read-only' : 'unknown';
+  if (first.startsWith('-')) return 'unknown';
+  const subcommand = first.toLowerCase();
+  const rest = args.slice(1);
+  const options = beforeTerminator(rest);
+  const invokesHelper =
+    options.some((arg) => GIT_EXTERNAL_HELPER_OPTION.test(arg)) ||
+    (subcommand === 'grep' && options.some((arg) => arg.startsWith('-O'))) ||
+    (['log', 'show'].includes(subcommand) &&
+      options.some((arg) => /%G[?GKFPST]/.test(arg)));
+  if (WRITE_GIT_SUBCOMMAND.test(subcommand)) {
+    const effectiveArgs =
+      subcommand === 'commit'
+        ? withoutOptionValues(rest, GIT_COMMIT_VALUE_OPTION)
+        : rest;
+    const effectiveOptions = beforeTerminator(effectiveArgs);
+    const help = hasHelp(effectiveArgs);
+    const dryRun =
+      effectiveOptions.includes('--dry-run') ||
+      (effectiveOptions.includes('-n') &&
+        ['add', 'clean', 'mv', 'push', 'rm'].includes(subcommand));
+    return help || dryRun ? 'unknown' : 'write';
+  }
+  if (!READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) return 'unknown';
+  if (['diff', 'log', 'show'].includes(subcommand)) {
+    const output = evaluateOutputOption(rest, true, false);
+    if (output) return output;
+  }
+  if (
+    subcommand === 'blame' &&
+    beforeTerminator(rest).some((arg) => /^--output(?:=|$)/.test(arg))
+  )
+    return 'unknown';
+  if (subcommand !== 'branch' && hasHelp(rest)) return 'unknown';
   if (subcommand === 'remote') {
-    return !rest.some((a) => BLOCKED_GIT_REMOTE_ACTIONS.has(a.toLowerCase()));
+    const action = rest.find((arg) => !arg.startsWith('-'))?.toLowerCase();
+    if (!action) return invokesHelper ? 'unknown' : 'read-only';
+    if (['show', 'get-url'].includes(action))
+      return rest.some((arg) =>
+        /^(?:add|remove|rm|rename|set-branches|set-head|set-url|update|prune)$/i.test(
+          arg,
+        ),
+      ) || invokesHelper
+        ? 'unknown'
+        : 'read-only';
+    if (WRITE_GIT_REMOTE_ACTION.test(action)) return 'write';
+    if (action === 'prune')
+      return rest.some((arg) => ['-n', '--dry-run'].includes(arg))
+        ? 'unknown'
+        : 'write';
+    return 'unknown';
   }
   if (subcommand === 'branch') {
-    return !rest.some((a) => BLOCKED_GIT_BRANCH_FLAGS.has(a));
+    const actions = withoutOptionValues(rest, /^--(?:format|sort)$/);
+    const actionOptions = beforeTerminator(actions);
+    if (hasHelp(actions)) return 'unknown';
+    if (actions.some((arg) => WRITE_GIT_BRANCH_FLAG.test(arg)))
+      return actionOptions.some((arg) => WRITE_GIT_BRANCH_FLAG.test(arg))
+        ? 'write'
+        : 'unknown';
+    if (actions.length !== rest.length) return 'unknown';
+    const lists = actionOptions.some((arg) => GIT_BRANCH_LIST_FLAG.test(arg));
+    if (lists) return 'read-only';
+    if (rest.some((arg) => !arg.startsWith('-'))) return 'write';
+    if (rest.includes('--')) return 'unknown';
+    if (invokesHelper) return 'unknown';
+    return rest.length === 0 ? 'read-only' : 'unknown';
   }
-  return true;
+  if (invokesHelper) return 'unknown';
+  return 'read-only';
 }
 
-function evaluateFindReadOnly(args: string[]): boolean {
-  for (const arg of args) {
-    const lower = arg.toLowerCase();
-    if (BLOCKED_FIND_FLAGS.has(lower)) return false;
-    if (BLOCKED_FIND_PREFIXES.some((p) => lower.startsWith(p))) return false;
+function evaluateFindSafety(args: string[]): ShellCommandSafety {
+  let result: ShellCommandSafety = 'read-only';
+  for (let i = 0; i < args.length; i++) {
+    const lower = args[i]!.toLowerCase();
+    if (lower === '--') return mergeSafety(result, 'unknown');
+    if (/^--(?:help|version)$/.test(lower)) return 'unknown';
+    if (FIND_VALUE_PREDICATE.test(lower)) {
+      if (!args[++i]?.match(/^[^-]/)) result = mergeSafety(result, 'unknown');
+      continue;
+    }
+    if (lower === '-delete') {
+      result = 'write';
+      continue;
+    }
+    if (BLOCKED_FIND_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+      result = 'write';
+      i += lower.startsWith('-fprintf') ? 2 : 1;
+      continue;
+    }
+    if (['-exec', '-execdir', '-ok', '-okdir'].includes(lower)) {
+      const invoked = args[i + 1]?.toLowerCase();
+      let end = -1;
+      for (let index = i + 2; index < args.length; index++) {
+        if ([';', '\\;', '+'].includes(args[index]!)) {
+          end = index;
+          break;
+        }
+      }
+      const invokedArgs = args.slice(i + 2, end < 0 ? undefined : end);
+      let nested: Safety = 'unknown';
+      if (invoked && WRITE_ROOT_COMMAND.test(invoked))
+        nested = hasHelp(invokedArgs) ? 'unknown' : 'write';
+      else if (invoked && /^(kill|killall|pkill)$/.test(invoked))
+        nested = processSafety(invoked, invokedArgs);
+      result = mergeSafety(result, nested);
+      i = end < 0 ? args.length : end;
+    }
   }
-  return true;
+  return result;
 }
 
-function evaluateSedReadOnly(args: string[]): boolean {
-  for (const arg of args) {
+function evaluateSedSafety(args: string[]): ShellCommandSafety {
+  return classifySedCommandSafety(args);
+}
+
+function evaluateAwkSafety(args: string[]): ShellCommandSafety {
+  return classifyAwkCommandSafety(args);
+}
+
+function evaluateUniqSafety(args: string[]): ShellCommandSafety {
+  let positional = 0;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === '--') {
+      return args.length - i + positional > 2 ? 'write' : 'read-only';
+    } else if (UNIQ_VALUE_OPTIONS.has(arg)) {
+      if (!args[++i]) return 'unknown';
+    } else if (arg === '-' || !arg.startsWith('-')) positional++;
+  }
+  return positional >= 2 ? 'write' : 'read-only';
+}
+
+function processSafety(root: string, args: string[]): Safety {
+  const options = beforeTerminator(args);
+  const signalZero = /^(?:SIG)?0+$/i;
+  const signalValueOptions = [
+    '--signal',
+    ...(root === 'pkill' ? [] : ['-s']),
+    ...(root === 'kill' ? ['-n'] : []),
+  ];
+  if (
+    args.length === 0 ||
+    hasHelp(args) ||
+    options.some((arg) => ['-h', '-V', '-help', '-version'].includes(arg))
+  )
+    return 'unknown';
+  if (
+    options.some(
+      (arg, index) =>
+        (/[$`*?()[\]{}]/.test(arg) &&
+          (arg.startsWith('-') ||
+            signalValueOptions.includes(options[index - 1]!))) ||
+        /^-(?:[lL0]|-(?:.*list|table)(?:=|$))/.test(arg) ||
+        (/^--signal=/.test(arg) && signalZero.test(arg.slice(9))) ||
+        /^-(?:SIG)?0+$/i.test(arg) ||
+        (root === 'kill' && /^-[sn](?:SIG)?0+$/i.test(arg)) ||
+        (root === 'killall' && /^-s(?:SIG)?0+$/i.test(arg)) ||
+        (index > 0 &&
+          signalValueOptions.includes(options[index - 1]!) &&
+          signalZero.test(arg)),
+    )
+  )
+    return 'unknown';
+  return 'write';
+}
+
+function evaluateSubstitutions(node: SyntaxNode): ShellCommandSafety {
+  const substitutions = collectDescendants(
+    node,
+    new Set(['command_substitution', 'process_substitution']),
+    true,
+  );
+  if (substitutions.length === 0) return 'read-only';
+  return mergeSafety(
+    'unknown',
+    ...substitutions
+      .flatMap((substitution) => substitution.namedChildren)
+      .map(evaluateStatementSafety),
+  );
+}
+
+function evaluateCommandSafety(commandNode: SyntaxNode): ShellCommandSafety {
+  const rawRoot = commandNode.childForFieldName('name')?.text;
+  const root = getCommandName(commandNode);
+  const argNodes = getArgumentNodes(commandNode);
+  const args = argNodes.map((node) => stripOuterQuotes(node.text));
+  let result: ShellCommandSafety;
+  if (!root) result = 'read-only';
+  else if (rawRoot !== root) result = 'unknown';
+  else if (WRITE_ROOT_COMMAND.test(root)) {
+    result = hasHelp(args) ? 'unknown' : 'write';
+  } else if (/^(kill|killall|pkill)$/.test(root)) {
+    result = processSafety(root, args);
+  } else if (root === 'git') result = evaluateGitSafety(args);
+  else if (root === 'find') result = evaluateFindSafety(args);
+  else if (root === 'sed') result = evaluateSedSafety(args);
+  else if (root === 'awk') result = evaluateAwkSafety(args);
+  else if (root === 'sort' || root === 'tree') {
+    result = evaluateOutputOption(args, root === 'sort') ?? 'read-only';
+    if (hasHelp(args, ['-o', '--output'])) result = 'unknown';
     if (
-      BLOCKED_SED_PREFIXES.some((p) => arg.startsWith(p)) ||
-      arg === '--in-place'
+      beforeTerminator(args).some(
+        (arg) =>
+          /^(?:--o|-[^-]+o)/.test(arg) ||
+          (root === 'sort' && arg.startsWith('--co')),
+      )
     ) {
-      return false;
+      result = mergeSafety(result, 'unknown');
+    }
+  } else if (root === 'uniq') {
+    result = hasHelp(args) ? 'unknown' : evaluateUniqSafety(args);
+  } else if (root === 'tee') {
+    const writesFile = args.some(
+      (arg, index) => !arg.startsWith('-') || args[index - 1] === '--',
+    );
+    result = writesFile ? 'write' : 'unknown';
+  } else if (root === 'dd') {
+    result = args.some((arg) => arg.startsWith('of=')) ? 'write' : 'unknown';
+  } else if (
+    (root === 'printf' &&
+      beforeTerminator(args).some((arg) => /^-[^-]*v/.test(arg))) ||
+    ['less', 'more'].includes(root) ||
+    (['rg', 'ripgrep'].includes(root) &&
+      beforeTerminator(args).some((arg) =>
+        /^(?:--(?:hostname-bin|pre)(?:=|$)|--search-zip$|-[^-]*z)/.test(arg),
+      ))
+  ) {
+    result = 'unknown';
+  } else {
+    result = READ_ONLY_ROOT_COMMANDS.has(root) ? 'read-only' : 'unknown';
+  }
+  if (
+    result === 'read-only' &&
+    root &&
+    /^(awk|find|git|printf|rg|ripgrep|sed|sort|tree|uniq)$/.test(root) &&
+    argNodes.some((node) => hasShellExpansion(node))
+  ) {
+    result = 'unknown';
+  }
+  if (
+    result === 'write' &&
+    !['find', 'git', 'sed', 'sort', 'tree'].includes(root ?? '') &&
+    hasHelp(args)
+  )
+    result = 'unknown';
+  const hasEnvironment = commandNode.namedChildren.some(
+    (child) => child.type === 'variable_assignment',
+  );
+  if (root && hasEnvironment) result = mergeSafety(result, 'unknown');
+  return mergeSafety(
+    result,
+    evaluateRedirectionSafety(commandNode),
+    ...commandNode.namedChildren
+      .filter((child) => !child.type.endsWith('_redirect'))
+      .map(evaluateSubstitutions),
+  );
+}
+
+function evaluateRedirectionSafety(node: SyntaxNode): ShellCommandSafety {
+  let result: ShellCommandSafety = 'read-only';
+  for (const redirect of node.namedChildren) {
+    if (!redirect.type.endsWith('_redirect')) continue;
+    result = mergeSafety(result, evaluateSubstitutions(redirect));
+    if (redirect.type !== 'file_redirect') continue;
+    const operator = redirect.children.find(
+      (child) => child.type !== 'file_descriptor',
+    );
+    if (!operator) return 'unknown';
+    if (WRITE_REDIRECT_OPERATORS.has(operator.type)) return 'write';
+    if (operator.type === '>&') {
+      const destination = redirect.childForFieldName('destination');
+      if (!destination) return 'unknown';
+      const target = stripOuterQuotes(destination.text);
+      if (/^(?:\d+|-)$/.test(target)) continue;
+      result = mergeSafety(
+        result,
+        /[$`*?()[\]{}]/.test(target) ? 'unknown' : 'write',
+      );
     }
   }
-  const scriptContent = args.join(' ');
-  return !SED_SIDE_EFFECT_PATTERNS.some((p) => p.test(scriptContent));
+  return result;
 }
 
-function evaluateAwkReadOnly(args: string[]): boolean {
-  const scriptContent = args.join(' ');
-  return !AWK_SIDE_EFFECT_PATTERNS.some((p) => p.test(scriptContent));
+function childrenSafety(node: SyntaxNode, floor: Safety = 'read-only'): Safety {
+  return mergeSafety(floor, ...node.namedChildren.map(evaluateStatementSafety));
 }
 
-// ---------------------------------------------------------------------------
-// Statement-level read-only analysis
-// ---------------------------------------------------------------------------
+function evaluateStatementSafety(node: SyntaxNode): ShellCommandSafety {
+  if (node.type === 'command') return evaluateCommandSafety(node);
+  if (CHILD_STATEMENT.test(node.type)) return childrenSafety(node);
+  if (node.type === 'redirected_statement')
+    return mergeSafety(
+      ...node.namedChildren
+        .filter((child) => !child.type.endsWith('_redirect'))
+        .map((child) => evaluateStatementSafety(child)),
+      evaluateRedirectionSafety(node),
+    );
+  if (/^variable_assignments?$/.test(node.type))
+    return mergeSafety(
+      node.parent?.namedChildCount === 1 ? 'read-only' : 'unknown',
+      evaluateSubstitutions(node),
+    );
+  if (node.type === 'function_definition') return 'unknown';
+  return childrenSafety(node, 'unknown');
+}
 
-/**
- * Recursively evaluate whether a statement AST node is read-only.
- *
- * Handles: command, pipeline, list, redirected_statement, subshell,
- * variable_assignment, negated_command, and compound statements.
- *
- * Command substitution (`$(...)`, `` `...` ``) and process substitution
- * (`<(...)`, `>(...)`) anywhere in the subtree mark the whole node as
- * NOT read-only — checked once at the top so every case below inherits
- * the guard. This matters for non-`command` node types like
- * `variable_assignment` (`FOO=$(curl evil)`) and `redirected_statement`
- * (`cat < $(curl evil)`) where the substitution sits outside any
- * `command` child. See PR #4386 round 4.
- */
-function evaluateStatementReadOnly(node: SyntaxNode): boolean {
-  if (containsCommandSubstitutionAST(node)) return false;
-
-  switch (node.type) {
-    case 'command':
-      return evaluateCommandReadOnly(node);
-
-    case 'pipeline': {
-      // All commands in the pipeline must be read-only
-      for (const child of node.namedChildren) {
-        if (!evaluateStatementReadOnly(child)) return false;
-      }
-      return true;
-    }
-
-    case 'list': {
-      // All commands joined by && / || must be read-only
-      for (const child of node.namedChildren) {
-        if (!evaluateStatementReadOnly(child)) return false;
-      }
-      return true;
-    }
-
-    case 'redirected_statement': {
-      // Write redirections make it non-read-only
-      if (hasWriteRedirection(node)) return false;
-      // Evaluate the body statement
-      const body = node.namedChildren[0];
-      return body ? evaluateStatementReadOnly(body) : true;
-    }
-
-    case 'subshell': {
-      // Evaluate all statements inside the subshell
-      for (const child of node.namedChildren) {
-        if (!evaluateStatementReadOnly(child)) return false;
-      }
-      return true;
-    }
-
-    case 'compound_statement': {
-      // { cmd1; cmd2; } – evaluate each inner statement
-      for (const child of node.namedChildren) {
-        if (!evaluateStatementReadOnly(child)) return false;
-      }
-      return true;
-    }
-
-    case 'variable_assignment':
-    case 'variable_assignments':
-      // Pure assignments without a command – read-only (just sets env)
-      return true;
-
-    case 'negated_command': {
-      const inner = node.namedChildren[0];
-      return inner ? evaluateStatementReadOnly(inner) : true;
-    }
-
-    case 'function_definition':
-      // Function definitions are not read-only operations per se
-      return false;
-
-    case 'if_statement':
-    case 'while_statement':
-    case 'for_statement':
-    case 'case_statement':
-    case 'c_style_for_statement':
-      // Control flow constructs – conservatively non-read-only
-      return false;
-
-    case 'declaration_command':
-      // export/declare/local/readonly/typeset – can modify env
-      return false;
-
-    default:
-      // Unknown node types – conservatively non-read-only
-      return false;
+async function classifyInternal(command: string): Promise<Safety> {
+  const tree = await parseShellCommand(command);
+  try {
+    const root = tree.rootNode;
+    if (root.namedChildCount === 0 || root.hasError) return 'unknown';
+    return mergeSafety(...root.namedChildren.map(evaluateStatementSafety));
+  } finally {
+    tree.delete();
   }
 }
-
-// ---------------------------------------------------------------------------
-// Public API: isShellCommandReadOnlyAST
-// ---------------------------------------------------------------------------
+export async function classifyShellCommandSafety(
+  command: string,
+): Promise<ShellCommandSafety> {
+  if (typeof command !== 'string' || !command.trim()) return 'unknown';
+  return classifyInternal(command).catch(() => 'unknown');
+}
 
 /**
  * AST-based check whether a shell command is read-only.
@@ -953,22 +1141,7 @@ export async function isShellCommandReadOnlyAST(
   }
 
   try {
-    const tree = await parseShellCommand(command);
-    const root = tree.rootNode;
-
-    // Empty program
-    if (root.namedChildCount === 0) return false;
-
-    // Evaluate every top-level statement
-    for (const stmt of root.namedChildren) {
-      if (!evaluateStatementReadOnly(stmt)) {
-        tree.delete();
-        return false;
-      }
-    }
-
-    tree.delete();
-    return true;
+    return (await classifyInternal(command)) === 'read-only';
   } catch {
     // Unexpected runtime failure (e.g. WASM init error on first call) –
     // fall back to the regex-based checker rather than propagating the error.

--- a/packages/core/src/utils/shellReadOnlyChecker.test.ts
+++ b/packages/core/src/utils/shellReadOnlyChecker.test.ts
@@ -157,6 +157,15 @@ describe('evaluateShellCommandReadOnly', () => {
       );
     });
 
+    it('rejects gawk indirect function calls', () => {
+      for (const command of [
+        'awk \'BEGIN { fn = "system"; @fn("touch /tmp/pwned") }\'',
+        'awk \'BEGIN { fn = "system"; @ fn("touch /tmp/pwned") }\'',
+      ]) {
+        expect(isShellCommandReadOnly(command)).toBe(false);
+      }
+    });
+
     it('rejects awk with file output redirection', () => {
       expect(
         isShellCommandReadOnly('awk \'{print > "output.txt"}\' input.txt'),

--- a/packages/core/src/utils/shellReadOnlyChecker.test.ts
+++ b/packages/core/src/utils/shellReadOnlyChecker.test.ts
@@ -18,6 +18,10 @@ describe('evaluateShellCommandReadOnly', () => {
     expect(result).toBe(false);
   });
 
+  it('rejects differently-cased command names', () => {
+    expect(isShellCommandReadOnly('LS -la')).toBe(false);
+  });
+
   it('rejects redirection output', () => {
     const result = isShellCommandReadOnly('ls > out.txt');
     expect(result).toBe(false);
@@ -49,9 +53,9 @@ describe('evaluateShellCommandReadOnly', () => {
     expect(result).toBe(false);
   });
 
-  it('respects environment prefix followed by allowed command', () => {
+  it('rejects environment prefix followed by allowed command', () => {
     const result = isShellCommandReadOnly('FOO=bar ls');
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   describe('multi-command security', () => {
@@ -200,7 +204,6 @@ describe('evaluateShellCommandReadOnly', () => {
     it('allows safe sed commands', () => {
       expect(isShellCommandReadOnly("sed 's/foo/bar/' file.txt")).toBe(true);
       expect(isShellCommandReadOnly("sed -n '1,5p' file.txt")).toBe(true);
-      expect(isShellCommandReadOnly("sed '/pattern/d' file.txt")).toBe(true);
     });
 
     it('rejects sed with execute command', () => {
@@ -229,6 +232,229 @@ describe('evaluateShellCommandReadOnly', () => {
       expect(
         isShellCommandReadOnly("sed --in-place 's/foo/bar/' file.txt"),
       ).toBe(false);
+    });
+  });
+
+  describe('tri-state classifier mirrors', () => {
+    it.each([
+      'sort -o output input',
+      'sort input',
+      'sort --help',
+      'sort --compress-program gzip input',
+      'sort --out=output input',
+      'sort -roout input',
+      'tree -Cofile .',
+      'sort --co=cat input',
+      'tree --output=tree.txt',
+      'tree directory',
+      'tree --help',
+      'uniq input output',
+      'uniq - output',
+      'uniq -- -f output',
+      'uniq input -- -f',
+      'uniq input',
+      'uniq -f',
+      'tee output',
+      'dd of=output',
+      'less file',
+      'more file',
+      'printf -v PATH /tmp',
+      'printf -v PATH /tmp; ls',
+      'rg --pre cat pattern',
+      'rg --hostname-bin=hostname pattern',
+      'rg -z pattern archive.gz',
+      'ripgrep -iz pattern archive.gz',
+      'rg --search-zip pattern archive.gz',
+      'rg -- -z file',
+      'git branch topic',
+      'git branch --color=always color-topic',
+      'git branch --column column-topic',
+      'git branch --sort=refname sort-topic',
+      "git branch --format='%(refname)' format-topic",
+      'git branch -v verbose-topic',
+      'git branch --edit-description',
+      'git branch -- --list',
+      'git branch --list -- -d',
+      'git branch --list --color=always topic',
+      'git branch --list topic',
+      'git remote set-url origin url',
+      'git remote unknown-action',
+      'git remote show remove',
+      'git remote get-url prune',
+      'git diff --output=patch',
+      'git log --output=log.out',
+      'git show --output=show.out HEAD',
+      'git blame --output=blame.out file',
+      'git diff --ext-diff',
+      'git --config-env=diff.external=HELPER diff',
+      'git --paginate log',
+      'git -p log',
+      'git --unknown-option status',
+      'git -- status',
+      'git --help commit',
+      'git status --help',
+      'git log --help',
+      'git diff --help',
+      'git log --show-signature -1',
+      'git show --format=%G? HEAD',
+      'GIT_EXTERNAL_DIFF=/tmp/helper git diff',
+      'FOO=bar GIT_EXTERNAL_DIFF=/tmp/helper git diff',
+      'FOO=bar ls',
+      'LD_PRELOAD=/tmp/evil.so ls',
+      'RIPGREP_CONFIG_PATH=/tmp/config rg pattern',
+      'PAGER=helper git log',
+      'git show --textconv HEAD:file',
+      'git grep --open-files-in-pager=less needle',
+      'git grep -Ovim needle',
+      'git cat-file --filters HEAD:file',
+      'git commit -m --ext-diff',
+      "git commit -m '%G?'",
+      'git add -- --help',
+      'git add -- --dry-run',
+      'touch -- --help',
+      'bash -c ls',
+      'find . -fls output',
+      'find --help',
+      'find . -name',
+      'find . -name -delete',
+      'find . -printf -delete',
+      'find . -newermt -delete',
+      'find . -samefile -delete',
+      'sed -f script.sed file',
+      'sed -e -i file',
+      'sed -f -i file',
+      'sed -e-i file',
+      'sed -- -i file',
+      "sed -I .bak 's/a/b/' file",
+      "sed -I.bak 's/a/b/' file",
+      "sed -ni.bak 's/a/b/' file",
+      "sed -nI.bak 's/a/b/' file",
+      'sed -fscript.sed file',
+      "sed --in-pl=.bak 's/a/b/' file",
+      'sed --f script.sed file',
+      'sed -newout input',
+      'sed -nEewout input',
+      'sed -es/a/b/e',
+      'sed -einstall file',
+      'sed -neinstall file',
+      "sed -e '' file",
+      "sed 's/a/printf hacked > marker/ep' file",
+      "sed 's#a#printf hacked > marker#pe' file",
+      "sed 'etouch marker' file",
+      "sed '1etouch marker' file",
+      "sed 's/a/b/woutput' file",
+      "sed 'woutput' file",
+      "sed '1woutput' file",
+      "sed '/pattern/woutput' file",
+      "sed 'W output' file",
+      "sed '1W output' file",
+      "sed 'p;w output' file",
+      "sed 's/a/b/;w output' file",
+      "sed 's/a/;/;w output' file",
+      "sed -e 's/a/b/' -e 'woutput' file",
+      'sed "$SCRIPT" file',
+      'sed s/a/*/ file',
+      "sed 's/a/b/w' file",
+      "sed 'w' file",
+      "sed '1w' file",
+      "sed 'R input' file",
+      "sed 's/a/b/' 'w file'",
+      "sed 's/a/new value/' file",
+      "sed 's/a/blue sky/' file",
+      "sed 's/a/car value/' file",
+      "sed 's/w /x/' file",
+      "sed '/p;w output/p' file",
+      "sed 's/a/;w output/' file",
+      "awk '{ print > output }' file",
+      'awk \'{ print>"output" }\' file',
+      'awk \'BEGIN { print("x")|"cat > output" }\'',
+      'awk \'BEGIN { print(1 > "0") }\'',
+      'awk \'BEGIN { printf("%d", 1 > "0") }\'',
+      'awk \'BEGIN { print "print > " "output" }\'',
+      'awk \'BEGIN { # print > "out"\nprint }\'',
+      'awk \'BEGIN { print /x; print y > "out";/ }\'',
+      'awk \'BEGIN { print x / 2 > "out" }\'',
+      "awk '{ print }' 'print > \"out\"'",
+      'awk -v mode=1 \'BEGIN { print > "out" }\' input',
+      'awk \'/pattern/ { print > "out" }\' input',
+      'awk -fscript.awk file',
+      'awk -W exec=script.awk file',
+      'awk -Wexec=script.awk file',
+      'awk "$PROGRAM" file',
+      'awk "$PROGRAM{ print }" file',
+      'sed "s/a/$SCRIPT" file',
+      'awk -v x="$VALUE" \'{ print x }\' file',
+      'awk \'@include "library.awk"\' file',
+      "awk -e '{ print }' file",
+      "awk --load extension '{ print }' file",
+      "awk --profile=report '{ print }' file",
+      'awk {print*2} file',
+      'uniq *',
+      'uniq "$FILES"',
+      'sort "$OPTIONS" input',
+      'sort {-o,output} input',
+      'find . "$EXPRESSION"',
+      'rg "$OPTIONS" pattern',
+      'git status "$OPTIONS"',
+      "awk '{ getline }' file",
+      "GIT_EXTERNAL_DIFF='touch /tmp/pwned'; git diff",
+      '(PATH=/tmp; ls)',
+      'ls |',
+      'ls | | cat',
+      'ls && && cat',
+      'ls || || cat',
+      'ls ; ; cat',
+      'ls |& | cat',
+      'ls & & cat',
+      '(; ls)',
+      '{ && ls; }',
+      '(ls |)',
+      '(ls | | cat)',
+      '(ls &&)',
+      '(ls ||)',
+    ])('does not schedule %j as read-only', (command) => {
+      expect(isShellCommandReadOnly(command)).toBe(false);
+    });
+
+    it.each([
+      'git remote get-url origin',
+      'git diff -- file',
+      'git diff -Oorderfile',
+      'git log -p',
+      'git show -p HEAD',
+      'git blame -p file',
+      'git log -- --output=log.out',
+      "sed 's/a/*/' file",
+      "sed 's/old/new/' file",
+      "sed 's/hello/world/' file",
+      "sed 's/error/warning/g' file",
+      "sed -n '/needle/p' file",
+      "sed '/pattern/d' file",
+      "sed 's/a/woutput/' file",
+      "sed 's#x#s/a/b/woutput#' file",
+      "sed 's#x#foo;woutput#' file",
+      "sed 'p;d' file",
+      "awk '{ print*2 }' file",
+      "awk -F : '{ print $1 }' input",
+    ])('preserves read-only classification for %j', (command) => {
+      expect(isShellCommandReadOnly(command)).toBe(true);
+    });
+
+    it('handles adversarial rule inputs without regex backtracking', () => {
+      const commands = [
+        `sed 's/${'\\'.repeat(10_000)}a' file`,
+        `sed '${'p;'.repeat(10_000)}' file`,
+        `awk 'BEGIN { ${'print value; '.repeat(10_000)} }'`,
+        `git status ${'\\{'.repeat(10_000)}`,
+      ];
+      const startedAt = performance.now();
+      expect(commands.map(isShellCommandReadOnly)).toEqual([
+        false,
+        true,
+        true,
+        true,
+      ]);
+      expect(performance.now() - startedAt).toBeLessThan(1000);
     });
   });
 });

--- a/packages/core/src/utils/shellReadOnlyChecker.ts
+++ b/packages/core/src/utils/shellReadOnlyChecker.ts
@@ -16,6 +16,11 @@ import {
   splitCommands,
   stripShellWrapper,
 } from './shell-utils.js';
+import {
+  classifyAwkCommandSafety,
+  classifySedCommandSafety,
+  hasShellBraceExpansion,
+} from './shell-safety-rules.js';
 
 const READ_ONLY_ROOT_COMMANDS = new Set([
   'awk',
@@ -32,21 +37,13 @@ const READ_ONLY_ROOT_COMMANDS = new Set([
   'git',
   'grep',
   'head',
-  'less',
   'ls',
-  'more',
   'printenv',
-  'printf',
   'ps',
   'pwd',
-  'rg',
-  'ripgrep',
   'sed',
-  'sort',
   'stat',
   'tail',
-  'tree',
-  'uniq',
   'wc',
   'which',
   'where',
@@ -61,7 +58,7 @@ const BLOCKED_FIND_FLAGS = new Set([
   '-okdir',
 ]);
 
-const BLOCKED_FIND_PREFIXES = ['-fprint', '-fprintf'];
+const BLOCKED_FIND_PREFIXES = ['-fls', '-fprint', '-fprintf'];
 
 const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   'blame',
@@ -81,47 +78,22 @@ const READ_ONLY_GIT_SUBCOMMANDS = new Set([
 const BLOCKED_GIT_REMOTE_ACTIONS = new Set([
   'add',
   'remove',
+  'rm',
   'rename',
+  'set-branches',
+  'set-head',
   'set-url',
   'prune',
   'update',
 ]);
+const GIT_EXTERNAL_HELPER_OPTION =
+  /(?:^--(?:ext-diff|filters|show-signature|textconv|open-files-in-pager)(?:=|$)|%G[?GKFPST])/;
 
-const BLOCKED_GIT_BRANCH_FLAGS = new Set([
-  '-d',
-  '-D',
-  '--delete',
-  '--move',
-  '-m',
-]);
-
-const BLOCKED_SED_PREFIXES = ['-i'];
-
-// AWK side-effect patterns that can execute commands or write files
-const AWK_SIDE_EFFECT_PATTERNS = [
-  /system\s*\(/, // system() function calls
-  /print\s+[^>|]*>\s*"[^"]*"/, // print > "file"
-  /printf\s+[^>|]*>\s*"[^"]*"/, // printf > "file"
-  /print\s+[^>|]*>>\s*"[^"]*"/, // print >> "file"
-  /printf\s+[^>|]*>>\s*"[^"]*"/, // printf >> "file"
-  /print\s+[^|]*\|\s*"[^"]*"/, // print | "command"
-  /printf\s+[^|]*\|\s*"[^"]*"/, // printf | "command"
-  /getline\s*<\s*"[^"]*"/, // getline < "command"
-  /"[^"]*"\s*\|\s*getline/, // "command" | getline
-  /close\s*\(/, // close() can trigger command execution
-];
-
-// SED side-effect patterns
-const SED_SIDE_EFFECT_PATTERNS = [
-  /[^\\]e\s/, // e command (execute)
-  /^e\s/, // e command at start
-  /[^\\]w\s/, // w command (write)
-  /^w\s/, // w command at start
-  /[^\\]r\s/, // r command (read file)
-  /^r\s/, // r command at start
-];
+const SAFE_SED_OPTION = /^(?:-[nErsuz]|--(?:quiet|silent))$/;
 
 const ENV_ASSIGNMENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const MALFORMED_CONTROL_OPERATOR =
+  /(?:^|[({])\s*(?:&&|\|\||\|&|[|;&])|(?:&&|\|\||\|&|[|;&])\s+(?:&&|\|\||\|&|[|;&])|(?!(?:&&|\|\||\|&))[|;&]{2}|[|;&]{3,}|(?:\|&?|&&|\|\|)\s*[)}]*\s*$/;
 
 function containsWriteRedirection(command: string): boolean {
   let inSingleQuotes = false;
@@ -158,11 +130,13 @@ function containsWriteRedirection(command: string): boolean {
 }
 
 function normalizeTokens(segment: string): string[] {
-  const parsed = parse(segment);
+  const parsed = parse(segment, (key) => `\0${key}`);
   const tokens: string[] = [];
   for (const token of parsed) {
     if (typeof token === 'string') {
       tokens.push(token);
+    } else if ('op' in token && token.op === 'glob') {
+      tokens.push(`\0${token.pattern}`);
     }
   }
   return tokens;
@@ -189,6 +163,7 @@ function skipEnvironmentAssignments(tokens: string[]): {
 
 function evaluateFindCommand(tokens: string[]): boolean {
   const [, ...rest] = tokens;
+  if (rest.at(-1)?.startsWith('-')) return false;
   for (const token of rest) {
     const lower = token.toLowerCase();
     if (BLOCKED_FIND_FLAGS.has(lower)) {
@@ -205,66 +180,47 @@ function evaluateSedCommand(tokens: string[]): boolean {
   const [, ...rest] = tokens;
   for (const token of rest) {
     if (
-      BLOCKED_SED_PREFIXES.some((prefix) => token.startsWith(prefix)) ||
-      token === '--in-place'
+      ['-i', '-I'].some((prefix) => token.startsWith(prefix)) ||
+      token === '--in-place' ||
+      token.startsWith('--in-place=') ||
+      token === '-f' ||
+      token === '--file' ||
+      (token.startsWith('-f') && token.length > 2) ||
+      token.startsWith('--file=') ||
+      (token.startsWith('-') && !SAFE_SED_OPTION.test(token))
     ) {
       return false;
     }
   }
 
-  // Check for side-effect patterns in sed script
-  const scriptContent = rest.join(' ');
-  for (const pattern of SED_SIDE_EFFECT_PATTERNS) {
-    if (pattern.test(scriptContent)) {
-      return false;
-    }
-  }
-
-  return true;
+  return classifySedCommandSafety(rest) === 'read-only';
 }
 
 function evaluateAwkCommand(tokens: string[]): boolean {
   const [, ...rest] = tokens;
-
-  // Join all arguments to check for awk script content
-  const scriptContent = rest.join(' ');
-
-  // Check for dangerous side-effect patterns
-  for (const pattern of AWK_SIDE_EFFECT_PATTERNS) {
-    if (pattern.test(scriptContent)) {
-      return false;
-    }
-  }
-
-  return true;
+  return classifyAwkCommandSafety(rest) === 'read-only';
 }
 
 function evaluateGitRemoteArgs(args: string[]): boolean {
+  const action = args.find((arg) => !arg.startsWith('-'))?.toLowerCase();
+  if (action && !['show', 'get-url'].includes(action)) return false;
   for (const arg of args) {
-    if (BLOCKED_GIT_REMOTE_ACTIONS.has(arg.toLowerCase())) {
-      return false;
-    }
+    if (BLOCKED_GIT_REMOTE_ACTIONS.has(arg.toLowerCase())) return false;
   }
   return true;
 }
 
 function evaluateGitBranchArgs(args: string[]): boolean {
-  for (const arg of args) {
-    if (BLOCKED_GIT_BRANCH_FLAGS.has(arg)) {
-      return false;
-    }
-  }
-  return true;
+  return args.length === 0 || (args.length === 1 && args[0] === '--list');
 }
 
 function evaluateGitCommand(tokens: string[]): boolean {
   let index = 1;
   while (index < tokens.length && tokens[index]!.startsWith('-')) {
-    const flag = tokens[index]!.toLowerCase();
-    if (flag === '--version' || flag === '--help') {
-      return true;
-    }
-    index++;
+    const flag = tokens[index++]!.toLowerCase();
+    if (flag === '--version') return true;
+    if (flag === '--help') return tokens.length === 2;
+    return false;
   }
 
   if (index >= tokens.length) {
@@ -277,6 +233,14 @@ function evaluateGitCommand(tokens: string[]): boolean {
   }
 
   const args = tokens.slice(index + 1);
+  const end = args.indexOf('--');
+  const options = args.slice(0, end < 0 ? args.length : end);
+  if (
+    options.some((arg) => GIT_EXTERNAL_HELPER_OPTION.test(arg)) ||
+    (subcommand === 'grep' && options.some((arg) => arg.startsWith('-O')))
+  )
+    return false;
+  if (options.some((arg) => /^(?:--help|--version)$/i.test(arg))) return false;
 
   if (subcommand === 'remote') {
     return evaluateGitRemoteArgs(args);
@@ -286,6 +250,9 @@ function evaluateGitCommand(tokens: string[]): boolean {
     return evaluateGitBranchArgs(args);
   }
 
+  if (['blame', 'diff', 'log', 'show'].includes(subcommand)) {
+    return !options.some((arg) => /^--output(?:=|$)/.test(arg));
+  }
   return true;
 }
 
@@ -300,7 +267,7 @@ function evaluateShellSegment(segment: string): boolean {
   // `stripShellWrapper`, leaving a substitution-free `echo ok` that
   // this fallback would then classify as read-only. Checking the raw
   // segment first keeps the regex-fallback path in lockstep with the
-  // AST path (`evaluateStatementReadOnly`) and the L3 gates added in
+  // AST classifier and the L3 gates added in
   // PR #4386 R6 (cid 3298521039).
   if (detectCommandSubstitution(segment)) {
     return false;
@@ -310,6 +277,7 @@ function evaluateShellSegment(segment: string): boolean {
   if (!stripped) {
     return true;
   }
+  if (stripped !== segment.trim()) return false;
 
   if (detectCommandSubstitution(stripped)) {
     return false;
@@ -328,8 +296,17 @@ function evaluateShellSegment(segment: string): boolean {
   if (!root) {
     return true;
   }
+  if (root !== tokens[0]) return false;
 
   const normalizedRoot = root.toLowerCase();
+  if (root !== normalizedRoot) return false;
+  if (
+    /^(awk|find|git|sed)$/.test(normalizedRoot) &&
+    args.some(
+      (arg) => !arg || arg.includes('\0') || hasShellBraceExpansion(arg),
+    )
+  )
+    return false;
   if (!READ_ONLY_ROOT_COMMANDS.has(normalizedRoot)) {
     return false;
   }
@@ -362,6 +339,12 @@ export function isShellCommandReadOnly(command: string): boolean {
   if (typeof command !== 'string' || !command.trim()) {
     return false;
   }
+  if (MALFORMED_CONTROL_OPERATOR.test(command)) return false;
+  if (
+    /[({;&|]\s*[A-Za-z_][A-Za-z0-9_]*=/.test(command) ||
+    /^[A-Za-z_][A-Za-z0-9_]*=.*[;&|]/s.test(command)
+  )
+    return false;
 
   const segments = splitCommands(command);
 


### PR DESCRIPTION
## What this PR does

This PR introduces an internal three-state shell safety fact layer that classifies commands as `read-only`, `write`, or `unknown`. Valid Bash syntax combines results with `write > unknown > read-only` precedence; syntax errors, parser unavailability, unsupported constructs, wrappers, and dynamic execution remain unknown. Command and process substitutions impose an unknown floor while still promoting nested known writes, and supported control-flow ASTs scan possible branches without treating function definitions as execution.

The classifier recognizes bounded mutation evidence for output redirections, direct filesystem writers, process signals, Git operations, find actions, sed and awk scripts, and explicit output modes in sort, tree, uniq, tee, and dd. Shared linear scanners keep sed and awk analysis bounded on adversarial input. Command matching is case-sensitive, parser failures fail closed for the new API, poisoned parser instances are replaced safely, and every classification tree is released exactly once.

The existing boolean API remains compatible: it returns true only for a proven read-only AST and keeps the legacy synchronous fallback when the parser cannot load or throws at runtime. The synchronous checker used by scheduling is hardened conservatively so wrappers, expansions, stateful assignments, malformed command lists, hidden output modes, and differently-cased command names stay sequential. This PR documents the contract and keeps the future Plan-mode approval routing change outside the fact layer.

## Why it's needed

Issue #6949 needs Plan mode to distinguish commands that are proven safe from commands whose behavior cannot be established statically. The current boolean result loses that uncertainty and cannot support a later one-off approval path without either over-allowing unknown commands or treating every non-read-only command as a known write. This refactor adds the missing safety fact while leaving Plan routing, approval copy, ACP behavior, and Plan exit semantics unchanged.

## Reviewer Test Plan

### How to verify

Confirm that ordinary reads such as `git status --short`, read-only pipelines, pure assignments, and subshell reads classify as `read-only`; direct writers, output redirections, Git mutations, `find -delete`, file-writing sed or awk forms, `sort -o`, and nested writers classify as `write`; and interpreters, wrappers, dynamic execution, read-only substitutions, control flow without a known write, malformed syntax, differently-cased commands, and parser failures classify as `unknown`.

Confirm that nested known writes win over an unknown floor, syntax errors do not enter the regex fallback, runtime parser failures return unknown through the new API while the compatibility API retains its fallback, and repeated initialization or parser replacement does not leak parser or tree resources. Confirm that the scheduler batches proven reads but keeps wrappers, output-writing commands, expansions, malformed command lists, and stateful assignments sequential.

Automated verification completed on macOS: 1,866 tests passed sequentially across the classifier, lazy parser runtime, compatibility checker, Shell, Monitor, PermissionManager, speculation gate, memory-scoped agent configuration, scheduler, and shell utilities. `npm run lint`, `npm run build`, `npm run typecheck`, Prettier checks, and diff whitespace checks passed. A full model-driven Plan-mode E2E run was unavailable because the configured API quota was exhausted; the checked-in design and local E2E plan preserve that follow-up verification boundary.

### Evidence (Before & After)

N/A — this is a non-UI refactor and does not change Plan-mode routing in this PR.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.4.1, Node.js v22.22.3, npm 10.9.8, local source build; the targeted unit tests are sandbox-independent.

## Risk & Scope

- Main risk or tradeoff: The classifier is intentionally bounded and conservative, so unsupported or ambiguous commands remain `unknown`; the synchronous scheduler checker is stricter and may serialize some commands that are safe in practice. Environment-prefixed commands are intentionally `unknown`; the existing exact Monitor/permission rule matcher does not normalize leading assignments, so an exact rule for such a command may still prompt.
- Not validated / out of scope: This PR does not route unknown Plan commands to one-off approval, change approval text, modify ACP or Plan exit behavior, or complete a model-driven Plan-mode E2E run because the configured API quota was unavailable. The packaged Bash parser currently throws on valid `case` statements; this PR fails those commands closed to `unknown` and rebuilds the parser for subsequent commands, while the underlying parser limitation remains follow-up work. Windows and Linux were not tested locally and are left to CI.
- Breaking changes / migration notes: None. The new API is internal to the Shell AST module and is not exported from the core package root.

## Linked Issues

Refs #6949

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 引入了一个内部三态 Shell 安全事实层，将命令分类为 `read-only`、`write` 或 `unknown`。对于有效 Bash 语法，结果按 `write > unknown > read-only` 的优先级聚合；语法错误、解析器不可用、未支持结构、包装器和动态执行均保持为 unknown。命令替换和进程替换设置 unknown 下限，同时仍会把嵌套的已知写操作提升为 write；能够成功生成 AST 的受支持控制流会扫描可能执行的分支，但不会把函数定义视为函数体已经执行。

分类器为输出重定向、直接文件系统写命令、进程信号、Git 操作、find 动作、sed 和 awk 脚本，以及 sort、tree、uniq、tee、dd 的显式输出模式识别有限且明确的修改证据。共享的线性扫描器保证 sed 和 awk 分析面对对抗性输入时仍保持有界。命令匹配区分大小写，新 API 在解析器失败时 fail closed，中毒的解析器实例会被安全替换，并且每棵用于分类的语法树都恰好释放一次。

现有布尔 API 保持兼容：只有 AST 被证明为只读时才返回 true，解析器无法加载或运行时抛错时仍保留旧同步 fallback。调度器使用的同步检查器也进行了保守加固，使包装器、展开、带状态赋值、畸形命令列表、隐藏输出模式以及大小写不同的命令名保持串行执行。本 PR 记录了完整契约，并把后续 Plan 模式审批路由变更留在事实层之外。

## 为什么需要它

#6949 要求 Plan 模式区分“已经证明安全”的命令和“无法静态确认行为”的命令。当前布尔结果丢失了这种不确定性，后续若要增加一次性审批路径，就只能在过度放行 unknown 命令和把所有非只读命令都视为已知写操作之间做错误取舍。本重构补上缺失的安全事实，同时不修改 Plan 路由、审批文案、ACP 行为或 Plan 退出语义。

## Reviewer Test Plan

### 如何验证

确认 `git status --short`、只读管道、纯赋值和子 Shell 读取等普通读取命令分类为 `read-only`；直接写命令、输出重定向、Git 修改命令、`find -delete`、sed 或 awk 的文件写入形式、`sort -o` 以及嵌套写命令分类为 `write`；解释器、包装器、动态执行、只读替换、不含已知写操作的控制流、畸形语法、大小写不同的命令和解析器失败分类为 `unknown`。

确认嵌套已知写操作优先于 unknown 下限，语法错误不会进入 regex fallback，解析器运行时失败时新 API 返回 unknown 而兼容 API 保留 fallback，并且重复初始化或解析器替换不会泄漏解析器和语法树资源。确认调度器可以并发批处理已证明只读的命令，但包装器、输出写入命令、展开、畸形命令列表和带状态赋值保持串行。

已在 macOS 完成自动验证：分类器、lazy parser runtime、兼容检查器、Shell、Monitor、PermissionManager、speculation gate、memory-scoped agent 配置、scheduler 和 shell utilities 共 1,866 个测试顺序通过。`npm run lint`、`npm run build`、`npm run typecheck`、Prettier 检查和 diff 空白检查均通过。由于配置的 API quota 已耗尽，未能完成完整的模型驱动 Plan 模式 E2E；已提交的设计文档和本地 E2E 计划保留了该后续验证边界。

### 证据（修改前后）

N/A——这是一个非 UI 重构，本 PR 不修改 Plan 模式路由。

### 测试平台

|     OS     |     状态      |
| :--------: | :-----------: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未本地测试 |
|  🐧 Linux  | ⚠️ 未本地测试 |

### 环境（可选）

macOS 26.4.1，Node.js v22.22.3，npm 10.9.8，本地源码构建；相关单元测试不依赖 sandbox。

## 风险与范围

- 主要风险或取舍：分类器有意保持有限和保守，未支持或有歧义的命令统一返回 `unknown`；同步调度检查器更严格，因此部分实际安全的命令可能被串行执行。带环境变量前缀的命令会有意归为 `unknown`；现有 Monitor/permission 精确规则匹配器不会归一化前导赋值，因此为这类命令配置精确规则后仍可能提示审批。
- 未验证 / 范围外：本 PR 不把 unknown 的 Plan 命令路由到一次性审批，不修改审批文案，不改 ACP 或 Plan 退出行为。由于配置的 API quota 不可用，未完成模型驱动的 Plan 模式 E2E。当前打包的 Bash parser 会在合法 `case` 语句上抛错；本 PR 会将其 fail closed 为 `unknown` 并为后续命令重建 parser，底层 parser 限制留待后续处理。Windows 和 Linux 未在本地测试，留给 CI 验证。
- 破坏性变更 / 迁移说明：无。新 API 仅为 Shell AST 模块内部导出，不从 core 包根入口导出。

## 关联 Issue

Refs #6949

</details>
