### PR TITLE
docs(cua-driver): fix broken relative-coordinate design link

### DIFF
--- a/packages/cua-driver/README.md
+++ b/packages/cua-driver/README.md
@@ -191,5 +191,5 @@ irm https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/
 ## Documentation
 
 - [Vendored patches](./.vendored-patches.md)
-- [Relative-coordinate design](./rust/docs/relative-coordinates-design.md)
+- [Relative-coordinate design](./docs/relative-coordinates-design.md)
 - [Upstream docs](https://github.com/trycua/cua/tree/main/libs/cua-driver/rust)


### PR DESCRIPTION
## What this PR does

Fixes a broken relative link in the cua-driver README. The "Relative-coordinate design" link points to `./rust/docs/relative-coordinates-design.md`, but that path doesn't exist — the file lives at `./docs/relative-coordinates-design.md`.

## Why it's needed

In `packages/cua-driver/README.md`, the Documentation section links to the design doc with the wrong path:

```
- [Relative-coordinate design](./rust/docs/relative-coordinates-design.md)
```

There is no `rust/docs/` directory; the file is at `packages/cua-driver/docs/relative-coordinates-design.md`. As written, the link 404s on GitHub and in local editors. This is a Qwen-owned README (rewritten in #6515), not vendored upstream content, so the fix belongs here.

## Reviewer Test Plan

### How to verify

- `ls packages/cua-driver/docs/relative-coordinates-design.md` — the file exists.
- `ls packages/cua-driver/rust/docs/` — no such directory (the old link target).
- The two sibling links in the same section still resolve: `./.vendored-patches.md` exists, and the "Upstream docs" link is an absolute URL.

### Evidence (Before & After)

Documentation section of `packages/cua-driver/README.md`:
Before: `- [Relative-coordinate design](./rust/docs/relative-coordinates-design.md)` (404)
After: `- [Relative-coordinate design](./docs/relative-coordinates-design.md)` (resolves)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: verified the target file exists at `./docs/...` and that `./rust/docs/` does not exist; confirmed the other two links in the section resolve. Windows/Linux: N/A — documentation-only relative-path correction with no platform-dependent behavior.

### Environment (optional)

`@qwen-code/qwen-code` monorepo; `packages/cua-driver`.

## Risk & Scope

- Main risk or tradeoff: none. Documentation-only; single relative-link path correction. No code or behavior change.
- Not validated / out of scope: no other README content or links touched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 cua-driver README 中的一个失效相对链接。"Relative-coordinate design" 链接指向 `./rust/docs/relative-coordinates-design.md`，但该路径不存在——文件实际位于 `./docs/relative-coordinates-design.md`。

## 为什么需要

在 `packages/cua-driver/README.md` 的 Documentation 部分，设计文档链接使用了错误路径：

```
- [Relative-coordinate design](./rust/docs/relative-coordinates-design.md)
```

并不存在 `rust/docs/` 目录；文件位于 `packages/cua-driver/docs/relative-coordinates-design.md`。按当前写法，该链接在 GitHub 及本地编辑器中均会 404。此 README 为 Qwen 自有内容（于 #6515 重写），并非上游 vendored 内容，因此修复应在此仓库进行。

## 复核测试计划

### 如何验证

- `ls packages/cua-driver/docs/relative-coordinates-design.md`——文件存在。
- `ls packages/cua-driver/rust/docs/`——无此目录（即旧链接目标）。
- 同一部分中另外两个相邻链接仍可解析：`./.vendored-patches.md` 存在，"Upstream docs" 为绝对 URL。

### 证据（修复前后对比）

`packages/cua-driver/README.md` 的 Documentation 部分：
修复前：`- [Relative-coordinate design](./rust/docs/relative-coordinates-design.md)`（404）
修复后：`- [Relative-coordinate design](./docs/relative-coordinates-design.md)`（可解析）

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：确认目标文件存在于 `./docs/...` 且 `./rust/docs/` 不存在；确认该部分其他两个链接可解析。Windows/Linux：N/A——仅文档相对路径修正，无平台相关行为。

### 运行环境（可选）

`@qwen-code/qwen-code` monorepo；`packages/cua-driver`。

## 风险与影响范围

- 主要风险或权衡：无。仅文档改动；单个相对链接路径修正。无代码或行为变更。
- 未验证 / 范围之外：未改动其他 README 内容或链接。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
