### PR TITLE
docs(vscode-ide-companion): correct JSDoc @param names to match signatures

### DIFF
--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -47,7 +47,8 @@ export class QwenConnectionHandler {
    *
    * @param connection - ACP connection instance
    * @param workingDir - Working directory
-   * @param cliPath - CLI path (optional, if provided will override the path in configuration)
+   * @param cliEntryPath - CLI path (optional, if provided will override the path in configuration)
+   * @param options - Optional connection options (e.g. autoAuthenticate)
    */
   async connect(
     connection: AcpConnection,

--- a/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
@@ -46,7 +46,7 @@ export class QwenSessionManager {
   /**
    * Load a saved session by name
    *
-   * @param sessionName - Name/tag of the session to load
+   * @param sessionId - ID of the session to load
    * @param workingDir - Current working directory
    * @returns Loaded session or null if not found
    */

--- a/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
@@ -44,7 +44,7 @@ export class QwenSessionManager {
   }
 
   /**
-   * Load a saved session by name
+   * Load a saved session by ID
    *
    * @param sessionId - ID of the session to load
    * @param workingDir - Current working directory


### PR DESCRIPTION
## What this PR does

Corrects two JSDoc `@param` blocks in `vscode-ide-companion` where the documented parameter name does not match the actual function signature:

- `qwenSessionManager.ts` — `loadSession(sessionId, workingDir)` documented `@param sessionName`; renamed to `@param sessionId` (and reworded "Name/tag" → "ID", since the value is used directly as `session-${sessionId}.json`).
- `qwenConnectionHandler.ts` — `connect(connection, workingDir, cliEntryPath, options?)` documented `@param cliPath`; renamed to `@param cliEntryPath` to match the real parameter, and added the previously-undocumented `@param options`.

## Why it's needed

A `@param` tag that names a parameter the function doesn't have is a factual documentation error: editors and IDE hovers surface these tags against the real signature, so the wrong names actively mislead anyone reading them (and `@param cliPath` / `@param sessionName` never bind to anything). These are doc-only corrections — no code, types, or behavior change.

## Reviewer Test Plan

### How to verify

- `qwenSessionManager.ts`: the `loadSession` signature's first parameter is `sessionId`; the JSDoc now says `@param sessionId`. No `sessionName` remains in that block.
- `qwenConnectionHandler.ts`: the `connect` signature is `(connection, workingDir, cliEntryPath, options?)`; the JSDoc now documents `cliEntryPath` and `options`, with no stray `cliPath`.
- `grep -n "@param sessionName\|@param cliPath" packages/vscode-ide-companion/src` returns nothing.

### Evidence (Before & After)

`qwenSessionManager.ts` `loadSession`:
Before: `@param sessionName - Name/tag of the session to load` (no such param).
After: `@param sessionId - ID of the session to load`.

`qwenConnectionHandler.ts` `connect`:
Before: `@param cliPath - CLI path (...)`; `options` undocumented.
After: `@param cliEntryPath - CLI path (...)` + `@param options - Optional connection options (e.g. autoAuthenticate)`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: doc-comment-only change — JSDoc does not affect compilation or runtime, so there is nothing to build or execute; verified by reading each corrected `@param` against its function signature and grepping that no old param names remain.

### Environment (optional)

`@qwen-code/vscode-ide-companion`.

## Risk & Scope

- Main risk or tradeoff: none — comments only; no code, type, or behavior change.
- Not validated / out of scope: other JSDoc drift elsewhere in the repo is not touched by this PR.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修正 `vscode-ide-companion` 中两处 JSDoc `@param` 块——其记录的参数名与实际函数签名不一致：

- `qwenSessionManager.ts` —— `loadSession(sessionId, workingDir)` 原记录为 `@param sessionName`；改为 `@param sessionId`（并将"Name/tag"改为"ID"，因为该值直接用于 `session-${sessionId}.json`）。
- `qwenConnectionHandler.ts` —— `connect(connection, workingDir, cliEntryPath, options?)` 原记录为 `@param cliPath`；改为与真实参数一致的 `@param cliEntryPath`，并补充此前未记录的 `@param options`。

## 为什么需要

`@param` 标注了函数并不存在的参数，属于事实性的文档错误：编辑器与 IDE 悬浮提示会将这些标注对照真实签名展示，因此错误的名称会实际误导读者（且 `@param cliPath` / `@param sessionName` 根本无法绑定到任何参数）。这些仅为文档修正——不改动任何代码、类型或行为。

## 复核测试计划

### 如何验证

- `qwenSessionManager.ts`：`loadSession` 签名的第一个参数为 `sessionId`；JSDoc 现为 `@param sessionId`，该块中不再出现 `sessionName`。
- `qwenConnectionHandler.ts`：`connect` 签名为 `(connection, workingDir, cliEntryPath, options?)`；JSDoc 现记录 `cliEntryPath` 与 `options`，不再有多余的 `cliPath`。
- `grep -n "@param sessionName\|@param cliPath" packages/vscode-ide-companion/src` 无任何结果。

### 证据（修复前后对比）

`qwenSessionManager.ts` `loadSession`：
修复前：`@param sessionName - Name/tag of the session to load`（无此参数）。
修复后：`@param sessionId - ID of the session to load`。

`qwenConnectionHandler.ts` `connect`：
修复前：`@param cliPath - CLI path (...)`；`options` 未记录。
修复后：`@param cliEntryPath - CLI path (...)` + `@param options - Optional connection options (e.g. autoAuthenticate)`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：仅改动文档注释——JSDoc 不影响编译或运行，故无需构建或执行；通过将每处修正后的 `@param` 与其函数签名逐一核对、并 grep 确认无旧参数名残留来验证。

### 运行环境（可选）

`@qwen-code/vscode-ide-companion`。

## 风险与影响范围

- 主要风险或权衡：无——仅注释；不改动任何代码、类型或行为。
- 未验证 / 范围之外：本 PR 未触及仓库中其他位置的 JSDoc 漂移。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
