### PR TITLE
fix(sdk-java): correct TIMEOUT_30_MINUTES to actually be 30 minutes

### DIFF
--- a/packages/sdk-java/client/src/main/java/com/alibaba/acp/sdk/utils/Timeout.java
+++ b/packages/sdk-java/client/src/main/java/com/alibaba/acp/sdk/utils/Timeout.java
@@ -68,5 +68,5 @@ public class Timeout {
     /**
      * A timeout of 30 minutes.
      */
-    public static final Timeout TIMEOUT_30_MINUTES = new Timeout(60L, TimeUnit.MINUTES);
+    public static final Timeout TIMEOUT_30_MINUTES = new Timeout(30L, TimeUnit.MINUTES);
 }

--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/utils/Timeout.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/utils/Timeout.java
@@ -64,5 +64,5 @@ public class Timeout {
     /**
      * A timeout of 30 minutes.
      */
-    public static final Timeout TIMEOUT_30_MINUTES = new Timeout(60L, TimeUnit.MINUTES);
+    public static final Timeout TIMEOUT_30_MINUTES = new Timeout(30L, TimeUnit.MINUTES);
 }


### PR DESCRIPTION
## What this PR does

Corrects the value of `Timeout.TIMEOUT_30_MINUTES` in the Java SDK, which was `new Timeout(60L, TimeUnit.MINUTES)` — i.e. 60 minutes, twice what its name and Javadoc declare. It changes the literal to `30L` in both copies of the constant:

- `packages/sdk-java/qwencode/.../cli/utils/Timeout.java`
- `packages/sdk-java/client/.../acp/sdk/utils/Timeout.java`

## Why it's needed

The constant is named `TIMEOUT_30_MINUTES` and its Javadoc says *"A timeout of 30 minutes."*, but the value is 60 minutes. It is not a cosmetic mislabel — it is the effective default in two behavioral paths:

- `ProcessTransport` uses it as the fallback **turn timeout** when the caller does not set one: `orElse(Timeout.TIMEOUT_30_MINUTES)`.
- `QwenCodeCli.simpleQuery(...)` passes it directly as the turn timeout.

Neither caller supplies an explicit value, so both wait **60 minutes** where the API contract promises 30. That 30-minute intent is corroborated independently by `TransportOptionsAdapter.DEFAULT_TURN_TIMEOUT = new Timeout(1000 * 60 * 30L, TimeUnit.MILLISECONDS)` (= 30 minutes), the sibling default for the same turn-timeout setting. The name, the Javadoc, and the parallel adapter default all agree on 30; only this literal disagrees. Fixing the literal (rather than renaming to `TIMEOUT_60_MINUTES`) aligns the value with all three.

## Reviewer Test Plan

### How to verify

- `Timeout.TIMEOUT_30_MINUTES.getValue()` is now `30L` with `getUnit() == TimeUnit.MINUTES` in both modules.
- Grep confirms the constant's only consumers rely on its stated semantics and pass no explicit value:
  - `packages/sdk-java/client/.../transport/process/ProcessTransport.java` — `orElse(Timeout.TIMEOUT_30_MINUTES)`
  - `packages/sdk-java/qwencode/.../cli/QwenCodeCli.java` — `simpleQuery(..., Timeout.TIMEOUT_30_MINUTES)`
- No test asserts the previous 60-minute value (`grep -rn "TIMEOUT_30_MINUTES" */src/test` returns nothing).

### Evidence (Before & After)

`Timeout.java` (both modules):
Before: `public static final Timeout TIMEOUT_30_MINUTES = new Timeout(60L, TimeUnit.MINUTES);` → resolves to 60 minutes; callers wait 2× the documented default.
After: `public static final Timeout TIMEOUT_30_MINUTES = new Timeout(30L, TimeUnit.MINUTES);` → matches the name, the Javadoc, and `DEFAULT_TURN_TIMEOUT` (30 min).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: static review only — no Java toolchain in the review environment. The change is a single `long` literal (`60L` → `30L`) inside an existing `new Timeout(long, TimeUnit)` call, so it cannot alter compilation or types; and no test pins the old value. The behavioral effect (fallback turn timeout / `simpleQuery` timeout) is 30 minutes instead of 60, as documented.

### Environment (optional)

`@qwen-code/sdk-java` (`client` and `qwencode` Maven modules).

## Risk & Scope

- Main risk or tradeoff: callers that were (perhaps unknowingly) relying on a 60-minute default will now time out at 30 minutes — but 30 is the documented, named, and otherwise-configured intent, and any caller needing longer can pass an explicit `Timeout`.
- Not validated / out of scope: no local Java compile/run (no toolchain available); no other constants changed.
- Breaking changes / migration notes: none to the API surface; the change only corrects the default turn-timeout duration to its documented value.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修正 Java SDK 中 `Timeout.TIMEOUT_30_MINUTES` 的取值。该常量原为 `new Timeout(60L, TimeUnit.MINUTES)`，即 60 分钟，是其名称与 Javadoc 所声明时长的两倍。本 PR 在该常量的两份副本中把字面量改为 `30L`：

- `packages/sdk-java/qwencode/.../cli/utils/Timeout.java`
- `packages/sdk-java/client/.../acp/sdk/utils/Timeout.java`

## 为什么需要

该常量名为 `TIMEOUT_30_MINUTES`，Javadoc 写明"A timeout of 30 minutes."，但其值为 60 分钟。这并非单纯的命名错误——它是两条行为路径上实际生效的默认值：

- `ProcessTransport` 在调用方未设置时，用它作为**轮次超时（turn timeout）**的兜底值：`orElse(Timeout.TIMEOUT_30_MINUTES)`。
- `QwenCodeCli.simpleQuery(...)` 直接把它作为轮次超时传入。

两处调用方都未显式传值，因此在 API 约定为 30 分钟之处实际等待 **60 分钟**。30 分钟的意图另有佐证：`TransportOptionsAdapter.DEFAULT_TURN_TIMEOUT = new Timeout(1000 * 60 * 30L, TimeUnit.MILLISECONDS)`（= 30 分钟），即同一轮次超时设置的另一处默认值。名称、Javadoc、以及并行的 adapter 默认值三者都指向 30，唯有此字面量不一致。修正字面量（而非改名为 `TIMEOUT_60_MINUTES`）使取值与三者一致。

## 复核测试计划

### 如何验证

- 两个模块中 `Timeout.TIMEOUT_30_MINUTES.getValue()` 现为 `30L`，`getUnit() == TimeUnit.MINUTES`。
- grep 确认该常量的唯一使用方均依赖其声明语义且未显式传值：
  - `packages/sdk-java/client/.../transport/process/ProcessTransport.java` — `orElse(Timeout.TIMEOUT_30_MINUTES)`
  - `packages/sdk-java/qwencode/.../cli/QwenCodeCli.java` — `simpleQuery(..., Timeout.TIMEOUT_30_MINUTES)`
- 无任何测试断言原先的 60 分钟取值（`grep -rn "TIMEOUT_30_MINUTES" */src/test` 无结果）。

### 证据（修复前后对比）

`Timeout.java`（两个模块）：
修复前：`public static final Timeout TIMEOUT_30_MINUTES = new Timeout(60L, TimeUnit.MINUTES);` → 解析为 60 分钟；调用方等待文档默认值的两倍。
修复后：`public static final Timeout TIMEOUT_30_MINUTES = new Timeout(30L, TimeUnit.MINUTES);` → 与名称、Javadoc 及 `DEFAULT_TURN_TIMEOUT`（30 分钟）一致。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：仅做静态复核——复核环境无 Java 工具链。改动仅为既有 `new Timeout(long, TimeUnit)` 调用内的一个 `long` 字面量（`60L` → `30L`），不会影响编译或类型；且无测试锁定旧值。行为影响（兜底轮次超时 / `simpleQuery` 超时）由 60 分钟变为文档所述的 30 分钟。

### 运行环境（可选）

`@qwen-code/sdk-java`（`client` 与 `qwencode` 两个 Maven 模块）。

## 风险与影响范围

- 主要风险或权衡：此前（或许无意间）依赖 60 分钟默认值的调用方，现在将在 30 分钟超时——但 30 分钟才是文档、命名及其他配置所表达的意图，任何需要更长时间的调用方均可显式传入 `Timeout`。
- 未验证 / 范围之外：未在本地编译/运行 Java（无可用工具链）；未改动其他常量。
- 破坏性变更 / 迁移说明：对 API 表面无破坏；仅将默认轮次超时时长修正为其文档所述取值。

## 关联 Issue

无。

</details>
