### PR TITLE
fix(cli): silence startup update check failure message

### DIFF
--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -382,21 +382,26 @@ describe('startupPrefetch', () => {
     expect(mockConnectIdeForStartup).toHaveBeenCalledWith(config);
   });
 
-  it('surfaces update check errors through the update event emitter', async () => {
+  it('logs update check errors without surfacing them to the user', async () => {
     const config = makeConfig();
+    const error = new Error('registry unavailable');
     mockCheckForUpdatesDetailed.mockResolvedValue({
       status: 'error',
-      error: new Error('registry unavailable'),
+      error,
     });
 
     startPostRenderPrefetches(config, makeSettings());
 
     await vi.dynamicImportSettled();
 
-    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
-      message:
-        'Failed to check for updates. Please check your network or registry configuration.',
-    });
+    expect(mockWarn).toHaveBeenCalledWith(
+      'Startup update check failed:',
+      error,
+    );
+    expect(mockUpdateEventEmit).not.toHaveBeenCalledWith(
+      'update-failed',
+      expect.anything(),
+    );
     expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
   });
 
@@ -622,11 +627,14 @@ describe('startupPrefetch', () => {
 
     await vi.dynamicImportSettled();
 
-    expect(mockWarn).toHaveBeenCalledWith('update_check failed:', error);
-    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
-      message:
-        'Failed to check for updates. Please check your network or registry configuration.',
-    });
+    expect(mockWarn).toHaveBeenCalledWith(
+      'Startup update check failed:',
+      error,
+    );
+    expect(mockUpdateEventEmit).not.toHaveBeenCalledWith(
+      'update-failed',
+      expect.anything(),
+    );
   });
 
   it('does not start housekeeping for non-interactive configs', async () => {

--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -627,10 +627,7 @@ describe('startupPrefetch', () => {
 
     await vi.dynamicImportSettled();
 
-    expect(mockWarn).toHaveBeenCalledWith(
-      'Startup update check failed:',
-      error,
-    );
+    expect(mockWarn).toHaveBeenCalledWith('update_check failed:', error);
     expect(mockRecordStartupEvent).toHaveBeenCalledWith(
       'startup_prefetch_failed',
       { name: 'update_check' },

--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -631,6 +631,10 @@ describe('startupPrefetch', () => {
       'Startup update check failed:',
       error,
     );
+    expect(mockRecordStartupEvent).toHaveBeenCalledWith(
+      'startup_prefetch_failed',
+      { name: 'update_check' },
+    );
     expect(mockUpdateEventEmit).not.toHaveBeenCalledWith(
       'update-failed',
       expect.anything(),

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -171,54 +171,49 @@ export function startPostRenderPrefetches(
         import('../utils/updateEventEmitter.js'),
         import('../i18n/index.js'),
       ]);
-      try {
-        const result = await checkForUpdatesDetailed();
-        if (result.status === 'update') {
-          const projectRoot = config.getProjectRoot();
-          const hostUpdateRelaunch = process.env[HOST_UPDATE_RELAUNCH_ENV_VAR];
-          if (hostUpdateRelaunch === 'true') {
-            updateEventEmitter.emit('update-info', {
-              message: `${result.info.message}\n${t(
-                'Run /update to install the update on the host.',
-              )}`,
-            });
-            return;
-          }
-          if (hostUpdateRelaunch === 'false') {
-            updateEventEmitter.emit('update-info', {
-              message: `${result.info.message}\n${t(
-                'Update Qwen Code on the host, then restart the sandbox.',
-              )}`,
-            });
-            return;
-          }
-          const installationInfo = getInstallationInfo(projectRoot, true);
-          if (
-            installationInfo.updateCommand ||
-            (installationInfo.isStandalone && installationInfo.standaloneDir)
-          ) {
-            if (requestUpdateOnExit()) {
-              updateEventEmitter.emit('update-info', {
-                message: `${result.info.message}\n${t(
-                  'The update will be installed after you exit this session.',
-                )}`,
-              });
-            } else {
-              updateEventEmitter.emit('update-info', {
-                message: `${result.info.message}\n${t(
-                  'Run /update to install the update.',
-                )}`,
-              });
-            }
-          } else {
-            void handleAutoUpdate(result.info, settings, projectRoot);
-          }
-        } else if (result.status === 'error') {
-          debugLogger.warn('Startup update check failed:', result.error);
+      const result = await checkForUpdatesDetailed();
+      if (result.status === 'update') {
+        const projectRoot = config.getProjectRoot();
+        const hostUpdateRelaunch = process.env[HOST_UPDATE_RELAUNCH_ENV_VAR];
+        if (hostUpdateRelaunch === 'true') {
+          updateEventEmitter.emit('update-info', {
+            message: `${result.info.message}\n${t(
+              'Run /update to install the update on the host.',
+            )}`,
+          });
+          return;
         }
-      } catch (error) {
-        debugLogger.warn('Startup update check failed:', error);
-        throw error;
+        if (hostUpdateRelaunch === 'false') {
+          updateEventEmitter.emit('update-info', {
+            message: `${result.info.message}\n${t(
+              'Update Qwen Code on the host, then restart the sandbox.',
+            )}`,
+          });
+          return;
+        }
+        const installationInfo = getInstallationInfo(projectRoot, true);
+        if (
+          installationInfo.updateCommand ||
+          (installationInfo.isStandalone && installationInfo.standaloneDir)
+        ) {
+          if (requestUpdateOnExit()) {
+            updateEventEmitter.emit('update-info', {
+              message: `${result.info.message}\n${t(
+                'The update will be installed after you exit this session.',
+              )}`,
+            });
+          } else {
+            updateEventEmitter.emit('update-info', {
+              message: `${result.info.message}\n${t(
+                'Run /update to install the update.',
+              )}`,
+            });
+          }
+        } else {
+          void handleAutoUpdate(result.info, settings, projectRoot);
+        }
+      } else if (result.status === 'error') {
+        debugLogger.warn('Startup update check failed:', result.error);
       }
     });
   }

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -171,9 +171,6 @@ export function startPostRenderPrefetches(
         import('../utils/updateEventEmitter.js'),
         import('../i18n/index.js'),
       ]);
-      const updateFailedMessage = t(
-        'Failed to check for updates. Please check your network or registry configuration.',
-      );
       try {
         const result = await checkForUpdatesDetailed();
         if (result.status === 'update') {
@@ -217,15 +214,10 @@ export function startPostRenderPrefetches(
             void handleAutoUpdate(result.info, settings, projectRoot);
           }
         } else if (result.status === 'error') {
-          updateEventEmitter.emit('update-failed', {
-            message: updateFailedMessage,
-          });
+          debugLogger.warn('Startup update check failed:', result.error);
         }
       } catch (error) {
-        updateEventEmitter.emit('update-failed', {
-          message: updateFailedMessage,
-        });
-        throw error;
+        debugLogger.warn('Startup update check failed:', error);
       }
     });
   }

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -218,6 +218,7 @@ export function startPostRenderPrefetches(
         }
       } catch (error) {
         debugLogger.warn('Startup update check failed:', error);
+        throw error;
       }
     });
   }


### PR DESCRIPTION
## Motivation

The startup update check is a best-effort background task. When it fails — slow registry, corporate proxy, offline network, DNS timeout (the check has a 2s budget) — qwen-code shows "Failed to check for updates. Please check your network or registry configuration." on every single startup. This is annoying and not actionable for the user.

## Changes

- Startup update check failures now log at debug level (`debugLogger.warn`) instead of emitting `update-failed` to the UI event bus.
- Explicit user-initiated commands (`/update`, `qwen update`) still surface errors as before — only the passive startup check is silenced.

## How to verify

1. Block or slow down access to the npm registry (e.g. `npm config set registry https://invalid.example.com`)
2. Start qwen-code — no error message should appear
3. Run `/update` — the error message should still appear

<details>
<summary>中文说明</summary>

## 动机

启动时的更新检查是一个 best-effort 后台任务。当它失败时（registry 响应慢、企业代理、离线网络、DNS 超时——检查只有 2 秒超时），qwen-code 每次启动都会显示 "Failed to check for updates. Please check your network or registry configuration."，非常烦人且用户无法采取任何行动。

## 改动

- 启动时更新检查失败改为仅记录 debug 日志（`debugLogger.warn`），不再向 UI 事件总线发送 `update-failed` 事件。
- 用户主动执行的命令（`/update`、`qwen update`）仍然会正常显示错误——只有被动的启动检查被静默化。

## 验证方式

1. 阻断或减慢 npm registry 访问（如 `npm config set registry https://invalid.example.com`）
2. 启动 qwen-code——不应出现错误消息
3. 执行 `/update`——错误消息应正常显示

</details>