### PR TITLE
ci(web-shell): denoise cross-job font-AA so visual previews stop false-flagging

### DIFF
--- a/.github/scripts/web-shell-visuals-compose.mjs
+++ b/.github/scripts/web-shell-visuals-compose.mjs
@@ -31,14 +31,63 @@ import { pathToFileURL } from 'node:url';
 
 // % of pixels that must differ for a view to count as "changed". Kept low so a
 // small-but-real change (an icon swap ~24×24, a one-word label) still registers
-// — this is the exact failure mode the preview exists to catch. before/after
-// render on the same runner + fonts with `animations: 'disabled'`, so AA jitter
-// between two identical renders is ~0. At 1280×800, 0.02% ≈ 205 px.
+// — this is the exact failure mode the preview exists to catch. The fraction is
+// measured AFTER the cluster denoise (see MIN_CLUSTER_NEIGHBORS): base and head
+// render in SEPARATE CI jobs, so font anti-aliasing is not bit-identical
+// between them and a text-heavy view scatters ~0.1-0.3% of isolated edge pixels
+// that would otherwise cross this line; the denoise erodes that scatter to ~0.
+// At 1280×800, 0.02% ≈ 205 px.
 export const CHANGED_PCT_THRESHOLD = 0.02;
 // A pixel "differs" when |ΔR|+|ΔG|+|ΔB| exceeds this (ignores imperceptible AA).
 export const PER_PIXEL_DELTA = 30;
+// Minimum of the 8 neighbours that must ALSO differ for a differing pixel to be
+// counted. Cross-job font-AA leaves a scatter of isolated / 1px-wide differing
+// pixels along glyph edges (a 1px-line pixel has 2 differing neighbours, an
+// isolated one has 0) — below this cutoff they erode to nothing, while a real
+// change (badge, chip, icon, panel) is a solid block whose interior keeps 5-8.
+export const MIN_CLUSTER_NEIGHBORS = 4;
 // Display width of each panel in the stitched composite.
 export const PANEL_WIDTH = 560;
+
+/**
+ * Count differing pixels that sit in a cluster: (x,y) counts only when at least
+ * `minNeighbors` of its 8 neighbours also differ. `changed` is a row-major 0/1
+ * mask of length `width*height`. Pure + deterministic (unit-tested); this is
+ * what drops cross-job font-AA scatter before the changed fraction is measured.
+ */
+export function countDenoisedChanges(
+  changed,
+  width,
+  height,
+  minNeighbors = MIN_CLUSTER_NEIGHBORS,
+) {
+  let count = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (!changed[y * width + x]) continue;
+      let neighbors = 0;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          if (changed[ny * width + nx]) neighbors++;
+        }
+      }
+      if (neighbors >= minNeighbors) count++;
+    }
+  }
+  return count;
+}
+
+/** Unpack a base64, LSB-first bit-mask into a 0/1 Uint8Array of length `n`. */
+export function unpackBitMask(base64, n) {
+  const buf = Buffer.from(base64, 'base64');
+  const out = new Uint8Array(n);
+  for (let i = 0; i < n; i++) out[i] = (buf[i >> 3] >> (i & 7)) & 1;
+  return out;
+}
 
 /** Parse `<view>-<light|dark>.png` → `{ view, theme }` or null (ignore others). */
 export function parseShot(name) {
@@ -117,13 +166,18 @@ function compositeHtml({
     </div></body></html>`;
 }
 
-// Differing-pixel fraction (%) between two PNG data URIs, measured on a canvas
-// (no native image deps). A size mismatch short-circuits to 100% (a dimension
-// change is itself a visual change); equal-size images compare pixel-for-pixel.
+// Differing-pixel fraction (%) between two PNG data URIs. The browser decodes on
+// a canvas (no native image deps) and returns a compact bit-mask of which pixels
+// differ by > PER_PIXEL_DELTA; the cluster denoise + count then run here in node
+// against the unit-tested `countDenoisedChanges`, so there is a single tested
+// implementation of the metric. A size mismatch or an undecodable image
+// short-circuits to 100% (both are themselves a visual change, and must be shown
+// rather than silently dropped).
 async function diffPct(page, beforeUri, afterUri) {
-  return page.evaluate(
-    // This arrow runs in the BROWSER (page.evaluate), where Image/document are
-    // defined; declare them so eslint's node env doesn't flag no-undef.
+  const result = await page.evaluate(
+    // This arrow runs in the BROWSER (page.evaluate), where Image and document
+    // are defined; declare them so eslint's node env doesn't flag no-undef.
+    // (btoa is a shared node+browser global, so it needs no declaration here.)
     /* global Image, document */
     async ([a, b, delta]) => {
       const load = (src) =>
@@ -137,13 +191,11 @@ async function diffPct(page, beforeUri, afterUri) {
           img.src = src;
         });
       const [ia, ib] = await Promise.all([load(a), load(b)]);
-      // An undecodable image can't be compared → treat the view as fully
-      // changed (so it is shown, not silently dropped).
-      if (!ia || !ib) return 100;
-      // A dimension change IS a visual change: comparing only the overlapping
-      // rectangle would hide it (a taller viewport whose top pixels are
-      // unchanged would read 0%). Treat any size mismatch as fully changed.
-      if (ia.width !== ib.width || ia.height !== ib.height) return 100;
+      // An undecodable image, or a dimension change, IS a visual change: show it
+      // (comparing only the overlapping rectangle would hide a size change).
+      if (!ia || !ib) return { full: true };
+      if (ia.width !== ib.width || ia.height !== ib.height)
+        return { full: true };
       const w = ia.width;
       const h = ia.height;
       const c = document.createElement('canvas');
@@ -155,8 +207,10 @@ async function diffPct(page, beforeUri, afterUri) {
       ctx.clearRect(0, 0, w, h);
       ctx.drawImage(ib, 0, 0);
       const db = ctx.getImageData(0, 0, w, h).data;
-      let diff = 0;
       const n = w * h;
+      // Bit-pack the differing-pixel mask (LSB-first) so it transfers to node in
+      // ~n/8 bytes rather than a per-pixel object.
+      const bytes = new Uint8Array((n + 7) >> 3);
       for (let i = 0; i < n; i++) {
         const j = i * 4;
         if (
@@ -165,12 +219,20 @@ async function diffPct(page, beforeUri, afterUri) {
             Math.abs(da[j + 2] - db[j + 2]) >
           delta
         )
-          diff++;
+          bytes[i >> 3] |= 1 << (i & 7);
       }
-      return n ? (diff / n) * 100 : 0;
+      let bin = '';
+      for (let i = 0; i < bytes.length; i++)
+        bin += String.fromCharCode(bytes[i]);
+      return { w, h, mask: btoa(bin) };
     },
     [beforeUri, afterUri, PER_PIXEL_DELTA],
   );
+  if (result.full) return 100;
+  const n = result.w * result.h;
+  if (!n) return 0;
+  const changed = unpackBitMask(result.mask, n);
+  return (countDenoisedChanges(changed, result.w, result.h) / n) * 100;
 }
 
 async function composeCli(beforeDir, afterDir, outDir) {

--- a/.github/scripts/web-shell-visuals-compose.test.mjs
+++ b/.github/scripts/web-shell-visuals-compose.test.mjs
@@ -9,10 +9,23 @@ import test from 'node:test';
 
 import {
   CHANGED_PCT_THRESHOLD,
+  countDenoisedChanges,
   isChanged,
   parseShot,
   planWork,
+  unpackBitMask,
 } from './web-shell-visuals-compose.mjs';
+
+/** Build a row-major 0/1 mask from a predicate. */
+function mask(width, height, isSet) {
+  const m = new Uint8Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      m[y * width + x] = isSet(x, y) ? 1 : 0;
+    }
+  }
+  return m;
+}
 
 test('parseShot extracts view + theme, is case-insensitive, and strips dirs', () => {
   assert.deepEqual(parseShot('mermaid-diagram-light.png'), {
@@ -88,4 +101,73 @@ test('planWork tolerates null/undefined args (exercises the ?? [] guards)', () =
   assert.deepEqual(planWork(['a-light.png'], null), [
     { name: 'a-light.png', hasBefore: false },
   ]);
+});
+
+test('countDenoisedChanges: isolated scatter (cross-job AA) erodes to zero', () => {
+  // Isolated single pixels, none adjacent — the shape of font-AA jitter.
+  const [w, h] = [20, 20];
+  const m = mask(w, h, (x, y) => x % 4 === 0 && y % 4 === 0);
+  // Every set pixel has 0 set neighbours → none survive the density cutoff.
+  assert.equal(countDenoisedChanges(m, w, h), 0);
+});
+
+test('countDenoisedChanges: a 1px-wide line (glyph edge) erodes to zero', () => {
+  const [w, h] = [20, 20];
+  const m = mask(w, h, (_x, y) => y === 5); // one horizontal line
+  // Interior line pixels have exactly 2 set neighbours (< 4) → none survive.
+  assert.equal(countDenoisedChanges(m, w, h), 0);
+});
+
+test('countDenoisedChanges: minNeighbors controls erosion strength on a solid block', () => {
+  const [w, h] = [3, 3];
+  const m = mask(w, h, () => true); // full 3×3
+  // Centre keeps all 8 neighbours; the 4 edges keep 5; the 4 corners keep 3.
+  assert.equal(countDenoisedChanges(m, w, h, 8), 1); // centre only
+  assert.equal(countDenoisedChanges(m, w, h, 4), 5); // centre + 4 edges
+  assert.equal(countDenoisedChanges(m, w, h, 3), 9); // corners survive too
+});
+
+test('countDenoisedChanges: a badge-shaped solid block mostly survives', () => {
+  const [w, h] = [40, 40];
+  // 15×12 solid block = 180 px.
+  const m = mask(w, h, (x, y) => x >= 10 && x < 25 && y >= 10 && y < 22);
+  const survivors = countDenoisedChanges(m, w, h);
+  // Only the 4 corners (3 neighbours) erode; the rest of the 180-px block keeps.
+  assert.ok(
+    survivors >= 170,
+    `expected most of the 180-px block to survive, got ${survivors}`,
+  );
+});
+
+test('at 1280×800: AA scatter erodes below the threshold, a real badge clears it', () => {
+  const [W, H] = [1280, 800];
+  const N = W * H;
+  // ~0.25% of pixels as an isolated scatter — well over the raw 0.02% line.
+  const aa = mask(W, H, (x, y) => x % 20 === 0 && y % 20 === 0);
+  const aaPct = (countDenoisedChanges(aa, W, H) / N) * 100;
+  assert.ok(
+    aaPct < CHANGED_PCT_THRESHOLD,
+    `AA scatter should denoise below ${CHANGED_PCT_THRESHOLD}%, got ${aaPct}`,
+  );
+
+  // A 55×18 badge-sized solid block (~0.075% of the frame).
+  const badge = mask(
+    W,
+    H,
+    (x, y) => x >= 100 && x < 155 && y >= 100 && y < 118,
+  );
+  const badgePct = (countDenoisedChanges(badge, W, H) / N) * 100;
+  assert.ok(
+    badgePct >= CHANGED_PCT_THRESHOLD,
+    `a real badge-sized change should stay above ${CHANGED_PCT_THRESHOLD}%, got ${badgePct}`,
+  );
+});
+
+test('unpackBitMask round-trips a packed mask (LSB-first)', () => {
+  // Pixels 0..9, set {0, 3, 8}: byte0 = 0b0000_1001, byte1 = 0b0000_0001.
+  const b64 = Buffer.from([0b00001001, 0b00000001]).toString('base64');
+  assert.deepEqual(
+    Array.from(unpackBitMask(b64, 10)),
+    [1, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+  );
 });


### PR DESCRIPTION
## What this PR does

Makes the web-shell before/after visual-preview diff **cluster-denoise** the differing-pixel mask before measuring the changed fraction: a differing pixel counts only when at least `MIN_CLUSTER_NEIGHBORS` (4) of its 8 neighbours also differ. This erodes cross-render font anti-aliasing scatter while leaving real changes untouched. The browser now returns a compact bit-mask and the denoise + count run in node against a unit-tested pure function, so the metric has one tested implementation.

## Why it's needed

The preview keeps flagging text-heavy views — most recently `workspace-sidebar` on **#7204** — as changed on PRs that don't touch them. The two panels are pixel-for-pixel indistinguishable, yet the header reads "0.2% changed":

![#7204 false positive](https://raw.githubusercontent.com/QwenLM/qwen-code/pr-assets/web-shell-visuals-aa-denoise/7204-workspace-sidebar-false-positive.png)

Root cause: base and head render in **separate CI jobs**, so Linux font anti-aliasing (freetype/fontconfig) is not bit-identical between the two runs. A text-heavy view leaves a scatter of isolated / 1px-wide differing pixels along glyph edges — ~0.1–0.3% of the frame — which the naive per-pixel diff counts. At the deliberately tight 0.02% threshold, that scatter crosses the line. (The earlier `sidebar-attention` spinner flake was a different, animation class, fixed in #7041 by freezing looping animations — that fix is intact; this is the residual sub-pixel text class it was never meant to cover.)

Raising the flat threshold isn't viable: the change this scenario exists to catch — the primary-workspace "Primary" badge — is itself only ~0.08%, the same order as the AA scatter. The distinguishing feature is **spatial clustering**: AA noise is scattered single pixels / thin lines; a real change is a solid block. The denoise keys off exactly that.

## Reviewer Test Plan

### How to verify

```
node --test .github/scripts/web-shell-visuals-compose.test.mjs   # 13 pass
```

The new unit tests pin the metric on the exact shapes involved:
- isolated scatter (cross-job AA) → erodes to 0
- a 1px-wide line (glyph edge, 2 neighbours) → erodes to 0
- `minNeighbors` erosion strength on a solid 3×3 (8/4/3 → 1/5/9 survivors)
- a badge-shaped block mostly survives
- **at 1280×800: a ~0.25% AA scatter denoises below the 0.02% threshold, while a 55×18 badge-sized block stays above it** — the decisive separation
- `unpackBitMask` round-trips a packed mask

End-to-end through the real browser→node pipeline (identical vs a genuine change):

```
node .github/scripts/web-shell-visuals-compose.mjs <before> <after> <out>
```

An identical pair reports `0% diff` and emits no composite; a genuinely different pair (e.g. a light-theme image in the dark slot) reports `99.89% diff` and emits the composite. Verified locally.

### Evidence (Before & After)

Before: the #7204 composite above — "0.2% changed" with no visible difference. After: that scatter denoises to ~0, so the view is no longer flagged; a real block-shaped change still is (unit + end-to-end proof above). The CI-only AA noise itself can't be reproduced on macOS (local same-commit renders are already 0px), so the fix is validated by the unit tests on the exact noise/real-change shapes plus the end-to-end pipeline run, not a live CI screenshot.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

Node `--test` + the compose CLI, macOS. The behaviour it fixes is Linux-CI-only.

### Environment (optional)

`node --test` (no build); the CLI lazy-imports `@playwright/test` chromium.

## Risk & Scope

- CI-tooling only (`.github/scripts/`), no product code. The public metric contract is unchanged — `diffPct` still returns a 0–100 number, `isChanged` and the manifest are untouched, and the size-mismatch / undecodable → 100% short-circuits are preserved.
- Main risk / tradeoff: the denoise erodes changes thinner than a ~2px cluster (a 1px-wide line, a lone icon pixel). For a visual **preview** with a 0.02% threshold that is below the perceptible/meaningful floor anyway, and the scenarios exist to surface block-shaped surfaces (dialogs, chips, badges, panels), which survive comfortably.
- Not validated / out of scope: reproducing the Linux CI AA noise locally (not possible on macOS — hence the synthetic-shape + end-to-end validation); tuning `MIN_CLUSTER_NEIGHBORS` against real CI captures (4 is derived from the 1px-line = 2-neighbour geometry at the 1280×800 DPR-1 capture).
- Breaking changes / migration notes: none.

## Linked Issues

None. Hardens the visual-preview engine (#6963); complements the animation-freeze fix (#7041). Motivated by the false positive on #7204.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell before/after 视觉预览在统计"变更像素比例"之前先做**聚类去噪**:一个差异像素只有在其 8 邻域中至少有 `MIN_CLUSTER_NEIGHBORS`(4)个也差异时才计数。这会侵蚀掉跨渲染的字体抗锯齿散点,同时不动真实改动。浏览器现在返回一个紧凑位掩码,去噪+计数在 node 里用一个有单测的纯函数完成,度量只有一份被测实现。

## 为什么需要它

预览一直把文字密集的视图——最近是 **#7204** 的 `workspace-sidebar`——在没碰它们的 PR 上标为"变更"。两半逐像素无法区分,标题却写着"0.2% changed"(见上图)。

根因:base 和 head 在**两个独立的 CI job** 里渲染,Linux 字体抗锯齿(freetype/fontconfig)在两次运行间并非逐位一致。文字密集的视图会在字形边缘留下一片孤立/1px 宽的差异像素散点(约占画面 0.1–0.3%),朴素逐像素 diff 会把它们全算上。在刻意设很紧的 0.02% 阈值下,这片散点就越线了。(此前 `sidebar-attention` 的转圈是**另一类**——动画,已在 #7041 用冻结循环动画修复,那个修复仍在生效;本次是它未覆盖的亚像素文字残留类。)

抬高扁平阈值行不通:这个场景要抓的改动——主工作区 "Primary" 徽章——本身也才约 0.08%,和 AA 散点同一量级。区分特征是**空间聚集性**:AA 噪声是散点/细线,真实改动是实心块。去噪正是抓这一点。

## 复现测试计划

### 如何验证

```
node --test .github/scripts/web-shell-visuals-compose.test.mjs   # 13 pass
```

新单测在涉及的确切形状上钉住度量:孤立散点(跨 job AA)→ 侵蚀为 0;1px 宽线(字形边缘,2 邻域)→ 侵蚀为 0;`minNeighbors` 在实心 3×3 上的侵蚀强度(8/4/3 → 1/5/9);徽章形实心块大体存活;**1280×800 下:约 0.25% 的 AA 散点去噪后低于 0.02% 阈值,而 55×18 徽章块仍在阈值之上**(决定性分离);`unpackBitMask` 位掩码往返。

端到端走真实"浏览器→node"管线:相同图对报 `0% diff`、不产出合成图;真正不同的图对(如把浅色图放进深色槽)报 `99.89% diff`、产出合成图。已本地验证。

### 证据(Before & After)

Before:上方 #7204 合成图——"0.2% changed" 却无可见差异。After:该散点去噪为约 0,不再被标记;而实心块状真实改动照旧被标记(上方单测+端到端证明)。CI-only 的 AA 噪声在 macOS 上复现不出(本地同 commit 渲染本就 0px),因此本修复靠"在确切噪声/真实改动形状上的单测 + 端到端管线运行"验证,而非一张实时 CI 截图。

### 测试平台

Node `--test` + compose CLI,macOS。它修复的行为是 Linux-CI-only。

## 风险与范围

- 仅 CI 工具(`.github/scripts/`),无产品代码。公开度量契约不变——`diffPct` 仍返回 0–100 数值,`isChanged`/manifest 不动,尺寸不符/无法解码→100% 的短路保留。
- 主要风险/取舍:去噪会侵蚀掉比约 2px 聚类更细的改动(1px 宽线、孤立单像素图标)。对一个阈值 0.02% 的视觉**预览**而言,这本就在可感知/有意义的地板以下,且这些场景就是为呈现块状界面(弹窗、chip、徽章、面板)而生,后者存活无虞。
- 未验证/不在范围内:本地复现 Linux CI 的 AA 噪声(macOS 做不到——故用合成形状+端到端验证);用真实 CI 截图去调 `MIN_CLUSTER_NEIGHBORS`(4 是从 1280×800 DPR-1 下"1px 线=2 邻域"的几何推出的)。
- 破坏性变更/迁移说明:无。

## 关联 Issue

无。加固视觉预览引擎(#6963);与动画冻结修复(#7041)互补。由 #7204 的假阳性触发。

</details>
