### PR TITLE
chore: fix typos in code comments and a Java SDK example

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -385,7 +385,7 @@ export async function main() {
         ),
       );
     }
-    // We intentially omit the list of extensions here because extensions
+    // We intentionally omit the list of extensions here because extensions
     // should not impact auth or setting up the sandbox.
     // TODO(jacobr): refactor loadCliConfig so there is a minimal version
     // that only initializes enough config to enable refreshAuth or find

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -21,7 +21,7 @@ import { type ReactNode } from 'react';
 export type { ThoughtSummary };
 
 export enum AuthState {
-  // Attemtping to authenticate or re-authenticate
+  // Attempting to authenticate or re-authenticate
   Unauthenticated = 'unauthenticated',
   // Auth dialog is open for user to select auth method
   Updating = 'updating',

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -226,7 +226,7 @@ export class MockModifiableTool
   extends BaseDeclarativeTool<Record<string, unknown>, ToolResult>
   implements ModifiableDeclarativeTool<Record<string, unknown>>
 {
-  // Should be overrided in test file. Functionality will be updated in follow
+  // Should be overridden in test file. Functionality will be updated in follow
   // up PR which has MockModifiableTool expect MockTool
   executeFn: (params: Record<string, unknown>) => ToolResult | undefined = () =>
     undefined;

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/example/SessionExample.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/example/SessionExample.java
@@ -163,7 +163,7 @@ public class SessionExample {
     public static void runPromptUseLowLevelEventExample(Session session) {
         try {
             session.setPermissionMode(PermissionMode.YOLO);
-            session.sendPrompt("devlop Fibonacci function by python", new SessionEventSimpleConsumers() {
+            session.sendPrompt("develop Fibonacci function by python", new SessionEventSimpleConsumers() {
                 @Override
                 public void onAssistantMessage(Session session, SDKAssistantMessage assistantMessage) {
                     logger.info("Received assistantMessage {}", JSON.toJSONString(assistantMessage));
@@ -212,7 +212,7 @@ public class SessionExample {
 
     public static void runPromptUseHighLevelEventExample(Session session) {
         try {
-            session.sendPrompt("devlop Fibonacci function by python", new SessionEventSimpleConsumers().setAssistantContentConsumer(new AssistantContentSimpleConsumers(){
+            session.sendPrompt("develop Fibonacci function by python", new SessionEventSimpleConsumers().setAssistantContentConsumer(new AssistantContentSimpleConsumers(){
                 @Override
                 public void onText(Session session, TextAssistantContent textAssistantContent) {
                     logger.info("Received textAssistantContent {}", textAssistantContent.getText());


### PR DESCRIPTION
## What this PR does

Fixes four spelling typos in code comments and one Java SDK example prompt. No behavior changes.

| Typo | Fix | Location |
| --- | --- | --- |
| `intentially` | `intentionally` | `packages/cli/src/gemini.tsx` (comment) |
| `Attemtping` | `Attempting` | `packages/cli/src/ui/types.ts` (comment) |
| `overrided` | `overridden` | `packages/core/src/test-utils/mock-tool.ts` (comment) |
| `devlop` ×2 | `develop` | `packages/sdk-java/.../SessionExample.java` (example prompt string) |

## Why it's needed

Minor readability cleanup. These are grouped into one PR rather than four micro-PRs to keep review overhead low.

## Reviewer Test Plan

### How to verify

- `grep -rn -e intentially -e Attemtping -e overrided -e devlop packages --include='*.ts' --include='*.tsx' --include='*.java'` returns nothing (remaining hits, if any, are only in generated `dist/` / `coverage/` artifacts that regenerate on build).
- Changes are limited to comments and one test-example string; no logic is touched.

### Evidence (Before & After)

- `gemini.tsx`: `// We intentially omit the list of extensions …` → `// We intentionally omit the list of extensions …`
- `types.ts`: `// Attemtping to authenticate or re-authenticate` → `// Attempting to authenticate or re-authenticate`
- `mock-tool.ts`: `// Should be overrided in test file. …` → `// Should be overridden in test file. …`
- `SessionExample.java`: `session.sendPrompt("devlop Fibonacci function by python", …)` → `session.sendPrompt("develop Fibonacci function by python", …)` (both call sites)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: `prettier --check` + `eslint` clean on the three TypeScript files; confirmed git tracks only the four intended source files (generated `dist/`/`coverage/` copies are git-ignored). The Java change is a string literal in a test example. Windows/Linux: N/A — comment/string edits with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code` monorepo.

## Risk & Scope

- Main risk or tradeoff: none. Comment and example-string spelling only; no runtime code paths affected.
- Not validated / out of scope: no functional or test-logic changes.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复代码注释中的四处拼写错误，以及一个 Java SDK 示例提示语。无行为改动。

| 拼写错误 | 修正 | 位置 |
| --- | --- | --- |
| `intentially` | `intentionally` | `packages/cli/src/gemini.tsx`（注释） |
| `Attemtping` | `Attempting` | `packages/cli/src/ui/types.ts`（注释） |
| `overrided` | `overridden` | `packages/core/src/test-utils/mock-tool.ts`（注释） |
| `devlop` ×2 | `develop` | `packages/sdk-java/.../SessionExample.java`（示例提示字符串） |

## 为什么需要

轻量的可读性清理。将这些合并到一个 PR 而非四个微型 PR，以降低复核开销。

## 复核测试计划

### 如何验证

- `grep -rn -e intentially -e Attemtping -e overrided -e devlop packages --include='*.ts' --include='*.tsx' --include='*.java'` 无任何结果（若仍有命中，仅存在于会在构建时重新生成的 `dist/` / `coverage/` 产物中）。
- 改动仅限注释与一个测试示例字符串，未触及任何逻辑。

### 证据（修复前后对比）

- `gemini.tsx`：`// We intentially omit the list of extensions …` → `// We intentionally omit the list of extensions …`
- `types.ts`：`// Attemtping to authenticate or re-authenticate` → `// Attempting to authenticate or re-authenticate`
- `mock-tool.ts`：`// Should be overrided in test file. …` → `// Should be overridden in test file. …`
- `SessionExample.java`：`session.sendPrompt("devlop Fibonacci function by python", …)` → `session.sendPrompt("develop Fibonacci function by python", …)`（两处调用）

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：三个 TypeScript 文件的 `prettier --check` 与 `eslint` 均无问题；确认 git 仅跟踪四个目标源文件（生成的 `dist/`/`coverage/` 副本已被 git 忽略）。Java 改动为测试示例中的字符串字面量。Windows/Linux：N/A——注释/字符串编辑，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code` monorepo。

## 风险与影响范围

- 主要风险或权衡：无。仅为注释与示例字符串的拼写修正，不影响任何运行时代码路径。
- 未验证 / 范围之外：无功能或测试逻辑改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
