### PR TITLE
perf(cli): Defer TUI runtime from ACP startup

### DIFF
--- a/docs/design/acp-channel-initialize-profiling.md
+++ b/docs/design/acp-channel-initialize-profiling.md
@@ -102,3 +102,66 @@ telemetry failure isolation, Config event ordering, and the serve fast-path
 bundle boundary. The release-built candidate is compared with the exact #6907
 merge baseline on the representative 2C4G host with paired, alternating cold
 runs before any optimization is selected.
+
+## P0-B optimization decision
+
+The 2C4G P0-A profile attributed 67.3% of child startup P50 to Gemini and ACP
+module loading. CPU profiles then showed that source-module compilation was the
+largest CPU cost and that the ACP static import graph loaded Ink, React, React
+Reconciler, and Yoga even though the ACP child does not render a TUI.
+
+The optional edges were existing UI-only dependencies rather than a new ACP
+entry point. The ACP Session imported an API-error classifier through a React
+hook; extension completion imported its data shape and result limit through a
+render component; the command registry statically loaded UI support needed
+only when `/init` asks for confirmation, approval mode enters auto mode, or
+collapsed history expands. The optimization moves the two pure data helpers
+out of render modules, makes the React type import type-only, and loads the
+three interactive action dependencies only when those actions execute.
+
+The ACP initialize response, startup ordering, Config initialization, command
+registry contents, failure handling, and Session behavior remain unchanged. A
+bundle-metafile check follows the ACP agent's static output closure and rejects
+Ink, React, React Reconciler, or Yoga inputs while continuing to allow them
+behind dynamic imports.
+
+The causal comparison used release artifacts built from the same main commit,
+`af6a9b640c5d9097c5151b8705dd73aee8e180d0`, with only this optimization
+applied to the candidate. Two alternating cold runs produced 60 pairs after an
+excluded warmup; a separate alternating preheated run produced 30 pairs. The
+second cold run was started after the first run exposed two candidate-side
+parent-listener stalls before the ACP path. No samples from either run were
+discarded. The pooled cold P50 results were:
+
+| Metric                    | Matched control | P0-B candidate |             Change |
+| ------------------------- | --------------: | -------------: | -----------------: |
+| ACP import                |       115.06 ms |       52.00 ms | -63.06 ms (-54.8%) |
+| Child process to response |      1102.88 ms |     1041.09 ms |          -61.80 ms |
+| `channel.initialize`      |      1098.25 ms |     1035.61 ms |          -62.64 ms |
+| Process to first Session  |      2046.88 ms |     1980.03 ms |          -66.85 ms |
+| Cold Session request      |      1358.95 ms |     1290.23 ms |          -68.72 ms |
+
+All 60 cold profiles in each variant and all 30 preheated profiles in each
+variant were complete. Every run exited cleanly, and concurrent first Sessions,
+telemetry-disabled startup, and legacy default `single` behavior succeeded in
+both functional rounds. In the pooled cold data, warm-Session P95 changed from
+137.53 ms to 104.98 ms, first-health P95 from 962.99 ms to 824.14 ms, and
+process-tree RSS P95 from 442.27 MiB to 435.70 MiB. In the preheated data,
+Session P50 changed from 73.90 ms to 73.75 ms and P95 from 88.38 ms to 76.17 ms.
+
+Transient host-wide stalls affected both variants and were retained. In the
+first 30-pair run, two candidate parent-listener stalls raised first-health P95
+from 803.82 ms to 1175.67 ms even though the health requests themselves took
+6-11 ms and the changed ACP path had not started. The diagnostic retry reversed
+the direction, with control/candidate first-health P95 of 1522.44/727.64 ms;
+pooling all 60 retained pairs produced the values above. The exact P0-A merge
+was also compared with the candidate as a secondary 30-pair check and
+independently showed the same ACP-import reduction and no P95 regression.
+
+The module-loading candidate therefore clears the P0-B gate: the selected
+phase improves by more than 30% and 10 ms, while both `channel.initialize` and
+process-to-first-Session P50 improve by more than 10 ms. Lazy top-level yargs
+command builders were rejected because their selected-phase improvement did
+not clear the 30% gate. Tool registry and warmup remain a separate descriptor
+decoupling design; extension refresh, hierarchical memory, and transport were
+too small to justify a P0 behavior change.

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -208,7 +208,7 @@ import {
   parseAcpModelOption,
   resolveAcpModelOption,
 } from '../../utils/acpModelUtils.js';
-import { classifyApiError } from '../../ui/hooks/useGeminiStream.js';
+import { classifyApiError } from '../../utils/classify-api-error.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import {

--- a/packages/cli/src/ui/commands/approvalModeCommand.test.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.test.ts
@@ -83,6 +83,20 @@ describe('approvalModeCommand', () => {
       expect(mockSetApprovalMode).toHaveBeenCalledWith('yolo');
     });
 
+    it('should emit the entry notice when switching to auto mode', async () => {
+      const result = (await approvalModeCommand.action?.(
+        mockContext,
+        'auto',
+      )) as MessageActionReturn;
+
+      expect(result.type).toBe('message');
+      expect(mockSetApprovalMode).toHaveBeenCalledWith('auto');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'info' }),
+        expect.any(Number),
+      );
+    });
+
     it('should set approval mode to "auto-edit" when argument is "auto-edit"', async () => {
       const result = (await approvalModeCommand.action?.(
         mockContext,

--- a/packages/cli/src/ui/commands/approvalModeCommand.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.ts
@@ -17,7 +17,6 @@ import {
   APPROVAL_MODES,
   ApprovalMode as ApprovalModeEnum,
 } from '@qwen-code/qwen-code-core';
-import { emitAutoModeEntryNotices } from '../hooks/useAutoAcceptIndicator.js';
 import { formatApprovalModeName } from '../utils/approvalModeDisplay.js';
 
 /**
@@ -92,6 +91,9 @@ export const approvalModeCommand: SlashCommand = {
       priorMode !== ApprovalModeEnum.AUTO &&
       config
     ) {
+      const { emitAutoModeEntryNotices } = await import(
+        '../hooks/useAutoAcceptIndicator.js'
+      );
       emitAutoModeEntryNotices({
         config,
         settings,

--- a/packages/cli/src/ui/commands/approvalModeCommand.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.ts
@@ -73,6 +73,24 @@ export const approvalModeCommand: SlashCommand = {
     if (config) {
       try {
         priorMode = config.getApprovalMode();
+      } catch (e) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: (e as Error).message,
+        };
+      }
+    }
+
+    const autoModeNotices =
+      mode === ApprovalModeEnum.AUTO &&
+      priorMode !== ApprovalModeEnum.AUTO &&
+      config
+        ? await import('../hooks/useAutoAcceptIndicator.js')
+        : undefined;
+
+    if (config) {
+      try {
         config.setApprovalMode(mode);
       } catch (e) {
         return {
@@ -86,15 +104,8 @@ export const approvalModeCommand: SlashCommand = {
     // When the user switches INTO AUTO via this command (not just via
     // Shift+Tab), emit the same first-time-acknowledgement + stripped-rules
     // notices as the keyboard handler.
-    if (
-      mode === ApprovalModeEnum.AUTO &&
-      priorMode !== ApprovalModeEnum.AUTO &&
-      config
-    ) {
-      const { emitAutoModeEntryNotices } = await import(
-        '../hooks/useAutoAcceptIndicator.js'
-      );
-      emitAutoModeEntryNotices({
+    if (autoModeNotices && config) {
+      autoModeNotices.emitAutoModeEntryNotices({
         config,
         settings,
         addItem: context.ui.addItem,

--- a/packages/cli/src/ui/commands/historyCommand.ts
+++ b/packages/cli/src/ui/commands/historyCommand.ts
@@ -8,7 +8,6 @@ import type { SlashCommand, MessageActionReturn } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { SettingScope } from '../../config/settings.js';
-import { expandCollapsedHistory } from '../utils/resumeHistoryUtils.js';
 
 const collapseOnResumeCommand: SlashCommand = {
   name: 'collapse-on-resume',
@@ -61,7 +60,7 @@ const expandNowCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive'] as const,
-  action: (context): MessageActionReturn | void => {
+  action: async (context): Promise<MessageActionReturn | void> => {
     const { history, loadHistory, refreshStatic } = context.ui;
 
     const hasSuppressed = history.some(
@@ -77,6 +76,9 @@ const expandNowCommand: SlashCommand = {
     }
 
     // Remove suppressOnRestore from all items and drop collapse summary items.
+    const { expandCollapsedHistory } = await import(
+      '../utils/resumeHistoryUtils.js'
+    );
     const updated = expandCollapsedHistory(history);
     loadHistory(updated);
     refreshStatic();

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -7,6 +7,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import React from 'react';
 import { initCommand } from './initCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { type CommandContext } from './types.js';
@@ -70,6 +71,23 @@ describe('initCommand', () => {
       }),
     );
     // Assert: Ensure no file was written yet
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it(`should preserve ${DEFAULT_CONTEXT_FILENAME} if the confirmation prompt cannot be built`, async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('# Existing content');
+    vi.spyOn(React, 'createElement').mockImplementationOnce(() => {
+      throw new Error('prompt unavailable');
+    });
+
+    const result = await initCommand.action!(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: `Unexpected error preparing ${DEFAULT_CONTEXT_FILENAME}: prompt unavailable`,
+    });
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -40,31 +40,32 @@ export const initCommand: SlashCommand = {
     try {
       if (fs.existsSync(contextFilePath)) {
         // If file exists but is empty (or whitespace), continue to initialize
+        let existing = '';
         try {
-          const existing = fs.readFileSync(contextFilePath, 'utf8');
-          if (existing && existing.trim().length > 0) {
-            // File exists and has content - ask for confirmation to overwrite
-            if (!context.overwriteConfirmed) {
-              const [{ Text }, { default: React }] = await Promise.all([
-                import('ink'),
-                import('react'),
-              ]);
-              return {
-                type: 'confirm_action',
-                prompt: React.createElement(
-                  Text,
-                  null,
-                  `A ${contextFileName} file already exists in this directory. Do you want to regenerate it?`,
-                ),
-                originalInvocation: {
-                  raw: context.invocation?.raw || '/init',
-                },
-              };
-            }
-            // User confirmed overwrite, continue with regeneration
-          }
+          existing = fs.readFileSync(contextFilePath, 'utf8');
         } catch {
           // If we fail to read, conservatively proceed to (re)create the file
+        }
+        if (existing && existing.trim().length > 0) {
+          // File exists and has content - ask for confirmation to overwrite
+          if (!context.overwriteConfirmed) {
+            const [{ Text }, { default: React }] = await Promise.all([
+              import('ink'),
+              import('react'),
+            ]);
+            return {
+              type: 'confirm_action',
+              prompt: React.createElement(
+                Text,
+                null,
+                `A ${contextFileName} file already exists in this directory. Do you want to regenerate it?`,
+              ),
+              originalInvocation: {
+                raw: context.invocation?.raw || '/init',
+              },
+            };
+          }
+          // User confirmed overwrite, continue with regeneration
         }
       }
 

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -13,8 +13,6 @@ import type {
 } from './types.js';
 import { getCurrentGeminiMdFilename } from '@qwen-code/qwen-code-core';
 import { CommandKind } from './types.js';
-import { Text } from 'ink';
-import React from 'react';
 import { t } from '../../i18n/index.js';
 
 export const initCommand: SlashCommand = {
@@ -47,10 +45,12 @@ export const initCommand: SlashCommand = {
           if (existing && existing.trim().length > 0) {
             // File exists and has content - ask for confirmation to overwrite
             if (!context.overwriteConfirmed) {
+              const [{ Text }, { default: React }] = await Promise.all([
+                import('ink'),
+                import('react'),
+              ]);
               return {
                 type: 'confirm_action',
-                // TODO: Move to .tsx file to use JSX syntax instead of React.createElement
-                // For now, using React.createElement to maintain .ts compatibility for PR review
                 prompt: React.createElement(
                   Text,
                   null,

--- a/packages/cli/src/ui/components/SuggestionsDisplay.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.tsx
@@ -9,40 +9,16 @@ import { Box, Text, type DOMElement } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { RowMouseController } from './shared/RowMouseController.js';
 import { PrepareLabel, MAX_WIDTH } from './PrepareLabel.js';
-import type {
-  CommandKind,
-  CommandSource,
-  ExecutionMode,
-} from '../commands/types.js';
 import { Colors } from '../colors.js';
 import { t } from '../../i18n/index.js';
-export interface Suggestion {
-  label: string;
-  value: string;
-  description?: string;
-  matchedIndex?: number;
-  /** @deprecated Use source/sourceBadge instead. */
-  commandKind?: CommandKind;
-  source?: CommandSource;
-  sourceLabel?: string;
-  sourceBadge?: string;
-  argumentHint?: string;
-  matchedAlias?: string;
-  supportedModes?: ExecutionMode[];
-  modelInvocable?: boolean;
-  /** Whether the suggestion represents a directory path. When true, handleAutocomplete should NOT append a trailing space so the user can continue tab-completing deeper into the directory tree. */
-  isDirectory?: boolean;
-  /**
-   * When true, the input layer should submit `/<value>` immediately on
-   * Enter-accept rather than just inserting the suggestion text and
-   * waiting for a second Enter. Mirrors the `submitOnAccept` flag on the
-   * underlying SlashCommand (see `commands/types.ts`). Used for parent
-   * commands like `/skills` whose bare action just opens a dialog and
-   * takes no further argument — typing `/skil<Enter>` should land in the
-   * dialog in one keystroke.
-   */
-  submitOnAccept?: boolean;
-}
+import {
+  MAX_SUGGESTIONS_TO_SHOW,
+  type Suggestion,
+} from '../utils/suggestions.js';
+
+export { MAX_SUGGESTIONS_TO_SHOW } from '../utils/suggestions.js';
+export type { Suggestion } from '../utils/suggestions.js';
+
 interface SuggestionsDisplayProps {
   suggestions: Suggestion[];
   activeIndex: number;
@@ -60,7 +36,6 @@ interface SuggestionsDisplayProps {
   mouseEnabled?: boolean;
 }
 
-export const MAX_SUGGESTIONS_TO_SHOW = 8;
 export { MAX_WIDTH };
 
 /**

--- a/packages/cli/src/ui/hooks/extension-mention-ref.ts
+++ b/packages/cli/src/ui/hooks/extension-mention-ref.ts
@@ -5,8 +5,10 @@
  */
 
 import type { Config } from '@qwen-code/qwen-code-core';
-import type { Suggestion } from '../components/SuggestionsDisplay.js';
-import { MAX_SUGGESTIONS_TO_SHOW } from '../components/SuggestionsDisplay.js';
+import {
+  MAX_SUGGESTIONS_TO_SHOW,
+  type Suggestion,
+} from '../utils/suggestions.js';
 import { t } from '../../i18n/index.js';
 export {
   EXTENSION_REF_PREFIX,

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -9,7 +9,6 @@ import type { Mock, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useGeminiStream } from './useGeminiStream.js';
-import { classifyApiError } from '../../utils/classify-api-error.js';
 import * as atCommandProcessor from './atCommandProcessor.js';
 import type {
   TrackedToolCall,
@@ -9959,117 +9958,5 @@ describe('useGeminiStream', () => {
         expect(call[0]).not.toHaveProperty('timestamp');
       }
     });
-  });
-});
-
-describe('classifyApiError', () => {
-  it('should classify rate limit errors by status code 429', () => {
-    expect(classifyApiError({ message: 'error', status: 429 })).toBe(
-      'rate_limit',
-    );
-  });
-
-  it('should classify rate limit errors by message', () => {
-    expect(classifyApiError({ message: 'Rate limit exceeded' })).toBe(
-      'rate_limit',
-    );
-  });
-
-  it('should classify authentication errors by status code 401', () => {
-    expect(classifyApiError({ message: 'error', status: 401 })).toBe(
-      'authentication_failed',
-    );
-  });
-
-  it('should classify authentication errors by message', () => {
-    expect(classifyApiError({ message: 'Unauthorized access' })).toBe(
-      'authentication_failed',
-    );
-  });
-
-  it('should classify billing errors by status code 402', () => {
-    expect(classifyApiError({ message: 'error', status: 402 })).toBe(
-      'billing_error',
-    );
-  });
-
-  it('should classify billing errors by status code 403', () => {
-    expect(classifyApiError({ message: 'error', status: 403 })).toBe(
-      'billing_error',
-    );
-  });
-
-  it('should classify billing errors by message containing billing', () => {
-    expect(classifyApiError({ message: 'Billing issue detected' })).toBe(
-      'billing_error',
-    );
-  });
-
-  it('should classify billing errors by message containing quota', () => {
-    expect(classifyApiError({ message: 'Quota exceeded' })).toBe(
-      'billing_error',
-    );
-  });
-
-  it('should classify invalid request errors by status code 400', () => {
-    expect(classifyApiError({ message: 'error', status: 400 })).toBe(
-      'invalid_request',
-    );
-  });
-
-  it('should classify invalid request errors by message', () => {
-    expect(classifyApiError({ message: 'Invalid request format' })).toBe(
-      'invalid_request',
-    );
-  });
-
-  it('should classify server errors by status code 500', () => {
-    expect(classifyApiError({ message: 'error', status: 500 })).toBe(
-      'server_error',
-    );
-  });
-
-  it('should classify server errors by status code 502', () => {
-    expect(classifyApiError({ message: 'error', status: 502 })).toBe(
-      'server_error',
-    );
-  });
-
-  it('should classify server errors by status code 503', () => {
-    expect(classifyApiError({ message: 'error', status: 503 })).toBe(
-      'server_error',
-    );
-  });
-
-  it('should classify max output tokens errors by message', () => {
-    expect(classifyApiError({ message: 'max_tokens limit reached' })).toBe(
-      'max_output_tokens',
-    );
-  });
-
-  it('should classify token limit errors by message', () => {
-    expect(classifyApiError({ message: 'Token limit exceeded' })).toBe(
-      'max_output_tokens',
-    );
-  });
-
-  it('should return unknown for unrecognized errors', () => {
-    expect(classifyApiError({ message: 'Some random error' })).toBe('unknown');
-  });
-
-  it('should return unknown for empty message', () => {
-    expect(classifyApiError({ message: '' })).toBe('unknown');
-  });
-
-  it('should handle case insensitive matching', () => {
-    expect(classifyApiError({ message: 'RATE LIMIT exceeded' })).toBe(
-      'rate_limit',
-    );
-    expect(classifyApiError({ message: 'UNAUTHORIZED' })).toBe(
-      'authentication_failed',
-    );
-    expect(classifyApiError({ message: 'BILLING error' })).toBe(
-      'billing_error',
-    );
   });
 });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -8,7 +8,8 @@
 import type { Mock, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useGeminiStream, classifyApiError } from './useGeminiStream.js';
+import { useGeminiStream } from './useGeminiStream.js';
+import { classifyApiError } from '../../utils/classify-api-error.js';
 import * as atCommandProcessor from './atCommandProcessor.js';
 import type {
   TrackedToolCall,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -25,7 +25,6 @@ import {
   type ThoughtSummary,
   type ToolCallRequestInfo,
   type GeminiErrorEventValue,
-  type StopFailureErrorType,
   type ActiveGoal,
   type SteerInput,
   GeminiEventType as ServerGeminiEventType,
@@ -118,6 +117,7 @@ import { useDualOutput } from '../../dualOutput/DualOutputContext.js';
 import { recordGoalStatusItem } from '../utils/restoreGoal.js';
 import { sanitizeDisplayText } from '../../utils/extension-mention.js';
 import process from 'node:process';
+import { classifyApiError } from '../../utils/classify-api-error.js';
 
 const debugLogger = createDebugLogger('GEMINI_STREAM');
 
@@ -237,43 +237,6 @@ function extractToolResultText(parts: Part[] | Part | undefined): unknown {
   if (chunks.length === 0) return '';
   if (chunks.length === 1) return chunks[0];
   return chunks;
-}
-
-/**
- * Classify API error to StopFailureErrorType
- * @internal Exported for testing purposes
- */
-export function classifyApiError(error: {
-  message: string;
-  status?: number;
-}): StopFailureErrorType {
-  const status = error.status;
-  const message = error.message?.toLowerCase() ?? '';
-
-  if (status === 429 || message.includes('rate limit')) {
-    return 'rate_limit';
-  }
-  if (status === 401 || message.includes('unauthorized')) {
-    return 'authentication_failed';
-  }
-  if (
-    status === 402 ||
-    status === 403 ||
-    message.includes('billing') ||
-    message.includes('quota')
-  ) {
-    return 'billing_error';
-  }
-  if (status === 400 || message.includes('invalid')) {
-    return 'invalid_request';
-  }
-  if (status !== undefined && status >= 500) {
-    return 'server_error';
-  }
-  if (message.includes('max_tokens') || message.includes('token limit')) {
-    return 'max_output_tokens';
-  }
-  return 'unknown';
 }
 
 /**

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -16,7 +16,7 @@ import type {
   ArenaDiffSummary,
 } from '@qwen-code/qwen-code-core';
 import type { PartListUnion } from '@google/genai';
-import { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export type { ThoughtSummary };
 

--- a/packages/cli/src/ui/utils/suggestions.ts
+++ b/packages/cli/src/ui/utils/suggestions.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  CommandKind,
+  CommandSource,
+  ExecutionMode,
+} from '../commands/types.js';
+
+export interface Suggestion {
+  label: string;
+  value: string;
+  description?: string;
+  matchedIndex?: number;
+  /** @deprecated Use source/sourceBadge instead. */
+  commandKind?: CommandKind;
+  source?: CommandSource;
+  sourceLabel?: string;
+  sourceBadge?: string;
+  argumentHint?: string;
+  matchedAlias?: string;
+  supportedModes?: ExecutionMode[];
+  modelInvocable?: boolean;
+  /** Whether the suggestion represents a directory path. When true, handleAutocomplete should NOT append a trailing space so the user can continue tab-completing deeper into the directory tree. */
+  isDirectory?: boolean;
+  /**
+   * When true, the input layer should submit `/<value>` immediately on
+   * Enter-accept rather than just inserting the suggestion text and
+   * waiting for a second Enter. Mirrors the `submitOnAccept` flag on the
+   * underlying SlashCommand (see `commands/types.ts`). Used for parent
+   * commands like `/skills` whose bare action just opens a dialog and
+   * takes no further argument — typing `/skil<Enter>` should land in the
+   * dialog in one keystroke.
+   */
+  submitOnAccept?: boolean;
+}
+
+export const MAX_SUGGESTIONS_TO_SHOW = 8;

--- a/packages/cli/src/utils/classify-api-error.test.ts
+++ b/packages/cli/src/utils/classify-api-error.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { classifyApiError } from './classify-api-error.js';
+
+describe('classifyApiError', () => {
+  it('should classify rate limit errors by status code 429', () => {
+    expect(classifyApiError({ message: 'error', status: 429 })).toBe(
+      'rate_limit',
+    );
+  });
+
+  it('should classify rate limit errors by message', () => {
+    expect(classifyApiError({ message: 'Rate limit exceeded' })).toBe(
+      'rate_limit',
+    );
+  });
+
+  it('should classify authentication errors by status code 401', () => {
+    expect(classifyApiError({ message: 'error', status: 401 })).toBe(
+      'authentication_failed',
+    );
+  });
+
+  it('should classify authentication errors by message', () => {
+    expect(classifyApiError({ message: 'Unauthorized access' })).toBe(
+      'authentication_failed',
+    );
+  });
+
+  it('should classify billing errors by status code 402', () => {
+    expect(classifyApiError({ message: 'error', status: 402 })).toBe(
+      'billing_error',
+    );
+  });
+
+  it('should classify billing errors by status code 403', () => {
+    expect(classifyApiError({ message: 'error', status: 403 })).toBe(
+      'billing_error',
+    );
+  });
+
+  it('should classify billing errors by message containing billing', () => {
+    expect(classifyApiError({ message: 'Billing issue detected' })).toBe(
+      'billing_error',
+    );
+  });
+
+  it('should classify billing errors by message containing quota', () => {
+    expect(classifyApiError({ message: 'Quota exceeded' })).toBe(
+      'billing_error',
+    );
+  });
+
+  it('should classify invalid request errors by status code 400', () => {
+    expect(classifyApiError({ message: 'error', status: 400 })).toBe(
+      'invalid_request',
+    );
+  });
+
+  it('should classify invalid request errors by message', () => {
+    expect(classifyApiError({ message: 'Invalid request format' })).toBe(
+      'invalid_request',
+    );
+  });
+
+  it('should classify server errors by status code 500', () => {
+    expect(classifyApiError({ message: 'error', status: 500 })).toBe(
+      'server_error',
+    );
+  });
+
+  it('should classify server errors by status code 502', () => {
+    expect(classifyApiError({ message: 'error', status: 502 })).toBe(
+      'server_error',
+    );
+  });
+
+  it('should classify server errors by status code 503', () => {
+    expect(classifyApiError({ message: 'error', status: 503 })).toBe(
+      'server_error',
+    );
+  });
+
+  it('should classify max output tokens errors by message', () => {
+    expect(classifyApiError({ message: 'max_tokens limit reached' })).toBe(
+      'max_output_tokens',
+    );
+  });
+
+  it('should classify token limit errors by message', () => {
+    expect(classifyApiError({ message: 'Token limit exceeded' })).toBe(
+      'max_output_tokens',
+    );
+  });
+
+  it('should return unknown for unrecognized errors', () => {
+    expect(classifyApiError({ message: 'Some random error' })).toBe('unknown');
+  });
+
+  it('should return unknown for empty message', () => {
+    expect(classifyApiError({ message: '' })).toBe('unknown');
+  });
+
+  it('should handle case insensitive matching', () => {
+    expect(classifyApiError({ message: 'RATE LIMIT exceeded' })).toBe(
+      'rate_limit',
+    );
+    expect(classifyApiError({ message: 'UNAUTHORIZED' })).toBe(
+      'authentication_failed',
+    );
+    expect(classifyApiError({ message: 'BILLING error' })).toBe(
+      'billing_error',
+    );
+  });
+});

--- a/packages/cli/src/utils/classify-api-error.ts
+++ b/packages/cli/src/utils/classify-api-error.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { StopFailureErrorType } from '@qwen-code/qwen-code-core';
+
+export function classifyApiError(error: {
+  message: string;
+  status?: number;
+}): StopFailureErrorType {
+  const status = error.status;
+  const message = error.message?.toLowerCase() ?? '';
+
+  if (status === 429 || message.includes('rate limit')) {
+    return 'rate_limit';
+  }
+  if (status === 401 || message.includes('unauthorized')) {
+    return 'authentication_failed';
+  }
+  if (
+    status === 402 ||
+    status === 403 ||
+    message.includes('billing') ||
+    message.includes('quota')
+  ) {
+    return 'billing_error';
+  }
+  if (status === 400 || message.includes('invalid')) {
+    return 'invalid_request';
+  }
+  if (status !== undefined && status >= 500) {
+    return 'server_error';
+  }
+  if (message.includes('max_tokens') || message.includes('token limit')) {
+    return 'max_output_tokens';
+  }
+  return 'unknown';
+}

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -36,6 +36,14 @@ const SERVE_PRE_LISTEN_ROOTS = [
   },
 ];
 
+const ACP_RUNTIME_ROOT = {
+  label: 'ACP agent runtime',
+  suffixes: [
+    'packages/cli/src/acp-integration/acpAgent.ts',
+    'packages/cli/dist/src/acp-integration/acpAgent.js',
+  ],
+};
+
 const FORBIDDEN_SOURCE_INPUTS = [
   {
     label: 'Gemini runtime',
@@ -114,6 +122,13 @@ const FORBIDDEN_VENDOR_PACKAGES = [
   { label: 'chokidar vendor package', packageName: 'chokidar' },
   { label: '@iarna/toml vendor package', packageName: '@iarna/toml' },
   { label: 'fzf vendor package', packageName: 'fzf' },
+];
+
+const FORBIDDEN_ACP_UI_PACKAGES = [
+  { label: 'Ink TUI runtime', packageName: 'ink' },
+  { label: 'React runtime', packageName: 'react' },
+  { label: 'React reconciler runtime', packageName: 'react-reconciler' },
+  { label: 'Yoga layout runtime', packageName: 'yoga-layout' },
 ];
 
 export function normalizeMetafilePath(filePath) {
@@ -219,6 +234,59 @@ function buildImportPath(entryOutputs, outputPath, parent) {
   return reversed.reverse();
 }
 
+export function findAcpImportBoundaryOffenders(metafile) {
+  const outputs = normalizeOutputs(metafile);
+  let entryOutput;
+
+  for (const [outputPath, output] of outputs) {
+    const inputs = Object.keys(output.inputs ?? {});
+    if (
+      inputs.some((input) =>
+        inputMatchesAnySuffix(input, ACP_RUNTIME_ROOT.suffixes),
+      )
+    ) {
+      entryOutput = outputPath;
+      break;
+    }
+  }
+
+  if (!entryOutput) {
+    throw new Error(
+      `Could not find bundled output for ${ACP_RUNTIME_ROOT.label} ` +
+        `(${ACP_RUNTIME_ROOT.suffixes.join(' or ')}).\n` +
+        `Run \`${METAFILE_BUILD_COMMAND}\` to produce the metafile.`,
+    );
+  }
+
+  const entryOutputs = [entryOutput];
+  const { closure, parent } = collectStaticClosure(outputs, entryOutputs);
+  const offenders = [];
+  const seen = new Set();
+
+  for (const outputPath of closure) {
+    const output = outputs.get(outputPath);
+    for (const input of Object.keys(output?.inputs ?? {})) {
+      const match = FORBIDDEN_ACP_UI_PACKAGES.find(({ packageName }) =>
+        inputMatchesPackage(input, packageName),
+      );
+      if (!match) continue;
+      const key = `${match.label}\0${outputPath}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      offenders.push({
+        label: match.label,
+        matchedInput: normalizeMetafilePath(input),
+        outputPath,
+        bytes: output?.bytes ?? 0,
+        importPath: buildImportPath(entryOutputs, outputPath, parent),
+      });
+    }
+  }
+
+  return offenders;
+}
+
 export function findServeFastPathBundleOffenders(metafile) {
   const outputs = normalizeOutputs(metafile);
   const entryOutputs = findServePreListenRootOutputs(outputs);
@@ -309,19 +377,54 @@ export function checkServeFastPathBundle({
   return { ok: offenders.length === 0, offenders };
 }
 
+export function checkAcpImportBoundary({
+  metafilePath = DEFAULT_METAFILE_PATH,
+} = {}) {
+  if (!existsSync(metafilePath)) {
+    throw new Error(
+      `Missing esbuild metafile at ${metafilePath}. ` +
+        `Run \`${METAFILE_BUILD_COMMAND}\` to produce it.`,
+    );
+  }
+
+  let metafile;
+  try {
+    metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Invalid esbuild metafile at ${metafilePath}: ${reason}. ` +
+        `Run \`${METAFILE_BUILD_COMMAND}\` to regenerate it.`,
+    );
+  }
+
+  const offenders = findAcpImportBoundaryOffenders(metafile);
+  return { ok: offenders.length === 0, offenders };
+}
+
 function main() {
   try {
-    const result = checkServeFastPathBundle();
-    if (result.ok) {
-      console.log('Serve fast-path bundle closure check passed.');
-      return;
+    const serveResult = checkServeFastPathBundle();
+    if (!serveResult.ok) {
+      console.error(
+        'Serve fast-path bundle closure includes pre-listen runtime modules:\n' +
+          formatServeFastPathBundleOffenders(serveResult.offenders),
+      );
+      process.exitCode = 1;
     }
 
-    console.error(
-      'Serve fast-path bundle closure includes pre-listen runtime modules:\n' +
-        formatServeFastPathBundleOffenders(result.offenders),
-    );
-    process.exitCode = 1;
+    const acpResult = checkAcpImportBoundary();
+    if (!acpResult.ok) {
+      console.error(
+        'ACP static import closure includes TUI runtime modules:\n' +
+          formatServeFastPathBundleOffenders(acpResult.offenders),
+      );
+      process.exitCode = 1;
+    }
+
+    if (serveResult.ok && acpResult.ok) {
+      console.log('Startup bundle closure checks passed.');
+    }
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -11,7 +11,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  checkAcpImportBoundary,
   checkServeFastPathBundle,
+  findAcpImportBoundaryOffenders,
   findServeFastPathBundleOffenders,
   formatServeFastPathBundleOffenders,
   normalizeMetafilePath,
@@ -32,6 +34,9 @@ function makeMetafile(outputs) {
       }),
       'dist/chunks/run-qwen-serve.js': output({
         inputs: ['packages/cli/src/serve/run-qwen-serve.ts'],
+      }),
+      'dist/chunks/acp-agent.js': output({
+        inputs: ['packages/cli/src/acp-integration/acpAgent.ts'],
       }),
       ...outputs,
     },
@@ -411,6 +416,78 @@ describe('serve fast-path bundle check', () => {
           stdio: 'pipe',
         }),
       ).toThrow(/Missing esbuild metafile/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ACP import boundary check', () => {
+  it('reports TUI packages reached through static imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/acp-agent.js': output({
+        inputs: ['packages/cli/src/acp-integration/acpAgent.ts'],
+        imports: [staticImport('dist/chunks/tui.js')],
+      }),
+      'dist/chunks/tui.js': output({
+        bytes: 250_000,
+        inputs: [
+          'node_modules/ink/build/index.js',
+          'node_modules/react/index.js',
+          'node_modules/react-reconciler/index.js',
+          'node_modules/yoga-layout/dist/src/index.js',
+        ],
+      }),
+    });
+
+    expect(findAcpImportBoundaryOffenders(metafile)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Ink TUI runtime' }),
+        expect.objectContaining({ label: 'React runtime' }),
+        expect.objectContaining({ label: 'React reconciler runtime' }),
+        expect.objectContaining({ label: 'Yoga layout runtime' }),
+      ]),
+    );
+  });
+
+  it('allows TUI packages behind dynamic imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/acp-agent.js': output({
+        inputs: ['packages/cli/src/acp-integration/acpAgent.ts'],
+        imports: [dynamicImport('dist/chunks/tui.js')],
+      }),
+      'dist/chunks/tui.js': output({
+        inputs: ['node_modules/ink/build/index.js'],
+      }),
+    });
+
+    expect(findAcpImportBoundaryOffenders(metafile)).toEqual([]);
+  });
+
+  it('reads a metafile path and returns ACP boundary offenders', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-import-boundary-'));
+    try {
+      const metafilePath = writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/chunks/acp-agent.js': output({
+            inputs: [
+              'packages/cli/src/acp-integration/acpAgent.ts',
+              'node_modules/ink/build/index.js',
+            ],
+          }),
+        }),
+      );
+
+      expect(checkAcpImportBoundary({ metafilePath })).toEqual({
+        ok: false,
+        offenders: [
+          expect.objectContaining({
+            label: 'Ink TUI runtime',
+            matchedInput: 'node_modules/ink/build/index.js',
+          }),
+        ],
+      });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one logical line.
-->

## What this PR does

This PR removes TUI-only Ink, React, React Reconciler, and Yoga modules from the ACP agent's static startup closure. Pure API-error and suggestion contracts no longer flow through render modules, React-only command dependencies load only when their interactive actions execute, and React types are erased at compile time. A bundle-metafile guard prevents those four packages from re-entering the ACP static closure while still allowing intentional dynamic imports.

The P0 design document now records the selected narrow optimization, the rejected alternatives, and the matched 2C4G evidence used to pass the implementation gate.

## Why it's needed

The P0-A profile showed that Gemini and ACP module loading account for 67.3% of child startup P50. CPU profiles identified source-module compilation as the largest CPU cost, and import-graph analysis found that the headless ACP child was compiling an entire TUI stack it never renders. Removing those accidental static edges reduces startup work without changing the initialize barrier, Config phases, failure semantics, command availability, or Session behavior.

On a matched 2C4G comparison using the same main commit for control and candidate, 60 alternating cold pairs reduced ACP import P50 from 115.06 ms to 52.00 ms (-54.8%), `channel.initialize` P50 from 1098.25 ms to 1035.61 ms (-62.64 ms), and process-to-first-Session P50 from 2046.88 ms to 1980.03 ms (-66.85 ms). Thirty preheated pairs and the pooled cold P95/RSS gates showed no regression.

## Reviewer Test Plan

### How to verify

Build and bundle the CLI, then run the startup bundle closure check. The check should pass and the ACP agent's static metafile closure should contain zero inputs from Ink, React, React Reconciler, and Yoga.

Exercise `/init` when a non-empty QWEN.md needs overwrite confirmation, `/approval-mode auto`, and `/history expand-now`. Each action should retain its existing UI result even though its UI-only dependency now loads on demand.

Start ACP through the daemon bridge with startup-profile negotiation. Initialization, concurrent first-Session creation, telemetry-disabled startup, and the legacy default `single` scope should all succeed and clean up without residual processes; the response and Session semantics should be unchanged.

### Evidence (Before & After)

N/A — startup/module-graph optimization with no user-visible or TUI change. Matched 2C4G measurements are included above and in the design document.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

### Environment (optional)

macOS local verification used Node.js v22.22.3 for focused Vitest, build, typecheck, release bundle, and metafile checks. Linux performance and functional verification used Node.js v22.23.1 on an x64 2-vCPU host with 3.56 GiB usable memory and no swap.

## Risk & Scope

- Main risk or tradeoff: Three rare interactive command paths now pay a one-time dynamic-import cost when invoked; focused tests cover each affected action, and the release bundle contains the required chunks.
- Not validated / out of scope: Windows runtime testing, tool descriptor/implementation decoupling, broader Gemini import-graph restructuring, readiness changes, and initialization parallelism.
- Breaking changes / migration notes: None. ACP protocol, initialization ordering, failure behavior, command surface, and Session behavior are unchanged.

## Linked Issues

Refs #4748

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 从 ACP agent 的静态启动闭包中移除了仅 TUI 使用的 Ink、React、React Reconciler 和 Yoga 模块。纯 API 错误分类与 suggestion 数据契约不再经过渲染模块，仅交互动作需要的 React 依赖改为动作实际执行时加载，React 类型在编译阶段完全擦除。同时新增 bundle metafile 门禁，阻止这四个包再次进入 ACP 静态闭包，并继续允许有意保留的动态导入。

P0 设计文档同步记录了最终选中的窄优化、被拒绝的候选方案，以及用于通过实现门禁的同 SHA 2C4G 实测证据。

## 为什么需要

P0-A profile 显示 Gemini 与 ACP 模块加载占子进程启动 P50 的 67.3%。CPU profile 进一步确认源码模块编译是最大的 CPU 成本，import graph 分析则发现无头 ACP 子进程会编译一整套它从不渲染的 TUI 运行时。移除这些意外静态边可以减少启动工作，同时不改变 initialize 屏障、Config 阶段、失败语义、命令可用性或 Session 行为。

在 control 与 candidate 使用同一个 main commit 的 2C4G 匹配对照中，60 组交替冷启动将 ACP import P50 从 115.06 ms 降至 52.00 ms（-54.8%），将 `channel.initialize` P50 从 1098.25 ms 降至 1035.61 ms（-62.64 ms），将 process-to-first-Session P50 从 2046.88 ms 降至 1980.03 ms（-66.85 ms）。另外 30 组 preheated 对照及合并冷启动样本的 P95/RSS 门禁均未发现回退。

## Reviewer 测试计划

### 如何验证

构建并 bundle CLI，然后运行启动 bundle 闭包检查。检查应通过，且 ACP agent 的静态 metafile 闭包中来自 Ink、React、React Reconciler 和 Yoga 的输入均应为零。

分别执行以下场景：非空 QWEN.md 触发 `/init` 覆盖确认、执行 `/approval-mode auto`、执行 `/history expand-now`。虽然对应 UI-only 依赖改为按需加载，每个动作都应保持现有 UI 结果。

通过 daemon bridge 启动 ACP 并协商 startup profile。初始化、并发创建首个 Session、关闭 telemetry 的启动以及旧版默认 `single` scope 都应成功，并在退出后无残留进程；响应与 Session 语义应保持不变。

### 证据（Before & After）

N/A——这是启动/module graph 优化，没有用户可见或 TUI 变化。同 SHA 2C4G 数据已列在上文和设计文档中。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ✅ 已测试   |

### 环境（可选）

macOS 本地验证使用 Node.js v22.22.3，覆盖 focused Vitest、build、typecheck、release bundle 和 metafile 检查。Linux 性能与功能验证使用 Node.js v22.23.1，运行在 x64、2 vCPU、3.56 GiB 可用内存且无 swap 的主机上。

## 风险与范围

- 主要风险或取舍：三个低频交互命令路径在首次执行时会承担一次动态导入成本；focused tests 已覆盖每个受影响动作，release bundle 也包含所需 chunks。
- 未验证 / 范围外：Windows 运行时测试、工具描述符与实现解耦、更广泛的 Gemini import graph 重构、readiness 变更和初始化并行化。
- 破坏性变更 / 迁移说明：无。ACP 协议、初始化顺序、失败行为、命令表面和 Session 行为均未改变。

## 关联 Issue

Refs #4748

</details>
