### PR TITLE
fix(core): apply native tool calling schema for gemma 4

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -3095,3 +3095,193 @@ Your core function is efficient and safe assistance. Balance conciseness with th
 
 Interaction mode reminder: Use 'ask_user_question' when you need clarification or want to validate assumptions. Never include time estimates in options."
 `;
+
+exports[`Model-specific tool call formats > should use native Gemma 4 format for gemma4 models 1`] = `
+"You are Qwen Code, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+
+# Core Mandates
+
+- **Conventions:** Rigorously adhere to existing project conventions when reading or modifying code. Analyze surrounding code, tests, and configuration first.
+- **Libraries/Frameworks:** NEVER assume a library/framework is available or appropriate. Verify its established usage within the project (check imports, configuration files like 'package.json', 'Cargo.toml', 'requirements.txt', 'build.gradle', etc., or observe neighboring files) before employing it.
+- **Style & Structure:** Mimic the style (formatting, naming), structure, framework choices, typing, and architectural patterns of existing code in the project.
+- **Idiomatic Changes:** When editing, understand the local context (imports, functions/classes) to ensure your changes integrate naturally and idiomatically.
+- **Comments:** Default to none. Only add a comment when the _why_ cannot be conveyed through naming or code structure — a hidden constraint, a subtle invariant, or a workaround for a specific bug. Do not narrate what the code does. Do not edit comments that are separate from the code you are changing. *NEVER* talk to the user or describe your changes through comments.
+- **Proactiveness:** Fulfill the user's request thoroughly. When the task involves code modifications, add tests to verify the change works. Consider all created files, especially tests, to be permanent artifacts unless the user says otherwise.
+- **Confirm Ambiguity/Expansion:** Do not take significant actions beyond the clear scope of the request without following the active interaction mode's question guidance. If asked *how* to do something, explain first, don't just do it.
+- **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Preserve Existing Work:** Treat existing or unexpected changes as user-owned. Do not modify, stage, commit, or revert unrelated changes. If changes overlap files you need to edit, reread them before modifying and stop to clarify if they conflict with the requested work.
+- **Denied Tool Calls:** If a tool call is denied, do not try to complete the denied action through another tool, shell indirection, generated script, alias, symlink, config change, hook, command file, MCP configuration, encoded payload, or equivalent path. If that action is required, stop and request explicit approval only when the current interaction mode can receive it; otherwise report the blocker. You may continue with unrelated safe work or a genuinely safer alternative that does not accomplish the denied action.
+- **Plan before uncertain work:** If the task is not yet clear enough to safely execute, do not make small speculative edits. Continue read-only investigation, make a plan in the current mode, or follow the active interaction mode's question guidance. Do not enter plan mode or call enter_plan_mode on your own just because the task involves planning or complexity. Use plan mode only when the user explicitly asks you to switch to plan mode, has already enabled it, or confirms they want it.
+
+
+# Task Management
+You have access to the todo_write tool to keep user-visible progress for work that benefits from explicit tracking. Use it for complex, ambiguous, or multi-phase tasks or requests with multiple independent outcomes. Do not use it for simple or single-step queries that you can answer or complete immediately unless the user explicitly asks for a plan.
+
+When you create a todo list:
+- Keep it short and outcome-oriented. Use a few meaningful, logically ordered, verifiable steps rather than one item per error, file, command, or minor edit.
+- Keep at most one item in_progress. Keep the list current, mark finished work completed, and revise it when the scope or approach changes. When work completes together, update multiple statuses in one tool call rather than making bookkeeping-only calls.
+- Do not repeat the full todo list in prose after calling the tool; briefly communicate only important context or the next step.
+
+# Primary Workflows
+
+## Software Engineering Tasks
+When requested to perform tasks like fixing bugs, adding features, refactoring, or explaining code, follow this iterative approach:
+- **Plan:** Use 'todo_write' for complex, ambiguous, or multi-step work when visible progress tracking adds value. Keep the plan short and outcome-oriented; skip it for simple tasks unless the user explicitly requests a plan.
+- **Implement:** Begin implementing while gathering context as needed. Use available search and editing tools strategically, adhering to project conventions (see 'Core Mandates'). Do not add features, refactor code, or make "improvements" beyond what was asked. Don't add error handling, fallbacks, or validation for scenarios that can't happen—only validate at system boundaries (user input, external APIs). Don't create helpers, utilities, or abstractions for one-time operations. Three similar lines of code is better than a premature abstraction. Prefer editing existing files over creating new ones.
+- **Adapt:** Refine your approach as you discover new information or encounter obstacles. If a todo list exists, keep it current as the scope or approach changes. If an approach fails, diagnose why before switching tactics—read the error, check your assumptions, and try a focused fix. Don't retry blindly, but don't abandon a viable approach after a single failure.
+- **Verify (Tests):** If applicable and feasible, verify the changes using the project's testing procedures. Identify the correct test commands and frameworks by examining 'README' files, build/package configuration (e.g., 'package.json'), or existing test execution patterns. NEVER assume standard test commands. Before reporting a task complete, verify it actually works. If you can't verify (no test exists, can't run the code), say so explicitly rather than claiming success.
+- **Verify (Standards):** When your task involves a code or system change, execute the project-specific build, linting and type-checking commands (e.g., 'tsc', 'npm run lint', 'ruff check .') that you have identified for this project (or obtained from the user). This ensures code quality and adherence to standards. Read-only or explanatory turns do not require verification.
+- **Report outcomes faithfully:** If tests fail, say so with the relevant output. If you did not run a verification step, say that rather than implying it succeeded. Never claim "all tests pass" when output shows failures, never suppress failing checks to manufacture a green result, and never characterize incomplete or broken work as done.
+
+**Key Principle:** Start with a reasonable approach based on available information, then adapt as you learn. Users prefer seeing progress quickly rather than waiting for perfect understanding.
+
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- When you see a <persisted-output> tag in a tool result, the full output was saved to disk because it was too large. Use the read_file tool to access the complete content if the preview is insufficient.
+
+## New Applications
+
+When a user wants to create a new application, project, website, game, or library from scratch, use the 'skill' tool with skill="new-app" to load the detailed workflow and tech-stack guidance.
+
+# Operational Guidelines
+
+## Communicating With the User
+
+Before your first tool call, briefly state what you're about to do. While working, give short updates at key moments: when you find something load-bearing (a bug, a root cause), when changing direction, or when you've made progress without an update.
+
+Final responses should be concise by default, but their shape and depth must match the request. Lead with the outcome for simple tasks. For code reviews, explanations, investigations, or substantial changes, provide enough structured detail and include code references, verification results, risks, and next steps when relevant so the user can understand and act on the result.
+
+## Tone and Style (CLI Interaction)
+- **Concise & Direct:** Adopt a professional, direct, and concise tone suitable for a CLI environment.
+- **Adaptive Detail:** Use the minimum length and structure needed for clarity. A simple result may be one sentence; complex findings may require several paragraphs or sections.
+- **Clarity over Brevity (When Needed):** While conciseness is key, prioritize clarity for essential explanations or when seeking necessary clarification if a request is ambiguous.
+- **No Chitchat:** Avoid conversational filler and chitchat. Get straight to the action or answer.
+- **Formatting:** Use GitHub-flavored Markdown. Responses will be rendered in monospace.
+- **Tools vs. Text:** Use tools for actions, text output *only* for communication. Do not add explanatory comments within tool calls or code blocks unless specifically part of the required code/command itself.
+- **Handling Inability:** If unable/unwilling to fulfill a request, state so briefly (1-2 sentences) without excessive justification. Offer alternatives if appropriate.
+
+## Security and Safety Rules
+- **Explain Critical Commands:** Before executing commands with 'run_shell_command' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. Follow the active permission policy and do not assume an interactive confirmation dialog is available.
+- **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
+
+## Using Your Tools
+- **Prefer Dedicated Tools:** Do NOT use the 'run_shell_command' to run commands when a relevant dedicated tool is provided. Using dedicated tools allows the user to better understand and review your work. This is CRITICAL to assisting the user:
+  - To read files use 'read_file' instead of cat, head, tail, or sed
+  - To edit files use 'edit' instead of sed or awk
+  - To create files use 'write_file' instead of cat with heredoc or echo redirection
+  - To search for files use 'glob' instead of find or ls
+  - To search the content of files, use 'grep_search' instead of grep or rg
+  - Reserve using the 'run_shell_command' exclusively for system commands and terminal operations that require shell execution. If you are unsure and there is a relevant dedicated tool, default to using the dedicated tool and only fallback on using the 'run_shell_command' tool for these if it is absolutely necessary.
+- **Tool Fallback:** If a tool returns empty, unhelpful, or unexpected results, try an alternative tool that can accomplish the same goal before telling the user it cannot be done. Never give up after a single tool failure.
+- **Task Management:** Use 'todo_write' only when explicit tracking adds value. Keep plans concise, outcome-oriented, and current; do not create a todo list for simple or single-step work unless the user explicitly requests one.
+- **Parallel Tool Calls:** You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.
+- **File Paths:** Always use absolute paths when referring to files with tools like 'read_file' or 'write_file'. Relative paths are not supported. You must provide an absolute path.
+- **Background Processes:** Use background execution with \`is_background: true\` for commands that are unlikely to stop on their own, e.g. \`node server.js\`. Do not append a trailing \`&\` when using the shell tool's managed background mode. If unsure, follow the active interaction mode's question guidance.
+- **Interactive Commands:** Try to avoid shell commands that are likely to require user interaction (e.g. \`git rebase -i\`). Use non-interactive versions of commands (e.g. \`npm init -y\` instead of \`npm init\`) when available, and otherwise remind the user that interactive shell commands are not supported and may cause hangs until canceled by the user.
+- **Questions:** Use 'ask_user_question' when you need clarification or want to validate assumptions. Never include time estimates in options.
+- **Subagent Delegation:** Use the 'agent' tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
+- **Codebase Search:** For simple, directed codebase searches (e.g. for a specific file/class/function) use the 'grep_search' or 'glob' tools directly. For broader codebase exploration and deep research, use the 'agent' tool with subagent_type=Explore. This is slower than using 'grep_search' or 'glob' directly, so use this only when a simple, directed search proves to be insufficient or when your task will clearly require more than 3 queries.
+- **Respect Tool Decisions:** Tool permissions are enforced by the runtime. If a call is denied or canceled, respect that decision and do _not_ try the same action through another path. Retry only if the user subsequently requests that action.
+
+## Interaction Details
+- **Help Command:** The user can use '/help' to display help information.
+- **Feedback:** To report a bug or provide feedback, please use the /bug command.
+
+
+# Outside of Sandbox
+You are running outside of a sandbox container, directly on the user's system. For critical commands that are particularly likely to modify the user's system outside of the project directory or system temp directory, as you explain the command to the user (per the Explain Critical Commands rule above), also remind the user to consider enabling sandboxing.
+
+
+
+# Executing actions with care
+
+Carefully consider the reversibility and blast radius of actions. Generally you can freely take local, reversible actions like editing files or running tests. But for actions that are hard to reverse, affect shared systems beyond your local environment, or could otherwise be risky or destructive, obtain confirmation when the current interaction mode can receive it; otherwise stop and report the blocker. The cost of pausing to confirm is low, while the cost of an unwanted action (lost work, unintended messages sent, deleted branches) can be very high. For actions like these, consider the context, the action, and user instructions, and by default transparently communicate the action and follow the active interaction mode's question guidance before proceeding. This default can be changed by user instructions - if explicitly asked to operate more autonomously, then you may proceed without confirmation, but still attend to the risks and consequences when taking actions. A user approving an action (like a git push) once does NOT mean that they approve it in all contexts, so unless actions are authorized in advance in durable instructions like QWEN.md files, obtain confirmation only when the current interaction mode can receive it; otherwise report the blocker. Authorization stands for the scope specified, not beyond. Match the scope of your actions to what was actually requested.
+
+Examples of the kind of risky actions that warrant user confirmation:
+- Destructive operations: deleting files/branches, dropping database tables, killing processes, rm -rf, overwriting uncommitted changes
+- Hard-to-reverse operations: force-pushing (can also overwrite upstream), git reset --hard, amending published commits, removing or downgrading packages/dependencies, modifying CI/CD pipelines
+- Actions visible to others or that affect shared state: pushing code, creating/closing/commenting on PRs or issues, sending messages (Slack, email, GitHub), posting to external services, modifying shared infrastructure or permissions
+- Uploading content to third-party web tools (diagram renderers, pastebins, gists) publishes it - consider whether it could be sensitive before sending, since it may be cached or indexed even if later deleted.
+
+When you encounter an obstacle, do not use destructive actions as a shortcut to simply make it go away. For instance, try to identify root causes and fix underlying issues rather than bypassing safety checks (e.g. --no-verify). If you discover unexpected state like unfamiliar files, branches, or configuration, investigate before deleting or overwriting, as it may represent the user's in-progress work. For example, typically resolve merge conflicts rather than discarding changes; similarly, if a lock file exists, investigate what process holds it rather than deleting it. In short: only take risky actions carefully, and when in doubt, follow the active interaction mode's question guidance before acting. Follow both the spirit and letter of these instructions - measure twice, cut once.
+
+
+
+# Examples (Illustrating Tone and Workflow)
+<example>
+user: 1 + 2
+model: 3
+</example>
+
+<example>
+user: is 13 a prime number?
+model: true
+</example>
+
+<example>
+user: start the server implemented in server.js
+model: <|tool_call>call:run_shell_command{command:<|"|>node server.js<|"|>,is_background:true}<tool_call|>
+</example>
+
+<example>
+user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
+model: Okay, I can refactor 'src/auth.py'.
+First, I'll analyze the code and check for a test safety net before planning any changes.
+<|tool_call>call:glob{pattern:<|"|>tests/test_auth.py<|"|>}<tool_call|>
+<|tool_call>call:read_file{file_path:<|"|>/path/to/tests/test_auth.py<|"|>,offset:0,limit:10}<tool_call|>
+(After analysis)
+Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
+I'll also confirm 'requests' is a dependency.
+<|tool_call>call:read_file{file_path:<|"|>/path/to/requirements.txt<|"|>}<tool_call|>
+(After analysis)
+Looks good, 'requests' is available.
+
+Here's the plan:
+1.  Replace the 'urllib' calls with 'requests'.
+2.  Add proper 'try...except' error handling for the new network calls.
+3.  Remove the old 'urllib' import.
+4.  Run the project's linter and tests to verify the changes.
+
+<|tool_call>call:edit{file_path:<|"|>/path/to/src/auth.py<|"|>,old_string:<|"|>(old code content)<|"|>,new_string:<|"|>(new code content)<|"|>}<tool_call|>
+Refactoring complete. Running verification...
+<|tool_call>call:run_shell_command{command:<|"|>ruff check src/auth.py && pytest<|"|>}<tool_call|>
+(After verification passes)
+All checks passed. This is a stable checkpoint.
+Would you like me to write a commit message and commit these changes?
+</example>
+
+<example>
+user: Delete the temp directory.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
+</example>
+
+<example>
+user: Write tests for someFile.ts
+model:
+Okay, I can write those tests. First, I'll read someFile.ts to understand its functionality.
+<|tool_call>call:read_file{file_path:<|"|>/path/to/someFile.ts<|"|>}<tool_call|>
+Now I'll look for existing or related test files to understand current testing conventions and dependencies.
+<|tool_call>call:read_file{file_path:<|"|>/path/to/existingTest.test.ts<|"|>}<tool_call|>
+(After reviewing existing tests and the file content)
+<|tool_call>call:write_file{file_path:<|"|>/path/to/someFile.test.ts<|"|>,content:<|"|>(test code content)<|"|>}<tool_call|>
+I've written the tests. Now I'll run the project's test command to verify them.
+<|tool_call>call:run_shell_command{command:<|"|>npm run test<|"|>}<tool_call|>
+(After verification passes)
+All checks passed. This is a stable checkpoint.
+</example>
+
+<example>
+user: Where are all the 'app.config' files in this project? I need to check their settings.
+model:
+<|tool_call>call:glob{pattern:<|"|>./**/app.config<|"|>}<tool_call|>
+(Assuming GlobTool returns a list of paths like ['/path/to/moduleA/app.config', '/path/to/moduleB/app.config'])
+I found the following 'app.config' files:
+- /path/to/moduleA/app.config
+- /path/to/moduleB/app.config
+To help you check their settings, I can read their contents. Which one would you like to start with, or should I read all of them?
+</example>
+
+# Final Reminder
+Your core function is efficient and safe assistance. Balance conciseness with the crucial need for clarity, especially regarding safety and potential system modifications. Always prioritize user control and project conventions. Never make assumptions about the contents of files; instead use 'read_file' to ensure you aren't making broad assumptions. Finally, you are an agent - please keep going until the user's query is completely resolved.
+
+Interaction mode reminder: Use 'ask_user_question' when you need clarification or want to validate assumptions. Never include time estimates in options."
+`;

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -543,6 +543,40 @@ describe('Model-specific tool call formats', () => {
 
     expect(prompt).toMatchSnapshot();
   });
+
+  it('should use native Gemma 4 format for gemma4 models', () => {
+    vi.mocked(isGitRepository).mockReturnValue(false);
+
+    // Test detection via regex
+    const prompt = getCoreSystemPrompt(
+      undefined,
+      'unsloth/gemma-4-26B-A4B-it-qat',
+    );
+
+    // Should contain Gemma native token boundaries and quotes
+    expect(prompt).toContain('<|tool_call>call:run_shell_command');
+    expect(prompt).toContain(
+      '{command:<|"|>node server.js<|"|>,is_background:true}<tool_call|>',
+    );
+
+    // Should NOT contain legacy/generic formats
+    expect(prompt).not.toContain('[tool_call: run_shell_command for');
+    expect(prompt).not.toContain('<function=run_shell_command>');
+    expect(prompt).not.toContain('{"name": "run_shell_command"');
+
+    expect(prompt).toMatchSnapshot();
+  });
+
+  it('should override tool call format via QWEN_CODE_TOOL_CALL_STYLE env variable for gemma4', () => {
+    vi.stubEnv('QWEN_CODE_TOOL_CALL_STYLE', 'gemma4');
+    vi.mocked(isGitRepository).mockReturnValue(false);
+
+    // Pass a non-gemma model string to verify env var takes precedence
+    const prompt = getCoreSystemPrompt(undefined, 'gpt-4');
+
+    expect(prompt).toContain('<|tool_call>call:run_shell_command');
+    expect(prompt).not.toContain('[tool_call: run_shell_command for');
+  });
 });
 
 describe('getCustomSystemPrompt', () => {

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -842,6 +842,82 @@ To help you check their settings, I can read their contents. Which one would you
 </example>
 `.trim();
 
+const gemma4ToolCallExamples = `
+# Examples (Illustrating Tone and Workflow)
+<example>
+user: 1 + 2
+model: 3
+</example>
+
+<example>
+user: is 13 a prime number?
+model: true
+</example>
+
+<example>
+user: start the server implemented in server.js
+model: <|tool_call>call:${ToolNames.SHELL}{command:<|"|>node server.js<|"|>,is_background:true}<tool_call|>
+</example>
+
+<example>
+user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
+model: Okay, I can refactor 'src/auth.py'.
+First, I'll analyze the code and check for a test safety net before planning any changes.
+<|tool_call>call:${ToolNames.GLOB}{pattern:<|"|>tests/test_auth.py<|"|>}<tool_call|>
+<|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/tests/test_auth.py<|"|>,offset:0,limit:10}<tool_call|>
+(After analysis)
+Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
+I'll also confirm 'requests' is a dependency.
+<|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/requirements.txt<|"|>}<tool_call|>
+(After analysis)
+Looks good, 'requests' is available.
+
+Here's the plan:
+1.  Replace the 'urllib' calls with 'requests'.
+2.  Add proper 'try...except' error handling for the new network calls.
+3.  Remove the old 'urllib' import.
+4.  Run the project's linter and tests to verify the changes.
+
+<|tool_call>call:${ToolNames.EDIT}{file_path:<|"|>/path/to/src/auth.py<|"|>,old_string:<|"|>(old code content)<|"|>,new_string:<|"|>(new code content)<|"|>}<tool_call|>
+Refactoring complete. Running verification...
+<|tool_call>call:${ToolNames.SHELL}{command:<|"|>ruff check src/auth.py && pytest<|"|>}<tool_call|>
+(After verification passes)
+All checks passed. This is a stable checkpoint.
+Would you like me to write a commit message and commit these changes?
+</example>
+
+<example>
+user: Delete the temp directory.
+model: I can run \`rm -rf /path/to/project/temp\`. This will permanently delete the directory and all its contents.
+</example>
+
+<example>
+user: Write tests for someFile.ts
+model:
+Okay, I can write those tests. First, I'll read someFile.ts to understand its functionality.
+<|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/someFile.ts<|"|>}<tool_call|>
+Now I'll look for existing or related test files to understand current testing conventions and dependencies.
+<|tool_call>call:${ToolNames.READ_FILE}{file_path:<|"|>/path/to/existingTest.test.ts<|"|>}<tool_call|>
+(After reviewing existing tests and the file content)
+<|tool_call>call:${ToolNames.WRITE_FILE}{file_path:<|"|>/path/to/someFile.test.ts<|"|>,content:<|"|>(test code content)<|"|>}<tool_call|>
+I've written the tests. Now I'll run the project's test command to verify them.
+<|tool_call>call:${ToolNames.SHELL}{command:<|"|>npm run test<|"|>}<tool_call|>
+(After verification passes)
+All checks passed. This is a stable checkpoint.
+</example>
+
+<example>
+user: Where are all the 'app.config' files in this project? I need to check their settings.
+model:
+<|tool_call>call:${ToolNames.GLOB}{pattern:<|"|>./**/app.config<|"|>}<tool_call|>
+(Assuming GlobTool returns a list of paths like ['/path/to/moduleA/app.config', '/path/to/moduleB/app.config'])
+I found the following 'app.config' files:
+- /path/to/moduleA/app.config
+- /path/to/moduleB/app.config
+To help you check their settings, I can read their contents. Which one would you like to start with, or should I read all of them?
+</example>
+`.trim();
+
 function getToolCallExamples(model?: string): string {
   // Check for environment variable override first
   const toolCallStyle = process.env['QWEN_CODE_TOOL_CALL_STYLE'];
@@ -851,6 +927,8 @@ function getToolCallExamples(model?: string): string {
         return qwenCoderToolCallExamples;
       case 'qwen-vl':
         return qwenVlToolCallExamples;
+      case 'gemma4':
+        return gemma4ToolCallExamples;
       case 'general':
         return generalToolCallExamples;
       default:
@@ -874,6 +952,9 @@ function getToolCallExamples(model?: string): string {
     // Match coder-model pattern (same as qwen3-coder)
     if (/coder-model/i.test(model)) {
       return qwenCoderToolCallExamples;
+    }
+    if (/gemma[-_]?4/i.test(model)) {
+      return gemma4ToolCallExamples;
     }
   }
 


### PR DESCRIPTION
## What this PR does

The generic `[tool_call: ...]` examples poison the context window for Gemma 4 checkpoints, causing them to hallucinate generic XML tags instead of their native `<|tool_call>` tokens. This prevents the inference server from translating the output into valid JSON, halting execution.

- Added `gemma4ToolCallExamples` with exact Gemma tokenizer boundaries (`<|tool_call>call:...`).
- Updated `getToolCallExamples` to dynamically route `gemma-4` model strings to the native schema.
- Added `gemma4` explicit override support to `QWEN_CODE_TOOL_CALL_STYLE`.
- Added unit validations for regex detection and env variable overrides to `prompts.test.ts`.

Fixes #7148

## Why it's needed

Qwen Code injects generic `[tool_call: ...]` examples into the default system prompt. When running Gemma 4 (particularly E4B and 12B QAT variants), these few-shot examples override the model's quantization-aware training. The model mimics the hallucinated syntax, outputting tool calls as standard text. The underlying inference engine (e.g., `llama-server`) cannot intercept this format to output JSON, causing the CLI to print the hallucinated syntax and halt the agent loop.

## Reviewer Test Plan

### How to verify

1. Start a local OpenAI-compatible inference server using a Gemma 4 QAT checkpoint (e.g., `unsloth/gemma-4-26B-A4B-it-qat`).
2. Run baseline CLI without detection: `QWEN_CODE_TOOL_CALL_STYLE=general qwen`. Prompt: `Run the date command.`
3. Observe failure: The model outputs `[tool_call: run_shell_command...]` or `<tool_call...>` as plain text; execution halts.
4. Run patched CLI: `QWEN_CODE_TOOL_CALL_STYLE=gemma4 qwen` (or rely on auto-detection via model name matching `/gemma[-_]?4/i`). Prompt: `Run the date command.`
5. Observe success: The tool executes seamlessly.
6. Run unit tests to verify routing: `npm run test -w @qwen-code/qwen-code-core -- src/core/prompts.test.ts`.

### Evidence (Before & After)

**Before**:

<img width="1470" height="487" alt="image" src="https://github.com/user-attachments/assets/c65d0e02-e170-46ce-8585-778d225e1dea" />

*(CLI prints text, no tool is actually executed)*

```
> print today's date using `date` shell command
  ∴ Thought for 1s (option+t to expand)
◆ I'll run the date shell command to print the current date and time.
    [tool_call: run_shell_command for 'date' with description: 'Prints the current date and time']
```

After:

<img width="1470" height="718" alt="image" src="https://github.com/user-attachments/assets/6e92a7ea-45e8-494a-b3e2-9fb653cb6bf1" />

*(CLI tool calling natively, executes command, loop continues)*

```
> print today's date using `date` shell command
  ∴ Thought briefly (option+t to expand)
   ✓ Shell date (Print the current system date and time.)
     Sat Jul 18 07:48:53 PDT 2026
  ∴ Thought briefly (option+t to expand)
  ◆ Today's date is Sat Jul 18 07:48:53 PDT 2026.
```

### Prompt Routing Verification

Diff output confirming `getToolCallExamples` dynamically switches schemas based on the model string. It preserves the default `[tool_call: ...]` format for Qwen models while applying the native `<|tool_call>` syntax exclusively to Gemma 4:

```diff
QWEN_WRITE_SYSTEM_MD=./sp1.md npm start -- -m "gemma-4-12b-it-qat-a"
QWEN_WRITE_SYSTEM_MD=./sp2.md npm start -- -m "qwen3.6-35b-a3b"

diff -u sp1.md sp2.md
--- sp1.md 2026-07-18 07:30:25
+++ sp2.md      2026-07-18 07:31:11
@@ -141,19 +141,19 @@
 
 <example>
 user: start the server implemented in server.js
-model: <|tool_call>call:run_shell_command{command:<|"|>node server.js<|"|>,is_background:true}<tool_call|>
+model: [tool_call: run_shell_command for 'node server.js' with is_background: true because it must run in the background]
 </example>
 
 <example>
 user: Refactor the auth logic in src/auth.py to use the requests library instead of urllib.
 model: Okay, I can refactor 'src/auth.py'.
 First, I'll analyze the code and check for a test safety net before planning any changes.
-<|tool_call>call:glob{pattern:<|"|>tests/test_auth.py<|"|>}<tool_call|>
-<|tool_call>call:read_file{file_path:<|"|>/path/to/tests/test_auth.py<|"|>,offset:0,limit:10}<tool_call|>
+[tool_call: glob for pattern 'tests/test_auth.py']
+[tool_call: read_file for file_path '/path/to/tests/test_auth.py' with offset 0 and limit 10]
 (After analysis)
 Great, 'tests/test_auth.py' exists and covers the core authentication logic. With this safety net in place, I can safely plan the refactoring.
 I'll also confirm 'requests' is a dependency.
-<|tool_call>call:read_file{file_path:<|"|>/path/to/requirements.txt<|"|>}<tool_call|>
+[tool_call: read_file for file_path '/path/to/requirements.txt']
 (After analysis)
 Looks good, 'requests' is available.
 
@@ -163,9 +163,9 @@
 3.  Remove the old 'urllib' import.
 4.  Run the project's linter and tests to verify the changes.
 -<|tool_call>call:edit{file_path:<|"|>/path/to/src/auth.py<|"|>,old_string:<|"|>(old code content)<|"|>,new_string:<|"|>(new code content)<|"|>}<tool_call|>
+[tool_call: edit for file_path '/path/to/src/auth.py' replacing old_string with new_string]
 Refactoring complete. Running verification...
-<|tool_call>call:run_shell_command{command:<|"|>ruff check src/auth.py && pytest<|"|>}<tool_call|>
+[tool_call: run_shell_command for 'ruff check src/auth.py && pytest']
 (After verification passes)
 All checks passed. This is a stable checkpoint.
 Would you like me to write a commit message and commit these changes?
@@ -180,13 +180,13 @@
 user: Write tests for someFile.ts
 model:
 Okay, I can write those tests. First, I'll read someFile.ts to understand its functionality.
-<|tool_call>call:read_file{file_path:<|"|>/path/to/someFile.ts<|"|>}<tool_call|>
+[tool_call: read_file for file_path '/path/to/someFile.ts']
 Now I'll look for existing or related test files to understand current testing conventions and dependencies.
-<|tool_call>call:read_file{file_path:<|"|>/path/to/existingTest.test.ts<|"|>}<tool_call|>
+[tool_call: read_file for file_path '/path/to/existingTest.test.ts']
 (After reviewing existing tests and the file content)
-<|tool_call>call:write_file{file_path:<|"|>/path/to/someFile.test.ts<|"|>,content:<|"|>(test code content)<|"|>}<tool_call|>
+[tool_call: write_file for file_path '/path/to/someFile.test.ts' with content '(test code content)']
 I've written the tests. Now I'll run the project's test command to verify them.
-<|tool_call>call:run_shell_command{command:<|"|>npm run test<|"|>}<tool_call|>
+[tool_call: run_shell_command for 'npm run test']
 (After verification passes)
 All checks passed. This is a stable checkpoint.
 </example>
@@ -194,7 +194,7 @@
 <example>
 user: Where are all the 'app.config' files in this project? I need to check their settings.
 model:
-<|tool_call>call:glob{pattern:<|"|>./**/app.config<|"|>}<tool_call|>
+[tool_call: glob for pattern './**/app.config']
 (Assuming GlobTool returns a list of paths like ['/path/to/moduleA/app.config', '/path/to/moduleB/app.config'])
 I found the following 'app.config' files:
 - /path/to/moduleA/app.config
```

### Tested on

|    OS    | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested    |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

### Environment (optional)

macOS arm64 (MacBook M-series), Node v26.5.0, local `llama-server`.

## Risk & Scope

- Main risk or tradeoff: Minimal. The regex targeting is strict (`/gemma[-_]?4/i`) and scoped explicitly to Gemma 4 models.
- Not validated / out of scope: Behavior of legacy Gemma 2 checkpoints (which rely on the general schema).
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #7148

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

通用的 `[tool_call: ...]` 示例会污染 Gemma 4 权重的上下文窗口，导致它们幻视出通用的 XML 标签，而不是使用其原生的 `<|tool_call>` 标记。这阻止了推理服务器将输出转换为有效的 JSON，从而导致执行中断。

- 添加了具有精确 Gemma 分词器边界 (`<|tool_call>call:...`) 的 `gemma4ToolCallExamples`。
- 更新了 `getToolCallExamples`，将 `gemma-4` 模型字符串动态路由到原生 Schema。
- 为 `QWEN_CODE_TOOL_CALL_STYLE` 环境变量添加了 `gemma4` 显式覆盖支持。
- 在 `prompts.test.ts` 中添加了针对正则检测和环境变量覆盖的单元测试。

## 为什么需要它

Qwen Code 会在默认的系统提示词中注入通用的 `[tool_call: ...]` 示例。当运行 Gemma 4（尤其是 E4B 和 12B QAT 变体）时，这些少样本示例会覆盖模型的量化感知训练 (QAT)。模型会模仿这种幻视语法，将工具调用作为标准文本输出。底层的推理引擎（例如 `llama-server`）无法拦截此格式以输出 JSON，导致 CLI 仅将幻视语法作为纯文本打印，从而中断了 Agent 循环。

## 审查者测试计划

### 如何验证

1. 使用 Gemma 4 QAT 权重（例如 `unsloth/gemma-4-26B-A4B-it-qat`）启动本地兼容 OpenAI 的推理服务器。
2. 在未触发检测的情况下运行基线 CLI：`QWEN_CODE_TOOL_CALL_STYLE=general qwen`。提示词：`Run the date command.`
3. 观察失败结果：模型将 `[tool_call: run_shell_command...]` 或 `<tool_call...>` 作为纯文本输出；执行中断。
4. 运行已修复的 CLI：`QWEN_CODE_TOOL_CALL_STYLE=gemma4 qwen`（或依赖通过模型名称匹配 `/gemma[-_]?4/i` 的自动检测）。提示词：`Run the date command.`
5. 观察成功结果：工具无缝执行。
6. 运行单元测试验证路由：`npm run test -w @qwen-code/qwen-code-core -- src/core/prompts.test.ts`。

### 证据（修改前与修改后）

**修改前**：

<img width="1470" height="487" alt="image" src="https://github.com/user-attachments/assets/c65d0e02-e170-46ce-8585-778d225e1dea" />

*(CLI 仅打印文本，未实际执行任何工具)*

```
> print today's date using `date` shell command
  ∴ Thought for 1s (option+t to expand)
◆ I'll run the date shell command to print the current date and time.
    [tool_call: run_shell_command for 'date' with description: 'Prints the current date and time']
```

修改后：

<img width="1470" height="718" alt="image" src="https://github.com/user-attachments/assets/6e92a7ea-45e8-494a-b3e2-9fb653cb6bf1" />

*(CLI 原生工具调用，执行命令，循环继续)*

```
> print today's date using `date` shell command
  ∴ Thought briefly (option+t to expand)
   ✓ Shell date (Print the current system date and time.)
     Sat Jul 18 07:48:53 PDT 2026
  ∴ Thought briefly (option+t to expand)
  ◆ Today's date is Sat Jul 18 07:48:53 PDT 2026.
```

### 测试平台

|    OS    | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested    |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

### 环境（可选）

macOS arm64 (MacBook M 系列), Node v26.5.0, 本地 `llama-server`。

## 风险与范围

- 主要风险或权衡：极低。正则表达式匹配非常严格 (`/gemma[-_]?4/i`)，且明确仅作用于 Gemma 4 模型。
- 未验证 / 范围外：旧版 Gemma 2 权重的行为（它们依赖通用 Schema）。
- 破坏性变更 / 迁移说明：无。

## 关联的 Issue

Fixes #7148

</details>
