### PR TITLE
fix(cli): correct misspelled handleUpdateRecieved -> handleUpdateReceived

### DIFF
--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -144,7 +144,7 @@ export function setUpdateHandler(
     }
   };
 
-  const handleUpdateRecieved = (info: UpdateObject) => {
+  const handleUpdateReceived = (info: UpdateObject) => {
     setUpdateInfo(info);
     const savedMessage = info.message;
     setTimeout(() => {
@@ -182,13 +182,13 @@ export function setUpdateHandler(
     });
   };
 
-  updateEventEmitter.on('update-received', handleUpdateRecieved);
+  updateEventEmitter.on('update-received', handleUpdateReceived);
   updateEventEmitter.on('update-failed', handleUpdateFailed);
   updateEventEmitter.on('update-success', handleUpdateSuccess);
   updateEventEmitter.on('update-info', handleUpdateInfo);
 
   const cleanup = () => {
-    updateEventEmitter.off('update-received', handleUpdateRecieved);
+    updateEventEmitter.off('update-received', handleUpdateReceived);
     updateEventEmitter.off('update-failed', handleUpdateFailed);
     updateEventEmitter.off('update-success', handleUpdateSuccess);
     updateEventEmitter.off('update-info', handleUpdateInfo);


### PR DESCRIPTION
## What this PR does

Fixes a misspelled local function name in `handleAutoUpdate.ts`: `handleUpdateRecieved` → `handleUpdateReceived`. The handler and both of its `updateEventEmitter.on(...)` / `.off(...)` references are renamed together. No behavior change.

## Why it's needed

`handleUpdateRecieved` is a local `const` arrow function registered as the `'update-received'` listener and removed again on cleanup. The identifier misspells "Received" (`Recieved`), which is confusing next to the correctly-spelled `'update-received'` event name it handles. The rename is confined to this one file (3 occurrences).

## Reviewer Test Plan

### How to verify

- `grep -rn handleUpdateRecieved packages` returns nothing.
- The handler, its `.on('update-received', …)` registration, and its `.off('update-received', …)` cleanup all reference the same renamed identifier (the event-name string `'update-received'` is unchanged).
- `npx vitest run src/utils/handleAutoUpdate.test.ts` from `packages/cli` passes.

### Evidence (Before & After)

`packages/cli/src/utils/handleAutoUpdate.ts`:
Before: `const handleUpdateRecieved = (info: UpdateObject) => { … }` + `.on('update-received', handleUpdateRecieved)` / `.off('update-received', handleUpdateRecieved)`
After: `const handleUpdateReceived = (info: UpdateObject) => { … }` + `.on('update-received', handleUpdateReceived)` / `.off('update-received', handleUpdateReceived)`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: `src/utils/handleAutoUpdate.test.ts` passes (24/24); `eslint` clean on the changed file; verified 0 remaining occurrences of the misspelling. Windows/Linux: N/A — local identifier rename with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code` CLI workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none. Renames a single local (non-exported) function and its two references within one file; the event-name string it listens on is untouched, so registration/cleanup behavior is identical.
- Not validated / out of scope: no other identifiers or files touched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `handleAutoUpdate.ts` 中拼写错误的局部函数名：`handleUpdateRecieved` → `handleUpdateReceived`。该处理函数及其两处 `updateEventEmitter.on(...)` / `.off(...)` 引用一并重命名。无行为改动。

## 为什么需要

`handleUpdateRecieved` 是一个注册为 `'update-received'` 监听器、并在清理时移除的局部 `const` 箭头函数。该标识符将 "Received" 拼错为 `Recieved`，与它所处理的拼写正确的 `'update-received'` 事件名并列时易造成困惑。此次重命名仅限于该文件（共 3 处）。

## 复核测试计划

### 如何验证

- `grep -rn handleUpdateRecieved packages` 无任何结果。
- 处理函数、其 `.on('update-received', …)` 注册与 `.off('update-received', …)` 清理均引用同一个重命名后的标识符（事件名字符串 `'update-received'` 未改动）。
- 在 `packages/cli` 下运行 `npx vitest run src/utils/handleAutoUpdate.test.ts` 通过。

### 证据（修复前后对比）

`packages/cli/src/utils/handleAutoUpdate.ts`：
修复前：`const handleUpdateRecieved = (info: UpdateObject) => { … }` + `.on('update-received', handleUpdateRecieved)` / `.off('update-received', handleUpdateRecieved)`
修复后：`const handleUpdateReceived = (info: UpdateObject) => { … }` + `.on('update-received', handleUpdateReceived)` / `.off('update-received', handleUpdateReceived)`

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：`src/utils/handleAutoUpdate.test.ts` 通过（24/24）；改动文件 `eslint` 无问题；确认无残留拼写错误。Windows/Linux：N/A——局部标识符重命名，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code` CLI 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：无。仅在单个文件内重命名一个局部（非导出）函数及其两处引用；所监听的事件名字符串未改动，因此注册/清理行为完全一致。
- 未验证 / 范围之外：未改动其他标识符或文件。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
