### PR TITLE
fix(cli): share one process.stdout resize listener in useTerminalSize

### DIFF
--- a/packages/cli/src/ui/hooks/useTerminalSize.test.ts
+++ b/packages/cli/src/ui/hooks/useTerminalSize.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTerminalSize } from './useTerminalSize.js';
+
+// The hook reads terminal dimensions from `process.stdout`, which is not a TTY
+// under vitest (columns/rows are inherited from the prototype as undefined).
+// Override them with own-properties for the duration of a test and restore the
+// original descriptor afterward so an override never leaks into a later test
+// file via the module-level snapshot.
+let originalColumns: PropertyDescriptor | undefined;
+let originalRows: PropertyDescriptor | undefined;
+
+function setStdoutProp(name: 'columns' | 'rows', value: number | undefined) {
+  Object.defineProperty(process.stdout, name, { value, configurable: true });
+}
+
+function restoreStdoutProp(
+  name: 'columns' | 'rows',
+  original: PropertyDescriptor | undefined,
+) {
+  if (original) {
+    Object.defineProperty(process.stdout, name, original);
+  } else {
+    delete (process.stdout as unknown as Record<string, unknown>)[name];
+  }
+}
+
+describe('useTerminalSize', () => {
+  beforeEach(() => {
+    originalColumns = Object.getOwnPropertyDescriptor(
+      process.stdout,
+      'columns',
+    );
+    originalRows = Object.getOwnPropertyDescriptor(process.stdout, 'rows');
+  });
+
+  afterEach(() => {
+    restoreStdoutProp('columns', originalColumns);
+    restoreStdoutProp('rows', originalRows);
+  });
+
+  it('returns the current terminal size on mount', () => {
+    setStdoutProp('columns', 123);
+    setStdoutProp('rows', 45);
+
+    const { result } = renderHook(() => useTerminalSize());
+
+    expect(result.current).toEqual({ columns: 123, rows: 45 });
+  });
+
+  it('falls back to 80x24 when the terminal size is unavailable', () => {
+    setStdoutProp('columns', undefined);
+    setStdoutProp('rows', undefined);
+
+    const { result } = renderHook(() => useTerminalSize());
+
+    expect(result.current).toEqual({ columns: 80, rows: 24 });
+  });
+
+  it('attaches exactly one resize listener no matter how many hooks mount', () => {
+    const baseline = process.stdout.listenerCount('resize');
+    const emitWarning = vi.spyOn(process, 'emitWarning');
+
+    const hooks = Array.from({ length: 15 }, () =>
+      renderHook(() => useTerminalSize()),
+    );
+
+    // A single shared listener backs all 15 consumers, so the count never
+    // grows past one and Node's MaxListenersExceededWarning cannot fire.
+    expect(process.stdout.listenerCount('resize')).toBe(baseline + 1);
+    expect(
+      emitWarning.mock.calls.some(
+        ([warning]) =>
+          warning instanceof Error &&
+          warning.name === 'MaxListenersExceededWarning',
+      ),
+    ).toBe(false);
+
+    hooks.forEach(({ unmount }) => unmount());
+
+    // The last unmount drains the subscriber set and detaches the listener.
+    expect(process.stdout.listenerCount('resize')).toBe(baseline);
+
+    emitWarning.mockRestore();
+  });
+
+  it('propagates a resize to every mounted consumer', () => {
+    setStdoutProp('columns', 100);
+    setStdoutProp('rows', 40);
+
+    const first = renderHook(() => useTerminalSize());
+    const second = renderHook(() => useTerminalSize());
+
+    expect(first.result.current).toEqual({ columns: 100, rows: 40 });
+    expect(second.result.current).toEqual({ columns: 100, rows: 40 });
+
+    setStdoutProp('columns', 200);
+    setStdoutProp('rows', 60);
+    act(() => {
+      process.stdout.emit('resize');
+    });
+
+    expect(first.result.current).toEqual({ columns: 200, rows: 60 });
+    expect(second.result.current).toEqual({ columns: 200, rows: 60 });
+  });
+
+  it('keeps the shared listener working after one of several consumers unmounts', () => {
+    setStdoutProp('columns', 100);
+    setStdoutProp('rows', 40);
+
+    const baseline = process.stdout.listenerCount('resize');
+    const first = renderHook(() => useTerminalSize());
+    const second = renderHook(() => useTerminalSize());
+
+    first.unmount();
+
+    // One consumer remains, so the shared listener stays attached.
+    expect(process.stdout.listenerCount('resize')).toBe(baseline + 1);
+
+    setStdoutProp('columns', 175);
+    setStdoutProp('rows', 55);
+    act(() => {
+      process.stdout.emit('resize');
+    });
+
+    expect(second.result.current).toEqual({ columns: 175, rows: 55 });
+
+    second.unmount();
+    expect(process.stdout.listenerCount('resize')).toBe(baseline);
+  });
+});

--- a/packages/cli/src/ui/hooks/useTerminalSize.ts
+++ b/packages/cli/src/ui/hooks/useTerminalSize.ts
@@ -6,28 +6,66 @@
 
 import { useEffect, useState } from 'react';
 
+interface TerminalSize {
+  columns: number;
+  rows: number;
+}
+
+function getTerminalSize(): TerminalSize {
+  return {
+    columns: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24,
+  };
+}
+
+// A single `process.stdout` 'resize' listener is shared across every
+// `useTerminalSize` instance. Each hook only adds its own `setState` callback
+// to `subscribers`, so the listener count on `process.stdout` stays at 1 no
+// matter how many components mount — otherwise Node emits a
+// MaxListenersExceededWarning once 11+ consumers are mounted concurrently.
+let currentSize: TerminalSize = getTerminalSize();
+const subscribers = new Set<(size: TerminalSize) => void>();
+
+function handleResize(): void {
+  currentSize = getTerminalSize();
+  for (const notify of subscribers) {
+    notify(currentSize);
+  }
+}
+
+function subscribe(callback: (size: TerminalSize) => void): () => void {
+  if (subscribers.size === 0) {
+    // First subscriber: refresh the snapshot (it may be stale if the terminal
+    // resized while no listener was attached) and attach the shared listener.
+    currentSize = getTerminalSize();
+    process.stdout.on('resize', handleResize);
+  }
+  subscribers.add(callback);
+
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0) {
+      process.stdout.off('resize', handleResize);
+    }
+  };
+}
+
 /**
  * Returns the actual terminal size without any padding adjustments.
  * Components should handle their own margins/padding as needed.
  */
-export function useTerminalSize(): { columns: number; rows: number } {
-  const [size, setSize] = useState({
-    columns: process.stdout.columns || 80,
-    rows: process.stdout.rows || 24,
-  });
+export function useTerminalSize(): TerminalSize {
+  // Read `process.stdout` at render time (like the original per-instance hook)
+  // so the first paint is always current, even if the terminal resized while no
+  // hook was subscribed and the module snapshot went stale.
+  const [size, setSize] = useState(getTerminalSize);
 
   useEffect(() => {
-    function updateSize() {
-      setSize({
-        columns: process.stdout.columns || 80,
-        rows: process.stdout.rows || 24,
-      });
-    }
-
-    process.stdout.on('resize', updateSize);
-    return () => {
-      process.stdout.off('resize', updateSize);
-    };
+    const unsubscribe = subscribe(setSize);
+    // `subscribe` refreshes the snapshot when it attaches the listener, so sync
+    // to the latest value in case a resize happened before this effect ran.
+    setSize(currentSize);
+    return unsubscribe;
   }, []);
 
   return size;


### PR DESCRIPTION
## What this PR does

Makes `useTerminalSize` share a single module-level `process.stdout` `'resize'` listener across every hook instance instead of registering a fresh listener on each component mount. A module-scoped size snapshot plus a `Set` of subscriber callbacks back all consumers; the one shared listener is attached lazily on the first mount and detached when the last consumer unmounts. Each hook instance only adds/removes its own `setState` callback and syncs to the snapshot on mount, so the listener count on `process.stdout` stays at 1 no matter how many components are mounted.

## Why it's needed

Around 30 UI components consume `useTerminalSize`, and each mount previously added its own `process.stdout.on('resize', ...)` listener. Once 11+ of them are mounted concurrently, `process.stdout` exceeds Node's default `maxListeners` of 10 and Node emits `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 resize listeners added to [WriteStream]`, which is both noisy and a genuine listener leak that grows over a long interactive session (#7159). Sharing one subscription removes the warning and caps the listener count regardless of how many components render.

## Reviewer Test Plan

### How to verify

Run the new unit test from the CLI package:

```
cd packages/cli && npx vitest run src/ui/hooks/useTerminalSize.test.ts
```

The tests assert the core behavior:

- Rendering 15 concurrent consumers keeps `process.stdout.listenerCount('resize')` at exactly 1 (the previous code would reach 15) and never emits a `MaxListenersExceededWarning`.
- A `process.stdout.emit('resize')` (with `columns`/`rows` restubbed) propagates the new size to every mounted consumer.
- A freshly mounted hook returns the current `process.stdout` dimensions, falling back to 80x24 when unavailable.
- Unmounting one of several consumers keeps the shared listener attached and the remaining consumers working; unmounting the last consumer detaches the listener.

Observed output:

```
 ✓ src/ui/hooks/useTerminalSize.test.ts (5 tests) 13ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

`npx eslint`, `npx prettier --check`, and `tsc --noEmit` (for these files) are clean.

### Evidence (Before & After)

No user-visible / TUI change — this only affects an internal listener-registration strategy and removes a diagnostic warning. Behavioral before/after: **Before**, `process.stdout.listenerCount('resize')` grew by one per mounted component and Node printed `MaxListenersExceededWarning` once it passed 10; **After**, the count stays at 1 and the warning never fires. Screenshots: N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Verified locally on macOS via the unit test above; Windows/Linux rely on CI.

### Environment (optional)

Unit tests only, via `npx vitest run` in `packages/cli`.

## Risk & Scope

- Main risk or tradeoff: the size snapshot and shared listener are now process-global module state rather than per-instance; the listener re-attaches whenever the subscriber set goes from 0 to 1, so mount/unmount cycles stay correct.
- Not validated / out of scope: not exercised against a live long-running interactive session (covered by reasoning plus the unit tests). No change to any of the ~30 consuming components.
- Breaking changes / migration notes: none. The hook's `{ columns, rows }` return shape and public API are unchanged.

## Linked Issues

Fixes #7159

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 `useTerminalSize` 在所有 hook 实例之间共享**一个**模块级的 `process.stdout` `'resize'` 监听器，而不是在每个组件挂载时都注册一个新的监听器。一个模块级的尺寸快照加上一组订阅回调（`Set`）为所有使用方提供数据；这个共享的监听器在第一个 hook 挂载时惰性附加，并在最后一个使用方卸载时移除。每个 hook 实例只负责添加/移除自己的 `setState` 回调，并在挂载时同步到当前快照，因此无论挂载了多少组件，`process.stdout` 上的监听器数量始终为 1。

## 为什么需要它

大约有 30 个 UI 组件使用 `useTerminalSize`，而之前每次挂载都会添加自己的 `process.stdout.on('resize', ...)` 监听器。一旦有 11 个以上的组件同时挂载，`process.stdout` 就会超过 Node 默认的 `maxListeners`（10），于是 Node 会打印 `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 resize listeners added to [WriteStream]`。这既产生噪声，也是一个在长时间交互会话中会不断增长的真实监听器泄漏（#7159）。共享一个订阅可以消除该警告，并且无论渲染多少组件，都能把监听器数量限制住。

## 如何验证

在 CLI 包中运行新增的单元测试：

```
cd packages/cli && npx vitest run src/ui/hooks/useTerminalSize.test.ts
```

测试断言了核心行为：渲染 15 个并发使用方后，`process.stdout.listenerCount('resize')` 恰好为 1，且从不触发 `MaxListenersExceededWarning`；`resize` 事件会把新尺寸传播到每个已挂载的使用方；新挂载的 hook 返回当前的 `process.stdout` 尺寸，在不可用时回退到 80x24；卸载多个使用方中的一个会保持共享监听器附加，卸载最后一个才会移除该监听器。5 个测试全部通过。

## 风险与范围

- 主要风险/权衡：尺寸快照和共享监听器现在是进程级的模块状态，而不是每个实例各自持有；当订阅集合从 0 变为 1 时监听器会重新附加，因此挂载/卸载循环保持正确。
- 未验证/超出范围：未在真实的长时间交互会话中实测（依赖推理加单元测试）。约 30 个使用方组件均无需改动。
- 破坏性变更：无。hook 的 `{ columns, rows }` 返回结构和公共 API 均保持不变。

## 关联 Issue

Fixes #7159

</details>

AI was used for assistance.
