### PR TITLE
fix(web-shell): scope advanced table overlays

### DIFF
--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -77,9 +77,7 @@
   font-weight: 600;
 }
 
-.copyButton,
-.secondaryButton,
-.primaryButton {
+.copyButton {
   padding: 3px 8px;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -92,24 +90,12 @@
   margin-right: 4px;
 }
 
-.copyButton,
-.secondaryButton {
+.copyButton {
   background: var(--card);
 }
 
-.primaryButton {
-  border-color: var(--agent-blue-500);
-  background: var(--agent-blue-500);
-  color: var(--card);
-}
-
-.copyButton:hover,
-.secondaryButton:hover {
+.copyButton:hover {
   background: var(--subtle-bg-strong);
-}
-
-.primaryButton:hover {
-  filter: brightness(1.08);
 }
 
 .scroller {
@@ -284,22 +270,6 @@
   color: var(--agent-blue-500);
 }
 
-.filterMenu {
-  position: fixed;
-  z-index: 1000;
-  width: 300px;
-  max-width: min(320px, 80vw);
-  max-height: min(430px, calc(100vh - 16px));
-  overflow: auto;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--card);
-  box-shadow: 0 16px 36px rgb(0 0 0 / 34%);
-  color: var(--foreground);
-  font-size: 12px;
-  font-weight: 400;
-}
-
 .columnContextMenu {
   position: fixed;
   z-index: 1000;
@@ -329,131 +299,6 @@
 .columnContextMenuAction:focus-visible {
   background: var(--subtle-bg-strong);
   outline: none;
-}
-
-.filterMenuTitle {
-  padding: 9px 10px;
-  border-bottom: 1px solid var(--border);
-  color: var(--foreground);
-  font-weight: 700;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.filterMenuSection {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-}
-
-.filterMenuAction {
-  width: 100%;
-  padding: 5px 7px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--foreground);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.filterMenuAction:hover,
-.activeAction {
-  background: var(--subtle-bg-strong);
-}
-
-.activeAction {
-  color: var(--agent-blue-500);
-  font-weight: 600;
-}
-
-.filterSearch,
-.conditionInput,
-.conditionSelect {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 5px 7px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--muted);
-  color: var(--foreground);
-  font: inherit;
-}
-
-.filterSearch::placeholder,
-.conditionInput::placeholder {
-  color: var(--muted-foreground);
-}
-
-.filterOptionList {
-  max-height: 170px;
-  overflow: auto;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--muted);
-}
-
-.filterOption {
-  display: flex;
-  gap: 7px;
-  align-items: center;
-  min-height: 26px;
-  padding: 3px 6px;
-  color: var(--foreground);
-  cursor: pointer;
-}
-
-.filterOption:hover {
-  background: var(--subtle-bg-strong);
-}
-
-.filterOption input {
-  flex: 0 0 auto;
-}
-
-.optionLabel {
-  min-width: 0;
-  flex: 1 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.optionCount {
-  margin-left: auto;
-  color: var(--muted-foreground);
-  font-variant-numeric: tabular-nums;
-}
-
-.optionLimitHint {
-  padding: 7px;
-  color: var(--muted-foreground);
-  text-align: center;
-}
-
-.conditionTitle {
-  color: var(--muted-foreground);
-  font-weight: 600;
-}
-
-.conditionInputs {
-  display: flex;
-  gap: 6px;
-}
-
-.filterFooter {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-  padding: 8px 10px;
-}
-
-.footerSpacer {
-  flex: 1 1 auto;
 }
 
 .cell {
@@ -649,141 +494,6 @@ tr:hover .frozenCell.selectedCell {
   white-space: pre-wrap;
 }
 
-.themeDark {
-  --background: #0d0d0d;
-  --foreground: #fafafa;
-  --muted-foreground: #808598;
-  --border: #2a2a2a;
-  --card: #161616;
-  --agent-blue-500: #6785ff;
-}
-
-.themeLight {
-  --background: #ffffff;
-  --foreground: #0a0a0b;
-  --muted-foreground: #a3a3a5;
-  --border: #e3e4e6;
-  --card: #ffffff;
-  --agent-blue-500: #0033ff;
-}
-
-.cellDialogBackdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  background: color-mix(in srgb, var(--background) 62%, transparent);
-}
-
-.cellDialog {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  width: min(520px, calc(100vw - 32px));
-  min-height: 190px;
-  padding: 20px 24px 16px;
-  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
-  border-radius: 10px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--card) 96%, white 4%),
-    color-mix(in srgb, var(--card) 92%, black 8%)
-  );
-  box-shadow: 0 18px 56px rgb(0 0 0 / 38%);
-  color: var(--foreground);
-  font-size: 13px;
-}
-
-.cellDialogCloseIcon {
-  position: absolute;
-  top: 12px;
-  right: 14px;
-  display: grid;
-  width: 24px;
-  height: 24px;
-  place-items: center;
-  border: 0;
-  background: transparent;
-  color: var(--muted-foreground);
-  font: inherit;
-  font-size: 24px;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.cellDialogCloseIcon:hover {
-  color: var(--foreground);
-}
-
-.cellDialogTitle {
-  margin-bottom: 16px;
-  font-size: inherit;
-  font-weight: 800;
-  line-height: 1.2;
-}
-
-.cellDialogValue {
-  min-height: 100px;
-  max-height: min(32vh, 200px);
-  overflow: auto;
-  padding: 10px 12px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--background) 72%, transparent);
-  color: var(--foreground);
-  font: inherit;
-  font-weight: 600;
-  line-height: 1.45;
-  cursor: text;
-  user-select: text;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-.cellDialogFooter {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  align-items: center;
-  margin-top: auto;
-  padding-top: 20px;
-}
-
-.cellDialogActions {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-}
-
-.cellDialogButton {
-  min-width: 64px;
-  padding: 6px 14px;
-  border: 0;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--foreground) 12%, transparent);
-  color: var(--foreground);
-  font: inherit;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.cellDialogButton:hover {
-  background: color-mix(in srgb, var(--foreground) 18%, transparent);
-}
-
-.cellDialogPrimaryButton {
-  background: var(--agent-blue-500);
-  color: white;
-}
-
-.cellDialogPrimaryButton:hover {
-  background: color-mix(in srgb, var(--agent-blue-500) 86%, white 14%);
-}
-
 .emptyValue {
   color: var(--muted-foreground);
   font-style: italic;
@@ -794,35 +504,4 @@ tr:hover .frozenCell.selectedCell {
   color: var(--muted-foreground);
   font-size: 13px;
   text-align: center;
-}
-
-@media (max-width: 640px) {
-  .cellDialogBackdrop {
-    padding: 10px;
-  }
-
-  .cellDialog {
-    width: 100%;
-    min-height: 0;
-    padding: 20px 14px 14px;
-  }
-
-  .cellDialogTitle {
-    margin-bottom: 14px;
-  }
-
-  .cellDialogFooter {
-    flex-direction: column;
-    align-items: stretch;
-    padding-top: 18px;
-  }
-
-  .cellDialogActions {
-    justify-content: flex-end;
-  }
-
-  .cellDialogButton {
-    min-width: 0;
-    padding: 6px 12px;
-  }
 }

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.module.css
@@ -84,14 +84,11 @@
   color: var(--foreground);
   font: inherit;
   cursor: pointer;
+  background: var(--card);
 }
 
 .copyCheck {
   margin-right: 4px;
-}
-
-.copyButton {
-  background: var(--card);
 }
 
 .copyButton:hover {

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -2756,7 +2756,7 @@ describe('EnhancedMarkdownTable', () => {
     expect(writeText).toHaveBeenCalledWith(['Alpha\t10', 'Beta\t2'].join('\n'));
   });
 
-  it('resets filter menu draft state when switching columns', () => {
+  it('resets filter menu draft state when switching columns', async () => {
     const container = renderWideTable();
 
     click(button(container, 'Filter Team'));
@@ -2767,6 +2767,11 @@ describe('EnhancedMarkdownTable', () => {
     inputValue(teamSearch!, 'Al');
 
     click(button(container, 'Filter Score'));
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+    });
     const scoreSearch = container.querySelector<HTMLInputElement>(
       'input[name="markdown-table-option-search-2"]',
     );

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StrictMode, act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider, type WebShellLanguage } from '../../i18n';
+import { WebShellPortalRootContext } from '../../portalRoot';
 import { immediateClipboardWrite } from '../../test/reactHarness';
 import { EnhancedMarkdownTable } from './EnhancedMarkdownTable';
 
@@ -10,7 +11,11 @@ import { EnhancedMarkdownTable } from './EnhancedMarkdownTable';
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+const mounted: Array<{
+  root: Root;
+  container: HTMLElement;
+  portalRoot?: HTMLElement;
+}> = [];
 const originalDocumentHidden = Object.getOwnPropertyDescriptor(
   document,
   'hidden',
@@ -19,9 +24,10 @@ const originalElementFromPoint = document.elementFromPoint;
 const COLUMN_DRAG_MIME = 'application/x-qwen-web-shell-table-column';
 
 afterEach(() => {
-  for (const { root, container } of mounted.splice(0)) {
+  for (const { root, container, portalRoot } of mounted.splice(0)) {
     act(() => root.unmount());
     container.remove();
+    portalRoot?.remove();
   }
   vi.restoreAllMocks();
   vi.useRealTimers();
@@ -47,18 +53,26 @@ function renderTableContent(
   fallback?: ReactNode,
 ): HTMLElement {
   const container = document.createElement('div');
+  const appRoot = document.createElement('div');
+  appRoot.dataset.webShellAppRoot = '';
+  const portalRoot = document.createElement('div');
+  portalRoot.dataset.webShellPortalRoot = '';
+  portalRoot.dataset.webShellShadcn = '';
   document.body.appendChild(container);
-  const root = createRoot(container);
+  container.append(appRoot, portalRoot);
+  const root = createRoot(appRoot);
   act(() => {
     root.render(
-      <I18nProvider language={language}>
-        <EnhancedMarkdownTable fallback={fallback}>
-          {children}
-        </EnhancedMarkdownTable>
-      </I18nProvider>,
+      <WebShellPortalRootContext.Provider value={portalRoot}>
+        <I18nProvider language={language}>
+          <EnhancedMarkdownTable fallback={fallback}>
+            {children}
+          </EnhancedMarkdownTable>
+        </I18nProvider>
+      </WebShellPortalRootContext.Provider>,
     );
   });
-  mounted.push({ root, container });
+  mounted.push({ root, container, portalRoot });
   return container;
 }
 
@@ -167,15 +181,13 @@ function inputValue(input: HTMLInputElement, value: string): void {
   });
 }
 
-function selectValue(select: HTMLSelectElement, value: string): void {
-  const setter = Object.getOwnPropertyDescriptor(
-    HTMLSelectElement.prototype,
-    'value',
-  )?.set;
-  act(() => {
-    setter?.call(select, value);
-    select.dispatchEvent(new Event('change', { bubbles: true }));
-  });
+function selectValue(trigger: HTMLElement, value: string): void {
+  click(trigger);
+  const option = document.querySelector<HTMLElement>(
+    `[role="option"][data-value="${value}"]`,
+  );
+  expect(option).not.toBeNull();
+  click(option!);
 }
 
 function rowTexts(container: HTMLElement): string[] {
@@ -447,8 +459,8 @@ describe('EnhancedMarkdownTable', () => {
     expect(search?.placeholder).toBe('Search filter values');
     expect(container.textContent).toContain('Select current results');
 
-    const beta = container.querySelector<HTMLInputElement>(
-      'input[name="markdown-table-filter-option-0-1"]',
+    const beta = container.querySelector<HTMLElement>(
+      '[data-name="markdown-table-filter-option-0-1"]',
     );
     expect(beta).not.toBeNull();
     click(beta!);
@@ -468,6 +480,38 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Average 20');
     expect(container.textContent).toContain('Min 10');
     expect(container.textContent).toContain('Max 30');
+  });
+
+  it('mounts filter overlays in the Web Shell portal root', () => {
+    const container = renderTable();
+    const portalRoot = container.querySelector<HTMLElement>(
+      '[data-web-shell-portal-root]',
+    );
+    const appRoot = container.querySelector<HTMLElement>(
+      '[data-web-shell-app-root]',
+    );
+
+    click(button(container, 'Filter Team'));
+    const popover = portalRoot?.querySelector<HTMLElement>(
+      '[data-slot="popover-content"]',
+    );
+    expect(popover).not.toBeNull();
+    expect(appRoot?.contains(popover)).toBe(false);
+    expect(document.body.style.pointerEvents).not.toBe('none');
+
+    click(
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
+      )!,
+    );
+    const select = portalRoot?.querySelector<HTMLElement>(
+      '[data-slot="select-content"]',
+    );
+    expect(select).not.toBeNull();
+    expect(select?.className).toContain('web-shell-popover-z-index');
+    expect(select?.dataset.markdownTableFilterOwner).toBe(
+      popover?.dataset.markdownTableFilterOwner,
+    );
   });
 
   it('applies a custom number filter', () => {
@@ -494,8 +538,8 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'Filter Score'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-number-operator-1"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-number-operator-1"]',
       )!,
       operator,
     );
@@ -520,8 +564,8 @@ describe('EnhancedMarkdownTable', () => {
       ),
     ).toBe(document.activeElement);
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-text-operator-0"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
       )!,
       'equals',
     );
@@ -540,8 +584,8 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'Filter Team'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-text-operator-0"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
       )!,
       'startsWith',
     );
@@ -558,8 +602,8 @@ describe('EnhancedMarkdownTable', () => {
     click(textButton(container, 'Reset'));
     click(button(container, 'Filter Team'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-text-operator-0"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
       )!,
       'endsWith',
     );
@@ -576,8 +620,8 @@ describe('EnhancedMarkdownTable', () => {
     click(textButton(container, 'Reset'));
     click(button(container, 'Filter Team'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-text-operator-0"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
       )!,
       'notEquals',
     );
@@ -596,8 +640,8 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'Filter Score'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-number-operator-1"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-number-operator-1"]',
       )!,
       'between',
     );
@@ -751,6 +795,25 @@ describe('EnhancedMarkdownTable', () => {
     expect(dialog?.textContent).toContain('Alpha');
   });
 
+  it('mounts the cell value dialog in the Web Shell portal root', () => {
+    const container = renderTable();
+
+    doubleClick(dataCell(container, 0, 0));
+
+    const dialog = cellDialog();
+    const portalRoot = document.querySelector<HTMLElement>(
+      '[data-web-shell-portal-root]',
+    );
+    const appRoot = container.querySelector<HTMLElement>(
+      '[data-web-shell-app-root]',
+    );
+    expect(portalRoot?.contains(dialog)).toBe(true);
+    expect(appRoot?.contains(dialog)).toBe(false);
+    expect(portalRoot?.querySelector('[data-slot="dialog-overlay"]')).not.toBe(
+      null,
+    );
+  });
+
   it('copies the current cell value from the dialog', async () => {
     const writeText = mockClipboard();
     const container = renderTable();
@@ -888,10 +951,15 @@ describe('EnhancedMarkdownTable', () => {
     const container = renderTable();
 
     doubleClick(dataCell(container, 0, 0));
-    const backdrop = cellDialog()?.parentElement;
+    const backdrop = document.querySelector<HTMLElement>(
+      '[data-slot="dialog-overlay"]',
+    );
     expect(backdrop).not.toBeNull();
     act(() => {
+      backdrop!.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
       backdrop!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      backdrop!.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      backdrop!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(cellDialog()).toBeNull();
 
@@ -920,42 +988,16 @@ describe('EnhancedMarkdownTable', () => {
     expect(document.activeElement).toBe(scroller);
   });
 
-  it('traps focus inside the cell value dialog', () => {
+  it('focuses the cell value dialog instead of the close button', () => {
     const container = renderTable();
 
     doubleClick(dataCell(container, 0, 0));
     const iconCloseButton = button(document.body, 'Close');
-    const footerCloseButton = textButton(document.body, 'Close');
-
-    expect(document.activeElement).toBe(iconCloseButton);
-
-    act(() => {
-      document.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          bubbles: true,
-          key: 'Tab',
-          shiftKey: true,
-        }),
-      );
-    });
-    expect(document.activeElement).toBe(footerCloseButton);
-
-    act(() => {
-      document.dispatchEvent(
-        new KeyboardEvent('keydown', { bubbles: true, key: 'Tab' }),
-      );
-    });
-    expect(document.activeElement).toBe(iconCloseButton);
-
     const dialog = cellDialog();
+
     expect(dialog).not.toBeNull();
-    act(() => {
-      dialog!.focus();
-      document.dispatchEvent(
-        new KeyboardEvent('keydown', { bubbles: true, key: 'Tab' }),
-      );
-    });
-    expect(document.activeElement).toBe(iconCloseButton);
+    expect(document.activeElement).toBe(dialog);
+    expect(document.activeElement).not.toBe(iconCloseButton);
   });
 
   it('keeps table Escape handling from running behind the cell dialog', () => {
@@ -1559,9 +1601,9 @@ describe('EnhancedMarkdownTable', () => {
     openColumnMenu(container, 'Team');
     click(textButton(container, 'Freeze first column'));
 
-    expect(container.querySelector('div')?.className).toContain(
-      'hasFrozenColumn',
-    );
+    expect(
+      container.querySelector<HTMLElement>('[class*="tableShell"]')?.className,
+    ).toContain('hasFrozenColumn');
     expect(container.textContent).not.toContain('Unfreeze first column');
     expect(container.querySelector('thead th')?.className).toContain(
       'stickyActionHeaderCell',
@@ -1880,8 +1922,8 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'Filter Team'));
     selectValue(
-      container.querySelector<HTMLSelectElement>(
-        'select[name="markdown-table-text-operator-0"]',
+      container.querySelector<HTMLElement>(
+        '[data-name="markdown-table-text-operator-0"]',
       )!,
       'equals',
     );
@@ -1926,7 +1968,7 @@ describe('EnhancedMarkdownTable', () => {
 
   it('cycles display density from the toolbar', () => {
     const container = renderTable();
-    const shell = container.querySelector('div');
+    const shell = container.querySelector<HTMLElement>('[class*="tableShell"]');
     const teamHeader = button(container, 'Sort by Team').closest('th');
     expect(shell?.className).toContain('densityStandard');
     expect(textButton(container, 'Density: Standard')).toBeDefined();
@@ -2409,8 +2451,8 @@ describe('EnhancedMarkdownTable', () => {
     expect(container.textContent).toContain('Copied!');
 
     click(button(container, 'Filter Team'));
-    const beta = container.querySelector<HTMLInputElement>(
-      'input[name="markdown-table-filter-option-0-1"]',
+    const beta = container.querySelector<HTMLElement>(
+      '[data-name="markdown-table-filter-option-0-1"]',
     );
     expect(beta).not.toBeNull();
     click(beta!);
@@ -2503,14 +2545,20 @@ describe('EnhancedMarkdownTable', () => {
 
   it('resets interactive state when table columns change', () => {
     const container = document.createElement('div');
+    const portalRoot = document.createElement('div');
+    portalRoot.dataset.webShellPortalRoot = '';
+    portalRoot.dataset.webShellShadcn = '';
     document.body.appendChild(container);
+    document.body.appendChild(portalRoot);
     const root = createRoot(container);
     const render = (children: ReactNode) => {
       act(() => {
         root.render(
-          <I18nProvider language="en">
-            <EnhancedMarkdownTable>{children}</EnhancedMarkdownTable>
-          </I18nProvider>,
+          <WebShellPortalRootContext.Provider value={portalRoot}>
+            <I18nProvider language="en">
+              <EnhancedMarkdownTable>{children}</EnhancedMarkdownTable>
+            </I18nProvider>
+          </WebShellPortalRootContext.Provider>,
         );
       });
     };
@@ -2530,7 +2578,7 @@ describe('EnhancedMarkdownTable', () => {
       </tbody>,
     ]);
     click(button(container, 'Filter Team'));
-    click(textButton(container, 'Hide column'));
+    click(textButton(portalRoot, 'Hide column'));
     expect(rowTexts(container)).toEqual(['10']);
 
     render([
@@ -2549,7 +2597,7 @@ describe('EnhancedMarkdownTable', () => {
     ]);
 
     expect(rowTexts(container)).toEqual(['Beta|20']);
-    mounted.push({ root, container });
+    mounted.push({ root, container, portalRoot });
   });
 
   it('clears hidden column filters and sort', () => {
@@ -2558,8 +2606,8 @@ describe('EnhancedMarkdownTable', () => {
     click(button(container, 'Sort by Team'));
     click(button(container, 'Sort by Team, ascending'));
     click(button(container, 'Filter Team'));
-    const beta = container.querySelector<HTMLInputElement>(
-      'input[name="markdown-table-filter-option-0-1"]',
+    const beta = container.querySelector<HTMLElement>(
+      '[data-name="markdown-table-filter-option-0-1"]',
     );
     expect(beta).not.toBeNull();
     click(beta!);
@@ -2724,6 +2772,35 @@ describe('EnhancedMarkdownTable', () => {
     expect(scoreSearch?.value).toBe('');
   });
 
+  it('lets an outside header action close the filter and run immediately', async () => {
+    const container = renderTable();
+
+    click(button(container, 'Filter Team'));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    const scoreSort = button(container, 'Sort by Score');
+    act(() => {
+      scoreSort.dispatchEvent(
+        new MouseEvent('pointerdown', { bubbles: true, button: 0 }),
+      );
+    });
+    act(() => {
+      scoreSort.dispatchEvent(
+        new MouseEvent('mousedown', { bubbles: true, button: 0 }),
+      );
+      scoreSort.dispatchEvent(
+        new MouseEvent('mouseup', { bubbles: true, button: 0 }),
+      );
+      scoreSort.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, button: 0 }),
+      );
+    });
+
+    expect(container.textContent).not.toContain('Custom filter');
+    expect(rowTexts(container)).toEqual(['Beta|2', 'Alpha|10', 'Gamma|30']);
+  });
+
   it('closes the filter menu when clicking outside it', () => {
     const container = renderTable();
 
@@ -2765,7 +2842,7 @@ describe('EnhancedMarkdownTable', () => {
     expect(document.activeElement).toBe(filterButton);
   });
 
-  it('keeps Tab focus within the filter dialog', () => {
+  it('keeps focus within the filter popover', () => {
     const container = renderTable();
 
     click(button(container, 'Filter Team'));
@@ -2778,7 +2855,7 @@ describe('EnhancedMarkdownTable', () => {
     focusableElements[0]!.focus();
 
     act(() => {
-      document.dispatchEvent(
+      focusableElements[0]!.dispatchEvent(
         new KeyboardEvent('keydown', {
           bubbles: true,
           cancelable: true,
@@ -2793,13 +2870,13 @@ describe('EnhancedMarkdownTable', () => {
     );
   });
 
-  it('does not trap Tab when focus is outside the filter dialog', () => {
+  it('does not trap Tab when focus is outside the filter popover', () => {
     const container = renderTable();
     const outsideButton = document.createElement('button');
     document.body.appendChild(outsideButton);
 
     click(button(container, 'Filter Team'));
-    outsideButton.focus();
+    act(() => outsideButton.focus());
     const event = new KeyboardEvent('keydown', {
       bubbles: true,
       cancelable: true,
@@ -2819,9 +2896,21 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'Filter Team'));
     expect(container.textContent).toContain('Custom filter');
+    const filterMenu = container.querySelector<HTMLElement>(
+      '[data-markdown-table-filter-owner]',
+    );
     act(() => {
-      document.dispatchEvent(new Event('scroll'));
+      filterMenu!.dispatchEvent(new Event('scroll'));
     });
+    expect(container.textContent).toContain('Custom filter');
+
+    const unrelatedPopover = document.createElement('div');
+    unrelatedPopover.dataset.markdownTableFilterOwner = 'unrelated';
+    document.body.appendChild(unrelatedPopover);
+    act(() => {
+      unrelatedPopover.dispatchEvent(new Event('scroll'));
+    });
+    unrelatedPopover.remove();
 
     expect(container.textContent).not.toContain('Custom filter');
   });
@@ -2866,8 +2955,8 @@ describe('EnhancedMarkdownTable', () => {
 
     click(button(container, 'View details for row 2'));
     click(button(container, 'Filter Team'));
-    const beta = container.querySelector<HTMLInputElement>(
-      'input[name="markdown-table-filter-option-0-1"]',
+    const beta = container.querySelector<HTMLElement>(
+      '[data-name="markdown-table-filter-option-0-1"]',
     );
     expect(beta).not.toBeNull();
     click(beta!);

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.test.tsx
@@ -996,6 +996,7 @@ describe('EnhancedMarkdownTable', () => {
     const dialog = cellDialog();
 
     expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute('tabindex')).toBe('-1');
     expect(document.activeElement).toBe(dialog);
     expect(document.activeElement).not.toBe(iconCloseButton);
   });

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -1270,6 +1270,14 @@ function ColumnFilterMenu({
       align="end"
       sideOffset={2}
       collisionPadding={6}
+      onCloseAutoFocus={(event) => {
+        if (
+          document.activeElement &&
+          document.activeElement !== document.body
+        ) {
+          event.preventDefault();
+        }
+      }}
       className="max-h-[min(430px,calc(100vh-16px))] w-[300px] max-w-[80vw] gap-0 overflow-auto p-0 text-xs"
       role="dialog"
       aria-labelledby={`${id}-title`}

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -18,10 +18,35 @@ import {
   type RefObject,
   type TouchEvent as ReactTouchEvent,
 } from 'react';
-import { createPortal } from 'react-dom';
 import { useI18n } from '../../i18n';
 import { useInteractionBlocker } from '../../interactionBlockContext';
-import { useTheme, WebShellThemeId } from '../../themeContext';
+import { Button } from '../ui/button';
+import { Checkbox } from '../ui/checkbox';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '../ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+import { XIcon } from 'lucide-react';
 import styles from './EnhancedMarkdownTable.module.css';
 
 type TableElement = ReactElement<{
@@ -96,8 +121,6 @@ interface ColumnFilter {
 
 interface OpenFilterMenu {
   columnIndex: number;
-  left: number;
-  top: number;
 }
 
 interface ColumnContextMenu {
@@ -159,26 +182,6 @@ const COMPACT_AUTO_COLUMN_STYLE: CSSProperties = {
 
 function clampColumnWidth(width: number): number {
   return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, width));
-}
-
-const FOCUSABLE_FILTER_MENU_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-const FOCUSABLE_CELL_DIALOG_SELECTOR =
-  'a[href]:not([hidden]), button:not([disabled]):not([hidden]), input:not([disabled]):not([hidden]), select:not([disabled]):not([hidden]), textarea:not([disabled]):not([hidden]), [tabindex]:not([tabindex="-1"]):not([hidden])';
-
-function getFocusableFilterMenuElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(FOCUSABLE_FILTER_MENU_SELECTOR),
-  ).filter((element) => !element.hasAttribute('hidden'));
-}
-
-function getFocusableCellDialogElements(
-  container: HTMLElement | null,
-): HTMLElement[] {
-  if (!container) return [];
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(FOCUSABLE_CELL_DIALOG_SELECTOR),
-  );
 }
 
 function isInteractiveSelectionTarget(target: EventTarget | null): boolean {
@@ -814,32 +817,38 @@ function SortMenuSection({
   const { t } = useI18n();
 
   return (
-    <div className={styles.filterMenuSection}>
-      <button
-        className={`${styles.filterMenuAction} ${
-          sortedThisColumn?.direction === 'asc' ? styles.activeAction : ''
+    <div className="flex flex-col gap-1.5 border-b px-2.5 py-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className={`w-full justify-start text-xs ${
+          sortedThisColumn?.direction === 'asc' ? 'bg-muted text-primary' : ''
         }`}
         type="button"
         onClick={() => onSort(columnIndex, 'asc')}
       >
         {t('markdownTable.sort.asc')}
-      </button>
-      <button
-        className={`${styles.filterMenuAction} ${
-          sortedThisColumn?.direction === 'desc' ? styles.activeAction : ''
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={`w-full justify-start text-xs ${
+          sortedThisColumn?.direction === 'desc' ? 'bg-muted text-primary' : ''
         }`}
         type="button"
         onClick={() => onSort(columnIndex, 'desc')}
       >
         {t('markdownTable.sort.desc')}
-      </button>
-      <button
-        className={styles.filterMenuAction}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start text-xs"
         type="button"
         onClick={() => onSort(columnIndex, null)}
       >
         {t('markdownTable.sort.clear')}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -848,14 +857,16 @@ function VisibilityMenuSection({ onHideColumn }: { onHideColumn: () => void }) {
   const { t } = useI18n();
 
   return (
-    <div className={styles.filterMenuSection}>
-      <button
-        className={styles.filterMenuAction}
+    <div className="flex flex-col gap-1.5 border-b px-2.5 py-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start text-xs"
         type="button"
         onClick={onHideColumn}
       >
         {t('markdownTable.hideColumn')}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -888,10 +899,10 @@ function ValueFilterSection({
   const { t } = useI18n();
 
   return (
-    <div className={styles.filterMenuSection}>
-      <input
+    <div className="flex flex-col gap-1.5 border-b px-2.5 py-2">
+      <Input
         ref={searchInputRef}
-        className={styles.filterSearch}
+        className="h-7 text-xs"
         value={search}
         onChange={(event) => onSearchChange(event.currentTarget.value)}
         placeholder={t('markdownTable.filter.searchPlaceholder')}
@@ -900,40 +911,53 @@ function ValueFilterSection({
           column: columnName,
         })}
       />
-      <label className={styles.filterOption}>
-        <input
-          type="checkbox"
+      <Label
+        htmlFor={`markdown-table-filter-all-${columnIndex}`}
+        className="min-h-7 cursor-pointer gap-2 px-1.5 py-1 text-xs font-normal hover:bg-muted"
+      >
+        <Checkbox
+          id={`markdown-table-filter-all-${columnIndex}`}
           name={`markdown-table-filter-all-${columnIndex}`}
+          data-name={`markdown-table-filter-all-${columnIndex}`}
           checked={allFilteredSelected}
-          onChange={(event) =>
-            onFilteredSelectionChange(event.currentTarget.checked)
+          onCheckedChange={(checked) =>
+            onFilteredSelectionChange(checked === true)
           }
         />
         <span>{t('markdownTable.filter.selectVisible')}</span>
-        <span className={styles.optionCount}>{filteredOptions.length}</span>
-      </label>
-      <div className={styles.filterOptionList}>
+        <span className="ml-auto text-muted-foreground tabular-nums">
+          {filteredOptions.length}
+        </span>
+      </Label>
+      <div className="max-h-[170px] overflow-auto rounded-md border bg-muted/50">
         {visibleOptions.map((option, optionIndex) => (
-          <label key={option.value} className={styles.filterOption}>
-            <input
-              type="checkbox"
+          <Label
+            key={option.value}
+            htmlFor={`markdown-table-filter-option-${columnIndex}-${optionIndex}`}
+            className="min-h-7 cursor-pointer gap-2 px-1.5 py-1 text-xs font-normal hover:bg-muted"
+          >
+            <Checkbox
+              id={`markdown-table-filter-option-${columnIndex}-${optionIndex}`}
               name={`markdown-table-filter-option-${columnIndex}-${optionIndex}`}
+              data-name={`markdown-table-filter-option-${columnIndex}-${optionIndex}`}
               checked={selectedValues.has(option.value)}
-              onChange={() => onToggleValue(option.value)}
+              onCheckedChange={() => onToggleValue(option.value)}
             />
-            <span className={styles.optionLabel}>{option.label}</span>
-            <span className={styles.optionCount}>{option.count}</span>
-          </label>
+            <span className="min-w-0 flex-1 truncate">{option.label}</span>
+            <span className="ml-auto text-muted-foreground tabular-nums">
+              {option.count}
+            </span>
+          </Label>
         ))}
         {filteredOptions.length > visibleOptions.length && (
-          <div className={styles.optionLimitHint}>
+          <div className="p-2 text-center text-muted-foreground">
             {t('markdownTable.filter.optionLimit', {
               count: visibleOptions.length,
             })}
           </div>
         )}
         {filteredOptions.length === 0 && (
-          <div className={styles.optionLimitHint}>
+          <div className="p-2 text-center text-muted-foreground">
             {t('markdownTable.filter.noOptions')}
           </div>
         )}
@@ -943,6 +967,7 @@ function ValueFilterSection({
 }
 
 function CustomFilterSection({
+  overlayId,
   columnIndex,
   columnName,
   isNumeric,
@@ -957,6 +982,7 @@ function CustomFilterSection({
   onNumberValueChange,
   onNumberValueToChange,
 }: {
+  overlayId: string;
   columnIndex: number;
   columnName: string;
   isNumeric: boolean;
@@ -974,36 +1000,50 @@ function CustomFilterSection({
   const { t } = useI18n();
 
   return (
-    <div className={styles.filterMenuSection}>
-      <div className={styles.conditionTitle}>
+    <div className="flex flex-col gap-1.5 border-b px-2.5 py-2">
+      <div className="font-semibold text-muted-foreground">
         {t('markdownTable.filter.custom')}
       </div>
       {isNumeric ? (
         <>
-          <select
-            className={styles.conditionSelect}
+          <Select
             value={numberOperator}
             name={`markdown-table-number-operator-${columnIndex}`}
-            onChange={(event) =>
-              onNumberOperatorChange(
-                event.currentTarget.value as NumberFilterOperator,
-              )
+            onValueChange={(value) =>
+              onNumberOperatorChange(value as NumberFilterOperator)
             }
-            aria-label={t('markdownTable.filter.numberAria', {
-              column: columnName,
-            })}
           >
-            {Object.entries(NUMBER_FILTER_LABEL_KEYS).map(
-              ([value, labelKey]) => (
-                <option key={value} value={value}>
-                  {t(labelKey)}
-                </option>
-              ),
-            )}
-          </select>
-          <div className={styles.conditionInputs}>
-            <input
-              className={styles.conditionInput}
+            <SelectTrigger
+              size="sm"
+              className="w-full text-xs"
+              data-name={`markdown-table-number-operator-${columnIndex}`}
+              aria-label={t('markdownTable.filter.numberAria', {
+                column: columnName,
+              })}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent
+              data-markdown-table-filter-owner={overlayId}
+              className="z-[calc(var(--web-shell-popover-z-index,1000)+1)]"
+            >
+              {Object.entries(NUMBER_FILTER_LABEL_KEYS).map(
+                ([value, labelKey]) => (
+                  <SelectItem
+                    key={value}
+                    value={value}
+                    data-value={value}
+                    className="text-xs"
+                  >
+                    {t(labelKey)}
+                  </SelectItem>
+                ),
+              )}
+            </SelectContent>
+          </Select>
+          <div className="flex gap-1.5">
+            <Input
+              className="h-7 text-xs"
               value={numberValue}
               onChange={(event) =>
                 onNumberValueChange(event.currentTarget.value)
@@ -1012,8 +1052,8 @@ function CustomFilterSection({
               name={`markdown-table-number-filter-${columnIndex}`}
             />
             {numberOperator === 'between' && (
-              <input
-                className={styles.conditionInput}
+              <Input
+                className="h-7 text-xs"
                 value={numberValueTo}
                 onChange={(event) =>
                   onNumberValueToChange(event.currentTarget.value)
@@ -1026,27 +1066,43 @@ function CustomFilterSection({
         </>
       ) : (
         <>
-          <select
-            className={styles.conditionSelect}
+          <Select
             value={textOperator}
             name={`markdown-table-text-operator-${columnIndex}`}
-            onChange={(event) =>
-              onTextOperatorChange(
-                event.currentTarget.value as TextFilterOperator,
-              )
+            onValueChange={(value) =>
+              onTextOperatorChange(value as TextFilterOperator)
             }
-            aria-label={t('markdownTable.filter.textAria', {
-              column: columnName,
-            })}
           >
-            {Object.entries(TEXT_FILTER_LABEL_KEYS).map(([value, labelKey]) => (
-              <option key={value} value={value}>
-                {t(labelKey)}
-              </option>
-            ))}
-          </select>
-          <input
-            className={styles.conditionInput}
+            <SelectTrigger
+              size="sm"
+              className="w-full text-xs"
+              data-name={`markdown-table-text-operator-${columnIndex}`}
+              aria-label={t('markdownTable.filter.textAria', {
+                column: columnName,
+              })}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent
+              data-markdown-table-filter-owner={overlayId}
+              className="z-[calc(var(--web-shell-popover-z-index,1000)+1)]"
+            >
+              {Object.entries(TEXT_FILTER_LABEL_KEYS).map(
+                ([value, labelKey]) => (
+                  <SelectItem
+                    key={value}
+                    value={value}
+                    data-value={value}
+                    className="text-xs"
+                  >
+                    {t(labelKey)}
+                  </SelectItem>
+                ),
+              )}
+            </SelectContent>
+          </Select>
+          <Input
+            className="h-7 text-xs"
             value={textValue}
             onChange={(event) => onTextValueChange(event.currentTarget.value)}
             placeholder={t('markdownTable.filter.textPlaceholder')}
@@ -1070,25 +1126,17 @@ function FilterMenuFooter({
   const { t } = useI18n();
 
   return (
-    <div className={styles.filterFooter}>
-      <button
-        className={styles.secondaryButton}
-        type="button"
-        onClick={onClear}
-      >
+    <div className="flex items-center gap-1.5 px-2.5 py-2">
+      <Button variant="outline" size="sm" type="button" onClick={onClear}>
         {t('markdownTable.filter.reset')}
-      </button>
-      <span className={styles.footerSpacer} />
-      <button
-        className={styles.secondaryButton}
-        type="button"
-        onClick={onClose}
-      >
+      </Button>
+      <span className="flex-1" />
+      <Button variant="outline" size="sm" type="button" onClick={onClose}>
         {t('markdownTable.filter.cancel')}
-      </button>
-      <button className={styles.primaryButton} type="button" onClick={onApply}>
+      </Button>
+      <Button size="sm" type="button" onClick={onApply}>
         {t('markdownTable.filter.confirm')}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -1101,8 +1149,6 @@ function ColumnFilterMenu({
   isNumeric,
   options,
   sort,
-  style,
-  menuRef,
   canHideColumn,
   onApply,
   onClose,
@@ -1116,8 +1162,6 @@ function ColumnFilterMenu({
   isNumeric: boolean;
   options: FilterOption[];
   sort: SortState | null;
-  style?: CSSProperties;
-  menuRef: RefObject<HTMLDivElement | null>;
   canHideColumn: boolean;
   onApply: (columnIndex: number, filter: ColumnFilter | undefined) => void;
   onClose: () => void;
@@ -1220,17 +1264,21 @@ function ColumnFilterMenu({
   const sortedThisColumn = sort?.columnIndex === columnIndex ? sort : null;
 
   return (
-    <div
-      ref={menuRef}
+    <PopoverContent
       id={id}
-      className={styles.filterMenu}
-      style={style}
+      data-markdown-table-filter-owner={id}
+      align="end"
+      sideOffset={2}
+      collisionPadding={6}
+      className="max-h-[min(430px,calc(100vh-16px))] w-[300px] max-w-[80vw] gap-0 overflow-auto p-0 text-xs"
       role="dialog"
       aria-labelledby={`${id}-title`}
     >
-      <div id={`${id}-title`} className={styles.filterMenuTitle}>
-        {columnName}
-      </div>
+      <PopoverHeader className="border-b px-2.5 py-2">
+        <PopoverTitle id={`${id}-title`} className="truncate text-xs font-bold">
+          {columnName}
+        </PopoverTitle>
+      </PopoverHeader>
       <SortMenuSection
         columnIndex={columnIndex}
         sortedThisColumn={sortedThisColumn}
@@ -1253,6 +1301,7 @@ function ColumnFilterMenu({
         onToggleValue={toggleValue}
       />
       <CustomFilterSection
+        overlayId={id}
         columnIndex={columnIndex}
         columnName={columnName}
         isNumeric={isNumeric}
@@ -1272,7 +1321,7 @@ function ColumnFilterMenu({
         onClose={onClose}
         onApply={applyDraft}
       />
-    </div>
+    </PopoverContent>
   );
 }
 
@@ -1316,7 +1365,6 @@ export function EnhancedTable({
   toolbarExtra?: ReactNode;
 }) {
   const { language, t } = useI18n();
-  const theme = useTheme();
   const registerInteractionBlocker = useInteractionBlocker();
   const tableId = useId();
   const [sort, setSort] = useState<SortState | null>(null);
@@ -1362,12 +1410,9 @@ export function EnhancedTable({
   const mountedRef = useRef(true);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const filterMenuRef = useRef<HTMLDivElement | null>(null);
   const columnContextMenuRef = useRef<HTMLDivElement | null>(null);
-  const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
   const cellDialogRef = useRef<HTMLDivElement | null>(null);
   const cellDialogFocusReturnRef = useRef<HTMLElement | null>(null);
-  const focusReturnFrameRef = useRef(0);
   const pendingSelectionRef = useRef<{
     rowIndex: number;
     columnIndex: number;
@@ -1383,21 +1428,9 @@ export function EnhancedTable({
   );
   const tableStructureKeyRef = useRef(tableStructureKey);
 
-  const focusFilterTrigger = useCallback(() => {
-    if (focusReturnFrameRef.current) {
-      cancelAnimationFrame(focusReturnFrameRef.current);
-    }
-    focusReturnFrameRef.current = requestAnimationFrame(() => {
-      focusReturnFrameRef.current = 0;
-      const trigger = filterTriggerRef.current;
-      if (trigger?.isConnected) trigger.focus();
-    });
-  }, []);
-
   const closeFilterMenu = useCallback(() => {
     setOpenFilterMenu(null);
-    focusFilterTrigger();
-  }, [focusFilterTrigger]);
+  }, []);
 
   const resetCopiedVisible = useCallback(() => {
     copiedVisibleGenRef.current += 1;
@@ -1465,9 +1498,6 @@ export function EnhancedTable({
       if (selectionFrameRef.current) {
         cancelAnimationFrame(selectionFrameRef.current);
       }
-      if (focusReturnFrameRef.current) {
-        cancelAnimationFrame(focusReturnFrameRef.current);
-      }
     };
   }, [stopDragging]);
 
@@ -1530,66 +1560,29 @@ export function EnhancedTable({
 
   useEffect(() => {
     if (!openFilterMenu) return;
-    const closeMenu = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (
-        !filterMenuRef.current?.contains(target) &&
-        !filterTriggerRef.current?.contains(target)
-      ) {
-        setOpenFilterMenu(null);
-      }
-    };
-    const handleMenuKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        closeFilterMenu();
-        return;
-      }
-      if (event.key !== 'Tab') return;
-      const menu = filterMenuRef.current;
-      const activeElement = document.activeElement;
-      if (
-        !menu ||
-        !(activeElement instanceof Node) ||
-        !menu.contains(activeElement)
-      ) {
-        return;
-      }
-      const focusableElements = getFocusableFilterMenuElements(menu);
-      if (focusableElements.length === 0) return;
-      const currentIndex =
-        activeElement instanceof HTMLElement
-          ? focusableElements.indexOf(activeElement)
-          : -1;
-      const nextIndex = event.shiftKey
-        ? currentIndex <= 0
-          ? focusableElements.length - 1
-          : currentIndex - 1
-        : currentIndex === -1 || currentIndex === focusableElements.length - 1
-          ? 0
-          : currentIndex + 1;
-      event.preventDefault();
-      focusableElements[nextIndex]?.focus();
-    };
+    const filterOwnerId = `${tableId}-filter-${openFilterMenu.columnIndex}`;
     const closeOnScroll = (event: Event) => {
-      const target = event.target;
-      if (target instanceof Node && filterMenuRef.current?.contains(target)) {
-        return;
+      if (event.target instanceof Element) {
+        const owner = event.target.closest(
+          '[data-markdown-table-filter-owner]',
+        );
+        if (
+          owner?.getAttribute('data-markdown-table-filter-owner') ===
+          filterOwnerId
+        ) {
+          return;
+        }
       }
       setOpenFilterMenu(null);
     };
     const closeOnResize = () => setOpenFilterMenu(null);
-    document.addEventListener('mousedown', closeMenu);
-    document.addEventListener('keydown', handleMenuKeyDown);
     document.addEventListener('scroll', closeOnScroll, true);
     window.addEventListener('resize', closeOnResize);
     return () => {
-      document.removeEventListener('mousedown', closeMenu);
-      document.removeEventListener('keydown', handleMenuKeyDown);
       document.removeEventListener('scroll', closeOnScroll, true);
       window.removeEventListener('resize', closeOnResize);
     };
-  }, [closeFilterMenu, openFilterMenu]);
+  }, [openFilterMenu, tableId]);
 
   useEffect(() => {
     if (!columnContextMenu) return;
@@ -1698,9 +1691,6 @@ export function EnhancedTable({
     return row?.cells[cellDialog.columnIndex] ?? null;
   }, [cellDialog, visibleRows]);
   const currentCellDialogText = currentCellDialogCell?.text;
-  const cellDialogThemeClass =
-    theme === WebShellThemeId.Light ? styles.themeLight : styles.themeDark;
-
   useEffect(() => {
     resetCopiedVisible();
   }, [resetCopiedVisible, orderedVisibleColumnIndexes, visibleRows]);
@@ -1777,55 +1767,12 @@ export function EnhancedTable({
 
   useEffect(() => {
     if (!cellDialog) return;
-    const dialog = cellDialogRef.current;
-    const focusableElements = getFocusableCellDialogElements(dialog);
-    (focusableElements[0] ?? dialog)?.focus();
-
-    const handleDialogKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if (event.isComposing || event.keyCode === 229) return;
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        event.stopPropagation();
-        setCellDialog(null);
-        resetCopiedCellDialog();
-        return;
-      }
-      if (event.key !== 'Tab') return;
-      const nextFocusableElements = getFocusableCellDialogElements(
-        cellDialogRef.current,
-      );
-      if (nextFocusableElements.length === 0) {
-        event.preventDefault();
-        cellDialogRef.current?.focus();
-        return;
-      }
-      const first = nextFocusableElements[0];
-      const last = nextFocusableElements[nextFocusableElements.length - 1];
-      const activeElement = document.activeElement;
-      const currentIndex =
-        activeElement instanceof HTMLElement
-          ? nextFocusableElements.indexOf(activeElement)
-          : -1;
-      if (event.shiftKey && (activeElement === first || currentIndex === -1)) {
-        event.preventDefault();
-        last?.focus();
-      } else if (
-        !event.shiftKey &&
-        (activeElement === last || currentIndex === -1)
-      ) {
-        event.preventDefault();
-        first?.focus();
-      }
-    };
-    document.addEventListener('keydown', handleDialogKeyDown);
     return () => {
-      document.removeEventListener('keydown', handleDialogKeyDown);
       const focusReturn = cellDialogFocusReturnRef.current;
       cellDialogFocusReturnRef.current = null;
       if (focusReturn?.isConnected) focusReturn.focus();
     };
-  }, [cellDialog, resetCopiedCellDialog]);
+  }, [cellDialog]);
 
   const setColumnFilter = (
     columnIndex: number,
@@ -1867,35 +1814,17 @@ export function EnhancedTable({
     });
   };
 
-  const toggleFilterMenu = (
-    event: ReactMouseEvent<HTMLButtonElement>,
-    columnIndex: number,
-  ) => {
+  const setFilterMenuOpen = (columnIndex: number, open: boolean) => {
+    if (!open) {
+      setOpenFilterMenu((current) =>
+        current?.columnIndex === columnIndex ? null : current,
+      );
+      return;
+    }
     setSelection(null);
     setActiveColumn(columnIndex);
     setColumnContextMenu(null);
-    filterTriggerRef.current = event.currentTarget;
-    const buttonRect = event.currentTarget.getBoundingClientRect();
-    const menuWidth = 300;
-    const menuHeight = 430;
-    const nextMenu = {
-      columnIndex,
-      left: Math.max(
-        6,
-        Math.min(
-          buttonRect.right - menuWidth,
-          window.innerWidth - menuWidth - 6,
-        ),
-      ),
-      top:
-        window.innerHeight - buttonRect.bottom < menuHeight
-          ? Math.max(8, buttonRect.top - menuHeight - 2)
-          : buttonRect.bottom + 2,
-    };
-
-    setOpenFilterMenu((current) =>
-      current?.columnIndex === columnIndex ? null : nextMenu,
-    );
+    setOpenFilterMenu({ columnIndex });
   };
 
   const hideColumn = (columnIndex: number) => {
@@ -2327,16 +2256,6 @@ export function EnhancedTable({
           visible: visibleRows.length,
           total: table.rows.length,
         });
-  const openFilterHeader =
-    openFilterMenu === null
-      ? undefined
-      : table.headers[openFilterMenu.columnIndex];
-  const openFilterColumnName =
-    openFilterHeader && openFilterMenu
-      ? openFilterHeader.text ||
-        t('markdownTable.column', { index: openFilterMenu.columnIndex + 1 })
-      : '';
-
   const renderCellContent = (cell: EnhancedTableCell, expanded: boolean) => {
     const displayText = cellReadableText(cell);
     const isLong = isLongCellText(displayText);
@@ -2613,22 +2532,48 @@ export function EnhancedTable({
                       >
                         ⋮⋮
                       </button>
-                      <button
-                        className={`${styles.filterTrigger} ${
-                          isFiltered ? styles.filterTriggerActive : ''
-                        }`}
-                        type="button"
-                        onClick={(event) =>
-                          toggleFilterMenu(event, columnIndex)
+                      <Popover
+                        open={isMenuOpen}
+                        onOpenChange={(open) =>
+                          setFilterMenuOpen(columnIndex, open)
                         }
-                        aria-label={t('markdownTable.filterColumn', {
-                          column: columnName,
-                        })}
-                        aria-expanded={isMenuOpen}
-                        aria-controls={isMenuOpen ? filterMenuId : undefined}
                       >
-                        ▾
-                      </button>
+                        <PopoverTrigger asChild>
+                          <button
+                            className={`${styles.filterTrigger} ${
+                              isFiltered ? styles.filterTriggerActive : ''
+                            }`}
+                            type="button"
+                            aria-label={t('markdownTable.filterColumn', {
+                              column: columnName,
+                            })}
+                            aria-controls={
+                              isMenuOpen ? filterMenuId : undefined
+                            }
+                          >
+                            ▾
+                          </button>
+                        </PopoverTrigger>
+                        {isMenuOpen && (
+                          <ColumnFilterMenu
+                            key={columnIndex}
+                            id={filterMenuId}
+                            columnName={columnName}
+                            columnIndex={columnIndex}
+                            filter={filters[columnIndex]}
+                            isNumeric={numericColumns[columnIndex] ?? false}
+                            options={openFilterOptions}
+                            sort={sort}
+                            canHideColumn={
+                              orderedVisibleColumnIndexes.length > 1
+                            }
+                            onApply={setColumnFilter}
+                            onClose={closeFilterMenu}
+                            onHideColumn={hideColumn}
+                            onSort={setColumnSort}
+                          />
+                        )}
+                      </Popover>
                     </div>
                     <button
                       className={styles.resizeHandle}
@@ -2797,84 +2742,53 @@ export function EnhancedTable({
           </button>
         </div>
       )}
-      {openFilterMenu && openFilterHeader && (
-        <ColumnFilterMenu
-          key={openFilterMenu.columnIndex}
-          id={`${tableId}-filter-${openFilterMenu.columnIndex}`}
-          columnName={openFilterColumnName}
-          columnIndex={openFilterMenu.columnIndex}
-          filter={filters[openFilterMenu.columnIndex]}
-          isNumeric={numericColumns[openFilterMenu.columnIndex] ?? false}
-          options={openFilterOptions}
-          sort={sort}
-          style={{ left: openFilterMenu.left, top: openFilterMenu.top }}
-          menuRef={filterMenuRef}
-          canHideColumn={orderedVisibleColumnIndexes.length > 1}
-          onApply={setColumnFilter}
-          onClose={closeFilterMenu}
-          onHideColumn={hideColumn}
-          onSort={setColumnSort}
-        />
-      )}
-      {cellDialog &&
-        currentCellDialogCell &&
-        createPortal(
-          <div
-            className={`${styles.cellDialogBackdrop} ${cellDialogThemeClass}`}
-            onMouseDown={closeCellDialog}
+      <Dialog
+        open={cellDialog !== null && currentCellDialogCell !== null}
+        onOpenChange={(open) => {
+          if (!open) closeCellDialog();
+        }}
+      >
+        {currentCellDialogCell && (
+          <DialogContent
+            ref={cellDialogRef}
+            className="sm:max-w-lg"
+            showCloseButton={false}
+            overlayProps={{ onMouseDown: closeCellDialog }}
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              cellDialogRef.current?.focus();
+            }}
           >
-            <div
-              ref={cellDialogRef}
-              className={styles.cellDialog}
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby={`${tableId}-cell-dialog-title`}
-              tabIndex={-1}
-              onMouseDown={(event) => event.stopPropagation()}
-            >
-              <button
-                className={styles.cellDialogCloseIcon}
-                type="button"
-                onClick={closeCellDialog}
+            <DialogClose asChild>
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
                 aria-label={t('markdownTable.close')}
               >
-                ×
-              </button>
-              <div
-                id={`${tableId}-cell-dialog-title`}
-                className={styles.cellDialogTitle}
-              >
-                {t('markdownTable.cellDialogTitle')}
-              </div>
-              <div className={styles.cellDialogValue}>
-                {currentCellDialogCell.content}
-              </div>
-              <div className={styles.cellDialogFooter}>
-                <div className={styles.cellDialogActions}>
-                  <button
-                    className={styles.cellDialogButton}
-                    type="button"
-                    onClick={copyCellDialogValue}
-                  >
-                    {copiedCellDialog
-                      ? t('code.copied')
-                      : t('markdownTable.copyCell')}
-                  </button>
-                  <button
-                    className={`${styles.cellDialogButton} ${
-                      styles.cellDialogPrimaryButton
-                    }`}
-                    type="button"
-                    onClick={closeCellDialog}
-                  >
-                    {t('markdownTable.close')}
-                  </button>
-                </div>
-              </div>
+                <XIcon />
+                <span className="sr-only">{t('markdownTable.close')}</span>
+              </Button>
+            </DialogClose>
+            <DialogHeader>
+              <DialogTitle>{t('markdownTable.cellDialogTitle')}</DialogTitle>
+            </DialogHeader>
+            <div className="max-h-[200px] min-h-[100px] cursor-text overflow-auto rounded-lg border bg-background/70 p-3 leading-relaxed font-semibold whitespace-pre-wrap break-words select-text">
+              {currentCellDialogCell.content}
             </div>
-          </div>,
-          document.body,
+            <DialogFooter>
+              <Button variant="outline" onClick={copyCellDialogValue}>
+                {copiedCellDialog
+                  ? t('code.copied')
+                  : t('markdownTable.copyCell')}
+              </Button>
+              <DialogClose asChild>
+                <Button>{t('markdownTable.close')}</Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
         )}
+      </Dialog>
     </div>
   );
 }

--- a/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
+++ b/packages/web-shell/client/components/messages/EnhancedMarkdownTable.tsx
@@ -2758,6 +2758,7 @@ export function EnhancedTable({
               event.preventDefault();
               cellDialogRef.current?.focus();
             }}
+            tabIndex={-1}
           >
             <DialogClose asChild>
               <Button

--- a/packages/web-shell/client/components/ui/checkbox.tsx
+++ b/packages/web-shell/client/components/ui/checkbox.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { CheckIcon } from 'lucide-react';
+
+const Checkbox = React.forwardRef<
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentProps<typeof CheckboxPrimitive.Root>
+>(function Checkbox({ className, ...props }, ref) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      data-slot="checkbox"
+      className={cn(
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+});
+
+export { Checkbox };


### PR DESCRIPTION
## What this PR does

This PR replaces the advanced Markdown table cell dialog and column filter overlay with the shared shadcn/Radix primitives. Dialogs, popovers, and nested selects now render through the Web Shell portal root, and the filter controls use the shared button, input, checkbox, label, and select components. The obsolete hand-written overlay and control styles are removed.

The filter popover remains non-modal so an outside header action can close the filter and execute with one click. Keyboard focus loops within the open filter, Escape restores focus to the trigger, and scroll handling distinguishes the current filter overlays from unrelated popovers.

## Why it's needed

The npm library build scopes generated styles to the Web Shell root and portal root. The previous cell dialog rendered directly under `document.body`, so its CSS module classes could not match the scoped selectors when Web Shell was consumed as a package.

The column filter used hand-written positioning, focus handling, and form controls instead of the shared Web Shell primitives. Moving it to the shared components keeps portal ownership, styling, focus behavior, and nested overlay stacking consistent with the rest of Web Shell.

## Reviewer Test Plan

### How to verify

1. Render an advanced Markdown table from the packaged Web Shell and double-click a cell. Confirm the cell dialog is fully styled, uses the active Web Shell theme, and the top-right close button does not receive initial focus.
2. Confirm Copy, Close, Escape, and backdrop dismissal still work and focus returns to the table after closing.
3. Open a column filter. Confirm the popover and all controls are styled, the custom filter select opens above the popover, and scrolling inside either current filter overlay does not dismiss the filter.
4. With a filter open, click another column filter or a header sort action. Confirm the target action runs on the first click and the previous filter closes.
5. Use Shift+Tab from the first filter control and confirm focus wraps to the final control.

### Evidence (Before & After)

Before: package consumers could receive an unstyled cell dialog because it was mounted outside the scoped Web Shell roots. The column filter used hand-written positioning, controls, and keyboard handling.

After: the affected overlays mount in the Web Shell portal root and use scoped shadcn styling. Automated tests assert portal ownership, nested overlay stacking, non-modal outside interaction, focus wrapping, and scroll ownership.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local npm workspace with the standalone and npm library builds.

## Risk & Scope

- Main risk or tradeoff: Overlay focus, dismissal, and stacking behavior changes from hand-written event handling to Radix primitives; focused regression coverage exercises these paths.
- Not validated / out of scope: Other advanced-table contextual menus and browser-specific visual rendering on Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将高级 Markdown 表格的单元格对话框和列筛选浮层替换为共享的 shadcn/Radix 基础组件。Dialog、Popover 以及嵌套 Select 现在都会通过 Web Shell portal root 渲染，筛选控件也改为使用共享的 Button、Input、Checkbox、Label 和 Select，并删除不再需要的手写浮层与控件样式。

筛选 Popover 保持非模态，因此点击外部表头操作时，可以在关闭筛选的同时一次点击完成目标操作。打开筛选后，键盘焦点会在浮层内循环，Escape 会关闭浮层并将焦点还给触发按钮；滚动处理也会区分当前筛选浮层与无关的其他 Popover。

## 为什么需要

npm library 构建会将生成样式限制在 Web Shell root 和 portal root 内。之前的单元格对话框直接渲染到 `document.body` 下，Web Shell 作为 npm 包接入时，其 CSS Module 类名无法匹配经过作用域限制的选择器。

列筛选使用了手写定位、焦点处理和表单控件，没有复用 Web Shell 的共享基础组件。迁移后，portal 归属、样式、焦点行为和嵌套浮层层级可以与 Web Shell 其他区域保持一致。

## Reviewer 测试计划

### 如何验证

1. 使用打包后的 Web Shell 渲染高级 Markdown 表格并双击单元格，确认单元格对话框样式完整、跟随当前 Web Shell 主题，并且右上角关闭按钮不会自动获得焦点。
2. 确认复制、关闭、Escape 和点击遮罩关闭仍然正常，关闭后焦点会回到表格。
3. 打开列筛选，确认 Popover 和内部控件样式正常，自定义筛选 Select 显示在 Popover 上方，并且滚动当前筛选的任一浮层都不会关闭筛选。
4. 在筛选打开时点击另一个列筛选或表头排序操作，确认第一次点击就能执行目标操作，同时关闭之前的筛选。
5. 从筛选中的第一个控件按 Shift+Tab，确认焦点循环到最后一个控件。

### 证据（修改前后）

修改前：npm 包消费者可能看到无样式的单元格对话框，因为它挂载在 Web Shell 样式作用域之外。列筛选使用手写定位、控件和键盘处理。

修改后：受影响的浮层都会挂载到 Web Shell portal root，并使用具备作用域隔离的 shadcn 样式。自动化测试覆盖 portal 归属、嵌套浮层层级、非模态外部交互、焦点循环和滚动归属。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 npm workspace，验证了 standalone 和 npm library 构建。

## 风险与范围

- 主要风险或取舍：浮层焦点、关闭与层级行为从手写事件处理迁移到 Radix 基础组件；已通过针对性回归测试覆盖这些路径。
- 未验证或不在范围内：高级表格的其他上下文菜单，以及 Windows 和 Linux 上的浏览器视觉表现。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
