### PR TITLE
feat(daemon): Advertise ACP preheat readiness

### DIFF
--- a/docs/design/acp-preheat-contract.md
+++ b/docs/design/acp-preheat-contract.md
@@ -1,0 +1,115 @@
+# ACP preheat contract and compatibility
+
+## Context
+
+The daemon exposes `POST /workspace/acp/preheat` and
+`GET /workspace/acp/status`, but released clients cannot discover those routes
+through `/capabilities`. The TypeScript SDK also sends both calls through its
+active ACP transport by default even though they are daemon REST control-plane
+routes. Finally, an HTTP waiter that times out currently clears the workspace
+service's shared preheat promise while the underlying channel initialization
+continues.
+
+This change makes the existing primary-workspace routes discoverable and
+reliable. It does not introduce a durable readiness state or move the first
+Session barrier. A Session remains the authoritative operation: preheat and
+Session creation coalesce through the bridge's shared channel initialization,
+and Session creation revalidates the channel after any point-in-time status or
+preheat response.
+
+## Capabilities and scope
+
+The daemon advertises two always-on v1 capability tags:
+
+- `workspace_acp_preheat` for `POST /workspace/acp/preheat`
+- `workspace_acp_status` for `GET /workspace/acp/status`
+
+Each tag means that the named route contract exists. Neither tag says that the
+ACP channel is currently live. The routes remain singular and primary-
+workspace-only. Clients must not use them for a secondary workspace or fall
+back from a secondary workspace to the primary runtime.
+
+Workspace-qualified ACP warmup requires separate ownership, trust, draining,
+and resource-limit semantics and is outside this change.
+
+## Response semantics
+
+`GET /workspace/acp/status` returns a point-in-time snapshot:
+
+```ts
+{
+  channelLive: boolean;
+}
+```
+
+`POST /workspace/acp/preheat` preserves its existing response shape:
+
+```ts
+interface WorkspaceAcpPreheatResult {
+  ready: boolean;
+  channelLive: boolean;
+  durationMs: number;
+  reason?: 'timeout' | 'error';
+  error?: string;
+}
+```
+
+The following invariants apply:
+
+- `ready` always equals `channelLive`.
+- A live snapshot returns `ready: true` without `reason` or `error`.
+- A waiter timeout returns `reason: 'timeout'` only if the channel is still not
+  live when the response is built.
+- A failed initialization, or a resolved preheat that did not produce a live
+  channel, returns `reason: 'error'`.
+- `durationMs` is a finite, non-negative integer measured with a monotonic
+  clock. It is the current HTTP call's elapsed time, not the lifetime of a
+  shared initialization that the call may have joined.
+- Client-visible error text is stable and sanitized. Detailed child-process
+  errors remain in daemon logs.
+
+Operational timeout and initialization failure continue to use HTTP 200 so
+existing clients can inspect the result. Invalid input, authentication, rate
+limit, and deferred-runtime startup failures retain their existing HTTP error
+contracts.
+
+## Concurrency and failure behavior
+
+The workspace service keeps one shared preheat promise until that promise
+settles. Every request races the same promise against its own timeout. A waiter
+timeout ends only that request; it neither cancels the bridge operation nor
+clears the shared promise. Settlement clears the promise only when its identity
+still matches the current shared operation, so an older completion cannot erase
+a newer attempt.
+
+Once the shared operation settles, a later request may retry if the channel is
+not live. A channel that exits after a successful response is not covered by a
+lease: status reports the new snapshot and the next Session or preheat starts a
+new channel.
+
+## Client compatibility
+
+The TypeScript SDK sends both routes through its REST fetch path regardless of
+the configured ACP transport. It does not automatically fetch capabilities;
+callers decide when to preflight.
+
+The Web UI uses the routes only in its deferred, no-session bootstrap flow. It
+requires `workspace_acp_preheat`, gates the optional status optimization on
+`workspace_acp_status`, and requires the effective workspace to exactly match
+`capabilities.workspaceCwd`. An exact comparison can conservatively skip a
+preheat for an alternate spelling of the primary path, but it cannot warm the
+wrong runtime.
+
+If an older daemon omits the capabilities, the Web UI makes no ACP status or
+preheat request and the first Session follows the existing lazy initialization
+path. Preheat failure remains best-effort and cannot fail connection or Session
+creation.
+
+## Non-goals
+
+- Awaiting preheat before the first Session
+- Moving preheat earlier in daemon or Web UI startup
+- A readiness lease, generation, token, or protocol-version bump
+- Cancelling shared channel initialization when an HTTP waiter times out
+- Workspace-qualified ACP preheat or status routes
+- Claiming a latency improvement from this contract-only change

--- a/docs/developers/daemon/11-capabilities-versioning.md
+++ b/docs/developers/daemon/11-capabilities-versioning.md
@@ -116,13 +116,13 @@ Identity and heartbeat: `client_identity`, `client_heartbeat`.
 
 Permissions: `session_permission_vote`, `permission_vote`, **`permission_mediation`** (`modes: ['first-responder', 'designated', 'consensus', 'local-only']`).
 
-Workspace read-only snapshots: `workspace_mcp`, `workspace_skills`, `workspace_providers`, `workspace_env`, `workspace_preflight`, `workspace_hooks`, `workspace_extensions`.
+Workspace read-only snapshots: `workspace_mcp`, `workspace_skills`, `workspace_providers`, `workspace_acp_status`, `workspace_env`, `workspace_preflight`, `workspace_hooks`, `workspace_extensions`.
 
 Extension management: `extension_management_v2` adds the global `/extensions/*` catalog/mutation/operation contract and the workspace activation projection. It is separate from the published `workspace_extensions` compatibility surface and from `workspace_qualified_rest_core`.
 
 Workspace-qualified session reads: `workspace_persisted_transcript`, `workspace_session_export`, `workspace_archived_session_export`. The active and archived export tags are independent from each other and from `session_export` and `workspace_qualified_rest_core`, so clients must pre-flight the exact storage state they intend to export. Persisted transcript paging permits an untrusted secondary under its bounded read policy; both full export paths remain trusted-only.
 
-Workspace mutation (Wave 4+): `workspace_memory`, `workspace_agents`, `workspace_agent_generate`, `workspace_tool_toggle`, **`workspace_settings`** (conditional), `workspace_permissions`, `workspace_init`, `workspace_github_setup`, `workspace_trust`, `workspace_mcp_restart`, `workspace_mcp_manage`, `workspace_file_read`, `workspace_file_bytes`, `workspace_file_write`, **`workspace_reload`** (conditional).
+Workspace mutation (Wave 4+): `workspace_memory`, `workspace_agents`, `workspace_agent_generate`, `workspace_acp_preheat`, `workspace_tool_toggle`, **`workspace_settings`** (conditional), `workspace_permissions`, `workspace_init`, `workspace_github_setup`, `workspace_trust`, `workspace_mcp_restart`, `workspace_mcp_manage`, `workspace_file_read`, `workspace_file_bytes`, `workspace_file_write`, **`workspace_reload`** (conditional).
 
 MCP guardrails: **`mcp_guardrails`** (`modes: ['warn', 'enforce']`), `mcp_guardrail_events`, `mcp_server_runtime_mutation`, **`mcp_workspace_pool`** (conditional), **`mcp_pool_restart`** (conditional).
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -168,7 +168,8 @@ registry. Clients **must** gate UI off `features`, not off `mode` (per design
  'slow_client_warning', 'typed_event_schema',
  'session_set_model', 'client_identity', 'client_heartbeat',
  'session_permission_vote', 'permission_vote', 'workspace_mcp', 'workspace_skills',
- 'workspace_providers', 'auth_provider_install', 'workspace_memory',
+ 'workspace_providers', 'workspace_acp_preheat', 'workspace_acp_status',
+ 'auth_provider_install', 'workspace_memory',
  'workspace_agents', 'workspace_agent_generate', 'workspace_env',
  'workspace_preflight', 'session_context', 'session_context_usage',
  'session_supported_commands', 'session_tasks', 'session_stats',
@@ -893,6 +894,7 @@ Capability tags:
 - `workspace_mcp` → `GET /workspace/mcp`
 - `workspace_skills` → `GET /workspace/skills`
 - `workspace_providers` → `GET /workspace/providers`
+- `workspace_acp_status` → `GET /workspace/acp/status`
 - `workspace_env` → `GET /workspace/env`
 - `workspace_preflight` → `GET /workspace/preflight`
 - `session_context` → `GET /session/:id/context`
@@ -904,6 +906,44 @@ Capability tags:
 - `workspace_persisted_transcript` → `GET /workspaces/:workspace/session/:id/transcript`
 - `workspace_session_export` → `GET /workspaces/:workspace/session/:id/export`
 - `workspace_archived_session_export` → `GET /workspaces/:workspace/session/:id/archive/export`
+
+`workspace_acp_status` reports the primary workspace ACP channel's
+point-in-time liveness as `{ channelLive: boolean }`. The handler does not
+create a channel, but reaching a runtime route can first start a deferred daemon
+runtime, whose configured startup policy may independently preheat ACP. The
+snapshot is not a lease: clients must let Session creation revalidate or start
+the channel.
+
+### ACP preheat
+
+Capability tag: `workspace_acp_preheat`.
+
+`POST /workspace/acp/preheat?timeoutMs=N` best-effort initializes the primary
+workspace ACP channel. `timeoutMs` defaults to 5000 and must be a positive
+integer no greater than 60000. Concurrent callers and Session creation share
+the same bridge initialization. A request timeout ends only that HTTP wait; it
+does not cancel the shared initialization.
+
+```ts
+interface WorkspaceAcpPreheatResult {
+  ready: boolean;
+  channelLive: boolean;
+  durationMs: number;
+  reason?: 'timeout' | 'error';
+  error?: string;
+}
+```
+
+`ready` always equals `channelLive`. A live response omits `reason` and
+`error`; otherwise `reason` is `timeout` or `error`. `durationMs` measures the
+current HTTP call, not the full lifetime of an initialization the call joined.
+Operational timeout or failure returns HTTP 200. Invalid `timeoutMs` returns
+400, while authentication, rate limiting, and deferred-runtime failures retain
+their normal responses.
+
+Both ACP workspace routes are singular and primary-workspace-only. Clients
+must not use them for a secondary workspace or interpret either response as a
+durable readiness guarantee.
 
 Common status cell:
 

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -323,6 +323,8 @@ describe('qwen serve — capabilities envelope', () => {
       'workspace_mcp',
       'workspace_skills',
       'workspace_providers',
+      'workspace_acp_preheat',
+      'workspace_acp_status',
       'auth_provider_install',
       'workspace_memory',
       'workspace_memory_remember',

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -72,6 +72,8 @@ export const SERVE_CAPABILITY_REGISTRY = {
   workspace_mcp: { since: 'v1' },
   workspace_skills: { since: 'v1' },
   workspace_providers: { since: 'v1' },
+  workspace_acp_preheat: { since: 'v1' },
+  workspace_acp_status: { since: 'v1' },
   auth_provider_install: { since: 'v1' },
   // Workspace memory CRUD (`GET/POST /workspace/memory`). Daemon exposes
   // hierarchical QWEN.md state and accepts append/replace writes scoped

--- a/packages/cli/src/serve/routes/workspace-status.ts
+++ b/packages/cli/src/serve/routes/workspace-status.ts
@@ -115,8 +115,9 @@ export function registerWorkspaceStatusRoutes(
           ? Number(timeoutMsRaw)
           : undefined;
       if (
-        timeoutMs !== undefined &&
-        (!Number.isFinite(timeoutMs) ||
+        timeoutMsRaw !== undefined &&
+        (timeoutMs === undefined ||
+          !Number.isFinite(timeoutMs) ||
           !Number.isInteger(timeoutMs) ||
           timeoutMs <= 0 ||
           timeoutMs > MAX_ACP_PREHEAT_TIMEOUT_MS)

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -4833,6 +4833,8 @@ describe('runQwenServe runtime startup failures', () => {
           'daemon_status',
           'workspace_settings',
           'workspace_reload',
+          'workspace_acp_preheat',
+          'workspace_acp_status',
           'persistent_workspace_registration',
           'workspace_runtime_removal',
         ]),

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -257,6 +257,8 @@ const EXPECTED_STAGE1_FEATURES = [
   'workspace_mcp',
   'workspace_skills',
   'workspace_providers',
+  'workspace_acp_preheat',
+  'workspace_acp_status',
   'auth_provider_install',
   'workspace_memory',
   'workspace_memory_remember',
@@ -3562,6 +3564,26 @@ describe('createServeApp', () => {
 
       const res = await request(app)
         .post('/workspace/acp/preheat?timeoutMs=60001')
+        .set('Host', `127.0.0.1:${opts.port}`)
+        .set('Authorization', 'Bearer secret');
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_timeout',
+        error: '`timeoutMs` must be a positive integer no greater than 60000',
+      });
+    });
+
+    it.each([
+      '/workspace/acp/preheat?timeoutMs=',
+      '/workspace/acp/preheat?timeoutMs=1&timeoutMs=2',
+    ])('rejects malformed workspace ACP preheat timeout %s', async (path) => {
+      const bridge = fakeBridge();
+      const opts = { ...baseOpts, workspace: WS_BOUND, token: 'secret' };
+      const app = createServeApp(opts, undefined, { bridge });
+
+      const res = await request(app)
+        .post(path)
         .set('Host', `127.0.0.1:${opts.port}`)
         .set('Authorization', 'Bearer secret');
 

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -1863,6 +1863,9 @@ describe('createDaemonWorkspaceService', () => {
         reason: 'error',
         error: 'ACP preheat did not produce a live channel',
       });
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'qwen serve: ACP preheat resolved without a live channel',
+      );
     });
 
     it('returns error when preheat fails before the deadline', async () => {

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -1732,6 +1732,19 @@ describe('createDaemonWorkspaceService', () => {
       expect(preheatAcpChild).not.toHaveBeenCalled();
     });
 
+    it('returns an error when ACP preheat is unavailable', async () => {
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ isChannelLive: () => false }),
+      );
+
+      await expect(svc.preheatAcpChild(makeCtx())).resolves.toMatchObject({
+        ready: false,
+        channelLive: false,
+        reason: 'error',
+        error: 'ACP preheat is unavailable',
+      });
+    });
+
     it('preheats the ACP child when the channel is not live', async () => {
       let live = false;
       const preheatAcpChild = vi.fn().mockImplementation(async () => {

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -88,6 +88,7 @@ const mockWriteStderrLine = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../utils/stdioHelpers.js', () => ({
   writeStderrLine: mockWriteStderrLine,
+  writeStderrLineSafe: mockWriteStderrLine,
 }));
 
 const { createDaemonWorkspaceService } = await import('../index.js');
@@ -205,6 +206,17 @@ async function withIsolatedWorkspace<T>(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 describe('createDaemonWorkspaceService', () => {
   beforeEach(() => {
@@ -1754,10 +1766,90 @@ describe('createDaemonWorkspaceService', () => {
         channelLive: false,
         reason: 'timeout',
       });
-      expect(preheatAcpChild).toHaveBeenCalledTimes(2);
+      expect(preheatAcpChild).toHaveBeenCalledOnce();
       expect(mockWriteStderrLine).toHaveBeenCalledWith(
         'qwen serve: ACP preheat timed out after 1ms',
       );
+    });
+
+    it('lets concurrent waiters share one preheat attempt', async () => {
+      const pending = deferred<void>();
+      let live = false;
+      const preheatAcpChild = vi.fn(() => pending.promise);
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ isChannelLive: () => live, preheatAcpChild }),
+      );
+
+      const first = svc.preheatAcpChild(makeCtx(), { timeoutMs: 1000 });
+      const second = svc.preheatAcpChild(makeCtx(), { timeoutMs: 1000 });
+      live = true;
+      pending.resolve();
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        expect.objectContaining({ ready: true, channelLive: true }),
+        expect.objectContaining({ ready: true, channelLive: true }),
+      ]);
+      expect(preheatAcpChild).toHaveBeenCalledOnce();
+    });
+
+    it('allows a new attempt after the shared preheat settles', async () => {
+      const firstAttempt = deferred<void>();
+      let live = false;
+      const preheatAcpChild = vi
+        .fn()
+        .mockImplementationOnce(() => firstAttempt.promise)
+        .mockImplementationOnce(async () => {
+          live = true;
+        });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ isChannelLive: () => live, preheatAcpChild }),
+      );
+
+      await svc.preheatAcpChild(makeCtx(), { timeoutMs: 1 });
+      firstAttempt.resolve();
+      await firstAttempt.promise;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const retry = await svc.preheatAcpChild(makeCtx(), { timeoutMs: 1000 });
+
+      expect(retry).toMatchObject({ ready: true, channelLive: true });
+      expect(preheatAcpChild).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns ready when the channel becomes live at the timeout boundary', async () => {
+      let live = false;
+      const preheatAcpChild = vi.fn(() => new Promise<void>(() => undefined));
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ isChannelLive: () => live, preheatAcpChild }),
+      );
+
+      const resultPromise = svc.preheatAcpChild(makeCtx(), { timeoutMs: 1 });
+      live = true;
+
+      await expect(resultPromise).resolves.toMatchObject({
+        ready: true,
+        channelLive: true,
+      });
+      const result = await resultPromise;
+      expect(result).not.toHaveProperty('reason');
+      expect(result).not.toHaveProperty('error');
+    });
+
+    it('returns an error when preheat resolves without a live channel', async () => {
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          isChannelLive: () => false,
+          preheatAcpChild: vi.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      await expect(
+        svc.preheatAcpChild(makeCtx(), { timeoutMs: 1000 }),
+      ).resolves.toMatchObject({
+        ready: false,
+        channelLive: false,
+        reason: 'error',
+        error: 'ACP preheat did not produce a live channel',
+      });
     });
 
     it('returns error when preheat fails before the deadline', async () => {
@@ -1774,7 +1866,34 @@ describe('createDaemonWorkspaceService', () => {
         ready: false,
         channelLive: false,
         reason: 'error',
+        error: 'ACP preheat failed',
       });
+      expect(Number.isInteger(result.durationMs)).toBe(true);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'qwen serve: ACP preheat failed: preheat failed',
+      );
+    });
+
+    it('sanitizes a synchronous bridge failure', async () => {
+      const preheatAcpChild = vi.fn(() => {
+        throw new Error('child command contained a secret');
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({ isChannelLive: () => false, preheatAcpChild }),
+      );
+
+      await expect(
+        svc.preheatAcpChild(makeCtx(), { timeoutMs: 1000 }),
+      ).resolves.toMatchObject({
+        ready: false,
+        channelLive: false,
+        reason: 'error',
+        error: 'ACP preheat failed',
+      });
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'qwen serve: ACP preheat failed: child command contained a secret',
+      );
     });
   });
 

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -57,7 +57,10 @@ import {
   WorkspaceVoiceError,
   type WorkspaceVoiceSettingsWrite,
 } from '../../services/voice-service.js';
-import { writeStderrLine } from '../../utils/stdioHelpers.js';
+import {
+  writeStderrLine,
+  writeStderrLineSafe,
+} from '../../utils/stdioHelpers.js';
 import {
   deleteWorkspaceSkill,
   installWorkspaceSkill,
@@ -337,13 +340,13 @@ export function createDaemonWorkspaceService(
       _ctx: WorkspaceRequestContext,
       opts?: { timeoutMs?: number },
     ): Promise<WorkspaceAcpPreheatResult> {
-      const startedAt = Date.now();
+      const startedAt = performance.now();
       const channelLive = () => isChannelLive?.() ?? false;
       const finish = (
         result: Omit<WorkspaceAcpPreheatResult, 'durationMs'>,
       ): WorkspaceAcpPreheatResult => ({
         ...result,
-        durationMs: Date.now() - startedAt,
+        durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
       });
 
       if (channelLive()) {
@@ -354,46 +357,70 @@ export function createDaemonWorkspaceService(
           ready: false,
           channelLive: false,
           reason: 'error',
-          error: 'ACP preheat is not wired',
+          error: 'ACP preheat is unavailable',
         });
       }
 
       if (!inFlightAcpPreheat) {
-        inFlightAcpPreheat = preheatAcpChildOnBridge().finally(() => {
-          inFlightAcpPreheat = undefined;
-        });
-        void inFlightAcpPreheat.catch((err) => {
-          writeStderrLine(
-            `qwen serve: ACP preheat failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+        const promise = Promise.resolve().then(preheatAcpChildOnBridge);
+        inFlightAcpPreheat = promise;
+        void promise.then(
+          () => {
+            if (inFlightAcpPreheat === promise) {
+              inFlightAcpPreheat = undefined;
+            }
+          },
+          (err) => {
+            try {
+              writeStderrLineSafe(
+                `qwen serve: ACP preheat failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            } finally {
+              if (inFlightAcpPreheat === promise) {
+                inFlightAcpPreheat = undefined;
+              }
+            }
+          },
+        );
       }
 
+      const sharedPreheat = inFlightAcpPreheat;
       try {
         await withTimeout(
-          inFlightAcpPreheat,
+          sharedPreheat,
           opts?.timeoutMs ?? 5_000,
           'ACP preheat',
         );
       } catch (err) {
         if (err instanceof TimeoutError) {
-          inFlightAcpPreheat = undefined;
-          writeStderrLine(
+          writeStderrLineSafe(
             `qwen serve: ACP preheat timed out after ${opts?.timeoutMs ?? 5_000}ms`,
           );
         }
         const live = channelLive();
-        const message = err instanceof Error ? err.message : String(err);
+        if (live) {
+          return finish({ ready: true, channelLive: true });
+        }
         return finish({
-          ready: live,
-          channelLive: live,
+          ready: false,
+          channelLive: false,
           reason: err instanceof TimeoutError ? 'timeout' : 'error',
-          error: message,
+          error:
+            err instanceof TimeoutError
+              ? 'ACP preheat did not complete before the timeout'
+              : 'ACP preheat failed',
         });
       }
 
       const live = channelLive();
-      return finish({ ready: live, channelLive: live });
+      return live
+        ? finish({ ready: true, channelLive: true })
+        : finish({
+            ready: false,
+            channelLive: false,
+            reason: 'error',
+            error: 'ACP preheat did not produce a live channel',
+          });
     },
 
     async getWorkspaceAcpStatus(

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -413,6 +413,11 @@ export function createDaemonWorkspaceService(
       }
 
       const live = channelLive();
+      if (!live) {
+        writeStderrLineSafe(
+          'qwen serve: ACP preheat resolved without a live channel',
+        );
+      }
       return live
         ? finish({ ready: true, channelLive: true })
         : finish({

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1096,29 +1096,22 @@ export class DaemonClient {
       timeoutMs !== undefined
         ? `?timeoutMs=${encodeURIComponent(timeoutMs)}`
         : '';
-    return await this.fetchWithTimeout(
-      `${this.baseUrl}/workspace/acp/preheat${suffix}`,
-      { method: 'POST', headers: this.headers() },
-      async (res) => {
-        if (!res.ok) {
-          throw await this.failOnError(res, 'POST /workspace/acp/preheat');
-        }
-        return (await res.json()) as DaemonWorkspaceAcpPreheatResult;
+    return await this.jsonRequest<DaemonWorkspaceAcpPreheatResult>(
+      `/workspace/acp/preheat${suffix}`,
+      'POST /workspace/acp/preheat',
+      {
+        method: 'POST',
+        timeoutMs: serverBudgetMs + 2_000,
+        mode: 'rest',
       },
-      serverBudgetMs + 2_000,
     );
   }
 
   async workspaceAcpStatus(): Promise<DaemonWorkspaceAcpStatusResult> {
-    return await this.fetchWithTimeout(
-      `${this.baseUrl}/workspace/acp/status`,
-      { headers: this.headers() },
-      async (res) => {
-        if (!res.ok) {
-          throw await this.failOnError(res, 'GET /workspace/acp/status');
-        }
-        return (await res.json()) as DaemonWorkspaceAcpStatusResult;
-      },
+    return await this.jsonRequest<DaemonWorkspaceAcpStatusResult>(
+      '/workspace/acp/status',
+      'GET /workspace/acp/status',
+      { mode: 'rest' },
     );
   }
 

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -684,6 +684,55 @@ describe('DaemonClient', () => {
       ]);
     });
 
+    it.each(['acp-http', 'acp-ws'] as const)(
+      'uses REST for ACP workspace control routes with %s',
+      async (transportType) => {
+        const preheat = {
+          ready: true,
+          channelLive: true,
+          durationMs: 12,
+        };
+        const acpStatus = { channelLive: true };
+        const { fetch: restFetch, calls } = recordingFetch((req) =>
+          req.url.endsWith('/workspace/acp/preheat?timeoutMs=1234')
+            ? jsonResponse(200, preheat)
+            : jsonResponse(200, acpStatus),
+        );
+        const transportFetch = vi.fn(async () =>
+          jsonResponse(404, { error: 'ACP transport route not found' }),
+        );
+        const transport: DaemonTransport = {
+          type: transportType,
+          supportsReplay: transportType === 'acp-http',
+          connected: true,
+          restFetch,
+          fetch: transportFetch,
+          async *subscribeEvents() {},
+          dispose() {},
+        };
+        const client = new DaemonClient({
+          baseUrl: 'http://daemon',
+          token: 'secret',
+          transport,
+        });
+
+        await expect(client.workspaceAcpPreheat(1234)).resolves.toEqual(
+          preheat,
+        );
+        await expect(client.workspaceAcpStatus()).resolves.toEqual(acpStatus);
+        expect(calls.map((call) => [call.method, call.url])).toEqual([
+          ['POST', 'http://daemon/workspace/acp/preheat?timeoutMs=1234'],
+          ['GET', 'http://daemon/workspace/acp/status'],
+        ]);
+        expect(
+          calls.every(
+            (call) => call.headers['authorization'] === 'Bearer secret',
+          ),
+        ).toBe(true);
+        expect(transportFetch).not.toHaveBeenCalled();
+      },
+    );
+
     it('reloads primary and workspace-qualified MCP settings over REST', async () => {
       const result = { accepted: true };
       const { fetch, calls } = recordingFetch(() => jsonResponse(202, result));

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -549,6 +549,10 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('preheats ACP and refreshes deferred skills when ACP is not running', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+    });
     sdkMocks.workspaceAcpStatus.mockResolvedValue({ channelLive: false });
     sdkMocks.workspaceSkills
       .mockResolvedValueOnce({
@@ -611,6 +615,10 @@ describe('DaemonSessionProvider', () => {
   });
 
   it('clears deferred skills when ACP refresh returns an empty list', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+    });
     sdkMocks.workspaceAcpStatus.mockResolvedValue({ channelLive: false });
     sdkMocks.workspaceSkills
       .mockResolvedValueOnce({
@@ -652,6 +660,148 @@ describe('DaemonSessionProvider', () => {
 
     expect(connection?.skills).toEqual([]);
     expect(connection?.commands).toEqual([]);
+  });
+
+  it('skips ACP workspace routes when the daemon lacks their capabilities', async () => {
+    function Harness() {
+      useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
+  });
+
+  it('skips primary ACP workspace routes for a secondary workspace', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+    });
+
+    function Harness() {
+      useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+      workspaceCwd: '/secondary-workspace',
+    });
+
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
+  });
+
+  it('preheats without probing status when only preheat is advertised', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat'],
+    });
+
+    function Harness() {
+      useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpPreheat).toHaveBeenCalledWith(5000);
+  });
+
+  it('does not preheat when the advertised ACP status is live', async () => {
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+    });
+
+    function Harness() {
+      useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+
+    expect(sdkMocks.workspaceAcpStatus).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
+  });
+
+  it('still preheats when the advertised ACP status request fails', async () => {
+    const statusError = new Error('status unavailable');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+    });
+    sdkMocks.workspaceAcpStatus.mockRejectedValue(statusError);
+
+    function Harness() {
+      useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonSessionProvider] workspaceAcpStatus failed in deferred connect:',
+      statusError,
+    );
+    expect(sdkMocks.workspaceAcpPreheat).toHaveBeenCalledWith(5000);
+  });
+
+  it('keeps the deferred connection usable when preheat fails', async () => {
+    const preheatError = new Error('preheat unavailable');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    sdkMocks.capabilities.mockResolvedValue({
+      workspaceCwd: '/mock-workspace',
+      features: ['workspace_acp_preheat'],
+    });
+    sdkMocks.workspaceAcpPreheat.mockRejectedValue(preheatError);
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      sessionId: undefined,
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      status: 'connected',
+      workspaceCwd: '/mock-workspace',
+    });
+    expect(connection).not.toHaveProperty('sessionId');
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonSessionProvider] ACP preheat for workspace skills failed:',
+      preheatError,
+    );
   });
 
   it('warns when deferred workspace providers fail', async () => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -123,6 +123,8 @@ export interface DaemonTranscriptHistory {
 }
 
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
+const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
+const WORKSPACE_ACP_STATUS_FEATURE = 'workspace_acp_status';
 
 function assistantDoneFromTurnEvent(
   event: DaemonEvent,
@@ -627,6 +629,15 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               resolvedWorkspaceCwdRef.current ??
               caps.workspaceCwd;
             activeWorkspaceCwdRef.current = effectWorkspaceCwd;
+            const capabilityFeatures = Array.isArray(caps.features)
+              ? caps.features
+              : [];
+            const canPreheatPrimaryWorkspace =
+              effectWorkspaceCwd === caps.workspaceCwd &&
+              capabilityFeatures.includes(WORKSPACE_ACP_PREHEAT_FEATURE);
+            const canReadPrimaryAcpStatus =
+              canPreheatPrimaryWorkspace &&
+              capabilityFeatures.includes(WORKSPACE_ACP_STATUS_FEATURE);
             if (
               (shouldDeferInitialSessionCreation ||
                 manualSessionClearRef.current) &&
@@ -644,7 +655,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 await Promise.allSettled([
                   client.workspaceProviders(),
                   client.workspaceSkills(),
-                  client.workspaceAcpStatus(),
+                  canReadPrimaryAcpStatus
+                    ? client.workspaceAcpStatus()
+                    : Promise.resolve(undefined),
                   effectWorkspaceCwd
                     ? client.workspaceByCwd(effectWorkspaceCwd).workspaceGit()
                     : client.workspaceGit(),
@@ -661,7 +674,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   skillsResult.reason,
                 );
               }
-              if (acpStatusResult.status === 'rejected') {
+              if (
+                canReadPrimaryAcpStatus &&
+                acpStatusResult.status === 'rejected'
+              ) {
                 console.warn(
                   '[DaemonSessionProvider] workspaceAcpStatus failed in deferred connect:',
                   acpStatusResult.reason,
@@ -706,8 +722,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   : deferredSkills,
               }));
               if (
-                acpStatusResult.status === 'fulfilled' &&
-                !acpStatusResult.value.channelLive &&
+                canPreheatPrimaryWorkspace &&
+                !(
+                  acpStatusResult.status === 'fulfilled' &&
+                  acpStatusResult.value?.channelLive === true
+                ) &&
                 !workspaceAcpPreheatInFlightRef.current
               ) {
                 workspaceAcpPreheatInFlightRef.current = true;


### PR DESCRIPTION
## What this PR does

This PR advertises the existing primary-workspace ACP status and preheat routes as independent v1 capabilities, defines their point-in-time readiness and failure contract, and hardens concurrent preheat waiters so an HTTP timeout no longer clears the shared channel initialization. The TypeScript SDK now always sends these daemon control-plane calls over REST, while the Web UI only uses them when the daemon advertises support and the selected workspace exactly matches the primary workspace.

Preheat responses now preserve `ready === channelLive`, use monotonic integer durations, sanitize client-visible failures while retaining detailed daemon logs, and reject malformed present timeout parameters instead of silently using the default.

## Why it's needed

Released clients could not discover these routes, ACP transports could misroute REST-only control calls, and a short waiter could clear service-level single-flight state while the bridge continued starting the same child. That made capability negotiation and retry behavior ambiguous and could cause clients to touch the primary runtime while operating on a secondary workspace.

This PR establishes the compatibility boundary required before any client-side timing change. It does not move preheat earlier, await it before first Session creation, add a readiness lease, or add workspace-qualified ACP routes.

## Reviewer Test Plan

### How to verify

1. Start `qwen serve` normally and with deferred runtime initialization failure, then confirm `/capabilities` advertises both `workspace_acp_status` and `workspace_acp_preheat` in each case.
2. Send concurrent preheat requests with different timeout budgets. The short request should return `reason: "timeout"` without starting a second child, while the longer waiter should still be able to observe the live channel. After a settled initialization failure, a later request should be allowed to retry.
3. Connect the Web UI to a daemon without the new capabilities and to a non-primary workspace. Neither case should call the singular ACP status or preheat routes. With a capable daemon on the exact primary workspace, a live status should skip preheat; a not-live or unavailable status should permit one best-effort preheat call without blocking Session creation.
4. Confirm the TypeScript SDK uses REST for both control-plane calls even when the configured Session transport is ACP over HTTP or WebSocket.
5. Run the focused CLI, SDK, Web UI, and packaged serve integration tests, followed by `npm run build`, `npm run bundle`, `npm run typecheck`, and `npm run lint`. All should pass.

### Evidence (Before & After)

N/A — this changes daemon protocol semantics, client compatibility, documentation, and tests without changing the TUI.

### Tested on

|     OS     |     Status     |
| :--------: | :------------: |
|  🍏 macOS  |    ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS with Node.js v22.22.3 and npm 10.9.8; local release build and bundled CLI, with the packaged serve integration tests run without a sandbox.

## Risk & Scope

- Main risk or tradeoff: Capability-aware clients may begin using the existing control-plane routes. The implementation limits that behavior to the exact primary workspace, keeps Session creation authoritative, and treats preheat as best effort.
- Not validated / out of scope: P1-B latency work, moving preheat earlier, awaiting readiness before the first Session, readiness leases, workspace-qualified ACP routes, and local Windows/Linux execution are not included. Those timing changes require separate 2C4G validation.
- Breaking changes / migration notes: None. The capability tags are additive, old daemons retain the existing fallback path, and old clients can ignore the new tags.

## Linked Issues

Part of #4748

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将现有的主工作空间 ACP 状态与预热路由分别声明为独立的 v1 capability，定义其时点型 readiness 与失败契约，并强化并发预热等待者的 single-flight 语义，使单个 HTTP 请求超时后不再清除仍在执行的共享 channel 初始化。TypeScript SDK 现在始终通过 REST 发送这两个 daemon control-plane 请求；Web UI 仅在 daemon 明确声明支持，并且当前所选工作空间与主工作空间完全一致时使用它们。

预热响应现在始终满足 `ready === channelLive`，使用单调时钟生成整数毫秒耗时，对客户端可见的失败信息做脱敏处理，同时在 daemon 日志中保留详细错误；当 timeout 参数存在但格式错误时会直接拒绝，而不是静默使用默认值。

## 为什么需要

已发布客户端此前无法发现这些路由；ACP transport 可能错误地路由仅支持 REST 的控制调用；短超时等待者还可能在 bridge 仍继续启动同一个子进程时清除 service 层的 single-flight 状态。这使 capability 协商与重试语义存在歧义，也可能导致客户端在操作次级工作空间时误触主 runtime。

本 PR 建立后续任何客户端触发时机调整所必需的兼容性边界。它不会提前触发预热、不会在创建首个 Session 前等待预热、不会增加 readiness lease，也不会增加按工作空间限定的 ACP 路由。

## Reviewer 测试计划

### 如何验证

1. 分别以正常方式和 runtime 延迟初始化失败的方式启动 `qwen serve`，确认两种情况下 `/capabilities` 都声明 `workspace_acp_status` 与 `workspace_acp_preheat`。
2. 使用不同超时预算发送并发预热请求。短请求应返回 `reason: "timeout"` 且不启动第二个子进程，长等待者仍应能观察到已存活的 channel。初始化最终失败后，后续请求应允许重试。
3. 分别让 Web UI 连接不具备新 capability 的 daemon 和非主工作空间。这两种情况都不应调用单例 ACP 状态或预热路由。对于支持新 capability 且工作空间与主工作空间完全一致的 daemon，状态为 live 时应跳过预热；状态为 not-live 或不可用时应允许一次 best-effort 预热，并且不阻塞 Session 创建。
4. 确认即使 Session transport 配置为 ACP over HTTP 或 WebSocket，TypeScript SDK 对这两个 control-plane 调用仍使用 REST。
5. 运行 CLI、SDK、Web UI 的 focused tests 以及打包后的 serve integration tests，再运行 `npm run build`、`npm run bundle`、`npm run typecheck` 和 `npm run lint`，所有检查都应通过。

### 证据（Before & After）

N/A —— 本 PR 修改 daemon 协议语义、客户端兼容性、文档与测试，不改变 TUI。

### 测试平台

|     OS     |     状态     |
| :--------: | :----------: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS，Node.js v22.22.3，npm 10.9.8；使用本地 release build 与 bundled CLI，打包后的 serve integration tests 在关闭 sandbox 的条件下运行。

## 风险与范围

- 主要风险或取舍：支持 capability 的客户端可能开始使用现有 control-plane 路由。实现将该行为限制在完全匹配的主工作空间，继续以 Session 创建作为权威路径，并将预热视为 best effort。
- 未验证或范围外内容：P1-B 延迟优化、提前触发预热、在首个 Session 前等待 readiness、readiness lease、按工作空间限定的 ACP 路由，以及本地 Windows/Linux 执行均不在本 PR 范围内。这些时机调整需要单独进行 2C4G 验证。
- Breaking changes / 迁移说明：无。capability 标签是增量添加的；旧 daemon 保留现有 fallback 路径；旧客户端可以忽略新标签。

## 关联 Issue

属于 #4748 的一部分

</details>
