### PR TITLE
feat(autofix): surface the running model in every autofix report

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1076,7 +1076,9 @@ jobs:
           # trigger CI. The bot PAT clears both problems.
           GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
           ISSUE: '${{ steps.decision.outputs.go_issue }}'
+          MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
+          MODEL_DISPLAY="${MODEL:-default}"
           if [[ -z "${GITHUB_TOKEN}" ]]; then
             echo '::error::CI_DEV_BOT_PAT is required to publish the PR as the autofix bot.'
             exit 1
@@ -1107,6 +1109,11 @@ jobs:
           echo "🚀 Opened ${PR_URL}"
 
           # Per AGENTS.md, post the E2E report as a separate PR comment.
+          {
+            echo
+            echo "---"
+            echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
+          } >> "${WORKDIR}/e2e-report.md"
           gh pr comment "${PR_URL}" --body-file "${WORKDIR}/e2e-report.md"
 
       - name: 'Report dry-run / failure'
@@ -2307,10 +2314,14 @@ jobs:
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           NEWEST: '${{ steps.prepare.outputs.newest }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
+          # Surfaced in the report footer for diagnosis + attribution; a repo
+          # variable (not a secret), already the agent's OPENAI_MODEL.
+          MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
           # Prepare may have adopted a sibling's live round; the matrix value
           # would double-write that round's marker.
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
+          MODEL_DISPLAY="${MODEL:-default}"
           if [[ -z "${GITHUB_TOKEN}" ]]; then
             echo '::error::CI_DEV_BOT_PAT is required to push and report as qwen-code-dev-bot.'
             exit 1
@@ -2355,6 +2366,9 @@ jobs:
               echo
               echo "Re-review when you have a moment. After round ${MAX_ROUNDS} this bot stops and leaves the PR for a human."
               echo
+              echo "---"
+              echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
+              echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=true round=${NEXT_ROUND} win=${WINDOW:-none} -->"
             } > "${WORKDIR}/report.md"
             STATUS="pushed (round ${NEXT_ROUND}/${MAX_ROUNDS})"
@@ -2367,6 +2381,9 @@ jobs:
               sed 's/<!--/<!\\-\\-/g' "${WORKDIR}/no-action.md"
               echo
               echo "Base-conflict check: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicts with main (no review fix needed, but a rebase/merge is required before merge).' || echo 'no conflict with main.')"
+              echo
+              echo "---"
+              echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} win=${WINDOW:-none} -->"
             } > "${WORKDIR}/report.md"
@@ -2401,8 +2418,10 @@ jobs:
           JOB_STATUS: '${{ job.status }}'
           STALE: '${{ steps.prepare.outputs.stale }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
+          MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
+          MODEL_DISPLAY="${MODEL:-default}"
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
           {
@@ -2515,6 +2534,9 @@ jobs:
               echo
               echo
               echo "Run log: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo
+              echo "---"
+              echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${MARK_TS} acted=false round=${MARK_ROUND} win=${WINDOW:-none} -->"
             } > "${WORKDIR}/report.md"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1876,6 +1876,7 @@ describe('qwen-autofix workflow', () => {
     // footer appears twice there; the handoff and issue-phase reports once.
     expect(pushAndReportStep.split(footer).length - 1).toBe(2);
     expect(reviewAddressReportStep.split(footer).length - 1).toBe(1);
+    expect(publishPrStep.split(footer).length - 1).toBe(1);
     // The footer is appended to the model-authored e2e report before it is
     // posted, not injected into the model's own file mid-generation.
     expect(publishPrStep).toContain(

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1855,6 +1855,39 @@ describe('qwen-autofix workflow', () => {
     );
   });
 
+  it('surfaces the running model in every autofix report for diagnosis and attribution', () => {
+    // The model is a repo variable (already the agent's OPENAI_MODEL), not a
+    // secret, so it is safe to echo into a public comment. Each reporting
+    // step must plumb it in and render a footer that names Qwen Code and the
+    // model, with an empty-variable fallback so the footer never renders a
+    // bare backtick pair.
+    const footer =
+      'echo "🧠 Handled by **Qwen Code** · model/模型 \\`${MODEL_DISPLAY}\\`"';
+    for (const step of [
+      pushAndReportStep,
+      reviewAddressReportStep,
+      publishPrStep,
+    ]) {
+      expect(step).toContain("MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'");
+      expect(step).toContain('MODEL_DISPLAY="${MODEL:-default}"');
+      expect(step).toContain(footer);
+    }
+    // Push-and-report carries BOTH the fixed and no-action bodies, so the
+    // footer appears twice there; the handoff and issue-phase reports once.
+    expect(pushAndReportStep.split(footer).length - 1).toBe(2);
+    expect(reviewAddressReportStep.split(footer).length - 1).toBe(1);
+    // The footer is appended to the model-authored e2e report before it is
+    // posted, not injected into the model's own file mid-generation.
+    expect(publishPrStep).toContain(
+      '} >> "${WORKDIR}/e2e-report.md"\n          gh pr comment "${PR_URL}" --body-file "${WORKDIR}/e2e-report.md"',
+    );
+    // The footer sits with the report bodies (before the eval marker), never
+    // inside the model output that gets comment-token-scrubbed.
+    expect(pushAndReportStep).toMatch(
+      /echo "🧠 Handled by[^\n]*\n\s+echo\n\s+echo "<!-- autofix-eval ts=\$\{NEWEST\} acted=true/,
+    );
+  });
+
   it('runs heavy autofix jobs on hosted runners with sandbox images', () => {
     const workflowAndSkill = `${workflow}\n${readAutofixSkill()}`;
 


### PR DESCRIPTION
## What this PR does

Adds a one-line footer to every visible autofix comment, naming **Qwen Code** and the model it ran:

```
---
🧠 Handled by **Qwen Code** · model/模型 `qwen3.7-max`
```

Four surfaces: the review-address **fixed** report, the **no-action** report, the **handoff** report, and the issue-phase PR's **E2E** comment.

Two reasons, both requested by the maintainer: **diagnosis** (which model produced a given result — invaluable when a run behaves oddly) and a small **attribution** for our own model.

## How it works

The model comes from the `QWEN_PR_REVIEW_MODEL` repo variable — already the agent's `OPENAI_MODEL`, a variable (not a secret), so it is safe to echo into a public comment. Each reporting step plumbs it into its env and computes `MODEL_DISPLAY="${MODEL:-default}"`, so an unset variable renders `default` rather than a bare backtick pair. The footer sits with the workflow-authored report body (immediately before the invisible `<!-- autofix-eval -->` marker); on the E2E path it is **appended** to the model-authored file after generation, never injected mid-stream.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 61/61. The new test pins the `MODEL` env plumbing and the footer on all four surfaces (it appears **twice** in push-and-report, which carries both the fixed and no-action bodies), the `default` fallback, and the append-after ordering on the E2E path.
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` — 12/12 (untouched).
3. Static: YAML parses; every `run:` block passes `bash -n`; the footer's escaped backticks render as inline code (verified by executing the body).

### Evidence (rendered footer)

```
🤖 Addressed the latest review feedback (round 3/100). What changed, and what I pushed back on:

changed X and Y

Base-conflict check: no conflict with main.

---
🧠 Handled by **Qwen Code** · model/模型 `qwen3.7-max`

<!-- autofix-eval ts=… acted=true round=3 win=… -->
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

## Risk & Scope

- Main risk or tradeoff: none — `QWEN_PR_REVIEW_MODEL` is a non-secret repo variable already exposed as `OPENAI_MODEL` and in logs; echoing it into a comment leaks nothing new. Purely additive display text.
- Not validated / out of scope: the footer is only *seen* once a review-address run completes; that path is currently blocked by the P0 in #7225 (independent regions, no conflict) — this PR rides on top of that fix landing.
- Breaking changes / migration notes: none.

## Linked Issues

Independent of, but best seen after, #7225 (P0 review-address fix).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给每一条可见的 autofix 评论加一行 footer,标注 **Qwen Code** 与本次运行的模型:

```
---
🧠 Handled by **Qwen Code** · model/模型 `qwen3.7-max`
```

四个出现位置:review-address 的**已修复**报告、**无需改动**报告、**交接(handoff)**报告,以及 issue 阶段新建 PR 的 **E2E** 评论。

两个目的(均为维护者要求):**诊断**(某次结果是哪个模型产出的 —— 运行异常时极有价值)与给自家模型做一点**署名/广告**。

## 实现方式

模型取自 `QWEN_PR_REVIEW_MODEL` 仓库变量 —— 本就是 agent 的 `OPENAI_MODEL`,是变量而非 secret,写入公开评论无泄露风险。每个报告步骤把它注入 env 并计算 `MODEL_DISPLAY="${MODEL:-default}"`,变量为空时显示 `default` 而非空的反引号对。footer 位于 workflow 生成的报告正文中(紧邻不可见的 `<!-- autofix-eval -->` marker 之前);E2E 路径上则在模型生成文件之后**追加**,绝不中途注入。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 61/61。新测试钉住四处的 `MODEL` env 注入与 footer(在同时承载「已修复 + 无需改动」两个正文的 push-and-report 中出现**两次**)、`default` 兜底,以及 E2E 路径的「先生成后追加」顺序。
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` —— 12/12(未改动)。
3. 静态:YAML 可解析;所有 `run:` 块通过 `bash -n`;footer 的转义反引号渲染为行内代码(已实跑正文验证)。

## 风险与范围

- 主要风险:无 —— `QWEN_PR_REVIEW_MODEL` 是非 secret 仓库变量,本就作为 `OPENAI_MODEL` 暴露、也出现在日志中,写入评论不新增泄露。纯展示文本、只增不改。
- 不在范围内:footer 只有在 review-address 运行完成后才**可见**,而该路径当前被 #7225 的 P0 阻断(两者区域独立、不冲突)—— 本 PR 依赖该修复合入后方能显现效果。
- 破坏性变更:无。

## 关联 Issue

与 #7225(P0 review-address 修复)相互独立,但建议在其合入后查看效果。

</details>
