### PR TITLE
fix(integration): harden flaky interactive read-then-write test

### DIFF
--- a/integration-tests/interactive/file-system-interactive.test.ts
+++ b/integration-tests/interactive/file-system-interactive.test.ts
@@ -76,8 +76,21 @@ describe('Interactive file system', () => {
         true,
       );
 
-      const newFileContent = rig.readFile(fileName);
-      expect(newFileContent).toBe('1.0.1');
+      // The tool call is logged once the model issues it, but the turn may
+      // still be settling (a failed edit can be retried) and the model may
+      // append a trailing newline. Poll the file until it reflects the new
+      // version instead of reading it once.
+      const updated = await rig.poll(
+        () => rig.readFile(fileName).includes('1.0.1'),
+        15000,
+        200,
+      );
+      if (!updated) {
+        printDebugInfo(rig, rig._interactiveOutput, { toolCall });
+      }
+      expect(updated, 'Expected file content to be updated to 1.0.1').toBe(
+        true,
+      );
     },
   );
 });

--- a/integration-tests/interactive/file-system-interactive.test.ts
+++ b/integration-tests/interactive/file-system-interactive.test.ts
@@ -81,8 +81,8 @@ describe('Interactive file system', () => {
       // append a trailing newline. Poll the file until it reflects the new
       // version instead of reading it once.
       const updated = await rig.poll(
-        () => rig.readFile(fileName).includes('1.0.1'),
-        15000,
+        () => rig.readFile(fileName).trimEnd() === '1.0.1',
+        rig.getDefaultTimeout(),
         200,
       );
       if (!updated) {


### PR DESCRIPTION
## What this PR does

Hardens the interactive `should perform a read-then-write sequence in interactive mode` E2E test. Instead of reading `version.txt` once immediately after the write/edit tool call is observed and asserting strict equality with `1.0.1`, the test now polls the file until it contains `1.0.1`. The existing assertion confirming a `write_file`/`edit` tool call was made is kept.

## Why it's needed

This test was flaky in CI in two ways, observed across the run and its retry:

- The model sometimes appends a trailing newline, so the file content was `1.0.1\n` while the test expected `1.0.1` under `toBe`.
- The file sometimes still held the original `1.0.0` when checked. The tool call is logged by name as soon as the model issues it, but a first `edit` whose `old_string` does not match is still logged (and `waitForAnyToolCall` only checks the tool name) and may be retried within the same turn, so the file is not guaranteed to reflect the new version the instant the call appears.

Polling until the file contains `1.0.1` absorbs both the trailing newline and the in-turn settling, while still failing if the model never actually updates the file. This matches the lenient `toContain('1.0.1')` assertion already used by the non-interactive sibling test in `cli/file-system.test.ts`.

## Reviewer Test Plan

### How to verify

This is a non-user-visible test-only change. Confirm the assertion now tolerates a trailing newline and waits for the write to land:

- Review the diff: the single immediate `readFile` + `toBe('1.0.1')` is replaced by `rig.poll(() => rig.readFile(fileName).includes('1.0.1'), 15000, 200)` followed by an assertion on the poll result.
- The `rig.poll` usage matches the established pattern in other interactive tests (e.g. `ctrl-c-exit.test.ts`).
- The interactive E2E requires a built bundle and a live model, so it is validated by CI rather than locally.

### Evidence (Before & After)

N/A (test-only change, no user-visible / TUI behavior).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A — test-only change; relies on CI E2E.

## Risk & Scope

- Main risk or tradeoff: the assertion is now lenient (`includes('1.0.1')`), consistent with the non-interactive sibling test; it still fails if the file is never updated to `1.0.1`.
- Not validated / out of scope: running the interactive E2E locally (needs built bundle + live model).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加固交互式 E2E 测试 `should perform a read-then-write sequence in interactive mode`。原测试在观察到 write/edit 工具调用后立即读一次 `version.txt` 并用 `toBe` 严格断言等于 `1.0.1`；现改为轮询该文件直到其包含 `1.0.1`。原有的"确认发起了 write_file/edit 工具调用"的断言保留。

## 为什么需要

该测试在 CI 中有两种 flaky 表现（分别出现在首次运行与重试中）：

- 模型有时会追加尾部换行符，文件内容为 `1.0.1\n`，而测试用 `toBe` 期望 `1.0.1`。
- 检查时文件有时仍是原始的 `1.0.0`。工具调用一旦由模型发起就会按名字记录，但首次 `edit` 若 old_string 未匹配也会被记录（且 `waitForAnyToolCall` 只校验工具名），并可能在同一回合内重试，因此调用出现的那一刻文件并不保证已反映新版本。

轮询直到文件包含 `1.0.1` 可同时吸收尾部换行与回合内的写入时序问题；若模型始终未把文件更新为 `1.0.1`，测试仍会失败。这与非交互式同名测试 `cli/file-system.test.ts` 中已使用的宽松断言 `toContain('1.0.1')` 保持一致。

## 评审验证计划

### 如何验证

这是仅改测试、对用户不可见的变更。确认新断言能容忍尾部换行并等待写入落盘：

- 查看 diff：原先的"立即读一次 + `toBe('1.0.1')`"被替换为 `rig.poll(() => rig.readFile(fileName).includes('1.0.1'), 15000, 200)`，随后对轮询结果做断言。
- `rig.poll` 的用法与其它交互式测试（如 `ctrl-c-exit.test.ts`）中的既有模式一致。
- 该交互式 E2E 需要构建产物与真实模型，因此由 CI 验证而非本地。

### 前后对比证据

N/A（仅测试改动，无用户可见 / TUI 行为）。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

N/A —— 仅测试改动，依赖 CI E2E。

## 风险与范围

- 主要风险/权衡：断言改为宽松匹配（`includes('1.0.1')`），与非交互式同名测试一致；若文件始终未更新为 `1.0.1` 仍会失败。
- 未验证/超出范围：本地运行该交互式 E2E（需构建产物 + 真实模型）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

无。

</details>
