### PR TITLE
fix(scripts): allow multiple dev:daemon instances by probing Vite port

### DIFF
--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -306,7 +306,7 @@ console.log(`qwen daemon dev`);
 console.log(`  daemon:   ${webEnv.QWEN_DAEMON_URL}`);
 console.log(`  workspace: ${workspace}`);
 console.log(
-  `  web-shell: http://localhost:5173/ (auto-increments if busy, token: ${token.slice(0, 4)}...)`,
+  `  web-shell: opening in browser (auto-increments from 5173 if busy — see Vite output for the actual URL, token: ${token.slice(0, 4)}...)`,
 );
 console.log('');
 

--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -259,6 +259,7 @@ const probeHostname =
 const port = hasOption('--port')
   ? String(startPort)
   : String(await findAvailablePort(probeHostname, startPort));
+const vitePort = await findAvailablePort('127.0.0.1', 5173);
 const token =
   readOption('--token') ||
   process.env.QWEN_SERVER_TOKEN ||
@@ -298,7 +299,7 @@ console.log(`qwen daemon dev`);
 console.log(`  daemon:   ${webEnv.QWEN_DAEMON_URL}`);
 console.log(`  workspace: ${workspace}`);
 console.log(
-  `  web-shell: http://localhost:5173/ (token: ${token.slice(0, 4)}...)`,
+  `  web-shell: http://localhost:${vitePort}/ (token: ${token.slice(0, 4)}...)`,
 );
 console.log('');
 
@@ -322,6 +323,8 @@ waitForDaemon(webEnv.QWEN_DAEMON_URL)
         '--',
         '--open',
         `/?token=${encodeURIComponent(token)}`,
+        '--port',
+        String(vitePort),
         '--strictPort',
       ],
       {

--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -256,10 +256,24 @@ const probeHostname =
   hostname.startsWith('[') && hostname.endsWith(']')
     ? hostname.slice(1, -1)
     : hostname;
-const port = hasOption('--port')
-  ? String(startPort)
-  : String(await findAvailablePort(probeHostname, startPort));
-const vitePort = await findAvailablePort('127.0.0.1', 5173);
+let port;
+let vitePort;
+try {
+  port = hasOption('--port')
+    ? String(startPort)
+    : String(await findAvailablePort(probeHostname, startPort));
+  // Unlike the daemon --port, the Vite dev server has no CLI escape hatch, so it
+  // always probes. When 5173–5182 are all taken (e.g. several dev:daemon
+  // instances already running), findAvailablePort rejects — surface that as a
+  // clean, actionable message and exit rather than an unhandled rejection with a
+  // raw stack, matching the validateLauncherArgs handling above.
+  vitePort = await findAvailablePort('127.0.0.1', 5173);
+} catch (err) {
+  console.error(
+    `[daemon-dev] ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+}
 const token =
   readOption('--token') ||
   process.env.QWEN_SERVER_TOKEN ||

--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -257,17 +257,10 @@ const probeHostname =
     ? hostname.slice(1, -1)
     : hostname;
 let port;
-let vitePort;
 try {
   port = hasOption('--port')
     ? String(startPort)
     : String(await findAvailablePort(probeHostname, startPort));
-  // Unlike the daemon --port, the Vite dev server has no CLI escape hatch, so it
-  // always probes. When 5173–5182 are all taken (e.g. several dev:daemon
-  // instances already running), findAvailablePort rejects — surface that as a
-  // clean, actionable message and exit rather than an unhandled rejection with a
-  // raw stack, matching the validateLauncherArgs handling above.
-  vitePort = await findAvailablePort('127.0.0.1', 5173);
 } catch (err) {
   console.error(
     `[daemon-dev] ${err instanceof Error ? err.message : String(err)}`,
@@ -313,7 +306,7 @@ console.log(`qwen daemon dev`);
 console.log(`  daemon:   ${webEnv.QWEN_DAEMON_URL}`);
 console.log(`  workspace: ${workspace}`);
 console.log(
-  `  web-shell: http://localhost:${vitePort}/ (token: ${token.slice(0, 4)}...)`,
+  `  web-shell: http://localhost:5173/ (auto-increments if busy, token: ${token.slice(0, 4)}...)`,
 );
 console.log('');
 
@@ -337,9 +330,6 @@ waitForDaemon(webEnv.QWEN_DAEMON_URL)
         '--',
         '--open',
         `/?token=${encodeURIComponent(token)}`,
-        '--port',
-        String(vitePort),
-        '--strictPort',
       ],
       {
         cwd: root,


### PR DESCRIPTION
## Motivation

Running a second `npm run dev:daemon` crashes immediately because the Vite dev server port is hardcoded to 5173 with `--strictPort`. This makes it inconvenient to develop web-shell features that require multiple daemon instances.

The daemon HTTP server already handles this correctly — it probes for an available port starting from 4170. The Vite dev server should do the same.

## Changes

Probe for an available Vite port (starting from 5173, up to 10 attempts) before spawning the web-shell dev server, and pass it explicitly via `--port`. The console banner now prints the actual port instead of a hardcoded 5173.

## How to verify

1. Run `npm run dev:daemon` in one terminal — daemon starts on 4170, web-shell on 5173.
2. Run `npm run dev:daemon` again in a second terminal — daemon starts on 4171, web-shell on 5174.
3. Both web-shell instances are accessible and functional.