### PR TITLE
fix(cli): repaint the TUI after OS sleep/wake or SIGCONT

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -118,6 +118,7 @@ const STARTUP_PROFILE_FINALIZE_CAP_MS = 35_000;
 import { useHistory } from './hooks/useHistoryManager.js';
 import { useMemoryMonitor } from './hooks/useMemoryMonitor.js';
 import { useResizeSettleRepaint } from './hooks/useResizeSettleRepaint.js';
+import { useWakeRepaint } from './hooks/use-wake-repaint.js';
 import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useFeedbackDialog } from './hooks/useFeedbackDialog.js';
 import { useAuthCommand } from './auth/useAuth.js';
@@ -3095,6 +3096,12 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Repaint static history on the trailing edge of a resize burst (#4891).
   useResizeSettleRepaint(terminalWidth, refreshStatic);
+
+  // Repaint after the process resumes from OS sleep / suspend (lid close,
+  // display sleep, Ctrl+Z → fg).  The terminal's screen buffer is stale but
+  // Ink's frame-diff state still reflects the pre-sleep output, so the next
+  // render strands border characters on screen.
+  useWakeRepaint(refreshStatic);
 
   useEffect(() => {
     if (ideNeedsRestart) {

--- a/packages/cli/src/ui/hooks/use-wake-repaint.test.ts
+++ b/packages/cli/src/ui/hooks/use-wake-repaint.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWakeRepaint } from './use-wake-repaint.js';
+
+const HEARTBEAT_MS = 5_000;
+const WAKE_THRESHOLD_MS = HEARTBEAT_MS * 2;
+
+describe('useWakeRepaint', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const setup = () => {
+    const repaint = vi.fn();
+    const view = renderHook(() => useWakeRepaint(repaint));
+    return { repaint, view };
+  };
+
+  it('does not repaint during normal heartbeat ticks', () => {
+    const { repaint } = setup();
+
+    // Advance through several normal heartbeat intervals.
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS * 5));
+
+    expect(repaint).not.toHaveBeenCalled();
+  });
+
+  it('repaints when a heartbeat gap exceeds the wake threshold', () => {
+    const { repaint } = setup();
+
+    // First tick at t=5000 — normal.
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS));
+    expect(repaint).not.toHaveBeenCalled();
+
+    // Simulate sleep: jump the clock far ahead so the next tick sees a gap
+    // larger than WAKE_THRESHOLD_MS.
+    vi.setSystemTime(Date.now() + WAKE_THRESHOLD_MS + 1_000);
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS));
+
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+
+  it('repaints on SIGCONT', () => {
+    const { repaint } = setup();
+
+    act(() => {
+      process.emit('SIGCONT');
+    });
+
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not repaint on SIGCONT after unmount', () => {
+    const { repaint, view } = setup();
+
+    view.unmount();
+
+    act(() => {
+      process.emit('SIGCONT');
+    });
+
+    expect(repaint).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the heartbeat timer on unmount', () => {
+    const { repaint, view } = setup();
+
+    view.unmount();
+
+    // Advance well past the wake threshold — no timer should fire.
+    vi.setSystemTime(Date.now() + WAKE_THRESHOLD_MS + 10_000);
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS * 5));
+
+    expect(repaint).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest repaint callback without re-arming listeners', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const view = renderHook(
+      ({ cb }: { cb: () => void }) => useWakeRepaint(cb),
+      { initialProps: { cb: first } },
+    );
+
+    // Swap the callback.
+    view.rerender({ cb: second });
+
+    act(() => {
+      process.emit('SIGCONT');
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/ui/hooks/use-wake-repaint.test.ts
+++ b/packages/cli/src/ui/hooks/use-wake-repaint.test.ts
@@ -60,6 +60,37 @@ describe('useWakeRepaint', () => {
     expect(repaint).toHaveBeenCalledTimes(1);
   });
 
+  it('does not double-repaint when the heartbeat follows a SIGCONT', () => {
+    const { repaint } = setup();
+
+    // Advance past the first normal tick so lastTick is established.
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS));
+
+    // Suspend + resume via SIGCONT.
+    vi.setSystemTime(Date.now() + WAKE_THRESHOLD_MS + 1_000);
+    act(() => {
+      process.emit('SIGCONT');
+    });
+    expect(repaint).toHaveBeenCalledTimes(1);
+
+    // The next heartbeat should see a small gap (SIGCONT reset lastTick).
+    act(() => vi.advanceTimersByTime(HEARTBEAT_MS));
+    expect(repaint).toHaveBeenCalledTimes(1); // still 1, not 2
+  });
+
+  it('unrefs the heartbeat timer so it does not keep the process alive', () => {
+    const unrefSpy = vi.fn();
+    vi.spyOn(globalThis, 'setInterval').mockReturnValue({
+      unref: unrefSpy,
+      [Symbol.toPrimitive]: () => 0,
+    } as unknown as ReturnType<typeof setInterval>);
+
+    renderHook(() => useWakeRepaint(vi.fn()));
+
+    expect(unrefSpy).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
   it('does not repaint on SIGCONT after unmount', () => {
     const { repaint, view } = setup();
 

--- a/packages/cli/src/ui/hooks/use-wake-repaint.ts
+++ b/packages/cli/src/ui/hooks/use-wake-repaint.ts
@@ -34,8 +34,8 @@ const WAKE_THRESHOLD_MS = HEARTBEAT_INTERVAL_MS * 2;
  * 2. **SIGCONT** — delivered when a stopped process is continued (`fg` after
  *    `Ctrl+Z`).  The terminal's screen buffer is likewise stale in this case.
  *
- * `repaint` must be referentially stable (e.g. `useCallback`) so an unrelated
- * re-render does not re-arm the listeners.
+ * `repaint` is read through a ref, so it does not need to be referentially
+ * stable — the listeners are armed once on mount and never re-created.
  */
 export function useWakeRepaint(repaint: () => void): void {
   const repaintRef = useRef(repaint);

--- a/packages/cli/src/ui/hooks/use-wake-repaint.ts
+++ b/packages/cli/src/ui/hooks/use-wake-repaint.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef } from 'react';
+
+// How often the heartbeat timer fires.
+const HEARTBEAT_INTERVAL_MS = 5_000;
+
+// If the gap between two consecutive heartbeats exceeds this threshold the
+// process was almost certainly suspended (macOS display sleep, system sleep,
+// lid close, `Ctrl+Z` + `fg`, etc.).  2× the heartbeat interval gives ample
+// margin for event-loop jitter while still catching any real suspend.
+const WAKE_THRESHOLD_MS = HEARTBEAT_INTERVAL_MS * 2;
+
+/**
+ * Repaint the UI when the process resumes after a suspend / sleep.
+ *
+ * After macOS display-sleep or system-sleep the terminal emulator's screen
+ * buffer may be reset or rearranged, but Ink's internal frame-diff state still
+ * reflects the pre-sleep output.  The next render then moves the cursor to the
+ * wrong row and the erase-and-redraw cycle strands border / separator
+ * characters on screen (the "horizontal lines" artifact).
+ *
+ * Detection is two-pronged:
+ *
+ * 1. **Heartbeat timer** — a `setInterval` that records `Date.now()` on each
+ *    tick.  If the gap between ticks exceeds {@link WAKE_THRESHOLD_MS} the
+ *    event loop was frozen (display sleep, system sleep, laptop lid close).
+ *    The timer is `.unref()`'d so it never keeps the process alive.
+ *
+ * 2. **SIGCONT** — delivered when a stopped process is continued (`fg` after
+ *    `Ctrl+Z`).  The terminal's screen buffer is likewise stale in this case.
+ *
+ * `repaint` must be referentially stable (e.g. `useCallback`) so an unrelated
+ * re-render does not re-arm the listeners.
+ */
+export function useWakeRepaint(repaint: () => void): void {
+  const repaintRef = useRef(repaint);
+  repaintRef.current = repaint;
+
+  useEffect(() => {
+    let lastTick = Date.now();
+
+    const timer = setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - lastTick;
+      lastTick = now;
+      if (elapsed > WAKE_THRESHOLD_MS) {
+        repaintRef.current();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+    timer.unref?.();
+
+    const onSigcont = () => {
+      lastTick = Date.now();
+      repaintRef.current();
+    };
+    process.on('SIGCONT', onSigcont);
+
+    return () => {
+      clearInterval(timer);
+      process.removeListener('SIGCONT', onSigcont);
+    };
+  }, []);
+}


### PR DESCRIPTION
## What this PR does

Adds a `useWakeRepaint` hook that detects when the process resumes after OS-level suspend (macOS display sleep, system sleep, laptop lid close, or `Ctrl+Z` → `fg`) and forces a full terminal repaint via the existing `refreshStatic` path (clear screen + remount static history). Detection is two-pronged: a heartbeat timer that flags any gap > 10 s between 5 s ticks (the event loop was frozen), and a `SIGCONT` listener for explicit process suspension. The timer is `.unref()`'d so it never keeps the process alive.

## Why it's needed

After macOS display-sleep or system-sleep the terminal emulator's screen buffer may be reset or rearranged, but Ink's internal frame-diff state still reflects the pre-sleep output. The next render then moves the cursor to the wrong row and the erase-and-redraw cycle strands border / separator characters on screen — the user sees the entire viewport filled with repeated `────` horizontal lines. The existing `useResizeSettleRepaint` only fires when the terminal **width changes**; if the terminal wakes with the same dimensions no repaint fires and the corrupted frame persists until the user manually presses `Ctrl+L`.

## Reviewer Test Plan

### How to verify

1. Start qwen-code in a terminal (tmux recommended).
2. Send a message so there is conversation content on screen.
3. Suspend the process: `kill -STOP <pid>` (or `Ctrl+Z` if job control is available).
4. Wait a few seconds, then resume: `kill -CONT <pid>` (or `fg`).
5. **Expected**: the screen clears and redraws cleanly — no stray horizontal lines or border artifacts.
6. Alternatively, close the laptop lid for > 10 s, reopen, and confirm the TUI repaints without artifacts.

### Evidence (Before & After)

**Before** — normal rendering prior to suspend:

![before](https://raw.githubusercontent.com/wenshao/qwen-pr-assets/main/wake-repaint/wake-test-before.png)

**After** — SIGCONT sent, `useWakeRepaint` triggers `refreshStatic`, UI repaints cleanly with no artifacts:

![after](https://raw.githubusercontent.com/wenshao/qwen-pr-assets/main/wake-repaint/wake-test-after.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` inside tmux 3.5a on macOS (Apple Silicon). Suspend/resume simulated via `kill -STOP` / `kill -CONT` to the tsx CLI process.

## Risk & Scope

- Main risk or tradeoff: the heartbeat timer fires every 5 s (lightweight `Date.now()` comparison, `.unref()`'d). A false-positive repaint is harmless — it just clears and redraws.
- Not validated / out of scope: VP mode (`ui.useTerminalBuffer`) uses Ink 7 native viewport clipping and may not exhibit the same artifact; the hook still calls `refreshStatic` which bumps the remount key but skips the physical `clearTerminal` in VP mode. Windows/Linux suspend semantics may differ but `SIGCONT` + timer are POSIX-standard.
- Breaking changes / migration notes: none.

## Linked Issues

<!-- No linked issue — reported verbally by a user. -->

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `useWakeRepaint` hook，在进程从操作系统级挂起（macOS 显示器休眠、系统休眠、合盖、`Ctrl+Z` → `fg`）恢复后，通过已有的 `refreshStatic` 路径（清屏 + 重挂载静态历史）强制完整重绘终端。检测采用双通道：心跳定时器（每 5 秒 tick 一次，若两次 tick 间隔 > 10 秒则判定事件循环被冻结）和 `SIGCONT` 信号监听（处理显式进程挂起）。定时器使用 `.unref()` 确保不会阻止进程退出。

## 为什么需要

macOS 显示器休眠或系统休眠后，终端模拟器的 screen buffer 可能被重置或重排，但 Ink 的内部帧 diff 状态仍反映休眠前的输出。下次渲染时光标移动到错误行，erase-and-redraw 循环会将边框/分隔符字符残留在屏幕上——用户看到整个视口被重复的 `────` 水平线填满。现有的 `useResizeSettleRepaint` 仅在终端**宽度变化**时触发；如果唤醒后尺寸不变，就不会重绘，损坏的帧会持续存在，直到用户手动按 `Ctrl+L`。

## 审阅者测试计划

### 如何验证

1. 在终端中启动 qwen-code（推荐 tmux）。
2. 发送一条消息，使屏幕上有对话内容。
3. 挂起进程：`kill -STOP <pid>`（或 `Ctrl+Z`）。
4. 等待几秒，然后恢复：`kill -CONT <pid>`（或 `fg`）。
5. **预期**：屏幕清除并干净地重绘——没有残留的水平线或边框伪影。
6. 或者，合上笔记本盖子 > 10 秒，重新打开，确认 TUI 无伪影地重绘。

### 证据（前后对比）

**之前** — 挂起前的正常渲染：

![before](https://raw.githubusercontent.com/wenshao/qwen-pr-assets/main/wake-repaint/wake-test-before.png)

**之后** — 发送 SIGCONT 后，`useWakeRepaint` 触发 `refreshStatic`，UI 干净重绘，无伪影：

![after](https://raw.githubusercontent.com/wenshao/qwen-pr-assets/main/wake-repaint/wake-test-after.png)

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

在 macOS (Apple Silicon) 的 tmux 3.5a 中使用 `npm run dev`。通过 `kill -STOP` / `kill -CONT` 模拟挂起/恢复。

## 风险与范围

- 主要风险或权衡：心跳定时器每 5 秒触发一次（轻量级 `Date.now()` 比较，使用 `.unref()`）。误触发的重绘是无害的——只是清屏并重绘。
- 未验证/超出范围：VP 模式（`ui.useTerminalBuffer`）使用 Ink 7 原生视口裁剪，可能不会出现相同的伪影；hook 仍会调用 `refreshStatic`，但在 VP 模式下跳过物理 `clearTerminal`。Windows/Linux 的挂起语义可能不同，但 `SIGCONT` + 定时器是 POSIX 标准的。
- 破坏性变更/迁移说明：无。

## 关联 Issue

<!-- 无关联 issue — 由用户口头报告。 -->

</details>
