### PR TITLE
feat(autofix): auto-manage the bot's own fork PRs without a label

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -21,7 +21,12 @@ name: 'Qwen Autofix'
 #                             unlabeled releases it. autofix/skip opts any PR
 #                             out everywhere and wins over takeover. Labels
 #                             need GitHub triage+, so the permission gate is
-#                             GitHub's own.
+#                             GitHub's own. The bot's OWN fork PRs (author ==
+#                             the autofix bot, e.g. its codex flow) are auto-
+#                             managed WITHOUT a label when allow-edits is on —
+#                             they are the bot's own generated work, trust-
+#                             equal to an in-repo bot PR; autofix/skip still
+#                             opts them out.
 #   • issue_comment         → '@qwen-code /takeover' (apply the label) and
 #                             '@qwen-code /takeover stop' (remove it) — sugar
 #                             for people without label access: the PR author,
@@ -1423,7 +1428,7 @@ jobs:
           else
             gh pr list --repo "${REPO}" --state open --author "${AUTOFIX_BOT}" \
               --base main \
-              --limit 100 --json number,headRefName,isCrossRepository,labels > "${WORKDIR}/bot-prs.json"
+              --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify > "${WORKDIR}/bot-prs.json"
             gh pr list --repo "${REPO}" --state open --label "${TAKEOVER_LABEL}" \
               --base main \
               --limit 100 --json number,headRefName,isCrossRepository,labels,author,maintainerCanModify > "${WORKDIR}/takeover-prs.json"
@@ -1446,10 +1451,15 @@ jobs:
                | .[]
                | .number' \
               "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json")"
-            # FORK takeover PRs are admitted per candidate: the author must
-            # hold write+ RIGHT NOW (the same live-privilege rule as the
-            # comment command) and the PR must allow maintainer edits (or
-            # the bot cannot push). Rare set — one permission call each.
+            # FORK PRs are admitted per candidate: the author must hold write+
+            # RIGHT NOW (the same live-privilege rule as the comment command)
+            # and the PR must allow maintainer edits (or the bot cannot push).
+            # Two sources, unioned: takeover-LABELED forks (any eligible author,
+            # explicit opt-in) AND the bot's OWN forks (bot-prs.json is
+            # --author AUTOFIX_BOT) — a fork the bot itself opened is its own
+            # generated work, trust-equal to an in-repo bot PR, so it needs no
+            # label (autofix/skip still opts it out). Rare set — one permission
+            # call each; the write+ check below still gates every candidate.
             # Appended after the rotated in-repo list: forks sit outside the
             # anti-starvation rotation, which only bites once in-repo
             # candidates alone exhaust the inspection budget.
@@ -1465,12 +1475,13 @@ jobs:
                   echo "🧭 fork takeover candidate #${FPR} skipped: author ${FAUTHOR} permission='${FPERM:-none}' below write"
                   ;;
               esac
-            done < <(jq -r --arg skip "${SKIP_LABEL}" '
-              .[] | select(.isCrossRepository == true)
-                  | select(.maintainerCanModify == true)
-                  | select([.labels[]?.name] | index($skip) | not)
-                  | [(.number | tostring), (.author.login // "")] | @tsv' \
-              "${WORKDIR}/takeover-prs.json")
+            done < <(jq -rs --arg skip "${SKIP_LABEL}" '
+              add | unique_by(.number)
+              | .[] | select(.isCrossRepository == true)
+                    | select(.maintainerCanModify == true)
+                    | select([.labels[]?.name] | index($skip) | not)
+                    | [(.number | tostring), (.author.login // "")] | @tsv' \
+              "${WORKDIR}/bot-prs.json" "${WORKDIR}/takeover-prs.json")
           fi
 
           # Pending-check staleness bound (invariant across candidate PRs, computed
@@ -2045,7 +2056,7 @@ jobs:
           # Base/branch invariants sit ABOVE the fork chain: the last fork
           # elif ends the ladder for eligible forks, so anything below it
           # would be unreachable for exactly the PR class we fetch and push.
-          elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_TAKEOVER}" != "true" ]]; then INELIGIBLE='fork head without takeover'
+          elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_TAKEOVER}" != "true" && "${LIVE_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then INELIGIBLE='fork head without takeover (a non-bot fork needs the label)'
           elif [[ "${LIVE_XREPO}" != "false" && "${LIVE_CAN_MODIFY}" != "true" ]]; then INELIGIBLE='fork head without maintainer-edit access'
           elif [[ "${LIVE_XREPO}" != "false" ]]; then
             # Live author-privilege re-check for fork targets: an author who

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -655,9 +655,25 @@ describe('qwen-autofix workflow', () => {
     expect(
       runRecheck(pr({ labels: [{ name: 'autofix/skip' }] })).out,
     ).toContain('stale=true');
-    // Fork heads: manageable ONLY with takeover + allow-edits + a fork
-    // author who holds write+ LIVE; anything less discards.
+    // Fork heads: manageable with allow-edits + a fork author who holds write+
+    // LIVE, PLUS either the takeover label (non-bot forks) OR bot authorship
+    // (the bot's own fork needs no label). Anything less discards.
+    // A bot fork with no allow-edits still discards.
     expect(runRecheck(pr({ isCrossRepository: true })).passed).toBe(false);
+    // The bot's OWN fork with allow-edits is eligible WITHOUT a label — the
+    // author check already exempts the bot, and the fork chain no longer
+    // demands a label for it. (head repo matches the HEAD_REPO env.)
+    const botFork = pr({
+      isCrossRepository: true,
+      maintainerCanModify: true,
+      headRepositoryOwner: { login: 'maint-fork' },
+      headRepository: { name: 'qwen-code' },
+    });
+    expect(runRecheck(botFork).passed).toBe(true);
+    // Remove allow-edits and the same bot fork discards (cannot push).
+    expect(runRecheck({ ...botFork, maintainerCanModify: false }).passed).toBe(
+      false,
+    );
     const forkPr = pr({
       isCrossRepository: true,
       maintainerCanModify: true,
@@ -1035,54 +1051,72 @@ describe('qwen-autofix workflow', () => {
     // Rotation: offset 1 starts one past the newest, wrapping — so the
     // oldest tail is reached within pool/budget scans instead of never.
     expect(pick([pr(1), pr(2)], [], 1)).toEqual(['1', '2']);
-    // Fork takeover candidates are admitted separately: allow-edits and no
-    // skip label filter in jq; the author's live write+ gate runs in bash.
+    // Fork candidates are unioned from TWO sources: the bot's own forks
+    // (bot-prs.json is --author AUTOFIX_BOT, so a fork there is the bot's own
+    // work and needs NO label) and takeover-LABELED forks (takeover-prs.json,
+    // any eligible author). Both require allow-edits and no skip; the author's
+    // live write+ gate runs in bash.
     const forkSel = reviewScanJob
       .match(
-        /done < <\(jq -r --arg skip "\$\{SKIP_LABEL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/takeover-prs\.json"\)/,
+        /done < <\(jq -rs --arg skip "\$\{SKIP_LABEL\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/bot-prs\.json" "\$\{WORKDIR\}\/takeover-prs\.json"\)/,
       )?.[1]
       ?.replace(/\n {14}/g, '\n');
     expect(forkSel).toBeTruthy();
     const forkRows = execFileSync(
       'jq',
-      ['-r', '--arg', 'skip', 'autofix/skip', forkSel],
+      ['-rs', '--arg', 'skip', 'autofix/skip', forkSel],
       {
         encoding: 'utf8',
-        input: JSON.stringify([
-          {
-            number: 9,
-            isCrossRepository: true,
-            maintainerCanModify: true,
-            labels: [{ name: 'autofix/takeover' }],
-            author: { login: 'maint-a' },
-          },
-          {
-            number: 8,
-            isCrossRepository: true,
-            maintainerCanModify: false,
-            labels: [{ name: 'autofix/takeover' }],
-            author: { login: 'maint-b' },
-          },
-          {
-            number: 7,
-            isCrossRepository: true,
-            maintainerCanModify: true,
-            labels: [{ name: 'autofix/takeover' }, { name: 'autofix/skip' }],
-            author: { login: 'maint-c' },
-          },
-          {
-            number: 6,
-            isCrossRepository: false,
-            maintainerCanModify: true,
-            labels: [{ name: 'autofix/takeover' }],
-            author: { login: 'maint-d' },
-          },
-        ]),
+        input:
+          // bot-prs.json (all --author qwen-code-dev-bot)
+          JSON.stringify([
+            {
+              number: 20,
+              isCrossRepository: true,
+              maintainerCanModify: true,
+              labels: [], // no label — admitted anyway, it's the bot's own fork
+              author: { login: 'qwen-code-dev-bot' },
+            },
+            {
+              number: 19,
+              isCrossRepository: true,
+              maintainerCanModify: false, // no allow-edits — the bot cannot push
+              labels: [],
+              author: { login: 'qwen-code-dev-bot' },
+            },
+            {
+              number: 18,
+              isCrossRepository: false, // in-repo bot PR — not a fork candidate
+              maintainerCanModify: true,
+              labels: [],
+              author: { login: 'qwen-code-dev-bot' },
+            },
+          ]) +
+          // takeover-prs.json (--label autofix/takeover)
+          JSON.stringify([
+            {
+              number: 9,
+              isCrossRepository: true,
+              maintainerCanModify: true,
+              labels: [{ name: 'autofix/takeover' }],
+              author: { login: 'maint-a' },
+            },
+            {
+              number: 7,
+              isCrossRepository: true,
+              maintainerCanModify: true,
+              labels: [{ name: 'autofix/takeover' }, { name: 'autofix/skip' }],
+              author: { login: 'maint-c' },
+            },
+          ]),
       },
     )
       .trim()
       .split('\n');
-    expect(forkRows).toEqual(['9\tmaint-a']);
+    // unique_by(.number) sorts ascending: the labeled human fork (#9) and the
+    // bot's own unlabeled fork (#20); #19 (no allow-edits), #18 (in-repo), and
+    // #7 (skip) are dropped.
+    expect(forkRows).toEqual(['9\tmaint-a', '20\tqwen-code-dev-bot']);
     expect(reviewScanJob).toContain('fork takeover candidate #${FPR} admitted');
     // Fork plumbing: the target carries its head repo; prepare fetches the
     // fork branch (origin has no copy) and the report pushes back via


### PR DESCRIPTION
## What this PR does

Auto-manages the **autofix bot's own fork PRs without requiring a label**.

The bot's codex flow opens PRs from its own fork (`qwen-code-dev-bot/qwen-code`). Those are the bot's own generated work — same author, same code provenance, and the bot holds `write+` — so they are **trust-equal to an in-repo bot PR**, which is already auto-managed with no label. Requiring a manual `autofix/takeover` label on them was redundant: the takeover label exists to authorize **external (human) fork authors**, not the bot itself. That's exactly why #7208 and #7220 (bot codex-flow fork PRs with actionable review suggestions) sat unprocessed until a label was applied by hand.

Now a fork authored by the autofix bot with **"Allow edits from maintainers"** is admitted and managed **without a label**:

- **Scan**: fork candidates are unioned from `bot-prs.json` (the bot's own forks — the list is `--author AUTOFIX_BOT`, so no label needed) **and** the takeover-labeled list (non-bot forks, explicit opt-in). Both still require allow-edits and pass the per-candidate **live `write+` gate**.
- **Eligibility (address time)**: the fork chain no longer demands the takeover label when the author is the bot — the author check already exempts it — while still demanding allow-edits, a live `write+` author, and a matching live head repo.

Unchanged: `autofix/skip` still opts any such PR out; **non-bot forks still need the explicit `autofix/takeover` label**.

## Why it's safe

A bot-authored fork adds **no trust surface beyond an in-repo bot PR**: `author` cannot be spoofed (it is the account that opened the PR), the fork is the bot's own (only the bot pushes to it), the executed-code provenance is identical to in-repo bot PRs, and the address run's constraints (coreTools allowlist, docker sandbox, severed hooks, trusted-base runner staging) are unchanged. The `write+` gate and allow-edits requirement remain.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 62/62. Behavioral coverage:
   - **Fork-candidate union jq** (verbatim-extracted, replayed over two fixtures): admits the bot's own unlabeled fork (#20) **and** a labeled human fork (#9); drops a no-allow-edits bot fork, an in-repo bot PR, and a skip-labeled fork.
   - **Eligibility replay**: a bot fork with allow-edits is eligible **without a label**; the same fork without allow-edits discards; non-bot / label logic unchanged.
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` — 12/12.
3. Static: YAML parses; every `run:` block passes `bash -n`.
4. Post-merge smoke: #7208 / #7220 (bot codex-flow forks, allow-edits on) are picked up by the next scheduled scan with **no label** and their review suggestions addressed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: none beyond the in-repo bot-PR envelope — the change only stops requiring a redundant label for the bot's own forks. `autofix/skip` is the opt-out; allow-edits + live `write+` remain hard gates.
- Not validated / out of scope: live round-trip needs a real bot fork PR (post-merge smoke).
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7213 (fork takeover). Motivated by #7208 / #7220 sitting unprocessed for want of a label.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix bot **自己 fork 的 PR 无需标签即自动托管**。

bot 的 codex 流程会从自己的 fork(`qwen-code-dev-bot/qwen-code`)开 PR。那是 bot 自己生成的工作 —— 同一作者、同样的代码来源、bot 持有 `write+` —— 与 in-repo bot PR **同等信任**,而后者本就无需标签自动托管。给它们打 `autofix/takeover` 标签是多余的:该标签是给**外部(人类)** fork 作者的显式授权,不是给 bot 自己的。这正是 #7208、#7220(带可执行 review suggestion 的 bot codex fork PR)一直没被处理、直到手动打标签的原因。

现在:由 autofix bot 作者、且勾选 **"Allow edits from maintainers"** 的 fork,**无需标签**即被纳入并托管:

- **扫描**:fork 候选从 `bot-prs.json`(bot 自己的 fork —— 列表是 `--author AUTOFIX_BOT`,无需标签)与 takeover 标签列表(非 bot fork,显式 opt-in)**并集**取得;两者仍需 allow-edits 并逐候选过**实时 `write+` 门**。
- **资格(address 时)**:作者为 bot 时,fork 链不再要求 takeover 标签(作者检查已豁免);仍要求 allow-edits + 实时 `write+` 作者 + 实时 head 仓库匹配。

不变:`autofix/skip` 仍可让任意此类 PR 退出;**非 bot fork 仍需显式 `autofix/takeover` 标签**。

## 为什么安全

bot 作者的 fork **不增加超出 in-repo bot PR 的信任面**:`author` 无法伪造(就是开 PR 的账号)、fork 是 bot 自己的(只有 bot 推送)、被执行代码来源与 in-repo bot PR 一致、address 运行的约束(coreTools 白名单、docker 沙箱、断 hook、可信基座 runner staging)均不变。`write+` 门与 allow-edits 要求保留。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 62/62:fork 候选并集 jq(逐字提取、双夹具回放)准入 bot 无标签 fork(#20)与带标签人类 fork(#9),丢弃无 allow-edits 的 bot fork、in-repo bot PR、skip fork;资格回放使带 allow-edits 的 bot fork **无标签**即合格、无 allow-edits 则丢弃。
2. `npx vitest run scripts/tests/qwen-fleet-shepherd-workflow.test.js` —— 12/12。
3. 静态:YAML 可解析;所有 `run:` 块过 `bash -n`。
4. 合并后冒烟:#7208 / #7220(bot codex fork、已勾 allow-edits)在下一轮定时扫描**无需标签**即被拾起并处理其 review suggestion。

## 风险与范围

- 主要风险:无 —— 仅停止对 bot 自己 fork 的冗余标签要求;`autofix/skip` 为退出开关,allow-edits + 实时 `write+` 仍是硬门。
- 破坏性变更:无。

## 关联 Issue

#7213(fork 托管)的后续;由 #7208 / #7220 因缺标签未被处理驱动。

</details>
