### PR TITLE
ci(autofix): run the schema gate from a trusted staged copy, not the branch tree

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -288,6 +288,12 @@ jobs:
           rm -rf "${WORKDIR}"
           mkdir -p "${WORKDIR}"
 
+      # Same staging as the review-address job: the verify gate always runs the
+      # trusted checkout's copy of the schema gate, never a working-tree copy.
+      - name: 'Stage trusted schema gate'
+        run: |-
+          cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
+
       - name: 'Check bot credentials'
         env:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
@@ -787,7 +793,11 @@ jobs:
           # verify step so the two copies cannot drift (rationale + the
           # generator crash guard live in the script). On failure it writes
           # outcome=failed to GITHUB_OUTPUT and exits 1.
-          bash .github/scripts/check-settings-schema.sh
+          # Run the copy staged from the trusted base checkout: a PR branch
+          # that predates the script does not contain it (bash would exit 127
+          # and kill the gate with no outcome), and the gate logic must come
+          # from the trusted base, not the branch under verification.
+          bash "${RUNNER_TEMP}/check-settings-schema.sh"
 
           # Run changed/related tests for the packages this fix touches.
           # --changed follows the import graph so transitive breakage is caught.
@@ -1196,6 +1206,16 @@ jobs:
           rm -rf "${WORKDIR}"
           mkdir -p "${WORKDIR}"
 
+      # Stage the schema gate script from the TRUSTED BASE checkout before
+      # "Prepare branch and feedback" switches the working tree to the PR
+      # branch. The verify gate must run the trusted copy: a PR branch that
+      # predates this script does not contain it (bash exits 127 and the gate
+      # dies without an outcome), and an in-branch copy would let branch code
+      # define its own gate.
+      - name: 'Stage trusted schema gate'
+        run: |-
+          cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
+
       - name: 'Check runner environment'
         env:
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
@@ -1474,7 +1494,11 @@ jobs:
           # the script); the write is on a tracked file compared by `git status`,
           # not the commit-level no-op git-diff below, and it is restored on
           # failure. On failure it writes outcome=failed and exits 1.
-          bash .github/scripts/check-settings-schema.sh
+          # Run the copy staged from the trusted base checkout: a PR branch
+          # that predates the script does not contain it (bash would exit 127
+          # and kill the gate with no outcome), and the gate logic must come
+          # from the trusted base, not the branch under verification.
+          bash "${RUNNER_TEMP}/check-settings-schema.sh"
 
           if git diff --quiet "origin/${BRANCH}...${BRANCH}"; then
             # No new commit. That is only legitimate as a deliberate no-action.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -978,12 +978,20 @@ describe('qwen-autofix workflow', () => {
         /cp \.github\/scripts\/check-settings-schema\.sh "\$\{RUNNER_TEMP\}\/check-settings-schema\.sh"/g,
       ) ?? [],
     ).toHaveLength(2);
+    // In the issue-autofix job the staging must happen BEFORE the verify gate's
+    // `git checkout "${BRANCH}"` (first occurrence in the file is the issue
+    // job's): the agent's commits can touch .github/scripts, so a post-checkout
+    // copy would stage the agent's version of the gate instead of the trusted
+    // base's. indexOf resolves to the issue job's staging (first occurrence).
+    expect(
+      workflow.indexOf("- name: 'Stage trusted schema gate'"),
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      workflow.indexOf("- name: 'Stage trusted schema gate'"),
+    ).toBeLessThan(workflow.indexOf('git checkout "${BRANCH}"'));
     // In the review-address job the staging must happen BEFORE the branch switch
     // ("Prepare branch and feedback" exists only in that job; the job's staging
     // step is the last occurrence of the staging step name in the file).
-    expect(
-      workflow.lastIndexOf("- name: 'Stage trusted schema gate'"),
-    ).toBeGreaterThanOrEqual(0);
     expect(
       workflow.lastIndexOf("- name: 'Stage trusted schema gate'"),
     ).toBeLessThan(workflow.indexOf("- name: 'Prepare branch and feedback'"));

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -958,14 +958,35 @@ describe('qwen-autofix workflow', () => {
       expect(step).toContain('npm run typecheck');
       expect(step).toContain('npm run lint');
       // The settings-schema freshness gate is extracted to a shared script so the
-      // two gates cannot drift; each verify step just invokes it.
-      expect(step).toContain('bash .github/scripts/check-settings-schema.sh');
+      // two gates cannot drift. Each verify step MUST invoke the copy staged from
+      // the trusted base checkout, NOT the working-tree path: after "Prepare
+      // branch and feedback" the tree is the PR branch, and a branch that predates
+      // the script does not contain it (bash exits 127 and the gate dies with no
+      // outcome), while an in-branch copy would let branch code define its own
+      // gate.
+      expect(step).toContain('bash "${RUNNER_TEMP}/check-settings-schema.sh"');
+      expect(step).not.toContain('bash .github/scripts/check-settings-schema.sh');
       expect(step).toContain(
         'No package changes detected; skipping package tests.',
       );
       expect(step).not.toContain('Fix does not touch any package');
       expect(step).not.toContain('PR does not touch any package');
     }
+    // Both jobs must stage the trusted copy before any branch switch.
+    expect(
+      workflow.match(
+        /cp \.github\/scripts\/check-settings-schema\.sh "\$\{RUNNER_TEMP\}\/check-settings-schema\.sh"/g,
+      ) ?? [],
+    ).toHaveLength(2);
+    // In the review-address job the staging must happen BEFORE the branch switch
+    // ("Prepare branch and feedback" exists only in that job; the job's staging
+    // step is the last occurrence of the staging step name in the file).
+    expect(
+      workflow.lastIndexOf("- name: 'Stage trusted schema gate'"),
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      workflow.lastIndexOf("- name: 'Stage trusted schema gate'"),
+    ).toBeLessThan(workflow.indexOf("- name: 'Prepare branch and feedback'"));
     // The shared script mirrors CI's freshness gate: regenerate + `git status
     // --porcelain` (version-agnostic — the generator's --check was reverted from
     // main by #7031 and must NOT be relied on), with a generator-crash guard, and
@@ -994,10 +1015,10 @@ describe('qwen-autofix workflow', () => {
     );
     expect(reviewVerifyGate).toBeTruthy();
     expect(
-      reviewVerifyGate.indexOf('bash .github/scripts/check-settings-schema.sh'),
+      reviewVerifyGate.indexOf('bash "${RUNNER_TEMP}/check-settings-schema.sh"'),
     ).toBeGreaterThanOrEqual(0);
     expect(
-      reviewVerifyGate.indexOf('bash .github/scripts/check-settings-schema.sh'),
+      reviewVerifyGate.indexOf('bash "${RUNNER_TEMP}/check-settings-schema.sh"'),
     ).toBeLessThan(reviewVerifyGate.indexOf('outcome=noop'));
   });
 


### PR DESCRIPTION
## What this PR does

Fixes a branch-age skew bug in the autofix verify gates introduced by #6998: the gates invoke the shared schema-freshness script via its repo path (`bash .github/scripts/check-settings-schema.sh`), but by the time the review-phase gate runs, the working tree has been switched to the PR branch — and any bot branch created before that script was merged does not contain it, so bash exits 127 and the gate dies without writing an outcome. This PR stages the script from the trusted-base checkout into `${RUNNER_TEMP}` before any branch switch (in both the issue and review jobs) and makes both verify gates invoke the staged copy. As a side benefit, the gate logic now always comes from the trusted base rather than from whatever the branch under verification contains.

## Why it's needed

Caught live on the first post-merge address run. The enhanced loop targeted PR #7072 (branch created at 02:53, before #6998 merged at 03:27), the agent produced a legitimate no-action evaluation, and then the verify gate crashed with `bash: .github/scripts/check-settings-schema.sh: No such file or directory` (exit 127) — see [the failing run](https://github.com/QwenLM/qwen-code/actions/runs/29552946622). The always-post-handoff behavior from #6998 kept the loop from going silent (it posted a round-1 handoff with an eval marker), but the gate itself is broken for every bot branch that predates the script, which at the time of writing was all of them. Syncing each branch with main works around it per-PR, but the structural fix is to stop resolving the gate from the working tree entirely.

## Reviewer Test Plan

### How to verify

1. **Reproduce the bug (before)**: on the failing run linked above, the `review-address (7072, …)` job's Verification gate step logs `bash: .github/scripts/check-settings-schema.sh: No such file or directory` followed by `Process completed with exit code 127`, and the step summary shows `outcome=unknown` — the gate died before writing an outcome.
2. **After**: both verify gates run `bash "${RUNNER_TEMP}/check-settings-schema.sh"`, and both jobs contain a `Stage trusted schema gate` step that copies the script out of the trusted-base checkout; in the review job that step is ordered before `Prepare branch and feedback` (the branch switch). Because the copy is taken before any switch, the gate works regardless of the PR branch's age and always runs the trusted version.
3. Run `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 49/49, including new assertions: staged invocation in both gates and no working-tree invocation remaining, exactly two staging `cp` lines, and the staging step ordered before the branch switch.
4. Static validation: the workflow parses as valid YAML and every `run:` block passes `bash -n`.

### Evidence (Before & After)

```
BEFORE (run 29552946622, review-address 7072 → Verification gate):
  bash: .github/scripts/check-settings-schema.sh: No such file or directory
  ##[error]Process completed with exit code 127.   → outcome=unknown, handoff via job.status only

AFTER:
  - name: 'Stage trusted schema gate'   (both jobs, before any branch switch)
      cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
  verify gates:  bash "${RUNNER_TEMP}/check-settings-schema.sh"   (works for any branch age)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Workflow-only change; runs on `ubuntu-latest` GitHub-hosted runners. Verified locally under bash: contract test 49/49, YAML parse, `bash -n` on every run block.

## Risk & Scope

- Main risk or tradeoff: none beyond a one-file copy per job run; the staged path lives in `${RUNNER_TEMP}`, which is job-scoped and wiped between runs.
- Not validated / out of scope: not exercised end-to-end on a live runner yet (the next address run on any bot PR will exercise it); the interim workaround (syncing existing bot branches with main) has already been applied to the currently open bot PRs.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #6998 (caught during its live validation on #7072).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 #6998 引入的 verify gate「分支年龄偏斜」bug:两个 gate 通过仓库路径调用共享的 schema 新鲜度脚本(`bash .github/scripts/check-settings-schema.sh`),但 review 阶段的 gate 执行时工作区已切换到 PR 分支 —— 任何早于该脚本合入的 bot 分支都不包含它,于是 bash 以 127 退出,gate 在写入 outcome 之前就死掉。本 PR 在任何分支切换之前,把脚本从可信 base 检出暂存到 `${RUNNER_TEMP}`(issue 和 review 两个 job 都做),两个 verify gate 改为调用暂存副本。附带收益:gate 逻辑始终来自可信 base,而不是被验证分支里的任意内容。

## 为什么需要

在合并后的第一次 address 运行中实战抓到。增强回路盯上了 PR #7072(分支创建于 02:53,早于 #6998 的 03:27 合并),agent 给出了合理的 no-action 评估,随后 verify gate 崩溃:`bash: .github/scripts/check-settings-schema.sh: No such file or directory`(exit 127)—— 见[失败的运行](https://github.com/QwenLM/qwen-code/actions/runs/29552946622)。#6998 的「失败必交接」让回路没有静默(发了 round-1 交接和 eval 标记),但 gate 本身对所有早于该脚本的 bot 分支全部失效 —— 当时是全部四个。逐 PR 与 main 同步只是绕过,结构性修复是让 gate 彻底不从工作区解析。

## 评审验证方案

### 如何验证

1. **复现(修复前)**:上面链接的失败运行里,`review-address (7072, …)` job 的 Verification gate step 日志出现 `bash: .github/scripts/check-settings-schema.sh: No such file or directory` 和 `Process completed with exit code 127`,step summary 显示 `outcome=unknown` —— gate 在写 outcome 前死亡。
2. **修复后**:两个 verify gate 运行 `bash "${RUNNER_TEMP}/check-settings-schema.sh"`;两个 job 都有 `Stage trusted schema gate` 步骤从可信 base 检出复制脚本;review job 中该步骤排在 `Prepare branch and feedback`(分支切换)之前。由于副本在任何切换前取得,gate 对任意年龄的 PR 分支都有效,且始终运行可信版本。
3. 运行 `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 49/49,含新断言:两个 gate 均调用暂存副本且不再有工作区路径调用、恰好两处暂存 `cp`、暂存步骤先于分支切换。
4. 静态校验:工作流 YAML 解析有效,所有 `run:` 块通过 `bash -n`。

### 证据(前后对比)

```
修复前(运行 29552946622,review-address 7072 → Verification gate):
  bash: .github/scripts/check-settings-schema.sh: No such file or directory
  ##[error]Process completed with exit code 127.   → outcome=unknown,仅靠 job.status 兜底交接

修复后:
  - name: 'Stage trusted schema gate'(两个 job,任何分支切换之前)
      cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
  verify gates:  bash "${RUNNER_TEMP}/check-settings-schema.sh"(任意分支年龄均可)
```

### 测试情况

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ 已测试 |

### 环境(可选)

仅工作流改动;运行于 `ubuntu-latest` GitHub 托管 runner。本地 bash 下验证:契约测试 49/49、YAML 解析、每个 run 块 `bash -n`。

## 风险与范围

- 主要风险/权衡:每次 job 多一次单文件复制;暂存路径在 `${RUNNER_TEMP}`,job 级隔离、运行间清理。
- 未验证/不在范围内:尚未在真实 runner 上端到端演练(任一 bot PR 的下一次 address 运行即会覆盖);临时绕过(把现有 bot 分支与 main 同步)已应用于当前所有 open 的 bot PR。
- 破坏性变更/迁移:无。

## 关联 Issue

#6998 的后续(在其对 #7072 的实战验证中发现)。

</details>
