### PR TITLE
fix(core): add kimi-k3 token limits (1M context, 128K output)

### DIFF
--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -221,6 +221,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // Moonshot / Kimi
   // -------------------
+  [/^kimi-k3/, LIMITS['1m']], // Kimi K3: 1M
   [/^kimi-/, LIMITS['256k']], // Kimi fallback: 256K
 
   // -------------------
@@ -268,6 +269,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^minimax-m2\.5/i, LIMITS['64k']],
 
   // Kimi
+  [/^kimi-k3/, LIMITS['128k']], // Kimi K3: 128K default max output (up to 1M configurable)
   [/^kimi-k2\.5/, LIMITS['32k']],
 ];
 

--- a/packages/vscode-ide-companion/src/utils/tokenLimits.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.ts
@@ -126,6 +126,7 @@ const INPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^minimax-/i, LIMITS['200k']],
 
   // Moonshot / Kimi
+  [/^kimi-k3/, LIMITS['1m']],
   [/^kimi-/, LIMITS['256k']],
 
   // ByteDance Seed-OSS
@@ -161,6 +162,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
 
   [/^minimax-m2\.5/i, LIMITS['64k']],
 
+  [/^kimi-k3/, LIMITS['128k']],
   [/^kimi-k2\.5/, LIMITS['32k']],
 ];
 


### PR DESCRIPTION
## What this PR does

Registers explicit token-limit rules for Kimi K3 so its context window is treated as one million tokens and its maximum output as 128K, instead of falling through to the generic Kimi fallback (256K context) and the default output limit. The same rules are mirrored into the VS Code companion's token-limit table so the editor's context-usage display stays consistent with the CLI.

## Why it's needed

Kimi K3 is Moonshot's new flagship model with a one-million-token context window and a documented default maximum output of 128K (configurable higher). Without explicit rules the CLI treated its context as 256K — triggering context compaction at roughly a quarter of the real window — and under-sized the output budget. Aligning the limits with the model's real capabilities lets long-context sessions use the full window and gives a sensible default output size. Model reference: https://platform.kimi.com/docs/api/models-overview

## Reviewer Test Plan

### How to verify

This is a lookup-table addition covered by the existing token-limit unit tests. A reviewer can confirm by resolving the limits for the model id `kimi-k3` and checking that the context window is one million and the output limit is 128K, while the existing `kimi-k2.x` ids stay at 256K.

Run from `packages/core`:

```
npx vitest run src/core/tokenLimits.test.ts
```

Expected resolution:

| Model | Context (input) | Max output | Auto request ceiling |
| :-- | --: | --: | --: |
| `kimi-k3` (new) | 1,000,000 | 131,072 | 64,000 |
| `kimi-k2.6` | 262,144 | 32,000 | 32,000 |
| `kimi-k2.5` | 262,144 | 32,768 | 32,768 |

### Evidence (Before & After)

N/A — internal token-limit table, no user-visible UI change. Before this PR `kimi-k3` resolved to 262,144 context and the 32K default output; after, it resolves to 1,000,000 context and 131,072 output as shown above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: registering an explicit output rule marks `kimi-k3` as a "known" model, so an explicitly user-configured `max_tokens` is capped at 128K. This is intentional — the auto request ceiling is 64K regardless, and output beyond 128K is not a realistic case for a coding CLI.
- Not validated / out of scope: no live call against the Kimi endpoint; no new provider preset or auth path is added (Kimi K3 is already usable through the OpenAI-compatible custom provider). Reasoning-content handling is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Kimi K3 注册了明确的 token 上限规则，使其上下文窗口按一百万 token 计算、最大输出按 128K 计算，而不是回退到通用的 Kimi 兜底规则（256K 上下文）和默认输出上限。同样的规则也同步到了 VS Code 配套插件的 token 上限表中，使编辑器的上下文用量显示与 CLI 保持一致。

## 为什么需要

Kimi K3 是 Moonshot 新的旗舰模型，拥有一百万 token 的上下文窗口，文档中默认最大输出为 128K（可配置更高）。在没有明确规则的情况下，CLI 会把它的上下文当作 256K 处理——在大约真实窗口四分之一处就触发上下文压缩——并且低估了输出预算。让上限与模型的真实能力对齐，可以让长上下文会话用满整个窗口，并给出合理的默认输出大小。模型文档：https://platform.kimi.com/docs/api/models-overview

## 复核测试计划

这是一处查表规则的新增，已被现有的 token 上限单元测试覆盖。复核者可以通过解析模型 id `kimi-k3` 的上限来确认：上下文窗口为一百万、输出上限为 128K，同时现有的 `kimi-k2.x` id 仍为 256K。

在 `packages/core` 下运行：

```
npx vitest run src/core/tokenLimits.test.ts
```

预期解析结果：

| 模型 | 上下文（输入） | 最大输出 | 自动请求上限 |
| :-- | --: | --: | --: |
| `kimi-k3`（新增） | 1,000,000 | 131,072 | 64,000 |
| `kimi-k2.6` | 262,144 | 32,000 | 32,000 |
| `kimi-k2.5` | 262,144 | 32,768 | 32,768 |

## 风险与范围

- 主要权衡：注册明确的输出规则会把 `kimi-k3` 标记为“已知”模型，因此用户显式配置的 `max_tokens` 会被限制在 128K。这是有意为之——自动请求上限本就是 64K，而超过 128K 的输出对编码 CLI 而言并不是现实场景。
- 未验证／范围之外：没有对 Kimi 端点做真实调用；没有新增 provider 预设或鉴权路径（Kimi K3 现在已可通过 OpenAI 兼容的自定义 provider 使用）；reasoning-content 处理保持不变。
- 破坏性变更／迁移说明：无。

</details>
