### PR TITLE
fix(web-shell): dedupe restored images and harden the sidebar shortcut handler

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1153,23 +1153,50 @@ export function App({
     if (!sidebarOptions.enabled) return undefined;
     const onKey = (e: KeyboardEvent) => {
       if (!isSidebarToggleShortcut(e)) return;
-      e.preventDefault();
-      if (window.matchMedia('(max-width: 760px)').matches) {
-        setMobileDrawerOpen((open) => {
-          if (open) setForceMobileDrawer(false);
-          return !open;
-        });
+      // The composer keeps the editor-convention behavior (VS Code toggles
+      // the sidebar while the editor is focused), but other editable targets
+      // — sidebar search, session rename, settings inputs — must not have
+      // the sidebar yanked around while the user is typing, matching the
+      // codebase's isEditableTarget convention.
+      const target = e.target as HTMLElement | null;
+      if (
+        isEditableTarget(target) &&
+        !target?.closest('[data-web-shell-composer-editor]')
+      ) {
         return;
       }
-      setSidebarCollapsed((collapsed) => {
-        const next = !collapsed;
-        writeSidebarCollapsed(next);
-        return next;
-      });
+      e.preventDefault();
+      // All state updates are dispatched sequentially outside the updater
+      // functions (React purity contract — mirrors the hamburger handler),
+      // which is why this effect re-binds on state changes: the listener
+      // closure must stay fresh.
+      if (
+        forceMobileDrawer ||
+        window.matchMedia('(max-width: 760px)').matches
+      ) {
+        // A forced drawer on a wide viewport still belongs to the drawer
+        // path: collapsing the rail underneath the overlay would look like
+        // a no-op to the user.
+        if (mobileDrawerOpen) {
+          setMobileDrawerOpen(false);
+          setForceMobileDrawer(false);
+        } else {
+          setMobileDrawerOpen(true);
+        }
+        return;
+      }
+      const next = !sidebarCollapsed;
+      setSidebarCollapsed(next);
+      writeSidebarCollapsed(next);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [sidebarOptions.enabled]);
+  }, [
+    sidebarOptions.enabled,
+    mobileDrawerOpen,
+    forceMobileDrawer,
+    sidebarCollapsed,
+  ]);
   const customization = useMemo(
     () => ({
       composerTagIcons,

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -304,9 +304,14 @@ export function useQueuedPrompts({
       const next = mergeRestoredPromptText(current, text);
       if (next !== current) {
         editorRef.current?.setText(next);
-      }
-      if (images && images.length > 0) {
-        editorRef.current?.restoreImages(images);
+        // Restore images only alongside a text change: restoreImages appends
+        // to the pasted-image list, so running it on a deduplicated restore
+        // (same prompt restored twice across reconnects/retries) would double
+        // the attachments while the text correctly stays single (#7134
+        // review follow-up).
+        if (images && images.length > 0) {
+          editorRef.current?.restoreImages(images);
+        }
       }
       editorRef.current?.focus();
     },


### PR DESCRIPTION
## What this PR does

Applies the four post-merge automated-review follow-ups left on #7134 and #7135. Restored prompt images are now deduplicated together with the text: `restoreImages` appends to the pasted-image list, so a second restore of the same prompt (reconnect/retry) previously doubled the attachments while the text correctly stayed single. The Cmd+B/Ctrl+B sidebar shortcut is hardened three ways: it no longer fires while a non-composer editable element is focused (sidebar search, session rename, settings inputs — the composer intentionally keeps the editor-convention behavior and still toggles); all state updates are dispatched sequentially outside React updater functions (purity contract, mirroring the existing hamburger handler), with the effect re-binding on the involved state so the listener closure stays fresh; and a drawer forced open on a wide viewport now takes the drawer path, closing the overlay instead of collapsing the rail invisibly underneath it.

## Why it's needed

Both PRs merged with non-blocking inline suggestions from the automated review that are real correctness gaps: doubled image attachments on duplicate restores produce an inconsistent editor state exactly in the failure-recovery flow #7128 was about; a shortcut firing inside the sidebar's own search or rename inputs yanks the sidebar away mid-typing; side effects inside updater functions violate React's purity contract and can misbehave under strict/concurrent double-invocation; and the forced-drawer branch made the shortcut look like a no-op on wide viewports.

## Reviewer Test Plan

### How to verify

1. Fail a prompt submission that carries pasted images, let the restore run twice (reconnect): the composer holds one copy of the text and one set of the images.
2. Focus the sidebar search input (or a session rename field) and press Ctrl+B: the sidebar does not move. Focus the composer and press Ctrl+B: it still toggles (editor convention preserved).
3. On a wide viewport, open the session drawer via the hamburger, then press Ctrl+B: the drawer closes; the rail is not collapsed underneath the overlay.
4. Toggle repeatedly: the collapse preference still persists across reloads.

Automated coverage: the guard branch semantics are pinned by the existing `mergeRestoredPromptText` suite (6 tests) and matcher suite (5 tests) — 11/11 pass; the image call now lives inside the already-tested text-change branch. `npm run typecheck`, the web-shell package build, eslint and prettier are clean.

### Evidence (Before & After)

Real-browser E2E (Playwright Chromium against a live `qwen serve` daemon built from this branch):

```
composer-focused Ctrl+B: 260 -> 56   (still toggles — editor convention kept ✓)
search-input Ctrl+B:     width 260   (guarded, no toggle ✓)
```

Before this change the search-input case toggled the sidebar mid-typing; the composer behavior is unchanged from #7135's original verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; Playwright Chromium against a live `qwen serve` daemon, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: the shortcut-handler effect now re-binds its window listener when drawer/collapse state changes — a single listener add/remove per state change, negligible. Images are only restored alongside a text change; the edge where the editor already contains identical manually-typed text while a first-time restore carries images will skip the images — acceptable and conservative for a failure-recovery path.
- Not validated / out of scope: no direct unit test drives the image-restore branch (it lives behind the editor-ref boundary); its guard branch is covered by the `mergeRestoredPromptText` suite and the behavior was reasoned through the same dedup semantics. The forced-drawer scenario was implemented per the review finding and manually reasoned; automation covers the desktop paths.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #7102, #7128 (follow-ups to the reviews on #7134 and #7135)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

落实 #7134 与 #7135 合并后自动评审留下的四条 follow-up。恢复失败 prompt 时图片随文本一起去重：`restoreImages` 是向粘贴图片列表追加，同一 prompt 的第二次恢复（重连/重试）此前会让附件翻倍而文本保持单份。Cmd+B/Ctrl+B 侧栏快捷键三处加固：非 composer 的可编辑元素聚焦时不再触发（侧栏搜索、会话重命名、设置输入框——composer 有意保留编辑器惯例仍可切换）；全部状态更新移出 React updater 函数（纯度契约，对齐既有汉堡按钮 handler），effect 依赖相关状态重绑定保证闭包新鲜；宽视口下被强制打开的抽屉走抽屉路径，快捷键关闭覆盖层而不是在其下面不可见地折叠侧栏。

## 为什么需要

两个 PR 合并时带着自动评审的非阻塞行内建议，但都是真实的正确性缺口：重复恢复时图片翻倍恰好发生在 #7128 关注的失败恢复流程里；快捷键在侧栏自己的搜索/重命名输入框里触发会在输入途中拽走侧栏；updater 内副作用违反 React 纯度契约、strict/并发双调用下可能不一致；强制抽屉分支让快捷键在宽视口看起来像无操作。

## 审阅测试计划

### 如何验证

1. 让带粘贴图片的 prompt 提交失败并触发两次恢复（重连）：composer 中文本一份、图片一组；
2. 聚焦侧栏搜索框（或会话重命名框）按 Ctrl+B：侧栏不动；聚焦 composer 按 Ctrl+B：仍切换（编辑器惯例保留）；
3. 宽视口用汉堡按钮打开会话抽屉后按 Ctrl+B：抽屉关闭，侧栏不会在覆盖层下被折叠；
4. 反复切换：折叠偏好仍跨刷新持久化。

自动化覆盖：守卫分支语义由既有 `mergeRestoredPromptText`（6 例）与匹配器（5 例）套件固定——11/11 通过；图片调用现位于已被测试的文本变更分支内。typecheck / web-shell 构建 / eslint / prettier 全绿。

### 证据（Before & After）

真实浏览器 E2E（Playwright Chromium 对本分支构建的真实 `qwen serve`）：composer 聚焦 Ctrl+B 仍切换（260→56）；搜索框聚焦 Ctrl+B 被守卫（保持 260）。改动前搜索框场景会在输入途中切换侧栏；composer 行为与 #7135 原验证一致。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；Playwright Chromium + 真实 daemon + vitest 单测。

## 风险与范围

- 主要风险/权衡：快捷键 effect 随抽屉/折叠状态重绑定 window listener——每次状态变化一次增删，开销可忽略。图片仅随文本变更恢复；「编辑器已含相同手输文本且首次恢复带图」的边缘场景会跳过图片——对失败恢复路径而言保守可接受。
- 未验证/超出范围：图片恢复分支无直接单测（位于 editor-ref 边界之后）；其守卫分支由 `mergeRestoredPromptText` 套件覆盖。强制抽屉场景按 review 发现实现并人工推演；自动化覆盖桌面路径。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Refs #7102, #7128（#7134 与 #7135 评审的 follow-up）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
