### PR TITLE
ci: add ECS runner qwen update workflow

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -390,7 +390,7 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: 'Resolve PR context'
         id: 'context'
@@ -898,7 +898,7 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: 'Set up Node.js'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -390,7 +390,7 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: 'Resolve PR context'
         id: 'context'
@@ -898,7 +898,7 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: 'Set up Node.js'

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -20,7 +20,7 @@ jobs:
   update:
     name: 'Update Qwen on Singapore ECS runner'
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
-    runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen-runner-sg']
+    runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
     timeout-minutes: 10
     steps:
       - name: 'Resolve version'
@@ -28,9 +28,13 @@ jobs:
         env:
           INPUT_VERSION: '${{ inputs.version }}'
         run: |-
-          version="${INPUT_VERSION#v}"
-          if [[ -z "${version}" ]]; then
-            version="$(npm view @qwen-code/qwen-code version)"
+          specifier="@qwen-code/qwen-code@${INPUT_VERSION#v}"
+          if [[ "${specifier}" == '@qwen-code/qwen-code@' ]]; then
+            specifier='@qwen-code/qwen-code@latest'
+          fi
+          if ! version="$(npm view "${specifier}" version | tail -n 1)"; then
+            echo "::error::No published qwen version matches '${INPUT_VERSION:-latest}'."
+            exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "Resolved qwen version: ${version}"
@@ -39,13 +43,14 @@ jobs:
         env:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
-          prefix="$(npm prefix -g)"
-          if [[ -w "${prefix}" ]]; then
+          global_root="$(npm root -g)"
+          global_bin="$(npm prefix -g)/bin"
+          if [[ -w "${global_root}" && -w "${global_bin}" ]]; then
             npm install -g "@qwen-code/qwen-code@${VERSION}"
           elif command -v sudo >/dev/null 2>&1 && sudo -n true; then
             sudo npm install -g "@qwen-code/qwen-code@${VERSION}"
           else
-            echo "::error::Global npm prefix ${prefix} is not writable and passwordless sudo is unavailable."
+            echo "::error::Global npm install directories are not writable and passwordless sudo is unavailable."
             exit 1
           fi
 

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -28,11 +28,12 @@ jobs:
         env:
           INPUT_VERSION: '${{ inputs.version }}'
         run: |-
+          set -euo pipefail
           specifier="@qwen-code/qwen-code@${INPUT_VERSION#v}"
           if [[ "${specifier}" == '@qwen-code/qwen-code@' ]]; then
             specifier='@qwen-code/qwen-code@latest'
           fi
-          version="$(npm view "${specifier}" version | tail -n 1)"
+          version="$(npm view "${specifier}" version | tail -n 1)" || true
           if [[ -z "${version}" ]]; then
             echo "::error::No published qwen version matches '${INPUT_VERSION:-latest}'."
             exit 1
@@ -44,6 +45,7 @@ jobs:
         env:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
+          set -euo pipefail
           global_root="$(npm root -g)"
           global_bin="$(npm prefix -g)/bin"
           if [[ -w "${global_root}" && -w "${global_bin}" ]]; then
@@ -59,6 +61,7 @@ jobs:
         env:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
+          set -euo pipefail
           actual="$(qwen --version)"
           echo "qwen version: ${actual}"
           test "${actual}" = "${VERSION}"

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -1,0 +1,58 @@
+name: 'Update ECS Runner Qwen'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional. Empty means latest from npm.'
+        required: false
+        default: ''
+        type: 'string'
+
+permissions:
+  contents: 'read'
+
+concurrency:
+  group: 'update-ecs-runner-qwen-sg'
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: 'Update Qwen on Singapore ECS runner'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen-runner-sg']
+    timeout-minutes: 10
+    steps:
+      - name: 'Resolve version'
+        id: 'version'
+        env:
+          INPUT_VERSION: '${{ inputs.version }}'
+        run: |-
+          version="${INPUT_VERSION#v}"
+          if [[ -z "${version}" ]]; then
+            version="$(npm view @qwen-code/qwen-code version)"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved qwen version: ${version}"
+
+      - name: 'Update qwen'
+        env:
+          VERSION: '${{ steps.version.outputs.version }}'
+        run: |-
+          prefix="$(npm prefix -g)"
+          if [[ -w "${prefix}" ]]; then
+            npm install -g "@qwen-code/qwen-code@${VERSION}"
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true; then
+            sudo npm install -g "@qwen-code/qwen-code@${VERSION}"
+          else
+            echo "::error::Global npm prefix ${prefix} is not writable and passwordless sudo is unavailable."
+            exit 1
+          fi
+
+      - name: 'Verify version'
+        env:
+          VERSION: '${{ steps.version.outputs.version }}'
+        run: |-
+          actual="$(qwen --version)"
+          echo "qwen version: ${actual}"
+          test "${actual}" = "${VERSION}"

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -32,7 +32,8 @@ jobs:
           if [[ "${specifier}" == '@qwen-code/qwen-code@' ]]; then
             specifier='@qwen-code/qwen-code@latest'
           fi
-          if ! version="$(npm view "${specifier}" version | tail -n 1)"; then
+          version="$(npm view "${specifier}" version | tail -n 1)"
+          if [[ -z "${version}" ]]; then
             echo "::error::No published qwen version matches '${INPUT_VERSION:-latest}'."
             exit 1
           fi


### PR DESCRIPTION
## What this PR does

Adds a manual maintenance workflow that updates the Singapore ECS self-hosted runner host to a requested Qwen Code version, or to the latest npm version when the version input is empty.

## Why it's needed

The ECS host runs multiple self-hosted runner instances that share the globally installed `qwen` CLI, so maintainers only need one targeted workflow run to update the host after a release.

## Reviewer Test Plan

### How to verify

Run the workflow manually with an explicit version such as `0.20.0`, then confirm the job resolves the version, installs `@qwen-code/qwen-code`, and verifies `qwen --version` matches the resolved version.

### Evidence (Before & After)

N/A, CI maintenance workflow only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ `node scripts/lint.js --actionlint`; ✅ `node scripts/lint.js --yamllint` |

### Environment (optional)

Local repository workflow lint checks.

## Risk & Scope

- Main risk or tradeoff: The target ECS runner must have either writable global npm install directories or passwordless `sudo` for npm global installs.
- Main risk or tradeoff: The workflow updates the global `qwen` install in place, so maintainers should dispatch it when the ECS runner pool is quiet.
- Not validated / out of scope: The new workflow was not manually dispatched against the ECS runner from this branch.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

新增一个手动维护 workflow，用来把新加坡 ECS self-hosted runner 宿主机更新到指定的 Qwen Code 版本；如果版本输入为空，则从 npm 获取最新版本。

## Why it's needed

这台 ECS 宿主机上有多个 self-hosted runner 实例，它们共享全局安装的 `qwen` CLI，所以发布后维护者只需要触发一次定向 workflow 就能更新这台宿主机。

## Reviewer Test Plan

### How to verify

手动运行该 workflow，输入 `0.20.0` 这类明确版本，然后确认 job 能解析版本、安装 `@qwen-code/qwen-code`，并校验 `qwen --version` 与解析出的版本一致。

### Evidence (Before & After)

N/A，仅维护 CI workflow。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ `node scripts/lint.js --actionlint`; ✅ `node scripts/lint.js --yamllint` |

### Environment (optional)

本地仓库 workflow lint 检查。

## Risk & Scope

- Main risk or tradeoff: 目标 ECS runner 需要全局 npm 安装目录可写，或者具备 passwordless `sudo` 来执行 npm 全局安装。
- Main risk or tradeoff: 这个 workflow 会原地更新全局 `qwen` 安装，维护者应该在 ECS runner 池空闲时触发。
- Not validated / out of scope: 这个新 workflow 还没有从当前分支手动 dispatch 到 ECS runner 上验证。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
