### PR TITLE
fix(cli): parse heatmapDays strictly

### DIFF
--- a/packages/cli/src/serve/routes/usage-stats.test.ts
+++ b/packages/cli/src/serve/routes/usage-stats.test.ts
@@ -174,6 +174,16 @@ describe('usage-stats route (cache + range + clamping)', () => {
     expect(min.body.heatmapDays).toBe(1);
     const def = await request(app).get('/usage/dashboard?heatmapDays=abc');
     expect(def.body.heatmapDays).toBe(183);
+    const fractional = await request(app).get(
+      '/usage/dashboard?heatmapDays=1.5',
+    );
+    expect(fractional.body.heatmapDays).toBe(183);
+    const trailingText = await request(app).get(
+      '/usage/dashboard?heatmapDays=7junk',
+    );
+    expect(trailingText.body.heatmapDays).toBe(183);
+    const exponent = await request(app).get('/usage/dashboard?heatmapDays=1e2');
+    expect(exponent.body.heatmapDays).toBe(183);
   });
 });
 

--- a/packages/cli/src/serve/routes/usage-stats.test.ts
+++ b/packages/cli/src/serve/routes/usage-stats.test.ts
@@ -174,6 +174,8 @@ describe('usage-stats route (cache + range + clamping)', () => {
     expect(min.body.heatmapDays).toBe(1);
     const def = await request(app).get('/usage/dashboard?heatmapDays=abc');
     expect(def.body.heatmapDays).toBe(183);
+    const negative = await request(app).get('/usage/dashboard?heatmapDays=-5');
+    expect(negative.body.heatmapDays).toBe(183);
     const fractional = await request(app).get(
       '/usage/dashboard?heatmapDays=1.5',
     );

--- a/packages/cli/src/serve/routes/usage-stats.ts
+++ b/packages/cli/src/serve/routes/usage-stats.ts
@@ -59,8 +59,10 @@ function parseRange(raw: unknown): UsageRange {
 
 /** Parse + clamp `?heatmapDays=`; anything invalid falls back to the default. */
 function parseHeatmapDays(raw: unknown): number {
-  const value = typeof raw === 'string' ? Number.parseInt(raw, 10) : Number.NaN;
-  if (!Number.isFinite(value)) return DEFAULT_HEATMAP_DAYS;
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) {
+    return DEFAULT_HEATMAP_DAYS;
+  }
+  const value = Number.parseInt(raw, 10);
   return Math.min(MAX_HEATMAP_DAYS, Math.max(MIN_HEATMAP_DAYS, value));
 }
 


### PR DESCRIPTION
## What this PR does

Strictly parses the `heatmapDays` query parameter for the usage dashboard before applying the existing `[1, 366]` clamp.

Unsigned decimal integer strings keep the current behavior, including `0` clamping to `1` and oversized values clamping to `366`. Malformed values such as `-5`, `1.5`, `7junk`, and `1e2` now fall back to the default `183` days instead of being accepted through `Number.parseInt()` prefix parsing or signed-number parsing.

## Why it's needed

`GET /usage/dashboard?heatmapDays=` is a public daemon/Web Shell query surface, and the local parser says invalid values should fall back to the default. Before this change, `parseHeatmapDays()` used `Number.parseInt(raw, 10)`, so malformed strings could still be treated as numbers: `-5` became `-5` and then clamped to `1`, `1.5` became `1`, `7junk` became `7`, and `1e2` became `1`.

That made malformed query values produce a different heatmap window than the caller actually requested. This PR keeps the existing clamp semantics for valid unsigned integer inputs while making malformed values follow the documented default fallback path.

## Reviewer Test Plan

### How to verify

Review `parseHeatmapDays()` and the route test. A reviewer can confirm that valid unsigned integer query values still clamp as before, while negative values and malformed partial numeric strings now return the default heatmap window.

Run:

```bash
npm test --workspace=packages/cli -- src/serve/routes/usage-stats.test.ts
npx prettier --check packages/cli/src/serve/routes/usage-stats.ts packages/cli/src/serve/routes/usage-stats.test.ts
npx eslint packages/cli/src/serve/routes/usage-stats.ts packages/cli/src/serve/routes/usage-stats.test.ts
```

### Evidence (Before & After)

Before, the parser accepted signed or partial numeric strings before clamping:

```text
-5 => 1
1.5 => 1
7junk => 7
1e2 => 1
abc => 183
99999 => 366
0 => 1
```

After, the focused route test pins negative and malformed partial numeric values to the default:

```ts
await request(app).get('/usage/dashboard?heatmapDays=-5') // heatmapDays === 183
await request(app).get('/usage/dashboard?heatmapDays=1.5') // heatmapDays === 183
await request(app).get('/usage/dashboard?heatmapDays=7junk') // heatmapDays === 183
await request(app).get('/usage/dashboard?heatmapDays=1e2') // heatmapDays === 183
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS     | not tested |
|  Windows   | tested |
|  Linux     | not tested - WSL run was blocked before tests by missing Linux Rollup optional dependency in the Windows-installed `node_modules` (`@rollup/rollup-linux-x64-gnu`) |

### Environment (optional)

Windows local validation used Node.js v24.15.0 from the existing workspace environment.

## Risk & Scope

- Main risk or tradeoff: Low. Callers that accidentally depended on `Number.parseInt()` behavior for malformed values such as `-5` or `7junk` will now receive the documented default instead.
- Not validated / out of scope: Full `npm run typecheck --workspace=packages/cli` currently fails in this checkout on unrelated upstream/local build-state errors involving ACP bridge declarations, channel memory exports, and Ink selection types; this PR only ran the focused route test plus file-level format/lint checks.
- Breaking changes / migration notes: None expected for valid unsigned integer `heatmapDays` values.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 收紧了 usage dashboard 的 `heatmapDays` query 参数解析：只有完整的无符号十进制整数字符串才会进入原有的 `[1, 366]` clamp 逻辑。

合法整数仍保持原行为，例如 `0` clamp 到 `1`、超大值 clamp 到 `366`。但 `-5`、`1.5`、`7junk`、`1e2` 这类格式错误的值不再通过 `Number.parseInt()` 被当作数字接受，而是回退到默认的 `183` 天。

## 为什么需要

`GET /usage/dashboard?heatmapDays=` 是 daemon/Web Shell usage dashboard 的公开查询参数。当前注释说明 invalid values 应回退到默认值，但旧实现使用 `Number.parseInt(raw, 10)`，导致 malformed 输入被悄悄转成数字：`-5` 会先变成 `-5` 再 clamp 到 `1`，`1.5` 变成 `1`，`7junk` 变成 `7`，`1e2` 变成 `1`。

这会让调用方传入的错误参数产生一个非预期的 heatmap window。这个 PR 保留合法无符号整数的 clamp 行为，只把 malformed value 拉回到已有的默认 fallback 语义。

## Reviewer Test Plan

可以检查 `parseHeatmapDays()` 和现有 route test：合法无符号整数仍按原逻辑 clamp，负数和格式错误的 partial numeric string 会回到默认 `183`。

已在 Windows 本地运行：

```bash
npm test --workspace=packages/cli -- src/serve/routes/usage-stats.test.ts
npx prettier --check packages/cli/src/serve/routes/usage-stats.ts packages/cli/src/serve/routes/usage-stats.test.ts
npx eslint packages/cli/src/serve/routes/usage-stats.ts packages/cli/src/serve/routes/usage-stats.test.ts
```

WSL/Linux 侧尝试运行同一 focused test，但当前共享的 Windows `node_modules` 缺少 Rollup Linux optional dependency，因此测试在启动 Vitest 前失败；这不是本 PR 代码路径的失败。

## 风险与范围

风险较低。唯一行为变化是 malformed 值不再被 `Number.parseInt()` 接受，而是按注释回到默认值；合法无符号整数输入不受影响。

</details>