### PR TITLE
fix(review): judge a CI check by its name's latest run, not by any leftover

### DIFF
--- a/packages/cli/src/commands/review/presubmit.test.ts
+++ b/packages/cli/src/commands/review/presubmit.test.ts
@@ -245,6 +245,35 @@ describe('classifyCi — a superseded run does not outvote the latest verdict', 
     );
     expect(got.class).toBe('all_pass');
   });
+
+  it('falls back to started_at when completed_at is absent', () => {
+    // The winning run is listed SECOND on purpose: with the fallback dropped
+    // (`completed_at ?? ''`) both stamps collapse to '' and first-seen keeps
+    // the name — so a fixture that lists the success first passes with or
+    // without the fallback and pins nothing. Listed second, the success can
+    // win only through its `started_at`.
+    const got = classifyCi(
+      [
+        {
+          name: 'route',
+          status: 'completed',
+          conclusion: 'cancelled',
+          completed_at: null,
+          started_at: '2026-07-18T15:10:00Z',
+        },
+        {
+          name: 'route',
+          status: 'completed',
+          conclusion: 'success',
+          completed_at: null,
+          started_at: '2026-07-18T15:30:00Z',
+        },
+      ],
+      [],
+    );
+    expect(got.class).toBe('all_pass');
+    expect(got.failedCheckNames).toEqual([]);
+  });
 });
 
 const {

--- a/packages/cli/src/commands/review/presubmit.test.ts
+++ b/packages/cli/src/commands/review/presubmit.test.ts
@@ -158,6 +158,95 @@ describe('classifyCi — a skipped check is not a passing check', () => {
   });
 });
 
+// A name's runs supersede each other: the routing workflows re-dispatch a name
+// several times per commit and cancel the displaced runs, and a flaky job
+// re-run to green leaves its failed attempt behind. Failure used to be judged
+// per RUN, so any one leftover pushed its name into `failedCheckNames` — two
+// real reviews were downgraded from Approve over exactly that (`route` at
+// #7150; route, review-pr, review-config and four more at #7171), each on a
+// commit whose every live check was green on the PR page.
+describe('classifyCi — a superseded run does not outvote the latest verdict', () => {
+  const at = (
+    name: string,
+    conclusion: string | null,
+    completed_at: string | null,
+    status = 'completed',
+  ) => ({ name, status, conclusion, completed_at });
+
+  it('a cancelled run displaced by a later success is not a failure — the #7150/#7171 false alarm', () => {
+    const got = classifyCi(
+      [
+        at('route', 'success', '2026-07-18T15:30:00Z'),
+        at('route', 'cancelled', '2026-07-18T15:10:00Z'),
+        at('route', 'success', '2026-07-18T15:20:00Z'),
+      ],
+      [],
+    );
+    expect(got.failedCheckNames).toEqual([]);
+    expect(got.class).toBe('all_pass');
+  });
+
+  it('a flaky job re-run to green is green — the failed attempt is history', () => {
+    const got = classifyCi(
+      [
+        at(
+          'Test (ubuntu-latest, Node 22.x)',
+          'failure',
+          '2026-07-18T10:00:00Z',
+        ),
+        at(
+          'Test (ubuntu-latest, Node 22.x)',
+          'success',
+          '2026-07-18T11:00:00Z',
+        ),
+      ],
+      [],
+    );
+    expect(got.class).toBe('all_pass');
+  });
+
+  it('a re-run that FAILS after a success is a failure — latest wins both ways', () => {
+    const got = classifyCi(
+      [
+        at('Test', 'success', '2026-07-18T10:00:00Z'),
+        at('Test', 'failure', '2026-07-18T11:00:00Z'),
+      ],
+      [],
+    );
+    expect(got.class).toBe('any_failure');
+    expect(got.failedCheckNames).toEqual(['Test']);
+  });
+
+  it('a name whose ONLY run was cancelled still fails — nothing superseded it', () => {
+    const got = classifyCi(
+      [at('E2E', 'cancelled', '2026-07-18T10:00:00Z')],
+      [],
+    );
+    expect(got.class).toBe('any_failure');
+    expect(got.failedCheckNames).toEqual(['E2E']);
+  });
+
+  it('a later skipped re-dispatch does not erase a real failure — skips are not verdicts', () => {
+    const got = classifyCi(
+      [
+        at('Test', 'failure', '2026-07-18T10:00:00Z'),
+        at('Test', 'skipped', '2026-07-18T11:00:00Z'),
+      ],
+      [],
+    );
+    expect(got.class).toBe('any_failure');
+    expect(got.failedCheckNames).toEqual(['Test']);
+  });
+
+  it('with no timestamps at all, the first-listed run keeps the name — the API lists newest first', () => {
+    const got = classifyCi(
+      [at('route', 'success', null), at('route', 'cancelled', null)],
+      [],
+    );
+    expect(got.class).toBe('all_pass');
+  });
+});
+
 const {
   ghMock,
   ghApiMock,

--- a/packages/cli/src/commands/review/presubmit.ts
+++ b/packages/cli/src/commands/review/presubmit.ts
@@ -48,8 +48,20 @@ interface CheckRun {
   name: string;
   status: string;
   conclusion: string | null;
+  /** ISO timestamps from the API — how re-runs of one name are ordered. */
+  started_at?: string | null;
+  completed_at?: string | null;
   details_url?: string;
   html_url?: string;
+}
+
+/**
+ * When this run's verdict was reached, for ordering re-runs of one name.
+ * ISO-8601 strings compare correctly as strings; a run with no timestamp
+ * sorts earliest, so it can never displace a dated verdict.
+ */
+function verdictStamp(run: CheckRun): string {
+  return run.completed_at ?? run.started_at ?? '';
 }
 
 interface CommitStatus {
@@ -145,13 +157,35 @@ export function classifyCi(checkRuns: CheckRun[], statuses: CommitStatus[]) {
     .filter((n) => !executedNames.has(n))
     .sort();
 
+  // Failure is judged per NAME, like execution above — and by the name's
+  // LATEST verdict, because a name's runs supersede each other: this repo's
+  // routing workflows re-dispatch a name several times per commit and cancel
+  // the displaced runs, and a flaky job re-run to green leaves its failed
+  // attempt behind. Any single failing run used to push its name into
+  // `failedCheckNames`, so a check whose newest run PASSED was reported as
+  // "CI failing" — two real reviews were downgraded from Approve over exactly
+  // that (`route` at #7150, seven routing names at #7171), each on a commit
+  // whose every live check was green. The latest run per name is also what
+  // GitHub's own PR page shows, so this judges the same evidence a human
+  // reviewer sees there. Skipped/neutral/stale runs stay non-verdicts: a
+  // re-dispatch that skipped must not erase a real failure beside it.
+  const latestVerdicts = new Map<string, CheckRun>();
   for (const run of relevantCheckRuns) {
-    if (run.status === 'completed') {
-      if (run.conclusion && FAIL_CONCLUSIONS.has(run.conclusion)) {
-        failedCheckNames.push(run.name);
-      }
-    } else if (PENDING_STATES.has(run.status)) {
-      hasPending = true;
+    if (run.status !== 'completed') {
+      if (PENDING_STATES.has(run.status)) hasPending = true;
+      continue;
+    }
+    if (!run.conclusion || NOT_RUN_CONCLUSIONS.has(run.conclusion)) continue;
+    const prev = latestVerdicts.get(run.name);
+    // Strict `>`: on equal (or absent) stamps the first-seen run keeps the
+    // name, and the API lists newest first.
+    if (!prev || verdictStamp(run) > verdictStamp(prev)) {
+      latestVerdicts.set(run.name, run);
+    }
+  }
+  for (const [name, run] of latestVerdicts) {
+    if (FAIL_CONCLUSIONS.has(run.conclusion as string)) {
+      failedCheckNames.push(name);
     }
   }
   for (const s of statuses) {


### PR DESCRIPTION
## What this PR does

Makes `presubmit`'s CI classifier judge each check by its **name's latest run** instead of by any single run. `classifyCi` already answers "did this name run" per name — because this repo's routing workflows re-dispatch a name several times per commit — but it judged *failure* per run: any one run with a failing conclusion pushed its name into `failedCheckNames`, including the `cancelled` runs those very re-dispatches displace and the failed attempt a flaky job leaves behind after being re-run to green.

Failure is now decided by the latest verdict per name, ordered by the runs' own timestamps (`completed_at`, falling back to `started_at`) — the same evidence GitHub's PR page shows a human. Skipped/neutral/stale runs remain non-verdicts, so a re-dispatch that skipped cannot erase a real failure beside it; a name whose only run was cancelled still fails, because nothing superseded it; and a re-run that fails after a success fails, because latest wins in both directions. On equal or absent timestamps the first-listed run keeps the name (the API lists newest first).

## Why it's needed

Two real reviews were downgraded from Approve over checks that were green on the PR page:

- PR #7150: the bot review read `⚠️ Downgraded from Approve to Comment: CI failing: route` while `route`'s latest runs were `success` — the "failure" was one `cancelled` run displaced by a newer dispatch.
- PR #7171: the same downgrade named seven routing checks (`route, review-pr, delay-automatic-review, resolve-pr, ack-review-request, authorize, review-config`) — every one green or skipped at its latest run, every one carrying a displaced `cancelled` leftover.

A wrong `CI failing` reason doesn't just misreport: it downgrades the verdict the review posts, and it sends whoever reads the review chasing failures that do not exist.

## Reviewer Test Plan

### How to verify

1. `cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts` — 19 tests green, including the new describe block: the #7150/#7171 shape (cancelled displaced by later success → `all_pass`), flaky-rerun-to-green → `all_pass`, success-then-failure → `any_failure` (latest wins both ways), lone-cancelled → `any_failure`, later-skip-does-not-erase-failure, and the no-timestamps order fallback.
2. Full suite: `npx vitest run src/commands/review` — 31 files, 728 tests green.
3. Mutation-tested: reverting to per-run judgment, letting skips count as verdicts, and flipping the tie-break each turn exactly their tests red (3/3 killed).
4. Live shape: `gh api repos/QwenLM/qwen-code/commits/37131de4d/check-runs --paginate` (PR #7171's head) shows `route` with success×2 + cancelled×1 and six more names in the same shape — the exact fixture the regression test encodes.

### Evidence (Before & After)

Before: `classifyCi` on #7171's head check-runs returns `any_failure` with `failedCheckNames: [ack-review-request, authorize, delay-automatic-review, resolve-pr, review-config, review-pr, route]`, and the review is downgraded from Approve.

After: the same input returns `all_pass` — matching the PR page, where every one of those checks shows green or skipped.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Single-run-per-name commits (the common case) are byte-identically classified; only multi-run names change, and only when their runs disagree.
- The stricter directions are preserved: lone cancellations still fail, a failing re-run after a success still fails, and skipped runs still cannot pass a check or erase a failure.
- The legacy commit-status path (`/status` contexts) is untouched — that endpoint already returns the latest status per context.

## Linked Issues

Third sighting of this false alarm (route at #7150, seven names at #7171), both documented in those PRs' threads.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `presubmit` 的 CI 分类器按**每个检查名字的最新一次 run** 裁决,而不是被任意一次 run 左右。`classifyCi` 对"该名字是否运行过"早已按名字聚合(本仓库的路由工作流会对同一名字反复 re-dispatch),但**失败**判定却按单次 run:任何一次带失败 conclusion 的 run 都会把名字推进 `failedCheckNames`——包括恰恰被那些 re-dispatch 取代的 `cancelled` run,以及 flaky 任务重跑变绿后留下的失败尝试。

现在失败由该名字的最新裁决决定,按 run 自身时间戳排序(`completed_at`,回退 `started_at`)——与 GitHub PR 页面展示给人类的证据一致。skipped/neutral/stale 仍是"非裁决":跳过的 re-dispatch 不能抹掉旁边的真失败;唯一一次 run 就是 cancelled 的名字仍然算失败(没有任何东西取代它);成功后重跑失败也算失败(最新裁决双向生效)。时间戳相等或缺失时,先列出的 run 保留名字(API 按最新在前排列)。

## 为什么需要

两次真实 review 因为 PR 页面上明明是绿的检查被从 Approve 降级:

- PR #7150:bot review 显示 `⚠️ Downgraded from Approve to Comment: CI failing: route`,而 `route` 最新的 run 全是 `success`——所谓失败是一次被新 dispatch 取代的 `cancelled`。
- PR #7171:同样的降级点名了七个路由检查,每一个的最新 run 都是绿或 skipped,每一个都拖着一条被取代的 `cancelled` 残留。

错误的 `CI failing` 不止是误报:它会降级 review 发布的 verdict,并让读 review 的人去追根本不存在的失败。

## 验证方式

1. `cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts` —— 19 测试全绿,新增描述块覆盖:#7150/#7171 形状(cancelled 被后来的 success 取代 → `all_pass`)、flaky 重跑变绿 → `all_pass`、成功后重跑失败 → `any_failure`(最新双向生效)、孤立 cancelled → `any_failure`、后续 skip 不抹真失败、无时间戳时的顺序回退。
2. 全套:`npx vitest run src/commands/review` —— 31 文件 728 测试绿。
3. 突变测试:回退为按 run 判定、让 skip 充当裁决、翻转平局规则——各自打红对应测试(3/3 击杀)。
4. 真实形状:`gh api repos/QwenLM/qwen-code/commits/37131de4d/check-runs --paginate`(#7171 的 head)可见 `route` success×2 + cancelled×1 及六个同形名字——正是回归测试编码的 fixture。

## 证据(前后对照)

修复前:对 #7171 head 的 check-runs,`classifyCi` 返回 `any_failure`,`failedCheckNames` 列出七个路由检查,review 被从 Approve 降级。

修复后:同一输入返回 `all_pass`——与 PR 页面一致(那些检查全部显示绿或 skipped)。

## 风险与范围

- 每名字单 run 的常见情形分类逐字节不变;只有同名多 run 且结论不一致时行为改变。
- 更严的方向全部保留:孤立 cancelled 仍失败、成功后重跑失败仍失败、skip 仍不能放行或抹失败。
- 旧式 commit status(`/status` contexts)路径未动——该端点本身就按 context 返回最新状态。

## 关联

同类误报第三次目击(#7150 的 route、#7171 的七个名字),均记录在对应 PR 线程。

</details>
