### PR TITLE
fix(web-shell): use formatSettingCategory for fallback UI category

### DIFF
--- a/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
@@ -222,6 +222,22 @@ describe('SettingsMessage user-scope editing', () => {
     expect(onSubDialog).toHaveBeenCalledWith('fastModel', 'user');
   });
 
+  it('shows a fallback UI category with a readable label when no theme setting exists', () => {
+    const setValue = vi.fn(() =>
+      Promise.resolve({} as DaemonSettingUpdateResult),
+    );
+    // boolSetting has key 'general.testFlag' — no 'ui.theme', so the
+    // fallback UI category branch is exercised.
+    const container = renderPanel(makeState([boolSetting()], setValue));
+
+    const nav = container.querySelector('nav');
+    const labels = Array.from(nav?.querySelectorAll('span') ?? []).map(
+      (s) => s.textContent,
+    );
+    expect(labels).toContain('UI');
+    expect(labels).not.toContain('settings.category.UI');
+  });
+
   it('renders the model-management block inside the Model category', () => {
     const setValue = vi.fn(() =>
       Promise.resolve({} as DaemonSettingUpdateResult),

--- a/packages/web-shell/client/components/messages/SettingsMessage.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.tsx
@@ -451,8 +451,8 @@ export function SettingsMessage({
       themeGroup.items.splice(themeIndex + 1, 0, localItem);
     } else {
       groups.push({
-        id: t('settings.category.UI'),
-        label: t('settings.category.UI'),
+        id: formatSettingCategory('UI', t),
+        label: formatSettingCategory('UI', t),
         items: [localItem],
       });
     }

--- a/packages/web-shell/client/components/messages/SettingsMessage.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.tsx
@@ -451,7 +451,7 @@ export function SettingsMessage({
       themeGroup.items.splice(themeIndex + 1, 0, localItem);
     } else {
       groups.push({
-        id: formatSettingCategory('UI', t),
+        id: 'UI',
         label: formatSettingCategory('UI', t),
         items: [localItem],
       });


### PR DESCRIPTION
## What this PR does

When the theme setting doesn't belong to any daemon-provided category group, the settings panel manually creates a fallback "UI" category. This fallback path used a direct `t('settings.category.UI')` call, but that key only exists in the Chinese dictionary. English users would see the raw i18n key string `settings.category.UI` instead of a readable label. This PR switches to `formatSettingCategory()` — the same helper that `groupByCategory` already uses for all other categories — so the label gracefully falls back to the daemon-provided name when no translation exists.

## Why it's needed

English-locale users see the literal string `settings.category.UI` as a settings tab label when the theme setting isn't grouped by the daemon. This is a visible i18n regression that `formatSettingCategory` was already designed to prevent.

## Reviewer Test Plan

### How to verify

1. Run the web shell with English locale.
2. Open a settings message where the theme setting is not in any daemon category group (edge case — the daemon must not provide a "UI" category).
3. Confirm the fallback category tab shows "UI" instead of `settings.category.UI`.
4. With Chinese locale, confirm it still shows "界面".

### Evidence (Before & After)

N/A — internal i18n fallback fix, hard to trigger without a specific daemon configuration.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

`npm run dev`

## Risk & Scope

- Main risk or tradeoff: None — this aligns the fallback path with the existing `groupByCategory` behavior.
- Not validated / out of scope: Other i18n issues in web-shell (hardcoded strings in MessageList, ChatEditor, etc.) are tracked separately.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的作用

当主题设置不属于任何 daemon 提供的分类组时，设置面板会手动创建一个备用的 "UI" 分类。该备用路径直接调用了 `t('settings.category.UI')`，但这个 key 只存在于中文词典中。英文用户会看到原始的 i18n key 字符串 `settings.category.UI`，而非可读的标签。本 PR 将其改为使用 `formatSettingCategory()` —— 与 `groupByCategory` 处理其他所有分类时使用的同一个辅助函数 —— 使得在没有翻译时能优雅地回退到 daemon 提供的名称。

## 为什么需要

英文环境用户在主题设置未被 daemon 分组时，会看到字面量 `settings.category.UI` 作为设置标签页名称。这是一个可见的国际化回退问题，而 `formatSettingCategory` 本就是为了防止此类情况而设计的。

## 审阅测试计划

### 如何验证

1. 以英文环境运行 web shell。
2. 打开一个主题设置未被归入任何 daemon 分类的设置消息（边缘场景 —— daemon 未提供 "UI" 分类）。
3. 确认备用分类标签页显示 "UI" 而非 `settings.category.UI`。
4. 以中文环境确认仍显示 "界面"。

### 前后对比证据

N/A —— 内部 i18n 回退修复，需特定 daemon 配置才能触发。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 运行环境

`npm run dev`

## 风险与范围

- 主要风险或权衡：无 —— 仅将备用路径与已有的 `groupByCategory` 行为对齐。
- 未验证 / 不在范围内：web-shell 中的其他国际化问题（MessageList、ChatEditor 等中的硬编码字符串）另行跟踪。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
