### PR TITLE
feat(channels): confirm natural memory mutations

### DIFF
--- a/docs/users/features/channels/overview.md
+++ b/docs/users/features/channels/overview.md
@@ -99,16 +99,24 @@ IDs, so a list response can be used for deterministic follow-up operations.
   request such as `只看中文偏好` to list the matching entries.
 - `查看刚才那条记忆`, `把关于 staging 的记忆改成默认使用 production`, and
   `忘掉刚才那条` work when the natural reference resolves to exactly one entry.
-  `把 <id> 改成默认使用 production` updates that entry immediately, and
-  `忘掉 <id>` removes it immediately. Neither operation needs confirmation.
+  Natural updates and removals first show the proposed change. Confirm an
+  update with `确认更新记忆` or `confirm memory update`, or a removal with
+  `确认删除记忆` or `confirm memory removal`, within 60 seconds. Exact-ID
+  updates and removals remain immediate and do not need confirmation.
 - `清空记忆` starts the clear-all confirmation flow; `确认清空记忆` completes
   it.
 
 When a natural inspect, update, or removal request matches multiple entries,
 the bot returns the candidate IDs and previews without changing memory. There
-is no pending selection or confirmation state: retry the request with one exact
-ID, such as `忘掉 m-a31f0d82c7e4`. Exact-ID operations remain the deterministic
-fast path. A natural request with no match reports that no entry matched.
+is no pending selection for an ambiguous result: retry the request with one
+exact ID, such as `忘掉 m-a31f0d82c7e4`. Exact-ID operations remain the
+deterministic fast path. A natural request with no match reports that no entry
+matched.
+
+Pending update, removal, and clear confirmations apply only to the sender and
+chat or thread that created them. A newer executable memory mutation replaces
+an older pending one for that sender and target. Pending confirmations are
+discarded when the channel process restarts.
 
 The legacy slash aliases `/remember-channel`, `/channel-memory`, and
 `/forget-channel` have been removed. They are no longer channel-memory

--- a/docs/users/features/channels/overview.md
+++ b/docs/users/features/channels/overview.md
@@ -114,9 +114,9 @@ deterministic fast path. A natural request with no match reports that no entry
 matched.
 
 Pending update, removal, and clear confirmations apply only to the sender and
-chat or thread that created them. A newer executable memory mutation replaces
-an older pending one for that sender and target. Pending confirmations are
-discarded when the channel process restarts.
+chat or thread that created them. A newer clear, natural update, or natural
+removal proposal replaces an older pending one for that sender and target.
+Pending confirmations are discarded when the channel process restarts.
 
 The legacy slash aliases `/remember-channel`, `/channel-memory`, and
 `/forget-channel` have been removed. They are no longer channel-memory

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2064,7 +2064,7 @@ describe('ChannelBase', () => {
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
 
-    it('plans a natural update against current entries and uses the selected text for CAS', async () => {
+    it('proposes a natural update before confirming it with the selected text for CAS', async () => {
       const target = {
         channelName: 'test-chan',
         chatId: 'chat1',
@@ -2101,6 +2101,23 @@ describe('ChannelBase', () => {
       ).toHaveBeenCalledWith('把刚才那条记忆改成 Use production.', [
         { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
       ]);
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: [
+            'Update channel memory m-a31f0d82c7e4?',
+            'Before: Use staging.',
+            'After: Use production.',
+            'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
+          ].join('\n'),
+        },
+      ]);
+
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
       expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledWith(
         target,
         {
@@ -2109,13 +2126,14 @@ describe('ChannelBase', () => {
           expectedText: 'Use staging.',
         },
       );
-      expect(ch.sent).toEqual([
-        { chatId: 'chat1', text: 'Channel memory m-a31f0d82c7e4 updated.' },
-      ]);
+      expect(ch.sent.at(-1)).toEqual({
+        chatId: 'chat1',
+        text: 'Channel memory m-a31f0d82c7e4 updated.',
+      });
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
 
-    it('does not retry or invalidate session context after a natural update CAS conflict', async () => {
+    it('consumes a natural update proposal after a CAS conflict without retrying or invalidating context', async () => {
       const channelMemory = createChannelMemory([
         { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
       ]);
@@ -2148,25 +2166,40 @@ describe('ChannelBase', () => {
         }),
       );
 
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
+
+      ch.sent = [];
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
       expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
       expect(ch.sent).toEqual([
         {
           chatId: 'chat1',
-          text: 'Failed to update channel memory: An error occurred while accessing channel memory.',
+          text: 'That channel memory entry changed since it was selected. View channel memory and start the operation again.',
         },
       ]);
 
       ch.sent = [];
-      await ch.handleInbound(envelope({ text: 'second', senderId: 'alice' }));
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
 
-      expect(channelMemory.readChannelMemory).toHaveBeenCalledTimes(1);
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: 'No pending channel memory update. Start a new update request first.',
+        },
+      ]);
       expect(stderrSpy).toHaveBeenCalledWith(
         expect.stringContaining('Channel memory entry changed'),
       );
       stderrSpy.mockRestore();
     });
 
-    it('plans a natural removal against current entries and uses the selected text for CAS', async () => {
+    it('proposes a natural removal before confirming it with the selected text for CAS', async () => {
       const target = {
         channelName: 'test-chan',
         chatId: 'chat1',
@@ -2191,6 +2224,22 @@ describe('ChannelBase', () => {
         envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
       );
 
+      expect(channelMemory.removeChannelMemoryEntries).not.toHaveBeenCalled();
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: [
+            'Remove channel memory m-a31f0d82c7e4?',
+            'Use staging.',
+            'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
+          ].join('\n'),
+        },
+      ]);
+
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
       expect(channelMemory.removeChannelMemoryEntries).toHaveBeenCalledWith(
         target,
         {
@@ -2198,11 +2247,246 @@ describe('ChannelBase', () => {
           expectedTextById: { 'm-a31f0d82c7e4': 'Use staging.' },
         },
       );
-      expect(ch.sent).toEqual([
-        { chatId: 'chat1', text: 'Channel memory m-a31f0d82c7e4 removed.' },
-      ]);
+      expect(ch.sent.at(-1)).toEqual({
+        chatId: 'chat1',
+        text: 'Channel memory m-a31f0d82c7e4 removed.',
+      });
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
+
+    it('consumes a natural removal proposal after a CAS conflict without retrying', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      channelMemory.removeChannelMemoryEntries.mockRejectedValue(
+        new Error('Channel memory entry changed'),
+      );
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'remove',
+          targetIds: ['m-a31f0d82c7e4'],
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(
+        envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.removeChannelMemoryEntries).toHaveBeenCalledTimes(1);
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: [
+            'Remove channel memory m-a31f0d82c7e4?',
+            'Use staging.',
+            'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
+          ].join('\n'),
+        },
+        {
+          chatId: 'chat1',
+          text: 'That channel memory entry changed since it was selected. View channel memory and start the operation again.',
+        },
+        {
+          chatId: 'chat1',
+          text: 'No pending channel memory removal. Start a new removal request first.',
+        },
+      ]);
+    });
+
+    it('consumes a natural update proposal after a storage failure', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      channelMemory.updateChannelMemoryEntry.mockRejectedValue(
+        new Error('unsafe\\nbackend failure'),
+      );
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(ch.sent.slice(-2)).toEqual([
+        {
+          chatId: 'chat1',
+          text: 'Failed to update channel memory: An error occurred while accessing channel memory.',
+        },
+        {
+          chatId: 'chat1',
+          text: 'No pending channel memory update. Start a new update request first.',
+        },
+      ]);
+    });
+
+    it('consumes a natural update proposal before concurrent confirmations complete', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      let resolveMutation: ((value: { changed: true }) => void) | undefined;
+      channelMemory.updateChannelMemoryEntry.mockImplementation(
+        () =>
+          new Promise((resolve: (value: { changed: true }) => void) => {
+            resolveMutation = resolve;
+          }),
+      );
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      const firstConfirmation = ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      const secondConfirmation = ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      await vi.waitFor(() => {
+        expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      });
+      resolveMutation?.({ changed: true });
+      await Promise.all([firstConfirmation, secondConfirmation]);
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(ch.sent.at(-2)).toEqual({
+        chatId: 'chat1',
+        text: 'No pending channel memory update. Start a new update request first.',
+      });
+      expect(ch.sent.at(-1)).toEqual({
+        chatId: 'chat1',
+        text: 'Channel memory m-a31f0d82c7e4 updated.',
+      });
+    });
+
+    it('invalidates injected memory only after confirming a natural update', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      channelMemory.readChannelMemory.mockResolvedValue('Use staging.');
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(envelope({ text: 'first', senderId: 'alice' }));
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(envelope({ text: 'second', senderId: 'alice' }));
+
+      expect(channelMemory.readChannelMemory).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      { exactText: '把 m-a31f0d82c7e4 改成Use production.' },
+      { exactText: '忘掉 m-a31f0d82c7e4' },
+    ])(
+      'lets an exact mutation cancel an older natural proposal',
+      async ({ exactText }) => {
+        const channelMemory = createChannelMemory([
+          { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+        ]);
+        const memoryIntentClassifier = {
+          classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+            intent: 'update',
+            targetIds: ['m-a31f0d82c7e4'],
+            memory: 'Use production.',
+            confidence: 0.92,
+          }),
+        };
+        const ch = createChannel(
+          { allowedUsers: ['alice'] },
+          { channelMemory, memoryIntentClassifier },
+        );
+
+        await ch.handleInbound(
+          envelope({
+            text: '把刚才那条记忆改成 Use production.',
+            senderId: 'alice',
+          }),
+        );
+        await ch.handleInbound(
+          envelope({ text: exactText, senderId: 'alice' }),
+        );
+        await ch.handleInbound(
+          envelope({ text: '确认更新记忆', senderId: 'alice' }),
+        );
+
+        expect(
+          memoryIntentClassifier.classifyChannelMemoryIntent,
+        ).toHaveBeenCalledTimes(1);
+        expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(
+          exactText.includes('改成') ? 1 : 0,
+        );
+        expect(channelMemory.removeChannelMemoryEntries).toHaveBeenCalledTimes(
+          exactText.includes('改成') ? 0 : 1,
+        );
+        expect(ch.sent.at(-1)).toEqual({
+          chatId: 'chat1',
+          text: 'No pending channel memory update. Start a new update request first.',
+        });
+      },
+    );
 
     it('inspects a unique natural memory match', async () => {
       const channelMemory = createChannelMemory([

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2196,6 +2196,9 @@ describe('ChannelBase', () => {
       expect(stderrSpy).toHaveBeenCalledWith(
         expect.stringContaining('Channel memory entry changed'),
       );
+
+      await ch.handleInbound(envelope({ text: 'second', senderId: 'alice' }));
+      expect(channelMemory.readChannelMemory).toHaveBeenCalledTimes(1);
       stderrSpy.mockRestore();
     });
 
@@ -2402,6 +2405,109 @@ describe('ChannelBase', () => {
         chatId: 'chat1',
         text: 'Channel memory m-a31f0d82c7e4 updated.',
       });
+    });
+
+    it('does not retain an undelivered natural update proposal', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'update',
+              targetIds: ['m-a31f0d82c7e4'],
+              memory: 'Use production.',
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+      vi.spyOn(ch, 'sendMessage').mockRejectedValueOnce(
+        new Error('delivery failed'),
+      );
+
+      await expect(
+        ch.handleInbound(
+          envelope({
+            text: '把刚才那条记忆改成 Use production.',
+            senderId: 'alice',
+          }),
+        ),
+      ).rejects.toThrow('delivery failed');
+
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: 'No pending channel memory update. Start a new update request first.',
+        },
+      ]);
+    });
+
+    it('keeps a newer proposal when delivery of an older proposal fails', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi
+              .fn()
+              .mockResolvedValueOnce({
+                intent: 'update',
+                targetIds: ['m-a31f0d82c7e4'],
+                memory: 'Use production.',
+                confidence: 0.92,
+              })
+              .mockResolvedValueOnce({
+                intent: 'remove',
+                targetIds: ['m-a31f0d82c7e4'],
+                confidence: 0.92,
+              }),
+          },
+        },
+      );
+      let rejectFirstDelivery!: (error: Error) => void;
+      vi.spyOn(ch, 'sendMessage')
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectFirstDelivery = reject;
+            }),
+        )
+        .mockImplementation(async (chatId, text) => {
+          ch.sent.push({ chatId, text });
+        });
+
+      const firstProposal = ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await vi.waitFor(() => expect(ch.sendMessage).toHaveBeenCalledOnce());
+
+      await ch.handleInbound(
+        envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
+      );
+      rejectFirstDelivery(new Error('delivery failed'));
+      await expect(firstProposal).rejects.toThrow('delivery failed');
+
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.removeChannelMemoryEntries).toHaveBeenCalledTimes(1);
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
     });
 
     it('accepts a natural update confirmation at 60 seconds and expires it after the boundary', async () => {
@@ -2690,6 +2796,70 @@ describe('ChannelBase', () => {
       });
     });
 
+    it('keeps pending proposals isolated when target or sender IDs contain colons', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice', 'two:alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi
+              .fn()
+              .mockResolvedValueOnce({
+                intent: 'update',
+                targetIds: ['m-a31f0d82c7e4'],
+                memory: 'Use production.',
+                confidence: 0.92,
+              })
+              .mockResolvedValueOnce({
+                intent: 'remove',
+                targetIds: ['m-a31f0d82c7e4'],
+                confidence: 0.92,
+              }),
+          },
+        },
+      );
+      const firstTarget = {
+        chatId: 'chat:one',
+        threadId: 'two',
+        senderId: 'alice',
+      };
+      const secondTarget = {
+        chatId: 'chat',
+        threadId: 'one',
+        senderId: 'two:alice',
+      };
+
+      await ch.handleInbound(
+        envelope({
+          ...firstTarget,
+          text: '把刚才那条记忆改成 Use production.',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({ ...secondTarget, text: '删掉刚才那条记忆' }),
+      );
+      await ch.handleInbound(
+        envelope({ ...firstTarget, text: '确认更新记忆' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledWith(
+        {
+          channelName: 'test-chan',
+          chatId: 'chat:one',
+          threadId: 'two',
+        },
+        {
+          id: 'm-a31f0d82c7e4',
+          text: 'Use production.',
+          expectedText: 'Use staging.',
+        },
+      );
+      expect(channelMemory.removeChannelMemoryEntries).not.toHaveBeenCalled();
+    });
+
     it.each([
       {
         name: 'another chat',
@@ -2749,6 +2919,59 @@ describe('ChannelBase', () => {
         });
       },
     );
+
+    it('cancels a pending update before an exact-ID mutation yields', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'update',
+              targetIds: ['m-a31f0d82c7e4'],
+              memory: 'Use production.',
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+
+      const exactMutation = ch.handleInbound(
+        envelope({
+          text: '把 m-a31f0d82c7e4 改成Use latest.',
+          senderId: 'alice',
+        }),
+      );
+      await Promise.resolve();
+      const confirmation = ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await Promise.all([exactMutation, confirmation]);
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledWith(
+        {
+          channelName: 'test-chan',
+          chatId: 'chat1',
+          threadId: undefined,
+        },
+        { id: 'm-a31f0d82c7e4', text: 'Use latest.' },
+      );
+      expect(ch.sent).toContainEqual({
+        chatId: 'chat1',
+        text: 'No pending channel memory update. Start a new update request first.',
+      });
+    });
 
     it('keeps a pending update through natural reads, no matches, and ambiguity', async () => {
       const entries = [

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2404,6 +2404,493 @@ describe('ChannelBase', () => {
       });
     });
 
+    it('accepts a natural update confirmation at 60 seconds and expires it after the boundary', async () => {
+      vi.useFakeTimers();
+      try {
+        const channelMemory = createChannelMemory([
+          { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+        ]);
+        const memoryIntentClassifier = {
+          classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+            intent: 'update',
+            targetIds: ['m-a31f0d82c7e4'],
+            memory: 'Use production.',
+            confidence: 0.92,
+          }),
+        };
+        const ch = createChannel(
+          { allowedUsers: ['alice'] },
+          { channelMemory, memoryIntentClassifier },
+        );
+
+        await ch.handleInbound(
+          envelope({
+            text: '把刚才那条记忆改成 Use production.',
+            senderId: 'alice',
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(60_000);
+        await ch.handleInbound(
+          envelope({ text: '确认更新记忆', senderId: 'alice' }),
+        );
+
+        expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+
+        await ch.handleInbound(
+          envelope({
+            text: '把刚才那条记忆改成 Use production.',
+            senderId: 'alice',
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(60_001);
+        await ch.handleInbound(
+          envelope({ text: '确认更新记忆', senderId: 'alice' }),
+        );
+
+        expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+        expect(ch.sent.at(-1)).toEqual({
+          chatId: 'chat1',
+          text: 'No pending channel memory update. Start a new update request first.',
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('replaces pending updates, removals, and clears with the latest executable mutation', async () => {
+      const entries = [{ id: 'm-a31f0d82c7e4', text: 'Use staging.' }];
+
+      const updateThenClearMemory = createChannelMemory(entries);
+      const updateThenClear = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory: updateThenClearMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'update',
+              targetIds: ['m-a31f0d82c7e4'],
+              memory: 'Use production.',
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+      await updateThenClear.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await updateThenClear.handleInbound(
+        envelope({ text: '清空记忆', senderId: 'alice' }),
+      );
+      await updateThenClear.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await updateThenClear.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+
+      expect(
+        updateThenClearMemory.updateChannelMemoryEntry,
+      ).not.toHaveBeenCalled();
+      expect(updateThenClearMemory.clearChannelMemory).toHaveBeenCalledTimes(1);
+      expect(updateThenClear.sent.at(-2)).toEqual({
+        chatId: 'chat1',
+        text: 'No pending channel memory update. Start a new update request first.',
+      });
+
+      const clearThenRemovalMemory = createChannelMemory(entries);
+      const clearThenRemoval = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory: clearThenRemovalMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'remove',
+              targetIds: ['m-a31f0d82c7e4'],
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+      await clearThenRemoval.handleInbound(
+        envelope({ text: '清空记忆', senderId: 'alice' }),
+      );
+      await clearThenRemoval.handleInbound(
+        envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
+      );
+      await clearThenRemoval.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+      await clearThenRemoval.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
+      expect(clearThenRemovalMemory.clearChannelMemory).not.toHaveBeenCalled();
+      expect(
+        clearThenRemovalMemory.removeChannelMemoryEntries,
+      ).toHaveBeenCalledTimes(1);
+      expect(clearThenRemoval.sent.at(-2)).toEqual({
+        chatId: 'chat1',
+        text: 'No pending clear request. Say "清空记忆" first.',
+      });
+
+      const updateThenRemovalMemory = createChannelMemory(entries);
+      const updateThenRemoval = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory: updateThenRemovalMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi
+              .fn()
+              .mockResolvedValueOnce({
+                intent: 'update',
+                targetIds: ['m-a31f0d82c7e4'],
+                memory: 'Use production.',
+                confidence: 0.92,
+              })
+              .mockResolvedValueOnce({
+                intent: 'remove',
+                targetIds: ['m-a31f0d82c7e4'],
+                confidence: 0.92,
+              }),
+          },
+        },
+      );
+      await updateThenRemoval.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await updateThenRemoval.handleInbound(
+        envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
+      );
+      await updateThenRemoval.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await updateThenRemoval.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
+      expect(
+        updateThenRemovalMemory.updateChannelMemoryEntry,
+      ).not.toHaveBeenCalled();
+      expect(
+        updateThenRemovalMemory.removeChannelMemoryEntries,
+      ).toHaveBeenCalledTimes(1);
+      expect(updateThenRemoval.sent.at(-2)).toEqual({
+        chatId: 'chat1',
+        text: 'No pending channel memory update. Start a new update request first.',
+      });
+    });
+
+    it('preserves a pending update when a removal confirmation has the wrong kind', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.removeChannelMemoryEntries).not.toHaveBeenCalled();
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(ch.sent.at(-2)).toEqual({
+        chatId: 'chat1',
+        text: 'No pending channel memory removal. Start a new removal request first.',
+      });
+    });
+
+    it('shares group memory but not pending update confirmations between accepted members', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        {
+          allowedUsers: ['alice', 'bob'],
+          groupPolicy: 'open',
+        },
+        { channelMemory, memoryIntentClassifier },
+      );
+      const groupEnvelope = {
+        isGroup: true,
+        isMentioned: true,
+        chatId: 'group-1',
+      };
+
+      await ch.handleInbound(
+        envelope({
+          ...groupEnvelope,
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({
+          ...groupEnvelope,
+          text: '确认更新记忆',
+          senderId: 'bob',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({
+          ...groupEnvelope,
+          text: '确认更新记忆',
+          senderId: 'alice',
+        }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledWith(
+        {
+          channelName: 'test-chan',
+          chatId: 'group-1',
+          threadId: undefined,
+        },
+        {
+          id: 'm-a31f0d82c7e4',
+          text: 'Use production.',
+          expectedText: 'Use staging.',
+        },
+      );
+      expect(ch.sent.at(-2)).toEqual({
+        chatId: 'group-1',
+        text: 'No pending channel memory update. Start a new update request first.',
+      });
+    });
+
+    it.each([
+      {
+        name: 'another chat',
+        proposal: { chatId: 'chat-a' },
+        otherTarget: { chatId: 'chat-b' },
+      },
+      {
+        name: 'another thread',
+        proposal: { chatId: 'chat-a', threadId: 'thread-a' },
+        otherTarget: { chatId: 'chat-a', threadId: 'thread-b' },
+      },
+    ])(
+      'does not confirm a pending update from $name',
+      async ({ proposal, otherTarget }) => {
+        const channelMemory = createChannelMemory([
+          { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+        ]);
+        const memoryIntentClassifier = {
+          classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+            intent: 'update',
+            targetIds: ['m-a31f0d82c7e4'],
+            memory: 'Use production.',
+            confidence: 0.92,
+          }),
+        };
+        const ch = createChannel(
+          { allowedUsers: ['alice'] },
+          { channelMemory, memoryIntentClassifier },
+        );
+
+        await ch.handleInbound(
+          envelope({
+            ...proposal,
+            text: '把刚才那条记忆改成 Use production.',
+            senderId: 'alice',
+          }),
+        );
+        await ch.handleInbound(
+          envelope({
+            ...otherTarget,
+            text: '确认更新记忆',
+            senderId: 'alice',
+          }),
+        );
+        await ch.handleInbound(
+          envelope({
+            ...proposal,
+            text: '确认更新记忆',
+            senderId: 'alice',
+          }),
+        );
+
+        expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+        expect(ch.sent.at(-2)).toEqual({
+          chatId: otherTarget.chatId,
+          text: 'No pending channel memory update. Start a new update request first.',
+        });
+      },
+    );
+
+    it('keeps a pending update through natural reads, no matches, and ambiguity', async () => {
+      const entries = [
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+        { id: 'm-b82c4e190a6f', text: 'Use development.' },
+      ];
+      const channelMemory = createChannelMemory(entries);
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi
+          .fn()
+          .mockResolvedValueOnce({
+            intent: 'update',
+            targetIds: ['m-a31f0d82c7e4'],
+            memory: 'Use production.',
+            confidence: 0.92,
+          })
+          .mockResolvedValueOnce({
+            intent: 'list',
+            targetIds: ['m-a31f0d82c7e4'],
+            confidence: 0.92,
+          })
+          .mockResolvedValueOnce({
+            intent: 'inspect',
+            targetIds: ['m-a31f0d82c7e4'],
+            confidence: 0.92,
+          })
+          .mockResolvedValueOnce({
+            intent: 'remove',
+            targetIds: [],
+            confidence: 0.92,
+          })
+          .mockResolvedValueOnce({
+            intent: 'remove',
+            targetIds: ['m-a31f0d82c7e4', 'm-b82c4e190a6f'],
+            confidence: 0.92,
+          }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+
+      await ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '列出刚才提到的记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '查看刚才那条记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '删除没有的记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '删除刚才提到的记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(channelMemory.removeChannelMemoryEntries).not.toHaveBeenCalled();
+      expect(ch.sent.at(-1)).toEqual({
+        chatId: 'chat1',
+        text: 'Channel memory m-a31f0d82c7e4 updated.',
+      });
+    });
+
+    it('keeps channel-memory pending state behind sender and mention gates', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'update',
+          targetIds: ['m-a31f0d82c7e4'],
+          memory: 'Use production.',
+          confidence: 0.92,
+        }),
+      };
+      const ch = createChannel(
+        {
+          senderPolicy: 'allowlist',
+          allowedUsers: ['alice'],
+          groupPolicy: 'open',
+          groups: { '*': { requireMention: true } },
+        },
+        { channelMemory, memoryIntentClassifier },
+      );
+      const accepted = {
+        isGroup: true,
+        isMentioned: true,
+        chatId: 'group-1',
+        senderId: 'alice',
+      };
+
+      await ch.handleInbound(
+        envelope({
+          ...accepted,
+          text: '把刚才那条记忆改成 Use production.',
+        }),
+      );
+      const readsAfterProposal =
+        channelMemory.listChannelMemoryEntries.mock.calls.length;
+      const classificationsAfterProposal =
+        memoryIntentClassifier.classifyChannelMemoryIntent.mock.calls.length;
+
+      for (const rejected of [
+        { senderId: 'bob', isMentioned: true },
+        { senderId: 'alice', isMentioned: false },
+      ]) {
+        for (const text of [
+          '查看记忆',
+          '查看记忆 m-a31f0d82c7e4',
+          '记住: reject this',
+          '清空记忆',
+          '确认更新记忆',
+        ]) {
+          await ch.handleInbound(envelope({ ...accepted, ...rejected, text }));
+        }
+      }
+
+      expect(channelMemory.listChannelMemoryEntries).toHaveBeenCalledTimes(
+        readsAfterProposal,
+      );
+      expect(
+        memoryIntentClassifier.classifyChannelMemoryIntent,
+      ).toHaveBeenCalledTimes(classificationsAfterProposal);
+      expect(channelMemory.addChannelMemoryEntries).not.toHaveBeenCalled();
+      expect(channelMemory.clearChannelMemory).not.toHaveBeenCalled();
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
+      expect(ch.sent).toHaveLength(1);
+
+      await ch.handleInbound(envelope({ ...accepted, text: '确认更新记忆' }));
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+    });
+
     it('invalidates injected memory only after confirming a natural update', async () => {
       const channelMemory = createChannelMemory([
         { id: 'm-a31f0d82c7e4', text: 'Use staging.' },

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2873,6 +2873,28 @@ describe('ChannelBase', () => {
       expect(bridge.prompt).not.toHaveBeenCalled();
     });
 
+    it('keeps a pending clear after an unmatched update confirmation', async () => {
+      const channelMemory = createChannelMemory();
+      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+
+      await ch.handleInbound(envelope({ text: '清空记忆', senderId: 'alice' }));
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.clearChannelMemory).not.toHaveBeenCalled();
+      expect(ch.sent.at(-1)?.text).toBe(
+        'No pending channel memory update. Start a new update request first.',
+      );
+
+      await ch.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.clearChannelMemory).toHaveBeenCalledTimes(1);
+      expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
     it('natural group clear uses the current group target and requires confirmation', async () => {
       const channelMemory = createChannelMemory();
       const ch = createChannel(

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2407,6 +2407,64 @@ describe('ChannelBase', () => {
       });
     });
 
+    it('does not confirm a natural update before proposal delivery completes', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'update',
+              targetIds: ['m-a31f0d82c7e4'],
+              memory: 'Use production.',
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+      let resolveDelivery!: () => void;
+      const delivery = new Promise<void>((resolve) => {
+        resolveDelivery = resolve;
+      });
+      let markDeliveryStarted!: () => void;
+      const deliveryStarted = new Promise<void>((resolve) => {
+        markDeliveryStarted = resolve;
+      });
+      vi.spyOn(ch, 'sendMessage').mockImplementation(async (chatId, text) => {
+        if (text.startsWith('Update channel memory')) {
+          markDeliveryStarted();
+          await delivery;
+          return;
+        }
+        ch.sent.push({ chatId, text });
+      });
+
+      const proposal = ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await deliveryStarted;
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      const callsBeforeDelivery =
+        channelMemory.updateChannelMemoryEntry.mock.calls.length;
+
+      resolveDelivery();
+      await proposal;
+
+      expect(callsBeforeDelivery).toBe(0);
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+    });
+
     it('does not retain an undelivered natural update proposal', async () => {
       const channelMemory = createChannelMemory([
         { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
@@ -2510,7 +2568,90 @@ describe('ChannelBase', () => {
       expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
     });
 
-    it('accepts a natural update confirmation at 60 seconds and expires it after the boundary', async () => {
+    it('does not let an older delivery overwrite a newer delivered proposal', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi
+              .fn()
+              .mockResolvedValueOnce({
+                intent: 'update',
+                targetIds: ['m-a31f0d82c7e4'],
+                memory: 'Use production.',
+                confidence: 0.92,
+              })
+              .mockResolvedValueOnce({
+                intent: 'remove',
+                targetIds: ['m-a31f0d82c7e4'],
+                confidence: 0.92,
+              }),
+          },
+        },
+      );
+      let resolveOlderDelivery!: () => void;
+      const olderDelivery = new Promise<void>((resolve) => {
+        resolveOlderDelivery = resolve;
+      });
+      let resolveNewerDelivery!: () => void;
+      const newerDelivery = new Promise<void>((resolve) => {
+        resolveNewerDelivery = resolve;
+      });
+      let markOlderStarted!: () => void;
+      const olderStarted = new Promise<void>((resolve) => {
+        markOlderStarted = resolve;
+      });
+      let markNewerStarted!: () => void;
+      const newerStarted = new Promise<void>((resolve) => {
+        markNewerStarted = resolve;
+      });
+      vi.spyOn(ch, 'sendMessage').mockImplementation(async (chatId, text) => {
+        if (text.startsWith('Update channel memory')) {
+          markOlderStarted();
+          await olderDelivery;
+          return;
+        }
+        if (text.startsWith('Remove channel memory')) {
+          markNewerStarted();
+          await newerDelivery;
+          return;
+        }
+        ch.sent.push({ chatId, text });
+      });
+
+      const olderProposal = ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await olderStarted;
+      const newerProposal = ch.handleInbound(
+        envelope({ text: '删掉刚才那条记忆', senderId: 'alice' }),
+      );
+      await newerStarted;
+
+      resolveNewerDelivery();
+      await newerProposal;
+      resolveOlderDelivery();
+      await olderProposal;
+
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+      await ch.handleInbound(
+        envelope({ text: '确认删除记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).not.toHaveBeenCalled();
+      expect(channelMemory.removeChannelMemoryEntries).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts the inclusive 60-second confirmation window after proposal delivery', async () => {
       vi.useFakeTimers();
       try {
         const channelMemory = createChannelMemory([
@@ -2528,13 +2669,33 @@ describe('ChannelBase', () => {
           { allowedUsers: ['alice'] },
           { channelMemory, memoryIntentClassifier },
         );
+        let resolveDelivery!: () => void;
+        const delivery = new Promise<void>((resolve) => {
+          resolveDelivery = resolve;
+        });
+        let markDeliveryStarted!: () => void;
+        const deliveryStarted = new Promise<void>((resolve) => {
+          markDeliveryStarted = resolve;
+        });
+        vi.spyOn(ch, 'sendMessage').mockImplementation(async (chatId, text) => {
+          if (text.startsWith('Update channel memory')) {
+            markDeliveryStarted();
+            await delivery;
+            return;
+          }
+          ch.sent.push({ chatId, text });
+        });
 
-        await ch.handleInbound(
+        const firstProposal = ch.handleInbound(
           envelope({
             text: '把刚才那条记忆改成 Use production.',
             senderId: 'alice',
           }),
         );
+        await deliveryStarted;
+        await vi.advanceTimersByTimeAsync(30_000);
+        resolveDelivery();
+        await firstProposal;
         await vi.advanceTimersByTimeAsync(60_000);
         await ch.handleInbound(
           envelope({ text: '确认更新记忆', senderId: 'alice' }),
@@ -2971,6 +3132,71 @@ describe('ChannelBase', () => {
         chatId: 'chat1',
         text: 'No pending channel memory update. Start a new update request first.',
       });
+    });
+
+    it('prevents an unresolved natural proposal from activating after an exact-ID mutation', async () => {
+      const channelMemory = createChannelMemory([
+        { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
+      ]);
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        {
+          channelMemory,
+          memoryIntentClassifier: {
+            classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+              intent: 'update',
+              targetIds: ['m-a31f0d82c7e4'],
+              memory: 'Use production.',
+              confidence: 0.92,
+            }),
+          },
+        },
+      );
+      let resolveDelivery!: () => void;
+      const delivery = new Promise<void>((resolve) => {
+        resolveDelivery = resolve;
+      });
+      let markDeliveryStarted!: () => void;
+      const deliveryStarted = new Promise<void>((resolve) => {
+        markDeliveryStarted = resolve;
+      });
+      vi.spyOn(ch, 'sendMessage').mockImplementation(async (chatId, text) => {
+        if (text.startsWith('Update channel memory')) {
+          markDeliveryStarted();
+          await delivery;
+          return;
+        }
+        ch.sent.push({ chatId, text });
+      });
+
+      const proposal = ch.handleInbound(
+        envelope({
+          text: '把刚才那条记忆改成 Use production.',
+          senderId: 'alice',
+        }),
+      );
+      await deliveryStarted;
+      await ch.handleInbound(
+        envelope({
+          text: '把 m-a31f0d82c7e4 改成Use latest.',
+          senderId: 'alice',
+        }),
+      );
+      resolveDelivery();
+      await proposal;
+      await ch.handleInbound(
+        envelope({ text: '确认更新记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledTimes(1);
+      expect(channelMemory.updateChannelMemoryEntry).toHaveBeenCalledWith(
+        {
+          channelName: 'test-chan',
+          chatId: 'chat1',
+          threadId: undefined,
+        },
+        { id: 'm-a31f0d82c7e4', text: 'Use latest.' },
+      );
     });
 
     it('keeps a pending update through natural reads, no matches, and ambiguity', async () => {
@@ -3865,6 +4091,69 @@ describe('ChannelBase', () => {
         { chatId: 'chat1', text: 'Channel memory cleared.' },
       ]);
       expect(bridge.prompt).not.toHaveBeenCalled();
+    });
+
+    it('does not confirm a clear before proposal delivery completes', async () => {
+      const channelMemory = createChannelMemory();
+      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      let resolveDelivery!: () => void;
+      const delivery = new Promise<void>((resolve) => {
+        resolveDelivery = resolve;
+      });
+      let markDeliveryStarted!: () => void;
+      const deliveryStarted = new Promise<void>((resolve) => {
+        markDeliveryStarted = resolve;
+      });
+      vi.spyOn(ch, 'sendMessage').mockImplementation(async (chatId, text) => {
+        if (text.startsWith('This clears channel memory')) {
+          markDeliveryStarted();
+          await delivery;
+          return;
+        }
+        ch.sent.push({ chatId, text });
+      });
+
+      const proposal = ch.handleInbound(
+        envelope({ text: '清空记忆', senderId: 'alice' }),
+      );
+      await deliveryStarted;
+      await ch.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+      const callsBeforeDelivery =
+        channelMemory.clearChannelMemory.mock.calls.length;
+
+      resolveDelivery();
+      await proposal;
+
+      expect(callsBeforeDelivery).toBe(0);
+      await ch.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+      expect(channelMemory.clearChannelMemory).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retain a clear proposal when delivery fails', async () => {
+      const channelMemory = createChannelMemory();
+      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      vi.spyOn(ch, 'sendMessage').mockRejectedValueOnce(
+        new Error('delivery failed'),
+      );
+
+      await expect(
+        ch.handleInbound(envelope({ text: '清空记忆', senderId: 'alice' })),
+      ).rejects.toThrow('delivery failed');
+      await ch.handleInbound(
+        envelope({ text: '确认清空记忆', senderId: 'alice' }),
+      );
+
+      expect(channelMemory.clearChannelMemory).not.toHaveBeenCalled();
+      expect(ch.sent).toEqual([
+        {
+          chatId: 'chat1',
+          text: 'No pending clear request. Say "清空记忆" first.',
+        },
+      ]);
     });
 
     it('keeps a pending clear after an unmatched update confirmation', async () => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -2925,38 +2925,48 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'natural_update') {
-      this.setPendingChannelMemoryMutation(envelope, {
+      const pending = this.setPendingChannelMemoryMutation(envelope, {
         kind: 'update',
         id: intent.id,
         expectedText: intent.expectedText,
         proposedText: intent.text,
       });
-      await this.sendMessage(
-        envelope.chatId,
-        [
-          `Update channel memory ${intent.id}?`,
-          `Before: ${sanitizePromptText(intent.expectedText).trim()}`,
-          `After: ${sanitizePromptText(intent.text).trim()}`,
-          'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
-        ].join('\n'),
-      );
+      try {
+        await this.sendMessage(
+          envelope.chatId,
+          [
+            `Update channel memory ${intent.id}?`,
+            `Before: ${sanitizePromptText(intent.expectedText).trim()}`,
+            `After: ${sanitizePromptText(intent.text).trim()}`,
+            'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
+          ].join('\n'),
+        );
+      } catch (error) {
+        this.deletePendingChannelMemoryMutationIfMatches(envelope, pending);
+        throw error;
+      }
       return;
     }
 
     if (intent.kind === 'natural_remove') {
-      this.setPendingChannelMemoryMutation(envelope, {
+      const pending = this.setPendingChannelMemoryMutation(envelope, {
         kind: 'remove',
         id: intent.id,
         expectedText: intent.expectedText,
       });
-      await this.sendMessage(
-        envelope.chatId,
-        [
-          `Remove channel memory ${intent.id}?`,
-          sanitizePromptText(intent.expectedText).trim(),
-          'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
-        ].join('\n'),
-      );
+      try {
+        await this.sendMessage(
+          envelope.chatId,
+          [
+            `Remove channel memory ${intent.id}?`,
+            sanitizePromptText(intent.expectedText).trim(),
+            'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
+          ].join('\n'),
+        );
+      } catch (error) {
+        this.deletePendingChannelMemoryMutationIfMatches(envelope, pending);
+        throw error;
+      }
       return;
     }
 
@@ -3065,7 +3075,6 @@ export abstract class ChannelBase {
       let changed: boolean;
       const isUpdate = intent.kind === 'update';
       const id = intent.id;
-      this.deletePendingChannelMemoryMutation(envelope);
       try {
         if (isUpdate) {
           ({ changed } = await channelMemory.updateChannelMemoryEntry(
@@ -3157,15 +3166,18 @@ export abstract class ChannelBase {
   }
 
   private channelMemoryPendingKey(envelope: Envelope): string {
-    return `${this.name}:${envelope.chatId}:${envelope.threadId ?? ''}:${
-      envelope.senderId ?? ''
-    }`;
+    return JSON.stringify([
+      this.name,
+      envelope.chatId,
+      envelope.threadId ?? null,
+      envelope.senderId ?? null,
+    ]);
   }
 
   private setPendingChannelMemoryMutation(
     envelope: Envelope,
     mutation: PendingChannelMemoryMutationInput,
-  ): void {
+  ): PendingChannelMemoryMutation {
     const now = Date.now();
     for (const [pendingKey, pending] of this.pendingChannelMemoryMutations) {
       if (pending.expiresAt < now) {
@@ -3173,10 +3185,12 @@ export abstract class ChannelBase {
       }
     }
     this.deletePendingChannelMemoryMutation(envelope);
+    const pending = { ...mutation, expiresAt: now + 60_000 };
     this.pendingChannelMemoryMutations.set(
       this.channelMemoryPendingKey(envelope),
-      { ...mutation, expiresAt: now + 60_000 },
+      pending,
     );
+    return pending;
   }
 
   private takePendingChannelMemoryMutation<
@@ -3205,6 +3219,16 @@ export abstract class ChannelBase {
     this.pendingChannelMemoryMutations.delete(
       this.channelMemoryPendingKey(envelope),
     );
+  }
+
+  private deletePendingChannelMemoryMutationIfMatches(
+    envelope: Envelope,
+    pending: PendingChannelMemoryMutation,
+  ): void {
+    const key = this.channelMemoryPendingKey(envelope);
+    if (this.pendingChannelMemoryMutations.get(key) === pending) {
+      this.pendingChannelMemoryMutations.delete(key);
+    }
   }
 
   private async classifyChannelMemoryIntent(
@@ -3795,6 +3819,9 @@ export abstract class ChannelBase {
 
     let memoryIntent: ResolvedChannelMemoryIntent | null =
       parseChannelMemoryIntent(envelope.text);
+    if (memoryIntent?.kind === 'update' || memoryIntent?.kind === 'remove') {
+      this.deletePendingChannelMemoryMutation(envelope);
+    }
     if (
       !memoryIntent &&
       this.shouldClassifyChannelMemoryIntent(envelope.text)

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -294,6 +294,10 @@ export abstract class ChannelBase {
     string,
     PendingChannelMemoryMutation
   >();
+  private pendingChannelMemoryMutationDeliveries = new Map<
+    string,
+    PendingChannelMemoryMutationInput
+  >();
 
   /** Per-session active prompt tracking for dispatch modes. */
   private activePrompts: Map<string, ActivePrompt> = new Map();
@@ -2848,9 +2852,9 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'clear_request') {
-      this.setPendingChannelMemoryMutation(envelope, { kind: 'clear' });
-      await this.sendMessage(
-        envelope.chatId,
+      await this.deliverPendingChannelMemoryMutation(
+        envelope,
+        { kind: 'clear' },
         'This clears channel memory for this chat. Say "确认清空记忆" or "confirm clear memory" to proceed.',
       );
       return;
@@ -2925,48 +2929,38 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'natural_update') {
-      const pending = this.setPendingChannelMemoryMutation(envelope, {
-        kind: 'update',
-        id: intent.id,
-        expectedText: intent.expectedText,
-        proposedText: intent.text,
-      });
-      try {
-        await this.sendMessage(
-          envelope.chatId,
-          [
-            `Update channel memory ${intent.id}?`,
-            `Before: ${sanitizePromptText(intent.expectedText).trim()}`,
-            `After: ${sanitizePromptText(intent.text).trim()}`,
-            'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
-          ].join('\n'),
-        );
-      } catch (error) {
-        this.deletePendingChannelMemoryMutationIfMatches(envelope, pending);
-        throw error;
-      }
+      await this.deliverPendingChannelMemoryMutation(
+        envelope,
+        {
+          kind: 'update',
+          id: intent.id,
+          expectedText: intent.expectedText,
+          proposedText: intent.text,
+        },
+        [
+          `Update channel memory ${intent.id}?`,
+          `Before: ${sanitizePromptText(intent.expectedText).trim()}`,
+          `After: ${sanitizePromptText(intent.text).trim()}`,
+          'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
+        ].join('\n'),
+      );
       return;
     }
 
     if (intent.kind === 'natural_remove') {
-      const pending = this.setPendingChannelMemoryMutation(envelope, {
-        kind: 'remove',
-        id: intent.id,
-        expectedText: intent.expectedText,
-      });
-      try {
-        await this.sendMessage(
-          envelope.chatId,
-          [
-            `Remove channel memory ${intent.id}?`,
-            sanitizePromptText(intent.expectedText).trim(),
-            'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
-          ].join('\n'),
-        );
-      } catch (error) {
-        this.deletePendingChannelMemoryMutationIfMatches(envelope, pending);
-        throw error;
-      }
+      await this.deliverPendingChannelMemoryMutation(
+        envelope,
+        {
+          kind: 'remove',
+          id: intent.id,
+          expectedText: intent.expectedText,
+        },
+        [
+          `Remove channel memory ${intent.id}?`,
+          sanitizePromptText(intent.expectedText).trim(),
+          'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
+        ].join('\n'),
+      );
       return;
     }
 
@@ -3174,10 +3168,11 @@ export abstract class ChannelBase {
     ]);
   }
 
-  private setPendingChannelMemoryMutation(
+  private async deliverPendingChannelMemoryMutation(
     envelope: Envelope,
     mutation: PendingChannelMemoryMutationInput,
-  ): PendingChannelMemoryMutation {
+    message: string,
+  ): Promise<void> {
     const now = Date.now();
     for (const [pendingKey, pending] of this.pendingChannelMemoryMutations) {
       if (pending.expiresAt < now) {
@@ -3185,12 +3180,24 @@ export abstract class ChannelBase {
       }
     }
     this.deletePendingChannelMemoryMutation(envelope);
-    const pending = { ...mutation, expiresAt: now + 60_000 };
-    this.pendingChannelMemoryMutations.set(
-      this.channelMemoryPendingKey(envelope),
-      pending,
-    );
-    return pending;
+    const key = this.channelMemoryPendingKey(envelope);
+    this.pendingChannelMemoryMutationDeliveries.set(key, mutation);
+    try {
+      await this.sendMessage(envelope.chatId, message);
+    } catch (error) {
+      if (this.pendingChannelMemoryMutationDeliveries.get(key) === mutation) {
+        this.pendingChannelMemoryMutationDeliveries.delete(key);
+      }
+      throw error;
+    }
+    if (this.pendingChannelMemoryMutationDeliveries.get(key) !== mutation) {
+      return;
+    }
+    this.pendingChannelMemoryMutationDeliveries.delete(key);
+    this.pendingChannelMemoryMutations.set(key, {
+      ...mutation,
+      expiresAt: Date.now() + 60_000,
+    });
   }
 
   private takePendingChannelMemoryMutation<
@@ -3216,19 +3223,9 @@ export abstract class ChannelBase {
   }
 
   private deletePendingChannelMemoryMutation(envelope: Envelope): void {
-    this.pendingChannelMemoryMutations.delete(
-      this.channelMemoryPendingKey(envelope),
-    );
-  }
-
-  private deletePendingChannelMemoryMutationIfMatches(
-    envelope: Envelope,
-    pending: PendingChannelMemoryMutation,
-  ): void {
     const key = this.channelMemoryPendingKey(envelope);
-    if (this.pendingChannelMemoryMutations.get(key) === pending) {
-      this.pendingChannelMemoryMutations.delete(key);
-    }
+    this.pendingChannelMemoryMutations.delete(key);
+    this.pendingChannelMemoryMutationDeliveries.delete(key);
   }
 
   private async classifyChannelMemoryIntent(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -2857,16 +2857,106 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'update_confirm' || intent.kind === 'remove_confirm') {
-      const kind = intent.kind === 'update_confirm' ? 'update' : 'remove';
-      const pending = this.takePendingChannelMemoryMutation(envelope, kind);
+      const pending =
+        intent.kind === 'update_confirm'
+          ? this.takePendingChannelMemoryMutation(envelope, 'update')
+          : this.takePendingChannelMemoryMutation(envelope, 'remove');
       if (!pending) {
         await this.sendMessage(
           envelope.chatId,
-          kind === 'update'
+          intent.kind === 'update_confirm'
             ? 'No pending channel memory update. Start a new update request first.'
             : 'No pending channel memory removal. Start a new removal request first.',
         );
+        return;
       }
+
+      const channelMemory = await this.getChannelMemory(envelope);
+      if (!channelMemory) return;
+      const isUpdate = pending.kind === 'update';
+      let changed: boolean;
+      try {
+        if (isUpdate) {
+          ({ changed } = await channelMemory.updateChannelMemoryEntry(
+            this.channelMemoryTarget(envelope),
+            {
+              id: pending.id,
+              text: pending.proposedText,
+              expectedText: pending.expectedText,
+            },
+          ));
+        } else {
+          ({ changed } = await channelMemory.removeChannelMemoryEntries(
+            this.channelMemoryTarget(envelope),
+            {
+              ids: [pending.id],
+              expectedTextById: { [pending.id]: pending.expectedText },
+            },
+          ));
+        }
+      } catch (error) {
+        const message = this.channelMemoryErrorMessage(error);
+        this.logChannelMemoryError(
+          isUpdate ? 'update' : 'remove',
+          envelope,
+          message,
+        );
+        await this.sendMessage(
+          envelope.chatId,
+          message === 'Channel memory entry changed'
+            ? 'That channel memory entry changed since it was selected. View channel memory and start the operation again.'
+            : `Failed to ${isUpdate ? 'update' : 'remove'} channel memory: ${this.channelMemoryUserErrorMessage()}`,
+        );
+        return;
+      }
+      if (!changed) {
+        await this.sendMessage(
+          envelope.chatId,
+          `No channel memory entry ${pending.id}.`,
+        );
+        return;
+      }
+      this.invalidateSessionContext(envelope);
+      await this.sendMessage(
+        envelope.chatId,
+        `Channel memory ${pending.id} ${isUpdate ? 'updated' : 'removed'}.`,
+      );
+      return;
+    }
+
+    if (intent.kind === 'natural_update') {
+      this.setPendingChannelMemoryMutation(envelope, {
+        kind: 'update',
+        id: intent.id,
+        expectedText: intent.expectedText,
+        proposedText: intent.text,
+      });
+      await this.sendMessage(
+        envelope.chatId,
+        [
+          `Update channel memory ${intent.id}?`,
+          `Before: ${sanitizePromptText(intent.expectedText).trim()}`,
+          `After: ${sanitizePromptText(intent.text).trim()}`,
+          'Say "确认更新记忆" or "confirm memory update" within 60 seconds.',
+        ].join('\n'),
+      );
+      return;
+    }
+
+    if (intent.kind === 'natural_remove') {
+      this.setPendingChannelMemoryMutation(envelope, {
+        kind: 'remove',
+        id: intent.id,
+        expectedText: intent.expectedText,
+      });
+      await this.sendMessage(
+        envelope.chatId,
+        [
+          `Remove channel memory ${intent.id}?`,
+          sanitizePromptText(intent.expectedText).trim(),
+          'Say "确认删除记忆" or "confirm memory removal" within 60 seconds.',
+        ].join('\n'),
+      );
       return;
     }
 
@@ -2971,37 +3061,21 @@ export abstract class ChannelBase {
       return;
     }
 
-    if (
-      intent.kind === 'update' ||
-      intent.kind === 'remove' ||
-      intent.kind === 'natural_update' ||
-      intent.kind === 'natural_remove'
-    ) {
+    if (intent.kind === 'update' || intent.kind === 'remove') {
       let changed: boolean;
-      const isUpdate =
-        intent.kind === 'update' || intent.kind === 'natural_update';
+      const isUpdate = intent.kind === 'update';
       const id = intent.id;
+      this.deletePendingChannelMemoryMutation(envelope);
       try {
         if (isUpdate) {
           ({ changed } = await channelMemory.updateChannelMemoryEntry(
             this.channelMemoryTarget(envelope),
-            intent.kind === 'natural_update'
-              ? {
-                  id: intent.id,
-                  text: intent.text,
-                  expectedText: intent.expectedText,
-                }
-              : { id: intent.id, text: intent.text },
+            { id: intent.id, text: intent.text },
           ));
         } else {
           ({ changed } = await channelMemory.removeChannelMemoryEntries(
             this.channelMemoryTarget(envelope),
-            intent.kind === 'natural_remove'
-              ? {
-                  ids: [intent.id],
-                  expectedTextById: { [intent.id]: intent.expectedText },
-                }
-              : { ids: [intent.id] },
+            { ids: [intent.id] },
           ));
         }
       } catch (error) {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -118,6 +118,26 @@ type ResolvedChannelMemoryIntent =
   | { kind: 'natural_update'; id: string; text: string; expectedText: string }
   | { kind: 'natural_remove'; id: string; expectedText: string };
 
+type PendingChannelMemoryMutationInput =
+  | { kind: 'clear' }
+  | {
+      kind: 'update';
+      id: string;
+      expectedText: string;
+      proposedText: string;
+    }
+  | {
+      kind: 'remove';
+      id: string;
+      expectedText: string;
+    };
+
+type PendingChannelMemoryMutation = PendingChannelMemoryMutationInput & {
+  expiresAt: number;
+};
+
+type PendingChannelMemoryMutationKind = PendingChannelMemoryMutation['kind'];
+
 export interface ChannelBaseOptions {
   router?: SessionRouter;
   proxy?: string;
@@ -270,7 +290,10 @@ export abstract class ChannelBase {
    * so a cleared session can't be resurrected by an already-queued prompt.
    */
   private sessionGenerations: Map<string, number> = new Map();
-  private pendingClears: Map<string, number> = new Map();
+  private pendingChannelMemoryMutations = new Map<
+    string,
+    PendingChannelMemoryMutation
+  >();
 
   /** Per-session active prompt tracking for dispatch modes. */
   private activePrompts: Map<string, ActivePrompt> = new Map();
@@ -2825,11 +2848,25 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'clear_request') {
-      this.setPendingClear(this.clearPendingKey(envelope));
+      this.setPendingChannelMemoryMutation(envelope, { kind: 'clear' });
       await this.sendMessage(
         envelope.chatId,
         'This clears channel memory for this chat. Say "确认清空记忆" or "confirm clear memory" to proceed.',
       );
+      return;
+    }
+
+    if (intent.kind === 'update_confirm' || intent.kind === 'remove_confirm') {
+      const kind = intent.kind === 'update_confirm' ? 'update' : 'remove';
+      const pending = this.takePendingChannelMemoryMutation(envelope, kind);
+      if (!pending) {
+        await this.sendMessage(
+          envelope.chatId,
+          kind === 'update'
+            ? 'No pending channel memory update. Start a new update request first.'
+            : 'No pending channel memory removal. Start a new removal request first.',
+        );
+      }
       return;
     }
 
@@ -2996,10 +3033,8 @@ export abstract class ChannelBase {
     }
 
     if (intent.kind === 'clear_confirm') {
-      const pendingKey = this.clearPendingKey(envelope);
-      const expiresAt = this.pendingClears.get(pendingKey);
-      this.pendingClears.delete(pendingKey);
-      if (expiresAt === undefined || expiresAt < Date.now()) {
+      const pending = this.takePendingChannelMemoryMutation(envelope, 'clear');
+      if (!pending) {
         await this.sendMessage(
           envelope.chatId,
           'No pending clear request. Say "清空记忆" first.',
@@ -3047,20 +3082,55 @@ export abstract class ChannelBase {
     );
   }
 
-  private clearPendingKey(envelope: Envelope): string {
+  private channelMemoryPendingKey(envelope: Envelope): string {
     return `${this.name}:${envelope.chatId}:${envelope.threadId ?? ''}:${
       envelope.senderId ?? ''
     }`;
   }
 
-  private setPendingClear(key: string): void {
+  private setPendingChannelMemoryMutation(
+    envelope: Envelope,
+    mutation: PendingChannelMemoryMutationInput,
+  ): void {
     const now = Date.now();
-    for (const [pendingKey, expiresAt] of this.pendingClears) {
-      if (expiresAt < now) {
-        this.pendingClears.delete(pendingKey);
+    for (const [pendingKey, pending] of this.pendingChannelMemoryMutations) {
+      if (pending.expiresAt < now) {
+        this.pendingChannelMemoryMutations.delete(pendingKey);
       }
     }
-    this.pendingClears.set(key, now + 60_000);
+    this.deletePendingChannelMemoryMutation(envelope);
+    this.pendingChannelMemoryMutations.set(
+      this.channelMemoryPendingKey(envelope),
+      { ...mutation, expiresAt: now + 60_000 },
+    );
+  }
+
+  private takePendingChannelMemoryMutation<
+    K extends PendingChannelMemoryMutationKind,
+  >(
+    envelope: Envelope,
+    kind: K,
+  ): Extract<PendingChannelMemoryMutation, { kind: K }> | undefined {
+    const key = this.channelMemoryPendingKey(envelope);
+    const pending = this.pendingChannelMemoryMutations.get(key);
+    if (!pending) {
+      return undefined;
+    }
+    if (pending.expiresAt < Date.now()) {
+      this.pendingChannelMemoryMutations.delete(key);
+      return undefined;
+    }
+    if (pending.kind !== kind) {
+      return undefined;
+    }
+    this.pendingChannelMemoryMutations.delete(key);
+    return pending as Extract<PendingChannelMemoryMutation, { kind: K }>;
+  }
+
+  private deletePendingChannelMemoryMutation(envelope: Envelope): void {
+    this.pendingChannelMemoryMutations.delete(
+      this.channelMemoryPendingKey(envelope),
+    );
   }
 
   private async classifyChannelMemoryIntent(

--- a/packages/channels/base/src/channel-memory-intent.test.ts
+++ b/packages/channels/base/src/channel-memory-intent.test.ts
@@ -150,6 +150,24 @@ describe('parseChannelMemoryIntent', () => {
     });
   });
 
+  it('parses action-specific update and removal confirmations', () => {
+    expect(parseChannelMemoryIntent('确认更新记忆')).toEqual({
+      kind: 'update_confirm',
+    });
+    expect(parseChannelMemoryIntent('confirm memory update')).toEqual({
+      kind: 'update_confirm',
+    });
+    expect(parseChannelMemoryIntent('确认删除记忆')).toEqual({
+      kind: 'remove_confirm',
+    });
+    expect(parseChannelMemoryIntent('confirm memory removal')).toEqual({
+      kind: 'remove_confirm',
+    });
+    for (const text of ['确认', 'confirm', '可以', '好的']) {
+      expect(parseChannelMemoryIntent(text)).toBeNull();
+    }
+  });
+
   it('leaves ambiguous prose alone', () => {
     expect(parseChannelMemoryIntent('保存配置到本地')).toBeNull();
     expect(parseChannelMemoryIntent('我想讨论一下记忆模块')).toBeNull();

--- a/packages/channels/base/src/channel-memory-intent.ts
+++ b/packages/channels/base/src/channel-memory-intent.ts
@@ -6,6 +6,8 @@ export type ChannelMemoryIntent =
   | { kind: 'inspect'; id: string }
   | { kind: 'remove'; id: string }
   | { kind: 'update'; id: string; text: string }
+  | { kind: 'update_confirm' }
+  | { kind: 'remove_confirm' }
   | { kind: 'clear_request' }
   | { kind: 'clear_confirm' };
 
@@ -68,6 +70,16 @@ const CLEAR_CONFIRM_PATTERNS: RegExp[] = [
   /^confirm clear memory$/iu,
 ];
 
+const UPDATE_CONFIRM_PATTERNS: RegExp[] = [
+  /^确认更新记忆$/u,
+  /^confirm memory update$/iu,
+];
+
+const REMOVE_CONFIRM_PATTERNS: RegExp[] = [
+  /^确认删除记忆$/u,
+  /^confirm memory removal$/iu,
+];
+
 export function parseChannelMemoryIntent(
   text: string,
 ): ChannelMemoryIntent | null {
@@ -76,6 +88,16 @@ export function parseChannelMemoryIntent(
     return null;
   }
 
+  for (const pattern of UPDATE_CONFIRM_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return { kind: 'update_confirm' };
+    }
+  }
+  for (const pattern of REMOVE_CONFIRM_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return { kind: 'remove_confirm' };
+    }
+  }
   for (const pattern of CLEAR_CONFIRM_PATTERNS) {
     if (pattern.test(trimmed)) {
       return { kind: 'clear_confirm' };


### PR DESCRIPTION
## What this PR does

Requires an action-specific confirmation before a natural-language channel-memory update or removal changes stored memory. The confirmation is sender- and target-isolated, expires after 60 seconds, consumes the proposal before storage executes, and uses the original selected text for compare-and-swap protection. Exact-ID updates and removals remain immediate.

## Why it's needed

Natural references are convenient but can identify a durable entry that the user did not intend to change immediately. Showing the selected entry and proposed action before mutation keeps the natural-language workflow safe while preserving the deterministic exact-ID fast path.

## Reviewer Test Plan

### How to verify

Create a unique natural memory-update request and confirm that it presents the selected ID, before/after content, and only mutates after `确认更新记忆` or `confirm memory update`. Repeat for a natural removal with `确认删除记忆` or `confirm memory removal`. Verify generic acknowledgements do not mutate, expiration rejects a late confirmation, a second accepted group member cannot confirm the first member's proposal, and an exact-ID update or removal completes without a confirmation prompt.

### Evidence (Before & After)

Before: a uniquely resolved natural update or removal applied immediately. After: it presents an action-specific 60-second confirmation and applies the stored compare-and-swap proposal exactly once after a matching confirmation. Focused automated coverage passes for parser forms, update/removal proposals, concurrent confirmation consumption, TTL, target and sender isolation, access gates, exact-ID cancellation, session invalidation, and clear-flow compatibility.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

macOS local workspace with Node.js dependencies already installed. No live bot process was started.

## Risk & Scope

- Main risk or tradeoff: external bot delivery, daemon restart behavior, and real platform group routing need a disposable live configuration for final validation.
- Not validated / out of scope: all disposable-only live E2E scenarios remain unobserved because no dedicated disposable bot and model credentials were available. Automated coverage and an independent whole-branch review are complete.
- Breaking changes / migration notes: natural updates and removals now require an action-specific confirmation; exact-ID mutations and existing clear confirmation behavior remain compatible.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的改动

在自然语言的频道记忆更新或删除实际修改存储前，要求使用与操作类型对应的明确确认。确认状态按发送者和目标隔离，60 秒后过期，在存储调用前先消费提案，并使用最初选中的文本执行 compare-and-swap 保护。精确 ID 的更新和删除仍会立即执行。

## 为什么需要

自然语言引用使用方便，但可能选中用户不希望立刻修改的持久记忆。先展示选中的条目和拟执行操作后再修改，可以让自然语言流程更安全，同时保留确定性的精确 ID 快速路径。

## Reviewer 测试计划

### 如何验证

创建一个唯一命中的自然语言记忆更新请求，确认它展示选中的 ID、修改前后内容，且只会在发送 `确认更新记忆` 或 `confirm memory update` 后修改。对自然语言删除和 `确认删除记忆` 或 `confirm memory removal` 重复验证。确认通用确认词不会修改数据、超时确认会被拒绝、同一群中的第二个已接受成员不能确认第一个成员的提案，以及精确 ID 更新或删除无需确认提示即可完成。

### 证据（修改前后）

修改前：唯一命中的自然语言更新或删除会立即执行。修改后：系统展示操作类型对应的 60 秒确认，并且仅在匹配确认后执行一次保存的 compare-and-swap 提案。聚焦自动化覆盖已通过：解析器确认形式、更新和删除提案、并发确认消费、TTL、目标和发送者隔离、访问门禁、精确 ID 取消、会话失效，以及清空流程兼容性。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### 环境（可选）

使用已安装 Node.js 依赖的 macOS 本地工作区。未启动线上机器人进程。

## 风险与范围

- 主要风险或权衡：外部机器人消息投递、守护进程重启行为和真实平台群聊路由仍需要一次性测试配置进行最终验证。
- 未验证 / 范围外：由于没有可用的专用一次性机器人和模型凭据，所有仅限一次性配置的线上 E2E 场景均未观察。自动化覆盖和独立的全分支审查均已完成。
- 破坏性变更 / 迁移说明：自然语言更新和删除现在要求与操作类型对应的确认；精确 ID 修改和既有清空确认行为保持兼容。

## 关联 Issue

不适用

</details>
