### PR TITLE
fix(core): remove ask_user_question from the Explore agent's toolset

### DIFF
--- a/packages/core/src/subagents/builtin-agents.test.ts
+++ b/packages/core/src/subagents/builtin-agents.test.ts
@@ -43,6 +43,16 @@ describe('BuiltinAgentRegistry', () => {
       expect(exploreAgent).toBeDefined();
       expect(exploreAgent?.model).toBeUndefined();
     });
+
+    // Regression for #7126: Explore is a read-only search worker that
+    // typically runs as a subagent with no human in the loop. An
+    // interactive question tool would block the pipeline forever.
+    it('should not give the Explore agent the interactive question tool', () => {
+      const exploreAgent = BuiltinAgentRegistry.getBuiltinAgent('Explore');
+
+      expect(exploreAgent?.tools).toBeDefined();
+      expect(exploreAgent?.tools).not.toContain('ask_user_question');
+    });
   });
 
   describe('getBuiltinAgent', () => {

--- a/packages/core/src/subagents/builtin-agents.ts
+++ b/packages/core/src/subagents/builtin-agents.ts
@@ -105,7 +105,9 @@ Notes:
         ToolNames.MEMORY,
         ToolNames.SKILL,
         ToolNames.LSP,
-        ToolNames.ASK_USER_QUESTION,
+        // ASK_USER_QUESTION is deliberately absent: Explore is a read-only
+        // search worker that typically runs as a subagent with no human in
+        // the loop — an interactive question would block forever (#7126).
       ],
     },
     {


### PR DESCRIPTION
## What this PR does

Removes `ask_user_question` from the built-in Explore agent's explicit tool list, so a read-only search worker can no longer pause itself (and any multi-agent pipeline built on it) waiting for human input that cannot arrive. The removal is documented in place with a comment, and a registry regression test pins the contract. The interactive `statusline-setup` agent keeps the tool — it is a user-facing configuration flow where a human is present by definition.

## Why it's needed

Explore's own system prompt declares it a read-only search agent, yet its `tools` array in `builtin-agents.ts` granted `ask_user_question`. When Explore runs as a subagent (the common case — the built-in `agent` tool and multi-agent orchestrations spawn it as a worker), there is no human in the loop: a prompt that even hints at a clarifying question can make the model call the tool and block indefinitely, deadlocking the whole pipeline (#7126). The triage analysis confirmed the mismatch and recommended exactly this one-line removal; because the tool is explicitly listed rather than inherited, the model was actively encouraged to use it.

## Reviewer Test Plan

### How to verify

1. Launch an Explore subagent (`agent` tool with `subagent_type: "Explore"`) with any search prompt and inspect the request the model receives: the `tools` array must not contain `ask_user_question`.
2. Confirm the rest of Explore's search toolset (read_file, grep, glob, shell, ls, web_fetch, todo_write, memory, skill, lsp) is unchanged.
3. Confirm `statusline-setup` still lists `ask_user_question`.

Automated coverage: a new registry test asserts Explore's tools do not contain `ask_user_question`; it fails on unpatched source (verified by stashing the fix). `npm run typecheck`, eslint and prettier are clean.

### Evidence (Before & After)

An E2E harness runs the real bundled CLI in a PTY against a local fake OpenAI-compatible server whose log captures the `tools` array of every `/chat/completions` request. The scripted flow has the main turn call the `agent` tool with `subagent_type: "Explore"`, so the server sees the exact toolset offered to the real Explore subagent:

| Request | before fix | after fix |
| --- | --- | --- |
| main session turn | includes `ask_user_question` (human present — correct) | unchanged |
| **Explore subagent turn** | `ask_user_question, glob, grep_search, list_directory, read_file, run_shell_command, skill, todo_write, web_fetch` ❌ | `glob, grep_search, list_directory, read_file, run_shell_command, skill, todo_write, web_fetch` ✅ |

![verification screenshot](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7126/assets/verify-7126.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; PTY harness + local fake OpenAI-compatible SSE server against the esbuild bundle, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: an Explore agent run interactively at top level also loses the question tool. That matches the agent's read-only report-findings contract — its prompt already instructs it to report rather than ask — and is the behavior the issue requests.
- Not validated / out of scope: no timeout/fallback mechanism for `ask_user_question` in headless contexts generally (a broader design question); custom user-defined agents that list the tool are untouched.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7126

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

从内置 Explore 代理的显式工具列表中移除 `ask_user_question`，使只读搜索工作代理不再可能因等待永远不会到来的人工输入而挂起（并连带阻塞其上的多 agent 管线）。移除处附有注释说明原因，并用注册表回归测试固定该契约。交互式的 `statusline-setup` 代理保留该工具——那是有人在场的用户配置流程。

## 为什么需要

Explore 的系统提示自称只读搜索代理，但 `builtin-agents.ts` 的 `tools` 数组却授予了 `ask_user_question`。Explore 作为子代理运行时（常态——内置 `agent` 工具与多 agent 编排都把它当工作代理），环路中没有人类：只要提示稍微暗示需要澄清，模型就可能调用该工具并无限期阻塞，令整条管线死锁（#7126）。triage 分析确认了这一错配并推荐了正是这一行的移除；由于该工具是显式列出而非继承，模型实际上被鼓励使用它。

## 审阅测试计划

### 如何验证

1. 用 `agent` 工具以 `subagent_type: "Explore"` 启动子代理，检查模型收到的请求：`tools` 数组不应包含 `ask_user_question`；
2. 确认 Explore 其余搜索工具集不变；
3. 确认 `statusline-setup` 仍保留 `ask_user_question`。

自动化覆盖：新增注册表测试断言 Explore 工具不含 `ask_user_question`，在未打补丁源码上失败（已验证）。typecheck / eslint / prettier 全部通过。

### 证据（Before & After）

E2E harness 在 PTY 中运行真实打包产物，对接本地伪 OpenAI 兼容服务器并记录每个请求的 `tools` 数组；主轮次通过 `agent` 工具启动真实 Explore 子代理。修复前子代理工具列表含 `ask_user_question`（❌），修复后不含且其余工具集不变（✅），见上方表格与截图。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；PTY harness + 本地伪 OpenAI SSE 服务器 + vitest 单测。

## 风险与范围

- 主要风险/权衡：顶层交互式运行的 Explore 也失去提问工具。这与其「只读、直接汇报发现」的契约一致（其提示本就要求汇报而非提问），也是 issue 所要求的行为。
- 未验证/超出范围：headless 场景下 `ask_user_question` 的通用超时/回退机制（更大的设计问题）；用户自定义 agent 若列出该工具不受影响。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7126

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
