### PR TITLE
fix(core): strip Qwen-internal daemon secrets from agent-spawned child env

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -322,6 +322,7 @@ export * from './services/usageHistoryService.js';
 export * from './services/usage-dashboard-service.js';
 export * from './utils/bareMode.js';
 export * from './utils/safe-mode.js';
+export * from './utils/sanitize-child-env.js';
 export * from './utils/toolResultDisplayCompaction.js';
 
 // ============================================================================

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -317,6 +317,31 @@ describe('ShellExecutionService', () => {
     return { result, handle, abortController };
   };
 
+  describe('child environment sanitization (#6601)', () => {
+    it('strips Qwen-internal daemon secrets from the pty child env while keeping user vars and third-party credentials', async () => {
+      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
+      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
+      process.env['GH_TOKEN'] = 'gh-abc';
+      process.env['PATH'] = '/usr/bin';
+
+      await simulateExecution('echo hi', (pty) => {
+        pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      });
+
+      const spawnEnv = (
+        mockPtySpawn.mock.calls[0][2] as { env: NodeJS.ProcessEnv }
+      ).env;
+      // Internal daemon secrets must not leak into agent-run commands.
+      expect(spawnEnv['QWEN_SERVER_TOKEN']).toBeUndefined();
+      expect(spawnEnv['QWEN_DAEMON_TOKEN']).toBeUndefined();
+      // Benign vars + third-party credentials user commands rely on are kept.
+      expect(spawnEnv['PATH']).toContain('/usr/bin');
+      expect(spawnEnv['GH_TOKEN']).toBe('gh-abc');
+      // The shell tool's own marker is still applied on top.
+      expect(spawnEnv['QWEN_CODE']).toBe('1');
+    });
+  });
+
   describe('Successful Execution', () => {
     it('should execute a command and capture output', async () => {
       const { result, handle } = await simulateExecution('ls -l', (pty) => {
@@ -2252,6 +2277,32 @@ describe('ShellExecutionService child_process fallback', () => {
     const result = await handle.result;
     return { result, handle, abortController };
   };
+
+  describe('child environment sanitization (#6601)', () => {
+    it('strips Qwen-internal daemon secrets from the child_process env while keeping user vars and third-party credentials', async () => {
+      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
+      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
+      process.env['GH_TOKEN'] = 'gh-abc';
+      process.env['PATH'] = '/usr/bin';
+
+      await simulateExecution('echo hi', (cp) => {
+        cp.emit('exit', 0, null);
+        cp.emit('close', 0, null);
+      });
+
+      const spawnEnv = (
+        mockCpSpawn.mock.calls[0][2] as { env: NodeJS.ProcessEnv }
+      ).env;
+      // Internal daemon secrets must not leak into agent-run commands.
+      expect(spawnEnv['QWEN_SERVER_TOKEN']).toBeUndefined();
+      expect(spawnEnv['QWEN_DAEMON_TOKEN']).toBeUndefined();
+      // Benign vars + third-party credentials user commands rely on are kept.
+      expect(spawnEnv['PATH']).toContain('/usr/bin');
+      expect(spawnEnv['GH_TOKEN']).toBe('gh-abc');
+      // The shell tool's own marker is still applied on top.
+      expect(spawnEnv['QWEN_CODE']).toBe('1');
+    });
+  });
 
   describe('Successful Execution', () => {
     it('should execute a command and capture stdout and stderr', async () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -319,10 +319,15 @@ describe('ShellExecutionService', () => {
 
   describe('child environment sanitization (#6601)', () => {
     it('strips Qwen-internal daemon secrets from the pty child env while keeping user vars and third-party credentials', async () => {
-      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
-      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
-      process.env['GH_TOKEN'] = 'gh-abc';
-      process.env['PATH'] = '/usr/bin';
+      // Replace (not mutate in place): this file restores process.env by
+      // reference in afterEach, so in-place keys would leak to later tests.
+      process.env = {
+        ...originalProcessEnv,
+        QWEN_SERVER_TOKEN: 'serve-secret',
+        QWEN_DAEMON_TOKEN: 'daemon-secret',
+        GH_TOKEN: 'gh-abc',
+        PATH: '/usr/bin',
+      };
 
       await simulateExecution('echo hi', (pty) => {
         pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
@@ -2280,10 +2285,15 @@ describe('ShellExecutionService child_process fallback', () => {
 
   describe('child environment sanitization (#6601)', () => {
     it('strips Qwen-internal daemon secrets from the child_process env while keeping user vars and third-party credentials', async () => {
-      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
-      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
-      process.env['GH_TOKEN'] = 'gh-abc';
-      process.env['PATH'] = '/usr/bin';
+      // Replace (not mutate in place): this file restores process.env by
+      // reference in afterEach, so in-place keys would leak to later tests.
+      process.env = {
+        ...originalProcessEnv,
+        QWEN_SERVER_TOKEN: 'serve-secret',
+        QWEN_DAEMON_TOKEN: 'daemon-secret',
+        GH_TOKEN: 'gh-abc',
+        PATH: '/usr/bin',
+      };
 
       await simulateExecution('echo hi', (cp) => {
         cp.emit('exit', 0, null);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -21,6 +21,7 @@ import {
   type AnsiOutput,
 } from '../utils/terminalSerializer.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
+import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import { getShellContextEnvVars } from '../utils/shellContextEnv.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -764,7 +765,7 @@ export class ShellExecutionService {
         detached: !isWindows,
         windowsHide: isWindows,
         env: {
-          ...normalizePathEnvForWindows(process.env),
+          ...normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
           ...getShellPagerEnv(pager, {
@@ -1467,7 +1468,7 @@ export class ShellExecutionService {
         cols,
         rows,
         env: {
-          ...normalizePathEnvForWindows(process.env),
+          ...normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
           QWEN_CODE: '1',
           TERM: 'xterm-256color',
           ...getShellPagerEnv(shellExecutionConfig.pager, {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2372,6 +2372,27 @@ describe('mcp-client', () => {
       });
     });
 
+    it('strips Qwen-internal daemon secrets from the stdio child env (#6601)', async () => {
+      process.env = {
+        ...ORIGINAL_ENV,
+        QWEN_SERVER_TOKEN: 'serve-secret',
+        QWEN_DAEMON_TOKEN: 'daemon-secret',
+        GH_TOKEN: 'gh-abc',
+      };
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      await createTransport('test-server', { command: 'test-command' }, false);
+
+      const transportEnv = mockedTransport.mock.calls[0]?.[0]?.env ?? {};
+      // Internal daemon secrets must never reach an agent-launched stdio server.
+      expect(transportEnv['QWEN_SERVER_TOKEN']).toBeUndefined();
+      expect(transportEnv['QWEN_DAEMON_TOKEN']).toBeUndefined();
+      // Third-party credentials the server may legitimately need are preserved.
+      expect(transportEnv['GH_TOKEN']).toBe('gh-abc');
+    });
+
     it('should normalize PATH-like env keys on Windows for stdio transport', async () => {
       vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
       process.env = {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -59,6 +59,7 @@ import { getErrorMessage, getErrorStatus } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { retryWithBackoff } from './mcp-retry.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
+import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
 import type {
   Unsubscribe,
   WorkspaceContext,
@@ -2148,7 +2149,7 @@ export async function createTransport(
     // config providing its own PATH fully replaces the parent value instead of
     // being merged with a stale case-variant.
     const env = {
-      ...normalizePathEnvForWindows({ ...process.env }),
+      ...normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
       ...(mcpServerConfig.env || {}),
     };
 

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -745,6 +745,39 @@ describe('MonitorTool', () => {
       expect(spawnOptions.env['GIT_PAGER']).toBeUndefined();
     });
 
+    it('strips Qwen-internal daemon secrets from the monitor child env (#6601)', async () => {
+      const originalServerToken = process.env['QWEN_SERVER_TOKEN'];
+      const originalDaemonToken = process.env['QWEN_DAEMON_TOKEN'];
+      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
+      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
+      try {
+        const invocation = createInvocation({
+          command: 'tail -f /var/log/app.log',
+        });
+
+        await invocation.execute(new AbortController().signal);
+
+        const spawnOptions = mockSpawn.mock.calls[0][2];
+        // Internal daemon secrets must not leak into an agent-run monitor.
+        expect(spawnOptions.env['QWEN_SERVER_TOKEN']).toBeUndefined();
+        expect(spawnOptions.env['QWEN_DAEMON_TOKEN']).toBeUndefined();
+        // Benign inherited env is preserved and the monitor marker still applied.
+        expect(spawnOptions.env['PATH']).toBeDefined();
+        expect(spawnOptions.env['QWEN_CODE']).toBe('1');
+      } finally {
+        if (originalServerToken === undefined) {
+          delete process.env['QWEN_SERVER_TOKEN'];
+        } else {
+          process.env['QWEN_SERVER_TOKEN'] = originalServerToken;
+        }
+        if (originalDaemonToken === undefined) {
+          delete process.env['QWEN_DAEMON_TOKEN'];
+        } else {
+          process.env['QWEN_DAEMON_TOKEN'] = originalDaemonToken;
+        }
+      }
+    });
+
     it('does not spawn when the turn signal is already aborted', async () => {
       const invocation = createInvocation({
         command: 'tail -f /var/log/app.log',

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -56,6 +56,7 @@ import {
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { getShellContextEnvVars } from '../utils/shellContextEnv.js';
 import { getShellPagerEnv } from '../utils/shell-pager-env.js';
+import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
 
 const debugLogger = createDebugLogger('MONITOR');
 
@@ -365,7 +366,7 @@ class MonitorToolInvocation extends BaseToolInvocation<
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: true,
         env: {
-          ...process.env,
+          ...sanitizeChildEnv(process.env),
           QWEN_CODE: '1',
           TERM: 'dumb', // no color codes for streaming
           ...getShellPagerEnv(this.config.getShellExecutionConfig().pager, {

--- a/packages/core/src/utils/sanitize-child-env.test.ts
+++ b/packages/core/src/utils/sanitize-child-env.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  INTERNAL_SECRET_ENV_VARS,
+  sanitizeChildEnv,
+} from './sanitize-child-env.js';
+
+describe('sanitizeChildEnv', () => {
+  it('removes Qwen-internal daemon/server secrets', () => {
+    const result = sanitizeChildEnv({
+      QWEN_SERVER_TOKEN: 'super-secret',
+      QWEN_DAEMON_TOKEN: 'also-secret',
+      PATH: '/usr/bin',
+    });
+    expect(result['QWEN_SERVER_TOKEN']).toBeUndefined();
+    expect(result['QWEN_DAEMON_TOKEN']).toBeUndefined();
+  });
+
+  it('preserves benign vars and third-party credentials that shell workflows need', () => {
+    const result = sanitizeChildEnv({
+      QWEN_SERVER_TOKEN: 'super-secret',
+      PATH: '/usr/bin',
+      GH_TOKEN: 'gh-abc',
+      GITHUB_TOKEN: 'gh-def',
+      AWS_ACCESS_KEY_ID: 'aws-key',
+      NPM_TOKEN: 'npm-tok',
+      HOME: '/home/user',
+    });
+    expect(result['PATH']).toBe('/usr/bin');
+    expect(result['GH_TOKEN']).toBe('gh-abc');
+    expect(result['GITHUB_TOKEN']).toBe('gh-def');
+    expect(result['AWS_ACCESS_KEY_ID']).toBe('aws-key');
+    expect(result['NPM_TOKEN']).toBe('npm-tok');
+    expect(result['HOME']).toBe('/home/user');
+  });
+
+  it('does not mutate the input environment', () => {
+    const source: NodeJS.ProcessEnv = {
+      QWEN_SERVER_TOKEN: 'super-secret',
+      PATH: '/usr/bin',
+    };
+    sanitizeChildEnv(source);
+    expect(source['QWEN_SERVER_TOKEN']).toBe('super-secret');
+  });
+
+  it('returns a fresh object each call', () => {
+    const source: NodeJS.ProcessEnv = { PATH: '/usr/bin' };
+    const a = sanitizeChildEnv(source);
+    const b = sanitizeChildEnv(source);
+    expect(a).not.toBe(source);
+    expect(a).not.toBe(b);
+  });
+
+  it('is a no-op for an env without internal secrets', () => {
+    const result = sanitizeChildEnv({ PATH: '/usr/bin', GH_TOKEN: 'x' });
+    expect(result).toEqual({ PATH: '/usr/bin', GH_TOKEN: 'x' });
+  });
+
+  it('keeps the denylist scoped to internal secrets only', () => {
+    // Guardrail: this list must not grow to include third-party credentials,
+    // which the shell tool legitimately inherits (see #6601 discussion).
+    expect([...INTERNAL_SECRET_ENV_VARS].sort()).toEqual([
+      'QWEN_DAEMON_TOKEN',
+      'QWEN_SERVER_TOKEN',
+    ]);
+  });
+});

--- a/packages/core/src/utils/sanitize-child-env.ts
+++ b/packages/core/src/utils/sanitize-child-env.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Env vars that carry Qwen-internal daemon/server bearer credentials. These
+ * must never be inherited by a child process the agent launches on the user's
+ * behalf — shell commands, the monitor tool, or a stdio MCP server — because
+ * no legitimate user command needs them and leaking them to arbitrary
+ * agent-run commands is a credential-exposure gap (issue #6601).
+ *
+ * `QWEN_SERVER_TOKEN` is the serve-daemon bearer token and `QWEN_DAEMON_TOKEN`
+ * is the channel-daemon worker token; the daemon worker already scrubs both
+ * from its own `process.env` after reading them.
+ *
+ * This denylist is intentionally NARROW: it strips only Qwen-internal secrets,
+ * NOT third-party credentials such as `GH_TOKEN`, `AWS_*`, or `NPM_TOKEN`.
+ * Real shell workflows legitimately depend on inheriting those (`gh`, the AWS
+ * CLI, `npm publish`, …), so stripping them here would break user commands.
+ * Broader third-party-credential stripping stays scoped to the sandbox / MCP
+ * infrastructure paths where it already lives.
+ */
+export const INTERNAL_SECRET_ENV_VARS: readonly string[] = [
+  'QWEN_SERVER_TOKEN',
+  'QWEN_DAEMON_TOKEN',
+];
+
+/**
+ * Return a shallow copy of `env` with Qwen-internal daemon/server secrets
+ * removed, so it is safe to pass to a child process spawned on the user's
+ * behalf. Does not mutate the input.
+ *
+ * @param env The source environment (defaults to `process.env`).
+ */
+export function sanitizeChildEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const sanitized: NodeJS.ProcessEnv = { ...env };
+  for (const key of INTERNAL_SECRET_ENV_VARS) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}


### PR DESCRIPTION
## What this PR does

Fixes #6601. Shell subprocesses (and the monitor tool and stdio MCP servers) spawned by Qwen Code inherited the **full** daemon `process.env`, including `QWEN_SERVER_TOKEN` — the serve-daemon bearer credential. An agent-run command like `printenv QWEN_SERVER_TOKEN` could therefore read an internal secret it should never see.

This adds a small shared `sanitizeChildEnv()` in `packages/core/src/utils/` that removes Qwen-internal daemon/server secrets from an env before it is handed to a child process, and applies it at the four spawn sites that inherit `process.env`:

- `services/shellExecutionService.ts` — the `child_process` fallback **and** the PTY path
- `tools/monitor.ts` — the monitor command spawn
- `tools/mcp-client.ts` — the stdio MCP transport

The denylist is **deliberately narrow** — only internal bearer tokens:

```
INTERNAL_SECRET_ENV_VARS = ['QWEN_SERVER_TOKEN', 'QWEN_DAEMON_TOKEN']
```

Per the maintainer's design guidance on the issue, it does **not** reuse the desktop `BLOCKED_ENV_VARS` denylist, and it intentionally does **not** strip third-party credentials (`GH_TOKEN`/`GITHUB_TOKEN`, `AWS_*`, `NPM_TOKEN`, …): the shell tool exists to run whatever the user asks, and real workflows (`gh`, the AWS CLI, `npm publish`) legitimately depend on inheriting those. Stripping only Qwen-internal secrets is pure upside with no workflow breakage. `sanitizeChildEnv` is exported from the package root so the desktop denylists can consolidate onto it as a follow-up.

## Why it's needed

`QWEN_SERVER_TOKEN` is the serve-daemon bearer token (`packages/cli/src/serve/auth.ts`); `QWEN_DAEMON_TOKEN` is the channel-daemon worker token (the daemon worker already scrubs both from its own `process.env`). Leaking either to arbitrary agent-run commands is a defense-in-depth credential-exposure gap — filed and confirmed as P1. This PR covers the four spawn sites in the scope agreed on #6601 — the shell tool's PTY and `child_process` paths, the monitor tool, and the stdio-MCP transport. Two more same-trust-class paths (`tools/tool-registry.ts` tool-call/discovery spawns and `hooks/hookRunner.ts` command hooks) also inherit the full env and are intentionally deferred to a follow-up (see Risk & Scope).

## Reviewer Test Plan

### How to verify

- `npx vitest run src/utils/sanitize-child-env.test.ts` (6/6): asserts the two internal tokens are removed while `PATH`, `GH_TOKEN`, `GITHUB_TOKEN`, `AWS_ACCESS_KEY_ID`, `NPM_TOKEN`, `HOME` survive; input is not mutated; and a guardrail test pins the denylist to exactly the two internal vars so it can't silently grow to include third-party creds.
- `npx vitest run src/services/shellExecutionService.test.ts` (132/132): includes a new regression test in **both** the PTY and `child_process` describe blocks asserting the spawn env has no `QWEN_SERVER_TOKEN`/`QWEN_DAEMON_TOKEN`, while `PATH`, `GH_TOKEN`, and the tool's own `QWEN_CODE=1` marker are present.
- `npx vitest run src/tools/monitor.test.ts` (80/80) and `src/tools/mcp-client.test.ts` (102/102): unchanged — confirms the one-line env wraps didn't regress those spawn paths.

### Evidence (Before & After)

Shell spawn env (`printenv QWEN_SERVER_TOKEN` in an agent-run command):
- Before: `...normalizePathEnvForWindows(process.env)` → child inherits `QWEN_SERVER_TOKEN`; the command prints the daemon bearer token.
- After: `...normalizePathEnvForWindows(sanitizeChildEnv(process.env))` → `QWEN_SERVER_TOKEN`/`QWEN_DAEMON_TOKEN` absent; `PATH`, `GH_TOKEN`, `AWS_*`, `NPM_TOKEN` still inherited.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS: the four suites above pass locally (320 tests across the changed files). The shell child env is asserted deterministically via the mocked pty/child_process spawn, so no manual QA is required.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: the change removes exactly two Qwen-internal token vars from child envs and nothing else — no third-party credential is stripped, so `gh`/AWS/`npm` and similar workflows are unaffected. All existing tests for the four touched spawn paths pass unchanged.
- Deferred to a follow-up (same trust class, not covered here): `tools/tool-registry.ts` (the `toolCallCommand`/`toolDiscoveryCommand` spawns pass no `env`, inheriting everything) and `hooks/hookRunner.ts` (command hooks spread full `process.env`). The identical one-line `sanitizeChildEnv(process.env)` wrap applies; kept out of this PR to hold scope to the #6601-agreed sites.
- Not validated / out of scope: broader third-party-credential stripping for the sandbox/MCP infrastructure paths stays where it already lives; consolidating the duplicated desktop `BLOCKED_ENV_VARS` lists onto the shared util is a suggested follow-up, not done here.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #6601. Implementation follows the design outlined by @doudouOUC on the issue (narrow internal-secrets denylist, applied at the shell/monitor/MCP-stdio spawn sites, third-party creds left inherited).

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 #6601。Qwen Code 启动的 shell 子进程（以及 monitor 工具、stdio MCP 服务）会继承**完整**的守护进程 `process.env`，其中包含 `QWEN_SERVER_TOKEN`——serve 守护进程的 bearer 凭证。因此像 `printenv QWEN_SERVER_TOKEN` 这样由 agent 执行的命令能读到本不该看到的内部密钥。

本 PR 在 `packages/core/src/utils/` 新增一个小的共享 `sanitizeChildEnv()`，在把 env 交给子进程前移除 Qwen 内部守护/服务密钥，并应用于四处继承 `process.env` 的 spawn 点：

- `services/shellExecutionService.ts`——`child_process` 兜底路径**与** PTY 路径
- `tools/monitor.ts`——monitor 命令 spawn
- `tools/mcp-client.ts`——stdio MCP 传输

denylist **刻意保持狭窄**——仅内部 bearer token：

```
INTERNAL_SECRET_ENV_VARS = ['QWEN_SERVER_TOKEN', 'QWEN_DAEMON_TOKEN']
```

按照 issue 上维护者的设计意见，它**不**复用桌面端的 `BLOCKED_ENV_VARS`，也**不**剥离第三方凭证（`GH_TOKEN`/`GITHUB_TOKEN`、`AWS_*`、`NPM_TOKEN` 等）：shell 工具的存在就是为了运行用户所要求的任何命令，而真实工作流（`gh`、AWS CLI、`npm publish`）确实依赖继承这些凭证。仅剥离 Qwen 内部密钥是纯收益、不会破坏工作流。`sanitizeChildEnv` 从包根导出，便于后续将桌面端 denylist 收敛到它之上。

## 为什么需要

`QWEN_SERVER_TOKEN` 是 serve 守护进程 bearer token（`packages/cli/src/serve/auth.ts`）；`QWEN_DAEMON_TOKEN` 是 channel 守护 worker token（守护 worker 已在其自身 `process.env` 中清除二者）。将任一泄露给任意 agent 执行的命令是纵深防御上的凭证暴露缺口——已被确认为 P1。本 PR 覆盖 #6601 商定范围内的四个 spawn 点——shell 工具的 PTY 与 `child_process` 路径、monitor 工具，以及 stdio-MCP 传输。另有两处同一信任级别的路径（`tools/tool-registry.ts` 的 tool-call/discovery spawn，以及 `hooks/hookRunner.ts` 的命令 hook）同样继承完整 env，特意留待后续 PR 处理（见「风险与范围」）。

## 复核测试计划

### 如何验证

- `npx vitest run src/utils/sanitize-child-env.test.ts`（6/6）：断言两个内部 token 被移除，而 `PATH`、`GH_TOKEN`、`GITHUB_TOKEN`、`AWS_ACCESS_KEY_ID`、`NPM_TOKEN`、`HOME` 保留；输入不被修改；并有一个护栏测试将 denylist 固定为恰好两个内部变量，防止其悄然扩张纳入第三方凭证。
- `npx vitest run src/services/shellExecutionService.test.ts`（132/132）：在 PTY 与 `child_process` **两个** describe 块中各新增一个回归测试，断言 spawn env 中无 `QWEN_SERVER_TOKEN`/`QWEN_DAEMON_TOKEN`，而 `PATH`、`GH_TOKEN` 及工具自身的 `QWEN_CODE=1` 标记均在。
- `npx vitest run src/tools/monitor.test.ts`（80/80）与 `src/tools/mcp-client.test.ts`（102/102）：保持通过——确认单行 env 包装未回归这些 spawn 路径。

### 证据（修复前后对比）

shell spawn env（agent 执行的命令中 `printenv QWEN_SERVER_TOKEN`）：
- 修复前：`...normalizePathEnvForWindows(process.env)` → 子进程继承 `QWEN_SERVER_TOKEN`；命令打印出守护 bearer token。
- 修复后：`...normalizePathEnvForWindows(sanitizeChildEnv(process.env))` → `QWEN_SERVER_TOKEN`/`QWEN_DAEMON_TOKEN` 不再存在；`PATH`、`GH_TOKEN`、`AWS_*`、`NPM_TOKEN` 仍被继承。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

macOS：上述四个套件在本地通过（改动文件共 320 个测试）。shell 子进程 env 通过 mock 的 pty/child_process spawn 确定性断言，无需人工 QA。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：本改动仅从子进程 env 移除恰好两个 Qwen 内部 token 变量，别无其他——不剥离任何第三方凭证，故 `gh`/AWS/`npm` 等工作流不受影响。四处受影响 spawn 路径的既有测试均不变通过。
- 留待后续（同一信任级别，本 PR 未覆盖）：`tools/tool-registry.ts`（`toolCallCommand`/`toolDiscoveryCommand` 的 spawn 未传 `env`，继承全部）与 `hooks/hookRunner.ts`（命令 hook 展开完整 `process.env`）。同样的一行 `sanitizeChildEnv(process.env)` 包装即可修复；为将范围收敛到 #6601 商定的站点而未纳入本 PR。
- 未验证 / 范围之外：面向 sandbox/MCP 基础设施路径的更广第三方凭证剥离维持原处；将重复的桌面端 `BLOCKED_ENV_VARS` 收敛到共享 util 为后续建议项，本 PR 未做。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #6601。实现遵循 @doudouOUC 在 issue 上给出的设计（狭窄的内部密钥 denylist，应用于 shell/monitor/MCP-stdio spawn 点，第三方凭证保留继承）。

</details>


