### PR TITLE
fix(acp): resolve textual @ image paths

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3565,6 +3565,62 @@ describe('Session', () => {
       }
     });
 
+    it('resolves image @ paths from ACP text through the vision bridge', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-acp-image-'),
+      );
+      const imagePath = path.join(tempDir, 'image.png');
+      await fs.writeFile(imagePath, 'image');
+      mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
+      mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
+        id: 'qwen3.7-plus',
+      });
+      const readManyFilesSpy = vi
+        .spyOn(core, 'readManyFiles')
+        .mockResolvedValue({
+          contentParts: {
+            inlineData: { mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+          },
+        } as Awaited<ReturnType<typeof core.readManyFiles>>);
+      runVisionBridgeSpy.mockResolvedValue({
+        applied: true,
+        status: 'ok',
+        parts: [{ text: 'look at this' }, { text: '[text @ file image]' }],
+        transcript: '[text @ file image]',
+        convertedCount: 1,
+        omittedCount: 0,
+        modelId: 'qwen3.7-plus',
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      try {
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [
+            {
+              type: 'text',
+              text: `look at @scope/pkg and @${imagePath}`,
+            },
+          ],
+        });
+
+        expect(readManyFilesSpy).toHaveBeenCalledWith(mockConfig, {
+          paths: [imagePath],
+          signal: expect.any(AbortSignal),
+          preserveUnsupportedImageForBridge: true,
+        });
+        const bridgeParts = runVisionBridgeSpy.mock.calls[0]?.[0]
+          ?.parts as Part[];
+        expect(bridgeParts.some((part) => 'inlineData' in part)).toBe(true);
+        expect(textParts(firstSentMessage())).toContain('[text @ file image]');
+      } finally {
+        readManyFilesSpy.mockRestore();
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('keeps the user prompt as the final part after referenced file content', async () => {
       // Regression: JetBrains ACP attaches the active editor as a file
       // reference. Appending its content AFTER the prompt buried the actual

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path';
 import {
   computeInitialTurnFromHistory,
   fireSessionPermissionDeniedForAutoMode,
+  isExistingFile,
   resolveHomeLoopResolverRoots,
   Session,
 } from './Session.js';
@@ -192,6 +193,20 @@ describe('computeInitialTurnFromHistory', () => {
         'test-session-id',
       ),
     ).toBe(2);
+  });
+});
+
+describe('isExistingFile', () => {
+  it('returns false when stat fails after exists succeeds', () => {
+    expect(
+      isExistingFile(
+        '/tmp/image.png',
+        () => true,
+        () => {
+          throw new Error('EACCES');
+        },
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -197,6 +197,20 @@ describe('computeInitialTurnFromHistory', () => {
 });
 
 describe('isExistingFile', () => {
+  it('returns false when the path does not exist', () => {
+    expect(isExistingFile('/tmp/missing.png', () => false)).toBe(false);
+  });
+
+  it('returns false when the path is not a file', () => {
+    expect(
+      isExistingFile(
+        '/tmp/dir',
+        () => true,
+        () => ({ isFile: () => false }),
+      ),
+    ).toBe(false);
+  });
+
   it('returns false when stat fails after exists succeeds', () => {
     expect(
       isExistingFile(

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3636,27 +3636,29 @@ describe('Session', () => {
       }
     });
 
-    it('ignores unsafe ACP text @ paths before reading files', async () => {
+    it('ignores non-image and relative ACP text @ paths', async () => {
       const tempDir = await fs.mkdtemp(
         path.join(os.tmpdir(), 'qwen-acp-paths-'),
       );
       const outsideDir = await fs.mkdtemp(
         path.join(os.tmpdir(), 'qwen-acp-outside-'),
       );
-      const outsidePath = path.join(outsideDir, 'secret.txt');
-      await fs.writeFile(path.join(tempDir, 'allowed.txt'), 'ok');
+      const textPath = path.join(tempDir, 'notes.txt');
+      const relativeImagePath = 'relative.png';
+      const outsidePath = path.join(outsideDir, 'outside.png');
+      const ignoredPath = path.join(tempDir, 'ignored.png');
+      await fs.writeFile(textPath, 'notes');
+      await fs.writeFile(path.join(tempDir, relativeImagePath), 'image');
       await fs.mkdir(path.join(tempDir, 'dir'));
-      await fs.writeFile(path.join(tempDir, 'ignored.txt'), 'ignored');
-      await fs.writeFile(outsidePath, 'secret');
+      await fs.writeFile(ignoredPath, 'ignored');
+      await fs.writeFile(outsidePath, 'outside');
       mockConfig.getProjectRoot = vi.fn().mockReturnValue(tempDir);
       mockConfig.getWorkspaceContext = vi.fn().mockReturnValue({
         isPathWithinWorkspace: (pathSpec: string) =>
           path.resolve(tempDir, pathSpec).startsWith(`${tempDir}${path.sep}`),
       });
       const fileService = {
-        shouldIgnoreFile: vi.fn(
-          (pathSpec: string) => pathSpec === 'ignored.txt',
-        ),
+        shouldIgnoreFile: vi.fn((pathSpec: string) => pathSpec === ignoredPath),
       };
       mockConfig.getFileService = vi.fn().mockReturnValue(fileService);
       mockConfig.getFileFilteringOptions = vi.fn().mockReturnValue({
@@ -3679,15 +3681,12 @@ describe('Session', () => {
           prompt: [
             {
               type: 'text',
-              text: `read @allowed.txt @dir @${outsidePath} @ignored.txt`,
+              text: `read @${textPath} @${relativeImagePath} @${path.join(tempDir, 'dir')} @${outsidePath} @${ignoredPath}`,
             },
           ],
         });
 
-        expect(readManyFilesSpy).toHaveBeenCalledWith(mockConfig, {
-          paths: ['allowed.txt'],
-          signal: expect.any(AbortSignal),
-        });
+        expect(readManyFilesSpy).not.toHaveBeenCalled();
       } finally {
         readManyFilesSpy.mockRestore();
         await fs.rm(tempDir, { recursive: true, force: true });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -467,7 +467,10 @@ describe('Session', () => {
       getTool: vi.fn(),
       ensureTool: vi.fn().mockResolvedValue(true),
     };
-    const fileService = { shouldGitIgnoreFile: vi.fn().mockReturnValue(false) };
+    const fileService = {
+      shouldGitIgnoreFile: vi.fn().mockReturnValue(false),
+      shouldIgnoreFile: vi.fn().mockReturnValue(false),
+    };
 
     mockConfig = {
       setApprovalMode: vi.fn(),
@@ -492,6 +495,13 @@ describe('Session', () => {
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
       getFileService: vi.fn().mockReturnValue(fileService),
       getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
+      getFileFilteringOptions: vi.fn().mockReturnValue({
+        respectGitIgnore: true,
+        respectQwenIgnore: true,
+      }),
+      getWorkspaceContext: vi.fn().mockReturnValue({
+        isPathWithinWorkspace: vi.fn().mockReturnValue(true),
+      }),
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
       getTargetDir: vi.fn().mockReturnValue(process.cwd()),
       getDebugMode: vi.fn().mockReturnValue(false),
@@ -3571,6 +3581,11 @@ describe('Session', () => {
       );
       const imagePath = path.join(tempDir, 'image.png');
       await fs.writeFile(imagePath, 'image');
+      mockConfig.getProjectRoot = vi.fn().mockReturnValue(tempDir);
+      mockConfig.getWorkspaceContext = vi.fn().mockReturnValue({
+        isPathWithinWorkspace: (pathSpec: string) =>
+          path.resolve(tempDir, pathSpec).startsWith(`${tempDir}${path.sep}`),
+      });
       mockConfig.getEffectiveInputModalities = vi.fn().mockReturnValue({});
       mockConfig.getDefaultVisionBridgeModel = vi.fn().mockReturnValue({
         id: 'qwen3.7-plus',
@@ -3618,6 +3633,65 @@ describe('Session', () => {
       } finally {
         readManyFilesSpy.mockRestore();
         await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('ignores unsafe ACP text @ paths before reading files', async () => {
+      const tempDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-acp-paths-'),
+      );
+      const outsideDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-acp-outside-'),
+      );
+      const outsidePath = path.join(outsideDir, 'secret.txt');
+      await fs.writeFile(path.join(tempDir, 'allowed.txt'), 'ok');
+      await fs.mkdir(path.join(tempDir, 'dir'));
+      await fs.writeFile(path.join(tempDir, 'ignored.txt'), 'ignored');
+      await fs.writeFile(outsidePath, 'secret');
+      mockConfig.getProjectRoot = vi.fn().mockReturnValue(tempDir);
+      mockConfig.getWorkspaceContext = vi.fn().mockReturnValue({
+        isPathWithinWorkspace: (pathSpec: string) =>
+          path.resolve(tempDir, pathSpec).startsWith(`${tempDir}${path.sep}`),
+      });
+      const fileService = {
+        shouldIgnoreFile: vi.fn(
+          (pathSpec: string) => pathSpec === 'ignored.txt',
+        ),
+      };
+      mockConfig.getFileService = vi.fn().mockReturnValue(fileService);
+      mockConfig.getFileFilteringOptions = vi.fn().mockReturnValue({
+        respectGitIgnore: true,
+        respectQwenIgnore: true,
+      });
+      const readManyFilesSpy = vi
+        .spyOn(core, 'readManyFiles')
+        .mockResolvedValue({
+          contentParts: 'allowed file',
+          files: [],
+        } as Awaited<ReturnType<typeof core.readManyFiles>>);
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      try {
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [
+            {
+              type: 'text',
+              text: `read @allowed.txt @dir @${outsidePath} @ignored.txt`,
+            },
+          ],
+        });
+
+        expect(readManyFilesSpy).toHaveBeenCalledWith(mockConfig, {
+          paths: ['allowed.txt'],
+          signal: expect.any(AbortSignal),
+        });
+      } finally {
+        readManyFilesSpy.mockRestore();
+        await fs.rm(tempDir, { recursive: true, force: true });
+        await fs.rm(outsideDir, { recursive: true, force: true });
       }
     });
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -5,7 +5,7 @@
  */
 
 import { Buffer } from 'node:buffer';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type {
@@ -5962,8 +5962,20 @@ export class Session implements SessionContext {
           collectExtensionMentionRefs(part.text, extensionMentions);
           collectMcpServerMentionRefs(part.text, mcpServerMentions);
           for (const pathSpec of extractAtPathCommands(part.text)) {
+            const resolved = path.resolve(
+              this.config.getProjectRoot(),
+              pathSpec,
+            );
+            const filteringOptions = this.config.getFileFilteringOptions();
             if (
-              existsSync(path.resolve(this.config.getProjectRoot(), pathSpec))
+              existsSync(resolved) &&
+              statSync(resolved).isFile() &&
+              this.config
+                .getWorkspaceContext()
+                .isPathWithinWorkspace(pathSpec) &&
+              !this.config
+                .getFileService()
+                .shouldIgnoreFile(pathSpec, filteringOptions)
             ) {
               textPathSpecsToRead.add(pathSpec);
             }

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -658,6 +658,20 @@ interface CronQueueItem {
 
 const MAX_NOTIFICATION_QUEUE = 20;
 
+export function isExistingFile(
+  resolved: string,
+  fileExists: (path: string) => boolean = existsSync,
+  statFile: (
+    path: string,
+  ) => Pick<ReturnType<typeof statSync>, 'isFile'> = statSync,
+): boolean {
+  try {
+    return fileExists(resolved) && statFile(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
 export function resolveHomeLoopResolverRoots({
   homeQwenDir = Storage.getGlobalQwenDir(),
   homeDir = os.homedir(),
@@ -5971,8 +5985,7 @@ export class Session implements SessionContext {
             if (
               path.isAbsolute(pathSpec) &&
               getSpecificMimeType(resolved)?.startsWith('image/') &&
-              existsSync(resolved) &&
-              statSync(resolved).isFile() &&
+              isExistingFile(resolved) &&
               this.config
                 .getWorkspaceContext()
                 .isPathWithinWorkspace(pathSpec) &&

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -64,6 +64,7 @@ import {
   getErrorStatus,
   UserPromptEvent,
   readManyFiles,
+  getSpecificMimeType,
   clampInlineMediaPart,
   Storage,
   ToolNames,
@@ -5968,6 +5969,8 @@ export class Session implements SessionContext {
             );
             const filteringOptions = this.config.getFileFilteringOptions();
             if (
+              path.isAbsolute(pathSpec) &&
+              getSpecificMimeType(resolved)?.startsWith('image/') &&
               existsSync(resolved) &&
               statSync(resolved).isFile() &&
               this.config

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -5,6 +5,7 @@
  */
 
 import { Buffer } from 'node:buffer';
+import { existsSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type {
@@ -190,6 +191,7 @@ import {
   MessageType,
   type HistoryItemGoalStatus,
 } from '../../ui/types.js';
+import { extractAtPathCommands } from '../../ui/hooks/atCommandProcessor.js';
 import {
   ACP_ROUTE_ID_PREFIX,
   buildAcpModelOptions,
@@ -5949,6 +5951,7 @@ export class Session implements SessionContext {
     const embeddedContext: EmbeddedResourceResource[] = [];
     const extensionMentions = new Map<string, string>();
     const mcpServerMentions = new Map<string, string>();
+    const textPathSpecsToRead = new Set<string>();
     const preserveUnsupportedImageForBridge = shouldRunVisionBridge(
       this.config,
     );
@@ -5958,6 +5961,13 @@ export class Session implements SessionContext {
         case 'text':
           collectExtensionMentionRefs(part.text, extensionMentions);
           collectMcpServerMentionRefs(part.text, mcpServerMentions);
+          for (const pathSpec of extractAtPathCommands(part.text)) {
+            if (
+              existsSync(path.resolve(this.config.getProjectRoot(), pathSpec))
+            ) {
+              textPathSpecsToRead.add(pathSpec);
+            }
+          }
           return { text: part.text };
         case 'image':
           if (preserveUnsupportedImageForBridge) {
@@ -6006,6 +6016,12 @@ export class Session implements SessionContext {
     });
 
     const atPathCommandParts = parts.filter((part) => 'fileData' in part);
+    const pathSpecsToRead = [
+      ...new Set([
+        ...textPathSpecsToRead,
+        ...atPathCommandParts.map((part) => part.fileData!.fileUri!),
+      ]),
+    ];
     const extensionParts = await this.#resolveExtensionMentionParts(
       extensionMentions,
       abortSignal,
@@ -6014,7 +6030,7 @@ export class Session implements SessionContext {
       this.#resolveMcpServerMentionParts(mcpServerMentions);
 
     if (
-      atPathCommandParts.length === 0 &&
+      pathSpecsToRead.length === 0 &&
       embeddedContext.length === 0 &&
       extensionParts.length === 0 &&
       mcpServerParts.length === 0
@@ -6022,18 +6038,12 @@ export class Session implements SessionContext {
       return this.#applyBridgeConversionsIfNeeded(parts, abortSignal);
     }
 
-    if (atPathCommandParts.length === 0 && embeddedContext.length === 0) {
+    if (pathSpecsToRead.length === 0 && embeddedContext.length === 0) {
       return this.#applyBridgeConversionsIfNeeded(
         [...parts, ...extensionParts, ...mcpServerParts],
         abortSignal,
       );
     }
-
-    // Extract paths from @ commands - pass directly to readManyFiles without filtering
-    // since this is user-triggered behavior, not LLM-triggered
-    const pathSpecsToRead: string[] = atPathCommandParts.map(
-      (part) => part.fileData!.fileUri!,
-    );
 
     // Construct the initial part of the query for the LLM
     let initialQueryText = '';

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -661,9 +661,7 @@ const MAX_NOTIFICATION_QUEUE = 20;
 export function isExistingFile(
   resolved: string,
   fileExists: (path: string) => boolean = existsSync,
-  statFile: (
-    path: string,
-  ) => Pick<ReturnType<typeof statSync>, 'isFile'> = statSync,
+  statFile: (path: string) => { isFile(): boolean } = statSync,
 ): boolean {
   try {
     return fileExists(resolved) && statFile(resolved).isFile();

--- a/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.test.ts
@@ -6,7 +6,10 @@
 
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { handleAtCommand } from './atCommandProcessor.js';
+import {
+  extractAtPathCommands,
+  handleAtCommand,
+} from './atCommandProcessor.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {
   FileDiscoveryService,
@@ -20,6 +23,16 @@ import { ToolCallStatus } from '../types.js';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
+
+describe('extractAtPathCommands', () => {
+  it('extracts only non-empty @path commands', () => {
+    expect(extractAtPathCommands('')).toEqual([]);
+    expect(extractAtPathCommands('@')).toEqual([]);
+    expect(extractAtPathCommands('hello')).toEqual([]);
+    expect(extractAtPathCommands('@foo')).toEqual(['foo']);
+    expect(extractAtPathCommands('@foo @bar')).toEqual(['foo', 'bar']);
+  });
+});
 
 describe('handleAtCommand', () => {
   let testRootDir: string;

--- a/packages/cli/src/ui/hooks/atCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/atCommandProcessor.ts
@@ -152,6 +152,14 @@ function parseAllAtCommands(query: string): AtCommandPart[] {
   );
 }
 
+export function extractAtPathCommands(query: string): string[] {
+  return parseAllAtCommands(query).flatMap((part) =>
+    part.type === 'atPath' && part.content !== '@'
+      ? [part.content.substring(1)]
+      : [],
+  );
+}
+
 /**
  * Detect an `@server:uri` MCP resource reference. Returns the parsed
  * `{ serverName, uri }` ONLY when `pathName` is prefixed by a configured MCP


### PR DESCRIPTION
## What this PR does

ACP sessions now resolve absolute local image references embedded in text as `@/path/to/image.png`. Only image files inside the active workspace and allowed by the existing ignore rules enter the file-reading and Vision Bridge pipeline.

Relative paths, non-image files, directories, nonexistent references such as `@scope/pkg`, and ignored or out-of-workspace paths remain ordinary text. Existing structured `resource_link` inputs are unchanged.

## Why it's needed

The interactive CLI already supports textual `@path` references, but ACP previously resolved only structured `resource_link` blocks. Some ACP clients send a local image path only as text, so the image never reached the Vision Bridge.

This PR adds that narrow compatibility path without enabling general textual file references in ACP.

## Reviewer Test Plan

### How to verify

1. Send an ACP text prompt containing an absolute local image path, such as `look at @/workspace/image.png`.
2. Confirm that the image enters the existing file-reading and Vision Bridge pipeline.
3. Repeat with a relative image path, a text file, a directory, an ignored image, and an out-of-workspace image; confirm that none are read.
4. Repeat with an existing `resource_link(file://...)` attachment and confirm that structured attachments still work.

Automated verification:

- Focused ACP image-path regression tests: 2/2 passed
- CLI typecheck: passed
- Prettier and `git diff --check`: passed

## Risk & Scope

- Main risk: textual `@...` tokens can resemble package names or ordinary prose. Requiring an absolute path, image MIME type, workspace containment, a regular file, and existing ignore checks keeps this behavior narrow.
- Out of scope: relative image paths, non-image files, directories, remote image URLs, bare paths without `@`, and full-turn multimodal routing proposed in #6988.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #6988, but this PR only handles ACP image input normalization before the image enters the existing multimodal pipeline.
