### PR TITLE
fix(cli): require a second Ctrl+C within 1s before a real SIGINT exits the TUI

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -1747,29 +1747,14 @@ describe('gemini.tsx main function kitty protocol', () => {
     );
   });
 
-  it('should run cleanup before exiting on interactive SIGINT', async () => {
-    const { loadCliConfig, parseArguments } = await import(
-      './config/config.js'
-    );
-    const { loadSettings } = await import('./config/settings.js');
-    const cleanupModule = await import('./utils/cleanup.js');
-    const signalHandlers = new Map<string, (...args: unknown[]) => void>();
-    const processOnceSpy = vi.spyOn(process, 'once').mockImplementation(((
-      eventName: string | symbol,
-      listener: (...args: unknown[]) => void,
-    ) => {
-      if (eventName === 'SIGTERM' || eventName === 'SIGINT') {
-        signalHandlers.set(eventName, listener);
-      }
-      return process;
-    }) as typeof process.once);
-    const processExitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => undefined) as unknown as typeof process.exit);
-    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
-    runExitCleanupMock.mockResolvedValue(undefined);
-
-    vi.mocked(loadCliConfig).mockResolvedValue({
+  // Shared config/settings mocks for the interactive signal-handler tests.
+  function applyInteractiveSigintConfigMocks(
+    loadCliConfig: unknown,
+    loadSettings: unknown,
+  ) {
+    vi.mocked(
+      loadCliConfig as (typeof import('./config/config.js'))['loadCliConfig'],
+    ).mockResolvedValue({
       isInteractive: () => true,
       getQuestion: () => '',
       getSandbox: () => false,
@@ -1794,7 +1779,9 @@ describe('gemini.tsx main function kitty protocol', () => {
       getSessionId: () => 'test-session-id',
       isTelemetryInitializationDeferred: () => true,
     } as unknown as Config);
-    vi.mocked(loadSettings).mockReturnValue({
+    vi.mocked(
+      loadSettings as (typeof import('./config/settings.js'))['loadSettings'],
+    ).mockReturnValue({
       errors: [],
       merged: {
         advanced: {},
@@ -1807,20 +1794,198 @@ describe('gemini.tsx main function kitty protocol', () => {
       getUserHooks: () => undefined,
       getProjectHooks: () => undefined,
     } as never);
+  }
+
+  it('exits on interactive SIGINT only after a second press inside the confirm window', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const signalHandlers = new Map<string, (...args: unknown[]) => void>();
+    const realProcessOn = process.on.bind(process);
+    const processOnSpy = vi.spyOn(process, 'on').mockImplementation(((
+      eventName: string | symbol,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      if (eventName === 'SIGTERM' || eventName === 'SIGINT') {
+        // Keep only the first (named) handler per signal; the swallow
+        // listener registered when cleanup begins is tracked separately.
+        if (!signalHandlers.has(eventName as string)) {
+          signalHandlers.set(eventName as string, listener);
+        }
+        return process;
+      }
+      return realProcessOn(
+        eventName as string,
+        listener as (...args: unknown[]) => void,
+      );
+    }) as typeof process.on);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as unknown as typeof process.exit);
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+
+    applyInteractiveSigintConfigMocks(loadCliConfig, loadSettings);
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: undefined,
+    } as never);
+
+    const nowSpy = vi.spyOn(Date, 'now');
+    try {
+      await main();
+
+      // First SIGINT: no cleanup, no exit — just the press-again hint.
+      mockWriteStderrLine.mockClear();
+      nowSpy.mockReturnValue(100_000);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      expect(runExitCleanupMock).not.toHaveBeenCalled();
+      expect(processExitSpy).not.toHaveBeenCalled();
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Press Ctrl+C again to exit.',
+      );
+
+      // `when-exit` re-raises the signal microseconds later — the repeat is
+      // the same press, not a confirmation.
+      nowSpy.mockReturnValue(100_002);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      expect(runExitCleanupMock).not.toHaveBeenCalled();
+      expect(processExitSpy).not.toHaveBeenCalled();
+
+      // Second real press inside the confirm window: cleanup once, exit 130.
+      nowSpy.mockReturnValue(100_400);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setRawModeSpy).toHaveBeenCalledWith(false);
+      expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+      expect(processExitSpy).toHaveBeenCalledWith(130);
+      // Cleanup registered a stand-in SIGINT listener so a stray Ctrl+C
+      // while cleanup runs cannot fall back to Node's default handler
+      // (#6776).
+      expect(
+        processOnSpy.mock.calls.filter(([event]) => event === 'SIGINT').length,
+      ).toBeGreaterThan(1);
+
+      // Further SIGINTs during cleanup are ignored (single cleanup pass).
+      nowSpy.mockReturnValue(100_800);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+    } finally {
+      nowSpy.mockRestore();
+      processOnSpy.mockRestore();
+      processExitSpy.mockRestore();
+    }
+  });
+
+  it('re-arms the SIGINT confirm window after it expires', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const signalHandlers = new Map<string, (...args: unknown[]) => void>();
+    const realProcessOn = process.on.bind(process);
+    const processOnSpy = vi.spyOn(process, 'on').mockImplementation(((
+      eventName: string | symbol,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      if (eventName === 'SIGTERM' || eventName === 'SIGINT') {
+        if (!signalHandlers.has(eventName as string)) {
+          signalHandlers.set(eventName as string, listener);
+        }
+        return process;
+      }
+      return realProcessOn(
+        eventName as string,
+        listener as (...args: unknown[]) => void,
+      );
+    }) as typeof process.on);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as unknown as typeof process.exit);
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+    applyInteractiveSigintConfigMocks(loadCliConfig, loadSettings);
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: undefined,
+    } as never);
+
+    const nowSpy = vi.spyOn(Date, 'now');
+    try {
+      await main();
+
+      nowSpy.mockReturnValue(100_000);
+      signalHandlers.get('SIGINT')?.();
+      // 1.5s later — outside the window, so this press re-arms instead of
+      // exiting…
+      nowSpy.mockReturnValue(101_500);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      expect(runExitCleanupMock).not.toHaveBeenCalled();
+      expect(processExitSpy).not.toHaveBeenCalled();
+
+      // …and a press right after it lands inside the fresh window.
+      nowSpy.mockReturnValue(101_900);
+      signalHandlers.get('SIGINT')?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+      expect(processExitSpy).toHaveBeenCalledWith(130);
+    } finally {
+      nowSpy.mockRestore();
+      processOnSpy.mockRestore();
+      processExitSpy.mockRestore();
+    }
+  });
+
+  it('still exits on the first SIGTERM with code 143', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const signalHandlers = new Map<string, (...args: unknown[]) => void>();
+    const realProcessOn = process.on.bind(process);
+    const processOnSpy = vi.spyOn(process, 'on').mockImplementation(((
+      eventName: string | symbol,
+      listener: (...args: unknown[]) => void,
+    ) => {
+      if (eventName === 'SIGTERM' || eventName === 'SIGINT') {
+        if (!signalHandlers.has(eventName as string)) {
+          signalHandlers.set(eventName as string, listener);
+        }
+        return process;
+      }
+      return realProcessOn(
+        eventName as string,
+        listener as (...args: unknown[]) => void,
+      );
+    }) as typeof process.on);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as unknown as typeof process.exit);
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+    applyInteractiveSigintConfigMocks(loadCliConfig, loadSettings);
     vi.mocked(parseArguments).mockResolvedValue({
       extensions: undefined,
     } as never);
 
     await main();
-    signalHandlers.get('SIGINT')?.();
+    signalHandlers.get('SIGTERM')?.();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(setRawModeSpy).toHaveBeenCalledWith(false);
     expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
-    expect(processExitSpy).toHaveBeenCalledWith(130);
+    expect(processExitSpy).toHaveBeenCalledWith(143);
 
-    processOnceSpy.mockRestore();
+    processOnSpy.mockRestore();
     processExitSpy.mockRestore();
   });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -187,10 +187,31 @@ function getSignalExitCode(signal: NodeJS.Signals): number {
   return signal === 'SIGINT' ? 130 : 143;
 }
 
+// A real SIGINT only reaches the process-level handler while raw mode is
+// off (in raw mode Ctrl+C arrives as input and goes through the UI's
+// double-press guard). Terminals that toggle raw mode around subprocesses
+// (e.g. the PyCharm terminal) deliver real SIGINTs, so mirror the UI's
+// press-twice-to-exit window here instead of exiting on the first signal.
+const SIGINT_EXIT_CONFIRM_WINDOW_MS = 1000;
+
+// `when-exit` (pulled in via `atomically`) re-raises the signal from its own
+// once-handler after running its callbacks, so one physical Ctrl+C surfaces
+// as two SIGINT events microseconds apart. Repeats inside this gap are the
+// same press, not a confirmation; a human double-press is far slower.
+const SIGINT_RERAISE_IGNORE_MS = 50;
+
 function installInteractiveSignalHandlers(wasRaw: boolean): () => void {
   let cleanupStarted = false;
+  let lastSigintAt = 0;
 
-  const handleSignal = (signal: NodeJS.Signals) => {
+  // The exit cleanup chain removes the named handlers below. Without a
+  // stand-in listener, a stray Ctrl+C during cleanup would fall back to
+  // Node's default SIGINT handling and kill the process before the
+  // terminal is restored (see #6776). Registered when cleanup begins;
+  // the process exits at the end of cleanup regardless.
+  const swallowSignalDuringCleanup = () => {};
+
+  const beginExit = (signal: NodeJS.Signals) => {
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(wasRaw);
     }
@@ -199,6 +220,7 @@ function installInteractiveSignalHandlers(wasRaw: boolean): () => void {
       return;
     }
     cleanupStarted = true;
+    process.on('SIGINT', swallowSignalDuringCleanup);
 
     void runExitCleanup()
       .catch((error) => {
@@ -210,14 +232,27 @@ function installInteractiveSignalHandlers(wasRaw: boolean): () => void {
   };
 
   const handleSigterm = () => {
-    handleSignal('SIGTERM');
+    beginExit('SIGTERM');
   };
   const handleSigint = () => {
-    handleSignal('SIGINT');
+    if (cleanupStarted) {
+      return;
+    }
+    const now = Date.now();
+    const sincePrevious = now - lastSigintAt;
+    if (sincePrevious <= SIGINT_RERAISE_IGNORE_MS) {
+      return;
+    }
+    if (sincePrevious <= SIGINT_EXIT_CONFIRM_WINDOW_MS) {
+      beginExit('SIGINT');
+      return;
+    }
+    lastSigintAt = now;
+    writeStderrLine('Press Ctrl+C again to exit.');
   };
 
-  process.once('SIGTERM', handleSigterm);
-  process.once('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
+  process.on('SIGINT', handleSigint);
 
   return () => {
     process.removeListener('SIGTERM', handleSigterm);


### PR DESCRIPTION
## What this PR does

Makes a real OS SIGINT follow the same press-twice-to-exit contract as the in-TUI Ctrl+C: the first signal prints `Press Ctrl+C again to exit.` and arms a 1-second confirm window; only a second SIGINT inside that window runs the exit cleanup and exits with 130. The window re-arms after it lapses. SIGTERM is unchanged — it still exits on the first signal with 143. Two additional hardenings that verification surfaced: repeated SIGINTs within 50 ms are treated as the same physical press (the `when-exit` library, pulled in via `atomically`, re-raises the signal from its own once-handler, so one keystroke surfaces as two SIGINT events microseconds apart), and a stand-in listener now swallows SIGINT while the exit cleanup chain runs, so a stray Ctrl+C during cleanup can no longer fall through to Node's default handler and kill the process before the terminal is restored (the race noted in #6776).

## Why it's needed

In raw mode Ctrl+C arrives as input and goes through the UI's double-press guard, but terminals that toggle raw mode around subprocesses — the PyCharm terminal in #4586 — deliver real SIGINTs to the process-level handler, which ran cleanup and exited on the very first signal. Users pressing Ctrl+C to copy text lost their entire session. The maintainer triage on the issue confirmed the split code path, reproduced the first-signal exit on current `main` (single OS SIGINT → exit 130 in ~58 ms), and spelled out the acceptance criteria this PR implements: first SIGINT warns without cleanup, second within 1 s exits 130, the window re-arms, SIGTERM keeps first-signal exit with 143, and extra SIGINTs during cleanup must not fall back to the default handler.

## Reviewer Test Plan

### How to verify

1. Build the bundle and start the CLI in a terminal (`QWEN_CODE_NO_RELAUNCH=1 node dist/cli.js` makes the observed pid the app itself).
2. From another shell, `kill -INT <pid>` once: the CLI stays up and prints `Press Ctrl+C again to exit.` on stderr.
3. `kill -INT <pid>` again within 1 s: the CLI runs cleanup and exits with code 130.
4. Repeat with >1 s between the signals: the second signal re-arms instead of exiting; a third quick signal exits.
5. `kill -TERM <pid>`: exits immediately with code 143, as before.
6. The original repro also works: in the PyCharm terminal, a single Ctrl+C while a subprocess has raw mode off no longer kills the session.

Automated coverage: the previous single-press SIGINT test is upgraded to the double-press contract and two tests are added (window re-arm, first-SIGTERM exit); the two SIGINT tests fail on unpatched source (verified by stashing the fix). `npm run typecheck`, eslint and prettier are clean.

### Evidence (Before & After)

A Python PTY harness — the same reproduction method the maintainer used in the issue — runs the real bundled CLI with an isolated `HOME` and sends real OS signals:

| Scenario | before fix | after fix |
| --- | --- | --- |
| 1× SIGINT | **exit 130 on the first signal**, no hint | **alive** + `Press Ctrl+C again to exit.` |
| 2× SIGINT, 0.4 s apart | exit 130 (first signal already fatal) | exit 130 (confirmed exit) |
| SIGINT → 1.6 s → SIGINT | exit 130 on the first signal | alive — window re-armed; a third signal 0.8 s later exits 130 |
| 1× SIGTERM | exit 143 | exit 143 (unchanged) |

![verification screenshot](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-4586/assets/verify-4586.png)

During verification the naive 1-second window failed in the real process while passing unit tests: a `--require` tracer on `process.exit`/`process.on` showed `when-exit`'s interceptor re-raising SIGINT from its once-handler, turning one keystroke into two SIGINT events ~2 ms apart — the second landed inside the confirm window and exited. The 50 ms same-press gap in this PR is the direct fix for that, and the shipped E2E results above are from the hardened build.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; Python `pty` harness sending real OS signals to the esbuild bundle, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: a script that sends a single SIGINT to stop an interactive session non-interactively now needs a second signal (or SIGTERM, which is the conventional programmatic stop and is unchanged). Two SIGINTs delivered faster than 50 ms apart count as one press; a genuine confirmation press from a human is far slower.
- Not validated / out of scope: the UI keypress path and the Kitty-protocol handling are untouched (per the maintainer's guidance); the PyCharm terminal itself was not driven directly — the harness reproduces its mechanism (real SIGINT while the process-level handler is active), which the maintainer's triage identified as the root cause.
- Breaking changes / migration notes: interactive sessions only; non-interactive/ACP modes install different handlers and are unaffected.

## Linked Issues

Fixes #4586

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让真实的 OS SIGINT 遵循与 TUI 内 Ctrl+C 相同的「按两次退出」契约：第一次信号打印 `Press Ctrl+C again to exit.` 并开启 1 秒确认窗口；窗口内的第二次 SIGINT 才执行退出清理并以 130 退出；窗口过期后重新计数。SIGTERM 行为不变——第一次信号即以 143 退出。验证过程还发现并加固了两点：50ms 内的重复 SIGINT 视为同一次物理按键（`atomically` 引入的 `when-exit` 库会在自己的 once-handler 里 re-raise 信号，一次按键会产生间隔仅几微秒的两个 SIGINT 事件）；清理链执行期间由替身 listener 吞掉 SIGINT，避免清理中的 Ctrl+C 落回 Node 默认处理器、在终端恢复前杀死进程（#6776 提到的竞态）。

## 为什么需要

raw mode 下 Ctrl+C 以输入字节到达、走 UI 的双击保护；但会在子进程执行期间临时关闭 raw mode 的终端（如 #4586 中的 PyCharm 终端）会把真实 SIGINT 投递给 process 级 handler——旧实现第一次信号就清理退出。用户按 Ctrl+C 复制文本就会丢掉整个会话。maintainer 在 issue 中确认了这条独立代码路径、在当前 main 上复现（单次 OS SIGINT 约 58ms 后以 130 退出），并给出了本 PR 实现的验收标准：第一次 SIGINT 只提示不清理、1 秒内第二次才以 130 退出、窗口过期重置、SIGTERM 保持第一次即 143 退出、清理期间的额外 SIGINT 不得落回默认处理器。

## 审阅测试计划

### 如何验证

1. 打包后启动 CLI（`QWEN_CODE_NO_RELAUNCH=1 node dist/cli.js` 使被观测的 pid 即应用本身）；
2. 另一个 shell 里 `kill -INT <pid>` 一次：CLI 存活并在 stderr 打印提示；
3. 1 秒内再 `kill -INT`：执行清理并以 130 退出；
4. 两次信号间隔 >1 秒：第二次只是重新开窗；紧接着第三次才退出；
5. `kill -TERM <pid>`：与之前一样立即以 143 退出；
6. 原始场景：PyCharm 终端中子进程关闭 raw mode 时按一次 Ctrl+C 不再杀死会话。

自动化覆盖：原单次 SIGINT 测试升级为双击契约，并新增窗口重置与 SIGTERM 用例；两个 SIGINT 用例在未打补丁源码上失败（已通过 stash 验证）。typecheck / eslint / prettier 全部通过。

### 证据（Before & After）

Python PTY harness——与 maintainer 在 issue 中使用的复现方法相同——以隔离 HOME 运行真实打包产物并发送真实 OS 信号：修复前单次 SIGINT 即 exit 130 且无提示；修复后四个场景全部符合验收标准（见上方表格与截图）。验证期间还发现朴素的 1 秒窗口在真实进程中会失败（单测却通过）：`--require` 追踪器显示 `when-exit` 在 once-handler 中 re-raise SIGINT，一次按键变成间隔约 2ms 的两个事件——第二个正落在确认窗口内导致退出。本 PR 的 50ms 同按键间隙正是对此的修复，上方 E2E 结果来自加固后的构建。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；Python `pty` harness 向 esbuild bundle 发送真实 OS 信号 + vitest 单测。

## 风险与范围

- 主要风险/权衡：用单次 SIGINT 非交互地停止交互会话的脚本现在需要第二个信号（或改用 SIGTERM——程序化停止的惯例方式，行为未变）。间隔小于 50ms 的两次 SIGINT 计为一次按键；人类的确认按键远慢于此。
- 未验证/超出范围：UI 按键路径与 Kitty 协议处理未改动（遵循 maintainer 的指引）；未直接驱动 PyCharm 终端本身——harness 复现的是其机制（process 级 handler 生效期间的真实 SIGINT），即 maintainer triage 认定的根因。
- 破坏性变更/迁移说明：仅影响交互式会话；非交互 / ACP 模式安装的是另外的 handler，不受影响。

## 关联 Issue

Fixes #4586

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
