### PR TITLE
fix(sdk-java): preserve exception cause in AcpClient init failures

### DIFF
--- a/packages/sdk-java/client/src/main/java/com/alibaba/acp/sdk/AcpClient.java
+++ b/packages/sdk-java/client/src/main/java/com/alibaba/acp/sdk/AcpClient.java
@@ -66,7 +66,7 @@ public class AcpClient {
         try {
             transport.start();
         } catch (IOException e) {
-            throw new AgentInitializeException("transport start error")
+            throw new AgentInitializeException("transport start error", e)
                     .addContextValue("initializeRequestParams", initializeRequestParams);
         }
         Validate.notNull(initializeRequestParams, "initializeRequestParams can't be null");
@@ -78,7 +78,7 @@ public class AcpClient {
             initializeResponse = TransportUtils.inputWaitForOneLine(transport, initializeRequest, InitializeResponse.class);
             logger.debug("initialize response: {}", initializeResponse);
         } catch (IOException | ExecutionException | InterruptedException | TimeoutException e) {
-            throw new AgentInitializeException("agent transport error")
+            throw new AgentInitializeException("agent transport error", e)
                     .addContextValue("initializeRequestParams", initializeRequestParams);
         }
         if (initializeResponse.getError() != null) {


### PR DESCRIPTION
## What this PR does

Preserves the underlying exception cause in two `AgentInitializeException` throw sites in `AcpClient`'s constructor. Both are inside `catch` blocks that capture `e` but then construct the new exception with only a message, discarding `e`:

- `AcpClient.java` line 69 — `catch (IOException e)` around `transport.start()`
- `AcpClient.java` line 81 — `catch (IOException | ExecutionException | InterruptedException | TimeoutException e)` around the initialize handshake

Both now pass the caught exception as the cause via the existing `AgentInitializeException(String, Throwable)` constructor.

## Why it's needed

`AgentInitializeException` (a `ContextedException`) provides a purpose-built `(String message, Throwable cause)` constructor, documented "with the specified message and cause." These two catch blocks ignore it and throw `new AgentInitializeException("...")` with no cause, so the root failure — the actual `IOException`/`ExecutionException`/`InterruptedException`/`TimeoutException` and its stack trace — is dropped from the exception chain. A caller that catches `AgentInitializeException` sees only "transport start error" / "agent transport error" with no indication of what actually failed underneath, making init failures hard to diagnose.

(The third throw site in the same constructor — the `if (initializeResponse.getError() != null)` branch — is not a catch block and has no cause to chain, so it is left unchanged.)

## Reviewer Test Plan

### How to verify

- `git diff` shows only `", e"` added to the two constructor calls; no other changes.
- The `(String, Throwable)` constructor already exists in `AgentInitializeException.java`, so the calls resolve to it.
- After the change, `getCause()` on an `AgentInitializeException` thrown from `AcpClient`'s constructor returns the originating I/O / execution / interrupt / timeout exception, and logging the thrown exception includes the "Caused by:" chain.

### Evidence (Before & After)

`AcpClient.java`, constructor:
Before: `throw new AgentInitializeException("transport start error").addContextValue(...)` — caught `e` discarded; no cause chain.
After: `throw new AgentInitializeException("transport start error", e).addContextValue(...)` — root cause preserved. Same for the "agent transport error" site.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: static review only — no Java toolchain in the review environment. The change adds an existing-overload argument (`e`) that is already in scope in each `catch`, so it cannot affect compilation; it only routes the caught exception into the exception's cause chain. No test asserts the absence of a cause.

### Environment (optional)

`@qwen-code/sdk-java` (`client` module).

## Risk & Scope

- Main risk or tradeoff: none — the caught exception is now attached as the cause; message text and context values are unchanged, so existing catch/handling behavior is preserved and only diagnostics improve.
- Not validated / out of scope: no local Java compile/run (no toolchain available); no changes to the non-catch throw site or to `AgentInitializeException` itself.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在 `AcpClient` 构造函数中的两处 `AgentInitializeException` 抛出点保留底层异常原因。二者都位于捕获了 `e` 的 `catch` 块中，但构造新异常时只传入了消息、丢弃了 `e`：

- `AcpClient.java` 第 69 行 —— `transport.start()` 外层的 `catch (IOException e)`
- `AcpClient.java` 第 81 行 —— 初始化握手外层的 `catch (IOException | ExecutionException | InterruptedException | TimeoutException e)`

现二者均通过既有的 `AgentInitializeException(String, Throwable)` 构造函数把捕获到的异常作为 cause 传入。

## 为什么需要

`AgentInitializeException`（一个 `ContextedException`）提供了专用的 `(String message, Throwable cause)` 构造函数，文档写明"with the specified message and cause."。这两处 catch 块忽略了它，抛出无 cause 的 `new AgentInitializeException("...")`，从而把根本失败——真正的 `IOException`/`ExecutionException`/`InterruptedException`/`TimeoutException` 及其堆栈——从异常链中丢弃。捕获 `AgentInitializeException` 的调用方只会看到 "transport start error" / "agent transport error"，无从得知底层究竟发生了什么，使初始化失败难以排查。

（同一构造函数中的第三处抛出点——`if (initializeResponse.getError() != null)` 分支——不在 catch 块中，无 cause 可链，故保持不变。）

## 复核测试计划

### 如何验证

- `git diff` 显示两处构造调用仅新增 `", e"`；无其他改动。
- `AgentInitializeException.java` 中已存在 `(String, Throwable)` 构造函数，故调用可正确解析到它。
- 改动后，从 `AcpClient` 构造函数抛出的 `AgentInitializeException` 上调用 `getCause()` 会返回原始的 I/O / 执行 / 中断 / 超时异常，且记录该异常时会包含 "Caused by:" 链。

### 证据（修复前后对比）

`AcpClient.java` 构造函数：
修复前：`throw new AgentInitializeException("transport start error").addContextValue(...)` —— 捕获的 `e` 被丢弃；无 cause 链。
修复后：`throw new AgentInitializeException("transport start error", e).addContextValue(...)` —— 保留根本原因。"agent transport error" 处同理。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：仅做静态复核——复核环境无 Java 工具链。改动为既有重载新增一个实参（`e`），且 `e` 在各 `catch` 中本就在作用域内，故不影响编译；仅把捕获到的异常接入异常的 cause 链。无测试断言"无 cause"。

### 运行环境（可选）

`@qwen-code/sdk-java`（`client` 模块）。

## 风险与影响范围

- 主要风险或权衡：无——捕获到的异常现作为 cause 附加；消息文本与 context 值不变，故既有的捕获/处理行为保持不变，仅诊断信息改善。
- 未验证 / 范围之外：未在本地编译/运行 Java（无可用工具链）；未改动非 catch 的抛出点，也未改动 `AgentInitializeException` 本身。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
