### PR TITLE
fix(cli): yield to single-slot background agents

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -259,6 +259,8 @@ describe('useGeminiStream', () => {
       getEmitToolUseSummaries: vi.fn(() => false),
       getFastModel: vi.fn(() => undefined),
       getBackgroundTaskRegistry: vi.fn(() => ({
+        canStartBackgroundAgent: vi.fn(() => true),
+        getMaxConcurrentBackgroundAgents: vi.fn(() => 10),
         setNotificationCallback: vi.fn(),
       })),
       getBackgroundShellRegistry: vi.fn(() => mockBackgroundShellRegistry),
@@ -1264,6 +1266,155 @@ describe('useGeminiStream', () => {
       'prompt-id-2',
       { type: SendMessageType.ToolResult },
     );
+  });
+
+  it('waits for a background agent when its launch exhausts capacity', async () => {
+    const responseParts: Part[] = [
+      {
+        functionResponse: {
+          id: 'agent-call',
+          name: 'agent',
+          response: { result: 'Background agent launched successfully.' },
+        },
+      },
+    ];
+    let notificationCallback:
+      | ((displayText: string, modelText: string) => void)
+      | undefined;
+    const getMaxConcurrentBackgroundAgents = vi.fn(() => 1);
+    mockConfig.getBackgroundTaskRegistry = vi.fn(() => ({
+      canStartBackgroundAgent: vi.fn(() => false),
+      getMaxConcurrentBackgroundAgents,
+      setNotificationCallback: vi.fn((callback) => {
+        notificationCallback = callback;
+      }),
+    })) as Config['getBackgroundTaskRegistry'];
+
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+
+    const client = new MockedGeminiClientClass(mockConfig);
+    renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        true,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+
+    await waitFor(() => expect(notificationCallback).toBeDefined());
+    await act(async () => {
+      await capturedOnComplete?.([
+        {
+          request: {
+            callId: 'agent-call',
+            name: 'agent',
+            args: { run_in_background: true },
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-agent',
+          },
+          status: 'success',
+          responseSubmittedToGemini: false,
+          response: {
+            callId: 'agent-call',
+            responseParts,
+            errorType: undefined,
+            resultDisplay: {
+              type: 'task_execution',
+              subagentName: 'researcher',
+              taskDescription: 'Research',
+              taskPrompt: 'Inspect the code',
+              status: 'background',
+            },
+          },
+          tool: { displayName: 'Agent' },
+          invocation: {
+            getDescription: () => 'Research',
+          } as unknown as AnyToolInvocation,
+        } as TrackedCompletedToolCall,
+      ]);
+    });
+
+    expect(mockMarkToolsAsSubmitted).toHaveBeenCalledWith(['agent-call']);
+    expect(client.addHistory).toHaveBeenCalledWith({
+      role: 'user',
+      parts: responseParts,
+    });
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+
+    act(() => {
+      notificationCallback?.(
+        'Background agent completed.',
+        '<task-notification>done</task-notification>',
+      );
+    });
+
+    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalledOnce());
+    expect(mockSendMessageStream).toHaveBeenCalledWith(
+      '<task-notification>done</task-notification>',
+      expect.any(AbortSignal),
+      expect.any(String),
+      expect.objectContaining({ type: SendMessageType.Notification }),
+    );
+
+    mockSendMessageStream.mockClear();
+    client.addHistory.mockClear();
+    getMaxConcurrentBackgroundAgents.mockReturnValue(2);
+    await act(async () => {
+      await capturedOnComplete?.([
+        {
+          request: {
+            callId: 'agent-call-2',
+            name: 'agent',
+            args: { run_in_background: true },
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-agent-2',
+          },
+          status: 'success',
+          responseSubmittedToGemini: false,
+          response: {
+            callId: 'agent-call-2',
+            responseParts,
+            errorType: undefined,
+            resultDisplay: {
+              type: 'task_execution',
+              subagentName: 'researcher',
+              taskDescription: 'Research',
+              taskPrompt: 'Inspect the code',
+              status: 'background',
+            },
+          },
+          tool: { displayName: 'Agent' },
+          invocation: {
+            getDescription: () => 'Research',
+          } as unknown as AnyToolInvocation,
+        } as TrackedCompletedToolCall,
+      ]);
+    });
+
+    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalledOnce());
+    expect(client.addHistory).not.toHaveBeenCalled();
   });
 
   it('records mid-turn queued user messages after tool results accept them', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3463,6 +3463,27 @@ export const useGeminiStream = (
         return;
       }
 
+      const backgroundTaskRegistry = config.getBackgroundTaskRegistry();
+      const backgroundLaunchExhaustedCapacity =
+        backgroundTaskRegistry.getMaxConcurrentBackgroundAgents() === 1 &&
+        !backgroundTaskRegistry.canStartBackgroundAgent() &&
+        geminiTools.some((toolCall) => {
+          const display = toolCall.response.resultDisplay;
+          return (
+            toolCall.request.name === ToolNames.AGENT &&
+            typeof display === 'object' &&
+            display !== null &&
+            'type' in display &&
+            'status' in display &&
+            display.type === 'task_execution' &&
+            display.status === 'background'
+          );
+        });
+      if (backgroundLaunchExhaustedCapacity) {
+        geminiClient?.addHistory({ role: 'user', parts: responsesToSend });
+        return;
+      }
+
       // Drain steerable user messages at this sampling boundary and append
       // them after the tool responses as genuine user content.
       // Skip if the turn was cancelled — messages stay in queue for next turn.

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -483,6 +483,7 @@ describe('BackgroundTaskRegistry', () => {
       registry = new BackgroundTaskRegistry({
         maxConcurrentBackgroundAgents: 2,
       });
+      expect(registry.getMaxConcurrentBackgroundAgents()).toBe(2);
 
       registry.register(makeRegistration('bg-1'));
       registry.register(makeRegistration('bg-2'));

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -530,6 +530,10 @@ export class BackgroundTaskRegistry {
     return true;
   }
 
+  getMaxConcurrentBackgroundAgents(): number {
+    return this.maxConcurrentBackgroundAgents;
+  }
+
   assertCanStartBackgroundAgent(model?: string): void {
     const claimed = this.getClaimedBackgroundSlotCount();
     if (claimed >= this.maxConcurrentBackgroundAgents) {


### PR DESCRIPTION
## What this PR does

When a background subagent takes the only available background slot, the interactive main agent now saves the tool result and waits. The subagent's completion notification resumes the conversation. Configurations with more than one background slot keep the current immediate follow-up behavior.

## Why it's needed

On a single-slot local endpoint such as llama.cpp, the main agent can otherwise start another request before the subagent gets inference time. The main agent waits for the delegated result while the subagent waits for the same occupied slot, which makes the session appear stuck. Fixes #7254.

## Reviewer Test Plan

### How to verify

Set background-agent concurrency to `1`, launch an agent with `run_in_background: true`, and confirm that the result is recorded without another main-model request. Completing the subagent should trigger exactly one request through its notification. With concurrency set to `2`, the immediate follow-up should still occur.

Focused command: `npx vitest run packages/core/src/agents/background-tasks.test.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx` (268 tests passed). Build, typecheck, lint, Prettier, and `git diff --check` also pass.

The repository-wide preflight reached the test stage after build/typecheck/lint succeeded. Seven unrelated tests failed: two path assertions do not handle this checkout's space-containing absolute path, and five auth-dialog navigation cases were timing-sensitive in the parallel run. Rerunning the affected unrelated files reproduced the path issue and one auth timing failure; both changed suites remain green.

### Evidence (Before & After)

Before, the regression test observes a main-model call immediately after the background launch. After, it observes no call until the completion notification, then exactly one call. The two-slot control still continues immediately. I could not record a live llama.cpp run because this environment does not have a compatible single-slot endpoint.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node.js 22.22.1, npm 10.9.4, Vitest; no live llama.cpp endpoint.

## Risk & Scope

- Main risk or tradeoff: with one slot, the main agent intentionally waits for the background completion notification.
- Not validated / out of scope: a live llama.cpp run, non-interactive/ACP paths, and policy changes for two or more slots.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7254

<details>
<summary>中文说明</summary>

## 本 PR 的作用

当后台子代理占用唯一可用的后台槽位时，交互式主代理现在会保存工具结果并等待。子代理完成后，其通知会恢复对话。后台槽位多于一个的配置仍保持现有的立即后续请求行为。

## 为什么需要此改动

在 llama.cpp 等单槽位本地端点上，主代理可能会在子代理获得推理时间之前发起另一个请求。主代理等待委派结果，子代理则等待同一个被占用的槽位，因此会话看起来像是卡住了。修复 #7254。

## 审查者测试计划

### 验证方法

将后台代理并发设为 `1`，使用 `run_in_background: true` 启动代理，并确认结果已记录但主模型不会立即再次请求。子代理完成后，其通知应恰好触发一次请求。将并发设为 `2` 时，仍应立即继续。

聚焦命令：`npx vitest run packages/core/src/agents/background-tasks.test.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx`（268 个测试通过）。构建、类型检查、lint、Prettier 和 `git diff --check` 也均通过。

仓库全量 preflight 在构建、类型检查和 lint 成功后进入测试阶段。共有 7 个无关测试失败：两个路径断言无法处理当前检出目录中带空格的绝对路径，五个认证对话框导航用例在并行运行中出现时序波动。单独重跑这些无关文件时复现了路径问题和一个认证时序失败；两个改动相关测试套件仍全部通过。

### 证据（改动前后）

改动前，回归测试会在后台代理启动后立即观察到一次主模型调用。改动后，完成通知之前没有调用，通知到达后恰好调用一次。双槽位对照仍会立即继续。由于此环境没有兼容的单槽位 llama.cpp 端点，因此无法录制实时运行。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ⚠️  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ✅  |

### 环境（可选）

Node.js 22.22.1、npm 10.9.4、Vitest；未使用实时 llama.cpp 端点。

## 风险与范围

- 主要风险或取舍：单槽位配置会有意等待后台完成通知。
- 未验证 / 不在范围内：实时 llama.cpp 运行、非交互式/ACP 路径，以及两个或更多槽位的策略变更。
- 破坏性变更 / 迁移说明：无。

## 关联问题

Fixes #7254

</details>
