### PR TITLE
fix(core): resolve a parameter expansion in command position to its command root

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -441,6 +441,25 @@ describe('getCommandRoot — parameter expansion in command position', () => {
     expect(getCommandRoot(`"$${NAME}" review foo`)).toBeUndefined();
   });
 
+  it('field-splits an UNQUOTED expansion the way the shell does', () => {
+    // Both cases verified against real bash. Unset: `$VAR printf OK` removes
+    // the empty expansion and runs `printf` — returning no root here would
+    // hard-refuse a command the shell executes fine. Multi-word: with
+    // VAR='/usr/bin/env printf', the shell's command is `env` after splitting;
+    // reporting 'env printf' would show the wrong permission root.
+    expect(getCommandRoot(`$${NAME} printf OK`)).toBe('printf');
+    expect(getCommandRoot(`\${${NAME}} printf OK`)).toBe('printf');
+    process.env[NAME] = '/usr/bin/env printf';
+    expect(getCommandRoot(`$${NAME} OK`)).toBe('env');
+    // Quoting suppresses splitting: the whole value is one (unrunnable) word,
+    // and the root is its basename — faithful to what the shell would exec.
+    expect(getCommandRoot(`"$${NAME}" OK`)).toBe('env printf');
+  });
+
+  it('an empty unquoted expansion with nothing after it still has no root', () => {
+    expect(getCommandRoot(`$${NAME}`)).toBeUndefined();
+  });
+
   it('skips leading env assignments before the expansion, like the plain path', () => {
     process.env[NAME] = '/repo/scripts/dev.js';
     expect(getCommandRoot(`FOO=1 "\${${NAME}:-qwen}" review foo`)).toBe(

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -12,6 +12,7 @@ import {
   COMMAND_SUBSTITUTION_WARNING,
   detectSelfKillCommand,
   escapeShellArg,
+  getCommandRoot,
   getCommandRoots,
   getShellConfiguration,
   hasNonFinalTopLevelBackgroundOperator,
@@ -398,6 +399,61 @@ describe('checkCommandPermissions', () => {
       expect(result.allAllowed).toBe(false);
       expect(result.disallowedCommands).toEqual(['rm -rf /']);
     });
+  });
+});
+
+describe('getCommandRoot — parameter expansion in command position', () => {
+  // The bundled /review skill invokes every command as
+  // `"${QWEN_CODE_CLI:-qwen}" review …`. Before this resolver, such a command
+  // had NO identifiable root — the shell tool hard-refused it ("Could not
+  // identify command root to obtain permission from user") before any approval
+  // mode was consulted, YOLO included. Dogfooded live on every /review run.
+  const NAME = 'SHELL_UTILS_TEST_ENTRY';
+  afterEach(() => {
+    delete process.env[NAME];
+  });
+
+  it('resolves ${VAR:-default} to the variable when set and non-empty', () => {
+    process.env[NAME] = '/repo/scripts/dev.js';
+    expect(getCommandRoot(`"\${${NAME}:-qwen}" review foo`)).toBe('dev.js');
+    expect(getCommandRoot(`\${${NAME}:-qwen} review foo`)).toBe('dev.js');
+  });
+
+  it('resolves ${VAR:-default} to the default when unset OR empty — POSIX :-', () => {
+    expect(getCommandRoot(`"\${${NAME}:-qwen}" review foo`)).toBe('qwen');
+    process.env[NAME] = '';
+    expect(getCommandRoot(`"\${${NAME}:-qwen}" review foo`)).toBe('qwen');
+  });
+
+  it('resolves ${VAR-default} to the default only when unset — POSIX -', () => {
+    expect(getCommandRoot(`"\${${NAME}-qwen}" review foo`)).toBe('qwen');
+    process.env[NAME] = '';
+    // Empty-but-set: `-` keeps the empty value; nothing to name, no root.
+    expect(getCommandRoot(`"\${${NAME}-qwen}" review foo`)).toBeUndefined();
+  });
+
+  it('resolves a bare "$VAR" head, and yields no root when it is unset', () => {
+    process.env[NAME] = '/usr/local/bin/qwen';
+    expect(getCommandRoot(`"$${NAME}" review foo`)).toBe('qwen');
+    delete process.env[NAME];
+    // Unset with no default resolves to nothing: the command stays refusable,
+    // exactly as an empty command would be — there is nothing to name.
+    expect(getCommandRoot(`"$${NAME}" review foo`)).toBeUndefined();
+  });
+
+  it('skips leading env assignments before the expansion, like the plain path', () => {
+    process.env[NAME] = '/repo/scripts/dev.js';
+    expect(getCommandRoot(`FOO=1 "\${${NAME}:-qwen}" review foo`)).toBe(
+      'dev.js',
+    );
+  });
+
+  it('feeds getCommandRoots, so the shell tool no longer hard-refuses the skill form', () => {
+    expect(
+      getCommandRoots(
+        `"\${${NAME}:-qwen}" review fetch-pr 7 --out x.json && echo done`,
+      ),
+    ).toEqual(['qwen', 'echo']);
   });
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -338,13 +338,17 @@ export function splitCommands(command: string): string[] {
  * user" until the model hand-resolved the variable itself.
  *
  * Resolution mirrors POSIX: `:-` substitutes the default when the variable is
- * unset OR empty; `-` only when unset; a bare `$VAR` that resolves to nothing
- * yields no root, and the command stays refusable — there is nothing to name.
- * The environment consulted is this process's own, which is what the spawned
- * shell inherits.
+ * unset OR empty; `-` only when unset. Quoting then decides what happens,
+ * exactly as it does in the shell. A QUOTED expansion is one word: empty means
+ * an empty command name, which has nothing to name and stays refusable. An
+ * UNQUOTED expansion field-splits: an empty result is REMOVED and the next
+ * token is the command (`$VAR printf OK` with VAR unset runs `printf`), and a
+ * multi-word value's FIRST field is the command (`$VAR OK` with
+ * VAR='/usr/bin/env printf' runs `env`). The environment consulted is this
+ * process's own, which is what the spawned shell inherits.
  */
 const PARAMETER_EXPANSION_COMMAND =
-  /^"?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?-)([^}]*))?\}|([A-Za-z_][A-Za-z0-9_]*))"?$/;
+  /^("?)\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?-)([^}]*))?\}|([A-Za-z_][A-Za-z0-9_]*))\1$/;
 
 function resolveLeadingParameterExpansion(command: string): string | undefined {
   let rest = command;
@@ -359,15 +363,27 @@ function resolveLeadingParameterExpansion(command: string): string | undefined {
   if (!head) return undefined;
   const m = PARAMETER_EXPANSION_COMMAND.exec(head.token);
   if (!m) return undefined;
-  const name = (m[1] ?? m[4]) as string;
-  const op = m[2];
+  const quoted = m[1] === '"';
+  const name = (m[2] ?? m[5]) as string;
+  const op = m[3];
   const value = process.env[name];
   const useDefault =
     op === undefined ? false : op === ':-' ? !value : value === undefined;
   const resolved = useDefault
-    ? stripSymmetricQuotes(m[3] ?? '').value
+    ? stripSymmetricQuotes(m[4] ?? '').value
     : (value ?? '');
-  return resolved || undefined;
+  if (quoted) {
+    // One word, splitting suppressed — empty is an empty command name.
+    return resolved || undefined;
+  }
+  // Unquoted: the shell field-splits the expansion before command lookup.
+  const fields = resolved.split(/[ \t\n]+/).filter(Boolean);
+  if (fields.length === 0) {
+    // The empty expansion is removed; the command is whatever follows it.
+    const next = head.rest.trim();
+    return next ? getCommandRoot(next) : undefined;
+  }
+  return fields[0];
 }
 
 /**

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -325,6 +325,52 @@ export function splitCommands(command: string): string[] {
 }
 
 /**
+ * A parameter expansion standing in command position — `$VAR`, `"$VAR"`,
+ * `${VAR}`, `"${VAR:-default}"`, `${VAR-default}` — resolved the way the shell
+ * will resolve it at execution time.
+ *
+ * Without this, such a command had NO identifiable root: the tokenizer turns
+ * the expansion into a non-string (or empty) token, `getCommandRoot` returns
+ * undefined, and the shell tool hard-refuses the command before any approval
+ * mode is consulted — including YOLO. Dogfooded live: the bundled /review
+ * skill invokes every command as `"${QWEN_CODE_CLI:-qwen}" review …`, and each
+ * run opened with "Could not identify command root to obtain permission from
+ * user" until the model hand-resolved the variable itself.
+ *
+ * Resolution mirrors POSIX: `:-` substitutes the default when the variable is
+ * unset OR empty; `-` only when unset; a bare `$VAR` that resolves to nothing
+ * yields no root, and the command stays refusable — there is nothing to name.
+ * The environment consulted is this process's own, which is what the spawned
+ * shell inherits.
+ */
+const PARAMETER_EXPANSION_COMMAND =
+  /^"?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?-)([^}]*))?\}|([A-Za-z_][A-Za-z0-9_]*))"?$/;
+
+function resolveLeadingParameterExpansion(command: string): string | undefined {
+  let rest = command;
+  // Leading env assignments come first (`FOO=1 "${BAR:-baz}" …`), exactly as
+  // the plain-token path below skips them.
+  while (true) {
+    const t = takeLeadingToken(rest);
+    if (!t || !isEnvAssignmentToken(t.token)) break;
+    rest = t.rest;
+  }
+  const head = takeLeadingToken(rest);
+  if (!head) return undefined;
+  const m = PARAMETER_EXPANSION_COMMAND.exec(head.token);
+  if (!m) return undefined;
+  const name = (m[1] ?? m[4]) as string;
+  const op = m[2];
+  const value = process.env[name];
+  const useDefault =
+    op === undefined ? false : op === ':-' ? !value : value === undefined;
+  const resolved = useDefault
+    ? stripSymmetricQuotes(m[3] ?? '').value
+    : (value ?? '');
+  return resolved || undefined;
+}
+
+/**
  * Extracts the root command from a given shell command string.
  * Skips leading env var assignments (VAR=value) so that
  * `PYTHONPATH=/tmp python3 -c "..."` returns `python3`.
@@ -333,6 +379,11 @@ export function getCommandRoot(command: string): string | undefined {
   const trimmedCommand = command.trim();
   if (!trimmedCommand) {
     return undefined;
+  }
+
+  const expanded = resolveLeadingParameterExpansion(trimmedCommand);
+  if (expanded !== undefined) {
+    return expanded.split(/[\\/]/).pop();
   }
 
   try {


### PR DESCRIPTION
## What

`getCommandRoot` now resolves a parameter expansion standing in command position — `"$VAR"`, `${VAR}`, `"${VAR:-default}"`, `${VAR-default}` — the way the spawned shell will resolve it, against the environment it will inherit.

## Why

A command with no identifiable root is **hard-refused** by the shell tool (`validateToolParamValues` → *"Could not identify command root to obtain permission from user"*) before any approval mode is consulted — **YOLO included**. And the form is not exotic: the bundled `/review` skill invokes every one of its ~27 commands as

```bash
"${QWEN_CODE_CLI:-qwen}" review …
```

so every review run opened with a refused command until the model noticed, hand-resolved the variable (`echo $QWEN_CODE_CLI`), and retried with the explicit path. Observed on every dogfooded run since #7033 landed the variable; reproduced directly:

```
before: getCommandRoots('"${QWEN_CODE_CLI:-qwen}" review fetch-pr …')  → []   (refused)
after:  var set   → ["dev.js"]     var unset → ["qwen"]
```

## Semantics

POSIX, deliberately narrow:

- `:-` substitutes the default when the variable is unset **or** empty; `-` only when unset
- a bare `$VAR` that resolves to nothing still yields **no root** — such a command has nothing to name, and stays refusable exactly like an empty command
- leading env assignments (`FOO=1 "${BAR:-baz}" …`) are skipped first, as the plain-token path already does
- with the variable set, the root is the real entry's basename (`dev.js`, `qwen`) — permission prompts and allowlists name the binary that actually runs, not a `${…}` literal

## Verification

- Six tests pin both directions of each operator; disabling the resolver turns all six red
- `shell.ts` / `monitor.ts` caller suites pass unchanged (423 tests)
- End-to-end: the exact skill form now executes through the real shell tool in **Auto mode** (root identified → auto-approvable), where it was previously refused even in YOLO
