### PR TITLE
fix(cli): restore cancelled prompt after streamed output

### DIFF
--- a/.qwen/e2e-tests/2026-07-18-cancelled-prompt-restore.md
+++ b/.qwen/e2e-tests/2026-07-18-cancelled-prompt-restore.md
@@ -1,0 +1,30 @@
+# Cancelled prompt restoration after streamed output
+
+## Scenario
+
+1. Start Qwen Code in interactive mode.
+2. Submit `Explain how a hash table handles collisions in detail.`
+3. Wait until response text is visible, then press Ctrl+C.
+4. Confirm the partial response remains in the transcript.
+5. Confirm the submitted prompt is restored to the input box and can be edited.
+
+## Regression checks
+
+- A draft typed while the response is running is not overwritten.
+- A queued follow-up remains the editable input instead of restoring the prior prompt.
+- Cancelling during a tool call keeps the existing tool-execution behavior.
+- Cancelling before any response still rewinds the empty turn as before.
+
+## Automated verification
+
+```bash
+cd packages/cli
+npx vitest run src/ui/AppContainer.test.tsx
+npx vitest run src/ui/hooks/useGeminiStream.test.tsx -t 'flushes buffered stream events before snapshotting'
+```
+
+Result: 119 AppContainer tests passed; the stream flush-race regression passed.
+
+## Manual status
+
+Not run in this environment because a global released `qwen` executable was not available for the required before/after comparison.

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1654,7 +1654,7 @@ describe('AppContainer State Management', () => {
       expect(mockRemoveLastUserMessage).not.toHaveBeenCalled();
     });
 
-    it('does not auto-restore when the model produced meaningful content', async () => {
+    it('restores the prompt without rewinding when the model produced meaningful content', async () => {
       const mockSetText = vi.fn();
       const mockTruncateToItem = vi.fn();
       mockedUseTextBuffer.mockReturnValue({
@@ -1709,7 +1709,7 @@ describe('AppContainer State Management', () => {
       triggerCancel(cancelInfoFor('what time is it?'));
 
       expect(mockTruncateToItem).not.toHaveBeenCalled();
-      expect(mockSetText).not.toHaveBeenCalled();
+      expect(mockSetText).toHaveBeenCalledWith('what time is it?');
     });
 
     it('does not auto-restore when the sync pendingItem snapshot has meaningful content (closes stale-state race)', async () => {
@@ -1785,14 +1785,14 @@ describe('AppContainer State Management', () => {
       expect(mockRemoveLastUserMessage).not.toHaveBeenCalled();
     });
 
-    it('does not auto-restore when info.turnProducedMeaningfulContent is true (closes the flush-race)', async () => {
+    it('restores the prompt without rewinding when turnProducedMeaningfulContent is true', async () => {
       // Race scenario flagged in PR review: pre-cancel flush commits a
       // gemini_content via addItem and then a synthetic thought event
       // replaces pendingHistoryItem. AppContainer's historyRef.current
       // doesn't see the committed content yet (React hasn't
       // re-rendered), so the trailing-only-synthetic check would
       // otherwise pass. `info.turnProducedMeaningfulContent: true`
-      // must short-circuit auto-restore regardless.
+      // must preserve the output and restore only the prompt text.
       const mockSetText = vi.fn();
       const mockTruncateToItem = vi.fn();
       const mockRemoveLastUserMessage = vi.fn().mockResolvedValue(true);
@@ -1843,8 +1843,8 @@ describe('AppContainer State Management', () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      // pendingItem is a (synthetic) thought, but turnProducedMeaningfulContent
-      // says content DID happen earlier — guard must bail.
+      // pendingItem is a synthetic thought, but meaningful content happened
+      // earlier. Preserve that output while restoring only the prompt text.
       triggerCancel({
         pendingItem: { type: 'gemini_thought', text: 'thinking…' },
         lastTurnUserItem: { id: 1, text: 'what time is it?' },
@@ -1852,7 +1852,7 @@ describe('AppContainer State Management', () => {
       });
 
       expect(mockTruncateToItem).not.toHaveBeenCalled();
-      expect(mockSetText).not.toHaveBeenCalled();
+      expect(mockSetText).toHaveBeenCalledWith('what time is it?');
       expect(mockRemoveLastUserMessage).not.toHaveBeenCalled();
     });
 
@@ -2126,7 +2126,10 @@ describe('AppContainer State Management', () => {
 
       // Matching lastTurnUserItem so the test reaches the
       // pending-tool-group bail path (the one the test name promises).
-      triggerCancel(cancelInfoFor('edit foo.ts'));
+      triggerCancel({
+        ...cancelInfoFor('edit foo.ts'),
+        turnProducedMeaningfulContent: true,
+      });
 
       expect(mockTruncateToItem).not.toHaveBeenCalled();
       expect(mockSetText).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2464,11 +2464,10 @@ export const AppContainer = (props: AppContainerProps) => {
         buffer.setText(currentText ? `${popped}\n${currentText}` : popped);
       }
 
-      // Auto-restore-on-cancel: if the user hit ESC immediately after submit
-      // (nothing meaningful was produced), pull the just-submitted prompt back
-      // into the input box and rewind the transcript so it doesn't show a
-      // stranded "user prompt + Request cancelled." pair. Mirrors claude-code
-      // (REPL.tsx auto-restore branch).
+      // Restore-on-cancel: pull the just-submitted prompt back into the input
+      // box when it is safe to do so. If nothing meaningful was produced,
+      // also rewind the stranded "user prompt + Request cancelled." pair. If
+      // output exists, keep the transcript and restore only the editable text.
       //
       // Guards (all required):
       //   - Buffer was empty before the queue drain (don't clobber typed-during-
@@ -2498,12 +2497,25 @@ export const AppContainer = (props: AppContainerProps) => {
         );
         return;
       }
-      if (pendingHistoryItems.some((item) => !isSyntheticHistoryItem(item))) {
+
+      // The cancelled turn must have added a `user` history item itself —
+      // Cron / Notification / slash submit_prompt / Retry paths submit
+      // without pushing a user item, so they have no prompt to restore.
+      const cancelledTurnUserItem = info?.lastTurnUserItem;
+      if (cancelledTurnUserItem == null) {
         debugLogger.debug(
-          'auto-restore bail: pending stream item has meaningful content',
+          'auto-restore bail: cancelled turn did not add a user history item',
         );
         return;
       }
+
+      if (pendingHistoryItems.some((item) => item.type === 'tool_group')) {
+        debugLogger.debug(
+          'auto-restore bail: tool execution is pending or committed',
+        );
+        return;
+      }
+
       // Synchronous "did the turn produce any content event" flag from
       // useGeminiStream. Catches the race where the pre-cancel flush
       // committed gemini_content via addItem and a later thought event
@@ -2513,20 +2525,14 @@ export const AppContainer = (props: AppContainerProps) => {
       // otherwise pass and we'd wrongly truncate the committed content.
       if (info?.turnProducedMeaningfulContent) {
         debugLogger.debug(
-          'auto-restore bail: turn produced meaningful content during stream/flush',
+          'auto-restore: preserving streamed output and restoring prompt text',
         );
+        buffer.setText(cancelledTurnUserItem.text);
         return;
       }
-
-      // The cancelled turn must have added a `user` history item itself —
-      // Cron / Notification / slash submit_prompt / Retry paths submit
-      // without pushing a user item, so an older user item that happens
-      // to be followed only by synthetic content must NOT be wrongly
-      // auto-restored on top of those turns.
-      const cancelledTurnUserItem = info?.lastTurnUserItem;
-      if (cancelledTurnUserItem == null) {
+      if (pendingHistoryItems.some((item) => !isSyntheticHistoryItem(item))) {
         debugLogger.debug(
-          'auto-restore bail: cancelled turn did not add a user history item',
+          'auto-restore bail: pending stream item has meaningful content',
         );
         return;
       }
@@ -2539,8 +2545,9 @@ export const AppContainer = (props: AppContainerProps) => {
       }
       if (!itemsAfterAreOnlySynthetic(history, lastUserIdx)) {
         debugLogger.debug(
-          'auto-restore bail: meaningful content committed after last user item',
+          'auto-restore: preserving committed output and restoring prompt text',
         );
+        buffer.setText(cancelledTurnUserItem.text);
         return;
       }
 


### PR DESCRIPTION
## What this PR does

When a user cancels after response text has already appeared, the submitted prompt is placed back in the input for editing while the visible response and conversation history remain intact. Cancelling during tool execution, while a draft or queued follow-up is present, or before any meaningful response keeps the existing behavior.

## Why it's needed

Prompt restoration was coupled to transcript rewinding, so the prompt was not restored once the model had produced meaningful output. That forced users to retype or recover the prompt manually after cancelling a long response. Separating prompt-only restoration from the rewind path preserves useful output while making the original prompt editable again.

## Reviewer Test Plan

### How to verify

1. Start an interactive session and submit a prompt that produces a long response.
2. After response text becomes visible, press Ctrl+C.
3. Confirm the partial response stays in the transcript and the submitted prompt reappears in the input box for editing.
4. Confirm that cancelling before any response still removes the empty cancelled turn, and that cancelling during tool execution does not restore the prompt.

Automated validation passed: 119 cancellation-container tests, the focused stream flush-race regression, CLI typecheck, ESLint, Prettier, package build, and diff checks.

### Evidence (Before & After)

Before: cancelling after response text appeared kept the response but left the input empty. After: the response remains visible and the submitted prompt is restored to the input without rewinding the transcript. A manual before/after capture was not produced because a released global `qwen` executable was unavailable in this environment; the deterministic cancellation tests cover the restore-only, rewind, draft, queue, and tool-execution paths.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v24.16.0 with the local monorepo installation on macOS.

## Risk & Scope

- Main risk or tradeoff: cancellation guard ordering could accidentally restore a prompt during tool execution; the combined meaningful-output and pending-tool regression covers this boundary.
- Not validated / out of scope: interactive provider-specific terminal behavior on Windows and Linux.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7138

<details>
<summary>中文说明</summary>

## 此 PR 的改动

当用户在回复文本已经出现后取消请求时，已提交的提示词会回到输入框中供继续编辑，同时保留可见回复和对话历史。工具执行期间取消、输入框中已有草稿或排队中的后续提示词，以及尚未产生有效回复时取消，都会保持现有行为。

## 为什么需要此改动

提示词恢复此前与对话记录回退绑定，因此模型一旦产生有效输出，就不会恢复原提示词。用户取消较长回复后只能重新输入或手动找回提示词。将“只恢复提示词”与回退路径分开后，既能保留已有输出，也能让原提示词重新进入可编辑状态。

## 审查测试计划

### 如何验证

1. 启动交互式会话，并提交一个会生成较长回复的提示词。
2. 等待回复文本出现后按 Ctrl+C。
3. 确认部分回复仍保留在对话记录中，同时已提交的提示词回到输入框并可编辑。
4. 确认在任何回复出现前取消仍会移除空的已取消轮次，并且工具执行期间取消不会恢复提示词。

自动验证已通过：119 个取消流程容器测试、流刷新竞态专项回归、CLI 类型检查、ESLint、Prettier、包构建和差异检查。

### 证据（改动前后）

改动前：回复文本出现后取消会保留回复，但输入框为空。改动后：回复继续可见，已提交的提示词会回到输入框，并且不会回退对话记录。由于当前环境没有可用的全局已发布 `qwen` 可执行文件，因此未生成手动前后对比记录；确定性的取消流程测试覆盖了只恢复提示词、回退、草稿、队列和工具执行路径。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS     |  ✅  |
|    🪟 Windows    |  ⚠️  |
|     🐧 Linux     |  ⚠️  |

### 环境（可选）

macOS 上使用 Node.js v24.16.0 和本地 monorepo 安装。

## 风险与范围

- 主要风险或权衡：取消流程守卫的顺序可能导致工具执行期间错误恢复提示词；组合了“已有有效输出”和“工具待执行”状态的回归测试覆盖了这一边界。
- 未验证或范围外：Windows 和 Linux 上与具体提供商相关的交互式终端行为。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #7138

</details>
