### PR TITLE
feat(vscode): route logs to the Qwen Code Companion output channel

### DIFF
--- a/docs/design/vscode-output-channel-logging.md
+++ b/docs/design/vscode-output-channel-logging.md
@@ -8,8 +8,9 @@ Tools, so users cannot easily collect a complete report.
 
 ## Design
 
-Create one `Champion` `OutputChannel` during extension activation and configure
-the existing logger to write in both development and production modes.
+Reuse the existing `Qwen Code Companion` `OutputChannel` during extension
+activation and configure the logger to write in both development and production
+modes.
 
 Extension Host runtime code uses the shared logger instead of `console.*`. The
 logger preserves log levels, formats objects and errors, redacts sensitive
@@ -18,14 +19,15 @@ object fields, and applies the existing log-credential redactor before writing.
 The Webview bundle redirects its global `console.*` methods so logs from the
 shared Web UI are included. It sends formatted log messages through the existing
 Webview-to-Extension Host message bridge. The host validates each message and
-escapes line breaks before writing it to the same `Champion` channel.
+escapes line breaks before writing it to the same `Qwen Code Companion`
+channel.
 
 Build scripts and tests keep using `console.*` because they do not run inside the
 extension.
 
 ## Verification
 
-- Production activation writes to the `Champion` channel.
+- Production activation writes to the `Qwen Code Companion` channel.
 - Multi-argument, object, circular, and `Error` values remain readable.
 - Sensitive object fields and common credentials are redacted.
 - Webview log messages reach the Extension Host logger.

--- a/docs/design/vscode-output-channel-logging.md
+++ b/docs/design/vscode-output-channel-logging.md
@@ -1,0 +1,32 @@
+# VS Code Output Channel Logging
+
+## Problem
+
+Runtime diagnostics currently use `console.*`. Extension Host logs require
+Developer Tools, while Webview logs require the separate Webview Developer
+Tools, so users cannot easily collect a complete report.
+
+## Design
+
+Create one `Champion` `OutputChannel` during extension activation and configure
+the existing logger to write in both development and production modes.
+
+Extension Host runtime code uses the shared logger instead of `console.*`. The
+logger preserves log levels, formats objects and errors, redacts sensitive
+object fields, and applies the existing log-credential redactor before writing.
+
+The Webview bundle redirects its global `console.*` methods so logs from the
+shared Web UI are included. It sends formatted log messages through the existing
+Webview-to-Extension Host message bridge. The host validates each message and
+escapes line breaks before writing it to the same `Champion` channel.
+
+Build scripts and tests keep using `console.*` because they do not run inside the
+extension.
+
+## Verification
+
+- Production activation writes to the `Champion` channel.
+- Multi-argument, object, circular, and `Error` values remain readable.
+- Sensitive object fields and common credentials are redacted.
+- Webview log messages reach the Extension Host logger.
+- The focused unit tests, package build, and package typecheck pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31202,6 +31202,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@qwen-code/acp-bridge": "*",
         "@qwen-code/sdk": "*",
         "@qwen-code/webui": "*",
         "cors": "^2.8.5",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -291,6 +291,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",
+    "@qwen-code/acp-bridge": "*",
     "@qwen-code/sdk": "*",
     "@qwen-code/webui": "*",
     "@modelcontextprotocol/sdk": "^1.25.2",

--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -131,7 +131,7 @@ export function registerNewCommands(
         outputChannel.show(true);
       } else {
         vscode.window.showWarningMessage(
-          'Champion log channel is not available.',
+          'Qwen Code Companion log channel is not available.',
         );
       }
     }),

--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -131,7 +131,7 @@ export function registerNewCommands(
         outputChannel.show(true);
       } else {
         vscode.window.showWarningMessage(
-          'Qwen Code Companion log channel is not available.',
+          'Champion log channel is not available.',
         );
       }
     }),

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -104,6 +104,7 @@ describe('activate', () => {
           version: '1.1.0',
         },
       },
+      extensionMode: vscode.ExtensionMode.Production,
     } as unknown as vscode.ExtensionContext;
   });
 
@@ -123,6 +124,18 @@ describe('activate', () => {
     expect(showInformationMessageMock).toHaveBeenCalledWith(
       'Qwen Code Companion extension successfully installed.',
     );
+  });
+
+  it('writes production logs to the Champion output channel', async () => {
+    const appendLine = vi.fn();
+    vi.mocked(vscode.window.createOutputChannel).mockReturnValue({
+      appendLine,
+    } as unknown as vscode.LogOutputChannel);
+
+    await activate(context);
+
+    expect(vscode.window.createOutputChannel).toHaveBeenCalledWith('Champion');
+    expect(appendLine).toHaveBeenCalledWith('[INFO] Extension activated');
   });
 
   it('launches Qwen Code with the full multi-root workspace env', async () => {

--- a/packages/vscode-ide-companion/src/extension.test.ts
+++ b/packages/vscode-ide-companion/src/extension.test.ts
@@ -126,7 +126,7 @@ describe('activate', () => {
     );
   });
 
-  it('writes production logs to the Champion output channel', async () => {
+  it('writes production logs to the Qwen Code Companion output channel', async () => {
     const appendLine = vi.fn();
     vi.mocked(vscode.window.createOutputChannel).mockReturnValue({
       appendLine,
@@ -134,7 +134,9 @@ describe('activate', () => {
 
     await activate(context);
 
-    expect(vscode.window.createOutputChannel).toHaveBeenCalledWith('Champion');
+    expect(vscode.window.createOutputChannel).toHaveBeenCalledWith(
+      'Qwen Code Companion',
+    );
     expect(appendLine).toHaveBeenCalledWith('[INFO] Extension activated');
   });
 

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -45,8 +45,6 @@ let ideServer: IDEServer;
 let outputChannel: vscode.OutputChannel;
 let chatProviderRegistry: ChatProviderRegistry<WebViewProvider> | null = null;
 
-let log: (message: string) => void = () => {};
-
 async function checkForUpdates(
   context: vscode.ExtensionContext,
   log: (message: string) => void,
@@ -115,10 +113,10 @@ async function checkForUpdates(
 
 export async function activate(context: vscode.ExtensionContext) {
   outputChannel = vscode.window.createOutputChannel('Qwen Code Companion');
-  log = createLogger(outputChannel, redactLogCredentials);
-  log('Extension activated');
+  createLogger(outputChannel, redactLogCredentials);
+  logger.info('Extension activated');
 
-  checkForUpdates(context, log);
+  checkForUpdates(context, logger.info);
 
   // Create and register readonly file system provider
   // The provider registers itself as a singleton in the constructor
@@ -131,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
     readonlyProvider,
   );
-  log('Readonly file system provider registered');
+  logger.info('Readonly file system provider registered');
 
   chatProviderRegistry = new ChatProviderRegistry(
     () => new WebViewProvider(context, context.extensionUri),
@@ -139,7 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const diffContentProvider = new DiffContentProvider();
   const diffManager = new DiffManager(
-    log,
+    logger.info,
     diffContentProvider,
     // Delay when any chat surface has a pending permission drawer
     () =>
@@ -203,7 +201,7 @@ export async function activate(context: vscode.ExtensionContext) {
         await provider.restorePanel(webviewPanel);
         logger.log('[Extension] Panel restore completed');
 
-        log('WebView panel restored from serialization');
+        logger.info('WebView panel restored from serialization');
       },
     }),
   );
@@ -211,7 +209,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register newly added commands via commands module
   registerNewCommands(
     context,
-    log,
+    logger.info,
     diffManager,
     () => chatProviderRegistry?.getEditorProviders() ?? [],
     createWebViewProvider,
@@ -302,12 +300,12 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   );
 
-  ideServer = new IDEServer(log, diffManager);
+  ideServer = new IDEServer(logger.info, diffManager);
   try {
     await ideServer.start(context);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log(`Failed to start IDE server: ${message}`);
+    logger.info(`Failed to start IDE server: ${message}`);
   }
 
   const infoMessageEnabled = !HIDE_INSTALLATION_GREETING_IDES.has(
@@ -410,7 +408,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate(): Promise<void> {
-  log('Extension deactivated');
+  logger.info('Extension deactivated');
   try {
     if (ideServer) {
       await ideServer.stop();
@@ -419,7 +417,7 @@ export async function deactivate(): Promise<void> {
     chatProviderRegistry = null;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log(`Failed to stop IDE server during deactivation: ${message}`);
+    logger.info(`Failed to stop IDE server during deactivation: ${message}`);
   } finally {
     if (outputChannel) {
       resetLoggerSink();

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -114,7 +114,7 @@ async function checkForUpdates(
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  outputChannel = vscode.window.createOutputChannel('Champion');
+  outputChannel = vscode.window.createOutputChannel('Qwen Code Companion');
   log = createLogger(outputChannel, redactLogCredentials);
   log('Extension activated');
 

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -305,7 +305,7 @@ export async function activate(context: vscode.ExtensionContext) {
     await ideServer.start(context);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.info(`Failed to start IDE server: ${message}`);
+    logger.warn(`Failed to start IDE server: ${message}`);
   }
 
   const infoMessageEnabled = !HIDE_INSTALLATION_GREETING_IDES.has(
@@ -417,7 +417,7 @@ export async function deactivate(): Promise<void> {
     chatProviderRegistry = null;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.info(`Failed to stop IDE server during deactivation: ${message}`);
+    logger.warn(`Failed to stop IDE server during deactivation: ${message}`);
   } finally {
     if (outputChannel) {
       resetLoggerSink();

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -8,12 +8,13 @@ import * as vscode from 'vscode';
 import { IDEServer } from './ide-server.js';
 import semver from 'semver';
 import { DiffContentProvider, DiffManager } from './diff-manager.js';
-import { createLogger } from './utils/logger.js';
+import { createLogger, logger, resetLoggerSink } from './utils/logger.js';
 import {
   detectIdeFromEnv,
   IDE_DEFINITIONS,
   type IdeInfo,
 } from '@qwen-code/qwen-code-core';
+import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
 import { WebViewProvider } from './webview/providers/WebViewProvider.js';
 import { ChatProviderRegistry } from './webview/providers/ChatProviderRegistry.js';
 import { registerChatViewProviders } from './webview/providers/chatViewRegistration.js';
@@ -41,7 +42,7 @@ const HIDE_INSTALLATION_GREETING_IDES: ReadonlySet<IdeInfo['name']> = new Set([
 ]);
 
 let ideServer: IDEServer;
-let logger: vscode.OutputChannel;
+let outputChannel: vscode.OutputChannel;
 let chatProviderRegistry: ChatProviderRegistry<WebViewProvider> | null = null;
 
 let log: (message: string) => void = () => {};
@@ -113,8 +114,8 @@ async function checkForUpdates(
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-  logger = vscode.window.createOutputChannel('Qwen Code Companion');
-  log = createLogger(context, logger);
+  outputChannel = vscode.window.createOutputChannel('Champion');
+  log = createLogger(outputChannel, redactLogCredentials);
   log('Extension activated');
 
   checkForUpdates(context, log);
@@ -177,18 +178,18 @@ export async function activate(context: vscode.ExtensionContext) {
         webviewPanel: vscode.WebviewPanel,
         state: unknown,
       ) {
-        console.log(
+        logger.log(
           '[Extension] Deserializing WebView panel with state:',
           state,
         );
 
         // Create a new provider for the restored panel
         const provider = createWebViewProvider();
-        console.log('[Extension] Provider created for deserialization');
+        logger.log('[Extension] Provider created for deserialization');
 
         // Restore state if available BEFORE restoring the panel
         if (state && typeof state === 'object') {
-          console.log('[Extension] Restoring state:', state);
+          logger.log('[Extension] Restoring state:', state);
           provider.restoreState(
             state as {
               conversationId: string | null;
@@ -196,11 +197,11 @@ export async function activate(context: vscode.ExtensionContext) {
             },
           );
         } else {
-          console.log('[Extension] No state to restore or invalid state');
+          logger.log('[Extension] No state to restore or invalid state');
         }
 
         await provider.restorePanel(webviewPanel);
-        console.log('[Extension] Panel restore completed');
+        logger.log('[Extension] Panel restore completed');
 
         log('WebView panel restored from serialization');
       },
@@ -214,7 +215,7 @@ export async function activate(context: vscode.ExtensionContext) {
     diffManager,
     () => chatProviderRegistry?.getEditorProviders() ?? [],
     createWebViewProvider,
-    logger,
+    outputChannel,
   );
 
   // Register copy commands for webview context menu
@@ -263,9 +264,9 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         }
       } catch (err) {
-        console.warn('[Extension] Auto-allow on diff.accept failed:', err);
+        logger.warn('[Extension] Auto-allow on diff.accept failed:', err);
       }
-      console.log('[Extension] Diff accepted');
+      logger.log('[Extension] Diff accepted');
     }),
     vscode.commands.registerCommand('qwen.diff.cancel', (uri?: vscode.Uri) => {
       const docUri = uri ?? vscode.window.activeTextEditor?.document.uri;
@@ -281,22 +282,22 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         }
       } catch (err) {
-        console.warn('[Extension] Auto-reject on diff.cancel failed:', err);
+        logger.warn('[Extension] Auto-reject on diff.cancel failed:', err);
       }
-      console.log('[Extension] Diff cancelled');
+      logger.log('[Extension] Diff cancelled');
     })),
     vscode.commands.registerCommand('qwen.diff.closeAll', async () => {
       try {
         await diffManager.closeAll();
       } catch (err) {
-        console.warn('[Extension] qwen.diff.closeAll failed:', err);
+        logger.warn('[Extension] qwen.diff.closeAll failed:', err);
       }
     }),
     vscode.commands.registerCommand('qwen.diff.suppressBriefly', async () => {
       try {
         diffManager.suppressFor(1200);
       } catch (err) {
-        console.warn('[Extension] qwen.diff.suppressBriefly failed:', err);
+        logger.warn('[Extension] qwen.diff.suppressBriefly failed:', err);
       }
     }),
   );
@@ -420,8 +421,9 @@ export async function deactivate(): Promise<void> {
     const message = err instanceof Error ? err.message : String(err);
     log(`Failed to stop IDE server during deactivation: ${message}`);
   } finally {
-    if (logger) {
-      logger.dispose();
+    if (outputChannel) {
+      resetLoggerSink();
+      outputChannel.dispose();
     }
   }
 }

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../utils/logger.js';
 import {
   ClientSideConnection,
   ndJsonStream,
@@ -99,7 +100,7 @@ export class AcpConnection {
     if (proxyArg) {
       const proxyIndex = extraArgs.indexOf('--proxy');
       const proxyUrl = extraArgs[proxyIndex + 1];
-      console.log('[ACP] Setting proxy environment variables:', proxyUrl);
+      logger.log('[ACP] Setting proxy environment variables:', proxyUrl);
       env['HTTP_PROXY'] = proxyUrl;
       env['HTTPS_PROXY'] = proxyUrl;
       env['http_proxy'] = proxyUrl;
@@ -120,7 +121,7 @@ export class AcpConnection {
       );
     }
 
-    console.log('[ACP] Spawning command:', spawnCommand, spawnArgs.join(' '));
+    logger.log('[ACP] Spawning command:', spawnCommand, spawnArgs.join(' '));
 
     const options: SpawnOptions = {
       cwd: workingDir,
@@ -149,9 +150,9 @@ export class AcpConnection {
         message.toLowerCase().includes('error') &&
         !message.includes('Loaded cached')
       ) {
-        console.error(`[ACP qwen]:`, message);
+        logger.error(`[ACP qwen]:`, message);
       } else {
-        console.log(`[ACP qwen]:`, message);
+        logger.log(`[ACP qwen]:`, message);
       }
     });
 
@@ -160,7 +161,7 @@ export class AcpConnection {
     });
 
     this.child!.on('exit', (code: number | null, signal: string | null) => {
-      console.error(
+      logger.error(
         `[ACP qwen] Process exited with code: ${code}, signal: ${signal}`,
       );
       this.lastExitCode = code;
@@ -214,10 +215,6 @@ export class AcpConnection {
     this.sdkConnection = new ClientSideConnection(
       (_agent: Agent): Client => ({
         sessionUpdate: (params: SessionNotification): Promise<void> => {
-          console.log(
-            '[ACP] >>> Processing session_update:',
-            JSON.stringify(params).substring(0, 300),
-          );
           this.onSessionUpdate(params as unknown as SessionNotification);
           return Promise.resolve();
         },
@@ -248,7 +245,7 @@ export class AcpConnection {
 
               const optionId = response?.optionId;
               const answers = response?.answers;
-              console.log('[ACP] AskUserQuestion response:', optionId);
+              logger.log('[ACP] AskUserQuestion response:', optionId);
 
               let outcome: 'selected' | 'cancelled';
               if (
@@ -275,7 +272,7 @@ export class AcpConnection {
             // Handle regular permission request
             const response = await this.onPermissionRequest(permissionData);
             const optionId = response?.optionId;
-            console.log('[ACP] Permission request:', optionId);
+            logger.log('[ACP] Permission request:', optionId);
             let outcome: 'selected' | 'cancelled';
             if (
               optionId &&
@@ -285,7 +282,7 @@ export class AcpConnection {
             } else {
               outcome = 'selected';
             }
-            console.log('[ACP] Permission outcome:', outcome);
+            logger.log('[ACP] Permission outcome:', outcome);
 
             if (outcome === 'cancelled') {
               return { outcome: { outcome: 'cancelled' } };
@@ -345,7 +342,7 @@ export class AcpConnection {
 
     // Race the SDK initialize against process exit so we don't hang forever
     // if the CLI crashes before responding.
-    console.log('[ACP] Sending initialize request...');
+    logger.log('[ACP] Sending initialize request...');
     const initResponse = await Promise.race([
       this.sdkConnection.initialize({
         protocolVersion: PROTOCOL_VERSION,
@@ -359,21 +356,18 @@ export class AcpConnection {
       processExitPromise,
     ]);
 
-    console.log('[ACP] Initialize successful');
-    console.log('[ACP] Initialization response:', initResponse);
+    logger.log('[ACP] Initialize successful');
+    logger.log('[ACP] Initialization response:', initResponse);
     try {
       this.onInitialized(initResponse);
     } catch (err) {
-      console.warn('[ACP] onInitialized callback error:', err);
+      logger.warn('[ACP] onInitialized callback error:', err);
     }
   }
 
   handleExtNotification(method: string, params: Record<string, unknown>): void {
     if (method === 'authenticate/update') {
-      console.log(
-        '[ACP] >>> Processing authenticate_update:',
-        JSON.stringify(params).substring(0, 300),
-      );
+      logger.log('[ACP] Processing authenticate update');
       this.onAuthenticateUpdate(
         params as unknown as AuthenticateUpdateNotification,
       );
@@ -388,7 +382,7 @@ export class AcpConnection {
         typeof params['source'] === 'string' ? params['source'] : undefined;
       this.onEndTurn(reason, source);
     } else {
-      console.warn(`[ACP] Unhandled extension notification: ${method}`);
+      logger.warn(`[ACP] Unhandled extension notification: ${method}`);
     }
   }
 
@@ -450,24 +444,24 @@ export class AcpConnection {
   async authenticate(methodId?: string): Promise<AuthenticateResponse> {
     const conn = this.ensureConnection();
     const authMethodId = methodId || 'default';
-    console.log(
+    logger.log(
       '[ACP] Sending authenticate request with methodId:',
       authMethodId,
     );
     const response = await conn.authenticate({ methodId: authMethodId });
-    console.log('[ACP] Authenticate successful', response);
+    logger.log('[ACP] Authenticate successful');
     return response;
   }
 
   async newSession(cwd: string = process.cwd()): Promise<NewSessionResponse> {
     const conn = this.ensureConnection();
-    console.log('[ACP] Sending session/new request with cwd:', cwd);
+    logger.log('[ACP] Sending session/new request with cwd:', cwd);
     const response: NewSessionResponse = await conn.newSession({
       cwd,
       mcpServers: [],
     });
     this.sessionId = response.sessionId || null;
-    console.log('[ACP] Session created with ID:', this.sessionId);
+    logger.log('[ACP] Session created with ID:', this.sessionId);
     return response;
   }
 
@@ -524,7 +518,7 @@ export class AcpConnection {
     cwdOverride?: string,
   ): Promise<LoadSessionResponse> {
     const conn = this.ensureConnection();
-    console.log('[ACP] Sending session/load request for session:', sessionId);
+    logger.log('[ACP] Sending session/load request for session:', sessionId);
     const cwd = cwdOverride || this.workingDir;
     try {
       const response = await conn.loadSession({
@@ -532,14 +526,14 @@ export class AcpConnection {
         cwd,
         mcpServers: [],
       });
-      console.log(
+      logger.log(
         '[ACP] Session load succeeded. Response:',
         JSON.stringify(response),
       );
       this.sessionId = sessionId;
       return response;
     } catch (error) {
-      console.error(
+      logger.error(
         '[ACP] Session load request failed:',
         error instanceof Error ? error.message : String(error),
       );
@@ -552,7 +546,7 @@ export class AcpConnection {
     size?: number;
   }): Promise<ListSessionsResponse> {
     const conn = this.ensureConnection();
-    console.log('[ACP] Requesting session list...');
+    logger.log('[ACP] Requesting session list...');
     try {
       const params: Record<string, unknown> = { cwd: this.workingDir };
       if (options?.cursor !== undefined) {
@@ -569,13 +563,13 @@ export class AcpConnection {
       const response = await conn.unstable_listSessions(
         params as Parameters<typeof conn.unstable_listSessions>[0],
       );
-      console.log(
-        '[ACP] Session list response:',
-        JSON.stringify(response).substring(0, 200),
-      );
+      const sessionCount = Array.isArray(response.sessions)
+        ? response.sessions.length
+        : undefined;
+      logger.log('[ACP] Session list response count:', sessionCount);
       return response;
     } catch (error) {
-      console.error('[ACP] Failed to get session list:', error);
+      logger.error('[ACP] Failed to get session list:', error);
       throw error;
     }
   }
@@ -589,7 +583,7 @@ export class AcpConnection {
       });
       return result as { success: boolean };
     } catch (error) {
-      console.error('[ACP] Failed to delete session:', error);
+      logger.error('[ACP] Failed to delete session:', error);
       throw error;
     }
   }
@@ -607,15 +601,15 @@ export class AcpConnection {
       });
       return result as { success: boolean };
     } catch (error) {
-      console.error('[ACP] Failed to rename session:', error);
+      logger.error('[ACP] Failed to rename session:', error);
       throw error;
     }
   }
 
   async switchSession(sessionId: string): Promise<void> {
-    console.log('[ACP] Switching to session:', sessionId);
+    logger.log('[ACP] Switching to session:', sessionId);
     this.sessionId = sessionId;
-    console.log(
+    logger.log(
       '[ACP] Session ID updated locally (switch not supported by CLI)',
     );
   }
@@ -623,12 +617,12 @@ export class AcpConnection {
   async cancelSession(): Promise<void> {
     const conn = this.ensureConnection();
     if (!this.sessionId) {
-      console.warn('[ACP] No active session to cancel');
+      logger.warn('[ACP] No active session to cancel');
       return;
     }
-    console.log('[ACP] Cancelling session:', this.sessionId);
+    logger.log('[ACP] Cancelling session:', this.sessionId);
     await conn.cancel({ sessionId: this.sessionId });
-    console.log('[ACP] Cancel notification sent');
+    logger.log('[ACP] Cancel notification sent');
   }
 
   async setMode(modeId: ApprovalModeValue): Promise<SetSessionModeResponse> {
@@ -636,12 +630,12 @@ export class AcpConnection {
     if (!this.sessionId) {
       throw new Error('No active ACP session');
     }
-    console.log('[ACP] Sending session/set_mode:', modeId);
+    logger.log('[ACP] Sending session/set_mode:', modeId);
     const res = await conn.setSessionMode({
       sessionId: this.sessionId,
       modeId,
     });
-    console.log('[ACP] set_mode response:', res);
+    logger.log('[ACP] set_mode response:', res);
     return res;
   }
 
@@ -668,12 +662,12 @@ export class AcpConnection {
     if (!this.sessionId) {
       throw new Error('No active ACP session');
     }
-    console.log('[ACP] Sending session/set_model:', modelId);
+    logger.log('[ACP] Sending session/set_model:', modelId);
     const res = await conn.unstable_setSessionModel({
       sessionId: this.sessionId,
       modelId,
     });
-    console.log('[ACP] set_model response:', res);
+    logger.log('[ACP] set_model response:', res);
     return res;
   }
 

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -526,10 +526,7 @@ export class AcpConnection {
         cwd,
         mcpServers: [],
       });
-      logger.log(
-        '[ACP] Session load succeeded. Response:',
-        JSON.stringify(response),
-      );
+      logger.log('[ACP] Session load succeeded. Response:', response);
       this.sessionId = sessionId;
       return response;
     } catch (error) {

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -357,7 +357,10 @@ export class AcpConnection {
     ]);
 
     logger.log('[ACP] Initialize successful');
-    logger.log('[ACP] Initialization response:', initResponse);
+    logger.log(
+      '[ACP] Initialization response protocol:',
+      initResponse.protocolVersion,
+    );
     try {
       this.onInitialized(initResponse);
     } catch (err) {
@@ -526,7 +529,7 @@ export class AcpConnection {
         cwd,
         mcpServers: [],
       });
-      logger.log('[ACP] Session load succeeded. Response:', response);
+      logger.log('[ACP] Session load succeeded for session:', sessionId);
       this.sessionId = sessionId;
       return response;
     } catch (error) {

--- a/packages/vscode-ide-companion/src/services/acpFileHandler.ts
+++ b/packages/vscode-ide-companion/src/services/acpFileHandler.ts
@@ -10,6 +10,7 @@
  * Responsible for handling file read and write operations in the ACP protocol
  */
 
+import { logger } from '../utils/logger.js';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getErrorMessage } from '../utils/errorMessage.js';
@@ -36,8 +37,8 @@ export class AcpFileHandler {
     line: number | null;
     limit: number | null;
   }): Promise<{ content: string }> {
-    console.log(`[ACP] fs/read_text_file request received for: ${params.path}`);
-    console.log(`[ACP] Parameters:`, {
+    logger.log(`[ACP] fs/read_text_file request received for: ${params.path}`);
+    logger.log(`[ACP] Parameters:`, {
       line: params.line,
       limit: params.limit,
       sessionId: params.sessionId,
@@ -50,7 +51,7 @@ export class AcpFileHandler {
       // source encoding (UTF-8, GBK, Shift-JIS, etc.).
       const document = await vscode.workspace.openTextDocument(uri);
       const content = document.getText();
-      console.log(
+      logger.log(
         `[ACP] Successfully read file: ${params.path} (${content.length} chars)`,
       );
 
@@ -62,16 +63,16 @@ export class AcpFileHandler {
         const endLine = params.limit ? startLine + params.limit : lines.length;
         const selectedLines = lines.slice(startLine, endLine);
         const result = { content: selectedLines.join('\n') };
-        console.log(`[ACP] Returning ${selectedLines.length} lines`);
+        logger.log(`[ACP] Returning ${selectedLines.length} lines`);
         return result;
       }
 
       const result = { content };
-      console.log(`[ACP] Returning full file content`);
+      logger.log(`[ACP] Returning full file content`);
       return result;
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      console.error(`[ACP] Failed to read file ${params.path}:`, errorMsg);
+      logger.error(`[ACP] Failed to read file ${params.path}:`, errorMsg);
 
       // Detect "file not found" from both Node.js (code === 'ENOENT') and
       // VS Code's FileSystemError.FileNotFound (code === 'FileNotFound').
@@ -110,17 +111,15 @@ export class AcpFileHandler {
     content: string;
     sessionId: string;
   }): Promise<null> {
-    console.log(
-      `[ACP] fs/write_text_file request received for: ${params.path}`,
-    );
-    console.log(`[ACP] Content size: ${params.content.length} bytes`);
+    logger.log(`[ACP] fs/write_text_file request received for: ${params.path}`);
+    logger.log(`[ACP] Content size: ${params.content.length} bytes`);
 
     try {
       const uri = vscode.Uri.file(params.path);
 
       // Ensure the parent directory exists.
       const dirUri = vscode.Uri.file(path.dirname(params.path));
-      console.log(`[ACP] Ensuring directory exists: ${dirUri.fsPath}`);
+      logger.log(`[ACP] Ensuring directory exists: ${dirUri.fsPath}`);
       await vscode.workspace.fs.createDirectory(dirUri);
 
       // Determine whether the file already exists so we can choose the right
@@ -162,11 +161,11 @@ export class AcpFileHandler {
         await vscode.workspace.fs.writeFile(uri, bytes);
       }
 
-      console.log(`[ACP] Successfully wrote file: ${params.path}`);
+      logger.log(`[ACP] Successfully wrote file: ${params.path}`);
       return null;
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      console.error(`[ACP] Failed to write file ${params.path}:`, errorMsg);
+      logger.error(`[ACP] Failed to write file ${params.path}:`, errorMsg);
 
       throw new Error(`Failed to write file '${params.path}': ${errorMsg}`);
     }

--- a/packages/vscode-ide-companion/src/services/conversationStore.ts
+++ b/packages/vscode-ide-companion/src/services/conversationStore.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../utils/logger.js';
 import type * as vscode from 'vscode';
 import type { ChatMessage } from './qwenAgentManager.js';
 
@@ -71,7 +72,7 @@ export class ConversationStore {
     const conversation = conversations.find((c) => c.id === conversationId);
 
     if (!conversation) {
-      console.warn(
+      logger.warn(
         '[ConversationStore] replaceMessages: conversation not found:',
         conversationId,
       );
@@ -98,7 +99,7 @@ export class ConversationStore {
     );
 
     if (sourceIndex < 0) {
-      console.warn(
+      logger.warn(
         '[ConversationStore] renameConversationId: source conversation not found:',
         fromConversationId,
       );
@@ -106,7 +107,7 @@ export class ConversationStore {
     }
 
     if (conversations.some((c) => c.id === toConversationId)) {
-      console.warn(
+      logger.warn(
         '[ConversationStore] renameConversationId: target conversation already exists:',
         toConversationId,
       );
@@ -161,7 +162,7 @@ export class ConversationStore {
     const conversation = conversations.find((c) => c.id === conversationId);
 
     if (!conversation) {
-      console.warn(
+      logger.warn(
         '[ConversationStore] truncateFromUserTurn: conversation not found:',
         conversationId,
       );
@@ -183,7 +184,7 @@ export class ConversationStore {
     }
 
     if (truncateAt < 0) {
-      console.warn(
+      logger.warn(
         '[ConversationStore] truncateFromUserTurn: target turn not found:',
         targetTurnIndex,
       );

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -16,6 +16,7 @@ import {
   type DaemonIdeEvent,
   type DaemonIdeSessionClient,
 } from './daemonIdeConnection.js';
+import { logger } from '../utils/logger.js';
 
 class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
   private events: DaemonIdeEvent[] = [];
@@ -387,7 +388,7 @@ describe('DaemonIdeConnection', () => {
   });
 
   it('cancels permission requests when the handler throws', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const events = new EventQueue();
     const session = createFakeSession(events);
     const connection = new DaemonIdeConnection();
@@ -761,7 +762,7 @@ describe('DaemonIdeConnection', () => {
   });
 
   it('does not advance replay state when permission responses fail', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const events = new EventQueue();
     const session = createFakeSession(events);
     session.respondToPermission.mockRejectedValueOnce(
@@ -807,7 +808,7 @@ describe('DaemonIdeConnection', () => {
   });
 
   it('surfaces event stream failures and normal stream completion', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const failedEvents = new EventQueue();
     failedEvents.fail(new Error('network down'));
     const failedSession = createFakeSession(failedEvents);
@@ -847,7 +848,7 @@ describe('DaemonIdeConnection', () => {
   });
 
   it('continues after handler failures while advancing replay state', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const events = new EventQueue();
     const session = createFakeSession(events);
     const connection = new DaemonIdeConnection();

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -9,6 +9,7 @@
  * shape while replacing the local child process with a qwen serve session.
  */
 
+import { logger } from '../utils/logger.js';
 import type {
   ContentBlock,
   RequestPermissionRequest,
@@ -187,7 +188,7 @@ export class DaemonIdeConnection {
       } catch (previousError) {
         // Let this connect attempt proceed with its own options after the
         // in-flight attempt reports its failure to its caller.
-        console.debug('[DaemonIdeConnection] Previous connect failed:', {
+        logger.debug('[DaemonIdeConnection] Previous connect failed:', {
           error: toSafeErrorMessage(previousError),
         });
       }
@@ -235,7 +236,7 @@ export class DaemonIdeConnection {
   ): Promise<DaemonIdePromptResult> {
     const session = this.ensureSession();
     const promptBlocks = normalizePrompt(prompt);
-    console.debug('[DaemonIdeConnection] Sending prompt:', {
+    logger.debug('[DaemonIdeConnection] Sending prompt:', {
       sessionId: session.sessionId,
     });
     try {
@@ -243,14 +244,14 @@ export class DaemonIdeConnection {
         { prompt: promptBlocks },
         this.eventController?.signal,
       );
-      console.debug('[DaemonIdeConnection] Prompt completed:', {
+      logger.debug('[DaemonIdeConnection] Prompt completed:', {
         sessionId: session.sessionId,
         stopReason: response.stopReason,
       });
       this.onEndTurn(response.stopReason);
       return response;
     } catch (error) {
-      console.warn('[DaemonIdeConnection] Prompt failed:', {
+      logger.warn('[DaemonIdeConnection] Prompt failed:', {
         sessionId: session.sessionId,
         error: toSafeErrorMessage(error),
       });
@@ -264,7 +265,7 @@ export class DaemonIdeConnection {
   async cancelSession(): Promise<void> {
     const session = this.session;
     if (!session) {
-      console.debug(
+      logger.debug(
         '[DaemonIdeConnection] cancelSession ignored without active session',
       );
       return;
@@ -333,7 +334,7 @@ export class DaemonIdeConnection {
         try {
           shouldAdvanceLastSeenEventId = await this.handleEvent(event, signal);
         } catch (error) {
-          console.warn('[DaemonIdeConnection] Event handler failed:', {
+          logger.warn('[DaemonIdeConnection] Event handler failed:', {
             sessionId: session.sessionId,
             eventType: event.type,
             eventId: event.id,
@@ -350,11 +351,11 @@ export class DaemonIdeConnection {
       }
     } catch (error) {
       if (!signal.aborted) {
-        console.warn(
+        logger.warn(
           '[DaemonIdeConnection] Event stream failed:',
           toSafeErrorMessage(error),
         );
-        console.debug('[DaemonIdeConnection] Event stream session:', {
+        logger.debug('[DaemonIdeConnection] Event stream session:', {
           sessionId: session.sessionId,
         });
         this.eventController?.abort();
@@ -383,7 +384,7 @@ export class DaemonIdeConnection {
         this.handleSessionDied(event.data);
         return true;
       default:
-        console.debug('[DaemonIdeConnection] Ignoring daemon event:', {
+        logger.debug('[DaemonIdeConnection] Ignoring daemon event:', {
           sessionId: this.session?.sessionId,
           eventType: event.type,
           eventId: event.id,
@@ -397,7 +398,7 @@ export class DaemonIdeConnection {
     signal: AbortSignal,
   ): Promise<boolean> {
     if (!isPermissionRequestData(data)) {
-      console.warn('[DaemonIdeConnection] Malformed permission request data');
+      logger.warn('[DaemonIdeConnection] Malformed permission request data');
       return true;
     }
 
@@ -405,7 +406,7 @@ export class DaemonIdeConnection {
     const request = data;
     const session = this.session;
     if (!session) {
-      console.warn(
+      logger.warn(
         '[DaemonIdeConnection] Dropping permission request: not connected',
         { requestId },
       );
@@ -419,7 +420,7 @@ export class DaemonIdeConnection {
       return true;
     }
     if (this.session !== session) {
-      console.warn(
+      logger.warn(
         '[DaemonIdeConnection] Permission response dropped: session changed',
         {
           requestId,
@@ -432,17 +433,17 @@ export class DaemonIdeConnection {
     try {
       const accepted = await session.respondToPermission(requestId, response);
       if (!accepted) {
-        console.warn(
+        logger.warn(
           '[DaemonIdeConnection] Permission response rejected by daemon for request:',
           requestId,
         );
-        console.debug('[DaemonIdeConnection] Permission response session:', {
+        logger.debug('[DaemonIdeConnection] Permission response session:', {
           sessionId: session.sessionId,
         });
       }
       return true;
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[DaemonIdeConnection] Permission response failed:',
         toSafeErrorMessage(error),
       );
@@ -460,7 +461,7 @@ export class DaemonIdeConnection {
 
     const responsePromise = this.resolvePermissionResponse(request).catch(
       (error: unknown) => {
-        console.warn(
+        logger.warn(
           '[DaemonIdeConnection] Permission handler failed:',
           toSafeErrorMessage(error),
         );
@@ -509,7 +510,7 @@ export class DaemonIdeConnection {
         askResponse.optionId,
       );
       if (!optionId) {
-        console.warn(
+        logger.warn(
           '[DaemonIdeConnection] AskUserQuestion option not advertised; cancelling',
           {
             requestId: (request as { requestId?: string }).requestId,
@@ -536,7 +537,7 @@ export class DaemonIdeConnection {
 
     const optionId = this.resolvePermissionOptionId(request, response.optionId);
     if (!optionId) {
-      console.warn(
+      logger.warn(
         '[DaemonIdeConnection] Permission option not advertised; cancelling',
         {
           requestId: (request as { requestId?: string }).requestId,
@@ -560,14 +561,14 @@ export class DaemonIdeConnection {
         ? data['sessionId']
         : undefined;
     if (!this.session) {
-      console.debug(
+      logger.debug(
         '[DaemonIdeConnection] session_died received with no active session',
         { eventSessionId },
       );
       return;
     }
     if (eventSessionId === undefined) {
-      console.warn('[DaemonIdeConnection] Malformed session_died event');
+      logger.warn('[DaemonIdeConnection] Malformed session_died event');
       return;
     }
     if (eventSessionId !== this.session.sessionId) {
@@ -578,7 +579,7 @@ export class DaemonIdeConnection {
       isRecord(data) && typeof data['reason'] === 'string'
         ? data['reason']
         : 'session_died';
-    console.debug('[DaemonIdeConnection] Session died:', {
+    logger.debug('[DaemonIdeConnection] Session died:', {
       sessionId: this.session.sessionId,
       reason,
     });
@@ -615,7 +616,7 @@ export class DaemonIdeConnection {
     if (this.session !== session) {
       return;
     }
-    console.debug('[DaemonIdeConnection] Clearing session:', {
+    logger.debug('[DaemonIdeConnection] Clearing session:', {
       sessionId: session.sessionId,
       reason,
     });

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -1087,8 +1087,8 @@ export class QwenAgentManager {
         cwdOverride,
       );
       logger.log(
-        '[QwenAgentManager] Session load succeeded. Response:',
-        response,
+        '[QwenAgentManager] Session load succeeded for session:',
+        sessionId,
       );
       this.applySessionStateFromResult(response);
       this.restoreBaselineSessionStateAfterLoad(response);
@@ -1268,10 +1268,11 @@ export class QwenAgentManager {
         let newSessionResult: unknown;
         // Try to create a new ACP session. If Qwen asks for auth, let it handle authentication.
         try {
-          newSessionResult = await this.connection.newSession(workingDir);
+          const createdSession = await this.connection.newSession(workingDir);
+          newSessionResult = createdSession;
           logger.log(
-            '[QwenAgentManager] newSession returned:',
-            newSessionResult,
+            '[QwenAgentManager] newSession returned session:',
+            createdSession.sessionId,
           );
         } catch (err) {
           const requiresAuth = isAuthenticationRequiredError(err);

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -1088,7 +1088,7 @@ export class QwenAgentManager {
       );
       logger.log(
         '[QwenAgentManager] Session load succeeded. Response:',
-        JSON.stringify(response).substring(0, 200),
+        response,
       );
       this.applySessionStateFromResult(response);
       this.restoreBaselineSessionStateAfterLoad(response);
@@ -1271,7 +1271,7 @@ export class QwenAgentManager {
           newSessionResult = await this.connection.newSession(workingDir);
           logger.log(
             '[QwenAgentManager] newSession returned:',
-            JSON.stringify(newSessionResult, null, 2),
+            newSessionResult,
           );
         } catch (err) {
           const requiresAuth = isAuthenticationRequiredError(err);

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -509,10 +509,6 @@ export class QwenAgentManager {
       const res: unknown = response;
       const items = extractSessionListItems(res);
 
-      logger.log(
-        '[QwenAgentManager] ACP session list item count:',
-        items.length,
-      );
       if (items.length > 0) {
         const sessions = items.map((item) => ({
           id: item.sessionId || item.id,

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -3,6 +3,7 @@
  * Copyright 2025 Qwen Team
  * SPDX-License-Identifier: Apache-2.0
  */
+import { logger } from '../utils/logger.js';
 import { AcpConnection } from './acpConnection.js';
 import type {
   ModelInfo,
@@ -213,7 +214,7 @@ export class QwenAgentManager {
           // the webview can process independently of streaming state.
         }
       } catch (err) {
-        console.warn('[QwenAgentManager] Rehydration routing failed:', err);
+        logger.warn('[QwenAgentManager] Rehydration routing failed:', err);
       }
 
       // Default handling path
@@ -254,7 +255,7 @@ export class QwenAgentManager {
           this.callbacks.onStreamChunk('');
         }
       } catch (err) {
-        console.warn('[QwenAgentManager] onEndTurn callback error:', err);
+        logger.warn('[QwenAgentManager] onEndTurn callback error:', err);
       }
     };
 
@@ -265,7 +266,7 @@ export class QwenAgentManager {
         // Handle authentication update notifications by showing VS Code notification
         handleAuthenticateUpdate(data);
       } catch (err) {
-        console.warn(
+        logger.warn(
           '[QwenAgentManager] onAuthenticateUpdate callback error:',
           err,
         );
@@ -304,7 +305,7 @@ export class QwenAgentManager {
           });
         }
       } catch (err) {
-        console.warn('[QwenAgentManager] onInitialized parse error:', err);
+        logger.warn('[QwenAgentManager] onInitialized parse error:', err);
       }
     };
 
@@ -312,7 +313,7 @@ export class QwenAgentManager {
       code: number | null,
       signal: string | null,
     ) => {
-      console.log(
+      logger.log(
         `[QwenAgentManager] Process disconnected (code: ${code}, signal: ${signal})`,
       );
       this.callbacks.onDisconnected?.(code, signal);
@@ -344,7 +345,7 @@ export class QwenAgentManager {
     // Emit available models from connect result
     if (res.availableModels && res.availableModels.length > 0) {
       this.baselineAvailableModels = res.availableModels;
-      console.log(
+      logger.log(
         '[QwenAgentManager] Emitting availableModels from connect():',
         res.availableModels.map((m) => m.modelId),
       );
@@ -378,7 +379,7 @@ export class QwenAgentManager {
     cliEntryPath: string,
     options?: AgentConnectOptions,
   ): Promise<QwenConnectionResult> {
-    console.log('[QwenAgentManager] Attempting reconnection...');
+    logger.log('[QwenAgentManager] Attempting reconnection...');
     try {
       this.connection.disconnect();
     } catch (_e) {
@@ -420,7 +421,7 @@ export class QwenAgentManager {
       this.callbacks.onModeChanged?.(confirmed);
       return confirmed;
     } catch (err) {
-      console.error('[QwenAgentManager] Failed to set mode:', err);
+      logger.error('[QwenAgentManager] Failed to set mode:', err);
       throw err;
     }
   }
@@ -442,7 +443,7 @@ export class QwenAgentManager {
       this.callbacks.onModelChanged?.(modelInfo);
       return modelInfo;
     } catch (err) {
-      console.error('[QwenAgentManager] Failed to set model:', err);
+      logger.error('[QwenAgentManager] Failed to set model:', err);
       throw err;
     }
   }
@@ -482,7 +483,7 @@ export class QwenAgentManager {
 
       return sessionExists;
     } catch (error) {
-      console.warn('[QwenAgentManager] Session validation failed:', error);
+      logger.warn('[QwenAgentManager] Session validation failed:', error);
       // If we can't validate, assume session is invalid
       return false;
     }
@@ -495,23 +496,21 @@ export class QwenAgentManager {
    * @returns Session list
    */
   async getSessionList(): Promise<Array<Record<string, unknown>>> {
-    console.log(
+    logger.log(
       '[QwenAgentManager] Getting session list with version-aware strategy',
     );
 
     try {
-      console.log(
+      logger.log(
         '[QwenAgentManager] Attempting to get session list via ACP method',
       );
       const response = await this.connection.listSessions();
-      console.log('[QwenAgentManager] ACP session list response:', response);
 
       const res: unknown = response;
       const items = extractSessionListItems(res);
 
-      console.log(
-        '[QwenAgentManager] Sessions retrieved via ACP:',
-        res,
+      logger.log(
+        '[QwenAgentManager] ACP session list item count:',
         items.length,
       );
       if (items.length > 0) {
@@ -528,14 +527,14 @@ export class QwenAgentManager {
           cwd: item.cwd,
         }));
 
-        console.log(
+        logger.log(
           '[QwenAgentManager] Sessions retrieved via ACP:',
           sessions.length,
         );
         return sessions;
       }
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[QwenAgentManager] ACP session list failed, falling back to file system method:',
         error,
       );
@@ -543,9 +542,9 @@ export class QwenAgentManager {
 
     // Always fall back to file system method
     try {
-      console.log('[QwenAgentManager] Getting session list from file system');
+      logger.log('[QwenAgentManager] Getting session list from file system');
       const sessions = await this.sessionReader.getAllSessions(undefined, true);
-      console.log(
+      logger.log(
         '[QwenAgentManager] Session list from file system (all projects):',
         sessions.length,
       );
@@ -565,13 +564,13 @@ export class QwenAgentManager {
         }),
       );
 
-      console.log(
+      logger.log(
         '[QwenAgentManager] Sessions retrieved from file system:',
         result.length,
       );
       return result;
     } catch (error) {
-      console.error(
+      logger.error(
         '[QwenAgentManager] Failed to get session list from file system:',
         error,
       );
@@ -633,7 +632,7 @@ export class QwenAgentManager {
 
       return { sessions: mapped, nextCursor: nextCursorNum, hasMore };
     } catch (error) {
-      console.warn('[QwenAgentManager] Paged ACP session list failed:', error);
+      logger.warn('[QwenAgentManager] Paged ACP session list failed:', error);
       // fall through to file system
     }
 
@@ -670,7 +669,7 @@ export class QwenAgentManager {
       const hasMore = filtered.length > size;
       return { sessions, nextCursor: nextCursorVal, hasMore };
     } catch (error) {
-      console.error('[QwenAgentManager] File system paged list failed:', error);
+      logger.error('[QwenAgentManager] File system paged list failed:', error);
       return { sessions: [], hasMore: false };
     }
   }
@@ -688,7 +687,7 @@ export class QwenAgentManager {
         const item = list.find(
           (s) => s.sessionId === sessionId || s.id === sessionId,
         );
-        console.log(
+        logger.log(
           '[QwenAgentManager] Session list item for filePath lookup:',
           item,
         );
@@ -704,7 +703,7 @@ export class QwenAgentManager {
           return messages;
         }
       } catch (e) {
-        console.warn('[QwenAgentManager] JSONL read path lookup failed:', e);
+        logger.warn('[QwenAgentManager] JSONL read path lookup failed:', e);
       }
 
       // Fallback: legacy JSON session files
@@ -723,10 +722,7 @@ export class QwenAgentManager {
         }),
       );
     } catch (error) {
-      console.error(
-        '[QwenAgentManager] Failed to get session messages:',
-        error,
-      );
+      logger.error('[QwenAgentManager] Failed to get session messages:', error);
       return [];
     }
   }
@@ -739,7 +735,7 @@ export class QwenAgentManager {
       const res = await this.connection.deleteSession(sessionId);
       return res.success;
     } catch (error) {
-      console.error('[QwenAgentManager] Failed to delete session:', error);
+      logger.error('[QwenAgentManager] Failed to delete session:', error);
       return false;
     }
   }
@@ -752,7 +748,7 @@ export class QwenAgentManager {
       const res = await this.connection.renameSession(sessionId, title);
       return res.success;
     } catch (error) {
-      console.error('[QwenAgentManager] Failed to rename session:', error);
+      logger.error('[QwenAgentManager] Failed to rename session:', error);
       return false;
     }
   }
@@ -784,7 +780,7 @@ export class QwenAgentManager {
         }
       }
       // Simple linear reconstruction: filter user/assistant and sort by timestamp
-      console.log(
+      logger.log(
         '[QwenAgentManager] JSONL records read:',
         records.length,
         filePath,
@@ -943,13 +939,13 @@ export class QwenAgentManager {
         // Handle other types if needed
       }
 
-      console.log(
+      logger.log(
         '[QwenAgentManager] JSONL messages reconstructed:',
         msgs.length,
       );
       return msgs;
     } catch (err) {
-      console.warn('[QwenAgentManager] Failed to read JSONL messages:', err);
+      logger.warn('[QwenAgentManager] Failed to read JSONL messages:', err);
       return [];
     }
   }
@@ -1082,11 +1078,11 @@ export class QwenAgentManager {
     try {
       // Route upcoming session/update messages as discrete messages for replay
       this.rehydratingSessionId = sessionId;
-      console.log(
+      logger.log(
         '[QwenAgentManager] Rehydration start for session:',
         sessionId,
       );
-      console.log(
+      logger.log(
         '[QwenAgentManager] Attempting session/load via ACP for session:',
         sessionId,
       );
@@ -1094,7 +1090,7 @@ export class QwenAgentManager {
         sessionId,
         cwdOverride,
       );
-      console.log(
+      logger.log(
         '[QwenAgentManager] Session load succeeded. Response:',
         JSON.stringify(response).substring(0, 200),
       );
@@ -1104,12 +1100,12 @@ export class QwenAgentManager {
       return response;
     } catch (error) {
       const errorMessage = getErrorMessage(error);
-      console.error(
+      logger.error(
         '[QwenAgentManager] Session load via ACP failed for session:',
         sessionId,
       );
-      console.error('[QwenAgentManager] Error type:', error?.constructor?.name);
-      console.error('[QwenAgentManager] Error message:', errorMessage);
+      logger.error('[QwenAgentManager] Error type:', error?.constructor?.name);
+      logger.error('[QwenAgentManager] Error message:', errorMessage);
 
       // Check if error is from ACP response
       if (error && typeof error === 'object') {
@@ -1119,24 +1115,24 @@ export class QwenAgentManager {
             error?: { code?: number; message?: string };
           };
           if (acpError.error) {
-            console.error(
+            logger.error(
               '[QwenAgentManager] ACP error code:',
               acpError.error.code,
             );
-            console.error(
+            logger.error(
               '[QwenAgentManager] ACP error message:',
               acpError.error.message,
             );
           }
         } else {
-          console.error('[QwenAgentManager] Non-ACPIf error details:', error);
+          logger.error('[QwenAgentManager] Non-ACPIf error details:', error);
         }
       }
 
       throw error;
     } finally {
       // End rehydration routing regardless of outcome
-      console.log('[QwenAgentManager] Rehydration end for session:', sessionId);
+      logger.log('[QwenAgentManager] Rehydration end for session:', sessionId);
       this.rehydratingSessionId = null;
     }
   }
@@ -1149,22 +1145,22 @@ export class QwenAgentManager {
    * @returns Loaded session messages or null
    */
   async loadSession(sessionId: string): Promise<ChatMessage[] | null> {
-    console.log(
+    logger.log(
       '[QwenAgentManager] Loading session with version-aware strategy:',
       sessionId,
     );
 
     try {
-      console.log(
+      logger.log(
         '[QwenAgentManager] Attempting to load session via ACP method',
       );
       await this.loadSessionViaAcp(sessionId);
-      console.log('[QwenAgentManager] Session loaded successfully via ACP');
+      logger.log('[QwenAgentManager] Session loaded successfully via ACP');
 
       // After loading via ACP, we still need to get messages from file system
       // In future, we might get them directly from the ACP response
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[QwenAgentManager] ACP session load failed, falling back to file system method:',
         error,
       );
@@ -1172,16 +1168,16 @@ export class QwenAgentManager {
 
     // Always fall back to file system method
     try {
-      console.log(
+      logger.log(
         '[QwenAgentManager] Loading session messages from file system',
       );
       const messages = await this.loadSessionMessagesFromFile(sessionId);
-      console.log(
+      logger.log(
         '[QwenAgentManager] Session messages loaded successfully from file system',
       );
       return messages;
     } catch (error) {
-      console.error(
+      logger.error(
         '[QwenAgentManager] Failed to load session messages from file system:',
         error,
       );
@@ -1199,7 +1195,7 @@ export class QwenAgentManager {
     sessionId: string,
   ): Promise<ChatMessage[] | null> {
     try {
-      console.log(
+      logger.log(
         '[QwenAgentManager] Loading session from file system:',
         sessionId,
       );
@@ -1211,7 +1207,7 @@ export class QwenAgentManager {
       );
 
       if (!session) {
-        console.log(
+        logger.log(
           '[QwenAgentManager] Session not found in file system:',
           sessionId,
         );
@@ -1227,7 +1223,7 @@ export class QwenAgentManager {
 
       return messages;
     } catch (error) {
-      console.error(
+      logger.error(
         '[QwenAgentManager] Session load from file system failed:',
         error,
       );
@@ -1252,7 +1248,7 @@ export class QwenAgentManager {
     // Reuse the current session for implicit session bootstrap paths.
     // Explicit "new session" actions must bypass this and call session/new.
     if (!forceNew && this.connection.currentSessionId) {
-      console.log(
+      logger.log(
         '[QwenAgentManager] createNewSession: reusing existing session',
         this.connection.currentSessionId,
       );
@@ -1260,7 +1256,7 @@ export class QwenAgentManager {
     }
     // Deduplicate concurrent session/new attempts
     if (this.sessionCreateInFlight) {
-      console.log(
+      logger.log(
         '[QwenAgentManager] createNewSession: session creation already in flight',
       );
       if (!forceNew) {
@@ -1269,7 +1265,7 @@ export class QwenAgentManager {
       await this.sessionCreateInFlight;
     }
 
-    console.log('[QwenAgentManager] Creating new session...');
+    logger.log('[QwenAgentManager] Creating new session...');
 
     this.sessionCreateInFlight = (async () => {
       try {
@@ -1277,7 +1273,7 @@ export class QwenAgentManager {
         // Try to create a new ACP session. If Qwen asks for auth, let it handle authentication.
         try {
           newSessionResult = await this.connection.newSession(workingDir);
-          console.log(
+          logger.log(
             '[QwenAgentManager] newSession returned:',
             JSON.stringify(newSessionResult, null, 2),
           );
@@ -1286,25 +1282,25 @@ export class QwenAgentManager {
 
           if (requiresAuth) {
             if (!autoAuthenticate) {
-              console.warn(
+              logger.warn(
                 '[QwenAgentManager] session/new requires authentication but auto-auth is disabled. Deferring until user logs in.',
               );
               throw err;
             }
-            console.warn(
+            logger.warn(
               '[QwenAgentManager] session/new requires authentication. Retrying with authenticate...',
             );
             try {
               // Let CLI handle authentication - it's the single source of truth
               await this.connection.authenticate(authMethod);
-              console.log(
+              logger.log(
                 '[QwenAgentManager] createNewSession Authentication successful. Retrying session/new...',
               );
               // Add a slight delay to ensure auth state is settled
               await new Promise((resolve) => setTimeout(resolve, 300));
               newSessionResult = await this.connection.newSession(workingDir);
             } catch (reauthErr) {
-              console.error(
+              logger.error(
                 '[QwenAgentManager] Re-authentication failed:',
                 reauthErr,
               );
@@ -1318,7 +1314,7 @@ export class QwenAgentManager {
         this.applySessionStateFromResult(newSessionResult);
 
         const newSessionId = this.connection.currentSessionId;
-        console.log(
+        logger.log(
           '[QwenAgentManager] New session created with ID:',
           newSessionId,
         );
@@ -1344,7 +1340,7 @@ export class QwenAgentManager {
    * Cancel current prompt
    */
   async cancelCurrentPrompt(): Promise<void> {
-    console.log('[QwenAgentManager] Cancelling current prompt');
+    logger.log('[QwenAgentManager] Cancelling current prompt');
     await this.connection.cancelSession();
   }
 

--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -165,8 +165,10 @@ export class QwenConnectionHandler {
             '[QwenAgentManager] Session creation requires authentication; waiting for user-triggered login.',
           );
         } else {
-          logger.log(`\n⚠️ [SESSION FAILED] newSessionWithRetry threw error\n`);
-          logger.log(`[QwenAgentManager] Error details:`, sessionError);
+          logger.error(
+            `\n⚠️ [SESSION FAILED] newSessionWithRetry threw error\n`,
+          );
+          logger.error(`[QwenAgentManager] Error details:`, sessionError);
           throw sessionError;
         }
       }

--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -10,6 +10,7 @@
  * Handles Qwen Agent connection establishment, authentication, and session creation
  */
 
+import { logger } from '../utils/logger.js';
 import * as vscode from 'vscode';
 import type { AcpConnection } from './acpConnection.js';
 import { isAuthenticationRequiredError } from '../utils/authErrors.js';
@@ -57,7 +58,7 @@ export class QwenConnectionHandler {
     },
   ): Promise<QwenConnectionResult> {
     const connectId = Date.now();
-    console.log(`[QwenAgentManager] 🚀 CONNECT() CALLED - ID: ${connectId}`);
+    logger.log(`[QwenAgentManager] 🚀 CONNECT() CALLED - ID: ${connectId}`);
     const autoAuthenticate = options?.autoAuthenticate ?? true;
     let sessionCreated = false;
     let requiresAuth = false;
@@ -79,7 +80,7 @@ export class QwenConnectionHandler {
       httpConfig.get<string>('proxy') || httpConfig.get<string>('https.proxy');
     if (proxyUrl) {
       extraArgs.push('--proxy', proxyUrl);
-      console.log(
+      logger.log(
         '[QwenAgentManager] Using proxy from VSCode settings:',
         proxyUrl,
       );
@@ -90,14 +91,14 @@ export class QwenConnectionHandler {
     const maxConnectAttempts = 3;
     for (let attempt = 1; attempt <= maxConnectAttempts; attempt++) {
       try {
-        console.log(
+        logger.log(
           `[QwenAgentManager] Connecting to ACP process (attempt ${attempt}/${maxConnectAttempts})...`,
         );
         await connection.connect(cliEntryPath!, workingDir, extraArgs);
-        console.log('[QwenAgentManager] ACP process connected successfully');
+        logger.log('[QwenAgentManager] ACP process connected successfully');
         break;
       } catch (connectError) {
-        console.error(
+        logger.error(
           `[QwenAgentManager] Connect attempt ${attempt} failed:`,
           getErrorMessage(connectError),
         );
@@ -105,7 +106,7 @@ export class QwenConnectionHandler {
           throw connectError;
         }
         const delay = Math.min(1000 * Math.pow(2, attempt - 1), 4000);
-        console.log(`[QwenAgentManager] Retrying connect in ${delay}ms...`);
+        logger.log(`[QwenAgentManager] Retrying connect in ${delay}ms...`);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
@@ -118,12 +119,12 @@ export class QwenConnectionHandler {
 
     // Create new session if unable to restore
     if (!sessionRestored) {
-      console.log(
+      logger.log(
         '[QwenAgentManager] no sessionRestored, Creating new session...',
       );
 
       try {
-        console.log(
+        logger.log(
           '[QwenAgentManager] Creating new session (letting CLI handle authentication)...',
         );
         const newSessionResult = await this.newSessionWithRetry(
@@ -143,7 +144,7 @@ export class QwenConnectionHandler {
           modelState.availableModels.length > 0
         ) {
           availableModels = modelState.availableModels;
-          console.log(
+          logger.log(
             '[QwenAgentManager] Extracted availableModels from session/new:',
             availableModels.map((m) => m.modelId),
           );
@@ -152,7 +153,7 @@ export class QwenConnectionHandler {
         currentModeId = modeState?.currentModeId;
         availableModes = modeState?.availableModes;
 
-        console.log('[QwenAgentManager] New session created successfully');
+        logger.log('[QwenAgentManager] New session created successfully');
         sessionCreated = true;
       } catch (sessionError) {
         const needsAuth =
@@ -160,14 +161,12 @@ export class QwenConnectionHandler {
           isAuthenticationRequiredError(sessionError);
         if (needsAuth) {
           requiresAuth = true;
-          console.log(
+          logger.log(
             '[QwenAgentManager] Session creation requires authentication; waiting for user-triggered login.',
           );
         } else {
-          console.log(
-            `\n⚠️ [SESSION FAILED] newSessionWithRetry threw error\n`,
-          );
-          console.log(`[QwenAgentManager] Error details:`, sessionError);
+          logger.log(`\n⚠️ [SESSION FAILED] newSessionWithRetry threw error\n`);
+          logger.log(`[QwenAgentManager] Error details:`, sessionError);
           throw sessionError;
         }
       }
@@ -175,9 +174,9 @@ export class QwenConnectionHandler {
       sessionCreated = true;
     }
 
-    console.log(`\n========================================`);
-    console.log(`[QwenAgentManager] ✅ CONNECT() COMPLETED SUCCESSFULLY`);
-    console.log(`========================================\n`);
+    logger.log(`\n========================================`);
+    logger.log(`[QwenAgentManager] ✅ CONNECT() COMPLETED SUCCESSFULLY`);
+    logger.log(`========================================\n`);
     return {
       sessionCreated,
       requiresAuth,
@@ -206,16 +205,16 @@ export class QwenConnectionHandler {
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        console.log(
+        logger.log(
           `[QwenAgentManager] Creating session (attempt ${attempt}/${maxRetries})...`,
         );
         const res = await connection.newSession(workingDir);
-        console.log('[QwenAgentManager] Session created successfully');
+        logger.log('[QwenAgentManager] Session created successfully');
         return res;
       } catch (error) {
         lastError = error;
         const errorMessage = getErrorMessage(error);
-        console.error(
+        logger.error(
           `[QwenAgentManager] Session creation attempt ${attempt} failed:`,
           errorMessage,
         );
@@ -225,12 +224,12 @@ export class QwenConnectionHandler {
         const requiresAuth = isAuthenticationRequiredError(error);
         if (requiresAuth) {
           if (!autoAuthenticate) {
-            console.log(
+            logger.log(
               '[QwenAgentManager] Authentication required but auto-authentication is disabled. Propagating error.',
             );
             throw error;
           }
-          console.log(
+          logger.log(
             '[QwenAgentManager] Qwen requires authentication. Authenticating and retrying session/new...',
           );
           try {
@@ -239,17 +238,17 @@ export class QwenConnectionHandler {
             // newSession may cause the cli authorization jump to be triggered again
             // Add a slight delay to ensure auth state is settled
             await new Promise((resolve) => setTimeout(resolve, 300));
-            console.log(
+            logger.log(
               '[QwenAgentManager] newSessionWithRetry Authentication successful',
             );
             // Retry immediately after successful auth
             const res = await connection.newSession(workingDir);
-            console.log(
+            logger.log(
               '[QwenAgentManager] Session created successfully after auth',
             );
             return res;
           } catch (authErr) {
-            console.error(
+            logger.error(
               '[QwenAgentManager] Re-authentication failed:',
               authErr,
             );
@@ -262,7 +261,7 @@ export class QwenConnectionHandler {
         }
 
         const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
-        console.log(`[QwenAgentManager] Retrying in ${delay}ms...`);
+        logger.log(`[QwenAgentManager] Retrying in ${delay}ms...`);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }

--- a/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../utils/logger.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -59,17 +60,17 @@ export class QwenSessionManager {
       const filePath = path.join(sessionDir, filename);
 
       if (!fs.existsSync(filePath)) {
-        console.log(`[QwenSessionManager] Session file not found: ${filePath}`);
+        logger.log(`[QwenSessionManager] Session file not found: ${filePath}`);
         return null;
       }
 
       const content = fs.readFileSync(filePath, 'utf-8');
       const session = JSON.parse(content) as QwenSession;
 
-      console.log(`[QwenSessionManager] Session loaded: ${filePath}`);
+      logger.log(`[QwenSessionManager] Session loaded: ${filePath}`);
       return session;
     } catch (error) {
-      console.error('[QwenSessionManager] Failed to load session:', error);
+      logger.error('[QwenSessionManager] Failed to load session:', error);
       return null;
     }
   }
@@ -102,7 +103,7 @@ export class QwenSessionManager {
           const session = JSON.parse(content) as QwenSession;
           sessions.push(session);
         } catch (error) {
-          console.error(
+          logger.error(
             `[QwenSessionManager] Failed to read session file ${file}:`,
             error,
           );
@@ -117,7 +118,7 @@ export class QwenSessionManager {
 
       return sessions;
     } catch (error) {
-      console.error('[QwenSessionManager] Failed to list sessions:', error);
+      logger.error('[QwenSessionManager] Failed to list sessions:', error);
       return [];
     }
   }
@@ -137,13 +138,13 @@ export class QwenSessionManager {
 
       if (fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
-        console.log(`[QwenSessionManager] Session deleted: ${filePath}`);
+        logger.log(`[QwenSessionManager] Session deleted: ${filePath}`);
         return true;
       }
 
       return false;
     } catch (error) {
-      console.error('[QwenSessionManager] Failed to delete session:', error);
+      logger.error('[QwenSessionManager] Failed to delete session:', error);
       return false;
     }
   }

--- a/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../utils/logger.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
@@ -71,7 +72,7 @@ export class QwenSessionReader {
         // All projects
         const tmpDir = path.join(this.runtimeDir, 'tmp');
         if (!fs.existsSync(tmpDir)) {
-          console.log('[QwenSessionReader] Tmp directory not found:', tmpDir);
+          logger.log('[QwenSessionReader] Tmp directory not found:', tmpDir);
           return [];
         }
 
@@ -91,7 +92,7 @@ export class QwenSessionReader {
 
       return sessions;
     } catch (error) {
-      console.error('[QwenSessionReader] Failed to get sessions:', error);
+      logger.error('[QwenSessionReader] Failed to get sessions:', error);
       return [];
     }
   }
@@ -124,7 +125,7 @@ export class QwenSessionReader {
         session.filePath = filePath;
         sessions.push(session);
       } catch (error) {
-        console.error(
+        logger.error(
           '[QwenSessionReader] Failed to read session file:',
           filePath,
           error,
@@ -141,7 +142,7 @@ export class QwenSessionReader {
           sessions.push(session);
         }
       } catch (error) {
-        console.error(
+        logger.error(
           '[QwenSessionReader] Failed to read JSONL session file:',
           filePath,
           error,
@@ -313,10 +314,7 @@ export class QwenSessionReader {
         cwd,
       };
     } catch (error) {
-      console.error(
-        '[QwenSessionReader] Failed to parse JSONL session:',
-        error,
-      );
+      logger.error('[QwenSessionReader] Failed to parse JSONL session:', error);
       return null;
     }
   }
@@ -405,7 +403,7 @@ export class QwenSessionReader {
       fs.unlinkSync(session.filePath);
       return true;
     } catch (error) {
-      console.error('[QwenSessionReader] Failed to delete session:', error);
+      logger.error('[QwenSessionReader] Failed to delete session:', error);
       return false;
     }
   }
@@ -450,7 +448,7 @@ export class QwenSessionReader {
       fs.appendFileSync(session.filePath, record + '\n');
       return true;
     } catch (error) {
-      console.error('[QwenSessionReader] Failed to rename session:', error);
+      logger.error('[QwenSessionReader] Failed to rename session:', error);
       return false;
     }
   }

--- a/packages/vscode-ide-companion/src/services/qwenSessionUpdateHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionUpdateHandler.ts
@@ -241,7 +241,10 @@ export class QwenSessionUpdateHandler {
       }
 
       default:
-        logger.log('[QwenAgentManager] Unhandled session update type');
+        logger.log(
+          '[SessionUpdateHandler] Unhandled session update type:',
+          sessionUpdate,
+        );
         break;
     }
   }

--- a/packages/vscode-ide-companion/src/services/qwenSessionUpdateHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionUpdateHandler.ts
@@ -10,6 +10,7 @@
  * Handles session updates from ACP and dispatches them to appropriate callbacks
  */
 
+import { logger } from '../utils/logger.js';
 import type {
   SessionNotification,
   AvailableCommand,
@@ -49,10 +50,6 @@ export class QwenSessionUpdateHandler {
   handleSessionUpdate(data: SessionNotification): void {
     const update = data.update;
     const sessionUpdate = (update as { sessionUpdate?: string }).sessionUpdate;
-    console.log(
-      '[SessionUpdateHandler] Processing update type:',
-      sessionUpdate,
-    );
 
     switch (sessionUpdate) {
       case 'user_message_chunk': {
@@ -115,7 +112,7 @@ export class QwenSessionUpdateHandler {
             this.callbacks.onThoughtChunk(text);
           } else if (this.callbacks.onStreamChunk) {
             // Fallback to regular stream processing
-            console.log(
+            logger.log(
               '[SessionUpdateHandler] 🧠 Falling back to onStreamChunk',
             );
             this.callbacks.onStreamChunk(text);
@@ -212,7 +209,7 @@ export class QwenSessionUpdateHandler {
             this.callbacks.onModeChanged(modeId);
           }
         } catch (err) {
-          console.warn(
+          logger.warn(
             '[SessionUpdateHandler] Failed to handle mode update',
             err,
           );
@@ -235,7 +232,7 @@ export class QwenSessionUpdateHandler {
             this.callbacks.onAvailableSkills(meta?.availableSkills ?? []);
           }
         } catch (err) {
-          console.warn(
+          logger.warn(
             '[SessionUpdateHandler] Failed to handle available commands update',
             err,
           );
@@ -244,7 +241,7 @@ export class QwenSessionUpdateHandler {
       }
 
       default:
-        console.log('[QwenAgentManager] Unhandled session update type');
+        logger.log('[QwenAgentManager] Unhandled session update type');
         break;
     }
   }

--- a/packages/vscode-ide-companion/src/services/readonlyFileSystemProvider.ts
+++ b/packages/vscode-ide-companion/src/services/readonlyFileSystemProvider.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../utils/logger.js';
 import * as vscode from 'vscode';
 
 /**
@@ -27,7 +28,7 @@ export class ReadonlyFileSystemProvider
   constructor() {
     // Ensure only one instance exists
     if (ReadonlyFileSystemProvider.instance !== null) {
-      console.warn(
+      logger.warn(
         '[ReadonlyFileSystemProvider] Instance already exists, replacing with new instance',
       );
     }

--- a/packages/vscode-ide-companion/src/services/settingsWriter.ts
+++ b/packages/vscode-ide-companion/src/services/settingsWriter.ts
@@ -7,6 +7,7 @@
  * Handles bidirectional sync between VSCode Settings and ~/.qwen/settings.json.
  */
 
+import { logger } from '../utils/logger.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
@@ -190,7 +191,7 @@ function readSettings(): Record<string, unknown> {
     // caller's catch will see this; refusing to overwrite a malformed file
     // is the whole point — better than silently destroying user state by
     // treating it as `{}`.
-    console.error(
+    logger.error(
       `[settingsWriter] Failed to parse ${settingsPath}; refusing to overwrite a malformed file.`,
       err,
     );
@@ -568,7 +569,7 @@ export function snapshotSettingsForRollback(): Record<string, unknown> | null {
     // Log only the error's class name (not its message) — consistent with the
     // providerMatchesCredentials guard, so the security stance holds even
     // though this catch is filesystem errors rather than user-defined fns.
-    console.warn(
+    logger.warn(
       '[settingsWriter] snapshotSettingsForRollback failed; credential rollback disabled:',
       err instanceof Error ? err.constructor.name : typeof err,
     );
@@ -604,7 +605,7 @@ export function readQwenSettingsForVSCode(): QwenSettingsForVSCode | null {
   try {
     settings = readSettings();
   } catch (error) {
-    console.error(
+    logger.error(
       '[settingsWriter] readQwenSettingsForVSCode failed; returning null:',
       error,
     );
@@ -723,7 +724,7 @@ export function clearPersistedAuth(): void {
 
     writeSettings(settings);
   } catch (error) {
-    console.error(
+    logger.error(
       '[settingsWriter] Failed to clear persisted auth credentials:',
       error,
     );

--- a/packages/vscode-ide-companion/src/utils/logger.test.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.test.ts
@@ -43,9 +43,9 @@ describe('logger', () => {
 
   it('redacts credentials from the final rendered line', () => {
     const { appendLine, outputChannel } = createOutputChannel();
-    const log = createLogger(outputChannel, redactLogCredentials);
+    createLogger(outputChannel, redactLogCredentials);
 
-    log(
+    logger.info(
       'ACP stderr:',
       new Error('Authorization: Bearer live-token-1234567890'),
     );

--- a/packages/vscode-ide-companion/src/utils/logger.test.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type * as vscode from 'vscode';
 import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
-import { createLogger, logger, resetLoggerSink } from './logger.js';
+import { createLogger, isLogLevel, logger, resetLoggerSink } from './logger.js';
 
 function createOutputChannel() {
   const appendLine = vi.fn();
@@ -64,5 +64,27 @@ describe('logger', () => {
     logger.warn('late shutdown warning');
 
     expect(warn).toHaveBeenCalledWith('late shutdown warning');
+  });
+
+  it('guards log levels from webview messages', () => {
+    expect(isLogLevel('error')).toBe(true);
+    expect(isLogLevel('trace')).toBe(false);
+    expect(isLogLevel(undefined)).toBe(false);
+  });
+
+  it('falls back to console when the output channel write fails', () => {
+    const outputChannel = {
+      appendLine: vi.fn(() => {
+        throw new Error('disposed');
+      }),
+    } as unknown as vscode.OutputChannel;
+    const error = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    createLogger(outputChannel);
+
+    logger.error('late failure');
+
+    expect(error).toHaveBeenCalledWith('late failure');
   });
 });

--- a/packages/vscode-ide-companion/src/utils/logger.test.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
+import { createLogger, logger, resetLoggerSink } from './logger.js';
+
+function createOutputChannel() {
+  const appendLine = vi.fn();
+  return {
+    appendLine,
+    outputChannel: { appendLine } as unknown as vscode.OutputChannel,
+  };
+}
+
+describe('logger', () => {
+  afterEach(() => {
+    resetLoggerSink();
+  });
+
+  it('formats errors and objects without exposing sensitive fields', () => {
+    const { appendLine, outputChannel } = createOutputChannel();
+    createLogger(outputChannel);
+    const details: Record<string, unknown> = {
+      apiKey: 'secret',
+      count: 2n,
+    };
+    details['self'] = details;
+
+    logger.error('Request failed:', new Error('boom'), details);
+
+    const line = vi.mocked(appendLine).mock.calls[0][0] as string;
+    expect(line).toContain('[ERROR] Request failed: Error: boom');
+    expect(line).toContain('"apiKey":"<redacted>"');
+    expect(line).toContain('"count":"2n"');
+    expect(line).toContain('"self":"[Circular]"');
+    expect(line).not.toContain('secret');
+  });
+
+  it('redacts credentials from the final rendered line', () => {
+    const { appendLine, outputChannel } = createOutputChannel();
+    const log = createLogger(outputChannel, redactLogCredentials);
+
+    log(
+      'ACP stderr:',
+      new Error('Authorization: Bearer live-token-1234567890'),
+    );
+
+    const line = vi.mocked(appendLine).mock.calls[0][0] as string;
+    expect(line).toContain('Authorization: <redacted>');
+    expect(line).not.toContain('live-token-1234567890');
+  });
+
+  it('restores console logging when the output channel is disposed', () => {
+    const { outputChannel } = createOutputChannel();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    createLogger(outputChannel);
+
+    resetLoggerSink();
+    logger.warn('late shutdown warning');
+
+    expect(warn).toHaveBeenCalledWith('late shutdown warning');
+  });
+});

--- a/packages/vscode-ide-companion/src/utils/logger.test.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.test.ts
@@ -64,6 +64,7 @@ describe('logger', () => {
     logger.warn('late shutdown warning');
 
     expect(warn).toHaveBeenCalledWith('late shutdown warning');
+    warn.mockRestore();
   });
 
   it('guards log levels from webview messages', () => {

--- a/packages/vscode-ide-companion/src/utils/logger.test.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.test.ts
@@ -72,7 +72,7 @@ describe('logger', () => {
     expect(isLogLevel(undefined)).toBe(false);
   });
 
-  it('falls back to console when the output channel write fails', () => {
+  it('falls back to sanitized console output when the channel write fails', () => {
     const outputChannel = {
       appendLine: vi.fn(() => {
         throw new Error('disposed');
@@ -81,10 +81,18 @@ describe('logger', () => {
     const error = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
-    createLogger(outputChannel);
+    createLogger(outputChannel, redactLogCredentials);
 
-    logger.error('late failure');
+    logger.error('late failure', {
+      apiKey: 'secret',
+      error: new Error('Authorization: Bearer live-token-1234567890'),
+    });
 
-    expect(error).toHaveBeenCalledWith('late failure');
+    const line = vi.mocked(error).mock.calls[0][0] as string;
+    expect(line).toContain('[ERROR] late failure');
+    expect(line).toContain('"apiKey":"<redacted>"');
+    expect(line).toContain('Authorization: <redacted>');
+    expect(line).not.toContain('secret');
+    expect(line).not.toContain('live-token-1234567890');
   });
 });

--- a/packages/vscode-ide-companion/src/utils/logger.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.ts
@@ -90,6 +90,10 @@ export function createLogger(
 ): void {
   sink = (level, args) => {
     const label = level === 'log' ? 'INFO' : level.toUpperCase();
-    outputChannel.appendLine(sanitize(`[${label}] ${formatLogArgs(args)}`));
+    try {
+      outputChannel.appendLine(sanitize(`[${label}] ${formatLogArgs(args)}`));
+    } catch {
+      globalThis.console[level](...args);
+    }
   };
 }

--- a/packages/vscode-ide-companion/src/utils/logger.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.ts
@@ -90,10 +90,11 @@ export function createLogger(
 ): void {
   sink = (level, args) => {
     const label = level === 'log' ? 'INFO' : level.toUpperCase();
+    const line = sanitize(`[${label}] ${formatLogArgs(args)}`);
     try {
-      outputChannel.appendLine(sanitize(`[${label}] ${formatLogArgs(args)}`));
+      outputChannel.appendLine(line);
     } catch {
-      globalThis.console[level](...args);
+      globalThis.console[level](line);
     }
   };
 }

--- a/packages/vscode-ide-companion/src/utils/logger.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.ts
@@ -4,15 +4,105 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
+
+export type LogLevel = 'debug' | 'error' | 'info' | 'log' | 'warn';
+
+type LogSink = (level: LogLevel, args: unknown[]) => void;
+
+const sensitiveKeys = new Set([
+  'accesstoken',
+  'apikey',
+  'authorization',
+  'cookie',
+  'password',
+  'refreshtoken',
+  'secret',
+  'token',
+]);
+
+const defaultSink: LogSink = (level, args) => {
+  globalThis.console[level](...args);
+};
+
+let sink = defaultSink;
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
+  }
+
+  const seen = new WeakSet<object>();
+  try {
+    return (
+      JSON.stringify(value, (key, nestedValue: unknown) => {
+        const normalizedKey = key.replace(/[-_]/g, '').toLowerCase();
+        if (sensitiveKeys.has(normalizedKey)) {
+          return '<redacted>';
+        }
+        if (typeof nestedValue === 'bigint') {
+          return `${nestedValue}n`;
+        }
+        if (nestedValue instanceof Error) {
+          return nestedValue.stack ?? nestedValue.message;
+        }
+        if (typeof nestedValue === 'object' && nestedValue !== null) {
+          if (seen.has(nestedValue)) {
+            return '[Circular]';
+          }
+          seen.add(nestedValue);
+        }
+        return nestedValue;
+      }) ?? String(value)
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatLogArgs(args: unknown[]): string {
+  return args.map(formatValue).join(' ');
+}
+
+export function isLogLevel(value: unknown): value is LogLevel {
+  return (
+    value === 'debug' ||
+    value === 'error' ||
+    value === 'info' ||
+    value === 'log' ||
+    value === 'warn'
+  );
+}
+
+function setLoggerSink(nextSink: LogSink): void {
+  sink = nextSink;
+}
+
+export function resetLoggerSink(): void {
+  sink = defaultSink;
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => sink('debug', args),
+  error: (...args: unknown[]) => sink('error', args),
+  info: (...args: unknown[]) => sink('info', args),
+  log: (...args: unknown[]) => sink('log', args),
+  warn: (...args: unknown[]) => sink('warn', args),
+};
 
 export function createLogger(
-  context: vscode.ExtensionContext,
-  logger: vscode.OutputChannel,
+  outputChannel: vscode.OutputChannel,
+  sanitize: (message: string) => string = (message) => message,
 ) {
-  return (message: string) => {
-    if (context.extensionMode === vscode.ExtensionMode.Development) {
-      logger.appendLine(message);
-    }
+  setLoggerSink((level, args) => {
+    const label = level === 'log' ? 'INFO' : level.toUpperCase();
+    outputChannel.appendLine(sanitize(`[${label}] ${formatLogArgs(args)}`));
+  });
+
+  return (...args: unknown[]) => {
+    logger.info(...args);
   };
 }

--- a/packages/vscode-ide-companion/src/utils/logger.ts
+++ b/packages/vscode-ide-companion/src/utils/logger.ts
@@ -6,7 +6,8 @@
 
 import type * as vscode from 'vscode';
 
-export type LogLevel = 'debug' | 'error' | 'info' | 'log' | 'warn';
+export const LOG_LEVELS = ['debug', 'error', 'info', 'log', 'warn'] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
 
 type LogSink = (level: LogLevel, args: unknown[]) => void;
 
@@ -68,17 +69,7 @@ export function formatLogArgs(args: unknown[]): string {
 }
 
 export function isLogLevel(value: unknown): value is LogLevel {
-  return (
-    value === 'debug' ||
-    value === 'error' ||
-    value === 'info' ||
-    value === 'log' ||
-    value === 'warn'
-  );
-}
-
-function setLoggerSink(nextSink: LogSink): void {
-  sink = nextSink;
+  return LOG_LEVELS.includes(value as LogLevel);
 }
 
 export function resetLoggerSink(): void {
@@ -96,13 +87,9 @@ export const logger = {
 export function createLogger(
   outputChannel: vscode.OutputChannel,
   sanitize: (message: string) => string = (message) => message,
-) {
-  setLoggerSink((level, args) => {
+): void {
+  sink = (level, args) => {
     const label = level === 'log' ? 'INFO' : level.toUpperCase();
     outputChannel.appendLine(sanitize(`[${label}] ${formatLogArgs(args)}`));
-  });
-
-  return (...args: unknown[]) => {
-    logger.info(...args);
   };
 }

--- a/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import { getErrorMessage } from '../../utils/errorMessage.js';
@@ -48,10 +49,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
         break;
 
       default:
-        console.warn(
-          '[AuthMessageHandler] Unknown message type:',
-          message.type,
-        );
+        logger.warn('[AuthMessageHandler] Unknown message type:', message.type);
         break;
     }
   }
@@ -85,7 +83,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
       });
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      console.error('[AuthMessageHandler] getAccountInfo failed:', error);
+      logger.error('[AuthMessageHandler] getAccountInfo failed:', error);
       this.sendToWebView({
         type: 'accountInfo',
         data: { error: errorMsg },
@@ -217,7 +215,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
 
       const provider = ALL_PROVIDERS.find((p) => p.id === selectedId);
       if (!provider) {
-        console.error('[AuthMessageHandler] Provider not found:', selectedId);
+        logger.error('[AuthMessageHandler] Provider not found:', selectedId);
         return;
       }
 
@@ -225,7 +223,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
       await this.runProviderSetupFlow(provider);
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      console.error('[AuthMessageHandler] auth failed:', error);
+      logger.error('[AuthMessageHandler] auth failed:', error);
       this.sendToWebView({
         type: 'authError',
         data: { message: `Auth failed: ${errorMsg}` },
@@ -409,7 +407,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
 
     // Submit
     if (!this.authInteractiveHandler) {
-      console.error(
+      logger.error(
         '[AuthMessageHandler] authInteractiveHandler not set; cannot apply provider config.',
       );
       // No authCancelled — see the base-URL validation note above.

--- a/packages/vscode-ide-companion/src/webview/handlers/EditorMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/EditorMessageHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import { getFileName } from '../utils/webviewUtils.js';
@@ -29,7 +30,7 @@ export class EditorMessageHandler extends BaseMessageHandler {
         break;
 
       default:
-        console.warn(
+        logger.warn(
           '[EditorMessageHandler] Unknown message type:',
           message.type,
         );
@@ -68,7 +69,7 @@ export class EditorMessageHandler extends BaseMessageHandler {
         });
       }
     } catch (error) {
-      console.error(
+      logger.error(
         '[EditorMessageHandler] Failed to get active editor:',
         error,
       );
@@ -102,7 +103,7 @@ export class EditorMessageHandler extends BaseMessageHandler {
         }
       }
     } catch (error) {
-      console.error(
+      logger.error(
         '[EditorMessageHandler] Failed to focus active editor:',
         error,
       );

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import { getFileName } from '../utils/webviewUtils.js';
@@ -96,7 +97,7 @@ export class FileMessageHandler extends BaseMessageHandler {
       return this.fileSearchInstances.get(rootPath) ?? null;
     } catch (error) {
       this.fileSearchInitializing.delete(rootPath);
-      console.error(
+      logger.error(
         '[FileMessageHandler] Failed to initialize file search:',
         error,
       );
@@ -117,7 +118,7 @@ export class FileMessageHandler extends BaseMessageHandler {
       // Already gone or never had a worker; nothing actionable here.
     });
     crawlCache.clear();
-    console.log(
+    logger.log(
       '[FileMessageHandler] Cleared file search cache, trigger:',
       rootPath,
     );
@@ -229,10 +230,7 @@ export class FileMessageHandler extends BaseMessageHandler {
         break;
 
       default:
-        console.warn(
-          '[FileMessageHandler] Unknown message type:',
-          message.type,
-        );
+        logger.warn('[FileMessageHandler] Unknown message type:', message.type);
         break;
     }
   }
@@ -264,7 +262,7 @@ export class FileMessageHandler extends BaseMessageHandler {
         });
       }
     } catch (error) {
-      console.error('[FileMessageHandler] Failed to attach file:', error);
+      logger.error('[FileMessageHandler] Failed to attach file:', error);
       const errorMsg = getErrorMessage(error);
       this.sendToWebView({
         type: 'error',
@@ -347,7 +345,7 @@ export class FileMessageHandler extends BaseMessageHandler {
         }
       }
     } catch (error) {
-      console.error(
+      logger.error(
         '[FileMessageHandler] Failed to show context picker:',
         error,
       );
@@ -367,7 +365,7 @@ export class FileMessageHandler extends BaseMessageHandler {
     requestId?: number,
   ): Promise<void> {
     try {
-      console.log('[FileMessageHandler] handleGetWorkspaceFiles start', {
+      logger.log('[FileMessageHandler] handleGetWorkspaceFiles start', {
         query,
         requestId,
       });
@@ -428,7 +426,7 @@ export class FileMessageHandler extends BaseMessageHandler {
 
       // Search or show recent files
       if (query) {
-        console.log(
+        logger.log(
           '[FileMessageHandler] Searching workspace files with fuzzy search for query',
           query,
         );
@@ -491,12 +489,12 @@ export class FileMessageHandler extends BaseMessageHandler {
             type: 'workspaceFiles',
             data: { files, query, requestId },
           });
-          console.log(
+          logger.log(
             '[FileMessageHandler] Sent initial workspaceFiles (open tabs/active)',
             files.length,
           );
         } catch (e) {
-          console.warn(
+          logger.warn(
             '[FileMessageHandler] Failed sending initial response',
             e,
           );
@@ -523,12 +521,12 @@ export class FileMessageHandler extends BaseMessageHandler {
         type: 'workspaceFiles',
         data: { files, query, requestId },
       });
-      console.log(
+      logger.log(
         '[FileMessageHandler] Sent final workspaceFiles',
         files.length,
       );
     } catch (error) {
-      console.error(
+      logger.error(
         '[FileMessageHandler] Failed to get workspace files:',
         error,
       );
@@ -545,18 +543,18 @@ export class FileMessageHandler extends BaseMessageHandler {
    */
   private async handleOpenFile(filePath?: string): Promise<void> {
     if (!filePath) {
-      console.warn('[FileMessageHandler] No path provided for openFile');
+      logger.warn('[FileMessageHandler] No path provided for openFile');
       return;
     }
 
     try {
-      console.log('[FileOperations] Opening file:', filePath);
+      logger.log('[FileOperations] Opening file:', filePath);
 
       // Parse file path, line number, and column number
       // Formats: path/to/file.ts, path/to/file.ts:123, path/to/file.ts:123:45
       const match = filePath.match(/^(.+?)(?::(\d+))?(?::(\d+))?$/);
       if (!match) {
-        console.warn('[FileOperations] Invalid file path format:', filePath);
+        logger.warn('[FileOperations] Invalid file path format:', filePath);
         return;
       }
 
@@ -592,9 +590,9 @@ export class FileMessageHandler extends BaseMessageHandler {
         );
       }
 
-      console.log('[FileOperations] File opened successfully:', absolutePath);
+      logger.log('[FileOperations] File opened successfully:', absolutePath);
     } catch (error) {
-      console.error('[FileMessageHandler] Failed to open file:', error);
+      logger.error('[FileMessageHandler] Failed to open file:', error);
       vscode.window.showErrorMessage(
         `Failed to open file: ${getErrorMessage(error)}`,
       );
@@ -608,7 +606,7 @@ export class FileMessageHandler extends BaseMessageHandler {
     data: Record<string, unknown> | undefined,
   ): Promise<void> {
     if (!data) {
-      console.warn('[FileMessageHandler] No data provided for openDiff');
+      logger.warn('[FileMessageHandler] No data provided for openDiff');
       return;
     }
 
@@ -619,7 +617,7 @@ export class FileMessageHandler extends BaseMessageHandler {
         newText: (data.newText as string) || '',
       });
     } catch (error) {
-      console.error('[FileMessageHandler] Failed to open diff:', error);
+      logger.error('[FileMessageHandler] Failed to open diff:', error);
       vscode.window.showErrorMessage(
         `Failed to open diff: ${getErrorMessage(error)}`,
       );
@@ -633,7 +631,7 @@ export class FileMessageHandler extends BaseMessageHandler {
     data: Record<string, unknown> | undefined,
   ): Promise<void> {
     if (!data) {
-      console.warn(
+      logger.warn(
         '[FileMessageHandler] No data provided for createAndOpenTempFile',
       );
       return;
@@ -647,7 +645,7 @@ export class FileMessageHandler extends BaseMessageHandler {
       const readonlyProvider = ReadonlyFileSystemProvider.getInstance();
       if (!readonlyProvider) {
         const errorMessage = 'Readonly file system provider not initialized';
-        console.error('[FileMessageHandler]', errorMessage);
+        logger.error('[FileMessageHandler]', errorMessage);
         this.sendToWebView({
           type: 'error',
           data: { message: errorMessage },
@@ -686,7 +684,7 @@ export class FileMessageHandler extends BaseMessageHandler {
           showOptions.viewColumn = existingViewColumn;
         }
         await vscode.window.showTextDocument(document, showOptions);
-        console.log(
+        logger.log(
           '[FileMessageHandler] Focused on existing readonly file:',
           uri.toString(),
           'in viewColumn:',
@@ -710,14 +708,14 @@ export class FileMessageHandler extends BaseMessageHandler {
         preserveFocus: false,
       });
 
-      console.log(
+      logger.log(
         '[FileMessageHandler] Created and opened readonly file:',
         uri.toString(),
         'in viewColumn:',
         targetViewColumn ?? 'Beside',
       );
     } catch (error) {
-      console.error(
+      logger.error(
         '[FileMessageHandler] Failed to create and open temporary file:',
         error,
       );

--- a/packages/vscode-ide-companion/src/webview/handlers/MessageRouter.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/MessageRouter.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import type * as vscode from 'vscode';
 import type { IMessageHandler } from './BaseMessageHandler.js';
 import type { QwenAgentManager } from '../../services/qwenAgentManager.js';
@@ -89,7 +90,7 @@ export class MessageRouter {
    * Route message to appropriate handler
    */
   async route(message: { type: string; data?: unknown }): Promise<void> {
-    console.log('[MessageRouter] Routing message:', message.type);
+    logger.log('[MessageRouter] Routing message:', message.type);
 
     // Handle permission response specially
     if (message.type === 'permissionResponse') {
@@ -114,11 +115,11 @@ export class MessageRouter {
       try {
         await handler.handle(message);
       } catch (error) {
-        console.error('[MessageRouter] Handler error:', error);
+        logger.error('[MessageRouter] Handler error:', error);
         throw error;
       }
     } else {
-      console.warn(
+      logger.warn(
         '[MessageRouter] No handler found for message type:',
         message.type,
       );

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import type { ChatMessage } from '../../services/qwenAgentManager.js';
@@ -169,7 +170,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
             initialModelId: modelId,
           });
         } catch (error) {
-          console.error(
+          logger.error(
             '[SessionMessageHandler] Failed to open new chat tab:',
             error,
           );
@@ -203,7 +204,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         break;
 
       default:
-        console.warn(
+        logger.warn(
           '[SessionMessageHandler] Unknown message type:',
           message.type,
         );
@@ -290,7 +291,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       snapshot.messages,
     );
     if (!restored) {
-      console.warn(
+      logger.warn(
         '[SessionMessageHandler] Failed to restore conversation snapshot; conversation not found:',
         snapshot.id,
       );
@@ -416,7 +417,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         return match.cwd;
       }
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[SessionMessageHandler] Failed to resolve export session cwd:',
         error,
       );
@@ -464,7 +465,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       });
     } catch (error) {
       const errorMsg = this.getErrorMessage(error);
-      console.error('[SessionMessageHandler] Failed to export session:', error);
+      logger.error('[SessionMessageHandler] Failed to export session:', error);
       this.sendToWebView({
         type: 'error',
         data: { message: `Failed to export session: ${errorMsg}` },
@@ -493,14 +494,17 @@ export class SessionMessageHandler extends BaseMessageHandler {
     attachments?: ImageAttachment[],
     editTargetTurnIndex?: number,
   ): Promise<void> {
-    console.log('[SessionMessageHandler] handleSendMessage called with:', text);
+    logger.log('[SessionMessageHandler] handleSendMessage called', {
+      textLength: text.length,
+      attachmentCount: attachments?.length ?? 0,
+    });
     // Guard: do not process empty or whitespace-only messages.
     // This prevents ghost user-message bubbles when slash-command completions
     // or model-selector interactions clear the input but still trigger a submit.
     const trimmedText = stripZeroWidthSpaces(text).trim();
     const hasAttachments = (attachments?.length ?? 0) > 0;
     if (!trimmedText && !hasAttachments) {
-      console.warn('[SessionMessageHandler] Ignoring empty message');
+      logger.warn('[SessionMessageHandler] Ignoring empty message');
       return;
     }
 
@@ -546,7 +550,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
     if (hasAttachments && !trimmedText && savedImageCount === 0) {
       const errorMsg =
         'Failed to attach the pasted image. Nothing was sent. Please paste the image again.';
-      console.warn('[SessionMessageHandler]', errorMsg);
+      logger.warn('[SessionMessageHandler]', errorMsg);
       vscode.window.showErrorMessage(errorMsg);
       this.sendToWebView({
         type: 'error',
@@ -557,7 +561,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
 
     // Ensure we have an active conversation
     if (!this.currentConversationId) {
-      console.log(
+      logger.log(
         '[SessionMessageHandler] No active conversation, creating one...',
       );
       try {
@@ -569,7 +573,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         });
       } catch (error) {
         const errorMsg = `Failed to create conversation: ${this.getErrorMessage(error)}`;
-        console.error('[SessionMessageHandler]', errorMsg);
+        logger.error('[SessionMessageHandler]', errorMsg);
         vscode.window.showErrorMessage(errorMsg);
         this.sendToWebView({
           type: 'error',
@@ -582,7 +586,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
     if (!this.currentConversationId) {
       const errorMsg =
         'Failed to create conversation. Please restart the extension.';
-      console.error('[SessionMessageHandler]', errorMsg);
+      logger.error('[SessionMessageHandler]', errorMsg);
       vscode.window.showErrorMessage(errorMsg);
       this.sendToWebView({
         type: 'error',
@@ -599,7 +603,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
     if (editTargetTurnIndex !== undefined) {
       if (!Number.isInteger(editTargetTurnIndex) || editTargetTurnIndex < 0) {
         const errorMsg = 'Invalid message edit target.';
-        console.error('[SessionMessageHandler]', errorMsg, editTargetTurnIndex);
+        logger.error('[SessionMessageHandler]', errorMsg, editTargetTurnIndex);
         this.sendToWebView({
           type: 'error',
           data: { message: errorMsg },
@@ -620,7 +624,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
           const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
           await this.agentManager.createNewSession(workingDir);
         } catch (createErr) {
-          console.error(
+          logger.error(
             '[SessionMessageHandler] Failed to create session before editing message:',
             createErr,
           );
@@ -643,7 +647,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
           this.currentConversationId,
         );
       } catch (error) {
-        console.error(
+        logger.error(
           '[SessionMessageHandler] Failed to capture edit restore snapshot:',
           error,
         );
@@ -657,7 +661,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       }
 
       if (!editRestoreSnapshot) {
-        console.warn(
+        logger.warn(
           '[SessionMessageHandler] Local conversation snapshot missing before edit; continuing with ACP rewind only.',
         );
       }
@@ -690,7 +694,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
               editAcpHistorySnapshot,
             );
           } catch (restoreError) {
-            console.warn(
+            logger.warn(
               '[SessionMessageHandler] Failed to restore ACP history after rewind failure:',
               restoreError,
             );
@@ -700,7 +704,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
           await this.restoreConversationSnapshot(editRestoreSnapshot);
         }
         const errorMsg = this.getErrorMessage(error);
-        console.error(
+        logger.error(
           '[SessionMessageHandler] Failed to rewind session:',
           error,
         );
@@ -724,7 +728,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         );
         isFirstMessage = !conversation || conversation.messages.length === 0;
       } catch (error) {
-        console.error(
+        logger.error(
           '[SessionMessageHandler] Failed to check conversation:',
           error,
         );
@@ -756,7 +760,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         userMessage,
       );
     } catch (error) {
-      console.error(
+      logger.error(
         '[SessionMessageHandler] Failed to save user message:',
         error,
       );
@@ -765,7 +769,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         try {
           await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
         } catch (restoreError) {
-          console.warn(
+          logger.warn(
             '[SessionMessageHandler] Failed to restore ACP history after user message save failure:',
             restoreError,
           );
@@ -792,7 +796,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
 
     // Check if agent is connected
     if (!this.agentManager.isConnected) {
-      console.warn('[SessionMessageHandler] Agent not connected');
+      logger.warn('[SessionMessageHandler] Agent not connected');
 
       // Show non-modal notification with Configure button
       await this.promptAuth(
@@ -808,7 +812,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
         await this.agentManager.createNewSession(workingDir);
       } catch (createErr) {
-        console.error(
+        logger.error(
           '[SessionMessageHandler] Failed to create session before sending message:',
           createErr,
         );
@@ -878,7 +882,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
             acpSessionId,
           );
           if (!renamed) {
-            console.warn(
+            logger.warn(
               '[SessionMessageHandler] Failed to align conversation store with ACP session id:',
               previousConversationId,
               acpSessionId,
@@ -898,13 +902,13 @@ export class SessionMessageHandler extends BaseMessageHandler {
         });
       }
     } catch (error) {
-      console.error('[SessionMessageHandler] Error sending message:', error);
+      logger.error('[SessionMessageHandler] Error sending message:', error);
 
       if (editAcpMutationApplied && editAcpHistorySnapshot) {
         try {
           await this.agentManager.restoreSessionHistory(editAcpHistorySnapshot);
         } catch (restoreError) {
-          console.warn(
+          logger.warn(
             '[SessionMessageHandler] Failed to restore ACP history after send failure:',
             restoreError,
           );
@@ -958,7 +962,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         if (isTimeoutError) {
           // Note: session_prompt no longer has a timeout, so this should rarely occur
           // This path may still be hit for other methods (initialize, etc.) or network-level timeouts
-          console.warn(
+          logger.warn(
             '[SessionMessageHandler] Request timed out; suppressing popup',
           );
 
@@ -993,7 +997,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
    */
   private async handleNewQwenSession(): Promise<void> {
     try {
-      console.log('[SessionMessageHandler] Creating new Qwen session...');
+      logger.log('[SessionMessageHandler] Creating new Qwen session...');
 
       // Ensure connection (auth) before creating a new session
       if (!this.agentManager.isConnected) {
@@ -1019,7 +1023,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       // Reset title flag when creating a new session
       this.isTitleSet = false;
     } catch (error) {
-      console.error(
+      logger.error(
         '[SessionMessageHandler] Failed to create new session:',
         error,
       );
@@ -1052,7 +1056,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
    */
   private async handleSwitchQwenSession(sessionId: string): Promise<void> {
     try {
-      console.log('[SessionMessageHandler] Switching to session:', sessionId);
+      logger.log('[SessionMessageHandler] Switching to session:', sessionId);
 
       // If not connected yet, offer to authenticate or view offline
       if (!this.agentManager.isConnected) {
@@ -1097,7 +1101,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
               s.id === sessionId || s.sessionId === sessionId,
           ) || null;
       } catch (err) {
-        console.log(
+        logger.log(
           '[SessionMessageHandler] Could not get session details:',
           err,
         );
@@ -1119,7 +1123,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
           sessionId,
           (sessionDetails?.cwd as string | undefined) || undefined,
         );
-        console.log(
+        logger.log(
           '[SessionMessageHandler] session/load succeeded (per ACP spec result is null; actual history comes via session/update):',
           loadResponse,
         );
@@ -1136,7 +1140,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         // Successfully loaded session, return early to avoid fallback logic
         return;
       } catch (loadError) {
-        console.warn(
+        logger.warn(
           '[SessionMessageHandler] session/load failed, using fallback:',
           loadError,
         );
@@ -1199,7 +1203,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
               );
             }
           } catch (createError) {
-            console.error(
+            logger.error(
               '[SessionMessageHandler] Failed to create session:',
               createError,
             );
@@ -1240,7 +1244,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         }
       }
     } catch (error) {
-      console.error('[SessionMessageHandler] Failed to switch session:', error);
+      logger.error('[SessionMessageHandler] Failed to switch session:', error);
 
       // Safely convert error to string
       const errorMsg = this.getErrorMessage(error);
@@ -1289,7 +1293,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
         },
       });
     } catch (error) {
-      console.error('[SessionMessageHandler] Failed to get sessions:', error);
+      logger.error('[SessionMessageHandler] Failed to get sessions:', error);
 
       // Safely convert error to string
       const errorMsg = this.getErrorMessage(error);
@@ -1319,7 +1323,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
    */
   private async handleCancelStreaming(): Promise<void> {
     try {
-      console.log('[SessionMessageHandler] Canceling streaming...');
+      logger.log('[SessionMessageHandler] Canceling streaming...');
 
       // Cancel the current streaming operation in the agent manager
       await this.agentManager.cancelCurrentPrompt();
@@ -1327,9 +1331,9 @@ export class SessionMessageHandler extends BaseMessageHandler {
       // Use sendStreamEnd to include requestId for proper correlation
       this.sendStreamEnd('user_cancelled');
 
-      console.log('[SessionMessageHandler] Streaming cancelled successfully');
+      logger.log('[SessionMessageHandler] Streaming cancelled successfully');
     } catch (_error) {
-      console.log('[SessionMessageHandler] Streaming cancelled (interrupted)');
+      logger.log('[SessionMessageHandler] Streaming cancelled (interrupted)');
 
       // Use sendStreamEnd (with duplicate guard) to include requestId
       this.sendStreamEnd('user_cancelled');
@@ -1400,7 +1404,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
 
       await this.handleGetQwenSessions();
     } catch (error) {
-      console.error('[SessionMessageHandler] Failed to resume session:', error);
+      logger.error('[SessionMessageHandler] Failed to resume session:', error);
 
       // Safely convert error to string
       const errorMsg = this.getErrorMessage(error);
@@ -1528,7 +1532,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       await this.agentManager.setApprovalModeFromUi(modeId);
       // No explicit response needed; WebView listens for modeChanged
     } catch (error) {
-      console.error('[SessionMessageHandler] Failed to set mode:', error);
+      logger.error('[SessionMessageHandler] Failed to set mode:', error);
       const errorMsg = this.getErrorMessage(error);
       this.sendToWebView({
         type: 'error',
@@ -1550,7 +1554,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       // Defensive guard: refuse non-runtime Qwen OAuth models in case the UI
       // is bypassed (programmatic call, stale webview, restored session).
       if (isDiscontinuedModel(modelId)) {
-        console.warn(
+        logger.warn(
           '[SessionMessageHandler] Rejected discontinued model',
           modelId,
         );
@@ -1568,7 +1572,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       );
     } catch (error) {
       const errorMsg = this.getErrorMessage(error);
-      console.error('[SessionMessageHandler] Failed to set model:', error);
+      logger.error('[SessionMessageHandler] Failed to set model:', error);
       vscode.window.showErrorMessage(`Failed to switch model: ${errorMsg}`);
       this.sendToWebView({
         type: 'error',

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('initializeWebviewLogger', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('forwards webview logs to the extension host', async () => {
+    const postMessage = vi.fn();
+    vi.stubGlobal('console', {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    });
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+    const { initializeWebviewLogger } = await import('./useVSCode.js');
+
+    initializeWebviewLogger();
+    console.error('Bundled WebUI failure');
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'log',
+      data: {
+        level: 'error',
+        message: 'Bundled WebUI failure',
+      },
+    });
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
@@ -8,6 +8,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('initializeWebviewLogger', () => {
   afterEach(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        __qwenWebviewLoggerInitialized?: boolean;
+      }
+    ).__qwenWebviewLoggerInitialized;
     vi.unstubAllGlobals();
     vi.resetModules();
   });
@@ -65,5 +70,28 @@ describe('initializeWebviewLogger', () => {
 
     expect(() => console.warn('late warning')).not.toThrow();
     expect(warn).toHaveBeenCalledWith('late warning');
+  });
+
+  it('does not stack console wrappers when initialized twice', async () => {
+    const postMessage = vi.fn();
+    vi.stubGlobal('console', {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    });
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+    const { initializeWebviewLogger } = await import('./useVSCode.js');
+
+    initializeWebviewLogger();
+    initializeWebviewLogger();
+    console.log('only once');
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
@@ -41,4 +41,29 @@ describe('initializeWebviewLogger', () => {
       },
     });
   });
+
+  it('keeps console calls alive when log forwarding fails', async () => {
+    const postMessage = vi.fn(() => {
+      throw new Error('disposed');
+    });
+    vi.stubGlobal('console', {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    });
+    const warn = vi.mocked(console.warn);
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+    const { initializeWebviewLogger } = await import('./useVSCode.js');
+
+    initializeWebviewLogger();
+
+    expect(() => console.warn('late warning')).not.toThrow();
+    expect(warn).toHaveBeenCalledWith('late warning');
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.test.ts
@@ -21,6 +21,7 @@ describe('initializeWebviewLogger', () => {
       log: vi.fn(),
       warn: vi.fn(),
     });
+    const error = vi.mocked(console.error);
     vi.stubGlobal('acquireVsCodeApi', () => ({
       postMessage,
       getState: vi.fn(),
@@ -31,6 +32,7 @@ describe('initializeWebviewLogger', () => {
     initializeWebviewLogger();
     console.error('Bundled WebUI failure');
 
+    expect(error).toHaveBeenCalledWith('Bundled WebUI failure');
     expect(postMessage).toHaveBeenCalledWith({
       type: 'log',
       data: {

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { formatLogArgs, type LogLevel } from '../../utils/logger.js';
+import {
+  formatLogArgs,
+  LOG_LEVELS,
+  type LogLevel,
+} from '../../utils/logger.js';
 
 export interface VSCodeAPI {
   postMessage: (message: unknown) => void;
@@ -59,8 +63,7 @@ export function initializeWebviewLogger(): void {
       data: { level, message: formatLogArgs(args) },
     });
   };
-  const levels: LogLevel[] = ['debug', 'error', 'info', 'log', 'warn'];
-  for (const level of levels) {
+  for (const level of LOG_LEVELS) {
     globalThis.console[level] = (...args: unknown[]) => postLog(level, args);
   }
 }

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { formatLogArgs, type LogLevel } from '../../utils/logger.js';
+
 export interface VSCodeAPI {
   postMessage: (message: unknown) => void;
   getState: () => unknown;
@@ -43,6 +45,24 @@ function getVSCodeAPI(): VSCodeAPI {
     },
   };
   return vscodeApiInstance;
+}
+
+export function initializeWebviewLogger(): void {
+  if (typeof acquireVsCodeApi === 'undefined') {
+    return;
+  }
+
+  const vscode = getVSCodeAPI();
+  const postLog = (level: LogLevel, args: unknown[]) => {
+    vscode.postMessage({
+      type: 'log',
+      data: { level, message: formatLogArgs(args) },
+    });
+  };
+  const levels: LogLevel[] = ['debug', 'error', 'info', 'log', 'warn'];
+  for (const level of levels) {
+    globalThis.console[level] = (...args: unknown[]) => postLog(level, args);
+  }
 }
 
 /**

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
@@ -67,7 +67,11 @@ export function initializeWebviewLogger(): void {
     const original = globalThis.console[level].bind(globalThis.console);
     globalThis.console[level] = (...args: unknown[]) => {
       original(...args);
-      postLog(level, args);
+      try {
+        postLog(level, args);
+      } catch {
+        // Logging must not crash the webview caller.
+      }
     };
   }
 }

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
@@ -55,6 +55,13 @@ export function initializeWebviewLogger(): void {
   if (typeof acquireVsCodeApi === 'undefined') {
     return;
   }
+  const state = globalThis as typeof globalThis & {
+    __qwenWebviewLoggerInitialized?: boolean;
+  };
+  if (state.__qwenWebviewLoggerInitialized) {
+    return;
+  }
+  state.__qwenWebviewLoggerInitialized = true;
 
   const vscode = getVSCodeAPI();
   const postLog = (level: LogLevel, args: unknown[]) => {

--- a/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useVSCode.ts
@@ -64,7 +64,11 @@ export function initializeWebviewLogger(): void {
     });
   };
   for (const level of LOG_LEVELS) {
-    globalThis.console[level] = (...args: unknown[]) => postLog(level, args);
+    const original = globalThis.console[level].bind(globalThis.console);
+    globalThis.console[level] = (...args: unknown[]) => {
+      original(...args);
+      postLog(level, args);
+    };
   }
 }
 

--- a/packages/vscode-ide-companion/src/webview/index.tsx
+++ b/packages/vscode-ide-companion/src/webview/index.tsx
@@ -7,6 +7,7 @@
 import ReactDOM from 'react-dom/client';
 import { App } from './App.js';
 import { VSCodePlatformProvider } from './context/VSCodePlatformProvider.js';
+import { initializeWebviewLogger } from './hooks/useVSCode.js';
 
 // Import webui shared styles (CSS variables, component styles)
 import '@qwen-code/webui/styles.css';
@@ -16,6 +17,8 @@ import '@qwen-code/webui/styles.css';
 import './styles/tailwind.css';
 // eslint-disable-next-line import/no-internal-modules
 import './styles/App.css';
+
+initializeWebviewLogger();
 
 const container = document.getElementById('root');
 if (container) {

--- a/packages/vscode-ide-companion/src/webview/providers/PanelManager.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/PanelManager.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as vscode from 'vscode';
 import { Storage } from '@qwen-code/qwen-code-core';
 
@@ -52,7 +53,7 @@ export class PanelManager {
    * Set Panel (for restoration)
    */
   setPanel(panel: vscode.WebviewPanel): void {
-    console.log('[PanelManager] Setting panel for restoration');
+    logger.log('[PanelManager] Setting panel for restoration');
     this.panel = panel;
   }
 
@@ -70,7 +71,7 @@ export class PanelManager {
 
     if (existingGroup) {
       // If Qwen Code webview already exists in a locked group, create the new panel in that same group
-      console.log(
+      logger.log(
         '[PanelManager] Found existing Qwen Code group, creating panel in same group',
       );
       this.panel = vscode.window.createWebviewPanel(
@@ -94,7 +95,7 @@ export class PanelManager {
         // Create a new group to the right of the current active group
         await vscode.commands.executeCommand('workbench.action.newGroupRight');
       } catch (error) {
-        console.warn(
+        logger.warn(
           '[PanelManager] Failed to create right editor group (continuing):',
           error,
         );
@@ -175,7 +176,7 @@ export class PanelManager {
           input.viewType === 'mainThreadWebview-qwenCode.chat'
         ) {
           // Found an existing Qwen Code tab
-          console.log('[PanelManager] Found existing Qwen Code group:', {
+          logger.log('[PanelManager] Found existing Qwen Code group:', {
             viewColumn: group.viewColumn,
             tabCount: group.tabs.length,
             isActive: group.isActive,
@@ -207,9 +208,9 @@ export class PanelManager {
       // The newly created panel is focused (preserveFocus: false), so this
       // locks the correct, active editor group.
       await vscode.commands.executeCommand('workbench.action.lockEditorGroup');
-      console.log('[PanelManager] Group locked after panel creation');
+      logger.log('[PanelManager] Group locked after panel creation');
     } catch (error) {
-      console.warn('[PanelManager] Failed to lock editor group:', error);
+      logger.warn('[PanelManager] Failed to lock editor group:', error);
     }
   }
 
@@ -336,7 +337,7 @@ export class PanelManager {
                       'workbench.action.removeActiveEditorGroup',
                     );
                   } catch (err) {
-                    console.warn(
+                    logger.warn(
                       '[PanelManager] Failed to close empty group after Qwen panel disposed:',
                       err,
                     );
@@ -344,7 +345,7 @@ export class PanelManager {
                 }
               }
             } catch (err) {
-              console.warn(
+              logger.warn(
                 '[PanelManager] Error while trying to close empty Qwen group:',
                 err,
               );

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -584,7 +584,7 @@ describe('WebViewProvider.attachToView', () => {
     const { messageHandler } = await setupAttachedProvider({
       captureMessageHandler: true,
     });
-    const message = `render failed\n${'x'.repeat(9_000)}`;
+    const message = `render failed\n${'x'.repeat(10_000)}`;
 
     await messageHandler?.({
       type: 'log',
@@ -593,7 +593,7 @@ describe('WebViewProvider.attachToView', () => {
 
     expect(error).toHaveBeenCalledWith(
       '[Webview]',
-      message.replace('\n', '\\n'),
+      `${message.slice(0, 10_000)}...[truncated]`.replace('\n', '\\n'),
     );
   });
 

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -355,6 +355,7 @@ import {
   truncatePanelTitle,
   MAX_PANEL_TITLE_LENGTH,
 } from '../utils/panelTitleUtils.js';
+import { logger } from '../../utils/logger.js';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -576,6 +577,24 @@ describe('WebViewProvider.attachToView', () => {
       type: 'copyToClipboardResult',
       data: { requestId: 'copy-1', success: true },
     });
+  });
+
+  it('writes webview log messages through the extension host logger', async () => {
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const { messageHandler } = await setupAttachedProvider({
+      captureMessageHandler: true,
+    });
+    const message = `render failed\n${'x'.repeat(9_000)}`;
+
+    await messageHandler?.({
+      type: 'log',
+      data: { level: 'error', message },
+    });
+
+    expect(error).toHaveBeenCalledWith(
+      '[Webview]',
+      message.replace('\n', '\\n'),
+    );
   });
 
   it('reports clipboard copy failures back to the requesting webview', async () => {

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -595,6 +595,7 @@ describe('WebViewProvider.attachToView', () => {
       '[Webview]',
       `${message.slice(0, 10_000)}...[truncated]`.replace('\n', '\\n'),
     );
+    error.mockRestore();
   });
 
   it('reports clipboard copy failures back to the requesting webview', async () => {

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -45,6 +45,7 @@ import { isLogLevel, logger } from '../../utils/logger.js';
 
 /** Threshold (ms) before a completed task triggers a notification. */
 const LONG_TASK_THRESHOLD_MS = 20_000;
+const MAX_WEBVIEW_LOG_LENGTH = 10_000;
 
 /** Possible tab-dot colours. */
 const DotColor = {
@@ -1844,10 +1845,11 @@ export class WebViewProvider {
         | { level?: unknown; message?: unknown }
         | undefined;
       if (isLogLevel(data?.level) && typeof data.message === 'string') {
-        logger[data.level](
-          '[Webview]',
-          data.message.replace(/\r\n|\r|\n/g, '\\n'),
-        );
+        const message =
+          data.message.length > MAX_WEBVIEW_LOG_LENGTH
+            ? `${data.message.slice(0, MAX_WEBVIEW_LOG_LENGTH)}...[truncated]`
+            : data.message;
+        logger[data.level]('[Webview]', message.replace(/\r\n|\r|\n/g, '\\n'));
       }
       return true;
     }

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -1537,7 +1537,7 @@ export class WebViewProvider {
         this.agentManager.disconnect();
         logger.log('[WebViewProvider] Existing connection disconnected');
       } catch (_error) {
-        logger.log('[WebViewProvider] Error disconnecting:', _error);
+        logger.warn('[WebViewProvider] Error disconnecting:', _error);
       }
       this.agentInitialized = false;
     }

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -1410,7 +1410,7 @@ export class WebViewProvider {
       try {
         this.agentManager.disconnect();
       } catch (e) {
-        logger.log('[WebViewProvider] Error disconnecting after rollback:', e);
+        logger.warn('[WebViewProvider] Error disconnecting after rollback:', e);
       }
       this.agentInitialized = false;
     };
@@ -1425,7 +1425,7 @@ export class WebViewProvider {
         try {
           this.agentManager.disconnect();
         } catch (e) {
-          logger.log('[WebViewProvider] Error disconnecting:', e);
+          logger.warn('[WebViewProvider] Error disconnecting:', e);
         }
         this.agentInitialized = false;
       }
@@ -1845,11 +1845,14 @@ export class WebViewProvider {
         | { level?: unknown; message?: unknown }
         | undefined;
       if (isLogLevel(data?.level) && typeof data.message === 'string') {
-        const message =
+        const logMessage =
           data.message.length > MAX_WEBVIEW_LOG_LENGTH
             ? `${data.message.slice(0, MAX_WEBVIEW_LOG_LENGTH)}...[truncated]`
             : data.message;
-        logger[data.level]('[Webview]', message.replace(/\r\n|\r|\n/g, '\\n'));
+        logger[data.level](
+          '[Webview]',
+          logMessage.replace(/\r\n|\r|\n/g, '\\n'),
+        );
       }
       return true;
     }

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -41,6 +41,7 @@ import {
   buildInstallPlan,
   parseInsightMessage,
 } from '@qwen-code/qwen-code-core';
+import { isLogLevel, logger } from '../../utils/logger.js';
 
 /** Threshold (ms) before a completed task triggers a notification. */
 const LONG_TASK_THRESHOLD_MS = 20_000;
@@ -192,7 +193,7 @@ export class WebViewProvider {
         );
 
         if (authSettingsChanged && !this.isSyncingToVSCode) {
-          console.log(
+          logger.log(
             '[WebViewProvider] Auth-related qwen-code settings changed by user, syncing...',
           );
           const synced = await this.syncVSCodeSettingsToQwenConfig();
@@ -206,7 +207,7 @@ export class WebViewProvider {
                 autoAuthenticate: false,
               });
             } catch (e) {
-              console.error(
+              logger.error(
                 '[WebViewProvider] Reconnect after settings change failed:',
                 e,
               );
@@ -224,7 +225,7 @@ export class WebViewProvider {
               .getConfiguration('qwen-code')
               .get<string>('apiKey', '');
             if (!apiKey) {
-              console.log(
+              logger.log(
                 '[WebViewProvider] apiKey cleared — de-authenticating and clearing persisted credentials',
               );
               clearPersistedAuth();
@@ -269,7 +270,7 @@ export class WebViewProvider {
           void this.conversationStore
             .addMessage(conversationId, message)
             .catch((error) => {
-              console.warn(
+              logger.warn(
                 '[WebViewProvider] Failed to persist background notification:',
                 error,
               );
@@ -423,7 +424,7 @@ export class WebViewProvider {
 
     // Surface available models (from session/new response)
     this.agentManager.onAvailableModels((models) => {
-      console.log(
+      logger.log(
         '[WebViewProvider] onAvailableModels received, sending to webview:',
         models,
       );
@@ -570,7 +571,7 @@ export class WebViewProvider {
                   try {
                     await this.agentManager.cancelCurrentPrompt();
                   } catch (err) {
-                    console.warn(
+                    logger.warn(
                       '[WebViewProvider] cancelCurrentPrompt error:',
                       err,
                     );
@@ -627,7 +628,7 @@ export class WebViewProvider {
                     },
                   });
                 } catch (err) {
-                  console.warn(
+                  logger.warn(
                     '[WebViewProvider] failed to synthesize failed tool_call_update:',
                     err,
                   );
@@ -702,7 +703,7 @@ export class WebViewProvider {
     );
 
     this.agentManager.onDisconnected((code, signal) => {
-      console.log(
+      logger.log(
         `[WebViewProvider] Agent disconnected (code: ${code}, signal: ${signal})`,
       );
       // Reset task timing to prevent phantom notifications after reconnect.
@@ -746,7 +747,7 @@ export class WebViewProvider {
     webviewView: vscode.WebviewView,
     viewType: string,
   ): Promise<void> {
-    console.log(
+    logger.log(
       `[WebViewProvider] Attaching to WebviewView (viewType=${viewType})`,
     );
 
@@ -877,7 +878,7 @@ export class WebViewProvider {
     });
 
     // Attempt to restore auth state and initialize connection
-    console.log(
+    logger.log(
       '[WebViewProvider] Attempting to restore auth state and connection for view...',
     );
     await this.attemptAuthStateRestoration();
@@ -911,7 +912,7 @@ export class WebViewProvider {
     // Set up state serialization
     newPanel.onDidChangeViewState(
       () => {
-        console.log(
+        logger.log(
           '[WebViewProvider] Panel view state changed, triggering serialization check',
         );
       },
@@ -1057,7 +1058,7 @@ export class WebViewProvider {
     }
 
     // Attempt to restore authentication state and initialize connection
-    console.log(
+    logger.log(
       '[WebViewProvider] Attempting to restore auth state and connection...',
     );
     await this.attemptAuthStateRestoration();
@@ -1112,7 +1113,7 @@ export class WebViewProvider {
       const provider = config.get<string>('provider', 'coding-plan');
 
       if (provider !== 'coding-plan') {
-        console.log(
+        logger.log(
           '[WebViewProvider] Skipping VSCode settings sync for api-key provider; interactive auth owns provider details',
         );
         return false;
@@ -1124,12 +1125,12 @@ export class WebViewProvider {
       );
       writeCodingPlanConfig(region, apiKey);
 
-      console.log(
+      logger.log(
         `[WebViewProvider] Synced VSCode settings → ~/.qwen/settings.json (provider=${provider})`,
       );
       return true;
     } catch (error) {
-      console.error('[WebViewProvider] Failed to sync VSCode settings:', error);
+      logger.error('[WebViewProvider] Failed to sync VSCode settings:', error);
       return false;
     }
   }
@@ -1146,7 +1147,7 @@ export class WebViewProvider {
         return;
       }
 
-      console.log(
+      logger.log(
         '[WebViewProvider] Syncing ~/.qwen/settings.json → VSCode settings',
       );
 
@@ -1174,7 +1175,7 @@ export class WebViewProvider {
       }
 
       if (updates.length === 0) {
-        console.log(
+        logger.log(
           '[WebViewProvider] VSCode settings already match ~/.qwen/settings.json',
         );
         return;
@@ -1188,7 +1189,7 @@ export class WebViewProvider {
         this.isSyncingToVSCode = false;
       }
     } catch (error) {
-      console.error(
+      logger.error(
         '[WebViewProvider] Failed to sync qwen config to VSCode settings:',
         error,
       );
@@ -1212,11 +1213,11 @@ export class WebViewProvider {
       try {
         await this.syncQwenConfigToVSCodeSettings();
 
-        console.log('[WebViewProvider] Attempting connection...');
+        logger.log('[WebViewProvider] Attempting connection...');
         // Attempt a connection to detect prior auth without forcing login
         await this.initializeAgentConnection({ autoAuthenticate: false });
       } catch (error) {
-        console.error(
+        logger.error(
           '[WebViewProvider] Error in attemptAuthStateRestoration:',
           error,
         );
@@ -1250,11 +1251,11 @@ export class WebViewProvider {
       const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
       const workingDir = workspaceFolder?.uri.fsPath || process.cwd();
 
-      console.log(
+      logger.log(
         '[WebViewProvider] Starting initialization, workingDir:',
         workingDir,
       );
-      console.log(
+      logger.log(
         `[WebViewProvider] Using CLI-managed authentication (autoAuth=${autoAuthenticate})`,
       );
 
@@ -1264,7 +1265,7 @@ export class WebViewProvider {
       );
 
       try {
-        console.log('[WebViewProvider] Connecting to agent...');
+        logger.log('[WebViewProvider] Connecting to agent...');
 
         // Pass the detected CLI path to ensure we use the correct installation
         const connectResult = await this.agentManager.connect(
@@ -1272,13 +1273,13 @@ export class WebViewProvider {
           cliEntry,
           options,
         );
-        console.log('[WebViewProvider] Agent connected successfully');
+        logger.log('[WebViewProvider] Agent connected successfully');
         this.agentInitialized = true;
 
         // If authentication is required and autoAuthenticate is false,
         // send authState message and return without creating session
         if (connectResult.requiresAuth && !autoAuthenticate) {
-          console.log(
+          logger.log(
             '[WebViewProvider] Authentication required, launching auth flow...',
           );
           this.sendMessageToWebView({
@@ -1323,13 +1324,13 @@ export class WebViewProvider {
             data: {},
           });
         } else {
-          console.log(
+          logger.log(
             '[WebViewProvider] Session creation deferred until user logs in.',
           );
         }
       } catch (_error) {
         const errorMsg = getErrorMessage(_error);
-        console.error('[WebViewProvider] Agent connection error:', _error);
+        logger.error('[WebViewProvider] Agent connection error:', _error);
         vscode.window.showWarningMessage(
           `Failed to connect to Qwen CLI: ${errorMsg}\nYou can still use the chat UI, but messages won't be sent to AI.`,
         );
@@ -1376,7 +1377,7 @@ export class WebViewProvider {
         return '[invalid]';
       }
     })();
-    console.log(
+    logger.log(
       `[WebViewProvider] authInteractive: provider=${providerConfig.id}, host=${baseUrlHost}`,
     );
 
@@ -1394,7 +1395,7 @@ export class WebViewProvider {
       try {
         restoreSettingsSnapshot(rollbackSnapshot);
       } catch (rollbackErr) {
-        console.error(
+        logger.error(
           '[WebViewProvider] settings rollback failed:',
           rollbackErr,
         );
@@ -1408,7 +1409,7 @@ export class WebViewProvider {
       try {
         this.agentManager.disconnect();
       } catch (e) {
-        console.log('[WebViewProvider] Error disconnecting after rollback:', e);
+        logger.log('[WebViewProvider] Error disconnecting after rollback:', e);
       }
       this.agentInitialized = false;
     };
@@ -1423,7 +1424,7 @@ export class WebViewProvider {
         try {
           this.agentManager.disconnect();
         } catch (e) {
-          console.log('[WebViewProvider] Error disconnecting:', e);
+          logger.log('[WebViewProvider] Error disconnecting:', e);
         }
         this.agentInitialized = false;
       }
@@ -1456,7 +1457,7 @@ export class WebViewProvider {
       }
     } catch (error) {
       const errorMsg = getErrorMessage(error);
-      console.error('[WebViewProvider] authInteractive failed:', error);
+      logger.error('[WebViewProvider] authInteractive failed:', error);
       // A throw can land here after the plan committed but before/while
       // reconnecting — restore the snapshot so partial/bad state doesn't
       // linger. (Redundant but harmless if the plan's own rollback already
@@ -1489,7 +1490,7 @@ export class WebViewProvider {
     const maxAttempts = 3;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      console.log(
+      logger.log(
         `[WebViewProvider] Auto-reconnect attempt ${attempt}/${maxAttempts}`,
       );
 
@@ -1498,11 +1499,11 @@ export class WebViewProvider {
 
       try {
         await this.doInitializeAgentConnection();
-        console.log('[WebViewProvider] Auto-reconnect succeeded');
+        logger.log('[WebViewProvider] Auto-reconnect succeeded');
         this.isReconnecting = false;
         return;
       } catch (error) {
-        console.error(
+        logger.error(
           `[WebViewProvider] Auto-reconnect attempt ${attempt} failed:`,
           error,
         );
@@ -1511,7 +1512,7 @@ export class WebViewProvider {
 
     // All attempts exhausted
     this.isReconnecting = false;
-    console.error('[WebViewProvider] Auto-reconnect failed after all attempts');
+    logger.error('[WebViewProvider] Auto-reconnect failed after all attempts');
 
     this.sendMessageToWebView({
       type: 'agentConnectionError',
@@ -1527,15 +1528,15 @@ export class WebViewProvider {
    * Called when restoring WebView after VSCode restart
    */
   async refreshConnection(): Promise<void> {
-    console.log('[WebViewProvider] Refresh connection requested');
+    logger.log('[WebViewProvider] Refresh connection requested');
 
     // Disconnect existing connection if any
     if (this.agentInitialized) {
       try {
         this.agentManager.disconnect();
-        console.log('[WebViewProvider] Existing connection disconnected');
+        logger.log('[WebViewProvider] Existing connection disconnected');
       } catch (_error) {
-        console.log('[WebViewProvider] Error disconnecting:', _error);
+        logger.log('[WebViewProvider] Error disconnecting:', _error);
       }
       this.agentInitialized = false;
     }
@@ -1546,9 +1547,7 @@ export class WebViewProvider {
     // Reinitialize connection (will use cached auth if available)
     try {
       await this.initializeAgentConnection();
-      console.log(
-        '[WebViewProvider] Connection refresh completed successfully',
-      );
+      logger.log('[WebViewProvider] Connection refresh completed successfully');
 
       // Notify webview that agent is connected after refresh
       this.sendMessageToWebView({
@@ -1557,7 +1556,7 @@ export class WebViewProvider {
       });
     } catch (_error) {
       const errorMsg = getErrorMessage(_error);
-      console.error('[WebViewProvider] Connection refresh failed:', _error);
+      logger.error('[WebViewProvider] Connection refresh failed:', _error);
 
       // Notify webview that agent connection failed after refresh
       this.sendMessageToWebView({
@@ -1581,7 +1580,7 @@ export class WebViewProvider {
     const autoAuthenticate = options?.autoAuthenticate ?? true;
     let sessionReady = false;
     try {
-      console.log(
+      logger.log(
         '[WebViewProvider] Initializing with new session (skipping restoration)',
       );
 
@@ -1591,7 +1590,7 @@ export class WebViewProvider {
       // avoid creating another session if connect() already created one.
       if (!this.agentManager.currentSessionId) {
         if (!autoAuthenticate) {
-          console.log(
+          logger.log(
             '[WebViewProvider] Skipping ACP session creation until user logs in.',
           );
           this.sendMessageToWebView({
@@ -1603,12 +1602,12 @@ export class WebViewProvider {
             await this.agentManager.createNewSession(workingDir, {
               autoAuthenticate,
             });
-            console.log('[WebViewProvider] ACP session created successfully');
+            logger.log('[WebViewProvider] ACP session created successfully');
             sessionReady = true;
           } catch (sessionError) {
             const requiresAuth = isAuthenticationRequiredError(sessionError);
             if (requiresAuth && !autoAuthenticate) {
-              console.log(
+              logger.log(
                 '[WebViewProvider] ACP session requires authentication; waiting for explicit login.',
               );
               this.sendMessageToWebView({
@@ -1617,7 +1616,7 @@ export class WebViewProvider {
               });
             } else {
               const errorMsg = getErrorMessage(sessionError);
-              console.error(
+              logger.error(
                 '[WebViewProvider] Failed to create ACP session:',
                 sessionError,
               );
@@ -1628,7 +1627,7 @@ export class WebViewProvider {
           }
         }
       } else {
-        console.log(
+        logger.log(
           '[WebViewProvider] Existing ACP session detected, skipping new session creation',
         );
         sessionReady = true;
@@ -1641,7 +1640,7 @@ export class WebViewProvider {
       await this.initializeEmptyConversation();
     } catch (_error) {
       const errorMsg = getErrorMessage(_error);
-      console.error(
+      logger.error(
         '[WebViewProvider] Failed to load session messages:',
         _error,
       );
@@ -1666,7 +1665,7 @@ export class WebViewProvider {
     try {
       await this.agentManager.setModelFromUi(modelId);
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[WebViewProvider] Failed to apply initial model selection:',
         error,
       );
@@ -1679,19 +1678,19 @@ export class WebViewProvider {
    */
   private async initializeEmptyConversation(): Promise<void> {
     try {
-      console.log('[WebViewProvider] Initializing empty conversation');
+      logger.log('[WebViewProvider] Initializing empty conversation');
       const newConv = await this.conversationStore.createConversation();
       this.messageHandler.setCurrentConversationId(newConv.id);
       this.sendMessageToWebView({
         type: 'conversationLoaded',
         data: newConv,
       });
-      console.log(
+      logger.log(
         '[WebViewProvider] Empty conversation initialized:',
         this.messageHandler.getCurrentConversationId(),
       );
     } catch (_error) {
-      console.error(
+      logger.error(
         '[WebViewProvider] Failed to initialize conversation:',
         _error,
       );
@@ -1763,7 +1762,7 @@ export class WebViewProvider {
 
     // Send cached available models to webview
     if (this.cachedAvailableModels && this.cachedAvailableModels.length > 0) {
-      console.log(
+      logger.log(
         '[WebViewProvider] Sending cached availableModels on webviewReady:',
         this.cachedAvailableModels.map((m) => m.modelId),
       );
@@ -1840,6 +1839,18 @@ export class WebViewProvider {
     message: { type: string; data?: unknown },
     webview: vscode.Webview,
   ): Promise<boolean> {
+    if (message.type === 'log') {
+      const data = message.data as
+        | { level?: unknown; message?: unknown }
+        | undefined;
+      if (isLogLevel(data?.level) && typeof data.message === 'string') {
+        logger[data.level](
+          '[Webview]',
+          data.message.replace(/\r\n|\r|\n/g, '\\n'),
+        );
+      }
+      return true;
+    }
     if (message.type === 'openDiff' && this.isAutoMode()) {
       return true;
     }
@@ -1947,7 +1958,7 @@ export class WebViewProvider {
   private playNotificationSound(): void {
     const onError = (err: Error | null) => {
       if (err) {
-        console.warn(
+        logger.warn(
           '[WebViewProvider] Notification sound failed:',
           err.message,
         );
@@ -1970,7 +1981,7 @@ export class WebViewProvider {
             ['/usr/share/sounds/freedesktop/stereo/complete.oga'],
             (paErr) => {
               if (paErr) {
-                console.warn(
+                logger.warn(
                   '[WebViewProvider] paplay fallback failed:',
                   paErr.message,
                 );
@@ -2212,7 +2223,7 @@ export class WebViewProvider {
     try {
       this.pendingPermissionResolve(optionId);
     } catch (_error) {
-      console.warn(
+      logger.warn(
         '[WebViewProvider] respondToPendingPermission failed:',
         _error,
       );
@@ -2224,7 +2235,7 @@ export class WebViewProvider {
    * Call this when auth cache is cleared to force re-authentication
    */
   resetAgentState(): void {
-    console.log('[WebViewProvider] Resetting agent state');
+    logger.log('[WebViewProvider] Resetting agent state');
     this.agentInitialized = false;
     this.authState = null;
     // Disconnect existing connection
@@ -2236,10 +2247,8 @@ export class WebViewProvider {
    * This sets up the panel with all event listeners
    */
   async restorePanel(panel: vscode.WebviewPanel): Promise<void> {
-    console.log('[WebViewProvider] Restoring WebView panel');
-    console.log(
-      '[WebViewProvider] Using CLI-managed authentication in restore',
-    );
+    logger.log('[WebViewProvider] Restoring WebView panel');
+    logger.log('[WebViewProvider] Using CLI-managed authentication in restore');
     this.panelManager.setPanel(panel);
 
     // Ensure restored tab starts from default label and icon
@@ -2252,7 +2261,7 @@ export class WebViewProvider {
         DOT_ICON.default,
       );
     } catch (e) {
-      console.warn(
+      logger.warn(
         '[WebViewProvider] Failed to reset restored panel title/icon:',
         e,
       );
@@ -2408,10 +2417,10 @@ export class WebViewProvider {
     // Capture the tab reference on restore
     this.panelManager.captureTab();
 
-    console.log('[WebViewProvider] Panel restored successfully');
+    logger.log('[WebViewProvider] Panel restored successfully');
 
     // Attempt to restore authentication state and initialize connection
-    console.log(
+    logger.log(
       '[WebViewProvider] Attempting to restore auth state and connection after restore...',
     );
     await this.attemptAuthStateRestoration();
@@ -2425,12 +2434,12 @@ export class WebViewProvider {
     conversationId: string | null;
     agentInitialized: boolean;
   } {
-    console.log('[WebViewProvider] Getting state for serialization');
-    console.log(
+    logger.log('[WebViewProvider] Getting state for serialization');
+    logger.log(
       '[WebViewProvider] Current conversationId:',
       this.messageHandler.getCurrentConversationId(),
     );
-    console.log(
+    logger.log(
       '[WebViewProvider] Current agentInitialized:',
       this.agentInitialized,
     );
@@ -2438,7 +2447,7 @@ export class WebViewProvider {
       conversationId: this.messageHandler.getCurrentConversationId(),
       agentInitialized: this.agentInitialized,
     };
-    console.log('[WebViewProvider] Returning state:', state);
+    logger.log('[WebViewProvider] Returning state:', state);
     return state;
   }
 
@@ -2456,11 +2465,11 @@ export class WebViewProvider {
     conversationId: string | null;
     agentInitialized: boolean;
   }): void {
-    console.log('[WebViewProvider] Restoring state:', state);
+    logger.log('[WebViewProvider] Restoring state:', state);
     this.messageHandler.setCurrentConversationId(state.conversationId);
     this.agentInitialized = state.agentInitialized;
     this.authState = null;
-    console.log(
+    logger.log(
       '[WebViewProvider] State restored. agentInitialized:',
       this.agentInitialized,
     );
@@ -2495,7 +2504,7 @@ export class WebViewProvider {
         data: {},
       });
     } catch (_error) {
-      console.error('[WebViewProvider] Failed to create new session:', _error);
+      logger.error('[WebViewProvider] Failed to create new session:', _error);
       vscode.window.showErrorMessage(
         `Failed to create new session: ${getErrorMessage(_error)}`,
       );

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { logger } from '../../utils/logger.js';
 import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
@@ -105,7 +106,7 @@ export async function saveImageToFile(
     await pruneClipboardImages();
     return filePath;
   } catch (error) {
-    console.error('[ImageHandler] Failed to save image:', error);
+    logger.error('[ImageHandler] Failed to save image:', error);
     return null;
   }
 }
@@ -133,7 +134,7 @@ export async function processImageAttachments(
         maxBytes: Math.min(MAX_IMAGE_SIZE, remainingBytes),
       });
       if (!normalizedAttachment) {
-        console.warn(
+        logger.warn(
           '[ImageHandler] Rejected invalid image attachment:',
           attachment.name,
         );
@@ -154,7 +155,7 @@ export async function processImageAttachments(
         remainingBytes -= normalizedAttachment.size;
         savedImageCount += 1;
       } else {
-        console.warn('[ImageHandler] Failed to save image:', attachment.name);
+        logger.warn('[ImageHandler] Failed to save image:', attachment.name);
       }
     }
 


### PR DESCRIPTION
## What this PR does

This PR reuses the existing `Qwen Code Companion` Output Channel and routes runtime logs from both the Extension Host and Webview into it.

Logs preserve their original levels and readable formatting for multiple arguments, objects, circular references, and Error stacks. Webview logs use the existing message bridge, with host-side validation and newline escaping. Sensitive object fields and common credentials are redacted before output.

The existing “Qwen Code: Show Logs” command opens the `Qwen Code Companion` channel directly.

## Why it's needed

Extension Host and Webview logs previously lived in separate Developer Tools consoles, which are difficult for most users to open and collect. This often produces incomplete diagnostic reports and makes troubleshooting dependent on the user's environment.

Using VS Code's native Output panel gives users one stable, copyable place to collect complete diagnostics without opening Developer Tools.

## Reviewer Test Plan

### How to verify

1. Start the extension in an Extension Development Host and open the Qwen Code chat view.
2. Create or resume a session and perform actions that produce both Extension Host and Webview logs.
3. Run “Qwen Code: Show Logs”.
4. Confirm that the Output panel opens the `Qwen Code Companion` channel and contains logs from both runtimes.
5. Confirm that levels, objects, and Error stacks remain readable, newlines cannot create forged log entries, and common credentials and sensitive object fields are redacted.
6. Companion lint, type checking, 77 focused tests, the production build, and the lockfile check pass locally.

### Evidence (Before & After)

- Before: users must open the Extension Host Developer Tools and Webview Developer Tools separately to collect logs.
- After: “Qwen Code: Show Logs” is expected to expose both log sources through the existing `Qwen Code Companion` Output Channel.
- No UI screenshot or recording is attached; local evidence currently consists of automated tests and the production build.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ automated checks |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 15.1.1 with Node.js 22.22.0. Automated package validation was completed; a manual Extension Development Host smoke test was not run.

## Risk & Scope

- Main risk or tradeoff: Centralizing logs increases Output Channel volume and the number of paths that may surface sensitive data. The implementation mitigates this through credential redaction, sensitive-field redaction, and removal of high-risk raw authentication and session-content logs.
- Not validated / out of scope: Windows, Linux, and a real Extension Development Host were not tested manually. The complete extension integration test is blocked locally by the macOS Keychain error `SecItemCopyMatching failed -50`.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 复用 VS Code 插件现有的 `Qwen Code Companion` Output Channel，并将 Extension Host 与 Webview 中的运行时日志集中写入该通道。

日志保留原有级别，支持多参数、对象、循环引用和 Error 堆栈格式化。Webview 日志通过现有消息桥转发到 Extension Host，输入会经过类型校验和换行转义。写入前还会脱敏敏感对象字段和常见凭证。

现有的 “Qwen Code: Show Logs” 命令会直接展示 `Qwen Code Companion` 通道。

## 为什么需要

此前 Extension Host 和 Webview 日志分别位于不同的 Developer Tools 中，普通用户很难打开并收集完整日志。这使问题定位高度依赖用户环境，也容易遗漏关键上下文。

迁移到 VS Code 原生 Output 面板后，用户可以从一个稳定、可复制的位置收集完整诊断信息，无需打开 Developer Tools。

## Reviewer Test Plan

### 如何验证

1. 在 Extension Development Host 中启动插件并打开 Qwen Code 聊天界面。
2. 新建或恢复一个会话，执行能够同时产生 Extension Host 和 Webview 日志的操作。
3. 运行 “Qwen Code: Show Logs”。
4. 确认 Output 面板打开 `Qwen Code Companion` 通道，并同时显示两侧日志。
5. 确认日志级别、对象内容和 Error 堆栈可读，换行不会伪造额外日志行，常见凭证与敏感对象字段已被脱敏。
6. Companion 的 lint、类型检查、77 个聚焦单测、生产构建和 lockfile 检查均已通过。

### 证据（Before & After）

- Before：用户需要分别打开 Extension Host Developer Tools 和 Webview Developer Tools 才能收集日志。
- After：预期通过 “Qwen Code: Show Logs” 在现有的 `Qwen Code Companion` Output Channel 中获取两侧日志。
- 尚未附加 UI 截图或录屏；本地验证以自动化测试和生产构建为主。

### 测试平台

| 操作系统 | 状态 |
| :--: | :--: |
| 🍏 macOS | ✅ 自动化检查通过 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境

macOS 15.1.1、Node.js 22.22.0。本地完成自动化验证，未完成 Extension Development Host 手工 smoke test。

## 风险与范围

- 主要风险或取舍：统一日志会增加 Output Channel 的日志量，并扩大敏感信息进入日志的潜在入口；实现通过凭证脱敏、敏感字段脱敏，以及移除高风险的原始认证和会话内容日志来降低风险。
- 未验证或超出范围：未在 Windows、Linux 或真实 Extension Development Host 中完成手工验证。完整 extension 集成测试受本机 macOS Keychain `SecItemCopyMatching failed -50` 错误阻塞。
- Breaking changes / 迁移说明：无。

## 关联 Issue

N/A

</details>
