### PR TITLE
fix(web-shell): proxy /goals route in Vite dev server

### DIFF
--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -86,6 +86,9 @@ export default defineConfig(({ command }) => ({
       // without it the SPA fallback returns index.html in dev and the dialog
       // fails JSON parsing / reports an HTTP error on open.
       '/scheduled-tasks': daemonProxy,
+      // Goals page (`GET /goals`). Without it the SPA fallback returns
+      // index.html in dev and the page fails JSON parsing on open.
+      '/goals': daemonProxy,
       // Token-usage dashboard (Daemon Status "统计" tab). Same reason as the
       // routes above — without it the SPA fallback returns index.html in dev and
       // the tab fails JSON parsing on `GET /usage/dashboard`.


### PR DESCRIPTION
## What this PR does

Adds the `/goals` route to the Vite dev server proxy configuration in the Web Shell package. Without this entry, the dev server's SPA fallback intercepts `GET /goals` requests and returns `index.html` instead of proxying them to the daemon, causing the Goals page to fail with an "Unexpected token '<'" JSON parse error.

## Why it's needed

When running the Web Shell in dev mode (`npx vite`), the Goals page is unusable because the `GET /goals` API request is not proxied to the daemon. The Vite dev server's catch-all fallback returns the HTML document, and the client-side code that expects a JSON response fails with `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`. This is the same class of bug that was previously fixed for `/daemon/status`, `/scheduled-tasks`, and `/usage` — each daemon API route needs an explicit proxy entry in `vite.config.ts` to avoid the SPA fallback in dev.

## Reviewer Test Plan

### How to verify

1. Build and start the daemon: `npm run build && npm run bundle && node dist/cli.js serve --port 4170`
2. In a separate terminal, start the Web Shell dev server: `cd packages/web-shell && npx vite --port 5173`
3. Open http://localhost:5173 in a browser
4. Click the "Goals" item in the sidebar
5. Confirm the Goals page loads and renders its content without any JSON parse error or "Unexpected token '<'" message in the console

### Evidence (Before & After)

Before: Goals page shows "Unexpected token '<'" error because `GET /goals` returns `index.html` from the SPA fallback.

After: Goals page loads correctly — screenshot will be added as a follow-up comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local dev: `node dist/cli.js serve` + `npx vite` dev server on macOS.

## Risk & Scope

- Main risk or tradeoff: None — this is a one-line addition to the dev-only proxy config, following the exact same pattern as the existing route entries.
- Not validated / out of scope: Production builds are unaffected (the Vite dev server proxy is only active during `vite serve`, not in the built output).
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Web Shell 包的 Vite 开发服务器代理配置中添加了 `/goals` 路由。如果没有此条目，开发服务器的 SPA 回退会拦截 `GET /goals` 请求并返回 `index.html`，而不是将其代理到守护进程，导致 Goals 页面因 "Unexpected token '<'" JSON 解析错误而无法使用。

## 为什么需要

在开发模式下运行 Web Shell（`npx vite`）时，Goals 页面不可用，因为 `GET /goals` API 请求没有被代理到守护进程。Vite 开发服务器的全局回退返回 HTML 文档，而期望 JSON 响应的客户端代码会报错 `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`。这与之前修复 `/daemon/status`、`/scheduled-tasks` 和 `/usage` 的问题属于同一类——每个守护进程 API 路由都需要在 `vite.config.ts` 中添加显式代理条目，以避免开发环境中的 SPA 回退。

## 审阅者测试计划

### 如何验证

1. 构建并启动守护进程：`npm run build && npm run bundle && node dist/cli.js serve --port 4170`
2. 在另一个终端启动 Web Shell 开发服务器：`cd packages/web-shell && npx vite --port 5173`
3. 在浏览器中打开 http://localhost:5173
4. 点击侧边栏中的 "Goals" 项
5. 确认 Goals 页面正常加载并渲染内容，控制台没有 JSON 解析错误或 "Unexpected token '<'" 消息

### 证据（修改前后）

修改前：Goals 页面显示 "Unexpected token '<'" 错误，因为 `GET /goals` 返回了 SPA 回退的 `index.html`。

修改后：Goals 页面正常加载——截图将作为后续评论添加。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地开发：macOS 上 `node dist/cli.js serve` + `npx vite` 开发服务器。

## 风险与范围

- 主要风险或权衡：无——这是开发专用代理配置的一行添加，与现有路由条目完全相同的模式。
- 未验证 / 超出范围：生产构建不受影响（Vite 开发服务器代理仅在 `vite serve` 期间活跃，不在构建输出中）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
