### PR TITLE
feat(web-shell): support custom slash command actions

### DIFF
--- a/docs/design/web-shell-custom-slash-command-actions.md
+++ b/docs/design/web-shell-custom-slash-command-actions.md
@@ -1,0 +1,35 @@
+# Web Shell Custom Slash Command Actions
+
+## Problem
+
+Web Shell handles built-in slash commands locally and forwards other slash
+commands to the daemon. Embedders cannot observe a command before that default
+behavior or replace it with an application-specific action.
+
+## Design
+
+Add an optional `onSlashCommand` prop. It runs before hidden-command,
+built-in-command, and daemon-forwarding behavior and receives:
+
+- `command`: the slash command name, normalized to lower case;
+- `args`: the trimmed text after the command name;
+- `input`: the original submitted text.
+
+Returning `true` marks the command as handled and skips Web Shell's default
+behavior. Returning `false` or nothing lets the existing command pipeline
+continue unchanged. The callback is synchronous so composer acceptance keeps
+the existing synchronous submit contract; embedders may start asynchronous
+work inside the callback.
+
+## Compatibility
+
+The prop is optional, so existing embedders and all current command behavior
+remain unchanged. The callback also observes unknown commands, allowing an
+embedder to implement a command without daemon support.
+
+## Test Plan
+
+- Verify an unknown slash command invokes the callback with parsed fields and
+  still reaches the daemon when the callback does not handle it.
+- Verify returning `true` prevents the command from reaching the daemon.
+- Verify returning `true` prevents a built-in command's local behavior.

--- a/docs/design/web-shell-custom-slash-command-actions.md
+++ b/docs/design/web-shell-custom-slash-command-actions.md
@@ -9,7 +9,8 @@ behavior or replace it with an application-specific action.
 ## Design
 
 Add an optional `onSlashCommand` prop. It runs before hidden-command,
-built-in-command, and daemon-forwarding behavior and receives:
+built-in-command, daemon-connection, and daemon-forwarding behavior in both the
+main composer and split-view composers. It receives:
 
 - `command`: the slash command name, normalized to lower case;
 - `args`: the trimmed text after the command name;
@@ -19,7 +20,12 @@ Returning `true` marks the command as handled and skips Web Shell's default
 behavior. Returning `false` or nothing lets the existing command pipeline
 continue unchanged. The callback is synchronous so composer acceptance keeps
 the existing synchronous submit contract; embedders may start asynchronous
-work inside the callback.
+work inside the callback. Callback errors are reported through Web Shell's
+existing error path before default handling continues.
+
+Only a leading slash followed by a word-or-hyphen command name and then
+whitespace or the end of the input is recognized. This keeps absolute paths
+such as `/usr/local/bin/tool` out of the host callback.
 
 ## Compatibility
 
@@ -33,3 +39,6 @@ embedder to implement a command without daemon support.
   still reaches the daemon when the callback does not handle it.
 - Verify returning `true` prevents the command from reaching the daemon.
 - Verify returning `true` prevents a built-in command's local behavior.
+- Verify main and split-view callbacks can handle commands while disconnected.
+- Verify callback errors are reported before default handling continues.
+- Verify absolute paths do not invoke the callback.

--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -203,6 +203,10 @@ const projection = projectChatRecordsToDaemonTranscript(records);
 />
 ```
 
+回调在主聊天和分屏聊天中都会触发，也可以在 daemon 断连时处理纯宿主操作。
+命令名后必须是空白或输入结束，因此 `/usr/local/bin/tool` 等绝对路径不会触发
+回调。如果回调抛出异常，Web Shell 会报告错误并继续执行默认命令流程。
+
 锁定工作区时，可以自定义 Sidebar 文件夹行的内容：
 
 ```tsx

--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -189,6 +189,19 @@ const projection = projectChatRecordsToDaemonTranscript(records);
 | `onThemeChange`     | `(theme: WebShellTheme) => void`                                                        | `/theme` 命令切换主题后触发                                                      |
 | `language`          | `'en' \| 'zh-CN' \| 'zh' \| 'zh-cn'`                                                    | UI 语言                                                                          |
 | `onLanguageChange`  | `(language: WebShellLanguage) => void`                                                  | `/language ui` 切换 UI 语言后触发                                                |
+| `onSlashCommand`    | `(command: WebShellSlashCommand) => boolean \| void`                                    | 斜杠命令进入默认处理前触发；返回 `true` 时由宿主接管并跳过默认行为               |
+
+宿主可以监听命令，也可以返回 `true` 接管对应操作：
+
+```tsx
+<WebShell
+  onSlashCommand={({ command, args, input }) => {
+    if (command !== 'deploy') return;
+    openDeployDialog({ environment: args, source: input });
+    return true;
+  }}
+/>
+```
 
 锁定工作区时，可以自定义 Sidebar 文件夹行的内容：
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2313,6 +2313,76 @@ describe('App session callbacks', () => {
     expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
   });
 
+  it('does not treat an absolute path as a slash command', async () => {
+    const onSlashCommand = vi.fn(() => true);
+    const { container } = renderApp({ onSlashCommand });
+    await flush();
+
+    testState.prompt = '/usr/local/bin/tool';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSlashCommand).not.toHaveBeenCalled();
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      '/usr/local/bin/tool',
+      expect.any(Object),
+    );
+  });
+
+  it('lets the host handle a slash command while the daemon is unavailable', async () => {
+    mockConnection.status = 'error';
+    const onSlashCommand = vi.fn(() => true);
+    const onToast = vi.fn();
+    const { container } = renderApp({ onSlashCommand, onToast });
+    await flush();
+
+    testState.prompt = '/deploy production';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSlashCommand).toHaveBeenCalledTimes(1);
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('reports a host slash command error and continues default handling', async () => {
+    const error = new Error('host handler exploded');
+    const onSlashCommand = vi.fn(() => {
+      throw error;
+    });
+    const onToast = vi.fn();
+    const { container } = renderApp({ onSlashCommand, onToast });
+    await flush();
+
+    testState.prompt = '/deploy staging';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onToast).toHaveBeenCalledWith('error', 'host handler exploded');
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      '/deploy staging',
+      expect.any(Object),
+    );
+  });
+
+  it('uses the latest slash command handler after a rerender', async () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn(() => true);
+    const { container, rerender } = renderApp({
+      onSlashCommand: firstHandler,
+    });
+    await flush();
+
+    rerender({ onSlashCommand: secondHandler });
+    await flush();
+
+    testState.prompt = '/deploy staging';
+    await clickSubmit(container);
+    await flush();
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+
   it('forwards input annotations for /plan prompts in active sessions', async () => {
     const annotation: DaemonInputAnnotation = {
       type: 'reference',

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -2259,6 +2259,60 @@ describe('App session callbacks', () => {
     expect(editorClear).not.toHaveBeenCalled();
   });
 
+  it('notifies the host before forwarding a slash command', async () => {
+    const onSlashCommand = vi.fn();
+    const { container } = renderApp({ onSlashCommand });
+    await flush();
+
+    testState.prompt = '/Deploy staging';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSlashCommand).toHaveBeenCalledWith({
+      command: 'deploy',
+      args: 'staging',
+      input: '/Deploy staging',
+    });
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      '/Deploy staging',
+      expect.any(Object),
+    );
+  });
+
+  it('lets the host handle a slash command instead of forwarding it', async () => {
+    const onSlashCommand = vi.fn(() => true);
+    const { container } = renderApp({ onSlashCommand });
+    await flush();
+
+    testState.prompt = '/deploy production';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSlashCommand).toHaveBeenCalledWith({
+      command: 'deploy',
+      args: 'production',
+      input: '/deploy production',
+    });
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+  });
+
+  it('lets the host override a built-in slash command', async () => {
+    const onSlashCommand = vi.fn(() => true);
+    const { container } = renderApp({ onSlashCommand });
+    await flush();
+
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+
+    expect(onSlashCommand).toHaveBeenCalledWith({
+      command: 'settings',
+      args: '',
+      input: '/settings',
+    });
+    expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
+  });
+
   it('forwards input annotations for /plan prompts in active sessions', async () => {
     const annotation: DaemonInputAnnotation = {
       type: 'reference',

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -455,6 +455,19 @@ export type WebShellComposerPlaceholders = Readonly<
   Partial<Record<WebShellComposerPlaceholderState, string>>
 >;
 
+export interface WebShellSlashCommand {
+  /** Slash command name without the leading slash, normalized to lower case. */
+  command: string;
+  /** Trimmed text following the command name. */
+  args: string;
+  /** Original text submitted from the composer. */
+  input: string;
+}
+
+export type WebShellSlashCommandHandler = (
+  command: WebShellSlashCommand,
+) => boolean | void;
+
 export interface WebShellProps {
   /** Called whenever the attached daemon session or workspace changes. */
   onSessionIdChange?: (
@@ -520,6 +533,11 @@ export interface WebShellProps {
   hiddenSlashCommands?: string[];
   /** Slash command category order. Defaults to custom, skill, system. */
   slashCommandCategoryOrder?: CommandDisplayCategoryOrder;
+  /**
+   * Called before Web Shell handles a slash command. Return true to skip the
+   * built-in or daemon behavior after handling the command in the host.
+   */
+  onSlashCommand?: WebShellSlashCommandHandler;
   /** Built-in @ mention providers to enable. Defaults to all built-ins. */
   builtinAtProviders?: WebShellBuiltinAtProvidersConfig;
   /** Additional @ mention categories shown alongside built-in files/extensions. */
@@ -1005,6 +1023,7 @@ export function App({
   onBugReport,
   hiddenSlashCommands,
   slashCommandCategoryOrder,
+  onSlashCommand,
   builtinAtProviders,
   atProviders,
   composerTagIcons,
@@ -4543,6 +4562,12 @@ export function App({
         const match = text.match(/^\/([\w-]+)/);
         if (match) {
           const cmd = match[1];
+          const handled = onSlashCommand?.({
+            command: cmd.toLowerCase(),
+            args: text.slice(match[0].length).trim(),
+            input: text,
+          });
+          if (handled) return true;
           if (hiddenCommands.has(normalizeHiddenCommand(cmd))) {
             if (promptBlocked) {
               return enqueuePrompt(
@@ -5383,6 +5408,7 @@ export function App({
       blockLocalCommandDuringTurn,
       openTasksPanel,
       hiddenCommands,
+      onSlashCommand,
       pushToast,
       reportError,
       runVisibleRecap,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -153,6 +153,10 @@ import {
   COPY_MESSAGES,
 } from './utils/copyCommand';
 import { isEditableTarget } from './utils/dom';
+import {
+  invokeSlashCommandHandler,
+  SLASH_COMMAND_PATTERN,
+} from './utils/slash-command-action';
 import { getModelDisplayName } from './utils/modelDisplay';
 import { isVisibleComposerModel } from './utils/composerModels';
 import { filterModelSwitchMessages } from './utils/modelSwitchMessages';
@@ -2858,6 +2862,8 @@ export function App({
   }, [lockedWorkspaceCwd, sessionActions, workspaces]);
   const onSubmitBeforeRef = useRef(onSubmitBefore);
   onSubmitBeforeRef.current = onSubmitBefore;
+  const onSlashCommandRef = useRef(onSlashCommand);
+  onSlashCommandRef.current = onSlashCommand;
   const [sessionListReloadToken, setSessionListReloadToken] = useState(0);
   const delayedReloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -4521,6 +4527,11 @@ export function App({
       commitComposerAccepted?: ComposerSubmitCommit,
       metadata?: { inputAnnotations?: DaemonInputAnnotation[] },
     ) => {
+      if (
+        invokeSlashCommandHandler(text, onSlashCommandRef.current, reportError)
+      ) {
+        return true;
+      }
       if (connectionRef.current.loadingTranscript) {
         pushToast('warning', t('editor.sessionLoading'));
         return false;
@@ -4559,15 +4570,9 @@ export function App({
         return clearComposerOnPromptStart ? false : true;
       };
       if (text.startsWith('/')) {
-        const match = text.match(/^\/([\w-]+)/);
+        const match = text.match(SLASH_COMMAND_PATTERN);
         if (match) {
           const cmd = match[1];
-          const handled = onSlashCommand?.({
-            command: cmd.toLowerCase(),
-            args: text.slice(match[0].length).trim(),
-            input: text,
-          });
-          if (handled) return true;
           if (hiddenCommands.has(normalizeHiddenCommand(cmd))) {
             if (promptBlocked) {
               return enqueuePrompt(
@@ -5408,7 +5413,6 @@ export function App({
       blockLocalCommandDuringTurn,
       openTasksPanel,
       hiddenCommands,
-      onSlashCommand,
       pushToast,
       reportError,
       runVisibleRecap,
@@ -6943,6 +6947,7 @@ export function App({
                         // is launched from), not the single-session chat.
                         onExit={handleSplitExit}
                         onError={reportError}
+                        onSlashCommand={onSlashCommand}
                         onRightPanelOpen={handleTurnOutputOpen}
                         onPaneArtifactsChange={handlePaneArtifactsChange}
                         messageTurnOutputs={messageTurnOutputs}

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -391,6 +391,87 @@ describe('ChatPane', () => {
     expect(enqueuePrompt).not.toHaveBeenCalled();
   });
 
+  it('lets the host handle a slash command', () => {
+    const onSlashCommand = vi.fn(() => true);
+    render({ onSlashCommand });
+    let returned: boolean | undefined;
+
+    act(() => {
+      returned = latestOnSubmit!('/deploy production');
+    });
+
+    expect(returned).toBe(true);
+    expect(onSlashCommand).toHaveBeenCalledWith({
+      command: 'deploy',
+      args: 'production',
+      input: '/deploy production',
+    });
+    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(enqueuePrompt).not.toHaveBeenCalled();
+  });
+
+  it('forwards a slash command the host does not handle', () => {
+    const onSlashCommand = vi.fn();
+    render({ onSlashCommand });
+
+    act(() => {
+      latestOnSubmit!('/deploy staging');
+    });
+
+    expect(onSlashCommand).toHaveBeenCalledTimes(1);
+    expect(sendPrompt).toHaveBeenCalledWith('/deploy staging', {
+      onAdmitted: expect.any(Function),
+    });
+  });
+
+  it('lets the host handle a slash command while the pane is disconnected', () => {
+    connectionState.status = 'disconnected';
+    const onSlashCommand = vi.fn(() => true);
+    render({ onSlashCommand });
+
+    act(() => {
+      latestOnSubmit!('/deploy staging');
+    });
+
+    expect(onSlashCommand).toHaveBeenCalledTimes(1);
+    expect(sendPrompt).not.toHaveBeenCalled();
+  });
+
+  it('reports a host slash command error and continues default handling', () => {
+    const error = new Error('host handler exploded');
+    const onSlashCommand = vi.fn(() => {
+      throw error;
+    });
+    const onError = vi.fn();
+    render({ onSlashCommand, onError });
+
+    act(() => {
+      latestOnSubmit!('/deploy staging');
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      error,
+      'onSlashCommand callback failed',
+    );
+    expect(sendPrompt).toHaveBeenCalledWith('/deploy staging', {
+      onAdmitted: expect.any(Function),
+    });
+  });
+
+  it('does not treat an absolute path as a slash command', () => {
+    const onSlashCommand = vi.fn(() => true);
+    render({ onSlashCommand });
+
+    act(() => {
+      latestOnSubmit!('/usr/local/bin/tool');
+    });
+
+    expect(onSlashCommand).not.toHaveBeenCalled();
+    expect(sendPrompt).toHaveBeenCalledWith('/usr/local/bin/tool', {
+      onAdmitted: expect.any(Function),
+    });
+  });
+
   it('commits an idle prompt only after daemon admission', () => {
     render();
     const commit = vi.fn();

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -34,6 +34,8 @@ import { isAskUserPermission } from '../utils/askUserPermission';
 import { isDaemonApprovalMode } from '../utils/sessionPreparation';
 import { isVisibleComposerModel } from '../utils/composerModels';
 import { shouldBlockComposerSubmit } from '../utils/composerInputState';
+import { invokeSlashCommandHandler } from '../utils/slash-command-action';
+import type { WebShellSlashCommandHandler } from '../App';
 import { getModelDisplayName } from '../utils/modelDisplay';
 import { hasMultipleWorkspaces, workspaceBasename } from '../utils/workspace';
 import { workspaceAccentColor } from '../utils/workspaceColor';
@@ -91,6 +93,8 @@ export interface ChatPaneProps {
   /** Whether this pane is currently the maximized (solo) one. */
   isMaximized?: boolean;
   onError?: (error: unknown, fallback: string) => void;
+  /** Host slash-command callback shared with the main chat composer. */
+  onSlashCommand?: WebShellSlashCommandHandler;
   onRightPanelOpen?: (request: TurnOutputOpenRequest) => void;
   onPaneArtifactsChange?: (
     sessionId: string,
@@ -116,6 +120,7 @@ export function ChatPane({
   onToggleMaximize,
   isMaximized = false,
   onError,
+  onSlashCommand,
   onRightPanelOpen,
   onPaneArtifactsChange,
   messageTurnOutputs,
@@ -166,6 +171,8 @@ export function ChatPane({
     },
     [onError],
   );
+  const onSlashCommandRef = useRef(onSlashCommand);
+  onSlashCommandRef.current = onSlashCommand;
   const notifySuccess = useCallback(
     (message: string) => store.dispatch([{ type: 'status', text: message }]),
     [store],
@@ -253,6 +260,11 @@ export function ChatPane({
     ): boolean => {
       const trimmed = text.trim();
       if (!trimmed) return false;
+      if (
+        invokeSlashCommandHandler(text, onSlashCommandRef.current, reportError)
+      ) {
+        return true;
+      }
       if (
         shouldBlockComposerSubmit({
           connectionStatus: connection.status,

--- a/packages/web-shell/client/components/SplitView.test.tsx
+++ b/packages/web-shell/client/components/SplitView.test.tsx
@@ -72,6 +72,7 @@ vi.mock('./ChatPane', () => ({
         data-pane-workspace={props.workspaceCwd}
         data-maximized={props.isMaximized ? 'true' : 'false'}
         data-pane-restart-sse={props.restartSseOnPrompt ? 'true' : 'false'}
+        data-slash-handler={props.onSlashCommand ? 'true' : 'false'}
       >
         <span data-testid="pane-title">{props.title}</span>
         {props.onToggleMaximize && (
@@ -201,6 +202,19 @@ describe('SplitView', () => {
         .querySelector('[data-session="s1"] [data-testid="chat-pane"]')
         ?.getAttribute('data-pane-restart-sse'),
     ).toBe('true');
+  });
+
+  it('passes the host slash command handler to every pane', () => {
+    render({
+      sessionIds: ['s1', 's2'],
+      onSlashCommand: vi.fn(),
+    });
+
+    expect(
+      panes().every(
+        (pane) => pane.getAttribute('data-slash-handler') === 'true',
+      ),
+    ).toBe(true);
   });
 
   it('seeds with the current session when no session ids are given', () => {

--- a/packages/web-shell/client/components/SplitView.tsx
+++ b/packages/web-shell/client/components/SplitView.tsx
@@ -11,6 +11,7 @@ import {
   type DaemonWorkspaceActions,
 } from '@qwen-code/webui/daemon-react-sdk';
 import type { DaemonSessionArtifact } from '@qwen-code/sdk/daemon';
+import type { WebShellSlashCommandHandler } from '../App';
 import { useI18n } from '../i18n';
 import { ChatPane } from './ChatPane';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -51,6 +52,7 @@ export interface SplitViewProps {
   /** Leave the split view (back to the single-session chat). */
   onExit: () => void;
   onError?: (error: unknown, fallback: string) => void;
+  onSlashCommand?: WebShellSlashCommandHandler;
   onRightPanelOpen?: (request: TurnOutputOpenRequest) => void;
   onPaneArtifactsChange?: (
     sessionId: string,
@@ -83,6 +85,7 @@ export function SplitView({
   onPanesChange,
   onExit,
   onError,
+  onSlashCommand,
   onRightPanelOpen,
   onPaneArtifactsChange,
   messageTurnOutputs,
@@ -488,6 +491,7 @@ export function SplitView({
                       }
                       isMaximized={isMaximized}
                       onError={onError}
+                      onSlashCommand={onSlashCommand}
                       onRightPanelOpen={onRightPanelOpen}
                       onPaneArtifactsChange={onPaneArtifactsChange}
                       messageTurnOutputs={messageTurnOutputs}

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -126,6 +126,8 @@ export type {
   WebShellApi,
   WebShellComposerPlaceholders,
   WebShellComposerPlaceholderState,
+  WebShellSlashCommand,
+  WebShellSlashCommandHandler,
   WebShellProps,
   WebShellSidebarOptions,
   BugReportInfo,

--- a/packages/web-shell/client/utils/slash-command-action.ts
+++ b/packages/web-shell/client/utils/slash-command-action.ts
@@ -1,0 +1,25 @@
+import type { WebShellSlashCommandHandler } from '../App';
+
+export const SLASH_COMMAND_PATTERN = /^\/([\w-]+)(?=\s|$)/;
+
+export function invokeSlashCommandHandler(
+  input: string,
+  handler: WebShellSlashCommandHandler | undefined,
+  reportError: (error: unknown, fallback: string) => void,
+): boolean {
+  if (!handler) return false;
+  const match = input.match(SLASH_COMMAND_PATTERN);
+  if (!match) return false;
+  try {
+    return (
+      handler({
+        command: match[1].toLowerCase(),
+        args: input.slice(match[0].length).trim(),
+        input,
+      }) === true
+    );
+  } catch (error: unknown) {
+    reportError(error, 'onSlashCommand callback failed');
+    return false;
+  }
+}


### PR DESCRIPTION
## What this PR does

Adds an optional Web Shell callback that observes parsed slash-command submissions before built-in or daemon handling. Embedders receive the normalized command name, trimmed arguments, and original input, and can return `true` to replace the default behavior with a host-specific action.

## Why it's needed

Embedded Web Shell consumers currently cannot connect slash commands to host application behavior. Unknown commands are always forwarded to the daemon, while built-in commands always use Web Shell behavior, which prevents integrations such as opening a host-owned deployment dialog or settings surface.

## Reviewer Test Plan

### How to verify

Render Web Shell with the new callback and submit `/deploy staging`; verify the callback receives `deploy`, `staging`, and the original input. Without returning `true`, verify the prompt still reaches the daemon. Return `true` and verify an unknown command no longer reaches the daemon. Return `true` for `/settings` and verify the host callback runs without opening Web Shell's built-in Settings panel. Repeat a handled command in split view and while disconnected, then verify `/usr/local/bin/tool` does not invoke the callback. Throw from the callback and verify the error is reported before default handling continues.

Automated coverage: the full Web Shell suite passed 1920/1920 tests across 119 files. Ordered core, SDK, webui, and web-shell builds, full workspace typecheck, and targeted ESLint checks also pass locally.

### Evidence (Before & After)

N/A — this adds an embedding API and does not change the default UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 with the Web Shell Vitest/jsdom component test environment.

## Risk & Scope

- Main risk or tradeoff: interception is intentionally synchronous to preserve the existing composer submit contract; asynchronous host work can be started by the callback after it returns `true`.
- Not validated / out of scope: adding host-defined commands to slash-command completion and help menus.
- Breaking changes / migration notes: none; the callback is optional and existing behavior is unchanged when omitted or when it does not return `true`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增一个可选的 Web Shell 回调，在内置逻辑或 daemon 处理之前监听解析后的斜杠命令。嵌入方会收到规范化的命令名、去除首尾空白的参数和原始输入，并可返回 `true`，用宿主自定义操作替换默认行为。

## 为什么需要

目前嵌入 Web Shell 的应用无法把斜杠命令连接到宿主行为。未知命令始终转发给 daemon，内置命令始终执行 Web Shell 行为，因此无法实现打开宿主部署弹窗或宿主设置页等集成。

## Reviewer 测试计划

### 如何验证

为 Web Shell 传入新回调并提交 `/deploy staging`，确认回调收到 `deploy`、`staging` 和原始输入。不返回 `true` 时，确认 prompt 仍发送给 daemon。返回 `true` 时，确认未知命令不再发送给 daemon。对 `/settings` 返回 `true`，确认宿主回调执行且 Web Shell 内置设置面板不会打开。在分屏和断连状态下重复接管命令，并确认 `/usr/local/bin/tool` 不触发回调。让回调抛出异常，确认错误被报告且默认处理继续执行。

自动化验证：Web Shell 全量测试共 119 个文件、1920/1920 项通过。core、SDK、webui、web-shell 按依赖顺序构建通过，全仓 typecheck 和定向 ESLint 检查也在本地通过。

### 证据（Before & After）

N/A——本变更新增嵌入 API，不改变默认 UI。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22，使用 Web Shell Vitest/jsdom 组件测试环境。

## 风险与范围

- 主要风险或权衡：为保持现有 composer 提交契约，拦截回调有意设计为同步；回调返回 `true` 后仍可启动宿主异步操作。
- 未验证或不在范围内：把宿主定义的命令加入斜杠命令补全和帮助菜单。
- 破坏性变更或迁移说明：无；回调为可选属性，未传入或未返回 `true` 时现有行为保持不变。

## 关联 Issue

N/A

</details>
