### PR TITLE
fix(vscode): avoid regenerating notices during install

### DIFF
--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -256,7 +256,6 @@
     "build:dev": "npm run check-types && npm run lint && node esbuild.js",
     "build:prod": "node esbuild.js --production",
     "generate:notices": "node ./scripts/generate-notices.js",
-    "prepare": "npm run generate:notices",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
     "watch": "npm-run-all2 -p watch:*",


### PR DESCRIPTION
## What this PR does

Stops normal dependency installation from regenerating the tracked VS Code companion notices. Notice generation remains explicit at the two points that need it: CI validation and VSIX packaging.

## Why it's needed

The companion workspace's `prepare` script ran during `npm ci`, so a normal dependency install could rewrite `NOTICES.txt` and leave an unrelated working-tree change. Removing that install-time hook keeps installs and ordinary builds clean without allowing stale notices to merge or ship.

## Reviewer Test Plan

### How to verify

From a clean checkout, install dependencies and run an ordinary build. Confirm that `NOTICES.txt` is unchanged. Then package the VS Code companion and confirm that prepackage explicitly generates notices, the generated file still matches the tracked copy, and the VSIX contains it. Dependency changes that require a notices update should continue to fail the existing CI drift check until the regenerated file is committed.

### Evidence (Before & After)

N/A (non-UI lifecycle change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS with Node.js 22.22.0. Verified a clean `npm ci` including the full root build, companion lint/typecheck/build, explicit notice regeneration with no drift, and a complete VSIX package through the real `npm run package` lifecycle.

## Risk & Scope

- Main risk or tradeoff: dependency updates rely on the existing explicit CI and packaging generation points instead of install-time generation.
- Not validated / out of scope: local packaging on Windows and Linux; the release workflow uses the same prepackage entrypoint on every target.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7161.
