### PR TITLE
fix(core): accept subagents created after startup instead of rejecting on stale cache

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -508,14 +508,27 @@ describe('AgentTool', () => {
       );
     });
 
-    it('should reject non-existent subagent', async () => {
+    it('accepts a subagent_type missing from the cache (may have been created after startup)', () => {
       const result = agentTool.validateToolParams({
         ...validParams,
-        subagent_type: 'non-existent',
+        subagent_type: 'created-after-startup',
       });
-      expect(result).toBe(
-        'Subagent "non-existent" not found. Available subagents: file-search, code-review',
-      );
+      expect(result).toBeNull();
+    });
+
+    it('kicks a cache refresh on a subagent_type cache miss', () => {
+      vi.mocked(mockSubagentManager.listSubagents).mockClear();
+      agentTool.validateToolParams({
+        ...validParams,
+        subagent_type: 'created-after-startup',
+      });
+      expect(mockSubagentManager.listSubagents).toHaveBeenCalled();
+    });
+
+    it('does not refresh the cache when the subagent_type is already known', () => {
+      vi.mocked(mockSubagentManager.listSubagents).mockClear();
+      agentTool.validateToolParams(validParams);
+      expect(mockSubagentManager.listSubagents).not.toHaveBeenCalled();
     });
 
     it('accepts isolation="worktree" when subagent_type is set', () => {
@@ -749,6 +762,42 @@ describe('AgentTool', () => {
       } finally {
         await fs.rm(repo, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('execution with an unknown subagent', () => {
+    it('reports not-found with the available list when the agent is missing on disk', async () => {
+      vi.mocked(mockSubagentManager.loadSubagent).mockResolvedValue(null);
+
+      const invocation = agentTool.build({
+        description: 'Use missing agent',
+        prompt: 'Do work',
+        subagent_type: 'non-existent',
+      });
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(mockSubagentManager.loadSubagent).toHaveBeenCalledWith(
+        'non-existent',
+      );
+      expect(result.llmContent).toBe(
+        'Subagent "non-existent" not found. Available subagents: file-search, code-review',
+      );
+    });
+
+    it('still reports not-found when listing available subagents fails', async () => {
+      vi.mocked(mockSubagentManager.loadSubagent).mockResolvedValue(null);
+      vi.mocked(mockSubagentManager.listSubagents).mockRejectedValue(
+        new Error('fs error'),
+      );
+
+      const invocation = agentTool.build({
+        description: 'Use missing agent',
+        prompt: 'Do work',
+        subagent_type: 'non-existent',
+      });
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.llmContent).toBe('Subagent "non-existent" not found');
     });
   });
 

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1001,9 +1001,8 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       ) {
         return 'Parameter "subagent_type" must be a non-empty string.';
       }
-      // Validate that the subagent exists (case-insensitive). `fork` is an
-      // explicit pseudo-type resolved by the dispatch logic (not a loadable
-      // subagent), so accept it regardless of the registered list; when
+      // `fork` is an explicit pseudo-type resolved by the dispatch logic (not
+      // a loadable subagent), so it never appears in the registered list; when
       // forking is unavailable, dispatch falls back to general-purpose.
       const lowerType = params.subagent_type.toLowerCase();
       if (lowerType !== FORK_SUBAGENT_TYPE) {
@@ -1012,8 +1011,13 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
         );
 
         if (!subagentExists) {
-          const availableNames = this.availableSubagents.map((s) => s.name);
-          return `Subagent "${params.subagent_type}" not found. Available subagents: ${availableNames.join(', ')}`;
+          // Not in the cached list — the agent file may have been created
+          // after this tool was initialized. Don't reject here: execution
+          // resolves the type via loadSubagent(), which reads from disk and
+          // fails with a clear "not found" error if the agent truly doesn't
+          // exist. Kick a refresh (validation must stay synchronous) so the
+          // cache and schema catch up for subsequent calls.
+          void this.refreshSubagents();
         }
       }
     }
@@ -2285,15 +2289,29 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           effectiveSubagentType!,
         );
         if (!loadedConfig) {
+          // loadSubagent() reads from disk, so reaching this point means the
+          // agent genuinely doesn't exist (validation no longer rejects on a
+          // stale cache miss). List what is available to help correct typos.
+          let notFoundMessage = `Subagent "${effectiveSubagentType}" not found`;
+          try {
+            const available = await this.subagentManager.listSubagents();
+            if (available.length > 0) {
+              notFoundMessage += `. Available subagents: ${available
+                .map((s) => s.name)
+                .join(', ')}`;
+            }
+          } catch {
+            // Listing is best-effort; the bare message is still actionable.
+          }
           return {
-            llmContent: `Subagent "${effectiveSubagentType}" not found`,
+            llmContent: notFoundMessage,
             returnDisplay: {
               type: 'task_execution' as const,
               subagentName: effectiveSubagentType!,
               taskDescription: this.params.description,
               taskPrompt: this.params.prompt,
               status: 'failed' as const,
-              terminateReason: `Subagent "${effectiveSubagentType}" not found`,
+              terminateReason: notFoundMessage,
             },
           };
         }


### PR DESCRIPTION
## What this PR does

Makes custom agents created during an active session immediately usable: the Agent tool no longer rejects a `subagent_type` that is missing from its startup-time cache. Validation lets the call proceed and execution resolves the agent from disk via `loadSubagent()`, which naturally discovers files created after startup. A cache miss also kicks a fire-and-forget `refreshSubagents()` so the cached list and the `subagent_type` schema enum catch up for subsequent calls, and the execution-time "not found" error now appends the list of available subagents so typo feedback stays as informative as the old validation error was.

## Why it's needed

Creating a `.qwen/agents/*.md` file mid-session and calling it via `agent({ subagent_type: "..." })` failed with `Subagent "..." not found` until the CLI was restarted (`/exit` + relaunch), even though the file was valid and `loadSubagent()` could read it from disk at any time. The stale `availableSubagents` cache in `validateToolParams` rejected the call before execution ever reached the loader, forcing a disruptive restart round-trip every time a user creates or edits a custom agent. This implements Approach A recommended by the triage analysis on #7108.

## Reviewer Test Plan

### How to verify

1. Start Qwen Code in any project.
2. Create `.qwen/agents/test-agent.md` with valid frontmatter (name, description) while the session is running.
3. Call the Agent tool with `subagent_type: "test-agent"`.
4. Expected (after this PR): the agent runs. Observed before this PR: `Subagent "test-agent" not found. Available subagents: ...` until restart.
5. Also confirm a genuinely nonexistent type still fails: calling `subagent_type: "no-such-agent"` returns `Subagent "no-such-agent" not found. Available subagents: ...` at execution time.

Automated coverage: `npx vitest run packages/core/src/tools/agent/agent.test.ts` — 156/156 pass, including new cases for cache-miss acceptance, refresh-on-miss, no-refresh-when-known, execution-time not-found with the available list, and graceful degradation when `listSubagents()` itself throws. `npm run typecheck`, eslint and prettier are clean on the changed files.

### Evidence (Before & After)

E2E reproduction script driving the real compiled `AgentTool` + `SubagentManager` (no mocks) against a temp project on disk, replaying the issue's repro steps — unpatched build reproduces the bug, patched build passes:

| Build | `validateToolParams` on an agent created after init | Verdict |
| --- | --- | --- |
| unpatched (`origin/main` @ `30984a2f5`) | `"Subagent \"hot-reload-agent\" not found. Available subagents: ..."` | ❌ bug reproduced |
| **this PR** | `null` (accepted; execution loads it from disk) | ✅ fixed |

![verification screenshot](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7108/assets/verify-7108.png)

Full verification report (script details, unit-test output, static checks): see the PR comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1, npm workspaces; unit tests via vitest plus a standalone Node script against the built `packages/core/dist`.

## Risk & Scope

- Main risk or tradeoff: an unknown `subagent_type` is now rejected at execution time instead of validation time. The failure is equally clear (same message, now with the available list) but surfaces one step later; the schema enum still advertises only cached agents until a refresh lands.
- Not validated / out of scope: no file watcher is added for `.qwen/agents/` (the change-listener mechanism is untouched); Windows/Linux runs rely on CI.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7108

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让会话进行中新建的自定义 agent 立即可用：Agent tool 不再因 `subagent_type` 不在启动时的缓存中而拒绝调用。校验放行后由执行路径的 `loadSubagent()` 从磁盘解析，天然能发现启动后创建的文件。缓存未命中同时触发一次 fire-and-forget 的 `refreshSubagents()`，让缓存列表和 `subagent_type` 的 schema enum 在后续调用中跟上；执行期的 "not found" 错误信息补充了可用 agent 列表，拼写错误时的提示信息量与旧校验错误持平。

## 为什么需要

会话中创建 `.qwen/agents/*.md` 后通过 `agent({ subagent_type: "..." })` 调用会报 `Subagent not found`，必须重启 CLI（`/exit` 后重新启动）才能生效——尽管文件有效且 `loadSubagent()` 随时可以从磁盘读取。`validateToolParams` 中过期的 `availableSubagents` 缓存在执行路径到达加载器之前就拒绝了调用，导致每次创建或修改自定义 agent 都要经历一次打断工作流的重启。本 PR 实现了 #7108 triage 分析推荐的方案 A。

## 审阅测试计划

### 如何验证

1. 在任意项目中启动 Qwen Code；
2. 会话运行期间创建带有效 frontmatter 的 `.qwen/agents/test-agent.md`；
3. 用 `subagent_type: "test-agent"` 调用 Agent tool；
4. 预期（本 PR 之后）：agent 正常运行。本 PR 之前的现象：报 `Subagent "test-agent" not found`，重启后才能用；
5. 同时确认真正不存在的类型仍会失败：调用 `subagent_type: "no-such-agent"` 会在执行期返回带可用列表的 not found 错误。

自动化覆盖：`agent.test.ts` 156/156 通过，包含缓存未命中放行、未命中触发刷新、已知类型不刷新、执行期 not-found 携带可用列表、`listSubagents()` 抛错时优雅降级等新用例。typecheck / eslint / prettier 全部通过。

### 证据（Before & After）

用真实编译产物中的 `AgentTool` + `SubagentManager`（非 mock）在磁盘临时项目上重放 issue 复现步骤：未打补丁的构建复现 bug，打补丁后通过（见上方表格与截图）。完整验证报告见下方 PR 评论。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1、npm workspaces；vitest 单测 + 针对 `packages/core/dist` 构建产物的独立 Node 脚本。

## 风险与范围

- 主要风险/权衡：未知 `subagent_type` 的拒绝从校验期移到执行期，错误同样清晰（同样的消息且附可用列表），只是晚一步出现；schema enum 在刷新落地前仍只展示缓存中的 agent。
- 未验证/超出范围：未为 `.qwen/agents/` 添加文件监听（change-listener 机制未改动）；Windows/Linux 依赖 CI。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7108

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
