### PR TITLE
feat(web-shell): toggle the session sidebar with Cmd+B / Ctrl+B

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -112,6 +112,7 @@ import {
   type WebShellSidebarFooterOptions,
   type WebShellSidebarLockedWorkspace,
 } from './components/sidebar/WebShellSidebar';
+import { isSidebarToggleShortcut } from './components/sidebar/sidebarToggleShortcut';
 import {
   getLocalCommands,
   localizeBuiltinDescriptions,
@@ -1145,6 +1146,33 @@ export function App({
     setSidebarCollapsed(collapsed);
     writeSidebarCollapsed(collapsed);
   }, []);
+
+  // #5074: Cmd+B / Ctrl+B toggles the session sidebar, matching the editor
+  // convention (VS Code et al.). It works while any element is focused —
+  // the composer has no bold formatting, so nothing competes for the
+  // binding. Phone-width layouts render the sidebar as a drawer, so the
+  // shortcut toggles that instead of the collapsed rail.
+  useEffect(() => {
+    if (!sidebarOptions.enabled) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (!isSidebarToggleShortcut(e)) return;
+      e.preventDefault();
+      if (window.matchMedia('(max-width: 760px)').matches) {
+        setMobileDrawerOpen((open) => {
+          if (open) setForceMobileDrawer(false);
+          return !open;
+        });
+        return;
+      }
+      setSidebarCollapsed((collapsed) => {
+        const next = !collapsed;
+        writeSidebarCollapsed(next);
+        return next;
+      });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOptions.enabled]);
   const customization = useMemo(
     () => ({
       composerTagIcons,

--- a/packages/web-shell/client/components/sidebar/sidebarToggleShortcut.test.ts
+++ b/packages/web-shell/client/components/sidebar/sidebarToggleShortcut.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { isSidebarToggleShortcut } from './sidebarToggleShortcut';
+
+const key = (
+  overrides: Partial<Parameters<typeof isSidebarToggleShortcut>[0]>,
+) => ({
+  key: 'b',
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...overrides,
+});
+
+describe('isSidebarToggleShortcut', () => {
+  it('matches Cmd+B and Ctrl+B, including uppercase', () => {
+    expect(isSidebarToggleShortcut(key({ metaKey: true }))).toBe(true);
+    expect(isSidebarToggleShortcut(key({ ctrlKey: true }))).toBe(true);
+    expect(isSidebarToggleShortcut(key({ ctrlKey: true, key: 'B' }))).toBe(
+      true,
+    );
+  });
+
+  it('ignores a bare B keypress (typing in the composer)', () => {
+    expect(isSidebarToggleShortcut(key({}))).toBe(false);
+  });
+
+  it('ignores other keys with the modifier held', () => {
+    expect(isSidebarToggleShortcut(key({ metaKey: true, key: 'k' }))).toBe(
+      false,
+    );
+  });
+
+  it('leaves Shift/Alt variants to the browser and other bindings', () => {
+    expect(
+      isSidebarToggleShortcut(key({ metaKey: true, shiftKey: true })),
+    ).toBe(false);
+    expect(isSidebarToggleShortcut(key({ ctrlKey: true, altKey: true }))).toBe(
+      false,
+    );
+  });
+
+  it('rejects the ambiguous Cmd+Ctrl combination', () => {
+    expect(isSidebarToggleShortcut(key({ metaKey: true, ctrlKey: true }))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/web-shell/client/components/sidebar/sidebarToggleShortcut.ts
+++ b/packages/web-shell/client/components/sidebar/sidebarToggleShortcut.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Cmd+B (macOS) / Ctrl+B toggles the session sidebar (#5074), mirroring the
+ * convention editors like VS Code use. Plain modifier+B only: Shift/Alt
+ * variants stay available to the browser and other bindings, and
+ * Cmd+Ctrl combined presses are rejected as ambiguous.
+ */
+export function isSidebarToggleShortcut(event: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}): boolean {
+  if (event.key !== 'b' && event.key !== 'B') return false;
+  if (event.altKey || event.shiftKey) return false;
+  return event.metaKey !== event.ctrlKey;
+}


### PR DESCRIPTION
## What this PR does

Adds the keyboard shortcut item from #5074: Cmd+B (macOS) / Ctrl+B toggles the web shell's session sidebar, following the editor convention (VS Code et al.). On desktop widths the shortcut collapses/expands the sidebar rail and persists the preference through the existing `writeSidebarCollapsed` path, so the choice survives a reload. On phone-width layouts (≤760px), where the sidebar renders as a drawer, the shortcut opens/closes the drawer instead. The key matcher lives in a small pure module (`sidebarToggleShortcut.ts`) with its own tests: plain modifier+B only — Shift/Alt variants and the ambiguous Cmd+Ctrl combination are left for the browser and other bindings, and a bare `b` typed into the composer never triggers it.

## Why it's needed

#5074 asked for a cmux-like session sidebar with several behaviors. Most of the list is already implemented on `main` (session list with active markers, one-click switching, inline rename, delete/release actions, search/filter, collapse with persistence) — but the "keyboard shortcut to toggle sidebar visibility (e.g. `Cmd+B` / `Ctrl+B`)" item was still missing: there was no way to show/hide the sidebar without the mouse. This PR closes that gap; the issue's remaining ask is a default-open policy for `dev:daemon`, which is a product default best decided by maintainers, so this PR deliberately references rather than closes the issue.

## Reviewer Test Plan

### How to verify

1. `qwen serve`, open the web shell on a desktop-width window.
2. Press Ctrl+B (or Cmd+B on macOS): the sidebar collapses to its icon rail; press again to expand.
3. Collapse it, reload the page: the sidebar stays collapsed (preference persisted).
4. Focus the composer and type text containing `b`: nothing toggles.
5. Narrow the window below 760px: the shortcut now opens/closes the mobile drawer.

Automated coverage: 5 unit tests for the matcher (Cmd+B / Ctrl+B / uppercase accepted; bare `b`, other keys, Shift/Alt variants, Cmd+Ctrl rejected). `npm run typecheck`, the web-shell package build, eslint and prettier are clean.

### Evidence (Before & After)

Before: no keyboard binding existed — Ctrl+B did nothing (the issue's unchecked list item). After, in a real browser (Playwright Chromium) against a real `qwen serve` daemon:

```
initial sidebar width: 260
after typing bare "b": 260 (unchanged ✓)
after Ctrl+B #1:        56 (collapsed ✓)
after Ctrl+B #2:       260 (expanded ✓)
after collapse + reload: 56 (persisted collapsed ✓)
VERDICT: OK — shortcut toggles, persists, and bare keys are ignored
```

![collapsed](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-5074/assets/shot-5074-collapsed.png)

![expanded](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-5074/assets/shot-5074-expanded.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; Playwright Chromium against a live `qwen serve` daemon, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: the binding fires while any element is focused, including the composer — intentional, matching VS Code, and safe because the composer has no bold formatting competing for modifier+B. Firefox's Ctrl+B bookmarks-sidebar default is overridden inside the web shell tab, same as other in-app editor bindings.
- Not validated / out of scope: the issue's "open by default on `dev:daemon`" item (a product-default decision); mobile-drawer toggling is implemented per the media query but only exercised via the desktop path in automation.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #5074

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

补上 #5074 中的键盘快捷键条目：Cmd+B（macOS）/ Ctrl+B 切换 web shell 会话侧边栏，遵循编辑器惯例（VS Code 等）。桌面宽度下快捷键折叠/展开侧边栏并通过既有 `writeSidebarCollapsed` 路径持久化偏好（刷新后保持）；手机宽度（≤760px）下侧边栏以抽屉呈现，快捷键改为开/关抽屉。按键判定放在独立纯模块（`sidebarToggleShortcut.ts`）并配套单测：仅裸 modifier+B——Shift/Alt 变体与含糊的 Cmd+Ctrl 组合留给浏览器和其他绑定，composer 中输入的裸 `b` 永不触发。

## 为什么需要

#5074 请求 cmux 式会话侧边栏的多项行为，其中大部分已在 `main` 实现（会话列表与活动标记、单击切换、行内重命名、删除/断开、搜索过滤、折叠持久化）——但「键盘快捷键切换侧边栏可见性（如 `Cmd+B` / `Ctrl+B`）」一项仍缺失：不用鼠标无法显示/隐藏侧边栏。本 PR 补齐该项；issue 剩余的「`dev:daemon` 默认展开」属产品默认值决策，留给 maintainer，因此本 PR 引用而不关闭该 issue。

## 审阅测试计划

### 如何验证

1. `qwen serve`，桌面宽度打开 web shell；
2. 按 Ctrl+B（macOS 上 Cmd+B）：侧边栏折叠为图标栏；再按展开；
3. 折叠后刷新页面：保持折叠（偏好持久化）；
4. 聚焦 composer 输入含 `b` 的文本：不触发切换；
5. 窗口缩窄至 760px 以下：快捷键改为开/关移动抽屉。

自动化覆盖：判定函数 5 个单测（接受 Cmd+B / Ctrl+B / 大写；拒绝裸 `b`、其他键、Shift/Alt 变体、Cmd+Ctrl）。typecheck / web-shell 包构建 / eslint / prettier 全部通过。

### 证据（Before & After）

Before：不存在任何键盘绑定——Ctrl+B 无作用（即 issue 中未勾选的清单项）。After：真实浏览器（Playwright Chromium）对真实 `qwen serve` daemon 的输出见上方代码块（260↔56 切换、刷新后保持 56、裸 `b` 无变化），并附两张真实浏览器截图。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；Playwright Chromium + 真实 `qwen serve` daemon + vitest 单测。

## 风险与范围

- 主要风险/权衡：任意元素聚焦时快捷键均生效（含 composer）——有意为之，与 VS Code 一致；composer 无粗体格式，无绑定冲突。Firefox 的 Ctrl+B 书签栏默认行为在 web shell 页内被覆盖，与其他应用内编辑器绑定一致。
- 未验证/超出范围：issue 中「`dev:daemon` 默认展开」一项（产品默认值决策）；移动抽屉切换按媒体查询实现，自动化仅覆盖桌面路径。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Refs #5074

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
