### PR TITLE
fix(web-shell): recover new-session decisions wrapped in prose or fences

### DIFF
--- a/packages/web-shell/client/hooks/useNewSessionSuggestion.test.tsx
+++ b/packages/web-shell/client/hooks/useNewSessionSuggestion.test.tsx
@@ -162,4 +162,96 @@ describe('useNewSessionSuggestion', () => {
 
     expect(latestSuggestion).toBeNull();
   });
+
+  // The classifier is instructed to return JSON only, but live it sometimes
+  // wraps a valid decision in prose or a code fence. These pin the extraction
+  // fallback: recover the object when one is there, stay fail-closed when not.
+  const NEW_TASK_DRAFT = '帮我写一篇新的设计文档，主题是 Web Shell 新功能方案';
+  const CONTEXT_MESSAGES = [
+    {
+      id: 'm-1',
+      role: 'user',
+      content: '先看一下当前实现',
+      timestamp: 1,
+    },
+    {
+      id: 'm-2',
+      role: 'assistant',
+      content: '这里是当前实现的说明',
+      timestamp: 2,
+    },
+  ] as Message[];
+
+  async function classify(decisionText: string) {
+    vi.useFakeTimers();
+    testState.inputText = NEW_TASK_DRAFT;
+    testState.messages = CONTEXT_MESSAGES;
+    testState.generateContent.mockImplementation(async function* () {
+      yield {
+        type: 'delta',
+        requestId: 'req-1',
+        seq: 0,
+        text: decisionText,
+      };
+      yield {
+        type: 'done',
+        requestId: 'req-1',
+        model: 'fast-model',
+        modelSource: 'fast',
+      };
+    });
+
+    await renderHost();
+    act(() => {
+      vi.advanceTimersByTime(701);
+    });
+    await flush(3);
+  }
+
+  it('recovers a positive decision wrapped in prose (observed live)', async () => {
+    // Verbatim shape from a live run: prose preamble + bare JSON.
+    await classify(
+      'The user is explicitly switching to a completely new task, which is ' +
+        'unrelated to the previous discussion. This is a clear topic change.\n\n' +
+        JSON.stringify({ shouldSuggestNewSession: true, confidence: 0.98 }),
+    );
+
+    expect(testState.generateContent).toHaveBeenCalledOnce();
+    expect(latestSuggestion).toEqual({
+      isVisible: true,
+      classifiedInput: NEW_TASK_DRAFT,
+    });
+  });
+
+  it('recovers a positive decision inside a code fence', async () => {
+    await classify(
+      '```json\n' +
+        JSON.stringify({ shouldSuggestNewSession: true, confidence: 0.95 }) +
+        '\n```',
+    );
+
+    expect(latestSuggestion).toEqual({
+      isVisible: true,
+      classifiedInput: NEW_TASK_DRAFT,
+    });
+  });
+
+  it('keeps the banner hidden for a prose-wrapped negative decision', async () => {
+    await classify(
+      'This is a follow-up on the same topic.\n\n' +
+        JSON.stringify({ shouldSuggestNewSession: false, confidence: 0.97 }),
+    );
+
+    expect(testState.generateContent).toHaveBeenCalledOnce();
+    expect(latestSuggestion).toBeNull();
+  });
+
+  it('stays fail-closed on prose with no recoverable JSON object', async () => {
+    await classify(
+      'I think {this draft} switches topics, but here is no JSON to parse.',
+    );
+
+    expect(testState.generateContent).toHaveBeenCalledOnce();
+    expect(latestSuggestion).toBeNull();
+  });
 });

--- a/packages/web-shell/client/hooks/useNewSessionSuggestion.ts
+++ b/packages/web-shell/client/hooks/useNewSessionSuggestion.ts
@@ -136,7 +136,7 @@ function buildPrompt(params: {
   ].join('\n');
 }
 
-function parseDecision(text: string): TopicShiftDecision | null {
+function tryParseDecision(text: string): TopicShiftDecision | null {
   try {
     const parsed = JSON.parse(text) as Partial<TopicShiftDecision>;
     if (typeof parsed.shouldSuggestNewSession !== 'boolean') return null;
@@ -148,6 +148,24 @@ function parseDecision(text: string): TopicShiftDecision | null {
   } catch {
     return null;
   }
+}
+
+function parseDecision(text: string): TopicShiftDecision | null {
+  const direct = tryParseDecision(text);
+  if (direct) return direct;
+  // Despite the JSON-only instruction, the model sometimes wraps a perfectly
+  // valid decision in prose or a code fence (observed live: prose preamble +
+  // bare JSON on ~1 of 3 runs). A bare JSON.parse throws and the warranted
+  // suggestion is silently dropped — a pure recall loss. Recover by slicing
+  // from the first '{' to the last '}' and re-parsing; anything still
+  // unparseable or mis-shaped stays null, so the gate remains fail-closed
+  // (the banner can only ever be under-shown, never mis-shown).
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  const sliced = text.slice(start, end + 1);
+  if (sliced === text) return null;
+  return tryParseDecision(sliced);
 }
 
 export function useNewSessionSuggestion({


### PR DESCRIPTION
## What this PR does

Makes `parseDecision` in the new-session suggestion hook (#7098) tolerant of a classifier response that wraps a valid decision in prose or a code fence: on a direct-parse failure it slices from the first `{` to the last `}` and re-parses. Anything still unparseable or mis-shaped stays `null`, so the gate remains fail-closed — the banner can only ever be under-shown, never mis-shown.

## Why it's needed

The classifier prompt says "Return JSON only", but against the real model the response format is a distribution, not a point: in the live verification of #7098 (see [the report](https://github.com/QwenLM/qwen-code/pull/7098#issuecomment-5004788012), §4), one of three runs for the *same* new-topic draft returned a prose preamble followed by perfectly valid JSON (`{"shouldSuggestNewSession": true, "confidence": 0.98}`). The bare `JSON.parse` threw, and the warranted suggestion was silently dropped. That is a pure recall loss — the feature simply doesn't appear for a meaningful fraction of the cases it was built for. A controlled experiment in that report showed the identical live flow flips to working with exactly this fallback patched in. The review bot's inline note about fenced output is the same defect; prose is the superset, and this fix covers both.

## Reviewer Test Plan

### How to verify

```
cd packages/web-shell
npx vitest run client/hooks/useNewSessionSuggestion.test.tsx   # 6 passed
npx vitest run client/App.test.tsx                             # 116 passed (consumer unchanged)
```

The four new tests drive the REAL hook (mocked `generateContent` stream, same harness as the existing tests):

- prose-wrapped positive decision (the live sample's shape) → banner shows
- fenced positive decision → banner shows
- prose-wrapped negative decision → banner stays hidden
- prose with `{...}` fragments but no recoverable JSON object → stays hidden (fail-closed)

Load-bearing check: reverting only the `parseDecision` change makes exactly the two recovery tests fail (`2 failed | 4 passed`) while every fail-closed test still passes — verified locally both directions.

### Evidence (Before & After)

Non-UI parsing change — N/A. Behavioral proof is the reverse experiment above: without the fix `2 failed | 4 passed`, with the fix `6 passed`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Verified locally on macOS; Windows/Linux left to CI.

### Environment (optional)

Package vitest only (`packages/web-shell`), jsdom.

## Risk & Scope

- Main risk or tradeoff: the slice heuristic can grab a non-decision object out of prose (e.g. text quoting braces around unrelated content) — that parse then fails the shape check and returns `null`, identical to today's behavior. The recovery can only ever *add* the banner for responses that contain a well-formed, correctly-shaped decision object; every rejection path is unchanged.
- Not validated / out of scope: teaching the prompt to be stricter (won't fix the tail — format drift is inherent), or streaming-side format enforcement in the daemon.
- Breaking changes / migration notes: none.

## Linked Issues

Fast-follow to #7098, implementing the §4 recommendation of its [verification report](https://github.com/QwenLM/qwen-code/pull/7098#issuecomment-5004788012).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让新会话建议功能（#7098）的 `parseDecision` 能容忍"分类器把有效判定包裹在散文或代码围栏里"的响应：直接解析失败时，从首个 `{` 到最后一个 `}` 截取子串重新解析。仍无法解析或形状不符的一律返回 `null`，门控保持 fail-closed——横幅只可能少弹，绝不会误弹。

## 为什么需要它

分类器提示词写明"只返回 JSON"，但对真实模型而言输出格式是一个分布而非一个点：在 #7098 的活体验证（见[验证报告](https://github.com/QwenLM/qwen-code/pull/7098#issuecomment-5004788012) §4）中，对*同一个*新话题草稿的三次运行里有一次返回了"散文前言 + 完全有效的 JSON"（`{"shouldSuggestNewSession": true, "confidence": 0.98}`）。裸 `JSON.parse` 抛异常，应当出现的建议被静默丢弃——纯粹的召回损失，功能在相当比例的目标场景下根本不出现。该报告的受控实验表明：打上正是本 PR 的回退补丁后，完全相同的活体流程即恢复正常。review bot 关于围栏输出的 inline 建议是同一缺陷，散文是其超集，本修复同时覆盖两者。

## 复现测试计划

### 如何验证

```
cd packages/web-shell
npx vitest run client/hooks/useNewSessionSuggestion.test.tsx   # 6 passed
npx vitest run client/App.test.tsx                             # 116 passed（消费方不变）
```

四个新测试全部驱动**真实 hook**（mock `generateContent` 流，与既有测试同一 harness）：

- 散文包裹的正向判定（活体样本的形状）→ 横幅出现
- 围栏包裹的正向判定 → 横幅出现
- 散文包裹的负向判定 → 横幅保持隐藏
- 含 `{...}` 片段但无可恢复 JSON 对象的散文 → 保持隐藏（fail-closed）

载荷验证：仅回退 `parseDecision` 的改动，恰好两个恢复测试转红（`2 failed | 4 passed`），所有 fail-closed 测试仍绿——两个方向均已本地验证。

### 证据（Before & After）

非 UI 的解析改动——N/A。行为证明即上述反向实验：无修复 `2 failed | 4 passed`，有修复 `6 passed`。

### 测试平台

仅在本地 macOS 验证；Windows/Linux 交由 CI。

## 风险与范围

- 主要风险/取舍：截取启发式可能从散文中抓到一个非判定对象（如引用了花括号的无关内容）——该解析随后过不了形状校验，返回 `null`，与现状行为一致。恢复逻辑只可能为"含格式良好且形状正确的判定对象"的响应*增加*横幅；所有拒绝路径不变。
- 未验证 / 不在范围内：把提示词写得更严（治不了长尾——格式漂移是固有的）、daemon 侧的流式格式强制。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#7098 的快速跟进，落实其[验证报告](https://github.com/QwenLM/qwen-code/pull/7098#issuecomment-5004788012) §4 的建议。

</details>
