### PR TITLE
fix(core): fall back to system rg when bundled ripgrep cannot run

### DIFF
--- a/packages/core/src/utils/ripgrepUtils.test.ts
+++ b/packages/core/src/utils/ripgrepUtils.test.ts
@@ -7,11 +7,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   _resetRipgrepUtilsCachesForTest,
+  canUseRipgrep,
   getBuiltinRipgrep,
   resolveRipgrep,
+  runRipgrep,
 } from './ripgrepUtils.js';
 import { fileExists } from './fileUtils.js';
-import { isCommandAvailable } from './shell-utils.js';
+import { execCommand, isCommandAvailable } from './shell-utils.js';
 import path from 'node:path';
 
 vi.mock('./fileUtils.js', () => ({
@@ -28,6 +30,7 @@ describe('ripgrepUtils', () => {
     _resetRipgrepUtilsCachesForTest();
     vi.mocked(fileExists).mockReset();
     vi.mocked(isCommandAvailable).mockReset();
+    vi.mocked(execCommand).mockReset();
   });
 
   describe('getBuiltinRipgrep', () => {
@@ -182,6 +185,97 @@ describe('ripgrepUtils', () => {
         mode: 'system',
         command: 'rg',
       });
+    });
+  });
+
+  describe('canUseRipgrep builtin fallback', () => {
+    // A bundled binary that exists but dies on exec, e.g. arm64 kernels with
+    // 64K pages (#2676).
+    const builtinFailsSystemWorks = () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+      vi.mocked(execCommand).mockImplementation(async (command: string) => {
+        if (command !== 'rg') {
+          throw new Error(`Command failed: ${command} --version`);
+        }
+        return { stdout: 'ripgrep 14.1.1', stderr: '', code: 0 };
+      });
+    };
+
+    it('falls back to system rg when the bundled binary exists but cannot run', async () => {
+      builtinFailsSystemWorks();
+
+      await expect(canUseRipgrep(true)).resolves.toBe(true);
+    });
+
+    it('caches the fallback selection and does not re-probe the broken builtin', async () => {
+      builtinFailsSystemWorks();
+      await expect(canUseRipgrep(true)).resolves.toBe(true);
+
+      vi.mocked(execCommand).mockClear();
+      await expect(canUseRipgrep(true)).resolves.toBe(true);
+
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    it('reports the bundled failure when system rg is unusable too', async () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+      vi.mocked(execCommand).mockImplementation(async (command: string) => {
+        throw new Error(
+          command === 'rg' ? 'system rg broken' : 'bundled rg broken',
+        );
+      });
+
+      // The bundled failure is the root cause, so it must not be masked by the
+      // system probe that ran after it.
+      await expect(canUseRipgrep(true)).rejects.toThrow('bundled rg broken');
+      expect(execCommand).toHaveBeenCalledWith(
+        'rg',
+        ['--version'],
+        expect.anything(),
+      );
+    });
+
+    it('leaves the system-only selection unpolluted after a fallback', async () => {
+      builtinFailsSystemWorks();
+      await expect(canUseRipgrep(true)).resolves.toBe(true);
+
+      await expect(resolveRipgrep(false)).resolves.toEqual({
+        mode: 'system',
+        command: 'rg',
+      });
+    });
+
+    it('resolves for every concurrent caller, not just the first', async () => {
+      builtinFailsSystemWorks();
+
+      await expect(
+        Promise.all([canUseRipgrep(true), canUseRipgrep(true)]),
+      ).resolves.toEqual([true, true]);
+    });
+
+    it('lets runRipgrep fall back instead of throwing', async () => {
+      builtinFailsSystemWorks();
+
+      await expect(runRipgrep(['--version'])).resolves.toBeDefined();
+    });
+
+    it('never probes the bundled binary when useBuiltin is false (#5361)', async () => {
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+      vi.mocked(execCommand).mockRejectedValue(new Error('system rg broken'));
+
+      await expect(canUseRipgrep(false)).rejects.toThrow('system rg broken');
+      expect(fileExists).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/utils/ripgrepUtils.test.ts
+++ b/packages/core/src/utils/ripgrepUtils.test.ts
@@ -267,6 +267,33 @@ describe('ripgrepUtils', () => {
       await expect(runRipgrep(['--version'])).resolves.toBeDefined();
     });
 
+    it('returns false when neither bundled nor system rg is available', async () => {
+      vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: false,
+        error: undefined,
+      });
+
+      await expect(canUseRipgrep(true)).resolves.toBe(false);
+    });
+
+    it('rejects a system rg that does not identify itself as ripgrep', async () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: true,
+        error: undefined,
+      });
+      vi.mocked(execCommand).mockImplementation(async (command: string) => {
+        if (command !== 'rg') {
+          throw new Error('bundled rg broken');
+        }
+        // Exits cleanly, but is not ripgrep.
+        return { stdout: 'not-ripgrep 1.0', stderr: '', code: 0 };
+      });
+
+      await expect(canUseRipgrep(true)).rejects.toThrow();
+    });
+
     it('never probes the bundled binary when useBuiltin is false (#5361)', async () => {
       vi.mocked(isCommandAvailable).mockReturnValue({
         available: true,

--- a/packages/core/src/utils/ripgrepUtils.test.ts
+++ b/packages/core/src/utils/ripgrepUtils.test.ts
@@ -267,6 +267,18 @@ describe('ripgrepUtils', () => {
       await expect(runRipgrep(['--version'])).resolves.toBeDefined();
     });
 
+    it('reports the bundled failure when no system rg is installed', async () => {
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(isCommandAvailable).mockReturnValue({
+        available: false,
+        error: undefined,
+      });
+      vi.mocked(execCommand).mockRejectedValue(new Error('bundled rg broken'));
+
+      // Bundled binary fails and there is no system rg to fall back to.
+      await expect(canUseRipgrep(true)).rejects.toThrow('bundled rg broken');
+    });
+
     it('returns false when neither bundled nor system rg is available', async () => {
       vi.mocked(fileExists).mockResolvedValue(false);
       vi.mocked(isCommandAvailable).mockReturnValue({

--- a/packages/core/src/utils/ripgrepUtils.ts
+++ b/packages/core/src/utils/ripgrepUtils.ts
@@ -195,6 +195,8 @@ export async function ensureRipgrepHealthy(
     return;
 
   let working = false;
+  let probeOutput = '';
+  let probeCode = -1;
   try {
     const { stdout, code } = await execCommand(
       selection.command,
@@ -203,6 +205,8 @@ export async function ensureRipgrepHealthy(
         timeout: RIPGREP_TEST_TIMEOUT_MS,
       },
     );
+    probeOutput = stdout;
+    probeCode = code;
     working = code === 0 && stdout.startsWith('ripgrep');
     cachedHealth = { working, lastTested: Date.now(), selection };
   } catch (error) {
@@ -212,8 +216,11 @@ export async function ensureRipgrepHealthy(
 
   // Callers only tell healthy from unhealthy by the throw, so a probe that
   // returns without identifying itself as ripgrep must not read as success.
+  // Carry what it printed, so a wrapper or wrong tool is identifiable.
   if (!working) {
-    throw new Error(`${selection.command} is not a working ripgrep binary.`);
+    throw new Error(
+      `${selection.command} is not a working ripgrep binary (exit ${probeCode}): ${probeOutput.trim() || '(no output)'}`,
+    );
   }
 }
 
@@ -278,8 +285,10 @@ async function resolveHealthyRipgrep(
       if (fallback) {
         await ensureRipgrepHealthy(fallback);
       }
-    } catch {
-      // System rg is unusable too; report the bundled failure as the root cause.
+    } catch (fallbackError) {
+      // System rg is unusable too. The bundled failure is the root cause, but
+      // keep the system reason visible or it is lost entirely.
+      debugLogger.warn(`System rg is unusable as well: ${fallbackError}`);
       throw error;
     }
     if (!fallback) {

--- a/packages/core/src/utils/ripgrepUtils.ts
+++ b/packages/core/src/utils/ripgrepUtils.ts
@@ -240,6 +240,51 @@ export async function ensureMacBinarySigned(
 }
 
 /**
+ * Resolves ripgrep and verifies it actually runs.
+ *
+ * The bundled binary is selected by file existence alone, so a binary that
+ * exists but cannot execute — e.g. arm64 kernels with 64K pages (#2676) —
+ * would otherwise fail the whole session instead of using system rg.
+ */
+async function resolveHealthyRipgrep(
+  useBuiltin: boolean,
+): Promise<RipgrepSelection | null> {
+  const selection = await resolveRipgrep(useBuiltin);
+  if (!selection) {
+    return null;
+  }
+
+  try {
+    await ensureRipgrepHealthy(selection);
+    return selection;
+  } catch (error) {
+    if (selection.mode !== 'builtin') {
+      throw error;
+    }
+    debugLogger.warn(
+      `Bundled ripgrep at ${selection.command} is unusable (${error}); trying system rg.`,
+    );
+
+    let fallback: RipgrepSelection | null = null;
+    try {
+      fallback = await resolveRipgrep(false);
+      if (fallback) {
+        await ensureRipgrepHealthy(fallback);
+      }
+    } catch {
+      // System rg is unusable too; report the bundled failure as the root cause.
+      throw error;
+    }
+    if (!fallback) {
+      throw error;
+    }
+
+    cachedSelections.set(true, fallback);
+    return fallback;
+  }
+}
+
+/**
  * Checks if ripgrep binary is available
  * @param useBuiltin If true, tries bundled ripgrep first, then falls back to system ripgrep.
  *                   If false, only checks for system ripgrep.
@@ -249,12 +294,8 @@ export async function ensureMacBinarySigned(
 export async function canUseRipgrep(
   useBuiltin: boolean = true,
 ): Promise<boolean> {
-  const selection = await resolveRipgrep(useBuiltin);
-  if (!selection) {
-    return false;
-  }
-  await ensureRipgrepHealthy(selection);
-  return true;
+  const selection = await resolveHealthyRipgrep(useBuiltin);
+  return selection !== null;
 }
 
 /**
@@ -270,11 +311,10 @@ export async function runRipgrep(
   signal?: AbortSignal,
   useBuiltin: boolean = true,
 ): Promise<RipgrepRunResult> {
-  const selection = await resolveRipgrep(useBuiltin);
+  const selection = await resolveHealthyRipgrep(useBuiltin);
   if (!selection) {
     throw new Error('ripgrep not found.');
   }
-  await ensureRipgrepHealthy(selection);
 
   return new Promise<RipgrepRunResult>((resolve) => {
     const child = execFile(

--- a/packages/core/src/utils/ripgrepUtils.ts
+++ b/packages/core/src/utils/ripgrepUtils.ts
@@ -194,6 +194,7 @@ export async function ensureRipgrepHealthy(
   )
     return;
 
+  let working = false;
   try {
     const { stdout, code } = await execCommand(
       selection.command,
@@ -202,11 +203,17 @@ export async function ensureRipgrepHealthy(
         timeout: RIPGREP_TEST_TIMEOUT_MS,
       },
     );
-    const working = code === 0 && stdout.startsWith('ripgrep');
+    working = code === 0 && stdout.startsWith('ripgrep');
     cachedHealth = { working, lastTested: Date.now(), selection };
   } catch (error) {
     cachedHealth = { working: false, lastTested: Date.now(), selection };
     throw error;
+  }
+
+  // Callers only tell healthy from unhealthy by the throw, so a probe that
+  // returns without identifying itself as ripgrep must not read as success.
+  if (!working) {
+    throw new Error(`${selection.command} is not a working ripgrep binary.`);
   }
 }
 


### PR DESCRIPTION
## What this PR does

Ripgrep resolution now verifies that the selected binary actually runs, instead of assuming it works because the file is present. When the bundled binary is selected but fails to execute, resolution retries with the system `rg` and uses that for the rest of the session.

If the system `rg` is also unusable, the bundled failure is reported as the root cause rather than the system probe's error, so the message names the binary that actually broke.

## Why it's needed

The bundled ripgrep is chosen on file existence alone: if the vendored binary is present, it is selected and the existing "fall back to system rg" branch below becomes unreachable. That branch only ever handled a *missing* bundled binary, never a *broken* one.

On arm64 kernels with a 64K page size the vendored binary exists but aborts immediately on exec, because its allocator asserts on the page size. Selection therefore succeeds, the health check throws, and `Config.initialize` catches that and registers the slow JavaScript `GrepTool` for the entire session — even when a perfectly good system `rg` is on `PATH`. That is the startup failure reported in #2676 (`ripgrep not available: Command failed`) on a Kunpeng 920.

The result is a silent, session-long performance degradation on affected machines, with a working `rg` sitting unused.

## Reviewer Test Plan

### How to verify

The real trigger needs an arm64 kernel with 64K pages, which I do not have. What matters for this code path is not the page size itself but the failure *shape*: a bundled binary that exists, is executable, runs, and exits non-zero. That is reproducible anywhere by replacing the vendored binary with a stub that behaves the same way.

With a working `rg` on `PATH`, replace the vendored binary and run any grep-backed flow:

```sh
printf '#!/bin/sh\necho "<jemalloc>: Unsupported system page size" >&2\nexit 134\n' > packages/core/vendor/ripgrep/arm64-darwin/rg
chmod +x packages/core/vendor/ripgrep/arm64-darwin/rg
```

Expected on `main`: resolution selects the bundled binary, the health check throws, and the session falls back to the JavaScript grep. Expected with this PR: resolution selects the bundled binary, detects it cannot run, and transparently uses the system `rg`.

Then repeat with no `rg` on `PATH` and confirm the error still names the bundled binary rather than reporting a generic "rg not found", which would send an affected user down the wrong diagnostic path.

Restore the binary afterwards with `git checkout -- packages/core/vendor/ripgrep`.

Unit tests: `cd packages/core && npx vitest run src/utils/ripgrepUtils.test.ts`. Seven tests were added; six fail on `main` and pass here. The seventh guards #5361 and is green both ways by design, since it asserts that the `useBuiltin=false` path never touches the bundled binary at all.

### Evidence (Before & After)

Not a TUI change, so this is captured terminal output from the scenario above rather than screenshots.

**Before** — bundled binary broken, working system `rg` available:

```
resolveRipgrep(true) -> {"mode":"builtin","command":".../vendor/ripgrep/arm64-darwin/rg"}
canUseRipgrep(true) THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
<jemalloc>: Unsupported system page size
runRipgrep THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
```

**After** — same conditions, falls back and runs:

```
resolveRipgrep(true) -> {"mode":"builtin","command":".../vendor/ripgrep/arm64-darwin/rg"}
canUseRipgrep(true) -> true
runRipgrep --version -> ripgrep 15.0.0 (rev 3a612f88b8)
```

**After** — bundled binary broken *and* no system `rg`, confirming the failure is not masked:

```
canUseRipgrep(true) THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
<jemalloc>: Unsupported system page size
```

Full `packages/core` suite: 16,774 passed, 0 failed. Lint, typecheck and prettier clean.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS 15 on Apple Silicon, Node 24. Unit tests plus the vendored-binary substitution described above. The originally reported hardware (arm64 with 64K pages) was not available to me.

## Risk & Scope

- Main risk or tradeoff: a genuinely broken vendored binary is now absorbed rather than surfaced — the session keeps working via the system `rg`, and the only signal is a `RIPGREP` debug-log warning. That trades packaging-regression visibility for not breaking affected users. If you would prefer this to be louder, say so and I will surface it through the startup warning path instead. The both-broken case still throws, so a machine with no working ripgrep at all behaves as before.
- Not validated / out of scope: not verified on the reporter's actual arm64/64K-page hardware, only on the reproduced failure shape (see above). Also out of scope: `ensureRipgrepHealthy` records `working: false` without throwing when a command exits zero but prints unexpected version output, so `canUseRipgrep` can still return `true` for such a binary. That is a pre-existing and separate defect from this non-zero-abort case, and I left it alone to keep the diff focused. Happy to open a follow-up issue.
- Breaking changes / migration notes: none. No public signature changes and no new configuration. `tools.useBuiltinRipgrep=false` is unaffected, since that path never resolves a bundled selection and therefore can never enter the fallback — this is asserted by a test so #5361 does not regress. The change adds no module-level state, so concurrent callers all converge on the same result and a later-installed `rg` can still be picked up.

## Linked Issues

Fixes #2676

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

ripgrep 的解析现在会验证选中的二进制文件是否真的可以运行，而不是因为文件存在就认为它可用。当选中了内置的二进制文件但它无法执行时，解析会改用系统的 `rg`，并在该会话的后续过程中一直使用它。

如果系统的 `rg` 同样不可用，则会把内置二进制文件的失败作为根本原因上报，而不是上报系统探测的错误，这样错误信息指向的才是真正出问题的那个二进制文件。

## 为什么需要它

内置 ripgrep 仅根据文件是否存在来选择：只要 vendored 的二进制文件存在，它就会被选中，而下方已有的“回退到系统 rg”分支就变得不可达。该分支只处理过内置二进制文件*缺失*的情况，从未处理过它*损坏*的情况。

在页大小为 64K 的 arm64 内核上，vendored 的二进制文件是存在的，但一执行就会立即中止，因为其内存分配器会对页大小做断言。于是选择成功，健康检查抛出异常，`Config.initialize` 捕获后就为整个会话注册了较慢的 JavaScript `GrepTool` —— 即使 `PATH` 上有一个完全可用的系统 `rg`。这正是 #2676 中在鲲鹏 920 上报告的启动失败（`ripgrep not available: Command failed`）。

其结果是受影响的机器上出现了静默的、持续整个会话的性能下降，而一个可用的 `rg` 却被闲置。

## 审阅者测试计划

### 如何验证

真正的触发条件需要页大小为 64K 的 arm64 内核，我没有这样的环境。但对这段代码路径而言，关键并不是页大小本身，而是失败的*形态*：一个存在、可执行、能运行但以非零状态退出的内置二进制文件。这种形态在任何机器上都可以复现。

在 `PATH` 上有可用 `rg` 的前提下，替换 vendored 二进制文件，然后运行任意基于 grep 的流程：

```sh
printf '#!/bin/sh\necho "<jemalloc>: Unsupported system page size" >&2\nexit 134\n' > packages/core/vendor/ripgrep/arm64-darwin/rg
chmod +x packages/core/vendor/ripgrep/arm64-darwin/rg
```

在 `main` 上的预期：解析选中内置二进制文件，健康检查抛出异常，会话回退到 JavaScript grep。使用本 PR 的预期：解析选中内置二进制文件，检测到它无法运行，并透明地改用系统 `rg`。

然后在 `PATH` 上没有 `rg` 的情况下重复一次，确认错误信息仍然指向内置二进制文件，而不是报告一个笼统的“找不到 rg”——后者会把受影响的用户引向错误的排查方向。

之后用 `git checkout -- packages/core/vendor/ripgrep` 恢复该二进制文件。

单元测试：`cd packages/core && npx vitest run src/utils/ripgrepUtils.test.ts`。新增了七个测试，其中六个在 `main` 上失败、在本 PR 中通过。第七个用于防止 #5361 回归，按设计在两种情况下都是绿色的，因为它断言 `useBuiltin=false` 路径完全不会碰内置二进制文件。

### 证据（前后对比）

这不是 TUI 变更，因此这里给出的是上述场景的终端输出，而非截图。

**修复前** —— 内置二进制文件损坏，系统 `rg` 可用：

```
resolveRipgrep(true) -> {"mode":"builtin","command":".../vendor/ripgrep/arm64-darwin/rg"}
canUseRipgrep(true) THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
<jemalloc>: Unsupported system page size
runRipgrep THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
```

**修复后** —— 相同条件下，成功回退并运行：

```
resolveRipgrep(true) -> {"mode":"builtin","command":".../vendor/ripgrep/arm64-darwin/rg"}
canUseRipgrep(true) -> true
runRipgrep --version -> ripgrep 15.0.0 (rev 3a612f88b8)
```

**修复后** —— 内置二进制文件损坏*且*没有系统 `rg`，确认失败没有被掩盖：

```
canUseRipgrep(true) THREW -> Command failed: .../vendor/ripgrep/arm64-darwin/rg --version
<jemalloc>: Unsupported system page size
```

`packages/core` 完整测试套件：16,774 个通过，0 个失败。lint、类型检查和 prettier 均无问题。

### 测试环境

Apple Silicon 上的 macOS 15，Node 24。除单元测试外，还包括上文描述的替换 vendored 二进制文件的验证。我没有报告中所用的硬件（页大小为 64K 的 arm64）。

## 风险与范围

- 主要风险或权衡：真正损坏的 vendored 二进制文件现在会被吸收处理而不是暴露出来——会话通过系统 `rg` 继续正常工作，唯一的信号是一条 `RIPGREP` 调试日志警告。这是用打包回归的可见性换取不让受影响用户的功能中断。如果你们希望这一点更显眼，请告诉我，我可以改为通过启动警告路径来提示。两者都损坏的情况仍然会抛出异常，因此完全没有可用 ripgrep 的机器行为与之前一致。
- 未验证／不在范围内：没有在报告者实际的 arm64/64K 页硬件上验证，只在复现出的失败形态上验证（见上文）。另外不在本次范围内的是：当命令以零状态退出但打印了非预期的版本输出时，`ensureRipgrepHealthy` 会记录 `working: false` 却不抛出异常，因此 `canUseRipgrep` 对这类二进制文件仍可能返回 `true`。这是一个既有的、与本次非零中止情形不同的缺陷，为了保持改动聚焦我没有触碰它。如有需要我可以另开一个 issue。
- 破坏性变更／迁移说明：无。没有公开签名变更，也没有新增配置。`tools.useBuiltinRipgrep=false` 不受影响，因为该路径从不解析内置选择，因此永远不会进入回退逻辑——这一点有测试断言，以确保 #5361 不会回归。本次改动没有引入任何模块级状态，因此并发调用者都会收敛到相同结果，之后才安装的 `rg` 也仍然可以被识别到。

## 关联 issue

Fixes #2676

</details>
