### PR TITLE
docs(core): correct JSDoc @param names in src/utils to match signatures

### DIFF
--- a/packages/core/src/utils/editHelper.ts
+++ b/packages/core/src/utils/editHelper.ts
@@ -404,7 +404,6 @@ const SNIPPET_MAX_LINES = 1000;
  *
  * @param oldContent The original file content before the edit (null for new files)
  * @param newContent The new file content after the edit
- * @param contextLines Number of context lines to show before and after the change
  * @returns Snippet information, or null if no meaningful snippet can be extracted
  */
 export function extractEditSnippet(

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -218,10 +218,11 @@ async function readFullStructure(
 }
 
 /**
- * Reads the directory structure using BFS, respecting maxItems.
+ * Formats an already-built folder structure into indented text lines.
  * @param node The current node in the reduced structure.
- * @param indent The current indentation string.
- * @param isLast Sibling indicator.
+ * @param currentIndent The current indentation string.
+ * @param isLastChildOfParent Whether this node is the last child of its parent.
+ * @param isProcessingRootNode Whether this node is the root node originally passed to getFolderStructure.
  * @param builder Array to build the string lines.
  */
 function formatStructure(

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -80,7 +80,7 @@ function validateUrl(
  * and resolves successfully to prevent application crashes.
  *
  * @param url - The URL to open.
- * @param options.allowFile - Allow file:// URLs for locally generated reports.
+ * @param browserOptions.allowFile - Allow file:// URLs for locally generated reports.
  * @returns A promise that resolves when the attempt is made (whether successful or logged).
  */
 export async function openBrowserSecurely(

--- a/packages/core/src/utils/subagentGenerator.ts
+++ b/packages/core/src/utils/subagentGenerator.ts
@@ -109,7 +109,7 @@ export interface SubagentGeneratedContent {
  * Generates subagent configuration content using LLM.
  *
  * @param userDescription - The user's description of what the subagent should do
- * @param geminiClient - Initialized GeminiClient instance
+ * @param config - The Config instance used to run the LLM query
  * @param abortSignal - AbortSignal for cancelling the request
  * @returns Promise resolving to generated subagent content
  */


### PR DESCRIPTION
## What this PR does

Corrects JSDoc in four `packages/core/src/utils` functions where a `@param` documents a name the signature does not have (and one wrong summary):

- **`getFolderStructure.ts`** — `formatStructure(node, currentIndent, isLastChildOfParent, isProcessingRootNode, builder)`: renamed `@param indent` → `currentIndent` and `@param isLast` → `isLastChildOfParent`, documented the previously-missing `isProcessingRootNode`, and fixed the summary — it said *"Reads the directory structure using BFS"*, but this function **formats** an already-built structure (the BFS read is done by the caller).
- **`editHelper.ts`** — `extractEditSnippet(oldContent, newContent)`: removed `@param contextLines`, which documents a parameter that does not exist (context size is the module constant `SNIPPET_CONTEXT_LINES`).
- **`subagentGenerator.ts`** — `subagentGenerator(userDescription, config, abortSignal)`: renamed `@param geminiClient` → `config` to match the real `config: Config` parameter.
- **`secure-browser-launcher.ts`** — `openBrowserSecurely(url, browserOptions)`: renamed `@param options.allowFile` → `browserOptions.allowFile` to match the real object-parameter name.

## Why it's needed

A `@param` tag that names a parameter the function does not have is a factual documentation error — IDE hovers surface these tags against the real signature, so the wrong names (`indent`, `isLast`, `contextLines`, `geminiClient`, `options`) mislead readers and never bind to anything. The `getFolderStructure` summary additionally misdescribed what the function does. These are doc-only corrections — no code, types, or behavior change.

## Reviewer Test Plan

### How to verify

- Read each corrected JSDoc against its signature:
  - `formatStructure` params are `node, currentIndent, isLastChildOfParent, isProcessingRootNode, builder` — all now documented, none stray; the BFS "read" happens in the calling `getFolderStructure`, so "formats an already-built structure" is accurate.
  - `extractEditSnippet` takes only `oldContent, newContent` — no `contextLines` param remains documented.
  - `subagentGenerator`'s second param is `config: Config`.
  - `openBrowserSecurely`'s object param is `browserOptions`.
- `grep -n "@param indent\b\|@param isLast\b\|@param contextLines\|@param geminiClient\|@param options.allowFile" packages/core/src/utils` returns nothing.

### Evidence (Before & After)

- `getFolderStructure` — Before: `Reads the directory structure using BFS…` + `@param indent` / `@param isLast`; `isProcessingRootNode` undocumented. After: `Formats an already-built folder structure…` + `@param currentIndent` / `@param isLastChildOfParent` / `@param isProcessingRootNode`.
- `editHelper` — Before: `@param contextLines …` (no such param). After: line removed.
- `subagentGenerator` — Before: `@param geminiClient - Initialized GeminiClient instance`. After: `@param config - The Config instance used to run the LLM query`.
- `secure-browser-launcher` — Before: `@param options.allowFile`. After: `@param browserOptions.allowFile`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: doc-comment-only change — JSDoc does not affect compilation or runtime, so there is nothing to build or execute; verified by reading each corrected `@param` against its function signature and grepping that no old param names remain.

### Environment (optional)

`@qwen-code/qwen-code-core`.

## Risk & Scope

- Main risk or tradeoff: none — comments only; no code, type, or behavior change.
- Not validated / out of scope: this PR covers only the four `src/utils` functions above; other JSDoc drift elsewhere in `core` is not touched.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修正 `packages/core/src/utils` 中四个函数的 JSDoc——其 `@param` 记录了签名中不存在的名称（以及一处错误的摘要）：

- **`getFolderStructure.ts`** —— `formatStructure(node, currentIndent, isLastChildOfParent, isProcessingRootNode, builder)`：将 `@param indent` 改为 `currentIndent`、`@param isLast` 改为 `isLastChildOfParent`，补充此前缺失的 `isProcessingRootNode`，并修正摘要——原文写"Reads the directory structure using BFS"，但该函数是**格式化**一个已构建好的结构（BFS 读取由调用方完成）。
- **`editHelper.ts`** —— `extractEditSnippet(oldContent, newContent)`：删除 `@param contextLines`，它记录了一个不存在的参数（上下文行数是模块常量 `SNIPPET_CONTEXT_LINES`）。
- **`subagentGenerator.ts`** —— `subagentGenerator(userDescription, config, abortSignal)`：将 `@param geminiClient` 改为 `config`，与真实参数 `config: Config` 一致。
- **`secure-browser-launcher.ts`** —— `openBrowserSecurely(url, browserOptions)`：将 `@param options.allowFile` 改为 `browserOptions.allowFile`，与真实对象参数名一致。

## 为什么需要

`@param` 标注了函数并不存在的参数，属于事实性文档错误——IDE 悬浮提示会将这些标注对照真实签名展示，因此错误名称（`indent`、`isLast`、`contextLines`、`geminiClient`、`options`）会误导读者且无法绑定到任何参数。`getFolderStructure` 的摘要还错误描述了函数职责。这些仅为文档修正——不改动任何代码、类型或行为。

## 复核测试计划

### 如何验证

- 将每处修正后的 JSDoc 与其签名逐一核对：
  - `formatStructure` 的参数为 `node, currentIndent, isLastChildOfParent, isProcessingRootNode, builder`——现已全部记录且无多余项；BFS"读取"发生在调用方 `getFolderStructure` 中，故"格式化已构建结构"的描述准确。
  - `extractEditSnippet` 仅接受 `oldContent, newContent`——不再有 `contextLines` 参数被记录。
  - `subagentGenerator` 的第二个参数为 `config: Config`。
  - `openBrowserSecurely` 的对象参数为 `browserOptions`。
- `grep -n "@param indent\b\|@param isLast\b\|@param contextLines\|@param geminiClient\|@param options.allowFile" packages/core/src/utils` 无任何结果。

### 证据（修复前后对比）

- `getFolderStructure` —— 修复前：`Reads the directory structure using BFS…` + `@param indent` / `@param isLast`；`isProcessingRootNode` 未记录。修复后：`Formats an already-built folder structure…` + `@param currentIndent` / `@param isLastChildOfParent` / `@param isProcessingRootNode`。
- `editHelper` —— 修复前：`@param contextLines …`（无此参数）。修复后：删除该行。
- `subagentGenerator` —— 修复前：`@param geminiClient - Initialized GeminiClient instance`。修复后：`@param config - The Config instance used to run the LLM query`。
- `secure-browser-launcher` —— 修复前：`@param options.allowFile`。修复后：`@param browserOptions.allowFile`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：仅改动文档注释——JSDoc 不影响编译或运行，故无需构建或执行；通过将每处修正后的 `@param` 与其函数签名逐一核对、并 grep 确认无旧参数名残留来验证。

### 运行环境（可选）

`@qwen-code/qwen-code-core`。

## 风险与影响范围

- 主要风险或权衡：无——仅注释；不改动任何代码、类型或行为。
- 未验证 / 范围之外：本 PR 仅覆盖上述四个 `src/utils` 函数；`core` 中其他位置的 JSDoc 漂移未触及。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
