### PR TITLE
fix(cli): pop the kitty keyboard protocol after leaving the alternate screen

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -2111,6 +2111,46 @@ describe('startInteractiveUI', () => {
     );
   });
 
+  // Regression for #6776: the kitty keyboard flags are tracked per screen
+  // (main vs alternate). The protocol is enabled on the main screen before
+  // render, so the pop must be written after Ink unmounts — i.e. after the
+  // alternate screen (when enabled) has been left — or the main screen's
+  // flags survive the exit and the shell receives kitty escape codes.
+  it('disables the Kitty keyboard protocol only after Ink has unmounted', async () => {
+    const unmount = vi.fn();
+    const { render } = await import('ink');
+    vi.mocked(render).mockReturnValue({ unmount } as never);
+    const { disableKittyProtocol } = await import(
+      './ui/utils/kittyProtocolDetector.js'
+    );
+
+    await startInteractiveUI(
+      mockConfig,
+      mockSettings,
+      mockStartupWarnings,
+      mockWorkspaceRoot,
+      {
+        authError: null,
+        themeError: null,
+        shouldOpenAuthDialog: false,
+        geminiMdFileCount: 0,
+      },
+    );
+
+    const { registerCleanup } = await import('./utils/cleanup.js');
+    const cleanupFn = vi.mocked(registerCleanup).mock.calls.at(-1)?.[0] as
+      | (() => Promise<void> | void)
+      | undefined;
+    expect(cleanupFn).toBeTypeOf('function');
+    await cleanupFn?.();
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(disableKittyProtocol).toHaveBeenCalledTimes(1);
+    expect(
+      vi.mocked(disableKittyProtocol).mock.invocationCallOrder[0],
+    ).toBeGreaterThan(unmount.mock.invocationCallOrder[0]);
+  });
+
   describe('periodic memory-pressure check', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/cli/src/ui/startInteractiveUI.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.tsx
@@ -251,11 +251,15 @@ export async function startInteractiveUI(
     }
     remoteInputWatcher?.shutdown();
     await dualOutputBridge?.shutdown();
-    // Explicitly disable the Kitty keyboard protocol before unmounting Ink so
-    // that the disable escape sequence is written while stdout is still fully
-    // operational, preventing garbled terminal output after the app exits.
-    disableKittyProtocol();
     instance.unmount();
+    // Pop the Kitty keyboard protocol only after Ink has unmounted. The
+    // protocol was enabled on the main screen before render, and the kitty
+    // spec tracks keyboard flags per screen: with alternateScreen enabled, a
+    // pop written before unmount lands on the alternate screen's (empty)
+    // stack, unmount then leaves the alternate screen, and the main screen's
+    // flags stay set — the user's shell keeps receiving kitty escape codes
+    // (e.g. "9;5u" on Ctrl-C) after exit.
+    disableKittyProtocol();
     if (useVP) {
       process.stdout.setMaxListeners(stdoutMaxListeners);
     }


### PR DESCRIPTION
## What this PR does

Restores the terminal's keyboard state correctly on exit when the alternate screen buffer is in use. The Kitty keyboard protocol pop sequence is now written after Ink has unmounted — that is, after the alternate screen (when `ui.useTerminalBuffer` is enabled) has been left — so the pop applies to the main screen, where the protocol was originally pushed. Previously the pop was written while the alternate screen was still active, popping that screen's empty stack and leaving the main screen's keyboard flags permanently set.

## Why it's needed

The kitty keyboard protocol spec tracks progressive-enhancement flags per screen (main and alternate screens have independent state). Qwen Code pushes the flags (`ESC[>1u`) on the main screen at startup, before Ink renders. With `ui.useTerminalBuffer: true`, Ink then enters the alternate screen, and the exit cleanup ran `disableKittyProtocol()` before `instance.unmount()` — so the pop (`ESC[<u`) landed inside the alternate screen and the main screen's flags survived the exit. On kitty-protocol terminals (Ghostty, Kitty, WezTerm), the user's shell then receives kitty escape fragments like `9;5u` on Ctrl-C until they run `reset` or `printf '\e[<u'` — exactly the symptom in #6776, including the follow-up report that a clean `/quit` also reproduces it.

## Reviewer Test Plan

### How to verify

1. In a kitty-protocol terminal (Ghostty/Kitty/WezTerm), set `ui.useTerminalBuffer: true` in `~/.qwen/settings.json`.
2. Run `qwen`, then exit (double Ctrl-C or `/quit`).
3. Before this PR: pressing Ctrl-C (and other keys) in the shell after exit produces fragments like `9;5u`; `printf '\e[<u'` fixes it. After this PR: the shell behaves normally.
4. Regression: repeat without `useTerminalBuffer` (default) — behavior is unchanged and the terminal is restored correctly.

Automated coverage: a new regression test asserts `disableKittyProtocol()` is invoked only after `instance.unmount()` in the exit cleanup (`gemini.test.tsx`, 42/42 pass). `npm run typecheck`, eslint and prettier are clean on the changed files.

### Evidence (Before & After)

A PTY harness runs the real bundled CLI (`dist/cli.js`, no mocks) inside a pseudo-terminal that answers the kitty-protocol detection probes (`ESC[?u` / `ESC[c`), drives a double-Ctrl-C exit, captures every output byte, and checks the order of the push (`ESC[>1u`), pop (`ESC[<u`), and alt-screen off (`ESC[?1049l`) sequences:

| Build (`useTerminalBuffer: true`) | Byte order observed | Verdict |
| --- | --- | --- |
| unpatched (`origin/main` @ `30984a2f5`) | push@14 → alt-on@41 → **pop@33919 → alt-off@33945** | ❌ pop inside alt screen; main-screen flags never cleared |
| **this PR** | push@14 → alt-on@41 → **alt-off@22593 → pop@22613** | ✅ pop lands on the main screen |
| this PR, default config (no alt screen) | push@14 → pop@18508 | ✅ unchanged |

![verification screenshot](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-6776/assets/verify-6776.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; PTY harness via Python `pty` module against the esbuild bundle, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: the pop is now written a few cleanup steps later (after unmount instead of before). stdout remains a synchronous TTY stream through unmount, so delivery is not at risk; the `process.on('exit'/'SIGINT'/'SIGTERM')` fallbacks in `kittyProtocolDetector.ts` are untouched and still cover abnormal exits.
- Not validated / out of scope: abnormal terminations that never reach the cleanup chain while the alternate screen is active (the terminal is then stuck in the alt screen anyway, a pre-existing broader issue); the original reporter's rapid-Ctrl-C timing on Linux/Ghostty was not separately reproducible on the current main — the PTY harness shows the default-config exit path already emits the pop correctly there.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6776

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复使用备用屏幕缓冲区时退出后终端键盘状态未恢复的问题。Kitty 键盘协议的 pop 序列现在改为在 Ink unmount **之后**写入——即（启用 `ui.useTerminalBuffer` 时）已离开备用屏幕之后——使 pop 作用于最初 push 协议的主屏幕。此前 pop 在备用屏幕仍激活时写入，弹的是备屏的空栈，主屏的键盘 flags 被永久残留。

## 为什么需要

kitty 键盘协议规范中，渐进增强 flags 是按屏幕独立跟踪的（主屏与备屏状态互不影响）。Qwen Code 在启动时（Ink 渲染之前）在主屏 push flags（`ESC[>1u`）。当 `ui.useTerminalBuffer: true` 时，Ink 随后进入备屏，而退出清理在 `instance.unmount()` 之前调用了 `disableKittyProtocol()`——pop（`ESC[<u`）落在备屏内，主屏的 flags 在退出后仍然生效。在 kitty 协议终端（Ghostty、Kitty、WezTerm）上，退出后 shell 里按 Ctrl-C 会出现 `9;5u` 这类片段，必须运行 `reset` 或 `printf '\e[<u'` 才能恢复——与 #6776 的症状完全一致，包括后续评论中"干净的 `/quit` 也复现"。

## 审阅测试计划

### 如何验证

1. 在 kitty 协议终端中，设置 `~/.qwen/settings.json` 的 `ui.useTerminalBuffer: true`；
2. 运行 `qwen` 后退出（双击 Ctrl-C 或 `/quit`）；
3. 本 PR 之前：退出后在 shell 中按 Ctrl-C 会输出 `9;5u` 之类的片段，`printf '\e[<u'` 可恢复。本 PR 之后：shell 行为正常；
4. 回归：不开 `useTerminalBuffer`（默认）重复上述步骤——行为不变，终端正确恢复。

自动化覆盖：新增回归测试断言退出清理中 `disableKittyProtocol()` 仅在 `instance.unmount()` 之后调用（`gemini.test.tsx`，42/42 通过）。typecheck / eslint / prettier 全部通过。

### 证据（Before & After）

PTY harness 在伪终端中运行真实打包产物（`dist/cli.js`，非 mock），应答 kitty 协议探测查询，驱动双 Ctrl-C 退出，捕获全部输出字节并检查 push / pop / 离开备屏序列的顺序（见上方表格与截图）。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；Python `pty` 模块驱动 esbuild 打包产物 + vitest 单测。

## 风险与范围

- 主要风险/权衡：pop 的写入时机在清理链中后移了几步（unmount 之后）。stdout 在 unmount 后仍是同步 TTY 流，送达无风险；`kittyProtocolDetector.ts` 中 `process.on('exit'/'SIGINT'/'SIGTERM')` 的兜底逻辑未改动，异常退出仍有覆盖。
- 未验证/超出范围：清理链未执行、备屏仍激活的异常终止场景（此时终端本就卡在备屏，属于既有的更大问题）；原报告人在 Linux/Ghostty 上的快速 Ctrl-C 时序在当前 main 上未能单独复现——PTY 实测表明默认配置的退出路径已能正确发出 pop。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #6776

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
