### PR TITLE
ci: auto-skip internal CI changes in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,7 @@
 # Configuration for GitHub's automatic release notes generation
-# PRs with 'skip-changelog' label will be excluded from release notes
+# Manual and automatically classified internal PRs are excluded.
 changelog:
   exclude:
     labels:
       - 'skip-changelog'
+      - 'skip-changelog-auto'

--- a/.github/scripts/classify-release-notes.mjs
+++ b/.github/scripts/classify-release-notes.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const INTERNAL_LABELS = new Set([
+  'category/development',
+  'scope/build-system',
+  'scope/ci-cd',
+  'scope/github-actions',
+  'scope/testing',
+]);
+const RELEASE_AUTOMATION_RE =
+  /^\.github\/.*(?:changelog|release|publish|deploy|sync|prebuild|package|installer|artifact|image|cd-)/i;
+const TEST_FILE_RE =
+  /(?:^|\/)(?:__tests__\/|[^/]+\.(?:test|spec)\.[^/]+$|(?:vitest|playwright)(?:\.[^/]+)?\.config\.[^/]+$)/;
+
+export function shouldAutoSkipChangelog({ title, labels = [], files = [] }) {
+  const names = labels.map((label) =>
+    (typeof label === 'string' ? label : label.name).toLowerCase(),
+  );
+  if (names.includes('skip-changelog')) return false;
+
+  const subject = /^(\w+)(?:\([^)]*\))?(!)?:/.exec(title.trim());
+  const type = subject?.[1].toLowerCase();
+  if (
+    subject?.[2] ||
+    (type
+      ? type !== 'ci'
+      : !names.some((label) =>
+          ['scope/ci-cd', 'scope/github-actions'].includes(label),
+        )) ||
+    names.includes('bug') ||
+    names.includes('breaking-change') ||
+    names.some(
+      (label) =>
+        /^(?:type|category|scope)\//.test(label) && !INTERNAL_LABELS.has(label),
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    files.length > 0 &&
+    files.every(
+      (file) =>
+        !RELEASE_AUTOMATION_RE.test(file) &&
+        (file.startsWith('.github/') ||
+          file.startsWith('.qwen/') ||
+          TEST_FILE_RE.test(file)),
+    )
+  );
+}
+
+function main() {
+  const repo = process.env.GITHUB_REPOSITORY || '';
+  const number = process.env.PR_NUMBER || '';
+  if (
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) ||
+    !/^[1-9]\d*$/.test(number)
+  ) {
+    throw new Error(
+      'GITHUB_REPOSITORY and PR_NUMBER must identify a pull request.',
+    );
+  }
+
+  const metadata = JSON.parse(
+    execFileSync(
+      'gh',
+      ['pr', 'view', number, '--repo', repo, '--json', 'title,labels'],
+      {
+        encoding: 'utf8',
+      },
+    ),
+  );
+  const files = execFileSync(
+    'gh',
+    [
+      'api',
+      '--paginate',
+      `repos/${repo}/pulls/${number}/files`,
+      '--jq',
+      '.[] | .filename, (.previous_filename // empty)',
+    ],
+    { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  )
+    .split(/\r?\n/)
+    .filter(Boolean);
+  process.stdout.write(
+    `${shouldAutoSkipChangelog({ ...metadata, files }) ? 'skip' : 'include'}\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/.github/scripts/classify-release-notes.mjs
+++ b/.github/scripts/classify-release-notes.mjs
@@ -48,10 +48,9 @@ export function shouldAutoSkipChangelog({ title, labels = [], files = [] }) {
     files.length > 0 &&
     files.every(
       (file) =>
-        !RELEASE_AUTOMATION_RE.test(file) &&
-        (file.startsWith('.github/') ||
-          file.startsWith('.qwen/') ||
-          TEST_FILE_RE.test(file)),
+        TEST_FILE_RE.test(file) ||
+        (!RELEASE_AUTOMATION_RE.test(file) &&
+          (file.startsWith('.github/') || file.startsWith('.qwen/'))),
     )
   );
 }

--- a/.github/scripts/classify-release-notes.mjs
+++ b/.github/scripts/classify-release-notes.mjs
@@ -11,15 +11,18 @@ const INTERNAL_LABELS = new Set([
   'scope/github-actions',
   'scope/testing',
 ]);
+const AUTO_LABEL = 'skip-changelog-auto';
 const RELEASE_AUTOMATION_RE =
   /^\.github\/.*(?:changelog|release|publish|deploy|sync|prebuild|package|installer|artifact|image|cd-)/i;
 const TEST_FILE_RE =
   /(?:^|\/)(?:__tests__\/|[^/]+\.(?:test|spec)\.[^/]+$|(?:vitest|playwright)(?:\.[^/]+)?\.config\.[^/]+$)/;
 
 export function shouldAutoSkipChangelog({ title, labels = [], files = [] }) {
-  const names = labels.map((label) =>
-    (typeof label === 'string' ? label : label.name).toLowerCase(),
-  );
+  const names = labels
+    .map((label) =>
+      (typeof label === 'string' ? label : label.name).toLowerCase(),
+    )
+    .filter((name) => name !== AUTO_LABEL);
   if (names.includes('skip-changelog')) return false;
 
   const subject = /^(\w+)(?:\([^)]*\))?(!)?:/.exec(title.trim());

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -31,9 +31,14 @@ describe('release note classification', () => {
       },
       {
         title: 'Fix flaky CI routing',
-        labels: ['scope/ci-cd'],
+        labels: [{ name: 'scope/ci-cd' }],
         files: ['.github/workflows/ci.yml'],
         expected: true,
+      },
+      {
+        title: 'ci!: breaking dispatch change',
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
       },
       {
         title: 'Update action permissions',
@@ -46,6 +51,24 @@ describe('release note classification', () => {
         labels: ['scope/ci-cd'],
         files: ['.github/workflows/ci.yml'],
         expected: false,
+      },
+      {
+        title: 'ci: fix check',
+        labels: ['bug'],
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: fix check',
+        labels: ['breaking-change'],
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: keep automatic exclusion stable',
+        labels: ['skip-changelog-auto'],
+        files: ['.github/workflows/ci.yml'],
+        expected: true,
       },
       {
         title: 'ci: update release automation',

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -259,6 +259,42 @@ describe('release note classification', () => {
     }
   });
 
+  it('prints skip for internal CI changes through main', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'release-note-classifier-'));
+    try {
+      const gh = join(dir, 'gh');
+      writeFileSync(
+        gh,
+        [
+          '#!/usr/bin/env node',
+          'const args = process.argv.slice(2);',
+          "if (args[0] === 'pr') { process.stdout.write(JSON.stringify({ title: 'ci: speed up checks', labels: [] })); process.exit(0); }",
+          "if (args.includes('.[] | .filename, (.previous_filename // empty)')) { process.stdout.write('.github/workflows/ci.yml\\n'); process.exit(0); }",
+          'process.exit(1);',
+        ].join('\n'),
+      );
+      chmodSync(gh, 0o755);
+
+      const decision = execFileSync(
+        process.execPath,
+        [join(import.meta.dirname, 'classify-release-notes.mjs')],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+            PATH: `${dir}:${process.env.PATH}`,
+            PR_NUMBER: '1',
+          },
+        },
+      );
+
+      assert.equal(decision, 'skip\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('wires reclassification and exclusion to the same automatic label', () => {
     const workflow = readFileSync(
       join(import.meta.dirname, '../workflows/classify-release-notes.yml'),
@@ -273,6 +309,10 @@ describe('release note classification', () => {
       assert.match(workflow, new RegExp(`- '${action}'`));
     }
     assert.match(workflow, /AUTO_LABEL: 'skip-changelog-auto'/);
+    assert.match(
+      workflow,
+      /github\.event\.label\.name != 'skip-changelog-auto'/,
+    );
     assert.match(workflow, /classification failed; including this PR/);
     assert.doesNotMatch(workflow, /decision=unchanged/);
     assert.match(release, /- 'skip-changelog-auto'/);

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -41,6 +41,16 @@ describe('release note classification', () => {
         expected: true,
       },
       {
+        title: 'ci: update spec tests',
+        files: ['packages/core/src/auth.spec.ts'],
+        expected: true,
+      },
+      {
+        title: 'ci: update playwright config',
+        files: ['packages/e2e/playwright.config.ts'],
+        expected: true,
+      },
+      {
         title: 'ci: update release classifier tests',
         files: ['.github/scripts/classify-release-notes.test.mjs'],
         expected: true,

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -71,6 +72,16 @@ describe('release note classification', () => {
         expected: true,
       },
       {
+        title: 'Update docs',
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: empty',
+        files: [],
+        expected: false,
+      },
+      {
         title: 'ci: update release automation',
         files: ['.github/workflows/finalize-release.yml'],
         expected: false,
@@ -113,6 +124,45 @@ describe('release note classification', () => {
     }
   });
 
+  it('rejects invalid pull request environment before invoking gh', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'release-note-classifier-'));
+    try {
+      const marker = join(dir, 'gh-invoked');
+      const gh = join(dir, 'gh');
+      writeFileSync(
+        gh,
+        [
+          '#!/usr/bin/env node',
+          `require('node:fs').writeFileSync(${JSON.stringify(marker)}, '1');`,
+          'process.exit(1);',
+        ].join('\n'),
+      );
+      chmodSync(gh, 0o755);
+
+      for (const env of [
+        { GITHUB_REPOSITORY: 'QwenLM/qwen-code/extra', PR_NUMBER: '1' },
+        { GITHUB_REPOSITORY: 'QwenLM/qwen-code', PR_NUMBER: 'abc' },
+      ]) {
+        assert.throws(() =>
+          execFileSync(
+            process.execPath,
+            [join(import.meta.dirname, 'classify-release-notes.mjs')],
+            {
+              env: {
+                ...process.env,
+                ...env,
+                PATH: `${dir}:${process.env.PATH}`,
+              },
+            },
+          ),
+        );
+        assert.equal(existsSync(marker), false);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps renamed production files by checking their previous paths', () => {
     const dir = mkdtempSync(join(tmpdir(), 'release-note-classifier-'));
     try {
@@ -151,10 +201,13 @@ describe('release note classification', () => {
 
   it('wires reclassification and exclusion to the same automatic label', () => {
     const workflow = readFileSync(
-      '.github/workflows/classify-release-notes.yml',
+      join(import.meta.dirname, '../workflows/classify-release-notes.yml'),
       'utf8',
     );
-    const release = readFileSync('.github/release.yml', 'utf8');
+    const release = readFileSync(
+      join(import.meta.dirname, '../release.yml'),
+      'utf8',
+    );
 
     for (const action of ['synchronize', 'edited', 'labeled', 'unlabeled']) {
       assert.match(workflow, new RegExp(`- '${action}'`));

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { shouldAutoSkipChangelog } from './classify-release-notes.mjs';
+
+describe('release note classification', () => {
+  it('only skips internal CI changes', () => {
+    const cases = [
+      {
+        title: 'ci: speed up PR checks',
+        files: ['.github/workflows/ci.yml'],
+        expected: true,
+      },
+      {
+        title: 'ci(autofix): harden review automation',
+        files: [
+          '.github/workflows/qwen-autofix.yml',
+          '.qwen/skills/autofix/SKILL.md',
+          'scripts/tests/qwen-autofix-workflow.test.js',
+        ],
+        expected: true,
+      },
+      {
+        title: 'Fix flaky CI routing',
+        labels: ['scope/ci-cd'],
+        files: ['.github/workflows/ci.yml'],
+        expected: true,
+      },
+      {
+        title: 'Update action permissions',
+        labels: ['scope/github-actions'],
+        files: ['.github/workflows/ci.yml'],
+        expected: true,
+      },
+      {
+        title: 'fix(ci): repair check results',
+        labels: ['scope/ci-cd'],
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update release automation',
+        files: ['.github/workflows/finalize-release.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update release helper',
+        files: ['.github/scripts/publish-release.mjs'],
+        expected: false,
+      },
+      {
+        title: 'ci: support a new platform build',
+        labels: ['category/platform'],
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update checks and runtime',
+        files: ['.github/workflows/ci.yml', 'packages/core/src/index.ts'],
+        expected: false,
+      },
+      {
+        title: 'ci: move a runtime file into automation',
+        files: ['.github/scripts/runtime.ts', 'packages/core/src/runtime.ts'],
+        expected: false,
+      },
+      {
+        title: 'ci: keep manual exclusion',
+        labels: ['skip-changelog'],
+        files: ['.github/workflows/ci.yml'],
+        expected: false,
+      },
+    ];
+
+    for (const { expected, ...pullRequest } of cases) {
+      assert.equal(
+        shouldAutoSkipChangelog(pullRequest),
+        expected,
+        pullRequest.title,
+      );
+    }
+  });
+
+  it('keeps renamed production files by checking their previous paths', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'release-note-classifier-'));
+    try {
+      const gh = join(dir, 'gh');
+      writeFileSync(
+        gh,
+        [
+          '#!/usr/bin/env node',
+          'const args = process.argv.slice(2);',
+          "if (args[0] === 'pr') { process.stdout.write(JSON.stringify({ title: 'ci: move runtime', labels: [] })); process.exit(0); }",
+          "if (args.includes('.[] | .filename, (.previous_filename // empty)')) { process.stdout.write('.github/scripts/runtime.ts\\npackages/core/src/runtime.ts\\n'); process.exit(0); }",
+          'process.exit(1);',
+        ].join('\n'),
+      );
+      chmodSync(gh, 0o755);
+
+      const decision = execFileSync(
+        process.execPath,
+        [join(import.meta.dirname, 'classify-release-notes.mjs')],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+            PATH: `${dir}:${process.env.PATH}`,
+            PR_NUMBER: '1',
+          },
+        },
+      );
+
+      assert.equal(decision, 'include\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('wires reclassification and exclusion to the same automatic label', () => {
+    const workflow = readFileSync(
+      '.github/workflows/classify-release-notes.yml',
+      'utf8',
+    );
+    const release = readFileSync('.github/release.yml', 'utf8');
+
+    for (const action of ['synchronize', 'edited', 'labeled', 'unlabeled']) {
+      assert.match(workflow, new RegExp(`- '${action}'`));
+    }
+    assert.match(workflow, /AUTO_LABEL: 'skip-changelog-auto'/);
+    assert.match(workflow, /classification failed; including this PR/);
+    assert.doesNotMatch(workflow, /decision=unchanged/);
+    assert.match(release, /- 'skip-changelog-auto'/);
+  });
+});

--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -31,6 +31,21 @@ describe('release note classification', () => {
         expected: true,
       },
       {
+        title: 'ci: update test helpers',
+        files: ['packages/core/src/__tests__/utils.ts'],
+        expected: true,
+      },
+      {
+        title: 'ci: update vitest config',
+        files: ['packages/cli/vitest.config.ts'],
+        expected: true,
+      },
+      {
+        title: 'ci: update release classifier tests',
+        files: ['.github/scripts/classify-release-notes.test.mjs'],
+        expected: true,
+      },
+      {
         title: 'Fix flaky CI routing',
         labels: [{ name: 'scope/ci-cd' }],
         files: ['.github/workflows/ci.yml'],
@@ -89,6 +104,51 @@ describe('release note classification', () => {
       {
         title: 'ci: update release helper',
         files: ['.github/scripts/publish-release.mjs'],
+        expected: false,
+      },
+      {
+        title: 'ci: update changelog helper',
+        files: ['.github/workflows/update-changelog.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update deploy pipeline',
+        files: ['.github/workflows/deploy-app.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: bump sync action',
+        files: ['.github/workflows/sync-labels.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update prebuild pipeline',
+        files: ['.github/workflows/prebuild.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update package pipeline',
+        files: ['.github/workflows/package-cli.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update installer pipeline',
+        files: ['.github/workflows/build-installer.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update artifact upload',
+        files: ['.github/workflows/upload-artifact.yml'],
+        expected: false,
+      },
+      {
+        title: 'ci: update image build',
+        files: ['.github/scripts/build-image.mjs'],
+        expected: false,
+      },
+      {
+        title: 'ci: update cd pipeline',
+        files: ['.github/workflows/cd-pages.yml'],
         expected: false,
       },
       {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ env:
   # BOTH the github_ci_only helper step and the full-profile Test step, so a
   # new helper test can't be added to one path and silently dropped from the
   # other.
-  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs'
+  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs'
 
 jobs:
   classify_pr:

--- a/.github/workflows/classify-release-notes.yml
+++ b/.github/workflows/classify-release-notes.yml
@@ -1,0 +1,65 @@
+name: 'Classify Release Notes'
+
+on:
+  pull_request_target:
+    branches:
+      - 'main'
+      - 'release/**'
+    types:
+      - 'opened'
+      - 'reopened'
+      - 'synchronize'
+      - 'edited'
+      - 'labeled'
+      - 'unlabeled'
+      - 'ready_for_review'
+
+permissions:
+  contents: 'read'
+  issues: 'write'
+  pull-requests: 'write'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    steps:
+      # pull_request_target checks out the trusted base branch; PR code is never
+      # executed with this workflow's label-write permission.
+      - name: 'Checkout trusted classifier'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Classify pull request'
+        id: 'classify'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+        run: |-
+          if decision="$(node .github/scripts/classify-release-notes.mjs)"; then
+            echo "decision=${decision}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::Release-note classification failed; including this PR."
+            echo "decision=include" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: 'Update automatic changelog label'
+        env:
+          AUTO_LABEL: 'skip-changelog-auto'
+          DECISION: '${{ steps.classify.outputs.decision }}'
+          GH_TOKEN: '${{ github.token }}'
+          HAS_AUTO_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog-auto') }}"
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+        run: |-
+          set -euo pipefail
+          if [[ "${DECISION}" == "skip" ]]; then
+            gh label create "${AUTO_LABEL}" --repo "${GITHUB_REPOSITORY}" --color 'ededed' --description 'Automatically exclude internal CI changes from release notes' --force
+            if [[ "${HAS_AUTO_LABEL}" != "true" ]]; then
+              gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "${AUTO_LABEL}"
+            fi
+          elif [[ "${DECISION}" == "include" && "${HAS_AUTO_LABEL}" == "true" ]]; then
+            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --remove-label "${AUTO_LABEL}"
+          fi

--- a/.github/workflows/classify-release-notes.yml
+++ b/.github/workflows/classify-release-notes.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   classify:
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     steps:

--- a/.github/workflows/classify-release-notes.yml
+++ b/.github/workflows/classify-release-notes.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   classify:
-    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    if: "${{ github.repository == 'QwenLM/qwen-code' && github.event.label.name != 'skip-changelog-auto' }}"
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## What this PR does

This PR automatically excludes purely internal CI pull requests from generated release notes while keeping release-relevant CI changes visible. A trusted base-branch workflow evaluates the PR title, labels, and every changed path whenever the PR changes, then owns a dedicated `skip-changelog-auto` label without interfering with the existing manual `skip-changelog` label.

Automatic exclusion requires an explicit `ci:` conventional type or an internal CI/GitHub Actions scope label, no bug, breaking, platform, packaging, or other product-facing semantic label, and only GitHub automation, agent workflow, test, or test-config paths. Release, publishing, deployment, installer, artifact, image, packaging, and changelog automation is always retained. Renamed files are evaluated using both their current and previous paths, and classification failures default to inclusion.

## Why it's needed

Generated release notes currently include maintenance-only CI pull requests unless a maintainer remembers to apply the manual exclusion label. This adds a conservative automated decision step so release notes stay user-focused without hiding CI work that can affect shipped products or distribution.

## Reviewer Test Plan

### How to verify

Confirm that a PR titled with `ci:` and changing only an ordinary CI workflow receives the automatic exclusion label. Then add a production path, a release-sensitive automation path, a breaking marker, or a product-facing category and confirm the automatic label is removed. Also confirm that manually applied `skip-changelog` remains untouched and that a renamed production file is classified using its old path.

### Evidence (Before & After)

Before: maintenance-only CI pull requests enter generated release notes unless manually labeled.

After: the local classifier marked representative internal CI PRs #7214, #7163, and #7142 as `skip`, while release/publishing-sensitive PRs #6975 and #6963 remained `include`. The full GitHub helper suite passed 83/83, the repository script suite passed 572 tests with 9 skipped, and formatting, ESLint, actionlint, build, and typecheck all passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, local macOS workspace; GitHub-hosted platform checks are delegated to PR CI.

## Risk & Scope

- Main risk or tradeoff: Conservative matching can leave some maintenance PRs in release notes, but ambiguous or failed classifications intentionally default to inclusion.
- Not validated / out of scope: Automatic categorization of non-CI documentation, dependencies, or product changes.
- Breaking changes / migration notes: None.

## Linked Issues

N/A — maintenance follow-up from release-note workflow review.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 会自动从生成的 release note 中排除纯内部 CI PR，同时继续保留与发布相关的 CI 改动。一个仅执行受信任 base 分支代码的工作流会在 PR 发生变化时，根据标题、标签和所有变更路径重新判断，并独立维护 `skip-changelog-auto` 标签，不会干扰现有的手动 `skip-changelog` 标签。

自动排除要求 PR 具有明确的 `ci:` Conventional Commit 类型，或内部 CI/GitHub Actions scope 标签；不能带有 bug、breaking、平台、打包或其他面向产品的语义标签；并且只能修改 GitHub 自动化、agent 工作流、测试或测试配置路径。release、publish、deploy、installer、artifact、image、package 和 changelog 自动化始终保留。重命名文件会同时检查新旧路径，分类失败时默认保留在 release note 中。

## 为什么需要

目前，维护性质的纯 CI PR 会进入生成的 release note，除非维护者记得手动添加排除标签。这个改动增加了一个保守的自动判断步骤，让 release note 更聚焦用户可感知的变化，同时不会隐藏可能影响最终产品或分发流程的 CI 改动。

## Reviewer 测试计划

### 如何验证

确认标题为 `ci:` 且只修改普通 CI 工作流的 PR 会获得自动排除标签。随后加入产品代码路径、发布敏感自动化路径、breaking 标记或面向产品的 category，确认自动标签会被移除。同时确认手动添加的 `skip-changelog` 不受影响，并确认重命名的生产文件会根据旧路径参与判断。

### 证据（Before & After）

Before：纯维护性质的 CI PR 会进入生成的 release note，除非手动添加标签。

After：本地分类器将代表性的内部 CI PR #7214、#7163 和 #7142 判定为 `skip`，同时将发布/上传敏感的 PR #6975 和 #6963 保持为 `include`。GitHub helper 测试 83/83 通过，仓库脚本测试 572 项通过、9 项跳过，格式检查、ESLint、actionlint、build 和 typecheck 均通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22，本地 macOS 工作区；GitHub 托管平台验证由 PR CI 完成。

## 风险与范围

- 主要风险或取舍：保守匹配可能让少量维护 PR 继续出现在 release note 中，但任何有歧义或分类失败的情况都会刻意默认保留。
- 未验证 / 范围外：非 CI 文档、依赖或产品改动的自动分类。
- Breaking change / 迁移说明：无。

## 关联 Issue

无——这是对 release-note 工作流审查的维护性跟进。

</details>
