### PR TITLE
fix(core): Enforce Plan mode entry boundary

### DIFF
--- a/docs/design/2026-07-20-plan-mode-mid-turn-guidance.md
+++ b/docs/design/2026-07-20-plan-mode-mid-turn-guidance.md
@@ -1,0 +1,33 @@
+# Plan mode mid-turn guidance and entry boundary
+
+## Problem
+
+`enter_plan_mode` changes the approval mode while a model turn is still being processed. Before this change, a successful invocation returned only a short sentence, so the model did not receive the full Plan mode constraints until a later turn. Sibling tool calls from the same model response could also execute on either side of the mode transition: calls before the entry ran under the previous mode, while calls after it ran after Plan mode became active without being rescheduled against the new boundary.
+
+## Contract
+
+A successful or already-active `enter_plan_mode` invocation returns the same complete reminder produced by `getPlanModeSystemReminder()`. SDK sessions receive the SDK-specific variant. Unsolicited YOLO entry, transition failures, and subagent or teammate rejection retain their existing results because no Plan mode transition occurred.
+
+When a post-deduplication executable batch contains more than one call and one call is `enter_plan_mode`, the first entry call is an execution boundary. Only that call is eligible to execute. Every other executable sibling, regardless of whether it appeared before or after the entry, receives a terminal `EXECUTION_DENIED` response instructing the model to retry in the next turn after observing the new approval mode. Entry failure or idempotent success does not release the siblings.
+
+Existing terminal decisions take precedence. Loop detection still rejects the whole batch first. Duplicate provider responses are emitted in their original positions but are not executable siblings. In structured-output mode, the existing structured-output pre-scan remains terminal and suppresses `enter_plan_mode` along with other non-structured calls.
+
+`exit_plan_mode` is not an execution boundary in this change. Its explicit user approval and stale-context protections are independent.
+
+## Integration
+
+The core scheduler applies the boundary after call-ID deduplication and canonical-name resolution, before permission checks, registry lookup, hooks, or invocation construction. Skipped calls therefore do not request permissions or run per-tool hooks. They remain terminal batch results so the existing completion callback, recording, telemetry, and `PostToolBatch` audit path observe a complete response for every accepted call ID. Runtime-specific content-generator views are cleaned with the other terminal results.
+
+ACP applies the same policy after loop and duplicate-provider handling and before executing its sequential or Agent batches. Duplicate responses remain ordered. ACP does not introduce a `PostToolBatch` hook because that path intentionally does not support one.
+
+Headless mode applies the policy after duplicate and structured-output filtering. Skipped calls are emitted and returned as denied tool results in their original order, but do not consume `--max-tool-calls` budget. The entry itself follows the normal budget and abort behavior.
+
+## Output preservation
+
+The reminder is lifecycle policy, not ordinary tool payload. `enter_plan_mode` declares an infinite per-tool output limit, is exempt from the scheduler's persistence spill gate, and is not a candidate for aggregate batch offloading. These three protections prevent the policy from being truncated, replaced with a file pointer, or reduced to a preview before the next model turn.
+
+## Validation
+
+Unit coverage verifies exact DEFAULT and SDK reminders, success and idempotent entry, first-entry selection, sibling denial on both sides, duplicate-provider ordering, headless budget accounting, full-reminder preservation under deliberately tiny output thresholds, `PostToolBatch` visibility, and runtime-view cleanup. Existing scheduler, ACP, and headless suites cover the surrounding permission, loop, duplicate, structured-output, and abort behavior.
+
+Managed-host validation should confirm that the ACP client receives one result for every tool call and that the next model request contains the complete reminder plus sibling denial responses. This validation requires a deployed build and a host session ID; it is not simulated by changing production routing in this PR.

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -13258,6 +13258,100 @@ describe('Session', () => {
       };
     }
 
+    it('isolates enter_plan_mode from executable ACP siblings while preserving duplicate responses', async () => {
+      const writeExecute = vi.fn().mockResolvedValue({
+        llmContent: 'wrote',
+        returnDisplay: 'wrote',
+      });
+      const enterExecute = vi.fn().mockResolvedValue({
+        llmContent: 'entered plan mode',
+        returnDisplay: 'entered plan mode',
+      });
+      const readExecute = vi.fn().mockResolvedValue({
+        llmContent: 'read',
+        returnDisplay: 'read',
+      });
+      mockToolRegistry.getTool.mockImplementation((name: string) => {
+        const execute =
+          name === core.ToolNames.ENTER_PLAN_MODE
+            ? enterExecute
+            : name === core.ToolNames.WRITE_FILE
+              ? writeExecute
+              : readExecute;
+        return mockAllowedTool(name, execute);
+      });
+      const historyIds = new Set(['duplicate_read']);
+      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
+        historyIds,
+      );
+      const [duplicatePart] = core.normalizeModelToolCallIds(
+        [
+          {
+            functionCall: {
+              id: 'duplicate_read',
+              name: core.ToolNames.READ_FILE,
+              args: { file_path: 'duplicate.ts' },
+            },
+          },
+        ],
+        historyIds,
+        new Set<string>(),
+      );
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-plan-boundary', [
+        {
+          id: 'write_before_entry',
+          name: core.ToolNames.WRITE_FILE,
+          args: { file_path: 'before.txt' },
+        },
+        duplicatePart.functionCall!,
+        {
+          id: 'enter_plan',
+          name: core.ToolNames.ENTER_PLAN_MODE,
+          args: {},
+        },
+        {
+          id: 'read_after_entry',
+          name: core.ToolNames.READ_FILE,
+          args: { file_path: 'after.ts' },
+        },
+      ]);
+
+      expect(writeExecute).not.toHaveBeenCalled();
+      expect(enterExecute).toHaveBeenCalledOnce();
+      expect(readExecute).not.toHaveBeenCalled();
+      expect(result.parts.map((part) => part.functionResponse?.id)).toEqual([
+        'write_before_entry',
+        'duplicate_read__qwen_dup_2',
+        'enter_plan',
+        'read_after_entry',
+      ]);
+      expect(result.parts[0].functionResponse?.response).toEqual({
+        error: core.PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+      });
+      expect(result.parts[1].functionResponse?.response).toEqual({
+        error: expect.stringContaining(
+          'Duplicate provider tool call id "duplicate_read"',
+        ),
+      });
+      expect(result.parts[2].functionResponse?.response).toEqual({
+        output: 'entered plan mode',
+      });
+      expect(result.parts[3].functionResponse?.response).toEqual({
+        error: core.PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+      });
+      expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledWith(
+        [result.parts[0]],
+        expect.objectContaining({
+          callId: 'write_before_entry',
+          status: 'error',
+          errorType: core.ToolErrorType.EXECUTION_DENIED,
+        }),
+      );
+    });
+
     it('keeps a structured timeout as an error after a later parent abort', async () => {
       const parentController = new AbortController();
       const messageBus = {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -51,8 +51,10 @@ import {
   convertToFunctionErrorResponse,
   convertToFunctionResponse,
   createDuplicateProviderToolCallResponse,
+  findPlanModeEntryBatchBoundaryIndex,
   findRepeatedDuplicateProviderToolCall,
   markDuplicateProviderToolCallResponseSent,
+  PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
   createDebugLogger,
   DiscoveredMCPTool,
   StreamEventType,
@@ -5374,6 +5376,7 @@ export class Session implements SessionContext {
       fc: FunctionCall,
       message = PERMISSION_CANCEL_SKIP_MESSAGE,
       emitStart = true,
+      errorType?: ToolErrorType,
     ): Promise<Part> => {
       const toolName = fc.name ?? 'unknown_tool';
       const callId = fc.id ?? `${toolName}-skip-${++skippedToolCallCounter}`;
@@ -5391,7 +5394,7 @@ export class Session implements SessionContext {
           status: 'error',
           resultDisplay: undefined,
           error,
-          errorType: undefined,
+          errorType,
         });
         if (emitStart) {
           await this.toolCallEmitter.emitStart({
@@ -5550,6 +5553,17 @@ export class Session implements SessionContext {
         batches.push({ kind: 'execute', concurrent: isAgent, calls: [fc] });
       }
     }
+
+    const executableCalls = batches.flatMap((batch) =>
+      batch.kind === 'execute' ? batch.calls : [],
+    );
+    const planModeEntryBoundaryIndex = findPlanModeEntryBatchBoundaryIndex(
+      executableCalls.map((call) => call.name),
+    );
+    const planModeEntryBoundary =
+      planModeEntryBoundaryIndex === undefined
+        ? undefined
+        : executableCalls[planModeEntryBoundaryIndex];
 
     const appendSkippedAfter = async (
       parts: Part[],
@@ -5710,6 +5724,22 @@ export class Session implements SessionContext {
         if (batch.kind === 'duplicate') {
           await emitDuplicateBatch(batch);
           parts.push(...batch.response.responseParts);
+          continue;
+        }
+        if (
+          planModeEntryBoundary &&
+          !batch.calls.includes(planModeEntryBoundary)
+        ) {
+          for (const fc of batch.calls) {
+            parts.push(
+              await recordSkippedToolCall(
+                fc,
+                PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+                true,
+                ToolErrorType.EXECUTION_DENIED,
+              ),
+            );
+          }
           continue;
         }
         if (batch.concurrent && batch.calls.length > 1) {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -32,6 +32,8 @@ import {
   LOOP_SENTINEL_DYNAMIC,
   TeamEventType,
   ToolConfirmationOutcome,
+  ToolNames,
+  PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
 } from '@qwen-code/qwen-code-core';
 import type { Part } from '@google/genai';
 import { EventEmitter } from 'node:events';
@@ -1204,6 +1206,90 @@ describe('runNonInteractive', () => {
         },
       }));
     }
+
+    it('isolates enter_plan_mode from headless siblings without charging skipped calls to the budget', async () => {
+      setupMetricsMock();
+      vi.mocked(mockConfig.getMaxToolCalls).mockReturnValue(1);
+      vi.mocked(mockToolRegistry.getTool).mockImplementation(
+        (name: string) =>
+          ({
+            kind:
+              name === ToolNames.READ_FILE
+                ? Kind.Read
+                : name === ToolNames.WRITE_FILE
+                  ? Kind.Edit
+                  : Kind.Other,
+          }) as unknown as ReturnType<typeof mockToolRegistry.getTool>,
+      );
+      mockCoreExecuteToolCall.mockImplementation(
+        async (
+          _config: unknown,
+          request: { callId: string; name: string },
+        ) => ({
+          responseParts: [
+            {
+              functionResponse: {
+                id: request.callId,
+                name: request.name,
+                response: { output: 'entered plan mode' },
+              },
+            },
+          ],
+          resultDisplay: 'entered plan mode',
+        }),
+      );
+
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents([
+            ...toolCallEvents(
+              ['write-before-entry'],
+              ToolNames.WRITE_FILE,
+              'p-plan-boundary',
+            ),
+            ...toolCallEvents(
+              ['enter-plan'],
+              ToolNames.ENTER_PLAN_MODE,
+              'p-plan-boundary',
+            ),
+            ...toolCallEvents(
+              ['read-after-entry'],
+              ToolNames.READ_FILE,
+              'p-plan-boundary',
+            ),
+          ]),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'enter plan mode',
+        'p-plan-boundary',
+      );
+
+      expect(mockCoreExecuteToolCall).toHaveBeenCalledOnce();
+      expect(mockCoreExecuteToolCall.mock.calls[0][1]).toMatchObject({
+        callId: 'enter-plan',
+        name: ToolNames.ENTER_PLAN_MODE,
+      });
+      const nextTurnParts = mockGeminiClient.sendMessageStream.mock
+        .calls[1][0] as Part[];
+      expect(nextTurnParts.map((part) => part.functionResponse?.id)).toEqual([
+        'write-before-entry',
+        'enter-plan',
+        'read-after-entry',
+      ]);
+      expect(nextTurnParts[0].functionResponse?.response).toEqual({
+        error: PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+      });
+      expect(nextTurnParts[1].functionResponse?.response).toEqual({
+        output: 'entered plan mode',
+      });
+      expect(nextTurnParts[2].functionResponse?.response).toEqual({
+        error: PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+      });
+    });
 
     it('runs a batch of concurrency-safe tool calls concurrently', async () => {
       setupMetricsMock();

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1253,7 +1253,7 @@ describe('runNonInteractive', () => {
               'p-plan-boundary',
             ),
             ...toolCallEvents(
-              ['read-after-entry'],
+              ['read-after-entry-1', 'read-after-entry-2'],
               ToolNames.READ_FILE,
               'p-plan-boundary',
             ),
@@ -1278,7 +1278,8 @@ describe('runNonInteractive', () => {
       expect(nextTurnParts.map((part) => part.functionResponse?.id)).toEqual([
         'write-before-entry',
         'enter-plan',
-        'read-after-entry',
+        'read-after-entry-1',
+        'read-after-entry-2',
       ]);
       expect(nextTurnParts[0].functionResponse?.response).toEqual({
         error: PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
@@ -1287,6 +1288,9 @@ describe('runNonInteractive', () => {
         output: 'entered plan mode',
       });
       expect(nextTurnParts[2].functionResponse?.response).toEqual({
+        error: PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+      });
+      expect(nextTurnParts[3].functionResponse?.response).toEqual({
         error: PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
       });
     });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -39,6 +39,7 @@ import {
   ApprovalMode,
   ToolConfirmationOutcome,
   createDuplicateProviderToolCallResponse,
+  findPlanModeEntryBatchBoundaryIndex,
   isSystemReminderContent,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
@@ -46,6 +47,8 @@ import {
   canonicalToolName,
   parsePositiveIntegerEnv,
   partitionByConcurrencySafety,
+  PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+  ToolErrorType,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -1167,6 +1170,13 @@ export async function runNonInteractive(
             (r) => r.name === ToolNames.STRUCTURED_OUTPUT,
           );
         }
+        const planModeEntryBoundaryIndex = findPlanModeEntryBatchBoundaryIndex(
+          requestsToExecute.map((request) => request.name),
+        );
+        const planModeEntryBoundary =
+          planModeEntryBoundaryIndex === undefined
+            ? undefined
+            : requestsToExecute[planModeEntryBoundaryIndex];
         const executedRequests = new Set<ToolCallRequestInfo>(
           respondedRequests,
         );
@@ -1333,6 +1343,30 @@ export async function runNonInteractive(
           return false;
         };
 
+        const finalizePlanModeEntrySiblingSkip = (
+          requestInfo: ToolCallRequestInfo,
+        ): void => {
+          const error = new Error(PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE);
+          const responseParts: Part[] = [
+            {
+              functionResponse: {
+                id: requestInfo.callId,
+                name: requestInfo.name,
+                response: { error: error.message },
+              },
+            },
+          ];
+          adapter.emitToolResult(requestInfo, {
+            callId: requestInfo.callId,
+            responseParts,
+            resultDisplay: error.message,
+            error,
+            errorType: ToolErrorType.EXECUTION_DENIED,
+          });
+          executedRequests.add(requestInfo);
+          toolResponseParts.push(...responseParts);
+        };
+
         const maxToolConcurrency = parsePositiveIntegerEnv(
           process.env['QWEN_CODE_MAX_TOOL_CONCURRENCY'],
           10,
@@ -1355,6 +1389,13 @@ export async function runNonInteractive(
             }> = [];
             const inFlight = new Set<Promise<void>>();
             for (const requestInfo of batch.calls) {
+              if (
+                planModeEntryBoundary &&
+                requestInfo !== planModeEntryBoundary
+              ) {
+                finalizePlanModeEntrySiblingSkip(requestInfo);
+                continue;
+              }
               if (!isBudgetExempt(requestInfo)) {
                 budgetEnforcer.tickToolCall();
               }
@@ -1420,6 +1461,13 @@ export async function runNonInteractive(
             // Sequential batch (a single tool, or a side-effecting tool):
             // identical to the pre-parallelisation behaviour.
             for (const requestInfo of batch.calls) {
+              if (
+                planModeEntryBoundary &&
+                requestInfo !== planModeEntryBoundary
+              ) {
+                finalizePlanModeEntrySiblingSkip(requestInfo);
+                continue;
+              }
               if (!isBudgetExempt(requestInfo)) {
                 budgetEnforcer.tickToolCall();
               }

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -35,6 +35,7 @@ import { SkillTool } from '../tools/skill.js';
 import { StructuredToolError } from '../tools/priorReadEnforcement.js';
 import { ToolNames, ToolNamesMigration } from '../tools/tool-names.js';
 import type {
+  CompletedToolCall,
   ExecutingToolCall,
   ToolCall,
   WaitingToolCall,
@@ -71,6 +72,8 @@ import {
 } from '../agents/runtime/agent-context.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
 import { normalizeToolNameForProvider } from '../utils/tool-name-utils.js';
+import { getPlanModeSystemReminder } from './prompts.js';
+import { PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE } from './plan-mode-entry-policy.js';
 
 type ToolSpanRecord = {
   name: string;
@@ -707,6 +710,8 @@ describe('CoreToolScheduler', () => {
     onToolCallsUpdate?: ReturnType<typeof vi.fn>;
     memoryMonitor?: { scheduleCheck: () => void };
     toolOutputBatchBudget?: number;
+    truncateToolOutputThreshold?: number;
+    truncateToolOutputLines?: number;
   }) {
     const ensureTool = vi.fn(
       async (name: string) =>
@@ -754,8 +759,10 @@ describe('CoreToolScheduler', () => {
         getToolResultBytesWritten: () => 0,
         trackToolResultBytes: vi.fn(),
         getTruncateToolOutputThreshold: () =>
+          options.truncateToolOutputThreshold ??
           DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
-        getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+        getTruncateToolOutputLines: () =>
+          options.truncateToolOutputLines ?? DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
         getToolOutputBatchBudget: () =>
           options.toolOutputBatchBudget ?? Number.POSITIVE_INFINITY,
         getToolRegistry: () => mockToolRegistry,
@@ -799,6 +806,221 @@ describe('CoreToolScheduler', () => {
       onToolCallsUpdate,
     };
   }
+
+  it('isolates enter_plan_mode as a batch boundary and preserves its full reminder', async () => {
+    const reminder = getPlanModeSystemReminder(false);
+    const writeExecute = vi.fn().mockResolvedValue({
+      llmContent: 'wrote',
+      returnDisplay: 'wrote',
+    });
+    const enterExecute = vi.fn().mockResolvedValue({
+      llmContent: reminder,
+      returnDisplay: 'Entered plan mode.',
+    });
+    const readExecute = vi.fn().mockResolvedValue({
+      llmContent: 'read',
+      returnDisplay: 'read',
+    });
+    const messageBus = {
+      request: vi.fn().mockImplementation(
+        async (request: {
+          eventName: string;
+        }): Promise<HookExecutionResponse> => ({
+          type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+          correlationId: `${request.eventName}-hook`,
+          success: true,
+          output: { decision: 'allow' },
+        }),
+      ),
+    };
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.WRITE_FILE,
+        new MockTool({ name: ToolNames.WRITE_FILE, execute: writeExecute }),
+      ],
+      [
+        ToolNames.ENTER_PLAN_MODE,
+        new MockTool({
+          name: ToolNames.ENTER_PLAN_MODE,
+          maxOutputChars: Number.POSITIVE_INFINITY,
+          execute: enterExecute,
+        }),
+      ],
+      [
+        ToolNames.READ_FILE,
+        new MockTool({ name: ToolNames.READ_FILE, execute: readExecute }),
+      ],
+    ]);
+    const { scheduler, ensureTool, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        messageBus,
+        disableHooks: false,
+        truncateToolOutputThreshold: 1,
+        truncateToolOutputLines: 1,
+        toolOutputBatchBudget: 1,
+      });
+    const runtimeView = {
+      contentGenerator: {},
+      contentGeneratorConfig: { model: 'vision-agent' },
+    } as RuntimeContentGeneratorView;
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'write-before-entry',
+          name: ToolNames.WRITE_FILE,
+          args: { file_path: 'before.txt' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-plan-boundary',
+        },
+        {
+          callId: 'enter-plan',
+          name: ToolNames.ENTER_PLAN_MODE,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-plan-boundary',
+        },
+        {
+          callId: 'read-after-entry',
+          name: ToolNames.READ_FILE,
+          args: { file_path: 'after.txt' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-plan-boundary',
+        },
+      ],
+      new AbortController().signal,
+      runtimeView,
+    );
+
+    expect(ensureTool).toHaveBeenCalledOnce();
+    expect(ensureTool).toHaveBeenCalledWith(ToolNames.ENTER_PLAN_MODE);
+    expect(writeExecute).not.toHaveBeenCalled();
+    expect(enterExecute).toHaveBeenCalledOnce();
+    expect(readExecute).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalledOnce();
+    });
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as CompletedToolCall[];
+    expect(completedCalls.map((call) => call.request.callId)).toEqual([
+      'write-before-entry',
+      'enter-plan',
+      'read-after-entry',
+    ]);
+    expect(completedCalls.map((call) => call.status)).toEqual([
+      'error',
+      'success',
+      'error',
+    ]);
+    const [writeCall, enterCall, readCall] = completedCalls;
+    expect(writeCall.response.error?.message).toBe(
+      PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+    );
+    expect(writeCall.response.errorType).toBe(ToolErrorType.EXECUTION_DENIED);
+    expect(
+      enterCall.response.responseParts[0]?.functionResponse?.response?.[
+        'output'
+      ],
+    ).toBe(reminder);
+    expect(readCall.response.error?.message).toBe(
+      PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+    );
+    expect(readCall.response.errorType).toBe(ToolErrorType.EXECUTION_DENIED);
+
+    const postBatchRequest = messageBus.request.mock.calls.find(
+      ([request]) => request.eventName === 'PostToolBatch',
+    )?.[0];
+    expect(
+      postBatchRequest.input.tool_calls.map(
+        (call: { status: string }) => call.status,
+      ),
+    ).toEqual(['error', 'success', 'error']);
+    expect(
+      (
+        scheduler as unknown as {
+          runtimeContentGeneratorViews: Map<
+            string,
+            RuntimeContentGeneratorView
+          >;
+        }
+      ).runtimeContentGeneratorViews.size,
+    ).toBe(0);
+  });
+
+  it('keeps siblings suppressed when enter_plan_mode itself fails', async () => {
+    const enterExecute = vi.fn().mockResolvedValue({
+      llmContent: 'Failed to enter plan mode: transition failed',
+      returnDisplay: 'Failed to enter plan mode: transition failed',
+      error: {
+        message: 'Failed to enter plan mode: transition failed',
+        type: ToolErrorType.EXECUTION_FAILED,
+      },
+    });
+    const writeExecute = vi.fn().mockResolvedValue({
+      llmContent: 'wrote',
+      returnDisplay: 'wrote',
+    });
+    const { scheduler, ensureTool, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName: new Map([
+          [
+            ToolNames.ENTER_PLAN_MODE,
+            new MockTool({
+              name: ToolNames.ENTER_PLAN_MODE,
+              execute: enterExecute,
+            }),
+          ],
+          [
+            ToolNames.WRITE_FILE,
+            new MockTool({
+              name: ToolNames.WRITE_FILE,
+              execute: writeExecute,
+            }),
+          ],
+        ]),
+      });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'failed-entry',
+          name: ToolNames.ENTER_PLAN_MODE,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-failed-entry',
+        },
+        {
+          callId: 'write-after-failed-entry',
+          name: ToolNames.WRITE_FILE,
+          args: { file_path: 'blocked.txt' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-failed-entry',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalledOnce();
+    });
+    expect(ensureTool).toHaveBeenCalledOnce();
+    expect(enterExecute).toHaveBeenCalledOnce();
+    expect(writeExecute).not.toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as CompletedToolCall[];
+    expect(completedCalls.map((call) => call.status)).toEqual([
+      'error',
+      'error',
+    ]);
+    expect(completedCalls[0].response.error?.message).toBe(
+      'Failed to enter plan mode: transition failed',
+    );
+    expect(completedCalls[1].response.error?.message).toBe(
+      PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+    );
+  });
 
   it('keeps interaction-required tools awaiting approval despite YOLO and an allow hook', async () => {
     const execute = vi.fn().mockResolvedValue({

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -90,6 +90,10 @@ import {
   validatePlanModeShellContext,
 } from './plan-mode-shell-policy.js';
 import {
+  findPlanModeEntryBatchBoundaryIndex,
+  PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+} from './plan-mode-entry-policy.js';
+import {
   applyAutoModeDecision,
   evaluateAutoMode,
   getAutoModePermissionDeniedReason,
@@ -189,6 +193,7 @@ const GATE_HEADROOM = 3000;
 const GATE_EXEMPT_TOOLS = new Set<string>([
   ToolNames.READ_FILE,
   ToolNames.READ_MCP_RESOURCE,
+  ToolNames.ENTER_PLAN_MODE,
 ]);
 
 function extractTextFromPartListUnion(c: PartListUnion): string {
@@ -2083,6 +2088,9 @@ export class CoreToolScheduler {
       const requestsToProcess = dedupeRequestsByCallId(
         Array.isArray(request) ? request : [request],
       );
+      const planModeEntryBoundaryIndex = findPlanModeEntryBatchBoundaryIndex(
+        requestsToProcess.map((item) => canonicalToolName(item.name)),
+      );
 
       // Prune validation retry state per-tool, not wholesale. Keys are
       // "<toolName>:<errorMessage>"; retain counters only for tools actually
@@ -2102,7 +2110,24 @@ export class CoreToolScheduler {
       }
 
       const newToolCalls: ToolCall[] = [];
-      for (const reqInfo of requestsToProcess) {
+      for (const [requestIndex, reqInfo] of requestsToProcess.entries()) {
+        if (
+          planModeEntryBoundaryIndex !== undefined &&
+          requestIndex !== planModeEntryBoundaryIndex
+        ) {
+          newToolCalls.push({
+            status: 'error',
+            request: reqInfo,
+            response: createErrorResponse(
+              reqInfo,
+              new Error(PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE),
+              ToolErrorType.EXECUTION_DENIED,
+            ),
+            durationMs: 0,
+          });
+          continue;
+        }
+
         const canonicalName = canonicalToolName(reqInfo.name);
 
         // Check if the tool is excluded due to permissions/environment restrictions
@@ -4966,7 +4991,7 @@ export class CoreToolScheduler {
     toolName: string,
     content: PartListUnion,
   ): Promise<PartListUnion> {
-    if (GATE_EXEMPT_TOOLS.has(toolName)) return content;
+    if (GATE_EXEMPT_TOOLS.has(canonicalToolName(toolName))) return content;
 
     const text = extractTextFromPartListUnion(content);
     if (!text || isAlreadyTruncated(text)) return content;
@@ -5086,6 +5111,10 @@ export class CoreToolScheduler {
   private async offloadCallOutput(
     call: CompletedToolCall,
   ): Promise<CompletedToolCall | null> {
+    if (canonicalToolName(call.request.name) === ToolNames.ENTER_PLAN_MODE) {
+      return null;
+    }
+
     const parts = call.response.responseParts;
     if (parts.length !== 1) return null;
     const fr = parts[0]?.functionResponse;

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -185,11 +185,10 @@ function dedupeRequestsByCallId(
 // the headroom ensures the gate only fires for genuinely un-truncated output
 // and must exceed the stub size (~2.3K) to avoid cascading re-persistence.
 const GATE_HEADROOM = 3000;
-// Tools that bound their own output and must bypass the persistence gate.
-// read_file pages/truncates itself; read_mcp_resource caps text in
-// formatMcpResourceContents and sets maxOutputChars=Infinity — but this gate
-// runs first, so without the exemption a 28k–100k resource is spilled to a
-// stub before that self-cap takes effect and the model never sees the body.
+// Tools whose output must bypass the persistence gate. read_file pages itself,
+// and read_mcp_resource caps text in formatMcpResourceContents. enter_plan_mode
+// returns lifecycle policy that must remain inline. This gate runs before
+// per-tool limits, so each requires an explicit exemption here.
 const GATE_EXEMPT_TOOLS = new Set<string>([
   ToolNames.READ_FILE,
   ToolNames.READ_MCP_RESOURCE,

--- a/packages/core/src/core/plan-mode-entry-policy.test.ts
+++ b/packages/core/src/core/plan-mode-entry-policy.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ToolNames } from '../tools/tool-names.js';
+import { findPlanModeEntryBatchBoundaryIndex } from './plan-mode-entry-policy.js';
+
+describe('findPlanModeEntryBatchBoundaryIndex', () => {
+  it.each([
+    { names: [], expected: undefined },
+    { names: [ToolNames.ENTER_PLAN_MODE], expected: undefined },
+    { names: [ToolNames.READ_FILE], expected: undefined },
+    {
+      names: [ToolNames.ENTER_PLAN_MODE, ToolNames.READ_FILE],
+      expected: 0,
+    },
+    {
+      names: [ToolNames.WRITE_FILE, ToolNames.ENTER_PLAN_MODE],
+      expected: 1,
+    },
+    {
+      names: [
+        ToolNames.READ_FILE,
+        ToolNames.ENTER_PLAN_MODE,
+        ToolNames.WRITE_FILE,
+      ],
+      expected: 1,
+    },
+    {
+      names: [ToolNames.ENTER_PLAN_MODE, ToolNames.ENTER_PLAN_MODE],
+      expected: 0,
+    },
+    {
+      names: [undefined, ToolNames.ENTER_PLAN_MODE],
+      expected: 1,
+    },
+  ])('returns $expected for $names', ({ names, expected }) => {
+    expect(findPlanModeEntryBatchBoundaryIndex(names)).toBe(expected);
+  });
+});

--- a/packages/core/src/core/plan-mode-entry-policy.ts
+++ b/packages/core/src/core/plan-mode-entry-policy.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ToolNames } from '../tools/tool-names.js';
+
+export const PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE =
+  'Tool call skipped because enter_plan_mode is an execution boundary. Retry it in the next model turn after observing the resulting approval mode.';
+
+export function findPlanModeEntryBatchBoundaryIndex(
+  toolNames: ReadonlyArray<string | undefined>,
+): number | undefined {
+  if (toolNames.length <= 1) return undefined;
+
+  const index = toolNames.indexOf(ToolNames.ENTER_PLAN_MODE);
+  return index === -1 ? undefined : index;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,11 @@ export {
   decoratePlanModeShellConfirmation,
   validatePlanModeShellApproval,
 } from './core/plan-mode-shell-policy.js';
+/** @internal */
+export {
+  PLAN_MODE_ENTRY_SIBLING_SKIP_MESSAGE,
+  findPlanModeEntryBatchBoundaryIndex,
+} from './core/plan-mode-entry-policy.js';
 export * from './core/geminiChat.js';
 export * from './core/geminiRequest.js';
 export * from './core/inlineMediaLimit.js';

--- a/packages/core/src/tools/enterPlanMode.test.ts
+++ b/packages/core/src/tools/enterPlanMode.test.ts
@@ -9,6 +9,7 @@ import { EnterPlanModeTool } from './enterPlanMode.js';
 import { ApprovalMode, type Config } from '../config/config.js';
 import { runWithAgentContext } from '../agents/runtime/agent-context.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
+import { getPlanModeSystemReminder } from '../core/prompts.js';
 
 describe('EnterPlanModeTool', () => {
   let tool: EnterPlanModeTool;
@@ -31,6 +32,7 @@ describe('EnterPlanModeTool', () => {
       isInteractive: vi.fn(() => true),
       getExperimentalZedIntegration: vi.fn(() => false),
       getInputFormat: vi.fn(() => undefined),
+      getSdkMode: vi.fn(() => false),
     } as unknown as Config;
 
     tool = new EnterPlanModeTool(mockConfig);
@@ -67,6 +69,10 @@ describe('EnterPlanModeTool', () => {
       expect(tool.shouldDefer).toBe(false);
     });
 
+    it('should exempt the complete reminder from output truncation', () => {
+      expect(tool.maxOutputChars).toBe(Number.POSITIVE_INFINITY);
+    });
+
     it('should expose only the userRequested flag in its schema', () => {
       expect(tool.schema.parametersJsonSchema).toEqual({
         type: 'object',
@@ -101,7 +107,7 @@ describe('EnterPlanModeTool', () => {
       );
       expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(savedPrePlanMode).toBe(ApprovalMode.DEFAULT);
-      expect(result.llmContent).toContain('Plan mode is now active');
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(false));
     });
 
     it('should switch from AUTO_EDIT to PLAN', async () => {
@@ -168,7 +174,7 @@ describe('EnterPlanModeTool', () => {
       );
       expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(savedPrePlanMode).toBe(ApprovalMode.DEFAULT);
-      expect(result.llmContent).toContain('Plan mode is now active');
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(false));
     });
 
     it('should switch from YOLO to PLAN when the user explicitly requested it', async () => {
@@ -186,7 +192,7 @@ describe('EnterPlanModeTool', () => {
       );
       expect(approvalMode).toBe(ApprovalMode.PLAN);
       expect(savedPrePlanMode).toBe(ApprovalMode.YOLO);
-      expect(result.llmContent).toContain('Plan mode is now active');
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(false));
     });
 
     it('should honour a user-requested YOLO entry in an ACP session', async () => {
@@ -206,7 +212,19 @@ describe('EnterPlanModeTool', () => {
         ApprovalMode.PLAN,
       );
       expect(approvalMode).toBe(ApprovalMode.PLAN);
-      expect(result.llmContent).not.toContain('non-interactive');
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(false));
+    });
+
+    it('should return plan-only guidance in SDK mode', async () => {
+      (mockConfig.getSdkMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const invocation = tool.build({});
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(true));
+      expect(result.llmContent).toContain('Present your plan directly');
+      expect(result.llmContent).not.toContain(
+        'by calling the exit_plan_mode tool',
+      );
     });
 
     it('should be idempotent: already in PLAN does not call setApprovalMode', async () => {
@@ -217,7 +235,7 @@ describe('EnterPlanModeTool', () => {
 
       expect(mockConfig.setApprovalMode).not.toHaveBeenCalled();
       expect(savedPrePlanMode).toBe(ApprovalMode.AUTO);
-      expect(result.llmContent).toContain('Plan mode is now active');
+      expect(result.llmContent).toBe(getPlanModeSystemReminder(false));
     });
 
     it('should return error when setApprovalMode throws', async () => {

--- a/packages/core/src/tools/enterPlanMode.ts
+++ b/packages/core/src/tools/enterPlanMode.ts
@@ -17,6 +17,7 @@ import {
   buildSubagentPlanToolBlockedResult,
   isPlanLifecycleToolUnavailableInSubagent,
 } from '../agents/runtime/subagent-plan-tool-policy.js';
+import { getPlanModeSystemReminder } from '../core/prompts.js';
 
 const debugLogger = createDebugLogger('ENTER_PLAN_MODE');
 
@@ -182,8 +183,7 @@ class EnterPlanModeToolInvocation extends BaseToolInvocation<
     }
 
     return {
-      llmContent:
-        'Plan mode is now active. Continue with read-only investigation, ask the user when needed, and use exit_plan_mode when the plan is ready.',
+      llmContent: getPlanModeSystemReminder(this.config.getSdkMode()),
       returnDisplay: 'Entered plan mode.',
     };
   }
@@ -194,6 +194,10 @@ export class EnterPlanModeTool extends BaseDeclarativeTool<
   ToolResult
 > {
   static readonly Name: string = ToolNames.ENTER_PLAN_MODE;
+
+  override get maxOutputChars(): number {
+    return Number.POSITIVE_INFINITY;
+  }
 
   constructor(private readonly config: Config) {
     super(


### PR DESCRIPTION
## What this PR does

This PR makes `enter_plan_mode` an execution boundary whenever it appears in a multi-tool model batch. Core, ACP, and headless execution now run the entry call, return ordered terminal denials for every same-batch sibling, and require the model to observe the new mode before retrying those calls on the next turn.

Successful and already-active Plan entry now returns the complete current Plan-mode system guidance, including SDK-specific guidance when applicable, instead of the previous short acknowledgement. The boundary is applied after each surface's duplicate and structured-output handling so existing precedence, result ordering, lifecycle reporting, tool-call budgets, and batch hooks remain intact.

## Why it's needed

A model can emit `enter_plan_mode` together with other tools in one response. Previously, those siblings could execute on the wrong side of the mode transition, while the entry result only gave a short acknowledgement and did not provide the restrictions needed for the rest of the turn. That made ACP and headless behavior diverge from the intended Plan-mode safety boundary and left the model without complete current-mode guidance.

## Reviewer Test Plan

### How to verify

Confirm that a batch with `enter_plan_mode` in the first, middle, or last position executes only the entry call and returns ordered `EXECUTION_DENIED` results for all siblings across Core, ACP, and headless execution. Confirm that a failed entry still suppresses same-batch siblings, while a single entry call remains unchanged.

Confirm that both a successful entry and an already-active Plan session return the exact complete Plan-mode reminder in default and SDK modes, even with small output persistence thresholds. Confirm that duplicate ACP calls and headless structured-output handling retain their existing precedence and that skipped siblings do not consume the headless tool-call budget.

Local verification passed on the rebased commit: 326 Core tests, 457 CLI tests with 1 existing skip, `npm run lint`, `npm run build`, and `npm run typecheck`. The repository no longer defines a `verify:pr` npm script, so that command is not an available validation target.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| A mixed batch could execute siblings before or after changing to Plan mode, and successful entry returned only a 136-character acknowledgement. | The entry call is the sole executed call in the batch, every sibling receives an ordered terminal denial, and successful entry returns the complete 3,771-character default Plan reminder measured in the baseline fixture. |

This changes model/tool protocol behavior and has no TUI screenshot surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local workspace with the repository's Node.js 22 toolchain; Core and CLI Vitest suites plus repository lint, build, and typecheck commands.

## Risk & Scope

- Main risk or tradeoff: Plan entry returns a substantially larger guidance payload, and multi-tool batches containing entry intentionally deny otherwise valid siblings so they can be reconsidered with the new mode visible.
- Not validated / out of scope: Managed public-cloud ACP host validation remains required after deployment; this PR does not change Plan exit approval, shell safety classification, unknown-command approval, or ACP permission wording.
- Breaking changes / migration notes: No public API migration is required. Internal consumers that batch `enter_plan_mode` with other calls will now receive terminal denials for those siblings and should retry them in the next model turn when appropriate.

## Linked Issues

Refs #6949

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当 `enter_plan_mode` 出现在模型生成的多工具批次中时，本 PR 将其设为执行边界。Core、ACP 和 headless 执行现在只运行进入 Plan 模式的调用，为同批次所有兄弟调用按原顺序返回终态拒绝，并要求模型先观察新模式，再在下一轮按需重试这些调用。

成功进入或已经处于 Plan 模式时，现在会返回完整的当前 Plan 模式系统指引；适用时也会包含 SDK 专用指引，不再只返回之前的简短确认。边界处理位于各执行面的重复调用和结构化输出处理之后，因此会保留既有优先级、结果顺序、生命周期记录、工具调用预算和批次 hook 语义。

## 为什么需要

模型可能在同一个响应中同时生成 `enter_plan_mode` 和其他工具。此前，这些兄弟调用可能在模式切换的错误一侧执行，而进入结果只包含简短确认，没有提供本轮后续行为所需的完整限制。这会让 ACP 和 headless 行为偏离预期的 Plan 模式安全边界，也使模型拿不到完整的当前模式指引。

## Reviewer 测试计划

### 验证方式

确认当 `enter_plan_mode` 位于批次首部、中部或尾部时，Core、ACP 和 headless 都只执行进入调用，并为所有兄弟调用按原顺序返回 `EXECUTION_DENIED`。确认即使进入失败，同批次兄弟调用仍会被抑制；单独的进入调用则保持原有行为。

确认成功进入和已经处于 Plan 模式两种情况，在默认模式和 SDK 模式下都会返回完全一致的完整 Plan 提醒，即使输出持久化阈值很小也不会被截断或转存。确认 ACP 重复调用和 headless 结构化输出仍保持既有优先级，且被跳过的兄弟调用不会消耗 headless 工具调用预算。

在 rebased 后的提交上，本地验证已通过：326 个 Core 测试、457 个 CLI 测试（另有 1 个既有跳过），以及 `npm run lint`、`npm run build` 和 `npm run typecheck`。仓库当前不再定义 `verify:pr` npm 脚本，因此该命令不是可用的验证目标。

### 证据（修改前后）

| 修改前 | 修改后 |
| --- | --- |
| 混合批次可能在切换到 Plan 模式之前或之后执行兄弟调用，成功进入只返回 136 个字符的简短确认。 | 进入调用成为批次中唯一执行的调用，所有兄弟调用按原顺序收到终态拒绝；在基线 fixture 中，成功进入会返回完整的 3,771 字符默认 Plan 提醒。 |

本改动影响模型/工具协议行为，没有可截图的 TUI 界面。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS 本地工作区，使用仓库要求的 Node.js 22 工具链；运行 Core 和 CLI Vitest 测试，以及仓库 lint、build 和 typecheck 命令。

## 风险与范围

- 主要风险或权衡：Plan 进入会返回明显更大的指引载荷；包含进入调用的多工具批次会有意拒绝其他原本可能有效的兄弟调用，以便它们在新模式可见后被重新评估。
- 未验证 / 范围外：部署后仍需在托管公网 ACP host 中验证；本 PR 不修改 Plan 退出审批、Shell 安全分类、未知命令审批或 ACP 权限措辞。
- 破坏性变更 / 迁移说明：无需迁移公共 API。内部消费者如果把 `enter_plan_mode` 与其他调用放在同一批次，将收到这些兄弟调用的终态拒绝，并应在合适时于下一模型轮次重试。

## 关联 Issue

Refs #6949

</details>
