### PR TITLE
fix(core): estimate reasoning_tokens when completion_tokens_details is missing

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3668,7 +3668,7 @@ describe('OpenAIContentConverter', () => {
               logprobs: null,
             },
           ],
-          usage: { prompt_tokens: 1, completion_tokens: 5, total_tokens: 6 },
+          usage: { prompt_tokens: 1, completion_tokens: 10, total_tokens: 11 },
         } as unknown as OpenAI.Chat.ChatCompletion,
         requestContext,
       );
@@ -3711,8 +3711,8 @@ describe('OpenAIContentConverter', () => {
           choices: [],
           usage: {
             prompt_tokens: 1,
-            completion_tokens: 1128,
-            total_tokens: 1129,
+            completion_tokens: 1200,
+            total_tokens: 1201,
           },
         } as unknown as OpenAI.Chat.ChatCompletionChunk,
         context,

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3676,6 +3676,33 @@ describe('OpenAIContentConverter', () => {
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
     });
 
+    it('estimates missing reasoning tokens from non-streaming reasoning field', () => {
+      const response = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-reasoning-field-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'answer',
+                reasoning: '先仔细想',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 10, total_tokens: 11 },
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
+    });
+
     it.each([0, 42])(
       'preserves provider reasoning tokens for non-streaming content: %s',
       (reasoningTokens) => {

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3676,6 +3676,45 @@ describe('OpenAIContentConverter', () => {
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
     });
 
+    it.each([0, 42])(
+      'preserves provider reasoning tokens for non-streaming content: %s',
+      (reasoningTokens) => {
+        const response = converter.convertOpenAIResponseToGemini(
+          {
+            object: 'chat.completion',
+            id: 'chatcmpl-provider-reasoning-usage',
+            created: 123,
+            model: 'test-model',
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: 'assistant',
+                  content: 'answer',
+                  reasoning_content: '先仔细想',
+                },
+                finish_reason: 'stop',
+                logprobs: null,
+              },
+            ],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 10,
+              total_tokens: 11,
+              completion_tokens_details: {
+                reasoning_tokens: reasoningTokens,
+              },
+            },
+          } as unknown as OpenAI.Chat.ChatCompletion,
+          requestContext,
+        );
+
+        expect(response.usageMetadata?.thoughtsTokenCount).toBe(
+          reasoningTokens,
+        );
+      },
+    );
+
     it('estimates reasoning tokens past the streaming detection window', () => {
       const context = withStreamParser();
       const reasoningChunk = (id: string, reasoning_content: string) =>
@@ -3720,6 +3759,52 @@ describe('OpenAIContentConverter', () => {
 
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(1128);
     });
+
+    it.each([0, 42])(
+      'preserves provider reasoning tokens for streaming content: %s',
+      (reasoningTokens) => {
+        const context = withStreamParser();
+        converter.convertOpenAIChunkToGemini(
+          {
+            object: 'chat.completion.chunk',
+            id: 'chunk-provider-reasoning',
+            created: 123,
+            model: 'test-model',
+            choices: [
+              {
+                index: 0,
+                delta: { reasoning_content: '先仔细想' },
+                finish_reason: null,
+                logprobs: null,
+              },
+            ],
+          } as unknown as OpenAI.Chat.ChatCompletionChunk,
+          context,
+        );
+        const response = converter.convertOpenAIChunkToGemini(
+          {
+            object: 'chat.completion.chunk',
+            id: 'chunk-provider-reasoning-usage',
+            created: 123,
+            model: 'test-model',
+            choices: [],
+            usage: {
+              prompt_tokens: 1,
+              completion_tokens: 10,
+              total_tokens: 11,
+              completion_tokens_details: {
+                reasoning_tokens: reasoningTokens,
+              },
+            },
+          } as unknown as OpenAI.Chat.ChatCompletionChunk,
+          context,
+        );
+
+        expect(response.usageMetadata?.thoughtsTokenCount).toBe(
+          reasoningTokens,
+        );
+      },
+    );
   });
 
   describe('OpenAI -> Gemini reasoning content', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3703,6 +3703,33 @@ describe('OpenAIContentConverter', () => {
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
     });
 
+    it('clamps estimated non-streaming reasoning tokens to completion tokens', () => {
+      const response = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-reasoning-clamped-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'answer',
+                reasoning_content: '想'.repeat(10),
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(3);
+    });
+
     it.each([0, 42])(
       'preserves provider reasoning tokens for non-streaming content: %s',
       (reasoningTokens) => {
@@ -3785,6 +3812,81 @@ describe('OpenAIContentConverter', () => {
       );
 
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(1128);
+    });
+
+    it('estimates reasoning tokens for short streaming content', () => {
+      const context = withStreamParser();
+      const reasoningChunk = (id: string, reasoning_content: string) =>
+        ({
+          object: 'chat.completion.chunk',
+          id,
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        }) as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      converter.convertOpenAIChunkToGemini(
+        reasoningChunk('chunk-short-reasoning-1', '先'),
+        context,
+      );
+      converter.convertOpenAIChunkToGemini(
+        reasoningChunk('chunk-short-reasoning-2', '仔细想'),
+        context,
+      );
+      const response = converter.convertOpenAIChunkToGemini(
+        {
+          object: 'chat.completion.chunk',
+          id: 'chunk-short-reasoning-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [],
+          usage: { prompt_tokens: 1, completion_tokens: 10, total_tokens: 11 },
+        } as unknown as OpenAI.Chat.ChatCompletionChunk,
+        context,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
+    });
+
+    it('clamps estimated streaming reasoning tokens to completion tokens', () => {
+      const context = withStreamParser();
+      converter.convertOpenAIChunkToGemini(
+        {
+          object: 'chat.completion.chunk',
+          id: 'chunk-clamped-reasoning',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content: '想'.repeat(10) },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletionChunk,
+        context,
+      );
+      const response = converter.convertOpenAIChunkToGemini(
+        {
+          object: 'chat.completion.chunk',
+          id: 'chunk-clamped-reasoning-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [],
+          usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+        } as unknown as OpenAI.Chat.ChatCompletionChunk,
+        context,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(3);
     });
 
     it.each([0, 42])(

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3855,6 +3855,42 @@ describe('OpenAIContentConverter', () => {
       expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
     });
 
+    it('estimates normalized cumulative reasoning without a completion count', () => {
+      const context = withStreamParser();
+      for (const reasoning_content of ['先仔细想', '先仔细想再检查']) {
+        converter.convertOpenAIChunkToGemini(
+          {
+            object: 'chat.completion.chunk',
+            id: 'chunk-cumulative-reasoning',
+            created: 123,
+            model: 'test-model',
+            choices: [
+              {
+                index: 0,
+                delta: { reasoning_content },
+                finish_reason: null,
+                logprobs: null,
+              },
+            ],
+          } as unknown as OpenAI.Chat.ChatCompletionChunk,
+          context,
+        );
+      }
+      const response = converter.convertOpenAIChunkToGemini(
+        {
+          object: 'chat.completion.chunk',
+          id: 'chunk-cumulative-reasoning-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [],
+          usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+        } as unknown as OpenAI.Chat.ChatCompletionChunk,
+        context,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(8);
+    });
+
     it('clamps estimated streaming reasoning tokens to completion tokens', () => {
       const context = withStreamParser();
       converter.convertOpenAIChunkToGemini(

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3648,6 +3648,78 @@ describe('OpenAIContentConverter', () => {
         (usage?.promptTokenCount ?? 0) + (usage?.candidatesTokenCount ?? 0),
       ).toBe(5);
     });
+
+    it('estimates missing reasoning tokens from non-streaming content', () => {
+      const response = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-reasoning-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'answer',
+                reasoning_content: '先仔细想',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 5, total_tokens: 6 },
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(5);
+    });
+
+    it('estimates reasoning tokens past the streaming detection window', () => {
+      const context = withStreamParser();
+      const reasoningChunk = (id: string, reasoning_content: string) =>
+        ({
+          object: 'chat.completion.chunk',
+          id,
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        }) as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      converter.convertOpenAIChunkToGemini(
+        reasoningChunk('chunk-reasoning-1', '想'.repeat(1024)),
+        context,
+      );
+      converter.convertOpenAIChunkToGemini(
+        reasoningChunk('chunk-reasoning-2', '想'),
+        context,
+      );
+      const response = converter.convertOpenAIChunkToGemini(
+        {
+          object: 'chat.completion.chunk',
+          id: 'chunk-reasoning-usage',
+          created: 123,
+          model: 'test-model',
+          choices: [],
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 1128,
+            total_tokens: 1129,
+          },
+        } as unknown as OpenAI.Chat.ChatCompletionChunk,
+        context,
+      );
+
+      expect(response.usageMetadata?.thoughtsTokenCount).toBe(1128);
+    });
   });
 
   describe('OpenAI -> Gemini reasoning content', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1269,8 +1269,8 @@ export function convertOpenAIResponseToGemini(
       estimateTextTokenUnits(reasoningText ?? '') /
         TOKEN_ESTIMATE_UNITS_PER_TOKEN,
     );
-    const thinkingTokens = providerReasoningTokens || estimatedThinkingTokens;
-    if (!providerReasoningTokens && estimatedThinkingTokens > 0) {
+    const thinkingTokens = providerReasoningTokens ?? estimatedThinkingTokens;
+    if (providerReasoningTokens == null && estimatedThinkingTokens > 0) {
       debugLogger.debug(
         `convertOpenAIResponseToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from text`,
       );
@@ -1741,8 +1741,8 @@ export function convertOpenAIChunkToGemini(
       (requestContext.reasoningDeltaState?.emittedTokenUnits ?? 0) /
         TOKEN_ESTIMATE_UNITS_PER_TOKEN,
     );
-    const thinkingTokens = providerReasoningTokens || estimatedThinkingTokens;
-    if (!providerReasoningTokens && estimatedThinkingTokens > 0) {
+    const thinkingTokens = providerReasoningTokens ?? estimatedThinkingTokens;
+    if (providerReasoningTokens == null && estimatedThinkingTokens > 0) {
       debugLogger.debug(
         `convertOpenAIChunkToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from streamed text`,
       );

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -22,6 +22,11 @@ import type OpenAI from 'openai';
 import { safeJsonParse } from '../../utils/safeJsonParse.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { createOpenAIReasoningThoughtPart } from '../../utils/thoughtUtils.js';
+import {
+  estimateTextTokens,
+  estimateTextTokenUnits,
+  TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+} from '../../utils/request-tokenizer/textTokenizer.js';
 import type { RequestContext, StreamingTextDeltaState } from './types.js';
 import { parseTaggedThinkingText } from './taggedThinkingParser.js';
 import {
@@ -1172,16 +1177,6 @@ function throwProtocolTagLeak(requestContext: RequestContext): never {
 }
 
 /**
- * Estimate token count from text length when the provider does not return
- * reasoning_tokens in usage. Uses ~4 chars/token as a rough approximation
- * for English/mixed content.
- */
-function estimateTokensFromText(text: string | undefined | null): number {
-  if (!text) return 0;
-  return Math.ceil(text.length / 4);
-}
-
-/**
  * Convert OpenAI response to Gemini format.
  */
 export function convertOpenAIResponseToGemini(
@@ -1189,6 +1184,8 @@ export function convertOpenAIResponseToGemini(
   requestContext: RequestContext,
 ): GenerateContentResponse {
   const choice = openaiResponse.choices?.[0];
+  const message = choice?.message as ExtendedCompletionMessage | undefined;
+  const reasoningText = message?.reasoning_content ?? message?.reasoning;
   const response = new GenerateContentResponse();
 
   if (choice) {
@@ -1201,9 +1198,6 @@ export function convertOpenAIResponseToGemini(
     // Tagged thinking providers may put thoughts in content, while other
     // responses still use reasoning_content. Preserve the separate reasoning
     // channel unless content parsing already produced thought parts.
-    const reasoningText =
-      (choice.message as ExtendedCompletionMessage).reasoning_content ??
-      (choice.message as ExtendedCompletionMessage).reasoning;
     if (reasoningText && !hasThoughtPart(textParts)) {
       parts.push(createOpenAIReasoningThoughtPart(reasoningText));
     }
@@ -1270,15 +1264,9 @@ export function convertOpenAIResponseToGemini(
       usage.prompt_tokens_details?.cached_tokens ??
       extendedUsage.cached_tokens ??
       0;
-    // reasoningText is scoped inside if(choice), so extract it here for the fallback
-    const reasoningTextForUsage =
-      (openaiResponse.choices?.[0]?.message as ExtendedCompletionMessage | undefined)
-        ?.reasoning_content ??
-      (openaiResponse.choices?.[0]?.message as ExtendedCompletionMessage | undefined)
-        ?.reasoning;
     const thinkingTokens =
       usage.completion_tokens_details?.reasoning_tokens ||
-      estimateTokensFromText(reasoningTextForUsage);
+      estimateTextTokens(reasoningText ?? '');
 
     // If we only have total tokens but no breakdown, estimate the split
     // Typically input is ~70% and output is ~30% for most conversations
@@ -1380,15 +1368,19 @@ export function convertOpenAIChunkToGemini(
       (!requestContext.responseParsingOptions?.taggedThinkingTags ||
         !requestContext.hasTaggedThinkingThought)
     ) {
+      const reasoningDeltaState = (requestContext.reasoningDeltaState ??= {
+        emittedText: '',
+        emittedLength: 0,
+        cumulativeMode: false,
+      });
       const normalizedReasoningText = normalizeStreamingTextDelta(
         reasoningText,
-        (requestContext.reasoningDeltaState ??= {
-          emittedText: '',
-          emittedLength: 0,
-          cumulativeMode: false,
-        }),
+        reasoningDeltaState,
       );
       if (normalizedReasoningText) {
+        reasoningDeltaState.emittedTokenUnits =
+          (reasoningDeltaState.emittedTokenUnits ?? 0) +
+          estimateTextTokenUnits(normalizedReasoningText);
         requestContext.hasStructuredReasoningContent = true;
         if (THINKING_TAG_PATTERN.test(normalizedReasoningText)) {
           requestContext.hasThinkingTagInReasoning = true;
@@ -1737,7 +1729,10 @@ export function convertOpenAIChunkToGemini(
     const totalTokens = usage.total_tokens || 0;
     const thinkingTokens =
       usage.completion_tokens_details?.reasoning_tokens ||
-      Math.ceil((requestContext.reasoningDeltaState?.emittedLength ?? 0) / 4);
+      Math.ceil(
+        (requestContext.reasoningDeltaState?.emittedTokenUnits ?? 0) /
+          TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+      );
     // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)
     // and cached_tokens (some models return it at top level)
     const extendedUsage = usage as ExtendedCompletionUsage;

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1266,12 +1266,18 @@ export function convertOpenAIResponseToGemini(
       0;
     const providerReasoningTokens =
       usage.completion_tokens_details?.reasoning_tokens;
-    const estimatedThinkingTokens = estimateTextTokens(reasoningText ?? '');
-    const thinkingTokens = providerReasoningTokens ?? estimatedThinkingTokens;
-    if (providerReasoningTokens == null && estimatedThinkingTokens > 0) {
-      debugLogger.debug(
-        `convertOpenAIResponseToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from text`,
-      );
+    let thinkingTokens = providerReasoningTokens;
+    if (thinkingTokens == null) {
+      const estimatedThinkingTokens = estimateTextTokens(reasoningText ?? '');
+      thinkingTokens =
+        completionTokens > 0
+          ? Math.min(estimatedThinkingTokens, completionTokens)
+          : estimatedThinkingTokens;
+      if (thinkingTokens > 0) {
+        debugLogger.debug(
+          `convertOpenAIResponseToGemini: reasoning_tokens absent; estimated ${thinkingTokens} from text`,
+        );
+      }
     }
 
     // If we only have total tokens but no breakdown, estimate the split
@@ -1739,10 +1745,14 @@ export function convertOpenAIChunkToGemini(
       (requestContext.reasoningDeltaState?.emittedTokenUnits ?? 0) /
         TOKEN_ESTIMATE_UNITS_PER_TOKEN,
     );
-    const thinkingTokens = providerReasoningTokens ?? estimatedThinkingTokens;
+    const thinkingTokens =
+      providerReasoningTokens ??
+      (completionTokens > 0
+        ? Math.min(estimatedThinkingTokens, completionTokens)
+        : estimatedThinkingTokens);
     if (providerReasoningTokens == null && estimatedThinkingTokens > 0) {
       debugLogger.debug(
-        `convertOpenAIChunkToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from streamed text`,
+        `convertOpenAIChunkToGemini: reasoning_tokens absent; estimated ${thinkingTokens} from streamed text`,
       );
     }
     // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -23,6 +23,7 @@ import { safeJsonParse } from '../../utils/safeJsonParse.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { createOpenAIReasoningThoughtPart } from '../../utils/thoughtUtils.js';
 import {
+  estimateTextTokens,
   estimateTextTokenUnits,
   TOKEN_ESTIMATE_UNITS_PER_TOKEN,
 } from '../../utils/request-tokenizer/textTokenizer.js';
@@ -1265,10 +1266,7 @@ export function convertOpenAIResponseToGemini(
       0;
     const providerReasoningTokens =
       usage.completion_tokens_details?.reasoning_tokens;
-    const estimatedThinkingTokens = Math.ceil(
-      estimateTextTokenUnits(reasoningText ?? '') /
-        TOKEN_ESTIMATE_UNITS_PER_TOKEN,
-    );
+    const estimatedThinkingTokens = estimateTextTokens(reasoningText ?? '');
     const thinkingTokens = providerReasoningTokens ?? estimatedThinkingTokens;
     if (providerReasoningTokens == null && estimatedThinkingTokens > 0) {
       debugLogger.debug(

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1270,9 +1270,15 @@ export function convertOpenAIResponseToGemini(
       usage.prompt_tokens_details?.cached_tokens ??
       extendedUsage.cached_tokens ??
       0;
+    // reasoningText is scoped inside if(choice), so extract it here for the fallback
+    const reasoningTextForUsage =
+      (openaiResponse.choices?.[0]?.message as ExtendedCompletionMessage | undefined)
+        ?.reasoning_content ??
+      (openaiResponse.choices?.[0]?.message as ExtendedCompletionMessage | undefined)
+        ?.reasoning;
     const thinkingTokens =
       usage.completion_tokens_details?.reasoning_tokens ||
-      estimateTokensFromText(reasoningText);
+      estimateTokensFromText(reasoningTextForUsage);
 
     // If we only have total tokens but no breakdown, estimate the split
     // Typically input is ~70% and output is ~30% for most conversations

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -23,7 +23,6 @@ import { safeJsonParse } from '../../utils/safeJsonParse.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { createOpenAIReasoningThoughtPart } from '../../utils/thoughtUtils.js';
 import {
-  estimateTextTokens,
   estimateTextTokenUnits,
   TOKEN_ESTIMATE_UNITS_PER_TOKEN,
 } from '../../utils/request-tokenizer/textTokenizer.js';
@@ -1264,9 +1263,18 @@ export function convertOpenAIResponseToGemini(
       usage.prompt_tokens_details?.cached_tokens ??
       extendedUsage.cached_tokens ??
       0;
-    const thinkingTokens =
-      usage.completion_tokens_details?.reasoning_tokens ||
-      estimateTextTokens(reasoningText ?? '');
+    const providerReasoningTokens =
+      usage.completion_tokens_details?.reasoning_tokens;
+    const estimatedThinkingTokens = Math.ceil(
+      estimateTextTokenUnits(reasoningText ?? '') /
+        TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+    );
+    const thinkingTokens = providerReasoningTokens || estimatedThinkingTokens;
+    if (!providerReasoningTokens && estimatedThinkingTokens > 0) {
+      debugLogger.debug(
+        `convertOpenAIResponseToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from text`,
+      );
+    }
 
     // If we only have total tokens but no breakdown, estimate the split
     // Typically input is ~70% and output is ~30% for most conversations
@@ -1727,12 +1735,18 @@ export function convertOpenAIChunkToGemini(
     const promptTokens = usage.prompt_tokens || 0;
     const completionTokens = usage.completion_tokens || 0;
     const totalTokens = usage.total_tokens || 0;
-    const thinkingTokens =
-      usage.completion_tokens_details?.reasoning_tokens ||
-      Math.ceil(
-        (requestContext.reasoningDeltaState?.emittedTokenUnits ?? 0) /
-          TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+    const providerReasoningTokens =
+      usage.completion_tokens_details?.reasoning_tokens;
+    const estimatedThinkingTokens = Math.ceil(
+      (requestContext.reasoningDeltaState?.emittedTokenUnits ?? 0) /
+        TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+    );
+    const thinkingTokens = providerReasoningTokens || estimatedThinkingTokens;
+    if (!providerReasoningTokens && estimatedThinkingTokens > 0) {
+      debugLogger.debug(
+        `convertOpenAIChunkToGemini: reasoning_tokens absent; estimated ${estimatedThinkingTokens} from streamed text`,
       );
+    }
     // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)
     // and cached_tokens (some models return it at top level)
     const extendedUsage = usage as ExtendedCompletionUsage;

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1172,6 +1172,16 @@ function throwProtocolTagLeak(requestContext: RequestContext): never {
 }
 
 /**
+/**
+ * Estimate token count from text length when the provider does not return
+ * reasoning_tokens in usage. Uses ~4 chars/token as a rough approximation
+ * for English/mixed content.
+ */
+function estimateTokensFromText(text: string | undefined | null): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
  * Convert OpenAI response to Gemini format.
  */
 export function convertOpenAIResponseToGemini(
@@ -1261,7 +1271,8 @@ export function convertOpenAIResponseToGemini(
       extendedUsage.cached_tokens ??
       0;
     const thinkingTokens =
-      usage.completion_tokens_details?.reasoning_tokens || 0;
+      usage.completion_tokens_details?.reasoning_tokens ||
+      estimateTokensFromText(reasoningText);
 
     // If we only have total tokens but no breakdown, estimate the split
     // Typically input is ~70% and output is ~30% for most conversations
@@ -1719,7 +1730,8 @@ export function convertOpenAIChunkToGemini(
     const completionTokens = usage.completion_tokens || 0;
     const totalTokens = usage.total_tokens || 0;
     const thinkingTokens =
-      usage.completion_tokens_details?.reasoning_tokens || 0;
+      usage.completion_tokens_details?.reasoning_tokens ||
+      Math.ceil((requestContext.reasoningDeltaState?.emittedLength ?? 0) / 4);
     // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)
     // and cached_tokens (some models return it at top level)
     const extendedUsage = usage as ExtendedCompletionUsage;

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1172,7 +1172,6 @@ function throwProtocolTagLeak(requestContext: RequestContext): never {
 }
 
 /**
-/**
  * Estimate token count from text length when the provider does not return
  * reasoning_tokens in usage. Uses ~4 chars/token as a rough approximation
  * for English/mixed content.
@@ -1182,6 +1181,7 @@ function estimateTokensFromText(text: string | undefined | null): number {
   return Math.ceil(text.length / 4);
 }
 
+/**
  * Convert OpenAI response to Gemini format.
  */
 export function convertOpenAIResponseToGemini(

--- a/packages/core/src/core/openaiContentGenerator/types.ts
+++ b/packages/core/src/core/openaiContentGenerator/types.ts
@@ -34,6 +34,8 @@ export interface StreamingTextDeltaState {
    * visible duplication).
    */
   emittedLength: number;
+  /** Integer token-estimate units accumulated from normalized emitted text. */
+  emittedTokenUnits?: number;
   cumulativeMode: boolean;
 }
 

--- a/packages/core/src/utils/request-tokenizer/textTokenizer.test.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { TextTokenizer } from './textTokenizer.js';
+import {
+  estimateTextTokens,
+  estimateTextTokenUnits,
+  TextTokenizer,
+  TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+} from './textTokenizer.js';
 
 describe('TextTokenizer', () => {
   let tokenizer: TextTokenizer;
@@ -28,6 +33,16 @@ describe('TextTokenizer', () => {
   });
 
   describe('calculateTokens', () => {
+    it('keeps token-unit estimates aligned with token estimates', () => {
+      for (const text of ['', 'Hello', '你好世界', 'Hello 世界']) {
+        expect(
+          Math.ceil(
+            estimateTextTokenUnits(text) / TOKEN_ESTIMATE_UNITS_PER_TOKEN,
+          ),
+        ).toBe(estimateTextTokens(text));
+      }
+    });
+
     it('should return 0 for empty text', async () => {
       const result = await tokenizer.calculateTokens('');
       expect(result).toBe(0);

--- a/packages/core/src/utils/request-tokenizer/textTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.ts
@@ -5,6 +5,7 @@
  */
 
 const NON_ASCII_RE = /[\u0080-\uffff]/;
+export const TOKEN_ESTIMATE_UNITS_PER_TOKEN = 20;
 
 /**
  * Text tokenizer for calculating text tokens using character-based estimation.
@@ -21,22 +22,42 @@ export function estimateTextTokens(text: string): number {
     return 0;
   }
 
-  // Fast path: pure-ASCII text (code, English prose). A single regex scan
-  // uses V8's optimized string search instead of a per-character JS loop.
   if (!NON_ASCII_RE.test(text)) {
     return Math.ceil(text.length / 4);
   }
 
-  let nonAsciiChars = 0;
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) >= 128) {
-      nonAsciiChars++;
-    }
-  }
+  const nonAsciiChars = countNonAsciiChars(text);
   const asciiChars = text.length - nonAsciiChars;
 
-  const tokens = asciiChars / 4 + nonAsciiChars * 1.1;
-  return Math.ceil(tokens);
+  return Math.ceil(asciiChars / 4 + nonAsciiChars * 1.1);
+}
+
+/** Returns 20 units per token so streams can accumulate without float drift. */
+export function estimateTextTokenUnits(text: string): number {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+
+  // Fast path: pure-ASCII text (code, English prose). A single regex scan
+  // uses V8's optimized string search instead of a per-character JS loop.
+  if (!NON_ASCII_RE.test(text)) {
+    return text.length * 5;
+  }
+
+  const nonAsciiChars = countNonAsciiChars(text);
+  const asciiChars = text.length - nonAsciiChars;
+
+  return asciiChars * 5 + nonAsciiChars * 22;
+}
+
+function countNonAsciiChars(text: string): number {
+  let count = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) >= 128) {
+      count++;
+    }
+  }
+  return count;
 }
 
 export class TextTokenizer {

--- a/packages/core/src/utils/request-tokenizer/textTokenizer.ts
+++ b/packages/core/src/utils/request-tokenizer/textTokenizer.ts
@@ -47,6 +47,7 @@ export function estimateTextTokenUnits(text: string): number {
   const nonAsciiChars = countNonAsciiChars(text);
   const asciiChars = text.length - nonAsciiChars;
 
+  // 5 = 20 / 4; 22 = 20 * 1.1. Keep in sync with estimateTextTokens().
   return asciiChars * 5 + nonAsciiChars * 22;
 }
 


### PR DESCRIPTION
## What this PR does

Adds a fallback to estimate thinking tokens from normalized reasoning text when an OpenAI-compatible provider omits `reasoning_tokens` from its usage response. Non-streaming responses reuse the existing text estimator, while streaming responses accumulate bounded integer estimate units after delta normalization.

## Why it's needed

Some providers, including llama.cpp server, return `reasoning_content` but omit the matching reasoning token count. The CLI therefore displayed zero thinking tokens even though reasoning was present.

## Reviewer Test Plan

### How to verify

Confirm that non-streaming and streaming responses with `reasoning_content` but no `reasoning_tokens` report a non-zero thinking-token count. Verify ASCII and CJK reasoning, streams beyond the 1 KB normalization window, cumulative/replayed deltas, and that provider-reported counts remain authoritative.

### Evidence (Before & After)

Before: responses missing `reasoning_tokens` reported zero thinking tokens. After: reasoning text is estimated without retaining an unbounded stream buffer; normalized replayed text is not double-counted.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment

Focused converter, tokenizer, and PDF regression tests passed (284/284). Full repository build and typecheck passed locally.

## Risk & Scope

- Main risk or tradeoff: Fallback counts remain heuristic because providers do not supply tokenizer-authoritative usage.
- Not validated / out of scope: Exact parity with every provider-specific tokenizer.
- Breaking changes / migration notes: None. Provider-reported reasoning token counts still take precedence.

## Linked Issues

Fixes #7236
