### PR TITLE
fix(ask-user-question): accept long headers and size chips to the container width

### DIFF
--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { AskUserQuestionDialog } from './AskUserQuestionDialog.js';
+import {
+  AskUserQuestionDialog,
+  computeHeaderCap,
+} from './AskUserQuestionDialog.js';
 import type { ToolAskUserQuestionConfirmationDetails } from '@qwen-code/qwen-code-core';
 import { ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import { renderWithProviders } from '../../../test-utils/render.js';
@@ -70,6 +73,53 @@ const createConfirmationDetails = (
   ...overrides,
 });
 
+describe('computeHeaderCap', () => {
+  const NO_CLIP = Number.MAX_SAFE_INTEGER;
+
+  it('does not clip when every header fits at its natural width', () => {
+    expect(computeHeaderCap([5, 8, 3], 100)).toBe(NO_CLIP);
+  });
+
+  it("reclaims a short header's slack so a longer one stays full", () => {
+    // An equal split of 30 across two headers would cap at 15 and clip the
+    // 19-wide header; water-filling gives the short header only 2 and lets the
+    // long one keep all 19.
+    expect(computeHeaderCap([2, 19], 30)).toBe(NO_CLIP);
+  });
+
+  it('clips so that the clipped headers fit the available width', () => {
+    const widths = [20, 18, 22];
+    const cap = computeHeaderCap(widths, 30);
+    const used = widths.reduce((sum, w) => sum + Math.min(w, cap), 0);
+    expect(cap).toBeLessThan(Math.max(...widths));
+    expect(used).toBeLessThanOrEqual(30);
+  });
+
+  it('is maximal — one more cell of cap would overflow the budget', () => {
+    const widths = [20, 18, 22];
+    const available = 30;
+    const cap = computeHeaderCap(widths, available);
+    const usedAt = (c: number) =>
+      widths.reduce((sum, w) => sum + Math.min(w, c), 0);
+    expect(usedAt(cap)).toBeLessThanOrEqual(available);
+    expect(usedAt(cap + 1)).toBeGreaterThan(available);
+  });
+
+  it('does not clip an empty or all-zero header set', () => {
+    expect(computeHeaderCap([], 0)).toBe(NO_CLIP);
+    expect(computeHeaderCap([0, 0], 0)).toBe(NO_CLIP);
+  });
+
+  it('gives a one-cell budget to the only header that needs clipping', () => {
+    expect(computeHeaderCap([0, 100], 1)).toBe(1);
+  });
+
+  it('never returns a negative cap when there is no room', () => {
+    expect(computeHeaderCap([10, 10], 0)).toBe(0);
+    expect(computeHeaderCap([10, 10], -5)).toBe(0);
+  });
+});
+
 describe('<AskUserQuestionDialog />', () => {
   describe('rendering', () => {
     it('renders single question with options', () => {
@@ -79,6 +129,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -99,6 +150,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -113,6 +165,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -127,6 +180,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -151,6 +205,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -162,6 +217,170 @@ describe('<AskUserQuestionDialog />', () => {
       expect(output).toContain('Switch tabs');
     });
 
+    it('renders an over-length header in full for a single question', () => {
+      // Regression: a header longer than the old 12-char cap (e.g.
+      // "Target config", 13 chars) must render. For a single question the
+      // header is on its own line, so it is shown in full — not truncated.
+      const details = createConfirmationDetails({
+        questions: [createSingleQuestion({ header: 'Target config' })],
+      });
+      const onConfirm = vi.fn();
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={80}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      expect(lastFrame()).toContain('Target config');
+    });
+
+    it('shows an over-length header in full when the tab row has room', () => {
+      // The 12-char limit is only guidance. In a normal-width terminal the tab
+      // row has ample space, so an over-length header (e.g. "Target config",
+      // 13 chars) is shown in full rather than clipped.
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: 'Target config' }),
+          createSingleQuestion({
+            header: 'Q2',
+            question: 'Second question?',
+          }),
+        ],
+      });
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={100}
+          onConfirm={vi.fn()}
+        />,
+      );
+
+      const output = lastFrame();
+      expect(output).toContain('Target config');
+      expect(output).not.toContain('Target conf…');
+    });
+
+    it('clips an over-length header and keeps the row within width when space is tight', () => {
+      // In a narrow terminal the headers cannot all fit, so an over-length
+      // header is truncated with an ellipsis and the row stays within width.
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: 'Target config' }),
+          createSingleQuestion({
+            header: 'Q2',
+            question: 'Second question?',
+          }),
+        ],
+      });
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={28}
+          onConfirm={vi.fn()}
+        />,
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('Target config'); // clipped
+      expect(output).toContain('…');
+    });
+
+    it('clips a wide CJK header width-aware when space is tight', () => {
+      // CJK characters occupy two cells each; the width-aware clip must bound
+      // them correctly rather than by character count.
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: '目标配置参数设置' }),
+          createSingleQuestion({
+            header: 'Q2',
+            question: 'Second question?',
+          }),
+        ],
+      });
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={28}
+          onConfirm={vi.fn()}
+        />,
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('目标配置参数设置'); // clipped
+      expect(output).toContain('…');
+    });
+
+    it('keeps a long header full when a short neighbor leaves room', () => {
+      // Water-filling reclaims a short header's unused width for a longer one:
+      // an equal split would clip "Configuration Params" to half the row, but
+      // since "Q1" needs almost nothing, the long header stays full.
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: 'Q1' }),
+          createSingleQuestion({
+            header: 'Configuration Params',
+            question: 'Second question?',
+          }),
+        ],
+      });
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={50}
+          onConfirm={vi.fn()}
+        />,
+      );
+
+      expect(lastFrame()).toContain('Configuration Params');
+    });
+
+    it('clips every header when four long tabs must share a tight row', () => {
+      // Overflow protection for the worst case: the maximum number of tabs, each
+      // with an over-length header, forces all of them to be clipped so the row
+      // still fits.
+      const availableWidth = 40;
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: 'Target config' }),
+          createSingleQuestion({ header: 'Primary metric', question: 'Q2?' }),
+          createSingleQuestion({ header: 'Output format', question: 'Q3?' }),
+          createSingleQuestion({ header: 'Retry policy', question: 'Q4?' }),
+        ],
+      });
+
+      const { lastFrame } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          availableWidth={availableWidth}
+          onConfirm={vi.fn()}
+        />,
+      );
+
+      const output = lastFrame();
+      expect(output).not.toContain('Target config');
+      expect(output).not.toContain('Primary metric');
+      expect(output).not.toContain('Output format');
+      expect(output).not.toContain('Retry policy');
+      expect(output).toContain('…');
+
+      // The rendered tab row must actually fit availableWidth. This pins the
+      // dialog's rowOverhead accounting to the JSX it mirrors — if the render
+      // structure changes without the accounting, this fails. (All-ASCII
+      // headers plus one-cell '▸'/'…', so string length equals display width.)
+      const tabRow = clean(output)
+        .split('\n')
+        .find((line) => line.includes('Submit'));
+      expect(tabRow).toBeDefined();
+      expect(tabRow!.trimEnd().length).toBeLessThanOrEqual(availableWidth);
+    });
+
     it('renders multi-select with checkboxes', () => {
       const details = createConfirmationDetails({
         questions: [createSingleQuestion({ multiSelect: true })],
@@ -171,6 +390,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { lastFrame } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -190,6 +410,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -212,6 +433,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -235,6 +457,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -254,6 +477,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -275,6 +499,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -294,6 +519,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -319,6 +545,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -344,6 +571,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -395,6 +623,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -417,6 +646,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -440,6 +670,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -478,6 +709,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -507,6 +739,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -562,6 +795,7 @@ describe('<AskUserQuestionDialog />', () => {
         const { stdin, unmount } = renderWithProviders(
           <AskUserQuestionDialog
             confirmationDetails={details}
+            availableWidth={80}
             onConfirm={onConfirm}
           />,
         );
@@ -599,6 +833,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, lastFrame, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           onConfirm={onConfirm}
         />,
       );
@@ -623,6 +858,7 @@ describe('<AskUserQuestionDialog />', () => {
       const { stdin, unmount } = renderWithProviders(
         <AskUserQuestionDialog
           confirmationDetails={details}
+          availableWidth={80}
           isFocused={false}
           onConfirm={onConfirm}
         />,

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
@@ -16,11 +16,39 @@ import { theme } from '../../semantic-colors.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../keyMatchers.js';
 import { TextInput } from '../shared/TextInput.js';
+import {
+  getCachedStringWidth,
+  truncateToWidth,
+} from '../../utils/textUtils.js';
 import { t } from '../../../i18n/index.js';
+
+// Largest per-chip display width (cells) such that every header, clipped to it,
+// lets the tab row fit within `available`. Headers narrower than the cap keep
+// their full width and their slack is reclaimed for the longer ones (water-
+// filling), so a header is clipped only when the row genuinely cannot fit it.
+// Returns a very large number when every header already fits at natural width.
+export function computeHeaderCap(
+  headerWidths: number[],
+  available: number,
+): number {
+  const ascending = [...headerWidths].sort((a, b) => a - b);
+  let remaining = available;
+  for (let i = 0; i < ascending.length; i++) {
+    const cap = Math.floor(remaining / (ascending.length - i));
+    if (ascending[i] > cap) {
+      return Math.max(0, cap);
+    }
+    remaining -= ascending[i];
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
 
 interface AskUserQuestionDialogProps {
   confirmationDetails: ToolAskUserQuestionConfirmationDetails;
   isFocused?: boolean;
+  /** Width (cells) of the box the dialog is rendered into; sizes the header
+   * tab row. */
+  availableWidth: number;
   onConfirm: (
     outcome: ToolConfirmationOutcome,
     payload?: ToolConfirmationPayload,
@@ -30,6 +58,7 @@ interface AskUserQuestionDialogProps {
 export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
   confirmationDetails,
   isFocused = true,
+  availableWidth,
   onConfirm,
 }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -93,6 +122,31 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     }
     return selectedOptions[idx];
   };
+
+  // Headers render as chips in a horizontal tab row. The 12-char schema limit is
+  // only guidance to the model, so at display time each header is shown in full
+  // whenever the row has room and clipped with an ellipsis only when the headers
+  // would otherwise overflow.
+  const numHeaders = confirmationDetails.questions.length;
+  const answeredHeaders = confirmationDetails.questions.filter(
+    (_, idx) => getAnswerForQuestion(idx) !== undefined,
+  ).length;
+  // Cells the row spends outside the header text, matching what it renders.
+  // Recomputed each render, so answering a question re-fits the row.
+  const dialogPadding = 2;
+  // "▸ " when the Submit tab is active, a single leading space otherwise, plus
+  // the (locale-dependent) label.
+  const submitChipWidth =
+    (isSubmitTab ? 2 : 1) + getCachedStringWidth(t('Submit'));
+  const chipGaps = numHeaders; // gap={1} between each chip and the Submit chip
+  const headerPrefixes = 2 * numHeaders; // "▸ " or "  " before each header
+  const answeredMarks = 2 * answeredHeaders; // " ✓" after answered headers
+  const rowOverhead =
+    dialogPadding + submitChipWidth + chipGaps + headerPrefixes + answeredMarks;
+  const headerCap = computeHeaderCap(
+    confirmationDetails.questions.map((q) => getCachedStringWidth(q.header)),
+    availableWidth - rowOverhead,
+  );
 
   const handleSubmit = async () => {
     const answers: Record<string, string> = {};
@@ -314,8 +368,8 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
             return (
               <Box key={idx}>
                 <Text dimColor>
-                  {isAnswered ? '  ' : '  '}
-                  {q.header}
+                  {'  '}
+                  {truncateToWidth(q.header, headerCap)}
                   {isAnswered ? ' ✓' : ''}
                 </Text>
               </Box>
@@ -405,7 +459,7 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
                   dimColor={idx !== currentQuestionIndex}
                 >
                   {idx === currentQuestionIndex ? '▸ ' : '  '}
-                  {q.header}
+                  {truncateToWidth(q.header, headerCap)}
                   {isAnswered ? ' ✓' : ''}
                 </Text>
               </Box>

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -437,6 +437,7 @@ export const ToolConfirmationMessage: React.FC<
       <AskUserQuestionDialog
         confirmationDetails={confirmationDetails}
         isFocused={isFocused}
+        availableWidth={contentWidth}
         onConfirm={onConfirm}
       />
     );

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -15,6 +15,7 @@ import {
   sanitizeMultilineForDisplay,
   sanitizeSensitiveText,
   sliceTextByVisualHeight,
+  truncateToWidth,
 } from './textUtils.js';
 
 describe('textUtils', () => {
@@ -359,6 +360,30 @@ describe('textUtils', () => {
       expect(result).not.toContain('secretkey12345678901234');
       expect(result).not.toContain('mypass123');
       expect(result).not.toContain('sk-test123456789012345678901');
+    });
+  });
+
+  describe('truncateToWidth', () => {
+    it('returns the full text when it fits the budget', () => {
+      expect(truncateToWidth('Color', 12)).toBe('Color');
+    });
+
+    it('clips with an ellipsis when over budget', () => {
+      expect(truncateToWidth('Target config', 6)).toBe('Targe…');
+    });
+
+    it('returns a lone ellipsis at a one-cell budget', () => {
+      expect(truncateToWidth('Target config', 1)).toBe('…');
+    });
+
+    it('returns empty (no stray ellipsis) at a zero or negative budget', () => {
+      expect(truncateToWidth('Target config', 0)).toBe('');
+      expect(truncateToWidth('Target config', -3)).toBe('');
+    });
+
+    it('bounds CJK text by display width, not character count', () => {
+      // 5 CJK characters (10 cells) plus the ellipsis fit an 11-cell budget.
+      expect(truncateToWidth('目标配置参数设置', 11)).toBe('目标配置参…');
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -146,6 +146,38 @@ export const getCachedStringWidth = (str: string): number => {
   return width;
 };
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: 'grapheme',
+});
+
+/**
+ * Truncate text to a display width (terminal cells), appending an ellipsis
+ * when clipped. Grapheme- and width-aware (via `getCachedStringWidth`) so CJK
+ * text — two cells per character — is bounded correctly. Returns an empty
+ * string when even the ellipsis would overflow the budget.
+ */
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) {
+    return '';
+  }
+  if (getCachedStringWidth(text) <= maxWidth) {
+    return text;
+  }
+  const ellipsis = '…';
+  const budget = Math.max(0, maxWidth - getCachedStringWidth(ellipsis));
+  let width = 0;
+  let result = '';
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    const segmentWidth = getCachedStringWidth(segment);
+    if (width + segmentWidth > budget) {
+      break;
+    }
+    result += segment;
+    width += segmentWidth;
+  }
+  return `${result}${ellipsis}`;
+}
+
 export interface VisualHeightSlice {
   text: string;
   hiddenLinesCount: number;

--- a/packages/core/src/tools/askUserQuestion.test.ts
+++ b/packages/core/src/tools/askUserQuestion.test.ts
@@ -74,12 +74,16 @@ describe('AskUserQuestionTool', () => {
       expect(result).toContain('between 1 and 4 questions');
     });
 
-    it('should reject question with header too long', () => {
+    it('should accept a header longer than 12 characters', () => {
+      // The 12-char limit is guidance in the schema, not a hard constraint.
+      // A slightly over-length header (e.g. "Target config", 13 chars) must
+      // pass validation instead of bouncing the tool call back to the model;
+      // the TUI truncates over-length headers for the chip/tab layout.
       const params = {
         questions: [
           {
             question: 'Test question?',
-            header: 'ThisHeaderIsTooLong',
+            header: 'Target config',
             options: [
               { label: 'A', description: 'Option A' },
               { label: 'B', description: 'Option B' },
@@ -90,7 +94,7 @@ describe('AskUserQuestionTool', () => {
       };
 
       const result = tool.validateToolParams(params);
-      expect(result).toContain('12 characters or less');
+      expect(result).toBeNull();
     });
 
     it('should reject question with too few options', () => {

--- a/packages/core/src/tools/askUserQuestion.ts
+++ b/packages/core/src/tools/askUserQuestion.ts
@@ -399,9 +399,12 @@ export class AskUserQuestionTool extends BaseDeclarativeTool<
         return `Question ${i + 1}: "header" must be a non-empty string.`;
       }
 
-      if (question.header.length > 12) {
-        return `Question ${i + 1}: "header" must be 12 characters or less.`;
-      }
+      // The schema advertises "max 12 chars" so the model keeps headers short
+      // enough for the chip/tab layout, but we deliberately do NOT hard-reject
+      // longer headers here: bouncing a slightly over-length label (e.g.
+      // "Target config", 13 chars) back to the model as a tool error is far
+      // worse UX than simply showing it. The TUI truncates over-length headers
+      // in the compact tab/chip contexts (see AskUserQuestionDialog).
 
       if (!Array.isArray(question.options)) {
         return `Question ${i + 1}: "options" must be an array.`;


### PR DESCRIPTION
## What this PR does

Makes the assistant's clarifying-question prompt tolerant of a slightly long heading. Until now, a heading of 13+ characters made the whole question fail with an error and no prompt appeared. Now the question always shows, and any over-length heading is shortened with an ellipsis so it still fits the tab row.

## Why it's needed

When the assistant asked you to pick between options and gave the question a heading like `Target config` (13 characters), the request was rejected with `"header" must be 12 characters or less.` and the interactive picker never rendered — the assistant either fell back to asking in plain prose or stalled. A one- or two-character overflow on a short label shouldn't break the entire interaction. The 12-character limit stays as guidance so the model is still nudged to keep headings short; it's just no longer a hard failure.

## Reviewer Test Plan

### How to verify

1. Get the assistant to ask a multiple-choice clarifying question whose heading is longer than 12 characters — e.g. ask it something ambiguous enough that it asks you to choose, or point the CLI at a mock model that returns a question with header `Target config`.
2. **Before:** the tool call fails with `Question 1: "header" must be 12 characters or less.` and no picker appears.
3. **After:** the picker appears normally with the full heading shown. In a multi-question view each tab is sized to the terminal width — headings show in full when the row has room (e.g. `Target config`, `Primary metric`), and are shortened with an ellipsis (e.g. `Target conf…`) only when several long headings would otherwise overflow a narrow terminal.

### Evidence (Before & After)

| Before (request rejected, no picker) | After (picker renders, full heading shown) |
| :---: | :---: |
| <img width="430" alt="before" src="https://github.com/user-attachments/assets/7aa991ed-ad13-4711-a0d3-41e74c8de674" /> | <img width="430" alt="after" src="https://github.com/user-attachments/assets/c7b4ebaf-d698-445d-a7de-2e3f8b3a8705" /> |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Bundled `dist/cli.js` driven against a local mock model in an xterm-based terminal capture.

## Risk & Scope

- Main risk or tradeoff: low — this loosens one input-validation check and adds display-only truncation. The 12-character limit remains in the tool schema as guidance, so models are still steered toward short headings.
- Not validated / out of scope: no change to how headings are chosen by the model; only how an over-length one is handled.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让助手的“澄清式提问”弹窗能够容忍稍长的标题。此前，标题超过 12 个字符会导致整个提问直接报错、弹窗根本不显示。现在提问始终会正常弹出，超长标题会以省略号截断，从而仍能放进标签行。

## 为什么需要它

当助手让你在若干选项中做选择、并给这个问题起了一个像 `Target config`（13 个字符）这样的标题时，请求会以 `"header" must be 12 characters or less.` 报错，交互式选择器根本不会渲染——助手要么退化成用纯文本提问，要么卡住。短标签多出一两个字符，不应该让整个交互中断。12 个字符的限制仍作为“建议”保留在工具 schema 中，用来引导模型把标题写短；只是它不再是硬性失败。

## 复现与验证

1. 让助手抛出一个标题超过 12 个字符的多选澄清问题——例如问它一个足够含糊的问题让它反过来让你做选择，或让 CLI 指向一个会返回标题为 `Target config` 的 mock 模型。
2. **修复前：** 工具调用以 `Question 1: "header" must be 12 characters or less.` 失败，选择器不出现。
3. **修复后：** 选择器正常出现并完整显示标题。多问题视图中每个标签会根据终端宽度自适应——空间足够时完整显示（如 `Target config`、`Primary metric`），只有当多个较长标题在窄终端下会溢出时才用省略号截断（如 `Target conf…`）。

## 证据（前后对比）

见上方英文部分的“Evidence (Before & After)”对比表。

## 风险与范围

- 主要风险：低——仅放宽了一处输入校验，并新增了纯展示层的截断。12 字符限制仍作为 schema 指引保留。
- 不在本次范围：不改变模型如何选择标题，只改变超长标题的处理方式。
- 破坏性变更：无。

</details>
