### PR TITLE
fix(sdk): clean up SSE requests on errors and dispose

### DIFF
--- a/packages/sdk-typescript/src/daemon/RestSseTransport.ts
+++ b/packages/sdk-typescript/src/daemon/RestSseTransport.ts
@@ -26,6 +26,7 @@ export class RestSseTransport implements DaemonTransport {
   private readonly baseUrl: string;
   private readonly token: string | undefined;
   private readonly _fetch: typeof globalThis.fetch;
+  private readonly activeSseRequests = new Set<AbortController>();
   private _disposed = false;
 
   readonly type = 'rest' as const;
@@ -75,102 +76,114 @@ export class RestSseTransport implements DaemonTransport {
       throw new DaemonTransportClosedError();
     }
 
-    const headers: Record<string, string> = { Accept: 'text/event-stream' };
-    if (this.token) {
-      headers['Authorization'] = `Bearer ${this.token}`;
-    }
-    if (opts.lastEventId !== undefined) {
-      headers['Last-Event-ID'] = String(opts.lastEventId);
-    }
+    const requestCtrl = new AbortController();
+    this.activeSseRequests.add(requestCtrl);
 
-    // Connect-phase timeout (request → headers received). The SSE
-    // body itself is long-lived and must NOT be timed out.
-    const connectCtrl = new AbortController();
-    let connectTimer: ReturnType<typeof setTimeout> | undefined;
-    const connectTimeoutMs = opts.connectTimeoutMs;
-    if (connectTimeoutMs && Number.isFinite(connectTimeoutMs)) {
-      connectTimer = setTimeout(
-        () =>
-          connectCtrl.abort(
-            new DOMException('Initial connect timed out', 'TimeoutError'),
-          ),
-        connectTimeoutMs,
-      );
-      if (
-        typeof connectTimer === 'object' &&
-        connectTimer &&
-        'unref' in connectTimer
-      ) {
-        (connectTimer as { unref: () => void }).unref();
-      }
-    }
-
-    const fetchSignal = opts.signal
-      ? composeAbortSignals([opts.signal, connectCtrl.signal])
-      : connectCtrl.signal;
-
-    // Build the SSE URL, optionally with `?maxQueued=N`.
-    let url = `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/events`;
-    if (opts.maxQueued !== undefined) {
-      url += `?maxQueued=${encodeURIComponent(String(opts.maxQueued))}`;
-    }
-
-    let res: Response;
     try {
-      res = await this._fetch(url, { headers, signal: fetchSignal });
-    } finally {
-      if (connectTimer !== undefined) clearTimeout(connectTimer);
-    }
+      const headers: Record<string, string> = { Accept: 'text/event-stream' };
+      if (this.token) {
+        headers['Authorization'] = `Bearer ${this.token}`;
+      }
+      if (opts.lastEventId !== undefined) {
+        headers['Last-Event-ID'] = String(opts.lastEventId);
+      }
 
-    if (!res.ok) {
-      // Read the error body for the caller.
-      let body: unknown;
-      try {
-        const text = await res.text();
-        try {
-          body = JSON.parse(text);
-        } catch {
-          body = text;
+      const fetchSignal = opts.signal
+        ? composeAbortSignals([opts.signal, requestCtrl.signal])
+        : requestCtrl.signal;
+
+      // Build the SSE URL, optionally with `?maxQueued=N`.
+      let url = `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/events`;
+      if (opts.maxQueued !== undefined) {
+        url += `?maxQueued=${encodeURIComponent(String(opts.maxQueued))}`;
+      }
+
+      // Connect-phase timeout (request → headers received). The SSE
+      // body itself is long-lived and must NOT be timed out.
+      let connectTimer: ReturnType<typeof setTimeout> | undefined;
+      const connectTimeoutMs = opts.connectTimeoutMs;
+      if (connectTimeoutMs && Number.isFinite(connectTimeoutMs)) {
+        connectTimer = setTimeout(
+          () =>
+            requestCtrl.abort(
+              new DOMException('Initial connect timed out', 'TimeoutError'),
+            ),
+          connectTimeoutMs,
+        );
+        if (
+          typeof connectTimer === 'object' &&
+          connectTimer &&
+          'unref' in connectTimer
+        ) {
+          (connectTimer as { unref: () => void }).unref();
         }
-      } catch {
-        /* body unreadable */
       }
-      const detail =
-        body && typeof body === 'object' && 'error' in body
-          ? String((body as { error: unknown }).error)
-          : `HTTP ${res.status}`;
-      throw new DaemonHttpError(
-        res.status,
-        body,
-        `GET /session/:id/events: ${detail}`,
-      );
-    }
 
-    // Content-type validation — a misconfigured proxy that swallows
-    // the SSE response would otherwise silently produce zero frames.
-    const ct = res.headers.get('content-type') ?? '';
-    if (!ct.toLowerCase().includes('text/event-stream')) {
+      let res: Response;
       try {
-        await res.body?.cancel();
-      } catch {
-        /* body already consumed or no body */
+        res = await this._fetch(url, { headers, signal: fetchSignal });
+      } finally {
+        if (connectTimer !== undefined) clearTimeout(connectTimer);
       }
-      throw new DaemonHttpError(
-        res.status,
-        ct,
-        `GET /session/:id/events: expected content-type text/event-stream, got "${ct}"`,
-      );
-    }
 
-    if (!res.body) {
-      throw new Error('No SSE body');
-    }
+      if (!res.ok) {
+        // Read the error body for the caller.
+        let body: unknown;
+        try {
+          const text = await res.text();
+          try {
+            body = JSON.parse(text);
+          } catch {
+            body = text;
+          }
+        } catch {
+          /* body unreadable */
+        }
+        const detail =
+          body && typeof body === 'object' && 'error' in body
+            ? String((body as { error: unknown }).error)
+            : `HTTP ${res.status}`;
+        throw new DaemonHttpError(
+          res.status,
+          body,
+          `GET /session/:id/events: ${detail}`,
+        );
+      }
 
-    yield* parseSseStream(res.body, opts.signal);
+      // Content-type validation — a misconfigured proxy that swallows
+      // the SSE response would otherwise silently produce zero frames.
+      const ct = res.headers.get('content-type') ?? '';
+      if (!ct.toLowerCase().includes('text/event-stream')) {
+        try {
+          await res.body?.cancel();
+        } catch {
+          /* body already consumed or no body */
+        }
+        throw new DaemonHttpError(
+          res.status,
+          ct,
+          `GET /session/:id/events: expected content-type text/event-stream, got "${ct}"`,
+        );
+      }
+
+      if (!res.body) {
+        throw new Error('No SSE body');
+      }
+
+      yield* parseSseStream(res.body, fetchSignal);
+    } finally {
+      requestCtrl.abort();
+      this.activeSseRequests.delete(requestCtrl);
+    }
   }
 
   dispose(): void {
+    if (this._disposed) return;
     this._disposed = true;
+    for (const requestCtrl of this.activeSseRequests) {
+      requestCtrl.abort();
+    }
+    this.activeSseRequests.clear();
   }
 }
 

--- a/packages/sdk-typescript/src/daemon/sse.ts
+++ b/packages/sdk-typescript/src/daemon/sse.ts
@@ -38,7 +38,7 @@ export class SseFramingError extends Error {
  *   - Malformed frames (non-JSON `data`, missing `data`) are skipped
  *     silently so a single bad frame can't poison the iterator.
  *
- * The reader is released in `finally` so `for await … break` paths and
+ * The body stream is cancelled in `finally` so `for await … break` paths and
  * AbortSignal cancellation both clean up cleanly.
  */
 /**
@@ -171,10 +171,9 @@ export async function* parseSseStream(
     if (signal && onAbort) {
       signal.removeEventListener('abort', onAbort);
     }
-    // `reader.cancel()` does both the release-lock work AND signals the
-    // upstream that we don't want any more data — closing the underlying
-    // HTTP body stream when the consumer breaks out early. Using only
-    // `releaseLock()` would orphan the connection until idle timeout.
+    // `reader.cancel()` cancels the body stream and unblocks pending reads. It
+    // does not reliably close a fetch socket in every runtime (notably Bun),
+    // so the transport that owns the request must also abort its fetch signal.
     try {
       await reader.cancel();
     } catch {

--- a/packages/sdk-typescript/test/unit/RestSseTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/RestSseTransport.test.ts
@@ -75,6 +75,22 @@ function sseResponse(frames: string): Response {
   });
 }
 
+function heldOpenSseResponse(frames: string, onCancel?: () => void): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(frames));
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -263,7 +279,7 @@ describe('RestSseTransport', () => {
     });
 
     it('rejects non-SSE content-type', async () => {
-      const { fetch } = recordingFetch(
+      const { fetch, calls } = recordingFetch(
         () =>
           new Response('not sse', {
             status: 200,
@@ -273,15 +289,17 @@ describe('RestSseTransport', () => {
       const transport = new RestSseTransport('http://d', undefined, fetch);
       const gen = transport.subscribeEvents('s1');
       await expect(gen.next()).rejects.toThrow(DaemonHttpError);
+      expect(calls[0].signal?.aborted).toBe(true);
     });
 
     it('throws DaemonHttpError on non-ok response', async () => {
-      const { fetch } = recordingFetch(() =>
+      const { fetch, calls } = recordingFetch(() =>
         jsonResponse(404, { error: 'session not found' }),
       );
       const transport = new RestSseTransport('http://d', undefined, fetch);
       const gen = transport.subscribeEvents('s1');
       await expect(gen.next()).rejects.toThrow(DaemonHttpError);
+      expect(calls[0].signal?.aborted).toBe(true);
     });
 
     it('throws DaemonHttpError with correct status on non-ok response', async () => {
@@ -300,7 +318,7 @@ describe('RestSseTransport', () => {
     });
 
     it('throws when response has no body', async () => {
-      const { fetch } = recordingFetch(
+      const { fetch, calls } = recordingFetch(
         () =>
           new Response(null, {
             status: 200,
@@ -310,6 +328,7 @@ describe('RestSseTransport', () => {
       const transport = new RestSseTransport('http://d', undefined, fetch);
       const gen = transport.subscribeEvents('s1');
       await expect(gen.next()).rejects.toThrow('No SSE body');
+      expect(calls[0].signal?.aborted).toBe(true);
     });
 
     it('parses SSE frames into DaemonEvents', async () => {
@@ -317,7 +336,7 @@ describe('RestSseTransport', () => {
         'data: {"type":"update","data":{"msg":"hello"},"id":1,"v":1}\n\n',
         'data: {"type":"done","data":{},"id":2,"v":1}\n\n',
       ].join('');
-      const { fetch } = recordingFetch(() => sseResponse(frames));
+      const { fetch, calls } = recordingFetch(() => sseResponse(frames));
       const transport = new RestSseTransport('http://d', undefined, fetch);
 
       const events: unknown[] = [];
@@ -327,6 +346,90 @@ describe('RestSseTransport', () => {
       expect(events).toHaveLength(2);
       expect((events[0] as { type: string }).type).toBe('update');
       expect((events[1] as { type: string }).type).toBe('done');
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
+
+    it('aborts the request when the generator is returned early', async () => {
+      const onCancel = vi.fn();
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse(
+          'data: {"type":"a","data":{},"id":1,"v":1}\n\n',
+          onCancel,
+        ),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1');
+
+      expect((await gen.next()).done).toBe(false);
+      expect(calls[0].signal?.aborted).toBe(false);
+      await gen.return(undefined);
+
+      expect(calls[0].signal?.aborted).toBe(true);
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('aborts the request when for-await exits early', async () => {
+      const onCancel = vi.fn();
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse(
+          'data: {"type":"a","data":{},"id":1,"v":1}\n\n',
+          onCancel,
+        ),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+
+      for await (const _event of transport.subscribeEvents('s1')) {
+        break;
+      }
+
+      expect(calls[0].signal?.aborted).toBe(true);
+      expect(onCancel).toHaveBeenCalledOnce();
+    });
+
+    it('aborts the request when the generator is thrown into', async () => {
+      const upstream = new Error('consumer stopped');
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1');
+
+      expect((await gen.next()).done).toBe(false);
+      await expect(gen.throw(upstream)).rejects.toBe(upstream);
+
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
+
+    it('aborts the request without replacing a stream error', async () => {
+      const upstream = new Error('upstream network drop');
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(upstream);
+        },
+      });
+      const { fetch, calls } = recordingFetch(
+        () =>
+          new Response(body, {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1');
+
+      await expect(gen.next()).rejects.toBe(upstream);
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
+
+    it('aborts the request without replacing a connection error', async () => {
+      const upstream = new Error('connection refused');
+      const { fetch, calls } = recordingFetch(() => {
+        throw upstream;
+      });
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1');
+
+      await expect(gen.next()).rejects.toBe(upstream);
+      expect(calls[0].signal?.aborted).toBe(true);
     });
 
     it('URL-encodes sessionId in path', async () => {
@@ -359,8 +462,10 @@ describe('RestSseTransport', () => {
 
     it('connect-phase timeout triggers abort', async () => {
       // Create a fetch that hangs until aborted
+      let capturedSignal: AbortSignal | null | undefined;
       const fetchFn = vi.fn(
         async (_input: RequestInfo | URL, init?: RequestInit) => {
+          capturedSignal = init?.signal;
           return new Promise<Response>((_, reject) => {
             if (init?.signal) {
               init.signal.addEventListener('abort', () => {
@@ -376,6 +481,22 @@ describe('RestSseTransport', () => {
       const transport = new RestSseTransport('http://d', undefined, fetchFn);
       const gen = transport.subscribeEvents('s1', { connectTimeoutMs: 50 });
       await expect(gen.next()).rejects.toThrow();
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('does not apply the connect timeout to the SSE body', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1', { connectTimeoutMs: 10 });
+
+      expect((await gen.next()).done).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(calls[0].signal?.aborted).toBe(false);
+
+      await gen.return(undefined);
+      expect(calls[0].signal?.aborted).toBe(true);
     });
 
     it('signal abort prevents iteration', async () => {
@@ -385,7 +506,7 @@ describe('RestSseTransport', () => {
       // When the signal is pre-aborted, the fetch call will receive
       // the aborted signal. The mock fetch proceeds anyway, but
       // parseSseStream sees the aborted signal and returns immediately.
-      const { fetch } = recordingFetch(() =>
+      const { fetch, calls } = recordingFetch(() =>
         sseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
       );
       const transport = new RestSseTransport('http://d', undefined, fetch);
@@ -402,6 +523,27 @@ describe('RestSseTransport', () => {
       }
       // Either way, no events should be yielded
       expect(events).toHaveLength(0);
+      expect(calls[0].signal?.aborted).toBe(true);
+    });
+
+    it('signal abort ends an active iteration', async () => {
+      const ctrl = new AbortController();
+      const onCancel = vi.fn();
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse(
+          'data: {"type":"a","data":{},"id":1,"v":1}\n\n',
+          onCancel,
+        ),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1', { signal: ctrl.signal });
+
+      expect((await gen.next()).done).toBe(false);
+      ctrl.abort();
+      expect((await gen.next()).done).toBe(true);
+
+      expect(calls[0].signal?.aborted).toBe(true);
+      expect(onCancel).toHaveBeenCalledOnce();
     });
   });
 
@@ -419,6 +561,65 @@ describe('RestSseTransport', () => {
       const transport = new RestSseTransport('http://d', undefined, fetch);
       transport.dispose();
       expect(() => transport.dispose()).not.toThrow();
+    });
+
+    it('aborts every active SSE request', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        heldOpenSseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const first = transport.subscribeEvents('s1');
+      const second = transport.subscribeEvents('s2');
+
+      await Promise.all([first.next(), second.next()]);
+      expect(calls).toHaveLength(2);
+      expect(calls.every((call) => call.signal?.aborted === false)).toBe(true);
+
+      transport.dispose();
+
+      expect(calls.every((call) => call.signal?.aborted === true)).toBe(true);
+      await Promise.all([first.return(undefined), second.return(undefined)]);
+    });
+
+    it('unblocks a pending iterator read', async () => {
+      const { fetch } = recordingFetch(() =>
+        heldOpenSseResponse('data: {"type":"a","data":{},"id":1,"v":1}\n\n'),
+      );
+      const transport = new RestSseTransport('http://d', undefined, fetch);
+      const gen = transport.subscribeEvents('s1');
+
+      expect((await gen.next()).done).toBe(false);
+      const pending = gen.next();
+      transport.dispose();
+
+      await expect(pending).resolves.toEqual({ done: true, value: undefined });
+    });
+
+    it('aborts a request that is still connecting', async () => {
+      const aborted = new DOMException(
+        'The operation was aborted',
+        'AbortError',
+      );
+      let capturedSignal: AbortSignal | null | undefined;
+      const fetchFn = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          capturedSignal = init?.signal;
+          return new Promise<Response>((_, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(aborted), {
+              once: true,
+            });
+          });
+        },
+      ) as unknown as typeof globalThis.fetch;
+      const transport = new RestSseTransport('http://d', undefined, fetchFn);
+      const gen = transport.subscribeEvents('s1');
+
+      const pending = gen.next();
+      await vi.waitFor(() => expect(capturedSignal).toBeDefined());
+      transport.dispose();
+
+      expect(capturedSignal?.aborted).toBe(true);
+      await expect(pending).rejects.toBe(aborted);
     });
   });
 });


### PR DESCRIPTION
## What this PR does

Now that #7257 is part of the base branch, this PR is a follow-up lifecycle hardening change. It extends the transport-owned request controller beyond normal iterator exit so the entire subscription setup, response validation, and stream-consumption path is covered. Active subscriptions are tracked until completion, every early error path aborts and de-registers its request, and transport disposal idempotently aborts all in-flight subscriptions. Caller cancellation still shares the same signal with the fetch request and stream parser, while the connect timeout remains limited to the request-to-response-headers phase.

Regression coverage verifies the four early error paths that were not covered by #7257, normal and early iterator completion, caller cancellation, connect-timeout scope, connecting-request disposal, pending-read unblocking, and concurrent subscription disposal.

## Why it's needed

#7257 fixed the original #7238 failure by aborting the fetch request when an event iterator exits, but its cleanup boundary started only around stream consumption and transport disposal did not affect active subscriptions. A rejected fetch, non-success response, incorrect content type, or missing response body could therefore exit without aborting the request controller, while disposal during connection establishment could leave the consumer waiting. This follow-up makes ownership deterministic across the full subscription lifecycle without changing the public API or protocol.

## Reviewer Test Plan

### How to verify

Run `cd packages/sdk-typescript && npx vitest run test/unit/RestSseTransport.test.ts`; all 40 tests should pass. In particular, verify that fetch rejection, non-success responses, incorrect content type, and missing bodies abort their request signals, and that disposal closes concurrent active subscriptions, releases pending reads, and aborts a request that is still connecting.

Run the complete SDK test suite, build, and typecheck. The expected result is 30 passing test files with 1,388 passing tests, followed by successful SDK declaration generation and TypeScript checking.

Using a loopback SSE server, open several subscriptions concurrently and dispose the transport. Every socket should close within the bounded wait. A subscription disposed while connecting may reject with the existing platform `AbortError`; a subscription disposed while streaming ends cleanly through the existing stream-parser cancellation behavior. The 70-cycle Bun 1.3.10/1.3.13 scenario remains useful regression evidence for #7238 and #7257, but the distinguishing behavior for this follow-up is cleanup on the four early error paths and on transport disposal.

### Evidence (Before & After)

N/A — this is a non-UI transport lifecycle fix. The separate E2E report contains the original Bun socket-leak evidence, and the Linux review additionally verifies disposal against a real loopback server.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

macOS arm64 with Node.js 22.22.3, Bun 1.3.10 and Bun 1.3.13, plus an independent Node HTTP loopback SSE server; Linux verification used the repository Node.js toolchain and a Node loopback SSE server.

## Risk & Scope

- Main risk or tradeoff: Disposal now actively aborts in-flight requests. A request disposed while connecting can surface the existing platform `AbortError`, while an already-streaming subscription follows the existing clean-cancellation behavior; this PR does not introduce a new cross-transport error-normalization contract.
- Not validated / out of scope: Real-socket E2E was not run on Windows. Directly abandoning a started async generator without `return()`, `throw()`, a cancellation signal, or transport disposal remains outside the AsyncIterator lifecycle contract. Daemon routes, EventBus limits, ACP transports, and bounded content-generation SSE requests are unchanged.
- Breaking changes / migration notes: None. Public APIs, protocol fields, replay behavior, authentication, `Last-Event-ID`, and `maxQueued` semantics are unchanged. Consumers must close subscriptions through the AsyncIterator contract, and injected custom fetch implementations must honor the standard `AbortSignal` contract for deterministic socket closure.

## Linked Issues

Refs #7238

Follow-up to #7257

<details>
<summary>中文说明</summary>

## 本 PR 的作用

由于 #7257 现已进入基础分支，本 PR 调整为一项后续的连接生命周期强化。它把 transport 持有的请求 controller 从正常迭代器退出场景扩展到完整的订阅建立、响应校验和流消费路径。活跃订阅会被跟踪到结束，每条提前报错路径都会中止请求并注销 controller，transport dispose 则会幂等地中止全部进行中的订阅。调用方取消仍与 fetch 请求及流解析器共享同一个信号，连接超时也仍然只覆盖从发起请求到收到响应头的阶段。

回归测试覆盖 #7257 尚未处理的四条提前报错路径、正常和提前结束迭代、调用方取消、连接超时范围、连接中请求的 dispose、挂起读取解除以及并发订阅 dispose。

## 为什么需要

#7257 已通过在事件迭代器退出时中止 fetch 请求修复原始 #7238 问题，但它的清理边界只包围流消费阶段，transport dispose 也不会影响活跃订阅。因此，fetch 拒绝、非成功响应、错误 content type 或缺失响应 body 时，订阅可能在未中止请求 controller 的情况下退出；在连接建立期间 dispose 还可能让消费者继续等待。本后续改动让完整订阅生命周期的归属与清理保持确定性，同时不改变公开 API 或协议。

## 审阅者测试计划

### 如何验证

运行 `cd packages/sdk-typescript && npx vitest run test/unit/RestSseTransport.test.ts`；40 项测试应全部通过。重点验证 fetch 拒绝、非成功响应、错误 content type 和缺失 body 都会中止对应请求信号，同时 dispose 会关闭并发活跃订阅、解除挂起读取，并中止仍在连接中的请求。

运行完整 SDK 测试、构建和类型检查。预期结果为 30 个测试文件、1,388 项测试全部通过，随后 SDK 声明文件生成和 TypeScript 检查成功。

使用回环 SSE 服务端并发打开多个订阅后 dispose transport，所有 socket 都应在有上限的等待时间内关闭。连接阶段被 dispose 的订阅可能抛出平台既有的 `AbortError`；流式阶段被 dispose 的订阅则沿用流解析器已有的干净取消行为。Bun 1.3.10/1.3.13 的 70 次循环场景仍是 #7238 和 #7257 的有效回归证据，但本后续改动的区分性行为是四条提前报错路径和 transport dispose 上的完整清理。

### 证据（修改前后）

N/A — 这是非 UI 的 transport 生命周期修复。独立 E2E 报告包含原始 Bun socket 泄漏证据，Linux 评审还使用真实回环服务端验证了 dispose 行为。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

macOS arm64、Node.js 22.22.3、Bun 1.3.10 和 Bun 1.3.13，并使用独立的 Node HTTP 回环 SSE 服务端；Linux 验证使用仓库 Node.js 工具链和 Node 回环 SSE 服务端。

## 风险与范围

- 主要风险或权衡：dispose 现在会主动中止进行中的请求。连接阶段被 dispose 的请求可能暴露平台既有的 `AbortError`，已经进入流式阶段的订阅则沿用现有的干净取消行为；本 PR 不新增跨 transport 的错误归一化契约。
- 未验证或不在范围内：未在 Windows 上运行真实 socket E2E。直接遗弃已经启动的 async generator，且不通过 `return()`、`throw()`、取消信号或 transport dispose 结束它，仍不属于 AsyncIterator 生命周期契约。daemon 路由、EventBus 上限、ACP transports 以及有界的内容生成 SSE 请求均未修改。
- 破坏性变更或迁移说明：无。公开 API、协议字段、replay 行为、鉴权、`Last-Event-ID` 和 `maxQueued` 语义均保持不变。消费者必须通过 AsyncIterator 契约关闭订阅，注入的自定义 fetch 实现也必须遵守标准 `AbortSignal` 契约，才能确定性关闭 socket。

## 关联 Issues

参考 #7238

#7257 的后续改进

</details>
