### PR TITLE
feat(daemon): propagate prompt IDs to turn events

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -5046,16 +5046,23 @@ describe('createAcpSessionBridge', () => {
       })();
 
       await expect(
-        bridge.sendPrompt(session.sessionId, {
-          sessionId: session.sessionId,
-          prompt: [{ type: 'text', text: 'stream may fail' }],
-        }),
+        bridge.sendPrompt(
+          session.sessionId,
+          {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'stream may fail' }],
+          },
+          undefined,
+          { promptId: 'prompt-error' },
+        ),
       ).rejects.toThrow('terminated');
 
       const event = await turnError;
+      expect(event.promptId).toBe('prompt-error');
       expect(event.data).toMatchObject({
         message: 'terminated',
         errorKind: 'model_stream_interrupted',
+        promptId: 'prompt-error',
       });
 
       abort.abort();
@@ -5087,15 +5094,24 @@ describe('createAcpSessionBridge', () => {
         iter: AsyncIterable<{
           type: string;
           data: unknown;
+          promptId?: string;
           originatorClientId?: string;
         }>,
-      ): Promise<{ originatorClientId?: string; data: unknown }> => {
+      ): Promise<{
+        promptId?: string;
+        originatorClientId?: string;
+        data: unknown;
+      }> => {
         for await (const e of iter) {
           if (e.type !== 'session_update') continue;
           const update = (e.data as { update?: { sessionUpdate?: string } })
             ?.update;
           if (update?.sessionUpdate === 'user_message_chunk') {
-            return { originatorClientId: e.originatorClientId, data: e.data };
+            return {
+              promptId: e.promptId,
+              originatorClientId: e.originatorClientId,
+              data: e.data,
+            };
           }
         }
         throw new Error('no user_message_chunk observed');
@@ -5127,7 +5143,7 @@ describe('createAcpSessionBridge', () => {
           _meta: { inputAnnotations, privateRequestId: 'hidden' },
         },
         undefined,
-        { clientId: session.clientId },
+        { clientId: session.clientId, promptId: 'prompt-echo' },
       );
 
       const [aChunk, bChunk] = await Promise.all([aPromise, bPromise]);
@@ -5148,6 +5164,7 @@ describe('createAcpSessionBridge', () => {
         // Originator stamp present so SDK `suppressOwnUserEcho` can dedup
         // on the originator's own UI.
         expect(chunk.originatorClientId).toBe(session.clientId);
+        expect(chunk.promptId).toBe('prompt-echo');
         // Source marker distinguishes the bridge echo from agent content.
         expect((update._meta as { source?: string })?.source).toBe(
           'bridge-echo',
@@ -5297,7 +5314,7 @@ describe('createAcpSessionBridge', () => {
             prompt: [{ type: 'text', text: 'long running' }],
           },
           promptAbort.signal,
-          { clientId: session.clientId },
+          { clientId: session.clientId, promptId: 'prompt-cancelled' },
         )
         .catch(() => {
           // AbortError is expected — the originator's connection dropped.
@@ -5314,6 +5331,7 @@ describe('createAcpSessionBridge', () => {
       );
       // Attributed to the prompt's originator (whose connection dropped).
       expect(evt.originatorClientId).toBe(session.clientId);
+      expect(evt.promptId).toBe('prompt-cancelled');
 
       // Let the hung promptImpl settle so shutdown doesn't wait on it.
       releasePrompt?.();
@@ -6064,14 +6082,26 @@ describe('createAcpSessionBridge', () => {
           events.push(ev);
         }
       })();
-      await bridge.sendPrompt(session.sessionId, {
-        sessionId: session.sessionId,
-        prompt: [{ type: 'text', text: 'first prompt' }],
-      });
+      await bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'first prompt' }],
+        },
+        undefined,
+        { promptId: 'prompt-single' },
+      );
       const addedEvents = events.filter(
         (e) => e.type === 'pending_prompt_added',
       );
       expect(addedEvents).toHaveLength(0);
+      await vi.waitFor(() => {
+        const completed = events.find((e) => e.type === 'turn_complete');
+        expect(completed?.promptId).toBe('prompt-single');
+        expect(
+          (completed?.data as { promptId?: string } | undefined)?.promptId,
+        ).toBe('prompt-single');
+      });
       expect(bridge.getPendingPrompts(session.sessionId)).toHaveLength(0);
       sub.catch(() => {});
       await bridge.shutdown();
@@ -6101,20 +6131,31 @@ describe('createAcpSessionBridge', () => {
         }
       })();
 
-      const p1 = bridge.sendPrompt(session.sessionId, {
-        sessionId: session.sessionId,
-        prompt: [{ type: 'text', text: 'blocking' }],
-      });
-      const p2 = bridge.sendPrompt(session.sessionId, {
-        sessionId: session.sessionId,
-        prompt: [{ type: 'text', text: 'queued behind first' }],
-      });
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'blocking' }],
+        },
+        undefined,
+        { promptId: 'prompt-first' },
+      );
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued behind first' }],
+        },
+        undefined,
+        { promptId: 'prompt-second' },
+      );
 
       await new Promise((r) => setTimeout(r, 20));
       const addedEvents = events.filter(
         (e) => e.type === 'pending_prompt_added',
       );
       expect(addedEvents).toHaveLength(1);
+      expect(addedEvents[0]?.promptId).toBe('prompt-second');
       expect(
         (addedEvents[0] as BridgeEvent & { data: { text: string } }).data.text,
       ).toBe('queued behind first');
@@ -6144,10 +6185,15 @@ describe('createAcpSessionBridge', () => {
         (e) => e.type === 'pending_prompt_started',
       );
       expect(startedEvents).toHaveLength(1);
+      expect(startedEvents[0]?.promptId).toBe('prompt-second');
       expect(
         (startedEvents[0] as BridgeEvent & { data: { text: string } }).data
           .text,
       ).toBe('queued behind first');
+      const completedEvents = events.filter(
+        (e) => e.type === 'pending_prompt_completed',
+      );
+      expect(completedEvents[0]?.promptId).toBe('prompt-second');
       expect(bridge.getPendingPrompts(session.sessionId)).toHaveLength(0);
       sub.catch(() => {});
       await bridge.shutdown();
@@ -6170,21 +6216,37 @@ describe('createAcpSessionBridge', () => {
         channelFactory: async () => handle.channel,
       });
       const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      const sub = (async () => {
+        for await (const event of bridge.subscribeEvents(session.sessionId)) {
+          events.push(event);
+        }
+      })();
 
-      const p1 = bridge.sendPrompt(session.sessionId, {
-        sessionId: session.sessionId,
-        prompt: [{ type: 'text', text: 'blocker' }],
-      });
-      const p2 = bridge.sendPrompt(session.sessionId, {
-        sessionId: session.sessionId,
-        prompt: [{ type: 'text', text: 'to be removed' }],
-      });
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'blocker' }],
+        },
+        undefined,
+        { promptId: 'prompt-running' },
+      );
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'to be removed' }],
+        },
+        undefined,
+        { promptId: 'prompt-removed' },
+      );
 
       await new Promise((r) => setTimeout(r, 20));
       const pending = bridge.getPendingPrompts(session.sessionId);
       expect(pending).toHaveLength(2);
       const queuedId = pending[1]?.promptId;
-      expect(queuedId).toBeDefined();
+      expect(queuedId).toBe('prompt-removed');
 
       const result = bridge.removePendingPrompt(session.sessionId, queuedId!);
       expect(result.removed).toBe(true);
@@ -6200,6 +6262,19 @@ describe('createAcpSessionBridge', () => {
       await p1;
       await expect(p2).rejects.toBeDefined();
       expect(handle.agent.cancelCalls).toHaveLength(0);
+      await vi.waitFor(() => {
+        const removed = events.find(
+          (event) =>
+            event.type === 'pending_prompt_completed' &&
+            (event.data as { state?: string }).state === 'removed',
+        );
+        expect(removed?.promptId).toBe('prompt-removed');
+        expect(removed?.data).toMatchObject({
+          promptId: 'prompt-removed',
+          state: 'removed',
+        });
+      });
+      sub.catch(() => {});
       await bridge.shutdown();
     });
 
@@ -15818,19 +15893,30 @@ describe('createAcpSessionBridge — mid-turn message queue (enqueueMidTurnMessa
     });
     const bridge = makeBridge({ channelFactory: async () => handle.channel });
     const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
-    const send = (text: string) =>
+    const send = (text: string, promptId: string) =>
       bridge
         .sendPrompt(
           session.sessionId,
           { sessionId: session.sessionId, prompt: [{ type: 'text', text }] },
           undefined,
-          { clientId: session.clientId },
+          { clientId: session.clientId, promptId },
         )
         .catch(() => {});
 
-    const p1 = send('p1');
+    const abort = new AbortController();
+    const iter = bridge.subscribeEvents(session.sessionId, {
+      signal: abort.signal,
+    });
+    const injected = (async () => {
+      for await (const event of iter) {
+        if (event.type === 'mid_turn_message_injected') return event;
+      }
+      throw new Error('no mid_turn_message_injected observed');
+    })();
+
+    const p1 = send('p1', 'prompt-1');
     await new Promise((r) => setTimeout(r, 10));
-    const p2 = send('p2'); // queued behind p1 ⇒ pendingPromptCount = 2
+    const p2 = send('p2', 'prompt-2'); // queued behind p1 ⇒ pendingPromptCount = 2
     expect(bridge.enqueueMidTurnMessage(session.sessionId, 'x')).toEqual({
       accepted: true,
     });
@@ -15843,9 +15929,101 @@ describe('createAcpSessionBridge — mid-turn message queue (enqueueMidTurnMessa
         sessionId: session.sessionId,
       }),
     ).toEqual({ messages: ['x'] });
+    expect((await injected).promptId).toBe('prompt-2');
 
     releases[1]!();
     await Promise.all([p1, p2]);
+    abort.abort();
+    await bridge.shutdown();
+  });
+
+  it('switches session-update attribution between queued turns and clears it at idle', async () => {
+    const releases: Array<() => void> = [];
+    const handle = makeChannel({
+      promptImpl: async () => {
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+        });
+        return { stopReason: 'end_turn' };
+      },
+    });
+    const bridge = makeBridge({ channelFactory: async () => handle.channel });
+    const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const abort = new AbortController();
+    const iter = bridge.subscribeEvents(session.sessionId, {
+      signal: abort.signal,
+    });
+    const updates = (async () => {
+      const observed: Array<{ text: string; promptId?: string }> = [];
+      for await (const event of iter) {
+        if (event.type !== 'session_update') continue;
+        const update = (
+          event.data as {
+            update?: { content?: { text?: string } };
+          }
+        ).update;
+        const text = update?.content?.text;
+        if (!text?.startsWith('agent-')) continue;
+        observed.push({ text, promptId: event.promptId });
+        if (observed.length === 3) return observed;
+      }
+      throw new Error('session update stream ended early');
+    })();
+
+    const p1 = bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'p1' }],
+      },
+      undefined,
+      { clientId: session.clientId, promptId: 'prompt-1' },
+    );
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
+    await handle.agentConnection.sessionUpdate({
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'agent-one' },
+      },
+    });
+
+    const p2 = bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'p2' }],
+      },
+      undefined,
+      { clientId: session.clientId, promptId: 'prompt-2' },
+    );
+    releases[0]!();
+    await p1;
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(2));
+    await handle.agentConnection.sessionUpdate({
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'agent-two' },
+      },
+    });
+
+    releases[1]!();
+    await p2;
+    await handle.agentConnection.sessionUpdate({
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'agent-idle' },
+      },
+    });
+
+    await expect(updates).resolves.toEqual([
+      { text: 'agent-one', promptId: 'prompt-1' },
+      { text: 'agent-two', promptId: 'prompt-2' },
+      { text: 'agent-idle', promptId: undefined },
+    ]);
+    abort.abort();
     await bridge.shutdown();
   });
 
@@ -15889,7 +16067,7 @@ describe('createAcpSessionBridge — mid-turn message queue (enqueueMidTurnMessa
           prompt: [{ type: 'text', text: 'go' }],
         },
         undefined,
-        { clientId: session.clientId },
+        { clientId: session.clientId, promptId: 'prompt-mid-turn' },
       )
       .catch(() => {});
     await new Promise((r) => setTimeout(r, 10));
@@ -15915,6 +16093,7 @@ describe('createAcpSessionBridge — mid-turn message queue (enqueueMidTurnMessa
     const it = iter[Symbol.asyncIterator]();
     const next = await it.next();
     expect(next.value?.type).toBe('mid_turn_message_injected');
+    expect(next.value?.promptId).toBe('prompt-mid-turn');
     expect(next.value?.originatorClientId).toBe(session.clientId);
     expect(next.value?.data).toMatchObject({ messages: ['hi'] });
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -10748,6 +10748,79 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('stamps terminal_sequence with the active promptId', async () => {
+      let releasePrompt: (() => void) | undefined;
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent({
+          promptImpl: async () => {
+            await new Promise<void>((resolve) => {
+              releasePrompt = resolve;
+            });
+            return { stopReason: 'end_turn' };
+          },
+        });
+        capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const terminalEvent = (async () => {
+        for await (const event of iter) {
+          if (event.type === 'terminal_sequence') return event;
+        }
+        throw new Error('terminal_sequence event not observed');
+      })();
+
+      const promptDone = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'keep the prompt active' }],
+        },
+        undefined,
+        { clientId: session.clientId, promptId: 'prompt-terminal' },
+      );
+
+      await vi.waitFor(() => {
+        expect(releasePrompt).toBeTypeOf('function');
+      });
+
+      void capturedConn!.extNotification(
+        'qwen/notify/session/terminal-sequence',
+        {
+          v: 1,
+          sessionId: session.sessionId,
+          terminalSequence: '\x07',
+        },
+      );
+
+      await expect(terminalEvent).resolves.toMatchObject({
+        type: 'terminal_sequence',
+        promptId: 'prompt-terminal',
+        data: { terminalSequence: '\x07' },
+      });
+
+      releasePrompt?.();
+      await promptDone;
+      abort.abort();
+      await bridge.shutdown();
+    });
+
     it('drops unknown extNotification methods, kinds, and missing sessionIds silently', async () => {
       let capturedConn: AgentSideConnection | undefined;
       const factory: ChannelFactory = async () => {
@@ -13428,6 +13501,83 @@ describe('createHttpAcpBridge — side-channel state layer (#4511)', () => {
       await bridge.shutdown();
     });
 
+    it('publishModelSwitched stamps the active promptId', async () => {
+      let releasePrompt: (() => void) | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent({
+          promptImpl: async () => {
+            await new Promise<void>((resolve) => {
+              releasePrompt = resolve;
+            });
+            return { stopReason: 'end_turn' };
+          },
+        });
+        const augmented = new Proxy(fakeAgent, {
+          get(target, prop) {
+            if (prop === 'unstable_setSessionModel') {
+              return async () => ({});
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (target as any)[prop];
+          },
+        });
+        new AgentSideConnection(() => augmented as Agent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const modelEvent = (async () => {
+        for await (const event of iter) {
+          if (event.type === 'model_switched') return event;
+        }
+        throw new Error('model_switched event not observed');
+      })();
+
+      const promptDone = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'keep the prompt active' }],
+        },
+        undefined,
+        { clientId: session.clientId, promptId: 'prompt-model' },
+      );
+
+      await vi.waitFor(() => {
+        expect(releasePrompt).toBeTypeOf('function');
+      });
+
+      await bridge.setSessionModel(
+        session.sessionId,
+        { sessionId: session.sessionId, modelId: 'qwen-max' },
+        undefined,
+      );
+
+      await expect(modelEvent).resolves.toMatchObject({
+        type: 'model_switched',
+        promptId: 'prompt-model',
+        data: { modelId: 'qwen-max' },
+      });
+
+      releasePrompt?.();
+      await promptDone;
+      abort.abort();
+      await bridge.shutdown();
+    });
+
     it('publishApprovalModeChanged publishes approval_mode_changed on setSessionApprovalMode', async () => {
       const factory: ChannelFactory = async () => {
         const { clientStream, agentStream } = createInMemoryChannel();
@@ -13472,6 +13622,83 @@ describe('createHttpAcpBridge — side-channel state layer (#4511)', () => {
       expect((next.value?.data as { next: string }).next).toBe(
         ApprovalMode.YOLO,
       );
+      abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('publishApprovalModeChanged stamps the active promptId', async () => {
+      let releasePrompt: (() => void) | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const agent = new FakeAgent({
+          promptImpl: async () => {
+            await new Promise<void>((resolve) => {
+              releasePrompt = resolve;
+            });
+            return { stopReason: 'end_turn' };
+          },
+          extMethodImpl: (method, params) => {
+            if (method === 'qwen/control/session/approval_mode') {
+              return Promise.resolve({
+                previous: 'default',
+                current: (params as { mode: string }).mode,
+              });
+            }
+            return Promise.resolve({});
+          },
+        });
+        new AgentSideConnection(() => agent as Agent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const approvalEvent = (async () => {
+        for await (const event of iter) {
+          if (event.type === 'approval_mode_changed') return event;
+        }
+        throw new Error('approval_mode_changed event not observed');
+      })();
+
+      const promptDone = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'keep the prompt active' }],
+        },
+        undefined,
+        { clientId: session.clientId, promptId: 'prompt-approval' },
+      );
+
+      await vi.waitFor(() => {
+        expect(releasePrompt).toBeTypeOf('function');
+      });
+
+      await bridge.setSessionApprovalMode(
+        session.sessionId,
+        ApprovalMode.YOLO,
+        { persist: false },
+      );
+
+      await expect(approvalEvent).resolves.toMatchObject({
+        type: 'approval_mode_changed',
+        promptId: 'prompt-approval',
+        data: { next: ApprovalMode.YOLO },
+      });
+
+      releasePrompt?.();
+      await promptDone;
       abort.abort();
       await bridge.shutdown();
     });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -526,6 +526,12 @@ interface SessionEntry {
    */
   clientIds: Map<string, number>;
   /**
+   * Admitted id for the prompt currently running on this session. ACP enforces
+   * one active prompt per session, and this bridge FIFO-serializes prompts, so
+   * turn-scoped events can safely inherit this id.
+   */
+  activePromptId?: string;
+  /**
    * Originator for the prompt currently running on this session. ACP enforces
    * one active prompt per session, and this bridge FIFO-serializes prompts, so
    * inline session updates / permission requests can safely inherit this id.
@@ -832,6 +838,7 @@ function pickUserInputEchoMeta(meta: unknown): Record<string, unknown> {
 function echoPromptToSessionBus(
   entry: SessionEntry,
   req: PromptRequest,
+  promptId: string,
   originatorClientId: string | undefined,
 ): void {
   // `PromptRequest.prompt` is a non-optional `ContentBlock[]` per the
@@ -856,6 +863,7 @@ function echoPromptToSessionBus(
     try {
       entry.events.publish({
         type: 'session_update',
+        promptId,
         data: {
           sessionId: req.sessionId,
           update: {
@@ -902,12 +910,14 @@ function echoPromptToSessionBus(
 function broadcastPromptCancelled(
   entry: SessionEntry,
   sessionId: string,
+  promptId: string | undefined,
   originatorClientId: string | undefined,
   reason?: 'forward_failed',
 ): void {
   try {
     entry.events.publish({
       type: 'prompt_cancelled',
+      ...(promptId ? { promptId } : {}),
       data: { sessionId, ...(reason ? { reason } : {}) },
       ...(originatorClientId ? { originatorClientId } : {}),
     });
@@ -926,6 +936,7 @@ function broadcastPromptCancelled(
 function broadcastPromptCancelledOnce(
   entry: SessionEntry,
   sessionId: string,
+  promptId: string | undefined,
   originatorClientId: string | undefined,
   reason?: 'forward_failed',
 ): void {
@@ -936,7 +947,13 @@ function broadcastPromptCancelledOnce(
     return;
   }
   entry.cancelBroadcast = true;
-  broadcastPromptCancelled(entry, sessionId, originatorClientId, reason);
+  broadcastPromptCancelled(
+    entry,
+    sessionId,
+    promptId,
+    originatorClientId,
+    reason,
+  );
 }
 
 function broadcastTurnComplete(
@@ -949,6 +966,7 @@ function broadcastTurnComplete(
   try {
     entry.events.publish({
       type: 'turn_complete',
+      ...(promptId ? { promptId } : {}),
       data: {
         sessionId,
         stopReason: promptResult.stopReason ?? 'end_turn',
@@ -1042,6 +1060,7 @@ function broadcastTurnError(
   try {
     entry.events.publish({
       type: 'turn_error',
+      ...(promptId ? { promptId } : {}),
       data: {
         sessionId,
         message,
@@ -3263,6 +3282,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // programming error (e.g. a `TypeError`) as a benign bus-closed swallow.
     entry.events.publish({
       type: 'model_switched',
+      ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
       data: { sessionId: entry.sessionId, modelId },
       ...(originatorClientId ? { originatorClientId } : {}),
     });
@@ -3278,6 +3298,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // See `publishModelSwitched`: `publish()` never throws, so no wrapper.
     entry.events.publish({
       type: 'approval_mode_changed',
+      ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
       data: {
         sessionId: entry.sessionId,
         previous: payload.previous,
@@ -4665,6 +4686,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       if (isQueued) {
         entry.events.publish({
           type: 'pending_prompt_added',
+          promptId: pendingEntry.promptId,
           data: {
             sessionId,
             promptId: pendingEntry.promptId,
@@ -4694,6 +4716,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             pendingEntry.state = 'running';
             entry.events.publish({
               type: 'pending_prompt_started',
+              promptId: pendingEntry.promptId,
               data: {
                 sessionId,
                 promptId: pendingEntry.promptId,
@@ -4761,6 +4784,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   return copy;
                 })();
                 entry.promptActive = true;
+                entry.activePromptId = pendingEntry.promptId;
                 delete entry.turnError;
                 activePromptCounter++;
                 entry.sessionLastSeenAt = Date.now();
@@ -4799,10 +4823,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     echoPromptToSessionBus(
                       entry,
                       promptRequest,
+                      pendingEntry.promptId,
                       originatorClientId,
                     );
                   }
                 } catch (echoErr) {
+                  delete entry.activePromptId;
                   delete entry.activePromptOriginatorClientId;
                   if (entry.promptActive) {
                     entry.promptActive = false;
@@ -4820,6 +4846,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                       entry.sessionLastSeenAt = Date.now();
                       touchActivity();
                     }
+                    delete entry.activePromptId;
                     delete entry.activePromptOriginatorClientId;
                     if (
                       entry.clientIds.size === 0 &&
@@ -4887,6 +4914,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                       broadcastPromptCancelledOnce(
                         entry,
                         sessionId,
+                        pendingEntry.promptId,
                         originatorClientId,
                         'forward_failed',
                       );
@@ -4908,6 +4936,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   broadcastPromptCancelledOnce(
                     entry,
                     sessionId,
+                    pendingEntry.promptId,
                     originatorClientId,
                   );
                   cancelPendingForSession(sessionId);
@@ -4982,6 +5011,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
               try {
                 entry.events.publish({
                   type: 'pending_prompt_completed',
+                  promptId: pendingEntry.promptId,
                   data: {
                     sessionId,
                     promptId: pendingEntry.promptId,
@@ -5054,7 +5084,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // that POSTs /cancel and then drops its socket doesn't emit two
       // `prompt_cancelled` frames for the same turn. The latch resets at
       // the next prompt start, so a later turn still broadcasts.
-      broadcastPromptCancelledOnce(entry, sessionId, cancelOriginatorClientId);
+      broadcastPromptCancelledOnce(
+        entry,
+        sessionId,
+        entry.activePromptId,
+        cancelOriginatorClientId,
+      );
       // ACP spec: cancelling a prompt MUST resolve outstanding
       // requestPermission calls with outcome.cancelled. Do this *before*
       // forwarding the notification so the agent's wind-down sees the
@@ -6612,6 +6647,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       try {
         entry.events.publish({
           type: 'pending_prompt_completed',
+          promptId,
           data: { sessionId, promptId, state: 'removed' },
           ...(target.originatorClientId
             ? { originatorClientId: target.originatorClientId }

--- a/packages/acp-bridge/src/bridgeClient.test.ts
+++ b/packages/acp-bridge/src/bridgeClient.test.ts
@@ -95,6 +95,42 @@ function makeClient(fileSystem?: BridgeFileSystem): BridgeClient {
 }
 
 describe('BridgeClient — recording degradation ownership', () => {
+  it('keeps session-level recording degradation prompt-neutral', async () => {
+    const sessionId = 'session-with-active-prompt';
+    const publish = vi.fn().mockReturnValue(true);
+    const entry = {
+      sessionId,
+      events: { publish },
+      recordingDegraded: false,
+      activePromptId: 'prompt-active',
+      activePromptOriginatorClientId: 'client-1',
+    };
+    const noPermissionFlow = () => {
+      throw new Error('test: permission flow should not run');
+    };
+    const client = new BridgeClient(
+      ((id: string) => (id === sessionId ? entry : undefined)) as never,
+      (() => undefined) as never,
+      { request: noPermissionFlow } as never,
+      0,
+      Infinity,
+    );
+
+    await client.extNotification('qwen/notify/session/recording-degraded', {
+      v: 1,
+      sessionId,
+      reason: 'write_failed',
+    });
+
+    expect(entry.recordingDegraded).toBe(true);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      type: 'session_recording_degraded',
+      originatorClientId: 'client-1',
+    });
+    expect(publish.mock.calls[0][0]).not.toHaveProperty('promptId');
+  });
+
   it('drops a stale channel notification for another channel session', async () => {
     const sessionId = 'session-owned-by-new-channel';
     const publish = vi.fn();
@@ -537,6 +573,7 @@ describe('BridgeClient — A2UI session update publishing', () => {
     const publish = vi.fn().mockReturnValue(true);
     const fakeEntry = {
       sessionId: 'sess:a2ui',
+      activePromptId: 'prompt-a2ui',
       activePromptOriginatorClientId: 'client-1',
       events: { publish },
     };
@@ -571,6 +608,7 @@ describe('BridgeClient — A2UI session update publishing', () => {
 
     type PublishedFrame = {
       type: string;
+      promptId?: string;
       originatorClientId?: string;
       data: {
         sessionId: string;
@@ -594,6 +632,7 @@ describe('BridgeClient — A2UI session update publishing', () => {
     expect(published).toHaveLength(3);
     expect(published[0]).toMatchObject({
       type: 'session_update',
+      promptId: 'prompt-a2ui',
       originatorClientId: 'client-1',
       data: {
         sessionId: 'sess:a2ui',
@@ -614,6 +653,7 @@ describe('BridgeClient — A2UI session update publishing', () => {
     });
     expect(published[1].data.update.a2ui?.commands).toHaveLength(1);
     expect(published[2].originatorClientId).toBe('client-1');
+    expect(published[2].promptId).toBe('prompt-a2ui');
     expect(published[2].data.update.content?.[0].content.text).toBe(
       'rendered fallback',
     );
@@ -2234,6 +2274,7 @@ describe('BridgeClient — mid-turn queue drain (craft/drainMidTurnQueue)', () =
           sessionId: string;
           midTurnMessageQueue: MidTurnQueueEntry[];
           events: { publish: ReturnType<typeof vi.fn> };
+          activePromptId?: string;
         }
       | undefined,
   ): BridgeClient {
@@ -2250,6 +2291,7 @@ describe('BridgeClient — mid-turn queue drain (craft/drainMidTurnQueue)', () =
     const publish = vi.fn().mockReturnValue(true);
     const entry = {
       sessionId: 'sess:drain',
+      activePromptId: 'prompt-drain',
       midTurnMessageQueue: [{ text: 'first' }, { text: 'second' }],
       events: { publish },
     };
@@ -2266,6 +2308,7 @@ describe('BridgeClient — mid-turn queue drain (craft/drainMidTurnQueue)', () =
     expect(publish).toHaveBeenCalledTimes(1);
     expect(publish.mock.calls[0][0]).toMatchObject({
       type: 'mid_turn_message_injected',
+      promptId: 'prompt-drain',
       data: { sessionId: 'sess:drain', messages: ['first', 'second'] },
     });
     // Anonymous queue entries (no originator) ⇒ no `originatorClientId` on the
@@ -2280,6 +2323,7 @@ describe('BridgeClient — mid-turn queue drain (craft/drainMidTurnQueue)', () =
     const publish = vi.fn().mockReturnValue(true);
     const entry = {
       sessionId: 'sess:multi',
+      activePromptId: 'prompt-multi',
       midTurnMessageQueue: [
         { text: 'a', originatorClientId: 'client-1' },
         { text: 'b', originatorClientId: 'client-2' },
@@ -2303,11 +2347,13 @@ describe('BridgeClient — mid-turn queue drain (craft/drainMidTurnQueue)', () =
     const c2 = frames.find((f) => f.originatorClientId === 'client-2');
     expect(c1).toMatchObject({
       type: 'mid_turn_message_injected',
+      promptId: 'prompt-multi',
       data: { sessionId: 'sess:multi', messages: ['a', 'c'] },
       originatorClientId: 'client-1',
     });
     expect(c2).toMatchObject({
       type: 'mid_turn_message_injected',
+      promptId: 'prompt-multi',
       data: { sessionId: 'sess:multi', messages: ['b'] },
       originatorClientId: 'client-2',
     });

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -441,8 +441,10 @@ function sliceLineRange(
  * structurally satisfies this interface, so no explicit conversion
  * is required.
  *
- * Only five fields cross the boundary: `sessionId`, `events`,
- * `pendingPermissionIds`, `pendingInteractions`, `activePromptOriginatorClientId`. New fields
+ * Only the fields declared on this narrowed interface cross the boundary:
+ * `sessionId`, `events`,
+ * `pendingPermissionIds`, `pendingInteractions`, `activePromptId`,
+ * `activePromptOriginatorClientId`. New fields
  * BridgeClient grows must be added here too (and the factory's
  * `SessionEntry` is required to provide them — TS enforces the
  * structural match at the callback signature).
@@ -464,6 +466,8 @@ export interface BridgeClientSessionEntry {
   midTurnMessageQueue: MidTurnQueueEntry[];
   /** True while a prompt is executing for this session. */
   promptActive?: boolean;
+  /** Admitted id for the prompt currently executing on this session. */
+  activePromptId?: string;
   activePromptOriginatorClientId?: string;
   /**
    * True while the bridge drives a model roundtrip; the
@@ -480,6 +484,7 @@ interface PreparedSessionUpdateFrames {
   frames: Array<Omit<BridgeEvent, 'id' | 'v'>>;
   artifacts: SessionArtifactInput[];
   trustedPublisher: boolean;
+  turn: Pick<BridgeEvent, 'promptId' | 'originatorClientId'>;
 }
 
 /**
@@ -669,6 +674,7 @@ export class BridgeClient implements Client {
     // symmetric defense for the publish-failure case.
     const published = entry.events.publish({
       type: 'permission_request',
+      ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
       data: {
         requestId,
         sessionId: entry.sessionId,
@@ -705,6 +711,7 @@ export class BridgeClient implements Client {
       const record: PermissionRequestRecord = {
         requestId,
         sessionId: entry.sessionId,
+        promptId: entry.activePromptId,
         originatorClientId: entry.activePromptOriginatorClientId,
         allowedOptionIds,
         issuedAtMs: Date.now(),
@@ -749,9 +756,14 @@ export class BridgeClient implements Client {
       // Metrics callback failed; artifact processing must still run.
     }
     if (entry && prepared.artifacts.length > 0) {
-      await this.upsertAndPublishArtifacts(entry, prepared.artifacts, {
-        trustedPublisher: prepared.trustedPublisher,
-      });
+      await this.upsertAndPublishArtifacts(
+        entry,
+        prepared.artifacts,
+        {
+          trustedPublisher: prepared.trustedPublisher,
+        },
+        prepared.turn,
+      );
     }
   }
 
@@ -759,9 +771,12 @@ export class BridgeClient implements Client {
     params: SessionNotification,
     entry?: BridgeClientSessionEntry,
   ): PreparedSessionUpdateFrames {
-    const originator = entry?.activePromptOriginatorClientId
-      ? { originatorClientId: entry.activePromptOriginatorClientId }
-      : {};
+    const turn = {
+      ...(entry?.activePromptId ? { promptId: entry.activePromptId } : {}),
+      ...(entry?.activePromptOriginatorClientId
+        ? { originatorClientId: entry.activePromptOriginatorClientId }
+        : {}),
+    };
     const frames: Array<Omit<BridgeEvent, 'id' | 'v'>> = [];
     // A2UI-over-MCP: tool_call_update results from an A2UI UI server carry
     // the A2UI command JSON flattened by core (EmbeddedResource -> text, the
@@ -788,7 +803,7 @@ export class BridgeClient implements Client {
               _meta: { serverTimestamp: Date.now(), source: 'a2ui-bridge' },
             },
           },
-          ...originator,
+          ...turn,
         });
       }
       params = a2ui.sanitizedParams;
@@ -821,13 +836,14 @@ export class BridgeClient implements Client {
     frames.push({
       type: 'session_update',
       data: publishParams,
-      ...originator,
+      ...turn,
       ...(serverTimestamp !== undefined ? { _meta: { serverTimestamp } } : {}),
     });
     return {
       frames,
       artifacts,
       trustedPublisher: isTrustedArtifactToolUpdate(params, updateMeta),
+      turn,
     };
   }
 
@@ -840,6 +856,7 @@ export class BridgeClient implements Client {
     const artifactBatches: Array<{
       artifacts: SessionArtifactInput[];
       trustedPublisher: boolean;
+      turn: Pick<BridgeEvent, 'promptId' | 'originatorClientId'>;
     }> = [];
     for (const update of updates) {
       const prepared = this.prepareSessionUpdateFrames(
@@ -851,14 +868,20 @@ export class BridgeClient implements Client {
         artifactBatches.push({
           artifacts: prepared.artifacts,
           trustedPublisher: prepared.trustedPublisher,
+          turn: prepared.turn,
         });
       }
     }
     entry.events.seedReplayEvents(frames);
     for (const batch of artifactBatches) {
-      await this.upsertAndPublishArtifacts(entry, batch.artifacts, {
-        trustedPublisher: batch.trustedPublisher,
-      });
+      await this.upsertAndPublishArtifacts(
+        entry,
+        batch.artifacts,
+        {
+          trustedPublisher: batch.trustedPublisher,
+        },
+        batch.turn,
+      );
     }
   }
 
@@ -1025,6 +1048,7 @@ export class BridgeClient implements Client {
       for (const [originatorClientId, texts] of byOriginator) {
         const published = entry.events.publish({
           type: MID_TURN_MESSAGE_INJECTED_EVENT,
+          ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
           data: { sessionId: entry.sessionId, messages: texts },
           ...(originatorClientId ? { originatorClientId } : {}),
         });
@@ -1333,6 +1357,9 @@ export class BridgeClient implements Client {
       }
       const entry = this.resolveEntry(sessionId);
       if (!entry) return;
+      // This child-generated promptId identifies a persisted history turn, not
+      // the daemon's admitted HTTP prompt UUID. Keep it in the legacy payload
+      // and do not promote it to the envelope correlation field.
       entry.events.publish({
         type: 'followup_suggestion',
         data: { sessionId, suggestion, promptId },
@@ -1345,7 +1372,7 @@ export class BridgeClient implements Client {
       const { v: _v, sessionId: _sid, ...rest } = params;
       void _v;
       void _sid;
-      this.publishExtNotification(sessionId, 'terminal_sequence', rest);
+      this.publishExtNotification(sessionId, 'terminal_sequence', rest, true);
       return;
     }
     if (method === 'qwen/notify/session/artifact-event') {
@@ -1426,17 +1453,24 @@ export class BridgeClient implements Client {
         toolCallId,
       }),
     );
-    await this.upsertAndPublishArtifacts(entry, artifacts);
+    const turn = {
+      ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
+      ...(entry.activePromptOriginatorClientId
+        ? { originatorClientId: entry.activePromptOriginatorClientId }
+        : {}),
+    };
+    await this.upsertAndPublishArtifacts(entry, artifacts, undefined, turn);
   }
 
   private async upsertAndPublishArtifacts(
     entry: BridgeClientSessionEntry,
     artifacts: SessionArtifactInput[],
     options?: Parameters<SessionArtifactStore['upsertMany']>[1],
+    turn: Pick<BridgeEvent, 'promptId' | 'originatorClientId'> = {},
   ): Promise<void> {
     try {
       const result = await entry.artifacts.upsertMany(artifacts, options);
-      this.publishArtifactChanges(entry, result.changes);
+      this.publishArtifactChanges(entry, result.changes, turn);
     } catch (error) {
       writeStderrLine(
         `[artifacts] session=${entry.sessionId} action=dropped reason=${JSON.stringify(
@@ -1449,14 +1483,13 @@ export class BridgeClient implements Client {
   private publishArtifactChanges(
     entry: BridgeClientSessionEntry,
     changes: SessionArtifactChange[],
+    turn: Pick<BridgeEvent, 'promptId' | 'originatorClientId'>,
   ): void {
     for (const change of changes) {
       entry.events.publish({
         type: 'artifact_changed',
         data: { sessionId: entry.sessionId, change },
-        ...(entry.activePromptOriginatorClientId
-          ? { originatorClientId: entry.activePromptOriginatorClientId }
-          : {}),
+        ...turn,
       });
     }
   }
@@ -1465,11 +1498,15 @@ export class BridgeClient implements Client {
     sessionId: string,
     type: string,
     data: Record<string, unknown>,
+    turnScoped = false,
   ): void {
     const entry = this.resolveEntry(sessionId);
     const frame: Omit<BridgeEvent, 'id' | 'v'> = {
       type,
       data,
+      ...(turnScoped && entry?.activePromptId
+        ? { promptId: entry.activePromptId }
+        : {}),
       ...(entry?.activePromptOriginatorClientId
         ? { originatorClientId: entry.activePromptOriginatorClientId }
         : {}),
@@ -1526,6 +1563,7 @@ export class BridgeClient implements Client {
       // its documented contract we don't wrap it.
       entry.events.publish({
         type: 'model_switched',
+        ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
         data: { sessionId, modelId: currentModelId },
         ...(entry.activePromptOriginatorClientId
           ? { originatorClientId: entry.activePromptOriginatorClientId }
@@ -1603,6 +1641,7 @@ export class BridgeClient implements Client {
       // per its documented contract we don't wrap it in try/catch.
       entry.events.publish({
         type: 'approval_mode_changed',
+        ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
         data: {
           sessionId,
           previous: 'default',
@@ -1646,6 +1685,7 @@ export class BridgeClient implements Client {
     // documented contract we don't wrap it in try/catch.
     entry.events.publish({
       type: 'session_update',
+      ...(entry.activePromptId ? { promptId: entry.activePromptId } : {}),
       data: {
         sessionId,
         update: {

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -394,9 +394,10 @@ export interface BridgeClientRequestContext {
   fromLoopback?: boolean;
   /**
    * Caller-generated correlation id for non-blocking prompt mode.
-   * When present, the bridge stamps `turn_complete` / `turn_error` events
-   * with this id so the SDK's `prompt()` can match the SSE event to the
-   * pending HTTP 202 request.
+   * When present, the bridge stamps turn-scoped event envelopes with this id.
+   * The legacy `turn_complete.data.promptId` / `turn_error.data.promptId`
+   * fields remain populated so the SDK's `prompt()` can match the terminal
+   * SSE event to the pending HTTP 202 request.
    */
   promptId?: string;
   /**
@@ -980,8 +981,9 @@ export interface AcpSessionBridge {
      * Replay cursor + correlation id for an accepted continuation, mirroring
      * the `POST /session/:id/prompt` 202 body. Present only when `accepted` —
      * the continuation runs as a tracked async turn, so clients use `promptId`
-     * to correlate `turn_complete` / `turn_error` and `lastEventId` to replay
-     * events emitted before they (re)attach the SSE stream.
+     * to correlate turn-scoped events, including `turn_complete` /
+     * `turn_error`, while `lastEventId` resumes events emitted before they
+     * (re)attach the SSE stream.
      */
     promptId?: string;
     lastEventId?: number;

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -95,26 +95,28 @@ describe('EventBus', () => {
     // Need to start consuming before publishing so the subscriber is
     // registered in the loop below.
     setTimeout(() => {
-      bus.publish({ type: 'foo', data: 'a' });
+      bus.publish({ type: 'foo', data: 'a', promptId: 'prompt-live' });
       bus.publish({ type: 'foo', data: 'b' });
     }, 5);
 
     const events = await collect(iter, 2);
     expect(events.map((e) => e.data)).toEqual(['a', 'b']);
+    expect(events.map((e) => e.promptId)).toEqual(['prompt-live', undefined]);
     abort.abort();
   });
 
   it('replays events newer than lastEventId from the ring', async () => {
     const bus = new EventBus();
-    bus.publish({ type: 'foo', data: 'a' });
-    bus.publish({ type: 'foo', data: 'b' });
-    bus.publish({ type: 'foo', data: 'c' });
+    bus.publish({ type: 'foo', data: 'a', promptId: 'prompt-a' });
+    bus.publish({ type: 'foo', data: 'b', promptId: 'prompt-b' });
+    bus.publish({ type: 'foo', data: 'c', promptId: 'prompt-c' });
 
     const abort = new AbortController();
     const iter = bus.subscribe({ lastEventId: 1, signal: abort.signal });
     const events = await collect(iter, 2);
     expect(events.map((e) => e.id)).toEqual([2, 3]);
     expect(events.map((e) => e.data)).toEqual(['b', 'c']);
+    expect(events.map((e) => e.promptId)).toEqual(['prompt-b', 'prompt-c']);
     abort.abort();
   });
 

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -51,6 +51,11 @@ export interface BridgeEvent {
   /** Frame payload — opaque JSON. */
   data: unknown;
   /**
+   * Identifier of the admitted prompt that produced this event, when the
+   * event belongs to a specific turn.
+   */
+  promptId?: string;
+  /**
    * Envelope metadata shared by SSE and load/replay responses.
    */
   _meta?: Record<string, unknown>;

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -55,6 +55,8 @@ export interface PermissionRequestRecord {
    * always per-session — workspace-scoped permission is out of
    * scope for v1. */
   readonly sessionId: string;
+  /** Admitted prompt that produced this permission request, when known. */
+  readonly promptId?: string;
   /**
    * `originatorClientId` that triggered the underlying prompt.
    * `designated` policy votes are only accepted from this id;

--- a/packages/acp-bridge/src/permissionMediator.test.ts
+++ b/packages/acp-bridge/src/permissionMediator.test.ts
@@ -83,6 +83,7 @@ function makeRecord(
   return {
     requestId: overrides.requestId ?? 'req-1',
     sessionId: overrides.sessionId ?? 'sess-1',
+    ...('promptId' in overrides ? { promptId: overrides.promptId } : {}),
     originatorClientId:
       'originatorClientId' in overrides
         ? overrides.originatorClientId
@@ -131,7 +132,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
 
   it('synchronously registers pending in `request()` (N1 invariant)', () => {
     const { mediator } = makeMediator();
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-permission' });
 
     // The Promise returned by request() must be already-pending; the
     // pending entry must be visible to peekSessionFor BEFORE we await.
@@ -144,7 +145,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
 
   it('resolves on first valid vote and emits permission_resolved with voter clientId as originator (O8)', async () => {
     const { mediator, calls, events } = makeMediator();
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-permission' });
     const promise = mediator.request(record, 5_000);
 
     const outcome = mediator.vote(makeVote({ clientId: 'client_B' }));
@@ -166,6 +167,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
       sessionId: 'sess-1',
       event: {
         type: 'permission_resolved',
+        promptId: 'prompt-permission',
         data: {
           requestId: 'req-1',
           outcome: { outcome: 'selected', optionId: 'proceed_once' },
@@ -194,7 +196,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
 
   it('omits both voterClientId and originatorClientId on permission_resolved when voter has no clientId', async () => {
     const { mediator, events } = makeMediator();
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-permission' });
     const promise = mediator.request(record, 5_000);
 
     mediator.vote(makeVote({ clientId: undefined }));
@@ -209,7 +211,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
 
   it('returns already_resolved on a duplicate vote and re-emits the SSE notification', async () => {
     const { mediator, events } = makeMediator();
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-permission' });
     const promise = mediator.request(record, 5_000);
 
     mediator.vote(makeVote({ clientId: 'client_A' }));
@@ -234,6 +236,7 @@ describe('MultiClientPermissionMediator — first-responder', () => {
       'permission_already_resolved',
     ]);
     const lateEvent = events[1]!;
+    expect(lateEvent.event.promptId).toBe('prompt-permission');
     expect(lateEvent.event.data).toEqual({
       requestId: 'req-1',
       sessionId: 'sess-1',
@@ -496,7 +499,7 @@ describe('MultiClientPermissionMediator — timeout', () => {
 
   it('resolves cancelled when the timer fires before any vote', async () => {
     const { mediator, events, calls } = makeMediator();
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-timeout' });
     const promise = mediator.request(record, 5_000);
 
     vi.advanceTimersByTime(5_000);
@@ -508,6 +511,7 @@ describe('MultiClientPermissionMediator — timeout', () => {
     // must omit `originatorClientId` rather than spread `undefined`.
     expect(events).toHaveLength(1);
     expect(events[0]!.event.type).toBe('permission_resolved');
+    expect(events[0]!.event.promptId).toBe('prompt-timeout');
     expect(events[0]!.event).not.toHaveProperty('originatorClientId');
 
     expect(calls.map((c) => c.kind)).toEqual([
@@ -618,7 +622,10 @@ describe('MultiClientPermissionMediator — designated', () => {
 
   it('rejects votes from non-originators with permission_forbidden', async () => {
     const { mediator, events, calls } = makeMediator('designated');
-    const record = makeRecord({ originatorClientId: 'client_A' });
+    const record = makeRecord({
+      promptId: 'prompt-forbidden',
+      originatorClientId: 'client_A',
+    });
     const promise = mediator.request(record, 5_000);
     const outcome = mediator.vote(makeVote({ clientId: 'client_B' }));
     expect(outcome).toEqual({
@@ -626,6 +633,7 @@ describe('MultiClientPermissionMediator — designated', () => {
       reason: 'designated_mismatch',
     });
     expect(events.map((e) => e.event.type)).toEqual(['permission_forbidden']);
+    expect(events[0]!.event.promptId).toBe('prompt-forbidden');
     expect(events[0]!.event.data).toEqual({
       requestId: 'req-1',
       sessionId: 'sess-1',
@@ -672,7 +680,7 @@ describe('MultiClientPermissionMediator — consensus', () => {
       'consensus',
       new Set(['client_A', 'client_B', 'client_C']),
     );
-    const record = makeRecord();
+    const record = makeRecord({ promptId: 'prompt-consensus' });
     const promise = mediator.request(record, 5_000);
 
     const v1 = mediator.vote(makeVote({ clientId: 'client_A' }));
@@ -680,6 +688,7 @@ describe('MultiClientPermissionMediator — consensus', () => {
     expect(events.map((e) => e.event.type)).toEqual([
       'permission_partial_vote',
     ]);
+    expect(events[0]!.event.promptId).toBe('prompt-consensus');
     expect(events[0]!.event.data).toEqual({
       requestId: 'req-1',
       sessionId: 'sess-1',
@@ -700,6 +709,7 @@ describe('MultiClientPermissionMediator — consensus', () => {
       'permission_partial_vote',
       'permission_resolved',
     ]);
+    expect(events[1]!.event.promptId).toBe('prompt-consensus');
 
     const decisionReason = calls.find((c) => c.kind === 'resolved')!
       .args[2] as PermissionDecisionReason;

--- a/packages/acp-bridge/src/permissionMediator.ts
+++ b/packages/acp-bridge/src/permissionMediator.ts
@@ -292,6 +292,7 @@ export interface MediatorDeps {
 interface MediatorPending {
   readonly requestId: string;
   readonly sessionId: string;
+  readonly promptId: string | undefined;
   /** Captured at request issue time so live-reload of the daemon
    * policy doesn't change the rules under in-flight requests. */
   readonly policy: PermissionPolicy;
@@ -319,6 +320,7 @@ interface MediatorPending {
 interface PermissionResolutionRecord {
   readonly requestId: string;
   readonly sessionId: string;
+  readonly promptId: string | undefined;
   readonly resolution: PermissionResolution;
   /** Voter's clientId (or undefined for timeout / session-closed paths)
    *  — replayed onto `permission_already_resolved` so late SSE
@@ -428,6 +430,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
       const pending: MediatorPending = {
         requestId: record.requestId,
         sessionId: record.sessionId,
+        promptId: record.promptId,
         policy,
         originatorClientId: record.originatorClientId,
         allowedOptionIds: record.allowedOptionIds,
@@ -570,6 +573,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
             : CANCEL_VOTE_SENTINEL;
         this.safeEmit(prior.sessionId, {
           type: 'permission_already_resolved',
+          ...(prior.promptId ? { promptId: prior.promptId } : {}),
           data: {
             requestId: prior.requestId,
             sessionId: prior.sessionId,
@@ -780,6 +784,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
     );
     this.safeEmit(pending.sessionId, {
       type: 'permission_partial_vote',
+      ...(pending.promptId ? { promptId: pending.promptId } : {}),
       data: {
         requestId: pending.requestId,
         sessionId: pending.sessionId,
@@ -871,6 +876,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
     );
     this.safeEmit(pending.sessionId, {
       type: 'permission_forbidden',
+      ...(pending.promptId ? { promptId: pending.promptId } : {}),
       data: {
         requestId: pending.requestId,
         sessionId: pending.sessionId,
@@ -1019,6 +1025,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
     // wire-shape preservation.
     this.safeEmit(pending.sessionId, {
       type: 'permission_resolved',
+      ...(pending.promptId ? { promptId: pending.promptId } : {}),
       data: {
         requestId: pending.requestId,
         outcome: this.toAcpOutcome(resolution),
@@ -1046,6 +1053,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
     this.rememberResolved({
       requestId: pending.requestId,
       sessionId: pending.sessionId,
+      promptId: pending.promptId,
       resolution,
       resolverClientId,
     });
@@ -1181,6 +1189,7 @@ export class MultiClientPermissionMediator implements PermissionMediator {
     return {
       requestId: pending.requestId,
       sessionId: pending.sessionId,
+      ...(pending.promptId ? { promptId: pending.promptId } : {}),
       originatorClientId: pending.originatorClientId,
       allowedOptionIds: pending.allowedOptionIds,
       issuedAtMs: pending.issuedAtMs,

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -18880,6 +18880,7 @@ describe('GET /session/:id/events (SSE)', () => {
           id: 1,
           v: 1,
           type: 'session_update',
+          promptId: 'prompt-1',
           data: { foo: 'bar' },
         };
         yield { id: 2, v: 1, type: 'session_update', data: { foo: 'baz' } };
@@ -18909,9 +18910,11 @@ describe('GET /session/:id/events (SSE)', () => {
       id: 1,
       v: 1,
       type: 'session_update',
+      promptId: 'prompt-1',
       data: { foo: 'bar' },
     });
     expect(frames[1]?.id).toBe('2');
+    expect(JSON.parse(frames[1]!.data!)).not.toHaveProperty('promptId');
   });
 
   it('stamps _meta.serverTimestamp on every SSE frame (#4175 F4 prereq, chiga0 #19 P0)', async () => {

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -2756,6 +2756,8 @@ export interface DaemonEvent {
   type: string;
   /** Frame payload — opaque JSON. */
   data: unknown;
+  /** Admitted prompt identifier for events belonging to a specific turn. */
+  promptId?: string;
   /** Envelope metadata, including daemon-emitted timestamps when available. */
   _meta?: Record<string, unknown>;
   originatorClientId?: string;

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -113,7 +113,7 @@ async function waitForPendingPrompt(
 }
 
 function turnCompleteFrame(promptId: string): string {
-  return `id: 1\nevent: turn_complete\ndata: {"id":1,"v":1,"type":"turn_complete","data":{"promptId":"${promptId}","stopReason":"end_turn"}}\n\n`;
+  return `id: 1\nevent: turn_complete\ndata: {"id":1,"v":1,"type":"turn_complete","promptId":"${promptId}","data":{"promptId":"${promptId}","stopReason":"end_turn"}}\n\n`;
 }
 
 describe('DaemonSessionClient', () => {


### PR DESCRIPTION
## What this PR does

This PR adds an optional envelope-level `promptId` to daemon events associated with an admitted prompt. Prompt echoes, agent updates, A2UI and artifact updates, model and approval-mode changes, permission lifecycle events, queued-prompt transitions, cancellation events, terminal events, and drained mid-turn messages now carry the admitted prompt ID when they belong to a specific turn.

The bridge records the active prompt ID while a prompt is executing and clears it when that prompt settles. Queue lifecycle and terminal events use the immutable ID stored with the admitted prompt rather than mutable session state. Mid-turn messages use the ID of the prompt that actually drains and consumes them, which may differ from the prompt that was active when the message was initially queued.

The change is additive and backward compatible. Existing payload-level `promptId` fields on queue and terminal events remain unchanged, while replay storage, SSE serialization, and SDK event types preserve the new optional envelope field. Session-level and workspace-level notifications remain prompt-neutral.

## Why it's needed

A daemon session can continue producing events after its frontend request has been cancelled. When the same session reconnects for a subsequent prompt, replay can include unconsumed events from the cancelled prompt. `Last-Event-ID` provides a useful replay and admission boundary, but it cannot identify late events emitted by an older prompt after a newer prompt has already been admitted. `originatorClientId` identifies the registered client responsible for an action, not the individual prompt.

Without prompt-level correlation on intermediate events, clients cannot reliably distinguish thought, message, tool, permission, cancellation, or other turn-scoped events from different prompts while preserving the same daemon session and its conversation memory. Adding the admitted prompt ID to each turn-scoped event envelope allows clients to filter replay and live events by exact turn ownership without creating a new session for every prompt.

## Reviewer Test Plan

### How to verify

1. Admit a prompt with a known `promptId`, subscribe to the session event stream, and confirm prompt echoes, agent message and thought updates, permission events, terminal events, and other turn-scoped events carry that ID at the event-envelope level.

2. Queue Prompt B while Prompt A is running. Confirm Prompt A updates carry A's ID, queued lifecycle events for Prompt B carry B's immutable ID, Prompt B updates carry B's ID after it starts, and updates emitted after the session becomes idle omit `promptId`.

3. Queue a mid-turn user message while Prompt A is running, allow Prompt A to settle while Prompt B remains queued, and drain the message during Prompt B. Confirm `mid_turn_message_injected` carries Prompt B's ID because Prompt B actually consumed the message.

4. Cancel or fail a running prompt and confirm `prompt_cancelled`, `turn_complete`, and `turn_error` carry the admitted ID at envelope level. Confirm existing `data.promptId` fields remain populated on terminal events for SDK compatibility.

5. Resolve permissions through normal voting, timeout, forbidden-vote, partial-vote, and late-vote paths. Confirm each resulting permission event retains the prompt ID captured when the permission request was issued.

6. Replay events through the event ring and serialize them through SSE. Confirm envelope-level `promptId` survives unchanged and prompt-neutral events continue to omit the property.

Run the focused tests:

```bash
cd packages/acp-bridge
npx vitest run src/eventBus.test.ts src/bridgeClient.test.ts src/permissionMediator.test.ts src/bridge.test.ts

cd ../sdk-typescript
npx vitest run test/unit/DaemonSessionClient.test.ts

cd ../cli
npx vitest run src/serve/server.test.ts -t "streams events from the bridge as SSE frames"

cd ../..
npm run typecheck
npm run build
```

Expected results:

```text
ACP bridge: 550 tests passed
SDK daemon session client: 43 tests passed
Focused CLI SSE serialization test: passed
Repository-wide TypeScript typecheck: passed
Full repository build: passed
Formatting, changed-file linting, and git diff checks: passed
```

### Evidence (Before & After)

N/A — this is a daemon protocol, bridge, and SDK compatibility change with no direct TUI or visual output.

Before: intermediate turn events could only be associated with a session and, in some cases, an originator client. Clients could not reliably determine which admitted prompt produced replayed or live intermediate events.

After: turn-scoped events expose the admitted prompt ID at envelope level while legacy payload fields remain available. Prompt-neutral session and workspace notifications remain unstamped.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

Tested locally on macOS with Node.js v26.4.0 and npm v11.17.0 using the native development environment without Docker or sandboxing.

## Risk & Scope

- Main risk or tradeoff: Incorrect active-prompt lifecycle management could attribute an event to the preceding or succeeding prompt. The tests cover queued prompt transitions, cancellation and error paths, post-settlement clearing, mid-turn drain-time attribution, delayed permission resolution, replay, and SSE serialization.
- Not validated / out of scope: Windows and Linux were not tested locally and are expected to be covered by CI. End-to-end browser rendering and downstream application-specific filtering are outside this PR. `followup_suggestion.data.promptId` remains an ACP history-turn identifier and is intentionally not promoted to the admitted HTTP prompt envelope field.
- Breaking changes / migration notes: None. The new envelope field is optional and additive. Existing queue and terminal payload-level `promptId` fields remain unchanged, so existing clients continue to work without modification.

## Linked Issues

N/A — no existing issue is currently linked.

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 为与已接收提示词相关的守护进程事件添加了一个可选的信封层级 `promptId`。当提示词回显、智能体更新、A2UI 和产物更新、模型及审批模式变更、权限生命周期事件、排队提示词状态变更、取消事件、终止事件以及被提取的中途消息属于某个特定轮次时，它们现在都会携带该轮次已接收的提示词 ID。

桥接层会在提示词执行期间记录当前活动的提示词 ID，并在该提示词结束后清除它。队列生命周期事件和终止事件使用与已接收提示词一同保存的不可变 ID，而不是可变的会话状态。中途消息使用实际提取并消费该消息的提示词 ID；这个 ID 可能与消息最初进入队列时正在运行的提示词 ID 不同。

此变更是增量式且向后兼容的。队列事件和终止事件中现有的载荷层级 `promptId` 字段保持不变，同时重放存储、SSE 序列化和 SDK 事件类型会保留新的可选信封字段。会话层级和工作区层级的通知仍然不带提示词归属信息。

## 为什么需要此变更

前端请求被取消后，守护进程会话仍可能继续生成事件。当同一个会话为后续提示词重新连接时，重放内容可能包含已取消提示词尚未被消费的事件。`Last-Event-ID` 可以提供有效的重放和接收边界，但无法识别在新提示词已经被接收后，旧提示词才生成的延迟事件。`originatorClientId` 标识的是触发操作的已注册客户端，而不是单个提示词。

如果中间事件没有提示词层级的关联信息，客户端就无法在保留同一个守护进程会话及其对话记忆的同时，可靠地区分来自不同提示词的思考、消息、工具、权限、取消或其他轮次事件。将已接收的提示词 ID 添加到每个轮次事件的信封中，可以让客户端根据精确的轮次归属过滤重放事件和实时事件，而无需为每个提示词创建新会话。

## 审阅者测试计划

### 验证方法

1. 使用一个已知的 `promptId` 接收提示词并订阅会话事件流，确认提示词回显、智能体消息和思考更新、权限事件、终止事件以及其他轮次事件都在事件信封层级携带该 ID。

2. 在提示词 A 运行期间将提示词 B 加入队列。确认提示词 A 的更新携带 A 的 ID，提示词 B 的队列生命周期事件携带 B 的不可变 ID，提示词 B 启动后的更新携带 B 的 ID，并且会话进入空闲状态后生成的更新不包含 `promptId`。

3. 在提示词 A 运行时将一条中途用户消息加入队列，让提示词 A 在提示词 B 仍处于队列中时结束，并在提示词 B 期间提取该消息。确认 `mid_turn_message_injected` 携带提示词 B 的 ID，因为实际消费该消息的是提示词 B。

4. 取消正在运行的提示词或让其执行失败，确认 `prompt_cancelled`、`turn_complete` 和 `turn_error` 在信封层级携带已接收的 ID。确认终止事件中现有的 `data.promptId` 字段仍然被填充，以保持 SDK 兼容性。

5. 通过正常投票、超时、禁止投票、部分投票和延迟投票路径处理权限请求。确认所有产生的权限事件都保留权限请求创建时捕获的提示词 ID。

6. 通过事件环重放事件，并通过 SSE 对事件进行序列化。确认信封层级的 `promptId` 保持不变，并且与提示词无关的事件仍然不包含该属性。

运行以下重点测试：

```bash
cd packages/acp-bridge
npx vitest run src/eventBus.test.ts src/bridgeClient.test.ts src/permissionMediator.test.ts src/bridge.test.ts

cd ../sdk-typescript
npx vitest run test/unit/DaemonSessionClient.test.ts

cd ../cli
npx vitest run src/serve/server.test.ts -t "streams events from the bridge as SSE frames"

cd ../..
npm run typecheck
npm run build
```

预期结果：

```text
ACP bridge：550 个测试通过
SDK 守护进程会话客户端：43 个测试通过
重点 CLI SSE 序列化测试：通过
整个代码库的 TypeScript 类型检查：通过
整个代码库的构建：通过
格式化、变更文件的代码检查和 git diff 检查：通过
```

### 证据（变更前与变更后）

不适用——这是守护进程协议、桥接层和 SDK 兼容性变更，不会直接产生 TUI 或视觉输出。

变更前：中间轮次事件只能与会话关联，在部分情况下还可以与发起客户端关联。客户端无法可靠判断重放或实时中间事件由哪个已接收的提示词生成。

变更后：轮次事件在信封层级公开已接收的提示词 ID，同时保留旧有的载荷字段。与提示词无关的会话和工作区通知仍然不带该字段。

### 测试平台

|     操作系统     |  状态  |
| :--------------: | :----: |
|     🍏 macOS      |   ✅   |
|    🪟 Windows     |   N/A   |
|     🐧 Linux      |   N/A   |

### 环境（可选）

在 macOS 本地环境中进行了测试，使用 Node.js v26.4.0 和 npm v11.17.0，未使用 Docker 或沙箱。

## 风险与范围

- 主要风险或权衡：如果活动提示词的生命周期管理不正确，事件可能会被错误地归属于前一个或后一个提示词。测试覆盖了排队提示词切换、取消和错误路径、结束后的状态清理、中途消息提取时归属、延迟权限处理、重放以及 SSE 序列化。
- 未验证或不在范围内：未在本地测试 Windows 和 Linux，预计由 CI 覆盖。端到端浏览器渲染和下游应用程序特定的过滤逻辑不在此 PR 的范围内。`followup_suggestion.data.promptId` 仍然是 ACP 历史轮次标识符，因此有意不将其提升为已接收 HTTP 提示词的信封字段。
- 破坏性变更或迁移说明：无。新的信封字段是可选且增量式的。队列事件和终止事件中现有的载荷层级 `promptId` 字段保持不变，因此现有客户端无需修改即可继续工作。

## 关联问题

不适用——目前没有关联现有问题。

</details>