### PR TITLE
fix(web-shell): prevent toolbar label clipping

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -1459,7 +1459,7 @@
   display: inline-flex;
   align-items: center;
   color: var(--agent-gray-500);
-  line-height: 1;
+  line-height: 1.4;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
## What this PR does

Increases the composer toolbar label line height so model names, approval modes, and other text with descenders render at their full height without changing the toolbar control height or horizontal layout.

## Why it's needed

Toolbar labels used a line box exactly equal to the 13 px font size while also clipping overflow. In Chromium, the rendered glyph bounds can be approximately 16 px high, so letters such as `q` and the lower edges of square brackets were visibly cut off. A 1.4 line height provides enough vertical room while remaining centered inside the existing 28 px controls.

## Reviewer Test Plan

### How to verify

Open Web Shell with a model label containing descenders, such as `[ModelStudio Token Plan] qwen3.7-max`. Confirm that the bottom of `q` and the square brackets render completely, and that the model icon, label, chevron, approval-mode control, and composer toolbar remain vertically aligned at the same overall height.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| The 13 px font was constrained to a 13 px line box while the measured glyph bounds were approximately 16 px, clipping the lower edge. | The line box measures 18.2 px inside the unchanged 28 px control, leaving the glyphs fully visible and centered. |
<img width="610" height="74" alt="image" src="https://github.com/user-attachments/assets/95ea98b1-2e0d-4b75-a054-02a093332125" />
<img width="604" height="78" alt="image" src="https://github.com/user-attachments/assets/b7fef0b5-e0d4-40c1-948a-b982f8bd0b94" />


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local Web Shell development server in Chromium, verified against the live daemon-backed model label. Formatting and Web Shell type checking also pass.

## Risk & Scope

- Main risk or tradeoff: Toolbar text receives a slightly taller line box, but the surrounding controls retain their existing fixed height and flex alignment.
- Not validated / out of scope: Platform-specific font rasterization on Windows and Linux.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

提高输入区工具栏标签的行高，使模型名称、审批模式以及其他包含下行笔画的文字能够完整显示，同时不改变工具栏控件高度或横向布局。

## 为什么需要

工具栏标签原本使用与 13 px 字号完全相等的行盒，并同时裁切溢出内容。在 Chromium 中，实际渲染的字形边界可能约为 16 px 高，因此 `q` 等字母以及方括号的下边缘会被明显截断。1.4 倍行高能够提供足够的垂直空间，同时文字仍居中于现有的 28 px 控件内。

## Reviewer 测试计划

### 验证方式

打开 Web Shell，并使用包含下行笔画的模型标签，例如 `[ModelStudio Token Plan] qwen3.7-max`。确认 `q` 和方括号底部能够完整显示，同时模型图标、标签、下拉箭头、审批模式控件和输入区工具栏仍保持垂直对齐，整体高度不变。

### 修改前后证据

| 修改前 | 修改后 |
| --- | --- |
| 13 px 字体被限制在 13 px 行盒内，而实测字形边界约为 16 px，导致下边缘被裁切。 | 行盒在保持 28 px 控件高度不变的情况下增至 18.2 px，字形完整可见并保持居中。 |

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

### 环境（可选）

在 Chromium 中使用本地 Web Shell 开发服务器，并针对连接真实 daemon 的模型标签完成验证。格式检查和 Web Shell 类型检查也已通过。

## 风险与范围

- 主要风险或权衡：工具栏文字获得略高的行盒，但外围控件仍保持原有固定高度和 flex 对齐。
- 未验证或不在范围内：Windows 和 Linux 上特定字体的栅格化效果。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
