### PR TITLE
fix(review): say an unread chunk once, under its cause

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1238,6 +1238,52 @@ describe('coverage is recomputed, never accepted', () => {
     ).toHaveLength(1);
   });
 
+  it('a chunk whose launch failure is already disclosed leaves the nobody-read sentence — cause, not consequence twice', () => {
+    // #7166's first post-grouping body carried seventeen chunks in BOTH the
+    // "nobody read them" sentence and the not-launched roster sentence: the
+    // consequence restated beside its cause. The cap and remediation keep the
+    // full list; only the posted sentence dedupes.
+    const p = plan();
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    // chunk 2 reviewed properly; chunk 1 built and never launched — its
+    // territory therefore unread, and its cause on record.
+    transcript('a2', goodPrompt(2), { toolCalls: 2 });
+    const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
+    expect(r.cappedBy).toContain('chunk-nobody-read'); // the cap keeps the fact
+    expect(r.remediation.join(' ')).toContain('chunks nobody read');
+    expect(r.body).toContain('chunk 1');
+    // …but only under its cause: no second sentence restating the consequence.
+    expect(r.body).not.toContain('nobody read them');
+  });
+
+  it('keeps the nobody-read sentence for a chunk with no disclosed cause', () => {
+    // The 3A shape: chunks are not roster requirements, so an unread chunk has
+    // no launch-side disclosure to explain it — the receipt sentence is the
+    // only place the author learns those lines went unread.
+    const p = join(dir, 'plan-3a.json');
+    writeFileSync(
+      p,
+      JSON.stringify({
+        diffPathAbsolute: DIFF,
+        srcDiffLines: 100,
+        diffLines: 200,
+        files: [
+          { path: 'a.ts', kind: 'source', removedLines: 0, heavy: false },
+        ],
+        chunks: [
+          { id: 1, startLine: 1, endLine: 100 },
+          { id: 2, startLine: 101, endLine: 200 },
+        ],
+      }),
+    );
+    const old = new Date(2020, 0, 1);
+    utimesSync(p, old, old);
+    const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
+    expect(r.body).toContain('nobody read them');
+    expect(r.body).toMatch(/chunk 1, chunk 2 — no agent reported covering/);
+  });
+
   it('does not merge two invariant files under one label — the em-dash is part of the subject', () => {
     // An invariant agent's label legitimately carries an em-dash segment
     // (`Invariant agent A … — src/foo.ts`). A first-dash dedup key would
@@ -1311,9 +1357,12 @@ describe('coverage is recomputed, never accepted', () => {
     );
     expect(r.remediation.join(' ')).toMatch(/do not relaunch the old prompt/);
     // Blind agents read nothing, so the chunks they owned are also chunks
-    // nobody read — that disclosure's repair must ride along too. Deleting the
-    // missingReceipts push used to fail no test: no fixture reached it.
-    expect(r.body).toContain('no agent reported covering');
+    // nobody read — the CAP and the repair ride along, while the posted body
+    // says it once, under the cause: the blind sentence already explains the
+    // unread territory, and restating it as "nobody read them" beside it was
+    // the #7166 double-disclosure.
+    expect(r.cappedBy).toContain('chunk-nobody-read');
+    expect(r.body).not.toContain('no agent reported covering');
     expect(r.remediation.join(' ')).toMatch(
       /chunks nobody read: build each with/,
     );

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -576,11 +576,26 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     // as a line too long to read, which is true of an *uncoverable* chunk and a
     // fabrication about one nobody receipted — the author would be told the diff
     // defeated the reader, when in fact no reader turned up.
-    notReviewedParts.push(
-      `Not reviewed: ${missingReceipts
-        .map((id) => `chunk ${id}`)
-        .join(', ')} — no agent reported covering these; nobody read them.`,
+    //
+    // But a chunk whose disclosure entry already says WHY it went unread — its
+    // launch never happened, or happened on a rewritten prompt — is one fact,
+    // not two: "nobody read chunk 2" beside "chunk 2 — its prompt was built,
+    // but no agent on record was launched with it" restates the consequence
+    // next to its cause, and #7166's first post-grouping body carried
+    // seventeen chunks twice exactly this way. The cap and the remediation
+    // above keep the FULL list — only the posted sentence dedupes, and only
+    // for subjects another sentence already explains.
+    const disclosedSubjects = new Set(coverageEntries.map((e) => e.subject));
+    const unexplainedReceipts = missingReceipts.filter(
+      (id) => !disclosedSubjects.has(`chunk ${id}`),
     );
+    if (unexplainedReceipts.length > 0) {
+      notReviewedParts.push(
+        `Not reviewed: ${unexplainedReceipts
+          .map((id) => `chunk ${id}`)
+          .join(', ')} — no agent reported covering these; nobody read them.`,
+      );
+    }
   }
   if (uncoverable.length > 0) {
     notReviewedParts.push(


### PR DESCRIPTION
## What this PR does

Says an unread chunk once, under its cause. A chunk whose disclosure entry already explains WHY it went unread — its launch never happened, or happened on a rewritten prompt — now leaves the `nobody read them` sentence in the posted body. The `chunk-nobody-read` cap and the `chunks nobody read` remediation keep the full list; only the posted sentence dedupes. A chunk with no disclosed cause — the 3A shape, where chunks are not roster requirements — keeps the sentence, because it is the only place the author learns those lines went unread.

## Why it's needed

The first body composed after #7190's grouping landed ([review 4730480309 on #7166](https://github.com/QwenLM/qwen-code/pull/7166#pullrequestreview-4730480309)) carried seventeen chunks **twice**: once in `— no agent reported covering these; nobody read them` and once in `— its prompt was built, but no agent on record was launched with it`. The consequence restated beside its cause, across two clause categories the per-subject dedup did not span — the last remaining double-disclosure shape.

## Reviewer Test Plan

### How to verify

1. `cd packages/cli && npx vitest run src/commands/review` — 31 files, 769 tests green.
2. New pins: a built-never-launched chunk appears only under its cause (`nobody read them` absent; cap and remediation intact); a 3A plan with no launch-side disclosures keeps the receipts sentence verbatim. The existing blind-launch test now asserts the deduped shape (cause once, cap and repair riding along).
3. Mutation-tested, 2/2 killed: removing the suppression and dropping the empty-clause guard each turn exactly their test red.

### Evidence (Before & After)

Before (#7166, live): `Not reviewed: chunk 2, chunk 3, … — no agent reported covering these; nobody read them. … Not reviewed: …, chunk 2, chunk 3, … — its prompt was built, but no agent on record was launched with it.`

After, same state: the seventeen twice-told chunks appear once, in the cause sentence; the receipts sentence renders only for chunks nothing else explains.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Body composition only; `cappedBy`, `remediation` and every event decision are untouched (pinned).
- Suppression keys on the exact `chunk <id>` subject already carried by a disclosure entry — a chunk explained by ANY cause (not-launched, rewritten, idle, blind, unopened) defers to it.

## Linked Issues

Exhibit: review 4730480309 on #7166 — the first post-#7190 body, and its one residual duplication.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

未读的 chunk 只说一次、挂在其原因之下。凡披露条目已解释"为何没被读"(launch 未发生、或发生在改写的 prompt 上)的 chunk,不再出现在正文的 `nobody read them` 句中;`chunk-nobody-read` cap 与修复命令保留全量列表——只有发布的句子去重。没有已披露原因的 chunk(3A 形状:chunk 不是 roster requirement)保留该句,因为那是作者得知这些行未被读的唯一出处。

## 为什么需要

#7190 分组落地后的第一条正文([#7166 上的 review 4730480309](https://github.com/QwenLM/qwen-code/pull/7166#pullrequestreview-4730480309))把 17 个 chunk 说了**两遍**:一遍在 `nobody read them`、一遍在 `its prompt was built, but no agent…`——后果与原因跨两个子句类别复述,是按 subject 去重未能覆盖的最后一个重复形状。

## 验证方式

1. `cd packages/cli && npx vitest run src/commands/review` —— 31 文件 769 测试全绿。
2. 新钉:built-never-launched 的 chunk 只在原因句出现(`nobody read them` 缺席;cap 与 remediation 原样);无 launch 侧披露的 3A plan 保留收据句。既有 blind-launch 测试改钉去重后的形状(原因一次,cap 与修复随行)。
3. 突变 2/2 击杀:删抑制、删空句守卫,各自打红对应测试。

## 证据(前后对照)

修复前(#7166 实况):17 个 chunk 同时出现在 `nobody read them` 句与 not-launched 句。

修复后,同一状态:这 17 个只在原因句出现;收据句只为无其他解释的 chunk 渲染。

## 风险与范围

- 只动正文;`cappedBy`、`remediation`、event 决策未触碰(已钉)。
- 抑制按披露条目已携带的 `chunk <id>` subject 精确匹配——被任一原因(not-launched/rewritten/idle/blind/unopened)解释的 chunk 均让位于该原因。

## 关联

展品:#7166 上的 review 4730480309——#7190 之后的第一条正文及其唯一残留重复。

</details>
