### PR TITLE
fix(sdk): abort SSE request on iterator exit to release daemon subscriber

### DIFF
--- a/packages/sdk-typescript/src/daemon/RestSseTransport.ts
+++ b/packages/sdk-typescript/src/daemon/RestSseTransport.ts
@@ -83,15 +83,23 @@ export class RestSseTransport implements DaemonTransport {
       headers['Last-Event-ID'] = String(opts.lastEventId);
     }
 
-    // Connect-phase timeout (request → headers received). The SSE
-    // body itself is long-lived and must NOT be timed out.
-    const connectCtrl = new AbortController();
+    // Request-lifetime controller. It drives the connect-phase timeout
+    // (request → headers received) AND owns teardown of the long-lived
+    // SSE body: aborting it in the `finally` around the `yield*` below
+    // releases the underlying fetch/TCP connection when the consumer
+    // exits the iterator for any reason (break, return, throw, or normal
+    // end), even when no caller signal was supplied. Without this,
+    // `reader.cancel()` alone does not reliably close the connection on
+    // some runtimes (e.g. Bun), leaking the daemon-side EventBus
+    // subscriber. The SSE body must NOT be timed out, so the connect
+    // timer only fires before headers arrive.
+    const requestCtrl = new AbortController();
     let connectTimer: ReturnType<typeof setTimeout> | undefined;
     const connectTimeoutMs = opts.connectTimeoutMs;
     if (connectTimeoutMs && Number.isFinite(connectTimeoutMs)) {
       connectTimer = setTimeout(
         () =>
-          connectCtrl.abort(
+          requestCtrl.abort(
             new DOMException('Initial connect timed out', 'TimeoutError'),
           ),
         connectTimeoutMs,
@@ -106,8 +114,8 @@ export class RestSseTransport implements DaemonTransport {
     }
 
     const fetchSignal = opts.signal
-      ? composeAbortSignals([opts.signal, connectCtrl.signal])
-      : connectCtrl.signal;
+      ? composeAbortSignals([opts.signal, requestCtrl.signal])
+      : requestCtrl.signal;
 
     // Build the SSE URL, optionally with `?maxQueued=N`.
     let url = `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/events`;
@@ -166,7 +174,16 @@ export class RestSseTransport implements DaemonTransport {
       throw new Error('No SSE body');
     }
 
-    yield* parseSseStream(res.body, opts.signal);
+    // Pass the composed signal (caller + request controller) to the
+    // parser, and abort the request controller when the iterator exits
+    // for any reason. This tears down the underlying fetch/TCP
+    // connection and releases the daemon EventBus subscriber regardless
+    // of whether the caller supplied `opts.signal`.
+    try {
+      yield* parseSseStream(res.body, fetchSignal);
+    } finally {
+      requestCtrl.abort();
+    }
   }
 
   dispose(): void {

--- a/packages/sdk-typescript/test/unit/RestSseTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/RestSseTransport.test.ts
@@ -403,6 +403,50 @@ describe('RestSseTransport', () => {
       // Either way, no events should be yielded
       expect(events).toHaveLength(0);
     });
+
+    it('aborts the underlying fetch when the consumer breaks early without a caller signal', async () => {
+      // Regression for #7238: a consumer that opens a subscription,
+      // receives an event, and `break`s out — without supplying
+      // opts.signal — must still tear down the fetch/TCP connection so
+      // the daemon EventBus subscriber is released. Previously the
+      // request-lifetime controller was never aborted on normal iterator
+      // exit, so the fetch signal stayed unaborted and the connection
+      // leaked.
+      const frames = [
+        'data: {"type":"a","data":{},"id":1,"v":1}\n\n',
+        'data: {"type":"b","data":{},"id":2,"v":1}\n\n',
+      ].join('');
+      const { fetch, calls } = recordingFetch(() => sseResponse(frames));
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+
+      const events: unknown[] = [];
+      for await (const event of transport.subscribeEvents('s1')) {
+        events.push(event);
+        break; // exit after the first event, no caller signal
+      }
+
+      expect(events).toHaveLength(1);
+      expect(calls[0].signal).not.toBeNull();
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
+
+    it('aborts the underlying fetch after the stream completes normally', async () => {
+      // The request-lifetime controller must be aborted on every exit
+      // path, including normal end-of-stream, so no fetch/TCP connection
+      // is left dangling.
+      const { fetch, calls } = recordingFetch(() =>
+        sseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+
+      const events: unknown[] = [];
+      for await (const event of transport.subscribeEvents('s1')) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
   });
 
   // ---- dispose() --------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Makes the default REST+SSE daemon transport reliably release its underlying HTTP connection when a consumer stops reading the event stream. The transport's `subscribeEvents()` now treats the AbortController it creates as owning the whole request lifetime: the composed signal (caller signal + request controller) is passed to the SSE parser, and the request controller is aborted in a `finally` around the stream, so the connection is torn down on every exit path — `break`, `return`, `throw`, or normal end-of-stream. Connect-timeout and caller-abort behavior are unchanged.

## Why it's needed

`RestSseTransport.subscribeEvents()` created a connect-phase `AbortController` but never aborted it once the SSE body was streaming, and it delegated only `opts.signal` to `parseSseStream`. When a consumer exits the async iterator normally without supplying its own signal — a common pattern of "subscribe, wait for the event I need, then `break`" — nothing aborts the underlying `fetch`, so the fetch/TCP connection stays open and the daemon-side EventBus subscriber leaks. Each completed turn can leak one subscriber; once the 64-subscriber cap is reached, `GET /session/:id/events` returns HTTP 429 and every client that depends on the daemon event stream stops receiving turn/completion events until the daemon is restarted. Relying on `reader.cancel()` alone does not reliably close the connection on some runtimes (observed on Bun), so the transport must own the teardown itself.

## Reviewer Test Plan

### How to verify

Run the SDK transport unit tests:

```
npx vitest run --root packages/sdk-typescript test/unit/RestSseTransport.test.ts
```

Two new regression tests assert that the signal handed to `fetch` is aborted after the consumer exits the iterator:
- exits early via `break` without providing `opts.signal`
- consumes the stream to normal completion

Both **fail on the current code** (the fetch signal is never aborted → `expected false to be true`) and **pass with this change**. Expected vs observed: after a normal iterator exit the transport-owned request signal must be `aborted === true`; before this change it stayed `false`, leaving the connection (and daemon subscriber) alive.

### Evidence (Before & After)

N/A — non-user-visible SDK transport fix. Verification is the unit tests above.

Before (fix reverted, new tests run against old source):
```
Test Files  1 failed (1)
     Tests  2 failed | 28 skipped (30)
 ❯ RestSseTransport.test.ts:448  expected false to be true
```
After:
```
Test Files  1 passed (1)
     Tests  30 passed (30)
```
Full `packages/sdk-typescript` suite with the change: `30 passed (30) files, 1378 passed (1378) tests`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest). No daemon runtime required.

## Risk & Scope

- Main risk or tradeoff: The request controller is now aborted on every iterator exit. Aborting after a stream has already ended is idempotent and harmless; the change does not alter connect-timeout or caller-supplied-signal semantics (those paths are covered by existing tests, all still green).
- Not validated / out of scope: The reporter's 65-cycle Bun soak test is not reproduced in CI; correctness is proven at the unit level by asserting the fetch signal is aborted on exit. No changes to ACP/WS transports.
- Breaking changes / migration notes: None. Public API and behavior for callers that already pass a signal are unchanged.

## Linked Issues

Fixes #7238

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让默认的 REST+SSE daemon 传输在消费者停止读取事件流时可靠地释放其底层 HTTP 连接。传输层的 `subscribeEvents()` 现在把它创建的 AbortController 视为拥有整个请求生命周期：将组合后的 signal（调用方 signal + 请求 controller）传给 SSE 解析器，并在包裹流的 `finally` 中 abort 该请求 controller，因此无论以何种方式退出——`break`、`return`、`throw` 或正常读到流结束——连接都会被拆除。连接超时和调用方 abort 的行为保持不变。

## 为什么需要它

`RestSseTransport.subscribeEvents()` 创建了一个连接阶段的 `AbortController`，但在 SSE body 开始流式传输后从未 abort 它，并且只把 `opts.signal` 传给 `parseSseStream`。当消费者在不提供自己 signal 的情况下正常退出异步迭代器时——即常见的"订阅、等待需要的事件、然后 `break`"模式——没有任何东西会 abort 底层的 `fetch`，因此 fetch/TCP 连接保持打开，daemon 端的 EventBus 订阅者发生泄漏。每个完成的 turn 都可能泄漏一个订阅者；一旦达到 64 个订阅者上限，`GET /session/:id/events` 就会返回 HTTP 429，所有依赖 daemon 事件流的客户端将无法再收到 turn/完成事件，直到 daemon 重启。仅依赖 `reader.cancel()` 在某些运行时（在 Bun 上观察到）不能可靠地关闭连接，因此传输层必须自己负责拆除。

## Reviewer Test Plan

### 如何验证

运行 SDK 传输单元测试：

```
npx vitest run --root packages/sdk-typescript test/unit/RestSseTransport.test.ts
```

两个新增的回归测试断言在消费者退出迭代器后，传给 `fetch` 的 signal 已被 abort：
- 在不提供 `opts.signal` 的情况下通过 `break` 提前退出
- 将流读取到正常结束

两者在**当前代码上均失败**（fetch signal 从未被 abort → `expected false to be true`），在本次改动后**通过**。期望与观察：正常退出迭代器后，传输层拥有的请求 signal 必须为 `aborted === true`；改动前它保持 `false`，导致连接（及 daemon 订阅者）继续存活。

### 证据（Before & After）

N/A——非用户可见的 SDK 传输修复。验证方式为上述单元测试。

改动前（还原修复，用旧源码运行新测试）：
```
Test Files  1 failed (1)
     Tests  2 failed | 28 skipped (30)
 ❯ RestSseTransport.test.ts:448  expected false to be true
```
改动后：
```
Test Files  1 passed (1)
     Tests  30 passed (30)
```
带本次改动的完整 `packages/sdk-typescript` 测试套件：`30 passed (30) 个文件，1378 passed (1378) 个测试`。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试（vitest），无需 daemon 运行时。

## 风险与范围

- 主要风险或权衡：请求 controller 现在会在每次迭代器退出时被 abort。在流已经结束后再 abort 是幂等且无害的；该改动不改变连接超时或调用方提供 signal 的语义（这些路径由现有测试覆盖，全部仍为绿色）。
- 未验证／超出范围：未在 CI 中复现报告者的 65 次循环 Bun 压测；正确性通过在单元层面断言退出时 fetch signal 已被 abort 来证明。未改动 ACP/WS 传输。
- 破坏性变更／迁移说明：无。公开 API 以及已经传入 signal 的调用方行为保持不变。

## 关联 Issue

Fixes #7238

</details>
