### PR TITLE
test(cli): actually exercise the paste-workaround path in useKeypress

### DIFF
--- a/packages/cli/src/ui/hooks/useKeypress.test.ts
+++ b/packages/cli/src/ui/hooks/useKeypress.test.ts
@@ -111,7 +111,7 @@ describe('useKeypress', () => {
       KeypressProvider,
       {
         kittyProtocolEnabled: false,
-        pasteWoraround: false,
+        pasteWorkaround: false,
       },
       children,
     );
@@ -125,7 +125,7 @@ describe('useKeypress', () => {
       KeypressProvider,
       {
         kittyProtocolEnabled: false,
-        pasteWoraround: true,
+        pasteWorkaround: true,
       },
       children,
     );
@@ -210,17 +210,20 @@ describe('useKeypress', () => {
       description: 'Modern Node (>= v20)',
       setup: () => setNodeVersion('20.0.0'),
       isLegacy: false,
-      pasteWoraround: false,
+      pasteWorkaround: false,
     },
     {
       description: 'PasteWorkaround Environment Variable',
       setup: () => {
         setNodeVersion('20.0.0');
       },
-      isLegacy: false,
-      pasteWoraround: true,
+      // The paste workaround puts KeypressProvider into passthrough mode,
+      // which reads raw `data` from stdin (not 'keypress' events). The mock
+      // must emit raw data for this path to be exercised at all.
+      isLegacy: true,
+      pasteWorkaround: true,
     },
-  ])('in $description', ({ setup, isLegacy, pasteWoraround }) => {
+  ])('in $description', ({ setup, isLegacy, pasteWorkaround }) => {
     beforeEach(() => {
       setup();
       stdin.setLegacy(isLegacy);
@@ -228,7 +231,7 @@ describe('useKeypress', () => {
 
     it('should process a paste as a single event', async () => {
       renderHook(() => useKeypress(onKeypress, { isActive: true }), {
-        wrapper: pasteWoraround ? wrapperWithWindowsWorkaround : wrapper,
+        wrapper: pasteWorkaround ? wrapperWithWindowsWorkaround : wrapper,
       });
       const pasteText = 'hello world';
       act(() => stdin.paste(pasteText));
@@ -249,7 +252,7 @@ describe('useKeypress', () => {
 
     it('should handle keypress interspersed with pastes', async () => {
       renderHook(() => useKeypress(onKeypress, { isActive: true }), {
-        wrapper: pasteWoraround ? wrapperWithWindowsWorkaround : wrapper,
+        wrapper: pasteWorkaround ? wrapperWithWindowsWorkaround : wrapper,
       });
 
       const keyA = { name: 'a', sequence: 'a' };
@@ -286,7 +289,7 @@ describe('useKeypress', () => {
       const { unmount } = renderHook(
         () => useKeypress(onKeypress, { isActive: true }),
         {
-          wrapper: pasteWoraround ? wrapperWithWindowsWorkaround : wrapper,
+          wrapper: pasteWorkaround ? wrapperWithWindowsWorkaround : wrapper,
         },
       );
       const pasteText = 'incomplete paste';


### PR DESCRIPTION
## What this PR does

Restores real test coverage for the Windows paste-workaround (passthrough) path in `useKeypress`. The `'PasteWorkaround Environment Variable'` test group was silently not exercising that path at all, for two compounding reasons:

1. **Misspelled prop.** The test wrappers passed `pasteWoraround` (typo) to `KeypressProvider`, whose real prop is `pasteWorkaround`. The misspelled prop was ignored, so `pasteWorkaround` defaulted to `false` — the workaround never turned on. The group was effectively a duplicate of the `'Modern Node'` group.
2. **Wrong input mode.** Even with the prop fixed, the group drove the mock stdin in `keypress`-event mode (`isLegacy: false`). But passthrough mode listens only to `stdin.on('data', …)` (it reads raw bytes and parses `\x1B[200~`/`\x1B[201~` paste markers itself); it never reads `'keypress'` events. So the mock's input was ignored and `onKeypress` fired 0 times.

This fixes the prop name (`pasteWoraround` → `pasteWorkaround`, 8 occurrences) and switches the group to raw-`data` input (`isLegacy: true`) so it genuinely runs the passthrough code path.

## Why it's needed

As-is, the Windows paste-workaround path (`usePassthrough` branch in `KeypressContext`) has **no** effective test coverage — the group that names it runs the non-passthrough path instead. A regression in the passthrough paste parsing would not be caught. This makes the group actually engage the workaround and assert correct paste reconstruction.

Note: this is a **test-only** change. It surfaces no product bug — once the group feeds the passthrough path correctly, the existing implementation produces the expected paste events (all assertions pass).

## Reviewer Test Plan

### How to verify

- `grep -rn pasteWoraround packages` returns nothing.
- `npx vitest run src/ui/hooks/useKeypress.test.ts` (from `packages/cli`) passes (15/15), including the three `'PasteWorkaround'` cases that now run with the workaround genuinely enabled.
- Load-bearing check (confirms the coverage is real, not green-by-accident):
  - Fixing only the prop typo but keeping `isLegacy: false` → the 3 paste cases fail (`onKeypress` called 0 times), because passthrough mode ignores the keypress-mode mock input.
  - Reverting `pasteWorkaround` back to `false` for the group → the cases pass again but exercise the non-passthrough path (i.e. the old, hollow coverage).

### Evidence (Before & After)

`packages/cli/src/ui/hooks/useKeypress.test.ts`, `'PasteWorkaround Environment Variable'` group:
Before: wrappers pass `pasteWoraround` (ignored typo) and `isLegacy: false` → group runs the non-passthrough path; passthrough path untested.
After: wrappers pass `pasteWorkaround` and the group uses `isLegacy: true` → group runs the passthrough path; 15/15 pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: `src/ui/hooks/useKeypress.test.ts` passes (15/15); verified the 3 passthrough cases fail if the input mode is left as `isLegacy: false` (proving they now exercise the passthrough path); verified 0 remaining occurrences of the `pasteWoraround` typo. Windows/Linux: N/A — test-only change; the workaround it now covers is Windows-oriented but the path is exercised deterministically via mocked stdin, not real terminals.

### Environment (optional)

Node v24; `@qwen-code/qwen-code` CLI workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none to product code — this touches only `useKeypress.test.ts`. It strengthens an existing test group so it actually covers the passthrough/paste-workaround path.
- Not validated / out of scope: no implementation changes; no other test files touched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

恢复 `useKeypress` 中 Windows 粘贴兼容（passthrough）路径的真实测试覆盖。`'PasteWorkaround Environment Variable'` 测试组此前因两个叠加原因而完全没有真正执行该路径：

1. **拼错的 prop。** 测试 wrapper 向 `KeypressProvider` 传入了 `pasteWoraround`（拼写错误），而其真实 prop 名为 `pasteWorkaround`。拼错的 prop 被忽略，`pasteWorkaround` 取默认值 `false`——兼容逻辑从未开启。该组实际上是 `'Modern Node'` 组的重复。
2. **错误的输入模式。** 即便修正 prop，该组仍以 `keypress` 事件模式驱动 mock stdin（`isLegacy: false`）。但 passthrough 模式只监听 `stdin.on('data', …)`（它读取原始字节并自行解析 `\x1B[200~`/`\x1B[201~` 粘贴标记），从不读取 `'keypress'` 事件。因此 mock 输入被忽略，`onKeypress` 触发 0 次。

本 PR 修正 prop 名（`pasteWoraround` → `pasteWorkaround`，共 8 处），并将该组切换为原始 `data` 输入（`isLegacy: true`），使其真正运行 passthrough 代码路径。

## 为什么需要

现状下，Windows 粘贴兼容路径（`KeypressContext` 中的 `usePassthrough` 分支）**没有**有效测试覆盖——以其命名的测试组实际运行的是非 passthrough 路径。passthrough 粘贴解析中的回归不会被捕获。本 PR 让该组真正启用兼容逻辑并断言正确的粘贴重建。

注意：这是一处**仅测试**的改动。它未暴露任何产品 bug——一旦该组正确地喂入 passthrough 路径，现有实现即产生预期的粘贴事件（所有断言通过）。

## 复核测试计划

### 如何验证

- `grep -rn pasteWoraround packages` 无任何结果。
- 在 `packages/cli` 下 `npx vitest run src/ui/hooks/useKeypress.test.ts` 通过（15/15），包括如今在兼容逻辑真正开启下运行的三个 `'PasteWorkaround'` 用例。
- 关键性验证（证明覆盖是真实的，而非偶然通过）：
  - 仅修正 prop 拼写但保留 `isLegacy: false` → 三个粘贴用例失败（`onKeypress` 触发 0 次），因为 passthrough 模式忽略 keypress 模式的 mock 输入。
  - 将该组的 `pasteWorkaround` 改回 `false` → 用例再次通过，但走的是非 passthrough 路径（即旧的、空洞的覆盖）。

### 证据（修复前后对比）

`packages/cli/src/ui/hooks/useKeypress.test.ts`，`'PasteWorkaround Environment Variable'` 组：
修复前：wrapper 传入 `pasteWoraround`（被忽略的拼写错误）与 `isLegacy: false` → 该组运行非 passthrough 路径；passthrough 路径未被测试。
修复后：wrapper 传入 `pasteWorkaround`，该组使用 `isLegacy: true` → 该组运行 passthrough 路径；15/15 通过。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：`src/ui/hooks/useKeypress.test.ts` 通过（15/15）；确认若将输入模式保留为 `isLegacy: false`，三个 passthrough 用例会失败（证明它们如今确实走 passthrough 路径）；确认无残留的 `pasteWoraround` 拼写错误。Windows/Linux：N/A——仅测试改动；其覆盖的兼容逻辑面向 Windows，但该路径通过 mock 的 stdin 确定性地执行，而非真实终端。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code` CLI 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：对产品代码无风险——仅改动 `useKeypress.test.ts`。它强化了一个既有测试组，使其真正覆盖 passthrough/粘贴兼容路径。
- 未验证 / 范围之外：无实现改动；未改动其他测试文件。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
