### PR TITLE
ci(autofix): fan out review targets and stop route-scan starvation

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -90,8 +90,15 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:
-      group: 'qwen-autofix-route'
-      cancel-in-progress: true
+      # Cron ticks dedupe among themselves (a newer tick supersedes a queued
+      # one). Dispatches and review/issue events each route independently:
+      # under runner backlog a route job can sit QUEUED for minutes, and the
+      # old shared cancel-in-progress group let any newer event kill pending
+      # full scans — observed as hours of scan starvation during review-event
+      # storms. Route is a seconds-long job, so unique groups cost nothing.
+      group: "${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || format('qwen-autofix-route-{0}', github.run_id) }}"
+      cancel-in-progress: |-
+        ${{ github.event_name == 'schedule' }}
     permissions:
       contents: 'read'
     outputs:
@@ -1152,7 +1159,11 @@ jobs:
               --arg round "${ROUND}" --arg wm "${EFF_WM}" \
               '. + [{pr: $pr, branch: $branch, issue: $issue, round: $round, watermark: $wm}]' \
               <<< "${TARGETS}")"
-            break # one PR per scheduled scan
+            # Fan out: emit EVERY eligible PR. The address matrix bounds
+            # simultaneity (max-parallel) and the per-PR concurrency groups
+            # prevent duplicate same-PR runs, so one scan drains the whole
+            # backlog instead of serving a single newest-first target per tick
+            # (which starved older PRs for hours when cron ticks were sparse).
           done
 
           COUNT="$(jq 'length' <<< "${TARGETS}")"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1395,6 +1395,47 @@ jobs:
           [[ -z "${NEWEST}" ]] && NEWEST="${WATERMARK}"
           echo "newest=${NEWEST}" >> "${GITHUB_OUTPUT}"
 
+          # Live-watermark revalidation: two near-simultaneous triggers for the
+          # SAME PR can both pass their (per-target, route-level) gates and both
+          # scan before either has emitted a matrix job, so both emit this PR
+          # with the same stale watermark. The per-PR address concurrency group
+          # QUEUES the duplicate rather than discarding it — but that queueing
+          # is exactly what makes this check sound: address jobs for one PR run
+          # strictly one at a time, so by the time the duplicate runs here, the
+          # first job's eval marker is posted and visible. Recompute the
+          # watermark from LIVE markers; if nothing is newer and there is no
+          # conflict, this run is a stale duplicate and discards itself.
+          STALE='false'
+          LIVE_EVAL_WM="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+            [ .[] | select((.user.login // "") == $ab) | (.body // "")
+              | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+) -->") ] | .[]
+              | .[0] ] | max // ""' "${WORKDIR}/ic.json")"
+          if [[ -n "${LIVE_EVAL_WM}" && "${LIVE_EVAL_WM}" > "${WATERMARK}" && "${CONFLICT}" != "true" ]]; then
+            LIVE_NEW="$(jq -rs \
+              --arg wm "${LIVE_EVAL_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
+              --argjson trust "${TRUSTED_ASSOC}" '
+              ((.[0] | map(select((.submitted_at // "") > $wm)
+                | select((.user.login // "") != $ab)
+                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.state // "") | IN("CHANGES_REQUESTED", "COMMENTED"))) | length)
+              + (.[1] | map(select((.created_at // "") > $wm)
+                | select((.user.login // "") != $ab)
+                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)) | length)
+              + (.[2] | map(select((.created_at // "") > $wm)
+                | select((.user.login // "") != $ab)
+                | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
+                | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)) | length)
+              + (.[3] | map(select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED"))
+                | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
+                | select((.completedAt // .updatedAt // "") > $wm)) | length)' \
+              "${WORKDIR}/rv.json" "${WORKDIR}/rc.json" "${WORKDIR}/ic.json" "${WORKDIR}/checks.json")"
+            if [[ "${LIVE_NEW}" == "0" ]]; then
+              STALE='true'
+              echo "🫥 stale duplicate target: a sibling run already evaluated through ${LIVE_EVAL_WM} and nothing is newer — discarding without action or marker"
+            fi
+          fi
+          echo "stale=${STALE}" >> "${GITHUB_OUTPUT}"
+
           # Render the actionable feedback into one prompt-ready file.
           {
             ISSUE_REF=""
@@ -1454,6 +1495,10 @@ jobs:
 
       - name: 'Triage and address'
         id: 'address'
+        # Skipped entirely for a stale duplicate target (see the live-watermark
+        # revalidation in prepare) — no agent run, no marker, no comment.
+        if: |-
+          ${{ steps.prepare.outputs.stale != 'true' }}
         # Bound the agent well below the 120-minute job timeout so a runaway agent
         # fails THIS step (not the whole job), leaving the always() verify and
         # report steps time to run and post a handoff. A job-level timeout would
@@ -1520,7 +1565,7 @@ jobs:
       - name: 'Verification gate'
         id: 'verify'
         if: |-
-          ${{ always() }}
+          ${{ always() && steps.prepare.outputs.stale != 'true' }}
         run: |-
           if [[ -f "${WORKDIR}/failure.md" && -n "$(git status --porcelain)" ]]; then
             echo "❌ Agent wrote failure.md after leaving a dirty workspace:"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -93,15 +93,19 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:
-      # Cron ticks dedupe among themselves (a newer tick supersedes a queued
-      # one). Dispatches and review/issue events each route independently:
-      # under runner backlog a route job can sit QUEUED for minutes, and the
-      # old shared cancel-in-progress group let any newer event kill pending
-      # full scans — observed as hours of scan starvation during review-event
-      # storms. Route is a seconds-long job, so unique groups cost nothing.
-      group: "${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || format('qwen-autofix-route-{0}', github.run_id) }}"
+      # Concurrency is keyed by TARGET, not shared and not fully unique:
+      #   • cron ticks share one group (a newer tick supersedes a queued one)
+      #   • review events coalesce PER PR (two reviews on the same PR seconds
+      #     apart route once — the old shared group's one useful side effect,
+      #     kept, without letting events on OTHER PRs cancel this one)
+      #   • issue events coalesce PER issue
+      #   • dispatches are unique per run and are never cancelled
+      # The old single shared cancel-in-progress group let ANY newer event kill
+      # pending full scans while route jobs sat queued behind runner backlog —
+      # observed as hours of scan starvation during review-event storms.
+      group: "${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || (github.event_name == 'pull_request_review' && format('qwen-autofix-route-pr-{0}', github.event.pull_request.number)) || (github.event_name == 'issues' && format('qwen-autofix-route-issue-{0}', github.event.issue.number)) || format('qwen-autofix-route-{0}', github.run_id) }}"
       cancel-in-progress: |-
-        ${{ github.event_name == 'schedule' }}
+        ${{ github.event_name != 'workflow_dispatch' }}
     permissions:
       contents: 'read'
     outputs:
@@ -1014,8 +1018,33 @@ jobs:
           # check and double-process the feedback).
           PENDING_STALE_MIN=240
           PENDING_CUTOFF="$(date -u -d "${PENDING_STALE_MIN} minutes ago" +%Y-%m-%dT%H:%M:%SZ)"
+
+          # PRs whose review-address is already RUNNING OR QUEUED in any live
+          # autofix run must not be re-targeted. Schedule/dispatch runs execute
+          # against main's SHA, so their matrix jobs never appear in the PR's
+          # statusCheckRollup — and a fanned-out matrix holds queued jobs well
+          # past a 10-minute tick, so without this the next scan re-emits the
+          # same PRs and the per-PR address groups accumulate duplicates that
+          # later replay stale watermarks. One runs-list plus one jobs-view per
+          # live run is cheap (there are at most a few).
+          BUSY_PRS=' '
+          while IFS= read -r LIVE_RUN; do
+            [[ -z "${LIVE_RUN}" ]] && continue
+            while IFS= read -r BUSY; do
+              [[ -n "${BUSY}" ]] && BUSY_PRS="${BUSY_PRS}${BUSY} "
+            done < <(gh run view "${LIVE_RUN}" --repo "${REPO}" --json jobs \
+              --jq '.jobs[] | select(.status != "completed") | .name | capture("^review-address \\((?<pr>[0-9]+),") | .pr' 2> /dev/null)
+          done < <(gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
+            --limit 15 --json databaseId,status \
+            --jq '.[] | select(.status != "completed") | .databaseId' 2> /dev/null)
+          [[ "${BUSY_PRS}" != ' ' ]] && echo "🚧 address in flight/queued for PR(s):${BUSY_PRS}"
+
           TARGETS='[]'
           for PR in ${CANDIDATES}; do
+            if [[ "${BUSY_PRS}" == *" ${PR} "* ]]; then
+              echo "⏳ #${PR}: review-address already in flight or queued — skipping"
+              continue
+            fi
             # One PR fetch for the branch name, check rollup, and creation time (the
             # watermark floor below) — avoids extra round-trips per candidate PR.
             PR_META="$(gh pr view "${PR}" --repo "${REPO}" \
@@ -1162,22 +1191,23 @@ jobs:
               --arg round "${ROUND}" --arg wm "${EFF_WM}" \
               '. + [{pr: $pr, branch: $branch, issue: $issue, round: $round, watermark: $wm}]' \
               <<< "${TARGETS}")"
-            # Fan out: emit EVERY eligible PR. The address matrix bounds
-            # simultaneity (max-parallel) and the per-PR concurrency groups
-            # prevent duplicate same-PR runs, so one scan drains the whole
-            # backlog instead of serving a single newest-first target per tick
-            # (which starved older PRs for hours when cron ticks were sparse).
+            # Fan out: emit EVERY eligible PR up to the per-scan budget. The
+            # address matrix bounds simultaneity (max-parallel) and the per-PR
+            # concurrency groups plus the busy-PR skip above prevent duplicate
+            # same-PR runs, so one scan drains the whole backlog instead of
+            # serving a single newest-first target per tick (which starved
+            # older PRs for hours when cron ticks were sparse). The budget
+            # break bounds this loop's RUNTIME and API usage too — each
+            # candidate costs several serial API reads, so scanning past a
+            # full budget would spend hundreds of calls for nothing. Never a
+            # silent cap: the deferral is logged and the next scan picks up
+            # the remainder (their signals persist).
+            if [[ "$(jq 'length' <<< "${TARGETS}")" -ge "${MAX_TARGETS_PER_SCAN}" ]]; then
+              echo "⚠️ target budget (${MAX_TARGETS_PER_SCAN}) reached; deferring the remaining candidates to the next scan"
+              break
+            fi
           done
 
-          # Defense-in-depth bound on a pathological backlog: cap the targets
-          # emitted per scan so both the address matrix size and this job's
-          # runtime stay bounded. Never a silent cap — log what was deferred;
-          # the next scan picks up the remainder (their signals persist).
-          TOTAL="$(jq 'length' <<< "${TARGETS}")"
-          if [[ "${TOTAL}" -gt "${MAX_TARGETS_PER_SCAN}" ]]; then
-            echo "⚠️ ${TOTAL} eligible PRs; emitting the first ${MAX_TARGETS_PER_SCAN}, deferring the rest to the next scan"
-            TARGETS="$(jq -c --argjson n "${MAX_TARGETS_PER_SCAN}" '.[0:$n]' <<< "${TARGETS}")"
-          fi
           COUNT="$(jq 'length' <<< "${TARGETS}")"
           echo "📋 ${COUNT} PR(s) to process"
           echo "targets=${TARGETS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -103,6 +103,11 @@ jobs:
       # The old single shared cancel-in-progress group let ANY newer event kill
       # pending full scans while route jobs sat queued behind runner backlog —
       # observed as hours of scan starvation during review-event storms.
+      # Four cases: schedule → one shared cron group (newer tick supersedes);
+      # pull_request_review → per-PR; issues → per-issue (same-target events
+      # coalesce, unrelated targets never collide); anything else (dispatch)
+      # → unique per run_id, and cancel-in-progress false below means manual
+      # dispatches are never cancelled at all.
       group: "${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || (github.event_name == 'pull_request_review' && format('qwen-autofix-route-pr-{0}', github.event.pull_request.number)) || (github.event_name == 'issues' && format('qwen-autofix-route-issue-{0}', github.event.issue.number)) || format('qwen-autofix-route-{0}', github.run_id) }}"
       cancel-in-progress: |-
         ${{ github.event_name != 'workflow_dispatch' }}
@@ -1040,7 +1045,11 @@ jobs:
               --jq '.jobs[] | select(.status != "completed") | .name | capture("^review-address \\((?<pr>[0-9]+),") | .pr' 2> /dev/null)
           done < <(
             for LIVE_STATUS in in_progress queued; do
-              # || true: one status query failing must not hide the other.
+              # || true: one status query failing must not hide the other. A
+              # DOUBLE failure yields an empty set — deliberately fail-open:
+              # this skip is an optimization, and the address-side live-marker
+              # revalidation is the correctness gate. If that revalidation is
+              # ever removed, this read must become fail-closed instead.
               gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
                 --status "${LIVE_STATUS}" --limit 50 --json databaseId \
                 --jq '.[].databaseId' 2> /dev/null || true

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1025,8 +1025,12 @@ jobs:
           # statusCheckRollup — and a fanned-out matrix holds queued jobs well
           # past a 10-minute tick, so without this the next scan re-emits the
           # same PRs and the per-PR address groups accumulate duplicates that
-          # later replay stale watermarks. One runs-list plus one jobs-view per
-          # live run is cheap (there are at most a few).
+          # later replay stale watermarks. The status filter is SERVER-side: a
+          # client-side filter over the N newest runs loses a long-lived
+          # fanned-out run once cron traffic pushes it past the window, and
+          # its queued PRs silently stop looking busy. Filtered this way the
+          # limit applies to LIVE runs only (at most a handful), and one
+          # jobs-view per live run stays cheap.
           BUSY_PRS=' '
           while IFS= read -r LIVE_RUN; do
             [[ -z "${LIVE_RUN}" ]] && continue
@@ -1034,9 +1038,14 @@ jobs:
               [[ -n "${BUSY}" ]] && BUSY_PRS="${BUSY_PRS}${BUSY} "
             done < <(gh run view "${LIVE_RUN}" --repo "${REPO}" --json jobs \
               --jq '.jobs[] | select(.status != "completed") | .name | capture("^review-address \\((?<pr>[0-9]+),") | .pr' 2> /dev/null)
-          done < <(gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
-            --limit 15 --json databaseId,status \
-            --jq '.[] | select(.status != "completed") | .databaseId' 2> /dev/null)
+          done < <(
+            for LIVE_STATUS in in_progress queued; do
+              # || true: one status query failing must not hide the other.
+              gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
+                --status "${LIVE_STATUS}" --limit 50 --json databaseId \
+                --jq '.[].databaseId' 2> /dev/null || true
+            done | sort -u
+          )
           [[ "${BUSY_PRS}" != ' ' ]] && echo "🚧 address in flight/queued for PR(s):${BUSY_PRS}"
 
           TARGETS='[]'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -77,6 +77,9 @@ env:
   # Hard cap on automated review-address rounds per PR. After this the bot stops
   # and leaves the PR for a human.
   MAX_ROUNDS: '5'
+  # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
+  # excess is logged and deferred to the next scan).
+  MAX_TARGETS_PER_SCAN: '10'
   # Do not claim more issues when too many existing autofix PRs are still open.
   MAX_OPEN_AUTOFIX_PRS: '5'
 
@@ -1166,6 +1169,15 @@ jobs:
             # (which starved older PRs for hours when cron ticks were sparse).
           done
 
+          # Defense-in-depth bound on a pathological backlog: cap the targets
+          # emitted per scan so both the address matrix size and this job's
+          # runtime stay bounded. Never a silent cap — log what was deferred;
+          # the next scan picks up the remainder (their signals persist).
+          TOTAL="$(jq 'length' <<< "${TARGETS}")"
+          if [[ "${TOTAL}" -gt "${MAX_TARGETS_PER_SCAN}" ]]; then
+            echo "⚠️ ${TOTAL} eligible PRs; emitting the first ${MAX_TARGETS_PER_SCAN}, deferring the rest to the next scan"
+            TARGETS="$(jq -c --argjson n "${MAX_TARGETS_PER_SCAN}" '.[0:$n]' <<< "${TARGETS}")"
+          fi
           COUNT="$(jq 'length' <<< "${TARGETS}")"
           echo "📋 ${COUNT} PR(s) to process"
           echo "targets=${TARGETS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1420,19 +1420,26 @@ jobs:
           # QUEUES the duplicate rather than discarding it — but that queueing
           # is exactly what makes this check sound: address jobs for one PR run
           # strictly one at a time, so by the time the duplicate runs here, the
-          # first job's eval marker is posted and visible. Recompute the
-          # watermark from LIVE markers; if nothing is newer and there is no
-          # conflict, this run is a stale duplicate and discards itself.
+          # first job's eval marker is posted and visible. Two duplicate
+          # signatures: (a) a sibling evaluated through a NEWER live ts than
+          # our matrix watermark; (b) a conflict-only sibling resolved and
+          # marked at the SAME ts — with no newer feedback its marker keeps
+          # ts=watermark while its ROUND advances past ours (ours is the max
+          # round observed at scan time). Either way, if there is no live
+          # conflict left and nothing newer than the live watermark, this run
+          # is a stale duplicate and discards itself.
           STALE='false'
-          LIVE_EVAL_WM="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+          LIVE_MARKS="$(jq -r --arg ab "${AUTOFIX_BOT}" '
             [ .[] | select((.user.login // "") == $ab) | (.body // "")
-              | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+) -->") ] | .[]
-              | .[0] ] | max // ""' "${WORKDIR}/ic.json")"
-          if [[ -n "${LIVE_EVAL_WM}" && "${LIVE_EVAL_WM}" > "${WATERMARK}" && "${CONFLICT}" != "true" ]]; then
+              | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+) -->") ] | .[] ]' "${WORKDIR}/ic.json")"
+          LIVE_EVAL_WM="$(jq -r 'map(.[0]) | max // ""' <<< "${LIVE_MARKS}")"
+          LIVE_MAX_ROUND="$(jq -r 'map(.[2] | tonumber) | max // 0' <<< "${LIVE_MARKS}")"
+          if [[ -n "${LIVE_EVAL_WM}" && "${CONFLICT}" != "true" ]] \
+            && { [[ "${LIVE_EVAL_WM}" > "${WATERMARK}" ]] || [[ "${LIVE_MAX_ROUND}" -gt "${ROUND}" ]]; }; then
             LIVE_NEW="$(jq -rs \
               --arg wm "${LIVE_EVAL_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
               --argjson trust "${TRUSTED_ASSOC}" '
-              ((.[0] | map(select((.submitted_at // "") > $wm)
+              (.[0] | map(select((.submitted_at // "") > $wm)
                 | select((.user.login // "") != $ab)
                 | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
                 | select((.state // "") | IN("CHANGES_REQUESTED", "COMMENTED"))) | length)
@@ -1449,7 +1456,7 @@ jobs:
               "${WORKDIR}/rv.json" "${WORKDIR}/rc.json" "${WORKDIR}/ic.json" "${WORKDIR}/checks.json")"
             if [[ "${LIVE_NEW}" == "0" ]]; then
               STALE='true'
-              echo "🫥 stale duplicate target: a sibling run already evaluated through ${LIVE_EVAL_WM} and nothing is newer — discarding without action or marker"
+              echo "🫥 stale duplicate target: a sibling run already evaluated through ${LIVE_EVAL_WM} (round ${LIVE_MAX_ROUND}) and nothing is newer — discarding without action or marker"
             fi
           fi
           echo "stale=${STALE}" >> "${GITHUB_OUTPUT}"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -300,6 +300,118 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('could not fetch PR metadata');
   });
 
+  it('behaviorally replays the stale-duplicate revalidation, including the conflict-only transition', () => {
+    // Extract the stale-gate VERBATIM from 'Prepare branch and feedback'
+    // (drift fails the test) and replay it over fixture feedback files. The
+    // subtle case: a conflict-only duplicate. Both scans emit the PR with
+    // watermark W; the first serialized job resolves the conflict, and with
+    // no newer feedback its marker keeps ts=W while its ROUND advances — so
+    // a ts-only comparison misses it. The gate must also treat
+    // same-ts-but-newer-round (with the conflict now cleared) as stale.
+    const staleGate = prepareBranchAndFeedbackStep.match(
+      /(STALE='false'\n[\s\S]*?echo "stale=\$\{STALE\}" >> "\$\{GITHUB_OUTPUT\}")/,
+    )?.[1];
+    expect(staleGate).toBeTruthy();
+    const W = '2026-07-18T08:00:00Z';
+    const runStaleGate = ({ marks, conflict, round, reviews = [] }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-stale-'));
+      try {
+        writeFileSync(
+          join(dir, 'ic.json'),
+          JSON.stringify(
+            marks.map((m) => ({
+              user: { login: 'qwen-code-dev-bot' },
+              created_at: '2026-07-18T09:00:00Z',
+              body: `eval <!-- autofix-eval ts=${m.ts} acted=${m.acted ?? 'true'} round=${m.round} -->`,
+            })),
+          ),
+        );
+        writeFileSync(join(dir, 'rv.json'), JSON.stringify(reviews));
+        writeFileSync(join(dir, 'rc.json'), '[]');
+        writeFileSync(join(dir, 'checks.json'), '[]');
+        const out = join(dir, 'out.txt');
+        writeFileSync(out, '');
+        execFileSync('bash', ['-c', staleGate.replace(/\n {10}/g, '\n')], {
+          env: {
+            ...process.env,
+            WORKDIR: dir,
+            GITHUB_OUTPUT: out,
+            WATERMARK: W,
+            ROUND: String(round),
+            CONFLICT: conflict,
+            AUTOFIX_BOT: 'qwen-code-dev-bot',
+            REVIEW_BOT: 'qwen-code-ci-bot',
+            TRUSTED_ASSOC: '["OWNER","MEMBER","COLLABORATOR"]',
+          },
+          encoding: 'utf8',
+        });
+        return readFileSync(out, 'utf8').includes('stale=true');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+    // Conflict-only duplicate: sibling resolved and marked round 3 at ts=W;
+    // our matrix says round 2, the conflict is now cleared → stale.
+    expect(
+      runStaleGate({
+        marks: [
+          { ts: W, round: 2 },
+          { ts: W, round: 3 },
+        ],
+        conflict: 'false',
+        round: 2,
+      }),
+    ).toBe(true);
+    // First job of a conflict round: round has not advanced → proceeds.
+    expect(
+      runStaleGate({
+        marks: [{ ts: W, round: 2 }],
+        conflict: 'false',
+        round: 2,
+      }),
+    ).toBe(false);
+    // A live conflict is always actionable, even past a sibling's marker.
+    expect(
+      runStaleGate({
+        marks: [
+          { ts: W, round: 2 },
+          { ts: W, round: 3 },
+        ],
+        conflict: 'true',
+        round: 2,
+      }),
+    ).toBe(false);
+    // ts-advanced duplicate (the original case): sibling evaluated through a
+    // newer live watermark and nothing newer exists → stale.
+    expect(
+      runStaleGate({
+        marks: [{ ts: '2026-07-18T08:30:00Z', round: 3 }],
+        conflict: 'false',
+        round: 2,
+      }),
+    ).toBe(true);
+    // Round advanced BUT trusted feedback arrived after the live watermark —
+    // the queued job has real work and must NOT discard itself.
+    expect(
+      runStaleGate({
+        marks: [
+          { ts: W, round: 2 },
+          { ts: W, round: 3 },
+        ],
+        conflict: 'false',
+        round: 2,
+        reviews: [
+          {
+            submitted_at: '2026-07-18T08:45:00Z',
+            user: { login: 'doudouOUC' },
+            author_association: 'MEMBER',
+            state: 'CHANGES_REQUESTED',
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it('falls back to existing issue backlog only when review has no target', () => {
     expect(issueAutofixJob).toContain("needs: ['route', 'review-scan']");
     expect(issueAutofixJob).toContain('always()');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -222,6 +222,11 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).not.toContain('break # one PR per scheduled scan');
     expect(reviewScanJob).toContain('Fan out: emit EVERY eligible PR');
     expect(workflow).toContain("max-parallel: 3");
+    // Pathological-backlog bound: targets per scan are capped, the excess is
+    // LOGGED and deferred to the next scan (never a silent cap).
+    expect(workflow).toContain("MAX_TARGETS_PER_SCAN: '10'");
+    expect(reviewScanJob).toContain('deferring the rest to the next scan');
+    expect(reviewScanJob).toContain(".[0:$n]");
     expect(reviewScanJob).toContain('statusCheckRollup');
     expect(reviewScanJob).toContain('HAS_PENDING_CHECKS');
     expect(reviewScanJob).toContain('N_FAILED_CHECKS');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -221,7 +221,7 @@ describe('qwen-autofix workflow', () => {
     // older PRs for hours whenever cron ticks were sparse.
     expect(reviewScanJob).not.toContain('break # one PR per scheduled scan');
     expect(reviewScanJob).toContain('Fan out: emit EVERY eligible PR');
-    expect(workflow).toContain("max-parallel: 3");
+    expect(workflow).toContain('max-parallel: 3');
     // Pathological-backlog bound: the budget BREAKS the candidate loop (so it
     // bounds runtime and API usage, not just matrix size), the deferral is
     // LOGGED, and the next scan picks up the remainder.
@@ -229,22 +229,29 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'deferring the remaining candidates to the next scan',
     );
-    expect(reviewScanJob).toMatch(/target budget \(\$\{MAX_TARGETS_PER_SCAN\}\) reached[\s\S]{0,120}break/);
+    expect(reviewScanJob).toMatch(
+      /target budget \(\$\{MAX_TARGETS_PER_SCAN\}\) reached[\s\S]{0,120}break/,
+    );
     // Fanned-out matrices hold QUEUED jobs past a tick and schedule/dispatch
     // runs never appear in the PR's checks — the scan must skip PRs whose
     // review-address is already running or queued in any live autofix run.
     expect(reviewScanJob).toContain(
       'review-address already in flight or queued — skipping',
     );
+    // The live-run listing filters status SERVER-side (in_progress + queued
+    // union): a client-side filter over the N newest runs loses a long-lived
+    // fanned-out run once cron traffic pushes it past the window, and its
+    // queued PRs silently stop looking busy.
+    expect(reviewScanJob).toContain('for LIVE_STATUS in in_progress queued');
+    expect(reviewScanJob).toContain('--status "${LIVE_STATUS}" --limit 50');
+    expect(reviewScanJob).not.toContain('--limit 15');
     // The busy-set cannot see a sibling scan that has not yet emitted its
     // matrix, so review-address REVALIDATES the watermark against LIVE
     // markers before doing work: the per-PR address group serializes
     // duplicates, so the later one reliably sees the first one's marker and
     // discards itself — no agent run, no marker, no comment.
     expect(prepareBranchAndFeedbackStep).toContain('LIVE_EVAL_WM');
-    expect(prepareBranchAndFeedbackStep).toContain(
-      'stale duplicate target',
-    );
+    expect(prepareBranchAndFeedbackStep).toContain('stale duplicate target');
     expect(
       workflow.split("steps.prepare.outputs.stale != 'true'").length - 1,
     ).toBe(2);
@@ -1040,7 +1047,9 @@ describe('qwen-autofix workflow', () => {
       // outcome), while an in-branch copy would let branch code define its own
       // gate.
       expect(step).toContain('bash "${RUNNER_TEMP}/check-settings-schema.sh"');
-      expect(step).not.toContain('bash .github/scripts/check-settings-schema.sh');
+      expect(step).not.toContain(
+        'bash .github/scripts/check-settings-schema.sh',
+      );
       expect(step).toContain(
         'No package changes detected; skipping package tests.',
       );
@@ -1098,10 +1107,14 @@ describe('qwen-autofix workflow', () => {
     );
     expect(reviewVerifyGate).toBeTruthy();
     expect(
-      reviewVerifyGate.indexOf('bash "${RUNNER_TEMP}/check-settings-schema.sh"'),
+      reviewVerifyGate.indexOf(
+        'bash "${RUNNER_TEMP}/check-settings-schema.sh"',
+      ),
     ).toBeGreaterThanOrEqual(0);
     expect(
-      reviewVerifyGate.indexOf('bash "${RUNNER_TEMP}/check-settings-schema.sh"'),
+      reviewVerifyGate.indexOf(
+        'bash "${RUNNER_TEMP}/check-settings-schema.sh"',
+      ),
     ).toBeLessThan(reviewVerifyGate.indexOf('outcome=noop'));
   });
 
@@ -1244,11 +1257,17 @@ describe('qwen-autofix workflow', () => {
     expect(reviewAddressReportStep).toContain('"${JOB_STATUS:-}" != "success"');
     // The env declaration must exist, else JOB_STATUS is always empty at runtime,
     // the :- default fires, and "!= success" is always true → over-eager handoffs.
-    expect(reviewAddressReportStep).toContain("JOB_STATUS: '${{ job.status }}'");
+    expect(reviewAddressReportStep).toContain(
+      "JOB_STATUS: '${{ job.status }}'",
+    );
     // ...but a published run (OUTCOME fixed/noop) must NOT post a handoff, even if
     // a later always() step fails the job — otherwise it contradicts the success.
-    expect(reviewAddressReportStep).toContain('"${OUTCOME:-unknown}" != "fixed"');
-    expect(reviewAddressReportStep).toContain('"${OUTCOME:-unknown}" != "noop"');
+    expect(reviewAddressReportStep).toContain(
+      '"${OUTCOME:-unknown}" != "fixed"',
+    );
+    expect(reviewAddressReportStep).toContain(
+      '"${OUTCOME:-unknown}" != "noop"',
+    );
     // Terminal round when feedback was never read (empty NEWEST) so the scan skips
     // instead of re-handing-off every tick.
     expect(reviewAddressReportStep).toContain('MARK_ROUND="${MAX_ROUNDS}"');
@@ -1265,9 +1284,7 @@ describe('qwen-autofix workflow', () => {
     // the terminal marker makes the scan skip forever, the headline must state the
     // real recovery (delete the marker), not promise a re-trigger the guard ignores.
     expect(reviewAddressReportStep).toContain('could not start evaluation');
-    expect(reviewAddressReportStep).toContain(
-      'delete this bot\'s terminal',
-    );
+    expect(reviewAddressReportStep).toContain("delete this bot's terminal");
     // Truncate UTF-8 safely so a split multi-byte sequence can't corrupt the body,
     // and keep the `|| true` — iconv -c exits 1 when it discards a byte, which under
     // set -eo pipefail would abort the step and skip the marker (a silent stall).
@@ -1316,27 +1333,47 @@ describe('qwen-autofix workflow', () => {
     )?.[1];
     expect(decision).toBeTruthy();
     const runPostHandoff = (env) =>
-      execFileSync(
-        'bash',
-        ['-c', `${decision}\nprintf '%s' "$POST_HANDOFF"`],
-        { env: { ...process.env, ...env }, encoding: 'utf8' },
-      );
+      execFileSync('bash', ['-c', `${decision}\nprintf '%s' "$POST_HANDOFF"`], {
+        env: { ...process.env, ...env },
+        encoding: 'utf8',
+      });
     const base = { DRY_RUN: 'false', GITHUB_TOKEN: 'x' };
     // A published run (fixed/noop) must NOT hand off even if a later always() step
     // failed the job — otherwise it contradicts the already-reported success.
-    expect(runPostHandoff({ ...base, OUTCOME: 'fixed', JOB_STATUS: 'failure' })).toBe('false');
-    expect(runPostHandoff({ ...base, OUTCOME: 'noop', JOB_STATUS: 'failure' })).toBe('false');
-    expect(runPostHandoff({ ...base, OUTCOME: 'fixed', JOB_STATUS: 'success' })).toBe('false');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: 'fixed', JOB_STATUS: 'failure' }),
+    ).toBe('false');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: 'noop', JOB_STATUS: 'failure' }),
+    ).toBe('false');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: 'fixed', JOB_STATUS: 'success' }),
+    ).toBe('false');
     // Dry-run never hands off.
-    expect(runPostHandoff({ ...base, DRY_RUN: 'true', OUTCOME: 'failed', JOB_STATUS: 'failure' })).toBe('false');
+    expect(
+      runPostHandoff({
+        ...base,
+        DRY_RUN: 'true',
+        OUTCOME: 'failed',
+        JOB_STATUS: 'failure',
+      }),
+    ).toBe('false');
     // Real non-success ends DO hand off: verify failure, pre-verify crash (empty
     // OUTCOME), and cancellation / job timeout.
-    expect(runPostHandoff({ ...base, OUTCOME: 'failed', JOB_STATUS: 'failure' })).toBe('true');
-    expect(runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'failure' })).toBe('true');
-    expect(runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'cancelled' })).toBe('true');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: 'failed', JOB_STATUS: 'failure' }),
+    ).toBe('true');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'failure' }),
+    ).toBe('true');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'cancelled' }),
+    ).toBe('true');
     // Empty OUTCOME with a *successful* job — documents that no handoff is posted
     // (verify runs always(), so in practice OUTCOME is set on a successful job).
-    expect(runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'success' })).toBe('false');
+    expect(
+      runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'success' }),
+    ).toBe('false');
 
     // Terminal-round transition: feedback read (NEWEST set) → normal increment;
     // feedback never read (empty) → MAX_ROUNDS so the scan skips instead of
@@ -1368,16 +1405,28 @@ describe('qwen-autofix workflow', () => {
       ).trim();
     // Started AFTER the cutoff (recent) → active → blocks.
     expect(
-      runStaleness([{ status: 'IN_PROGRESS', startedAt: '2026-07-16T01:00:00Z', workflowName: 'CI' }]),
+      runStaleness([
+        {
+          status: 'IN_PROGRESS',
+          startedAt: '2026-07-16T01:00:00Z',
+          workflowName: 'CI',
+        },
+      ]),
     ).toBe('true');
     // Started BEFORE the cutoff (stuck past the bound) → dead → does not block.
     expect(
-      runStaleness([{ status: 'IN_PROGRESS', startedAt: '2026-07-15T00:00:00Z', workflowName: 'CI' }]),
+      runStaleness([
+        {
+          status: 'IN_PROGRESS',
+          startedAt: '2026-07-15T00:00:00Z',
+          workflowName: 'CI',
+        },
+      ]),
     ).toBe('false');
     // Queued, never started (no startedAt) → does not block.
-    expect(
-      runStaleness([{ status: 'QUEUED', workflowName: 'CI' }]),
-    ).toBe('false');
+    expect(runStaleness([{ status: 'QUEUED', workflowName: 'CI' }])).toBe(
+      'false',
+    );
   });
 
   it('writes agent output to a log and marks loop guard failures for handoff', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -222,11 +222,23 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).not.toContain('break # one PR per scheduled scan');
     expect(reviewScanJob).toContain('Fan out: emit EVERY eligible PR');
     expect(workflow).toContain("max-parallel: 3");
-    // Pathological-backlog bound: targets per scan are capped, the excess is
-    // LOGGED and deferred to the next scan (never a silent cap).
+    // Pathological-backlog bound: the budget BREAKS the candidate loop (so it
+    // bounds runtime and API usage, not just matrix size), the deferral is
+    // LOGGED, and the next scan picks up the remainder.
     expect(workflow).toContain("MAX_TARGETS_PER_SCAN: '10'");
-    expect(reviewScanJob).toContain('deferring the rest to the next scan');
-    expect(reviewScanJob).toContain(".[0:$n]");
+    expect(reviewScanJob).toContain(
+      'deferring the remaining candidates to the next scan',
+    );
+    expect(reviewScanJob).toMatch(/target budget \(\$\{MAX_TARGETS_PER_SCAN\}\) reached[\s\S]{0,120}break/);
+    // Fanned-out matrices hold QUEUED jobs past a tick and schedule/dispatch
+    // runs never appear in the PR's checks — the scan must skip PRs whose
+    // review-address is already running or queued in any live autofix run.
+    expect(reviewScanJob).toContain(
+      'review-address already in flight or queued — skipping',
+    );
+    expect(reviewScanJob).toContain(
+      'capture("^review-address \\\\((?<pr>[0-9]+),")',
+    );
     expect(reviewScanJob).toContain('statusCheckRollup');
     expect(reviewScanJob).toContain('HAS_PENDING_CHECKS');
     expect(reviewScanJob).toContain('N_FAILED_CHECKS');
@@ -318,11 +330,22 @@ describe('qwen-autofix workflow', () => {
     // but dispatches and review/issue events get unique per-run groups — a
     // shared cancel-in-progress group let any newer event kill pending full
     // scans while route jobs sat queued behind runner backlog.
+    // Per-TARGET keys: cron ticks coalesce with each other; review events
+    // coalesce per PR (near-simultaneous reviews on one PR route once, without
+    // events on OTHER PRs cancelling this one); issue events per issue;
+    // dispatches unique and never cancelled.
+    expect(routeJob).toContain("'qwen-autofix-route-cron'");
     expect(routeJob).toContain(
-      "group: \"${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || format('qwen-autofix-route-{0}', github.run_id) }}\"",
+      "format('qwen-autofix-route-pr-{0}', github.event.pull_request.number)",
     );
     expect(routeJob).toContain(
-      "cancel-in-progress: |-\n        ${{ github.event_name == 'schedule' }}",
+      "format('qwen-autofix-route-issue-{0}', github.event.issue.number)",
+    );
+    expect(routeJob).toContain(
+      "format('qwen-autofix-route-{0}', github.run_id)",
+    );
+    expect(routeJob).toContain(
+      "cancel-in-progress: |-\n        ${{ github.event_name != 'workflow_dispatch' }}",
     );
     expect(routeJob).not.toContain("group: 'qwen-autofix-route'");
     expect(workflow).toContain(

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -200,7 +200,7 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain('.[0:10] | map(. + {autofixTier: 1})');
   });
 
-  it('runs scheduled autofix as a 10-minute single-target worker', () => {
+  it('runs scheduled autofix as a 10-minute multi-target fan-out worker', () => {
     expect(workflow).toContain("cron: '*/10 * * * *'");
     expect(workflow).not.toContain("cron: '0 0,12 * * *'");
     expect(workflow).not.toContain("cron: '0 4,8,16,20 * * *'");
@@ -215,7 +215,13 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('isCrossRepository');
     expect(reviewScanJob).toContain('not an open in-repo main-targeting PR');
     expect(reviewScanJob).toContain('.isCrossRepository != true');
-    expect(reviewScanJob).toContain('break # one PR per scheduled scan');
+    // Fan-out: one scan emits EVERY eligible PR (no single-target break). The
+    // address matrix's max-parallel bounds simultaneity and per-PR concurrency
+    // groups prevent duplicate same-PR runs; a single-target break starved
+    // older PRs for hours whenever cron ticks were sparse.
+    expect(reviewScanJob).not.toContain('break # one PR per scheduled scan');
+    expect(reviewScanJob).toContain('Fan out: emit EVERY eligible PR');
+    expect(workflow).toContain("max-parallel: 3");
     expect(reviewScanJob).toContain('statusCheckRollup');
     expect(reviewScanJob).toContain('HAS_PENDING_CHECKS');
     expect(reviewScanJob).toContain('N_FAILED_CHECKS');
@@ -303,8 +309,17 @@ describe('qwen-autofix workflow', () => {
       "ASSIGNEE_LOGIN: '${{ github.event.assignee.login }}'",
     );
     expect(workflow).toContain("permissions:\n      contents: 'read'");
-    expect(routeJob).toContain("group: 'qwen-autofix-route'");
-    expect(routeJob).toContain('cancel-in-progress: true');
+    // Route concurrency: cron ticks share one group and supersede each other,
+    // but dispatches and review/issue events get unique per-run groups — a
+    // shared cancel-in-progress group let any newer event kill pending full
+    // scans while route jobs sat queued behind runner backlog.
+    expect(routeJob).toContain(
+      "group: \"${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || format('qwen-autofix-route-{0}', github.run_id) }}\"",
+    );
+    expect(routeJob).toContain(
+      "cancel-in-progress: |-\n        ${{ github.event_name == 'schedule' }}",
+    );
+    expect(routeJob).not.toContain("group: 'qwen-autofix-route'");
     expect(workflow).toContain(
       'gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission"',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -236,6 +236,18 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'review-address already in flight or queued — skipping',
     );
+    // The busy-set cannot see a sibling scan that has not yet emitted its
+    // matrix, so review-address REVALIDATES the watermark against LIVE
+    // markers before doing work: the per-PR address group serializes
+    // duplicates, so the later one reliably sees the first one's marker and
+    // discards itself — no agent run, no marker, no comment.
+    expect(prepareBranchAndFeedbackStep).toContain('LIVE_EVAL_WM');
+    expect(prepareBranchAndFeedbackStep).toContain(
+      'stale duplicate target',
+    );
+    expect(
+      workflow.split("steps.prepare.outputs.stale != 'true'").length - 1,
+    ).toBe(2);
     expect(reviewScanJob).toContain(
       'capture("^review-address \\\\((?<pr>[0-9]+),")',
     );
@@ -514,10 +526,13 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain(
       '.[3] | map(select((.conclusion // .state // "")',
     );
+    // Three sites: the NEWEST computation, the live-watermark revalidation,
+    // and the feedback rendering — all must share the same address-check
+    // carve-out.
     expect(
       prepareBranchAndFeedbackStep.match(/startswith\("review-address"\)/g) ??
         [],
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(prepareBranchAndFeedbackStep).toContain(
       'gsub("[^A-Za-z0-9 _./()-]"; "") | .[0:80]',
     );
@@ -1199,7 +1214,7 @@ describe('qwen-autofix workflow', () => {
     const reviewVerificationGateStep = verificationGateSteps[1];
 
     expect(reviewVerificationGateStep).toContain(
-      'if: |-\n          ${{ always() }}',
+      "if: |-\n          ${{ always() && steps.prepare.outputs.stale != 'true' }}",
     );
     expect(reviewVerificationGateStep).toContain('failure.md');
     expect(reviewVerificationGateStep).toContain('outcome=failed');


### PR DESCRIPTION
## What this PR does

Makes the autofix review loop process its backlog concurrently instead of serially, and makes scan scheduling survive busy repositories. Two coordinated changes: (1) `review-scan` now emits **every** eligible PR as a matrix target instead of a single newest-first target per scan — the address matrix's `max-parallel: 3` bounds simultaneity and the existing per-PR concurrency groups prevent duplicate same-PR runs, so one surviving scan drains the whole backlog; (2) the `route` job's concurrency is re-keyed so cron ticks still supersede each other, but manual dispatches and review/issue events each route in their own group and are never cancelled.

## Why it's needed

Both problems were observed live while driving the loop across all open bot PRs. **Starvation by single-target selection**: an armed PR (fresh failed checks above its watermark) sat unprocessed for ~16 hours because each rare surviving scan handed its one slot to a newer PR, and overnight cron ticks did not fire at all. **Starvation by route cancellation**: the route job shared one `cancel-in-progress` concurrency group across all triggers; under runner backlog a route sits queued for minutes, and review-submission events arrive constantly — five consecutive dispatched scans were cancelled this way, and during event storms no full scan survived at all. Route is a seconds-long job, so unique groups for non-cron triggers cost nothing while guaranteeing that every trigger actually routes.

## Reviewer Test Plan

### How to verify

1. In the diff: `review-scan`'s per-PR loop no longer ends with `break # one PR per scheduled scan`; the eligible-target accumulation runs to the end of the candidate list, and the fan-out rationale is documented inline. The `review-address` matrix (`max-parallel: 3`, `concurrency: qwen-autofix-review-<pr>` with `cancel-in-progress: false`) is unchanged — it already supported multiple targets.
2. `route.concurrency.group` is now `schedule → 'qwen-autofix-route-cron'` (ticks supersede each other, preserving the original dedupe) and `format('qwen-autofix-route-{0}', github.run_id)` otherwise (unique → never cancelled); `cancel-in-progress` is true only for the cron group.
3. Run `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 50/50, including the updated assertions: the single-target break is asserted ABSENT, the fan-out comment and `max-parallel: 3` are asserted present, and the new concurrency expressions are pinned.
4. Static validation: workflow parses as YAML (concurrency expressions verified via parse), every `run:` block passes `bash -n`.

Behavioral expectation after merge: the first scan (cron tick or one dispatch) targets ALL armed bot PRs at once — the matrix shows one `review-address (…)` job per PR, up to 3 running concurrently — and a dispatched scan is no longer cancelled by unrelated review events.

### Evidence (Before & After)

```
BEFORE (live, 2026-07-17):
  scan 15:24 → targets exactly one PR (newest); an armed PR waits 16h+ for its turn
  dispatched scans 15:34 / 15:38 / 15:44 / 16:0x / next-morning: route completed/cancelled ×5
  overnight: zero full scans survive → backlog frozen

AFTER:
  one surviving scan → matrix fans out: review-address (7072,…) + (7062,…) + (6984,…) run
  concurrently (max-parallel 3); dispatch/event routes are never cancelled; cron still dedupes.
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Contract test via vitest on a worktree checkout of main; YAML parse + `bash -n` static checks locally. The behavior itself runs on `ubuntu-latest` in the autofix workflow.

## Risk & Scope

- Main risk or tradeoff: a full-backlog scan can start up to `max-parallel` (3) agent runs at once — cost scales with open bot PRs, which `MAX_OPEN_AUTOFIX_PRS` (5) already bounds; previously the same total work happened, just serialized over many hours. Never-cancelled routes mean each event spends a few runner-seconds even in bursts.
- Not validated / out of scope: not yet exercised on a live tick (the first post-merge cron/dispatch will exercise it); scan ordering fairness (newest-first) is unchanged since fan-out makes ordering moot; the stale-snapshot duplicate-round race across runs is pre-existing and unchanged.
- Breaking changes / migration notes: none; eval markers, watermarks, and per-PR groups are untouched.

## Linked Issues

Follow-up to #6998/#7094, prompted by live fleet-driving: a 16-hour starvation of an armed PR and five consecutive route cancellations.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix review 回路**并发**处理积压而非串行,并让扫描调度在繁忙仓库中存活。两处协同改动:(1) `review-scan` 现在把**每一个**合格 PR 都作为 matrix 目标发出,而不是每次扫描只发一个 newest-first 目标 —— address matrix 的 `max-parallel: 3` 约束并发度,既有的每 PR 并发组防止同 PR 重复运行,因此一次存活的扫描即可清空整个积压;(2) `route` job 的并发键重设:cron tick 之间仍互相顶替,但手动 dispatch 与 review/issue 事件各自独立路由、永不被取消。

## 为什么需要

两个问题都是在驱动全部 open bot PR 的实战中观察到的。**单目标选择导致的饥饿**:一个已武装的 PR(新鲜失败检查高于水位线)等了约 16 小时未被处理 —— 稀少的存活扫描每次都把唯一名额给了更新的 PR,而夜间 cron 完全没有触发。**route 取消导致的饥饿**:route job 全触发器共享一个 `cancel-in-progress` 并发组;runner 积压时 route 排队数分钟,而 review 提交事件源源不断 —— 连续五次 dispatch 的扫描被这样取消,事件风暴期间没有任何全量扫描存活。route 是秒级 job,非 cron 触发用唯一组零成本,且保证每次触发必然完成路由。

## 评审验证方案

### 如何验证

1. 看 diff:`review-scan` 的按 PR 循环不再以 `break # one PR per scheduled scan` 结尾;合格目标累积会跑完整个候选列表,fan-out 理由内联注释。`review-address` matrix(`max-parallel: 3`、`concurrency: qwen-autofix-review-<pr>`、`cancel-in-progress: false`)未动 —— 它本就支持多目标。
2. `route.concurrency.group` 现为:`schedule → 'qwen-autofix-route-cron'`(tick 互相顶替,保留原有去重),否则 `format('qwen-autofix-route-{0}', github.run_id)`(唯一 → 永不取消);`cancel-in-progress` 仅对 cron 组为 true。
3. 运行 `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 50/50,含更新断言:单目标 break 断言**不存在**、fan-out 注释与 `max-parallel: 3` 断言存在、新并发表达式被钉住。
4. 静态校验:工作流 YAML 可解析(并发表达式经解析验证),所有 `run:` 块通过 `bash -n`。

合并后的行为预期:第一次扫描(cron 或一次 dispatch)同时锁定**所有**已武装的 bot PR —— matrix 中每个 PR 一个 `review-address (…)` job,最多 3 个并发 —— 且 dispatch 的扫描不再被无关 review 事件取消。

### 证据(前后对比)

```
改动前(实况,2026-07-17):
  15:24 的扫描 → 只发一个目标(最新的);已武装的 PR 等 16h+ 轮不到
  15:34 / 15:38 / 15:44 / 16:0x / 次日清晨的 dispatch:route completed/cancelled ×5
  整夜:没有任何全量扫描存活 → 积压冻结

改动后:
  一次存活扫描 → matrix 扇出:review-address (7072,…) + (7062,…) + (6984,…) 并发运行
  (max-parallel 3);dispatch/事件路由永不被取消;cron 仍自我去重。
```

### 测试情况

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境(可选)

在 main 的 worktree 检出上用 vitest 跑契约测试;本地 YAML 解析 + `bash -n` 静态检查。行为本身运行于 autofix 工作流的 `ubuntu-latest`。

## 风险与范围

- 主要风险/权衡:一次全积压扫描最多同时启动 `max-parallel`(3)个 agent 运行 —— 成本随 open bot PR 数扩展,而 `MAX_OPEN_AUTOFIX_PRS`(5)已有上限;此前同样的总工作量只是被串行摊到数小时。route 永不取消意味着突发事件各花几秒 runner 时间。
- 未验证/不在范围内:尚未在真实 tick 上演练(合并后的首次 cron/dispatch 即会覆盖);扫描排序(newest-first)未改 —— fan-out 之后顺序不再重要;跨 run 的过期快照重复轮竞态为既有问题、未改动。
- 破坏性变更/迁移:无;eval 标记、水位线、每 PR 并发组均未触碰。

## 关联 Issue

#6998/#7094 的后续,由实战驱动舰队时发现:一个已武装 PR 的 16 小时饥饿与连续五次 route 取消。

</details>
