### PR TITLE
fix(vscode): preserve Electron Node mode for ACP launch

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -410,6 +410,80 @@ describe('gemini.tsx main function', () => {
     processExitSpy.mockRestore();
   });
 
+  it('removes Electron Node mode before the ACP relaunch', async () => {
+    vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
+    vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
+
+    const { parseArguments } = await import('./config/config.js');
+    const { loadSettings } = await import('./config/settings.js');
+    vi.mocked(parseArguments).mockResolvedValue({
+      acp: true,
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockImplementation(() => {
+      expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
+      expect(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
+      throw new Error('stop before relaunch');
+    });
+
+    try {
+      await expect(main()).rejects.toThrow('stop before relaunch');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it.each([
+    ['relaunched', 'QWEN_CODE_NO_RELAUNCH', 'true'],
+    ['sandboxed', 'SANDBOX', 'sandbox-exec'],
+  ])(
+    'scrubs Electron bootstrap env in the final %s ACP process',
+    async (_name, finalProcessKey, finalProcessValue) => {
+      vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
+      vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
+      vi.stubEnv(finalProcessKey, finalProcessValue);
+
+      const { parseArguments } = await import('./config/config.js');
+      const { loadSettings } = await import('./config/settings.js');
+      vi.mocked(parseArguments).mockResolvedValue({
+        acp: true,
+      } as unknown as CliArgs);
+      vi.mocked(loadSettings).mockImplementation(() => {
+        expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
+        expect(
+          process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'],
+        ).toBeUndefined();
+        throw new Error('stop after scrub');
+      });
+
+      try {
+        await expect(main()).rejects.toThrow('stop after scrub');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it('preserves Electron Node mode outside managed ACP startup', async () => {
+    vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
+    vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
+    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', 'true');
+
+    const { parseArguments } = await import('./config/config.js');
+    const { loadSettings } = await import('./config/settings.js');
+    vi.mocked(parseArguments).mockResolvedValue({} as CliArgs);
+    vi.mocked(loadSettings).mockImplementation(() => {
+      expect(process.env['ELECTRON_RUN_AS_NODE']).toBe('1');
+      expect(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
+      throw new Error('stop without scrub');
+    });
+
+    try {
+      await expect(main()).rejects.toThrow('stop without scrub');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('should skip full settings discovery in bare mode', async () => {
     const originalArgv = process.argv;
     process.argv = ['node', 'script.js', '--bare'];

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -413,6 +413,13 @@ describe('gemini.tsx main function', () => {
   it.each([
     ['before the ACP relaunch', { acp: true }, {}, undefined, '1'],
     [
+      'before the experimental ACP relaunch',
+      { experimentalAcp: true },
+      {},
+      undefined,
+      '1',
+    ],
+    [
       'in the relaunched ACP process',
       { acp: true },
       { QWEN_CODE_NO_RELAUNCH: 'true' },
@@ -432,6 +439,13 @@ describe('gemini.tsx main function', () => {
       { QWEN_CODE_NO_RELAUNCH: 'true' },
       '1',
       '1',
+    ],
+    [
+      'ACP without bootstrap marker',
+      { acp: true },
+      { QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE: undefined },
+      '1',
+      undefined,
     ],
   ])(
     'manages Electron bootstrap env %s',

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -413,13 +413,6 @@ describe('gemini.tsx main function', () => {
   it.each([
     ['before the ACP relaunch', { acp: true }, {}, undefined, '1'],
     [
-      'before the experimental ACP relaunch',
-      { experimentalAcp: true },
-      {},
-      undefined,
-      '1',
-    ],
-    [
       'in the relaunched ACP process',
       { acp: true },
       { QWEN_CODE_NO_RELAUNCH: 'true' },

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -410,79 +410,57 @@ describe('gemini.tsx main function', () => {
     processExitSpy.mockRestore();
   });
 
-  it('removes Electron Node mode before the ACP relaunch', async () => {
-    vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
-    vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
-
-    const { parseArguments } = await import('./config/config.js');
-    const { loadSettings } = await import('./config/settings.js');
-    vi.mocked(parseArguments).mockResolvedValue({
-      acp: true,
-    } as unknown as CliArgs);
-    vi.mocked(loadSettings).mockImplementation(() => {
-      expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
-      expect(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
-      throw new Error('stop before relaunch');
-    });
-
-    try {
-      await expect(main()).rejects.toThrow('stop before relaunch');
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
-
   it.each([
-    ['relaunched', 'QWEN_CODE_NO_RELAUNCH', 'true'],
-    ['sandboxed', 'SANDBOX', 'sandbox-exec'],
+    ['before the ACP relaunch', { acp: true }, {}, undefined, '1'],
+    [
+      'in the relaunched ACP process',
+      { acp: true },
+      { QWEN_CODE_NO_RELAUNCH: 'true' },
+      undefined,
+      undefined,
+    ],
+    [
+      'in the sandboxed ACP process',
+      { acp: true },
+      { SANDBOX: 'sandbox-exec' },
+      undefined,
+      undefined,
+    ],
+    [
+      'outside managed ACP startup',
+      {},
+      { QWEN_CODE_NO_RELAUNCH: 'true' },
+      '1',
+      '1',
+    ],
   ])(
-    'scrubs Electron bootstrap env in the final %s ACP process',
-    async (_name, finalProcessKey, finalProcessValue) => {
+    'manages Electron bootstrap env %s',
+    async (_name, argv, extraEnv, expectedElectron, expectedMarker) => {
       vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
       vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
-      vi.stubEnv(finalProcessKey, finalProcessValue);
+      vi.stubEnv('QWEN_CODE_NO_RELAUNCH', '');
+      for (const [key, value] of Object.entries(extraEnv)) {
+        vi.stubEnv(key, value);
+      }
 
       const { parseArguments } = await import('./config/config.js');
       const { loadSettings } = await import('./config/settings.js');
-      vi.mocked(parseArguments).mockResolvedValue({
-        acp: true,
-      } as unknown as CliArgs);
+      vi.mocked(parseArguments).mockResolvedValue(argv as CliArgs);
       vi.mocked(loadSettings).mockImplementation(() => {
-        expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
-        expect(
-          process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'],
-        ).toBeUndefined();
-        throw new Error('stop after scrub');
+        expect(process.env['ELECTRON_RUN_AS_NODE']).toBe(expectedElectron);
+        expect(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe(
+          expectedMarker,
+        );
+        throw new Error('stop after env check');
       });
 
       try {
-        await expect(main()).rejects.toThrow('stop after scrub');
+        await expect(main()).rejects.toThrow('stop after env check');
       } finally {
         vi.unstubAllEnvs();
       }
     },
   );
-
-  it('preserves Electron Node mode outside managed ACP startup', async () => {
-    vi.stubEnv('ELECTRON_RUN_AS_NODE', '1');
-    vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '1');
-    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', 'true');
-
-    const { parseArguments } = await import('./config/config.js');
-    const { loadSettings } = await import('./config/settings.js');
-    vi.mocked(parseArguments).mockResolvedValue({} as CliArgs);
-    vi.mocked(loadSettings).mockImplementation(() => {
-      expect(process.env['ELECTRON_RUN_AS_NODE']).toBe('1');
-      expect(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
-      throw new Error('stop without scrub');
-    });
-
-    try {
-      await expect(main()).rejects.toThrow('stop without scrub');
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
 
   it('should skip full settings discovery in bare mode', async () => {
     const originalArgv = process.argv;

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -251,6 +251,16 @@ export async function main() {
   let argv = await parseArguments();
   profileCheckpoint('after_parse_arguments');
 
+  if (
+    (argv.acp || argv.experimentalAcp) &&
+    process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] === '1'
+  ) {
+    delete process.env['ELECTRON_RUN_AS_NODE'];
+    if (process.env['QWEN_CODE_NO_RELAUNCH'] || process.env['SANDBOX']) {
+      delete process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'];
+    }
+  }
+
   if (isBareMode(argv.bare)) {
     process.env[QWEN_CODE_SIMPLE_ENV_VAR] = '1';
   }

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -383,33 +383,43 @@ describe('relaunchAppInChildProcess', () => {
       expect(processExitSpy).toHaveBeenCalledWith(0);
     });
 
-    it('restores Electron Node mode for every managed ACP relaunch', async () => {
-      process.argv = ['/usr/bin/node', '/app/cli.js'];
-      process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = '1';
-      delete process.env['ELECTRON_RUN_AS_NODE'];
+    it.each([
+      ['managed ACP', '1', '1'],
+      ['ordinary', undefined, undefined],
+    ])(
+      'handles Electron Node mode for every %s relaunch',
+      async (_name, marker, expectedElectron) => {
+        process.argv = ['/usr/bin/node', '/app/cli.js'];
+        if (marker) {
+          process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = marker;
+        } else {
+          delete process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'];
+        }
+        delete process.env['ELECTRON_RUN_AS_NODE'];
 
-      const firstChild = createMockChildProcess(0, false);
-      const secondChild = createMockChildProcess(0, false);
-      mockedSpawn
-        .mockReturnValueOnce(firstChild)
-        .mockReturnValueOnce(secondChild);
+        const firstChild = createMockChildProcess(0, false);
+        const secondChild = createMockChildProcess(0, false);
+        mockedSpawn
+          .mockReturnValueOnce(firstChild)
+          .mockReturnValueOnce(secondChild);
 
-      const promise = relaunchAppInChildProcess([], []);
+        const promise = relaunchAppInChildProcess([], []);
 
-      firstChild.emit('close', RELAUNCH_EXIT_CODE);
-      await vi.waitFor(() => expect(mockedSpawn).toHaveBeenCalledTimes(2));
+        firstChild.emit('close', RELAUNCH_EXIT_CODE);
+        await vi.waitFor(() => expect(mockedSpawn).toHaveBeenCalledTimes(2));
 
-      for (const call of mockedSpawn.mock.calls) {
-        const env = call[2]?.env;
-        expect(env?.['ELECTRON_RUN_AS_NODE']).toBe('1');
-        expect(env?.['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
-        expect(env?.['QWEN_CODE_NO_RELAUNCH']).toBe('true');
-      }
-      expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
+        for (const call of mockedSpawn.mock.calls) {
+          const env = call[2]?.env;
+          expect(env?.['ELECTRON_RUN_AS_NODE']).toBe(expectedElectron);
+          expect(env?.['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe(marker);
+          expect(env?.['QWEN_CODE_NO_RELAUNCH']).toBe('true');
+        }
+        expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
 
-      secondChild.emit('close', 0);
-      await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
-    });
+        secondChild.emit('close', 0);
+        await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
+      },
+    );
 
     it('should handle null exit code from child process', async () => {
       process.argv = ['/usr/bin/node', '/app/cli.js'];

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -383,6 +383,34 @@ describe('relaunchAppInChildProcess', () => {
       expect(processExitSpy).toHaveBeenCalledWith(0);
     });
 
+    it('restores Electron Node mode for every managed ACP relaunch', async () => {
+      process.argv = ['/usr/bin/node', '/app/cli.js'];
+      process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = '1';
+      delete process.env['ELECTRON_RUN_AS_NODE'];
+
+      const firstChild = createMockChildProcess(0, false);
+      const secondChild = createMockChildProcess(0, false);
+      mockedSpawn
+        .mockReturnValueOnce(firstChild)
+        .mockReturnValueOnce(secondChild);
+
+      const promise = relaunchAppInChildProcess([], []);
+
+      firstChild.emit('close', RELAUNCH_EXIT_CODE);
+      await vi.waitFor(() => expect(mockedSpawn).toHaveBeenCalledTimes(2));
+
+      for (const call of mockedSpawn.mock.calls) {
+        const env = call[2]?.env;
+        expect(env?.['ELECTRON_RUN_AS_NODE']).toBe('1');
+        expect(env?.['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
+        expect(env?.['QWEN_CODE_NO_RELAUNCH']).toBe('true');
+      }
+      expect(process.env['ELECTRON_RUN_AS_NODE']).toBeUndefined();
+
+      secondChild.emit('close', 0);
+      await expect(promise).rejects.toThrow('PROCESS_EXIT_CALLED');
+    });
+
     it('should handle null exit code from child process', async () => {
       process.argv = ['/usr/bin/node', '/app/cli.js'];
 

--- a/packages/cli/src/utils/relaunch.ts
+++ b/packages/cli/src/utils/relaunch.ts
@@ -66,7 +66,13 @@ export async function relaunchAppInChildProcess(
       ...additionalScriptArgs,
       ...scriptArgs,
     ];
-    const newEnv = { ...process.env, QWEN_CODE_NO_RELAUNCH: 'true' };
+    const newEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      QWEN_CODE_NO_RELAUNCH: 'true',
+    };
+    if (newEnv['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] === '1') {
+      newEnv['ELECTRON_RUN_AS_NODE'] = '1';
+    }
 
     // The parent process should not be reading from stdin while the child is running.
     process.stdin.pause();

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -102,7 +102,7 @@ describe('resolveSeatbeltProfileFile', () => {
     ['managed ACP', '1', true],
     ['ordinary', undefined, false],
   ])(
-    'sets Electron Node mode only for a %s seatbelt re-exec',
+    'handles Electron Node mode for a %s seatbelt re-exec',
     async (_name, marker, expected) => {
       vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', marker ?? '');
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);

--- a/packages/cli/src/utils/sandbox.test.ts
+++ b/packages/cli/src/utils/sandbox.test.ts
@@ -6,9 +6,28 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { EventEmitter } from 'node:events';
 import { pathToFileURL } from 'node:url';
 import { FatalSandboxError, QWEN_DIR } from '@qwen-code/qwen-code-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      execSync: execSyncMock,
+      spawn: spawnMock,
+    },
+    execSync: execSyncMock,
+    spawn: spawnMock,
+  };
+});
+
 import { isContainerPathWithinWorkdir } from './sandbox-path.js';
 import {
   getSandboxPassthroughEnvArgs,
@@ -78,6 +97,37 @@ describe('resolveSeatbeltProfileFile', () => {
       ),
     );
   });
+
+  it.each([
+    ['managed ACP', '1', true],
+    ['ordinary', undefined, false],
+  ])(
+    'sets Electron Node mode only for a %s seatbelt re-exec',
+    async (_name, marker, expected) => {
+      vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', marker ?? '');
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined);
+      vi.spyOn(fs, 'realpathSync').mockImplementation(
+        (filePath) => String(filePath) || '/tmp',
+      );
+      execSyncMock.mockReturnValue(Buffer.from('/tmp/cache\n'));
+
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child);
+      const result = start_sandbox(
+        { command: 'sandbox-exec', image: '' },
+        [],
+        undefined,
+        [process.execPath, '/path/to/cli.js', '--acp'],
+      );
+
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      expect(args.at(-1)?.includes('ELECTRON_RUN_AS_NODE=1')).toBe(expected);
+
+      child.emit('close', 0);
+      await expect(result).resolves.toBe(0);
+    },
+  );
 });
 
 describe('getSandboxPassthroughEnvArgs', () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -297,6 +297,9 @@ export async function start_sandbox(
       'sh',
       '-c',
       [
+        ...(process.env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] === '1'
+          ? ['ELECTRON_RUN_AS_NODE=1']
+          : []),
         `SANDBOX=sandbox-exec`,
         `NODE_OPTIONS="${nodeOptions}"`,
         ...finalArgv.map((arg) => quote([arg])),

--- a/packages/vscode-ide-companion/src/services/acpConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.test.ts
@@ -8,9 +8,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { ContentBlock } from '@agentclientprotocol/sdk';
 
+const spawnMock = vi.hoisted(() => vi.fn());
+
 // AcpConnection imports AcpFileHandler which imports vscode.
 // Mock vscode so it can be resolved without the actual VS Code runtime.
 vi.mock('vscode', () => ({}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: spawnMock };
+});
 
 import { AcpConnection } from './acpConnection.js';
 import { ACP_ERROR_CODES } from '../constants/acpSchema.js';
@@ -41,6 +47,31 @@ function createMockChild(overrides?: Record<string, unknown>) {
     ...overrides,
   } as unknown as AcpConnectionInternal['child'];
 }
+
+describe('AcpConnection process spawning', () => {
+  it('runs the managed ACP child in Electron Node mode', async () => {
+    vi.stubEnv('ELECTRON_RUN_AS_NODE', '');
+    vi.stubEnv('QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE', '');
+    spawnMock.mockReturnValue(createMockChild());
+    const conn = new AcpConnection() as unknown as {
+      connect: (cliEntryPath: string) => Promise<void>;
+      setupChildProcessHandlers: () => Promise<void>;
+    };
+    conn.setupChildProcessHandlers = vi.fn().mockResolvedValue(undefined);
+
+    try {
+      await conn.connect(process.execPath);
+      const options = spawnMock.mock.calls[0]?.[2] as {
+        env?: NodeJS.ProcessEnv;
+      };
+
+      expect(options.env?.['ELECTRON_RUN_AS_NODE']).toBe('1');
+      expect(options.env?.['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE']).toBe('1');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});
 
 describe('AcpConnection readTextFile error mapping', () => {
   it('maps ENOENT to RESOURCE_NOT_FOUND RequestError', () => {

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -92,6 +92,8 @@ export class AcpConnection {
     this.workingDir = workingDir;
 
     const env = { ...process.env };
+    env['ELECTRON_RUN_AS_NODE'] = '1';
+    env['QWEN_CODE_SCRUB_ELECTRON_RUN_AS_NODE'] = '1';
 
     const proxyArg = extraArgs.find(
       (arg, i) => arg === '--proxy' && i + 1 < extraArgs.length,


### PR DESCRIPTION
## What this PR does

This makes VS Code Companion ACP startup explicitly enable Electron's Node mode instead of relying on the Extension Host's inherited environment. A private bootstrap marker carries that requirement across CLI relaunches and macOS seatbelt re-execs, while the final ACP workload removes both variables before tools and MCP servers start.

## Why it's needed

On Linux, the VS Code Extension Host does not consistently inherit `ELECTRON_RUN_AS_NODE`. Without it, launching the bundled CLI through the Electron executable starts Chromium instead of Node and the ACP process exits. The previous behavior therefore depended on how VS Code itself was launched.

## Reviewer Test Plan

### How to verify

1. On Linux, start VS Code with `ELECTRON_RUN_AS_NODE` absent from the Extension Host environment, then open a Qwen Code Companion ACP session.
2. Confirm the ACP process remains connected and does not print Chromium startup warnings.
3. Exercise a CLI relaunch or the macOS seatbelt path and confirm Electron Node mode is restored only for the managed bootstrap, then removed before tools and MCP servers are started.
4. Confirm an ordinary non-ACP relaunch and ordinary seatbelt startup do not gain `ELECTRON_RUN_AS_NODE`.

### Evidence (Before & After)

Before: the regression contract observed `ELECTRON_RUN_AS_NODE` as `undefined` in the Companion ACP child environment, matching the Linux failure in #7101.

After: the same contract passes, and focused tests cover the initial Companion spawn, repeated CLI relaunches, macOS seatbelt re-exec, final environment cleanup, and ordinary non-ACP negative cases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64 with Node.js 22.22.0. Verified with the full workspace typecheck, changed-file ESLint, 102 focused tests, and the repository build. Linux VS Code runtime verification is left to CI or a Linux reviewer.

## Risk & Scope

- Main risk or tradeoff: the bootstrap marker must survive only until the final managed ACP process; regression tests cover propagation and cleanup at each launch boundary.
- Not validated / out of scope: a real Linux VS Code installation was not available locally.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #7101

Related to #7056 and #7067.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

VS Code Companion 启动 ACP 时会显式启用 Electron 的 Node 模式，不再依赖 Extension Host 继承到的环境变量。一个私有启动标记负责把这个要求传递过 CLI relaunch 和 macOS seatbelt re-exec；进入最终 ACP workload 后，两个环境变量都会在工具和 MCP server 启动前被清理。

## 为什么需要

在 Linux 上，VS Code Extension Host 不会稳定继承 `ELECTRON_RUN_AS_NODE`。缺少该变量时，通过 Electron 可执行文件启动内置 CLI 会启动 Chromium 而不是 Node，ACP 进程随即退出。之前的行为因此取决于 VS Code 本身的启动方式。

## Reviewer 测试计划

### 如何验证

1. 在 Linux 上确保 Extension Host 环境中没有 `ELECTRON_RUN_AS_NODE`，然后打开一个 Qwen Code Companion ACP session。
2. 确认 ACP 进程保持连接，并且不再输出 Chromium 启动警告。
3. 触发一次 CLI relaunch 或 macOS seatbelt 路径，确认 Electron Node 模式只在受管理的启动阶段恢复，并在工具和 MCP server 启动前清理。
4. 确认普通的非 ACP relaunch 和普通 seatbelt 启动不会获得 `ELECTRON_RUN_AS_NODE`。

### 证据（Before & After）

Before：回归契约在 Companion ACP 子进程环境中读到的 `ELECTRON_RUN_AS_NODE` 是 `undefined`，与 #7101 的 Linux 失败一致。

After：同一个契约已经通过；聚焦测试覆盖 Companion 首次启动、重复 CLI relaunch、macOS seatbelt re-exec、最终环境清理，以及普通非 ACP 路径的负向场景。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS arm64，Node.js 22.22.0。已通过全仓 typecheck、改动文件 ESLint、102 个聚焦测试和仓库构建。Linux VS Code 真机验证留给 CI 或 Linux reviewer。

## 风险与范围

- 主要风险或取舍：启动标记只能保留到最终受管理的 ACP 进程；回归测试覆盖了每个启动边界的传递和清理。
- 未验证 / 范围外：本地没有可用的 Linux VS Code 安装。
- Breaking changes / migration：无。

## 关联 Issue

Resolves #7101

Related to #7056 and #7067.

</details>
