### PR TITLE
fix(windows): improve PowerShell fallback for checksum verification

### DIFF
--- a/scripts/installation/install-qwen-standalone.bat
+++ b/scripts/installation/install-qwen-standalone.bat
@@ -784,9 +784,23 @@ if "!EXPECTED_HASH!"=="" (
 
 set "ACTUAL_HASH="
 set "QWEN_HASH_FILE=!ARCHIVE_FILE!"
-for /f "delims=" %%H in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; (Get-FileHash -Algorithm SHA256 -LiteralPath $env:QWEN_HASH_FILE).Hash" 2^>nul') do (
-    if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
+
+where pwsh.exe >nul 2>&1
+if !ERRORLEVEL! EQU 0 (
+    for /f "delims=" %%H in ('pwsh.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; (Get-FileHash -Algorithm SHA256 -LiteralPath $env:QWEN_HASH_FILE).Hash"') do (
+        if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
+    )
 )
+
+if "!ACTUAL_HASH!"=="" (
+    where powershell.exe >nul 2>&1
+    if !ERRORLEVEL! EQU 0 (
+        for /f "delims=" %%H in ('powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; (Get-FileHash -Algorithm SHA256 -LiteralPath $env:QWEN_HASH_FILE).Hash"') do (
+            if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
+        )
+    )
+)
+
 set "QWEN_HASH_FILE="
 
 if not "!TEMP_CHECKSUM!"=="" del /F /Q "!TEMP_CHECKSUM!" >nul 2>&1


### PR DESCRIPTION
## Summary

Fix SHA-256 verification failures in the Windows standalone installer when `powershell.exe` cannot resolve `Get-FileHash` but PowerShell 7 is available.

## Changes

- Prefer `pwsh.exe` for checksum calculation when available.
- Fall back to `powershell.exe` if PowerShell 7 is unavailable or does not produce a hash.
- Preserve the underlying PowerShell error output instead of suppressing stderr.
- Keep checksum verification fully enabled.

## Root cause

`install-qwen-standalone.bat` hardcoded `powershell` for SHA-256 calculation and redirected stderr to `nul`. On affected systems, Windows PowerShell could not resolve `Get-FileHash`, while PowerShell 7 worked correctly.

## Validation

- The branch is one commit ahead of `main`.
- Only `scripts/installation/install-qwen-standalone.bat` is modified.
- Diff size: 16 additions, 2 deletions.

Fixes #7118