### PR TITLE
docs(autofix): make bot PR comments bilingual with collapsed Chinese

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -50,6 +50,24 @@ owns the model-driven decisions, code changes, and pre-commit verification.
   infra failure IS worth reporting: quote the exact command and its real output
   in `<workdir>/failure.md` rather than skipping the check or guessing at the
   cause (e.g. do not claim "node_modules is incomplete" unless you saw it fail).
+- Bilingual PR-comment outputs: any file the workflow posts VERBATIM as a PR
+  comment — `address-summary.md`, `no-action.md`, and `e2e-report.md` — must be
+  written in English and END with a complete collapsed Chinese translation of
+  its content, mirroring the repository's PR-body convention:
+
+  ```markdown
+  <details>
+  <summary>中文说明</summary>
+
+  …完整逐段翻译…
+
+  </details>
+  ```
+
+  Translate the whole body, section by section; do not summarize or omit.
+  Keep `failure.md` and `handoff.md` English-only WITHOUT a details block:
+  handoff comments embed a byte-truncated excerpt of them, and a severed
+  `<details>` tag would swallow the rest of the comment when rendered.
 - Never ask the user a question in this headless workflow. If blocked, write
   `<workdir>/failure.md` with what you learned and stop.
 
@@ -108,7 +126,8 @@ Implement the selected issue in the checked-out repository:
 8. Ensure `git status --short` shows only intended files, then create one
    Conventional Commit, e.g. `fix(core): summary (#<issue>)`.
 9. Write all required outputs:
-   - `<workdir>/e2e-report.md`
+   - `<workdir>/e2e-report.md` (bilingual per Shared Rules — it is posted
+     verbatim as a PR comment)
    - `<workdir>/pr-title.txt`
    - `<workdir>/pr-body.md` using `.qwen/skills/prepare-pr/SKILL.md`
 
@@ -146,6 +165,7 @@ Finish with exactly one outcome:
   tests for touched packages (plus `npm run generate:settings-schema`, staging
   the regenerated schema, if a settings source changed), commit once only after
   they pass, then write `<workdir>/address-summary.md` with each feedback point,
-  decision, changes, conflict notes, and verification results.
-- No change: write `<workdir>/no-action.md`.
+  decision, changes, conflict notes, and verification results (bilingual per
+  Shared Rules).
+- No change: write `<workdir>/no-action.md` (bilingual per Shared Rules).
 - Cannot confidently proceed: write `<workdir>/failure.md` and do not commit.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -444,6 +444,22 @@ describe('qwen-autofix workflow', () => {
     expect(skill).toContain('drop one silently');
   });
 
+  it('requires bilingual bodies for files posted verbatim as PR comments', () => {
+    const skill = readAutofixSkill();
+    // Comment bodies mirror the repository's PR-body convention: English
+    // content ending with a complete collapsed Chinese translation.
+    expect(skill).toContain('<summary>中文说明</summary>');
+    expect(skill).toMatch(
+      /`address-summary\.md`, `no-action\.md`, and `e2e-report\.md`/,
+    );
+    // failure/handoff excerpts are byte-truncated into handoff comments; a
+    // severed <details> tag would swallow the rest of the comment, so those
+    // two files must stay English-only.
+    expect(skill).toContain(
+      'Keep `failure.md` and `handoff.md` English-only WITHOUT a details block',
+    );
+  });
+
   it('includes issue-level comments in review feedback scanning', () => {
     const reviewScanStep =
       workflow.match(


### PR DESCRIPTION
## What this PR does

Makes the autofix bot's PR comments bilingual. Every agent-written file that the workflow posts verbatim as a PR comment — the review-round report bodies (`address-summary.md`, `no-action.md`) and the issue-phase E2E report (`e2e-report.md`) — must now be written in English and end with a complete collapsed Chinese translation (`<details><summary>中文说明</summary>…</details>`), mirroring the repository's existing PR-body convention. `failure.md` and `handoff.md` are explicitly kept English-only without a details block. The contract test pins the rule.

## Why it's needed

The repository already requires every PR body to carry a full collapsed Chinese translation, but the bot's comment output — e.g. its per-round review reports like the one on PR #7113 — is English-only, so half the convention's audience reads machine reports in a foreign language while human-authored PR bodies are bilingual. Extending the same convention to bot comments closes that gap at zero workflow cost (it is an agent-output rule, not a pipeline change). The failure/handoff exclusion is deliberate: handoff comments embed a byte-truncated excerpt of those files (`head -c 1500`), and a `<details>` block severed mid-tag would swallow the remainder of the rendered comment.

## Reviewer Test Plan

### How to verify

1. Read the new Shared Rules bullet in `.qwen/skills/autofix/SKILL.md`: it names exactly the three verbatim-posted files, shows the details-block shape, requires a complete section-by-section translation, and states the truncation-safety exclusion for `failure.md`/`handoff.md`. The three write sites (develop-issue step 9, the two address-review outcomes) carry short pointers to the rule.
2. Confirm the file set against the workflow: `address-summary.md`/`no-action.md` are `cat`-ed into `report.md` and posted via `gh pr comment` in the review phase; `e2e-report.md` is posted via `gh pr comment --body-file` in the issue phase; `failure.md`/`handoff.md` only ever reach comments as truncated excerpts.
3. Run `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 51/51, including the new test asserting the bilingual instruction, the three file names, and the English-only exclusion.

Behavioral expectation after merge: the next address round or issue-phase E2E report posts a comment whose English body ends with a collapsed 中文说明 section containing the full translation.

### Evidence (Before & After)

```
BEFORE (e.g. PR #7113 round-4 report):  English-only comment body.
AFTER:   English body … followed by
         <details><summary>中文说明</summary> …完整逐段翻译… </details>
         (failure/handoff comments unchanged — excerpt-truncation keeps them EN-only)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Contract test via vitest on a worktree checkout of main. Prompt-only change; the behavior lands on the next agent run.

## Risk & Scope

- Main risk or tradeoff: slightly longer agent outputs (full translation per comment); no pipeline or marker-format changes, so scan/watermark parsing is untouched.
- Not validated / out of scope: not yet exercised by a live agent run (the next review round exercises it); translation quality is the agent model's responsibility; workflow-composed wrapper lines (the 🤖 headline, base-conflict footer) stay English — the body carries the bilingual content.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #6998/#7094; prompted by maintainer feedback on the report comment at PR #7113.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix bot 的 PR 评论双语化。工作流逐字发布为 PR 评论的每个 agent 产物 —— review 轮次报告正文(`address-summary.md`、`no-action.md`)与 issue 阶段的 E2E 报告(`e2e-report.md`)—— 现在必须以英文撰写,并以完整的折叠中文翻译结尾(`<details><summary>中文说明</summary>…</details>`),与仓库既有的 PR 正文约定一致。`failure.md` 与 `handoff.md` 明确保持纯英文、不带 details 块。契约测试钉住该规则。

## 为什么需要

仓库已要求每个 PR 正文携带完整折叠中文翻译,但 bot 的评论输出(例如 PR #7113 上的逐轮 review 报告)是纯英文 —— 该约定的一半受众要用外语读机器报告,而人写的 PR 正文却是双语。把同一约定延伸到 bot 评论零工作流成本地补齐了这个缺口(这是 agent 输出规则,不是管道改动)。failure/handoff 的排除是刻意的:交接评论嵌入这两个文件的字节截断摘录(`head -c 1500`),`<details>` 块若在标签中间被切断,会吞掉渲染后评论的剩余部分。

## 评审验证方案

### 如何验证

1. 阅读 `.qwen/skills/autofix/SKILL.md` 新增的 Shared Rules 条目:精确点名三个逐字发布的文件、给出 details 块样式、要求逐段完整翻译、说明 `failure.md`/`handoff.md` 的截断安全排除。三处写入点(develop-issue 第 9 步、address-review 两个结局)带有指向该规则的简短提示。
2. 对照工作流确认文件集合:review 阶段 `address-summary.md`/`no-action.md` 被 `cat` 进 `report.md` 后经 `gh pr comment` 发布;issue 阶段 `e2e-report.md` 经 `gh pr comment --body-file` 发布;`failure.md`/`handoff.md` 只以截断摘录形式进入评论。
3. 运行 `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 51/51,含新测试:断言双语指令存在、三个文件名被点名、纯英文排除条款在案。

合并后的行为预期:下一次 address 轮次或 issue 阶段 E2E 报告发布的评论,英文正文之后以折叠的 中文说明 段收尾,内含完整翻译。

### 证据(前后对比)

```
改动前(如 PR #7113 第 4 轮报告):纯英文评论正文。
改动后:英文正文 … 随后
        <details><summary>中文说明</summary> …完整逐段翻译… </details>
        (failure/handoff 评论不变 —— 截断摘录保持纯英文)
```

### 测试情况

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境(可选)

在 main 的 worktree 检出上用 vitest 跑契约测试。纯 prompt 改动;行为在下一次 agent 运行时生效。

## 风险与范围

- 主要风险/权衡:agent 输出略长(每条评论含完整翻译);不改管道与标记格式,scan/水位线解析不受影响。
- 未验证/不在范围内:尚未由真实 agent 运行演练(下一轮 review 即会覆盖);翻译质量由 agent 模型负责;工作流拼接的包装行(🤖 标题、base-conflict 脚注)保持英文 —— 双语内容由正文承载。
- 破坏性变更/迁移:无。

## 关联 Issue

#6998/#7094 的后续;由维护者对 PR #7113 报告评论的反馈触发。

</details>
