### PR TITLE
fix(autofix): stage SKILL.md beside run-agent.mjs so review-address boots (P0, regression from #7165)

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1777,9 +1777,17 @@ jobs:
           # The agent step runs AFTER prepare checks out the PR branch, so
           # invoking the runner from the working tree would execute
           # branch-controlled code on the host with the model key in env
-          # (takeover targets human-authored branches). Stage it from the
-          # trusted base and invoke the staged copy.
-          cp .qwen/skills/autofix/scripts/run-agent.mjs "${RUNNER_TEMP}/run-agent.mjs"
+          # (takeover targets human-authored branches). Stage the runner AND
+          # its SKILL from the trusted base, MIRRORING the skill's on-disk
+          # layout (autofix/{SKILL.md,scripts/run-agent.mjs}) — run-agent.mjs
+          # resolves the skill as `<its dir>/../SKILL.md`, so a flat stage
+          # (RUNNER_TEMP/run-agent.mjs) points ../SKILL.md at RUNNER_TEMP/..
+          # and the agent crashes with ENOENT before reading any feedback.
+          # The mirror also means the model's instructions come from the
+          # trusted base, never the PR branch.
+          mkdir -p "${RUNNER_TEMP}/autofix-skill/scripts"
+          cp .qwen/skills/autofix/SKILL.md "${RUNNER_TEMP}/autofix-skill/SKILL.md"
+          cp .qwen/skills/autofix/scripts/run-agent.mjs "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs"
 
       - name: 'Check runner environment'
         env:
@@ -2175,9 +2183,9 @@ jobs:
           # write-capable collaborators); keep AUTOFIX_OPENAI_API_KEY a
           # low-privilege, quota-bounded, rotatable key.
           git config core.hooksPath .husky
-          # Trusted staged copy — never the PR branch's version (see the
-          # staging step).
-          node "${RUNNER_TEMP}/run-agent.mjs" \
+          # Trusted staged copy in the mirrored layout — resolves
+          # ../SKILL.md to the trusted staged SKILL, never the PR branch's.
+          node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \
             --mode address-review \
             --pr "${PR}" \
             --issue "${ISSUE}" \

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2012,7 +2012,7 @@ describe('qwen-autofix workflow', () => {
       // repo copy; the review address step runs AFTER the PR branch is
       // checked out and must invoke the TRUSTED STAGED copy instead.
       expect(step).toMatch(
-        /node (?:"\$\{RUNNER_TEMP\}\/run-agent\.mjs"|\.qwen\/skills\/autofix\/scripts\/run-agent\.mjs)/,
+        /node (?:"\$\{RUNNER_TEMP\}\/autofix-skill\/scripts\/run-agent\.mjs"|\.qwen\/skills\/autofix\/scripts\/run-agent\.mjs)/,
       );
       expect(step).not.toContain('qwen --yolo --prompt "${PROMPT}"');
       expect(step).not.toContain('AUTOFIX_INVOCATION:');
@@ -2061,11 +2061,31 @@ describe('qwen-autofix workflow', () => {
       'run-agent.mjs \\\n            --mode develop-issue',
     );
     expect(triageAndAddressStep).toContain(
-      'node "${RUNNER_TEMP}/run-agent.mjs" \\\n            --mode address-review',
+      'node "${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs" \\\n            --mode address-review',
+    );
+    // Staging must MIRROR the skill layout: run-agent.mjs resolves its
+    // SKILL as `<own dir>/../SKILL.md`, so the staged runner and a staged
+    // SKILL.md must sit in autofix-skill/{scripts/run-agent.mjs,SKILL.md}.
+    // A flat stage crashes the agent with ENOENT before it reads feedback
+    // (regression: #7165 staged run-agent.mjs alone → ../SKILL.md pointed
+    // one dir above RUNNER_TEMP). Derive the invariant from the invocation
+    // rather than hard-coding the path, so any future relocation stays
+    // self-consistent.
+    const stagedRunner = triageAndAddressStep.match(
+      /node "(\$\{RUNNER_TEMP\}\/\S+\/run-agent\.mjs)"/,
+    )?.[1];
+    expect(stagedRunner).toBeTruthy();
+    // `<dir>/../SKILL.md` where dir = dirname(dirname(stagedRunner)).
+    const stagedSkillDir = stagedRunner
+      .replace(/\/scripts\/run-agent\.mjs$/, '')
+      .trim();
+    expect(workflow).toContain(
+      `cp .qwen/skills/autofix/scripts/run-agent.mjs "${stagedRunner}"`,
     );
     expect(workflow).toContain(
-      `cp .qwen/skills/autofix/scripts/run-agent.mjs "\${RUNNER_TEMP}/run-agent.mjs"`,
+      `cp .qwen/skills/autofix/SKILL.md "${stagedSkillDir}/SKILL.md"`,
     );
+    expect(workflow).toContain(`mkdir -p "${stagedSkillDir}/scripts"`);
     expect(workflow).not.toContain('.github/scripts/build-autofix-prompt.mjs');
 
     for (const step of [
@@ -2285,7 +2305,7 @@ describe('qwen-autofix workflow', () => {
       /git config core\.hooksPath \/dev\/null\n\s+git checkout -B "\$\{BRANCH\}"/,
     );
     expect(workflow).toMatch(
-      /git config core\.hooksPath \.husky\n[\s\S]{0,200}node "\$\{RUNNER_TEMP\}\/run-agent\.mjs"/,
+      /git config core\.hooksPath \.husky\n[\s\S]{0,200}node "\$\{RUNNER_TEMP\}\/autofix-skill\/scripts\/run-agent\.mjs"/,
     );
   });
 


### PR DESCRIPTION
## What this PR does

Fixes a **P0 regression from #7165** that has taken the autofix loop's entire review-address path down on `main`.

#7165 stages a trusted copy of `run-agent.mjs` (so the agent never executes the checked-out PR branch's version on the host with the model key). But `run-agent.mjs` resolves its instructions relative to its own location:

```js
const skillPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'SKILL.md');
```

The staging was **flat** — `${RUNNER_TEMP}/run-agent.mjs` — so `../SKILL.md` resolved to `${RUNNER_TEMP}/../SKILL.md` = `/home/runner/work/SKILL.md`, which does not exist. Every review-address run since #7165 merged crashed:

```
Error: ENOENT: no such file or directory, open '/home/runner/work/SKILL.md'
    at promptFor (file:///home/runner/work/_temp/run-agent.mjs:152:17)
##[error]Process completed with exit code 1.
```

— before reading any feedback. Feedback-addressing **and** takeover were both down on `main`.

The fix stages the runner **and** its SKILL in a mirrored layout and invokes the staged runner from there, so `../SKILL.md` resolves to the staged SKILL:

```
${RUNNER_TEMP}/autofix-skill/SKILL.md
${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs   ← invoked
```

This also closes a latent gap: the model's instructions now come from the **trusted base** too, never the checked-out PR branch (the issue-phase invocations, which run the in-repo copy before any untrusted checkout, are unchanged).

## Why it's needed

The loop's core function — addressing review feedback on bot PRs and takeover PRs — has been failing on every run since #7165 merged (07:35 UTC). The agent crashes before it can read the feedback, so it produces a "could not start evaluation" handoff at best and a red job at worst.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 60/60. The staging test previously pinned the `cp` string and the invocation but never checked SKILL.md was *resolvable* from the staged location — exactly the blind spot that let this ship. It now derives the staged runner path from the invocation, computes `<dir>/../SKILL.md`, and asserts a `cp` stages exactly that path (plus the mirrored `mkdir -p .../scripts`). A flat re-stage fails the suite.
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` — 12/12 (untouched).
3. Static: YAML parses; every `run:` block passes `bash -n`.
4. Post-merge smoke: the next review-address run (a bot PR with new feedback, or any takeover PR) reaches "Triage and address" and reads the SKILL instead of crashing at `promptFor`.

### Evidence (Before & After)

```
BEFORE (main, since #7165):
  stage: cp run-agent.mjs → ${RUNNER_TEMP}/run-agent.mjs
  boot:  ../SKILL.md → /home/runner/work/SKILL.md   → ENOENT, job fails

AFTER (this PR):
  stage: cp SKILL.md          → ${RUNNER_TEMP}/autofix-skill/SKILL.md
         cp run-agent.mjs     → ${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs
  boot:  ../SKILL.md → ${RUNNER_TEMP}/autofix-skill/SKILL.md   → reads trusted skill ✓
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: none meaningful — the change is confined to how two trusted files are laid out under `${RUNNER_TEMP}` and which path the review-address step invokes. The issue-phase invocations (in-repo copy, pre-checkout) are unchanged. Security strictly improves: model instructions now come from the trusted base.
- Not validated / out of scope: live round-trip needs a real review-address run (post-merge smoke above).
- Breaking changes / migration notes: none.

## Linked Issues

Regression fix for #7165.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 **#7165 引入的 P0 回归** —— 它已经让 `main` 上 autofix 循环的整条「处理评审反馈(review-address)」路径瘫痪。

#7165 会 stage 一份可信的 `run-agent.mjs`(避免在宿主上以带模型密钥的环境执行检出的 PR 分支版本)。但 `run-agent.mjs` 相对自身位置解析指令文件:

```js
const skillPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'SKILL.md');
```

原先是**扁平** stage —— `${RUNNER_TEMP}/run-agent.mjs` —— 于是 `../SKILL.md` 落到 `${RUNNER_TEMP}/../SKILL.md` = `/home/runner/work/SKILL.md`,该文件不存在。#7165 合入后每一次 review-address 运行都在读取任何反馈之前崩溃(`ENOENT`)。反馈处理与接管两条路都断了。

修复:把 runner 与其 SKILL 以**镜像布局**一起 stage,并从该位置调用,使 `../SKILL.md` 解析到 staged 的 SKILL:

```
${RUNNER_TEMP}/autofix-skill/SKILL.md
${RUNNER_TEMP}/autofix-skill/scripts/run-agent.mjs   ← 调用
```

同时顺带关闭一个潜在缺口:模型指令现在也来自**可信基座**,而非检出的 PR 分支(issue 阶段在任何不可信检出之前跑仓库内副本,不受影响)。

## 为什么需要

循环的核心功能 —— 处理 bot PR 与接管 PR 的评审反馈 —— 自 #7165 合入(07:35 UTC)起每次运行都失败。agent 在读到反馈前就崩溃。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 60/60。staging 测试此前只钉了 `cp` 字符串与调用串,却从未检查 SKILL.md 能否从 staged 位置解析到 —— 正是这个盲点放行了本次回归。现在测试从调用串推出 staged runner 路径,计算 `<dir>/../SKILL.md`,断言存在一条 `cp` 恰好 stage 该路径(以及镜像的 `mkdir -p .../scripts`);扁平 stage 会让套件失败。
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` —— 12/12(未改动)。
3. 静态:YAML 可解析;所有 `run:` 块通过 `bash -n`。
4. 合并后冒烟:下一次 review-address 运行(有新反馈的 bot PR,或任一接管 PR)能进入「Triage and address」并读到 SKILL,而不再在 `promptFor` 崩溃。

## 风险与范围

- 主要风险:无实质风险 —— 改动仅限于两份可信文件在 `${RUNNER_TEMP}` 下的布局,以及 review-address 步骤调用哪条路径。issue 阶段调用(仓库内副本、检出前)不变。安全面严格改善:模型指令改为来自可信基座。
- 破坏性变更:无。

## 关联 Issue

#7165 的回归修复。

</details>
