### PR TITLE
test: raise timeout ceiling for I/O-bound tests flaky under CI contention

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -112,6 +112,10 @@ export default defineConfig({
     },
   },
   test: {
+    // See packages/core/vitest.config.ts: raise the per-test ceiling above
+    // vitest's 5s default so I/O-bound tests (e.g. the workspace registration
+    // store's tempdir round-trip) don't blow it purely under CI contention.
+    testTimeout: 15000,
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', 'config.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**'],
     environment: 'jsdom',

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -2075,9 +2075,14 @@ describe('git extension helpers', () => {
     }
 
     async function waitForFileData(filePath: string): Promise<void> {
-      for (let attempt = 0; attempt < 1_000; attempt += 1) {
+      // Poll on a real wall-clock budget (~10s), not a fixed iteration count:
+      // setImmediate turns are sub-millisecond, so 1_000 of them could elapse
+      // in <100ms while the tar extraction I/O is still catching up on a
+      // contended runner — the source of the "Timed out waiting for extracted
+      // data" flake. Stays well under the 15s per-test ceiling.
+      for (let attempt = 0; attempt < 2_000; attempt += 1) {
         if ((await getFileSize(filePath)) > 0) return;
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setTimeout(resolve, 5));
       }
       throw new Error(`Timed out waiting for extracted data at ${filePath}`);
     }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Raise the per-test ceiling above vitest's 5s default: the self-hosted
+    // CI runners are heavily oversubscribed (maxThreads: 16 below), and I/O-
+    // or WASM-load-bound tests (e.g. the web-tree-sitter lazy runtime, tar
+    // extraction) blow 5s purely under contention, not from any logic fault.
+    // Assertions still fail instantly; only the timeout ceiling grows.
+    testTimeout: 15000,
     reporters: ['default', 'junit'],
     silent: true,
     setupFiles: ['./test-setup.ts'],


### PR DESCRIPTION
## What this PR does

Deterministically eliminates a recurring **flaky-test class** by fixing its root cause — too-tight timeouts under CI contention — instead of leaning on reruns.

The self-hosted runners are heavily oversubscribed (core runs `maxThreads: 16`), and a handful of I/O- or load-bound tests blow vitest's **5s default** purely under that contention — **not** from any logic fault. This has recurred across unrelated PRs (#7213, #7219) and earlier sessions; each time the failing test was in a package the PR didn't touch, and each rerun landed a *different* one of these:

- `packages/core/src/utils/shell-ast-parser-lazy.test.ts` — fully **mocked** (it never loads the real WASM), but the dynamic `import()` + async coordination exceeds 5s when 16 threads contend.
- `packages/cli/src/serve/workspace-registration-store.test.ts` — tempdir round-trip.
- `packages/core/src/extension/github.test.ts > extractFile` — its `waitForFileData` helper polled a **fixed 1 000 `setImmediate` turns**, which elapse in <100 ms while the tar-extraction I/O is still catching up, throwing `Timed out waiting for extracted data`.

## The fix

- **`testTimeout: 15000`** in the core and cli vitest configs — 3× the default. Assertions still fail **instantly**; only the timeout ceiling grows, so this masks no logic bug (a genuine hang still fails, just later, and the job-level timeout still bounds it).
- **`waitForFileData`** now polls a real **~10 s wall-clock budget** (`2 000 × 5 ms`) instead of a fixed iteration count, so a slow extraction is *awaited* rather than raced. Stays under the 15 s ceiling.

Reruns and the CI Failure Patrol's model classifier were treating the *symptom*; these are the deterministic cures for the *cause*.

## Reviewer Test Plan

### How to verify

1. CI runs the full suite — the three tests above should stop timing out under load. (They fail to even load in a partial worktree due to missing package deps like `ajv`/`diff`; they must run in a full install, i.e. CI or a built checkout.)
2. Inspect the diff: two config lines + one poll-loop change. No test logic or assertion is altered.
3. Confirm the change can only *reduce* flakiness: raising a timeout ceiling and lengthening a poll budget cannot make a passing test fail.

### Evidence (why it's contention, not logic)

```
#7219 attempt: shell-ast-parser-lazy  → "Test timed out in 5000ms"  (fully mocked test)
#7213 attempt1: workspace-registration-store + shell-ast-parser → 5000ms timeouts
#7213 attempt2: github.test.ts extractFile → "Timed out waiting for extracted data"
        ^ a DIFFERENT test each rerun, none touched by the PR = runner load, not the diff
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ configs load-verified (vitest parsed them); full run needs CI |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

Local package runs aren't possible in the review worktree (partial `node_modules` → `Cannot find package 'ajv/...'` at import, unrelated to this change). vitest **did** load the modified core config and reach the test-run phase, confirming the config is valid.

## Risk & Scope

- Main risk or tradeoff: a genuinely hung test now takes 15 s (was 5 s) to fail — 3× slower feedback on real hangs, which are rare and still bounded by the job timeout. In exchange, the contention flake class disappears. `testTimeout` is global to each package's suite; it does not weaken any assertion.
- Not validated / out of scope: full local run (needs a complete install); other latent timing flakes not yet observed will be added if they surface.
- Breaking changes / migration notes: none.

## Linked Issues

Root-cause fix for the flake class seen on #7213 / #7219; complements #7229 (which stops a crash from stranding a PR) so the loop stops re-encountering these as unrecoverable.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

从**根因**上确定性消除一类反复出现的 flaky 测试 —— CI 争用下超时预算太紧 —— 而不是靠重试硬扛。

自建 runner 严重超订(core 用 `maxThreads: 16`),少数 I/O 或加载型测试在争用下挤爆 vitest 的 **5s 默认超时**,并非任何逻辑错。这在多个不相关 PR(#7213、#7219)反复出现,每次失败的测试都在 PR 没碰过的包里,且每次重试命中**不同**的一个:

- `shell-ast-parser-lazy.test.ts` —— **全 mock**(根本没加载真 WASM),但 16 线程争用下 `import()` + 异步编排超过 5s。
- `workspace-registration-store.test.ts` —— tempdir 往返。
- `github.test.ts > extractFile` —— 其 `waitForFileData` 轮询**固定 1000 次 `setImmediate`**,这些在 <100ms 内就跑完,而 tar 解压 I/O 还没跟上,于是抛 `Timed out waiting for extracted data`。

## 修复

- core 与 cli 的 vitest 配置加 **`testTimeout: 15000`**(默认的 3 倍)。断言仍**秒失败**,只是抬高超时上限 —— 不掩盖任何逻辑 bug(真卡死仍会失败,只是晚一点,且 job 级超时兜底)。
- **`waitForFileData`** 改为真实 **~10s 时钟预算**(`2000 × 5ms`)轮询,而非固定迭代次数 —— 慢解压是被**等待**而非被赛过。仍在 15s 上限内。

重试与 CI Failure Patrol 的模型分类只治标;这是治本的确定性修复。

## 评审验证

1. CI 跑全套 —— 上述三个测试在负载下不再超时。(它们在残缺 worktree 里因缺 `ajv`/`diff` 等包依赖连加载都失败,须在完整安装即 CI 或已构建检出中运行。)
2. 看 diff:两行配置 + 一处轮询改动,不改任何测试逻辑或断言。
3. 改动只可能**降低** flaky:抬高超时上限、拉长轮询预算,不可能让通过的测试变失败。

## 风险与范围

- 主要权衡:真卡死的测试现在需 15s(原 5s)才失败 —— 对真卡死反馈慢 3 倍,但这类罕见且有 job 超时兜底;换来争用 flaky 类别消失。`testTimeout` 对各包套件全局生效,不削弱任何断言。
- 破坏性变更:无。

## 关联 Issue

#7213 / #7219 所见 flaky 类别的根因修复;与 #7229(阻止崩溃卡死 PR)互补,使循环不再把它们当作不可恢复反复遇到。

</details>
