### PR TITLE
test(web-shell): align workspace sidebar visual smoke

### DIFF
--- a/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
+++ b/packages/web-shell/client/e2e/visuals/screenshots.spec.ts
@@ -342,11 +342,7 @@ for (const theme of THEMES) {
     });
 
     test(`workspace sidebar`, async ({ page }, testInfo) => {
-      // Two workspaces make the sidebar group sessions per workspace and tag the
-      // primary one — the surface the "primary workspace" label/badge lives on.
-      // Every other scenario here is single-workspace, where that tag never
-      // renders (it is gated on more than one displayed workspace), so this is
-      // the only scenario that can surface a change to the workspace labels.
+      // Two workspaces make the sidebar group sessions per workspace.
       //
       // Pin the primary workspace cwd and its loaded session name explicitly,
       // rather than leaning on createWebShellDaemonScenario's defaults: the
@@ -381,10 +377,7 @@ for (const theme of THEMES) {
         resolveBaseURL(testInfo),
       );
       await gotoSession(page, scenario, daemon, theme);
-      // Each workspace renders a section headed by its basename; the primary one
-      // also carries a "Primary" tag. Assert both workspace names and the tag so
-      // a regression in the grouping or the (removable) primary label fails an
-      // assertion, not only the visually-reviewed screenshot.
+      // Each workspace renders a section headed by its basename.
       const sidebar = page.getByRole('complementary');
       await expect(
         sidebar.getByText('qwen-web-shell-e2e', { exact: true }),
@@ -392,7 +385,6 @@ for (const theme of THEMES) {
       await expect(
         sidebar.getByText('qwen-api-service', { exact: true }),
       ).toBeVisible();
-      await expect(sidebar.getByText('Primary', { exact: true })).toBeVisible();
       // The primary workspace auto-expands and streams its session rows in via a
       // per-workspace fetch. Wait for the loaded session's row before capturing
       // so the async load has settled — otherwise the row list races the


### PR DESCRIPTION
## What this PR does

Aligns the workspace sidebar visual smoke test with the current UI contract. It continues to verify that both workspaces are grouped by basename and that the primary workspace session loads, without expecting the removed `Primary` badge.

## Why it's needed

#7035 removed the redundant `Primary` badge, but #7041 subsequently added a visual assertion that still expected it. This caused the Web-shell Visuals check to fail in both themes across unrelated PRs.

## Reviewer Test Plan

### How to verify

Run `npm run test:e2e:visuals --workspace=packages/web-shell -- --grep "workspace sidebar"` and confirm that the dark and light scenarios both pass while still rendering both workspace groups and the primary workspace session.

### Evidence (Before & After)

- Before: the dark and light scenarios timed out waiting for `Primary` — `2 failed`.
- After: the same targeted command completes with `2 passed`.
- The sidebar regression suite completes with `20 passed`.
- Web Shell lint, typecheck, and build pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ CI pending |

### Environment (optional)

Node.js 22.22.0 with Playwright Chromium.

## Risk & Scope

- Main risk or tradeoff: This removes one visual assertion, but the asserted badge is intentionally absent and that contract is already covered by the sidebar component regression test. Workspace grouping and session-settling assertions remain.
- Not validated / out of scope: The full visual suite was not run locally; Windows and Linux are left to CI.
- Breaking changes / migration notes: None.

## Linked Issues

Related: #7035, #7041

<details>
<summary>中文说明</summary>

## 此 PR 做什么

让 workspace sidebar 视觉测试与当前 UI 行为保持一致：继续验证两个 workspace 按目录名分组，以及主 workspace 的 session 正常加载；不再查找已经删除的 `Primary` 标签。

## 为什么需要

#7035 删除了冗余的 `Primary` 标签，但随后合入的 #7041 新增了要求该标签存在的视觉断言，导致多个无关 PR 的 Web-shell Visuals 检查在亮色和暗色主题下同时失败。

## Reviewer Test Plan

### 如何验证

运行 `npm run test:e2e:visuals --workspace=packages/web-shell -- --grep "workspace sidebar"`，确认亮色和暗色场景均通过，并确认两个 workspace 分组和主 workspace session 仍正常渲染。

### 证据（Before & After）

- Before：亮色、暗色场景均因等待 `Primary` 超时，`2 failed`。
- After：相同定向命令 `2 passed`。
- 侧栏回归测试：`20 passed`。
- Web Shell lint、typecheck 和 build 均通过。

### Tested on

| OS | Status |
| :--: | :--: |
| 🍏 macOS | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ CI pending |

### Environment

Node.js 22.22.0，Playwright Chromium。

## Risk & Scope

- 主要风险：减少了一个视觉断言；但该标签不存在是当前明确契约，侧栏组件回归测试已经覆盖，workspace 分组和 session settle 断言仍保留。
- 未验证/范围外：未在本地运行完整视觉测试套件；Windows/Linux 留给 CI。
- Breaking changes：无。

## Linked Issues

Related: #7035, #7041

</details>
