### PR TITLE
revert(vscode): undo Electron Node mode changes from #6866

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -410,45 +410,6 @@ describe('gemini.tsx main function', () => {
     processExitSpy.mockRestore();
   });
 
-  it('scrubs Electron node bootstrap env before ACP startup', async () => {
-    const originalElectronRunAsNode = process.env['ELECTRON_RUN_AS_NODE'];
-    const originalScrubMarker =
-      process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'];
-    process.env['ELECTRON_RUN_AS_NODE'] = '1';
-    process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = '1';
-
-    const { parseArguments } = await import('./config/config.js');
-    const { loadSettings } = await import('./config/settings.js');
-
-    vi.mocked(parseArguments).mockResolvedValue({
-      acp: true,
-      experimentalAcp: undefined,
-    } as unknown as CliArgs);
-    vi.mocked(loadSettings).mockImplementation(() => {
-      expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
-      expect(
-        process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'],
-      ).toBeUndefined();
-      throw new Error('stop after scrub');
-    });
-
-    try {
-      await expect(main()).rejects.toThrow('stop after scrub');
-    } finally {
-      if (originalElectronRunAsNode === undefined) {
-        delete process.env['ELECTRON_RUN_AS_NODE'];
-      } else {
-        process.env['ELECTRON_RUN_AS_NODE'] = originalElectronRunAsNode;
-      }
-      if (originalScrubMarker === undefined) {
-        delete process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'];
-      } else {
-        process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] =
-          originalScrubMarker;
-      }
-    }
-  });
-
   it('should skip full settings discovery in bare mode', async () => {
     const originalArgv = process.argv;
     process.argv = ['node', 'script.js', '--bare'];

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -251,14 +251,6 @@ export async function main() {
   let argv = await parseArguments();
   profileCheckpoint('after_parse_arguments');
 
-  if (
-    (argv.acp || argv.experimentalAcp) &&
-    process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] === '1'
-  ) {
-    delete process.env['ELECTRON_RUN_AS_NODE'];
-    delete process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'];
-  }
-
   if (isBareMode(argv.bare)) {
     process.env[QWEN_CODE_SIMPLE_ENV_VAR] = '1';
   }

--- a/packages/vscode-ide-companion/src/services/acpConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.test.ts
@@ -8,15 +8,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { ContentBlock } from '@agentclientprotocol/sdk';
 
-const spawnMock = vi.hoisted(() => vi.fn());
-
 // AcpConnection imports AcpFileHandler which imports vscode.
 // Mock vscode so it can be resolved without the actual VS Code runtime.
 vi.mock('vscode', () => ({}));
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
-  return { ...actual, spawn: spawnMock };
-});
 
 import { AcpConnection } from './acpConnection.js';
 import { ACP_ERROR_CODES } from '../constants/acpSchema.js';
@@ -47,27 +41,6 @@ function createMockChild(overrides?: Record<string, unknown>) {
     ...overrides,
   } as unknown as AcpConnectionInternal['child'];
 }
-
-describe('AcpConnection process spawning', () => {
-  it('runs the bundled CLI with Electron in Node mode', async () => {
-    spawnMock.mockReset();
-    spawnMock.mockReturnValue(createMockChild());
-    const conn = new AcpConnection() as unknown as {
-      connect: (cliEntryPath: string) => Promise<void>;
-      setupChildProcessHandlers: () => Promise<void>;
-    };
-    conn.setupChildProcessHandlers = vi.fn().mockResolvedValue(undefined);
-
-    await conn.connect(process.execPath);
-
-    expect(spawnMock).toHaveBeenCalledOnce();
-    const options = spawnMock.mock.calls[0]?.[2] as {
-      env?: NodeJS.ProcessEnv;
-    };
-    expect(options.env?.ELECTRON_RUN_AS_NODE).toBe('1');
-    expect(options.env?.QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE).toBe('1');
-  });
-});
 
 describe('AcpConnection readTextFile error mapping', () => {
   it('maps ENOENT to RESOURCE_NOT_FOUND RequestError', () => {

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -92,9 +92,6 @@ export class AcpConnection {
     this.workingDir = workingDir;
 
     const env = { ...process.env };
-    // VS Code's process.execPath is Electron; force Node mode for CLI args.
-    env['ELECTRON_RUN_AS_NODE'] = '1';
-    env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = '1';
 
     const proxyArg = extraArgs.find(
       (arg, i) => arg === '--proxy' && i + 1 < extraArgs.length,


### PR DESCRIPTION
## What this PR does

Reverts #6866 (fix(vscode): run ACP process in Electron Node mode) which did not resolve the underlying issue and caused regressions in v0.19.11.

## Why the revert

After #6866 shipped in v0.19.11, users on Windows and Linux report:

```
Failed to connect to Qwen agent: Qwen ACP process exited unexpectedly (exit code: 0, signal: null)
CLI stderr: Warning: acp is not in the list of known options, but still passed to Electron/Chromium.
```

ELECTRON_RUN_AS_NODE=1 does not work reliably across VS Code Electron builds. The fix did not resolve the original problem and affected users who were previously working on v0.19.10.

## Files reverted

- packages/cli/src/gemini.tsx - removed scrub logic
- packages/cli/src/gemini.test.tsx - removed scrub test  
- packages/vscode-ide-companion/src/services/acpConnection.ts - removed ELECTRON_RUN_AS_NODE env vars
- packages/vscode-ide-companion/src/services/acpConnection.test.ts - removed spawn mock test

Closes #7051, #7056.