### PR TITLE
fix(cli): correct misspelled migratedInMemorScopes -> migratedInMemoryScopes

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -419,7 +419,7 @@ export class LoadedSettings {
     user: SettingsFile,
     workspace: SettingsFile,
     isTrusted: boolean,
-    migratedInMemorScopes: Set<SettingScope>,
+    migratedInMemoryScopes: Set<SettingScope>,
     migrationWarnings: string[] = [],
     corruptedPath: string | undefined = undefined,
     wasRecovered: boolean = false,
@@ -430,7 +430,7 @@ export class LoadedSettings {
     this.user = user;
     this.workspace = workspace;
     this.isTrusted = isTrusted;
-    this.migratedInMemorScopes = migratedInMemorScopes;
+    this.migratedInMemoryScopes = migratedInMemoryScopes;
     this.migrationWarnings = migrationWarnings;
     this.corruptedPath = corruptedPath;
     this.wasRecovered = wasRecovered;
@@ -443,7 +443,7 @@ export class LoadedSettings {
   readonly user: SettingsFile;
   readonly workspace: SettingsFile;
   readonly isTrusted: boolean;
-  readonly migratedInMemorScopes: Set<SettingScope>;
+  readonly migratedInMemoryScopes: Set<SettingScope>;
   readonly migrationWarnings: string[];
   readonly corruptedPath: string | undefined;
   readonly wasRecovered: boolean;
@@ -687,7 +687,7 @@ export function loadSettings(
   const settingsErrors: SettingsError[] = [];
   const systemSettingsPath = getSystemSettingsPath();
   const systemDefaultsPath = getSystemDefaultsPath();
-  const migratedInMemorScopes = new Set<SettingScope>();
+  const migratedInMemoryScopes = new Set<SettingScope>();
 
   // Resolve paths to their canonical representation to handle symlinks
   const resolvedWorkspaceDir = path.resolve(workspaceDir);
@@ -1040,7 +1040,7 @@ export function loadSettings(
       rawJson: workspaceResult.rawJson,
     },
     isTrusted,
-    migratedInMemorScopes,
+    migratedInMemoryScopes,
     allMigrationWarnings,
     userResult.corruptedPath,
     userResult.wasRecovered ?? false,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -344,7 +344,7 @@ describe('runNonInteractive', () => {
         },
       },
       isTrusted: true,
-      migratedInMemorScopes: new Set(),
+      migratedInMemoryScopes: new Set(),
       forScope: vi.fn(),
       computeMergedSettings: vi.fn(),
     } as unknown as LoadedSettings;

--- a/packages/cli/src/ui/utils/customBanner.test.ts
+++ b/packages/cli/src/ui/utils/customBanner.test.ts
@@ -60,7 +60,7 @@ function makeSettings(opts: {
         )
       : empty,
     isTrusted: opts.isTrusted ?? true,
-    migratedInMemorScopes: new Set(),
+    migratedInMemoryScopes: new Set(),
     migrationWarnings: [],
     merged,
   } as unknown as LoadedSettings;

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -90,7 +90,7 @@ describe('validateNonInterActiveAuth', () => {
         },
       },
       isTrusted: true,
-      migratedInMemorScopes: new Set(),
+      migratedInMemoryScopes: new Set(),
       forScope: vi.fn(),
       computeMergedSettings: vi.fn(),
     } as unknown as LoadedSettings;


### PR DESCRIPTION
## What this PR does

Fixes a misspelled field name on the `LoadedSettings` class: `migratedInMemorScopes` → `migratedInMemoryScopes` (the "Memory" was missing its `y`). All references are renamed together — the class field declaration, the constructor parameter, the assignment, the local that feeds it in `loadSettings`, and the three test mocks that set it.

## Why it's needed

`LoadedSettings.migratedInMemorScopes` tracks which setting scopes were migrated in memory. The identifier misspells "Memory" as "Memor", which is easy to typo again and inconsistent with the rest of the code. The field is `readonly` and, although the class is exported, no code reads this field outside the five in-package references and three test mocks — so the rename is fully self-contained (8 occurrences across 4 files) and behavior-preserving.

## Reviewer Test Plan

### How to verify

- `grep -rn migratedInMemorScopes packages` returns nothing.
- `npx tsc --noEmit` (from `packages/cli`) reports no error referencing `migratedInMemory*` or `LoadedSettings` — i.e. the rename is internally consistent (any missed reference would be a compile error on a `readonly` field access).
- `npx vitest run src/config/settings.test.ts src/ui/utils/customBanner.test.ts` passes — these exercise the class and a consumer that sets the field.

### Evidence (Before & After)

`packages/cli/src/config/settings.ts` (`LoadedSettings`):
Before: `readonly migratedInMemorScopes: Set<SettingScope>;` (+ constructor param, assignment, local, and 3 test mocks)
After: `readonly migratedInMemoryScopes: Set<SettingScope>;` (all references renamed in lockstep)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: verified 0 remaining occurrences; `npx tsc --noEmit` produces no error referencing the renamed symbol (the only diagnostics are pre-existing, unrelated to this change — missing exports from the unbuilt `@qwen-code/qwen-code-core` workspace dep); `settings.test.ts` (149) and `customBanner.test.ts` (40) pass. Note: `validateNonInterActiveAuth.test.ts` fails to *load* locally on any branch with `Failed to resolve entry for package "@qwen-code/channel-base"` (an unbuilt workspace dep) — a pre-existing environmental issue unrelated to this rename; its only change here is the field name inside a mock object. Windows/Linux: N/A — identifier rename with no platform-dependent behavior.

### Environment (optional)

Node v24; `@qwen-code/qwen-code` CLI workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: minimal. Renames a `readonly` field (and its writers) on the exported `LoadedSettings` class. No code reads the field outside this package; `tsc` would flag any missed reference to a `readonly` member, and none exist. No runtime behavior changes.
- Not validated / out of scope: no other fields, classes, or files touched.
- Breaking changes / migration notes: none in practice — the field is only written internally and never read by external consumers.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `LoadedSettings` 类上拼写错误的字段名：`migratedInMemorScopes` → `migratedInMemoryScopes`（"Memory" 少了 `y`）。所有引用一并重命名——类字段声明、构造函数参数、赋值、`loadSettings` 中传入它的局部变量，以及三处设置该字段的测试 mock。

## 为什么需要

`LoadedSettings.migratedInMemorScopes` 用于跟踪哪些设置作用域在内存中被迁移。该标识符将 "Memory" 拼作 "Memor"，容易再次拼错且与其余代码不一致。该字段为 `readonly`，尽管类是导出的，但除本包内的 5 处引用与 3 处测试 mock 外没有任何代码读取此字段——因此此次重命名完全自包含（4 个文件共 8 处），且保持行为不变。

## 复核测试计划

### 如何验证

- `grep -rn migratedInMemorScopes packages` 无任何结果。
- 在 `packages/cli` 下 `npx tsc --noEmit` 不会报告任何引用 `migratedInMemory*` 或 `LoadedSettings` 的错误——即重命名内部一致（对 `readonly` 字段访问的任何遗漏引用都会导致编译错误）。
- `npx vitest run src/config/settings.test.ts src/ui/utils/customBanner.test.ts` 通过——它们覆盖了该类以及一个设置此字段的消费者。

### 证据（修复前后对比）

`packages/cli/src/config/settings.ts`（`LoadedSettings`）：
修复前：`readonly migratedInMemorScopes: Set<SettingScope>;`（外加构造函数参数、赋值、局部变量与 3 处测试 mock）
修复后：`readonly migratedInMemoryScopes: Set<SettingScope>;`（所有引用同步重命名）

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：确认无残留；`npx tsc --noEmit` 未产生任何引用被重命名符号的错误（仅有的诊断为既有问题，与本次改动无关——来自未构建的 `@qwen-code/qwen-code-core` 工作区依赖的缺失导出）；`settings.test.ts`（149）与 `customBanner.test.ts`（40）通过。注意：`validateNonInterActiveAuth.test.ts` 在任意分支上本地均因 `Failed to resolve entry for package "@qwen-code/channel-base"`（未构建的工作区依赖）而无法加载——属既有环境问题，与本次重命名无关；该文件此处的唯一改动是 mock 对象中的字段名。Windows/Linux：N/A——标识符重命名，无平台相关行为。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code` CLI 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：极小。重命名导出的 `LoadedSettings` 类上的一个 `readonly` 字段（及其写入方）。本包之外没有代码读取该字段；`tsc` 会标记对 `readonly` 成员的任何遗漏引用，而并不存在此类遗漏。无运行时行为改动。
- 未验证 / 范围之外：未改动其他字段、类或文件。
- 破坏性变更 / 迁移说明：实际上无——该字段仅在内部写入，从不被外部消费者读取。

## 关联 Issue

无。

</details>
