### PR TITLE
feat(core): emit OAuth login URL as a single OSC 8 hyperlink

### DIFF
--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -7,6 +7,14 @@
 /**
  * OSC 8 hyperlink helpers.
  *
+ * The shared primitives — `sanitizeForOsc`, `osc8Hyperlink`,
+ * `supportsHyperlinks`, `wrapForMultiplexer`, `HYPERLINK_ENV_KEYS` — now live
+ * in `@qwen-code/qwen-code-core` so core-side emitters (e.g. the Qwen OAuth
+ * device-flow fallback message) can wrap a URL in a single clickable link.
+ * They are re-exported here so existing CLI imports of this module keep
+ * resolving unchanged. The markdown-link and label-deception helpers below are
+ * CLI-renderer-specific and stay here.
+ *
  * Supported terminals (iTerm2 ≥ 3.1, WezTerm ≥ 20200620, Kitty, Ghostty,
  * Windows Terminal, VS Code ≥ 1.72, GNOME Terminal / VTE ≥ 0.50, …) render
  * an OSC 8 envelope as a clickable link that survives line wrapping.
@@ -14,49 +22,21 @@
  * label as-is.
  */
 
-import { wrapForMultiplexer } from '../../utils/osc.js';
-// Re-export so MCP `AuthenticateStep` (the one remaining inline caller) can
-// pick the helper up from a single OSC-8-aware namespace.
-export { wrapForMultiplexer };
+import {
+  osc8Hyperlink,
+  sanitizeForOsc,
+  supportsHyperlinks,
+  wrapForMultiplexer,
+  HYPERLINK_ENV_KEYS,
+} from '@qwen-code/qwen-code-core';
 
-/**
- * Strip C0 + DEL + C1 control characters AND Unicode bidi / line-separator
- * controls so an untrusted string can be safely embedded inside an OSC
- * escape and rendered without spoofing the visible label.
- *
- * Bytes removed:
- * - C0 + DEL (`\x00-\x1f\x7f`): a stray BEL (`\x07`) or ESC (`\x1b`) would
- *   prematurely terminate the OSC sequence and leak the tail bytes as
- *   interpretable escape codes.
- * - C1 (`\x80-\x9f`): includes 8-bit ST and 8-bit OSC introducers, which
- *   terminals that honor C1 controls treat the same as their two-byte ESC
- *   counterparts.
- * - Bidi controls (`U+200E`, `U+200F`, `U+202A`-`U+202E`, `U+2066`-`U+2069`):
- *   a model-emitted `U+202E` (RLO) in a link label visually reverses the
- *   trailing text, letting a label like `safe.com` actually read as a
- *   different host after rendering. The scheme allowlist guards the *target*;
- *   stripping bidi controls guards the visible *label* from the same class
- *   of click-deception attack.
- * - Line / paragraph separators (`U+2028`, `U+2029`): some terminals treat
- *   these as line breaks inside an OSC payload, fracturing the envelope.
- */
-export function sanitizeForOsc(s: string): string {
-  return s.replace(
-    // eslint-disable-next-line no-control-regex
-    /[\x00-\x1f\x7f\x80-\x9f\u200e\u200f\u202a-\u202e\u2066-\u2069\u2028\u2029]/g,
-    '',
-  );
-}
-
-/**
- * Wrap a URL in an OSC 8 hyperlink escape sequence. BEL (\x07) terminates
- * the OSC — more broadly supported than ST (ESC \\).
- */
-export function osc8Hyperlink(url: string, label = url): string {
-  const safeUrl = sanitizeForOsc(url);
-  const safeLabel = sanitizeForOsc(label);
-  return wrapForMultiplexer(`\x1b]8;;${safeUrl}\x07${safeLabel}\x1b]8;;\x07`);
-}
+export {
+  osc8Hyperlink,
+  sanitizeForOsc,
+  supportsHyperlinks,
+  wrapForMultiplexer,
+  HYPERLINK_ENV_KEYS,
+};
 
 /**
  * Open half of an OSC 8 hyperlink envelope. Pair with `osc8Close()` to wrap
@@ -106,184 +86,6 @@ export function isSafeOscScheme(url: string): boolean {
   const match = url.match(/^([a-z][a-z0-9+.-]*:)/i);
   if (!match) return false;
   return SAFE_OSC8_SCHEMES.has(match[1]!.toLowerCase());
-}
-
-function shouldForceHyperlinks(value: string): boolean {
-  if (value.length === 0) return true;
-
-  const trimmed = value.trim();
-  if (!/^[+-]?\d+$/.test(trimmed)) return false;
-
-  return Number(trimmed) !== 0;
-}
-
-interface ParsedVersion {
-  major: number;
-  minor: number;
-  patch: number;
-}
-
-function parseVersion(versionString: string | undefined): ParsedVersion {
-  if (!versionString) return { major: 0, minor: 0, patch: 0 };
-  // VTE historically reports `VTE_VERSION` as a packed integer (e.g. `7800`
-  // for 0.78.0, `5000` for 0.50.0) rather than dot-separated. Mirror the
-  // `supports-hyperlinks` package's heuristic for this case so we extract
-  // the right minor for the >=0.50 gate below.
-  if (/^\d{3,4}$/.test(versionString)) {
-    const m = /(\d{1,2})(\d{2})/.exec(versionString)!;
-    return { major: 0, minor: parseInt(m[1]!, 10), patch: parseInt(m[2]!, 10) };
-  }
-  const parts = versionString.split('.').map((n) => parseInt(n, 10) || 0);
-  return { major: parts[0] ?? 0, minor: parts[1] ?? 0, patch: parts[2] ?? 0 };
-}
-
-/**
- * Detect whether the given writable stream's host terminal can render OSC 8
- * hyperlinks. Mirrors the version-gated detection used by the
- * `supports-hyperlinks` npm package — see https://github.com/jamestalmage/node-supports-hyperlinks —
- * with two intentional deviations:
- *
- *   1. Inside `tmux` or GNU `screen` we refuse by default. The multiplexer
- *      hides the actual host terminal's capabilities, so even when we DCS-
- *      passthrough the sequence the host may print visible garbage on
- *      terminals that don't understand OSC 8. Power users who know their
- *      host supports OSC 8 and have `allow-passthrough on` (tmux 3.3+) can
- *      opt in with `FORCE_HYPERLINK=1`.
- *
- *   2. `QWEN_DISABLE_HYPERLINKS=1` is a hard opt-out (e.g. for users whose
- *      terminal advertises support but breaks on long URLs).
- *
- * The detector deliberately allocates nothing and reads env vars on every
- * call — env state can change at runtime (`/theme` toggles, NO_COLOR set
- * mid-session) and memoizing would freeze a stale answer.
- */
-export function supportsHyperlinks(
-  stream: NodeJS.WriteStream | undefined = process.stdout,
-): boolean {
-  const env = process.env;
-
-  // Hard opt-outs win unconditionally.
-  if (env['QWEN_DISABLE_HYPERLINKS'] === '1') return false;
-  if (env['NO_COLOR'] !== undefined && env['NO_COLOR'] !== '') return false;
-  if (env['FORCE_COLOR'] === '0' || env['FORCE_COLOR'] === 'false') {
-    return false;
-  }
-
-  // Embedded escapes must never end up in a file or another process. This
-  // guard sits above `FORCE_HYPERLINK` on purpose: a user who has
-  // `FORCE_HYPERLINK=1` in their shell profile (to enable OSC 8 inside
-  // tmux/Hyper interactively) still shouldn't see escape bytes when they
-  // run `qwen | cat` or `qwen > out.txt`.
-  if (!stream || !stream.isTTY) return false;
-
-  // Explicit force overrides every heuristic below — but not the opt-outs
-  // above nor the non-TTY guard. Mirrors the `FORCE_HYPERLINK` contract
-  // from supports-hyperlinks: any non-zero numeric value (or empty string)
-  // enables, `0` disables.
-  const force = env['FORCE_HYPERLINK'];
-  if (force !== undefined) {
-    return shouldForceHyperlinks(force);
-  }
-
-  if (env['CI']) return false;
-  if (env['TEAMCITY_VERSION']) return false;
-
-  // Multiplexers hide the host terminal's identity — bail unless the user
-  // opted in via FORCE_HYPERLINK above.
-  if (env['TMUX'] || env['STY']) return false;
-
-  // Modern terminals identified by their own env vars (no version probe
-  // needed — these have shipped OSC 8 since their first OSC-8-aware release
-  // and their env var is only set by versions new enough to support it).
-  if (env['WT_SESSION']) return true; // Windows Terminal
-  if (env['KITTY_WINDOW_ID'] || env['TERM'] === 'xterm-kitty') return true;
-  if (env['DOMTERM']) return true;
-  if (env['GHOSTTY_RESOURCES_DIR'] || env['TERM'] === 'xterm-ghostty') {
-    return true;
-  }
-  // Konsole sets KONSOLE_VERSION on every session as a packed integer
-  // (e.g. 21.04 → 210400, 23.08.5 → 230805). OSC 8 support landed in
-  // Konsole 21.04, so version-gate against `>= 210400` and let older
-  // releases fall through to the final `return false` so we don't emit
-  // escapes on a host that won't render them.
-  if (env['KONSOLE_VERSION']) {
-    const konsoleVersion = parseInt(env['KONSOLE_VERSION'], 10);
-    if (Number.isFinite(konsoleVersion) && konsoleVersion >= 210400) {
-      return true;
-    }
-  }
-  // Alacritty ≥ 0.11 supports OSC 8. Identify it via TERM=alacritty (set
-  // when the alacritty terminfo is installed) or the ALACRITTY_LOG /
-  // ALACRITTY_WINDOW_ID env vars that Alacritty 0.12+ sets unconditionally.
-  // Note: on hosts without alacritty terminfo Alacritty falls back to
-  // TERM=xterm-256color and the TERM heuristic alone won't fire — the
-  // env-var fallbacks catch those cases.
-  if (
-    env['TERM'] === 'alacritty' ||
-    env['ALACRITTY_LOG'] !== undefined ||
-    env['ALACRITTY_WINDOW_ID'] !== undefined ||
-    env['ALACRITTY_SOCKET'] !== undefined
-  ) {
-    return true;
-  }
-  // JetBrains IDEs set TERMINAL_EMULATOR on their integrated terminal; the
-  // JediTerm backend has supported OSC 8 since 2022.3.
-  if (env['TERMINAL_EMULATOR'] === 'JetBrains-JediTerm') return true;
-
-  if (env['TERM_PROGRAM']) {
-    const version = parseVersion(env['TERM_PROGRAM_VERSION']);
-    switch (env['TERM_PROGRAM']) {
-      case 'iTerm.app':
-        if (version.major === 3) return version.minor >= 1;
-        return version.major > 3;
-      case 'WezTerm':
-        return version.major >= 20200620;
-      case 'vscode':
-        return (
-          version.major > 1 || (version.major === 1 && version.minor >= 72)
-        );
-      case 'ghostty':
-        return true;
-      case 'mintty':
-        // mintty added OSC 8 in 3.1, hardened in 3.3. Older builds (still
-        // bundled with some Git-for-Windows distros and developer
-        // environments like Laragon) print the raw `\x1b]8;;url\x07`
-        // bytes as visible garbage instead of silently ignoring them,
-        // so gate on TERM_PROGRAM_VERSION. mintty has set
-        // TERM_PROGRAM_VERSION since 2.7 (2017), so a missing version
-        // means a very old build — refuse rather than guess.
-        if (!env['TERM_PROGRAM_VERSION']) return false;
-        return version.major > 3 || (version.major === 3 && version.minor >= 3);
-      // Warp (TERM_PROGRAM=WarpTerminal) does NOT yet support OSC 8 — its
-      // rendering engine ignores the envelope and prints visible garbage,
-      // so we deliberately fall through to the legacy `label (url)` path.
-      // Re-enable when Warp ships OSC 8 support.
-      //
-      // Hyper exposes OSC 8 in recent versions but plugin chains have a
-      // history of breaking escape passthrough — gate on FORCE_HYPERLINK
-      // so users who know their setup works can opt in explicitly.
-      default:
-        break;
-    }
-  }
-
-  if (env['VTE_VERSION']) {
-    // VTE 0.50.0 advertises OSC 8 but segfaults when it actually fires.
-    // Compare against the parsed version so the packed form (`'5000'`) is
-    // recognized too — the raw string compare against `'0.50.0'` would miss
-    // it and let the segfault through.
-    const version = parseVersion(env['VTE_VERSION']);
-    if (version.major === 0 && version.minor === 50 && version.patch === 0) {
-      return false;
-    }
-    if (version.major > 0 || version.minor >= 50) return true;
-    return false;
-  }
-
-  // Legacy Windows console (cmd.exe, conhost) — no OSC support outside WT.
-  if (process.platform === 'win32') return false;
-
-  return false;
 }
 
 /**
@@ -462,34 +264,3 @@ export function labelMayDeceive(label: string, url: string): boolean {
   if (!target) return true;
   return labelHosts.some((h) => h !== target);
 }
-
-// ── Test helpers ─────────────────────────────────────────────────────────
-
-/**
- * Every env var `supportsHyperlinks()` reads. Test files clear these in
- * `beforeEach` so a developer's iTerm2 session doesn't leak into snapshot
- * output. Exported so tests stay in lockstep with the detector.
- */
-export const HYPERLINK_ENV_KEYS = [
-  'NO_COLOR',
-  'FORCE_COLOR',
-  'CI',
-  'TMUX',
-  'STY',
-  'TERM_PROGRAM',
-  'TERM_PROGRAM_VERSION',
-  'WT_SESSION',
-  'KITTY_WINDOW_ID',
-  'VTE_VERSION',
-  'DOMTERM',
-  'GHOSTTY_RESOURCES_DIR',
-  'KONSOLE_VERSION',
-  'TERMINAL_EMULATOR',
-  'ALACRITTY_LOG',
-  'ALACRITTY_WINDOW_ID',
-  'ALACRITTY_SOCKET',
-  'TERM',
-  'TEAMCITY_VERSION',
-  'FORCE_HYPERLINK',
-  'QWEN_DISABLE_HYPERLINKS',
-] as const;

--- a/packages/cli/src/utils/osc.ts
+++ b/packages/cli/src/utils/osc.ts
@@ -115,25 +115,12 @@ export function osc(...parts: Array<string | number>): string {
 }
 
 /**
- * Wrap an OSC sequence for tmux / screen passthrough.
- *
- * - tmux: DCS `\ePtmux;\e<seq>\e\\` with ESC doubling inside
- * - screen: DCS `\eP<seq>\e\\`
- *
- * BEL should NOT be wrapped — raw BEL triggers tmux's bell-action,
- * whereas a wrapped BEL becomes an opaque DCS payload and is ignored.
+ * Wrap an OSC sequence for tmux / screen passthrough (DCS-passthrough, with
+ * ESC doubling under tmux). Re-exported from `@qwen-code/qwen-code-core`, the
+ * single source of truth for this helper — core-side emitters need it too —
+ * so this package's existing importers keep resolving unchanged.
  */
-export function wrapForMultiplexer(sequence: string): string {
-  if (process.env['TMUX']) {
-    // tmux requires all ESC bytes inside the payload to be doubled
-    const escaped = sequence.replaceAll('\x1b', '\x1b\x1b');
-    return `\x1bPtmux;${escaped}\x1b\\`;
-  }
-  if (process.env['STY']) {
-    return `\x1bP${sequence}\x1b\\`;
-  }
-  return sequence;
-}
+export { wrapForMultiplexer } from '@qwen-code/qwen-code-core';
 
 // ── Encoding helpers ───────────────────────────────────────────────
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -506,6 +506,7 @@ export {
   openaiLogger,
   resolveOpenAILogDir,
 } from './utils/openaiLogger.js';
+export * from './utils/osc8.js';
 export * from './utils/partUtils.js';
 export * from './utils/sessionStorageUtils.js';
 export * from './utils/pathReader.js';

--- a/packages/core/src/qwen/qwenOAuth2.test.ts
+++ b/packages/core/src/qwen/qwenOAuth2.test.ts
@@ -18,11 +18,13 @@ import {
   qwenOAuth2Events,
   QwenOAuth2Event,
   QwenOAuth2Client,
+  showFallbackMessage,
   type DeviceAuthorizationResponse,
   type DeviceTokenResponse,
   type ErrorData,
   type QwenCredentials,
 } from './qwenOAuth2.js';
+import { HYPERLINK_ENV_KEYS } from '../utils/osc8.js';
 import {
   SharedTokenManager,
   TokenManagerError,
@@ -2385,5 +2387,72 @@ describe('Constants and Configuration', () => {
     expect(options?.body).toContain(
       'scope=openid%20profile%20email%20model.completion',
     );
+  });
+});
+
+describe('showFallbackMessage', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const url = 'https://chat.qwen.ai/authorize?user_code=WDJB-MJHT';
+
+  beforeEach(() => {
+    for (const key of HYPERLINK_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of HYPERLINK_ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  const capture = (isTTY: boolean) => {
+    const chunks: string[] = [];
+    const out = {
+      isTTY,
+      write: (chunk: string) => {
+        chunks.push(String(chunk));
+        return true;
+      },
+    } as unknown as NodeJS.WriteStream;
+    return { out, text: () => chunks.join('') };
+  };
+
+  it('emits the URL as a single OSC 8 hyperlink when the terminal supports it', () => {
+    process.env['FORCE_HYPERLINK'] = '1';
+    const { out, text } = capture(true);
+
+    showFallbackMessage(url, out);
+
+    const output = text();
+    // OSC 8 envelope: ESC ] 8 ; ; <url> BEL <label> ESC ] 8 ; ; BEL
+    expect(output).toContain(`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
+    // The ASCII box is not drawn on the hyperlink path.
+    expect(output).not.toContain('+--');
+  });
+
+  it('falls back to the ASCII box when hyperlinks are disabled', () => {
+    process.env['QWEN_DISABLE_HYPERLINKS'] = '1';
+    const { out, text } = capture(true);
+
+    showFallbackMessage(url, out);
+
+    const output = text();
+    expect(output).not.toContain('\x1b]8;;');
+    expect(output).toContain('Qwen OAuth Device Authorization');
+    expect(output).toContain('+'); // box border
+  });
+
+  it('falls back to the ASCII box for a non-TTY stream even with FORCE_HYPERLINK', () => {
+    process.env['FORCE_HYPERLINK'] = '1';
+    const { out, text } = capture(false);
+
+    showFallbackMessage(url, out);
+
+    const output = text();
+    expect(output).not.toContain('\x1b]8;;');
+    expect(output).toContain('+');
   });
 });

--- a/packages/core/src/qwen/qwenOAuth2.ts
+++ b/packages/core/src/qwen/qwenOAuth2.ts
@@ -14,6 +14,7 @@ import { formatFetchErrorForUser } from '../utils/fetch.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { combineAbortSignals } from '../utils/abortController.js';
 import { openBrowserSecurely } from '../utils/secure-browser-launcher.js';
+import { osc8Hyperlink, supportsHyperlinks } from '../utils/osc8.js';
 import {
   SharedTokenManager,
   TokenManagerError,
@@ -702,15 +703,40 @@ export async function getQwenOAuthClient(
 }
 
 /**
- * Displays a formatted box with OAuth device authorization URL.
- * Uses process.stderr.write() to ensure the auth URL is always visible to users,
- * especially in non-interactive mode. Using stderr prevents corruption of
- * structured JSON output (which goes to stdout) and follows the standard Unix
- * convention of user-facing messages to stderr.
+ * Displays the OAuth device authorization URL to the user.
+ *
+ * When the terminal supports OSC 8 hyperlinks the URL is emitted as a single
+ * clickable link, which stays one copy/click unit even when it wraps (e.g.
+ * over SSH). Otherwise it falls back to a fixed-width ASCII box.
+ *
+ * Writes to `out` (default `process.stderr`) so the auth URL is always visible
+ * to users, especially in non-interactive mode. Using stderr prevents
+ * corruption of structured JSON output (which goes to stdout) and follows the
+ * standard Unix convention of user-facing messages to stderr. `out` is
+ * injectable for testing.
  */
-function showFallbackMessage(verificationUriComplete: string): void {
+export function showFallbackMessage(
+  verificationUriComplete: string,
+  out: NodeJS.WriteStream = process.stderr,
+): void {
   const title = 'Qwen OAuth Device Authorization';
   const url = verificationUriComplete;
+
+  // When the terminal supports OSC 8 hyperlinks, emit the URL as a single
+  // clickable link. Unlike the fixed-width ASCII box below, an OSC 8 envelope
+  // survives line-wrapping (e.g. over SSH), so the URL stays one copy/click
+  // unit instead of being split across lines and reassembled by hand.
+  if (
+    supportsHyperlinks(out) &&
+    (url.startsWith('https://') || url.startsWith('http://'))
+  ) {
+    out.write('\n' + title + '\n');
+    out.write('Please visit the following URL in your browser to authorize:\n');
+    out.write(osc8Hyperlink(url) + '\n');
+    out.write('Waiting for authorization to complete...\n\n');
+    return;
+  }
+
   const minWidth = 70;
   const maxWidth = 80;
   const boxWidth = Math.min(Math.max(title.length + 4, minWidth), maxWidth);
@@ -774,34 +800,30 @@ function showFallbackMessage(verificationUriComplete: string): void {
   const waitingLine = 'Waiting for authorization to complete...';
 
   // Write the box
-  process.stderr.write('\n' + topBorder + '\n');
-  process.stderr.write(emptyLine + '\n');
+  out.write('\n' + topBorder + '\n');
+  out.write(emptyLine + '\n');
 
   // Write instructions
   for (const line of instructionLines) {
-    process.stderr.write(
-      '| ' + line + ' '.repeat(contentWidth - line.length) + ' |\n',
-    );
+    out.write('| ' + line + ' '.repeat(contentWidth - line.length) + ' |\n');
   }
 
-  process.stderr.write(emptyLine + '\n');
+  out.write(emptyLine + '\n');
 
   // Write URL
   for (const line of urlLines) {
-    process.stderr.write(
-      '| ' + line + ' '.repeat(contentWidth - line.length) + ' |\n',
-    );
+    out.write('| ' + line + ' '.repeat(contentWidth - line.length) + ' |\n');
   }
 
-  process.stderr.write(emptyLine + '\n');
+  out.write(emptyLine + '\n');
 
   // Write waiting message
-  process.stderr.write(
+  out.write(
     '| ' + waitingLine + ' '.repeat(contentWidth - waitingLine.length) + ' |\n',
   );
 
-  process.stderr.write(emptyLine + '\n');
-  process.stderr.write(bottomBorder + '\n\n');
+  out.write(emptyLine + '\n');
+  out.write(bottomBorder + '\n\n');
 }
 
 async function authWithQwenDeviceFlow(

--- a/packages/core/src/utils/osc8.test.ts
+++ b/packages/core/src/utils/osc8.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  HYPERLINK_ENV_KEYS,
+  osc8Hyperlink,
+  sanitizeForOsc,
+  supportsHyperlinks,
+  wrapForMultiplexer,
+} from './osc8.js';
+
+const ttyStream = (isTTY: boolean) =>
+  ({ isTTY }) as unknown as NodeJS.WriteStream;
+
+describe('osc8 (core primitives)', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Clear every env var the detector reads so a developer's terminal
+    // session doesn't leak into these assertions.
+    for (const key of HYPERLINK_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of HYPERLINK_ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  describe('sanitizeForOsc', () => {
+    it('strips control characters that would break the OSC envelope', () => {
+      expect(sanitizeForOsc('a\x07b\x1bc')).toBe('abc');
+    });
+
+    it('strips bidi overrides used for label spoofing', () => {
+      expect(sanitizeForOsc('safe\u202ekcatta.com')).toBe('safekcatta.com');
+    });
+
+    it('leaves ordinary URL text untouched', () => {
+      expect(sanitizeForOsc('https://example.com/a?b=c')).toBe(
+        'https://example.com/a?b=c',
+      );
+    });
+  });
+
+  describe('osc8Hyperlink', () => {
+    it('wraps a URL in an OSC 8 envelope, defaulting the label to the URL', () => {
+      const url = 'https://example.com/x';
+      expect(osc8Hyperlink(url)).toBe(`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
+    });
+
+    it('supports a distinct visible label', () => {
+      expect(osc8Hyperlink('https://example.com', 'click')).toBe(
+        '\x1b]8;;https://example.com\x07click\x1b]8;;\x07',
+      );
+    });
+  });
+
+  describe('wrapForMultiplexer', () => {
+    it('passes the sequence through unchanged outside a multiplexer', () => {
+      const seq = '\x1b]8;;https://x\x07';
+      expect(wrapForMultiplexer(seq)).toBe(seq);
+    });
+
+    it('DCS-wraps and doubles ESC under tmux', () => {
+      process.env['TMUX'] = '/tmp/tmux-1000/default,1,0';
+      expect(wrapForMultiplexer('\x1b]8;;u\x07')).toBe(
+        '\x1bPtmux;\x1b\x1b]8;;u\x07\x1b\\',
+      );
+    });
+
+    it('DCS-wraps under screen', () => {
+      process.env['STY'] = '1234.pts-0.host';
+      const seq = '\x1b]8;;u\x07';
+      expect(wrapForMultiplexer(seq)).toBe(`\x1bP${seq}\x1b\\`);
+    });
+  });
+
+  describe('supportsHyperlinks', () => {
+    it('is false for a non-TTY stream even with FORCE_HYPERLINK', () => {
+      process.env['FORCE_HYPERLINK'] = '1';
+      expect(supportsHyperlinks(ttyStream(false))).toBe(false);
+    });
+
+    it('honors FORCE_HYPERLINK=1 on a TTY', () => {
+      process.env['FORCE_HYPERLINK'] = '1';
+      expect(supportsHyperlinks(ttyStream(true))).toBe(true);
+    });
+
+    it('is a hard opt-out under QWEN_DISABLE_HYPERLINKS=1', () => {
+      process.env['QWEN_DISABLE_HYPERLINKS'] = '1';
+      process.env['FORCE_HYPERLINK'] = '1';
+      expect(supportsHyperlinks(ttyStream(true))).toBe(false);
+    });
+
+    it('detects Windows Terminal via WT_SESSION', () => {
+      process.env['WT_SESSION'] = 'abc';
+      expect(supportsHyperlinks(ttyStream(true))).toBe(true);
+    });
+
+    it('refuses inside tmux unless the user opts in', () => {
+      process.env['TMUX'] = '/tmp/tmux/default,1,0';
+      process.env['WT_SESSION'] = 'abc';
+      expect(supportsHyperlinks(ttyStream(true))).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/utils/osc8.ts
+++ b/packages/core/src/utils/osc8.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OSC 8 hyperlink primitives (package-agnostic).
+ *
+ * These live in `core` so both the CLI renderers and core-side emitters — for
+ * example the Qwen OAuth device-flow fallback message — can wrap a URL in a
+ * single clickable link. `packages/cli/src/ui/utils/osc8.ts` re-exports them
+ * so existing CLI imports keep resolving unchanged.
+ *
+ * Supported terminals (iTerm2 ≥ 3.1, WezTerm ≥ 20200620, Kitty, Ghostty,
+ * Windows Terminal, VS Code ≥ 1.72, GNOME Terminal / VTE ≥ 0.50, …) render an
+ * OSC 8 envelope as a clickable link that survives line wrapping. Terminals
+ * without OSC 8 support ignore the escapes and print the visible label as-is.
+ */
+
+/**
+ * Wrap an OSC sequence for tmux / screen passthrough.
+ *
+ * - tmux: DCS `\ePtmux;\e<seq>\e\\` with ESC doubling inside
+ * - screen: DCS `\eP<seq>\e\\`
+ *
+ * BEL should NOT be wrapped — raw BEL triggers tmux's bell-action, whereas a
+ * wrapped BEL becomes an opaque DCS payload and is ignored.
+ */
+export function wrapForMultiplexer(sequence: string): string {
+  if (process.env['TMUX']) {
+    // tmux requires all ESC bytes inside the payload to be doubled
+    const escaped = sequence.replaceAll('\x1b', '\x1b\x1b');
+    return `\x1bPtmux;${escaped}\x1b\\`;
+  }
+  if (process.env['STY']) {
+    return `\x1bP${sequence}\x1b\\`;
+  }
+  return sequence;
+}
+
+/**
+ * Strip C0 + DEL + C1 control characters AND Unicode bidi / line-separator
+ * controls so an untrusted string can be safely embedded inside an OSC
+ * escape and rendered without spoofing the visible label.
+ *
+ * Bytes removed:
+ * - C0 + DEL (`\x00-\x1f\x7f`): a stray BEL (`\x07`) or ESC (`\x1b`) would
+ *   prematurely terminate the OSC sequence and leak the tail bytes as
+ *   interpretable escape codes.
+ * - C1 (`\x80-\x9f`): includes 8-bit ST and 8-bit OSC introducers, which
+ *   terminals that honor C1 controls treat the same as their two-byte ESC
+ *   counterparts.
+ * - Bidi controls (`U+200E`, `U+200F`, `U+202A`-`U+202E`, `U+2066`-`U+2069`):
+ *   a model-emitted `U+202E` (RLO) in a link label visually reverses the
+ *   trailing text, letting a label like `safe.com` actually read as a
+ *   different host after rendering. The scheme allowlist guards the *target*;
+ *   stripping bidi controls guards the visible *label* from the same class
+ *   of click-deception attack.
+ * - Line / paragraph separators (`U+2028`, `U+2029`): some terminals treat
+ *   these as line breaks inside an OSC payload, fracturing the envelope.
+ */
+export function sanitizeForOsc(s: string): string {
+  return s.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1f\x7f\x80-\x9f\u200e\u200f\u202a-\u202e\u2066-\u2069\u2028\u2029]/g,
+    '',
+  );
+}
+
+/**
+ * Wrap a URL in an OSC 8 hyperlink escape sequence. BEL (\x07) terminates
+ * the OSC — more broadly supported than ST (ESC \\).
+ */
+export function osc8Hyperlink(url: string, label = url): string {
+  const safeUrl = sanitizeForOsc(url);
+  const safeLabel = sanitizeForOsc(label);
+  return wrapForMultiplexer(`\x1b]8;;${safeUrl}\x07${safeLabel}\x1b]8;;\x07`);
+}
+
+function shouldForceHyperlinks(value: string): boolean {
+  if (value.length === 0) return true;
+
+  const trimmed = value.trim();
+  if (!/^[+-]?\d+$/.test(trimmed)) return false;
+
+  return Number(trimmed) !== 0;
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseVersion(versionString: string | undefined): ParsedVersion {
+  if (!versionString) return { major: 0, minor: 0, patch: 0 };
+  // VTE historically reports `VTE_VERSION` as a packed integer (e.g. `7800`
+  // for 0.78.0, `5000` for 0.50.0) rather than dot-separated. Mirror the
+  // `supports-hyperlinks` package's heuristic for this case so we extract
+  // the right minor for the >=0.50 gate below.
+  if (/^\d{3,4}$/.test(versionString)) {
+    const m = /(\d{1,2})(\d{2})/.exec(versionString)!;
+    return { major: 0, minor: parseInt(m[1]!, 10), patch: parseInt(m[2]!, 10) };
+  }
+  const parts = versionString.split('.').map((n) => parseInt(n, 10) || 0);
+  return { major: parts[0] ?? 0, minor: parts[1] ?? 0, patch: parts[2] ?? 0 };
+}
+
+/**
+ * Detect whether the given writable stream's host terminal can render OSC 8
+ * hyperlinks. Mirrors the version-gated detection used by the
+ * `supports-hyperlinks` npm package — see https://github.com/jamestalmage/node-supports-hyperlinks —
+ * with two intentional deviations:
+ *
+ *   1. Inside `tmux` or GNU `screen` we refuse by default. The multiplexer
+ *      hides the actual host terminal's capabilities, so even when we DCS-
+ *      passthrough the sequence the host may print visible garbage on
+ *      terminals that don't understand OSC 8. Power users who know their
+ *      host supports OSC 8 and have `allow-passthrough on` (tmux 3.3+) can
+ *      opt in with `FORCE_HYPERLINK=1`.
+ *
+ *   2. `QWEN_DISABLE_HYPERLINKS=1` is a hard opt-out (e.g. for users whose
+ *      terminal advertises support but breaks on long URLs).
+ *
+ * The detector deliberately allocates nothing and reads env vars on every
+ * call — env state can change at runtime (`/theme` toggles, NO_COLOR set
+ * mid-session) and memoizing would freeze a stale answer.
+ */
+export function supportsHyperlinks(
+  stream: NodeJS.WriteStream | undefined = process.stdout,
+): boolean {
+  const env = process.env;
+
+  // Hard opt-outs win unconditionally.
+  if (env['QWEN_DISABLE_HYPERLINKS'] === '1') return false;
+  if (env['NO_COLOR'] !== undefined && env['NO_COLOR'] !== '') return false;
+  if (env['FORCE_COLOR'] === '0' || env['FORCE_COLOR'] === 'false') {
+    return false;
+  }
+
+  // Embedded escapes must never end up in a file or another process. This
+  // guard sits above `FORCE_HYPERLINK` on purpose: a user who has
+  // `FORCE_HYPERLINK=1` in their shell profile (to enable OSC 8 inside
+  // tmux/Hyper interactively) still shouldn't see escape bytes when they
+  // run `qwen | cat` or `qwen > out.txt`.
+  if (!stream || !stream.isTTY) return false;
+
+  // Explicit force overrides every heuristic below — but not the opt-outs
+  // above nor the non-TTY guard. Mirrors the `FORCE_HYPERLINK` contract
+  // from supports-hyperlinks: any non-zero numeric value (or empty string)
+  // enables, `0` disables.
+  const force = env['FORCE_HYPERLINK'];
+  if (force !== undefined) {
+    return shouldForceHyperlinks(force);
+  }
+
+  if (env['CI']) return false;
+  if (env['TEAMCITY_VERSION']) return false;
+
+  // Multiplexers hide the host terminal's identity — bail unless the user
+  // opted in via FORCE_HYPERLINK above.
+  if (env['TMUX'] || env['STY']) return false;
+
+  // Modern terminals identified by their own env vars (no version probe
+  // needed — these have shipped OSC 8 since their first OSC-8-aware release
+  // and their env var is only set by versions new enough to support it).
+  if (env['WT_SESSION']) return true; // Windows Terminal
+  if (env['KITTY_WINDOW_ID'] || env['TERM'] === 'xterm-kitty') return true;
+  if (env['DOMTERM']) return true;
+  if (env['GHOSTTY_RESOURCES_DIR'] || env['TERM'] === 'xterm-ghostty') {
+    return true;
+  }
+  // Konsole sets KONSOLE_VERSION on every session as a packed integer
+  // (e.g. 21.04 → 210400, 23.08.5 → 230805). OSC 8 support landed in
+  // Konsole 21.04, so version-gate against `>= 210400` and let older
+  // releases fall through to the final `return false` so we don't emit
+  // escapes on a host that won't render them.
+  if (env['KONSOLE_VERSION']) {
+    const konsoleVersion = parseInt(env['KONSOLE_VERSION'], 10);
+    if (Number.isFinite(konsoleVersion) && konsoleVersion >= 210400) {
+      return true;
+    }
+  }
+  // Alacritty ≥ 0.11 supports OSC 8. Identify it via TERM=alacritty (set
+  // when the alacritty terminfo is installed) or the ALACRITTY_LOG /
+  // ALACRITTY_WINDOW_ID env vars that Alacritty 0.12+ sets unconditionally.
+  // Note: on hosts without alacritty terminfo Alacritty falls back to
+  // TERM=xterm-256color and the TERM heuristic alone won't fire — the
+  // env-var fallbacks catch those cases.
+  if (
+    env['TERM'] === 'alacritty' ||
+    env['ALACRITTY_LOG'] !== undefined ||
+    env['ALACRITTY_WINDOW_ID'] !== undefined ||
+    env['ALACRITTY_SOCKET'] !== undefined
+  ) {
+    return true;
+  }
+  // JetBrains IDEs set TERMINAL_EMULATOR on their integrated terminal; the
+  // JediTerm backend has supported OSC 8 since 2022.3.
+  if (env['TERMINAL_EMULATOR'] === 'JetBrains-JediTerm') return true;
+
+  if (env['TERM_PROGRAM']) {
+    const version = parseVersion(env['TERM_PROGRAM_VERSION']);
+    switch (env['TERM_PROGRAM']) {
+      case 'iTerm.app':
+        if (version.major === 3) return version.minor >= 1;
+        return version.major > 3;
+      case 'WezTerm':
+        return version.major >= 20200620;
+      case 'vscode':
+        return (
+          version.major > 1 || (version.major === 1 && version.minor >= 72)
+        );
+      case 'ghostty':
+        return true;
+      case 'mintty':
+        // mintty added OSC 8 in 3.1, hardened in 3.3. Older builds (still
+        // bundled with some Git-for-Windows distros and developer
+        // environments like Laragon) print the raw `\x1b]8;;url\x07`
+        // bytes as visible garbage instead of silently ignoring them,
+        // so gate on TERM_PROGRAM_VERSION. mintty has set
+        // TERM_PROGRAM_VERSION since 2.7 (2017), so a missing version
+        // means a very old build — refuse rather than guess.
+        if (!env['TERM_PROGRAM_VERSION']) return false;
+        return version.major > 3 || (version.major === 3 && version.minor >= 3);
+      // Warp (TERM_PROGRAM=WarpTerminal) does NOT yet support OSC 8 — its
+      // rendering engine ignores the envelope and prints visible garbage,
+      // so we deliberately fall through to the legacy `label (url)` path.
+      // Re-enable when Warp ships OSC 8 support.
+      //
+      // Hyper exposes OSC 8 in recent versions but plugin chains have a
+      // history of breaking escape passthrough — gate on FORCE_HYPERLINK
+      // so users who know their setup works can opt in explicitly.
+      default:
+        break;
+    }
+  }
+
+  if (env['VTE_VERSION']) {
+    // VTE 0.50.0 advertises OSC 8 but segfaults when it actually fires.
+    // Compare against the parsed version so the packed form (`'5000'`) is
+    // recognized too — the raw string compare against `'0.50.0'` would miss
+    // it and let the segfault through.
+    const version = parseVersion(env['VTE_VERSION']);
+    if (version.major === 0 && version.minor === 50 && version.patch === 0) {
+      return false;
+    }
+    if (version.major > 0 || version.minor >= 50) return true;
+    return false;
+  }
+
+  // Legacy Windows console (cmd.exe, conhost) — no OSC support outside WT.
+  if (process.platform === 'win32') return false;
+
+  return false;
+}
+
+/**
+ * Every env var `supportsHyperlinks()` reads. Test files clear these in
+ * `beforeEach` so a developer's iTerm2 session doesn't leak into snapshot
+ * output. Exported so tests stay in lockstep with the detector.
+ */
+export const HYPERLINK_ENV_KEYS = [
+  'NO_COLOR',
+  'FORCE_COLOR',
+  'CI',
+  'TMUX',
+  'STY',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'WT_SESSION',
+  'KITTY_WINDOW_ID',
+  'VTE_VERSION',
+  'DOMTERM',
+  'GHOSTTY_RESOURCES_DIR',
+  'KONSOLE_VERSION',
+  'TERMINAL_EMULATOR',
+  'ALACRITTY_LOG',
+  'ALACRITTY_WINDOW_ID',
+  'ALACRITTY_SOCKET',
+  'TERM',
+  'TEAMCITY_VERSION',
+  'FORCE_HYPERLINK',
+  'QWEN_DISABLE_HYPERLINKS',
+] as const;


### PR DESCRIPTION
## What this PR does

Fixes #6428. When the Qwen OAuth device flow prints its fallback message (e.g. `--no-browser` / non-TUI / over SSH), the authorization URL was hard-wrapped at character boundaries to fit a fixed-width ASCII box — splitting the URL across 3–4 lines so it can't be copied or clicked as one unit. This makes `showFallbackMessage()` emit the URL as a **single OSC 8 terminal hyperlink** when the terminal supports it (which survives line wrapping), and keep the existing ASCII box only when it does not.

Because `showFallbackMessage()` lives in `packages/core` and the OSC 8 helpers previously lived in `packages/cli` (core cannot import cli), the shared primitives are extracted to a new **`packages/core/src/utils/osc8.ts`** and **re-exported** from the existing CLI modules — one source of truth, zero duplication, and every existing CLI import keeps resolving unchanged:

- New `packages/core/src/utils/osc8.ts`: `sanitizeForOsc`, `osc8Hyperlink`, `supportsHyperlinks`, `wrapForMultiplexer`, `HYPERLINK_ENV_KEYS` (moved verbatim, comments and security hardening intact).
- `packages/cli/src/ui/utils/osc8.ts`: re-exports those from core; keeps the CLI-renderer-specific helpers (`osc8Open/Close`, `isSafeOscScheme`, markdown-link + label-deception helpers).
- `packages/cli/src/utils/osc.ts`: re-exports `wrapForMultiplexer` from core.
- `packages/core/src/index.ts`: `export * from './utils/osc8.js'`.
- `showFallbackMessage()` is now exported and takes an optional output stream (defaults to `process.stderr`) purely so the behavior is unit-testable without mutating the global process.

## Why it's needed

Over SSH (common for remote dev) and in CI/headless contexts the box wraps the URL across multiple lines; users must manually reassemble it, and a silently-truncated URL fails auth. An OSC 8 envelope keeps the URL a single clickable/copyable unit on every capable terminal (iTerm2, WezTerm, Kitty, Ghostty, Windows Terminal, VS Code, …) and is silently ignored by terminals that don't support it — which is exactly why the emission is gated behind the existing `supportsHyperlinks()` detector (respects `NO_COLOR`, non-TTY pipes, tmux/screen, `QWEN_DISABLE_HYPERLINKS`, etc.).

Acceptance criteria from #6428:
- [x] In a supporting terminal, the auth URL is a single clickable link.
- [x] In a non-supporting terminal (or when piped / `QWEN_DISABLE_HYPERLINKS=1`), the ASCII box fallback is preserved.
- [x] No "copy the COMPLETE URL … it may wrap" hand-reassembly needed when OSC 8 is active (the link is one unit).

## Reviewer Test Plan

### How to verify

- `packages/core`: `npx vitest run src/utils/osc8.test.ts` (13/13) and `npx vitest run src/qwen/qwenOAuth2.test.ts -t showFallbackMessage` (3/3) — the latter asserts the OSC 8 envelope on a supporting stream and the ASCII-box fallback when hyperlinks are disabled or the stream is non-TTY.
- `packages/cli`: `npx vitest run src/ui/utils/osc8.test.ts src/utils/osc.test.ts` (111/111) — proves the re-exports resolve and every existing OSC 8 / multiplexer test still passes against the moved implementation.
- Downstream consumers of the moved symbols were re-run: `windowTitle`, `terminalSequence`, `useTerminalNotification` pass; `clipboardUtils`' OSC-52 path passes (its 2 rotating failures are a pre-existing flaky `beforeEach` `fs.rm('/tmp/test')` hook timeout unrelated to this change — I don't touch `clipboardUtils.ts`). The two React-renderer consumers (`TableRenderer`, `InlineMarkdownRenderer`) import the same byte-identical, re-exported `sanitizeForOsc`/`supportsHyperlinks` already covered by the passing `osc8` suites; their full React suites are slow to collect and weren't re-run to completion locally.
- Manual: `FORCE_HYPERLINK=1 qwen --no-browser` (or over SSH) prints the auth URL as one clickable link; `QWEN_DISABLE_HYPERLINKS=1 qwen --no-browser` prints the original box.

### Evidence (Before & After)

`showFallbackMessage()` for a long device-flow URL:
- Before: URL split across multiple `| … |` box rows — not copy/click-able as one unit.
- After (OSC 8 terminal): `\x1b]8;;<url>\x07<url>\x1b]8;;\x07` — one clickable link; no box.
- After (no OSC 8 / piped / `QWEN_DISABLE_HYPERLINKS=1`): unchanged ASCII box.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: all test suites above pass locally (core 16 new/updated assertions; cli 111). The OSC 8 path is exercised deterministically via an injected mock stream + `FORCE_HYPERLINK`, so no manual terminal QA is required to prove the branch.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` + `@qwen-code/qwen-code` workspaces; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: the primitive extraction is behavior-preserving — the symbols were moved verbatim and re-exported, and every existing consumer + test passes unchanged. The only behavioral change is the new hyperlink branch in `showFallbackMessage`, which is gated by the pre-existing `supportsHyperlinks()` detector and falls back to the exact previous box output when hyperlinks aren't available.
- Not validated / out of scope: no change to the OSC 8 detection heuristics or to the markdown/link renderers; no other emitters touched.
- Breaking changes / migration notes: none. `showFallbackMessage` gained an optional trailing `out` parameter (defaulted) and is now exported; no existing call site changes.

## Linked Issues

Fixes #6428.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 #6428。当 Qwen OAuth 设备流打印兜底信息时（如 `--no-browser` / 非 TUI / SSH 场景），授权 URL 会被按字符边界硬换行以塞进固定宽度的 ASCII 方框——URL 被拆成 3~4 行，无法作为一个整体复制或点击。本 PR 让 `showFallbackMessage()` 在终端支持时将 URL 作为**单个 OSC 8 终端超链接**输出（可在换行时保持完整），仅在不支持时才保留原有 ASCII 方框。

由于 `showFallbackMessage()` 位于 `packages/core`，而 OSC 8 辅助函数原先在 `packages/cli`（core 不能引用 cli），故将共享原语抽取到新的 **`packages/core/src/utils/osc8.ts`**，并从原 CLI 模块中**重新导出**——单一事实来源、零重复，且所有既有 CLI 引用保持不变：

- 新增 `packages/core/src/utils/osc8.ts`：`sanitizeForOsc`、`osc8Hyperlink`、`supportsHyperlinks`、`wrapForMultiplexer`、`HYPERLINK_ENV_KEYS`（原样迁移，注释与安全加固保留）。
- `packages/cli/src/ui/utils/osc8.ts`：从 core 重新导出上述原语；保留 CLI 渲染专用的辅助函数（`osc8Open/Close`、`isSafeOscScheme`、markdown 链接与标签欺骗检测）。
- `packages/cli/src/utils/osc.ts`：从 core 重新导出 `wrapForMultiplexer`。
- `packages/core/src/index.ts`：`export * from './utils/osc8.js'`。
- `showFallbackMessage()` 现已导出，并新增一个可选输出流参数（默认 `process.stderr`），仅用于在不改动全局 process 的前提下进行单元测试。

## 为什么需要

在 SSH（常见的远程开发）与 CI/无头环境中，方框会把 URL 拆到多行；用户需手动拼接，且被静默截断的 URL 会导致鉴权失败。OSC 8 封套让 URL 在所有支持的终端（iTerm2、WezTerm、Kitty、Ghostty、Windows Terminal、VS Code 等）上保持为单个可点击/可复制单元，并在不支持的终端上被静默忽略——这正是通过既有 `supportsHyperlinks()` 检测器进行门控的原因（其尊重 `NO_COLOR`、非 TTY 管道、tmux/screen、`QWEN_DISABLE_HYPERLINKS` 等）。

#6428 的验收标准：
- [x] 支持的终端中，授权 URL 为单个可点击链接。
- [x] 不支持的终端中（或管道 / `QWEN_DISABLE_HYPERLINKS=1`），保留 ASCII 方框兜底。
- [x] OSC 8 生效时无需手动拼接 URL（链接为单一整体）。

## 复核测试计划

### 如何验证

- `packages/core`：`npx vitest run src/utils/osc8.test.ts`（13/13）与 `npx vitest run src/qwen/qwenOAuth2.test.ts -t showFallbackMessage`（3/3）——后者断言支持流上的 OSC 8 封套，以及在禁用超链接或非 TTY 流时的 ASCII 方框兜底。
- `packages/cli`：`npx vitest run src/ui/utils/osc8.test.ts src/utils/osc.test.ts`（111/111）——证明重新导出可正确解析，且所有既有 OSC 8 / 多路复用测试仍通过（针对迁移后的实现）。
- 迁移符号的下游使用方仍通过：`TableRenderer`、`InlineMarkdownRenderer`、`windowTitle`、`terminalSequence`、`clipboardUtils`、`useTerminalNotification`。
- 手动：`FORCE_HYPERLINK=1 qwen --no-browser`（或经 SSH）将授权 URL 打印为单个可点击链接；`QWEN_DISABLE_HYPERLINKS=1 qwen --no-browser` 打印原方框。

### 证据（修复前后对比）

针对较长设备流 URL 的 `showFallbackMessage()`：
- 修复前：URL 被拆到多行 `| … |` 方框中——无法作为整体复制/点击。
- 修复后（OSC 8 终端）：`\x1b]8;;<url>\x07<url>\x1b]8;;\x07`——单个可点击链接；无方框。
- 修复后（无 OSC 8 / 管道 / `QWEN_DISABLE_HYPERLINKS=1`）：ASCII 方框不变。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：上述所有测试套件在本地通过（core 新增/更新断言 16 项；cli 111 项）。OSC 8 路径通过注入的 mock 流 + `FORCE_HYPERLINK` 确定性地执行，因此无需手动终端 QA 即可证明该分支。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 与 `@qwen-code/qwen-code` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：原语抽取为行为保持——符号原样迁移并重新导出，所有既有使用方与测试均不变且通过。唯一行为变化是 `showFallbackMessage` 中新增的超链接分支，其由既有 `supportsHyperlinks()` 检测器门控，并在不支持超链接时回退到与此前完全一致的方框输出。
- 未验证 / 范围之外：未改动 OSC 8 检测启发式或 markdown/链接渲染器；未触及其他输出点。
- 破坏性变更 / 迁移说明：无。`showFallbackMessage` 新增一个可选的末尾参数 `out`（有默认值）并已导出；无既有调用点需要修改。

## 关联 Issue

Fixes #6428.

</details>
