### PR TITLE
ci(autofix): harden the address path against stale targets and untrusted route events

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -80,6 +80,12 @@ env:
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'
+  # Maintainer-facing engagement labels (applying labels requires GitHub
+  # triage+, so the permission gate is GitHub's own): TAKEOVER opts a PR —
+  # including a human-authored one — into the loop; SKIP opts any PR out
+  # everywhere, and wins when both are present.
+  TAKEOVER_LABEL: 'autofix/takeover'
+  SKIP_LABEL: 'autofix/skip'
   # Do not claim more issues when too many existing autofix PRs are still open.
   MAX_OPEN_AUTOFIX_PRS: '5'
 
@@ -1385,15 +1391,22 @@ jobs:
           # UNKNOWN and discards too (fail closed — the next scan re-emits a
           # still-valid target).
           PR_LIVE="$(gh pr view "${PR}" --repo "${REPO}" \
-            --json state,author,isCrossRepository,baseRefName,headRefName 2> /dev/null || echo '{}')"
+            --json state,author,isCrossRepository,baseRefName,headRefName,labels 2> /dev/null || echo '{}')"
           LIVE_STATE="$(jq -r '.state // ""' <<< "${PR_LIVE}")"
           LIVE_AUTHOR="$(jq -r '.author.login // ""' <<< "${PR_LIVE}")"
           LIVE_XREPO="$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_LIVE}")"
           LIVE_BASE="$(jq -r '.baseRefName // ""' <<< "${PR_LIVE}")"
           LIVE_BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_LIVE}")"
+          # Engagement labels are re-read LIVE too: a takeover label grants a
+          # human-authored PR the author exemption, and a skip label applied
+          # while this job sat queued withdraws consent — both must hold at
+          # the moment the secret-bearing run starts, not at scan time.
+          LIVE_TAKEOVER="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_LIVE}")"
+          LIVE_SKIP="$(jq -r --arg t "${SKIP_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_LIVE}")"
           INELIGIBLE=''
           if [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
-          elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}'"
+          elif [[ "${LIVE_SKIP}" == "true" ]]; then INELIGIBLE="${SKIP_LABEL} label present"
+          elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}' without ${TAKEOVER_LABEL}"
           elif [[ "${LIVE_XREPO}" != "false" ]]; then INELIGIBLE='fork head'
           elif [[ "${LIVE_BASE}" != "main" ]]; then INELIGIBLE="base='${LIVE_BASE:-unknown}'"
           elif [[ "${LIVE_BRANCH}" != "${BRANCH}" ]]; then INELIGIBLE="head branch is now '${LIVE_BRANCH:-unknown}'"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -81,9 +81,11 @@ env:
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'
   # Maintainer-facing engagement labels (applying labels requires GitHub
-  # triage+, so the permission gate is GitHub's own): TAKEOVER opts a PR —
-  # including a human-authored one — into the loop; SKIP opts any PR out
-  # everywhere, and wins when both are present.
+  # triage+, so the permission gate is GitHub's own). In THIS change they are
+  # honored at the address-time eligibility gate and the scan's skip filter;
+  # the scan-side widening that makes TAKEOVER actually summon the loop onto
+  # human-authored PRs ships with the takeover feature PR — the two commute
+  # in either merge order.
   TAKEOVER_LABEL: 'autofix/takeover'
   SKIP_LABEL: 'autofix/skip'
   # Do not claim more issues when too many existing autofix PRs are still open.
@@ -1026,9 +1028,15 @@ jobs:
           else
             gh pr list --repo "${REPO}" --state open --author "${AUTOFIX_BOT}" \
               --base main \
-              --limit 100 --json number,headRefName,isCrossRepository > "${WORKDIR}/bot-prs.json"
-            CANDIDATES="$(jq -r \
-              '.[] | select(.isCrossRepository != true) | .number' \
+              --limit 100 --json number,headRefName,isCrossRepository,labels > "${WORKDIR}/bot-prs.json"
+            # Skip-labeled PRs are excluded HERE, not only at the address
+            # gate: that gate discards without writing a marker, so the
+            # watermark never advances and an unfiltered scan would re-emit
+            # the PR (checkout, npm ci, build) every tick forever.
+            CANDIDATES="$(jq -r --arg skip "${SKIP_LABEL}" \
+              '.[] | select(.isCrossRepository != true)
+                   | select([.labels[]?.name] | index($skip) | not)
+                   | .number' \
               "${WORKDIR}/bot-prs.json")"
           fi
 
@@ -1404,7 +1412,8 @@ jobs:
           LIVE_TAKEOVER="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_LIVE}")"
           LIVE_SKIP="$(jq -r --arg t "${SKIP_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_LIVE}")"
           INELIGIBLE=''
-          if [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
+          if [[ "${PR_LIVE}" == '{}' ]]; then INELIGIBLE='metadata fetch failed (API error) — fail-closed'
+          elif [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
           elif [[ "${LIVE_SKIP}" == "true" ]]; then INELIGIBLE="${SKIP_LABEL} label present"
           elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}' without ${TAKEOVER_LABEL}"
           elif [[ "${LIVE_XREPO}" != "false" ]]; then INELIGIBLE='fork head'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -108,7 +108,18 @@ jobs:
       # coalesce, unrelated targets never collide); anything else (dispatch)
       # → unique per run_id, and cancel-in-progress false below means manual
       # dispatches are never cancelled at all.
-      group: "${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || (github.event_name == 'pull_request_review' && format('qwen-autofix-route-pr-{0}', github.event.pull_request.number)) || (github.event_name == 'issues' && format('qwen-autofix-route-issue-{0}', github.event.issue.number)) || format('qwen-autofix-route-{0}', github.run_id) }}"
+      # SECURITY: only reviews whose PAYLOAD already looks trusted (repo
+      # association, or the review bot) may share the per-PR group — the group
+      # is entered before any step runs, so an arbitrary commenter's review
+      # would otherwise cancel a queued legitimate route for the same PR and
+      # then die in 'Decide phases', losing the real-time scan. Untrusted
+      # payloads get a run-unique group (cancel nothing, still fully
+      # authorized inside). The payload check is a CHEAP PRE-FILTER for group
+      # assignment only — 'Decide phases' remains the real permission gate,
+      # and a trusted sender the payload misses merely loses coalescing. The
+      # association list mirrors TRUSTED_ASSOC; the login mirrors REVIEW_BOT.
+      group: >-
+        ${{ github.event_name == 'schedule' && 'qwen-autofix-route-cron' || (github.event_name == 'pull_request_review' && (contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) || github.event.review.user.login == 'qwen-code-ci-bot') && format('qwen-autofix-route-pr-{0}', github.event.pull_request.number)) || (github.event_name == 'issues' && format('qwen-autofix-route-issue-{0}', github.event.issue.number)) || format('qwen-autofix-route-{0}', github.run_id) }}
       cancel-in-progress: |-
         ${{ github.event_name != 'workflow_dispatch' }}
     permissions:
@@ -1363,6 +1374,41 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
         run: |-
           mkdir -p "${WORKDIR}"
+
+          # ---- address-time eligibility recheck ---------------------------
+          # Fan-out can hold this job queued for hours behind max-parallel,
+          # and the matrix snapshot cannot see lifecycle changes: a PR
+          # closed or merged while queued must not get a secret-bearing
+          # agent run, a branch push, or a comment; an author/base/head
+          # change must not be processed against stale assumptions. Re-fetch
+          # and require the same shape the scan selected. A failed fetch is
+          # UNKNOWN and discards too (fail closed — the next scan re-emits a
+          # still-valid target).
+          PR_LIVE="$(gh pr view "${PR}" --repo "${REPO}" \
+            --json state,author,isCrossRepository,baseRefName,headRefName 2> /dev/null || echo '{}')"
+          LIVE_STATE="$(jq -r '.state // ""' <<< "${PR_LIVE}")"
+          LIVE_AUTHOR="$(jq -r '.author.login // ""' <<< "${PR_LIVE}")"
+          LIVE_XREPO="$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_LIVE}")"
+          LIVE_BASE="$(jq -r '.baseRefName // ""' <<< "${PR_LIVE}")"
+          LIVE_BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_LIVE}")"
+          INELIGIBLE=''
+          if [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
+          elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}'"
+          elif [[ "${LIVE_XREPO}" != "false" ]]; then INELIGIBLE='fork head'
+          elif [[ "${LIVE_BASE}" != "main" ]]; then INELIGIBLE="base='${LIVE_BASE:-unknown}'"
+          elif [[ "${LIVE_BRANCH}" != "${BRANCH}" ]]; then INELIGIBLE="head branch is now '${LIVE_BRANCH:-unknown}'"
+          fi
+          if [[ -n "${INELIGIBLE}" ]]; then
+            echo "🫥 target no longer eligible (${INELIGIBLE}) — discarding without action or marker"
+            {
+              echo "stale=true"
+              echo "conflict=false"
+              echo "newest=${WATERMARK}"
+              echo "effective_round=${ROUND}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           echo 'Restoring tracked build output before switching to the PR branch.'
           git status --short
           git restore --source=HEAD --staged --worktree .
@@ -1459,7 +1505,30 @@ jobs:
               echo "🫥 stale duplicate target: a sibling run already evaluated through ${LIVE_EVAL_WM} (round ${LIVE_MAX_ROUND}) and nothing is newer — discarding without action or marker"
             fi
           fi
+          # A NON-stale run must still not replay a sibling's work: if live
+          # markers advanced past the matrix snapshot, adopt the live
+          # watermark (so the renderers below list only feedback the fleet
+          # has not yet evaluated) and the live round (so the next marker
+          # continues the live sequence instead of double-writing a round).
+          if [[ "${STALE}" != "true" && -n "${LIVE_EVAL_WM}" && "${LIVE_EVAL_WM}" > "${WATERMARK}" && "${LIVE_EVAL_WM}" != "9999-12-31T23:59:59Z" ]]; then
+            echo "⏩ adopting live watermark ${LIVE_EVAL_WM} (matrix had ${WATERMARK})"
+            WATERMARK="${LIVE_EVAL_WM}"
+          fi
+          if [[ "${STALE}" != "true" && "${LIVE_MAX_ROUND}" -gt "${ROUND}" ]]; then
+            echo "⏩ adopting live round ${LIVE_MAX_ROUND} (matrix had ${ROUND})"
+            ROUND="${LIVE_MAX_ROUND}"
+          fi
+          # The live round may already sit at the hard cap (a sibling consumed
+          # the final round after this target was emitted). Running would do
+          # round MAX+1 work and write a second capped marker, concealing the
+          # cap — the scan itself skips capped PRs before even looking at
+          # conflicts, so mirror that and discard.
+          if [[ "${STALE}" != "true" && "${ROUND}" -ge "${MAX_ROUNDS}" ]]; then
+            STALE='true'
+            echo "⛔ live round ${ROUND} already at MAX_ROUNDS (${MAX_ROUNDS}) — discarding without action or marker"
+          fi
           echo "stale=${STALE}" >> "${GITHUB_OUTPUT}"
+          echo "effective_round=${ROUND}" >> "${GITHUB_OUTPUT}"
 
           # Render the actionable feedback into one prompt-ready file.
           {
@@ -1704,7 +1773,11 @@ jobs:
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           NEWEST: '${{ steps.prepare.outputs.newest }}'
+          EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
         run: |-
+          # Prepare may have adopted a sibling's live round; the matrix value
+          # would double-write that round's marker.
+          ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
           if [[ -z "${GITHUB_TOKEN}" ]]; then
             echo '::error::CI_DEV_BOT_PAT is required to push and report as qwen-code-dev-bot.'
             exit 1
@@ -1781,7 +1854,10 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
           NEWEST: '${{ steps.prepare.outputs.newest }}'
           JOB_STATUS: '${{ job.status }}'
+          STALE: '${{ steps.prepare.outputs.stale }}'
+          EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
         run: |-
+          ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
           {
@@ -1811,8 +1887,13 @@ jobs:
           # post a contradictory acted=false handoff on top of the published fix.
           # (A genuine push failure leaves OUTCOME=fixed but writes no marker, so
           # the next scan simply retries — it does not need a handoff here.)
+          #
+          # SUPPRESS likewise for a stale-discarded run: it did no work, so a
+          # late always()-step failure (e.g. artifact upload) must not turn a
+          # deliberate no-comment/no-marker discard into a handoff that
+          # consumes a round.
           POST_HANDOFF=false
-          if [[ "${DRY_RUN}" != "true" && -n "${GITHUB_TOKEN:-}" && "${OUTCOME:-unknown}" != "fixed" && "${OUTCOME:-unknown}" != "noop" ]]; then
+          if [[ "${DRY_RUN}" != "true" && "${STALE:-}" != "true" && -n "${GITHUB_TOKEN:-}" && "${OUTCOME:-unknown}" != "fixed" && "${OUTCOME:-unknown}" != "noop" ]]; then
             if [[ "${OUTCOME:-unknown}" == "failed" || "${JOB_STATUS:-}" != "success" ]]; then
               POST_HANDOFF=true
             fi

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -462,6 +462,100 @@ describe('qwen-autofix workflow', () => {
     expect(sentinel.wm).toBe(W);
   });
 
+  it('behaviorally replays the eligibility recheck across lifecycle and label states', () => {
+    // Extract the recheck VERBATIM (drift fails the test) and run it with a
+    // PATH-stubbed gh: the discard path must actually WRITE stale=true (and
+    // the outputs later gates read) — string pins alone would stay green if
+    // a future edit dropped the echo, leaving STALE empty and letting a
+    // late always() failure post a spurious handoff for a discarded job.
+    const recheck = prepareBranchAndFeedbackStep.match(
+      /(PR_LIVE="\$\(gh pr view[\s\S]*?exit 0\n {10}fi)/,
+    )?.[1];
+    expect(recheck).toBeTruthy();
+    const runRecheck = (prJson) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-elig-'));
+      try {
+        const gh = join(dir, 'gh');
+        writeFileSync(
+          gh,
+          prJson === null
+            ? '#!/bin/bash\nexit 1\n'
+            : `#!/bin/bash\nprintf '%s' '${JSON.stringify(prJson)}'\n`,
+        );
+        chmodSync(gh, 0o755);
+        const out = join(dir, 'out.txt');
+        writeFileSync(out, '');
+        const stdout = execFileSync(
+          'bash',
+          ['-c', `${recheck.replace(/\n {10}/g, '\n')}\nprintf 'PASSED'`],
+          {
+            env: {
+              ...process.env,
+              PATH: `${dir}:${process.env.PATH}`,
+              PR: '7163',
+              REPO: 'QwenLM/qwen-code',
+              BRANCH: 'ci/some-branch',
+              WATERMARK: '2026-07-18T08:00:00Z',
+              ROUND: '2',
+              AUTOFIX_BOT: 'qwen-code-dev-bot',
+              TAKEOVER_LABEL: 'autofix/takeover',
+              SKIP_LABEL: 'autofix/skip',
+              GITHUB_OUTPUT: out,
+              GITHUB_TOKEN: 'x',
+            },
+            encoding: 'utf8',
+          },
+        );
+        return {
+          passed: stdout.endsWith('PASSED'),
+          out: readFileSync(out, 'utf8'),
+        };
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+    const pr = (over = {}) => ({
+      state: 'OPEN',
+      author: { login: 'qwen-code-dev-bot' },
+      isCrossRepository: false,
+      baseRefName: 'main',
+      headRefName: 'ci/some-branch',
+      labels: [],
+      ...over,
+    });
+    // Healthy bot PR → proceeds, nothing written.
+    const ok = runRecheck(pr());
+    expect(ok.passed).toBe(true);
+    expect(ok.out).not.toContain('stale=true');
+    // Closed while queued → discards AND writes every output later gates
+    // read (this is the assertion string pins cannot make).
+    const closed = runRecheck(pr({ state: 'CLOSED' }));
+    expect(closed.passed).toBe(false);
+    expect(closed.out).toContain('stale=true');
+    expect(closed.out).toContain('conflict=false');
+    expect(closed.out).toContain('newest=2026-07-18T08:00:00Z');
+    expect(closed.out).toContain('effective_round=2');
+    // Live engagement labels: takeover exempts a human author, skip
+    // withdraws consent even for the bot's own PR.
+    expect(
+      runRecheck(
+        pr({
+          author: { login: 'human' },
+          labels: [{ name: 'autofix/takeover' }],
+        }),
+      ).passed,
+    ).toBe(true);
+    expect(runRecheck(pr({ author: { login: 'human' } })).passed).toBe(false);
+    expect(
+      runRecheck(pr({ labels: [{ name: 'autofix/skip' }] })).out,
+    ).toContain('stale=true');
+    // Fork head, renamed branch, and a FAILED fetch (unknown ≠ eligible)
+    // all discard.
+    expect(runRecheck(pr({ isCrossRepository: true })).passed).toBe(false);
+    expect(runRecheck(pr({ headRefName: 'renamed' })).passed).toBe(false);
+    expect(runRecheck(null).passed).toBe(false);
+  });
+
   it('rechecks target eligibility at address time and discards inactive targets', () => {
     // A queued matrix job can start hours after its scan: a PR closed or
     // merged meanwhile must not get a secret-bearing agent run, branch push,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -469,7 +469,7 @@ describe('qwen-autofix workflow', () => {
     // against stale assumptions. The recheck runs BEFORE the PR branch is
     // even checked out, and a failed fetch discards too (unknown ≠ eligible).
     expect(prepareBranchAndFeedbackStep).toContain(
-      '--json state,author,isCrossRepository,baseRefName,headRefName',
+      '--json state,author,isCrossRepository,baseRefName,headRefName,labels',
     );
     expect(prepareBranchAndFeedbackStep).toContain(
       'target no longer eligible (${INELIGIBLE}) — discarding without action or marker',
@@ -482,9 +482,15 @@ describe('qwen-autofix workflow', () => {
     // The discard path must publish the outputs later gates read, and the
     // eligibility conditions cover the full scan shape.
     expect(prepareBranchAndFeedbackStep).toContain('"${LIVE_STATE}" != "OPEN"');
+    // Engagement labels are honored LIVE: a takeover label exempts a
+    // human-authored PR from the bot-author requirement, and a skip label
+    // applied while queued withdraws consent before the secret-bearing run.
     expect(prepareBranchAndFeedbackStep).toContain(
-      '"${LIVE_AUTHOR}" != "${AUTOFIX_BOT}"',
+      '"${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true"',
     );
+    expect(prepareBranchAndFeedbackStep).toContain('"${LIVE_SKIP}" == "true"');
+    expect(workflow).toContain("TAKEOVER_LABEL: 'autofix/takeover'");
+    expect(workflow).toContain("SKIP_LABEL: 'autofix/skip'");
     expect(prepareBranchAndFeedbackStep).toContain(
       '"${LIVE_XREPO}" != "false"',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -460,6 +460,17 @@ describe('qwen-autofix workflow', () => {
       reviews: [F2],
     });
     expect(sentinel.wm).toBe(W);
+    // …and the != sentinel guard itself, on a path that actually reaches
+    // the adoption block: a live conflict skips the stale gate, so without
+    // the guard the terminal ts would be adopted as the feedback watermark
+    // and filter ALL future feedback out of the renderers.
+    const sentinelConflict = runStaleGate({
+      marks: [{ ts: '9999-12-31T23:59:59Z', round: 3 }],
+      conflict: 'true',
+      round: 2,
+    });
+    expect(sentinelConflict.stale).toBe(false);
+    expect(sentinelConflict.wm).toBe(W);
   });
 
   it('behaviorally replays the eligibility recheck across lifecycle and label states', () => {
@@ -508,6 +519,7 @@ describe('qwen-autofix workflow', () => {
         );
         return {
           passed: stdout.endsWith('PASSED'),
+          log: stdout,
           out: readFileSync(out, 'utf8'),
         };
       } finally {
@@ -553,7 +565,13 @@ describe('qwen-autofix workflow', () => {
     // all discard.
     expect(runRecheck(pr({ isCrossRepository: true })).passed).toBe(false);
     expect(runRecheck(pr({ headRefName: 'renamed' })).passed).toBe(false);
-    expect(runRecheck(null).passed).toBe(false);
+    // Retargeted off main while queued → discard (previously only pinned).
+    expect(runRecheck(pr({ baseRefName: 'develop' })).passed).toBe(false);
+    // A FAILED fetch discards too, but with an infra-distinct message so an
+    // API outage is never misread as a PR-state change.
+    const failed = runRecheck(null);
+    expect(failed.passed).toBe(false);
+    expect(failed.log).toContain('metadata fetch failed (API error)');
   });
 
   it('rechecks target eligibility at address time and discards inactive targets', () => {
@@ -583,6 +601,15 @@ describe('qwen-autofix workflow', () => {
       '"${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true"',
     );
     expect(prepareBranchAndFeedbackStep).toContain('"${LIVE_SKIP}" == "true"');
+    // Skip is ALSO filtered at candidate selection: the address-gate discard
+    // writes no marker, so an unfiltered scan would re-emit a skip-labeled
+    // PR (full checkout/install) every tick forever.
+    expect(reviewScanJob).toContain(
+      'select([.labels[]?.name] | index($skip) | not)',
+    );
+    expect(reviewScanJob).toContain(
+      '--json number,headRefName,isCrossRepository,labels',
+    );
     expect(workflow).toContain("TAKEOVER_LABEL: 'autofix/takeover'");
     expect(workflow).toContain("SKIP_LABEL: 'autofix/skip'");
     expect(prepareBranchAndFeedbackStep).toContain(
@@ -682,6 +709,14 @@ describe('qwen-autofix workflow', () => {
     );
     expect(routeJob).toContain(
       "github.event.review.user.login == 'qwen-code-ci-bot'",
+    );
+    // The load-bearing STRUCTURE, not just substrings: the trust || is
+    // parenthesized and the whole clause gates the per-PR format. Without
+    // the parens, Actions' && binding tighter than || would hand every
+    // OWNER/MEMBER/COLLABORATOR review the run-unique group and the
+    // review-bot the per-PR group unconditionally.
+    expect(routeJob).toContain(
+      "(github.event_name == 'pull_request_review' && (contains(fromJSON('[\"OWNER\", \"MEMBER\", \"COLLABORATOR\"]'), github.event.review.author_association) || github.event.review.user.login == 'qwen-code-ci-bot') && format('qwen-autofix-route-pr-{0}', github.event.pull_request.number))",
     );
     expect(workflow).toContain(
       'TRUSTED_ASSOC: \'["OWNER", "MEMBER", "COLLABORATOR"]\'',

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -309,7 +309,7 @@ describe('qwen-autofix workflow', () => {
     // a ts-only comparison misses it. The gate must also treat
     // same-ts-but-newer-round (with the conflict now cleared) as stale.
     const staleGate = prepareBranchAndFeedbackStep.match(
-      /(STALE='false'\n[\s\S]*?echo "stale=\$\{STALE\}" >> "\$\{GITHUB_OUTPUT\}")/,
+      /(STALE='false'\n[\s\S]*?echo "effective_round=\$\{ROUND\}" >> "\$\{GITHUB_OUTPUT\}")/,
     )?.[1];
     expect(staleGate).toBeTruthy();
     const W = '2026-07-18T08:00:00Z';
@@ -331,24 +331,45 @@ describe('qwen-autofix workflow', () => {
         writeFileSync(join(dir, 'checks.json'), '[]');
         const out = join(dir, 'out.txt');
         writeFileSync(out, '');
-        execFileSync('bash', ['-c', staleGate.replace(/\n {10}/g, '\n')], {
-          env: {
-            ...process.env,
-            WORKDIR: dir,
-            GITHUB_OUTPUT: out,
-            WATERMARK: W,
-            ROUND: String(round),
-            CONFLICT: conflict,
-            AUTOFIX_BOT: 'qwen-code-dev-bot',
-            REVIEW_BOT: 'qwen-code-ci-bot',
-            TRUSTED_ASSOC: '["OWNER","MEMBER","COLLABORATOR"]',
+        const stdout = execFileSync(
+          'bash',
+          [
+            '-c',
+            `${staleGate.replace(/\n {10}/g, '\n')}\nprintf '\\nADOPTED %s %s' "$WATERMARK" "$ROUND"`,
+          ],
+          {
+            env: {
+              ...process.env,
+              WORKDIR: dir,
+              GITHUB_OUTPUT: out,
+              WATERMARK: W,
+              ROUND: String(round),
+              CONFLICT: conflict,
+              MAX_ROUNDS: '5',
+              AUTOFIX_BOT: 'qwen-code-dev-bot',
+              REVIEW_BOT: 'qwen-code-ci-bot',
+              TRUSTED_ASSOC: '["OWNER","MEMBER","COLLABORATOR"]',
+            },
+            encoding: 'utf8',
           },
-          encoding: 'utf8',
-        });
-        return readFileSync(out, 'utf8').includes('stale=true');
+        );
+        const adopted = stdout.match(/ADOPTED (\S+) (\S+)$/);
+        const outputs = readFileSync(out, 'utf8');
+        return {
+          stale: outputs.includes('stale=true'),
+          effectiveRound: outputs.match(/effective_round=(\d+)/)?.[1],
+          wm: adopted?.[1],
+          round: adopted?.[2],
+        };
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
+    };
+    const F2 = {
+      submitted_at: '2026-07-18T08:45:00Z',
+      user: { login: 'doudouOUC' },
+      author_association: 'MEMBER',
+      state: 'CHANGES_REQUESTED',
     };
     // Conflict-only duplicate: sibling resolved and marked round 3 at ts=W;
     // our matrix says round 2, the conflict is now cleared → stale.
@@ -360,7 +381,7 @@ describe('qwen-autofix workflow', () => {
         ],
         conflict: 'false',
         round: 2,
-      }),
+      }).stale,
     ).toBe(true);
     // First job of a conflict round: round has not advanced → proceeds.
     expect(
@@ -368,7 +389,7 @@ describe('qwen-autofix workflow', () => {
         marks: [{ ts: W, round: 2 }],
         conflict: 'false',
         round: 2,
-      }),
+      }).stale,
     ).toBe(false);
     // A live conflict is always actionable, even past a sibling's marker.
     expect(
@@ -379,7 +400,7 @@ describe('qwen-autofix workflow', () => {
         ],
         conflict: 'true',
         round: 2,
-      }),
+      }).stale,
     ).toBe(false);
     // ts-advanced duplicate (the original case): sibling evaluated through a
     // newer live watermark and nothing newer exists → stale.
@@ -388,28 +409,99 @@ describe('qwen-autofix workflow', () => {
         marks: [{ ts: '2026-07-18T08:30:00Z', round: 3 }],
         conflict: 'false',
         round: 2,
-      }),
+      }).stale,
     ).toBe(true);
     // Round advanced BUT trusted feedback arrived after the live watermark —
-    // the queued job has real work and must NOT discard itself.
+    // the queued job has real work and must NOT discard itself. It must ALSO
+    // adopt the live round so its marker continues the sequence instead of
+    // double-writing round 3.
+    const advanced = runStaleGate({
+      marks: [
+        { ts: W, round: 2 },
+        { ts: W, round: 3 },
+      ],
+      conflict: 'false',
+      round: 2,
+      reviews: [F2],
+    });
+    expect(advanced.stale).toBe(false);
+    expect(advanced.round).toBe('3');
+    expect(advanced.effectiveRound).toBe('3');
+    // W/T1/T2: the sibling evaluated F1 through T1; F2 arrived after T1. The
+    // duplicate proceeds for F2 but must adopt T1 as its effective watermark
+    // so the renderers below list ONLY F2 — never the already-addressed F1.
+    const T1 = '2026-07-18T08:30:00Z';
+    const adopted = runStaleGate({
+      marks: [{ ts: T1, round: 3 }],
+      conflict: 'false',
+      round: 2,
+      reviews: [F2],
+    });
+    expect(adopted.stale).toBe(false);
+    expect(adopted.wm).toBe(T1);
+    expect(adopted.round).toBe('3');
+    // Live round already at the hard cap: even with new feedback, running
+    // would produce round MAX+1 work and a second capped marker, concealing
+    // the cap the scan enforces — discard.
     expect(
       runStaleGate({
-        marks: [
-          { ts: W, round: 2 },
-          { ts: W, round: 3 },
-        ],
+        marks: [{ ts: W, round: 5 }],
         conflict: 'false',
-        round: 2,
-        reviews: [
-          {
-            submitted_at: '2026-07-18T08:45:00Z',
-            user: { login: 'doudouOUC' },
-            author_association: 'MEMBER',
-            state: 'CHANGES_REQUESTED',
-          },
-        ],
-      }),
-    ).toBe(false);
+        round: 4,
+        reviews: [F2],
+      }).stale,
+    ).toBe(true);
+    // The terminal-handoff sentinel ts must never be adopted as a feedback
+    // watermark (it would filter ALL future feedback out of the renderers).
+    const sentinel = runStaleGate({
+      marks: [{ ts: '9999-12-31T23:59:59Z', round: 3 }],
+      conflict: 'false',
+      round: 2,
+      reviews: [F2],
+    });
+    expect(sentinel.wm).toBe(W);
+  });
+
+  it('rechecks target eligibility at address time and discards inactive targets', () => {
+    // A queued matrix job can start hours after its scan: a PR closed or
+    // merged meanwhile must not get a secret-bearing agent run, branch push,
+    // or comment; author/repo/base/branch changes must not be processed
+    // against stale assumptions. The recheck runs BEFORE the PR branch is
+    // even checked out, and a failed fetch discards too (unknown ≠ eligible).
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '--json state,author,isCrossRepository,baseRefName,headRefName',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain(
+      'target no longer eligible (${INELIGIBLE}) — discarding without action or marker',
+    );
+    expect(
+      prepareBranchAndFeedbackStep.indexOf('target no longer eligible'),
+    ).toBeLessThan(
+      prepareBranchAndFeedbackStep.indexOf('git checkout -B "${BRANCH}"'),
+    );
+    // The discard path must publish the outputs later gates read, and the
+    // eligibility conditions cover the full scan shape.
+    expect(prepareBranchAndFeedbackStep).toContain('"${LIVE_STATE}" != "OPEN"');
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '"${LIVE_AUTHOR}" != "${AUTOFIX_BOT}"',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '"${LIVE_XREPO}" != "false"',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain('"${LIVE_BASE}" != "main"');
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '"${LIVE_BRANCH}" != "${BRANCH}"',
+    );
+    // Reporters must use the effective round (a sibling may have advanced
+    // it) — both the success reporter and the failure reporter.
+    expect(
+      workflow.split(
+        "EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'",
+      ).length - 1,
+    ).toBe(2);
+    expect(
+      workflow.split('ROUND="${EFFECTIVE_ROUND:-${ROUND}}"').length - 1,
+    ).toBe(2);
   });
 
   it('falls back to existing issue backlog only when review has no target', () => {
@@ -479,6 +571,22 @@ describe('qwen-autofix workflow', () => {
       "cancel-in-progress: |-\n        ${{ github.event_name != 'workflow_dispatch' }}",
     );
     expect(routeJob).not.toContain("group: 'qwen-autofix-route'");
+    // The per-PR group is entered BEFORE any step runs, so only reviews whose
+    // payload already looks trusted may share it — an arbitrary commenter's
+    // review would otherwise cancel a queued legitimate route and then die in
+    // 'Decide phases'. Untrusted payloads get a run-unique group; the real
+    // permission gate stays inside the job. The literal association list must
+    // mirror TRUSTED_ASSOC and the login must mirror REVIEW_BOT.
+    expect(routeJob).toContain(
+      'contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'), github.event.review.author_association)',
+    );
+    expect(routeJob).toContain(
+      "github.event.review.user.login == 'qwen-code-ci-bot'",
+    );
+    expect(workflow).toContain(
+      'TRUSTED_ASSOC: \'["OWNER", "MEMBER", "COLLABORATOR"]\'',
+    );
+    expect(workflow).toContain("REVIEW_BOT: 'qwen-code-ci-bot'");
     expect(workflow).toContain(
       'gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission"',
     );
@@ -1502,6 +1610,20 @@ describe('qwen-autofix workflow', () => {
     expect(
       runPostHandoff({ ...base, OUTCOME: '', JOB_STATUS: 'success' }),
     ).toBe('false');
+    // A stale-discarded run did no work: even if a later always() step fails
+    // the job (empty OUTCOME + failure), the deliberate no-comment/no-marker
+    // discard must NOT turn into a handoff that consumes a round.
+    expect(
+      runPostHandoff({
+        ...base,
+        STALE: 'true',
+        OUTCOME: '',
+        JOB_STATUS: 'failure',
+      }),
+    ).toBe('false');
+    expect(reviewAddressReportStep).toContain(
+      "STALE: '${{ steps.prepare.outputs.stale }}'",
+    );
 
     // Terminal-round transition: feedback read (NEWEST set) → normal increment;
     // feedback never read (empty) → MAX_ROUNDS so the scan skips instead of


### PR DESCRIPTION
## What this PR does

Hardens the review-address pipeline against stale targets and untrusted route events — a follow-up fixing the five Critical findings from #7127's post-merge review ([4728499913](https://github.com/QwenLM/qwen-code/pull/7127#pullrequestreview-4728499913)):

1. **Route-group trust prefilter.** The per-PR concurrency group is entered before any step runs, so on a public repo an arbitrary commenter's review could cancel a queued legitimate route for the same PR and then fail authorization inside `Decide phases` — losing the real-time scan. Reviews whose payload does not already look trusted (repo association `OWNER/MEMBER/COLLABORATOR`, or the review bot) now get a run-unique group: they cancel nothing and still go through the full permission gate inside the job. The payload check is a cheap pre-filter for group assignment only; a trusted sender it misses merely loses coalescing.
2. **Address-time eligibility recheck.** Fan-out can hold a matrix job queued for hours; a PR closed or merged meanwhile must not get a secret-bearing agent run, a branch push, or a comment. Before the PR branch is even checked out, the job re-fetches the PR and requires the same shape the scan selected (open, bot author, in-repo head, base `main`, unchanged head branch); anything else — including a failed fetch (unknown ≠ eligible) — discards silently with all downstream outputs published.
3. **Non-stale duplicates adopt the live watermark.** When a queued duplicate finds newer feedback (sibling handled F1 through T1, F2 arrived after T1), it previously rendered from the original matrix watermark W and replayed the already-addressed F1 to the agent. The revalidation now advances the effective watermark to the live eval mark (never the terminal sentinel), so the renderers list only F2.
4. **Live round cap enforced at address time.** A queued job whose matrix said round 4 could see live markers already at `MAX_ROUNDS` yet proceed on newer feedback, doing round-6 work and double-writing a capped marker. The job now adopts the live round (both reporters consume the effective round) and discards when it is already at the cap — mirroring the scan, which skips capped PRs before even looking at conflicts.
5. **Stale discard suppresses the failure-path handoff.** After a `stale=true` discard, a late `always()` step failure (e.g. artifact upload) flipped the job to failure and the failure reporter posted a handoff + eval marker — converting a deliberate no-comment/no-marker discard into a consumed round. The `POST_HANDOFF` decision now short-circuits on stale.

## Why it's needed

All five are reachable on current main and three of them waste or corrupt the loop's core bookkeeping: replayed feedback produces duplicate or contradictory changes (3), a concealed round cap breaks the "5 rounds then a human" contract (4), and a handoff on a discarded duplicate consumes a round for work that never happened (5). (1) is a griefing vector on a public repository — any account could suppress real-time routing for a targeted PR with junk reviews. (2) runs the secret-bearing agent against closed PRs, pushing branches and commenting where nobody asked.

## Reviewer Test Plan

### How to verify

1. Run `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 53/53. New/extended behavioral replays (all extracted VERBATIM from the workflow, drift fails the suite):
   - **W/T1/T2**: sibling marker at T1, F2 after T1 → not stale, adopted watermark == T1 (renderers list only F2), adopted round continues the live sequence; same fixture without F2 → stale.
   - **Cap**: live marker at round 5 with matrix round 4 and fresh feedback → discarded; sentinel ts `9999-…` is never adopted as a watermark.
   - **Stale-suppressed handoff**: `STALE=true` + empty outcome + failed job → no handoff (previous cases unchanged).
   - **Eligibility**: recheck sits before `git checkout -B`, covers state/author/fork/base/branch, and the discard path publishes every output later gates read.
2. Route group: read the concurrency expression — the review branch now requires `contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) || github.event.review.user.login == 'qwen-code-ci-bot'` before granting the per-PR group; the literal list mirrors `TRUSTED_ASSOC` and the login mirrors `REVIEW_BOT` (pinned against each other in the tests).
3. Static checks: YAML parses; every `run:` block passes `bash -n`.

### Evidence (Before & After)

```
BEFORE (main):
  untrusted review  → enters qwen-autofix-route-pr-N → cancels queued route
  closed-PR target  → checkout, npm ci, agent run, push, comment
  dup w/ newer F2   → renders F1+F2 from matrix W → agent replays F1
  live round at cap → runs round MAX+1, second capped marker
  stale + late fail → handoff + marker posted for a run that did nothing

AFTER (this PR):
  untrusted review  → run-unique group (cancels nothing) → dies in Decide phases
  closed-PR target  → '🫥 target no longer eligible (state=…) — discarding'
  dup w/ newer F2   → '⏩ adopting live watermark T1' → renders only F2
  live round at cap → '⛔ live round 5 already at MAX_ROUNDS — discarding'
  stale + late fail → POST_HANDOFF=false (replay-proven)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Contract suite via vitest on a worktree checkout of main; YAML/`bash -n` static validation. The workflow itself runs on `ubuntu-latest`.

## Risk & Scope

- Main risk or tradeoff: the eligibility recheck fails CLOSED (a transient PR-fetch failure discards the round) — safe direction for a secret-bearing run, and the next scan re-emits a still-valid target within 10 minutes. The route prefilter can deny per-PR coalescing (never routing) to a trusted sender whose payload association is unusual; `Decide phases` still authorizes them.
- Not validated / out of scope: the nine Suggestion-level findings of the same review are explicitly "Follow-up only" per the reviewer and are not included; live exercise of the route prefilter requires an untrusted review event on a public PR, which cannot be simulated in CI.
- Breaking changes / migration notes: none; no new secrets or variables.

## Linked Issues

Follow-up to #7127 (post-merge review [4728499913](https://github.com/QwenLM/qwen-code/pull/7127#pullrequestreview-4728499913)).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

加固 review-address 流水线,修复 #7127 合入后评审([4728499913](https://github.com/QwenLM/qwen-code/pull/7127#pullrequestreview-4728499913))的五个 Critical:

1. **路由组信任预过滤。** per-PR 并发组在任何 step 运行前就被进入,公共仓库上任意账号的 review 事件可先取消同 PR 排队中的合法 route、再在 `Decide phases` 内因鉴权失败而死 —— 实时扫描就此丢失。现在载荷看起来不可信的 review(非 `OWNER/MEMBER/COLLABORATOR` 关联、也非 review bot)拿到 run 级唯一组:什么都取消不了,进入 job 后仍走完整权限门。载荷检查只是分组用的廉价预过滤;漏判的可信发送者只损失合并去重,不损失路由。
2. **address 时资格复核。** 扇出可让 matrix job 排队数小时;期间被关闭/合并的 PR 绝不能再获得带 secret 的 agent 运行、分支推送或评论。在检出 PR 分支**之前**重新拉取 PR,要求与扫描选中时同形(open、bot 作者、同仓库 head、base `main`、head 分支未变);不符合 —— 包括拉取失败(未知 ≠ 合格)—— 一律静默丢弃,且丢弃路径发布所有下游 outputs。
3. **非 stale 的重复任务采纳 live 水印。** 排队中的重复任务发现更新反馈时(sibling 已把 F1 处理到 T1,F2 在 T1 之后到达),此前仍按矩阵水印 W 渲染,把已处理的 F1 重放给 agent。复核现在把生效水印推进到 live eval 标记(绝不采纳终止哨兵),渲染只剩 F2。
4. **轮次上限在 address 时强制执行。** 矩阵写着第 4 轮的排队任务可能看到 live 标记已达 `MAX_ROUNDS` 却因有新反馈继续,做第 6 轮工作并重复写 capped 标记。现在任务采纳 live 轮次(两个报告步骤均消费生效轮次),已达上限即丢弃 —— 与扫描一致(扫描在看冲突之前就跳过 capped PR)。
5. **stale 丢弃抑制失败路径的 handoff。** `stale=true` 丢弃后,若靠后的 `always()` 步骤(如工件上传)失败把 job 翻红,失败报告器会发 handoff + eval 标记 —— 把刻意的"无评论无标记"丢弃变成消耗一轮。`POST_HANDOFF` 判定现在对 stale 短路。

## 为什么需要

五项在当前 main 上全部可达,其中三项直接浪费或污染回路的核心记账:重放反馈产生重复或矛盾的更改(3);隐藏轮次上限破坏"5 轮后交人"契约(4);对已丢弃任务发 handoff 白白消耗一轮(5)。(1) 是公共仓库上的滋扰向量 —— 任何账号都能用垃圾 review 压制目标 PR 的实时路由。(2) 会对已关闭的 PR 运行带 secret 的 agent、推分支、发评论。

## 评审验证方案

### 如何验证

1. 运行 `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 53/53。新增/扩展的行为回放(全部从工作流逐字提取,漂移即测试失败):
   - **W/T1/T2**:sibling 标记在 T1、F2 在 T1 后 → 非 stale,采纳水印 == T1(渲染只剩 F2)、采纳轮次接续 live 序列;同夹具去掉 F2 → stale。
   - **封顶**:live 标记 round 5、矩阵 round 4、有新反馈 → 丢弃;哨兵 ts `9999-…` 绝不被采纳为水印。
   - **stale 抑制 handoff**:`STALE=true` + 空 outcome + job 失败 → 不发 handoff(原有用例不变)。
   - **资格复核**:位于 `git checkout -B` 之前,覆盖 state/作者/fork/base/分支,丢弃路径发布全部下游 outputs。
2. 路由组:阅读并发表达式 —— review 分支现在要求 `contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) || github.event.review.user.login == 'qwen-code-ci-bot'` 才授予 per-PR 组;字面量列表与 `TRUSTED_ASSOC`、登录名与 `REVIEW_BOT` 在测试中互相钉住。
3. 静态检查:YAML 可解析;每个 `run:` 块通过 `bash -n`。

### 证据(前后对比)

```
改动前(main):
  不可信 review    → 进入 qwen-autofix-route-pr-N → 取消排队中的 route
  已关闭 PR 目标   → checkout、npm ci、agent 运行、推送、评论
  带新 F2 的重复   → 按矩阵 W 渲染 F1+F2 → agent 重放 F1
  live 轮次到顶    → 跑 MAX+1 轮、第二个 capped 标记
  stale + 迟到失败 → 为什么都没做的运行发 handoff + 标记

改动后(本 PR):
  不可信 review    → run 级唯一组(取消不了任何东西)→ 死在 Decide phases
  已关闭 PR 目标   → '🫥 target no longer eligible (state=…) — discarding'
  带新 F2 的重复   → '⏩ adopting live watermark T1' → 只渲染 F2
  live 轮次到顶    → '⛔ live round 5 already at MAX_ROUNDS — discarding'
  stale + 迟到失败 → POST_HANDOFF=false(回放证明)
```

### 测试情况

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境(可选)

在 main 的 worktree 检出上运行 vitest 契约套件;YAML/`bash -n` 静态校验。工作流本身运行于 `ubuntu-latest`。

## 风险与范围

- 主要风险/权衡:资格复核 fail-closed(瞬时 PR 拉取失败会丢弃本轮)—— 对带 secret 的运行这是安全方向,且下一次扫描 10 分钟内会重新发出仍然有效的目标。路由预过滤可能让载荷关联异常的可信发送者失去 per-PR 合并(不会失去路由);`Decide phases` 仍会为其放行。
- 未验证/不在范围内:同评审的九条 Suggestion 按评审者自己的标注为 "Follow-up only",不含在本 PR;路由预过滤的实弹演练需要公共 PR 上的不可信 review 事件,CI 中无法模拟。
- 破坏性变更/迁移:无;不新增 secret 或变量。

## 关联 Issue

#7127 合入后评审([4728499913](https://github.com/QwenLM/qwen-code/pull/7127#pullrequestreview-4728499913))的后续。

</details>
