### PR TITLE
fix(core,cli): drain background notifications outside the subagent's ALS frame

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -33,6 +33,8 @@ import {
   SendMessageType,
   ToolErrorType,
   ToolConfirmationOutcome,
+  getRuntimeContentGenerator,
+  runWithRuntimeContentGenerator,
 } from '@qwen-code/qwen-code-core';
 import type { Part, PartListUnion } from '@google/genai';
 import type { UseHistoryManagerReturn } from './useHistoryManager.js';
@@ -6434,6 +6436,50 @@ describe('useGeminiStream', () => {
         expect(
           mockSendMessageStream.mock.calls[0][3].modelOverride,
         ).toBeUndefined();
+      });
+
+      // Regression for #7156: progress setState calls issued from inside a
+      // background subagent's AsyncLocalStorage frame can batch with the
+      // notification trigger into one React commit, so the drain effect
+      // executes on a stack that still carries the subagent's frame. The
+      // drained turn — and every async continuation it starts — then
+      // resolves Config.getModel() to the subagent's runtime view and the
+      // main session switches onto the subagent's model. The drain effect
+      // must therefore run via runOutsideAgentContext. This test drives the
+      // notification callback from inside an agent frame (bypassing the
+      // producer-side guard in BackgroundTaskRegistry.emitNotification) and
+      // fails if the consumer-side wrapping is removed.
+      it('drains a notification outside a background agent ALS frame', async () => {
+        renderTestHook();
+        const callback = mockBackgroundShellRegistry.setNotificationCallback
+          .mock.calls[0][0] as (displayText: string, modelText: string) => void;
+
+        let capturedRuntimeView: unknown = 'unset';
+        mockSendMessageStream.mockImplementationOnce(() => {
+          capturedRuntimeView = getRuntimeContentGenerator();
+          return (async function* () {})();
+        });
+
+        const subagentView = {
+          contentGenerator: {},
+          contentGeneratorConfig: { model: 'small-default' },
+        } as never;
+        // The whole act() flush runs inside the agent frame, mirroring the
+        // contaminated React commit from the issue.
+        await runWithRuntimeContentGenerator(subagentView, async () => {
+          await act(async () => {
+            callback(
+              'Background shell "npm test" completed.',
+              '<task-notification>completed</task-notification>',
+            );
+          });
+        });
+
+        await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+        expect(mockSendMessageStream.mock.calls[0][3]).toMatchObject({
+          type: SendMessageType.Notification,
+        });
+        expect(capturedRuntimeView).toBeUndefined();
       });
     });
   });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -13,6 +13,7 @@ import {
   useLayoutEffect,
 } from 'react';
 import {
+  runOutsideAgentContext,
   type Config,
   type EditorType,
   type GeminiClient,
@@ -3760,45 +3761,59 @@ export const useGeminiStream = (
       !isSubmittingQueryRef.current &&
       notificationQueueRef.current.length > 0
     ) {
-      const queue = notificationQueueRef.current;
-      const targetType = queue[0]!.sendMessageType;
+      // Consumer-side guard for #7156: this effect can run on a render pass
+      // that React batched together with progress setState calls issued from
+      // INSIDE a subagent's AsyncLocalStorage frame, in which case the whole
+      // synchronous effect stack — and every async continuation submitQuery
+      // starts — inherits the subagent's runtime view, and the notification
+      // turn resolves Config.getModel() to the SUBAGENT's model. Exiting the
+      // frame here guarantees the drained turn always runs on the main
+      // session's configuration, regardless of which producer's setState
+      // triggered the commit.
+      runOutsideAgentContext(() => {
+        const queue = notificationQueueRef.current;
+        const targetType = queue[0]!.sendMessageType;
 
-      // Cron prompts must run as individual turns — each needs its own
-      // slash/shell/@ preprocessing and approval cycle. Only batch
-      // Notification items (which pass through without preprocessing).
-      if (targetType === SendMessageType.Cron) {
-        const item = queue.shift()!;
-        addItem(
-          { type: 'notification' as const, text: item.displayText },
-          Date.now(),
-        );
-        submitQuery(item.modelText, item.sendMessageType, undefined, {
-          notificationDisplayText: item.displayText,
-          onDelivered: item.onDelivered,
-          onDeliveryFailed: item.onDeliveryFailed,
+        // Cron prompts must run as individual turns — each needs its own
+        // slash/shell/@ preprocessing and approval cycle. Only batch
+        // Notification items (which pass through without preprocessing).
+        if (targetType === SendMessageType.Cron) {
+          const item = queue.shift()!;
+          addItem(
+            { type: 'notification' as const, text: item.displayText },
+            Date.now(),
+          );
+          submitQuery(item.modelText, item.sendMessageType, undefined, {
+            notificationDisplayText: item.displayText,
+            onDelivered: item.onDelivered,
+            onDeliveryFailed: item.onDeliveryFailed,
+          });
+          return;
+        }
+
+        // Drain contiguous leading Notification items into one batch.
+        let splitIdx = 0;
+        while (
+          splitIdx < queue.length &&
+          queue[splitIdx]!.sendMessageType === targetType
+        ) {
+          splitIdx++;
+        }
+        const batch = queue.splice(0, splitIdx);
+
+        const now = Date.now();
+        for (const item of batch) {
+          addItem(
+            { type: 'notification' as const, text: item.displayText },
+            now,
+          );
+        }
+
+        const combinedModelText = batch.map((e) => e.modelText).join('\n\n');
+        const combinedDisplayText = batch.map((e) => e.displayText).join('; ');
+        submitQuery(combinedModelText, targetType, undefined, {
+          notificationDisplayText: combinedDisplayText,
         });
-        return;
-      }
-
-      // Drain contiguous leading Notification items into one batch.
-      let splitIdx = 0;
-      while (
-        splitIdx < queue.length &&
-        queue[splitIdx]!.sendMessageType === targetType
-      ) {
-        splitIdx++;
-      }
-      const batch = queue.splice(0, splitIdx);
-
-      const now = Date.now();
-      for (const item of batch) {
-        addItem({ type: 'notification' as const, text: item.displayText }, now);
-      }
-
-      const combinedModelText = batch.map((e) => e.modelText).join('\n\n');
-      const combinedDisplayText = batch.map((e) => e.displayText).join('; ');
-      submitQuery(combinedModelText, targetType, undefined, {
-        notificationDisplayText: combinedDisplayText,
       });
     }
   }, [streamingState, submitQuery, notificationTrigger, addItem]);

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -16,6 +16,12 @@ import {
   type BackgroundApproval,
   type BackgroundTaskEntry,
 } from './background-tasks.js';
+import {
+  getCurrentAgentId,
+  getRuntimeContentGenerator,
+  runWithAgentContext,
+  runWithRuntimeContentGenerator,
+} from './runtime/agent-context.js';
 import * as transcript from './agent-transcript.js';
 import { AgentEventEmitter, AgentEventType } from './runtime/agent-events.js';
 import { ToolConfirmationOutcome } from '../tools/tools.js';
@@ -51,6 +57,56 @@ function makeRegistration(
     ...overrides,
   };
 }
+
+describe('notification emission and agent context (#7156)', () => {
+  // A background agent's terminal transition fires inside its own
+  // AsyncLocalStorage frame, and ALS context follows every async
+  // continuation the notification callback starts (React state updates,
+  // the drain effect, the next conversation turn). The callback must
+  // therefore run with NO agent frame, or Config.getModel() resolves to
+  // the subagent's model for the notification turn and the main session's
+  // history can overflow the smaller context window.
+  it('invokes the notification callback outside the agent ALS frame', async () => {
+    const registry = new BackgroundTaskRegistry();
+    const seen: Array<{
+      agentId: string | null;
+      runtimeView: unknown;
+    }> = [];
+    registry.setNotificationCallback(() => {
+      seen.push({
+        agentId: getCurrentAgentId(),
+        runtimeView: getRuntimeContentGenerator(),
+      });
+    });
+
+    registry.register({
+      agentId: 'bg-1',
+      description: 'bg agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      isBackgrounded: true,
+      outputFile: '/tmp/bg.jsonl',
+    });
+
+    const fakeView = {
+      contentGenerator: {} as never,
+      contentGeneratorConfig: { model: 'subagent-model' } as never,
+    };
+    await runWithAgentContext('bg-1', () =>
+      runWithRuntimeContentGenerator(fakeView, async () => {
+        // Sanity: we ARE inside the subagent frame here.
+        expect(getCurrentAgentId()).toBe('bg-1');
+        expect(getRuntimeContentGenerator()).toBe(fakeView);
+        registry.complete('bg-1', 'done');
+      }),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.agentId).toBeNull();
+    expect(seen[0]!.runtimeView).toBeUndefined();
+  });
+});
 
 describe('BackgroundTaskRegistry', () => {
   let registry: BackgroundTaskRegistry;

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -26,6 +26,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { parsePositiveIntegerEnv } from '../utils/env.js';
 import { escapeXml } from '../utils/xml.js';
 import { patchAgentMeta } from './agent-transcript.js';
+import { runOutsideAgentContext } from './runtime/agent-context.js';
 import {
   AgentEventType,
   type AgentApprovalRequestEvent,
@@ -1428,7 +1429,18 @@ export class BackgroundTaskRegistry {
     };
 
     try {
-      this.notificationCallback(displayLine, xmlParts.join('\n'), meta);
+      // The terminal transition (complete/fail/cancel) that reaches this
+      // point runs inside the finished agent's AsyncLocalStorage frame, and
+      // ALS context follows every async continuation the callback starts —
+      // including the React state update that drains the notification into
+      // a new conversation turn. Without exiting the frame here, that turn
+      // resolves Config.getModel() to the SUBAGENT's model and the main
+      // session's history can overflow its smaller context window (#7156).
+      // A notification is main-session-owned, so emit it with no agent
+      // frame at all.
+      runOutsideAgentContext(() =>
+        this.notificationCallback!(displayLine, xmlParts.join('\n'), meta),
+      );
     } catch (error) {
       debugLogger.error('Failed to emit background notification:', error);
     }

--- a/packages/core/src/agents/runtime/agent-context.ts
+++ b/packages/core/src/agents/runtime/agent-context.ts
@@ -99,6 +99,23 @@ export function getRuntimeContentGenerator():
 }
 
 /**
+ * Runs `fn` with NO agent frame on the async-local stack, so
+ * `Config.getModel()` / `getContentGeneratorConfig()` resolve to the main
+ * session's configuration and `getCurrentAgentId()` returns null.
+ *
+ * AsyncLocalStorage context propagates through every async continuation
+ * started inside `fn` — React state updates, queued microtasks, timers —
+ * which is exactly how a background agent's runtime view leaked into the
+ * notification drain and switched the main session onto the subagent's
+ * model (#7156). Wrap main-session-owned work that can be triggered from
+ * inside an agent frame (notification emission, completion bookkeeping)
+ * with this helper.
+ */
+export function runOutsideAgentContext<T>(fn: () => T): T {
+  return storage.exit(fn);
+}
+
+/**
  * True when there is no active agent frame — i.e. we are in the top-level
  * user session, not inside a sub-agent. The canonical "top-level only"
  * predicate for gating capabilities (teammate spawning, forking) that must

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
   getRuntimeContentGenerator,
   runWithRuntimeContentGenerator,
   type RuntimeContentGeneratorView,
+  runOutsideAgentContext,
 } from './agents/runtime/agent-context.js';
 export * from './core/reasoning-effort.js';
 export * from './core/coreToolScheduler.js';


### PR DESCRIPTION
## What this PR does

Stops a background subagent's model from leaking into the main session when its completion notification drains. Two layers: the decisive **consumer guard** — the notification drain effect in `useGeminiStream` now runs inside a new `runOutsideAgentContext()` helper (`AsyncLocalStorage.exit`), so the drained turn and every async continuation it starts resolve `Config.getModel()` to the main session's configuration regardless of which producer's setState triggered the React commit; and a **producer defense** — `BackgroundTaskRegistry.emitNotification` invokes the notification callback with no agent frame on the stack, pinned by a unit regression test. The helper is exported from core for reuse by other main-session-owned paths that can be triggered from inside an agent frame.

## Why it's needed

#7156: a session on a large-context model launching a background subagent on a smaller model got a 400 on the notification turn — the accumulated history was sent to the subagent's model. #7119 fixed a different path to the same symptom (override clearing); here the model resolution itself was mis-scoped. The mechanism, confirmed with a deterministic reproducer: progress setState calls issued from **inside the subagent's AsyncLocalStorage frame** can be batched by React/Ink into the same commit as the notification trigger; the drain effect then executes on that batch's synchronous stack, and everything `submitQuery` starts inherits the subagent's runtime view. The "persistent" model switch users observed (all turns after the notification wrong, status line flickering) is each subsequent turn deriving from the contaminated drain chain — which is also why guarding a single producer is a whack-a-mole; the consumer guard closes the class. Credit to @Aleks-0's instrumented traces on the issue for ruling out persistent `ModelsConfig` mutation and pinning the ALS mechanism.

## Reviewer Test Plan

### How to verify

1. Configure a session model with a large context and a custom agent (`.qwen/agents/worker.md`) with `model:` pointing at a smaller-context model.
2. Ask the model to launch that agent with `run_in_background: true`; wait for completion and the notification to drain.
3. Before this PR: the notification turn — and every call after it — goes out on the subagent's model (400 once history exceeds its window; status line shows the wrong model). After: everything stays on the session model.

Automated coverage: a unit regression test proves the notification callback previously ran inside the subagent's frame (`getCurrentAgentId()`/`runtimeView` set) and now runs with none — it fails on the unpatched registry. `useGeminiStream` suite 169/169, `background-tasks` suite 111/111, `npm run typecheck`, eslint, prettier all clean.

### Evidence (Before & After)

Deterministic E2E: PTY harness drives the real bundle against a local fake OpenAI-compatible server logging the `model` of every request. Session model `big-context`; project-level custom agent `worker` with `model: small-default`; scripted turn launches it in background:

| # | Request | before fix | after fix |
| --- | --- | --- | --- |
| 1 | user turn → agent tool call | `big-context` | `big-context` |
| 2 | tool-result continuation | `big-context` | `big-context` |
| 3 | subagent's own turn | `small-default` (its model ✓) | `small-default` (unchanged ✓) |
| 4 | system call **before** the notification | `big-context` | `big-context` |
| 5 | **notification turn** | **`small-default`** ❌ | **`big-context`** ✅ |
| 6 | system call **after** the notification | **`small-default`** ❌ (persistent leak) | **`big-context`** ✅ |

Row 6 shows the fix also ends the "session permanently switched" aspect — the contamination chain is severed at the drain.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; PTY harness + local fake OpenAI-compatible SSE server against the esbuild bundle, plus vitest unit tests.

## Risk & Scope

- Main risk or tradeoff: the drain effect body now executes via `AsyncLocalStorage.exit` — a no-op when no frame is active (the common case). Notification semantics are unchanged; only the async-context scoping of the drained turn changes.
- Not validated / out of scope: the compaction-on-leaked-model consequence reported later in #7156 is expected to be fixed by the same guard (compaction for the drained turn now runs outside the frame) but was not separately reproduced; other main-session paths that might run inside an agent frame (e.g. teammate drains) can adopt the exported helper in follow-ups.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7156

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

阻止后台子 agent 的模型在完成通知汇入时泄漏进主会话。两层防护：决定性的**消费端防线**——`useGeminiStream` 的通知 drain effect 整体运行在新的 `runOutsideAgentContext()`（`AsyncLocalStorage.exit`）内，无论哪个 producer 的 setState 触发了这次 React commit，汇入轮次及其启动的所有异步延续都以主会话配置解析 `Config.getModel()`；以及**生产端防御**——`BackgroundTaskRegistry.emitNotification` 在无 agent frame 下调用通知回调，由单测回归固定。helper 从 core 导出，供其它可能在 agent frame 内被触发的主会话路径复用。

## 为什么需要

#7156：大上下文会话启动小上下文后台子 agent，通知轮次 400——累积历史被发给了子 agent 的模型。#7119 修复的是同一症状的另一条路径（override 清除）；这里是模型解析本身作用域错误。经确定性复现器证实的机制：子 agent **ALS frame 内**发出的进度 setState 会被 React/Ink 与通知触发合并进同一次 commit；drain effect 在该批次的同步栈上执行，`submitQuery` 启动的一切都继承子 agent 的 runtime view。用户观察到的「持久」切换（通知后所有轮次都错、状态栏闪烁）是每个后续轮次都从被污染的 drain 链派生——这也是只防单个 producer 属于打地鼠的原因；消费端防线关闭整类问题。感谢 @Aleks-0 在 issue 中的插桩记录排除了持久 `ModelsConfig` mutation 并锁定 ALS 机制。

## 审阅测试计划

### 如何验证

1. 会话配大上下文模型，自定义 agent（`.qwen/agents/worker.md`）的 `model:` 指向小上下文模型；
2. 让模型以 `run_in_background: true` 启动该 agent，等完成与通知汇入；
3. 本 PR 之前：通知轮次及其后所有调用走子 agent 模型（历史超窗即 400、状态栏显示错误模型）；之后：全部保持会话模型。

自动化覆盖：单测证明通知回调此前运行在子 agent frame 内、现在无 frame（在未修复的 registry 上失败）；`useGeminiStream` 169/169、`background-tasks` 111/111、typecheck / eslint / prettier 全绿。

### 证据（Before & After）

确定性 E2E（PTY + 伪 OpenAI 服务器记录每请求 model；会话 `big-context`、自定义 agent `model: small-default`、后台启动）：修复前 #5 通知轮次与 #6 后续系统调用均为 `small-default`（❌ 持久泄漏）；修复后全部保持 `big-context`（✅）——第 6 行同时证明「会话被永久切换」的表象随 drain 链被切断而消失。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；PTY harness + 本地伪 OpenAI SSE 服务器 + vitest 单测。

## 风险与范围

- 主要风险/权衡：drain effect 主体经 `AsyncLocalStorage.exit` 执行——无 frame 时是 no-op（常态）。通知语义不变，仅改变汇入轮次的异步上下文作用域。
- 未验证/超出范围：issue 后续报告的「压缩在泄漏模型上运行」预计由同一防线修复（汇入轮次的压缩现在也在 frame 外运行）但未单独复现；其它可能在 agent frame 内运行的主会话路径（如 teammate drain）可在后续采用该导出 helper。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7156

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
