### PR TITLE
fix: keep quit and stream logging reliable

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -576,9 +576,11 @@ describe('AppContainer State Management', () => {
   };
 
   describe('Basic Rendering', () => {
-    it('cancels an active request before quitting', () => {
+    it('continues quitting when cancelling the active request fails', () => {
       vi.useFakeTimers();
-      const cancelOngoingRequest = vi.fn();
+      const cancelOngoingRequest = vi.fn(() => {
+        throw new Error('cancel failed');
+      });
       const requestShutdown = vi.fn();
       mockedUseGeminiStream.mockReturnValue({
         streamingState: StreamingState.Responding,
@@ -610,10 +612,12 @@ describe('AppContainer State Management', () => {
       const slashCommandActions = mockedUseSlashCommandProcessor.mock.calls.at(
         -1,
       )?.[12] as { quit: (messages: HistoryItem[]) => void };
-      slashCommandActions.quit([]);
+      const timerCount = vi.getTimerCount();
+      expect(() => slashCommandActions.quit([])).not.toThrow();
 
       expect(cancelOngoingRequest).toHaveBeenCalledOnce();
       expect(requestShutdown).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(timerCount + 1);
     });
 
     it('shows recording failures as warnings and unsubscribes on unmount', async () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1557,7 +1557,11 @@ export const AppContainer = (props: AppContainerProps) => {
       openApprovalModeDialog,
       openEffortDialog,
       quit: (messages: HistoryItem[]) => {
-        cancelOngoingRequestRef.current();
+        try {
+          cancelOngoingRequestRef.current();
+        } catch (error) {
+          debugLogger.debug('Failed to cancel request while quitting:', error);
+        }
         setQuittingMessages(messages);
         // Signal the client to skip background memory tasks (extract, dream,
         // skill review) so the process can exit without spawning new agent

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -1315,8 +1315,14 @@ describe('LoggingContentGenerator', () => {
         { functionCall: { id: 'call-1', name: 'tool', args: '{"x":1}' } },
         { functionResponse: { name: 'tool', response: { output: 'ok' } } },
       ],
-      usage2,
+      undefined,
       'STOP',
+    );
+    const usageResponse = createResponse(
+      'resp-usage',
+      'model-stream',
+      [],
+      usage2,
     );
 
     const wrapped = createWrappedGenerator(
@@ -1324,6 +1330,7 @@ describe('LoggingContentGenerator', () => {
       vi.fn().mockResolvedValue(
         (async function* () {
           yield response1;
+          yield usageResponse;
           yield response2;
         })(),
       ),
@@ -1349,7 +1356,7 @@ describe('LoggingContentGenerator', () => {
     for await (const item of stream) {
       seen.push(item);
     }
-    expect(seen).toHaveLength(2);
+    expect(seen).toHaveLength(3);
 
     expect(logApiResponse).toHaveBeenCalledTimes(1);
     const [, responseEvent] = vi.mocked(logApiResponse).mock.calls[0];

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -645,6 +645,9 @@ export class LoggingContentGenerator implements ContentGenerator {
       const consolidatedResponse = shouldCollectResponses
         ? this.consolidateGeminiResponsesForLogging(responses)
         : undefined;
+      if (consolidatedResponse) {
+        consolidatedResponse.usageMetadata = lastUsageMetadata;
+      }
       const shouldCollectSensitiveSpanAttributes =
         !isInternal &&
         span !== undefined &&


### PR DESCRIPTION
## What this PR does

This PR closes two residual edge cases after #7038. Explicit `/quit` now continues requesting shutdown and scheduling exit cleanup even if cancelling the active request throws. Stream response consolidation also preserves the latest usage metadata when it arrives in a metadata-only chunk that is intentionally excluded from content aggregation.

## Why it's needed

The quit path cancelled the active request before scheduling shutdown, so a synchronous cancellation error could leave the process running. Separately, bounded stream logging filters metadata-only chunks from content aggregation; when a later content chunk omitted usage metadata, that could make an older usage value win in the optional OpenAI interaction log. The fix keeps aggregation bounded while preserving the final usage semantics.

## Reviewer Test Plan

### How to verify

1. Make active-request cancellation throw during `/quit`. Confirm that no exception escapes, shutdown is requested once, and exit cleanup is still scheduled.
2. Stream a content chunk with initial usage, a metadata-only chunk with newer usage, and a final content chunk without usage. Confirm that all three chunks are yielded unchanged while the consolidated log response uses the newer usage and the final content/finish reason.

### Evidence (Before & After)

Before: a cancellation exception stopped `/quit` before shutdown scheduling; filtered metadata-only chunks could leave consolidated interaction logs with stale usage.

After: `/quit` completes its shutdown sequence despite cancellation failure, and consolidated logs retain the latest observed usage metadata.

![Local regression verification](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/qwen-code-quit-usage-c284b5f6.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 15.1.1 arm64, Node.js v22.22.0, npm 10.9.4, sandbox disabled.

## Risk & Scope

- Main risk or tradeoff: explicit quit now treats cancellation as best-effort and records failures in debug logging so shutdown can proceed.
- Not validated / out of scope: manual Windows and Linux verification; automated CI should cover those platforms.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7038.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 补上 #7038 合并后仍存在的两个边缘问题。执行 `/quit` 时，即使取消当前请求抛出异常，也会继续请求关闭并安排退出清理。流式响应整合也会保留最新的 usage 元数据，即使该数据来自为了控制内容聚合内存而被过滤掉的纯元数据分块。

## 为什么需要

退出路径原本会先取消当前请求，再安排关闭；因此同步取消异常可能让进程继续运行。另一方面，有界流日志会从内容聚合中排除纯元数据分块；如果后续内容分块不含 usage，OpenAI 可选交互日志就可能错误保留更旧的 usage。本修复在继续保持有界聚合的同时，恢复正确的最终 usage 语义。

## Reviewer 测试计划

### 如何验证

1. 在 `/quit` 期间让当前请求的取消逻辑抛出异常。确认异常不会继续向外抛出、关闭请求只执行一次，并且退出清理仍被安排。
2. 依次返回带初始 usage 的内容分块、带更新 usage 的纯元数据分块，以及不含 usage 的最终内容分块。确认三个分块均原样交给调用方，同时整合后的日志响应使用更新后的 usage 和最终内容/结束原因。

### 证据（修复前后）

修复前：取消异常会在安排关闭之前中断 `/quit`；被过滤的纯元数据分块可能导致整合交互日志保留过期 usage。

修复后：即使取消失败，`/quit` 仍会完成关闭流程；整合日志会保留最后一次观察到的 usage 元数据。

![本地回归验收](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/qwen-code-quit-usage-c284b5f6.png)

### 已测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 15.1.1 arm64、Node.js v22.22.0、npm 10.9.4、未启用 sandbox。

## 风险与范围

- 主要风险或取舍：显式退出时把取消视为尽力而为；失败会写入 debug 日志，以保证关闭继续执行。
- 未验证 / 范围外：Windows 和 Linux 手工验证；这些平台由自动化 CI 覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联问题

#7038 的后续修复。

</details>
