### PR TITLE
feat(web-shell): add directory autocomplete to the Add Workspace dialog

### DIFF
--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express, { type Request, type Response } from 'express';
 import request from 'supertest';
 import {
@@ -18,7 +18,7 @@ import type {
 } from '../workspace-registry.js';
 import { tmpdir } from 'node:os';
 import { realpathSync } from 'node:fs';
-import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   workspaceRegistrationId,
@@ -1425,5 +1425,102 @@ describe('persistent workspace registrations', () => {
     expect((await forgetResult).status).toBe(500);
     await seal;
     expect(sealed).toBe(true);
+  });
+});
+
+describe('GET /workspace-path-suggestions', () => {
+  let base: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    base = await mkdtemp(join(REAL_DIR, 'qwen-suggest-'));
+    await mkdir(join(base, 'alpha'));
+    await mkdir(join(base, 'alpine'));
+    await mkdir(join(base, 'beta'));
+    await mkdir(join(base, '.hidden'));
+    await writeFile(join(base, 'a-file.txt'), 'x');
+    await symlink(join(base, 'beta'), join(base, 'beta-link'));
+  });
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it('lists only directories inside a prefix ending with a separator', async () => {
+    const { app } = createApp();
+    const res = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: `${base}/` });
+    expect(res.status).toBe(200);
+    expect(res.body.dir).toBe(base);
+    const names = res.body.suggestions.map((s: { name: string }) => s.name);
+    // Plain files are excluded; symlinked directories are navigable.
+    expect(names).toEqual(['alpha', 'alpine', 'beta', 'beta-link']);
+    expect(res.body.truncated).toBe(false);
+    for (const s of res.body.suggestions) {
+      expect(s.path).toBe(join(base, s.name));
+    }
+  });
+
+  it('filters by the case-insensitive final segment of the prefix', async () => {
+    const { app } = createApp();
+    const res = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: join(base, 'ALP') });
+    expect(res.status).toBe(200);
+    expect(res.body.dir).toBe(base);
+    const names = res.body.suggestions.map((s: { name: string }) => s.name);
+    expect(names).toEqual(['alpha', 'alpine']);
+  });
+
+  it('hides dot-directories unless the filter starts with a dot', async () => {
+    const { app } = createApp();
+    const withoutDot = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: `${base}/` });
+    expect(
+      withoutDot.body.suggestions.map((s: { name: string }) => s.name),
+    ).not.toContain('.hidden');
+
+    const withDot = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: join(base, '.hi') });
+    expect(
+      withDot.body.suggestions.map((s: { name: string }) => s.name),
+    ).toEqual(['.hidden']);
+  });
+
+  it('returns an empty list for a nonexistent directory', async () => {
+    const { app } = createApp();
+    const res = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: join(base, 'no-such-dir', 'x') });
+    expect(res.status).toBe(200);
+    expect(res.body.suggestions).toEqual([]);
+  });
+
+  it('rejects a relative prefix', async () => {
+    const { app } = createApp();
+    const res = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: 'relative/path' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_prefix');
+  });
+
+  it('rejects a missing prefix', async () => {
+    const { app } = createApp();
+    const res = await request(app).get('/workspace-path-suggestions');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_prefix');
+  });
+
+  it('rejects an over-long prefix before touching the filesystem', async () => {
+    const { app } = createApp();
+    const res = await request(app)
+      .get('/workspace-path-suggestions')
+      .query({ prefix: '/' + 'x'.repeat(5000) });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_prefix');
   });
 });

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { stat } from 'node:fs/promises';
+import { readdir, stat } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
-import { isAbsolute, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Application, Request, Response } from 'express';
 import { isWithinRoot } from '@qwen-code/qwen-code-core';
 import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
@@ -33,6 +33,12 @@ import {
 // launcher), so an unbounded POST /workspaces would let an authenticated
 // client exhaust memory / file descriptors. Forgetting persistence does not
 // unload an active runtime, so this remains the runtime backpressure.
+
+// Cap on directory suggestions returned by GET /workspace-path-suggestions.
+// Autocomplete only needs the first screenful; anything more is wasted
+// readdir/stat work on huge directories.
+const MAX_PATH_SUGGESTIONS = 50;
+
 export interface WorkspaceManagementRouteDeps {
   workspaceRegistry: WorkspaceRegistry;
   mutate: (opts?: { strict?: boolean }) => import('express').RequestHandler;
@@ -111,6 +117,92 @@ export function registerWorkspaceManagementRoutes(
       code: 'daemon_shutting_down',
     });
   };
+
+  // Read-only directory suggestions for the "Add workspace" flow. The
+  // existing `GET /list` route resolves paths through a registered
+  // workspace's filesystem boundary, so it cannot browse a path that is
+  // not yet a workspace. This route fills that gap with a deliberately
+  // narrow surface: it reveals only the *names* of subdirectories (no
+  // files, no contents, no stat details) at an absolute prefix, capped at
+  // MAX_PATH_SUGGESTIONS entries. That is the same trust surface as
+  // `POST /workspaces`, which already lets an authenticated client stat
+  // and register any absolute directory path.
+  app.get(
+    '/workspace-path-suggestions',
+    async (req: Request, res: Response) => {
+      const prefixRaw = req.query['prefix'];
+      if (typeof prefixRaw !== 'string' || prefixRaw.trim().length === 0) {
+        res.status(400).json({
+          error: '`prefix` must be a non-empty string',
+          code: 'invalid_prefix',
+        });
+        return;
+      }
+      const prefix = prefixRaw;
+      if (prefix.length > MAX_WORKSPACE_PATH_LENGTH) {
+        res.status(400).json({
+          error: `\`prefix\` exceeds the ${MAX_WORKSPACE_PATH_LENGTH}-character limit`,
+          code: 'invalid_prefix',
+        });
+        return;
+      }
+      if (!isAbsolute(prefix)) {
+        res.status(400).json({
+          error: '`prefix` must be an absolute path',
+          code: 'invalid_prefix',
+        });
+        return;
+      }
+      // A prefix ending in a separator means "list inside this directory";
+      // otherwise the final segment is an in-progress name used as a filter.
+      const endsWithSep =
+        prefix.endsWith('/') ||
+        (process.platform === 'win32' && prefix.endsWith('\\'));
+      // join(x, '.') normalizes away the trailing separator while leaving a
+      // bare root ('/', 'C:\') intact.
+      const dir = endsWithSep ? join(prefix, '.') : dirname(prefix);
+      const filter = endsWithSep ? '' : basename(prefix);
+      const filterLower = filter.toLowerCase();
+      const suggestions: Array<{ name: string; path: string }> = [];
+      let truncated = false;
+      try {
+        const entries = await readdir(dir, { withFileTypes: true });
+        entries.sort((a, b) => a.name.localeCompare(b.name));
+        for (const entry of entries) {
+          // Hidden directories only surface once the user explicitly starts
+          // typing a dot — mirrors shell completion behavior.
+          if (entry.name.startsWith('.') && !filter.startsWith('.')) continue;
+          if (filter && !entry.name.toLowerCase().startsWith(filterLower)) {
+            continue;
+          }
+          let isDir = entry.isDirectory();
+          if (!isDir && entry.isSymbolicLink()) {
+            try {
+              isDir = (await stat(join(dir, entry.name))).isDirectory();
+            } catch {
+              continue; // broken symlink — not a navigable directory
+            }
+          }
+          if (!isDir) continue;
+          if (suggestions.length >= MAX_PATH_SUGGESTIONS) {
+            truncated = true;
+            break;
+          }
+          suggestions.push({ name: entry.name, path: join(dir, entry.name) });
+        }
+      } catch {
+        // Nonexistent / unreadable directory: an empty suggestion list is the
+        // correct autocomplete answer, not an error dialog.
+      }
+      res.status(200).json({
+        kind: 'workspace-path-suggestions',
+        dir,
+        sep,
+        suggestions,
+        truncated,
+      });
+    },
+  );
 
   app.post(
     '/workspaces',

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1498,6 +1498,25 @@ export class DaemonClient {
     );
   }
 
+  /**
+   * Directory-name suggestions for an absolute path prefix, for flows that
+   * pick a path outside any registered workspace (e.g. "Add workspace").
+   */
+  async workspacePathSuggestions(prefix: string): Promise<unknown> {
+    const url = new URL(`${this.baseUrl}/workspace-path-suggestions`);
+    url.searchParams.set('prefix', prefix);
+    return await this.fetchWithTimeout(
+      url.toString(),
+      { headers: this.headers() },
+      async (res) => {
+        if (!res.ok) {
+          throw await this.failOnError(res, 'GET /workspace-path-suggestions');
+        }
+        return (await res.json()) as unknown;
+      },
+    );
+  }
+
   async glob(pattern: string): Promise<unknown> {
     const url = new URL(`${this.baseUrl}/glob`);
     url.searchParams.set('pattern', pattern);

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider } from '../../i18n';
@@ -173,6 +173,189 @@ describe('AddWorkspaceDialog', () => {
 
     expect(alert()?.textContent).toBe('Failed to add workspace');
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe('path autocomplete', () => {
+    const SUGGESTIONS = {
+      dir: '/home/me',
+      sep: '/',
+      suggestions: [
+        { name: 'code', path: '/home/me/code' },
+        { name: 'coding-katas', path: '/home/me/coding-katas' },
+      ],
+      truncated: false,
+    };
+    const listbox = () => document.querySelector('[role="listbox"]');
+    const options = () =>
+      Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
+    const keydown = (key: string) => {
+      act(() => {
+        input().dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+    };
+    const settle = async () => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('debounces a suggestion fetch for an absolute prefix and lists directories', async () => {
+      const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/co');
+      expect(onSuggest).not.toHaveBeenCalled(); // debounce window
+      await settle();
+
+      expect(onSuggest).toHaveBeenCalledWith('/home/me/co');
+      expect(listbox()).not.toBeNull();
+      expect(options().map((o) => o.textContent)).toEqual([
+        'code/',
+        'coding-katas/',
+      ]);
+      expect(input().getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('never queries for a non-absolute value', async () => {
+      const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('relative/pa');
+      await settle();
+
+      expect(onSuggest).not.toHaveBeenCalled();
+      expect(listbox()).toBeNull();
+    });
+
+    it('accepts the highlighted entry with Enter without submitting the form', async () => {
+      const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
+      const onAdd = vi.fn().mockResolvedValue(undefined);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={onAdd}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/co');
+      await settle();
+      keydown('ArrowDown');
+      expect(options()[0]?.getAttribute('aria-selected')).toBe('true');
+      keydown('Enter');
+
+      expect(input().value).toBe('/home/me/code/');
+      expect(onAdd).not.toHaveBeenCalled();
+      // Accepting descends into the directory: the follow-up fetch runs for
+      // the new prefix.
+      await settle();
+      expect(onSuggest).toHaveBeenLastCalledWith('/home/me/code/');
+    });
+
+    it('accepts a single suggestion with Tab', async () => {
+      const single = {
+        ...SUGGESTIONS,
+        suggestions: [SUGGESTIONS.suggestions[0]],
+      };
+      const onSuggest = vi.fn().mockResolvedValue(single);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/cod');
+      await settle();
+      keydown('Tab');
+
+      expect(input().value).toBe('/home/me/code/');
+    });
+
+    it('accepts a suggestion on mousedown', async () => {
+      const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/co');
+      await settle();
+      act(() => {
+        options()[1]!.dispatchEvent(
+          new MouseEvent('mousedown', { bubbles: true, cancelable: true }),
+        );
+      });
+
+      expect(input().value).toBe('/home/me/coding-katas/');
+    });
+
+    it('closes only the list on Escape, keeping the dialog open', async () => {
+      const onSuggest = vi.fn().mockResolvedValue(SUGGESTIONS);
+      const onClose = vi.fn();
+      mount(
+        <AddWorkspaceDialog
+          onClose={onClose}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/co');
+      await settle();
+      expect(listbox()).not.toBeNull();
+
+      keydown('Escape');
+
+      expect(listbox()).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('shows no list when the lookup fails', async () => {
+      const onSuggest = vi.fn().mockRejectedValue(new Error('offline'));
+      mount(
+        <AddWorkspaceDialog
+          onClose={vi.fn()}
+          onAdd={vi.fn()}
+          onSuggest={onSuggest}
+        />,
+      );
+
+      type('/home/me/co');
+      await settle();
+
+      expect(listbox()).toBeNull();
+      expect(alert()).toBeNull(); // best-effort: no error surfaced
+    });
   });
 
   it('shows the adding state and disables controls while submitting', async () => {

--- a/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/AddWorkspaceDialog.tsx
@@ -13,40 +13,184 @@ import {
 import { Input } from '../ui/input';
 import { Switch } from '../ui/switch';
 
+export interface WorkspacePathSuggestion {
+  name: string;
+  path: string;
+}
+
+export interface WorkspacePathSuggestions {
+  dir: string;
+  sep: string;
+  suggestions: WorkspacePathSuggestion[];
+  truncated: boolean;
+}
+
 interface AddWorkspaceDialogProps {
   onClose: () => void;
   onAdd: (cwd: string, persist: boolean) => Promise<void>;
+  /**
+   * Directory autocomplete backend. When provided, typing an absolute path
+   * surfaces matching subdirectories in a listbox under the input.
+   */
+  onSuggest?: (prefix: string) => Promise<WorkspacePathSuggestions>;
 }
 
 const HINT_ID = 'add-workspace-hint';
 const ERROR_ID = 'add-workspace-error';
+const LISTBOX_ID = 'add-workspace-suggestions';
+const SUGGEST_DEBOUNCE_MS = 150;
+
+function isAbsoluteLike(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
+}
 
 export function AddWorkspaceDialog({
   onClose,
   onAdd,
+  onSuggest,
 }: AddWorkspaceDialogProps) {
   const { t } = useI18n();
   const [path, setPath] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [persist, setPersist] = useState(true);
+  const [suggestions, setSuggestions] = useState<WorkspacePathSuggestion[]>([]);
+  const [listOpen, setListOpen] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+  const [hostSep, setHostSep] = useState('/');
   const inputRef = useRef<HTMLInputElement>(null);
+  const listOpenRef = useRef(false);
+  listOpenRef.current = listOpen && suggestions.length > 0;
+  const suggestSeqRef = useRef(0);
+  // Set when a suggestion is accepted or the list is dismissed, so the
+  // path-change effect knows whether to reopen the list for that update.
+  const suppressNextFetchOpenRef = useRef(false);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  const closeList = useCallback(() => {
+    setListOpen(false);
+    setHighlight(-1);
+  }, []);
+
+  // Debounced suggestion fetch, keyed off the current path value. A stale
+  // response (older sequence number) never overwrites a newer one.
+  useEffect(() => {
+    if (!onSuggest) return undefined;
+    if (!isAbsoluteLike(path)) {
+      setSuggestions([]);
+      closeList();
+      return undefined;
+    }
+    const seq = ++suggestSeqRef.current;
+    const openOnResult = !suppressNextFetchOpenRef.current;
+    suppressNextFetchOpenRef.current = false;
+    const timer = setTimeout(() => {
+      onSuggest(path).then(
+        (result) => {
+          if (seq !== suggestSeqRef.current) return;
+          setSuggestions(result.suggestions);
+          setHostSep(result.sep || '/');
+          setHighlight(-1);
+          if (openOnResult || listOpenRef.current) {
+            setListOpen(result.suggestions.length > 0);
+          }
+        },
+        () => {
+          if (seq !== suggestSeqRef.current) return;
+          // Autocomplete is best-effort; a failed lookup just yields no list.
+          setSuggestions([]);
+          closeList();
+        },
+      );
+    }, SUGGEST_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [path, onSuggest, closeList]);
+
+  // Radix listens for Escape on document capture; intercept one step earlier
+  // (window capture) so an open suggestion list consumes the Escape instead
+  // of closing the whole dialog (DialogShell skips `defaultPrevented`).
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || !listOpenRef.current) return;
+      if (event.isComposing || event.keyCode === 229) return;
+      event.preventDefault();
+      closeList();
+    };
+    window.addEventListener('keydown', handler, { capture: true });
+    return () =>
+      window.removeEventListener('keydown', handler, { capture: true });
+  }, [closeList]);
+
+  const acceptSuggestion = useCallback(
+    (suggestion: WorkspacePathSuggestion) => {
+      // Append the host separator so the next keystroke (or the immediate
+      // refetch below) descends into the accepted directory.
+      suppressNextFetchOpenRef.current = false;
+      setPath(suggestion.path + hostSep);
+      setError(null);
+      closeList();
+      inputRef.current?.focus();
+    },
+    [hostSep, closeList],
+  );
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const open = listOpen && suggestions.length > 0;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (!open) {
+          if (suggestions.length > 0) setListOpen(true);
+          return;
+        }
+        setHighlight((current) => (current + 1) % suggestions.length);
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        if (!open) return;
+        event.preventDefault();
+        setHighlight(
+          (current) => (current <= 0 ? suggestions.length : current) - 1,
+        );
+        return;
+      }
+      if (event.key === 'Tab' && open && !event.shiftKey) {
+        const target =
+          highlight >= 0
+            ? suggestions[highlight]
+            : suggestions.length === 1
+              ? suggestions[0]
+              : undefined;
+        if (target) {
+          event.preventDefault();
+          acceptSuggestion(target);
+        }
+        return;
+      }
+      if (event.key === 'Enter' && open && highlight >= 0) {
+        // Enter accepts the highlighted directory instead of submitting.
+        event.preventDefault();
+        acceptSuggestion(suggestions[highlight]);
+      }
+    },
+    [listOpen, suggestions, highlight, acceptSuggestion],
+  );
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
       const trimmed = path.trim();
       if (!trimmed) return;
-      if (!trimmed.startsWith('/') && !/^[A-Za-z]:[\\//]/.test(trimmed)) {
+      if (!isAbsoluteLike(trimmed)) {
         setError(t('sidebar.addWorkspaceAbsError'));
         return;
       }
       setError(null);
       setSubmitting(true);
+      closeList();
       try {
         await onAdd(trimmed, persist);
         onClose();
@@ -58,8 +202,10 @@ export function AddWorkspaceDialog({
         setSubmitting(false);
       }
     },
-    [path, persist, onAdd, onClose, t],
+    [path, persist, onAdd, onClose, closeList, t],
   );
+
+  const showList = listOpen && suggestions.length > 0;
 
   return (
     <DialogShell
@@ -73,24 +219,74 @@ export function AddWorkspaceDialog({
             <FieldLabel htmlFor="add-workspace-path">
               {t('sidebar.addWorkspacePath')}
             </FieldLabel>
-            <Input
-              ref={inputRef}
-              id="add-workspace-path"
-              type="text"
-              placeholder="/absolute/path/to/project"
-              value={path}
-              onChange={(e) => {
-                setPath(e.target.value);
-                if (error) setError(null);
-              }}
-              disabled={submitting}
-              autoCapitalize="off"
-              autoCorrect="off"
-              autoComplete="off"
-              spellCheck={false}
-              aria-describedby={error ? `${ERROR_ID} ${HINT_ID}` : HINT_ID}
-              aria-invalid={error ? true : undefined}
-            />
+            <div className="relative">
+              <Input
+                ref={inputRef}
+                id="add-workspace-path"
+                type="text"
+                placeholder="/absolute/path/to/project"
+                value={path}
+                onChange={(e) => {
+                  setPath(e.target.value);
+                  if (error) setError(null);
+                }}
+                onKeyDown={handleInputKeyDown}
+                onBlur={() => {
+                  // Delay so a mousedown on a suggestion wins over blur.
+                  setTimeout(() => {
+                    suppressNextFetchOpenRef.current = true;
+                    closeList();
+                  }, 100);
+                }}
+                disabled={submitting}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+                role="combobox"
+                aria-expanded={showList}
+                aria-controls={showList ? LISTBOX_ID : undefined}
+                aria-activedescendant={
+                  showList && highlight >= 0
+                    ? `${LISTBOX_ID}-${highlight}`
+                    : undefined
+                }
+                aria-describedby={error ? `${ERROR_ID} ${HINT_ID}` : HINT_ID}
+                aria-invalid={error ? true : undefined}
+              />
+              {showList && (
+                <ul
+                  id={LISTBOX_ID}
+                  role="listbox"
+                  aria-label={t('sidebar.addWorkspaceSuggestions')}
+                  className="absolute inset-x-0 top-full z-50 mt-1 max-h-56 overflow-y-auto rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
+                >
+                  {suggestions.map((suggestion, index) => (
+                    <li
+                      key={suggestion.path}
+                      id={`${LISTBOX_ID}-${index}`}
+                      role="option"
+                      aria-selected={index === highlight}
+                      className={`cursor-pointer truncate px-3 py-1.5 ${
+                        index === highlight
+                          ? 'bg-accent text-accent-foreground'
+                          : 'hover:bg-accent/50'
+                      }`}
+                      onMouseDown={(event) => {
+                        // Keep focus in the input; blur would close the list
+                        // before click lands.
+                        event.preventDefault();
+                        acceptSuggestion(suggestion);
+                      }}
+                      onMouseEnter={() => setHighlight(index)}
+                    >
+                      {suggestion.name}
+                      <span className="text-muted-foreground">{hostSep}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
             <FieldDescription id={HINT_ID}>
               {t('sidebar.addWorkspaceHint')}
             </FieldDescription>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -1191,6 +1191,11 @@ export function WebShellSidebar({
     [t, workspaceActions, workspace],
   );
 
+  const handleSuggestWorkspacePaths = useCallback(
+    (prefix: string) => workspaceActions.suggestWorkspacePaths(prefix),
+    [workspaceActions],
+  );
+
   const reconcileRemovedWorkspace = useCallback(
     async (removed: DaemonWorkspaceCapability) => {
       if (!workspaceRemovalMountedRef.current) return;
@@ -3768,6 +3773,7 @@ export function WebShellSidebar({
         <AddWorkspaceDialog
           onClose={() => setShowAddWorkspaceDialog(false)}
           onAdd={handleAddWorkspace}
+          onSuggest={handleSuggestWorkspacePaths}
         />
       )}
     </>

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -856,6 +856,7 @@ const EN: Messages = {
     'The daemon did not confirm persistent workspace registration',
   'sidebar.addWorkspaceAbsError': 'Path must be absolute',
   'sidebar.addWorkspaceHint': 'Enter the absolute path to a project directory.',
+  'sidebar.addWorkspaceSuggestions': 'Directory suggestions',
   'sidebar.addWorkspacePersist': 'Keep after daemon restart',
   'sidebar.addWorkspacePersistHint':
     'Persist this workspace registration in the daemon configuration.',
@@ -2932,6 +2933,7 @@ const ZH: Messages = {
   'sidebar.addWorkspacePersistenceError': '守护进程未确认工作区已持久化注册',
   'sidebar.addWorkspaceAbsError': '路径必须是绝对路径',
   'sidebar.addWorkspaceHint': '请输入项目目录的绝对路径。',
+  'sidebar.addWorkspaceSuggestions': '目录建议',
   'sidebar.addWorkspacePersist': '服务重启后保留',
   'sidebar.addWorkspacePersistHint': '将此工作区注册持久化到守护进程配置中。',
   'sidebar.addWorkspaceAdding': '添加中…',

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -11,6 +11,7 @@ import type {
   DaemonFileStat,
   DaemonScheduledTask,
   DaemonWorkspaceActions,
+  DaemonWorkspacePathSuggestions,
 } from './types.js';
 
 const AGENT_GENERATE_TIMEOUT_MS = 330_000;
@@ -819,6 +820,15 @@ export function createDaemonWorkspaceActions({
         client.addWorkspace(cwd, options),
         'Add workspace timed out',
       );
+    },
+
+    async suggestWorkspacePaths(prefix) {
+      const client = requireClient(getClient, 'Suggest workspace paths failed');
+      const result = await withActionTimeout(
+        client.workspacePathSuggestions(prefix),
+        'Suggest workspace paths timed out',
+      );
+      return result as DaemonWorkspacePathSuggestions;
     },
 
     async removeWorkspace(workspaceId, options) {

--- a/packages/webui/src/daemon/workspace/types.ts
+++ b/packages/webui/src/daemon/workspace/types.ts
@@ -258,6 +258,21 @@ export interface DaemonAddWorkspaceResult {
   persisted?: boolean;
 }
 
+export interface DaemonWorkspacePathSuggestion {
+  name: string;
+  path: string;
+}
+
+export interface DaemonWorkspacePathSuggestions {
+  kind: 'workspace-path-suggestions';
+  /** Directory the suggestions were listed from. */
+  dir: string;
+  /** Path separator of the daemon host, for appending on accept. */
+  sep: string;
+  suggestions: DaemonWorkspacePathSuggestion[];
+  truncated: boolean;
+}
+
 export interface DaemonWorkspaceActions {
   // Sessions
   listSessions(
@@ -491,6 +506,9 @@ export interface DaemonWorkspaceActions {
     cwd: string,
     options?: { persist?: boolean },
   ): Promise<DaemonAddWorkspaceResult>;
+  suggestWorkspacePaths(
+    prefix: string,
+  ): Promise<DaemonWorkspacePathSuggestions>;
   removeWorkspace(
     workspaceId: string,
     options?: { force?: boolean; timeoutMs?: number },


### PR DESCRIPTION
## What this PR does

Adds inline directory autocomplete to the web shell's "Add workspace" dialog. As the user types an absolute path, a listbox under the input suggests matching subdirectories read live from the daemon host: ArrowUp/Down move the highlight, Enter/Tab or a click accepts a directory and descends into it (appending the host's path separator and immediately fetching the next level), and Escape dismisses just the list without closing the dialog. Requests are debounced (150 ms) and stale responses are dropped, hidden dot-directories only appear once the user types a leading dot, and symlinked directories are navigable. The listbox is a proper ARIA combobox (`role="combobox"` + `listbox`/`option` with `aria-activedescendant`).

## Why it's needed

The dialog previously offered a bare text box that required typing the full absolute path from memory; a typo produced only a generic "must be absolute" / "failed to add" error after submitting (#7102). The triage analysis confirmed the pain and flagged the key blocker: the existing `GET /list` route resolves paths through a registered workspace's filesystem boundary, so it cannot browse a path that is not yet a workspace. This PR adds the missing backend piece as a deliberately narrow, read-only daemon route — `GET /workspace-path-suggestions?prefix=<absolute>` — that returns only the names of matching subdirectories (no files, no contents, no stat details), capped at 50 entries, behind the same bearer-token auth as every other daemon route. That is the same trust surface as `POST /workspaces`, which already lets an authenticated client stat and register any absolute directory path.

## Reviewer Test Plan

### How to verify

1. `qwen serve --port <p> --token <t>`, open the web shell, click the sidebar's "Add workspace" (+) button.
2. Type an absolute prefix (e.g. `/Users/you/`): a listbox of subdirectories appears; only directories are listed, dot-directories stay hidden until you type `.`.
3. Continue typing to filter case-insensitively; press ArrowDown then Enter (or Tab, or click) to accept — the input descends into the directory and the next level loads.
4. With the list open, press Escape: only the list closes; the dialog stays. Submitting still validates and registers the workspace exactly as before.
5. Route-level: `curl -H "Authorization: Bearer <t>" "http://127.0.0.1:<p>/workspace-path-suggestions?prefix=/some/dir/"` — and confirm `401` without the token, `400` for a relative prefix, `200` with empty `suggestions` for a nonexistent directory.

Automated coverage: 7 new supertest cases for the route (directories-only + symlink handling, case-insensitive filtering, dot-directory gating, nonexistent dir, relative/missing/oversized prefix) and 7 new jsdom cases for the dialog (debounced fetch, no fetch for relative input, Enter-accept without submit + descend, Tab-accept, mousedown-accept, Escape closes list but not dialog, failed lookup degrades silently). `npm run typecheck`, the web-shell `build` (vite + lib tsc), eslint and prettier are all clean.

### Evidence (Before & After)

Before: a plain text input with no suggestions (unchanged behavior remains if `onSuggest` is not provided — the prop is optional). After, against a **real daemon** (`qwen serve`) and a real directory tree, driven by Playwright in a real Chromium:

Typing a prefix lists real subdirectories (symlinked dir included, files and dot-dirs excluded), first entry highlighted via ArrowDown:

![suggestion list](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7102/assets/shot-7102-list.png)

Typing `front` narrows the list case-insensitively:

![filtered list](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7102/assets/shot-7102-filtered.png)

Route-level E2E against the same daemon: trailing-separator listing, prefix filtering, `.g` surfacing `.git`, `401` without token, `400` for a relative prefix, and an empty list for a nonexistent directory — full transcript in the PR comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; real `qwen serve` daemon from the esbuild bundle + Playwright Chromium for the browser E2E; vitest (node) for the route, vitest (jsdom) for the dialog.

## Risk & Scope

- Main risk or tradeoff: the new route lets an authenticated client enumerate directory *names* anywhere on the daemon host. This is intentionally scoped (directories only, names only, 50-entry cap) and is not an escalation: the same client can already stat and register arbitrary absolute paths via `POST /workspaces`, and full filesystem access follows workspace registration. The route is read-only and never echoes symlink targets.
- Not validated / out of scope: a native "Browse…" folder picker (a browser cannot browse the daemon host's filesystem; server-backed autocomplete is the workable half of the issue's ask); Windows path semantics are implemented (drive-letter prefixes, `\` separator) but only exercised on macOS locally.
- Breaking changes / migration notes: none — `onSuggest` is an optional prop and the dialog behaves exactly as before when it is absent.

## Linked Issues

Fixes #7102

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 web shell 的「添加工作区」对话框加入目录自动补全。用户输入绝对路径时，输入框下方的列表实时从 daemon 主机读取并展示匹配的子目录：ArrowUp/Down 移动高亮，Enter/Tab 或点击接受某个目录并下钻（自动补上主机的路径分隔符并立即拉取下一层），Escape 只关闭列表而不关闭对话框。请求做了 150ms 防抖、过期响应丢弃；隐藏目录（点开头）只在用户输入 `.` 后才出现；软链目录可导航。列表实现为标准 ARIA combobox（`role="combobox"` + `listbox`/`option` + `aria-activedescendant`）。

## 为什么需要

对话框此前只有一个裸文本框，必须凭记忆输入完整绝对路径，输错后只有笼统的报错（#7102）。triage 分析确认了痛点并指出关键障碍：现有 `GET /list` 路由经已注册工作区的文件系统边界解析路径，无法浏览「尚未成为工作区」的路径。本 PR 补上缺失的后端能力——刻意收窄的只读路由 `GET /workspace-path-suggestions?prefix=<绝对路径>`，只返回匹配子目录的**名字**（不含文件、内容、stat 详情），上限 50 条，受与其他 daemon 路由相同的 bearer token 鉴权保护。这与 `POST /workspaces` 的信任面一致——已认证客户端本就可以对任意绝对路径 stat 并注册工作区。

## 审阅测试计划

### 如何验证

1. `qwen serve --port <p> --token <t>`，打开 web shell，点击侧边栏「添加工作区」(+) 按钮；
2. 输入绝对路径前缀（如 `/Users/you/`）：出现子目录列表；只列目录，点开头的隐藏目录在输入 `.` 前不显示；
3. 继续输入可大小写不敏感过滤；ArrowDown + Enter（或 Tab、点击）接受——输入框下钻进该目录并加载下一层；
4. 列表打开时按 Escape：只关列表、对话框保留。提交流程与之前完全一致；
5. 路由层：`curl -H "Authorization: Bearer <t>" ".../workspace-path-suggestions?prefix=/some/dir/"`；确认无 token 返回 `401`、相对路径返回 `400`、不存在的目录返回空 `suggestions`。

自动化覆盖：路由 7 个新 supertest 用例 + 对话框 7 个新 jsdom 用例（防抖、相对路径不请求、Enter 接受不提交并下钻、Tab 接受、点击接受、Escape 只关列表、查询失败静默降级）。typecheck / web-shell 构建 / eslint / prettier 全部通过。

### 证据（Before & After）

Before：纯文本输入框、无任何建议（`onSuggest` 为可选 prop，不传时行为与之前完全一致）。After：对**真实 daemon**（`qwen serve`）+ 真实目录树，用 Playwright 驱动真实 Chromium 验证——输入前缀列出真实子目录（含软链目录、排除文件与隐藏目录）、输入 `front` 过滤、键盘接受并下钻、Escape 只关列表（见上方两张截图）。路由层 E2E 完整记录见下方 PR 评论。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；esbuild bundle 的真实 `qwen serve` daemon + Playwright Chromium 浏览器 E2E；vitest（node）路由测试 + vitest（jsdom）组件测试。

## 风险与范围

- 主要风险/权衡：新路由允许已认证客户端枚举 daemon 主机上任意位置的目录**名**。范围刻意收窄（仅目录、仅名字、50 条上限），且不构成权限升级：同一客户端本就可通过 `POST /workspaces` 对任意绝对路径 stat 并注册，注册后即获得完整文件系统访问。路由只读，且不回显软链目标。
- 未验证/超出范围：原生「浏览…」文件夹选择器（浏览器无法浏览 daemon 主机的文件系统；服务端驱动的自动补全是 issue 诉求中可实现的那一半）；Windows 路径语义已实现（盘符前缀、`\` 分隔符）但本地仅在 macOS 验证。
- 破坏性变更/迁移说明：无——`onSuggest` 是可选 prop，不传时对话框行为与之前完全一致。

## 关联 Issue

Fixes #7102

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
