### PR TITLE
fix(i18n): correct "extenison" typo in extension enable/disable scope help

### DIFF
--- a/packages/cli/src/commands/extensions/disable.ts
+++ b/packages/cli/src/commands/extensions/disable.ts
@@ -46,7 +46,7 @@ export const disableCommand: CommandModule = {
         type: 'string',
       })
       .option('scope', {
-        describe: t('The scope to disable the extenison in.'),
+        describe: t('The scope to disable the extension in.'),
         type: 'string',
         default: SettingScope.User,
       })

--- a/packages/cli/src/commands/extensions/enable.ts
+++ b/packages/cli/src/commands/extensions/enable.ts
@@ -54,7 +54,7 @@ export const enableCommand: CommandModule = {
       })
       .option('scope', {
         describe: t(
-          'The scope to enable the extenison in. If not set, will be enabled in all scopes.',
+          'The scope to enable the extension in. If not set, will be enabled in all scopes.',
         ),
         type: 'string',
       })

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -653,7 +653,7 @@ export default {
     "Incloeu el nom de l'extensió a desinstal·lar com a argument posicional.",
   'Enables an extension.': 'Activa una extensió.',
   'The name of the extension to enable.': "El nom de l'extensió a activar.",
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     "L'àmbit en el qual activar l'extensió. Si no s'estableix, s'activarà en tots els àmbits.",
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'L\'extensió "{{name}}" s\'ha activat correctament per a l\'àmbit "{{scope}}".',
@@ -663,7 +663,7 @@ export default {
     'Àmbit no vàlid: {{scope}}. Useu un dels següents: {{scopes}}.',
   'Disables an extension.': 'Desactiva una extensió.',
   'The name of the extension to disable.': "El nom de l'extensió a desactivar.",
-  'The scope to disable the extenison in.':
+  'The scope to disable the extension in.':
     "L'àmbit en el qual desactivar l'extensió.",
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'L\'extensió "{{name}}" s\'ha desactivat correctament per a l\'àmbit "{{scope}}".',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -586,7 +586,7 @@ export default {
   'Enables an extension.': 'Aktiviert eine Erweiterung.',
   'The name of the extension to enable.':
     'Der Name der zu aktivierenden Erweiterung.',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     'Der Bereich, in dem die Erweiterung aktiviert werden soll. Wenn nicht gesetzt, wird sie in allen Bereichen aktiviert.',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'Erweiterung "{{name}}" erfolgreich für Bereich "{{scope}}" aktiviert.',
@@ -597,7 +597,7 @@ export default {
   'Disables an extension.': 'Deaktiviert eine Erweiterung.',
   'The name of the extension to disable.':
     'Der Name der zu deaktivierenden Erweiterung.',
-  'The scope to disable the extenison in.':
+  'The scope to disable the extension in.':
     'Der Bereich, in dem die Erweiterung deaktiviert werden soll.',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'Erweiterung "{{name}}" erfolgreich für Bereich "{{scope}}" deaktiviert.',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -928,8 +928,8 @@ export default {
   'Enables an extension.': 'Enables an extension.',
   'The name of the extension to enable.':
     'The name of the extension to enable.',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
-    'The scope to enable the extenison in. If not set, will be enabled in all scopes.',
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
+    'The scope to enable the extension in. If not set, will be enabled in all scopes.',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'Extension "{{name}}" successfully enabled for scope "{{scope}}".',
   'Extension "{{name}}" successfully enabled in all scopes.':
@@ -939,8 +939,8 @@ export default {
   'Disables an extension.': 'Disables an extension.',
   'The name of the extension to disable.':
     'The name of the extension to disable.',
-  'The scope to disable the extenison in.':
-    'The scope to disable the extenison in.',
+  'The scope to disable the extension in.':
+    'The scope to disable the extension in.',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'Extension "{{name}}" successfully disabled for scope "{{scope}}".',
   'Extension "{{name}}" successfully updated: {{oldVersion}} → {{newVersion}}.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -661,7 +661,7 @@ export default {
     "Veuillez inclure le nom de l'extension à désinstaller comme argument positionnel.",
   'Enables an extension.': 'Active une extension.',
   'The name of the extension to enable.': "Le nom de l'extension à activer.",
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     "La portée dans laquelle activer l'extension. Si non définie, sera activée dans toutes les portées.",
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'Extension "{{name}}" activée avec succès pour la portée "{{scope}}".',
@@ -672,7 +672,7 @@ export default {
   'Disables an extension.': 'Désactive une extension.',
   'The name of the extension to disable.':
     "Le nom de l'extension à désactiver.",
-  'The scope to disable the extenison in.':
+  'The scope to disable the extension in.':
     "La portée dans laquelle désactiver l'extension.",
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'Extension "{{name}}" désactivée avec succès pour la portée "{{scope}}".',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1686,7 +1686,7 @@ export default {
     'アンインストールする拡張機能名を位置引数として指定してください。',
   'Enables an extension.': '拡張機能を有効にします。',
   'The name of the extension to enable.': '有効化する拡張機能の名前。',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     '拡張機能を有効化するスコープ。未指定の場合はすべてのスコープで有効化されます。',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'スコープ "{{scope}}" で拡張機能 "{{name}}" を正常に有効化しました。',
@@ -1696,7 +1696,7 @@ export default {
     '無効なスコープです: {{scope}}。{{scopes}} のいずれかを指定してください。',
   'Disables an extension.': '拡張機能を無効にします。',
   'The name of the extension to disable.': '無効化する拡張機能の名前。',
-  'The scope to disable the extenison in.': '拡張機能を無効化するスコープ。',
+  'The scope to disable the extension in.': '拡張機能を無効化するスコープ。',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'スコープ "{{scope}}" で拡張機能 "{{name}}" を正常に無効化しました。',
   'Extension "{{name}}" successfully updated: {{oldVersion}} → {{newVersion}}.':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -606,7 +606,7 @@ export default {
     'Inclua o nome da extensão para desinstalar como um argumento posicional.',
   'Enables an extension.': 'Ativa uma extensão.',
   'The name of the extension to enable.': 'O nome da extensão para ativar.',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     'O escopo para ativar a extensão. Se não definido, será ativada em todos os escopos.',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'Extensão "{{name}}" ativada com sucesso para o escopo "{{scope}}".',
@@ -616,7 +616,7 @@ export default {
     'Escopo inválido: {{scope}}. Use um de {{scopes}}.',
   'Disables an extension.': 'Desativa uma extensão.',
   'The name of the extension to disable.': 'O nome da extensão para desativar.',
-  'The scope to disable the extenison in.':
+  'The scope to disable the extension in.':
     'O escopo para desativar a extensão.',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'Extensão "{{name}}" desativada com sucesso para o escopo "{{scope}}".',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -604,7 +604,7 @@ export default {
     'Пожалуйста, укажите имя удаляемого расширения как позиционный аргумент.',
   'Enables an extension.': 'Включает расширение.',
   'The name of the extension to enable.': 'Имя включаемого расширения.',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     'Область для включения расширения. Если не задана, будет включено во всех областях.',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     'Расширение "{{name}}" успешно включено для области "{{scope}}".',
@@ -614,7 +614,7 @@ export default {
     'Недопустимая область: {{scope}}. Пожалуйста, используйте одну из {{scopes}}.',
   'Disables an extension.': 'Отключает расширение.',
   'The name of the extension to disable.': 'Имя отключаемого расширения.',
-  'The scope to disable the extenison in.':
+  'The scope to disable the extension in.':
     'Область для отключения расширения.',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     'Расширение "{{name}}" успешно отключено для области "{{scope}}".',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -867,7 +867,7 @@ export default {
     '請將要卸載的擴展名稱作為位置參數。',
   'Enables an extension.': '啟用擴展。',
   'The name of the extension to enable.': '要啟用的擴展名稱。',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     '啟用擴展的作用域。如果未設置，將在所有作用域中啟用。',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     '擴展 "{{name}}" 已在作用域 "{{scope}}" 中啟用。',
@@ -877,7 +877,7 @@ export default {
     '無效的作用域：{{scope}}。請使用 {{scopes}} 之一。',
   'Disables an extension.': '禁用擴展。',
   'The name of the extension to disable.': '要禁用的擴展名稱。',
-  'The scope to disable the extenison in.': '禁用擴展的作用域。',
+  'The scope to disable the extension in.': '禁用擴展的作用域。',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     '擴展 "{{name}}" 已在作用域 "{{scope}}" 中禁用。',
   'Extension "{{name}}" successfully updated: {{oldVersion}} → {{newVersion}}.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -911,7 +911,7 @@ export default {
     '请将要卸载的扩展名称作为位置参数。',
   'Enables an extension.': '启用扩展。',
   'The name of the extension to enable.': '要启用的扩展名称。',
-  'The scope to enable the extenison in. If not set, will be enabled in all scopes.':
+  'The scope to enable the extension in. If not set, will be enabled in all scopes.':
     '启用扩展的作用域。如果未设置，将在所有作用域中启用。',
   'Extension "{{name}}" successfully enabled for scope "{{scope}}".':
     '扩展 "{{name}}" 已在作用域 "{{scope}}" 中启用。',
@@ -921,7 +921,7 @@ export default {
     '无效的作用域：{{scope}}。请使用 {{scopes}} 之一。',
   'Disables an extension.': '禁用扩展。',
   'The name of the extension to disable.': '要禁用的扩展名称。',
-  'The scope to disable the extenison in.': '禁用扩展的作用域。',
+  'The scope to disable the extension in.': '禁用扩展的作用域。',
   'Extension "{{name}}" successfully disabled for scope "{{scope}}".':
     '扩展 "{{name}}" 已在作用域 "{{scope}}" 中禁用。',
   'Extension "{{name}}" successfully updated: {{oldVersion}} → {{newVersion}}.':


### PR DESCRIPTION
## What this PR does

Fixes the misspelling **"extenison" → "extension"** in the `extensions enable` / `extensions disable` command help, and in the matching i18n lookup keys across all 9 locale files.

## Why it's needed

Both commands describe their `--scope` flag with a typo:

- `enable`: `The scope to enable the extenison in. If not set, will be enabled in all scopes.`
- `disable`: `The scope to disable the extenison in.`

These strings are shown in `--help` output. Because the i18n system uses the **English source string as the lookup key**, the same misspelling appears as the key in every locale file (`en, zh, zh-TW, ja, fr, de, pt, ru, ca`). Fixing only the source would change the key and break the translation lookup, silently dropping the localized text. So the source strings and every locale key are corrected together (22 occurrences across 11 files); the translated *values* (e.g. `拡張機能を無効化するスコープ。`) don't contain the typo and are left untouched.

## Reviewer Test Plan

### How to verify

- `grep -rn extenison packages` returns nothing.
- The source strings in `enable.ts` / `disable.ts` still match their locale keys, so `t(...)` lookups resolve (i.e. no fallback to the raw English string for non-English locales).
- `npx vitest run src/i18n/index.test.ts` from `packages/cli` passes (11/11) — this exercises key resolution.

### Evidence (Before & After)

`extensions enable --help` scope description:
Before: `The scope to enable the extenison in. If not set, will be enabled in all scopes.`
After: `The scope to enable the extension in. If not set, will be enabled in all scopes.`

`extensions disable --help` scope description:
Before: `The scope to disable the extenison in.`
After: `The scope to disable the extension in.`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: `src/i18n/index.test.ts` passes (11/11); `prettier --check` + `eslint` clean on all 11 changed files; verified 0 remaining occurrences of the typo and that source strings match locale keys. (`src/i18n/mustTranslateKeys.test.ts` fails to load on both this branch and clean `main` due to an unrelated unbuilt workspace dep, `@qwen-code/channel-base` — pre-existing, not affected by this change.) Windows/Linux: N/A — pure string edit with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code` CLI workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none of note. Purely a spelling correction in user-facing help text and the matching i18n keys; no logic changes. Source and all locale keys were updated in lockstep (verified 0 remaining), so translation lookups continue to resolve and localized values are unchanged.
- Not validated / out of scope: no other strings or command behavior touched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `extensions enable` / `extensions disable` 命令帮助文本中的拼写错误 **"extenison" → "extension"**，并同步修正所有 9 个语言文件中对应的 i18n 查找键。

## 为什么需要

两个命令对 `--scope` 参数的描述均存在拼写错误：

- `enable`：`The scope to enable the extenison in. If not set, will be enabled in all scopes.`
- `disable`：`The scope to disable the extenison in.`

这些字符串会显示在 `--help` 输出中。由于 i18n 系统使用**英文源字符串作为查找键**，同样的拼写错误也出现在每个语言文件的键中（`en, zh, zh-TW, ja, fr, de, pt, ru, ca`）。若仅修改源代码，键会改变并导致翻译查找失败，从而悄悄丢失本地化文本。因此源字符串与所有语言键一并修正（11 个文件共 22 处）；翻译后的**值**（如 `拡張機能を無効化するスコープ。`）不含该拼写错误，保持不变。

## 复核测试计划

### 如何验证

- `grep -rn extenison packages` 无任何结果。
- `enable.ts` / `disable.ts` 中的源字符串仍与语言键匹配，因此 `t(...)` 查找可正常解析（非英文语言不会回退到原始英文字符串）。
- 在 `packages/cli` 下运行 `npx vitest run src/i18n/index.test.ts` 通过（11/11）——该用例覆盖键解析。

### 证据（修复前后对比）

`extensions enable --help` 的 scope 描述：
修复前：`The scope to enable the extenison in. If not set, will be enabled in all scopes.`
修复后：`The scope to enable the extension in. If not set, will be enabled in all scopes.`

`extensions disable --help` 的 scope 描述：
修复前：`The scope to disable the extenison in.`
修复后：`The scope to disable the extension in.`

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：`src/i18n/index.test.ts` 通过（11/11）；11 个改动文件的 `prettier --check` 与 `eslint` 均无问题；确认无残留拼写错误且源字符串与语言键匹配。（`src/i18n/mustTranslateKeys.test.ts` 在本分支与干净的 `main` 上均因无关的未构建工作区依赖 `@qwen-code/channel-base` 而无法加载——属既有问题，与本次改动无关。）Windows/Linux：N/A——纯字符串编辑，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code` CLI 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：基本没有。仅为用户可见帮助文本及对应 i18n 键的拼写修正，无逻辑改动。源与所有语言键同步更新（确认无残留），翻译查找仍可解析，本地化值不变。
- 未验证 / 范围之外：未改动其他字符串或命令行为。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
