### PR TITLE
fix(review): one disclosure per subject — dedupe Not-reviewed, collapse an all-built-none-launched roster

### DIFF
--- a/packages/cli/src/commands/review/check-coverage.test.ts
+++ b/packages/cli/src/commands/review/check-coverage.test.ts
@@ -818,41 +818,38 @@ describe('the roster — who should have been here', () => {
     expect(r.missingRoles[0]).not.toMatch(/--role/);
   });
 
-  it('says one thing once when every prompt was built and none was launched', () => {
-    // The launched-side twin of the collapse above, and it shipped: on #7188
-    // the run built all eleven roster prompts, launched not one agent, and
-    // the posted body was eleven identical "its prompt was built, but no
-    // agent on record was launched with it" lines — burying the single fact
-    // that the run stopped at the builder.
+  it("keeps per-role entries when every prompt was built and none was launched — the collapse is compose's job", () => {
+    // The first cut collapsed this shape HERE, into one "the run stopped at
+    // the prompt builder" line — and misfired: candidatesOf is also all-empty
+    // when every agent ran on a REWRITTEN prompt, so the aggregate claimed
+    // nothing launched beside forty-three rewritten-launch disclosures that
+    // said otherwise. Coverage now reports per role, structurally
+    // (`disclosures`), and compose-review groups same-reason subjects into
+    // the one sentence — after the caller's echoes have been deduped against
+    // the very subjects a coverage-side collapse would have discarded.
     const p = planPr();
-    // satisfyRoster wrote a matching transcript per role; remove every
-    // transcript — the records and briefs stay, so every requirement is
-    // BUILT, and nothing on record was launched.
     for (const f of readdirSync(join(dir, 'subagents', 'S1'))) {
       rmSync(join(dir, 'subagents', 'S1', f), { force: true });
     }
-    // An agent DID run — on a prompt matching no record — so the transcript
-    // store is not empty and the chunks are covered; only the roles gap.
     transcript('stray', wholeDiff(), { calls: 8 });
 
     const r = coverageFromTranscripts(p, ENV);
     expect(r.ok).toBe(false);
-    expect(r.missingRoles).toHaveLength(1);
-    expect(r.missingRoles[0]).toMatch(
-      /^every dimension — all \d+ required prompts were built/,
-    );
-    expect(r.missingRoles[0]).toContain(
-      'no agent on record was launched with any of them',
-    );
-    // The collapse is a body-side mercy, not a repair-side one: the operator
-    // still gets one selector per requirement.
     const roster = requiredAgents(
       JSON.parse(readFileSync(p, 'utf8')) as RosterPlan,
     );
     expect(roster.length).toBeGreaterThan(1);
+    expect(r.missingRoles).toHaveLength(roster.length);
     expect(r.missingRoleSelectors).toHaveLength(roster.length);
-    // Author-facing register: no internal command in the posted line.
-    expect(r.missingRoles[0]).not.toContain('agent-prompt');
+    // Structural twins, one per role, all sharing the one reason — what the
+    // compose-side grouping turns into a single sentence.
+    const notLaunched = r.disclosures.filter(
+      (d) =>
+        d.reason ===
+        'its prompt was built, but no agent on record was launched with it',
+    );
+    expect(notLaunched).toHaveLength(roster.length);
+    expect(new Set(notLaunched.map((d) => d.subject)).size).toBe(roster.length);
   });
 
   it('keeps the per-role not-launched text when only SOME launches are missing', () => {

--- a/packages/cli/src/commands/review/check-coverage.test.ts
+++ b/packages/cli/src/commands/review/check-coverage.test.ts
@@ -818,6 +818,59 @@ describe('the roster — who should have been here', () => {
     expect(r.missingRoles[0]).not.toMatch(/--role/);
   });
 
+  it('says one thing once when every prompt was built and none was launched', () => {
+    // The launched-side twin of the collapse above, and it shipped: on #7188
+    // the run built all eleven roster prompts, launched not one agent, and
+    // the posted body was eleven identical "its prompt was built, but no
+    // agent on record was launched with it" lines — burying the single fact
+    // that the run stopped at the builder.
+    const p = planPr();
+    // satisfyRoster wrote a matching transcript per role; remove every
+    // transcript — the records and briefs stay, so every requirement is
+    // BUILT, and nothing on record was launched.
+    for (const f of readdirSync(join(dir, 'subagents', 'S1'))) {
+      rmSync(join(dir, 'subagents', 'S1', f), { force: true });
+    }
+    // An agent DID run — on a prompt matching no record — so the transcript
+    // store is not empty and the chunks are covered; only the roles gap.
+    transcript('stray', wholeDiff(), { calls: 8 });
+
+    const r = coverageFromTranscripts(p, ENV);
+    expect(r.ok).toBe(false);
+    expect(r.missingRoles).toHaveLength(1);
+    expect(r.missingRoles[0]).toMatch(
+      /^every dimension — all \d+ required prompts were built/,
+    );
+    expect(r.missingRoles[0]).toContain(
+      'no agent on record was launched with any of them',
+    );
+    // The collapse is a body-side mercy, not a repair-side one: the operator
+    // still gets one selector per requirement.
+    const roster = requiredAgents(
+      JSON.parse(readFileSync(p, 'utf8')) as RosterPlan,
+    );
+    expect(roster.length).toBeGreaterThan(1);
+    expect(r.missingRoleSelectors).toHaveLength(roster.length);
+    // Author-facing register: no internal command in the posted line.
+    expect(r.missingRoles[0]).not.toContain('agent-prompt');
+  });
+
+  it('keeps the per-role not-launched text when only SOME launches are missing', () => {
+    // The collapse must not swallow the partial case: one unlaunched role
+    // beside launched siblings is that role's own line, naming it.
+    const p = planPr();
+    rmSync(join(dir, 'subagents', 'S1', 'agent-r-1c.jsonl'), { force: true });
+    transcript('sec', wholeDiff(), { calls: 8 });
+
+    const r = coverageFromTranscripts(p, ENV);
+    const gap = r.missingRoles.join(' ');
+    expect(gap).toContain('Cross-file tracer');
+    expect(gap).toContain(
+      'its prompt was built, but no agent on record was launched with it',
+    );
+    expect(gap).not.toContain('every dimension');
+  });
+
   it('tells the operator where it looked, so a wrong --plan is not a missing file', () => {
     // "The builder never ran" and "the builder ran against a different --plan" reach
     // this check as the same thing: an absent record. They are fixed differently, so

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1139,6 +1139,92 @@ describe('coverage is recomputed, never accepted', () => {
     );
   });
 
+  it('an all-rewritten roster never claims nothing launched — precise cause, no contradicting aggregate', () => {
+    // The first cut collapsed all-empty verbatim matches into "the run
+    // stopped at the prompt builder" — but candidatesOf is also all-empty
+    // when every agent RAN on a rewritten prompt, and the aggregate then
+    // contradicted the rewritten-launch disclosures beside it. Reproduced
+    // and refused: both chunks rewritten, the whole-diff role unlaunched —
+    // each cause its own sentence, no "every dimension" claim anywhere.
+    const p = plan();
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    transcript(
+      'a1',
+      `You are reviewing chunk 1 of 2.\nread_file(file_path="${DIFF}", offset=0, limit=100)`,
+      { toolCalls: 2 },
+    );
+    transcript(
+      'a2',
+      `You are reviewing chunk 2 of 2.\nread_file(file_path="${DIFF}", offset=100, limit=100)`,
+      { toolCalls: 2 },
+    );
+    const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
+    expect(r.body).toMatch(
+      /Not reviewed: [^.]*chunk 1[^.]*chunk 2[^.]*— launched with a prompt that is not the one the CLI built\./,
+    );
+    expect(r.body).not.toContain('every dimension');
+    expect(r.body).not.toContain('stopped at the prompt builder');
+    // And the chunks appear under their PRECISE cause only — to the roster
+    // they are also requirements with no verbatim launch, and repeating them
+    // under that vaguer cause would claim nothing launched about agents that
+    // demonstrably ran.
+    expect(r.body).not.toContain('no agent on record was launched with it');
+  });
+
+  it('a reason carrying its own em-dash neither garbles the subject nor duplicates the line', () => {
+    // Reasons are free-form — internal failures interpolate raw error
+    // messages — so a subject/reason boundary reparsed from rendered prose
+    // regroups exactly the entries it garbles. The entries are structural
+    // now; the caller's echo of a dashed line still dedupes, by prefix
+    // against the known subject.
+    const p = plan();
+    const r = composeReview({
+      planPath: p,
+      // Transcripts unreadable: the coverage AND verification reasons both
+      // interpolate an error message — with an em-dash of their own.
+      env: {
+        QWEN_CODE_PROJECT_DIR: join(dir, 'nowhere — missing'),
+        QWEN_CODE_SESSION_ID: 'S1',
+      },
+      unreviewedDimensions: [
+        'coverage — could not read the transcripts — echoed back by the caller',
+      ],
+      modelId: MODEL,
+    });
+    // One coverage clause — the caller's dashed echo deduped by subject
+    // prefix, the machine's own text rendered once, subject intact.
+    expect(r.body.match(/Not reviewed: coverage/g)).toHaveLength(1);
+    expect(r.body).not.toContain('echoed back by the caller');
+  });
+
+  it('caller echoes of per-role gaps fold into the one grouped sentence — the #7188 shape end to end', () => {
+    // The coverage-side collapse discarded the per-role subjects before the
+    // caller's echoes could collide with them, so the body carried the
+    // caller's per-role sentences PLUS an overlapping aggregate. Per-role
+    // subjects now survive to the dedup, and the grouping makes the one
+    // sentence afterwards.
+    const p = plan();
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    // Chunks reviewed properly; the whole-diff role built but never launched.
+    transcript('a1', goodPrompt(1), { toolCalls: 3 });
+    transcript('a2', goodPrompt(2), { toolCalls: 2 });
+    const label = 'Test coverage matrix (whole-diff)';
+    const r = composeReview({
+      planPath: p,
+      env: ENV,
+      unreviewedDimensions: [
+        `${label} — its prompt was built, but no agent on record was launched with it`,
+      ],
+      modelId: MODEL,
+    });
+    expect(r.body.split(label)).toHaveLength(2);
+    expect(
+      r.body.match(/no record shows its brief reaching an agent/g) ?? [],
+    ).toHaveLength(1);
+  });
+
   it('does not merge two invariant files under one label — the em-dash is part of the subject', () => {
     // An invariant agent's label legitimately carries an em-dash segment
     // (`Invariant agent A … — src/foo.ts`). A first-dash dedup key would

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1106,6 +1106,36 @@ describe('coverage is recomputed, never accepted', () => {
     );
   });
 
+  it('says a shared cause once, with every subject on the one sentence', () => {
+    // #7166's posted body: ninety-nine disclosure paragraphs over FOUR causes
+    // — forty-three chunks all rewritten, fifty-five roles all unlaunched —
+    // with the six real findings buried beneath. Same cause, one sentence.
+    const p = plan();
+    // Both chunk launches rewritten: recorded prompts exist, the agents ran
+    // on hand-written prompts that DROP the brief line — an add-only wrap
+    // would rightly pass the delivery check.
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    transcript(
+      'a1',
+      `You are reviewing chunk 1 of 2.\nread_file(file_path="${DIFF}", offset=0, limit=100)`,
+      { toolCalls: 2 },
+    );
+    transcript(
+      'a2',
+      `You are reviewing chunk 2 of 2.\nread_file(file_path="${DIFF}", offset=100, limit=100)`,
+      { toolCalls: 2 },
+    );
+    const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
+    const reason = 'launched with a prompt that is not the one the CLI built';
+    // One clause for the shared cause — not one per chunk…
+    expect(r.body.split(reason)).toHaveLength(2);
+    // …and both subjects ride it.
+    expect(r.body).toMatch(
+      new RegExp(`Not reviewed: [^.]*chunk 1[^.]*chunk 2[^.]*— ${reason}\\.`),
+    );
+  });
+
   it('does not merge two invariant files under one label — the em-dash is part of the subject', () => {
     // An invariant agent's label legitimately carries an em-dash segment
     // (`Invariant agent A … — src/foo.ts`). A first-dash dedup key would

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1071,6 +1071,63 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
 });
 
 describe('coverage is recomputed, never accepted', () => {
+  it('does not repeat a disclosure the caller echoed back — one subject, one line', () => {
+    // #7188: the orchestrator pasted the gate's own gap sentences into
+    // `unreviewedDimensions`, coverage recomputed the same gaps, and the
+    // public body carried every disclosure twice — 22 "Not reviewed" clauses
+    // for 11 roles. The chunk list already dedupes by its `chunk <id>`
+    // prefix; the role list dedupes by label now, and when both sides name
+    // the same subject the coverage-derived text wins.
+    const p = plan();
+    transcript('a1', goodPrompt(1), { toolCalls: 3 });
+    transcript('a2', goodPrompt(2), { toolCalls: 2 });
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    // test-matrix is required by this plan's roster and never built → exactly
+    // one coverage-derived role gap.
+    const label = 'Test coverage matrix (whole-diff)';
+    const r = composeReview({
+      planPath: p,
+      env: ENV,
+      modelId: MODEL,
+      unreviewedDimensions: [
+        `${label} — the run described this gap in its own words`,
+        'a subject only the caller noticed — the auditor returned nothing twice',
+      ],
+    });
+    // One clause for the shared subject — and it is the machine's sentence,
+    // not the caller's paraphrase.
+    expect(r.body.split(label)).toHaveLength(2);
+    expect(r.body).toContain('no record shows its brief reaching an agent');
+    expect(r.body).not.toContain('described this gap in its own words');
+    // A subject the coverage recomputation cannot see survives untouched.
+    expect(r.body).toContain(
+      'a subject only the caller noticed — the auditor returned nothing twice',
+    );
+  });
+
+  it('does not merge two invariant files under one label — the em-dash is part of the subject', () => {
+    // An invariant agent's label legitimately carries an em-dash segment
+    // (`Invariant agent A … — src/foo.ts`). A first-dash dedup key would
+    // merge two files into one subject and silently drop a disclosure.
+    const p = plan();
+    transcript('a1', goodPrompt(1), { toolCalls: 3 });
+    transcript('a2', goodPrompt(2), { toolCalls: 2 });
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    const r = composeReview({
+      planPath: p,
+      env: ENV,
+      modelId: MODEL,
+      unreviewedDimensions: [
+        'Invariant agent A: state, timers — src/a.ts — the agent whiffed twice',
+        'Invariant agent A: state, timers — src/b.ts — the agent whiffed twice',
+      ],
+    });
+    expect(r.body).toContain('src/a.ts');
+    expect(r.body).toContain('src/b.ts');
+  });
+
   it('caps when no plan is given — nothing can show the diff was read', () => {
     const r = composeReview({
       criticalsInline: 0,

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -421,9 +421,12 @@ describe('composeReview — 422 recovery (round-7 Critical #1 & round-6: verdict
     // Before the 422: S=2. After dropping both anchors: recompose.
     const r = composeReview(base({ suggestionsDiscarded: 2 }));
     expect(r.event).toBe('COMMENT');
+    // Self-contained for the PR author — the old text said "see the terminal
+    // output", a terminal only the operator has.
     expect(r.body).toContain(
-      '2 Suggestion-level finding(s) could not be anchored to the diff; see the terminal output.',
+      '2 Suggestion-level finding(s) could not be anchored to a changed line and were dropped; nothing further to act on here.',
     );
+    expect(r.body).not.toContain('terminal output');
     // Nothing is inline — the body must not claim otherwise while the
     // discarded sentence says the opposite (round-9: `s` included discarded).
     expect(r.body).not.toContain('Suggestions are inline.');

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -204,6 +204,11 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     input.unreviewedDimensions,
     'unreviewedDimensions',
   );
+  // Everything past this index is coverage-derived: the recomputation below
+  // only ever appends. The disclosure dedup prefers those entries — they are
+  // the evidence-bounded register — and the boundary is how it tells them
+  // from the caller's.
+  const callerUnreviewedCount = unreviewed.length;
   // The fixes for the gaps above, for stderr — never for the body. The gap says
   // what the review cannot certify, to the PR author; the remediation names the
   // command that repairs it, to the orchestrator. #7012's public body was fourteen
@@ -512,17 +517,33 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // before the entry's LAST em-dash segment, because an invariant agent's
   // label legitimately carries one (`Invariant agent A … — src/foo.ts`) and a
   // first-dash key would merge two files into one subject. This mirrors the
-  // chunk list above deduping by its `chunk <id>` prefix. When both sides
-  // name the same subject the LATER entry wins — coverage pushes after the
-  // input is read, and its texts are the evidence-bounded register this body
-  // is written in. First-appearance order is kept so deduping never reorders
-  // the disclosure list.
+  // chunk list above deduping by its `chunk <id>` prefix.
+  //
+  // Which text survives a collision: a coverage-derived entry beats the
+  // caller's — it is the evidence-bounded register this body is written in —
+  // and among coverage entries the EARLIEST wins, because the categories push
+  // in precision order: a chunk flagged `rewritten` is also, to the roster, a
+  // requirement with no verbatim launch, and keeping the later roster text
+  // would tell the author "no agent was launched" about an agent that
+  // demonstrably ran. First-appearance order is kept so deduping never
+  // reorders the disclosure list.
   const labelOf = (d: string): string => {
     const parts = d.split(' — ');
     return parts.length > 1 ? parts.slice(0, -1).join(' — ').trim() : d.trim();
   };
   const chosen = new Map<string, string>();
-  for (const d of unreviewed) chosen.set(labelOf(d), d);
+  const chosenFromCoverage = new Map<string, boolean>();
+  unreviewed.forEach((d, i) => {
+    const label = labelOf(d);
+    const fromCoverage = i >= callerUnreviewedCount;
+    if (!chosen.has(label)) {
+      chosen.set(label, d);
+      chosenFromCoverage.set(label, fromCoverage);
+    } else if (fromCoverage && !chosenFromCoverage.get(label)) {
+      chosen.set(label, d);
+      chosenFromCoverage.set(label, true);
+    }
+  });
   const seenLabels = new Set<string>();
   const dedupedUnreviewed: string[] = [];
   for (const d of unreviewed) {
@@ -543,8 +564,25 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       `Not reviewed: ${whiffedDimensions.join(', ')} — the agent returned no evidence of its walk twice.`,
     );
   }
+  // Same cause, one sentence. Forty-three chunks launched with rewritten
+  // prompts are one failure with forty-three subjects, not forty-three
+  // paragraphs: a posted body on #7166 was ninety-nine disclosure clauses
+  // over four causes, with the six real findings buried beneath the wall.
+  // Grouped by the reason text — the entry's last em-dash segment, the same
+  // split the dedup above keys on — exactly as the bare names group under
+  // the shared whiff sentence. A reason that embeds per-subject detail (an
+  // unread brief's own path) differs per entry and keeps its own line.
+  const byReason = new Map<string, string[]>();
   for (const d of explainedDimensions) {
-    notReviewedParts.push(`Not reviewed: ${d}.`);
+    const parts = d.split(' — ');
+    const reason = (parts.pop() as string).trim();
+    const subject = parts.join(' — ').trim();
+    const subjects = byReason.get(reason) ?? [];
+    subjects.push(subject);
+    byReason.set(reason, subjects);
+  }
+  for (const [reason, subjects] of byReason) {
+    notReviewedParts.push(`Not reviewed: ${subjects.join(', ')} — ${reason}.`);
   }
 
   // Clause 5 — blockers the review could neither confirm nor clear. They

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -204,11 +204,10 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     input.unreviewedDimensions,
     'unreviewedDimensions',
   );
-  // Everything past this index is coverage-derived: the recomputation below
-  // only ever appends. The disclosure dedup prefers those entries — they are
-  // the evidence-bounded register — and the boundary is how it tells them
-  // from the caller's.
-  const callerUnreviewedCount = unreviewed.length;
+  // The coverage-derived disclosures, kept STRUCTURAL ({subject, reason})
+  // from the site that knows the boundary — reparsing the rendered prose for
+  // it was the bug. `unreviewed` above stays what the caller wrote, verbatim.
+  const coverageEntries: Array<{ subject: string; reason: string }> = [];
   // The fixes for the gaps above, for stderr — never for the body. The gap says
   // what the review cannot certify, to the PR author; the remediation names the
   // command that repairs it, to the orchestrator. #7012's public body was fourteen
@@ -246,10 +245,12 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // What it supplies is `planPath` — a path, whose contents the CLI wrote. The
   // transcripts are found from the environment the CLI exported.
   if (!input.planPath) {
-    unreviewed.push(
-      'coverage — no plan was given, so this run cannot show that any of the ' +
-        'diff was read',
-    );
+    coverageEntries.push({
+      subject: 'coverage',
+      reason:
+        'no plan was given, so this run cannot show that any of the diff ' +
+        'was read',
+    });
   } else {
     try {
       const cov = coverageFromTranscripts(input.planPath, input.env);
@@ -266,9 +267,10 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
         if (!already) uncoverable.push(prefix);
       }
       for (const label of cov.idleAgents) {
-        unreviewed.push(
-          `${label} — the agent made no tool call: it read nothing`,
-        );
+        coverageEntries.push({
+          subject: label,
+          reason: 'the agent made no tool call: it read nothing',
+        });
       }
       if (cov.idleAgents.length > 0) {
         remediation.push(
@@ -285,10 +287,12 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       // this line: the line lands in the posted body, and `qwen review
       // agent-prompt` is not something a PR author can run.
       for (const label of cov.blindAgents) {
-        unreviewed.push(
-          `${label} — launched with a prompt that never named the diff file, ` +
-            'so it could not have read it',
-        );
+        coverageEntries.push({
+          subject: label,
+          reason:
+            'launched with a prompt that never named the diff file, so it ' +
+            'could not have read it',
+        });
       }
       if (cov.blindAgents.length > 0) {
         remediation.push(
@@ -303,10 +307,12 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       // spent its run somewhere else, which on a diff with deletions means it
       // reviewed a file the removed lines are simply not in.
       for (const label of cov.unopenedAgents) {
-        unreviewed.push(
-          `${label} — pointed at diff lines it never opened: it made tool calls, ` +
-            'but none of them read the diff',
-        );
+        coverageEntries.push({
+          subject: label,
+          reason:
+            'pointed at diff lines it never opened: it made tool calls, but ' +
+            'none of them read the diff',
+        });
       }
       if (cov.unopenedAgents.length > 0) {
         remediation.push(
@@ -322,9 +328,10 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       // prompt that is not the one the CLI built`), so push the label as-is —
       // wrapping it in a second ` — ` clause read as one run-on sentence with two
       // dashes. Same for `missingRoles` below; `unreadBriefs` already did this.
-      for (const label of cov.rewrittenPrompts) {
-        unreviewed.push(label);
-      }
+      // rewritten, missing-role and unread-brief entries arrive structurally
+      // (`cov.disclosures`, push order preserved) — their labels can carry
+      // em-dashes of their own, which is why they are never reparsed here.
+      coverageEntries.push(...cov.disclosures);
       if (cov.rewrittenPrompts.length > 0) {
         remediation.push(
           'rewritten launches: re-run `"${QWEN_CODE_CLI:-qwen}" review ' +
@@ -338,9 +345,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       // A dimension nobody reviewed. This is exactly what `unreviewedDimensions`
       // has always meant, arrived at from the plan instead of from the orchestrator
       // noticing — which, on the run that never launched Agent 0, it did not.
-      for (const label of cov.missingRoles) {
-        unreviewed.push(label);
-      }
+
       if (cov.missingRoles.length > 0) {
         remediation.push(
           'missing briefs: build every required prompt in one call — ' +
@@ -352,9 +357,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       }
       // Launched, but never read the brief it was pointed at: it reviewed with no
       // dimension, no severity definitions and no project rules.
-      for (const label of cov.unreadBriefs) {
-        unreviewed.push(label);
-      }
+
       if (cov.unreadBriefs.length > 0) {
         remediation.push(
           'unread briefs: relaunch each agent with the same printed prompt — ' +
@@ -373,9 +376,10 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
         err instanceof TranscriptsUnavailableError
           ? `could not read the agents' transcripts (${err.message})`
           : `the plan could not be used (${(err as Error).message})`;
-      unreviewed.push(
-        `coverage — ${why}, so this run cannot show that any of the diff was read`,
-      );
+      coverageEntries.push({
+        subject: 'coverage',
+        reason: `${why}, so this run cannot show that any of the diff was read`,
+      });
     }
 
     // Step 4 (verify) and Step 5 (reverse audit) ran, and read their briefs?
@@ -399,13 +403,23 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
         { postsFindings: findingsToVerify > 0 },
         input.env,
       );
-      for (const gap of verification.gaps) unreviewed.push(gap);
+      for (const gap of verification.gaps) {
+        // The machine's own two subjects ('verification', 'reverse audit'),
+        // dash-free by construction — the first separator is the boundary.
+        const cut = gap.indexOf(' — ');
+        coverageEntries.push({
+          subject: gap.slice(0, cut),
+          reason: gap.slice(cut + ' — '.length),
+        });
+      }
       remediation.push(...verification.remediation);
     } catch (err) {
-      unreviewed.push(
-        `verification — could not check that Step 4 and Step 5 ran ` +
+      coverageEntries.push({
+        subject: 'verification',
+        reason:
+          `could not check that Step 4 and Step 5 ran ` +
           `(${(err as Error).message})`,
-      );
+      });
     }
   }
   const contextUnavailable = toBool(
@@ -456,7 +470,9 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   if (cannotTell.length > 0) cappedBy.push('cannot-tell-existing-critical');
   if (missingReceipts.length > 0) cappedBy.push('chunk-nobody-read');
   if (uncoverable.length > 0) cappedBy.push('uncoverable-chunk');
-  if (unreviewed.length > 0) cappedBy.push('unreviewed-dimension');
+  if (unreviewed.length + coverageEntries.length > 0) {
+    cappedBy.push('unreviewed-dimension');
+  }
   if (contextUnavailable) cappedBy.push('context-unavailable');
 
   let event: ReviewEvent = baseEvent;
@@ -509,74 +525,61 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       `Not reviewed: ${uncoverable.join(', ')} — a line there exceeds the read limit.`,
     );
   }
-  // One disclosure per subject. `unreviewed` fills from two sides — the
-  // caller's `unreviewedDimensions` and the coverage recomputation — and they
-  // describe the same failures: a run that pasted the gate's own gap lines
-  // into its input posted every one of them twice, 22 "Not reviewed" clauses
-  // for 11 roles on a public PR (#7188). Keyed by the label — everything
-  // before the entry's LAST em-dash segment, because an invariant agent's
-  // label legitimately carries one (`Invariant agent A … — src/foo.ts`) and a
-  // first-dash key would merge two files into one subject. This mirrors the
-  // chunk list above deduping by its `chunk <id>` prefix.
-  //
-  // Which text survives a collision: a coverage-derived entry beats the
-  // caller's — it is the evidence-bounded register this body is written in —
-  // and among coverage entries the EARLIEST wins, because the categories push
-  // in precision order: a chunk flagged `rewritten` is also, to the roster, a
-  // requirement with no verbatim launch, and keeping the later roster text
-  // would tell the author "no agent was launched" about an agent that
-  // demonstrably ran. First-appearance order is kept so deduping never
-  // reorders the disclosure list.
-  const labelOf = (d: string): string => {
-    const parts = d.split(' — ');
-    return parts.length > 1 ? parts.slice(0, -1).join(' — ').trim() : d.trim();
-  };
-  const chosen = new Map<string, string>();
-  const chosenFromCoverage = new Map<string, boolean>();
-  unreviewed.forEach((d, i) => {
-    const label = labelOf(d);
-    const fromCoverage = i >= callerUnreviewedCount;
-    if (!chosen.has(label)) {
-      chosen.set(label, d);
-      chosenFromCoverage.set(label, fromCoverage);
-    } else if (fromCoverage && !chosenFromCoverage.get(label)) {
-      chosen.set(label, d);
-      chosenFromCoverage.set(label, true);
-    }
-  });
-  const seenLabels = new Set<string>();
-  const dedupedUnreviewed: string[] = [];
+  // One disclosure per subject, one sentence per cause — structurally, not by
+  // reparsing prose. The first cut recovered a subject/reason boundary from
+  // the rendered text (the last ` — ` segment), and a reason is free-form:
+  // an invariant label carries a dash for its file, an error interpolation
+  // can carry anything, and a boundary guessed wrong regroups the entries it
+  // garbles. Coverage now hands the entries over as `{subject, reason}`
+  // pairs; only the CALLER\'s entries are prose, and those are never parsed —
+  // they are matched against known coverage subjects by prefix (exactly how
+  // the chunk list above dedupes), and rendered verbatim when nothing
+  // matches. A run that pasted the gate\'s own gap lines into its input
+  // posted every disclosure twice — 22 clauses for 11 roles on a public PR
+  // (#7188) — and the coverage-derived text wins the collision: it is the
+  // evidence-bounded register this body is written in.
+  const covEntries: Array<{ subject: string; reason: string }> = [
+    ...coverageEntries,
+  ];
+  const callerLeft: string[] = [];
+  const seenCaller = new Set<string>();
   for (const d of unreviewed) {
-    const label = labelOf(d);
-    if (seenLabels.has(label)) continue;
-    seenLabels.add(label);
-    dedupedUnreviewed.push(chosen.get(label) as string);
+    if (seenCaller.has(d)) continue; // a caller pasting itself twice
+    seenCaller.add(d);
+    const echoesCoverage = covEntries.some(
+      (e) => d === e.subject || d.startsWith(`${e.subject} — `),
+    );
+    if (!echoesCoverage) callerLeft.push(d);
   }
-  // Bare dimension names share the whiffed-agent explanation; an entry that
-  // brought its own reason (after an em-dash) must not have the whiff
-  // sentence appended to it — that would misstate why it went unreviewed.
-  const whiffedDimensions = dedupedUnreviewed.filter((d) => !d.includes(' — '));
-  const explainedDimensions = dedupedUnreviewed.filter((d) =>
-    d.includes(' — '),
-  );
+  // Bare caller names share the whiffed-agent explanation; an entry that
+  // brought its own reason (after an em-dash) is rendered verbatim, its own
+  // line — unparsed, ungrouped, because its structure is not ours to guess.
+  const whiffedDimensions = callerLeft.filter((d) => !d.includes(' — '));
+  const explainedCaller = callerLeft.filter((d) => d.includes(' — '));
   if (whiffedDimensions.length > 0) {
     notReviewedParts.push(
       `Not reviewed: ${whiffedDimensions.join(', ')} — the agent returned no evidence of its walk twice.`,
     );
   }
-  // Same cause, one sentence. Forty-three chunks launched with rewritten
+  for (const d of explainedCaller) {
+    notReviewedParts.push(`Not reviewed: ${d}.`);
+  }
+  // Same cause, one sentence: forty-three chunks launched with rewritten
   // prompts are one failure with forty-three subjects, not forty-three
-  // paragraphs: a posted body on #7166 was ninety-nine disclosure clauses
-  // over four causes, with the six real findings buried beneath the wall.
-  // Grouped by the reason text — the entry's last em-dash segment, the same
-  // split the dedup above keys on — exactly as the bare names group under
-  // the shared whiff sentence. A reason that embeds per-subject detail (an
-  // unread brief's own path) differs per entry and keeps its own line.
+  // paragraphs — a posted body on #7166 was ninety-nine clauses over four
+  // causes, the six real findings buried beneath. Grouped by the reason
+  // STRING, so a reason embedding per-subject detail (an unread brief\'s own
+  // path) differs per entry and keeps its own line. One subject that appears
+  // under two causes keeps the FIRST — the categories push in precision
+  // order, and a chunk flagged `rewritten` is also, to the roster, a
+  // requirement with no verbatim launch; repeating it under the later, vaguer
+  // cause would tell the author "no agent was launched" about an agent that
+  // demonstrably ran.
+  const seenSubjects = new Set<string>();
   const byReason = new Map<string, string[]>();
-  for (const d of explainedDimensions) {
-    const parts = d.split(' — ');
-    const reason = (parts.pop() as string).trim();
-    const subject = parts.join(' — ').trim();
+  for (const { subject, reason } of covEntries) {
+    if (seenSubjects.has(subject)) continue;
+    seenSubjects.add(subject);
     const subjects = byReason.get(reason) ?? [];
     subjects.push(subject);
     byReason.set(reason, subjects);
@@ -666,7 +669,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       c === 0 &&
       cannotTell.length === 0 &&
       uncoverable.length === 0 &&
-      unreviewed.length === 0 &&
+      unreviewed.length + coverageEntries.length === 0 &&
       // A missing receipt caps the event but was left out of certification, so a
       // body could open "Reviewed — no blockers." two lines above "nobody read
       // them." Nothing nobody read can be certified blocker-free.

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -681,8 +681,14 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   //    above.)
   if (suggestionsInline > 0) clauses.push('Suggestions are inline.');
   if (suggestionsDiscarded > 0) {
+    // Self-contained: this lands in the posted body, and "see the terminal
+    // output" pointed the PR author at a terminal only the operator has —
+    // eight hours of real bot reviews carried that dead reference on five
+    // different pull requests.
     clauses.push(
-      `${suggestionsDiscarded} Suggestion-level finding(s) could not be anchored to the diff; see the terminal output.`,
+      `${suggestionsDiscarded} Suggestion-level finding(s) could not be ` +
+        `anchored to a changed line and were dropped; nothing further to act ` +
+        `on here.`,
     );
   }
 

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -407,10 +407,14 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
         // The machine's own two subjects ('verification', 'reverse audit'),
         // dash-free by construction — the first separator is the boundary.
         const cut = gap.indexOf(' — ');
-        coverageEntries.push({
-          subject: gap.slice(0, cut),
-          reason: gap.slice(cut + ' — '.length),
-        });
+        coverageEntries.push(
+          cut === -1
+            ? { subject: gap, reason: '' }
+            : {
+                subject: gap.slice(0, cut),
+                reason: gap.slice(cut + ' — '.length),
+              },
+        );
       }
       remediation.push(...verification.remediation);
     } catch (err) {
@@ -538,9 +542,7 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // posted every disclosure twice — 22 clauses for 11 roles on a public PR
   // (#7188) — and the coverage-derived text wins the collision: it is the
   // evidence-bounded register this body is written in.
-  const covEntries: Array<{ subject: string; reason: string }> = [
-    ...coverageEntries,
-  ];
+  const covEntries = coverageEntries;
   const callerLeft: string[] = [];
   const seenCaller = new Set<string>();
   for (const d of unreviewed) {
@@ -585,7 +587,11 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     byReason.set(reason, subjects);
   }
   for (const [reason, subjects] of byReason) {
-    notReviewedParts.push(`Not reviewed: ${subjects.join(', ')} — ${reason}.`);
+    notReviewedParts.push(
+      reason
+        ? `Not reviewed: ${subjects.join(', ')} — ${reason}.`
+        : `Not reviewed: ${subjects.join(', ')}.`,
+    );
   }
 
   // Clause 5 — blockers the review could neither confirm nor clear. They

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -504,11 +504,40 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       `Not reviewed: ${uncoverable.join(', ')} — a line there exceeds the read limit.`,
     );
   }
+  // One disclosure per subject. `unreviewed` fills from two sides — the
+  // caller's `unreviewedDimensions` and the coverage recomputation — and they
+  // describe the same failures: a run that pasted the gate's own gap lines
+  // into its input posted every one of them twice, 22 "Not reviewed" clauses
+  // for 11 roles on a public PR (#7188). Keyed by the label — everything
+  // before the entry's LAST em-dash segment, because an invariant agent's
+  // label legitimately carries one (`Invariant agent A … — src/foo.ts`) and a
+  // first-dash key would merge two files into one subject. This mirrors the
+  // chunk list above deduping by its `chunk <id>` prefix. When both sides
+  // name the same subject the LATER entry wins — coverage pushes after the
+  // input is read, and its texts are the evidence-bounded register this body
+  // is written in. First-appearance order is kept so deduping never reorders
+  // the disclosure list.
+  const labelOf = (d: string): string => {
+    const parts = d.split(' — ');
+    return parts.length > 1 ? parts.slice(0, -1).join(' — ').trim() : d.trim();
+  };
+  const chosen = new Map<string, string>();
+  for (const d of unreviewed) chosen.set(labelOf(d), d);
+  const seenLabels = new Set<string>();
+  const dedupedUnreviewed: string[] = [];
+  for (const d of unreviewed) {
+    const label = labelOf(d);
+    if (seenLabels.has(label)) continue;
+    seenLabels.add(label);
+    dedupedUnreviewed.push(chosen.get(label) as string);
+  }
   // Bare dimension names share the whiffed-agent explanation; an entry that
   // brought its own reason (after an em-dash) must not have the whiff
   // sentence appended to it — that would misstate why it went unreviewed.
-  const whiffedDimensions = unreviewed.filter((d) => !d.includes(' — '));
-  const explainedDimensions = unreviewed.filter((d) => d.includes(' — '));
+  const whiffedDimensions = dedupedUnreviewed.filter((d) => !d.includes(' — '));
+  const explainedDimensions = dedupedUnreviewed.filter((d) =>
+    d.includes(' — '),
+  );
   if (whiffedDimensions.length > 0) {
     notReviewedParts.push(
       `Not reviewed: ${whiffedDimensions.join(', ')} — the agent returned no evidence of its walk twice.`,

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -140,6 +140,17 @@ export interface CoverageFromTranscripts {
   uncoverableChunks: number[];
   /** Chunk ids a working agent actually reviewed. */
   coveredChunks: number[];
+  /**
+   * The pre-formed disclosure entries (`rewrittenPrompts`, `missingRoles`,
+   * `unreadBriefs`), as `{subject, reason}` pairs in push order — for
+   * `compose-review`, which dedupes caller echoes by subject and groups
+   * same-reason subjects into one sentence. The prose twins above remain for
+   * the stderr formatting; REPARSING them was the bug: a reason is free-form
+   * text (labels carry ` — ` for an invariant's file, error interpolations
+   * can carry anything), so a subject/reason boundary recovered from rendered
+   * prose garbles exactly the entries it matters for.
+   */
+  disclosures: Array<{ subject: string; reason: string }>;
 }
 
 /** The plan, as far as coverage needs it. The roster reads more of it — see RosterPlan. */
@@ -285,6 +296,10 @@ export function coverageFromTranscripts(
   const idleAgents: string[] = [];
   const unopenedAgents: string[] = [];
   const rewrittenPrompts: string[] = [];
+  const disclosures: Array<{ subject: string; reason: string }> = [];
+  const disclose = (subject: string, reason: string): void => {
+    disclosures.push({ subject, reason });
+  };
   const covered = new Set<number>();
   const uncoverable = new Set<number>();
 
@@ -395,12 +410,21 @@ export function coverageFromTranscripts(
             `${name} — ran on a prompt the run wrote itself (none was built for ` +
               `this chunk), so the brief with its method and rules never reached it`,
           );
+          disclose(
+            name,
+            'ran on a prompt the run wrote itself (none was built for this ' +
+              'chunk), so the brief with its method and rules never reached it',
+          );
         }
       } else if (!wasDeliveredVerbatim(rec.launchPrompt, b)) {
         rewrittenThisRecord = true;
         if (!superseded(rec, chunk)) {
           rewrittenPrompts.push(
             `${name} — launched with a prompt that is not the one the CLI built`,
+          );
+          disclose(
+            name,
+            'launched with a prompt that is not the one the CLI built',
           );
         }
       }
@@ -489,6 +513,14 @@ export function coverageFromTranscripts(
         `shows the severity bar, the finding format or this project's own rules ` +
         `reaching an agent`,
     );
+    disclose(
+      'every dimension',
+      `none of the ${roster.length} required agents is on record as launched ` +
+        `with a prompt this skill built, so this diff was reviewed, if at ` +
+        `all, from prompts the run wrote for itself: no record shows the ` +
+        `severity bar, the finding format or this project's own rules ` +
+        `reaching an agent`,
+    );
   }
 
   // Injective: one transcript may satisfy ONE roster requirement. Without this,
@@ -541,25 +573,6 @@ export function coverageFromTranscripts(
   const assignment = new Map<number, AgentRecord>();
   for (const [rec, i] of matchedRec) assignment.set(i, rec);
 
-  // The launched-side twin of `nobodyBuiltAnything`: every prompt was built and
-  // not one of them reached any agent on record. Said once per dimension it
-  // becomes N identical lines burying the single fact that explains all of
-  // them — the run stopped at the builder — and on #7188 a public review body
-  // was exactly that wall, eleven roles' worth. One line, same as the
-  // never-built collapse; the per-role selectors below survive for the repair.
-  const nobodyLaunchedAnything =
-    roster.length > 1 &&
-    buildable.length === roster.length &&
-    candidatesOf.every((c) => c.length === 0);
-  if (nobodyLaunchedAnything) {
-    missingRoles.push(
-      `every dimension — all ${roster.length} required prompts were built, ` +
-        `and no agent on record was launched with any of them: the run ` +
-        `stopped at the prompt builder, so this diff was reviewed, if at ` +
-        `all, from prompts the run wrote for itself`,
-    );
-  }
-
   let buildableIdx = -1;
   for (const req of roster) {
     const b = builtOf(req.key);
@@ -569,6 +582,11 @@ export function coverageFromTranscripts(
           `${roleLabel(req)} — no record shows its brief reaching an agent, so ` +
             `this dimension was reviewed, if at all, from a prompt the run ` +
             `wrote for itself`,
+        );
+        disclose(
+          roleLabel(req),
+          'no record shows its brief reaching an agent, so this dimension ' +
+            'was reviewed, if at all, from a prompt the run wrote for itself',
         );
       }
       missingRoleSelectors.push(selectorOf(req));
@@ -580,16 +598,22 @@ export function coverageFromTranscripts(
       // Not assignable even under a MAXIMUM matching — so this is provably a
       // shortage of transcripts, not an artifact of claim order.
       const anyMatch = candidatesOf[buildableIdx].length > 0;
-      if (!nobodyLaunchedAnything) {
-        missingRoles.push(
-          anyMatch
-            ? `${roleLabel(req)} — its prompt reached only an agent already ` +
-                `credited with another block; one agent was given several blocks, ` +
-                `and one transcript cannot certify two dimensions`
-            : `${roleLabel(req)} — its prompt was built, but no agent on record ` +
-                `was launched with it`,
-        );
-      }
+      missingRoles.push(
+        anyMatch
+          ? `${roleLabel(req)} — its prompt reached only an agent already ` +
+              `credited with another block; one agent was given several blocks, ` +
+              `and one transcript cannot certify two dimensions`
+          : `${roleLabel(req)} — its prompt was built, but no agent on record ` +
+              `was launched with it`,
+      );
+      disclose(
+        roleLabel(req),
+        anyMatch
+          ? 'its prompt reached only an agent already credited with another ' +
+              'block; one agent was given several blocks, and one transcript ' +
+              'cannot certify two dimensions'
+          : 'its prompt was built, but no agent on record was launched with it',
+      );
       missingRoleSelectors.push(selectorOf(req));
       continue;
     }
@@ -621,6 +645,11 @@ export function coverageFromTranscripts(
         `${roleLabel(req)} — never opened its brief (${brief}), so it reviewed ` +
           'without the instructions it was launched to follow',
       );
+      disclose(
+        roleLabel(req),
+        `never opened its brief (${brief}), so it reviewed without the ` +
+          'instructions it was launched to follow',
+      );
     }
   }
 
@@ -649,6 +678,7 @@ export function coverageFromTranscripts(
     rewrittenPrompts,
     missingRoles,
     missingRoleSelectors,
+    disclosures,
     unreadBriefs,
     missingChunks,
     uncoverableChunks: [...uncoverable].sort((a, b) => a - b),

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -541,6 +541,25 @@ export function coverageFromTranscripts(
   const assignment = new Map<number, AgentRecord>();
   for (const [rec, i] of matchedRec) assignment.set(i, rec);
 
+  // The launched-side twin of `nobodyBuiltAnything`: every prompt was built and
+  // not one of them reached any agent on record. Said once per dimension it
+  // becomes N identical lines burying the single fact that explains all of
+  // them — the run stopped at the builder — and on #7188 a public review body
+  // was exactly that wall, eleven roles' worth. One line, same as the
+  // never-built collapse; the per-role selectors below survive for the repair.
+  const nobodyLaunchedAnything =
+    roster.length > 1 &&
+    buildable.length === roster.length &&
+    candidatesOf.every((c) => c.length === 0);
+  if (nobodyLaunchedAnything) {
+    missingRoles.push(
+      `every dimension — all ${roster.length} required prompts were built, ` +
+        `and no agent on record was launched with any of them: the run ` +
+        `stopped at the prompt builder, so this diff was reviewed, if at ` +
+        `all, from prompts the run wrote for itself`,
+    );
+  }
+
   let buildableIdx = -1;
   for (const req of roster) {
     const b = builtOf(req.key);
@@ -561,14 +580,16 @@ export function coverageFromTranscripts(
       // Not assignable even under a MAXIMUM matching — so this is provably a
       // shortage of transcripts, not an artifact of claim order.
       const anyMatch = candidatesOf[buildableIdx].length > 0;
-      missingRoles.push(
-        anyMatch
-          ? `${roleLabel(req)} — its prompt reached only an agent already ` +
-              `credited with another block; one agent was given several blocks, ` +
-              `and one transcript cannot certify two dimensions`
-          : `${roleLabel(req)} — its prompt was built, but no agent on record ` +
-              `was launched with it`,
-      );
+      if (!nobodyLaunchedAnything) {
+        missingRoles.push(
+          anyMatch
+            ? `${roleLabel(req)} — its prompt reached only an agent already ` +
+                `credited with another block; one agent was given several blocks, ` +
+                `and one transcript cannot certify two dimensions`
+            : `${roleLabel(req)} — its prompt was built, but no agent on record ` +
+                `was launched with it`,
+        );
+      }
       missingRoleSelectors.push(selectorOf(req));
       continue;
     }

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -297,8 +297,13 @@ export function coverageFromTranscripts(
   const unopenedAgents: string[] = [];
   const rewrittenPrompts: string[] = [];
   const disclosures: Array<{ subject: string; reason: string }> = [];
-  const disclose = (subject: string, reason: string): void => {
+  // The one source for both registers: the structural entry feeds the posted
+  // body (compose-review), and the returned prose feeds the stderr arrays —
+  // maintained as a pair, an edit to one and not the other would silently
+  // diverge what the operator reads from what the author was told.
+  const disclose = (subject: string, reason: string): string => {
     disclosures.push({ subject, reason });
+    return `${subject} — ${reason}`;
   };
   const covered = new Set<number>();
   const uncoverable = new Set<number>();
@@ -407,24 +412,21 @@ export function coverageFromTranscripts(
         rewrittenThisRecord = true;
         if (!nothingBuiltAtAll && !superseded(rec, chunk)) {
           rewrittenPrompts.push(
-            `${name} — ran on a prompt the run wrote itself (none was built for ` +
-              `this chunk), so the brief with its method and rules never reached it`,
-          );
-          disclose(
-            name,
-            'ran on a prompt the run wrote itself (none was built for this ' +
-              'chunk), so the brief with its method and rules never reached it',
+            disclose(
+              name,
+              'ran on a prompt the run wrote itself (none was built for this ' +
+                'chunk), so the brief with its method and rules never reached it',
+            ),
           );
         }
       } else if (!wasDeliveredVerbatim(rec.launchPrompt, b)) {
         rewrittenThisRecord = true;
         if (!superseded(rec, chunk)) {
           rewrittenPrompts.push(
-            `${name} — launched with a prompt that is not the one the CLI built`,
-          );
-          disclose(
-            name,
-            'launched with a prompt that is not the one the CLI built',
+            disclose(
+              name,
+              'launched with a prompt that is not the one the CLI built',
+            ),
           );
         }
       }
@@ -507,19 +509,14 @@ export function coverageFromTranscripts(
     // Phrased to read under the `Not reviewed: ` prefix `compose-review` renders it
     // with, which is where a PR author meets it.
     missingRoles.push(
-      `every dimension — none of the ${roster.length} required agents is on ` +
-        `record as launched with a prompt this skill built, so this diff was ` +
-        `reviewed, if at all, from prompts the run wrote for itself: no record ` +
-        `shows the severity bar, the finding format or this project's own rules ` +
-        `reaching an agent`,
-    );
-    disclose(
-      'every dimension',
-      `none of the ${roster.length} required agents is on record as launched ` +
-        `with a prompt this skill built, so this diff was reviewed, if at ` +
-        `all, from prompts the run wrote for itself: no record shows the ` +
-        `severity bar, the finding format or this project's own rules ` +
-        `reaching an agent`,
+      disclose(
+        'every dimension',
+        `none of the ${roster.length} required agents is on record as ` +
+          `launched with a prompt this skill built, so this diff was ` +
+          `reviewed, if at all, from prompts the run wrote for itself: no ` +
+          `record shows the severity bar, the finding format or this ` +
+          `project's own rules reaching an agent`,
+      ),
     );
   }
 
@@ -579,14 +576,11 @@ export function coverageFromTranscripts(
     if (b === undefined) {
       if (!nobodyBuiltAnything) {
         missingRoles.push(
-          `${roleLabel(req)} — no record shows its brief reaching an agent, so ` +
-            `this dimension was reviewed, if at all, from a prompt the run ` +
-            `wrote for itself`,
-        );
-        disclose(
-          roleLabel(req),
-          'no record shows its brief reaching an agent, so this dimension ' +
-            'was reviewed, if at all, from a prompt the run wrote for itself',
+          disclose(
+            roleLabel(req),
+            'no record shows its brief reaching an agent, so this dimension ' +
+              'was reviewed, if at all, from a prompt the run wrote for itself',
+          ),
         );
       }
       missingRoleSelectors.push(selectorOf(req));
@@ -599,20 +593,15 @@ export function coverageFromTranscripts(
       // shortage of transcripts, not an artifact of claim order.
       const anyMatch = candidatesOf[buildableIdx].length > 0;
       missingRoles.push(
-        anyMatch
-          ? `${roleLabel(req)} — its prompt reached only an agent already ` +
-              `credited with another block; one agent was given several blocks, ` +
-              `and one transcript cannot certify two dimensions`
-          : `${roleLabel(req)} — its prompt was built, but no agent on record ` +
-              `was launched with it`,
-      );
-      disclose(
-        roleLabel(req),
-        anyMatch
-          ? 'its prompt reached only an agent already credited with another ' +
-              'block; one agent was given several blocks, and one transcript ' +
-              'cannot certify two dimensions'
-          : 'its prompt was built, but no agent on record was launched with it',
+        disclose(
+          roleLabel(req),
+          anyMatch
+            ? 'its prompt reached only an agent already credited with ' +
+                'another block; one agent was given several blocks, and one ' +
+                'transcript cannot certify two dimensions'
+            : 'its prompt was built, but no agent on record was launched ' +
+                'with it',
+        ),
       );
       missingRoleSelectors.push(selectorOf(req));
       continue;
@@ -642,13 +631,11 @@ export function coverageFromTranscripts(
     );
     if (!opened) {
       unreadBriefs.push(
-        `${roleLabel(req)} — never opened its brief (${brief}), so it reviewed ` +
-          'without the instructions it was launched to follow',
-      );
-      disclose(
-        roleLabel(req),
-        `never opened its brief (${brief}), so it reviewed without the ` +
-          'instructions it was launched to follow',
+        disclose(
+          roleLabel(req),
+          `never opened its brief (${brief}), so it reviewed without the ` +
+            'instructions it was launched to follow',
+        ),
       );
     }
   }


### PR DESCRIPTION
## What this PR does

One disclosure per subject, one sentence per cause, in the register the reader can use — taken from two shipped review bodies (#7188: 22 duplicate clauses for 11 roles; #7166: 99 clauses over four causes, six real findings buried beneath).

- **Coverage hands `compose-review` its disclosures structurally** (`disclosures: {subject, reason}[]`, beside the prose twins the stderr formatting keeps; the prose is derived from the structural entry, so the two registers cannot diverge). Reparsing rendered prose for a subject/reason boundary was refused by review — reasons are free-form (invariant labels carry ` — ` for their file; error interpolations carry anything).
- **Caller-echoed disclosures dedupe by subject**: `unreviewedDimensions` entries are never parsed; they match known coverage subjects by prefix (exactly how the chunk list already dedupes) and render verbatim otherwise. On a collision the coverage text wins, and within coverage the earliest category wins — a chunk flagged `rewritten` must not also read "no agent was launched" about an agent that demonstrably ran.
- **Same-reason subjects group into one sentence** — `Not reviewed: chunk 1, …, chunk 43 — launched with a prompt that is not the one the CLI built.` — which collapses every wall shape at once (all-unlaunched, all-rewritten, caller-echo variants). An earlier coverage-side collapse was removed in review: it misfired on all-rewritten rosters and discarded the per-role subjects the dedup needs.
- **The discarded-suggestions clause is self-contained**: it used to say "see the terminal output", a terminal the PR author does not have.

## Why it's needed

The two linked bodies are what an external contributor actually received when a review run failed: walls of operator-register process text burying the review itself. The delivery gates were right to disclose; the composition of the disclosure was the defect.

## Reviewer Test Plan

### How to verify

1. `cd packages/cli && npx vitest run src/commands/review` — 31 files, 746 tests green.
2. Tests named for their failures: caller echo renders once with the machine's text winning; two invariant files never merge under one label; a reason carrying its own em-dash neither garbles nor duplicates; an all-rewritten roster renders its precise cause with no contradicting aggregate; the #7188 shape (caller echo + per-role gaps) folds into one grouped sentence; all-built-none-launched keeps per-role entries and selectors at the coverage layer (grouping is compose's job); `terminal output` is banned from the body.
3. Mutation-tested across the four commits (12 total, all killed): dedup bypass, first-dash key, grouping removal, first-cause-wins flip, disclosures never pushed, collapse variants, and more — each turns exactly its test red.

### Evidence (Before & After)

Before (#7166, verbatim): 99 paragraphs of `Not reviewed: chunk N — launched with a prompt that is not the one the CLI built.` / `… — its prompt was built, but no agent on record was launched with it.`

After, same state: one sentence per cause — `Not reviewed: chunk 1, chunk 2, …, chunk 43 — launched with a prompt that is not the one the CLI built. Not reviewed: <55 roles> — its prompt was built, but no agent on record was launched with it.` — and a caller echoing any of it adds nothing.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Body composition only: events, caps, remediation and `missingRoleSelectors` are unchanged (the cap and `canCertify` sum both inlets, pinned by the suites).
- Grouping is by exact reason string, so a reason embedding per-subject detail (an unread brief's path) keeps its own line.
- macOS `test-efficacy` local failures observed by a reviewer are pre-existing `safeRmWithin` symlink behavior, unrelated (Linux CI green).

## Linked Issues

Exhibits: the review bodies posted on #7188 and #7166.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

一个主题一条披露、一个原因一句话、且用读者能用的语域——取材自两条已发布的 review 正文(#7188:11 角色重复成 22 条;#7166:四种原因 99 条,6 条真 findings 被埋)。

- **coverage 以结构化形式移交披露**(`disclosures: {subject, reason}[]`,prose 双胞胎保留给 stderr 且由结构化条目派生,两个语域不可能分叉)。从渲染文本反解析 subject/reason 边界被 review 否决——reason 是自由文本(invariant label 自带 ` — ` 文件段、错误插值什么都可能有)。
- **caller 回抄按 subject 去重**:`unreviewedDimensions` 条目从不解析,按已知 coverage subject 前缀匹配(与 chunk 列表既有做法一致),否则原样渲染。碰撞时 coverage 文本胜出,coverage 内部最早类别胜出——被判 `rewritten` 的 chunk 不能同时被说成"无 agent 启动"。
- **同因 subject 并入一句**——`Not reviewed: chunk 1, …, chunk 43 — launched with a prompt that is not the one the CLI built.`——一次性坍缩所有墙形(全未启动、全改写、回抄变体)。早先 coverage 侧的坍缩被 review 否决后移除:它在全改写 roster 上误触发,且丢弃了去重所需的 per-role subject。
- **丢弃建议的句子自含**:原文 "see the terminal output" 指向作者没有的终端。

## 为什么需要

两条展品正文就是外部贡献者在 run 失败时真实收到的东西:操作语域的过程文本墙压过 review 本身。交付门披露是对的;披露的**作文**是缺陷。

## 验证方式

1. `cd packages/cli && npx vitest run src/commands/review` —— 31 文件 746 测试全绿。
2. 测试皆以失败场景命名:回抄只渲一次且机器文本胜出;双 invariant 文件不并;自带 em-dash 的 reason 不乱组不重复;全改写 roster 呈现精确原因且无矛盾聚合;#7188 形状(回抄 + per-role 缺口)折入分组句;全建零启在 coverage 层保留 per-role 条目与 selector(分组是 compose 的职责);正文禁 "terminal output"。
3. 四个 commit 合计 12 个突变全部击杀:绕过去重、首 dash 键、删分组、翻转先例胜出、disclosures 永不推入、坍缩变体等——各自打红对应测试。

## 证据(前后对照)

修复前(#7166 原样):99 段 `Not reviewed: chunk N — launched with a prompt that is not the one the CLI built.` / `… — its prompt was built, but no agent on record was launched with it.`

修复后,同一状态:每原因一句——`Not reviewed: chunk 1, …, chunk 43 — <rewritten 原因>. Not reviewed: <55 角色> — its prompt was built, but no agent on record was launched with it.`——caller 再回抄也不增行。

## 风险与范围

- 只动正文拼装:event、cap、remediation、`missingRoleSelectors` 不变(cap 与 `canCertify` 对两个进水口求和,套件钉住)。
- 分组按 reason 原文,内嵌 per-subject 细节(unread brief 路径)自成一行。
- reviewer 在 macOS 本地遇到的 `test-efficacy` 失败是既有 `safeRmWithin` symlink 行为,与本 PR 无关(Linux CI 绿)。

## 关联

展品:#7188 与 #7166 上发布的 review 正文。

</details>
