### PR TITLE
fix(web-shell): stop stacking duplicate copies when restoring prompt text

### DIFF
--- a/packages/web-shell/client/hooks/useQueuedPrompts.test.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mergeRestoredPromptText } from './useQueuedPrompts';
+
+// Regression for #7128: restoration paths can fire more than once for the
+// same prompt (failed submit + reconnect/refresh, queue clear racing an
+// abort), and a user retrying an identical message restores identical text.
+// Stacking those copies is what surfaced as "sent messages concatenated back
+// into the input box after refresh".
+describe('mergeRestoredPromptText', () => {
+  it('fills an empty editor with the restored text', () => {
+    expect(mergeRestoredPromptText('', 'hello')).toBe('hello');
+    expect(mergeRestoredPromptText('   ', 'hello')).toBe('hello');
+  });
+
+  it('prepends above a different draft the user is typing', () => {
+    expect(mergeRestoredPromptText('draft', 'restored')).toBe(
+      'restored\ndraft',
+    );
+  });
+
+  it('is a no-op when the same text was already restored', () => {
+    expect(mergeRestoredPromptText('hello', 'hello')).toBe('hello');
+  });
+
+  it('is a no-op when the text already sits at the top of the editor', () => {
+    expect(mergeRestoredPromptText('hello\ndraft', 'hello')).toBe(
+      'hello\ndraft',
+    );
+  });
+
+  it('stays idempotent across repeated restores of the same prompt', () => {
+    let editor = '';
+    for (let i = 0; i < 3; i++) {
+      editor = mergeRestoredPromptText(editor, '用python写一个hello world');
+    }
+    expect(editor).toBe('用python写一个hello world');
+  });
+
+  it('does not treat a same-prefix but different first line as a duplicate', () => {
+    expect(mergeRestoredPromptText('hello world\ndraft', 'hello')).toBe(
+      'hello\nhello world\ndraft',
+    );
+  });
+});

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -53,6 +53,21 @@ interface UseQueuedPromptsArgs {
 
 const MAX_COMPLETED_PROMPT_IDS = 100;
 
+/**
+ * Merge a restored prompt's text into the editor content. Restoration paths
+ * (failed submits, failed mid-turn inserts, queue clears) prepend the prompt
+ * above whatever the user is currently typing — but several of them can fire
+ * for the same prompt across reconnects/refreshes, and a user retrying an
+ * identical message produces the same text twice. Stacking those copies is
+ * what #7128 reports as "inputs concatenated after refresh", so restoring
+ * text that is already present at the top of the editor is a no-op.
+ */
+export function mergeRestoredPromptText(current: string, text: string): string {
+  if (!current.trim()) return text;
+  if (current === text || current.startsWith(`${text}\n`)) return current;
+  return `${text}\n${current}`;
+}
+
 type RefreshPendingPromptsResult =
   | 'refreshed'
   | 'skipped'
@@ -286,8 +301,10 @@ export function useQueuedPrompts({
         return;
       }
       const current = editorRef.current?.getText() ?? '';
-      const next = current.trim() ? `${text}\n${current}` : text;
-      editorRef.current?.setText(next);
+      const next = mergeRestoredPromptText(current, text);
+      if (next !== current) {
+        editorRef.current?.setText(next);
+      }
       if (images && images.length > 0) {
         editorRef.current?.restoreImages(images);
       }


### PR DESCRIPTION
## What this PR does

Makes the composer's prompt-restoration merge idempotent, so a prompt whose text is already sitting at the top of the editor is not stacked again. Restoration paths (failed queue submits, failed mid-turn inserts, queue clears racing an abort) prepend a failed prompt's text above the current draft; several of them can fire for the same prompt across reconnects and page refreshes, and a user retrying an identical message restores identical text — each pass previously prepended another copy. The merge logic is extracted into an exported pure function, `mergeRestoredPromptText(current, text)`, with the duplicate check documented in place; restoring *different* text still prepends above the draft exactly as before.

## Why it's needed

#7128 reports that after two failed sends of the same message, a page refresh shows the two texts concatenated into one string in the input box. The triage analysis identified three defects; this PR fixes the text-stacking one (bug 3): `restoreTextToEditor` unconditionally computed `` `${text}\n${current}` ``, so duplicate restore passes and identical retried messages accumulated copies. The suggested fix directions were "replace instead of prepend, track restored prompts, or clear before batch restoration" — this PR implements the minimal-behavior-change variant: keep the prepend (a user's in-progress draft must not be destroyed), but make an already-restored text a no-op. The SSE-reconnect-on-prompt question (bug 1) is a behavioral default best decided by maintainers and is intentionally out of scope.

## Reviewer Test Plan

### How to verify

1. Trigger any restoration path twice for the same prompt text (e.g. queue a message during streaming, make its submission fail, reconnect so a second restore fires — or retry an identical message after a failed send): the composer holds one copy, not a growing concatenation.
2. With a different draft in the composer, trigger a restore: the failed prompt's text still lands above the draft, separated by a newline.
3. Normal send flows are untouched: submit succeeds → editor clears, as before.

Automated coverage: 6 new unit tests for `mergeRestoredPromptText` — empty editor, prepend-above-draft, exact-duplicate no-op, duplicate-at-top no-op, idempotence across repeated restores of the reported CJK message, and a same-prefix-different-line case that must NOT be deduplicated. `npm run typecheck`, the web-shell package build, eslint and prettier are clean.

### Evidence (Before & After)

| Sequence | before fix | after fix |
| --- | --- | --- |
| restore `msg` into empty editor | `msg` | `msg` |
| second restore of the same `msg` | `msg\nmsg` ❌ | `msg` ✅ |
| third restore (reconnect/refresh path re-fires) | `msg\nmsg\nmsg` ❌ | `msg` ✅ |
| restore `msg` above a draft `draft` | `msg\ndraft` | `msg\ndraft` (unchanged) |

Regression safety was additionally checked in a real browser: a Playwright run against a live `qwen serve` daemon exercised the normal send path (submit accepted, editor cleared) and a network-refused direct submit — both behave identically before and after this change. The exact multi-restore browser reproduction depends on a mid-stream reconnect timing that is impractical to script deterministically, which is why the contract is pinned at the unit level.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest for the unit contract, Playwright Chromium against a live daemon for send-path regression.

## Risk & Scope

- Main risk or tradeoff: if a user legitimately wants two literal copies of the same failed message restored, they now get one — the information content is identical, and the stacking behavior was the reported defect.
- Not validated / out of scope: the SSE `restartEventStreamOnPrompt` default (triage bug 1) and the editor-clearing semantics on failed sends in `App.tsx`/`ChatPane.tsx` (triage bug 2) — both are behavioral decisions that deserve their own review.
- Breaking changes / migration notes: none; `mergeRestoredPromptText` is a new export used internally.

## Linked Issues

Fixes #7128

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 composer 的 prompt 恢复合并逻辑幂等：若某条 prompt 的文本已位于编辑器顶部，不再重复堆叠。恢复路径（排队提交失败、mid-turn 插入失败、清空队列与 abort 竞争）会把失败 prompt 的文本前置到当前草稿之上；同一条 prompt 在重连/刷新过程中可能触发多条恢复路径，用户重试相同消息也会恢复相同文本——此前每次都会再前置一份副本。合并逻辑抽取为导出的纯函数 `mergeRestoredPromptText(current, text)` 并附注释；恢复**不同**文本时仍照旧前置到草稿之上。

## 为什么需要

#7128 报告：同一消息两次发送失败后，刷新页面看到两段文本拼接成一条出现在输入框。triage 分析识别出三个缺陷；本 PR 修复其中的文本堆叠缺陷（bug 3）：`restoreTextToEditor` 无条件计算 `${text}\n${current}`，重复的恢复触发与重试的相同消息不断累积副本。triage 给出的修复方向是「改覆盖、跟踪已恢复、或批量恢复前清空」——本 PR 实现行为变更最小的变体：保留前置（不能破坏用户正在输入的草稿），但对已恢复的文本作 no-op。SSE 重连默认值问题（bug 1）属于应由 maintainer 决定的行为默认值，刻意不在本 PR 范围内。

## 审阅测试计划

### 如何验证

1. 让同一条 prompt 文本触发两次恢复（如 streaming 中排队、提交失败、重连再次触发恢复；或失败后重试相同消息）：composer 中只保留一份，而非不断拼接；
2. composer 中已有其他草稿时触发恢复：失败 prompt 的文本仍以换行分隔置于草稿上方；
3. 正常发送流程不受影响：提交成功 → 编辑器清空，与之前一致。

自动化覆盖：`mergeRestoredPromptText` 的 6 个新单测——空编辑器、草稿上方前置、完全相同 no-op、顶部重复 no-op、对 issue 中中文消息的重复恢复幂等、以及**不应**被去重的同前缀不同首行用例。typecheck / web-shell 包构建 / eslint / prettier 全部通过。

### 证据（Before & After）

见上方表格：重复恢复同一消息由 `msg\nmsg\nmsg`（❌）变为始终一份（✅）；向草稿上方恢复不同文本的行为不变。另在真实浏览器中做了回归检查：Playwright 驱动真实 `qwen serve` daemon 验证正常发送路径（提交成功、编辑器清空）与网络拒绝的直接提交在改动前后行为一致。精确的多次恢复浏览器复现依赖流中重连时序、难以确定性脚本化，故契约以单测层固定。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest 单测 + Playwright Chromium 对真实 daemon 的发送路径回归。

## 风险与范围

- 主要风险/权衡：若用户确实希望恢复同一失败消息的两份字面副本，现在只得到一份——信息量相同，且堆叠正是被报告的缺陷。
- 未验证/超出范围：SSE `restartEventStreamOnPrompt` 默认值（triage bug 1）与 `App.tsx`/`ChatPane.tsx` 发送失败时的编辑器清空语义（triage bug 2）——两者都是值得单独评审的行为决策。
- 破坏性变更/迁移说明：无；`mergeRestoredPromptText` 为新导出、仅内部使用。

## 关联 Issue

Fixes #7128

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
