### PR TITLE
fix(acp-bridge): map Windows-shaped workspace paths to their sandbox mount

### DIFF
--- a/packages/acp-bridge/src/bridge.sandbox.test.ts
+++ b/packages/acp-bridge/src/bridge.sandbox.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeBridge, makeChannel } from './internal/testUtils.js';
+import { _setSandboxMountExistsForTest } from './workspacePaths.js';
+
+// #7139 wiring for the bridge ingestion site: `resolveWorkspaceKey` guards
+// with `path.isAbsolute` before canonicalizing, so a Windows-shaped
+// `workspaceCwd` arriving via spawnOrAttach (clients, persisted
+// registrations) must be translated to its bind mount first — the sibling
+// of the dispatch/request-helpers/route/boot-validator wiring tests.
+describe('bridge spawnOrAttach inside a POSIX container sandbox (#7139)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _setSandboxMountExistsForTest(undefined);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'accepts a Windows-shaped workspaceCwd bound to its mount location',
+    async () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        boundWorkspace: '/c/qwen-repro',
+        channelFactory: vi.fn().mockResolvedValue(handle.channel),
+      });
+      try {
+        const session = await bridge.spawnOrAttach({
+          workspaceCwd: 'C:\\qwen-repro',
+        });
+        expect(session.sessionId).toBeTruthy();
+      } finally {
+        await bridge.shutdown();
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects a Windows-shaped workspaceCwd outside a sandbox',
+    async () => {
+      vi.stubEnv('SANDBOX', '');
+      const handle = makeChannel();
+      const bridge = makeBridge({
+        boundWorkspace: '/c/qwen-repro',
+        channelFactory: vi.fn().mockResolvedValue(handle.channel),
+      });
+      try {
+        await expect(
+          bridge.spawnOrAttach({ workspaceCwd: 'C:\\qwen-repro' }),
+        ).rejects.toThrow('workspaceCwd must be an absolute path');
+      } finally {
+        await bridge.shutdown();
+      }
+    },
+  );
+});

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -82,7 +82,10 @@ import {
   SessionBusyError,
   InvalidRewindTargetError,
 } from './bridgeErrors.js';
-import { canonicalizeWorkspace } from './workspacePaths.js';
+import {
+  canonicalizeWorkspace,
+  translateWindowsWorkspaceForPosixSandbox,
+} from './workspacePaths.js';
 import { parseSessionSource } from './session-source.js';
 import {
   CHANNEL_STARTUP_PROFILE_META_KEY,
@@ -2845,7 +2848,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     return entry.transportClosedReject;
   };
 
-  const resolveWorkspaceKey = (workspaceCwd: string): string => {
+  const resolveWorkspaceKey = (rawWorkspaceCwd: string): string => {
+    // #7139: host-shaped Windows paths reach the in-container bridge via
+    // clients and persisted registrations; map to the bind mount before
+    // the absolute-path guard (no-op outside a POSIX container sandbox).
+    const workspaceCwd =
+      translateWindowsWorkspaceForPosixSandbox(rawWorkspaceCwd);
     if (!path.isAbsolute(workspaceCwd)) {
       throw new Error(
         `workspaceCwd must be an absolute path; got "${workspaceCwd}"`,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -84,7 +84,7 @@ import {
 } from './bridgeErrors.js';
 import {
   canonicalizeWorkspace,
-  translateWindowsWorkspaceForPosixSandbox,
+  translateAndCheckAbsoluteWorkspacePath,
 } from './workspacePaths.js';
 import { parseSessionSource } from './session-source.js';
 import {
@@ -2850,13 +2850,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
 
   const resolveWorkspaceKey = (rawWorkspaceCwd: string): string => {
     // #7139: host-shaped Windows paths reach the in-container bridge via
-    // clients and persisted registrations; map to the bind mount before
-    // the absolute-path guard (no-op outside a POSIX container sandbox).
+    // clients and persisted registrations; the shared helper maps them to
+    // the bind mount before the absolute-path check.
     const workspaceCwd =
-      translateWindowsWorkspaceForPosixSandbox(rawWorkspaceCwd);
-    if (!path.isAbsolute(workspaceCwd)) {
+      translateAndCheckAbsoluteWorkspacePath(rawWorkspaceCwd);
+    if (workspaceCwd === null) {
       throw new Error(
-        `workspaceCwd must be an absolute path; got "${workspaceCwd}"`,
+        `workspaceCwd must be an absolute path; got "${rawWorkspaceCwd}"`,
       );
     }
     const workspaceKey =

--- a/packages/acp-bridge/src/workspacePaths.sandbox.test.ts
+++ b/packages/acp-bridge/src/workspacePaths.sandbox.test.ts
@@ -37,6 +37,10 @@ describe('canonicalizeWorkspace inside a POSIX container sandbox (#7139)', () =>
   it.skipIf(process.platform === 'win32')(
     'keeps Windows-shaped input untouched outside a sandbox',
     () => {
+      // Explicitly clear SANDBOX: when this suite itself runs inside the
+      // project's Docker sandbox the launcher sets it, and unstubAllEnvs
+      // would not remove a genuinely inherited value.
+      vi.stubEnv('SANDBOX', '');
       const result = canonicalizeWorkspace('C:\\qwen-repro');
       // Unsandboxed POSIX behavior is unchanged: the string resolves
       // relative to the cwd (and stays broken — which is what the

--- a/packages/acp-bridge/src/workspacePaths.sandbox.test.ts
+++ b/packages/acp-bridge/src/workspacePaths.sandbox.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { canonicalizeWorkspace } from './workspacePaths.js';
+
+// Isolated from workspacePaths.test.ts because it mocks node:fs — the other
+// file drives real filesystem fixtures.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs');
+  return {
+    ...actual,
+    existsSync: (p: unknown) =>
+      p === '/c/qwen-repro' ? true : actual.existsSync(p as never),
+  };
+});
+
+describe('canonicalizeWorkspace inside a POSIX container sandbox (#7139)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'resolves a Windows-shaped workspace to its bind-mount location',
+    () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      // The mount exists (mocked), realpath on it ENOENTs on this host, so
+      // the fallback returns the translated absolute path — NOT the cwd
+      // concatenation `path.resolve` alone would produce.
+      expect(canonicalizeWorkspace('C:\\qwen-repro')).toBe('/c/qwen-repro');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps Windows-shaped input untouched outside a sandbox',
+    () => {
+      const result = canonicalizeWorkspace('C:\\qwen-repro');
+      // Unsandboxed POSIX behavior is unchanged: the string resolves
+      // relative to the cwd (and stays broken — which is what the
+      // pre-#7139 sandbox path produced too).
+      expect(result.endsWith('C:\\qwen-repro')).toBe(true);
+      expect(result.startsWith('/')).toBe(true);
+    },
+  );
+});

--- a/packages/acp-bridge/src/workspacePaths.test.ts
+++ b/packages/acp-bridge/src/workspacePaths.test.ts
@@ -8,7 +8,10 @@ import { promises as fsp, realpathSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { canonicalizeWorkspaces } from './workspacePaths.js';
+import {
+  canonicalizeWorkspaces,
+  translateWindowsWorkspaceForPosixSandbox,
+} from './workspacePaths.js';
 
 const scratches: string[] = [];
 
@@ -44,5 +47,79 @@ describe('canonicalizeWorkspaces', () => {
 
   it('returns an empty array for empty input', () => {
     expect(canonicalizeWorkspaces([])).toEqual([]);
+  });
+});
+
+// Regression for #7139: a Windows host relaunching `qwen serve` into a Linux
+// Docker sandbox forwards `--workspace C:\…` (and client/persisted workspace
+// registrations) in host shape; every ACP child then failed with
+// `chdir(2) ENOENT`. These tests pin the container-side translation.
+describe('translateWindowsWorkspaceForPosixSandbox', () => {
+  const sandboxOpts = (exists: boolean) => ({
+    platform: 'linux' as NodeJS.Platform,
+    sandboxEnv: 'qwen-code-sandbox-0',
+    exists: () => exists,
+  });
+
+  it('maps a Windows-absolute path to its bind-mount location', () => {
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'C:\\qwen-repro',
+        sandboxOpts(true),
+      ),
+    ).toBe('/c/qwen-repro');
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'D:/Work/proj sub',
+        sandboxOpts(true),
+      ),
+    ).toBe('/d/Work/proj sub');
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'C:\\nested\\dir\\leaf',
+        sandboxOpts(true),
+      ),
+    ).toBe('/c/nested/dir/leaf');
+  });
+
+  it('leaves the path alone when the translated mount does not exist', () => {
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'C:\\qwen-repro',
+        sandboxOpts(false),
+      ),
+    ).toBe('C:\\qwen-repro');
+  });
+
+  it('leaves non-Windows-shaped paths alone', () => {
+    for (const p of ['/c/qwen-repro', 'relative/dir', 'C:', 'CC:\\x', '']) {
+      expect(
+        translateWindowsWorkspaceForPosixSandbox(p, sandboxOpts(true)),
+      ).toBe(p);
+    }
+  });
+
+  it('is inert on Windows hosts, outside sandboxes, and under seatbelt', () => {
+    expect(
+      translateWindowsWorkspaceForPosixSandbox('C:\\qwen-repro', {
+        platform: 'win32',
+        sandboxEnv: 'qwen-code-sandbox-0',
+        exists: () => true,
+      }),
+    ).toBe('C:\\qwen-repro');
+    expect(
+      translateWindowsWorkspaceForPosixSandbox('C:\\qwen-repro', {
+        platform: 'linux',
+        sandboxEnv: undefined,
+        exists: () => true,
+      }),
+    ).toBe('C:\\qwen-repro');
+    expect(
+      translateWindowsWorkspaceForPosixSandbox('C:\\qwen-repro', {
+        platform: 'darwin',
+        sandboxEnv: 'sandbox-exec',
+        exists: () => true,
+      }),
+    ).toBe('C:\\qwen-repro');
   });
 });

--- a/packages/acp-bridge/src/workspacePaths.test.ts
+++ b/packages/acp-bridge/src/workspacePaths.test.ts
@@ -91,6 +91,24 @@ describe('translateWindowsWorkspaceForPosixSandbox', () => {
     ).toBe('C:\\qwen-repro');
   });
 
+  it('refuses ..-laden input that escapes the drive mount', () => {
+    // existsSync would resolve /c/../../etc to /etc and return true — the
+    // guard must refuse before the probe can bless an out-of-mount path.
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'C:\\..\\..\\etc',
+        sandboxOpts(true),
+      ),
+    ).toBe('C:\\..\\..\\etc');
+    // In-mount .. that stays under the drive prefix is still fine.
+    expect(
+      translateWindowsWorkspaceForPosixSandbox(
+        'C:\\work\\..\\proj',
+        sandboxOpts(true),
+      ),
+    ).toBe('/c/work/../proj');
+  });
+
   it('leaves non-Windows-shaped paths alone', () => {
     for (const p of ['/c/qwen-repro', 'relative/dir', 'C:', 'CC:\\x', '']) {
       expect(

--- a/packages/acp-bridge/src/workspacePaths.test.ts
+++ b/packages/acp-bridge/src/workspacePaths.test.ts
@@ -7,9 +7,11 @@
 import { promises as fsp, realpathSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  _setSandboxMountExistsForTest,
   canonicalizeWorkspaces,
+  translateAndCheckAbsoluteWorkspacePath,
   translateWindowsWorkspaceForPosixSandbox,
 } from './workspacePaths.js';
 
@@ -47,6 +49,39 @@ describe('canonicalizeWorkspaces', () => {
 
   it('returns an empty array for empty input', () => {
     expect(canonicalizeWorkspaces([])).toEqual([]);
+  });
+});
+
+// The single ingestion-ordering enforcement point: translation before the
+// absolute-path check, shared by all five workspace-ingestion sites.
+describe('translateAndCheckAbsoluteWorkspacePath', () => {
+  it('returns the translated mount for Windows-shaped input in a sandbox', () => {
+    vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+    _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+    try {
+      expect(translateAndCheckAbsoluteWorkspacePath('C:\\qwen-repro')).toBe(
+        '/c/qwen-repro',
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      _setSandboxMountExistsForTest(undefined);
+    }
+  });
+
+  it('returns null for non-absolute input (untranslated Windows shape included)', () => {
+    vi.stubEnv('SANDBOX', '');
+    try {
+      expect(translateAndCheckAbsoluteWorkspacePath('C:\\qwen-repro')).toBe(
+        null,
+      );
+      expect(translateAndCheckAbsoluteWorkspacePath('relative/dir')).toBe(null);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('passes POSIX absolute paths through unchanged', () => {
+    expect(translateAndCheckAbsoluteWorkspacePath('/work/a')).toBe('/work/a');
   });
 });
 

--- a/packages/acp-bridge/src/workspacePaths.ts
+++ b/packages/acp-bridge/src/workspacePaths.ts
@@ -4,8 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { realpathSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import * as path from 'node:path';
+
+const WINDOWS_ABSOLUTE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
+
+/**
+ * Maps a Windows-shaped absolute path to the container mount produced by the
+ * host-side sandbox launcher (`C:\work\proj` → `/c/work/proj`, mirroring
+ * `getContainerPath` in `cli/src/utils/sandbox.ts`).
+ *
+ * A Windows host relaunching `qwen serve` into a Linux Docker/Podman sandbox
+ * translates the bind mount and `--workdir`, but path-valued CLI arguments
+ * (`--workspace C:\…`), client-registered workspaces, and persisted
+ * registrations reach the in-container daemon in host shape. Left alone,
+ * `path.resolve` on Linux mangles them further (prepends the cwd) and every
+ * ACP child spawn fails with `chdir(2) ENOENT` before running anything
+ * (#7139).
+ *
+ * Deliberately conservative — the input is returned unchanged unless ALL of:
+ * - the daemon is running on POSIX inside a container sandbox (`SANDBOX` env
+ *   set by the launcher; macOS `sandbox-exec` does not remap paths and is
+ *   excluded),
+ * - the path is Windows-absolute (`<drive>:\…` or `<drive>:/…`),
+ * - the translated candidate actually exists (i.e. the drive really is
+ *   mounted the way the launcher mounts workspaces).
+ *
+ * The `opts` seams exist for tests; production callers use the defaults.
+ */
+export function translateWindowsWorkspaceForPosixSandbox(
+  p: string,
+  opts: {
+    platform?: NodeJS.Platform;
+    sandboxEnv?: string | undefined;
+    exists?: (candidate: string) => boolean;
+  } = {},
+): string {
+  const platform = opts.platform ?? process.platform;
+  const sandboxEnv =
+    'sandboxEnv' in opts ? opts.sandboxEnv : process.env['SANDBOX'];
+  const exists = opts.exists ?? existsSync;
+  if (platform === 'win32' || !sandboxEnv || sandboxEnv === 'sandbox-exec') {
+    return p;
+  }
+  const match = WINDOWS_ABSOLUTE_PATH_RE.exec(p);
+  if (!match) return p;
+  const translated = `/${match[1]!.toLowerCase()}/${match[2]!.replace(/\\/g, '/')}`;
+  return exists(translated) ? translated : p;
+}
 
 /**
  * Canonicalize a workspace path so the boot-time bound path and every
@@ -40,7 +86,11 @@ import * as path from 'node:path';
  * at the original location.
  */
 export function canonicalizeWorkspace(p: string): string {
-  const resolved = path.resolve(p);
+  // #7139: inside a Linux container sandbox, host-shaped Windows workspace
+  // paths must be mapped to their bind-mount location BEFORE resolution —
+  // `path.resolve('C:\\x')` on POSIX treats the whole string as relative
+  // and prepends the cwd.
+  const resolved = path.resolve(translateWindowsWorkspaceForPosixSandbox(p));
   try {
     // FIXME(stage-2): switch to `fs.promises.realpath` once the
     // bridge call sites become async-friendly. This sync syscall

--- a/packages/acp-bridge/src/workspacePaths.ts
+++ b/packages/acp-bridge/src/workspacePaths.ts
@@ -32,6 +32,17 @@ const WINDOWS_ABSOLUTE_PATH_RE = /^([A-Za-z]):[\\/](.*)$/;
  *
  * The `opts` seams exist for tests; production callers use the defaults.
  */
+// Test-only override for the mount-existence probe: the translated target
+// (`/c/…`) sits at the filesystem root, which tests cannot create, and
+// cross-package node:fs mocks don't reach this module's binding. Follows
+// the `_reset*ForTest` convention.
+let sandboxMountExistsOverrideForTest: ((p: string) => boolean) | undefined;
+export function _setSandboxMountExistsForTest(
+  fn?: (p: string) => boolean,
+): void {
+  sandboxMountExistsOverrideForTest = fn;
+}
+
 export function translateWindowsWorkspaceForPosixSandbox(
   p: string,
   opts: {
@@ -43,7 +54,7 @@ export function translateWindowsWorkspaceForPosixSandbox(
   const platform = opts.platform ?? process.platform;
   const sandboxEnv =
     'sandboxEnv' in opts ? opts.sandboxEnv : process.env['SANDBOX'];
-  const exists = opts.exists ?? existsSync;
+  const exists = opts.exists ?? sandboxMountExistsOverrideForTest ?? existsSync;
   if (platform === 'win32' || !sandboxEnv || sandboxEnv === 'sandbox-exec') {
     return p;
   }

--- a/packages/acp-bridge/src/workspacePaths.ts
+++ b/packages/acp-bridge/src/workspacePaths.ts
@@ -61,7 +61,19 @@ export function translateWindowsWorkspaceForPosixSandbox(
   const match = WINDOWS_ABSOLUTE_PATH_RE.exec(p);
   if (!match) return p;
   const translated = `/${match[1]!.toLowerCase()}/${match[2]!.replace(/\\/g, '/')}`;
-  return exists(translated) ? translated : p;
+  // `..` segments would let the existence probe resolve outside the drive
+  // mount (`C:\..\..\etc` -> existsSync('/c/../../etc') === true via /etc),
+  // making the "translated candidate actually exists" contract a lie. Not a
+  // privilege escalation (downstream workspace binding still rejects it),
+  // but refuse to translate anything that escapes the drive prefix.
+  const resolvedTranslated = path.resolve(translated);
+  if (
+    resolvedTranslated !== `/${match[1]!.toLowerCase()}` &&
+    !resolvedTranslated.startsWith(`/${match[1]!.toLowerCase()}/`)
+  ) {
+    return p;
+  }
+  return exists(resolvedTranslated) ? translated : p;
 }
 
 /**

--- a/packages/acp-bridge/src/workspacePaths.ts
+++ b/packages/acp-bridge/src/workspacePaths.ts
@@ -108,6 +108,25 @@ export function translateWindowsWorkspaceForPosixSandbox(
  * `cli/src/serve/fs/paths.ts` re-exports for callers still pointing
  * at the original location.
  */
+/**
+ * Single enforcement point for the workspace-ingestion ordering (#7139):
+ * the sandbox translation MUST run before the absolute-path check, because
+ * `path.isAbsolute('C:\\…')` is false on POSIX and would reject the
+ * host-shaped input before `canonicalizeWorkspace`'s own translation could
+ * ever see it. Every ingestion site calls this instead of hand-rolling the
+ * translate-then-isAbsolute pair, so a future sixth endpoint cannot forget
+ * the ordering.
+ *
+ * Returns the translated path, or null when it is not absolute — callers
+ * keep their own error surface (HTTP 400, AcpParamError, boot Error).
+ */
+export function translateAndCheckAbsoluteWorkspacePath(
+  raw: string,
+): string | null {
+  const translated = translateWindowsWorkspaceForPosixSandbox(raw);
+  return path.isAbsolute(translated) ? translated : null;
+}
+
 export function canonicalizeWorkspace(p: string): string {
   // #7139: inside a Linux container sandbox, host-shaped Windows workspace
   // paths must be mapped to their bind-mount location BEFORE resolution —

--- a/packages/cli/src/serve/acp-http/dispatch.sandbox.test.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.sandbox.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge/workspacePaths';
+import { parseOptionalWorkspaceCwd } from './dispatch.js';
+
+// #7139 wiring: the ACP JSON-RPC `cwd` entry point must translate a
+// Windows-shaped path to its bind mount BEFORE its absolute-path guard —
+// this is the dispatch-side sibling of request-helpers.sandbox.test.ts.
+describe('ACP dispatch parseOptionalWorkspaceCwd inside a POSIX container sandbox (#7139)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _setSandboxMountExistsForTest(undefined);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'accepts a Windows-shaped cwd and returns its bind-mount location',
+    () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+      expect(
+        parseOptionalWorkspaceCwd({ cwd: 'C:\\qwen-repro' }, '/c/qwen-repro'),
+      ).toBe('/c/qwen-repro');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects a Windows-shaped cwd outside a sandbox',
+    () => {
+      vi.stubEnv('SANDBOX', '');
+      expect(() =>
+        parseOptionalWorkspaceCwd({ cwd: 'C:\\qwen-repro' }, '/tmp'),
+      ).toThrow('`cwd` must be an absolute path when provided');
+    },
+  );
+});

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -42,7 +42,10 @@ import {
 } from '../auth/device-flow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { parseSessionSource } from '@qwen-code/acp-bridge';
-import { translateWindowsWorkspaceForPosixSandbox , canonicalizeWorkspace } from '@qwen-code/acp-bridge/workspacePaths';
+import {
+  translateWindowsWorkspaceForPosixSandbox,
+  canonicalizeWorkspace,
+} from '@qwen-code/acp-bridge/workspacePaths';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {
   SessionShellClientRequiredError,
@@ -305,7 +308,9 @@ function parseOptionalSafeIntegerInRange(
  * Closes the body-amplification DoS the REST code documents. Returns the
  * bound workspace when omitted.
  */
-function parseOptionalWorkspaceCwd(
+// Exported for the sandbox-translation wiring test — this is the entry
+// point for every ACP JSON-RPC `cwd` (#7139).
+export function parseOptionalWorkspaceCwd(
   params: Record<string, unknown>,
   boundWorkspace: string,
 ): string {

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -41,7 +41,10 @@ import {
   UpstreamDeviceFlowError,
 } from '../auth/device-flow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
-import { parseSessionSource } from '@qwen-code/acp-bridge';
+import {
+  parseSessionSource,
+  translateWindowsWorkspaceForPosixSandbox,
+} from '@qwen-code/acp-bridge';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {
   SessionShellClientRequiredError,
@@ -321,13 +324,16 @@ function parseOptionalWorkspaceCwd(
       `\`cwd\` exceeds the ${MAX_WORKSPACE_PATH_LENGTH}-character limit`,
     );
   }
+  // #7139: map a Windows-shaped cwd to its container bind mount before
+  // the absolute-path guard (no-op outside a POSIX container sandbox).
+  const sandboxCwd = translateWindowsWorkspaceForPosixSandbox(cwd);
   // `path.isAbsolute` (platform-aware) — same as the REST route. A bare
   // `startsWith('/')` would reject valid Windows `C:\…`/UNC paths a client
   // gets back from `/capabilities.workspaceCwd`.
-  if (!path.isAbsolute(cwd)) {
+  if (!path.isAbsolute(sandboxCwd)) {
     throw new AcpParamError('`cwd` must be an absolute path when provided');
   }
-  return cwd;
+  return sandboxCwd;
 }
 
 /** Validate a `session/prompt` body before it reaches the bridge/agent. */

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -41,10 +41,8 @@ import {
   UpstreamDeviceFlowError,
 } from '../auth/device-flow.js';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
-import {
-  parseSessionSource,
-  translateWindowsWorkspaceForPosixSandbox,
-} from '@qwen-code/acp-bridge';
+import { parseSessionSource } from '@qwen-code/acp-bridge';
+import { translateWindowsWorkspaceForPosixSandbox , canonicalizeWorkspace } from '@qwen-code/acp-bridge/workspacePaths';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {
   SessionShellClientRequiredError,
@@ -55,7 +53,6 @@ import {
   SessionArtifactAuthorizationError,
   SessionArtifactValidationError,
 } from '@qwen-code/acp-bridge/sessionArtifacts';
-import { canonicalizeWorkspace } from '@qwen-code/acp-bridge/workspacePaths';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { MAX_WORKSPACE_PATH_LENGTH } from '../fs/paths.js';
 import {

--- a/packages/cli/src/serve/acp-http/dispatch.ts
+++ b/packages/cli/src/serve/acp-http/dispatch.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'node:path';
 import {
   APPROVAL_MODES,
   type ApprovalMode,
@@ -43,7 +42,7 @@ import {
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { parseSessionSource } from '@qwen-code/acp-bridge';
 import {
-  translateWindowsWorkspaceForPosixSandbox,
+  translateAndCheckAbsoluteWorkspacePath,
   canonicalizeWorkspace,
 } from '@qwen-code/acp-bridge/workspacePaths';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
@@ -326,13 +325,11 @@ export function parseOptionalWorkspaceCwd(
       `\`cwd\` exceeds the ${MAX_WORKSPACE_PATH_LENGTH}-character limit`,
     );
   }
-  // #7139: map a Windows-shaped cwd to its container bind mount before
-  // the absolute-path guard (no-op outside a POSIX container sandbox).
-  const sandboxCwd = translateWindowsWorkspaceForPosixSandbox(cwd);
-  // `path.isAbsolute` (platform-aware) — same as the REST route. A bare
-  // `startsWith('/')` would reject valid Windows `C:\…`/UNC paths a client
-  // gets back from `/capabilities.workspaceCwd`.
-  if (!path.isAbsolute(sandboxCwd)) {
+  // #7139: the shared helper maps a Windows-shaped cwd to its container
+  // bind mount before the (platform-aware) absolute-path check — same as
+  // the REST route.
+  const sandboxCwd = translateAndCheckAbsoluteWorkspacePath(cwd);
+  if (sandboxCwd === null) {
     throw new AcpParamError('`cwd` must be an absolute path when provided');
   }
   return sandboxCwd;

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -452,9 +452,13 @@ describe('CLI entry import boundary', () => {
     expect(requestHelpersSource).toContain(
       "import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';",
     );
-    expect(requestHelpersSource).toContain(
-      "import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';",
+    // MAX_WORKSPACE_PATH_LENGTH (and, since #7139, the sandbox path
+    // translation) must come from the workspacePaths subpath — never the
+    // acp-bridge barrel or the compatibility shim.
+    expect(requestHelpersSource).toMatch(
+      /import \{[^}]*\bMAX_WORKSPACE_PATH_LENGTH\b[^}]*\} from '@qwen-code\/acp-bridge\/workspacePaths';/,
     );
+    expect(requestHelpersSource).not.toMatch(/from '@qwen-code\/acp-bridge';/);
   });
 
   it('keeps the runQwenServe static source graph free of ACP runtime modules', () => {

--- a/packages/cli/src/serve/process-env-guard.test.ts
+++ b/packages/cli/src/serve/process-env-guard.test.ts
@@ -53,6 +53,17 @@ const allowedProcessEnvAccesses = normalizeAllowances([
     },
   ],
   [
+    'packages/acp-bridge/src/workspacePaths.ts',
+    {
+      reason:
+        'Whether the daemon runs inside a container sandbox is process-scoped: ' +
+        'the sandbox launcher marks the whole process via the SANDBOX env, and ' +
+        'workspace canonicalization uses it to map Windows-shaped host paths ' +
+        'to their bind-mount location (#7139).',
+      accesses: { 'key:SANDBOX': 1 },
+    },
+  ],
+  [
     'packages/cli/src/serve/acp-http-enabled.ts',
     {
       reason:

--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge/workspacePaths';
 import express, { type Request, type Response } from 'express';
 import request from 'supertest';
 import {
@@ -189,6 +190,48 @@ describe('POST /workspaces', () => {
     expect(res.status).toBe(400);
     expect(res.body.code).toBe('invalid_path');
   });
+
+  // #7139 wiring: with a container sandbox active, a Windows-shaped cwd is
+  // translated to its bind mount BEFORE the absolute-path guard — the 400
+  // moves from the isAbsolute rejection to the (deeper) existence check,
+  // because the root-level translated mount cannot exist in a test.
+  it.skipIf(process.platform === 'win32')(
+    'translates a Windows-shaped cwd past the absolute-path guard in a sandbox',
+    async () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+      try {
+        const { app } = createApp();
+        const res = await request(app)
+          .post('/workspaces')
+          .send({ cwd: 'C:\\qwen-repro' });
+        expect(res.status).toBe(400);
+        // Past the guard: the failure is now the realpath existence check,
+        // not the absolute-path rejection.
+        expect(res.body.error).toBe('Path does not exist or is not accessible');
+      } finally {
+        vi.unstubAllEnvs();
+        _setSandboxMountExistsForTest(undefined);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects a Windows-shaped cwd outside a sandbox',
+    async () => {
+      vi.stubEnv('SANDBOX', '');
+      try {
+        const { app } = createApp();
+        const res = await request(app)
+          .post('/workspaces')
+          .send({ cwd: 'C:\\qwen-repro' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('`cwd` must be an absolute path');
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it('returns 400 when path does not exist', async () => {
     const { app } = createApp();

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -5,6 +5,7 @@
  */
 
 import { readdir, stat } from 'node:fs/promises';
+import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
 import { realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Application, Request, Response } from 'express';
@@ -240,7 +241,10 @@ export function registerWorkspaceManagementRoutes(
         return;
       }
 
-      if (!isAbsolute(cwd)) {
+      // #7139: map a Windows-shaped cwd to its container bind mount before
+      // the absolute-path guard (no-op outside a POSIX container sandbox).
+      const sandboxCwd = translateWindowsWorkspaceForPosixSandbox(cwd);
+      if (!isAbsolute(sandboxCwd)) {
         res.status(400).json({
           error: '`cwd` must be an absolute path',
           code: 'invalid_path',
@@ -265,7 +269,7 @@ export function registerWorkspaceManagementRoutes(
       // two distinct canonical strings and defeat the duplicate check.
       let canonical: string;
       try {
-        canonical = realpathSync.native(resolve(cwd));
+        canonical = realpathSync.native(resolve(sandboxCwd));
       } catch {
         res.status(400).json({
           error: 'Path does not exist or is not accessible',

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -6,7 +6,7 @@
 
 import { readdir, stat } from 'node:fs/promises';
 import {
-  translateWindowsWorkspaceForPosixSandbox,
+  translateAndCheckAbsoluteWorkspacePath,
   MAX_WORKSPACE_PATH_LENGTH,
 } from '@qwen-code/acp-bridge/workspacePaths';
 import { realpathSync } from 'node:fs';
@@ -255,10 +255,10 @@ export function registerWorkspaceManagementRoutes(
         return;
       }
 
-      // #7139: map a Windows-shaped cwd to its container bind mount before
-      // the absolute-path guard (no-op outside a POSIX container sandbox).
-      const sandboxCwd = translateWindowsWorkspaceForPosixSandbox(cwd);
-      if (!isAbsolute(sandboxCwd)) {
+      // #7139: the shared helper maps a Windows-shaped cwd to its container
+      // bind mount before the absolute-path check.
+      const sandboxCwd = translateAndCheckAbsoluteWorkspacePath(cwd);
+      if (sandboxCwd === null) {
         res.status(400).json({
           error: '`cwd` must be an absolute path',
           code: 'invalid_path',

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -5,7 +5,10 @@
  */
 
 import { readdir, stat } from 'node:fs/promises';
-import { translateWindowsWorkspaceForPosixSandbox , MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
+import {
+  translateWindowsWorkspaceForPosixSandbox,
+  MAX_WORKSPACE_PATH_LENGTH,
+} from '@qwen-code/acp-bridge/workspacePaths';
 import { realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Application, Request, Response } from 'express';
@@ -240,22 +243,24 @@ export function registerWorkspaceManagementRoutes(
         return;
       }
 
+      // Bound the input before any filesystem work, matching the limit other
+      // workspace routes enforce (memory-amplification guard). Must run
+      // before the sandbox translation below — its existence probe is a
+      // filesystem call.
+      if (cwd.length > MAX_WORKSPACE_PATH_LENGTH) {
+        res.status(400).json({
+          error: `\`cwd\` exceeds the ${MAX_WORKSPACE_PATH_LENGTH}-character limit`,
+          code: 'invalid_path',
+        });
+        return;
+      }
+
       // #7139: map a Windows-shaped cwd to its container bind mount before
       // the absolute-path guard (no-op outside a POSIX container sandbox).
       const sandboxCwd = translateWindowsWorkspaceForPosixSandbox(cwd);
       if (!isAbsolute(sandboxCwd)) {
         res.status(400).json({
           error: '`cwd` must be an absolute path',
-          code: 'invalid_path',
-        });
-        return;
-      }
-
-      // Bound the input before any filesystem work, matching the limit other
-      // workspace routes enforce (memory-amplification guard).
-      if (cwd.length > MAX_WORKSPACE_PATH_LENGTH) {
-        res.status(400).json({
-          error: `\`cwd\` exceeds the ${MAX_WORKSPACE_PATH_LENGTH}-character limit`,
           code: 'invalid_path',
         });
         return;

--- a/packages/cli/src/serve/routes/workspace-management.ts
+++ b/packages/cli/src/serve/routes/workspace-management.ts
@@ -5,12 +5,11 @@
  */
 
 import { readdir, stat } from 'node:fs/promises';
-import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
+import { translateWindowsWorkspaceForPosixSandbox , MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
 import { realpathSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Application, Request, Response } from 'express';
 import { isWithinRoot } from '@qwen-code/qwen-code-core';
-import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { MAX_REGISTERED_WORKSPACES } from '../workspace-inputs.js';
 import type {

--- a/packages/cli/src/serve/run-qwen-serve.sandbox.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.sandbox.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge/workspacePaths';
+import { validateAndCanonicalizeWorkspaceInput } from './run-qwen-serve.js';
+
+// #7139 wiring for the PRIMARY reproduction path: `qwen serve --workspace
+// C:\qwen-repro` relaunched into a Linux Docker sandbox. The boot validator
+// must translate to the bind mount BEFORE its absolute-path guard. statSync
+// is mocked so the (root-level, uncreatable) translated mount stats as a
+// directory; acp-bridge's canonicalizeWorkspace then falls back to the
+// resolved path on ENOENT, matching a real container where the mount exists.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs');
+  return {
+    ...actual,
+    statSync: ((p: unknown, ...rest: unknown[]) =>
+      p === '/c/qwen-repro'
+        ? ({ isDirectory: () => true } as ReturnType<typeof actual.statSync>)
+        : (actual.statSync as (...a: unknown[]) => unknown)(
+            p,
+            ...rest,
+          )) as typeof actual.statSync,
+  };
+});
+
+describe('validateAndCanonicalizeWorkspaceInput inside a POSIX container sandbox (#7139)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _setSandboxMountExistsForTest(undefined);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'boots a Windows-shaped --workspace via its bind-mount location',
+    () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+      expect(validateAndCanonicalizeWorkspaceInput('C:\\qwen-repro')).toBe(
+        '/c/qwen-repro',
+      );
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects a Windows-shaped --workspace outside a sandbox',
+    () => {
+      vi.stubEnv('SANDBOX', '');
+      expect(() =>
+        validateAndCanonicalizeWorkspaceInput('C:\\qwen-repro'),
+      ).toThrow('must be an absolute path');
+    },
+  );
+});

--- a/packages/cli/src/serve/run-qwen-serve.sandbox.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.sandbox.test.ts
@@ -54,4 +54,13 @@ describe('validateAndCanonicalizeWorkspaceInput inside a POSIX container sandbox
       ).toThrow('must be an absolute path');
     },
   );
+
+  it('echoes the operator-typed input in the rejection, not the translation result', () => {
+    vi.stubEnv('SANDBOX', '');
+    // The extraction renamed the parameter; the message must interpolate
+    // the RAW input ("relative/path"), never the null translation result.
+    expect(() =>
+      validateAndCanonicalizeWorkspaceInput('relative/path'),
+    ).toThrow('Invalid --workspace "relative/path": must be an absolute path.');
+  });
 });

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -1714,7 +1714,7 @@ export function validateAndCanonicalizeWorkspaceInput(
   const workspace = translateAndCheckAbsoluteWorkspacePath(rawWorkspace);
   if (workspace === null) {
     throw new Error(
-      `Invalid --workspace "${workspace}": must be an absolute path.`,
+      `Invalid --workspace "${rawWorkspace}": must be an absolute path.`,
     );
   }
   try {

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -37,7 +37,7 @@ import {
   resolveWorkspaceInputs,
 } from './workspace-inputs.js';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
-import { canonicalizeWorkspace } from '@qwen-code/acp-bridge/workspacePaths';
+import { canonicalizeWorkspace , translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge/workspacePaths';
 import type {
   AuthType,
   ProviderSetupInputs,
@@ -94,7 +94,6 @@ import {
   type WorkspaceRegistrationStore,
 } from './workspace-registration-store.js';
 import type { PermissionPolicy } from '@qwen-code/acp-bridge';
-import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
 import { getCliVersion } from '../utils/version.js';
 import { getRateLimiter } from './rate-limit.js';
 import type { AcpHttpHandle } from './acp-http/index.js';

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -39,7 +39,7 @@ import {
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import {
   canonicalizeWorkspace,
-  translateWindowsWorkspaceForPosixSandbox,
+  translateAndCheckAbsoluteWorkspacePath,
 } from '@qwen-code/acp-bridge/workspacePaths';
 import type {
   AuthType,
@@ -1711,8 +1711,8 @@ export function validateAndCanonicalizeWorkspaceInput(
   // `--workspace C:\…` in host shape; translate to the bind-mount
   // location BEFORE the absolute-path guard, which would otherwise
   // reject it (`path.isAbsolute('C:\…')` is false on POSIX).
-  const workspace = translateWindowsWorkspaceForPosixSandbox(rawWorkspace);
-  if (!path.isAbsolute(workspace)) {
+  const workspace = translateAndCheckAbsoluteWorkspacePath(rawWorkspace);
+  if (workspace === null) {
     throw new Error(
       `Invalid --workspace "${workspace}": must be an absolute path.`,
     );

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -94,6 +94,7 @@ import {
   type WorkspaceRegistrationStore,
 } from './workspace-registration-store.js';
 import type { PermissionPolicy } from '@qwen-code/acp-bridge';
+import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
 import { getCliVersion } from '../utils/version.js';
 import { getRateLimiter } from './rate-limit.js';
 import type { AcpHttpHandle } from './acp-http/index.js';
@@ -2053,7 +2054,12 @@ async function runQwenServeImpl(
     );
   }
 
-  const validateAndCanonicalizeWorkspace = (workspace: string): string => {
+  const validateAndCanonicalizeWorkspace = (rawWorkspace: string): string => {
+    // #7139: inside a Linux container sandbox a Windows host forwards
+    // `--workspace C:\…` in host shape; translate to the bind-mount
+    // location BEFORE the absolute-path guard, which would otherwise
+    // reject it (`path.isAbsolute('C:\…')` is false on POSIX).
+    const workspace = translateWindowsWorkspaceForPosixSandbox(rawWorkspace);
     if (!path.isAbsolute(workspace)) {
       throw new Error(
         `Invalid --workspace "${workspace}": must be an absolute path.`,

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -37,7 +37,10 @@ import {
   resolveWorkspaceInputs,
 } from './workspace-inputs.js';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
-import { canonicalizeWorkspace , translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge/workspacePaths';
+import {
+  canonicalizeWorkspace,
+  translateWindowsWorkspaceForPosixSandbox,
+} from '@qwen-code/acp-bridge/workspacePaths';
 import type {
   AuthType,
   ProviderSetupInputs,
@@ -1695,6 +1698,60 @@ interface DaemonLoggerLifecycleCallbacks {
   signalOwned(): void;
 }
 
+/**
+ * Validates and canonicalizes a `--workspace` boot argument. Extracted to
+ * module scope (from the runQwenServe closure) so the #7139 sandbox path
+ * translation ahead of the absolute-path guard is testable — this is the
+ * primary reproduction path of that issue.
+ */
+export function validateAndCanonicalizeWorkspaceInput(
+  rawWorkspace: string,
+): string {
+  // #7139: inside a Linux container sandbox a Windows host forwards
+  // `--workspace C:\…` in host shape; translate to the bind-mount
+  // location BEFORE the absolute-path guard, which would otherwise
+  // reject it (`path.isAbsolute('C:\…')` is false on POSIX).
+  const workspace = translateWindowsWorkspaceForPosixSandbox(rawWorkspace);
+  if (!path.isAbsolute(workspace)) {
+    throw new Error(
+      `Invalid --workspace "${workspace}": must be an absolute path.`,
+    );
+  }
+  try {
+    const stats = fs.statSync(workspace);
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `Invalid --workspace "${workspace}": exists but is not a directory.`,
+      );
+    }
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err) {
+      const code = (err as { code?: unknown }).code;
+      if (code === 'ENOENT') {
+        throw new Error(
+          `Invalid --workspace "${workspace}": directory does not exist.`,
+        );
+      }
+      // EACCES / EPERM: the path exists but the current user can't
+      // stat it (typical for SIP-protected paths on macOS, root-owned
+      // dirs the daemon's user can't traverse, etc.). The raw Node
+      // SystemError has the path AND the syscall but no operator-
+      // facing breadcrumb that this came from `--workspace`. Wrap
+      // both codes so the boot failure points at the flag the
+      // operator actually set.
+      if (code === 'EACCES' || code === 'EPERM') {
+        throw new Error(
+          `Invalid --workspace "${workspace}": permission denied ` +
+            `(${String(code)}). The path exists but cannot be stat'd ` +
+            `by the current user.`,
+        );
+      }
+    }
+    throw err;
+  }
+  return canonicalizeWorkspace(workspace);
+}
+
 export async function runQwenServe(
   optsIn: RunQwenServeOptions,
   deps: RunQwenServeDeps = {},
@@ -2053,51 +2110,8 @@ async function runQwenServeImpl(
     );
   }
 
-  const validateAndCanonicalizeWorkspace = (rawWorkspace: string): string => {
-    // #7139: inside a Linux container sandbox a Windows host forwards
-    // `--workspace C:\…` in host shape; translate to the bind-mount
-    // location BEFORE the absolute-path guard, which would otherwise
-    // reject it (`path.isAbsolute('C:\…')` is false on POSIX).
-    const workspace = translateWindowsWorkspaceForPosixSandbox(rawWorkspace);
-    if (!path.isAbsolute(workspace)) {
-      throw new Error(
-        `Invalid --workspace "${workspace}": must be an absolute path.`,
-      );
-    }
-    try {
-      const stats = fs.statSync(workspace);
-      if (!stats.isDirectory()) {
-        throw new Error(
-          `Invalid --workspace "${workspace}": exists but is not a directory.`,
-        );
-      }
-    } catch (err) {
-      if (err && typeof err === 'object' && 'code' in err) {
-        const code = (err as { code?: unknown }).code;
-        if (code === 'ENOENT') {
-          throw new Error(
-            `Invalid --workspace "${workspace}": directory does not exist.`,
-          );
-        }
-        // EACCES / EPERM: the path exists but the current user can't
-        // stat it (typical for SIP-protected paths on macOS, root-owned
-        // dirs the daemon's user can't traverse, etc.). The raw Node
-        // SystemError has the path AND the syscall but no operator-
-        // facing breadcrumb that this came from `--workspace`. Wrap
-        // both codes so the boot failure points at the flag the
-        // operator actually set.
-        if (code === 'EACCES' || code === 'EPERM') {
-          throw new Error(
-            `Invalid --workspace "${workspace}": permission denied ` +
-              `(${String(code)}). The path exists but cannot be stat'd ` +
-              `by the current user.`,
-          );
-        }
-      }
-      throw err;
-    }
-    return canonicalizeWorkspace(workspace);
-  };
+  const validateAndCanonicalizeWorkspace =
+    validateAndCanonicalizeWorkspaceInput;
 
   // Resolve the bound workspace list. The first explicit workspace remains the
   // primary workspace for legacy APIs; later workspaces are isolated secondary

--- a/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
+++ b/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
@@ -6,7 +6,7 @@
 
 import type { Response } from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge';
+import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge/workspacePaths';
 import { parseOptionalWorkspaceCwd } from './request-helpers.js';
 
 // Regression for the #7228 review finding: every workspace-ingestion path

--- a/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
+++ b/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
@@ -48,6 +48,7 @@ describe('parseOptionalWorkspaceCwd inside a POSIX container sandbox (#7139)', (
   it.skipIf(process.platform === 'win32')(
     'still rejects a Windows-shaped cwd outside a sandbox',
     () => {
+      vi.stubEnv('SANDBOX', '');
       const { res, status } = mockRes();
       const cwd = parseOptionalWorkspaceCwd(
         { cwd: 'C:\\qwen-repro' },

--- a/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
+++ b/packages/cli/src/serve/server/request-helpers.sandbox.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Response } from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _setSandboxMountExistsForTest } from '@qwen-code/acp-bridge';
+import { parseOptionalWorkspaceCwd } from './request-helpers.js';
+
+// Regression for the #7228 review finding: every workspace-ingestion path
+// validates with `path.isAbsolute` BEFORE canonicalization, and on POSIX
+// `isAbsolute('C:\\…')` is false — so a translation that only lives inside
+// canonicalizeWorkspace never runs on the real request path. This test
+// drives the real exported REST-route parser (guard included), not the
+// canonicalization choke point. The mount-existence probe is stubbed via
+// the acp-bridge test seam (the `/c/…` target sits at the filesystem root,
+// which tests cannot create).
+
+function mockRes(): { res: Response; status: ReturnType<typeof vi.fn> } {
+  const status = vi.fn().mockReturnValue({ json: vi.fn() });
+  return { res: { status } as unknown as Response, status };
+}
+
+describe('parseOptionalWorkspaceCwd inside a POSIX container sandbox (#7139)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    _setSandboxMountExistsForTest(undefined);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'accepts a Windows-shaped cwd and returns its bind-mount location',
+    () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      _setSandboxMountExistsForTest((p) => p === '/c/qwen-repro');
+      const { res, status } = mockRes();
+      const cwd = parseOptionalWorkspaceCwd(
+        { cwd: 'C:\\qwen-repro' },
+        '/c/qwen-repro',
+        res,
+      );
+      expect(cwd).toBe('/c/qwen-repro');
+      expect(status).not.toHaveBeenCalled();
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects a Windows-shaped cwd outside a sandbox',
+    () => {
+      const { res, status } = mockRes();
+      const cwd = parseOptionalWorkspaceCwd(
+        { cwd: 'C:\\qwen-repro' },
+        '/tmp',
+        res,
+      );
+      expect(cwd).toBeUndefined();
+      expect(status).toHaveBeenCalledWith(400);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects when the translated mount does not exist (no invented paths)',
+    () => {
+      vi.stubEnv('SANDBOX', 'qwen-code-sandbox-0');
+      const { res, status } = mockRes();
+      const cwd = parseOptionalWorkspaceCwd(
+        { cwd: 'D:\\never-mounted' },
+        '/tmp',
+        res,
+      );
+      expect(cwd).toBeUndefined();
+      expect(status).toHaveBeenCalledWith(400);
+    },
+  );
+});

--- a/packages/cli/src/serve/server/request-helpers.ts
+++ b/packages/cli/src/serve/server/request-helpers.ts
@@ -5,7 +5,10 @@
  */
 
 import * as path from 'node:path';
-import { translateWindowsWorkspaceForPosixSandbox , MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
+import {
+  MAX_WORKSPACE_PATH_LENGTH,
+  translateWindowsWorkspaceForPosixSandbox,
+} from '@qwen-code/acp-bridge/workspacePaths';
 import type { Request, Response } from 'express';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';

--- a/packages/cli/src/serve/server/request-helpers.ts
+++ b/packages/cli/src/serve/server/request-helpers.ts
@@ -5,10 +5,9 @@
  */
 
 import * as path from 'node:path';
-import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
+import { translateWindowsWorkspaceForPosixSandbox , MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
 import type { Request, Response } from 'express';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
-import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import type { WorkspaceRequestContext } from '../workspace-service/index.js';
 

--- a/packages/cli/src/serve/server/request-helpers.ts
+++ b/packages/cli/src/serve/server/request-helpers.ts
@@ -5,6 +5,7 @@
  */
 
 import * as path from 'node:path';
+import { translateWindowsWorkspaceForPosixSandbox } from '@qwen-code/acp-bridge';
 import type { Request, Response } from 'express';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { MAX_WORKSPACE_PATH_LENGTH } from '@qwen-code/acp-bridge/workspacePaths';
@@ -143,7 +144,11 @@ export function parseOptionalWorkspaceCwd(
     });
     return undefined;
   }
-  const cwd = hasCwd ? (body['cwd'] as string) : boundWorkspace;
+  // #7139: map a Windows-shaped cwd to its container bind mount before the
+  // absolute-path guard (no-op outside a POSIX container sandbox).
+  const cwd = hasCwd
+    ? translateWindowsWorkspaceForPosixSandbox(body['cwd'] as string)
+    : boundWorkspace;
   if (!path.isAbsolute(cwd)) {
     res
       .status(400)

--- a/packages/cli/src/serve/server/request-helpers.ts
+++ b/packages/cli/src/serve/server/request-helpers.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'node:path';
 import {
   MAX_WORKSPACE_PATH_LENGTH,
-  translateWindowsWorkspaceForPosixSandbox,
+  translateAndCheckAbsoluteWorkspacePath,
 } from '@qwen-code/acp-bridge/workspacePaths';
 import type { Request, Response } from 'express';
 import type { AcpSessionBridge } from '@qwen-code/acp-bridge/bridgeTypes';
@@ -146,12 +145,12 @@ export function parseOptionalWorkspaceCwd(
     });
     return undefined;
   }
-  // #7139: map a Windows-shaped cwd to its container bind mount before the
-  // absolute-path guard (no-op outside a POSIX container sandbox).
-  const cwd = hasCwd
-    ? translateWindowsWorkspaceForPosixSandbox(body['cwd'] as string)
-    : boundWorkspace;
-  if (!path.isAbsolute(cwd)) {
+  // #7139: the shared helper maps a Windows-shaped cwd to its container
+  // bind mount before the absolute-path check.
+  const cwd = translateAndCheckAbsoluteWorkspacePath(
+    hasCwd ? (body['cwd'] as string) : boundWorkspace,
+  );
+  if (cwd === null) {
     res
       .status(400)
       .json({ error: '`cwd` must be an absolute path when provided' });


### PR DESCRIPTION
## What this PR does

Makes `canonicalizeWorkspace` — the choke point every workspace path flows through (boot `--workspace` argv, client-registered workspaces, persisted registrations) — map Windows-shaped absolute paths to the sandbox launcher's mount convention (`C:\work\proj` → `/c/work/proj`, mirroring `getContainerPath` in `cli/src/utils/sandbox.ts`) before resolution. The new `translateWindowsWorkspaceForPosixSandbox` helper is deliberately conservative: it only applies on POSIX inside a container sandbox (`SANDBOX` env set by the launcher; macOS `sandbox-exec` excluded, since seatbelt does not remap paths), only to `<drive>:\…` / `<drive>:/…`-shaped input, and only when the translated candidate actually exists on disk. Every other input — Windows hosts, unsandboxed runs, POSIX-shaped paths — passes through byte-for-byte unchanged.

## Why it's needed

#7139 (P1): on Windows 11, `qwen serve` with `QWEN_SANDBOX=docker` relaunches itself into the Linux container correctly — `docker inspect` shows the right bind mount and `WorkingDir`, and direct `docker exec` works — yet every shell tool call fails with `chdir(2) failed.: No such file or directory`. The mechanism (confirmed against the triage's source read): the host-side launcher translates the mount and `--workdir` via `getContainerPath`, but `entrypoint()` forwards CLI arguments verbatim, so the in-container daemon receives `--workspace C:\qwen-repro` in host shape. On POSIX, `path.resolve('C:\qwen-repro')` treats the whole string as relative and prepends the cwd, producing a path that exists nowhere; the ACP child spawn's `chdir` then fails before any command runs. The same shape reaches the daemon through client-registered workspaces and persisted registrations (the runtime dir is mounted into the container), which is why the fix sits at the canonicalization choke point rather than at any single entry.

## Reviewer Test Plan

### How to verify

1. Windows 11 + Docker Desktop (WSL2): `$env:QWEN_SANDBOX="docker"; qwen serve --workspace "C:\qwen-repro" …`, open a Web Shell session, run `pwd` / `test -f marker.txt && echo FOUND_MARKER`. Before this PR: every command fails with `chdir(2) failed.: No such file or directory`. After: commands run in `/c/qwen-repro`. (I don't have a Windows + Docker Desktop environment — validation on the reporter's setup is requested on the issue; see Risk & Scope.)
2. Everywhere else, behavior is pinned unchanged: `npx vitest run` in `packages/acp-bridge` — 864/864, including the new guard matrix (Windows host / no sandbox / seatbelt / non-Windows-shaped input / translated mount missing → all inert) and a wiring regression test that fails on the unpatched source.
3. macOS smoke (run locally): `qwen serve --workspace <tmp>` boots, `GET /capabilities` responds, `POST /session` creates a session with the correctly canonicalized `workspaceCwd` — the normal POSIX path through the changed function is untouched.

### Evidence (Before & After)

The wiring regression test (`workspacePaths.sandbox.test.ts`) drives the real `canonicalizeWorkspace` with a stubbed `SANDBOX` env and a mocked mount-existence probe:

| input (in-container) | before fix | after fix |
| --- | --- | --- |
| `C:\qwen-repro` with `SANDBOX` set | `<cwd>/C:\qwen-repro` (mangled → `chdir` ENOENT) ❌ | `/c/qwen-repro` (the bind-mount location) ✅ |
| `C:\qwen-repro`, no sandbox | unchanged legacy behavior | unchanged ✅ |
| translated mount does not exist | — | input returned untouched (never invent a path) ✅ |

Verified via `git stash`: the sandbox wiring test fails on the unpatched source. Local macOS `qwen serve` smoke: boot + `POST /session` → `{"sessionId": "…", "workspaceCwd": "/private/tmp/qwen7139-ws.…"}` (canonicalization intact).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest unit + wiring tests, real `qwen serve` HTTP smoke against `packages/cli/dist`. The Windows + Docker Desktop reproduction requires the reporter's environment.

## Risk & Scope

- Main risk or tradeoff: a translation applied too eagerly could redirect a legitimate path. The three-condition guard (POSIX container sandbox only, Windows-absolute shape only, translated target must exist) bounds this to exactly the launcher's own mount convention; a Linux directory literally named `C:\x` inside a sandbox whose `/c/x` also exists would be redirected — a deliberate trade against the P1.
- Not validated / out of scope: the end-to-end Windows 11 + Docker Desktop flow is not reproducible on my hardware — the fix is derived from the triage's confirmed source read plus the launcher's own translation convention, and reporter validation is requested on the issue (same disclosure discipline as #7195). The host-side launcher (`entrypoint()` forwarding args verbatim) is intentionally untouched: translating argv there would fix only the `--workspace` entry, while this choke point also covers client-registered and persisted workspace paths.
- Breaking changes / migration notes: none — `translateWindowsWorkspaceForPosixSandbox` is a new export; `canonicalizeWorkspace`'s behavior outside a container sandbox is byte-for-byte unchanged.

## Linked Issues

Fixes #7139

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在所有 workspace 路径的收口点 `canonicalizeWorkspace`（启动 `--workspace` 参数、客户端注册、持久化注册都经过它）把 Windows 形状的绝对路径按 sandbox 启动器的挂载约定映射（`C:\work\proj` → `/c/work/proj`，与 `cli/src/utils/sandbox.ts` 的 `getContainerPath` 一致）后再解析。新增的 `translateWindowsWorkspaceForPosixSandbox` 刻意保守：仅在 POSIX 容器沙箱内（启动器设置的 `SANDBOX` env；不重映射路径的 macOS `sandbox-exec` 排除）、仅对 `<盘符>:\…` 形状输入、且翻译后的目标真实存在时才生效。其余输入——Windows 宿主、非沙箱运行、POSIX 形状路径——逐字节原样通过。

## 为什么需要

#7139（P1）：Windows 11 上 `QWEN_SANDBOX=docker` 的 `qwen serve` 能正确把自己重启进 Linux 容器——`docker inspect` 显示挂载与 `WorkingDir` 都正确、直接 `docker exec` 也正常——但每个 shell 工具调用都报 `chdir(2) failed.: No such file or directory`。机制（与 triage 源码分析相互印证）：宿主侧启动器翻译了挂载与 `--workdir`，但 `entrypoint()` 把 CLI 参数原样转发，容器内 daemon 收到宿主形状的 `--workspace C:\qwen-repro`；POSIX 上 `path.resolve` 把整串当相对路径拼上 cwd，得到一个不存在的路径，ACP 子进程 spawn 的 `chdir` 在执行任何命令前就失败。同样形状还会经客户端注册与持久化注册（runtime 目录挂载进容器）到达 daemon——因此修复放在规范化收口点而非任何单一入口。

## 审阅测试计划

### 如何验证

1. Windows 11 + Docker Desktop：按 issue 复现步骤，本 PR 之前每个命令 `chdir(2) ENOENT`；之后命令在 `/c/qwen-repro` 内正常执行（本机无 Windows+Docker 环境，已在 issue 请报告者验证，见风险与范围）；
2. 其他环境行为钉死不变：`packages/acp-bridge` 864/864，含守卫矩阵（Windows 宿主/无沙箱/seatbelt/非 Windows 形状/翻译目标不存在 → 全部不生效）与在未修复源码上失败的接线回归测试；
3. macOS 冒烟（本地已跑）：`qwen serve` 启动、`GET /capabilities` 正常、`POST /session` 返回正确规范化的 `workspaceCwd`——常规 POSIX 路径不受影响。

### 证据（Before & After）

接线回归测试用 stub 的 `SANDBOX` env + mock 的挂载存在性探针驱动真实 `canonicalizeWorkspace`：修复前 `C:\qwen-repro` 被拼成 `<cwd>/C:\qwen-repro`（即 chdir ENOENT 的来源）；修复后解析为挂载位置 `/c/qwen-repro`；无沙箱时行为不变；翻译目标不存在时原样返回。`git stash` 验证该测试在未修复源码上失败。macOS 冒烟：boot + `POST /session` 返回 `workspaceCwd` 正常。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI 与报告者真机（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest 单测/接线测试 + 真实 `qwen serve` HTTP 冒烟。Windows + Docker Desktop 复现依赖报告者环境。

## 风险与范围

- 主要风险/权衡：翻译过度激进可能改写合法路径。三重守卫（仅 POSIX 容器沙箱、仅 Windows 绝对形状、翻译目标必须存在）把影响面限定在启动器自身的挂载约定内；沙箱内字面命名为 `C:\x` 且恰好 `/c/x` 存在的 Linux 目录会被重定向——这是对 P1 的有意取舍。
- 未验证/超出范围：Windows 11 + Docker Desktop 全链路无法在本机复现——修复基于 triage 已确认的源码分析与启动器自身的翻译约定，已在 issue 请报告者验证（与 #7195 相同的披露纪律）。宿主侧启动器（`entrypoint()` 原样转发参数）有意不动：在那里翻译 argv 只能覆盖 `--workspace` 一个入口，而本收口点同时覆盖客户端注册与持久化注册路径。
- 破坏性变更/迁移说明：无——`translateWindowsWorkspaceForPosixSandbox` 为新导出；非容器沙箱下 `canonicalizeWorkspace` 行为逐字节不变。

## 关联 Issue

Fixes #7139

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
