### PR TITLE
feat(core): Route Plan-mode shell commands by safety

### DIFF
--- a/docs/design/2026-07-17-plan-mode-shell-routing.md
+++ b/docs/design/2026-07-17-plan-mode-shell-routing.md
@@ -1,0 +1,118 @@
+---
+title: 'Plan Mode Shell Routing and Exact One-Off Approval'
+date: '2026-07-17'
+status: 'implemented'
+---
+
+# Plan Mode Shell Routing and Exact One-Off Approval
+
+## Problem
+
+Plan mode historically treated confirmation shape as a proxy for whether a tool was read-only. That is insufficient for `run_shell_command` and `monitor`: both tools can represent read-only, state-modifying, or parser-unknown shell programs, while permission rules, hooks, ACP hosts, stream-json, TUI, teammate, and background bridges can all resolve the same approval through different paths.
+
+The security boundary must distinguish a known write from an unknown command without turning `unknown` into a way to evade Plan mode. An approval must also remain bound to the exact model request that produced the prompt; a later mode change, permission-policy change, host rewrite, editor modification, or racing response must not reuse it.
+
+This design depends on the tri-state shell classifier merged in #7053.
+
+## Goals
+
+- Apply one routing policy to model-initiated Shell and Monitor calls in Core and ACP.
+- Execute only commands classified `read-only` without a new Plan-specific prompt.
+- Block commands classified `write` before confirmation hooks or hosts can approve them.
+- Permit `unknown` only through an exact, one-time confirmation while keeping Plan mode active.
+- Preserve an explicit PermissionManager deny over every Plan-specific route.
+- Carry warnings and the actual allowed choices through TUI, ACP, stream-json, dual-output, teammate, subagent, and background bridges.
+- Keep non-Shell Plan behavior and explicit plan-exit semantics unchanged.
+
+## Non-goals
+
+- Changing Plan gate lifecycle or injecting a new reminder during an already-running ACP turn.
+- Governing user-entered `!command` shell input.
+- Adding a confirmation type, setting, cache, feature flag, or persistent one-off capability.
+- Changing DataWorks-specific query tools.
+- Making speculation provide an interactive approval surface.
+
+## Threat model
+
+The protected asset is the user's filesystem, processes, network-visible state, repository state, and approval-mode boundary while Plan mode is active. Untrusted inputs include model tool arguments, shell syntax the parser cannot prove safe, hook-returned `updatedInput`, ACP option IDs, stream-json host rewrites, IDE edit callbacks, teammate/background responses, and duplicate responses from concurrently attached hosts.
+
+The relevant attacks are:
+
+- using an allow rule or YOLO-like bridge to bypass Plan mode;
+- disguising a known write with a wrapper so it reaches a weaker path;
+- approving one command and executing a modified request or validated invocation;
+- leaving Plan mode and re-entering it while an old prompt remains visible;
+- adding a deny rule after prompt display but before approval consumption;
+- forging an unoffered persistent or modify option;
+- approving twice through TUI, remote input, IDE, or background bridges;
+- using a sibling call's persistent approval to auto-approve the Plan Shell call.
+
+## Routing policy
+
+PermissionManager L3/L4 evaluation remains authoritative for hard deny. After that decision and the plan-required teammate gate, Plan Shell routing classifies the validated command.
+
+| Classification | PM deny | PM allow             | PM ask/default       | No approval host                                 |
+| -------------- | ------- | -------------------- | -------------------- | ------------------------------------------------ |
+| `read-only`    | deny    | execute              | exact one-off prompt | deny when the ordinary PM prompt cannot be shown |
+| `write`        | deny    | Plan block           | Plan block           | Plan block                                       |
+| `unknown`      | deny    | exact one-off prompt | exact one-off prompt | Plan-safe refusal                                |
+
+Monitor classification uses `normalizeMonitorCommand(command).safetyCommand`; Shell classification uses the validated invocation's original command string. Speculation executes only when the tri-state result is exactly `read-only`; `write`, `unknown`, parser failure, and empty input stop at the speculation boundary.
+
+## Exact invocation capability
+
+Classification creates an immutable snapshot containing:
+
+- the original tool request arguments;
+- the validated invocation parameters;
+- the current approval-mode revision;
+- the PermissionManager check context, including the effective Shell/Monitor working directory;
+- the raw Shell or Monitor command used for display.
+
+Core and ACP clone the Plan Shell/Monitor invocation before classification so host-visible raw input cannot retain an alias to the executable parameters. When the model omits `directory`, that clone is also bound to the current session working directory. The original request remains unchanged, while execution no longer follows a later daemon/ACP directory relocation or request-object mutation after approval has been consumed.
+
+The scheduler validates this snapshot after classification, before displaying confirmation, and before consuming a confirmation. Validation requires:
+
+- a live, non-aborted request;
+- Plan mode with the same revision, so Plan → other mode → Plan invalidates the prompt;
+- deep equality of request arguments and validated invocation parameters;
+- the same effective working directory when the invocation relies on the session's ambient directory;
+- a successful current PermissionManager evaluation that does not return `deny`.
+
+Later `allow`, `ask`, or `default` changes do not reroute a prompt that was already selected. A PermissionManager exception fails closed. Once final validation succeeds, the capability is consumed; a later mode or rule change does not revoke the already-consumed invocation.
+
+Only `ProceedOnce` and `Cancel` are accepted. `updatedInput` is accepted only when deeply equal to the snapshotted request. `newContent` is never accepted. Successful approval passes an empty payload to the tool, so answers, permission rules, or host-only metadata cannot become a persistent grant. Invalid results become `Cancel` with the stale-approval message.
+
+The Core confirmation closure claims the response synchronously before its first `await`. Racing TUI, remote-input, teammate, IDE, or background responses therefore cannot consume the capability twice. Plan Shell edit confirmations never enter the IDE auto-diff path, and sibling persistent approvals skip confirmations marked `hideAlwaysAllow`.
+
+## Confirmation presentation
+
+Every Plan Shell prompt hides persistent approval. Unknown confirmations add:
+
+> Plan mode could not determine whether this shell command is read-only. Approval applies only to this exact invocation once; it may modify system state, and Plan mode will remain active.
+
+Unknown edit confirmations also hide modification actions and add the raw command as a second warning while retaining the diff. TUI renders edit warnings above the diff and reserves their wrapped height so the options remain visible on small terminals. ACP sends warnings before diff or plan content. Stream-json and dual-output include warnings in their existing `permission_suggestions` field.
+
+ACP and nested subagent bridges validate the returned option ID against the exact options sent to the host. Plan-exit keeps its existing four special choices because those choices were actually sent. Missing, forged, hidden, or malformed options fail closed.
+
+Teammate events carry optional callback-free confirmation details. Stream-json uses them for warnings while the teammate's Core scheduler remains the final exact-invocation validator. Headless YOLO cancels a non-plan confirmation marked `hideAlwaysAllow` because no interactive warning surface exists. Background approval never converts an unoffered persistent result into `ProceedOnce`; non-plan persistent results cancel, while plan confirmation retains only its actual `ProceedAlways` choice.
+
+## Failure messages
+
+Known writes, unavailable unknown approval surfaces, and stale approvals use the fixed messages from the implementation plan. These messages deliberately state that Plan mode remains active and prohibit retrying known writes through wrappers or obfuscation.
+
+## Rejected alternatives
+
+- **Treat unknown as write.** Simpler, but blocks necessary investigation when the parser cannot model an otherwise legitimate command.
+- **Treat unknown as read-only after PM allow.** An allow rule is not proof of read-only behavior and would erase the Plan boundary.
+- **Persist an allow rule after unknown approval.** The classifier result and exact request are transient; persistence would authorize a broader future command.
+- **Reuse IDE diff acceptance.** IDE callbacks can change content and race the warning surface, so they cannot safely consume an exact shell capability.
+- **Validate only raw request arguments.** Tool builders normalize and validate input; both raw and executable forms must remain bound.
+- **Validate only when the prompt is created.** Mode and permission state can change while a prompt is visible.
+- **Add a dedicated confirmation type or feature flag.** Existing confirmation shapes and warning fields are sufficient and keep the change smaller.
+
+## Verification
+
+Unit coverage exercises policy classification, snapshots, abort, revision and argument changes, PermissionManager deny/error, warning decoration, payload sanitization, Core routing, duplicate response ownership, sibling auto-approval, wrapped sed edit behavior, Monitor parity, speculation, ACP options and warnings, SubAgentTracker, teammate stream-json, background normalization, dual-output, TUI layout, and prompt wording.
+
+Manual validation is recorded in `.qwen/e2e-tests/plan-mode-shell-routing.md`.

--- a/docs/design/2026-07-17-plan-mode-shell-routing.md
+++ b/docs/design/2026-07-17-plan-mode-shell-routing.md
@@ -115,4 +115,18 @@ Known writes, unavailable unknown approval surfaces, and stale approvals use the
 
 Unit coverage exercises policy classification, snapshots, abort, revision and argument changes, PermissionManager deny/error, warning decoration, payload sanitization, Core routing, duplicate response ownership, sibling auto-approval, wrapped sed edit behavior, Monitor parity, speculation, ACP options and warnings, SubAgentTracker, teammate stream-json, background normalization, dual-output, TUI layout, and prompt wording.
 
-Manual validation is recorded in `.qwen/e2e-tests/plan-mode-shell-routing.md`.
+Manual validation uses a disposable Git workspace containing a sample file and
+covers these cases:
+
+1. In Plan mode, verify that `git status` runs, `touch changed.txt` is blocked,
+   and an unknown command such as `python -c 'print(1)'` offers only one-time
+   approval and cancel before prompting again on its next invocation.
+2. Run a wrapped edit in a narrow compact confirmation and verify that the raw
+   command, warning, diff context, question, and available choices remain
+   visible while modification and persistent approval stay unavailable.
+3. Change the Plan-mode revision or working directory while an approval is
+   pending, return changed or unoffered approval payloads, and send duplicate or
+   late responses; verify that each path cancels without execution.
+4. Repeat read-only, write, and unknown cases through Monitor, ACP, stream-json,
+   nested teammates, and background execution; verify that every surface uses
+   the same classification and fail-closed behavior.

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -38,6 +38,7 @@ import * as core from '@qwen-code/qwen-code-core';
 import { SettingScope } from '../../config/settings.js';
 import type {
   AgentSideConnection,
+  PermissionOption,
   PromptRequest,
   SessionNotification,
 } from '@agentclientprotocol/sdk';
@@ -521,6 +522,7 @@ describe('Session', () => {
       // session.prompt(), so the default must be defined. Individual tests
       // that care override via `mockConfig.getApprovalMode = vi.fn()...`.
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getApprovalModeRevision: vi.fn().mockReturnValue(0),
       switchModel: switchModelSpy,
       getModel: vi.fn().mockImplementation(() => currentModel),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
@@ -10194,6 +10196,473 @@ describe('Session', () => {
         { answers: undefined },
       );
       expect(executeSpy).toHaveBeenCalled();
+    });
+
+    it('blocks known Plan shell writes before requesting ACP permission', async () => {
+      const executeSpy = vi.fn();
+      const getConfirmationDetails = vi.fn();
+      const invocation = {
+        params: { command: 'touch changed.txt' },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails,
+        getDescription: vi.fn().mockReturnValue('touch changed.txt'),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(1);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-write',
+                  name: core.ToolNames.SHELL,
+                  args: { command: 'touch changed.txt' },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run write' }],
+      });
+
+      expect(getConfirmationDetails).not.toHaveBeenCalled();
+      expect(mockClient.requestPermission).not.toHaveBeenCalled();
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining('classified as state-modifying'),
+          }),
+        }),
+      );
+    });
+
+    it('routes unknown resolved shell aliases to exact one-off ACP approval', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn().mockResolvedValue({
+        llmContent: 'ok',
+        returnDisplay: 'ok',
+      });
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(2);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-unknown',
+                  name: 'Shell',
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+      });
+
+      expect(mockClient.requestPermission).toHaveBeenCalledOnce();
+      const permissionRequest = vi.mocked(mockClient.requestPermission).mock
+        .calls[0][0];
+      expect(
+        (permissionRequest.options as PermissionOption[]).map(
+          (option) => option.optionId,
+        ),
+      ).toEqual([
+        core.ToolConfirmationOutcome.ProceedOnce,
+        core.ToolConfirmationOutcome.Cancel,
+      ]);
+      expect(permissionRequest.toolCall.content[0]).toMatchObject({
+        content: {
+          text: expect.stringContaining('exact invocation once'),
+        },
+      });
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.ProceedOnce,
+        undefined,
+      );
+      expect(executeSpy).toHaveBeenCalledOnce();
+    });
+
+    it('rejects ACP shell args mutated while building the invocation', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const executeSpy = vi.fn();
+      const getConfirmationDetails = vi.fn();
+      const build = vi.fn((input: Record<string, unknown>) => {
+        input['command'] = 'touch changed.txt';
+        return {
+          params: input,
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getConfirmationDetails,
+          getDescription: vi.fn().mockReturnValue('touch changed.txt'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          execute: executeSpy,
+        };
+      });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build,
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(2);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-build-mutation',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run wrapper' }],
+      });
+
+      expect(build).toHaveBeenCalledOnce();
+      expect(getConfirmationDetails).not.toHaveBeenCalled();
+      expect(mockClient.requestPermission).not.toHaveBeenCalled();
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining('exact invocation changed'),
+          }),
+        }),
+      );
+    });
+
+    it('cancels forged ACP outcomes that were not offered', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(3);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      vi.mocked(mockClient.requestPermission).mockImplementation(
+        async (params) => {
+          params.options.push({
+            optionId: core.ToolConfirmationOutcome.ProceedAlwaysProject,
+            name: 'Injected persistent approval',
+            kind: 'allow_always',
+          });
+          return {
+            outcome: {
+              outcome: 'selected',
+              optionId: core.ToolConfirmationOutcome.ProceedAlwaysProject,
+            },
+          };
+        },
+      );
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-forged',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run wrapper' }],
+      });
+
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps ambient Shell cwd fixed after ACP approval is consumed', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const modelArgs = { command: rawCommand };
+      let targetDir = '/workspace/one';
+      const onConfirmSpy = vi.fn().mockImplementation(async () => {
+        targetDir = '/workspace/two';
+        modelArgs.command = 'touch changed.txt';
+      });
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: modelArgs,
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(4);
+      mockConfig.getTargetDir = vi.fn(() => targetDir);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-cwd-consumed',
+                  name: core.ToolNames.SHELL,
+                  args: modelArgs,
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+      });
+
+      expect(invocation.params).toEqual({
+        command: rawCommand,
+        directory: '/workspace/one',
+      });
+      expect(targetDir).toBe('/workspace/two');
+      expect(modelArgs.command).toBe('touch changed.txt');
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.ProceedOnce,
+        undefined,
+      );
+      expect(executeSpy).toHaveBeenCalledOnce();
+    });
+
+    it('invalidates ACP approval when ambient Shell cwd moves while pending', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      let targetDir = '/workspace/one';
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(4);
+      mockConfig.getTargetDir = vi.fn(() => targetDir);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      vi.mocked(mockClient.requestPermission).mockImplementation(async () => {
+        targetDir = '/workspace/two';
+        return {
+          outcome: {
+            outcome: 'selected',
+            optionId: core.ToolConfirmationOutcome.ProceedOnce,
+          },
+        };
+      });
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-cwd-stale',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+      });
+
+      expect(invocation.params).toEqual({
+        command: rawCommand,
+        directory: '/workspace/one',
+      });
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+        expect.objectContaining({
+          cancelMessage: expect.stringContaining('no longer valid'),
+        }),
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('revalidates Plan shell context after a pending permission hook', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      let revision = 4;
+      const hookSpy = vi
+        .spyOn(core, 'firePermissionRequestHook')
+        .mockImplementation(async () => {
+          revision++;
+          return { hasDecision: false };
+        });
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: vi.fn().mockResolvedValue(undefined),
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn(() => revision);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+      mockConfig.getMessageBus = vi.fn().mockReturnValue({});
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-hook-stale',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      try {
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+        });
+      } finally {
+        hookSpy.mockRestore();
+      }
+
+      expect(mockClient.requestPermission).not.toHaveBeenCalled();
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: expect.stringContaining('no longer valid'),
+          }),
+        }),
+      );
     });
 
     it('returns permission error for disabled tools (L1 isToolEnabled check)', async () => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -10326,6 +10326,144 @@ describe('Session', () => {
       expect(executeSpy).toHaveBeenCalledOnce();
     });
 
+    it('reports ACP Plan shell approval request failures accurately', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(2);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      vi.mocked(mockClient.requestPermission).mockRejectedValueOnce(
+        new Error('ACP host disconnected'),
+      );
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-approval-failed',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+      });
+
+      expect(mockClient.requestPermission).toHaveBeenCalledOnce();
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message:
+              'Plan mode could not complete approval for this shell command: ACP host disconnected. The command was not run; Plan mode remains active.',
+          }),
+        }),
+      );
+    });
+
+    it('rejects permission-hook rewrites of unknown Plan shell commands', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const hookSpy = vi
+        .spyOn(core, 'firePermissionRequestHook')
+        .mockResolvedValue({
+          hasDecision: true,
+          shouldAllow: true,
+          updatedInput: { command: 'touch changed.txt' },
+        });
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(2);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+      mockConfig.getMessageBus = vi.fn().mockReturnValue({});
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-hook-rewrite',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      try {
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+        });
+      } finally {
+        hookSpy.mockRestore();
+      }
+
+      expect(mockClient.requestPermission).not.toHaveBeenCalled();
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+        expect.objectContaining({
+          cancelMessage: expect.stringContaining('exact invocation changed'),
+        }),
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
     it('rejects ACP shell args mutated while building the invocation', async () => {
       const rawCommand = "python -c 'print(1)'";
       const executeSpy = vi.fn();

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -6599,7 +6599,9 @@ export class Session implements SessionContext {
                 const permissionFailureMessage = isExitPlanModeTool
                   ? 'The host could not present plan-exit approval. Plan mode remains active; use the host mode selector or /plan exit to leave plan mode.'
                   : planShellDecision.classification === 'unknown'
-                    ? planShellDecision.noApprovalMessage
+                    ? `Plan mode could not complete approval for this shell command: ${this.#formatError(
+                        error,
+                      )}. The command was not run; Plan mode remains active.`
                     : `Permission request failed for "${toolName}": ${this.#formatError(
                         error,
                       )}`;

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -18,6 +18,7 @@ import type {
   Config,
   GeminiChat,
   ToolCallConfirmationDetails,
+  ToolConfirmationPayload,
   ToolResult,
   ToolResultDisplay,
   ShellProgressData,
@@ -93,6 +94,10 @@ import {
   getEffectivePermissionForConfirmation,
   needsConfirmation,
   isPlanModeBlocked,
+  decoratePlanModeShellConfirmation,
+  evaluatePlanModeShellPolicy,
+  validatePlanModeShellApproval,
+  validatePlanModeShellContext,
   abortGoalForStopHookCap,
   formatStopHookBlockingCapWarning,
   applyAutoModeDecision,
@@ -178,7 +183,6 @@ import type {
   AgentSideConnection,
 } from '@agentclientprotocol/sdk';
 import { SettingScope, type LoadedSettings } from '../../config/settings.js';
-import { z } from 'zod';
 import {
   insertAfterFunctionResponses,
   normalizePartList,
@@ -239,6 +243,8 @@ import { SubAgentTracker } from './SubAgentTracker.js';
 import {
   buildPermissionRequestContent,
   interactionMetaFields,
+  requestPermissionWithAbort,
+  resolvePermissionOutcome,
   toPermissionOptions,
 } from './permissionUtils.js';
 import {
@@ -5980,14 +5986,19 @@ export class Session implements SessionContext {
         { recordInvalidToolParams: true },
       );
     }
+    const policyToolName = tool.name;
+    const originalPolicyRequestArgs =
+      policyToolName === ToolNames.SHELL || policyToolName === ToolNames.MONITOR
+        ? structuredClone(args)
+        : args;
 
-    const toolSpan = startToolSpan(toolName, {
+    const toolSpan = startToolSpan(policyToolName, {
       'tool.call_id': callId,
       // Dual-emit the legacy call_id/tool_name aliases like CoreToolScheduler
       // (coreToolScheduler.ts) so pre-Phase-2 dashboards keyed off call_id keep
       // matching daemon/ACP tool spans during the migration window.
       call_id: callId,
-      tool_name: toolName,
+      tool_name: policyToolName,
     });
     let spanSuccess = false;
 
@@ -5995,7 +6006,7 @@ export class Session implements SessionContext {
       return await runInToolSpanContext(toolSpan, async () => {
         // ---- L1: Tool enablement check ----
         const pm = this.config.getPermissionManager?.();
-        if (pm && !(await pm.isToolEnabled(toolName))) {
+        if (pm && !(await pm.isToolEnabled(policyToolName))) {
           return earlyErrorResponse(
             new Error(`Tool "${toolName}" is disabled.`),
             toolName,
@@ -6035,7 +6046,7 @@ export class Session implements SessionContext {
         const toolUseId = generateToolUseId();
 
         // Get approval mode for hook context (defined outside try for catch block access)
-        const approvalMode = this.config.getApprovalMode();
+        let approvalMode = this.config.getApprovalMode();
 
         let toolBuildSucceeded = false;
         try {
@@ -6088,14 +6099,14 @@ export class Session implements SessionContext {
           // AUTO_EDIT auto-approval is handled HERE, same as coreToolScheduler.
           // The VS Code extension is just a UI layer for requestPermission.
           const isAskUserQuestionTool =
-            toolName === ToolNames.ASK_USER_QUESTION;
+            policyToolName === ToolNames.ASK_USER_QUESTION;
 
           // ---- L3→L4: Shared permission flow ----
-          const toolParams = invocation.params as Record<string, unknown>;
+          let toolParams = invocation.params as Record<string, unknown>;
           const flowResult = await evaluatePermissionFlow(
             this.config,
             invocation,
-            toolName,
+            policyToolName,
             toolParams,
           );
           const {
@@ -6107,7 +6118,12 @@ export class Session implements SessionContext {
           } = flowResult;
 
           // ---- L5: ApprovalMode overrides ----
+          approvalMode = this.config.getApprovalMode();
           const isPlanMode = approvalMode === ApprovalMode.PLAN;
+          const isPlanShellCall =
+            isPlanMode &&
+            (policyToolName === ToolNames.SHELL ||
+              policyToolName === ToolNames.MONITOR);
 
           if (finalPermission === 'deny') {
             return earlyErrorResponse(
@@ -6115,6 +6131,58 @@ export class Session implements SessionContext {
               toolName,
             );
           }
+
+          let planShellAmbientWorkingDirectory: string | undefined;
+          if (isPlanShellCall) {
+            const directory = toolParams['directory'];
+            planShellAmbientWorkingDirectory =
+              typeof directory === 'string' && directory.length > 0
+                ? undefined
+                : this.config.getTargetDir();
+            invocation.params = {
+              ...structuredClone(invocation.params),
+              directory:
+                typeof directory === 'string' && directory.length > 0
+                  ? directory
+                  : planShellAmbientWorkingDirectory,
+            };
+            toolParams = invocation.params as Record<string, unknown>;
+          }
+
+          const planShellDecision = isPlanShellCall
+            ? await evaluatePlanModeShellPolicy({
+                config: this.config,
+                toolName: policyToolName,
+                requestArgs: originalPolicyRequestArgs,
+                invocationParams: toolParams,
+                permissionContext: pmCtx,
+                ambientWorkingDirectory: planShellAmbientWorkingDirectory,
+                signal: activeToolAbortSignal,
+              })
+            : ({ classification: 'not-applicable' } as const);
+          if (planShellDecision.classification !== 'not-applicable') {
+            const initialPlanShellError = await validatePlanModeShellContext({
+              config: this.config,
+              decision: planShellDecision,
+              requestArgs: args,
+              invocationParams: invocation.params as Record<string, unknown>,
+              signal: activeToolAbortSignal,
+            });
+            if (initialPlanShellError) {
+              return earlyErrorResponse(
+                new Error(initialPlanShellError),
+                toolName,
+              );
+            }
+          }
+          if (planShellDecision.classification === 'write') {
+            return earlyErrorResponse(
+              new Error(planShellDecision.writeBlockMessage),
+              toolName,
+            );
+          }
+          const planShellRequiresConfirmation =
+            planShellDecision.classification === 'unknown';
 
           // Explicit allow (user rule matched, or tool's L3 default is 'allow')
           // is authoritative for ordinary calls. In AUTO, protected
@@ -6126,18 +6194,20 @@ export class Session implements SessionContext {
           const forceAutoReviewForAllow =
             approvalMode === ApprovalMode.AUTO &&
             (shouldForceAutoModeReviewForAllow(pmCtx, this.config.getCwd()) ||
-              shouldClassifyAllShellForAutoMode(toolName, this.config));
+              shouldClassifyAllShellForAutoMode(policyToolName, this.config));
           const confirmationPermission = getEffectivePermissionForConfirmation(
             finalPermission,
             forceAutoReviewForAllow,
           );
           if (finalPermission === 'allow' && forceAutoReviewForAllow) {
             debugLogger.info(
-              `Auto mode: L4 allow overridden by protected-write guard for ${toolName}`,
+              `Auto mode: L4 allow overridden by protected-write guard for ${policyToolName}`,
             );
           }
           let autoModeAllowed =
-            finalPermission === 'allow' && !forceAutoReviewForAllow;
+            finalPermission === 'allow' &&
+            !forceAutoReviewForAllow &&
+            !planShellRequiresConfirmation;
           if (autoModeAllowed && approvalMode === ApprovalMode.AUTO) {
             this.config.setAutoModeDenialState(
               recordAllow(this.config.getAutoModeDenialState()),
@@ -6153,7 +6223,7 @@ export class Session implements SessionContext {
           if (
             !autoModeAllowed &&
             !requiresUserInteraction &&
-            shouldRunAutoModeForCall(approvalMode, toolName)
+            shouldRunAutoModeForCall(approvalMode, policyToolName)
           ) {
             const denialState = this.config.getAutoModeDenialState();
             const fallback = shouldFallback(denialState);
@@ -6192,7 +6262,7 @@ export class Session implements SessionContext {
               this.config,
               decision,
               outcome,
-              toolName,
+              policyToolName,
               toolParams,
               callId,
               abortSignal,
@@ -6203,7 +6273,7 @@ export class Session implements SessionContext {
                 break;
               case 'blocked':
                 debugLogger.warn(
-                  `Auto mode blocked (${outcome.reason}): tool=${toolName}, ` +
+                  `Auto mode blocked (${outcome.reason}): tool=${policyToolName}, ` +
                     formatDenialStateLog(denialState),
                 );
                 return earlyErrorResponse(
@@ -6262,19 +6332,56 @@ export class Session implements SessionContext {
           if (
             !autoModeAllowed &&
             needsConfirmation(
-              confirmationPermission,
+              planShellRequiresConfirmation ? 'ask' : confirmationPermission,
               approvalMode,
-              toolName,
+              policyToolName,
               requiresUserInteraction,
             )
           ) {
-            confirmationDetails =
-              await invocation.getConfirmationDetails(abortSignal);
+            confirmationDetails = await invocation.getConfirmationDetails(
+              activeToolAbortSignal,
+            );
+
+            if (planShellDecision.classification !== 'not-applicable') {
+              const preDisplayPlanShellError =
+                await validatePlanModeShellContext({
+                  config: this.config,
+                  decision: planShellDecision,
+                  requestArgs: args,
+                  invocationParams: invocation.params as Record<
+                    string,
+                    unknown
+                  >,
+                  signal: activeToolAbortSignal,
+                });
+              if (preDisplayPlanShellError) {
+                return earlyErrorResponse(
+                  new Error(preDisplayPlanShellError),
+                  toolName,
+                );
+              }
+            }
+
+            try {
+              confirmationDetails = decoratePlanModeShellConfirmation(
+                planShellDecision,
+                confirmationDetails,
+              );
+            } catch {
+              if (planShellDecision.classification === 'unknown') {
+                return earlyErrorResponse(
+                  new Error(planShellDecision.noApprovalMessage),
+                  toolName,
+                );
+              }
+              throw new Error('Unable to prepare shell confirmation.');
+            }
 
             // Centralised rule injection (for display and persistence)
             injectPermissionRulesIfMissing(confirmationDetails, pmCtx);
 
             if (
+              planShellDecision.classification === 'not-applicable' &&
               isPlanModeBlocked(
                 isPlanMode,
                 isExitPlanModeTool,
@@ -6299,9 +6406,11 @@ export class Session implements SessionContext {
             if (hooksEnabled && messageBus) {
               const hookResult = await firePermissionRequestHook(
                 messageBus,
-                toolName,
+                policyToolName,
                 args,
                 String(approvalMode),
+                undefined,
+                activeToolAbortSignal,
               );
 
               if (
@@ -6310,18 +6419,49 @@ export class Session implements SessionContext {
               ) {
                 hookHandled = true;
                 if (hookResult.shouldAllow) {
-                  if (hookResult.updatedInput) {
-                    args = hookResult.updatedInput;
-                    invocation.params =
-                      hookResult.updatedInput as typeof invocation.params;
-                  }
+                  if (planShellDecision.classification !== 'not-applicable') {
+                    const approval = await validatePlanModeShellApproval({
+                      config: this.config,
+                      decision: planShellDecision,
+                      requestArgs: args,
+                      invocationParams: invocation.params as Record<
+                        string,
+                        unknown
+                      >,
+                      signal: activeToolAbortSignal,
+                      outcome: ToolConfirmationOutcome.ProceedOnce,
+                      payload: hookResult.updatedInput
+                        ? { updatedInput: hookResult.updatedInput }
+                        : undefined,
+                    });
+                    await confirmationDetails.onConfirm(
+                      approval.outcome,
+                      approval.payload,
+                    );
+                    if (approval.outcome === ToolConfirmationOutcome.Cancel) {
+                      return earlyErrorResponse(
+                        new Error(
+                          approval.payload?.cancelMessage ??
+                            planShellDecision.noApprovalMessage,
+                        ),
+                        toolName,
+                      );
+                    }
+                    recordAutoModeFallbackResolution(approval.outcome);
+                  } else {
+                    if (hookResult.updatedInput) {
+                      args = hookResult.updatedInput;
+                      invocation.params =
+                        hookResult.updatedInput as typeof invocation.params;
+                    }
 
-                  await confirmationDetails.onConfirm(
-                    ToolConfirmationOutcome.ProceedOnce,
-                  );
-                  recordAutoModeFallbackResolution(
-                    ToolConfirmationOutcome.ProceedOnce,
-                  );
+                    await confirmationDetails.onConfirm(
+                      ToolConfirmationOutcome.ProceedOnce,
+                    );
+                    recordAutoModeFallbackResolution(
+                      ToolConfirmationOutcome.ProceedOnce,
+                    );
+                  }
                 } else {
                   return earlyErrorResponse(
                     new Error(
@@ -6345,6 +6485,26 @@ export class Session implements SessionContext {
               // Auto-approve, skip requestPermission.
               // didRequestPermission stays false → emitStart below.
             } else if (!hookHandled) {
+              if (planShellDecision.classification !== 'not-applicable') {
+                const finalPreDisplayPlanShellError =
+                  await validatePlanModeShellContext({
+                    config: this.config,
+                    decision: planShellDecision,
+                    requestArgs: args,
+                    invocationParams: invocation.params as Record<
+                      string,
+                      unknown
+                    >,
+                    signal: activeToolAbortSignal,
+                  });
+                if (finalPreDisplayPlanShellError) {
+                  return earlyErrorResponse(
+                    new Error(finalPreDisplayPlanShellError),
+                    toolName,
+                  );
+                }
+              }
+
               // Show permission dialog via ACP requestPermission
               didRequestPermission = true;
               const content =
@@ -6353,7 +6513,7 @@ export class Session implements SessionContext {
               // Map tool kind, using switch_mode for exit_plan_mode per ACP spec
               const mappedKind = this.toolCallEmitter.mapToolKind(
                 tool.kind,
-                toolName,
+                policyToolName,
               );
 
               if (hooksEnabled && messageBus) {
@@ -6365,9 +6525,16 @@ export class Session implements SessionContext {
                 );
               }
 
+              const permissionOptions = toPermissionOptions(
+                confirmationDetails,
+                pmForcedAsk,
+              );
+              const offeredPermissionOptions = permissionOptions.map(
+                (option) => ({ ...option }),
+              );
               const params: RequestPermissionRequest = {
                 sessionId: this.sessionId,
-                options: toPermissionOptions(confirmationDetails, pmForcedAsk),
+                options: permissionOptions,
                 toolCall: {
                   toolCallId: callId,
                   status: 'pending',
@@ -6386,10 +6553,12 @@ export class Session implements SessionContext {
                   },
                 },
               };
-              const stopAfterPermissionCancel = () => {
+              const stopAfterPermissionCancel = (message?: string) => {
                 onStopAfterPermissionCancel?.();
                 return earlyErrorResponse(
-                  new Error(`Tool "${toolName}" was canceled by the user.`),
+                  new Error(
+                    message ?? `Tool "${toolName}" was canceled by the user.`,
+                  ),
                   toolName,
                   { stopAfterPermissionCancel: true },
                 );
@@ -6400,17 +6569,17 @@ export class Session implements SessionContext {
               };
               let outcome: ToolConfirmationOutcome;
               try {
-                output = (await this.client.requestPermission(
+                output = (await requestPermissionWithAbort(
+                  this.client,
                   params,
+                  activeToolAbortSignal,
                 )) as RequestPermissionResponse & {
                   answers?: Record<string, string>;
                 };
-                outcome =
-                  output.outcome.outcome === 'cancelled'
-                    ? ToolConfirmationOutcome.Cancel
-                    : z
-                        .nativeEnum(ToolConfirmationOutcome)
-                        .parse(output.outcome.optionId);
+                outcome = resolvePermissionOutcome(
+                  output,
+                  offeredPermissionOptions,
+                );
               } catch (error) {
                 debugLogger.error(
                   `Permission request failed for tool ${toolName}:`,
@@ -6429,9 +6598,11 @@ export class Session implements SessionContext {
                 onStopAfterPermissionCancel?.();
                 const permissionFailureMessage = isExitPlanModeTool
                   ? 'The host could not present plan-exit approval. Plan mode remains active; use the host mode selector or /plan exit to leave plan mode.'
-                  : `Permission request failed for "${toolName}": ${this.#formatError(
-                      error,
-                    )}`;
+                  : planShellDecision.classification === 'unknown'
+                    ? planShellDecision.noApprovalMessage
+                    : `Permission request failed for "${toolName}": ${this.#formatError(
+                        error,
+                      )}`;
                 return earlyErrorResponse(
                   new Error(permissionFailureMessage),
                   toolName,
@@ -6439,12 +6610,32 @@ export class Session implements SessionContext {
                 );
               }
 
+              let confirmationPayload: ToolConfirmationPayload | undefined = {
+                answers: output.answers,
+              };
+              if (planShellDecision.classification !== 'not-applicable') {
+                const approval = await validatePlanModeShellApproval({
+                  config: this.config,
+                  decision: planShellDecision,
+                  requestArgs: args,
+                  invocationParams: invocation.params as Record<
+                    string,
+                    unknown
+                  >,
+                  signal: activeToolAbortSignal,
+                  outcome,
+                  payload: confirmationPayload,
+                });
+                outcome = approval.outcome;
+                confirmationPayload = approval.payload;
+              }
               recordAutoModeFallbackResolution(outcome);
 
               try {
-                await confirmationDetails.onConfirm(outcome, {
-                  answers: output.answers,
-                });
+                await confirmationDetails.onConfirm(
+                  outcome,
+                  confirmationPayload,
+                );
               } catch (error) {
                 if (outcome !== ToolConfirmationOutcome.Cancel) {
                   throw error;
@@ -6470,7 +6661,7 @@ export class Session implements SessionContext {
                   confirmationDetails,
                   this.config.getOnPersistPermissionRule?.(),
                   this.config.getPermissionManager?.(),
-                  { answers: output.answers },
+                  confirmationPayload,
                 );
               }
 
@@ -6488,7 +6679,9 @@ export class Session implements SessionContext {
                   // cancellation reason (plain errorResponse leaves it unset,
                   // which makes endToolSpan fall back to the generic 'tool
                   // error' message) and the declined call is still recorded.
-                  return stopAfterPermissionCancel();
+                  return stopAfterPermissionCancel(
+                    confirmationPayload?.cancelMessage,
+                  );
                 case ToolConfirmationOutcome.ProceedOnce:
                 case ToolConfirmationOutcome.ProceedAlways:
                 case ToolConfirmationOutcome.ProceedAlwaysProject:
@@ -6526,7 +6719,7 @@ export class Session implements SessionContext {
           if (hooksEnabledForTool && messageBusForTool) {
             const preHookResult = await firePreToolUseHook(
               messageBusForTool,
-              toolName,
+              policyToolName,
               args,
               toolUseId,
               permissionMode,
@@ -6708,7 +6901,7 @@ export class Session implements SessionContext {
             };
             const postHookResult = await firePostToolUseHook(
               messageBusForTool,
-              toolName,
+              policyToolName,
               args,
               toolResponse,
               toolUseId,
@@ -6751,7 +6944,7 @@ export class Session implements SessionContext {
             const failureHookResult = await firePostToolUseFailureHook(
               messageBusForTool,
               toolUseId,
-              toolName,
+              policyToolName,
               args,
               toolResult.error?.message ?? 'Tool execution was cancelled',
               isInterrupt,
@@ -6869,7 +7062,7 @@ export class Session implements SessionContext {
             const failureHookResult = await firePostToolUseFailureHook(
               messageBusForError,
               toolUseId,
-              toolName,
+              policyToolName,
               args,
               error.message,
               isInterrupt,

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
@@ -545,6 +545,37 @@ describe('SubAgentTracker', () => {
       });
     });
 
+    it('cancels outcomes that were not offered to the ACP host', async () => {
+      requestPermissionSpy.mockResolvedValue({
+        outcome: {
+          outcome: 'selected',
+          optionId: ToolConfirmationOutcome.ProceedAlwaysProject,
+        },
+      });
+      tracker.setup(eventEmitter, abortController.signal);
+      const respondSpy = vi.fn().mockResolvedValue(undefined);
+      eventEmitter.emit(
+        AgentEventType.TOOL_WAITING_APPROVAL,
+        createApprovalEvent({
+          name: 'shell',
+          callId: 'call-exact-shell',
+          confirmationDetails: {
+            type: 'exec',
+            title: 'Confirm shell',
+            command: "python -c 'print(1)'",
+            rootCommand: 'python',
+            hideAlwaysAllow: true,
+            warnings: ['Exact one-off approval required'],
+          } as AgentApprovalRequestEvent['confirmationDetails'],
+          respond: respondSpy,
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(respondSpy).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
+      });
+    });
+
     it('notifies when nested ask_user_question is cancelled', async () => {
       requestPermissionSpy.mockResolvedValue({
         outcome: { outcome: 'cancelled' },

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.ts
@@ -20,7 +20,6 @@ import {
   ToolConfirmationOutcome,
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
-import { z } from 'zod';
 import type { SessionContext } from './types.js';
 import { ToolCallEmitter } from './emitters/tool-call-emitter.js';
 import { MessageEmitter } from './emitters/MessageEmitter.js';
@@ -31,6 +30,8 @@ import type {
 import {
   buildPermissionRequestContent,
   interactionMetaFields,
+  requestPermissionWithAbort,
+  resolvePermissionOutcome,
   toPermissionOptions,
 } from './permissionUtils.js';
 
@@ -199,9 +200,13 @@ export class SubAgentTracker {
       const { title, locations, kind } =
         this.toolCallEmitter.resolveToolMetadata(event.name, state?.args);
 
+      const permissionOptions = toPermissionOptions(fullConfirmationDetails);
+      const offeredPermissionOptions = permissionOptions.map((option) => ({
+        ...option,
+      }));
       const params: RequestPermissionRequest = {
         sessionId: this.ctx.sessionId,
-        options: toPermissionOptions(fullConfirmationDetails),
+        options: permissionOptions,
         toolCall: {
           toolCallId: event.callId,
           status: 'pending',
@@ -224,16 +229,21 @@ export class SubAgentTracker {
 
       try {
         // Request permission from client
-        const output = await this.client.requestPermission(params);
-        const outcome =
-          output.outcome.outcome === 'cancelled'
-            ? ToolConfirmationOutcome.Cancel
-            : z
-                .nativeEnum(ToolConfirmationOutcome)
-                .parse(output.outcome.optionId);
+        const output = await requestPermissionWithAbort(
+          this.client,
+          params,
+          abortSignal,
+        );
+        const outcome = resolvePermissionOutcome(
+          output,
+          offeredPermissionOptions,
+        );
         // Respond to subagent with the outcome
         await event.respond(outcome, {
-          answers: 'answers' in output ? output.answers : undefined,
+          answers:
+            'answers' in output
+              ? (output.answers as Record<string, string> | undefined)
+              : undefined,
         });
         if (outcome === ToolConfirmationOutcome.Cancel) {
           this.onPermissionCancel?.();

--- a/packages/cli/src/acp-integration/session/permissionUtils.test.ts
+++ b/packages/cli/src/acp-integration/session/permissionUtils.test.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import {
+  buildPermissionRequestContent,
   interactionMetaFields,
+  requestPermissionWithAbort,
+  resolvePermissionOutcome,
   toPermissionOptions,
 } from './permissionUtils.js';
 
@@ -131,5 +134,82 @@ describe('permissionUtils', () => {
         }),
       ).toEqual({});
     });
+  });
+
+  it('places warnings before edit diff content', () => {
+    const content = buildPermissionRequestContent({
+      type: 'edit',
+      title: 'Confirm edit',
+      fileName: 'a.txt',
+      filePath: '/tmp/a.txt',
+      fileDiff: 'diff',
+      originalContent: 'a',
+      newContent: 'b',
+      warnings: ['Unknown safety', 'Exact shell command: sed -i s/a/b/ a.txt'],
+      onConfirm: async () => undefined,
+    });
+
+    expect(content.map((item) => item.type)).toEqual([
+      'content',
+      'content',
+      'diff',
+    ]);
+    expect(content[0]).toMatchObject({
+      content: { text: 'Unknown safety' },
+    });
+  });
+
+  it('accepts only an option that was actually offered', () => {
+    const options = toPermissionOptions({
+      type: 'exec',
+      title: 'Confirm shell',
+      command: 'python script.py',
+      rootCommand: 'python',
+      hideAlwaysAllow: true,
+      onConfirm: async () => undefined,
+    });
+    expect(
+      resolvePermissionOutcome(
+        {
+          outcome: {
+            outcome: 'selected',
+            optionId: ToolConfirmationOutcome.ProceedOnce,
+          },
+        },
+        options,
+      ),
+    ).toBe(ToolConfirmationOutcome.ProceedOnce);
+    expect(() =>
+      resolvePermissionOutcome(
+        {
+          outcome: {
+            outcome: 'selected',
+            optionId: ToolConfirmationOutcome.ProceedAlwaysProject,
+          },
+        },
+        options,
+      ),
+    ).toThrow('unoffered option');
+  });
+
+  it('aborts permission requests and ignores late settlement', async () => {
+    let resolveRequest: ((value: never) => void) | undefined;
+    const client = {
+      requestPermission: vi.fn(
+        () =>
+          new Promise<never>((resolve) => {
+            resolveRequest = resolve;
+          }),
+      ),
+    };
+    const controller = new AbortController();
+    const request = requestPermissionWithAbort(
+      client as never,
+      { sessionId: 'session', options: [], toolCall: {} as never },
+      controller.signal,
+    );
+    controller.abort();
+    await expect(request).rejects.toThrow('aborted');
+    resolveRequest?.({} as never);
   });
 });

--- a/packages/cli/src/acp-integration/session/permissionUtils.ts
+++ b/packages/cli/src/acp-integration/session/permissionUtils.ts
@@ -7,7 +7,10 @@
 import type { ToolCallConfirmationDetails } from '@qwen-code/qwen-code-core';
 import { ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import type {
+  AgentSideConnection,
   PermissionOption,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
   ToolCallContent,
 } from '@agentclientprotocol/sdk';
 
@@ -85,6 +88,17 @@ export function buildPermissionRequestContent(
 ): ToolCallContent[] {
   const content: ToolCallContent[] = [];
 
+  const warnings =
+    confirmation.type === 'exec' || confirmation.type === 'edit'
+      ? (confirmation.warnings ?? [])
+      : [];
+  for (const warning of warnings) {
+    content.push({
+      type: 'content',
+      content: { type: 'text', text: warning },
+    });
+  }
+
   if (confirmation.type === 'edit') {
     content.push({
       type: 'diff',
@@ -105,6 +119,70 @@ export function buildPermissionRequestContent(
   }
 
   return content;
+}
+
+function permissionAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Permission request was aborted.');
+}
+
+export function requestPermissionWithAbort(
+  client: Pick<AgentSideConnection, 'requestPermission'>,
+  params: RequestPermissionRequest,
+  signal: AbortSignal,
+): Promise<RequestPermissionResponse> {
+  if (signal.aborted) {
+    return Promise.reject(permissionAbortError(signal));
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      callback();
+    };
+    const onAbort = () => finish(() => reject(permissionAbortError(signal)));
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    let request: Promise<RequestPermissionResponse>;
+    try {
+      request = client.requestPermission(params);
+    } catch (error) {
+      finish(() => reject(error));
+      return;
+    }
+    request.then(
+      (response) => finish(() => resolve(response)),
+      (error: unknown) => finish(() => reject(error)),
+    );
+  });
+}
+
+export function resolvePermissionOutcome(
+  response: RequestPermissionResponse,
+  offeredOptions: readonly PermissionOption[],
+): ToolConfirmationOutcome {
+  if (response.outcome.outcome === 'cancelled') {
+    return ToolConfirmationOutcome.Cancel;
+  }
+
+  const optionId = response.outcome.optionId;
+  if (!offeredOptions.some((option) => option.optionId === optionId)) {
+    throw new Error(
+      `Permission response selected unoffered option: ${optionId}`,
+    );
+  }
+  if (
+    !Object.values(ToolConfirmationOutcome).includes(
+      optionId as ToolConfirmationOutcome,
+    )
+  ) {
+    throw new Error(`Permission response selected invalid option: ${optionId}`);
+  }
+  return optionId as ToolConfirmationOutcome;
 }
 
 export function toPermissionOptions(

--- a/packages/cli/src/dualOutput/DualOutputBridge.test.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.test.ts
@@ -217,7 +217,20 @@ describe('DualOutputBridge', () => {
 
     it('routes permission requests + responses through the adapter', async () => {
       bridge = new DualOutputBridge(config, { filePath: target });
-      bridge.emitPermissionRequest('req-1', 'shell', 'tu-1', { cmd: 'ls' });
+      bridge.emitPermissionRequest(
+        'req-1',
+        'shell',
+        'tu-1',
+        { cmd: 'ls' },
+        null,
+        [
+          {
+            type: 'allow',
+            label: 'Allow Command',
+            description: 'Exact one-off approval required',
+          },
+        ],
+      );
       bridge.emitControlResponse('req-1', false);
       await bridge.shutdown();
 
@@ -232,6 +245,13 @@ describe('DualOutputBridge', () => {
           tool_name: 'shell',
           tool_use_id: 'tu-1',
           input: { cmd: 'ls' },
+          permission_suggestions: [
+            {
+              type: 'allow',
+              label: 'Allow Command',
+              description: 'Exact one-off approval required',
+            },
+          ],
           blocked_path: null,
         },
       });

--- a/packages/cli/src/dualOutput/DualOutputBridge.ts
+++ b/packages/cli/src/dualOutput/DualOutputBridge.ts
@@ -17,6 +17,7 @@ import type {
   ToolCallRequestInfo,
   ToolCallResponseInfo,
 } from '@qwen-code/qwen-code-core';
+import type { PermissionSuggestion } from '../nonInteractive/types.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { StreamJsonOutputAdapter } from '../nonInteractive/io/index.js';
@@ -291,6 +292,7 @@ export class DualOutputBridge {
     toolUseId: string,
     input: unknown,
     blockedPath: string | null = null,
+    permissionSuggestions: PermissionSuggestion[] | null = null,
   ): void {
     if (!this.active) return;
     this.disableIfBufferOverflowed();
@@ -302,6 +304,7 @@ export class DualOutputBridge {
         toolUseId,
         input,
         blockedPath,
+        permissionSuggestions,
       );
     } catch (err) {
       debugLogger.error('DualOutput emitPermissionRequest error:', err);

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
@@ -559,6 +559,50 @@ describe('PermissionController', () => {
     );
   });
 
+  it('includes teammate Plan shell warnings in permission suggestions', async () => {
+    const controller = new PermissionController(
+      createContext(120_000),
+      createRegistry(),
+      'PermissionController',
+    );
+    const send = vi.spyOn(controller, 'sendControlRequest').mockResolvedValue({
+      subtype: 'success',
+      request_id: 'teammate-warning',
+      response: { behavior: 'deny' },
+    });
+
+    await controller.handleTeammateApproval({
+      teammateName: 'worker',
+      toolName: 'run_shell_command',
+      toolInput: { command: "python -c 'print(1)'" },
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Confirm shell',
+        command: "python -c 'print(1)'",
+        rootCommand: 'python',
+        hideAlwaysAllow: true,
+        warnings: ['Exact one-off approval required'],
+      },
+      respond: vi.fn().mockResolvedValue(undefined),
+      timestamp: 790,
+    });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permission_suggestions: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'allow',
+            description: expect.stringContaining(
+              'Exact one-off approval required',
+            ),
+          }),
+        ]),
+      }),
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
   it('omits modify suggestions when edit confirmation hides modify actions', () => {
     const controller = new PermissionController(
       createContext(),

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -35,9 +35,7 @@ import type {
   PermissionSuggestion,
 } from '../../types.js';
 import { BaseController } from './baseController.js';
-
-// Import ToolCallConfirmationDetails types for type alignment
-type ToolConfirmationType = 'edit' | 'exec' | 'mcp' | 'info' | 'plan';
+import { buildPermissionSuggestions } from '../../../utils/permission-suggestions.js';
 
 const DEFAULT_CAN_USE_TOOL_TIMEOUT_MS = 60_000;
 
@@ -251,117 +249,7 @@ export class PermissionController extends BaseController {
   buildPermissionSuggestions(
     confirmationDetails: unknown,
   ): PermissionSuggestion[] | null {
-    if (
-      !confirmationDetails ||
-      typeof confirmationDetails !== 'object' ||
-      !('type' in confirmationDetails)
-    ) {
-      return null;
-    }
-
-    const details = confirmationDetails as Record<string, unknown>;
-    const type = String(details['type'] ?? '');
-    const title =
-      typeof details['title'] === 'string' ? details['title'] : undefined;
-
-    // Ensure type matches ToolCallConfirmationDetails union
-    const confirmationType = type as ToolConfirmationType;
-
-    switch (confirmationType) {
-      case 'exec': // ToolExecuteConfirmationDetails
-        return [
-          {
-            type: 'allow',
-            label: 'Allow Command',
-            description: `Execute: ${details['command']}`,
-          },
-          {
-            type: 'deny',
-            label: 'Deny',
-            description: 'Block this command execution',
-          },
-        ];
-
-      case 'edit': // ToolEditConfirmationDetails
-        return [
-          {
-            type: 'allow',
-            label: 'Allow Edit',
-            description: `Edit file: ${details['fileName']}`,
-          },
-          {
-            type: 'deny',
-            label: 'Deny',
-            description: 'Block this file edit',
-          },
-          ...(details['hideModify'] === true
-            ? []
-            : [
-                {
-                  type: 'modify' as const,
-                  label: 'Review Changes',
-                  description: 'Review the proposed changes before applying',
-                },
-              ]),
-        ];
-
-      case 'plan': // ToolPlanConfirmationDetails
-        return [
-          {
-            type: 'allow',
-            label: 'Approve Plan',
-            description: title || 'Execute the proposed plan',
-          },
-          {
-            type: 'deny',
-            label: 'Reject Plan',
-            description: 'Do not execute this plan',
-          },
-        ];
-
-      case 'mcp': // ToolMcpConfirmationDetails
-        return [
-          {
-            type: 'allow',
-            label: 'Allow MCP Call',
-            description: `${details['serverName']}: ${details['toolName']}`,
-          },
-          {
-            type: 'deny',
-            label: 'Deny',
-            description: 'Block this MCP server call',
-          },
-        ];
-
-      case 'info': // ToolInfoConfirmationDetails
-        return [
-          {
-            type: 'allow',
-            label: 'Allow Info Request',
-            description: title || 'Allow information request',
-          },
-          {
-            type: 'deny',
-            label: 'Deny',
-            description: 'Block this information request',
-          },
-        ];
-
-      default:
-        // Fallback for unknown types
-        return [
-          {
-            type: 'allow',
-            label: 'Allow',
-            description: title || `Allow ${type} operation`,
-          },
-          {
-            type: 'deny',
-            label: 'Deny',
-            description: `Block ${type} operation`,
-          },
-        ];
-    }
+    return buildPermissionSuggestions(confirmationDetails);
   }
 
   /**
@@ -462,7 +350,9 @@ export class PermissionController extends BaseController {
           tool_name: event.toolName,
           tool_use_id: callId,
           input: event.toolInput,
-          permission_suggestions: [],
+          permission_suggestions: buildPermissionSuggestions(
+            event.confirmationDetails,
+          ),
           blocked_path: null,
         } as CLIControlPermissionRequest,
         undefined,

--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -34,6 +34,7 @@ import type {
   ContentBlock,
   ControlMessage,
   ExtendedUsage,
+  PermissionSuggestion,
   TextBlock,
   ThinkingBlock,
   ToolResultBlock,
@@ -1101,6 +1102,7 @@ export abstract class BaseJsonOutputAdapter {
     toolUseId: string,
     input: unknown,
     blockedPath: string | null = null,
+    permissionSuggestions: PermissionSuggestion[] | null = null,
   ): void {
     const message: ControlMessage = {
       type: 'control_request',
@@ -1110,7 +1112,7 @@ export abstract class BaseJsonOutputAdapter {
         tool_name: toolName,
         tool_use_id: toolUseId,
         input,
-        permission_suggestions: null,
+        permission_suggestions: permissionSuggestions,
         blocked_path: blockedPath,
       },
     };

--- a/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.dualOutput.test.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonOutputAdapter.dualOutput.test.ts
@@ -98,6 +98,30 @@ describe('StreamJsonOutputAdapter — dual-output extensions', () => {
       });
     });
 
+    it('emits supplied warning-aware permission suggestions', () => {
+      const adapter = new StreamJsonOutputAdapter(mockConfig, false);
+      stdoutWriteSpy.mockClear();
+      const suggestions = [
+        {
+          type: 'allow' as const,
+          label: 'Allow Command',
+          description: 'Exact one-off approval required',
+        },
+      ];
+
+      adapter.emitPermissionRequest(
+        'req-warning',
+        'run_shell_command',
+        'tool-warning',
+        { command: "python -c 'print(1)'" },
+        null,
+        suggestions,
+      );
+
+      const parsed = JSON.parse(stdoutWriteSpy.mock.calls[0][0] as string);
+      expect(parsed.request.permission_suggestions).toEqual(suggestions);
+    });
+
     it('emits a control_response with the supplied request_id and allowed flag', () => {
       const adapter = new StreamJsonOutputAdapter(mockConfig, false);
       stdoutWriteSpy.mockClear();

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -30,8 +30,11 @@ import {
   AUTONOMOUS_SENTINEL_DYNAMIC,
   LOOP_SENTINEL_CRON,
   LOOP_SENTINEL_DYNAMIC,
+  TeamEventType,
+  ToolConfirmationOutcome,
 } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
+import { EventEmitter } from 'node:events';
 import {
   runNonInteractive,
   skipHeadlessLoopSentinel,
@@ -447,6 +450,67 @@ describe('runNonInteractive', () => {
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('Hello World\n');
     expect(mockShutdownTelemetry).toHaveBeenCalled();
+  });
+
+  it('does not let headless YOLO bypass explicit teammate approval', async () => {
+    setupMetricsMock();
+    const teamEvents = new EventEmitter();
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const teamManager = {
+      setLeaderMessageCallback: vi.fn(),
+      getEventEmitter: () => teamEvents,
+      hasActiveTeammates: () => false,
+      drainLeaderInbox: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(mockConfig.getApprovalMode).mockReturnValue(ApprovalMode.YOLO);
+    vi.mocked(mockConfig.getTeamManager).mockReturnValue(teamManager as never);
+    let emittedApproval = false;
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+        if (!emittedApproval) {
+          emittedApproval = true;
+          teamEvents.emit(TeamEventType.TEAMMATE_APPROVAL_REQUEST, {
+            teammateName: 'worker',
+            toolName: 'run_shell_command',
+            toolInput: { command: "python -c 'print(1)'" },
+            confirmationDetails: {
+              type: 'info',
+              title: 'Permission rule requires confirmation',
+              prompt: 'Allow this operation?',
+              hideAlwaysAllow: true,
+            },
+            respond,
+            timestamp: Date.now(),
+          });
+        }
+        yield {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 0 },
+          },
+        };
+      },
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Test input',
+      'prompt-exact-teammate',
+    );
+
+    await vi.waitFor(() =>
+      expect(respond).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel),
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'requires an explicit interactive approval surface',
+      ),
+    );
+    expect(processStderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('exact-invocation'),
+    );
   });
 
   describe('continueInterrupted', () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -513,6 +513,72 @@ describe('runNonInteractive', () => {
     );
   });
 
+  it('describes the active mode when explicit teammate approval cannot be shown', async () => {
+    setupMetricsMock();
+    const teamEvents = new EventEmitter();
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const teamManager = {
+      setLeaderMessageCallback: vi.fn(),
+      getEventEmitter: () => teamEvents,
+      hasActiveTeammates: () => false,
+      drainLeaderInbox: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(mockConfig.getApprovalMode).mockReturnValue(ApprovalMode.DEFAULT);
+    vi.mocked(mockConfig.getTeamManager).mockReturnValue(teamManager as never);
+    let emittedApproval = false;
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      async function* (): AsyncGenerator<ServerGeminiStreamEvent> {
+        if (!emittedApproval) {
+          emittedApproval = true;
+          teamEvents.emit(TeamEventType.TEAMMATE_APPROVAL_REQUEST, {
+            teammateName: 'worker',
+            toolName: 'run_shell_command',
+            toolInput: { command: "python -c 'print(1)'" },
+            confirmationDetails: {
+              type: 'info',
+              title: 'Permission rule requires confirmation',
+              prompt: 'Allow this operation?',
+              hideAlwaysAllow: true,
+            },
+            respond,
+            timestamp: Date.now(),
+          });
+        }
+        yield {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 0 },
+          },
+        };
+      },
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Test input',
+      'prompt-exact-teammate-default',
+    );
+
+    await vi.waitFor(() =>
+      expect(respond).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel),
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `current approval mode (${ApprovalMode.DEFAULT})`,
+      ),
+    );
+    expect(processStderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Use --input-format stream-json --output-format stream-json',
+      ),
+    );
+    expect(processStderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('cannot be bypassed by YOLO mode'),
+    );
+  });
+
   describe('continueInterrupted', () => {
     it('re-submits an orphaned trailing user prompt with Retry semantics', async () => {
       setupMetricsMock();

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -584,7 +584,9 @@ export async function runNonInteractive(
             // Surface a clear reason on stderr — otherwise the
             // failure looks like the teammate gave up for no reason.
             const reason = requiresExplicitHostApproval
-              ? `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": this request requires an explicit interactive approval surface and cannot be bypassed by YOLO mode.`
+              ? mode === ApprovalMode.YOLO
+                ? `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": this request requires an explicit interactive approval surface and cannot be bypassed by YOLO mode.`
+                : `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": this request requires an explicit interactive approval surface, which is unavailable in non-stream-json mode with the current approval mode (${mode}). Use --input-format stream-json --output-format stream-json to review it.`
               : `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": current approval mode (${mode}) cannot prompt in non-stream-json mode. Use --yolo or stream-json to allow teammate tool calls.`;
             process.stderr.write(`[team] ${reason}\n`);
             // Also surface to the leader's LLM, otherwise it just

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -561,7 +561,13 @@ export async function runNonInteractive(
           // hangs until its 600s stall timeout fires.
           approvalListener = (event) => {
             const mode = config.getApprovalMode();
-            if (mode === ApprovalMode.YOLO) {
+            const confirmationDetails = event.confirmationDetails;
+            const requiresExplicitHostApproval =
+              confirmationDetails?.type !== 'plan' &&
+              confirmationDetails !== undefined &&
+              'hideAlwaysAllow' in confirmationDetails &&
+              confirmationDetails.hideAlwaysAllow === true;
+            if (mode === ApprovalMode.YOLO && !requiresExplicitHostApproval) {
               // `respond` may reject if the teammate terminates between the
               // approval request and our response — catch it so it doesn't
               // become an unhandledRejection that can crash the process.
@@ -577,11 +583,9 @@ export async function runNonInteractive(
             }
             // Surface a clear reason on stderr — otherwise the
             // failure looks like the teammate gave up for no reason.
-            const reason =
-              `Auto-cancelling tool ${event.toolName} requested by ` +
-              `teammate "${event.teammateName}": current approval mode ` +
-              `(${mode}) cannot prompt in non-stream-json mode. ` +
-              `Use --yolo or stream-json to allow teammate tool calls.`;
+            const reason = requiresExplicitHostApproval
+              ? `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": this request requires an explicit interactive approval surface and cannot be bypassed by YOLO mode.`
+              : `Auto-cancelling tool ${event.toolName} requested by teammate "${event.teammateName}": current approval mode (${mode}) cannot prompt in non-stream-json mode. Use --yolo or stream-json to allow teammate tool calls.`;
             process.stderr.write(`[team] ${reason}\n`);
             // Also surface to the leader's LLM, otherwise it just
             // sees the teammate fail without any signal that an

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -217,6 +217,7 @@ import {
 import { getLiveAgentPanelLayoutKey } from './components/background-view/liveAgentPanelVisibility.js';
 import { t } from '../i18n/index.js';
 import { TUI_CHAT_RECORDING_FAILURE_MESSAGE } from '../utils/chat-recording-failure.js';
+import { buildPermissionSuggestions } from '../utils/permission-suggestions.js';
 import { useWelcomeBack } from './hooks/useWelcomeBack.js';
 import { useDialogClose } from './hooks/useDialogClose.js';
 import { useInitializationAuthError } from './hooks/useInitializationAuthError.js';
@@ -2075,6 +2076,8 @@ export const AppContainer = (props: AppContainerProps) => {
           tc.request.name,
           tc.request.callId,
           tc.request.args,
+          null,
+          buildPermissionSuggestions(tc.confirmationDetails),
         );
       }
     }

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -628,6 +628,31 @@ describe('ToolConfirmationMessage', () => {
       expect(frame).toContain('No');
     });
 
+    it('keeps the diff placeholder visible without warnings on one-line bodies', () => {
+      const availableTerminalHeight = 8;
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            fileDiff: '@@ -1 +1 @@\n-a\n+b',
+            hideAlwaysAllow: true,
+            hideModify: true,
+          }}
+          config={mockConfig}
+          availableTerminalHeight={availableTerminalHeight}
+          contentWidth={50}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('diff hidden');
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+    });
+
     it('keeps compact edit warnings and diff within the available height', () => {
       const availableTerminalHeight = 9;
       const { lastFrame } = renderWithProviders(

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EOL } from 'node:os';
 import { promises as fsp } from 'node:fs';
+import { Box } from 'ink';
 
 // Capture launches of the external editor so the full-plan viewer (#7001)
 // can be asserted without spawning a real editor process.
@@ -22,6 +23,7 @@ import type {
   ToolCallConfirmationDetails,
   Config,
 } from '@qwen-code/qwen-code-core';
+import { IdeClient, ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import { renderWithProviders } from '../../../test-utils/render.js';
 import type { LoadedSettings } from '../../../config/settings.js';
 
@@ -476,6 +478,252 @@ describe('ToolConfirmationMessage', () => {
       );
 
       expect(lastFrame()).not.toContain('Modify with external editor');
+    });
+
+    it('renders edit warnings and honors hideAlwaysAllow on small terminals', () => {
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getIdeMode: () => false,
+      } as unknown as Config;
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            hideAlwaysAllow: true,
+            warnings: [
+              'Unknown shell safety',
+              'Exact shell command: sed -i s/a/b/ test.txt',
+            ],
+          }}
+          config={mockConfig}
+          availableTerminalHeight={10}
+          contentWidth={50}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Unknown shell safety');
+      expect(frame).toContain('Exact shell command');
+      expect(frame).toContain('Yes, allow once');
+      expect(frame).not.toContain('Yes, allow always');
+    });
+
+    it('budgets edit warnings using their rendered inner width', () => {
+      const availableTerminalHeight = 11;
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            fileDiff: '@@ -1 +1 @@\n-a\n+b',
+            hideAlwaysAllow: true,
+            hideModify: true,
+            warnings: ['x'.repeat(44)],
+          }}
+          config={mockConfig}
+          availableTerminalHeight={availableTerminalHeight}
+          contentWidth={50}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('x'.repeat(44));
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+    });
+
+    it('keeps a multiline exact command visible within the body budget', () => {
+      const availableTerminalHeight = 11;
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            fileDiff: '@@ -1 +1 @@\n-a\n+b',
+            hideAlwaysAllow: true,
+            hideModify: true,
+            warnings: [
+              'Plan mode could not determine whether this command is read-only.',
+              'Exact shell command: `printf a\nprintf b`',
+            ],
+          }}
+          config={mockConfig}
+          availableTerminalHeight={availableTerminalHeight}
+          contentWidth={50}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('Plan mode could not determine');
+      expect(frame).toContain('Exact shell command');
+      expect(frame).toContain('printf a ↵');
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+    });
+
+    it('budgets compact edit warnings at the wrapping boundary', () => {
+      const availableTerminalHeight = 9;
+      const { lastFrame } = renderWithProviders(
+        <Box width={50}>
+          <ToolConfirmationMessage
+            confirmationDetails={{
+              ...editConfirmationDetails,
+              fileDiff: '@@ -1 +1 @@\n-a\n+b',
+              hideAlwaysAllow: true,
+              hideModify: true,
+              warnings: ['x'.repeat(46), 'y'.repeat(46)],
+            }}
+            config={mockConfig}
+            availableTerminalHeight={availableTerminalHeight}
+            contentWidth={50}
+            compactMode={true}
+          />
+        </Box>,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('x'.repeat(46));
+      expect(frame).toContain('y'.repeat(46));
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+    });
+
+    it('keeps one-line compact bodies within the terminal height', () => {
+      const availableTerminalHeight = 5;
+      const { lastFrame } = renderWithProviders(
+        <Box width={50}>
+          <ToolConfirmationMessage
+            confirmationDetails={{
+              ...editConfirmationDetails,
+              fileDiff: '@@ -1 +1 @@\n-a\n+b',
+              hideAlwaysAllow: true,
+              hideModify: true,
+              warnings: [
+                'Plan mode could not determine whether this command is read-only.',
+                'Exact shell command: `printf a\nprintf b`',
+              ],
+            }}
+            config={mockConfig}
+            availableTerminalHeight={availableTerminalHeight}
+            contentWidth={50}
+            compactMode={true}
+          />
+        </Box>,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('Exact shell command');
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+      expect(frame).toContain('No');
+    });
+
+    it('keeps compact edit warnings and diff within the available height', () => {
+      const availableTerminalHeight = 9;
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            fileDiff:
+              '@@ -1,3 +1,3 @@\n-old one\n-old two\n+new one\n+new two\n context',
+            hideAlwaysAllow: true,
+            hideModify: true,
+            warnings: [
+              'Plan mode could not determine whether this shell command is read-only. Approval applies only to this exact invocation once.',
+              `Exact shell command: \`python -c "${"open('result.txt', 'a').write('changed');".repeat(12)}"\``,
+            ],
+          }}
+          config={mockConfig}
+          availableTerminalHeight={availableTerminalHeight}
+          contentWidth={50}
+          compactMode={true}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame.split(EOL).length).toBeLessThanOrEqual(
+        availableTerminalHeight,
+      );
+      expect(frame).toContain('Plan mode could not determine');
+      expect(frame).toContain('Exact shell command');
+      expect(frame).toContain('lines hidden');
+      expect(frame).toContain('Apply this change?');
+      expect(frame).toContain('Yes, allow once');
+      expect(frame).toContain('No');
+    });
+
+    it('resolves ordinary IDE edits but skips confirmations that have no IDE diff', async () => {
+      const resolveDiffFromCli = vi.fn().mockResolvedValue(undefined);
+      const isDiffingEnabled = vi.fn().mockReturnValue(true);
+      const getInstanceSpy = vi
+        .spyOn(IdeClient, 'getInstance')
+        .mockResolvedValue({
+          isDiffingEnabled,
+          resolveDiffFromCli,
+        } as unknown as IdeClient);
+      const ideConfig = {
+        isTrustedFolder: () => true,
+        getIdeMode: () => true,
+      } as unknown as Config;
+
+      const ordinaryOnConfirm = vi.fn().mockResolvedValue(undefined);
+      const ordinary = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            onConfirm: ordinaryOnConfirm,
+          }}
+          config={ideConfig}
+          availableTerminalHeight={30}
+          contentWidth={80}
+        />,
+      );
+      await vi.waitFor(() => expect(isDiffingEnabled).toHaveBeenCalled());
+      ordinary.stdin.write('\r');
+      await vi.waitFor(() =>
+        expect(resolveDiffFromCli).toHaveBeenCalledWith(
+          '/test.txt',
+          'accepted',
+        ),
+      );
+      ordinary.unmount();
+
+      resolveDiffFromCli.mockClear();
+      isDiffingEnabled.mockClear();
+      const skippedOnConfirm = vi.fn().mockResolvedValue(undefined);
+      const skipped = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={{
+            ...editConfirmationDetails,
+            onConfirm: skippedOnConfirm,
+            skipIdeDiff: true,
+          }}
+          config={ideConfig}
+          availableTerminalHeight={30}
+          contentWidth={80}
+        />,
+      );
+      await vi.waitFor(() => expect(isDiffingEnabled).toHaveBeenCalled());
+      skipped.stdin.write('\r');
+      await vi.waitFor(() =>
+        expect(skippedOnConfirm).toHaveBeenCalledWith(
+          ToolConfirmationOutcome.ProceedOnce,
+        ),
+      );
+      expect(resolveDiffFromCli).not.toHaveBeenCalled();
+
+      skipped.unmount();
+      getInstanceSpy.mockRestore();
     });
   });
 

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -274,6 +274,7 @@ export const ToolConfirmationMessage: React.FC<
     }
 
     const constrainWarnings =
+      warnings.length > 0 &&
       bodyHeight !== undefined &&
       warningsHeight(warnings) + MINIMUM_MAX_HEIGHT > bodyHeight;
     let warningMaxHeight: number | undefined;

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -10,6 +10,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { Box, Text } from 'ink';
+import wrapAnsi from 'wrap-ansi';
 import { DiffRenderer } from './DiffRenderer.js';
 import { RenderInline } from '../../utils/InlineMarkdownRenderer.js';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
@@ -27,7 +28,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import type { RadioSelectItem } from '../shared/RadioButtonSelect.js';
 import { RadioButtonSelect } from '../shared/RadioButtonSelect.js';
-import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { MaxSizedBox, MINIMUM_MAX_HEIGHT } from '../shared/MaxSizedBox.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { useLaunchEditor } from '../../hooks/useLaunchEditor.js';
 import { useSettings } from '../../contexts/SettingsContext.js';
@@ -93,7 +94,10 @@ export const ToolConfirmationMessage: React.FC<
     // with ProceedOnce, racing with the intended CLI outcome.
     onConfirm(outcome);
 
-    if (confirmationDetails.type === 'edit') {
+    if (
+      confirmationDetails.type === 'edit' &&
+      !confirmationDetails.skipIdeDiff
+    ) {
       if (config.getIdeMode() && isDiffingEnabled) {
         const cliOutcome =
           outcome === ToolConfirmationOutcome.Cancel ? 'rejected' : 'accepted';
@@ -189,6 +193,27 @@ export const ToolConfirmationMessage: React.FC<
     return Math.max(availableTerminalHeight - surroundingElementsHeight, 1);
   }
 
+  // The warning box uses marginLeft={1} and paddingX={1}. Regular mode also
+  // renders inside the outer box's padding={1}.
+  const warningContentWidth = Math.max(
+    contentWidth - 3 - (compactMode ? 0 : 2),
+    1,
+  );
+
+  function warningsHeight(warnings: string[]): number {
+    if (warnings.length === 0) return 0;
+    const wrappedRows = warnings.reduce(
+      (sum, warning) =>
+        sum +
+        wrapAnsi(`⚠ ${warning}`, warningContentWidth, {
+          trim: false,
+          hard: true,
+        }).split('\n').length,
+      0,
+    );
+    return wrappedRows + 1;
+  }
+
   if (confirmationDetails.type === 'edit') {
     if (confirmationDetails.isModifying) {
       return (
@@ -214,7 +239,7 @@ export const ToolConfirmationMessage: React.FC<
       value: ToolConfirmationOutcome.ProceedOnce,
       key: 'Yes, allow once',
     });
-    if (isTrustedFolder) {
+    if (isTrustedFolder && !confirmationDetails.hideAlwaysAllow) {
       options.push({
         label: t('Yes, allow always'),
         value: ToolConfirmationOutcome.ProceedAlways,
@@ -239,14 +264,94 @@ export const ToolConfirmationMessage: React.FC<
       key: 'No, suggest changes (esc)',
     });
 
+    const warnings = confirmationDetails.warnings ?? [];
+    let bodyHeight = availableBodyContentHeight();
+    if (compactMode) {
+      bodyHeight = Math.min(
+        bodyHeight ?? COMPACT_BODY_MAX_LINES,
+        COMPACT_BODY_MAX_LINES,
+      );
+    }
+
+    const constrainWarnings =
+      bodyHeight !== undefined &&
+      warningsHeight(warnings) + MINIMUM_MAX_HEIGHT > bodyHeight;
+    let warningMaxHeight: number | undefined;
+    let warningMarginBottom = warnings.length > 0 ? 1 : 0;
+    let diffHeight = bodyHeight;
+    if (constrainWarnings && bodyHeight !== undefined) {
+      const desiredWarningHeight = Math.max(
+        warnings.length,
+        MINIMUM_MAX_HEIGHT,
+      );
+      warningMarginBottom =
+        bodyHeight >= desiredWarningHeight + MINIMUM_MAX_HEIGHT + 1 ? 1 : 0;
+      warningMaxHeight = Math.min(
+        desiredWarningHeight,
+        Math.max(
+          bodyHeight - MINIMUM_MAX_HEIGHT - warningMarginBottom,
+          MINIMUM_MAX_HEIGHT,
+        ),
+        bodyHeight,
+      );
+      diffHeight = bodyHeight - warningMaxHeight - warningMarginBottom;
+    } else if (diffHeight !== undefined) {
+      diffHeight = Math.max(diffHeight - warningsHeight(warnings), 1);
+    }
+
+    const renderedDiff =
+      diffHeight === undefined || diffHeight >= MINIMUM_MAX_HEIGHT ? (
+        <DiffRenderer
+          diffContent={confirmationDetails.fileDiff}
+          filename={confirmationDetails.fileName}
+          availableTerminalHeight={diffHeight}
+          contentWidth={contentWidth}
+          settings={settings}
+        />
+      ) : diffHeight === 1 ? (
+        <Text color={theme.text.secondary} wrap="truncate">
+          ... diff hidden ...
+        </Text>
+      ) : null;
+
     bodyContent = (
-      <DiffRenderer
-        diffContent={confirmationDetails.fileDiff}
-        filename={confirmationDetails.fileName}
-        availableTerminalHeight={availableBodyContentHeight()}
-        contentWidth={contentWidth}
-        settings={settings}
-      />
+      <Box flexDirection="column">
+        {warnings.length > 0 ? (
+          <Box
+            flexDirection="column"
+            paddingX={1}
+            marginLeft={1}
+            marginBottom={warningMarginBottom}
+          >
+            {constrainWarnings && warningMaxHeight === 1 ? (
+              <Text color={theme.status.warning} wrap="truncate">
+                ⚠ {warnings.at(-1)?.replace(/\r\n?|\n/g, ' ↵ ')}
+              </Text>
+            ) : constrainWarnings ? (
+              <MaxSizedBox
+                maxHeight={warningMaxHeight}
+                maxWidth={warningContentWidth}
+                overflowDirection="bottom"
+              >
+                {warnings.map((warning, idx) => (
+                  <Box key={idx}>
+                    <Text color={theme.status.warning} wrap="truncate">
+                      ⚠ {warning.replace(/\r\n?|\n/g, ' ↵ ')}
+                    </Text>
+                  </Box>
+                ))}
+              </MaxSizedBox>
+            ) : (
+              warnings.map((warning, idx) => (
+                <Text key={idx} color={theme.status.warning}>
+                  ⚠ {warning}
+                </Text>
+              ))
+            )}
+          </Box>
+        ) : null}
+        {renderedDiff}
+      </Box>
     );
   } else if (confirmationDetails.type === 'exec') {
     const executionProps =
@@ -297,23 +402,11 @@ export const ToolConfirmationMessage: React.FC<
     // list off-screen.
     //
     // Each warning may wrap across multiple visual rows on a narrow
-    // terminal. Account for that by computing `ceil(rendered_len /
-    // contentWidth)` per warning (rendered length includes the leading
-    // `⚠ ` glyph + space, so add 2). Falling back to a 1-row estimate
-    // when contentWidth is non-positive keeps the math defined for
-    // pathological inputs.
-    const warningPrefixLen = 2; // "⚠ "
-    const safeWidth = Math.max(contentWidth, 1);
+    // terminal. Account for the warning container's effective content width
+    // and use the same wrapping semantics as Ink's Text renderer.
     const warnings = executionProps.warnings ?? [];
     const warningsCount = warnings.length;
-    const wrappedWarningRows = warnings.reduce(
-      (sum, w) =>
-        sum + Math.max(Math.ceil((w.length + warningPrefixLen) / safeWidth), 1),
-      0,
-    );
-    // wrapped rows + 1 line for the marginTop separator (only when at
-    // least one warning is present).
-    const warningsHeight = warningsCount > 0 ? wrappedWarningRows + 1 : 0;
+    const reservedWarningsHeight = warningsHeight(warnings);
 
     let bodyContentHeight = availableBodyContentHeight();
     if (bodyContentHeight !== undefined) {
@@ -328,8 +421,11 @@ export const ToolConfirmationMessage: React.FC<
     // Subtract the warnings footprint last so it applies in both the
     // normal-height and compact-cap paths. Floor at 1 so a long warning
     // list never zeroes out the command body.
-    if (bodyContentHeight !== undefined && warningsHeight > 0) {
-      bodyContentHeight = Math.max(bodyContentHeight - warningsHeight, 1);
+    if (bodyContentHeight !== undefined && reservedWarningsHeight > 0) {
+      bodyContentHeight = Math.max(
+        bodyContentHeight - reservedWarningsHeight,
+        1,
+      );
     }
     bodyContent = (
       <Box flexDirection="column">

--- a/packages/cli/src/utils/permission-suggestions.ts
+++ b/packages/cli/src/utils/permission-suggestions.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PermissionSuggestion } from '../nonInteractive/types.js';
+
+function withWarnings(
+  description: string,
+  details: Record<string, unknown>,
+): string {
+  const warnings = Array.isArray(details['warnings'])
+    ? details['warnings'].filter(
+        (warning): warning is string => typeof warning === 'string',
+      )
+    : [];
+  return warnings.length > 0
+    ? `${warnings.join('\n')}\n${description}`
+    : description;
+}
+
+export function buildPermissionSuggestions(
+  confirmationDetails: unknown,
+): PermissionSuggestion[] | null {
+  if (
+    !confirmationDetails ||
+    typeof confirmationDetails !== 'object' ||
+    !('type' in confirmationDetails)
+  ) {
+    return null;
+  }
+
+  const details = confirmationDetails as Record<string, unknown>;
+  const type = String(details['type'] ?? '');
+  const title =
+    typeof details['title'] === 'string' ? details['title'] : undefined;
+
+  switch (type) {
+    case 'exec':
+      return [
+        {
+          type: 'allow',
+          label: 'Allow Command',
+          description: withWarnings(`Execute: ${details['command']}`, details),
+        },
+        {
+          type: 'deny',
+          label: 'Deny',
+          description: 'Block this command execution',
+        },
+      ];
+    case 'edit':
+      return [
+        {
+          type: 'allow',
+          label: 'Allow Edit',
+          description: withWarnings(
+            `Edit file: ${details['fileName']}`,
+            details,
+          ),
+        },
+        {
+          type: 'deny',
+          label: 'Deny',
+          description: 'Block this file edit',
+        },
+        ...(details['hideModify'] === true
+          ? []
+          : [
+              {
+                type: 'modify' as const,
+                label: 'Review Changes',
+                description: 'Review the proposed changes before applying',
+              },
+            ]),
+      ];
+    case 'plan':
+      return [
+        {
+          type: 'allow',
+          label: 'Approve Plan',
+          description: title || 'Execute the proposed plan',
+        },
+        {
+          type: 'deny',
+          label: 'Reject Plan',
+          description: 'Do not execute this plan',
+        },
+      ];
+    case 'mcp':
+      return [
+        {
+          type: 'allow',
+          label: 'Allow MCP Call',
+          description: `${details['serverName']}: ${details['toolName']}`,
+        },
+        {
+          type: 'deny',
+          label: 'Deny',
+          description: 'Block this MCP server call',
+        },
+      ];
+    case 'info':
+      return [
+        {
+          type: 'allow',
+          label: 'Allow Info Request',
+          description: title || 'Allow information request',
+        },
+        {
+          type: 'deny',
+          label: 'Deny',
+          description: 'Block this information request',
+        },
+      ];
+    default:
+      return [
+        {
+          type: 'allow',
+          label: 'Allow',
+          description: title || `Allow ${type} operation`,
+        },
+        {
+          type: 'deny',
+          label: 'Deny',
+          description: `Block ${type} operation`,
+        },
+      ];
+  }
+}

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -2156,29 +2156,48 @@ describe('BackgroundTaskRegistry', () => {
       ToolConfirmationOutcome.ProceedAlwaysUser,
       ToolConfirmationOutcome.ProceedAlwaysServer,
       ToolConfirmationOutcome.ProceedAlwaysTool,
-    ])(
-      'downgrades persistent approval outcome %s to one-time approval',
-      async (outcome) => {
-        const respond = vi.fn(async () => {});
-        registry.register(makeRegistration(`bg-appr-${outcome}`));
-        registry.addPendingApproval(
-          `bg-appr-${outcome}`,
-          makeApproval('c1', respond),
-        );
+    ])('cancels unoffered persistent approval outcome %s', async (outcome) => {
+      const respond = vi.fn(async () => {});
+      registry.register(makeRegistration(`bg-appr-${outcome}`));
+      registry.addPendingApproval(
+        `bg-appr-${outcome}`,
+        makeApproval('c1', respond),
+      );
 
-        const resolved = await registry.resolvePendingApproval(
-          `bg-appr-${outcome}`,
-          'c1',
-          outcome,
-        );
+      const resolved = await registry.resolvePendingApproval(
+        `bg-appr-${outcome}`,
+        'c1',
+        outcome,
+      );
 
-        expect(resolved).toBe(true);
-        expect(respond).toHaveBeenCalledWith(
-          ToolConfirmationOutcome.ProceedOnce,
-          undefined,
-        );
-      },
-    );
+      expect(resolved).toBe(true);
+      expect(respond).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.Cancel,
+        undefined,
+      );
+    });
+
+    it('preserves the explicit plan ProceedAlways outcome', async () => {
+      const respond = vi.fn(async () => {});
+      registry.register(makeRegistration('bg-plan-always'));
+      registry.addPendingApproval('bg-plan-always', {
+        ...makeApproval('c1', respond),
+        confirmationDetails: {
+          type: 'plan',
+        } as BackgroundApproval['confirmationDetails'],
+      });
+
+      await registry.resolvePendingApproval(
+        'bg-plan-always',
+        'c1',
+        ToolConfirmationOutcome.ProceedAlways,
+      );
+
+      expect(respond).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.ProceedAlways,
+        undefined,
+      );
+    });
 
     it('returns false when resolving a non-parked call', async () => {
       registry.register(makeRegistration('bg-appr-5'));

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -51,6 +51,7 @@ export const BACKGROUND_AGENT_CONCURRENCY_ENV =
 
 function normalizeBackgroundApprovalOutcome(
   outcome: Parameters<BackgroundApproval['respond']>[0],
+  confirmationDetails: BackgroundApproval['confirmationDetails'],
 ): Parameters<BackgroundApproval['respond']>[0] {
   if (
     outcome === ToolConfirmationOutcome.ProceedAlways ||
@@ -59,7 +60,13 @@ function normalizeBackgroundApprovalOutcome(
     outcome === ToolConfirmationOutcome.ProceedAlwaysServer ||
     outcome === ToolConfirmationOutcome.ProceedAlwaysTool
   ) {
-    return ToolConfirmationOutcome.ProceedOnce;
+    if (
+      confirmationDetails.type === 'plan' &&
+      outcome === ToolConfirmationOutcome.ProceedAlways
+    ) {
+      return outcome;
+    }
+    return ToolConfirmationOutcome.Cancel;
   }
   return outcome;
 }
@@ -955,9 +962,13 @@ export class BackgroundTaskRegistry {
     );
     this.emitApprovalChange(entry);
     try {
+      const normalizedOutcome = normalizeBackgroundApprovalOutcome(
+        outcome,
+        approval.confirmationDetails,
+      );
       await approval.respond(
-        normalizeBackgroundApprovalOutcome(outcome),
-        payload,
+        normalizedOutcome,
+        normalizedOutcome === outcome ? payload : undefined,
       );
     } catch (error) {
       debugLogger.error(

--- a/packages/core/src/agents/runtime/agent-events.ts
+++ b/packages/core/src/agents/runtime/agent-events.ts
@@ -22,6 +22,13 @@ import type {
 import type { Part, GenerateContentResponseUsageMetadata } from '@google/genai';
 import type { AgentStatus } from './agent-types.js';
 
+type WithoutConfirmationCallback<T> = T extends unknown
+  ? Omit<T, 'onConfirm'>
+  : never;
+
+export type AgentConfirmationDetails =
+  WithoutConfirmationCallback<ToolCallConfirmationDetails>;
+
 // ─── Event Types ────────────────────────────────────────────
 
 export type AgentEvent =
@@ -159,9 +166,7 @@ export interface AgentApprovalRequestEvent {
    * `command`) which differs from the raw tool arguments.
    */
   args: Record<string, unknown>;
-  confirmationDetails: Omit<ToolCallConfirmationDetails, 'onConfirm'> & {
-    type: ToolCallConfirmationDetails['type'];
-  };
+  confirmationDetails: AgentConfirmationDetails;
   respond: (
     outcome: ToolConfirmationOutcome,
     payload?: Parameters<ToolCallConfirmationDetails['onConfirm']>[1],

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -1559,6 +1559,7 @@ export class TeamManager {
       // fileDiff}`), which doesn't match what permission policies
       // expect to see (e.g. `{file_path, content}`).
       toolInput: event.args ?? {},
+      confirmationDetails: event.confirmationDetails,
       respond: event.respond,
       timestamp: Date.now(),
     };

--- a/packages/core/src/agents/team/team-events.ts
+++ b/packages/core/src/agents/team/team-events.ts
@@ -12,6 +12,7 @@
  */
 
 import { EventEmitter } from 'events';
+import type { AgentApprovalRequestEvent } from '../runtime/agent-events.js';
 import type { AgentStatus } from '../runtime/agent-types.js';
 import type {
   ToolConfirmationOutcome,
@@ -100,6 +101,8 @@ export interface TeammateApprovalRequestEvent {
   toolName: string;
   /** Tool input parameters (for display). */
   toolInput: Record<string, unknown>;
+  /** Renderable confirmation details without the runtime-owned callback. */
+  confirmationDetails?: AgentApprovalRequestEvent['confirmationDetails'];
   /** Callback to resolve the approval. */
   respond: (
     outcome: ToolConfirmationOutcome,

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1006,7 +1006,7 @@ describe('CoreToolScheduler', () => {
     );
 
     expect(siblingWouldOtherwiseAllow).toBe(true);
-    expect(siblingPermission).toHaveBeenCalledTimes(2);
+    expect(siblingPermission).toHaveBeenCalledOnce();
     const latestCalls = onToolCallsUpdate.mock.calls.at(-1)?.[0] as ToolCall[];
     expect(
       latestCalls.find(
@@ -7581,6 +7581,674 @@ describe('CoreToolScheduler plan mode with ask_user_question', () => {
     const completedCalls = onAllToolCallsComplete.mock
       .calls[0][0] as ToolCall[];
     expect(completedCalls[0].status).toBe('cancelled');
+  });
+});
+
+describe('CoreToolScheduler Plan shell routing', () => {
+  const unknownWarning =
+    'Plan mode could not determine whether this shell command is read-only. Approval applies only to this exact invocation once; it may modify system state, and Plan mode will remain active.';
+
+  function buildPlanShellScheduler(options: {
+    tools: MockTool[];
+    mode?: () => ApprovalMode;
+    revision?: () => number;
+    interactive?: boolean;
+    ideMode?: boolean;
+    permissionManager?: unknown;
+    messageBus?: MessageBus;
+    disableHooks?: boolean;
+    avoidPermissionPrompts?: boolean;
+    targetDir?: () => string;
+  }) {
+    const tools = new Map(options.tools.map((tool) => [tool.name, tool]));
+    const registry = {
+      getTool: (name: string) => tools.get(name),
+      ensureTool: async (name: string) => tools.get(name),
+      getToolByName: (name: string) => tools.get(name),
+      getFunctionDeclarations: () => [],
+      tools,
+      discovery: {},
+      registerTool: () => {},
+      getToolByDisplayName: (name: string) => tools.get(name),
+      getTools: () => [...tools.values()],
+      discoverTools: async () => {},
+      getAllTools: () => [...tools.values()],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+    const config = {
+      getSessionId: () => 'plan-shell-session',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: options.mode ?? (() => ApprovalMode.PLAN),
+      getApprovalModeRevision: options.revision ?? (() => 0),
+      getSdkMode: () => false,
+      getPermissionsAllow: () => [],
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: { getProjectTempDir: () => '/tmp' },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getToolRegistry: () => registry,
+      getPermissionManager: () => options.permissionManager,
+      getTargetDir: options.targetDir ?? (() => '/tmp'),
+      getConditionalRulesRegistry: () => undefined,
+      getSkillManager: () => undefined,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      isInteractive: () => options.interactive ?? true,
+      getIdeMode: () => options.ideMode ?? false,
+      getExperimentalZedIntegration: () => false,
+      getInputFormat: () => InputFormat.TEXT,
+      getChatRecordingService: () => undefined,
+      getMessageBus: () => options.messageBus,
+      getDisableAllHooks: () => options.disableHooks ?? true,
+      getShouldAvoidPermissionPrompts: () =>
+        options.avoidPermissionPrompts ?? false,
+      getOnPersistPermissionRule: () => undefined,
+    } as unknown as Config;
+
+    return {
+      scheduler: new CoreToolScheduler({
+        config,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+        getPreferredEditor: () => 'vscode',
+        onEditorClose: vi.fn(),
+      }),
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+    };
+  }
+
+  function request(
+    callId: string,
+    command: string,
+    name: string = ToolNames.SHELL,
+  ) {
+    return {
+      callId,
+      name,
+      args: { command },
+      isClientInitiated: false,
+      prompt_id: `prompt-${callId}`,
+    };
+  }
+
+  function shellTool(
+    options: {
+      name?: string;
+      permission?: PermissionDecision;
+      confirmation?: () => Promise<ToolCallConfirmationDetails>;
+      execute?: ReturnType<typeof vi.fn>;
+    } = {},
+  ) {
+    return new MockTool({
+      name: options.name ?? ToolNames.SHELL,
+      getDefaultPermission: async () => options.permission ?? 'allow',
+      getConfirmationDetails:
+        options.confirmation ??
+        (async () => ({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: 'shell command',
+          rootCommand: 'shell',
+          onConfirm: async () => undefined,
+        })),
+      execute:
+        options.execute ??
+        vi.fn().mockResolvedValue({
+          llmContent: 'ok',
+          returnDisplay: 'ok',
+        }),
+    });
+  }
+
+  it.each([
+    [ToolNames.SHELL, 'git status'],
+    [ToolNames.MONITOR, "/bin/bash -c 'git status &' ignored"],
+  ])('executes read-only %s calls without a prompt', async (name, command) => {
+    const getConfirmationDetails = vi.fn();
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          name,
+          confirmation: getConfirmationDetails,
+          execute,
+        }),
+      ],
+    });
+
+    await scheduler.schedule(
+      [request(`read-${name}`, command, name)],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(getConfirmationDetails).not.toHaveBeenCalled();
+  });
+
+  it('limits PM-confirmed read-only shell calls to exact one-off approval', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          permission: 'ask',
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: 'git status',
+            rootCommand: 'git',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+    });
+
+    await scheduler.schedule(
+      [request('read-ask', 'git status')],
+      new AbortController().signal,
+    );
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    expect(waiting.confirmationDetails).toMatchObject({
+      hideAlwaysAllow: true,
+    });
+
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+      { permissionRules: ['Bash(git status)'] },
+    );
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.ProceedOnce,
+      undefined,
+    );
+  });
+
+  it.each([ToolNames.SHELL, ToolNames.MONITOR])(
+    'blocks known writes for %s without requesting confirmation',
+    async (name) => {
+      const getConfirmationDetails = vi.fn();
+      const execute = vi.fn();
+      const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+        tools: [
+          shellTool({ name, confirmation: getConfirmationDetails, execute }),
+        ],
+      });
+
+      await scheduler.schedule(
+        [request(`write-${name}`, 'touch changed.txt', name)],
+        new AbortController().signal,
+      );
+      await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+      const completed = onAllToolCallsComplete.mock.calls[0][0] as ToolCall[];
+      expect(completed[0].status).toBe('error');
+      expect(JSON.stringify(completed[0])).toContain(
+        'classified as state-modifying',
+      );
+      expect(getConfirmationDetails).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it('forces unknown PM-allowed commands through exact one-off approval every time', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const tool = shellTool({
+      confirmation: async () => ({
+        type: 'exec',
+        title: 'Confirm shell',
+        command: "python -c 'print(1)'",
+        rootCommand: 'python',
+        onConfirm,
+      }),
+      execute,
+    });
+    const { scheduler, onAllToolCallsComplete, onToolCallsUpdate } =
+      buildPlanShellScheduler({ tools: [tool] });
+
+    await scheduler.schedule(
+      [request('unknown-1', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    const first = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    expect(first.confirmationDetails).toMatchObject({
+      hideAlwaysAllow: true,
+      warnings: [unknownWarning],
+    });
+    await first.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+      { permissionRules: ['Bash(python:*)'] },
+    );
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.ProceedOnce,
+      undefined,
+    );
+
+    onToolCallsUpdate.mockClear();
+    onAllToolCallsComplete.mockClear();
+    await scheduler.schedule(
+      [request('unknown-2', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    const second = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    expect(second.request.callId).toBe('unknown-2');
+    await second.confirmationDetails.onConfirm(ToolConfirmationOutcome.Cancel);
+  });
+
+  it('invalidates exact approval when ambient cwd moves while pending', async () => {
+    const rawCommand = "python -c 'print(1)'";
+    let targetDir = '/tmp/one';
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn();
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: rawCommand,
+            rootCommand: 'python',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+      targetDir: () => targetDir,
+    });
+    const shellRequest = request('ambient-cwd', rawCommand);
+
+    await scheduler.schedule([shellRequest], new AbortController().signal);
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    targetDir = '/tmp/two';
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.Cancel,
+      expect.objectContaining({ cancelMessage: expect.any(String) }),
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(shellRequest.args).toEqual({ command: rawCommand });
+  });
+
+  it('keeps the bound cwd after exact approval is consumed', async () => {
+    const rawCommand = "python -c 'print(1)'";
+    let targetDir = '/tmp/one';
+    const onConfirm = vi.fn().mockImplementation(async () => {
+      targetDir = '/tmp/two';
+    });
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: rawCommand,
+            rootCommand: 'python',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+      targetDir: () => targetDir,
+    });
+    const shellRequest = request('consumed-cwd', rawCommand);
+
+    await scheduler.schedule([shellRequest], new AbortController().signal);
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+    expect(execute).toHaveBeenCalledWith({
+      command: rawCommand,
+      directory: '/tmp/one',
+    });
+    expect(targetDir).toBe('/tmp/two');
+    expect(shellRequest.args).toEqual({ command: rawCommand });
+  });
+
+  it('atomically consumes only the first Plan shell response', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn();
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: "python -c 'print(1)'",
+            rootCommand: 'python',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+    });
+    await scheduler.schedule(
+      [request('racing', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+
+    await Promise.all([
+      waiting.confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.ProceedAlwaysProject,
+      ),
+      waiting.confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.ProceedOnce,
+      ),
+    ]);
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.Cancel,
+      expect.objectContaining({ cancelMessage: expect.any(String) }),
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-approve a Plan shell from a sibling Always decision', async () => {
+    const infoExecute = vi.fn().mockResolvedValue({
+      llmContent: 'info',
+      returnDisplay: 'info',
+    });
+    const shellExecute = vi.fn();
+    const infoTool = new MockTool({
+      name: ToolNames.WEB_FETCH,
+      getDefaultPermission: async () => 'ask',
+      getConfirmationDetails: async () => ({
+        type: 'info',
+        title: 'Confirm fetch',
+        prompt: 'Fetch docs?',
+        onConfirm: async () => undefined,
+      }),
+      execute: infoExecute,
+    });
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [infoTool, shellTool({ execute: shellExecute })],
+    });
+    await scheduler.schedule(
+      [
+        {
+          callId: 'sibling-info',
+          name: ToolNames.WEB_FETCH,
+          args: { url: 'https://example.com' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-sibling-info',
+        },
+        request('sibling-shell', "python -c 'print(1)'"),
+      ],
+      new AbortController().signal,
+    );
+    const waitingCalls = onToolCallsUpdate.mock.calls
+      .flatMap((call) => call[0] as ToolCall[])
+      .filter(
+        (call): call is WaitingToolCall =>
+          ['sibling-info', 'sibling-shell'].includes(call.request.callId) &&
+          call.status === 'awaiting_approval',
+      );
+    const infoWaiting = waitingCalls.find(
+      (call) => call.request.callId === 'sibling-info',
+    );
+    expect(infoWaiting).toBeDefined();
+    await infoWaiting!.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedAlwaysProject,
+    );
+
+    const latestShell = onToolCallsUpdate.mock.calls
+      .flatMap((call) => call[0] as ToolCall[])
+      .filter((call) => call.request.callId === 'sibling-shell')
+      .at(-1);
+    expect(latestShell?.status).toBe('awaiting_approval');
+    expect(shellExecute).not.toHaveBeenCalled();
+    if (latestShell?.status === 'awaiting_approval') {
+      await latestShell.confirmationDetails.onConfirm(
+        ToolConfirmationOutcome.Cancel,
+      );
+    }
+  });
+
+  it('invalidates approval after Plan mode exits and re-enters', async () => {
+    let mode = ApprovalMode.PLAN;
+    let revision = 1;
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn();
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: "python -c 'print(1)'",
+            rootCommand: 'python',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+      mode: () => mode,
+      revision: () => revision,
+    });
+    await scheduler.schedule(
+      [request('stale', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    mode = ApprovalMode.DEFAULT;
+    revision++;
+    mode = ApprovalMode.PLAN;
+    revision++;
+
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.Cancel,
+      expect.objectContaining({
+        cancelMessage: expect.stringContaining('no longer valid'),
+      }),
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for unknown commands without an approval host', async () => {
+    const execute = vi.fn();
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [shellTool({ execute })],
+      interactive: false,
+    });
+    await scheduler.schedule(
+      [request('headless', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(JSON.stringify(onAllToolCallsComplete.mock.calls[0][0])).toContain(
+      'no approval surface is available',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('keeps wrapped sed warnings and bypasses IDE auto-diff acceptance', async () => {
+    vi.mocked(IdeClient.getInstance).mockClear();
+    const rawCommand = "bash -c 'sed -i s/a/b/ file.txt'";
+    const { scheduler, onToolCallsUpdate } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'edit',
+            title: 'Confirm sed edit',
+            fileName: 'file.txt',
+            filePath: '/tmp/file.txt',
+            fileDiff: 'diff',
+            originalContent: 'a',
+            newContent: 'b',
+            onConfirm: async () => undefined,
+          }),
+        }),
+      ],
+      ideMode: true,
+    });
+    await scheduler.schedule(
+      [request('wrapped-sed', rawCommand)],
+      new AbortController().signal,
+    );
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+
+    expect(waiting.confirmationDetails).toMatchObject({
+      type: 'edit',
+      hideAlwaysAllow: true,
+      hideModify: true,
+      skipIdeDiff: true,
+      warnings: [unknownWarning, `Exact shell command: \`${rawCommand}\``],
+    });
+    expect(IdeClient.getInstance).not.toHaveBeenCalled();
+    await waiting.confirmationDetails.onConfirm(ToolConfirmationOutcome.Cancel);
+  });
+
+  it('rejects PermissionRequest hook parameter rewrites', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn();
+    const messageBus = {
+      request: vi.fn().mockResolvedValue({
+        type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+        correlationId: 'permission-hook',
+        success: true,
+        output: {
+          hookSpecificOutput: {
+            decision: {
+              behavior: 'allow',
+              updatedInput: { command: 'touch changed.txt' },
+            },
+          },
+        },
+      } satisfies HookExecutionResponse),
+    } as unknown as MessageBus;
+    const { scheduler, onAllToolCallsComplete } = buildPlanShellScheduler({
+      tools: [
+        shellTool({
+          confirmation: async () => ({
+            type: 'exec',
+            title: 'Confirm shell',
+            command: "python -c 'print(1)'",
+            rootCommand: 'python',
+            onConfirm,
+          }),
+          execute,
+        }),
+      ],
+      messageBus,
+      disableHooks: false,
+    });
+
+    await scheduler.schedule(
+      [request('hook-rewrite', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.Cancel,
+      expect.objectContaining({
+        cancelMessage: expect.stringContaining('exact invocation changed'),
+      }),
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('revalidates Plan shell context after a pending permission hook', async () => {
+    let revision = 1;
+    const execute = vi.fn();
+    const messageBus = {
+      request: vi.fn().mockImplementation(async () => {
+        revision++;
+        return {
+          type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+          correlationId: 'permission-hook-no-decision',
+          success: false,
+        } satisfies HookExecutionResponse;
+      }),
+    } as unknown as MessageBus;
+    const { scheduler, onAllToolCallsComplete, onToolCallsUpdate } =
+      buildPlanShellScheduler({
+        tools: [shellTool({ execute })],
+        revision: () => revision,
+        messageBus,
+        disableHooks: false,
+      });
+
+    await scheduler.schedule(
+      [request('hook-stale', "python -c 'print(1)'")],
+      new AbortController().signal,
+    );
+    await vi.waitFor(() => expect(onAllToolCallsComplete).toHaveBeenCalled());
+
+    expect(
+      onToolCallsUpdate.mock.calls
+        .flatMap((call) => call[0] as ToolCall[])
+        .some((call) => call.status === 'awaiting_approval'),
+    ).toBe(false);
+    expect(JSON.stringify(onAllToolCallsComplete.mock.calls[0][0])).toContain(
+      'no longer valid',
+    );
+    expect(execute).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -84,6 +84,12 @@ import {
   isAutoEditApproved,
 } from './permissionFlow.js';
 import {
+  decoratePlanModeShellConfirmation,
+  evaluatePlanModeShellPolicy,
+  validatePlanModeShellApproval,
+  validatePlanModeShellContext,
+} from './plan-mode-shell-policy.js';
+import {
   applyAutoModeDecision,
   evaluateAutoMode,
   getAutoModePermissionDeniedReason,
@@ -2312,7 +2318,7 @@ export class CoreToolScheduler {
           // =================================================================
 
           // ---- L3→L4: Shared permission flow ----
-          const toolParams = invocation.params as Record<string, unknown>;
+          let toolParams = invocation.params as Record<string, unknown>;
           const flowResult = await evaluatePermissionFlow(
             this.config,
             invocation,
@@ -2331,6 +2337,10 @@ export class CoreToolScheduler {
           // ---- L5: Final decision based on permission + ApprovalMode ----
           const approvalMode = this.config.getApprovalMode();
           const isPlanMode = approvalMode === ApprovalMode.PLAN;
+          const isPlanShellCall =
+            isPlanMode &&
+            (canonicalName === ToolNames.SHELL ||
+              canonicalName === ToolNames.MONITOR);
           const isExitPlanModeTool = canonicalName === ToolNames.EXIT_PLAN_MODE;
           const isEnterPlanModeTool =
             canonicalName === ToolNames.ENTER_PLAN_MODE;
@@ -2396,7 +2406,96 @@ export class CoreToolScheduler {
             continue;
           }
 
-          if (finalPermission === 'allow' && !forceAutoReviewForAllow) {
+          if (finalPermission === 'deny') {
+            // Hard deny: security violation or PM explicit deny
+            this.setStatusInternal(
+              reqInfo.callId,
+              'error',
+              createErrorResponse(
+                reqInfo,
+                new Error(denyMessage ?? `Tool "${reqInfo.name}" is denied.`),
+                ToolErrorType.EXECUTION_DENIED,
+              ),
+            );
+            setToolSpanFailure(
+              toolSpan,
+              TOOL_FAILURE_KIND_PERMISSION_DENIED,
+              TOOL_SPAN_STATUS_PERMISSION_DENIED,
+            );
+            this.finalizeToolSpan(reqInfo.callId);
+            continue;
+          }
+
+          let planShellAmbientWorkingDirectory: string | undefined;
+          if (isPlanShellCall) {
+            const directory = toolParams['directory'];
+            planShellAmbientWorkingDirectory =
+              typeof directory === 'string' && directory.length > 0
+                ? undefined
+                : this.config.getTargetDir();
+            invocation.params = {
+              ...structuredClone(invocation.params),
+              directory:
+                typeof directory === 'string' && directory.length > 0
+                  ? directory
+                  : planShellAmbientWorkingDirectory,
+            };
+            toolParams = invocation.params as Record<string, unknown>;
+          }
+
+          const planShellDecision = isPlanShellCall
+            ? await evaluatePlanModeShellPolicy({
+                config: this.config,
+                toolName: canonicalName,
+                requestArgs: reqInfo.args,
+                invocationParams: toolParams,
+                permissionContext: pmCtx,
+                ambientWorkingDirectory: planShellAmbientWorkingDirectory,
+                signal,
+              })
+            : ({ classification: 'not-applicable' } as const);
+          const rejectPlanShell = (message: string) => {
+            this.setStatusInternal(reqInfo.callId, 'error', {
+              ...createErrorResponse(
+                reqInfo,
+                new Error(message),
+                ToolErrorType.EXECUTION_DENIED,
+              ),
+              resultDisplay: message,
+            });
+            setToolSpanFailure(
+              toolSpan,
+              TOOL_FAILURE_KIND_PLAN_MODE_BLOCKED,
+              TOOL_SPAN_STATUS_PLAN_MODE_BLOCKED,
+            );
+            this.finalizeToolSpan(reqInfo.callId);
+          };
+
+          if (planShellDecision.classification !== 'not-applicable') {
+            const initialPlanShellError = await validatePlanModeShellContext({
+              config: this.config,
+              decision: planShellDecision,
+              requestArgs: reqInfo.args,
+              invocationParams: invocation.params as Record<string, unknown>,
+              signal,
+            });
+            if (initialPlanShellError) {
+              rejectPlanShell(initialPlanShellError);
+              continue;
+            }
+          }
+          if (planShellDecision.classification === 'write') {
+            rejectPlanShell(planShellDecision.writeBlockMessage);
+            continue;
+          }
+          const planShellRequiresConfirmation =
+            planShellDecision.classification === 'unknown';
+
+          if (
+            finalPermission === 'allow' &&
+            !forceAutoReviewForAllow &&
+            !planShellRequiresConfirmation
+          ) {
             // Auto-approve: tool is inherently safe (read-only) or PM allows.
             // In AUTO mode, also reset denialTracking so an L4 allow-rule
             // match counts as a successful call and clears any in-flight
@@ -2416,26 +2515,6 @@ export class CoreToolScheduler {
               ToolConfirmationOutcome.ProceedAlways,
             );
             this.setStatusInternal(reqInfo.callId, 'scheduled');
-            continue;
-          }
-
-          if (finalPermission === 'deny') {
-            // Hard deny: security violation or PM explicit deny
-            this.setStatusInternal(
-              reqInfo.callId,
-              'error',
-              createErrorResponse(
-                reqInfo,
-                new Error(denyMessage ?? `Tool "${reqInfo.name}" is denied.`),
-                ToolErrorType.EXECUTION_DENIED,
-              ),
-            );
-            setToolSpanFailure(
-              toolSpan,
-              TOOL_FAILURE_KIND_PERMISSION_DENIED,
-              TOOL_SPAN_STATUS_PERMISSION_DENIED,
-            );
-            this.finalizeToolSpan(reqInfo.callId);
             continue;
           }
 
@@ -2551,7 +2630,7 @@ export class CoreToolScheduler {
 
           if (
             !needsConfirmation(
-              confirmationPermission,
+              planShellRequiresConfirmation ? 'ask' : confirmationPermission,
               approvalMode,
               canonicalName,
               requiresUserInteraction,
@@ -2566,10 +2645,42 @@ export class CoreToolScheduler {
             confirmationDetails =
               await invocation.getConfirmationDetails(signal);
 
+            if (planShellDecision.classification !== 'not-applicable') {
+              const preDisplayPlanShellError =
+                await validatePlanModeShellContext({
+                  config: this.config,
+                  decision: planShellDecision,
+                  requestArgs: reqInfo.args,
+                  invocationParams: invocation.params as Record<
+                    string,
+                    unknown
+                  >,
+                  signal,
+                });
+              if (preDisplayPlanShellError) {
+                rejectPlanShell(preDisplayPlanShellError);
+                continue;
+              }
+            }
+
+            try {
+              confirmationDetails = decoratePlanModeShellConfirmation(
+                planShellDecision,
+                confirmationDetails,
+              );
+            } catch {
+              if (planShellDecision.classification === 'unknown') {
+                rejectPlanShell(planShellDecision.noApprovalMessage);
+                continue;
+              }
+              throw new Error('Unable to prepare shell confirmation.');
+            }
+
             // ── Centralised rule injection ──────────────────────────────────
             injectPermissionRulesIfMissing(confirmationDetails, pmCtx);
 
             if (
+              planShellDecision.classification === 'not-applicable' &&
               isPlanModeBlocked(
                 isPlanMode,
                 isExitPlanModeTool,
@@ -2632,7 +2743,14 @@ export class CoreToolScheduler {
               this.config.getInputFormat() !== InputFormat.STREAM_JSON;
 
             if (isNonInteractiveDeny) {
-              const errorMessage = `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined (non-interactive mode cannot prompt for confirmation).`;
+              const errorMessage =
+                planShellDecision.classification === 'unknown'
+                  ? planShellDecision.noApprovalMessage
+                  : `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined (non-interactive mode cannot prompt for confirmation).`;
+              if (planShellDecision.classification === 'unknown') {
+                rejectPlanShell(errorMessage);
+                continue;
+              }
               this.setStatusInternal(
                 reqInfo.callId,
                 'error',
@@ -2666,6 +2784,8 @@ export class CoreToolScheduler {
                 canonicalName,
                 (reqInfo.args as Record<string, unknown>) || {},
                 permissionMode,
+                undefined,
+                signal,
               );
 
               if (
@@ -2673,6 +2793,44 @@ export class CoreToolScheduler {
                 (!hookResult.shouldAllow || !requiresUserInteraction)
               ) {
                 if (hookResult.shouldAllow) {
+                  if (planShellDecision.classification !== 'not-applicable') {
+                    const approval = await validatePlanModeShellApproval({
+                      config: this.config,
+                      decision: planShellDecision,
+                      requestArgs: reqInfo.args,
+                      invocationParams: invocation.params as Record<
+                        string,
+                        unknown
+                      >,
+                      signal,
+                      outcome: ToolConfirmationOutcome.ProceedOnce,
+                      payload: hookResult.updatedInput
+                        ? { updatedInput: hookResult.updatedInput }
+                        : undefined,
+                    });
+                    if (approval.outcome === ToolConfirmationOutcome.Cancel) {
+                      await confirmationDetails.onConfirm(
+                        approval.outcome,
+                        approval.payload,
+                      );
+                      rejectPlanShell(
+                        approval.payload?.cancelMessage ??
+                          planShellDecision.noApprovalMessage,
+                      );
+                      continue;
+                    }
+                    await confirmationDetails.onConfirm(
+                      approval.outcome,
+                      approval.payload,
+                    );
+                    this.recordAutoModeFallbackResolution(
+                      reqInfo.callId,
+                      approval.outcome,
+                    );
+                    this.setToolCallOutcome(reqInfo.callId, approval.outcome);
+                    this.setStatusInternal(reqInfo.callId, 'scheduled');
+                    continue;
+                  }
                   // Hook granted permission - apply updated input if provided and proceed
                   if (
                     hookResult.updatedInput &&
@@ -2738,7 +2896,14 @@ export class CoreToolScheduler {
             // Background agents can't show interactive prompts.
             // Auto-deny after hooks have had a chance to decide.
             if (this.config.getShouldAvoidPermissionPrompts?.()) {
-              const errorMessage = `Tool "${reqInfo.name}" requires permission, but background agents cannot prompt for confirmation. The tool call was denied.`;
+              const errorMessage =
+                planShellDecision.classification === 'unknown'
+                  ? planShellDecision.noApprovalMessage
+                  : `Tool "${reqInfo.name}" requires permission, but background agents cannot prompt for confirmation. The tool call was denied.`;
+              if (planShellDecision.classification === 'unknown') {
+                rejectPlanShell(errorMessage);
+                continue;
+              }
               this.setStatusInternal(
                 reqInfo.callId,
                 'error',
@@ -2777,14 +2942,38 @@ export class CoreToolScheduler {
               continue;
             }
 
+            if (planShellDecision.classification !== 'not-applicable') {
+              const finalPreDisplayPlanShellError =
+                await validatePlanModeShellContext({
+                  config: this.config,
+                  decision: planShellDecision,
+                  requestArgs: reqInfo.args,
+                  invocationParams: invocation.params as Record<
+                    string,
+                    unknown
+                  >,
+                  signal,
+                });
+              if (finalPreDisplayPlanShellError) {
+                rejectPlanShell(finalPreDisplayPlanShellError);
+                continue;
+              }
+            }
+
             // Allow IDE to resolve confirmation
-            this.openIdeDiffIfEnabled(
-              confirmationDetails,
-              reqInfo.callId,
-              signal,
-            );
+            if (
+              confirmationDetails.type !== 'edit' ||
+              !confirmationDetails.skipIdeDiff
+            ) {
+              this.openIdeDiffIfEnabled(
+                confirmationDetails,
+                reqInfo.callId,
+                signal,
+              );
+            }
 
             const originalOnConfirm = confirmationDetails.onConfirm;
+            let planShellResponseClaimed = false;
             const wrappedConfirmationDetails: ToolCallConfirmationDetails = {
               ...confirmationDetails,
               // When PM has an explicit 'ask' rule, 'always allow' would be
@@ -2793,17 +2982,48 @@ export class CoreToolScheduler {
               ...(pmForcedAsk || requiresUserInteraction
                 ? { hideAlwaysAllow: true }
                 : {}),
-              onConfirm: (
+              onConfirm: async (
                 outcome: ToolConfirmationOutcome,
                 payload?: ToolConfirmationPayload,
-              ) =>
-                this.handleConfirmationResponse(
+              ) => {
+                if (planShellDecision.classification !== 'not-applicable') {
+                  if (planShellResponseClaimed) return;
+                  planShellResponseClaimed = true;
+                  const currentCall = this.toolCalls.find(
+                    (call) =>
+                      call.request.callId === reqInfo.callId &&
+                      call.status === 'awaiting_approval',
+                  ) as WaitingToolCall | undefined;
+                  if (!currentCall) return;
+                  const approval = await validatePlanModeShellApproval({
+                    config: this.config,
+                    decision: planShellDecision,
+                    requestArgs: currentCall.request.args,
+                    invocationParams: currentCall.invocation.params as Record<
+                      string,
+                      unknown
+                    >,
+                    signal,
+                    outcome,
+                    payload,
+                  });
+                  await this.handleConfirmationResponse(
+                    reqInfo.callId,
+                    originalOnConfirm,
+                    approval.outcome,
+                    signal,
+                    approval.payload,
+                  );
+                  return;
+                }
+                await this.handleConfirmationResponse(
                   reqInfo.callId,
                   originalOnConfirm,
                   outcome,
                   signal,
                   payload,
-                ),
+                );
+              },
             };
             this.setStatusInternal(
               reqInfo.callId,
@@ -4936,6 +5156,8 @@ export class CoreToolScheduler {
       (call) =>
         call.status === 'awaiting_approval' &&
         call.request.callId !== triggeringCallId &&
+        (!('hideAlwaysAllow' in call.confirmationDetails) ||
+          call.confirmationDetails.hideAlwaysAllow !== true) &&
         // A tool bounced by a PreToolUse 'ask' must NOT be auto-approved as a
         // side effect of approving a sibling: the hook explicitly requested
         // confirmation, and re-execution skips the hook — auto-approving here

--- a/packages/core/src/core/plan-mode-shell-policy.test.ts
+++ b/packages/core/src/core/plan-mode-shell-policy.test.ts
@@ -1,0 +1,459 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/config.js';
+import type { PermissionManager } from '../permissions/permission-manager.js';
+import type { PermissionCheckContext } from '../permissions/types.js';
+import { ToolNames } from '../tools/tool-names.js';
+import type { ToolCallConfirmationDetails } from '../tools/tools.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
+import {
+  decoratePlanModeShellConfirmation,
+  evaluatePlanModeShellPolicy,
+  validatePlanModeShellApproval,
+  validatePlanModeShellContext,
+} from './plan-mode-shell-policy.js';
+
+const UNKNOWN_WARNING =
+  'Plan mode could not determine whether this shell command is read-only. Approval applies only to this exact invocation once; it may modify system state, and Plan mode will remain active.';
+const STALE_MESSAGE =
+  'Plan-mode shell approval is no longer valid because the mode, permission policy, or exact invocation changed. Submit a new tool call.';
+
+function createContext(toolName: string, command: string) {
+  return {
+    toolName,
+    command,
+    toolParams: { command },
+  } satisfies PermissionCheckContext;
+}
+
+function createConfig(
+  options: {
+    mode?: ApprovalMode;
+    revision?: number;
+    targetDir?: () => string;
+    permissionManager?: Partial<PermissionManager>;
+  } = {},
+): Config {
+  return {
+    getApprovalMode: vi.fn(() => options.mode ?? ApprovalMode.PLAN),
+    getApprovalModeRevision: vi.fn(() => options.revision ?? 7),
+    getTargetDir: vi.fn(() => options.targetDir?.() ?? '/workspace'),
+    getPermissionManager: vi.fn(() =>
+      options.permissionManager
+        ? (options.permissionManager as PermissionManager)
+        : undefined,
+    ),
+  } as unknown as Config;
+}
+
+async function evaluate(
+  command: string,
+  options: {
+    toolName?: string;
+    config?: Config;
+    requestArgs?: Record<string, unknown>;
+    invocationParams?: Record<string, unknown>;
+    signal?: AbortSignal;
+  } = {},
+) {
+  const toolName = options.toolName ?? ToolNames.SHELL;
+  const requestArgs = options.requestArgs ?? { command };
+  const invocationParams = options.invocationParams ?? { command };
+  return evaluatePlanModeShellPolicy({
+    config: options.config ?? createConfig(),
+    toolName,
+    requestArgs,
+    invocationParams,
+    permissionContext: createContext(toolName, command),
+    signal: options.signal ?? new AbortController().signal,
+  });
+}
+
+function execConfirmation(): ToolCallConfirmationDetails {
+  return {
+    type: 'exec',
+    title: 'Confirm shell',
+    command: "python -c 'print(1)'",
+    rootCommand: 'python',
+    warnings: ['existing warning'],
+    onConfirm: vi.fn(),
+  };
+}
+
+describe('plan-mode shell policy', () => {
+  it.each([
+    ['git status', 'read-only'],
+    ['touch changed.txt', 'write'],
+    ["python -c 'print(1)'", 'unknown'],
+  ] as const)('classifies %s as %s', async (command, expected) => {
+    await expect(evaluate(command)).resolves.toMatchObject({
+      classification: expected,
+      rawCommand: command,
+    });
+  });
+
+  it('classifies monitor safetyCommand rather than the wrapper', async () => {
+    await expect(
+      evaluate("/bin/bash -c 'git status &' ignored", {
+        toolName: ToolNames.MONITOR,
+      }),
+    ).resolves.toMatchObject({ classification: 'read-only' });
+    await expect(
+      evaluate("/bin/bash -c 'python script.py &' ignored", {
+        toolName: ToolNames.MONITOR,
+      }),
+    ).resolves.toMatchObject({ classification: 'unknown' });
+  });
+
+  it('does not apply outside Plan mode or to non-shell tools', async () => {
+    await expect(
+      evaluate('git status', {
+        config: createConfig({ mode: ApprovalMode.DEFAULT }),
+      }),
+    ).resolves.toEqual({ classification: 'not-applicable' });
+    await expect(
+      evaluate('git status', { toolName: ToolNames.READ_FILE }),
+    ).resolves.toEqual({ classification: 'not-applicable' });
+  });
+
+  it('races classification with abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      evaluate('git status', { signal: controller.signal }),
+    ).rejects.toThrow('aborted');
+  });
+
+  it('invalidates mode revisions and exact request or invocation changes', async () => {
+    let mode = ApprovalMode.PLAN;
+    let revision = 3;
+    const config = {
+      getApprovalMode: () => mode,
+      getApprovalModeRevision: () => revision,
+      getTargetDir: () => '/workspace',
+      getPermissionManager: () => undefined,
+    } as unknown as Config;
+    const decision = await evaluate('git status', { config });
+    const signal = new AbortController().signal;
+
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git status' },
+        signal,
+      }),
+    ).resolves.toBeUndefined();
+
+    mode = ApprovalMode.DEFAULT;
+    revision++;
+    mode = ApprovalMode.PLAN;
+    revision++;
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git status' },
+        signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+
+    const freshDecision = await evaluate('git status', { config });
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision: freshDecision,
+        requestArgs: { command: 'git diff' },
+        invocationParams: { command: 'git status' },
+        signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision: freshDecision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git diff' },
+        signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+  });
+
+  it('binds ambient working directory without invalidating explicit directories', async () => {
+    let targetDir = '/workspace/one';
+    const config = createConfig({ targetDir: () => targetDir });
+    const signal = new AbortController().signal;
+    const ambientDecision = await evaluate("python -c 'print(1)'", {
+      config,
+    });
+
+    targetDir = '/workspace/two';
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision: ambientDecision,
+        requestArgs: { command: "python -c 'print(1)'" },
+        invocationParams: { command: "python -c 'print(1)'" },
+        signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+
+    const explicitArgs = {
+      command: "python -c 'print(1)'",
+      directory: '/workspace/fixed',
+    };
+    const explicitDecision = await evaluate(explicitArgs.command, {
+      config,
+      requestArgs: explicitArgs,
+      invocationParams: explicitArgs,
+    });
+    targetDir = '/workspace/three';
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision: explicitDecision,
+        requestArgs: explicitArgs,
+        invocationParams: explicitArgs,
+        signal,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails closed when current permission rules deny or throw', async () => {
+    const denyConfig = createConfig({
+      permissionManager: { evaluate: vi.fn().mockResolvedValue('deny') },
+    });
+    const denyDecision = await evaluate('git status', { config: denyConfig });
+    await expect(
+      validatePlanModeShellContext({
+        config: denyConfig,
+        decision: denyDecision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git status' },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+
+    const errorConfig = createConfig({
+      permissionManager: { evaluate: vi.fn().mockRejectedValue(new Error()) },
+    });
+    const errorDecision = await evaluate('git status', {
+      config: errorConfig,
+    });
+    await expect(
+      validatePlanModeShellContext({
+        config: errorConfig,
+        decision: errorDecision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git status' },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+  });
+
+  it.each(['allow', 'ask', 'default'] as const)(
+    'keeps the selected route when permission recheck returns %s',
+    async (permission) => {
+      const config = createConfig({
+        permissionManager: {
+          evaluate: vi.fn().mockResolvedValue(permission),
+        },
+      });
+      const decision = await evaluate('git status', { config });
+
+      await expect(
+        validatePlanModeShellContext({
+          config,
+          decision,
+          requestArgs: { command: 'git status' },
+          invocationParams: { command: 'git status' },
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it('rechecks the frozen cwd and tool params needed by virtual denies', async () => {
+    const evaluatePermission = vi.fn().mockResolvedValue('deny');
+    const config = createConfig({
+      permissionManager: { evaluate: evaluatePermission },
+    });
+    const requestArgs = { command: 'git status' };
+    const invocationParams = {
+      command: 'git status',
+      directory: '/workspace',
+    };
+    const decision = await evaluate('git status', {
+      config,
+      requestArgs,
+      invocationParams,
+    });
+
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision,
+        requestArgs,
+        invocationParams,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe(STALE_MESSAGE);
+    expect(evaluatePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: ToolNames.SHELL,
+        command: 'git status',
+        cwd: '/workspace',
+        toolParams: invocationParams,
+      }),
+    );
+  });
+
+  it('owns a permission rejection when evaluation synchronously aborts', async () => {
+    const controller = new AbortController();
+    const evaluatePermission = vi.fn(() => {
+      controller.abort();
+      return Promise.reject(new Error('late permission rejection'));
+    });
+    const config = createConfig({
+      permissionManager: { evaluate: evaluatePermission },
+    });
+    const decision = await evaluate('git status', { config });
+
+    await expect(
+      validatePlanModeShellContext({
+        config,
+        decision,
+        requestArgs: { command: 'git status' },
+        invocationParams: { command: 'git status' },
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('aborted');
+    expect(evaluatePermission).toHaveBeenCalledOnce();
+  });
+
+  it('decorates unknown exec and edit confirmations idempotently', async () => {
+    const decision = await evaluate("python -c 'print(1)'");
+    const once = decoratePlanModeShellConfirmation(
+      decision,
+      execConfirmation(),
+    );
+    const twice = decoratePlanModeShellConfirmation(decision, once);
+    expect(twice).toMatchObject({ hideAlwaysAllow: true });
+    if (twice.type === 'exec') {
+      expect(twice.warnings).toEqual(['existing warning', UNKNOWN_WARNING]);
+    }
+
+    const edit = decoratePlanModeShellConfirmation(decision, {
+      type: 'edit',
+      title: 'Confirm edit',
+      fileName: 'a.txt',
+      filePath: '/tmp/a.txt',
+      fileDiff: 'diff',
+      originalContent: '',
+      newContent: 'x',
+      onConfirm: vi.fn(),
+    });
+    expect(edit).toMatchObject({
+      hideAlwaysAllow: true,
+      hideModify: true,
+      skipIdeDiff: true,
+      warnings: [
+        UNKNOWN_WARNING,
+        "Exact shell command: `python -c 'print(1)'`",
+      ],
+    });
+  });
+
+  it('hides persistent approval for read-only shell prompts', async () => {
+    const decision = await evaluate('git status');
+    expect(
+      decoratePlanModeShellConfirmation(decision, execConfirmation()),
+    ).toMatchObject({ hideAlwaysAllow: true });
+  });
+
+  it('rejects unsupported unknown confirmation surfaces', async () => {
+    const decision = await evaluate("python -c 'print(1)'");
+    expect(() =>
+      decoratePlanModeShellConfirmation(decision, {
+        type: 'info',
+        title: 'Unexpected',
+        prompt: 'Unexpected',
+        onConfirm: vi.fn(),
+      }),
+    ).toThrow('no approval surface is available');
+  });
+
+  it('accepts only exact one-off approval and clears its payload', async () => {
+    const config = createConfig();
+    const decision = await evaluate("python -c 'print(1)'", { config });
+    const base = {
+      config,
+      decision,
+      requestArgs: { command: "python -c 'print(1)'" },
+      invocationParams: { command: "python -c 'print(1)'" },
+      signal: new AbortController().signal,
+    };
+
+    await expect(
+      validatePlanModeShellApproval({
+        ...base,
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+        payload: {
+          updatedInput: { command: "python -c 'print(1)'" },
+          permissionRules: ['Bash(python:*)'],
+        },
+      }),
+    ).resolves.toEqual({ outcome: ToolConfirmationOutcome.ProceedOnce });
+
+    for (const input of [
+      {
+        outcome: ToolConfirmationOutcome.ProceedAlwaysProject,
+      },
+      {
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+        payload: { updatedInput: { command: 'touch changed.txt' } },
+      },
+      {
+        outcome: ToolConfirmationOutcome.ProceedOnce,
+        payload: { newContent: 'changed' },
+      },
+    ]) {
+      await expect(
+        validatePlanModeShellApproval({ ...base, ...input }),
+      ).resolves.toEqual({
+        outcome: ToolConfirmationOutcome.Cancel,
+        payload: { cancelMessage: STALE_MESSAGE },
+      });
+    }
+  });
+
+  it('preserves cancellation after the approval signal is aborted', async () => {
+    const config = createConfig();
+    const decision = await evaluate("python -c 'print(1)'", { config });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      validatePlanModeShellApproval({
+        config,
+        decision,
+        requestArgs: { command: "python -c 'print(1)'" },
+        invocationParams: { command: "python -c 'print(1)'" },
+        signal: abortController.signal,
+        outcome: ToolConfirmationOutcome.Cancel,
+        payload: { cancelMessage: 'Host cancelled approval' },
+      }),
+    ).resolves.toEqual({
+      outcome: ToolConfirmationOutcome.Cancel,
+      payload: { cancelMessage: 'Host cancelled approval' },
+    });
+  });
+});

--- a/packages/core/src/core/plan-mode-shell-policy.ts
+++ b/packages/core/src/core/plan-mode-shell-policy.ts
@@ -1,0 +1,320 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isDeepStrictEqual } from 'node:util';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/config.js';
+import type { PermissionCheckContext } from '../permissions/types.js';
+import { ToolNames } from '../tools/tool-names.js';
+import type {
+  ToolCallConfirmationDetails,
+  ToolConfirmationPayload,
+} from '../tools/tools.js';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
+import {
+  classifyShellCommandSafety,
+  type ShellCommandSafety,
+} from '../utils/shellAstParser.js';
+import { normalizeMonitorCommand } from '../utils/shell-utils.js';
+
+const UNKNOWN_WARNING =
+  'Plan mode could not determine whether this shell command is read-only. Approval applies only to this exact invocation once; it may modify system state, and Plan mode will remain active.';
+const WRITE_BLOCK_MESSAGE =
+  'Plan mode blocked this shell command because it was classified as state-modifying. Do not retry it through wrappers or obfuscation; continue read-only investigation and include the action in the plan.';
+const NO_APPROVAL_MESSAGE =
+  'Plan mode could not determine whether this shell command is read-only, and no approval surface is available. The command was not run; Plan mode remains active.';
+const STALE_APPROVAL_MESSAGE =
+  'Plan-mode shell approval is no longer valid because the mode, permission policy, or exact invocation changed. Submit a new tool call.';
+
+interface PlanModeShellContextSnapshot {
+  requestArgs: Record<string, unknown>;
+  invocationParams: Record<string, unknown>;
+  approvalModeRevision: number;
+  permissionContext: PermissionCheckContext;
+  ambientWorkingDirectory?: string;
+}
+
+type ApplicablePlanModeShellDecision = {
+  classification: ShellCommandSafety;
+  rawCommand: string;
+  snapshot: PlanModeShellContextSnapshot;
+  writeBlockMessage: typeof WRITE_BLOCK_MESSAGE;
+  noApprovalMessage: typeof NO_APPROVAL_MESSAGE;
+};
+
+/** @internal */
+export type PlanModeShellDecision =
+  | { classification: 'not-applicable' }
+  | ApplicablePlanModeShellDecision;
+
+function isApplicable(
+  decision: PlanModeShellDecision,
+): decision is ApplicablePlanModeShellDecision {
+  return decision.classification !== 'not-applicable';
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Plan-mode shell policy evaluation was aborted.');
+}
+
+function raceWithAbort<T>(
+  operation: () => Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(abortError(signal));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      callback();
+    };
+    const onAbort = () => finish(() => reject(abortError(signal)));
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    let pending: Promise<T>;
+    try {
+      pending = operation();
+    } catch (error) {
+      finish(() => reject(error));
+      return;
+    }
+    pending.then(
+      (value) => finish(() => resolve(value)),
+      (error: unknown) => finish(() => reject(error)),
+    );
+  });
+}
+
+function appendUnique(values: string[] | undefined, value: string): string[] {
+  return values?.includes(value) ? values : [...(values ?? []), value];
+}
+
+function effectiveWorkingDirectory(
+  config: Config,
+  invocationParams: Record<string, unknown>,
+): string {
+  const directory = invocationParams['directory'];
+  return typeof directory === 'string' && directory.length > 0
+    ? directory
+    : config.getTargetDir();
+}
+
+/** @internal */
+export async function evaluatePlanModeShellPolicy(input: {
+  config: Config;
+  toolName: string;
+  requestArgs: Record<string, unknown>;
+  invocationParams: Record<string, unknown>;
+  permissionContext: PermissionCheckContext;
+  ambientWorkingDirectory?: string;
+  signal: AbortSignal;
+}): Promise<PlanModeShellDecision> {
+  if (
+    input.toolName !== ToolNames.SHELL &&
+    input.toolName !== ToolNames.MONITOR
+  ) {
+    return { classification: 'not-applicable' };
+  }
+  if (input.config.getApprovalMode() !== ApprovalMode.PLAN) {
+    return { classification: 'not-applicable' };
+  }
+
+  const rawCommand =
+    typeof input.invocationParams['command'] === 'string'
+      ? input.invocationParams['command']
+      : '';
+  const safetyCommand =
+    input.toolName === ToolNames.MONITOR
+      ? normalizeMonitorCommand(rawCommand).safetyCommand
+      : rawCommand;
+  const permissionContext = clone(input.permissionContext);
+  permissionContext.cwd = effectiveWorkingDirectory(
+    input.config,
+    input.invocationParams,
+  );
+  permissionContext.toolParams = clone(input.invocationParams);
+  const invocationDirectory = input.invocationParams['directory'];
+  const ambientWorkingDirectory =
+    input.ambientWorkingDirectory ??
+    (typeof invocationDirectory !== 'string' || invocationDirectory.length === 0
+      ? input.config.getTargetDir()
+      : undefined);
+  const snapshot: PlanModeShellContextSnapshot = {
+    requestArgs: clone(input.requestArgs),
+    invocationParams: clone(input.invocationParams),
+    approvalModeRevision: input.config.getApprovalModeRevision(),
+    permissionContext,
+    ambientWorkingDirectory,
+  };
+
+  let classification: ShellCommandSafety;
+  try {
+    classification = await raceWithAbort(
+      () => classifyShellCommandSafety(safetyCommand),
+      input.signal,
+    );
+  } catch (error) {
+    if (input.signal.aborted) throw error;
+    classification = 'unknown';
+  }
+
+  return {
+    classification,
+    rawCommand,
+    snapshot,
+    writeBlockMessage: WRITE_BLOCK_MESSAGE,
+    noApprovalMessage: NO_APPROVAL_MESSAGE,
+  };
+}
+
+/** @internal */
+export async function validatePlanModeShellContext(input: {
+  config: Config;
+  decision: PlanModeShellDecision;
+  requestArgs: Record<string, unknown>;
+  invocationParams: Record<string, unknown>;
+  signal: AbortSignal;
+}): Promise<string | undefined> {
+  if (!isApplicable(input.decision)) return undefined;
+  const decision = input.decision;
+
+  if (input.signal.aborted) throw abortError(input.signal);
+
+  const matchesSnapshot = () =>
+    !input.signal.aborted &&
+    input.config.getApprovalMode() === ApprovalMode.PLAN &&
+    input.config.getApprovalModeRevision() ===
+      decision.snapshot.approvalModeRevision &&
+    (decision.snapshot.ambientWorkingDirectory === undefined ||
+      input.config.getTargetDir() ===
+        decision.snapshot.ambientWorkingDirectory) &&
+    effectiveWorkingDirectory(input.config, input.invocationParams) ===
+      decision.snapshot.permissionContext.cwd &&
+    isDeepStrictEqual(input.requestArgs, decision.snapshot.requestArgs) &&
+    isDeepStrictEqual(
+      input.invocationParams,
+      decision.snapshot.invocationParams,
+    );
+
+  if (!matchesSnapshot()) return STALE_APPROVAL_MESSAGE;
+
+  const permissionManager = input.config.getPermissionManager?.();
+  if (permissionManager) {
+    try {
+      const currentPermission = await raceWithAbort(
+        () =>
+          permissionManager.evaluate(
+            clone(decision.snapshot.permissionContext),
+          ),
+        input.signal,
+      );
+      if (currentPermission === 'deny') return STALE_APPROVAL_MESSAGE;
+    } catch {
+      if (input.signal.aborted) throw abortError(input.signal);
+      return STALE_APPROVAL_MESSAGE;
+    }
+  }
+
+  if (input.signal.aborted) throw abortError(input.signal);
+  return matchesSnapshot() ? undefined : STALE_APPROVAL_MESSAGE;
+}
+
+/** @internal */
+export function decoratePlanModeShellConfirmation(
+  decision: PlanModeShellDecision,
+  confirmation: ToolCallConfirmationDetails,
+): ToolCallConfirmationDetails {
+  if (!isApplicable(decision)) return confirmation;
+
+  if (confirmation.type === 'ask_user_question') {
+    throw new Error(decision.noApprovalMessage);
+  }
+
+  if (decision.classification !== 'unknown') {
+    return { ...confirmation, hideAlwaysAllow: true };
+  }
+
+  if (confirmation.type === 'exec') {
+    return {
+      ...confirmation,
+      hideAlwaysAllow: true,
+      warnings: appendUnique(confirmation.warnings, UNKNOWN_WARNING),
+    };
+  }
+
+  if (confirmation.type === 'edit') {
+    const warnings = appendUnique(confirmation.warnings, UNKNOWN_WARNING);
+    return {
+      ...confirmation,
+      hideAlwaysAllow: true,
+      hideModify: true,
+      skipIdeDiff: true,
+      warnings: appendUnique(
+        warnings,
+        `Exact shell command: \`${decision.rawCommand}\``,
+      ),
+    };
+  }
+
+  throw new Error(decision.noApprovalMessage);
+}
+
+/** @internal */
+export async function validatePlanModeShellApproval(input: {
+  config: Config;
+  decision: PlanModeShellDecision;
+  requestArgs: Record<string, unknown>;
+  invocationParams: Record<string, unknown>;
+  signal: AbortSignal;
+  outcome: ToolConfirmationOutcome;
+  payload?: ToolConfirmationPayload;
+}): Promise<{
+  outcome: ToolConfirmationOutcome;
+  payload?: ToolConfirmationPayload;
+}> {
+  if (!isApplicable(input.decision)) {
+    return { outcome: input.outcome, payload: input.payload };
+  }
+
+  if (input.outcome === ToolConfirmationOutcome.Cancel) {
+    return {
+      outcome: ToolConfirmationOutcome.Cancel,
+      ...(input.payload?.cancelMessage
+        ? { payload: { cancelMessage: input.payload.cancelMessage } }
+        : {}),
+    };
+  }
+
+  const invalidContext = await validatePlanModeShellContext(input);
+  const invalidOutcome = input.outcome !== ToolConfirmationOutcome.ProceedOnce;
+  const invalidPayload =
+    input.payload?.newContent !== undefined ||
+    (input.payload?.updatedInput !== undefined &&
+      !isDeepStrictEqual(
+        input.payload.updatedInput,
+        input.decision.snapshot.requestArgs,
+      ));
+
+  if (invalidContext || invalidOutcome || invalidPayload) {
+    return {
+      outcome: ToolConfirmationOutcome.Cancel,
+      payload: { cancelMessage: STALE_APPROVAL_MESSAGE },
+    };
+  }
+
+  return { outcome: ToolConfirmationOutcome.ProceedOnce };
+}

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -643,7 +643,12 @@ describe('getPlanModeSystemReminder', () => {
 
     expect(result).toContain('When a Tool is Blocked by Plan Mode');
     expect(result).toContain('Do NOT retry');
+    expect(result).toContain(
+      'wrappers, quoting tricks, aliases, or obfuscation',
+    );
     expect(result).toContain('Pivot to read-only');
+    expect(result).toContain('does not approve the plan');
+    expect(result).toContain('exit Plan mode');
   });
 
   it('should be deterministic', () => {

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -985,7 +985,7 @@ function getToolCallExamples(model?: string): string {
  */
 export function getPlanModeSystemReminder(planOnly = false): string {
   return `<system-reminder>
-Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received (for example, to make edits).
+Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run tools classified as state-modifying (including changing configs or making commits), or otherwise make changes to the system. A shell command whose safety cannot be determined may run only after the user explicitly approves that exact invocation once, and only when it is necessary for the investigation. This supersedes any other instructions you have received (for example, to make edits).
 
 ## Iterative Planning Workflow
 
@@ -1021,9 +1021,12 @@ Start by quickly scanning a few key files to form an initial understanding of th
 
 If a non-read-only tool is blocked:
 - Do NOT retry the blocked tool or repeatedly attempt similar non-read-only tools
+- Do NOT use wrappers, quoting tricks, aliases, or obfuscation to make a blocked write look unknown
 - Do NOT immediately call exit_plan_mode just to unblock it — continue gathering context with read-only tools first
 - Pivot to read-only tools (read_file, grep_search, glob, list_directory, agents) to gather the information the blocked tool would have provided
 - Once you have enough context to form a complete plan, call exit_plan_mode
+
+An exact one-off approval for an unknown shell command approves only that invocation. It does not approve the plan, authorize related commands, or exit Plan mode.
 
 ### When to Converge
 

--- a/packages/core/src/followup/speculationToolGate.test.ts
+++ b/packages/core/src/followup/speculationToolGate.test.ts
@@ -130,6 +130,16 @@ describe('speculationToolGate', () => {
       expect(result.action).toBe('boundary');
     });
 
+    it('hits boundary when shell safety is unknown', async () => {
+      const result = await evaluateToolCall(
+        ToolNames.SHELL,
+        { command: "python -c 'print(1)'" },
+        overlayFs,
+        ApprovalMode.DEFAULT,
+      );
+      expect(result.action).toBe('boundary');
+    });
+
     it('hits boundary for empty command', async () => {
       const result = await evaluateToolCall(
         ToolNames.SHELL,

--- a/packages/core/src/followup/speculationToolGate.ts
+++ b/packages/core/src/followup/speculationToolGate.ts
@@ -16,7 +16,7 @@
  */
 
 import { ToolNames } from '../tools/tool-names.js';
-import { isShellCommandReadOnlyAST } from '../utils/shellAstParser.js';
+import { classifyShellCommandSafety } from '../utils/shellAstParser.js';
 import { ApprovalMode } from '../config/config.js';
 import { unescapePath, PATH_ARG_KEYS } from '../utils/paths.js';
 import type { OverlayFs } from './overlayFs.js';
@@ -94,7 +94,10 @@ export async function evaluateToolCall(
   // Shell — use AST parser for accurate read-only detection
   if (toolName === ToolNames.SHELL) {
     const command = typeof args['command'] === 'string' ? args['command'] : '';
-    if (command && (await isShellCommandReadOnlyAST(command))) {
+    if (
+      command &&
+      (await classifyShellCommandSafety(command)) === 'read-only'
+    ) {
       return { action: 'allow' };
     }
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,14 @@ export * from './core/reasoning-effort.js';
 export * from './core/coreToolScheduler.js';
 export * from './core/permissionFlow.js';
 export * from './core/permission-helpers.js';
+/** @internal */
+export {
+  type PlanModeShellDecision,
+  evaluatePlanModeShellPolicy,
+  validatePlanModeShellContext,
+  decoratePlanModeShellConfirmation,
+  validatePlanModeShellApproval,
+} from './core/plan-mode-shell-policy.js';
 export * from './core/geminiChat.js';
 export * from './core/geminiRequest.js';
 export * from './core/inlineMediaLimit.js';

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -792,6 +792,10 @@ export interface ToolEditConfirmationDetails {
   isModifying?: boolean;
   /** Hide UI affordances that let the user edit the proposed content. */
   hideModify?: boolean;
+  /** Skip opening or resolving an IDE diff for this confirmation. */
+  skipIdeDiff?: boolean;
+  /** Informational warnings to render alongside the proposed diff. */
+  warnings?: string[];
 }
 
 export interface ToolConfirmationPayload {


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR routes model-initiated Shell and Monitor calls in Plan mode through the tri-state shell-safety classifier introduced by #7053. Read-only commands continue through the existing permission flow, state-modifying commands are blocked before any approval surface can authorize them, and unknown commands require an exact one-time approval that is revalidated against the Plan-mode revision, working directory, permission policy, raw request, and executable invocation.

The exact-approval contract is propagated through the Core scheduler, ACP sessions, stream-json and dual-output control requests, nested subagents, teammates, and background agents. Every Plan-mode Shell and Monitor confirmation hides persistent approval; unknown-command prompts additionally hide modification choices, reject rewritten or stale approvals, avoid IDE diff races, preserve the raw command and safety warning, and keep Plan mode active. Plan-mode calls without an explicit directory are pinned to the resolved target workspace, so confirmation titles consistently include `[in <absolute path>]`. Compact edit confirmations now allocate the complete body-height budget across warnings and diffs, including a one-row fallback for extremely short terminals so the approval question and choices remain visible.

ACP permission outcomes are validated against the exact options offered for every tool approval, not only Plan mode, so a host cannot mint a withheld persistent choice. Background approval consumers likewise cancel unoffered `ProceedAlways*` outcomes instead of downgrading them to one-time approval. In headless teammate YOLO mode, any non-plan confirmation marked `hideAlwaysAllow`—including PM explicit-`ask` rules and `ask_user_question`—is cancelled because it requires an interactive approval surface.

## Why it's needed

Plan mode previously used confirmation shape as a proxy for shell safety even though Shell and Monitor can each represent read-only, state-modifying, or parser-unknown programs. Different approval hosts could therefore apply inconsistent behavior, stale or rewritten responses could cross the intended Plan boundary, aborted permission requests could surface rejected cancellation callbacks, and narrow confirmation viewports could clip the context required to make a safe decision. This change establishes one fail-closed policy and one exact-invocation approval contract across every supported execution surface.

## Reviewer Test Plan

### How to verify

1. In a temporary workspace, enter Plan mode and request `git status`; confirm it runs without a new Plan-specific prompt and Plan mode stays active.
2. Request `touch changed.txt`; confirm it is blocked before prompting and no file is created.
3. Request a command classified as unknown, such as `python -c 'print(1)'`; confirm the prompt offers only one-time approval and cancel, approval does not exit Plan mode, and repeating the same tool call prompts again.
4. Exercise an unknown wrapped edit such as `bash -c 'sed -i s/alpha/beta/ sample.txt'`; confirm the safety warning, exact raw command, diff, question, and choices remain visible in a narrow compact confirmation, with modification, persistent approval, and IDE auto-diff paths unavailable.
5. While an ACP or stream-json permission request is pending, abort the turn and then deliver a late host rejection; confirm the tool cancels cleanly without an unhandled rejection. Also return a changed `updatedInput`, `newContent`, or an unoffered persistent option and confirm the call is cancelled rather than executed.
6. Repeat read-only, write, and unknown cases through Monitor and a nested/background approval route; confirm they follow the same classification and fail-closed rules.
7. Automated verification passed on macOS: Core focused suites 527/527; CLI focused suites 561 passed with 1 pre-existing unrelated skip; compact confirmation suite 28/28; full lint, Prettier check, build, and typecheck all passed.

### Evidence (Before & After)

Before: the deterministic 50-column compact renderer produced 10 rows for a 9-row viewport when an edit confirmation carried the Plan-mode safety warning and exact-command warning, so the warning, command, diff, question, or choices could be clipped. Static path verification showed that an aborted cancellation could reach context validation before the Cancel branch and reject through a fire-and-forget permission handler.

After: the same renderer uses 8/9 rows at 50×9 and 7/8 rows at 50×8 while retaining both warning labels, the flattened multiline-command marker, diff context, question, and one-time/cancel choices. At the extreme 50×5 case it uses 4/5 rows and deliberately prioritizes the exact command, question, and choices within the one-row body budget. An independent abort harness observed the expected abort reason and zero `unhandledRejection` events even when the host promise rejected late.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local workspace; Node.js v22.22.3; npm 10.9.8; focused Vitest suites plus repository lint, Prettier check, build, and typecheck; no sandbox. Live model-driven TUI and externally managed ACP host testing were not available, so the repository's deterministic Session and Ink renderer harnesses were used.

## Risk & Scope

- Main risk or tradeoff: This is a broad cross-package permission-boundary change touching central Core and ACP execution paths, so regressions could affect approval routing beyond the TUI; the implementation therefore revalidates at each consumption boundary and includes focused coverage for every downstream bridge. The production diff exceeds the repository's advisory threshold for core infrastructure and should receive maintainer awareness.
- Not validated / out of scope: No live model-driven TUI session, externally managed ACP host, Windows run, or Linux run was performed locally. User-entered `!command` input, DataWorks-specific query tools, and speculative interactive approval are intentionally out of scope.
- Breaking changes / migration notes: No API migration is required. In Plan mode, parser-unknown Shell and Monitor calls now require an exact one-time approval or fail closed when no approval surface exists; persistent, modified, stale, or forged approvals are rejected by design. ACP hosts must return an option that the prompt actually offered; previously accepted but unoffered persistent enum values now fail closed. Background callers that bypass the UI contract and send unoffered `ProceedAlways*` outcomes now cancel rather than downgrade to one-time approval. Headless YOLO no longer bypasses teammate confirmations marked `hideAlwaysAllow`, including PM explicit-`ask` rules and `ask_user_question`.

## Linked Issues

Part of #6949; builds on #7053.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将 Plan 模式下由模型发起的 Shell 与 Monitor 调用统一接入 #7053 引入的三态 Shell 安全分类器。只读命令继续走现有权限流程，状态修改命令会在任何审批界面有机会授权前被阻止，无法确定安全性的命令则必须获得一次与精确调用绑定的批准，并在执行前重新校验 Plan 模式版本、工作目录、权限策略、原始请求与实际执行参数。

该精确审批契约被传递到 Core 调度器、ACP 会话、stream-json 与 dual-output 控制请求、嵌套子代理、队友代理及后台代理。所有 Plan 模式 Shell 与 Monitor 确认都会隐藏持久授权；未知命令提示还会隐藏修改选项，拒绝被改写或已失效的批准，避免 IDE diff 竞态，保留原始命令与安全警告，并保持 Plan 模式继续生效。没有显式目录的 Plan 模式调用会绑定到解析后的目标工作区，因此确认标题会稳定包含 `[in <绝对路径>]`。紧凑编辑确认现在会在警告与 diff 之间分配完整的正文高度预算；对于极短终端还提供单行降级路径，确保审批问题和选项仍然可见。

ACP 会针对每个工具审批（而非仅 Plan 模式）校验宿主返回值是否属于提示实际提供的选项，因此宿主无法伪造被隐藏的持久授权。后台审批消费者同样会取消未提供的 `ProceedAlways*` 结果，而不再将其降级为单次批准。在无头队友 YOLO 模式中，任何标记了 `hideAlwaysAllow` 的非 plan 确认（包括 PM 显式 `ask` 规则和 `ask_user_question`）都会被取消，因为它们需要交互式审批界面。

## 为什么需要

Plan 模式此前把确认形态当作 Shell 安全性的代理，但 Shell 和 Monitor 都可能表示只读、状态修改或解析器无法判断的程序。不同审批宿主因此可能产生不一致行为，过期或被改写的响应可能越过预期的 Plan 边界，中止的权限请求可能暴露被拒绝的取消回调，狭窄确认视口也可能裁掉安全决策所需的上下文。本改动为所有支持的执行界面建立统一的失败关闭策略和精确调用审批契约。

## 审阅者测试计划

### 验证方式

1. 在临时工作区进入 Plan 模式并请求 `git status`；确认它不出现新的 Plan 专用提示即可运行，且 Plan 模式保持生效。
2. 请求 `touch changed.txt`；确认它在提示前即被阻止，并且没有创建文件。
3. 请求一个被分类为未知的命令，例如 `python -c 'print(1)'`；确认提示只提供单次批准和取消，批准不会退出 Plan 模式，再次发起相同工具调用时仍会重新提示。
4. 验证未知的包装编辑命令，例如 `bash -c 'sed -i s/alpha/beta/ sample.txt'`；确认在狭窄紧凑确认中仍能看到安全警告、精确原始命令、diff、问题与选项，并且修改、持久授权及 IDE 自动 diff 路径均不可用。
5. 在 ACP 或 stream-json 权限请求等待期间中止当前轮次，随后让宿主产生延迟拒绝；确认工具被干净取消且不会产生未处理拒绝。同时返回被修改的 `updatedInput`、`newContent` 或未提供的持久授权选项，确认调用被取消而不是执行。
6. 通过 Monitor 以及嵌套/后台审批路径重复只读、写入和未知三类用例；确认它们遵循相同的分类与失败关闭规则。
7. macOS 上的自动验证已通过：Core 定向测试 527/527；CLI 定向测试 561 项通过，另有 1 项既有且无关的跳过；紧凑确认测试 28/28；完整 lint、Prettier 检查、build 与 typecheck 均通过。

### 证据（前后对比）

之前：当编辑确认同时携带 Plan 模式安全警告和精确命令警告时，确定性的 50 列紧凑渲染器在 9 行视口内产生 10 行内容，因此警告、命令、diff、问题或选项可能被裁掉。静态路径验证表明，中止后的取消可能在进入 Cancel 分支前先执行上下文校验，并通过 fire-and-forget 权限处理器产生拒绝。

之后：同一渲染器在 50×9 下使用 8/9 行，在 50×8 下使用 7/8 行，同时保留两个警告标签、折叠后的多行命令标记、diff 上下文、问题以及单次批准/取消选项。在极端的 50×5 场景下使用 4/5 行，并在仅一行正文预算内按设计优先保留精确命令、问题和选项。独立中止测试即使在宿主 Promise 延迟拒绝时，也只观察到预期的中止原因，且 `unhandledRejection` 事件为零。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地工作区；Node.js v22.22.3；npm 10.9.8；运行了定向 Vitest 测试以及仓库 lint、Prettier 检查、build 和 typecheck；未使用 sandbox。由于无法使用真实模型驱动的 TUI 和外部托管 ACP Host，本次采用仓库提供的确定性 Session 与 Ink 渲染器测试工具。

## 风险与范围

- 主要风险或权衡：这是一个跨包的广泛权限边界改动，涉及 Core 与 ACP 的中心执行路径，因此回归可能影响 TUI 之外的审批路由；实现会在每个消费边界重新校验，并为每个下游桥接面提供定向覆盖。生产代码 diff 超过仓库对核心基础设施的提示阈值，应提醒维护者关注。
- 未验证 / 不在范围内：本地未执行真实模型驱动的 TUI 会话、外部托管 ACP Host、Windows 或 Linux 验证。用户输入的 `!command`、DataWorks 专用查询工具及推测执行中的交互审批均明确不在范围内。
- 破坏性变更 / 迁移说明：无需 API 迁移。在 Plan 模式下，解析器无法判断的 Shell 和 Monitor 调用现在必须获得精确单次批准；没有审批界面时会失败关闭。持久、修改、过期或伪造的批准会按设计被拒绝。ACP 宿主必须返回提示实际提供的选项；过去会被接受但未展示的持久授权枚举值现在会失败关闭。绕过 UI 契约并发送未提供 `ProceedAlways*` 结果的后台调用方现在会被取消，而不再降级为单次批准。无头 YOLO 不再绕过标记了 `hideAlwaysAllow` 的队友确认，包括 PM 显式 `ask` 规则和 `ask_user_question`。

## 关联问题

属于 #6949 的一部分；基于 #7053。

</details>
