### PR TITLE
feat(serve): add workspace session-info aggregate endpoint

### DIFF
--- a/docs/design/2026-07-17-workspace-session-info.md
+++ b/docs/design/2026-07-17-workspace-session-info.md
@@ -1,0 +1,65 @@
+# Workspace `session-info` aggregate endpoint
+
+## Problem
+
+`GET /workspace/:id/sessions` is cursor-paginated and does not return a total.
+`GET /daemon/status` exposes live in-memory `sessionCount` only. Workspaces with
+many persisted sessions (for example from scheduled tasks) cannot learn the
+local store size without paging every session.
+
+## Proposal
+
+Add:
+
+```http
+GET /workspace/:id/session-info
+GET /workspaces/:workspace/session-info
+```
+
+Response (illustrative):
+
+```json
+{
+  "active": 450,
+  "archived": 30,
+  "total": 480,
+  "live": 2,
+  "expensive": true,
+  "cost": "disk_scan"
+}
+```
+
+`live` is omitted for an untrusted secondary workspace because those catalog
+reads must not query the live bridge. If the scan reaches its safety limit or
+cannot classify a candidate JSONL file, the response includes
+`"truncated": true`; persisted counts are then lower bounds.
+
+## Cost model
+
+Persisted counts reuse the existing full-directory scan pattern already used by
+session title search (`SessionService.findSessionsByTitle` /
+`findSessionTitlesByPrefix`):
+
+1. `readdir` the project chats dir (and archive twin)
+2. filter UUID `*.jsonl`
+3. cap at the same file-processing safety limit
+4. read only the first JSONL record for project-hash membership
+
+No title/prompt hydration. This is O(n) on disk and **must not be polled**. The
+response always sets `expensive: true` and `cost: "disk_scan"` so clients can
+fail closed on hot paths. Docs call this out explicitly.
+
+Default list pagination stays unchanged and does not compute totals. Do not
+reuse organized-view `listAllPersistedSummaries` for counts — that path hydrates
+full list metadata up to 50k sessions.
+
+## Capability
+
+Always-on `session_info` on `/capabilities`, next to `session_list`.
+
+## Non-goals
+
+- Cached counters / mutation-hook accounting (possible follow-up if call sites
+  need lower latency)
+- Stuffing `total` into every list page
+- Organized-group or parent-filtered totals in v1

--- a/docs/developers/daemon/08-session-lifecycle.md
+++ b/docs/developers/daemon/08-session-lifecycle.md
@@ -306,7 +306,7 @@ new session arrives.
 - `BridgeOptions.sessionScope` (default `'single'`; optional `'thread'`).
 - `BridgeOptions.initializeTimeoutMs` (default 10s) — ACP `initialize` handshake.
 - `BridgeOptions.channelIdleTimeoutMs` (default 0; reap the ACP child immediately).
-- Capability tags: `session_create`, `session_scope_override`, `session_load`, `session_resume`, `unstable_session_resume` (deprecated alias), `session_list`, `session_close`, `session_metadata`, `session_set_model`, `client_identity`, `client_heartbeat`, `session_recap`, `session_generation`, `session_btw`, `session_context_usage`, `session_tasks`, `session_stats`, `session_lsp`, `session_status`, `non_blocking_prompt`.
+- Capability tags: `session_create`, `session_scope_override`, `session_load`, `session_resume`, `unstable_session_resume` (deprecated alias), `session_list`, `session_info`, `session_close`, `session_metadata`, `session_set_model`, `client_identity`, `client_heartbeat`, `session_recap`, `session_generation`, `session_btw`, `session_context_usage`, `session_tasks`, `session_stats`, `session_lsp`, `session_status`, `non_blocking_prompt`.
 
 ### Stateless generation (`session_generation` capability tag)
 

--- a/docs/developers/daemon/11-capabilities-versioning.md
+++ b/docs/developers/daemon/11-capabilities-versioning.md
@@ -108,7 +108,7 @@ Baseline tags are not present in the `Map` and are advertised unconditionally. T
 
 Foundation: `health`, `daemon_status`, `capabilities`.
 
-Sessions: `session_create`, `session_scope_override`, `session_load`, `session_resume`, `unstable_session_resume`, `session_list`, `session_prompt`, `session_cancel`, `session_events`, `session_set_model`, `session_close`, `session_metadata`, `session_archive`, `session_export`, `session_transcript`, `session_context`, `session_context_usage`, `session_supported_commands`, `session_tasks`, `session_stats`, `session_lsp`, `session_status`, `session_approval_mode_control`, `session_recap`, `session_btw`, **`session_shell_command`** (conditional), `session_language`, `session_rewind`, `session_hooks`, `session_branch`.
+Sessions: `session_create`, `session_scope_override`, `session_load`, `session_resume`, `unstable_session_resume`, `session_list`, `session_info`, `session_prompt`, `session_cancel`, `session_events`, `session_set_model`, `session_close`, `session_metadata`, `session_archive`, `session_export`, `session_transcript`, `session_context`, `session_context_usage`, `session_supported_commands`, `session_tasks`, `session_stats`, `session_lsp`, `session_status`, `session_approval_mode_control`, `session_recap`, `session_btw`, **`session_shell_command`** (conditional), `session_language`, `session_rewind`, `session_hooks`, `session_branch`.
 
 Streaming: `slow_client_warning`, `typed_event_schema`.
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -164,7 +164,7 @@ registry. Clients **must** gate UI off `features`, not off `mode` (per design
 ['health', 'capabilities', 'session_create', 'session_scope_override',
  'session_load', 'session_resume', 'session_transcript',
  'unstable_session_resume',
- 'session_list', 'session_prompt', 'session_cancel', 'session_events',
+ 'session_list', 'session_info', 'session_prompt', 'session_cancel', 'session_events',
  'slow_client_warning', 'typed_event_schema',
  'session_set_model', 'client_identity', 'client_heartbeat',
  'session_permission_vote', 'permission_vote', 'workspace_mcp', 'workspace_skills',
@@ -232,6 +232,8 @@ registry. Clients **must** gate UI off `features`, not off `mode` (per design
 `session_lsp` advertises `GET /session/:id/lsp`, the read-only structured LSP status snapshot for daemon clients. Older daemons return `404`; pre-flight this tag before exposing remote LSP status.
 
 `session_status` advertises `GET /session/:id/status`, the live bridge summary for a single session by id. In addition to `clientCount` and `hasActivePrompt`, live sessions expose `isWaitingForPermission`, `isWaitingForUserQuestion`, `pendingInteractionCount`, and a retained `turnError` after a failed turn. The error clears when the next prompt actually starts. Both the single-session status response and workspace session lists include `turnError` and `pendingInteractions`: render-ready permission actions or `ask_user_question` questions plus the `requestId` and selectable options required by the existing permission vote routes. Each user question has an `answerKey`; vote with `answers`, for example `{ "0": "Polling" }`, keyed by that value. Persisted-only sessions omit runtime state because no runtime exists. Older daemons return `404`; pre-flight this tag before polling a single session's status instead of scanning the full session list.
+
+`session_info` advertises `GET /workspace/:id/session-info` and its `/workspaces/:workspace/session-info` twin. The response aggregates persisted active and archived session counts without hydrating list metadata. It is an explicit O(n) disk scan and must not be polled; clients should treat `truncated: true` as a lower-bound result.
 
 `session_approval_mode_control`, `workspace_tool_toggle`, `workspace_skill_toggle`, `workspace_init`, and `workspace_mcp_restart` advertise the mutation control routes documented below. They are strict-gated by the mutation gate (a daemon configured without a bearer token rejects them with 401 `token_required`). Older daemons return `404`; pre-flight each tag before exposing the corresponding affordance.
 
@@ -893,6 +895,7 @@ Capability tags:
 - `session_supported_commands` → `GET /session/:id/supported-commands`
 - `session_tasks` → `GET /session/:id/tasks`
 - `session_status` → `GET /session/:id/status`
+- `session_info` → `GET /workspace/:id/session-info` and `GET /workspaces/:workspace/session-info`
 - `session_transcript` → `GET /session/:id/transcript`
 - `workspace_persisted_transcript` → `GET /workspaces/:workspace/session/:id/transcript`
 - `workspace_session_export` → `GET /workspaces/:workspace/session/:id/export`
@@ -1820,6 +1823,25 @@ Same request shape as `/load`. Same response shape — `state` mirrors ACP's `Re
 Use `/load` when the client has no history rendered (cold reconnect, picker → open). Use `/resume` when the client already has the turns on screen and only needs the daemon-side handle back.
 
 > ⚠️ **Why is `unstable_session_resume` still advertised?** The daemon's HTTP route and `session_resume` capability are stable for v1, but the bridge still calls ACP's `connection.unstable_resumeSession`. The old tag remains only so SDKs that shipped before `session_resume` can keep working.
+
+### `GET /workspace/:id/session-info` and `GET /workspaces/:workspace/session-info`
+
+Return aggregate persisted session counts for the selected workspace without changing the paginated session-list path:
+
+```json
+{
+  "active": 450,
+  "archived": 30,
+  "total": 480,
+  "live": 2,
+  "expensive": true,
+  "cost": "disk_scan"
+}
+```
+
+`active`, `archived`, and `total` count local JSONL sessions. `live` is the matching in-memory bridge count and is omitted for a registered untrusted secondary workspace because that persisted-only read must not query live state. `expensive` is always `true` and `cost` is always `"disk_scan"`; clients must call this endpoint infrequently rather than poll it. If the scan reaches its safety limit or cannot classify every candidate file, the response adds `"truncated": true` and the persisted counts are lower bounds. Missing storage returns zero persisted counts. The plural route uses the same workspace selector and trust policy as the plural session catalog; an untrusted primary still returns `403 untrusted_workspace`.
+
+The TypeScript daemon SDK exposes the plural route through `workspaceById(...)` or `workspaceByCwd(...)`, followed by `getWorkspaceSessionInfo()`.
 
 ### `GET /workspace/:id/sessions` and `GET /workspaces/:workspace/sessions`
 

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -125,10 +125,34 @@ The daemon also exposes read-only runtime snapshots for client UIs and
 operators: `GET /daemon/status`, `GET /workspace/mcp`,
 `GET /workspace/skills`, `GET /workspace/providers`, `GET /workspace/env`,
 `GET /workspace/preflight`,
+`GET /workspace/:id/session-info`,
 `GET /session/:id/status`, `GET /session/:id/context`,
 `GET /session/:id/supported-commands`, and
 `GET /session/:id/tasks`, `GET /session/:id/lsp`, and
 `GET /session/:id/transcript`.
+
+`GET /workspace/:id/session-info` (and the plural
+`GET /workspaces/:workspace/session-info` twin) returns aggregate session
+counts for a workspace: persisted `active` / `archived` / `total`, plus the
+current in-memory `live` count when live state is available. Registered
+untrusted secondary workspaces omit `live` because their catalog reads do not
+query the live bridge. The paginated `GET /workspace/:id/sessions` list does
+not include a total, so this is the dedicated surface for “how many sessions
+exist?” — useful when scheduled or recurring tasks leave a large local store.
+
+> ⚠️ **Disk scan — do not poll.** This endpoint walks local session JSONL
+> files under the workspace chats directory. Responses always include
+> `expensive: true` and `cost: "disk_scan"`. Call it infrequently (manual
+> refresh, operator tooling, occasional UI load) — never on a tight timer or
+> on every sidebar render. Prefer `GET /workspace/:id/sessions` for browsing
+> pages and `GET /daemon/status` for live in-memory session counts. A response
+> with `truncated: true` means the scan hit its safety limit or could not
+> classify every candidate file, so persisted counts are lower bounds.
+
+```bash
+curl http://127.0.0.1:4170/workspace/$(python3 -c "import urllib.parse,os; print(urllib.parse.quote(os.getcwd(), safe=''))")/session-info
+# → {"active":450,"archived":30,"total":480,"live":2,"expensive":true,"cost":"disk_scan"}
+```
 
 `GET /session/:id/status` returns the live bridge summary for a single session:
 `sessionId`, `workspaceCwd`, `createdAt`, optional `displayName`, `clientCount`,

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -41,6 +41,13 @@ export const SERVE_CAPABILITY_REGISTRY = {
   // the underlying ACP method from unstable_resumeSession to resumeSession.
   unstable_session_resume: { since: 'v1' },
   session_list: { since: 'v1' },
+  // Aggregate persisted session counts via
+  // `GET /workspace/:id/session-info` (and the plural
+  // `/workspaces/:workspace/session-info` twin). Performs a disk scan of
+  // local JSONL files — advertised so clients can discover it, but the
+  // response itself marks `expensive: true` / `cost: "disk_scan"` and
+  // must not be polled in a tight loop.
+  session_info: { since: 'v1' },
   session_source_metadata: { since: 'v1' },
   session_prompt: { since: 'v1' },
   session_cancel: { since: 'v1' },

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -55,6 +55,7 @@ import {
 } from '../server/request-helpers.js';
 import {
   InvalidCursorError,
+  getWorkspaceSessionInfoForResponse,
   listLiveWorkspaceSessionsForResponse,
   listWorkspaceSessionsForResponse,
   parseSessionPageSizeQuery,
@@ -2927,6 +2928,43 @@ export function registerSessionRoutes(
   app.get(
     '/workspaces/:workspace/sessions',
     listWorkspaceSessionsHandler('workspace'),
+  );
+
+  const workspaceSessionInfoHandler =
+    (paramName: 'id' | 'workspace'): RequestHandler =>
+    async (req, res) => {
+      const route =
+        paramName === 'workspace'
+          ? 'GET /workspaces/:workspace/session-info'
+          : 'GET /workspace/:id/session-info';
+      const runtime = resolveRuntimeForCatalogRoute(req, res, paramName, route);
+      if (runtime === null) return;
+      const key = runtime.workspaceCwd;
+      try {
+        // Disk-scan aggregate: do not call this from hot paths / UI polls.
+        const info = await runWorkspaceInspectionWithLogPolicy(runtime, () =>
+          getWorkspaceSessionInfoForResponse(runtime.bridge, key, {
+            includeLive: !isReadOnlyWorkspaceInspection(runtime),
+          }),
+        );
+        res.status(200).json(info);
+      } catch (err) {
+        writeStderrLine(
+          `qwen serve: failed to read session-info for workspace ${safeLogValue(
+            key,
+          )}: ${safeLogValue(err instanceof Error ? err.message : String(err))}`,
+        );
+        res.status(500).json({
+          error: 'Failed to read session info',
+          code: 'session_info_failed',
+        });
+      }
+    };
+
+  app.get('/workspace/:id/session-info', workspaceSessionInfoHandler('id'));
+  app.get(
+    '/workspaces/:workspace/session-info',
+    workspaceSessionInfoHandler('workspace'),
   );
 
   app.post(

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -232,6 +232,7 @@ const EXPECTED_STAGE1_FEATURES = [
   'session_resume',
   'unstable_session_resume',
   'session_list',
+  'session_info',
   'session_source_metadata',
   'session_prompt',
   'session_cancel',
@@ -10658,6 +10659,229 @@ describe('createServeApp', () => {
 
         expect(res.status).toBe(400);
         expect(res.body.code).toBe('invalid_session_source');
+      });
+    });
+  });
+
+  describe('GET /workspace/:id/session-info', () => {
+    let previousRuntimeDir: string | undefined;
+    let runtimeDir: string;
+
+    beforeEach(async () => {
+      previousRuntimeDir = process.env['QWEN_RUNTIME_DIR'];
+      runtimeDir = await fsp.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-serve-session-info-'),
+      );
+      process.env['QWEN_RUNTIME_DIR'] = runtimeDir;
+    });
+
+    afterEach(async () => {
+      if (previousRuntimeDir === undefined) {
+        delete process.env['QWEN_RUNTIME_DIR'];
+      } else {
+        process.env['QWEN_RUNTIME_DIR'] = previousRuntimeDir;
+      }
+      await fsp.rm(runtimeDir, { recursive: true, force: true });
+    });
+
+    async function writeStoredSession(input: {
+      sessionId: string;
+      cwd: string;
+      timestamp: string;
+      prompt: string;
+      mtime: Date;
+      state?: 'active' | 'archived';
+    }): Promise<void> {
+      const chatsDir = path.join(
+        new Storage(input.cwd).getProjectDir(),
+        'chats',
+        ...(input.state === 'archived' ? ['archive'] : []),
+      );
+      await fsp.mkdir(chatsDir, { recursive: true });
+      const filePath = path.join(chatsDir, `${input.sessionId}.jsonl`);
+      const record = {
+        uuid: `${input.sessionId}-user-1`,
+        parentUuid: null,
+        sessionId: input.sessionId,
+        timestamp: input.timestamp,
+        type: 'user',
+        message: { role: 'user', parts: [{ text: input.prompt }] },
+        cwd: input.cwd,
+      };
+      await fsp.writeFile(filePath, `${JSON.stringify(record)}\n`, 'utf8');
+      await fsp.utimes(filePath, input.mtime, input.mtime);
+    }
+
+    it('returns persisted totals with disk-scan cost markers and live count', async () => {
+      await writeStoredSession({
+        sessionId: '550e8400-e29b-41d4-a716-446655440001',
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T12:00:00.000Z',
+        prompt: 'active one',
+        mtime: new Date('2026-05-17T12:00:00.000Z'),
+      });
+      await writeStoredSession({
+        sessionId: '550e8400-e29b-41d4-a716-446655440002',
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T12:01:00.000Z',
+        prompt: 'active two',
+        mtime: new Date('2026-05-17T12:01:00.000Z'),
+      });
+      await writeStoredSession({
+        sessionId: '550e8400-e29b-41d4-a716-446655440003',
+        cwd: WS_BOUND,
+        timestamp: '2026-05-17T11:00:00.000Z',
+        prompt: 'archived one',
+        mtime: new Date('2026-05-17T11:00:00.000Z'),
+        state: 'archived',
+      });
+
+      const bridge = fakeBridge({
+        listImpl: () => [
+          {
+            sessionId: 'live-1',
+            workspaceCwd: WS_BOUND,
+            createdAt: '2026-05-17T12:02:00.000Z',
+            clientCount: 1,
+            hasActivePrompt: false,
+          },
+        ],
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge, boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/session-info`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        active: 2,
+        archived: 1,
+        total: 3,
+        live: 1,
+        expensive: true,
+        cost: 'disk_scan',
+      });
+    });
+
+    it('supports plural /workspaces/:workspace/session-info for non-primary workspaces', async () => {
+      await writeStoredSession({
+        sessionId: '550e8400-e29b-41d4-a716-446655440010',
+        cwd: WS_DIFFERENT,
+        timestamp: '2026-05-17T12:00:00.000Z',
+        prompt: 'only active',
+        mtime: new Date('2026-05-17T12:00:00.000Z'),
+      });
+      const registry = createWorkspaceRegistry([
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'ws-primary',
+          workspaceCwd: WS_BOUND,
+          primary: true,
+          bridge: fakeBridge(),
+        }),
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'ws-secondary',
+          workspaceCwd: WS_DIFFERENT,
+          primary: false,
+          bridge: fakeBridge(),
+        }),
+      ]);
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { workspaceRegistry: registry },
+      );
+      const res = await request(app)
+        .get('/workspaces/ws-secondary/session-info')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          active: 1,
+          archived: 0,
+          total: 1,
+          expensive: true,
+          cost: 'disk_scan',
+        }),
+      );
+    });
+
+    it('omits live state for an untrusted secondary workspace', async () => {
+      await writeStoredSession({
+        sessionId: '550e8400-e29b-41d4-a716-446655440011',
+        cwd: WS_DIFFERENT,
+        timestamp: '2026-05-17T12:00:00.000Z',
+        prompt: 'persisted only',
+        mtime: new Date('2026-05-17T12:00:00.000Z'),
+      });
+      const secondaryBridge = fakeBridge({
+        listImpl: () => [
+          {
+            sessionId: 'live-secondary',
+            workspaceCwd: WS_DIFFERENT,
+            createdAt: '2026-05-17T12:01:00.000Z',
+            clientCount: 1,
+            hasActivePrompt: false,
+          },
+        ],
+      });
+      const registry = createWorkspaceRegistry([
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'ws-primary',
+          workspaceCwd: WS_BOUND,
+          primary: true,
+          bridge: fakeBridge(),
+        }),
+        makeWorkspaceRuntimeForTest({
+          workspaceId: 'ws-secondary',
+          workspaceCwd: WS_DIFFERENT,
+          primary: false,
+          trusted: false,
+          bridge: secondaryBridge,
+        }),
+      ]);
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { workspaceRegistry: registry },
+      );
+
+      const res = await request(app)
+        .get('/workspaces/ws-secondary/session-info')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        active: 1,
+        archived: 0,
+        total: 1,
+      });
+      expect(res.body).not.toHaveProperty('live');
+      expect(secondaryBridge.listCalls).toEqual([]);
+    });
+
+    it('returns zeros when the chats directory is empty', async () => {
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge: fakeBridge(), boundWorkspace: WS_BOUND },
+      );
+      const res = await request(app)
+        .get(`/workspace/${encodeURIComponent(WS_BOUND)}/session-info`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        active: 0,
+        archived: 0,
+        total: 0,
+        live: 0,
+        expensive: true,
+        cost: 'disk_scan',
       });
     });
   });

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -224,12 +224,14 @@ export {
 export { detectFromLoopback } from './server/request-helpers.js';
 export {
   InvalidCursorError,
+  getWorkspaceSessionInfoForResponse,
   listWorkspaceSessionsForResponse,
 } from './server/session-list.js';
 export type {
   ListWorkspaceSessionsOptions,
   ListWorkspaceSessionsReadOptions,
   ListWorkspaceSessionsResult,
+  WorkspaceSessionInfoResult,
 } from './server/session-list.js';
 export { getActiveSseCount } from './routes/sse-events.js';
 

--- a/packages/cli/src/serve/server/session-list.ts
+++ b/packages/cli/src/serve/server/session-list.ts
@@ -49,6 +49,26 @@ export interface ListWorkspaceSessionsResult {
   truncated?: boolean;
 }
 
+/**
+ * Aggregate session counts for `GET .../session-info`.
+ *
+ * `expensive` is always true: the persisted totals require a disk scan of
+ * local JSONL files and must not be polled in a tight loop.
+ */
+export interface WorkspaceSessionInfoResult {
+  active: number;
+  archived: number;
+  total: number;
+  live?: number;
+  expensive: true;
+  /**
+   * Stable machine-readable hint that this response came from a full disk
+   * scan. Clients should refresh infrequently / on demand only.
+   */
+  cost: 'disk_scan';
+  truncated?: boolean;
+}
+
 export interface ListWorkspaceSessionsReadOptions {
   /** Merge live bridge state into persisted summaries. */
   mergeLive?: boolean;
@@ -808,6 +828,32 @@ export function listLiveWorkspaceSessionsForResponse(
   return {
     sessions: page,
     ...(nextCursor !== undefined ? { nextCursor } : {}),
+  };
+}
+
+/**
+ * Scans local persisted session JSONL files for aggregate counts and merges
+ * the current in-memory live count from the bridge.
+ *
+ * This is an O(n) disk walk. Callers (and HTTP clients) must treat it as an
+ * infrequent / on-demand operator endpoint, not a polling source.
+ */
+export async function getWorkspaceSessionInfoForResponse(
+  bridge: AcpSessionBridge,
+  workspaceCwd: string,
+  options: { includeLive?: boolean } = {},
+): Promise<WorkspaceSessionInfoResult> {
+  const counts = await new SessionService(workspaceCwd).getSessionInfoCounts();
+  return {
+    active: counts.active,
+    archived: counts.archived,
+    total: counts.total,
+    ...(options.includeLive === false
+      ? {}
+      : { live: bridge.listWorkspaceSessions(workspaceCwd).length }),
+    expensive: true,
+    cost: 'disk_scan',
+    ...(counts.truncated ? { truncated: true } : {}),
   };
 }
 

--- a/packages/cli/src/serve/server/telemetry.test.ts
+++ b/packages/cli/src/serve/server/telemetry.test.ts
@@ -183,6 +183,46 @@ describe('daemonTelemetryMiddleware — recordRequest seam', () => {
     );
   });
 
+  it('attributes workspace session-info reads to the shared session-info route', () => {
+    const mw = daemonTelemetryMiddleware(() => '/ws');
+    const res = mockRes(200);
+
+    mw(
+      mockReq('GET', '/workspace/%2Fwork%2Fa/session-info'),
+      res,
+      vi.fn() as unknown as NextFunction,
+    );
+    res.emit('finish');
+
+    expect(coreMocks.withDaemonRequestSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        route: 'GET /workspace/:id/session-info',
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('attributes plural workspace session-info reads to the shared session-info route', () => {
+    const mw = daemonTelemetryMiddleware(() => '/workspace/secondary');
+    const res = mockRes(200);
+
+    mw(
+      mockReq('GET', '/workspaces/ws-secondary/session-info'),
+      res,
+      vi.fn() as unknown as NextFunction,
+    );
+    res.emit('finish');
+
+    expect(coreMocks.withDaemonRequestSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'GET',
+        route: 'GET /workspace/:id/session-info',
+      }),
+      expect.any(Function),
+    );
+  });
+
   it('attributes workspace exports to the target workspace and session', () => {
     const mw = daemonTelemetryMiddleware(() => '/workspace/secondary');
     const res = mockRes(200);

--- a/packages/cli/src/serve/server/telemetry.ts
+++ b/packages/cli/src/serve/server/telemetry.ts
@@ -133,6 +133,15 @@ export function resolveDaemonTelemetryRoute(
   if (req.method === 'GET' && /^\/workspaces\/[^/]+\/sessions$/.test(path)) {
     return { route: 'GET /workspace/:id/sessions' };
   }
+  if (req.method === 'GET' && /^\/workspace\/[^/]+\/session-info$/.test(path)) {
+    return { route: 'GET /workspace/:id/session-info' };
+  }
+  if (
+    req.method === 'GET' &&
+    /^\/workspaces\/[^/]+\/session-info$/.test(path)
+  ) {
+    return { route: 'GET /workspace/:id/session-info' };
+  }
   const workspaceTranscript = path.match(
     /^\/workspaces\/[^/]+\/session\/([^/]+)\/transcript$/,
   );

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -240,6 +240,77 @@ describe('SessionService', () => {
       );
     });
 
+    it('getSessionInfoCounts aggregates active and archived membership', async () => {
+      readdirSyncSpy.mockImplementation((dir: fs.PathLike) => {
+        if (dir.toString().endsWith(`${path.sep}archive`)) {
+          return [`${sessionIdB}.jsonl`] as unknown as Array<fs.Dirent<Buffer>>;
+        }
+        return [
+          `${sessionIdA}.jsonl`,
+          'archive',
+          'not-a-session.txt',
+        ] as unknown as Array<fs.Dirent<Buffer>>;
+      });
+      vi.mocked(jsonl.readLines).mockImplementation(
+        async (filePath: string) => {
+          if (filePath.includes(sessionIdA)) return [recordA1];
+          if (filePath.includes(sessionIdB)) return [recordB1];
+          return [];
+        },
+      );
+
+      const result = await sessionService.getSessionInfoCounts();
+
+      expect(result).toEqual({
+        active: 1,
+        archived: 1,
+        total: 2,
+        truncated: false,
+      });
+      // Membership scan only needs the first record — never a deep read.
+      for (const [, lineLimit] of vi.mocked(jsonl.readLines).mock.calls) {
+        expect(lineLimit).toBe(1);
+      }
+    });
+
+    it('getSessionInfoCounts returns zeros when chats dirs are missing', async () => {
+      const error = new Error('ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      readdirSyncSpy.mockImplementation(() => {
+        throw error;
+      });
+
+      await expect(sessionService.getSessionInfoCounts()).resolves.toEqual({
+        active: 0,
+        archived: 0,
+        total: 0,
+        truncated: false,
+      });
+    });
+
+    it('marks counts truncated when a candidate session cannot be read', async () => {
+      readdirSyncSpy.mockImplementation((dir: fs.PathLike) =>
+        dir.toString().endsWith(`${path.sep}archive`)
+          ? ([] as unknown as Array<fs.Dirent<Buffer>>)
+          : ([`${sessionIdA}.jsonl`, `${sessionIdB}.jsonl`] as unknown as Array<
+              fs.Dirent<Buffer>
+            >),
+      );
+      vi.mocked(jsonl.readLines).mockImplementation(
+        async (filePath: string) => {
+          if (filePath.includes(sessionIdA)) return [recordA1];
+          throw new Error('unreadable');
+        },
+      );
+
+      await expect(sessionService.getSessionInfoCounts()).resolves.toEqual({
+        active: 1,
+        archived: 0,
+        total: 1,
+        truncated: true,
+      });
+    });
+
     it('should extract prompt text from first record', async () => {
       const now = Date.now();
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -141,6 +141,27 @@ export interface ListSessionsResult {
 }
 
 /**
+ * Aggregate persisted-session counts for a workspace.
+ *
+ * Built by scanning local JSONL files. This is intentionally separate from
+ * {@link listSessions} so paginated list callers are not forced into a full
+ * disk walk.
+ */
+export interface SessionInfoCounts {
+  /** Persisted active (non-archived) sessions belonging to this project. */
+  active: number;
+  /** Persisted archived sessions belonging to this project. */
+  archived: number;
+  /** `active + archived`. */
+  total: number;
+  /**
+   * True when the scan could not classify every candidate session file, so
+   * counts may be lower than the true population.
+   */
+  truncated: boolean;
+}
+
+/**
  * Result of removing multiple sessions.
  */
 export interface RemoveSessionsResult {
@@ -994,6 +1015,86 @@ export class SessionService {
       nextCursor,
       hasMore: hasMoreFiles,
     };
+  }
+
+  /**
+   * Counts persisted sessions for this project by scanning the active and
+   * archived chats directories.
+   *
+   * Same disk-walk shape as {@link findSessionTitlesByPrefix} /
+   * {@link findSessionsByTitle}: `readdir` the chats dir, cap at the
+   * file-processing safety limit, then read only the first JSONL record for
+   * project membership. Title/prompt/message hydration is skipped entirely.
+   *
+   * Still an O(n) disk walk — callers (and HTTP clients of
+   * `GET .../session-info`) must not poll this in a tight loop.
+   */
+  async getSessionInfoCounts(): Promise<SessionInfoCounts> {
+    const [active, archived] = await Promise.all([
+      this.countSessionsInState('active'),
+      this.countSessionsInState('archived'),
+    ]);
+    return {
+      active: active.count,
+      archived: archived.count,
+      total: active.count + archived.count,
+      truncated: active.truncated || archived.truncated,
+    };
+  }
+
+  private async countSessionsInState(
+    archiveState: SessionArchiveState,
+  ): Promise<{ count: number; truncated: boolean }> {
+    const chatsDir = this.getChatsDirForState(archiveState);
+    let fileNames: string[];
+    try {
+      fileNames = fs.readdirSync(chatsDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return { count: 0, truncated: false };
+      }
+      throw error;
+    }
+
+    let count = 0;
+    let filesProcessed = 0;
+    let truncated = false;
+
+    for (const name of fileNames) {
+      if (!SESSION_FILE_PATTERN.test(name)) continue;
+      if (filesProcessed >= MAX_FILES_TO_PROCESS) {
+        truncated = true;
+        break;
+      }
+      filesProcessed++;
+
+      const filePath = path.join(chatsDir, name);
+      // Project filter only — same first-record membership check as
+      // findSessionTitlesByPrefix, without the title tail-read (every file
+      // is a candidate when counting).
+      try {
+        const records = await jsonl.readLines<ChatRecord>(filePath, 1);
+        if (records.length === 0) {
+          truncated = true;
+          continue;
+        }
+        const firstRecord = records[0]!;
+        if (
+          !(await this.sessionBelongsToCurrentProject(
+            firstRecord.sessionId,
+            firstRecord.cwd,
+          ))
+        ) {
+          continue;
+        }
+        count++;
+      } catch {
+        truncated = true;
+        continue;
+      }
+    }
+
+    return { count, truncated };
   }
 
   /**

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -47,6 +47,7 @@ import type {
   DaemonSessionLspStatus,
   DaemonSessionListPage,
   DaemonSessionListPageOptions,
+  DaemonWorkspaceSessionInfo,
   DaemonSessionOrganizationResult,
   DaemonSessionOrganizationUpdate,
   DaemonSessionSummary,
@@ -4294,6 +4295,10 @@ export class WorkspaceDaemonClient {
   ): Promise<DaemonSessionSummary[]> {
     const page = await this.listWorkspaceSessionsPage(options);
     return page.sessions;
+  }
+
+  getWorkspaceSessionInfo(): Promise<DaemonWorkspaceSessionInfo> {
+    return this.get('/session-info', 'GET /workspaces/:workspace/session-info');
   }
 
   /**

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -454,6 +454,7 @@ export type {
   DaemonSessionListPage,
   DaemonSessionListPageOptions,
   DaemonSessionListView,
+  DaemonWorkspaceSessionInfo,
   DaemonSessionOrganizationResult,
   DaemonSessionOrganizationUpdate,
   DaemonPendingInteraction,

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -724,6 +724,16 @@ export interface DaemonSessionListPage {
   truncated?: boolean;
 }
 
+export interface DaemonWorkspaceSessionInfo {
+  active: number;
+  archived: number;
+  total: number;
+  live?: number;
+  expensive: true;
+  cost: 'disk_scan';
+  truncated?: boolean;
+}
+
 export interface DaemonArchiveSessionsResult {
   archived: string[];
   alreadyArchived: string[];

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -31,6 +31,7 @@ import type {
   DaemonWorkspaceMcpStatus,
   DaemonWorkspacePreflightStatus,
   DaemonWorkspaceProvidersStatus,
+  DaemonWorkspaceSessionInfo,
   DaemonWorkspaceSkillsStatus,
 } from '../../src/daemon/types.js';
 
@@ -2627,6 +2628,27 @@ describe('DaemonClient', () => {
   });
 
   describe('listWorkspaceSessions', () => {
+    it('gets aggregate session info for a scoped workspace', async () => {
+      const reply: DaemonWorkspaceSessionInfo = {
+        active: 4,
+        archived: 2,
+        total: 6,
+        live: 1,
+        expensive: true,
+        cost: 'disk_scan',
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, reply));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await expect(
+        client.workspaceById('workspace/id').getWorkspaceSessionInfo(),
+      ).resolves.toEqual(reply);
+
+      expect(calls.map((call) => call.url)).toEqual([
+        'http://daemon/workspaces/workspace%2Fid/session-info',
+      ]);
+    });
+
     it('GETs /workspace/:id/sessions and returns the array', async () => {
       const { fetch, calls } = recordingFetch(() =>
         jsonResponse(200, {


### PR DESCRIPTION
## What this PR does

Adds workspace-scoped session aggregate endpoints for both legacy and registered-workspace route forms. The response reports persisted active, archived, and total counts, optionally includes the current live count, and marks the operation as an explicit disk scan. It also advertises the capability, exposes the registered-workspace request through the TypeScript daemon SDK, and documents the cost and trust semantics.

The persisted count scans candidate session files but reads only their first record for workspace membership. Missing storage returns zero counts. If the safety limit is reached or a candidate cannot be classified, the response includes `truncated: true`, making the persisted counts explicit lower bounds. Registered untrusted secondary workspaces omit `live` instead of reporting a misleading zero because their catalog reads must not query the live bridge.

## Why it's needed

Paginated session lists answer whether another page exists but cannot tell clients or operators how large a workspace's local session store is. This is especially limiting for scheduled and recurring tasks that can accumulate many persisted sessions. A dedicated aggregate endpoint provides that information without adding a full scan to every list request.

## Reviewer Test Plan

### How to verify

1. Start an API-only daemon against an empty workspace and request either session-info route. Expect `200` with zero persisted counts, `live: 0` for a trusted workspace, `expensive: true`, and `cost: "disk_scan"`.
2. Add active and archived session records for the selected workspace and confirm the response reports the corresponding active, archived, and total counts without changing paginated session-list responses.
3. Request the registered-workspace route for an untrusted secondary workspace. Expect persisted counts but no `live` field, and confirm the live bridge is not queried.
4. Make one candidate session unreadable or exceed the scan safety limit. Expect valid lower-bound counts plus `truncated: true`.
5. Confirm capabilities include `session_info`, and confirm the scoped TypeScript daemon SDK returns the typed aggregate response.

### Evidence (Before & After)

Before: the globally installed `qwen 0.19.10-preview.0` returned `404` for the session-info route and did not advertise `session_info`.

After: the branch build returned `200` with `{"active":0,"archived":0,"total":0,"live":0,"expensive":true,"cost":"disk_scan"}` for an empty workspace and advertised `session_info`.

Local verification passed: full repository build; all workspace type checks; focused formatting and lint checks; 117 core session-service tests; 274 daemon SDK client tests; 4 session-info server tests; and 21 daemon telemetry tests. The full CLI serve suite passed once at 769/769; a later run hit one unrelated archive-overlap timing flake, which passed immediately when rerun in isolation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.14.0, API-only daemon on loopback, sandbox disabled.

## Risk & Scope

- Main risk or tradeoff: counting is O(n) in candidate session files, so responses always carry machine-readable disk-scan cost markers and documentation explicitly prohibits tight polling.
- Not validated / out of scope: cached mutation counters, organized or parent-filtered totals, production-scale latency measurements, and platform-specific E2E runs outside macOS.
- Breaking changes / migration notes: none; the routes, capability, response type, and SDK method are additive, while existing paginated list behavior is unchanged.

## Linked Issues

Closes #7071

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 workspace 级别的会话聚合端点，同时支持旧版路由和已注册 workspace 路由。响应包含持久化 active、archived 和 total 计数，可在允许读取实时状态时返回当前 live 数量，并明确标记该操作为磁盘扫描。同时新增 capability 声明，通过 TypeScript daemon SDK 暴露已注册 workspace 的请求入口，并补充成本与信任语义文档。

持久化计数会扫描候选会话文件，但只读取首条记录来判断 workspace 归属。存储目录不存在时返回零计数。如果达到安全上限，或某个候选文件无法分类，响应会包含 `truncated: true`，明确表示持久化计数是下界。对于已注册但未信任的 secondary workspace，响应会省略 `live`，而不是返回容易误解的零，因为这类目录读取不能查询实时 bridge。

## 为什么需要

分页会话列表只能说明是否还有下一页，无法告诉客户端或运维人员某个 workspace 的本地会话存储规模。定时任务和循环任务可能积累大量持久化会话，这一限制尤其明显。独立的聚合端点可以提供总量信息，同时不会让每次列表请求都承担全量扫描成本。

## Reviewer 测试计划

### 如何验证

1. 针对空 workspace 启动仅 API daemon，并请求任一 session-info 路由。预期返回 `200`、持久化计数均为零；受信任 workspace 返回 `live: 0`，同时包含 `expensive: true` 和 `cost: "disk_scan"`。
2. 为目标 workspace 添加 active 和 archived 会话记录，确认响应中的 active、archived 和 total 正确，且分页会话列表响应保持不变。
3. 请求未信任 secondary workspace 的已注册 workspace 路由。预期返回持久化计数但不包含 `live`，并确认没有查询实时 bridge。
4. 让一个候选会话文件不可读，或超过扫描安全上限。预期返回有效的下界计数以及 `truncated: true`。
5. 确认 capabilities 包含 `session_info`，并确认 scoped TypeScript daemon SDK 能返回带类型的聚合响应。

### 证据（前后对比）

变更前：全局安装的 `qwen 0.19.10-preview.0` 对 session-info 路由返回 `404`，且未声明 `session_info`。

变更后：分支构建对空 workspace 返回 `200`，响应为 `{"active":0,"archived":0,"total":0,"live":0,"expensive":true,"cost":"disk_scan"}`，并声明 `session_info`。

本地验证已通过：全仓构建、所有 workspace 类型检查、定向格式与 lint 检查、117 个 core 会话服务测试、274 个 daemon SDK 客户端测试、4 个 session-info 服务端测试，以及 21 个 daemon telemetry 测试。CLI serve 全套测试曾以 769/769 全部通过；后续一次复跑遇到一个无关的 archive overlap 时序波动，该用例单独立即复跑通过。

### 测试平台

|    操作系统    | 状态 |
| :------------: | :--: |
|    🍏 macOS    |  ✅  |
|   🪟 Windows   |  ⚠️  |
|    🐧 Linux    |  ⚠️  |

### 环境（可选）

Node.js 22.14.0，loopback 上的仅 API daemon，禁用 sandbox。

## 风险与范围

- 主要风险或权衡：计数对候选会话文件数量是 O(n)，因此响应始终携带机器可读的磁盘扫描成本标记，文档也明确禁止高频轮询。
- 未验证 / 不在范围内：基于变更点维护的缓存计数器、organized 或 parent-filtered 总量、生产规模延迟测量，以及 macOS 之外的平台 E2E。
- 破坏性变更 / 迁移说明：无。路由、capability、响应类型和 SDK 方法均为增量新增，现有分页列表行为不变。

## 关联 Issue

Closes #7071

</details>
