### PR TITLE
feat(channels): stamp daemon sourceId with channel instance name on created sessions

### DIFF
--- a/docs/design/2026-07-15-daemon-session-source-metadata.md
+++ b/docs/design/2026-07-15-daemon-session-source-metadata.md
@@ -26,6 +26,12 @@ matched together. Source filters are not combined with the organized view.
 Daemon scheduled tasks tag their dedicated session with
 `sourceType: "scheduled_task"` and the durable task id as `sourceId`.
 
+Daemon channel workers tag sessions they create with `sourceType: "channel"`
+and the configured channel instance name (e.g. `feishu-main`) as `sourceId`,
+so the channel instance — and, via the channel configuration, the channel kind
+(dingtalk/feishu/...) — is attributable on the daemon data plane. Loading or
+attaching an existing session never re-stamps its creation source.
+
 ## Persistence
 
 A fresh session stores one `session_source` system record near the head of its

--- a/packages/channels/base/src/ChannelAgentBridge.ts
+++ b/packages/channels/base/src/ChannelAgentBridge.ts
@@ -80,6 +80,13 @@ export interface BridgeSessionInfo {
 
 export interface ChannelAgentBridgeSessionOptions {
   approvalMode?: string;
+  /**
+   * Channel instance name (e.g. `feishu-main`) stamped as the daemon `sourceId`
+   * on **new** sessions — creation-time attribution paired with
+   * `sourceType: 'channel'`. Ignored by `loadSession`: loading an existing
+   * session never re-stamps its creation attribution.
+   */
+  sourceId?: string;
 }
 
 export interface ChannelAgentBridge {

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -220,6 +220,38 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
+  it('forwards sourceId to the session factory only for new sessions', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const factory = vi.fn().mockResolvedValue(session);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: factory,
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo', { sourceId: 'feishu-main' });
+    await bridge.loadSession('session-1', '/repo', { sourceId: 'feishu-main' });
+
+    // New session: sourceId is forwarded to the factory (creation attribution);
+    expect(factory).toHaveBeenNthCalledWith(1, {
+      workspaceCwd: '/repo',
+      modelServiceId: undefined,
+      sessionScope: 'thread',
+      sourceId: 'feishu-main',
+    });
+    // Load: never forwarded even when provided — loads never re-stamp creation source.
+    expect(factory).toHaveBeenNthCalledWith(2, {
+      workspaceCwd: '/repo',
+      modelServiceId: undefined,
+      sessionId: 'session-1',
+      sessionScope: 'thread',
+    });
+
+    events.close();
+    bridge.stop();
+  });
+
   it('drains daemon chunks queued with prompt completion', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -7,6 +7,7 @@ import type {
   AvailableCommand,
   BridgeSessionInfo,
   ChannelAgentBridge,
+  ChannelAgentBridgeSessionOptions,
   ToolCallEvent,
 } from './ChannelAgentBridge.js';
 import { readAvailableCommandAltNames } from './AcpBridge.js';
@@ -56,6 +57,8 @@ export interface DaemonChannelSessionFactoryRequest {
   sessionId?: string;
   sessionScope?: SessionScope;
   approvalMode?: string;
+  /** Channel instance name stamped as daemon `sourceId` (new sessions only). */
+  sourceId?: string;
 }
 
 export type DaemonChannelSessionFactory = (
@@ -253,7 +256,7 @@ export class DaemonChannelBridge
 
   async newSession(
     cwd: string,
-    options?: { approvalMode?: string },
+    options?: ChannelAgentBridgeSessionOptions,
     bindingToken?: object,
   ): Promise<string> {
     const lifecycleGeneration = this.lifecycleGeneration;
@@ -262,6 +265,7 @@ export class DaemonChannelBridge
       modelServiceId: this.options.modelServiceId,
       sessionScope: this.options.sessionScope ?? 'thread',
       ...(options?.approvalMode ? { approvalMode: options.approvalMode } : {}),
+      ...(options?.sourceId ? { sourceId: options.sourceId } : {}),
     });
     if (lifecycleGeneration !== this.lifecycleGeneration) {
       await this.rejectStaleSession(session);
@@ -273,7 +277,7 @@ export class DaemonChannelBridge
   async loadSession(
     sessionId: string,
     cwd: string,
-    options?: { approvalMode?: string },
+    options?: ChannelAgentBridgeSessionOptions,
     bindingToken?: object,
   ): Promise<string> {
     const lifecycleGeneration = this.lifecycleGeneration;

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -136,7 +136,19 @@ describe('SessionRouter', () => {
 
       expect(bridge.newSession).toHaveBeenCalledWith(
         '/tmp',
-        { approvalMode: 'yolo' },
+        { approvalMode: 'yolo', sourceId: 'ch' },
+        expect.any(Object),
+      );
+    });
+
+    it('stamps channel name as sourceId when creating sessions', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+
+      await router.resolve('dingtalk-main', 'alice', 'chat1');
+
+      expect(bridge.newSession).toHaveBeenCalledWith(
+        '/tmp',
+        { sourceId: 'dingtalk-main' },
         expect.any(Object),
       );
     });
@@ -270,7 +282,7 @@ describe('SessionRouter', () => {
       await router.resolve('ch', 'alice', 'chat1', undefined, '/custom');
       expect(bridge.newSession).toHaveBeenCalledWith(
         '/custom',
-        undefined,
+        { sourceId: 'ch' },
         expect.any(Object),
       );
     });
@@ -280,7 +292,7 @@ describe('SessionRouter', () => {
       await router.resolve('ch', 'alice', 'chat1');
       expect(bridge.newSession).toHaveBeenCalledWith(
         '/default',
-        undefined,
+        { sourceId: 'ch' },
         expect.any(Object),
       );
     });
@@ -290,7 +302,7 @@ describe('SessionRouter', () => {
       await router.resolve('ch', 'alice', 'chat1', undefined, '');
       expect(bridge.newSession).toHaveBeenCalledWith(
         '/default',
-        undefined,
+        { sourceId: 'ch' },
         expect.any(Object),
       );
     });

--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -1768,6 +1768,12 @@ describe('SessionRouter', () => {
       await expect(router.resolve('ch', 'alice', 'chat1')).resolves.toBe(
         'replacement-session',
       );
+      // Load-failure replacement also stamps the channel name as sourceId.
+      expect(lazyBridge.newSession).toHaveBeenCalledWith(
+        '/tmp',
+        { sourceId: 'ch' },
+        expect.any(Object),
+      );
       expect(JSON.parse(readFileSync(persistPath, 'utf-8'))).toEqual({
         'ch:alice:chat1': expect.objectContaining({
           sessionId: 'replacement-session',

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -238,6 +238,7 @@ export class SessionRouter {
         key,
         this.sessionOptions(input.channelName),
         operation,
+        input.channelName,
       );
       try {
         this.assertOperationCurrent(operation);
@@ -321,6 +322,7 @@ export class SessionRouter {
             key,
             this.sessionOptions(input.channelName),
             operation,
+            input.channelName,
           );
           try {
             this.assertOperationCurrent(operation);
@@ -798,11 +800,16 @@ export class SessionRouter {
     routingKey: string,
     options: { approvalMode?: string } | undefined,
     operation: SessionOperation,
+    sourceId: string,
   ): Promise<string> {
     const maxAttempts = 2;
     let lastDeadSessionId: string | undefined;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const sessionId = await this.bridge.newSession(cwd, options, operation);
+      const sessionId = await this.bridge.newSession(
+        cwd,
+        { ...options, sourceId },
+        operation,
+      );
       try {
         this.assertOperationCurrent(operation);
       } catch (error) {

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -380,6 +380,44 @@ describe('createDaemonSessionFactory', () => {
       'qwen-channel-worker',
     );
   });
+
+  it('stamps channel sourceId on created sessions only', async () => {
+    const sdk = createSdk();
+    const factory = createDaemonSessionFactory({
+      client: sdk.client,
+      DaemonSessionClient: sdk.DaemonSessionClient,
+      clientId: 'qwen-channel-worker',
+    });
+
+    await factory({ workspaceCwd: '/workspace', sourceId: 'dingtalk-main' });
+    await factory({
+      workspaceCwd: '/workspace',
+      sessionId: 'existing-session',
+      sourceId: 'dingtalk-main',
+    });
+
+    expect(sdk.DaemonSessionClient.createOrAttach).toHaveBeenCalledWith(
+      sdk.client,
+      {
+        workspaceCwd: '/workspace',
+        sessionScope: 'thread',
+        sourceType: 'channel',
+        sourceId: 'dingtalk-main',
+      },
+      'qwen-channel-worker',
+    );
+    // The load branch never re-stamps creation attribution: no sourceId in the
+    // load request even when the factory request carried one.
+    expect(sdk.DaemonSessionClient.load).toHaveBeenCalledWith(
+      sdk.client,
+      'existing-session',
+      {
+        workspaceCwd: '/workspace',
+        sessionScope: 'thread',
+      },
+      'qwen-channel-worker',
+    );
+  });
 });
 
 describe('createDaemonChannelBridgeFacade', () => {

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -95,6 +95,7 @@ interface DaemonSessionClientStaticLike {
       sessionScope: 'thread';
       approvalMode?: string;
       sourceType?: string;
+      sourceId?: string;
     },
     clientId?: string,
   ): Promise<DaemonChannelSessionClient>;

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -177,7 +177,16 @@ export function createDaemonSessionFactory({
     }
     return await DaemonSessionClient.createOrAttach(
       client,
-      { ...daemonReq, sourceType: 'channel' },
+      {
+        ...daemonReq,
+        sourceType: 'channel',
+        // sourceId = channel instance name (e.g. feishu-main): distinguishes
+        // channel instances on the daemon data plane; the channel kind
+        // (dingtalk/feishu) is derivable from the name via the channel config.
+        // The load branch above deliberately omits it: loading never re-stamps
+        // creation attribution.
+        ...(req.sourceId ? { sourceId: req.sourceId } : {}),
+      },
       clientId,
     );
   };


### PR DESCRIPTION
## What this PR does

Channel-created daemon sessions are now stamped with the channel instance name as the daemon `sourceId` (paired with the existing `sourceType: 'channel'`): `SessionRouter.createLiveSession` passes the channel name through the new `ChannelAgentBridgeSessionOptions.sourceId` into the session factory, and the channel worker factory includes it in the `createOrAttach` request. `loadSession` deliberately never forwards it — loading an existing session never re-stamps its creation attribution. The session-source design doc is updated accordingly.

## Why it's needed

#6991 tagged channel-created sessions with `sourceType: 'channel'`, but all channel instances share that single value — sessions from `dingtalk-main` vs `feishu-main` are indistinguishable in daemon session lists, transcripts, and `?sourceType=` filters, so per-channel attribution (needed for the log-shipping / SLS / subscription use cases in #6962) is still impossible. The session-source mechanism already supports a paired `sourceId` (scheduled tasks use it for the task id), and channel kind (dingtalk/feishu/…) is derivable from the instance name via the channel configuration.

## Reviewer Test Plan

### How to verify

Run the affected suites: `cd packages/channels/base && npx vitest run` (expect 764 passed) and `cd packages/cli && npx vitest run src/commands/channel/daemon-worker.test.ts` (expect 66 passed). New cases assert: `SessionRouter` passes the channel name as `sourceId` to `bridge.newSession`; `DaemonChannelBridge` forwards `sourceId` to the session factory only for new sessions (never for `loadSession`); the worker factory sends `sourceType: 'channel'` + `sourceId: <channel name>` on `createOrAttach` and omits `sourceId` on load. Manually: create a session via a channel worker and confirm the daemon session-list response shows `sourceType: 'channel'` with `sourceId` equal to the configured channel name.

### Evidence (Before & After)

N/A (no UI changes; test commands and expected output above). Before: channel sessions carried only `sourceType: 'channel'`. After: they also carry `sourceId: <channel instance name>`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI `Test (ubuntu-latest, Node 22.x)` ✅ |

### Environment (optional)

Local: Node v26.5.0, `npx vitest run` (per-package vitest configs). Dependencies installed with `QWEN_SKIP_PREPARE=1 npm ci`.

## Risk & Scope

- Main risk or tradeoff: daemon validates `sourceId` (non-empty, ≤256 chars, no control characters) — a pathological channel name violating this would surface as create 400 `invalid_session_source`; normal configured names are unaffected.
- Not validated / out of scope: no live-daemon end-to-end run (router/bridge/factory unit level only); channel-kind mapping (name → type) stays in channel configuration, not in the daemon.
- Breaking changes / migration notes: none. Older daemons ignore the unknown field (`safeBody`), so workers keep creating sessions, just without attribution.

## Linked Issues

Refs #6962 (session source metadata for channel sessions; `sourceType: 'channel'` was delivered in #6991 — this PR extends it to per-instance `sourceId`).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

channel 创建的 daemon 会话现在会把渠道实例名写入 daemon 的 `sourceId`（与既有 `sourceType: 'channel'` 配对）：`SessionRouter.createLiveSession` 经由新增的 `ChannelAgentBridgeSessionOptions.sourceId` 把渠道名传入会话工厂，channel worker 工厂在 `createOrAttach` 请求中带上它。`loadSession` 刻意不透传——加载既有会话绝不重写其创建时归因。session-source 设计文档已同步更新。

## 为什么需要

#6991 已为 channel 创建的会话打上 `sourceType: 'channel'`，但所有渠道实例共享同一个值——`dingtalk-main` 与 `feishu-main` 的会话在 daemon 会话列表、transcript 与 `?sourceType=` 过滤中无法区分，按渠道归因（#6962 的日志投递 / SLS / 订阅场景所需）仍然做不到。会话来源机制本就支持与 `sourceType` 配对的 `sourceId`（定时任务用它记录 task id），渠道类型（dingtalk/feishu 等）可经实例名关联渠道配置得到。

## Reviewer 验证计划

### 如何验证

运行受影响测试套件：`cd packages/channels/base && npx vitest run`（预期 764 passed）和 `cd packages/cli && npx vitest run src/commands/channel/daemon-worker.test.ts`（预期 66 passed）。新增用例断言：`SessionRouter` 把渠道名作为 `sourceId` 传给 `bridge.newSession`；`DaemonChannelBridge` 仅新建会话时把 `sourceId` 传给会话工厂（`loadSession` 绝不传）；worker 工厂在 `createOrAttach` 时发送 `sourceType: 'channel'` + `sourceId: <渠道名>`、load 时不带 `sourceId`。手动验证：经 channel worker 创建一个会话，确认 daemon 会话列表响应中该会话 `sourceType: 'channel'` 且 `sourceId` 等于配置的渠道名。

### 证据（前后对比）

N/A（无 UI 变更；测试命令与预期输出见上）。改动前：channel 会话仅带 `sourceType: 'channel'`；改动后：同时带 `sourceId: <渠道实例名>`。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测 |
| 🪟 Windows | ⚠️ 未测 |
|  🐧 Linux  | ⚠️ 本地未测；CI `Test (ubuntu-latest, Node 22.x)` 已通过 ✅ |

### 运行环境（可选）

本地：Node v26.5.0，`npx vitest run`（各包 vitest 配置）。依赖以 `QWEN_SKIP_PREPARE=1 npm ci` 安装。

## 风险与范围

- 主要风险/取舍：daemon 校验 `sourceId`（非空、≤256 字符、无控制字符）——病态渠道名会表现为 create 400 `invalid_session_source`；正常配置的渠道名不受影响。
- 未验证/范围外：未做真实 daemon 端到端（仅 router/bridge/factory 单测级）；渠道类型映射（名称→类型）留在渠道配置中，不进 daemon。
- 破坏性变更/迁移说明：无。旧版 daemon 忽略未知字段（`safeBody`），worker 照常建会话，只是无归因。

## 关联 Issue

Refs #6962（channel 会话的来源元数据；`sourceType: 'channel'` 已由 #6991 交付——本 PR 将其扩展到实例级 `sourceId`）。

</details>
