### PR TITLE
feat(autofix): direct takeover of maintainer-fork PRs

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1529,9 +1529,33 @@ jobs:
             # manual labels may race the ack job, so a takeover PR with NO
             # engage ack yet gets one here (identity-verified) — it is also
             # the round-window anchor. ic.json is re-fetched so THIS scan
-            # already counts under the fresh key.
-            if [[ "${HAS_TAKEOVER}" == "true" ]] \
-              && ! grep -q 'takeover-ack engaged' "${WORKDIR}/ic.json"; then
+            # already counts under the fresh key. Dedup is author-filtered
+            # (a forged human marker must not suppress the real ack), and a
+            # label application NEWER than the latest bot ack means a fresh
+            # engagement — post a fresh ack so the round window and cap
+            # reset as documented (re-arm), which no ack job can do for
+            # forks.
+            NEED_ENGAGE_ACK='false'
+            if [[ "${HAS_TAKEOVER}" == "true" ]]; then
+              LAST_ENGAGE_ACK_TS="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+                [.[] | select((.user.login // "") == $ab)
+                     | select(.body // "" | contains("<!-- takeover-ack engaged -->"))
+                     | .created_at] | sort | last // ""' "${WORKDIR}/ic.json")"
+              if [[ -z "${LAST_ENGAGE_ACK_TS}" ]]; then
+                NEED_ENGAGE_ACK='true'
+              else
+                gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
+                  || echo '[]' > "${WORKDIR}/pr-events.json"
+                LAST_LABELED_TS="$(jq -r --arg lb "${TAKEOVER_LABEL}" '
+                  [.[] | select(.event == "labeled")
+                       | select((.label.name // "") == $lb)
+                       | .created_at] | sort | last // ""' "${WORKDIR}/pr-events.json")"
+                if [[ -n "${LAST_LABELED_TS}" && "${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}" ]]; then
+                  NEED_ENGAGE_ACK='true'
+                fi
+              fi
+            fi
+            if [[ "${NEED_ENGAGE_ACK}" == "true" ]]; then
               if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
                 SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
               fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1513,7 +1513,7 @@ jobs:
                 echo "⚠️ #${PR}: fork head repository unresolved — skipping"
                 continue
               fi
-            fi"
+            fi
             BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_META}")"
             HAS_TAKEOVER="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_META}")"
             # The candidate snapshot filtered skip once, but this per-PR fetch
@@ -1545,7 +1545,7 @@ jobs:
               else
                 echo "::warning::engage ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}'"
               fi
-            fi"
+            fi
             if [[ -z "${BRANCH}" ]]; then
               # Metadata fetch failed (transient API error / rate limit). Skip rather
               # than fall through with an empty branch, which would make the address

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1611,15 +1611,26 @@ jobs:
                 add | [.[] | select((.user.login // "") == $ab)
                      | select(.body // "" | contains("<!-- takeover-ack engaged -->"))
                      | .created_at] | sort | last // ""' "${WORKDIR}/ic.json")"
+              gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
+                || echo '[]' > "${WORKDIR}/pr-events.json"
+              LAST_LABELED_TS="$(jq -rs --arg lb "${TAKEOVER_LABEL}" '
+                add | [.[] | select(.event == "labeled")
+                     | select((.label.name // "") == $lb)
+                     | .created_at] | sort | last // ""' "${WORKDIR}/pr-events.json")"
               if [[ -z "${LAST_ENGAGE_ACK_TS}" ]]; then
                 NEED_ENGAGE_ACK='true'
+                # In-repo label events have a DEDICATED ack job — the scan is
+                # only its healer. Within a short grace after the label lands,
+                # defer: a concurrent ack job must not be double-posted (that
+                # shifts the window anchor). A failed ack job is healed by the
+                # next scan, which is past the grace. Forks have no ack job,
+                # so no grace applies there.
+                if [[ "$(jq -r '.isCrossRepository // false' <<< "${PR_META}")" != "true" ]] \
+                  && [[ -n "${LAST_LABELED_TS}" && "${LAST_LABELED_TS}" > "$(date -u -d '3 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" ]]; then
+                  echo "🧭 engage ack deferred for #${PR}: in-repo label applied <3m ago — the ack job owns it"
+                  NEED_ENGAGE_ACK='false'
+                fi
               else
-                gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
-                  || echo '[]' > "${WORKDIR}/pr-events.json"
-                LAST_LABELED_TS="$(jq -rs --arg lb "${TAKEOVER_LABEL}" '
-                  add | [.[] | select(.event == "labeled")
-                       | select((.label.name // "") == $lb)
-                       | .created_at] | sort | last // ""' "${WORKDIR}/pr-events.json")"
                 if [[ -n "${LAST_LABELED_TS}" && "${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}" ]]; then
                   NEED_ENGAGE_ACK='true'
                 fi
@@ -1996,7 +2007,7 @@ jobs:
           # UNKNOWN and discards too (fail closed — the next scan re-emits a
           # still-valid target).
           PR_LIVE="$(gh pr view "${PR}" --repo "${REPO}" \
-            --json state,author,isCrossRepository,baseRefName,headRefName,labels,maintainerCanModify 2> /dev/null || echo '{}')"
+            --json state,author,isCrossRepository,baseRefName,headRefName,labels,maintainerCanModify,headRepositoryOwner,headRepository 2> /dev/null || echo '{}')"
           LIVE_STATE="$(jq -r '.state // ""' <<< "${PR_LIVE}")"
           LIVE_AUTHOR="$(jq -r '.author.login // ""' <<< "${PR_LIVE}")"
           LIVE_XREPO="$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_LIVE}")"
@@ -2014,6 +2025,11 @@ jobs:
           elif [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
           elif [[ "${LIVE_SKIP}" == "true" ]]; then INELIGIBLE="${SKIP_LABEL} label present"
           elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}' without ${TAKEOVER_LABEL}"
+          elif [[ "${LIVE_BASE}" != "main" ]]; then INELIGIBLE="base='${LIVE_BASE:-unknown}'"
+          elif [[ "${LIVE_BRANCH}" != "${BRANCH}" ]]; then INELIGIBLE="head branch is now '${LIVE_BRANCH:-unknown}'"
+          # Base/branch invariants sit ABOVE the fork chain: the last fork
+          # elif ends the ladder for eligible forks, so anything below it
+          # would be unreachable for exactly the PR class we fetch and push.
           elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE='fork head without takeover'
           elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_CAN_MODIFY}" != "true" ]]; then INELIGIBLE='fork head without maintainer-edit access'
           elif [[ "${LIVE_XREPO}" != "false" ]]; then
@@ -2024,8 +2040,17 @@ jobs:
               admin|maintain|write) : ;;
               *) INELIGIBLE="fork author '${LIVE_AUTHOR}' permission='${FORK_AUTHOR_PERM:-none}' below write" ;;
             esac
-          elif [[ "${LIVE_BASE}" != "main" ]]; then INELIGIBLE="base='${LIVE_BASE:-unknown}'"
-          elif [[ "${LIVE_BRANCH}" != "${BRANCH}" ]]; then INELIGIBLE="head branch is now '${LIVE_BRANCH:-unknown}'"
+            # The fetch source and token-push target must still be the LIVE
+            # head repository — a fork renamed or transferred since the scan
+            # would route both to a stale path. Fail-closed: moved or
+            # unresolved discards; the next scan re-admits the fresh path.
+            if [[ -z "${INELIGIBLE}" ]]; then
+              LIVE_HR_OWNER="$(jq -r '.headRepositoryOwner.login // ""' <<< "${PR_LIVE}")"
+              LIVE_HR_NAME="$(jq -r '.headRepository.name // ""' <<< "${PR_LIVE}")"
+              if [[ -z "${LIVE_HR_OWNER}" || -z "${LIVE_HR_NAME}" || "${LIVE_HR_OWNER}/${LIVE_HR_NAME}" != "${HEAD_REPO:-${REPO}}" ]]; then
+                INELIGIBLE="fork head repository moved or unresolved (live='${LIVE_HR_OWNER}/${LIVE_HR_NAME}' target='${HEAD_REPO:-${REPO}}')"
+              fi
+            fi
           fi
           if [[ -n "${INELIGIBLE}" ]]; then
             echo "🫥 target no longer eligible (${INELIGIBLE}) — discarding without action or marker"
@@ -2049,7 +2074,16 @@ jobs:
           if [[ "${HEAD_REPO:-${REPO}}" != "${REPO}" ]]; then
             # Maintainer-fork target: the branch does not exist on origin —
             # fetch it (data only; hooks are severed) from the fork.
-            git fetch "https://github.com/${HEAD_REPO}.git" "refs/heads/${BRANCH}"
+            if ! git fetch "https://github.com/${HEAD_REPO}.git" "refs/heads/${BRANCH}"; then
+              echo "🫥 fork fetch failed for ${HEAD_REPO} (${BRANCH}) — discarding without action or marker"
+              {
+                echo "stale=true"
+                echo "conflict=false"
+                echo "newest=${WATERMARK}"
+                echo "effective_round=${ROUND}"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
             git checkout -B "${BRANCH}" FETCH_HEAD
             # Allow-edits pushes ride the classic-PAT grant — GITHUB_TOKEN
             # and fine-grained PATs are documented as NOT receiving it.

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1225,7 +1225,7 @@ jobs:
           # FRONT — unlike the label path this job runs in issue_comment
           # context WITH secrets, so it can explain itself, and refusing here
           # keeps the label from ever sticking to a fork PR via the command.
-          if ! PR_INFO="$(gh pr view "${PR}" --repo "${REPO}" --json labels,isCrossRepository,state,baseRefName 2> /dev/null)"; then
+          if ! PR_INFO="$(gh pr view "${PR}" --repo "${REPO}" --json labels,isCrossRepository,state,baseRefName,author,maintainerCanModify 2> /dev/null)"; then
             echo "::error::could not read PR #${PR}"
             exit 1
           fi
@@ -1249,12 +1249,30 @@ jobs:
           # (org-owned forks cannot — adoption stays the path there), and
           # only write+ senders reach this job for forks (fork authors are
           # silently dropped at route). Without allow-edits, refuse with the
-          # actionable ask.
-          if [[ "$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_INFO}")" != "false" \
+          # actionable ask. Engage-side requirement only: release ('stop')
+          # is never blocked.
+          if [[ "${CMD}" == 'add' && "$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_INFO}")" != "false" \
             && "$(jq -r '.maintainerCanModify // false' <<< "${PR_INFO}")" != "true" ]]; then
             gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🚫 Takeover needs push access to this fork branch: please tick “Allow edits from maintainers” on the PR and re-run `%s`. (Org-owned forks cannot enable it — a maintainer can adopt the PR instead: snapshot the head into an in-repo branch and take that over.)\n\n<details>\n<summary>中文说明</summary>\n\n🚫 托管需要对 fork 分支的推送权限：请在 PR 上勾选 “Allow edits from maintainers” 后重新执行 `%s`。（组织账号的 fork 无法勾选 —— 维护者可改用领养：将 head 快照为本仓库分支后接管。）\n\n</details>\n\n<!-- takeover-ack fork-refused -->' "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}")"
             echo "🧭 takeover command refused: fork PR #${PR} without maintainer-edit access"
             exit 0
+          fi
+          # The fork AUTHOR must hold write+ too (the scan re-checks this on
+          # every pickup and the address job once more live): engaging a
+          # below-write fork would stick a label that nothing ever manages —
+          # a silent ghost engagement with no ack and no explanation.
+          # Engage-side only; release is never blocked.
+          if [[ "${CMD}" == 'add' && "$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_INFO}")" != "false" ]]; then
+            FORK_PR_AUTHOR="$(jq -r '.author.login // ""' <<< "${PR_INFO}")"
+            FORK_AUTHOR_PERM="$(gh api "repos/${REPO}/collaborators/${FORK_PR_AUTHOR}/permission" --jq '.permission // ""' 2> /dev/null || echo '')"
+            case "${FORK_AUTHOR_PERM}" in
+              admin|maintain|write) : ;;
+              *)
+                gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🚫 Takeover not engaged: fork takeover requires the PR author to hold write access on this repository (author `%s` currently: `%s`). A maintainer can adopt the PR instead: snapshot the head into an in-repo branch, open a new PR (commit authorship is preserved), and take that over.\n\n<details>\n<summary>中文说明</summary>\n\n🚫 未接管：fork 托管要求 PR 作者在本仓库持有 write 及以上权限（作者 `%s` 当前为：`%s`）。维护者可改用领养：将 head 快照为本仓库分支并另开 PR（commit 署名保留），再对新 PR 执行接管。\n\n</details>\n\n<!-- takeover-ack fork-refused -->' "${FORK_PR_AUTHOR}" "${FORK_AUTHOR_PERM:-none}" "${FORK_PR_AUTHOR}" "${FORK_AUTHOR_PERM:-none}")"
+                echo "🧭 takeover command refused: fork PR #${PR} author '${FORK_PR_AUTHOR}' permission='${FORK_AUTHOR_PERM:-none}' below write"
+                exit 0
+                ;;
+            esac
           fi
           HAS="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[].name] | index($t) != null' <<< "${PR_INFO}")"
           if [[ "${CMD}" == 'add' ]]; then
@@ -1389,7 +1407,7 @@ jobs:
                  and (.isCrossRepository == false)
                  and ((.baseRefName // "") == "main"))' <<< "${META}")"
             if [[ "${OK}" != "true" ]]; then
-              echo "❌ #${FORCED_PR} is not an open in-repo main-targeting PR owned by ${AUTOFIX_BOT} or labeled ${TAKEOVER_LABEL} (or it carries ${SKIP_LABEL})"
+              echo "❌ #${FORCED_PR} is not an open in-repo main-targeting PR owned by ${AUTOFIX_BOT} or labeled ${TAKEOVER_LABEL} (or it carries ${SKIP_LABEL}); fork takeover PRs are engaged by the scheduled scan, not manual dispatch"
               echo "targets=[]" >> "${GITHUB_OUTPUT}"
               echo "has_targets=false" >> "${GITHUB_OUTPUT}"
               exit 0
@@ -1425,6 +1443,9 @@ jobs:
             # hold write+ RIGHT NOW (the same live-privilege rule as the
             # comment command) and the PR must allow maintainer edits (or
             # the bot cannot push). Rare set — one permission call each.
+            # Appended after the rotated in-repo list: forks sit outside the
+            # anti-starvation rotation, which only bites once in-repo
+            # candidates alone exhaust the inspection budget.
             while IFS=$'\t' read -r FPR FAUTHOR; do
               [[ -z "${FPR}" ]] && continue
               FPERM="$(gh api "repos/${REPO}/collaborators/${FAUTHOR}/permission" --jq '.permission // ""' 2> /dev/null || echo '')"
@@ -1508,11 +1529,15 @@ jobs:
               --json headRefName,statusCheckRollup,createdAt,labels,isCrossRepository,headRepositoryOwner,headRepository 2> /dev/null || echo '{}')"
             HEAD_REPO_FULL="${REPO}"
             if [[ "$(jq -r '.isCrossRepository // false' <<< "${PR_META}")" == "true" ]]; then
-              HEAD_REPO_FULL="$(jq -r '(.headRepositoryOwner.login // "") + "/" + (.headRepository.name // "")' <<< "${PR_META}")"
-              if [[ "${HEAD_REPO_FULL}" == "/" ]]; then
-                echo "⚠️ #${PR}: fork head repository unresolved — skipping"
+              HR_OWNER="$(jq -r '.headRepositoryOwner.login // ""' <<< "${PR_META}")"
+              HR_NAME="$(jq -r '.headRepository.name // ""' <<< "${PR_META}")"
+              # Component-wise: a deleted fork yields owner XOR name empty,
+              # which a joined '/' test would wave through into a red fetch.
+              if [[ -z "${HR_OWNER}" || -z "${HR_NAME}" ]]; then
+                echo "⚠️ #${PR}: fork head repository unresolved (owner='${HR_OWNER}' name='${HR_NAME}') — skipping"
                 continue
               fi
+              HEAD_REPO_FULL="${HR_OWNER}/${HR_NAME}"
             fi
             BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_META}")"
             HAS_TAKEOVER="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_META}")"
@@ -1525,51 +1550,6 @@ jobs:
             fi
             EFF_MAX_ROUNDS="${MAX_ROUNDS}"
             [[ "${HAS_TAKEOVER}" == "true" ]] && EFF_MAX_ROUNDS="${TAKEOVER_MAX_ROUNDS}"
-            # First-pickup engage ack: fork label events carry no secrets and
-            # manual labels may race the ack job, so a takeover PR with NO
-            # engage ack yet gets one here (identity-verified) — it is also
-            # the round-window anchor. ic.json is re-fetched so THIS scan
-            # already counts under the fresh key. Dedup is author-filtered
-            # (a forged human marker must not suppress the real ack), and a
-            # label application NEWER than the latest bot ack means a fresh
-            # engagement — post a fresh ack so the round window and cap
-            # reset as documented (re-arm), which no ack job can do for
-            # forks.
-            NEED_ENGAGE_ACK='false'
-            if [[ "${HAS_TAKEOVER}" == "true" ]]; then
-              LAST_ENGAGE_ACK_TS="$(jq -r --arg ab "${AUTOFIX_BOT}" '
-                [.[] | select((.user.login // "") == $ab)
-                     | select(.body // "" | contains("<!-- takeover-ack engaged -->"))
-                     | .created_at] | sort | last // ""' "${WORKDIR}/ic.json")"
-              if [[ -z "${LAST_ENGAGE_ACK_TS}" ]]; then
-                NEED_ENGAGE_ACK='true'
-              else
-                gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
-                  || echo '[]' > "${WORKDIR}/pr-events.json"
-                LAST_LABELED_TS="$(jq -r --arg lb "${TAKEOVER_LABEL}" '
-                  [.[] | select(.event == "labeled")
-                       | select((.label.name // "") == $lb)
-                       | .created_at] | sort | last // ""' "${WORKDIR}/pr-events.json")"
-                if [[ -n "${LAST_LABELED_TS}" && "${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}" ]]; then
-                  NEED_ENGAGE_ACK='true'
-                fi
-              fi
-            fi
-            if [[ "${NEED_ENGAGE_ACK}" == "true" ]]; then
-              if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
-                SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
-              fi
-              if [[ "${SCAN_BOT_ACTOR}" == "${AUTOFIX_BOT}" ]]; then
-                if gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"; then
-                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json" \
-                    || echo "::warning::ic re-fetch after engage ack failed for #${PR}"
-                else
-                  echo "::warning::first-pickup engage ack failed for #${PR}; window anchors on a later scan"
-                fi
-              else
-                echo "::warning::engage ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}'"
-              fi
-            fi
             if [[ -z "${BRANCH}" ]]; then
               # Metadata fetch failed (transient API error / rate limit). Skip rather
               # than fall through with an empty branch, which would make the address
@@ -1611,6 +1591,59 @@ jobs:
             CREATED_WM="$(jq -r '.createdAt // ""' <<< "${PR_META}")"
 
             gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"
+            # First-pickup engage ack: fork label events carry no secrets and
+            # manual labels may race the ack job, so a takeover PR with NO
+            # engage ack yet gets one here (identity-verified) — it is also
+            # the round-window anchor. ic.json is re-fetched so THIS scan
+            # already counts under the fresh key. ORDERING IS LOAD-BEARING:
+            # ic.json for THIS candidate is fetched just above — reading a
+            # previous candidate's file would mis-dedup (spurious re-ack →
+            # window reset every scan), and a missing file would kill the
+            # whole scan step under -eo pipefail. Dedup is author-filtered
+            # (a forged human marker must not suppress the real ack), and a
+            # label application NEWER than the latest bot ack means a fresh
+            # engagement — post a fresh ack so the round window and cap
+            # reset as documented (re-arm), which no ack job can do for
+            # forks.
+            NEED_ENGAGE_ACK='false'
+            if [[ "${HAS_TAKEOVER}" == "true" ]]; then
+              LAST_ENGAGE_ACK_TS="$(jq -rs --arg ab "${AUTOFIX_BOT}" '
+                add | [.[] | select((.user.login // "") == $ab)
+                     | select(.body // "" | contains("<!-- takeover-ack engaged -->"))
+                     | .created_at] | sort | last // ""' "${WORKDIR}/ic.json")"
+              if [[ -z "${LAST_ENGAGE_ACK_TS}" ]]; then
+                NEED_ENGAGE_ACK='true'
+              else
+                gh api "repos/${REPO}/issues/${PR}/events" --paginate > "${WORKDIR}/pr-events.json" 2> /dev/null \
+                  || echo '[]' > "${WORKDIR}/pr-events.json"
+                LAST_LABELED_TS="$(jq -rs --arg lb "${TAKEOVER_LABEL}" '
+                  add | [.[] | select(.event == "labeled")
+                       | select((.label.name // "") == $lb)
+                       | .created_at] | sort | last // ""' "${WORKDIR}/pr-events.json")"
+                if [[ -n "${LAST_LABELED_TS}" && "${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}" ]]; then
+                  NEED_ENGAGE_ACK='true'
+                fi
+              fi
+            fi
+            if [[ "${NEED_ENGAGE_ACK}" == "true" && "${DRY_RUN}" == "true" ]]; then
+              echo "🧪 DRY-RUN: would post engage ack on #${PR} (window key untouched)"
+              NEED_ENGAGE_ACK='false'
+            fi
+            if [[ "${NEED_ENGAGE_ACK}" == "true" ]]; then
+              if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
+                SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
+              fi
+              if [[ "${SCAN_BOT_ACTOR}" == "${AUTOFIX_BOT}" ]]; then
+                if gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"; then
+                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json" \
+                    || echo "::warning::ic re-fetch after engage ack failed for #${PR}"
+                else
+                  echo "::warning::first-pickup engage ack failed for #${PR}; window anchors on a later scan"
+                fi
+              else
+                echo "::warning::engage ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}'"
+              fi
+            fi
             # Eval markers the bot left after a previous evaluation carry the
             # newest feedback timestamp it already considered, plus the round.
             # Only our own comments are trusted, so a spoofed marker is ignored.
@@ -2016,8 +2049,22 @@ jobs:
           if [[ "${HEAD_REPO:-${REPO}}" != "${REPO}" ]]; then
             # Maintainer-fork target: the branch does not exist on origin —
             # fetch it (data only; hooks are severed) from the fork.
-            git fetch "https://github.com/${HEAD_REPO}.git" "${BRANCH}"
+            git fetch "https://github.com/${HEAD_REPO}.git" "refs/heads/${BRANCH}"
             git checkout -B "${BRANCH}" FETCH_HEAD
+            # Allow-edits pushes ride the classic-PAT grant — GITHUB_TOKEN
+            # and fine-grained PATs are documented as NOT receiving it.
+            # Prove push access NOW, before an agent round is spent, instead
+            # of 403ing at the report step after the work is done.
+            if ! git push --no-verify --dry-run "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}" > /dev/null 2>&1; then
+              echo "🫥 fork push preflight failed for ${HEAD_REPO} (allow-edits grant or PAT type) — discarding without action or marker"
+              {
+                echo "stale=true"
+                echo "conflict=false"
+                echo "newest=${WATERMARK}"
+                echo "effective_round=${ROUND}"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
           else
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -12,7 +12,12 @@ name: 'Qwen Autofix'
 #   • issues:labeled        → issue phase when ready label, state, and sender match
 #   • pull_request_review   → review phase for submitted feedback on bot PRs
 #   • pull_request:labeled  → maintainer applies autofix/takeover → the loop
-#                             manages that PR (human-authored included);
+#                             manages that PR (human-authored included, and
+#                             maintainer FORKS too: the fork's author must
+#                             hold write+ live and the PR must allow
+#                             maintainer edits — the bot then fetches/pushes
+#                             the fork branch directly; org-owned forks
+#                             cannot enable allow-edits → adoption instead);
 #                             unlabeled releases it. autofix/skip opts any PR
 #                             out everywhere and wins over takeover. Labels
 #                             need GitHub triage+, so the permission gate is
@@ -382,9 +387,13 @@ jobs:
                   echo "🧭 pull_request ${EVENT_ACTION} ignored: label '${ISSUE_LABEL:-n/a}' is not ${TAKEOVER_LABEL}"
                 elif [[ "${EVENT_ACTION}" == 'labeled' ]]; then
                   if [[ "${PR_HEAD_REPO}" != "${REPO}" ]]; then
-                    # Fork pull_request events carry no secrets — we cannot
-                    # even post a rejection comment. Log and stop.
-                    echo "🧭 takeover ignored: PR is a fork (${PR_HEAD_REPO} != ${REPO})"
+                    # Fork pull_request events carry NO secrets, so neither
+                    # the immediate scan nor the ack job can run from this
+                    # event. The label still counts: the next scheduled scan
+                    # (repo context, ≤10m) admits fork takeover PRs whose
+                    # author holds write+ and whose PR allows maintainer
+                    # edits, and posts the engage ack on first pickup.
+                    echo "🧭 fork takeover noted for #${PR_NUMBER_EVENT} — the next scheduled scan engages (author write+ and allow-edits required)"
                   elif [[ "${PR_STATE}" != 'open' ]]; then
                     echo "🧭 takeover ignored: PR state '${PR_STATE:-unknown}' is not open"
                   elif [[ "${PR_BASE_REF}" != 'main' ]]; then
@@ -1235,9 +1244,16 @@ jobs:
             echo "🧭 takeover command refused: ${SKIP_LABEL} present on #${PR}"
             exit 0
           fi
-          if [[ "$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_INFO}")" != "false" ]]; then
-            gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🚫 Takeover is not available for fork-based PRs. A maintainer can adopt this PR instead: snapshot the head into an in-repo branch, open a new PR (commit authorship is preserved), and take that over.\n\n<details>\n<summary>中文说明</summary>\n\n🚫 fork PR 暂不支持托管。维护者可改用领养方式：将 head 快照为本仓库分支并另开 PR（commit 署名保留），再对新 PR 执行接管。\n\n</details>\n\n<!-- takeover-ack fork-refused -->')"
-            echo "🧭 takeover command refused: PR #${PR} is a fork"
+          # Fork PRs are manageable when the bot can actually push: the
+          # author must have granted 'Allow edits from maintainers'
+          # (org-owned forks cannot — adoption stays the path there), and
+          # only write+ senders reach this job for forks (fork authors are
+          # silently dropped at route). Without allow-edits, refuse with the
+          # actionable ask.
+          if [[ "$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_INFO}")" != "false" \
+            && "$(jq -r '.maintainerCanModify // false' <<< "${PR_INFO}")" != "true" ]]; then
+            gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🚫 Takeover needs push access to this fork branch: please tick “Allow edits from maintainers” on the PR and re-run `%s`. (Org-owned forks cannot enable it — a maintainer can adopt the PR instead: snapshot the head into an in-repo branch and take that over.)\n\n<details>\n<summary>中文说明</summary>\n\n🚫 托管需要对 fork 分支的推送权限：请在 PR 上勾选 “Allow edits from maintainers” 后重新执行 `%s`。（组织账号的 fork 无法勾选 —— 维护者可改用领养：将 head 快照为本仓库分支后接管。）\n\n</details>\n\n<!-- takeover-ack fork-refused -->' "${TAKEOVER_COMMAND}" "${TAKEOVER_COMMAND}")"
+            echo "🧭 takeover command refused: fork PR #${PR} without maintainer-edit access"
             exit 0
           fi
           HAS="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[].name] | index($t) != null' <<< "${PR_INFO}")"
@@ -1385,7 +1401,7 @@ jobs:
               --limit 100 --json number,headRefName,isCrossRepository,labels > "${WORKDIR}/bot-prs.json"
             gh pr list --repo "${REPO}" --state open --label "${TAKEOVER_LABEL}" \
               --base main \
-              --limit 100 --json number,headRefName,isCrossRepository,labels > "${WORKDIR}/takeover-prs.json"
+              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify > "${WORKDIR}/takeover-prs.json"
             # Skip-labeled PRs are excluded HERE, not only at the address
             # gate: that gate discards without writing a marker, so the
             # watermark never advances and an unfiltered scan would re-emit
@@ -1405,6 +1421,28 @@ jobs:
                | .[]
                | .number' \
               "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json")"
+            # FORK takeover PRs are admitted per candidate: the author must
+            # hold write+ RIGHT NOW (the same live-privilege rule as the
+            # comment command) and the PR must allow maintainer edits (or
+            # the bot cannot push). Rare set — one permission call each.
+            while IFS=$'\t' read -r FPR FAUTHOR; do
+              [[ -z "${FPR}" ]] && continue
+              FPERM="$(gh api "repos/${REPO}/collaborators/${FAUTHOR}/permission" --jq '.permission // ""' 2> /dev/null || echo '')"
+              case "${FPERM}" in
+                admin|maintain|write)
+                  echo "🌿 fork takeover candidate #${FPR} admitted (author ${FAUTHOR}=${FPERM})"
+                  CANDIDATES="${CANDIDATES} ${FPR}"
+                  ;;
+                *)
+                  echo "🧭 fork takeover candidate #${FPR} skipped: author ${FAUTHOR} permission='${FPERM:-none}' below write"
+                  ;;
+              esac
+            done < <(jq -r --arg skip "${SKIP_LABEL}" '
+              .[] | select(.isCrossRepository == true)
+                  | select(.maintainerCanModify == true)
+                  | select([.labels[]?.name] | index($skip) | not)
+                  | [(.number | tostring), (.author.login // "")] | @tsv' \
+              "${WORKDIR}/takeover-prs.json")
           fi
 
           # Pending-check staleness bound (invariant across candidate PRs, computed
@@ -1467,7 +1505,15 @@ jobs:
             # (the watermark floor below), and labels (the effective round
             # cap) — avoids extra round-trips per candidate PR.
             PR_META="$(gh pr view "${PR}" --repo "${REPO}" \
-              --json headRefName,statusCheckRollup,createdAt,labels 2> /dev/null || echo '{}')"
+              --json headRefName,statusCheckRollup,createdAt,labels,isCrossRepository,headRepositoryOwner,headRepository 2> /dev/null || echo '{}')"
+            HEAD_REPO_FULL="${REPO}"
+            if [[ "$(jq -r '.isCrossRepository // false' <<< "${PR_META}")" == "true" ]]; then
+              HEAD_REPO_FULL="$(jq -r '(.headRepositoryOwner.login // "") + "/" + (.headRepository.name // "")' <<< "${PR_META}")"
+              if [[ "${HEAD_REPO_FULL}" == "/" ]]; then
+                echo "⚠️ #${PR}: fork head repository unresolved — skipping"
+                continue
+              fi
+            fi"
             BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_META}")"
             HAS_TAKEOVER="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_META}")"
             # The candidate snapshot filtered skip once, but this per-PR fetch
@@ -1479,6 +1525,27 @@ jobs:
             fi
             EFF_MAX_ROUNDS="${MAX_ROUNDS}"
             [[ "${HAS_TAKEOVER}" == "true" ]] && EFF_MAX_ROUNDS="${TAKEOVER_MAX_ROUNDS}"
+            # First-pickup engage ack: fork label events carry no secrets and
+            # manual labels may race the ack job, so a takeover PR with NO
+            # engage ack yet gets one here (identity-verified) — it is also
+            # the round-window anchor. ic.json is re-fetched so THIS scan
+            # already counts under the fresh key.
+            if [[ "${HAS_TAKEOVER}" == "true" ]] \
+              && ! grep -q 'takeover-ack engaged' "${WORKDIR}/ic.json"; then
+              if [[ -z "${SCAN_BOT_ACTOR:-}" ]]; then
+                SCAN_BOT_ACTOR="$(gh api user --jq '.login' 2> /dev/null || echo 'unknown')"
+              fi
+              if [[ "${SCAN_BOT_ACTOR}" == "${AUTOFIX_BOT}" ]]; then
+                if gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"; then
+                  gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json" \
+                    || echo "::warning::ic re-fetch after engage ack failed for #${PR}"
+                else
+                  echo "::warning::first-pickup engage ack failed for #${PR}; window anchors on a later scan"
+                fi
+              else
+                echo "::warning::engage ack skipped: PAT authenticates as '${SCAN_BOT_ACTOR}'"
+              fi
+            fi"
             if [[ -z "${BRANCH}" ]]; then
               # Metadata fetch failed (transient API error / rate limit). Skip rather
               # than fall through with an empty branch, which would make the address
@@ -1685,8 +1752,8 @@ jobs:
             TARGETS="$(jq -c \
               --arg pr "${PR}" --arg branch "${BRANCH}" --arg issue "${ISSUE}" \
               --arg round "${ROUND}" --arg wm "${EFF_WM}" --arg mr "${EFF_MAX_ROUNDS}" \
-              --arg win "${REARM_KEY}" \
-              '. + [{pr: $pr, branch: $branch, issue: $issue, round: $round, watermark: $wm, max_rounds: $mr, win: $win}]' \
+              --arg win "${REARM_KEY}" --arg hr "${HEAD_REPO_FULL}" \
+              '. + [{pr: $pr, branch: $branch, issue: $issue, round: $round, watermark: $wm, max_rounds: $mr, win: $win, head_repo: $hr}]' \
               <<< "${TARGETS}")"
             # Fan out: emit EVERY eligible PR up to the per-scan budget. The
             # address matrix bounds simultaneity (max-parallel) and the per-PR
@@ -1747,6 +1814,10 @@ jobs:
       # marker this job writes records it, and prepare discards the job if a
       # re-arm superseded the key while it sat queued.
       WINDOW: '${{ matrix.target.win }}'
+      # owner/name of the PR's HEAD repository — equals REPO for in-repo
+      # branches; a fork for maintainer-fork takeover targets (pushable via
+      # 'Allow edits from maintainers').
+      HEAD_REPO: '${{ matrix.target.head_repo }}'
     steps:
       # SECURITY: checkout trusted base code first. The PR branch is checked
       # out later in "Prepare branch and feedback" after the trusted CLI bundle
@@ -1868,10 +1939,11 @@ jobs:
           # UNKNOWN and discards too (fail closed — the next scan re-emits a
           # still-valid target).
           PR_LIVE="$(gh pr view "${PR}" --repo "${REPO}" \
-            --json state,author,isCrossRepository,baseRefName,headRefName,labels 2> /dev/null || echo '{}')"
+            --json state,author,isCrossRepository,baseRefName,headRefName,labels,maintainerCanModify 2> /dev/null || echo '{}')"
           LIVE_STATE="$(jq -r '.state // ""' <<< "${PR_LIVE}")"
           LIVE_AUTHOR="$(jq -r '.author.login // ""' <<< "${PR_LIVE}")"
           LIVE_XREPO="$(jq -r 'if has("isCrossRepository") then .isCrossRepository else true end' <<< "${PR_LIVE}")"
+          LIVE_CAN_MODIFY="$(jq -r '.maintainerCanModify // false' <<< "${PR_LIVE}")"
           LIVE_BASE="$(jq -r '.baseRefName // ""' <<< "${PR_LIVE}")"
           LIVE_BRANCH="$(jq -r '.headRefName // ""' <<< "${PR_LIVE}")"
           # Engagement labels are re-read LIVE too: a takeover label grants a
@@ -1885,7 +1957,16 @@ jobs:
           elif [[ "${LIVE_STATE}" != "OPEN" ]]; then INELIGIBLE="state='${LIVE_STATE:-unknown}'"
           elif [[ "${LIVE_SKIP}" == "true" ]]; then INELIGIBLE="${SKIP_LABEL} label present"
           elif [[ "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE="author='${LIVE_AUTHOR:-unknown}' without ${TAKEOVER_LABEL}"
-          elif [[ "${LIVE_XREPO}" != "false" ]]; then INELIGIBLE='fork head'
+          elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE='fork head without takeover'
+          elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_CAN_MODIFY}" != "true" ]]; then INELIGIBLE='fork head without maintainer-edit access'
+          elif [[ "${LIVE_XREPO}" != "false" ]]; then
+            # Live author-privilege re-check for fork targets: an author who
+            # lost write+ since the scan must not get a secret-bearing run.
+            FORK_AUTHOR_PERM="$(gh api "repos/${REPO}/collaborators/${LIVE_AUTHOR}/permission" --jq '.permission // ""' 2> /dev/null || echo '')"
+            case "${FORK_AUTHOR_PERM}" in
+              admin|maintain|write) : ;;
+              *) INELIGIBLE="fork author '${LIVE_AUTHOR}' permission='${FORK_AUTHOR_PERM:-none}' below write" ;;
+            esac
           elif [[ "${LIVE_BASE}" != "main" ]]; then INELIGIBLE="base='${LIVE_BASE:-unknown}'"
           elif [[ "${LIVE_BRANCH}" != "${BRANCH}" ]]; then INELIGIBLE="head branch is now '${LIVE_BRANCH:-unknown}'"
           fi
@@ -1908,7 +1989,14 @@ jobs:
           # agent step (no PAT, sandboxed tools) re-points hooksPath at
           # .husky itself so ITS commits still get checked.
           git config core.hooksPath /dev/null
-          git checkout -B "${BRANCH}" "origin/${BRANCH}"
+          if [[ "${HEAD_REPO:-${REPO}}" != "${REPO}" ]]; then
+            # Maintainer-fork target: the branch does not exist on origin —
+            # fetch it (data only; hooks are severed) from the fork.
+            git fetch "https://github.com/${HEAD_REPO}.git" "${BRANCH}"
+            git checkout -B "${BRANCH}" FETCH_HEAD
+          else
+            git checkout -B "${BRANCH}" "origin/${BRANCH}"
+          fi
 
           # Does the branch conflict with base? merge-tree computes the merge
           # without touching the tree; exit 1 means conflicts. UNKNOWN/errors are
@@ -2338,7 +2426,14 @@ jobs:
             # commits get checked). A pre-push hook would execute that code
             # with the PAT in env — sever hooks entirely before pushing.
             git config core.hooksPath /dev/null
-            git push --no-verify origin "${BRANCH}"
+            if [[ "${HEAD_REPO:-${REPO}}" != "${REPO}" ]]; then
+              # Push back to the FORK branch via allow-edits (PAT has push
+              # rights on the upstream, which GitHub extends to the fork's
+              # PR branch when the author ticked the box).
+              git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"
+            else
+              git push --no-verify origin "${BRANCH}"
+            fi
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on:"
               echo

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -112,6 +112,10 @@ export default defineConfig({
     },
   },
   test: {
+    // See packages/core/vitest.config.ts: raise the per-test ceiling above
+    // vitest's 5s default so I/O-bound tests (e.g. the workspace registration
+    // store's tempdir round-trip) don't blow it purely under CI contention.
+    testTimeout: 15000,
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', 'config.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'jsdom',

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -2075,9 +2075,14 @@ describe('git extension helpers', () => {
     }
 
     async function waitForFileData(filePath: string): Promise<void> {
-      for (let attempt = 0; attempt < 1_000; attempt += 1) {
+      // Poll on a real wall-clock budget (~10s), not a fixed iteration count:
+      // setImmediate turns are sub-millisecond, so 1_000 of them could elapse
+      // in <100ms while the tar extraction I/O is still catching up on a
+      // contended runner — the source of the "Timed out waiting for extracted
+      // data" flake. Stays well under the 15s per-test ceiling.
+      for (let attempt = 0; attempt < 2_000; attempt += 1) {
         if ((await getFileSize(filePath)) > 0) return;
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setTimeout(resolve, 5));
       }
       throw new Error(`Timed out waiting for extracted data at ${filePath}`);
     }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Raise the per-test ceiling above vitest's 5s default: the self-hosted
+    // CI runners are heavily oversubscribed (maxThreads: 16 below), and I/O-
+    // or WASM-load-bound tests (e.g. the web-tree-sitter lazy runtime, tar
+    // extraction) blow 5s purely under contention, not from any logic fault.
+    // Assertions still fail instantly; only the timeout ceiling grows.
+    testTimeout: 15000,
     reporters: ['default', 'junit'],
     silent: true,
     setupFiles: ['./test-setup.ts'],

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1080,6 +1080,84 @@ describe('qwen-autofix workflow', () => {
     // under the fresh key.
     expect(reviewScanJob).toContain('takeover-ack engaged');
     expect(reviewScanJob).toContain('ic re-fetch after engage ack failed');
+    // Ack dedup is author-filtered (a forged human marker must not suppress
+    // the real ack) and re-armable: a takeover-label application newer than
+    // the latest bot ack posts a fresh ack, resetting the round window.
+    const ackTsProgram = reviewScanJob
+      .match(
+        /LAST_ENGAGE_ACK_TS="\$\(jq -r --arg ab "\$\{AUTOFIX_BOT\}" '([\s\S]*?)' "\$\{WORKDIR\}\/ic\.json"\)"/,
+      )?.[1]
+      ?.replace(/\n {16}/g, '\n');
+    expect(ackTsProgram).toBeTruthy();
+    const ackTs = execFileSync(
+      'jq',
+      ['-r', '--arg', 'ab', 'bot', ackTsProgram],
+      {
+        encoding: 'utf8',
+        input: JSON.stringify([
+          {
+            user: { login: 'bot' },
+            body: 'x <!-- takeover-ack engaged -->',
+            created_at: '2026-07-01T00:00:00Z',
+          },
+          {
+            user: { login: 'mallory' },
+            body: 'fake <!-- takeover-ack engaged -->',
+            created_at: '2026-07-05T00:00:00Z',
+          },
+          {
+            user: { login: 'bot' },
+            body: 'y <!-- takeover-ack engaged -->',
+            created_at: '2026-07-03T00:00:00Z',
+          },
+          {
+            user: { login: 'bot' },
+            body: 'released <!-- takeover-ack released -->',
+            created_at: '2026-07-04T00:00:00Z',
+          },
+        ]),
+      },
+    ).trim();
+    expect(ackTs).toBe('2026-07-03T00:00:00Z');
+    const labeledTsProgram = reviewScanJob
+      .match(
+        /LAST_LABELED_TS="\$\(jq -r --arg lb "\$\{TAKEOVER_LABEL\}" '([\s\S]*?)' "\$\{WORKDIR\}\/pr-events\.json"\)"/,
+      )?.[1]
+      ?.replace(/\n {18}/g, '\n');
+    expect(labeledTsProgram).toBeTruthy();
+    const labeledTs = execFileSync(
+      'jq',
+      ['-r', '--arg', 'lb', 'autofix/takeover', labeledTsProgram],
+      {
+        encoding: 'utf8',
+        input: JSON.stringify([
+          {
+            event: 'labeled',
+            label: { name: 'autofix/takeover' },
+            created_at: '2026-07-02T00:00:00Z',
+          },
+          {
+            event: 'labeled',
+            label: { name: 'other' },
+            created_at: '2026-07-09T00:00:00Z',
+          },
+          {
+            event: 'unlabeled',
+            label: { name: 'autofix/takeover' },
+            created_at: '2026-07-08T00:00:00Z',
+          },
+          {
+            event: 'labeled',
+            label: { name: 'autofix/takeover' },
+            created_at: '2026-07-06T00:00:00Z',
+          },
+        ]),
+      },
+    ).trim();
+    expect(labeledTs).toBe('2026-07-06T00:00:00Z');
+    expect(reviewScanJob).toContain(
+      '"${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}"',
+    );
     // The producers must actually REQUEST labels — the jq consumers above
     // stay green on handcrafted fixtures even if a future edit drops the
     // field and skip/takeover filtering silently dies in production.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -902,7 +902,7 @@ describe('qwen-autofix workflow', () => {
     const ackBodies = workflow.match(
       /printf '[^']*takeover-(?:ack|cap)[^']*'/g,
     );
-    expect(ackBodies).toHaveLength(10);
+    expect(ackBodies).toHaveLength(11);
     for (const body of ackBodies) {
       expect(body).toContain('<summary>中文说明</summary>');
     }
@@ -1069,13 +1069,20 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain("HEAD_REPO: '${{ matrix.target.head_repo }}'");
     expect(reviewScanJob).toContain('head_repo: $hr');
     expect(workflow).toContain(
-      'git fetch "https://github.com/${HEAD_REPO}.git" "${BRANCH}"',
+      'git fetch "https://github.com/${HEAD_REPO}.git" "refs/heads/${BRANCH}"',
     );
     expect(workflow).toContain(
       'git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"',
     );
+    // The allow-edits grant rides the classic-PAT path only — prepare must
+    // prove push access BEFORE an agent round is spent, discarding
+    // gracefully instead of 403ing at the report step.
+    expect(workflow).toContain(
+      'git push --no-verify --dry-run "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"',
+    );
+    expect(workflow).toContain('fork push preflight failed');
     // First-pickup engage ack anchors the window when the label path could
-    // not (fork events carry no secrets), deduped on any existing ack,
+    // not (fork events carry no secrets), author-filtered-deduped,
     // identity-verified, with ic.json re-fetched so the same scan counts
     // under the fresh key.
     expect(reviewScanJob).toContain('takeover-ack engaged');
@@ -1085,78 +1092,100 @@ describe('qwen-autofix workflow', () => {
     // the latest bot ack posts a fresh ack, resetting the round window.
     const ackTsProgram = reviewScanJob
       .match(
-        /LAST_ENGAGE_ACK_TS="\$\(jq -r --arg ab "\$\{AUTOFIX_BOT\}" '([\s\S]*?)' "\$\{WORKDIR\}\/ic\.json"\)"/,
+        /LAST_ENGAGE_ACK_TS="\$\(jq -rs --arg ab "\$\{AUTOFIX_BOT\}" '([\s\S]*?)' "\$\{WORKDIR\}\/ic\.json"\)"/,
       )?.[1]
       ?.replace(/\n {16}/g, '\n');
     expect(ackTsProgram).toBeTruthy();
+    // Two concatenated page-documents, the true latest in page 2 — proves
+    // the slurp handles gh api --paginate output past 100 comments.
     const ackTs = execFileSync(
       'jq',
-      ['-r', '--arg', 'ab', 'bot', ackTsProgram],
+      ['-rs', '--arg', 'ab', 'bot', ackTsProgram],
       {
         encoding: 'utf8',
-        input: JSON.stringify([
-          {
-            user: { login: 'bot' },
-            body: 'x <!-- takeover-ack engaged -->',
-            created_at: '2026-07-01T00:00:00Z',
-          },
-          {
-            user: { login: 'mallory' },
-            body: 'fake <!-- takeover-ack engaged -->',
-            created_at: '2026-07-05T00:00:00Z',
-          },
-          {
-            user: { login: 'bot' },
-            body: 'y <!-- takeover-ack engaged -->',
-            created_at: '2026-07-03T00:00:00Z',
-          },
-          {
-            user: { login: 'bot' },
-            body: 'released <!-- takeover-ack released -->',
-            created_at: '2026-07-04T00:00:00Z',
-          },
-        ]),
+        input:
+          JSON.stringify([
+            {
+              user: { login: 'bot' },
+              body: 'x <!-- takeover-ack engaged -->',
+              created_at: '2026-07-01T00:00:00Z',
+            },
+            {
+              user: { login: 'mallory' },
+              body: 'fake <!-- takeover-ack engaged -->',
+              created_at: '2026-07-05T00:00:00Z',
+            },
+          ]) +
+          JSON.stringify([
+            {
+              user: { login: 'bot' },
+              body: 'y <!-- takeover-ack engaged -->',
+              created_at: '2026-07-03T00:00:00Z',
+            },
+            {
+              user: { login: 'bot' },
+              body: 'released <!-- takeover-ack released -->',
+              created_at: '2026-07-04T00:00:00Z',
+            },
+          ]),
       },
     ).trim();
     expect(ackTs).toBe('2026-07-03T00:00:00Z');
     const labeledTsProgram = reviewScanJob
       .match(
-        /LAST_LABELED_TS="\$\(jq -r --arg lb "\$\{TAKEOVER_LABEL\}" '([\s\S]*?)' "\$\{WORKDIR\}\/pr-events\.json"\)"/,
+        /LAST_LABELED_TS="\$\(jq -rs --arg lb "\$\{TAKEOVER_LABEL\}" '([\s\S]*?)' "\$\{WORKDIR\}\/pr-events\.json"\)"/,
       )?.[1]
       ?.replace(/\n {18}/g, '\n');
     expect(labeledTsProgram).toBeTruthy();
     const labeledTs = execFileSync(
       'jq',
-      ['-r', '--arg', 'lb', 'autofix/takeover', labeledTsProgram],
+      ['-rs', '--arg', 'lb', 'autofix/takeover', labeledTsProgram],
       {
         encoding: 'utf8',
-        input: JSON.stringify([
-          {
-            event: 'labeled',
-            label: { name: 'autofix/takeover' },
-            created_at: '2026-07-02T00:00:00Z',
-          },
-          {
-            event: 'labeled',
-            label: { name: 'other' },
-            created_at: '2026-07-09T00:00:00Z',
-          },
-          {
-            event: 'unlabeled',
-            label: { name: 'autofix/takeover' },
-            created_at: '2026-07-08T00:00:00Z',
-          },
-          {
-            event: 'labeled',
-            label: { name: 'autofix/takeover' },
-            created_at: '2026-07-06T00:00:00Z',
-          },
-        ]),
+        input:
+          JSON.stringify([
+            {
+              event: 'labeled',
+              label: { name: 'autofix/takeover' },
+              created_at: '2026-07-02T00:00:00Z',
+            },
+            {
+              event: 'labeled',
+              label: { name: 'other' },
+              created_at: '2026-07-09T00:00:00Z',
+            },
+          ]) +
+          JSON.stringify([
+            {
+              event: 'unlabeled',
+              label: { name: 'autofix/takeover' },
+              created_at: '2026-07-08T00:00:00Z',
+            },
+            {
+              event: 'labeled',
+              label: { name: 'autofix/takeover' },
+              created_at: '2026-07-06T00:00:00Z',
+            },
+          ]),
       },
     ).trim();
     expect(labeledTs).toBe('2026-07-06T00:00:00Z');
     expect(reviewScanJob).toContain(
       '"${LAST_LABELED_TS}" > "${LAST_ENGAGE_ACK_TS}"',
+    );
+    // The dedup must read the CURRENT candidate's comments: pin the per-PR
+    // ic.json fetch BEFORE the first ack-timestamp read (reading a previous
+    // candidate's file mis-dedups; a missing file kills the scan step under
+    // -eo pipefail). Same textual-order technique as the hooks-severed pins.
+    const icFetchAt = reviewScanJob.indexOf(
+      'gh api "repos/${REPO}/issues/${PR}/comments" --paginate > "${WORKDIR}/ic.json"',
+    );
+    const ackReadAt = reviewScanJob.indexOf('LAST_ENGAGE_ACK_TS=');
+    expect(icFetchAt).toBeGreaterThan(-1);
+    expect(ackReadAt).toBeGreaterThan(icFetchAt);
+    // A dry-run scan must neither comment nor advance the real window key.
+    expect(reviewScanJob).toContain(
+      'DRY-RUN: would post engage ack on #${PR} (window key untouched)',
     );
     // The producers must actually REQUEST labels — the jq consumers above
     // stay green on handcrafted fixtures even if a future edit drops the
@@ -1299,6 +1328,7 @@ describe('qwen-autofix workflow', () => {
       labels = [],
       fork = false,
       canModify = true,
+      authorPerm = 'write',
       state = 'OPEN',
       base = 'main',
     }) => {
@@ -1307,6 +1337,7 @@ describe('qwen-autofix workflow', () => {
         const prJson = JSON.stringify({
           isCrossRepository: fork,
           maintainerCanModify: canModify,
+          author: { login: 'fork-owner' },
           state,
           baseRefName: base,
           labels: labels.map((name) => ({ name })),
@@ -1315,7 +1346,8 @@ describe('qwen-autofix workflow', () => {
           join(dir, 'gh'),
           [
             '#!/bin/bash',
-            `if [[ "$1" == "pr" && "$2" == "view" ]]; then printf '%s' '${prJson}';`,
+            `if [[ "$1" == "api" && "$2" == */collaborators/*/permission ]]; then printf '%s' '${authorPerm}';`,
+            `elif [[ "$1" == "pr" && "$2" == "view" ]]; then printf '%s' '${prJson}';`,
             `elif [[ "$1" == "pr" && "$2" == "edit" ]]; then echo "EDIT $*" >> '${join(dir, 'writes.log')}';`,
             `elif [[ "$1" == "pr" && "$2" == "comment" ]]; then echo "COMMENT $4" >> '${join(dir, 'writes.log')}'; cat > /dev/null <<< "$6";`,
             'fi',
@@ -1382,6 +1414,21 @@ describe('qwen-autofix workflow', () => {
     const forkManaged = runToggle({ cmd: 'add', fork: true });
     expect(forkManaged.writes).toContain('--add-label');
     expect(forkManaged.writes).not.toContain('COMMENT');
+    // A below-write fork author would be a ghost engagement (label sticks,
+    // nothing ever manages it) — the command refuses with the adoption ask.
+    const forkGhost = runToggle({ cmd: 'add', fork: true, authorPerm: 'read' });
+    expect(forkGhost.writes).toContain('COMMENT');
+    expect(forkGhost.writes).not.toContain('EDIT');
+    expect(forkGhost.log).toContain('below write');
+    // Release is NEVER blocked by engage-side fork requirements: stop on an
+    // allow-edits-revoked fork still removes the label.
+    const forkStop = runToggle({
+      cmd: 'remove',
+      fork: true,
+      canModify: false,
+      labels: ['autofix/takeover'],
+    });
+    expect(forkStop.writes).toContain('--remove-label');
   });
 
   it('behaviorally resets round counting at the latest takeover engage ack', () => {
@@ -2458,12 +2505,15 @@ describe('qwen-autofix workflow', () => {
     // the PAT in env there); the agent step — no PAT, sandboxed tools —
     // re-points .husky itself so its commits still get checked.
     // Hooks are severed BEFORE either checkout form (origin branch or the
-    // fork-remote FETCH_HEAD path used by maintainer-fork takeover).
+    // fork-remote FETCH_HEAD path used by maintainer-fork takeover). The
+    // origin form sits in the else-branch AFTER the fork branch's push
+    // preflight, hence the wider window — the assertion is about order,
+    // and one hooksPath site genuinely covers both arms of the if.
     expect(workflow).toMatch(
       /git config core\.hooksPath \/dev\/null\n[\s\S]{0,400}git checkout -B "\$\{BRANCH\}" FETCH_HEAD/,
     );
     expect(workflow).toMatch(
-      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,400}git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/,
+      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,1500}git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/,
     );
     expect(workflow).toMatch(
       /git config core\.hooksPath \.husky\n[\s\S]{0,200}node "\$\{RUNNER_TEMP\}\/run-agent\.mjs"/,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -200,6 +200,13 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain('.[0:10] | map(. + {autofixTier: 1})');
   });
 
+  it('carries no patch-artifact stray quotes on shell keywords', () => {
+    // A trailing '"' after a lone fi/done/esac balances against the NEXT
+    // quote in the script, so bash -n stays green while runtime semantics
+    // are scrambled — pin the artifact class directly.
+    expect(workflow).not.toMatch(/^\s*(fi|done|esac)"\s*$/m);
+  });
+
   it('runs scheduled autofix as a 10-minute multi-target fan-out worker', () => {
     expect(workflow).toContain("cron: '*/10 * * * *'");
     expect(workflow).not.toContain("cron: '0 0,12 * * *'");

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -569,7 +569,7 @@ describe('qwen-autofix workflow', () => {
       /(PR_LIVE="\$\(gh pr view[\s\S]*?exit 0\n {10}fi)/,
     )?.[1];
     expect(recheck).toBeTruthy();
-    const runRecheck = (prJson) => {
+    const runRecheck = (prJson, authorPerm = 'write') => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-elig-'));
       try {
         const gh = join(dir, 'gh');
@@ -577,7 +577,7 @@ describe('qwen-autofix workflow', () => {
           gh,
           prJson === null
             ? '#!/bin/bash\nexit 1\n'
-            : `#!/bin/bash\nprintf '%s' '${JSON.stringify(prJson)}'\n`,
+            : `#!/bin/bash\nif [[ "$*" == *"/collaborators/"* ]]; then printf '%s' '${authorPerm}'; else printf '%s' '${JSON.stringify(prJson)}'; fi\n`,
         );
         chmodSync(gh, 0o755);
         const out = join(dir, 'out.txt');
@@ -647,9 +647,20 @@ describe('qwen-autofix workflow', () => {
     expect(
       runRecheck(pr({ labels: [{ name: 'autofix/skip' }] })).out,
     ).toContain('stale=true');
-    // Fork head, renamed branch, and a FAILED fetch (unknown ≠ eligible)
-    // all discard.
+    // Fork heads: manageable ONLY with takeover + allow-edits + a fork
+    // author who holds write+ LIVE; anything less discards.
     expect(runRecheck(pr({ isCrossRepository: true })).passed).toBe(false);
+    const forkPr = pr({
+      isCrossRepository: true,
+      maintainerCanModify: true,
+      author: { login: 'maint-fork' },
+      labels: [{ name: 'autofix/takeover' }],
+    });
+    expect(runRecheck(forkPr).passed).toBe(true);
+    expect(runRecheck({ ...forkPr, maintainerCanModify: false }).passed).toBe(
+      false,
+    );
+    expect(runRecheck(forkPr, 'read').passed).toBe(false);
     expect(runRecheck(pr({ headRefName: 'renamed' })).passed).toBe(false);
     // Retargeted off main while queued → discard (previously only pinned).
     expect(runRecheck(pr({ baseRefName: 'develop' })).passed).toBe(false);
@@ -861,7 +872,9 @@ describe('qwen-autofix workflow', () => {
     // Decide gates: takeover only for open in-repo main-targeting PRs; fork
     // label events carry no secrets, so they are logged and dropped.
     expect(routeStep).toContain('→ review phase (takeover)');
-    expect(routeStep).toContain('takeover ignored: PR is a fork');
+    // Fork label events (no secrets) note the takeover for the next
+    // scheduled scan instead of dropping it.
+    expect(routeStep).toContain('fork takeover noted for #${PR_NUMBER_EVENT}');
     expect(routeStep).toContain('is not open');
     expect(routeStep).toContain('→ released');
     // Every toggle produces a visible bilingual ack via the PAT-verified bot
@@ -876,12 +889,13 @@ describe('qwen-autofix workflow', () => {
     // EVERY body proves it individually (a global count alone could balance
     // one lost Chinese section against a duplicate elsewhere): engage,
     // honest bot-PR release, skip-labeled bot-PR release, human-PR
-    // release, re-arm, fork refusal, two skip-blocked refusals, and the cap
-    // pause.
+    // release, re-arm, fork allow-edits refusal, two skip-blocked refusals,
+    // the cap pause, and the scan-side first-pickup engage ack (fork label
+    // events carry no secrets, so the scan anchors the window itself).
     const ackBodies = workflow.match(
       /printf '[^']*takeover-(?:ack|cap)[^']*'/g,
     );
-    expect(ackBodies).toHaveLength(9);
+    expect(ackBodies).toHaveLength(10);
     for (const body of ackBodies) {
       expect(body).toContain('<summary>中文说明</summary>');
     }
@@ -905,7 +919,12 @@ describe('qwen-autofix workflow', () => {
     // and the command job — which DOES have secrets — refuses forks up
     // front with an explanation instead of toggling the label.
     expect(routeStep).toContain('takeover release ignored: PR is a fork');
-    expect(workflow).toContain('takeover command refused: PR #${PR} is a fork');
+    // Fork PRs with allow-edits ARE manageable now; only a fork WITHOUT
+    // maintainer-edit access refuses (with the actionable ask).
+    expect(workflow).toContain(
+      'takeover command refused: fork PR #${PR} without maintainer-edit access',
+    );
+    expect(workflow).toContain('Allow edits from maintainers');
     expect(workflow).toContain('<!-- takeover-ack fork-refused -->');
     // Convention: every write verifies the PAT identity first — including
     // the scan's cap notice (a foreign login would defeat the dedup and
@@ -988,6 +1007,72 @@ describe('qwen-autofix workflow', () => {
     // Rotation: offset 1 starts one past the newest, wrapping — so the
     // oldest tail is reached within pool/budget scans instead of never.
     expect(pick([pr(1), pr(2)], [], 1)).toEqual(['1', '2']);
+    // Fork takeover candidates are admitted separately: allow-edits and no
+    // skip label filter in jq; the author's live write+ gate runs in bash.
+    const forkSel = reviewScanJob
+      .match(
+        /done < <\(jq -r --arg skip "\$\{SKIP_LABEL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/takeover-prs\.json"\)/,
+      )?.[1]
+      ?.replace(/\n {14}/g, '\n');
+    expect(forkSel).toBeTruthy();
+    const forkRows = execFileSync(
+      'jq',
+      ['-r', '--arg', 'skip', 'autofix/skip', forkSel],
+      {
+        encoding: 'utf8',
+        input: JSON.stringify([
+          {
+            number: 9,
+            isCrossRepository: true,
+            maintainerCanModify: true,
+            labels: [{ name: 'autofix/takeover' }],
+            author: { login: 'maint-a' },
+          },
+          {
+            number: 8,
+            isCrossRepository: true,
+            maintainerCanModify: false,
+            labels: [{ name: 'autofix/takeover' }],
+            author: { login: 'maint-b' },
+          },
+          {
+            number: 7,
+            isCrossRepository: true,
+            maintainerCanModify: true,
+            labels: [{ name: 'autofix/takeover' }, { name: 'autofix/skip' }],
+            author: { login: 'maint-c' },
+          },
+          {
+            number: 6,
+            isCrossRepository: false,
+            maintainerCanModify: true,
+            labels: [{ name: 'autofix/takeover' }],
+            author: { login: 'maint-d' },
+          },
+        ]),
+      },
+    )
+      .trim()
+      .split('\n');
+    expect(forkRows).toEqual(['9\tmaint-a']);
+    expect(reviewScanJob).toContain('fork takeover candidate #${FPR} admitted');
+    // Fork plumbing: the target carries its head repo; prepare fetches the
+    // fork branch (origin has no copy) and the report pushes back via
+    // allow-edits.
+    expect(workflow).toContain("HEAD_REPO: '${{ matrix.target.head_repo }}'");
+    expect(reviewScanJob).toContain('head_repo: $hr');
+    expect(workflow).toContain(
+      'git fetch "https://github.com/${HEAD_REPO}.git" "${BRANCH}"',
+    );
+    expect(workflow).toContain(
+      'git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"',
+    );
+    // First-pickup engage ack anchors the window when the label path could
+    // not (fork events carry no secrets), deduped on any existing ack,
+    // identity-verified, with ic.json re-fetched so the same scan counts
+    // under the fresh key.
+    expect(reviewScanJob).toContain('takeover-ack engaged');
+    expect(reviewScanJob).toContain('ic re-fetch after engage ack failed');
     // The producers must actually REQUEST labels — the jq consumers above
     // stay green on handcrafted fixtures even if a future edit drops the
     // field and skip/takeover filtering silently dies in production.
@@ -1128,6 +1213,7 @@ describe('qwen-autofix workflow', () => {
       cmd,
       labels = [],
       fork = false,
+      canModify = true,
       state = 'OPEN',
       base = 'main',
     }) => {
@@ -1135,6 +1221,7 @@ describe('qwen-autofix workflow', () => {
       try {
         const prJson = JSON.stringify({
           isCrossRepository: fork,
+          maintainerCanModify: canModify,
           state,
           baseRefName: base,
           labels: labels.map((name) => ({ name })),
@@ -1202,10 +1289,14 @@ describe('qwen-autofix workflow', () => {
     const skipBlocked = runToggle({ cmd: 'add', labels: ['autofix/skip'] });
     expect(skipBlocked.writes).toContain('COMMENT');
     expect(skipBlocked.writes).not.toContain('EDIT');
-    // fork PRs are refused with an explanation, never toggled.
-    const forkRefused = runToggle({ cmd: 'add', fork: true });
+    // Fork WITHOUT allow-edits refuses with the actionable ask, never
+    // toggling; fork WITH allow-edits is fully manageable and toggles.
+    const forkRefused = runToggle({ cmd: 'add', fork: true, canModify: false });
     expect(forkRefused.writes).toContain('COMMENT');
     expect(forkRefused.writes).not.toContain('EDIT');
+    const forkManaged = runToggle({ cmd: 'add', fork: true });
+    expect(forkManaged.writes).toContain('--add-label');
+    expect(forkManaged.writes).not.toContain('COMMENT');
   });
 
   it('behaviorally resets round counting at the latest takeover engage ack', () => {
@@ -2281,8 +2372,13 @@ describe('qwen-autofix workflow', () => {
     // …both pushes AND the prepare checkout (post-checkout hooks fire with
     // the PAT in env there); the agent step — no PAT, sandboxed tools —
     // re-points .husky itself so its commits still get checked.
+    // Hooks are severed BEFORE either checkout form (origin branch or the
+    // fork-remote FETCH_HEAD path used by maintainer-fork takeover).
     expect(workflow).toMatch(
-      /git config core\.hooksPath \/dev\/null\n\s+git checkout -B "\$\{BRANCH\}"/,
+      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,400}git checkout -B "\$\{BRANCH\}" FETCH_HEAD/,
+    );
+    expect(workflow).toMatch(
+      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,400}git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/,
     );
     expect(workflow).toMatch(
       /git config core\.hooksPath \.husky\n[\s\S]{0,200}node "\$\{RUNNER_TEMP\}\/run-agent\.mjs"/,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -599,6 +599,7 @@ describe('qwen-autofix workflow', () => {
               PR: '7163',
               REPO: 'QwenLM/qwen-code',
               BRANCH: 'ci/some-branch',
+              HEAD_REPO: 'maint-fork/qwen-code',
               WATERMARK: '2026-07-18T08:00:00Z',
               ROUND: '2',
               AUTOFIX_BOT: 'qwen-code-dev-bot',
@@ -662,12 +663,32 @@ describe('qwen-autofix workflow', () => {
       maintainerCanModify: true,
       author: { login: 'maint-fork' },
       labels: [{ name: 'autofix/takeover' }],
+      headRepositoryOwner: { login: 'maint-fork' },
+      headRepository: { name: 'qwen-code' },
     });
     expect(runRecheck(forkPr).passed).toBe(true);
     expect(runRecheck({ ...forkPr, maintainerCanModify: false }).passed).toBe(
       false,
     );
     expect(runRecheck(forkPr, 'read').passed).toBe(false);
+    // The base/branch invariants must remain REACHABLE for eligible forks:
+    // the fork elif chain ends the ladder, so a retargeted or head-renamed
+    // fork previously sailed through to a wrong-base push.
+    expect(runRecheck({ ...forkPr, baseRefName: 'develop' }).passed).toBe(
+      false,
+    );
+    expect(runRecheck({ ...forkPr, headRefName: 'renamed' }).passed).toBe(
+      false,
+    );
+    // A fork renamed/transferred since the scan must not be fetched or
+    // pushed at the stale path — moved or unresolved discards.
+    expect(
+      runRecheck({ ...forkPr, headRepositoryOwner: { login: 'somewhere' } })
+        .passed,
+    ).toBe(false);
+    expect(runRecheck({ ...forkPr, headRepository: { name: '' } }).passed).toBe(
+      false,
+    );
     expect(runRecheck(pr({ headRefName: 'renamed' })).passed).toBe(false);
     // Retargeted off main while queued → discard (previously only pinned).
     expect(runRecheck(pr({ baseRefName: 'develop' })).passed).toBe(false);
@@ -1135,7 +1156,7 @@ describe('qwen-autofix workflow', () => {
       .match(
         /LAST_LABELED_TS="\$\(jq -rs --arg lb "\$\{TAKEOVER_LABEL\}" '([\s\S]*?)' "\$\{WORKDIR\}\/pr-events\.json"\)"/,
       )?.[1]
-      ?.replace(/\n {18}/g, '\n');
+      ?.replace(/\n {16}/g, '\n');
     expect(labeledTsProgram).toBeTruthy();
     const labeledTs = execFileSync(
       'jq',
@@ -1187,6 +1208,14 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'DRY-RUN: would post engage ack on #${PR} (window key untouched)',
     );
+    // In-repo first-pickup defers to the label event's DEDICATED ack job
+    // within a short grace, so a concurrent ack job is never double-posted.
+    expect(reviewScanJob).toContain('engage ack deferred for #${PR}');
+    // A fork fetch failure (force-push/rename race) discards gracefully
+    // instead of a red run, and a fork moved since the scan is discarded at
+    // the live re-check rather than fetched/pushed at the stale path.
+    expect(workflow).toContain('fork fetch failed for ${HEAD_REPO}');
+    expect(workflow).toContain('fork head repository moved or unresolved');
     // The producers must actually REQUEST labels — the jq consumers above
     // stay green on handcrafted fixtures even if a future edit drops the
     // field and skip/takeover filtering silently dies in production.
@@ -2506,14 +2535,15 @@ describe('qwen-autofix workflow', () => {
     // re-points .husky itself so its commits still get checked.
     // Hooks are severed BEFORE either checkout form (origin branch or the
     // fork-remote FETCH_HEAD path used by maintainer-fork takeover). The
-    // origin form sits in the else-branch AFTER the fork branch's push
-    // preflight, hence the wider window — the assertion is about order,
-    // and one hooksPath site genuinely covers both arms of the if.
+    // fork arm carries the fetch-failure discard before its checkout and
+    // the origin form sits in the else-branch after the push preflight,
+    // hence the wider windows — the assertions are about order, and one
+    // hooksPath site genuinely covers both arms of the if.
     expect(workflow).toMatch(
-      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,400}git checkout -B "\$\{BRANCH\}" FETCH_HEAD/,
+      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,900}git checkout -B "\$\{BRANCH\}" FETCH_HEAD/,
     );
     expect(workflow).toMatch(
-      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,1500}git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/,
+      /git config core\.hooksPath \/dev\/null\n[\s\S]{0,2200}git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/,
     );
     expect(workflow).toMatch(
       /git config core\.hooksPath \.husky\n[\s\S]{0,200}node "\$\{RUNNER_TEMP\}\/run-agent\.mjs"/,


### PR DESCRIPTION
## What this PR does

Extends label-driven takeover (#7165) to **maintainer-fork PRs**: a fork-based PR becomes directly manageable when three conditions hold **live** —

1. the `autofix/takeover` label (triage+-gated, as everywhere),
2. **"Allow edits from maintainers"** on the PR (this is what gives the bot PAT push rights to the fork branch; org-owned forks cannot enable it — the adoption-snapshot path remains theirs), and
3. a fork **author who holds write+ right now** (the same live-privilege rule as the comment command: an ex-member's fork can never summon secret-bearing runs, and this keeps the executed-code provenance equal to in-repo takeover — write-capable collaborators only).

Mechanics: the scan admits fork takeover candidates per candidate (allow-edits and skip filtered in jq, one live permission call per fork candidate — a rare set) and stamps every matrix target with its head repo; prepare fetches the fork branch (origin has no copy) and checks out `FETCH_HEAD` with hooks already severed, re-verifying all three conditions live at address time; the report step pushes back to the fork through the allow-edits grant. Fork `pull_request` label events carry **no secrets**, so the route notes them and the next scheduled scan engages (≤10 min); the comment command toggles fork PRs too (write+ senders only — fork authors stay silently dropped) and refuses only a missing allow-edits, with the actionable ask. The scan posts a **first-pickup engage ack** (identity-verified; dedup is author-filtered so a forged human marker cannot suppress it; `ic.json` re-fetched so the same scan already counts under the fresh window key) — closing the fork/manual-label ack gap. Because forks never get an ack job, the scan also carries **re-arm**: when the takeover label's latest application is newer than the latest bot ack (issue events, fetched only in that rare case), a fresh ack is posted — resetting the round window and cap exactly as the documented remove-and-re-add gesture promises.

## Why it's needed

Many maintainers work from personal forks. v1 rejected all forks, and the adoption-snapshot workaround forks the collaboration — the maintainer's local checkout no longer matches the managed branch. For write+ authors the two fork blockers identified in v1 (self-service by arbitrary authors; per-head re-authorization) dissolve: the author could already push anything to the repo, so managing their fork branch adds no trust surface beyond in-repo takeover.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 61/61. New behavioral coverage (verbatim-extracted; drift fails the suite):
   - **Fork-candidate admission jq**: allow-edits required, skip excluded even with takeover, in-repo rows excluded from the fork path; emits `number\tauthor` rows for the bash write+ gate.
   - **Eligibility replay** (two-shape gh stub: PR view + permission API): fork+takeover+allow-edits+write author passes; missing allow-edits discards; a `read` author discards.
   - **Toggle replay**: fork without allow-edits → actionable refusal, never a toggle; fork with allow-edits → toggles normally.
   - Plumbing pins: `head_repo` threading, fork `git fetch`/`git push` URL forms (hooks severed on both), first-pickup ack + `ic.json` re-fetch, decide's fork-noted message, and a stray-quote artifact guard (lone `fi/done/esac` followed by a quote fails).
   - **Ack jq replays**: bot-authored engaged-ack selection excludes forged human markers and released acks; labeled-event selection filters to the takeover label across label churn; the lexicographic re-arm gate is pinned.
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` — 12/12 (shepherd stays bot-PR-only; unchanged).
3. Static: YAML parses; every `run:` block passes `bash -n`.
4. Post-merge smoke: label a personal-fork PR (write+ author, allow-edits ticked) → next scheduled scan logs `🌿 fork takeover candidate #N admitted`, posts the engage ack, and the address run pushes to the fork branch. Untick allow-edits → the eligibility gate discards with `fork head without maintainer-edit access`.

### Evidence (Before & After)

```
BEFORE (main):
  fork PR + takeover label     → scan filters it out; command refuses all forks
AFTER (this PR):
  personal fork, write+ author, allow-edits  → fully managed (fetch fork branch,
                                               agent rounds, push back via allow-edits)
  fork without allow-edits                   → actionable refusal (tick the box / adoption)
  fork author below write (live check)       → skipped at scan AND discarded at address
  org-owned fork                             → cannot enable allow-edits ⇒ adoption path

candidate jq:  [9✓(ok) 8(no allow-edits) 7(skip) 6(in-repo)] → "9\tmaint-a"
eligibility:   fork+take+edits+write→pass   no-edits→discard   read-author→discard
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Contract suites via vitest on a worktree checkout of main; YAML/`bash -n` static validation. Workflows run on `ubuntu-latest`.

## Risk & Scope

- Main risk or tradeoff: the secret-exposure envelope is **unchanged from in-repo takeover** — the PAT is fully severed (trusted-base runner staging, hooks severed at every host checkout including the new fork-fetch path), and the documented model-key-in-sandbox exposure applies to code whose author is verified write+ **live** at both scan and address time. The allow-edits grant is scoped by GitHub to the PR branch only.
- Not validated / out of scope: live fork round-trip needs a real personal-fork PR (post-merge smoke above); org-fork support is a GitHub platform limitation; the CLI-side follow-up (do not forward the model key into the tool sandbox) remains the structural close for the key-exposure class.
- Breaking changes / migration notes: none; no new secrets, labels, or variables.

## Linked Issues

Follow-up to #7165 (v1 in-repo takeover), completing the approved maintainer-fork plan.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 label 驱动的接管(#7165)扩展到**维护者 fork PR**:当三个条件**实时**成立时,fork PR 可被直接托管 ——

1. `autofix/takeover` 标签(一如既往 triage+ 门控);
2. PR 勾选 **"Allow edits from maintainers"**(这是 bot PAT 获得 fork 分支推送权的来源;组织账号的 fork 无法勾选 —— 仍走领养快照路径);
3. fork **作者当下持有 write+**(与评论命令同一实时权限规则:退出成员的 fork 永远召唤不了带 secret 的运行,同时使被执行代码的来源信任等价于同仓库接管 —— 仅限具 write 能力的协作者)。

机制:扫描逐候选准入 fork 接管 PR(allow-edits 与 skip 在 jq 过滤,每个 fork 候选一次实时权限调用 —— 集合很小),并给每个 matrix 目标带上 head 仓库;prepare 从 fork 拉取分支(origin 上没有副本)、在 hook 已切断的前提下检出 `FETCH_HEAD`,并在 address 时实时复核全部三条件;报告步骤经 allow-edits 授权把提交推回 fork。fork 的 `pull_request` 标签事件**不带 secrets**,route 记录后由下一轮定时扫描接管(≤10 分钟);评论命令现在也能切换 fork PR(仅 write+ 发送者 —— fork 作者仍被静默丢弃),仅在缺 allow-edits 时给出可执行的拒绝提示。扫描新增**首次拾取接管确认**(身份校验;去重按作者过滤,人类伪造的 marker 无法压制真确认;重取 `ic.json` 使同一轮扫描即按新窗口键计数)—— 补上 fork/手动打标的确认缺口。由于 fork 永远没有 ack job,扫描还承担**重武装**:当接管标签的最近一次打标时间新于最近一次 bot 确认(仅在该罕见情形拉取 issue events),即发新确认 —— 按文档承诺的"摘除再打标"手势重置轮次窗口与上限。

## 为什么需要

许多维护者以个人 fork 开展工作。v1 全量拒绝 fork,而领养快照会使协作分叉 —— 维护者本地检出与被托管分支脱节。对 write+ 作者而言,v1 认定的两大 fork 阻碍(任意作者自助、逐 head 重授权)自然消解:作者本就能向仓库推任何东西,托管其 fork 分支不增加超出同仓库接管的信任面。

## 评审验证方案

### 如何验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 61/61。新增行为覆盖(逐字提取,漂移即失败):
   - **确认 jq 回放**:bot 作者的 engaged 确认选取排除人类伪造 marker 与 released 确认;labeled 事件选取在标签变动中只认接管标签;字典序重武装门已钉住。
   - **fork 候选准入 jq**:必须 allow-edits;带 skip 即使有 takeover 也排除;同仓库行不入 fork 通道;输出 `number\tauthor` 行交给 bash 的 write+ 门。
   - **资格回放**(双形态 gh 桩:PR view + 权限 API):fork+takeover+allow-edits+write 作者通过;缺 allow-edits 丢弃;`read` 作者丢弃。
   - **切换回放**:fork 无 allow-edits → 可执行拒绝、绝不切换;有 allow-edits → 正常切换。
   - 管线钉串:`head_repo` 贯穿、fork 的 `git fetch`/`git push` URL 形态(两路均已切断 hook)、首拾确认去重 + `ic.json` 重取、route 的 fork-noted 消息。
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` —— 12/12(shepherd 维持仅 bot PR;无改动)。
3. 静态:YAML 可解析;所有 `run:` 块通过 `bash -n`。
4. 合并后冒烟:给个人 fork PR(write+ 作者、已勾 allow-edits)打标 → 下一轮定时扫描日志出现 `🌿 fork takeover candidate #N admitted`、发接管确认、address 运行推回 fork 分支;取消勾选 → 资格门以 `fork head without maintainer-edit access` 丢弃。

### 证据(前后对比)

```
改动前(main):
  fork PR + takeover 标签      → 扫描过滤;命令拒绝一切 fork
改动后(本 PR):
  个人 fork、write+ 作者、勾选 allow-edits → 完整托管(拉取 fork 分支、agent 轮次、经授权推回)
  fork 未勾 allow-edits                    → 可执行拒绝(勾选 / 领养)
  fork 作者低于 write(实时校验)           → 扫描跳过且 address 丢弃
  组织账号 fork                            → 无法勾选 ⇒ 领养路径

候选 jq:[9✓ 8(无勾选) 7(skip) 6(同仓库)] → "9\tmaint-a"
资格:  fork+标+勾选+write→通过   无勾选→丢弃   read 作者→丢弃
```

### 测试情况

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境(可选)

在 main 的 worktree 检出上运行 vitest 契约套件;YAML/`bash -n` 静态校验。工作流运行于 `ubuntu-latest`。

## 风险与范围

- 主要风险/权衡:secret 暴露包络与同仓库接管**完全一致** —— PAT 全链路隔离(可信基座 runner staging、含新 fork-fetch 路径在内的所有宿主 checkout 均切断 hook);已明示的沙箱内模型密钥暴露,只作用于扫描与 address **双时点实时验证过 write+** 的作者的代码。allow-edits 授权被 GitHub 限定于该 PR 分支。
- 未验证/不在范围内:实弹 fork 往返需真实个人 fork PR(见合并后冒烟);组织 fork 属 GitHub 平台限制;CLI 侧后续(不向工具沙箱转发模型密钥)仍是该暴露类的结构性关闭手段。
- 破坏性变更/迁移:无;不新增 secret、标签或变量。

## 关联 Issue

#7165(v1 同仓库接管)的后续,完成既定的维护者 fork 方案。

</details>
