### PR TITLE
fix(core,cli): let a queued /goal command break the /goal loop at the turn boundary

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -162,7 +162,11 @@ import {
 } from './hooks/useGeminiStream.js';
 import type { TrackedExecutingToolCall } from './hooks/useReactToolScheduler.js';
 import { useVim } from './hooks/vim.js';
-import { isBtwCommand, isSlashCommand } from './utils/commandUtils.js';
+import {
+  isBtwCommand,
+  isGoalCommand,
+  isSlashCommand,
+} from './utils/commandUtils.js';
 import {
   detectWorkflowKeyword,
   buildWorkflowSteeringNotice,
@@ -1866,6 +1870,7 @@ export const AppContainer = (props: AppContainerProps) => {
   const cancelHandlerRef = useRef<(info?: CancelSubmitInfo) => void>(() => {});
   const midTurnDrainRef = useRef<(() => string[]) | null>(null);
   const midTurnRestoreRef = useRef<((messages: string[]) => void) | null>(null);
+  const queuedGoalCommandRef = useRef<(() => boolean) | null>(null);
 
   const {
     streamingState,
@@ -1906,6 +1911,7 @@ export const AppContainer = (props: AppContainerProps) => {
     availableTerminalHeightRef,
     terminalWidthRef,
     midTurnRestoreRef,
+    queuedGoalCommandRef,
   );
   cancelOngoingRequestRef.current = cancelOngoingRequest;
 
@@ -2020,6 +2026,7 @@ export const AppContainer = (props: AppContainerProps) => {
     restoreMessages,
     drainQueue,
     popNextSegment,
+    getQueuedMessages,
   } = useMessageQueue();
 
   // Bridge message queue to mid-turn drain via ref.
@@ -2027,6 +2034,11 @@ export const AppContainer = (props: AppContainerProps) => {
   // stays consistent with popNextSegment even before React re-renders.
   midTurnDrainRef.current = drainQueue;
   midTurnRestoreRef.current = restoreMessages;
+  // Bridge for the Stop-hook continuation (#7181): a queued `/goal` command
+  // (clear or replacement) must break the /goal loop at the next boundary
+  // instead of waiting forever behind blocking continuations.
+  queuedGoalCommandRef.current = () =>
+    getQueuedMessages().some((text) => isGoalCommand(text));
 
   // Connect remote input watcher to submitQuery for bidirectional sync.
   // When an external process writes a command to the input-file,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -421,6 +421,10 @@ export const useGeminiStream = (
   // both dimensions consistently across a mid-stream resize.
   terminalWidthRef?: React.RefObject<number>,
   midTurnRestoreRef?: React.RefObject<((messages: string[]) => void) | null>,
+  // Synchronous "is a /goal slash command queued?" probe. Consulted by the
+  // core Stop-hook continuation (#7181) so a blocking /goal loop yields back
+  // to the turn boundary instead of starving the queued command forever.
+  queuedGoalCommandRef?: React.RefObject<(() => boolean) | null>,
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -2806,6 +2810,12 @@ export const useGeminiStream = (
               ...(!allowConcurrentBtwDuringResponse && midTurnDrainRef
                 ? { getSteerInput: drainSteerAtBoundary }
                 : {}),
+              ...(queuedGoalCommandRef
+                ? {
+                    hasQueuedGoalCommand: () =>
+                      queuedGoalCommandRef.current?.() ?? false,
+                  }
+                : {}),
             },
           );
 
@@ -2940,6 +2950,7 @@ export const useGeminiStream = (
       dualOutput,
       drainSteerAtBoundary,
       midTurnDrainRef,
+      queuedGoalCommandRef,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useMessageQueue.test.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.test.ts
@@ -85,6 +85,23 @@ describe('useMessageQueue', () => {
     );
   });
 
+  it('getQueuedMessages returns a synchronous snapshot including slash commands', () => {
+    const { result } = renderHook(() => useMessageQueue());
+    act(() => {
+      result.current.addMessage('plain steer text');
+      result.current.addMessage('/goal clear');
+    });
+    expect(result.current.getQueuedMessages()).toEqual([
+      'plain steer text',
+      '/goal clear',
+    ]);
+    // Draining plain prompts keeps the slash command in the snapshot.
+    act(() => {
+      result.current.drainQueue(true);
+    });
+    expect(result.current.getQueuedMessages()).toEqual(['/goal clear']);
+  });
+
   describe('popAllMessages (cancel and ESC/Up restore)', () => {
     it('returns null when the queue is empty', () => {
       const { result } = renderHook(() => useMessageQueue());

--- a/packages/cli/src/ui/hooks/useMessageQueue.ts
+++ b/packages/cli/src/ui/hooks/useMessageQueue.ts
@@ -24,6 +24,12 @@ export interface UseMessageQueueReturn {
   drainQueue: (includeDeferred?: boolean) => string[];
   /** Pop the first item from the queue. */
   popNextSegment: () => string | null;
+  /**
+   * Synchronous snapshot of queued message texts, read from the ref mirror so
+   * mid-turn probes (e.g. the Stop-hook continuation's queued-/goal check,
+   * #7181) see the latest queue without waiting for a React re-render.
+   */
+  getQueuedMessages: () => string[];
 }
 
 interface QueuedMessage {
@@ -98,6 +104,11 @@ export function useMessageQueue(): UseMessageQueueReturn {
     return head.text;
   }, []);
 
+  const getQueuedMessages = useCallback(
+    (): string[] => queueRef.current.map(({ text }) => text),
+    [],
+  );
+
   return {
     messageQueue: queuedMessages.map(({ text }) => text),
     addMessage,
@@ -107,5 +118,6 @@ export function useMessageQueue(): UseMessageQueueReturn {
     restoreMessages,
     drainQueue,
     popNextSegment,
+    getQueuedMessages,
   };
 }

--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -10,6 +10,7 @@ import type { spawn, SpawnOptions } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import {
   isAtCommand,
+  isGoalCommand,
   isSlashCommand,
   copyToClipboard,
   getUrlOpenCommand,
@@ -129,6 +130,22 @@ describe('commandUtils', () => {
       expect(isSlashCommand('/home/user/.qwen/settings.json')).toBe(false);
       expect(isSlashCommand('/tmp/test.txt')).toBe(false);
       expect(isSlashCommand('/tmp\\test.txt')).toBe(false);
+    });
+  });
+
+  describe('isGoalCommand', () => {
+    it('matches /goal set, replace, and clear forms', () => {
+      expect(isGoalCommand('/goal clear')).toBe(true);
+      expect(isGoalCommand('/goal write done to /tmp/x.txt')).toBe(true);
+      expect(isGoalCommand('/goal')).toBe(true);
+      expect(isGoalCommand('  /goal clear  ')).toBe(true);
+    });
+
+    it('does not match other commands or plain text', () => {
+      expect(isGoalCommand('/goals overview')).toBe(false);
+      expect(isGoalCommand('/help')).toBe(false);
+      expect(isGoalCommand('reach the goal quickly')).toBe(false);
+      expect(isGoalCommand('')).toBe(false);
     });
   });
 

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -83,6 +83,19 @@ export const isSlashCommand = (query: string): boolean => {
   return true;
 };
 
+const GOAL_COMMAND_RE = /^\/goal(?:\s|$)/;
+
+/**
+ * Checks if a query is a `/goal` slash command (set, replace, or clear).
+ * Used by the Stop-hook continuation probe (#7181): a queued /goal command
+ * must break an active /goal loop at the next turn boundary instead of
+ * waiting behind blocking continuations forever.
+ */
+export const isGoalCommand = (query: string): boolean => {
+  const trimmed = query.trim();
+  return trimmed.length > 0 && GOAL_COMMAND_RE.test(trimmed);
+};
+
 const BTW_COMMAND_RE = /^[/?]btw(?:\s|$)/;
 
 /**

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -8115,6 +8115,123 @@ Other open files:
         });
       });
 
+      // Regression for #7181: with a /goal loop active, every queued slash
+      // command waits for a turn boundary that blocking continuations skip —
+      // the user cannot clear or replace the goal until it terminates on its
+      // own. A queued /goal command must end the chain at the next boundary.
+      it('yields back instead of continuing when a /goal command is queued during a blocking Stop hook', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            output: {
+              decision: 'block',
+              reason: 'Keep working',
+            },
+            stopHookCount: 1,
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi
+            .fn()
+            .mockReturnValue([
+              { role: 'model', parts: [{ text: 'not done' }] },
+            ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'not done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-goal-queued',
+            {
+              type: SendMessageType.UserQuery,
+              hasQueuedGoalCommand: () => true,
+            },
+          ),
+        );
+
+        // No continuation turn ran and no loop event was emitted — the chain
+        // ended at the boundary so the queue drain can run the /goal command.
+        expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+        expect(events).not.toContainEqual(
+          expect.objectContaining({
+            type: GeminiEventType.StopHookLoop,
+          }),
+        );
+        expect(events).toContainEqual({
+          type: GeminiEventType.HookSystemMessage,
+          value:
+            'Pausing the Stop-hook continuation to run your queued /goal command.',
+        });
+      });
+
+      it('continues the blocking Stop hook chain when no /goal command is queued', async () => {
+        const mockMessageBus = {
+          request: vi
+            .fn()
+            .mockResolvedValueOnce({
+              output: { decision: 'block', reason: 'Keep working' },
+              stopHookCount: 1,
+            })
+            .mockResolvedValue({ output: undefined }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi
+            .fn()
+            .mockReturnValue([
+              { role: 'model', parts: [{ text: 'not done' }] },
+            ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockImplementation(() =>
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'not done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-goal-not-queued',
+            {
+              type: SendMessageType.UserQuery,
+              hasQueuedGoalCommand: () => false,
+            },
+          ),
+        );
+
+        expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: GeminiEventType.StopHookLoop,
+          }),
+        );
+      });
+
       it('gives a blocking Stop hook continuation a fresh per-turn tool-call budget', async () => {
         // First Stop check blocks (like a /goal "not met" verdict); the
         // second allows the loop to end.

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -166,6 +166,14 @@ export interface SendMessageOptions {
   type: SendMessageType;
   /** Returns user input waiting to steer the active turn at a model boundary. */
   getSteerInput?: (signal: AbortSignal) => Promise<SteerInput | undefined>;
+  /**
+   * True when a `/goal` slash command (clear / replacement) is queued for the
+   * next turn boundary. A blocking Stop hook continuation (#7181) would skip
+   * that boundary indefinitely, so the loop yields back instead of continuing
+   * — the queue drain runs the command, and a still-active goal resumes on
+   * the next turn's Stop event.
+   */
+  hasQueuedGoalCommand?: () => boolean;
   /** Steer lease already appended to this request, settled after history push. */
   steerInput?: SteerInput;
   /** Track stop hook iterations to prevent infinite loops and display loop info */
@@ -2727,6 +2735,30 @@ export class GeminiClient {
 
           const continueReason = stopOutput.getEffectiveReason();
 
+          // #7181: a queued `/goal` command (clear or replacement) waits for a
+          // turn boundary that this blocking continuation would skip — with a
+          // /goal loop running, the user would otherwise lose control of the
+          // session until the goal terminates. Yield back to the boundary
+          // instead of looping: the CLI's idle queue drain executes the
+          // command, and if a goal is still (or newly) active, its Stop hook
+          // resumes the loop on the next turn.
+          if (options?.hasQueuedGoalCommand?.()) {
+            const pauseMessage =
+              'Pausing the Stop-hook continuation to run your queued /goal command.';
+            const activeGoalEvent = maybeEmitActiveGoalChange(
+              activeGoalAfterStopHook,
+            );
+            if (activeGoalEvent) {
+              yield activeGoalEvent;
+            }
+            yield {
+              type: GeminiEventType.HookSystemMessage,
+              value: pauseMessage,
+            };
+            if (isTopLevelInteraction) endInteractionSpan('ok');
+            return turn;
+          }
+
           // Track stop hook iterations
           const currentIterationCount =
             (options?.stopHookState?.iterationCount ?? 0) + 1;
@@ -2813,6 +2845,7 @@ export class GeminiClient {
                 type: SendMessageType.Hook,
                 modelOverride: options?.modelOverride,
                 getSteerInput: options?.getSteerInput,
+                hasQueuedGoalCommand: options?.hasQueuedGoalCommand,
                 stopHookState: {
                   iterationCount: currentIterationCount,
                   reasons: currentReasons,


### PR DESCRIPTION
## What this PR does

Lets a queued `/goal` command (clear or replacement) break an active `/goal` loop at the next turn boundary. The blocking Stop-hook continuation path in `client.ts` now consults an optional `hasQueuedGoalCommand` probe before recursing into the next `sendMessageStream`: when a `/goal` command is waiting in the message queue, the chain ends at the boundary with a visible HookSystemMessage instead of continuing — the CLI's idle queue drain then runs the command, and a goal that is still (or newly) active resumes looping on the next turn's Stop event via the existing `isCurrentGoal` guard. The CLI wires the probe from `useMessageQueue`'s synchronous ref mirror (new `getQueuedMessages` accessor + `isGoalCommand` classifier) through `AppContainer` into the `sendMessageStream` options, alongside the existing steer-input bridge. Non-goal slash commands keep today's semantics, and plain-text input already steers via `getSteerInput`.

## Why it's needed

#7181 (P1): once a `/goal` loop is running, every Stop-hook `block` decision immediately feeds the continuation prompt back into `sendMessageStream`, so the turn boundary where queued slash commands are processed never arrives. `/goal clear` and `/goal <new condition>` show "queued" and never execute — the user loses control of the session; the only escape is Ctrl+C, which silently discards the queued commands. The triage confirmed the root cause (drainQueue keeps slash commands for a boundary that the `block` path skips) and proposed exactly this fix direction: check for pending goal commands at the Stop-hook boundary before triggering the next continuation.

## Reviewer Test Plan

### How to verify

1. `/goal <some condition the judge won't satisfy quickly>` in a trusted folder, let the loop run a couple of iterations.
2. Type `/goal clear` while the loop is running (it gets queued). Before this PR: the loop keeps iterating and the command never executes. After: at the next boundary the loop pauses ("Pausing the Stop-hook continuation to run your queued /goal command."), the queue drains, and "Goal cleared" appears; no further continuation turns run.
3. Type a replacement `/goal <new condition>` instead: same pause, then the new goal registers and kicks off — the old loop's stale hook is inert thanks to the existing `isCurrentGoal` guard.
4. Tests: packages/core `client.test.ts` 262/262 (two new: queued → yields back, no StopHookLoop event, pause message emitted; not queued → chain continues); packages/cli `commandUtils` / `useMessageQueue` / `useGeminiStream` suites 229/229 (new `isGoalCommand` matrix and `getQueuedMessages` snapshot tests).

### Evidence (Before & After)

Deterministic E2E: a PTY harness drives the real CLI against a local fake OpenAI-compatible server whose goal judge always answers `{"ok": false}` — the loop would run forever. After two observed continuation turns, the harness types `/goal clear` (queued by the TUI) and watches the request stream:

| | before fix | after fix |
| --- | --- | --- |
| continuation turns after `/goal clear` queued | **5+ (harness gives up)** ❌ | **0** ✅ |
| `/goal clear` executes | never (lost on Ctrl+C) ❌ | at the next boundary — "○ Goal cleared · 3 turns" ✅ |
| pause message shown | — | "Pausing the Stop-hook continuation …" ✅ |

![verification](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7181/verify-7181.png)

The new core regression test fails on the unpatched source (continuation runs and no pause message).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; PTY harness + local fake OpenAI-compatible server (streaming turns + non-streaming judge) against `packages/cli/dist`, plus vitest unit tests. `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: the probe is deliberately scoped to `/goal` commands (the triage's recommendation) — other queued slash commands still wait for the loop to terminate, preserving today's behavior for them; widening the probe later is a one-line change at the call site. The yield-back path reuses the same event plumbing as the existing blocking-cap exit (goal-change event, HookSystemMessage, interaction-span close), and the probe defaults to absent, so non-interactive/ACP/daemon paths that never pass it are unchanged.
- Not validated / out of scope: replacement-goal flow is covered by reasoning + unit guards (`isCurrentGoal` already handles replace-while-in-flight) but the scripted E2E exercises the clear path; ACP/daemon goal loops (no message queue concept) are untouched.
- Breaking changes / migration notes: none — `SendMessageOptions.hasQueuedGoalCommand` is optional and additive.

## Linked Issues

Fixes #7181

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让排队的 `/goal` 命令（clear 或替换）能在下一个 turn 边界打断活跃的 `/goal` 循环。`client.ts` 中阻塞式 Stop-hook 续传路径在递归下一次 `sendMessageStream` 前查询可选的 `hasQueuedGoalCommand` 探针：队列中有 `/goal` 命令时，链条在边界结束并给出可见的 HookSystemMessage——CLI 的空闲队列 drain 随即执行该命令；若仍有（或新设了）活跃 goal，依托既有 `isCurrentGoal` 守卫在下一轮 Stop 事件恢复循环。CLI 侧把探针从 `useMessageQueue` 的同步 ref 镜像（新增 `getQueuedMessages` 访问器 + `isGoalCommand` 分类器）经 `AppContainer` 接入 `sendMessageStream` options，与既有 steer-input 桥并列。非 goal 斜杠命令保持现状；纯文本输入本就可经 `getSteerInput` 注入。

## 为什么需要

#7181（P1）：`/goal` 循环运行时，Stop hook 的 `block` 决策直接把续传提示喂回 `sendMessageStream`，处理排队斜杠命令的 turn 边界永远不会到来。`/goal clear` 与 `/goal <新条件>` 显示"排到下一轮"却永不执行——用户失去会话控制，唯一退路 Ctrl+C 还会静默丢弃排队命令。triage 已确认根因（drainQueue 把斜杠命令留给被 `block` 跳过的边界）并给出了正是本 PR 的修复方向。

## 审阅测试计划

### 如何验证

1. 受信目录中 `/goal <judge 不会很快满足的条件>`，让循环跑几轮；
2. 循环期间输入 `/goal clear`（被排队）。本 PR 之前：循环继续、命令永不执行；之后：下一边界出现暂停提示，队列 drain，"Goal cleared" 出现，无后续续传轮次；
3. 改输入替换 `/goal <新条件>`：同样暂停，新 goal 注册并启动——旧循环的过期 hook 因 `isCurrentGoal` 守卫而失效；
4. 测试：core `client.test.ts` 262/262（新增两个：有排队 → 让位且无 StopHookLoop 事件、发暂停消息；无排队 → 链条继续）；cli 三个套件 229/229（新增 `isGoalCommand` 矩阵与 `getQueuedMessages` 快照）。

### 证据（Before & After）

确定性 E2E（PTY + 伪 OpenAI 服务器，judge 恒判 `{"ok": false}` 使循环永不停止；观察到 2 次续传后输入 `/goal clear`）：修复前排队后仍有 **5+ 次续传**、命令饿死；修复后 **0 次续传**、下一边界即执行 "Goal cleared"。新核心回归测试在未修复源码上失败。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；PTY harness + 本地伪 OpenAI 服务器（流式轮次 + 非流式 judge）+ vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：探针刻意只识别 `/goal` 命令（triage 的建议范围）——其它排队斜杠命令维持现状，后续放宽只需改一处调用点；让位路径复用既有 blocking-cap 退出的事件管线（goal 变更事件、HookSystemMessage、interaction span 收尾）；探针默认为空，从不传它的非交互/ACP/daemon 路径行为不变。
- 未验证/超出范围：替换 goal 流程由推理 + 单测守卫覆盖（`isCurrentGoal` 已处理飞行中替换），脚本化 E2E 走的是 clear 路径；ACP/daemon 的 goal 循环（无消息队列概念）未改动。
- 破坏性变更/迁移说明：无——`SendMessageOptions.hasQueuedGoalCommand` 为可选新增。

## 关联 Issue

Fixes #7181

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
