### PR TITLE
perf(telemetry): lazy-load the SDK and split OTLP exporter chains by protocol

### DIFF
--- a/docs/design/2026-07-19-lazy-telemetry-sdk-loading.md
+++ b/docs/design/2026-07-19-lazy-telemetry-sdk-loading.md
@@ -1,7 +1,7 @@
 # Lazy-load the OpenTelemetry SDK off the ACP child startup path
 
 - **Issue**: #4748 (Optimize daemon cold start and qwen serve fast-path latency)
-- **Status**: Draft
+- **Status**: implemented
 - **Date**: 2026-07-19
 - **Depends on**: #7182 (TUI module removal), the metafile audit below
 
@@ -148,6 +148,16 @@ Key properties:
    which is _already_ the behavior for the entire pre-constructor window and
    for the interactive TUI path, where telemetry init is deferred to a
    background task (`startup-prefetch.ts:259`). No new failure mode.
+
+   Behavior change (intentional, documented): on the non-deferred paths — the
+   ACP child and headless `-p` runs, where `deferTelemetryInitialization` is
+   false — telemetry was previously fully registered by the time the
+   synchronous `initializeTelemetry` call returned; it now settles
+   asynchronously, so the existing drop window widens by the dynamic-import
+   cost (~50–150ms). We do _not_ `await` here on purpose: awaiting would put
+   the 2.16 MiB import back on the ACP child's critical path and undo the win.
+   Callers that need telemetry guaranteed-ready before proceeding (the daemon
+   runtime, caller 3) `await` explicitly.
 
 2. **`packages/cli/src/startup/startup-prefetch.ts:261`** (deferred task
    runner). Change the task closure to return the promise

--- a/docs/design/2026-07-19-lazy-telemetry-sdk-loading.md
+++ b/docs/design/2026-07-19-lazy-telemetry-sdk-loading.md
@@ -1,0 +1,235 @@
+# Lazy-load the OpenTelemetry SDK off the ACP child startup path
+
+- **Issue**: #4748 (Optimize daemon cold start and qwen serve fast-path latency)
+- **Status**: Draft
+- **Date**: 2026-07-19
+- **Depends on**: #7182 (TUI module removal), the metafile audit below
+
+## Problem
+
+`channel.initialize` (~1035ms P50 on 2C4G) is the dominant cost of the daemon's
+cold first Session, and ~67% of it is module loading in the ACP child. A
+metafile audit of the post-#7182 bundle (commit `de962a5ecf`, esbuild metafile
+with `DEV=true`) shows the ACP child's eager static closure is **17.24 MiB /
+2420 modules**, of which the OpenTelemetry cluster is the single largest
+coherent block:
+
+| group                                                                  | bytes (post-tree-shake) |
+| ---------------------------------------------------------------------- | ----------------------- |
+| `@grpc/grpc-js`                                                        | 577 KiB                 |
+| `@opentelemetry/otlp-transformer`                                      | 479 KiB                 |
+| `protobufjs` + `long` + `@grpc/proto-loader`                           | 305 KiB                 |
+| `@opentelemetry/sdk-metrics` / `sdk-node` / `sdk-trace-*` / `sdk-logs` | ~260 KiB                |
+| `@opentelemetry/instrumentation-*` + `instrumentation`                 | ~132 KiB                |
+| remaining `@opentelemetry/*` (exporters, propagators, resources, …)    | ~250 KiB                |
+| **total telemetry cluster**                                            | **2.16 MiB**            |
+
+Every byte of this is evaluated at ACP child startup even though:
+
+1. Telemetry is **disabled by default** — the common case pays the full module
+   tax for code that `initializeTelemetry()` then refuses to run
+   (`!config.getTelemetryEnabled()` early-return at `sdk.ts:202`).
+2. Even when enabled, nothing needs the SDK before the first span/log/metric,
+   which is always after `initialize` has been ACK'd.
+
+For calibration: #7182 removed 1.16 MiB and cut ACP import time 115→52ms
+(-63ms). This cluster is nearly 2× that size, so an effect in the same order
+is plausible — subject to the issue's measurement gate (below).
+
+## Why the import chain is eager
+
+`sdk.ts` statically imports everything at top level (`sdk.ts:13-32`): six OTLP
+exporters (gRPC + HTTP × traces/logs/metrics), `NodeSDK`, batch processors,
+`PeriodicExportingMetricReader`, and both instrumentations. `sdk.ts` itself is
+reached statically from the core barrel via `telemetry/index.ts`, and cannot be
+made wholly lazy because two hot-path modules statically depend on its cheap
+state getter:
+
+- `telemetry/loggers.ts:80` → `isTelemetrySdkInitialized()` (gates every log)
+- `telemetry/session-tracing.ts:31` → same (gates every span helper)
+
+So the split must separate the **cheap state facade** from the **heavy SDK
+assembly**, not just wrap six exporter imports in `await import()` — the
+`NodeSDK` / instrumentation / sdk-metrics imports (~0.7 MiB) are equally
+removable and live in the same file.
+
+## Design
+
+### File split inside `packages/core/src/telemetry/`
+
+**`sdk.ts` (stays; becomes the facade — no heavy imports).** Keeps, unchanged
+in name and semantics, everything other modules statically reach:
+
+- module state: `sdk`, `telemetryInitialized`, `telemetryShutdownPromise`,
+  `activeMetricReader` (typed via `import type` so no runtime load)
+- `isTelemetrySdkInitialized()`, `refreshSessionContext()`,
+  `shutdownTelemetry()`, `forceFlushMetrics()`
+- `resolveHttpOtlpUrl()` (exported, pure; no heavy deps)
+- the `diag.setLogger(...)` side effect (only needs `@opentelemetry/api`,
+  which is already ubiquitous and cheap — 56 KiB, also used by
+  `loggers.ts`/`metrics.ts`)
+
+Its only `@opentelemetry/*` runtime import is `@opentelemetry/api`.
+
+**`sdk-impl.ts` (new; the heavy half).** Receives verbatim: the six OTLP
+exporter imports, `NodeSDK`, `BatchSpanProcessor`, `BatchLogRecordProcessor`,
+`PeriodicExportingMetricReader`, both instrumentations, `CompressionAlgorithm`,
+`resourceFromAttributes`, `SessionIdSpanProcessor`, `parseOtlpEndpoint`,
+`validateUrl`, `normalizeOtlpPrefix` + prefix matching, the propagator gate,
+and the body of today's `initializeTelemetry()` from the resource build
+onward. It exports one function:
+
+```ts
+export function startTelemetrySdk(config: TelemetryRuntimeConfig):
+  | {
+      sdk: NodeSDK;
+      metricReader: PeriodicExportingMetricReader | undefined;
+    }
+  | undefined;
+```
+
+returning `undefined` on the existing "gRPC without base endpoint" skip path.
+`file-exporters.ts` and `log-to-span-processor.ts` move behind `sdk-impl.ts`
+too (they are only imported by `sdk.ts` today, and pull `sdk-logs`/
+`sdk-metrics`/`sdk-trace-base`).
+
+### `initializeTelemetry` becomes async
+
+In the facade:
+
+```ts
+let telemetryInitPromise: Promise<void> | undefined;
+
+export function initializeTelemetry(
+  config: TelemetryRuntimeConfig,
+): Promise<void> {
+  if (telemetryInitialized || !config.getTelemetryEnabled()) {
+    return Promise.resolve();
+  }
+  telemetryInitPromise ??= (async () => {
+    const { startTelemetrySdk } = await import('./sdk-impl.js');
+    const started = startTelemetrySdk(config);
+    if (!started) return;
+    sdk = started.sdk;
+    // sdk.start() + telemetryInitialized = true + setSessionContext +
+    // setShellTracePropagation + initializeMetrics — same order as today,
+    // same try/catch that only logs.
+  })().finally(() => {
+    telemetryInitPromise = undefined;
+  });
+  return telemetryInitPromise;
+}
+```
+
+Key properties:
+
+- **Disabled path stays synchronous and free** — the `getTelemetryEnabled()`
+  check runs before the dynamic import, so default-config users never load
+  the 2.16 MiB cluster at all. This is the actual win for the ACP child.
+- Single-flight guard (`telemetryInitPromise`) keeps the function idempotent
+  under concurrent callers, matching today's `telemetryInitialized` recheck.
+- `shutdownTelemetry()` needs no changes: it operates on the facade's `sdk`
+  variable and already no-ops when `!telemetryInitialized`.
+
+### Call-site treatment (all three production callers)
+
+1. **`packages/core/src/config/config.ts:2192`** (Config constructor —
+   synchronous context; this is the path the ACP child takes since
+   `deferTelemetryInitialization` is false for ACP mode, see
+   `packages/cli/src/config/config.ts:2075`). Fire-and-forget with a logged
+   catch:
+
+   ```ts
+   void initializeTelemetry(this).catch(...)
+   ```
+
+   Risk analysis: the only consequence of late start is that spans/logs
+   emitted in the gap are dropped by the `isTelemetrySdkInitialized()` gates —
+   which is _already_ the behavior for the entire pre-constructor window and
+   for the interactive TUI path, where telemetry init is deferred to a
+   background task (`startup-prefetch.ts:259`). No new failure mode.
+
+2. **`packages/cli/src/startup/startup-prefetch.ts:261`** (deferred task
+   runner). Change the task closure to return the promise
+   (`() => initializeTelemetry(config)`) so `runDeferredTask`'s existing
+   error handling observes rejections. Semantics otherwise unchanged.
+
+3. **`packages/cli/src/serve/run-qwen-serve.ts:2925`** (daemon runtime).
+   **Must `await`.** The very next line calls `initializeDaemonMetrics()`,
+   and OTel's `metrics.getMeter()` caches a noop meter permanently if called
+   before the SDK registers the global MeterProvider — daemon metrics would
+   silently die. The enclosing function is already async, so `await
+core.initializeTelemetry(...)` is a one-word change. This adds the
+   module-load cost to the _daemon runtime_ load (deferred, off the
+   fast path) only when telemetry is enabled — acceptable, and strictly
+   better than paying it in every ACP child.
+
+   The same ordering hazard exists in principle for `initializeMetrics()`
+   (`metrics.ts:409`), but that is called _inside_ the init promise after
+   `sdk.start()`, so ordering is preserved by construction.
+
+### Bundle guard extension
+
+Extend `scripts/check-serve-fast-path-bundle.js`'s ACP-boundary check
+(`findAcpImportBoundaryOffenders`) with a telemetry blacklist so the split
+cannot silently regress:
+
+```
+@grpc/grpc-js, @grpc/proto-loader, protobufjs,
+@opentelemetry/otlp-transformer, @opentelemetry/sdk-node,
+@opentelemetry/exporter-trace-otlp-grpc, @opentelemetry/exporter-logs-otlp-grpc,
+@opentelemetry/exporter-metrics-otlp-grpc,
+@opentelemetry/instrumentation-http, @opentelemetry/instrumentation-undici
+```
+
+(`@opentelemetry/api`, `semantic-conventions`, `core`, `resources`, `api-logs`
+stay off the blacklist — they are legitimately reachable from `loggers.ts`,
+`metrics.ts`, and type-level exports.)
+
+## What this does NOT change
+
+- No behavior change when telemetry is enabled — same exporters, same
+  processors, same instrumentation hooks, same shutdown/flush semantics.
+- No public API removal: `initializeTelemetry`'s return type changes
+  `void → Promise<void>`, which is source-compatible for existing
+  fire-and-forget callers (all call sites are updated in the same commit
+  anyway; this is a core-package change, maintainer-authored per AGENTS.md).
+- `telemetry/index.ts` barrel exports keep the same names.
+
+## Acceptance (issue #4748 measurement gate)
+
+Byte counts do not convert to milliseconds; the change must pass the issue's
+standing discipline before merging:
+
+1. **2C4G, 30 serial cold starts**, telemetry disabled (default config):
+   compare `channel.initialize` P50/P95 and process→first-Session P50 against
+   the `de962a5ecf` baseline. Ship only if P50 improves beyond run-to-run
+   noise.
+2. **Telemetry-enabled functional pass**: OTLP gRPC and HTTP targets each
+   receive traces/logs/metrics after the change (existing
+   `sdk.test.ts` matrix, plus one manual end-to-end against a local
+   collector); `--telemetry-outfile` file exporters still write.
+3. **Daemon metrics**: with telemetry enabled, daemon Status metrics ring and
+   `initializeDaemonMetrics()` gauges still report (guards the await at call
+   site 3).
+4. **Bundle guard**: `node scripts/check-serve-fast-path-bundle.js` green with
+   the extended blacklist; re-run the closure audit
+   (`.qwen/scripts/acp-closure-audit.mjs`) and record the new ACP closure
+   total (expected ≈ 17.24 − ~2.0 MiB, minus whatever `@opentelemetry/api` and
+   friends keep eager).
+5. **Unit tests**: `sdk.test.ts` awaits `initializeTelemetry` (15 call sites);
+   tests asserting exporter construction move to or mock `sdk-impl.ts`.
+
+## Alternatives considered
+
+- **Lazy-import only the six exporter classes, keep `initializeTelemetry`
+  sync.** Rejected: leaves ~0.7 MiB (`NodeSDK`, instrumentations,
+  `sdk-metrics`, batch processors) eager for no reason, and still forces the
+  async boundary somewhere — the enabled path constructs exporters
+  unconditionally, so the function goes async either way.
+- **Make the whole `telemetry/sdk.ts` module dynamic.** Rejected:
+  `loggers.ts` and `session-tracing.ts` gate every telemetry call on
+  `isTelemetrySdkInitialized()`; making that gate async would poison dozens
+  of hot synchronous call sites.
+- **Skip telemetry entirely in the ACP child.** Rejected in the issue already
+  (blanket skips change observable behavior for users who enable telemetry).

--- a/docs/design/2026-07-19-telemetry-protocol-split.md
+++ b/docs/design/2026-07-19-telemetry-protocol-split.md
@@ -1,0 +1,120 @@
+# Telemetry exporter protocol split (lazy SDK phase 2)
+
+- Status: implemented
+- Issue: QwenLM/qwen-code#7264 (candidate 1), follow-up to #4748
+- Predecessor: `2026-07-19-lazy-telemetry-sdk-loading.md` (facade / impl split)
+
+## Problem
+
+Phase 1 moved the whole telemetry SDK behind a dynamic `import()`, so
+telemetry-off processes load nothing. But telemetry-**on** processes still load
+`sdk-impl.ts`'s full static closure, which bundles both OTLP protocol chains
+regardless of which one the config selects:
+
+| Cluster                                                                                                              | Size (metafile, de962a5ecf + phase 1) | Needed by                            |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------ |
+| gRPC chain (`@grpc/grpc-js`, `protobufjs`, `@grpc/proto-loader`, `exporter-*-otlp-grpc`, `long`, `lodash.camelcase`) | 1121 KiB / 125 modules                | `otlpProtocol: 'grpc'` only          |
+| HTTP chain (`exporter-*-otlp-http`)                                                                                  | 23 KiB / 17 modules                   | `otlpProtocol: 'http'` only          |
+| Shared OTLP layer (`otlp-transformer`, `otlp-exporter-base`)                                                         | 915 KiB / 41 modules                  | both OTLP protocols, **not** outfile |
+
+The metafile shows two static importers of the OTLP surface outside the
+exporter packages themselves:
+
+1. `sdk-impl.ts` (its `CompressionAlgorithm` import) — removed by moving
+   exporter construction into the protocol modules.
+2. `@opentelemetry/sdk-node` itself — its `utils.js`/`sdk.js` eagerly
+   `require()` every exporter package (otlp proto/http/grpc × 3 signals,
+   zipkin, prometheus) to support `OTEL_*_EXPORTER` env-based
+   auto-configuration. qwen-code never reaches those code paths: it always
+   passes explicit `spanProcessors` / `logRecordProcessors` (an empty array
+   still short-circuits the env fallback). Handled by a bundle-time stub,
+   see below.
+
+With both cut, the split drops the entire OTLP surface from the outfile
+path, the gRPC chain from the HTTP path, and the HTTP chain from the gRPC
+path.
+
+The 2C4G benchmark for phase 1 showed why this matters: with telemetry on
+(outfile), the dynamic load of sdk-impl competes for CPU with session setup on
+2 cores (`config_construction`/`bootstrap` +50 ms), eating most of the −50 ms
+import-chain win. Shrinking what actually loads shrinks that contention.
+
+## Design
+
+Two new modules own exporter construction, loaded via dynamic `import()` from
+`startTelemetrySdk` only on their respective config branch:
+
+- `packages/core/src/telemetry/sdk-exporters-grpc.ts`
+  - Imports the three gRPC exporters + `CompressionAlgorithm` +
+    `PeriodicExportingMetricReader`.
+  - `createGrpcExporters(endpoint)` → `{ spanExporter, logExporter, metricReader }`,
+    all gzip-compressed, matching current construction exactly.
+- `packages/core/src/telemetry/sdk-exporters-http.ts`
+  - Imports the three HTTP exporters + `PeriodicExportingMetricReader` +
+    `LogToSpanProcessor`.
+  - `createHttpExporters({ tracesUrl, logsUrl, metricsUrl, logToSpan })` →
+    `{ spanExporter?, logExporter?, metricReader?, logToSpanProcessor? }`.
+    The logs→spans bridge decision (logs endpoint absent, traces present)
+    moves here with it, since the bridge constructs an HTTP trace exporter.
+
+`sdk-impl.ts` changes:
+
+- Drops all six exporter imports and `CompressionAlgorithm`; exporter
+  variables are typed against the SDK interfaces (`SpanExporter`,
+  `LogRecordExporter`) it already depends on.
+- `startTelemetrySdk` becomes `async`. Branch order is preserved:
+  - gRPC without a base endpoint still returns `undefined` **before** any
+    protocol module loads.
+  - HTTP URL validation (`validateUrl`) stays in `sdk-impl.ts`; the HTTP
+    module is only imported when at least one signal URL survives validation.
+  - The outfile branch touches neither protocol module.
+- The facade awaits `startTelemetrySdk` (it already runs inside the
+  single-flight async closure, so no caller-visible change).
+
+`esbuild.config.js` gains `sdkNodeExporterStubPlugin`: when — and only when —
+the importer is `@opentelemetry/sdk-node`, the exporter packages resolve to a
+stub whose constructors throw. Our protocol modules keep resolving the real
+packages. sdk-node only touches these bindings inside its env-driven
+configuration functions, which qwen-code's explicit processor arguments make
+unreachable for traces and logs; the one reachable path
+(`OTEL_METRICS_EXPORTER=otlp` etc.) now throws inside `NodeSDK.start()` —
+caught by the facade's existing try/catch — instead of silently exporting to
+a default localhost endpoint. Env-based exporter selection was never a
+supported qwen-code configuration surface.
+
+What each configuration loads after the split (measured static closure of
+each bundled entry chunk):
+
+| Config    | Loads                                             | Skips                |
+| --------- | ------------------------------------------------- | -------------------- |
+| outfile   | sdk-impl closure only (975 KiB)                   | both protocol chains |
+| OTLP http | + HTTP chain closure (1.2 MiB incl. shared layer) | gRPC cluster         |
+| OTLP grpc | + gRPC chain closure (1.9 MiB incl. shared layer) | HTTP exporters       |
+
+## Guard
+
+`scripts/check-serve-fast-path-bundle.js` gains a check rooted at the
+`sdk-impl` chunk: its static import closure must not reach any
+`FORBIDDEN_OTLP_PROTOCOL_PACKAGES` member — the gRPC cluster
+(`@grpc/grpc-js`, `@grpc/proto-loader`, `protobufjs`,
+`exporter-*-otlp-grpc`) plus `@opentelemetry/otlp-transformer`, which sits
+in the shared serialization layer both protocol chains pull in and so also
+catches a static re-import of the HTTP module. This locks the protocol
+split the same way the phase 1 blacklist locks the facade split.
+
+## Testing
+
+- `sdk.test.ts` keeps its `vi.mock` setup unchanged: vitest interception
+  applies to the protocol modules' imports of the same exporter packages, so
+  existing constructor-argument assertions carry over.
+- Acceptance follows the #4748 discipline: 30 paired serial cold starts on the
+  2C4G host, telemetry on (outfile), control = phase 1 build, candidate =
+  this change, reporting channel.initialize and process→first-session P50/P95.
+
+## Alternatives rejected
+
+- **Per-exporter (per-signal) modules**: three more modules for no measurable
+  gain — the three signals of one protocol are always configured together.
+- **Moving URL validation into the HTTP module**: would defer `diag` warnings
+  for invalid URLs behind a module load and change the no-valid-URL path from
+  "no import at all" to "import then no-op".

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { wasmLoader } from 'esbuild-plugin-wasm';
+import { isStubbedSdkNodeExporterImport } from './scripts/sdk-node-exporter-stub.js';
 
 let esbuild;
 try {
@@ -66,25 +67,13 @@ const wasmBinaryPlugin = {
 // sdk-node itself — our own protocol modules keep resolving the real ones.
 // The stubbed constructors throw so an unexpectedly reached env path (e.g.
 // `OTEL_METRICS_EXPORTER=otlp`) fails loudly instead of exporting nowhere;
-// NodeSDK.start() is wrapped in try/catch in `sdk.ts`.
-const SDK_NODE_STUBBED_EXPORTERS = new RegExp(
-  '^@opentelemetry/(' +
-    [
-      'exporter-trace-otlp-(grpc|http|proto)',
-      'exporter-logs-otlp-(grpc|http|proto)',
-      'exporter-metrics-otlp-(grpc|http|proto)',
-      'exporter-zipkin',
-      'exporter-prometheus',
-    ].join('|') +
-    ')$',
-);
-
+// NodeSDK.start() is wrapped in try/catch in `sdk.ts`. The resolve decision
+// lives in scripts/sdk-node-exporter-stub.js so it stays unit-testable.
 const sdkNodeExporterStubPlugin = {
   name: 'sdk-node-exporter-stub',
   setup(build) {
     build.onResolve({ filter: /^@opentelemetry\/exporter-/ }, (args) => {
-      if (!SDK_NODE_STUBBED_EXPORTERS.test(args.path)) return null;
-      if (!args.importer.includes(`@opentelemetry${path.sep}sdk-node`)) {
+      if (!isStubbedSdkNodeExporterImport(args.path, args.importer)) {
         return null;
       }
       return { path: args.path, namespace: 'sdk-node-exporter-stub' };
@@ -102,10 +91,22 @@ const sdkNodeExporterStubPlugin = {
             );
           };
           const handler = {
-            get: (_t, prop) =>
-              typeof prop === 'string'
-                ? function stubbedExporter() { throwStubbed(prop); }
-                : undefined,
+            // Module interop and thenable probes must see a plain, non-callable
+            // namespace: a bundler or await import() reads then and __esModule
+            // (Symbol.* keys are already covered by the typeof check), and
+            // constructing those as "exporters" would throw a confusing error.
+            get: (_t, prop) => {
+              if (
+                typeof prop !== 'string' ||
+                prop === 'then' ||
+                prop === '__esModule'
+              ) {
+                return undefined;
+              }
+              return function stubbedExporter() {
+                throwStubbed(prop);
+              };
+            },
           };
           module.exports = new Proxy({}, handler);
         `,

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -55,6 +55,66 @@ const wasmBinaryPlugin = {
   },
 };
 
+// `@opentelemetry/sdk-node` eagerly require()s every exporter package to
+// support `OTEL_*_EXPORTER` env-based auto-configuration, which would drag
+// both OTLP protocol chains (~2 MiB) back into the sdk-impl static closure
+// and defeat the per-protocol dynamic imports in
+// `packages/core/src/telemetry/sdk-{impl,exporters-grpc,exporters-http}.ts`
+// (issue #7264). qwen-code always passes explicit `spanProcessors` /
+// `logRecordProcessors` to NodeSDK, so those env code paths are unreachable
+// for traces and logs. Stub the exporter packages ONLY when imported by
+// sdk-node itself — our own protocol modules keep resolving the real ones.
+// The stubbed constructors throw so an unexpectedly reached env path (e.g.
+// `OTEL_METRICS_EXPORTER=otlp`) fails loudly instead of exporting nowhere;
+// NodeSDK.start() is wrapped in try/catch in `sdk.ts`.
+const SDK_NODE_STUBBED_EXPORTERS = new RegExp(
+  '^@opentelemetry/(' +
+    [
+      'exporter-trace-otlp-(grpc|http|proto)',
+      'exporter-logs-otlp-(grpc|http|proto)',
+      'exporter-metrics-otlp-(grpc|http|proto)',
+      'exporter-zipkin',
+      'exporter-prometheus',
+    ].join('|') +
+    ')$',
+);
+
+const sdkNodeExporterStubPlugin = {
+  name: 'sdk-node-exporter-stub',
+  setup(build) {
+    build.onResolve({ filter: /^@opentelemetry\/exporter-/ }, (args) => {
+      if (!SDK_NODE_STUBBED_EXPORTERS.test(args.path)) return null;
+      if (!args.importer.includes(`@opentelemetry${path.sep}sdk-node`)) {
+        return null;
+      }
+      return { path: args.path, namespace: 'sdk-node-exporter-stub' };
+    });
+    build.onLoad(
+      { filter: /.*/, namespace: 'sdk-node-exporter-stub' },
+      (args) => ({
+        contents: `
+          const throwStubbed = (name) => {
+            throw new Error(
+              'qwen-code bundles @opentelemetry/sdk-node without ' +
+                ${JSON.stringify(args.path)} + ' (env-based exporter ' +
+                'selection is unsupported; configure telemetry via ' +
+                'qwen-code settings instead). Attempted to construct: ' + name,
+            );
+          };
+          const handler = {
+            get: (_t, prop) =>
+              typeof prop === 'string'
+                ? function stubbedExporter() { throwStubbed(prop); }
+                : undefined,
+          };
+          module.exports = new Proxy({}, handler);
+        `,
+        loader: 'js',
+      }),
+    );
+  },
+};
+
 const external = [
   '@lydell/node-pty',
   'node-pty',
@@ -141,7 +201,11 @@ const mainBuild = esbuild.build({
     __filename: '__qwen_filename',
   },
   loader: { '.node': 'file' },
-  plugins: [wasmBinaryPlugin, wasmLoader({ mode: 'embedded' })],
+  plugins: [
+    sdkNodeExporterStubPlugin,
+    wasmBinaryPlugin,
+    wasmLoader({ mode: 'embedded' }),
+  ],
   metafile: true,
   write: true,
   keepNames: true,

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1142,7 +1142,7 @@ describe('runQwenServe telemetry validation', () => {
     tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qws-tv-')));
     const initializeTelemetry = vi
       .spyOn(qwenCore, 'initializeTelemetry')
-      .mockImplementation(() => {});
+      .mockResolvedValue(undefined);
     vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
       enabled: false,
       sensitiveSpanAttributeMaxLength: 1024 * 1024,

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -2922,7 +2922,10 @@ async function runQwenServeImpl(
       }
       throw err;
     }
-    core.initializeTelemetry(
+    // Must settle before initializeDaemonMetrics(): metrics.getMeter() caches
+    // a noop meter permanently if called before the SDK registers the global
+    // MeterProvider. This runs in the deferred runtime load, off the fast path.
+    await core.initializeTelemetry(
       createDaemonTelemetryRuntimeConfig(
         daemonTelemetrySettings,
         resolvedCliVersion,

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -257,9 +257,7 @@ export function startPostRenderPrefetches(
   }
 
   if (options.initializeTelemetry) {
-    runDeferredTask('telemetry_init', () => {
-      initializeTelemetry(config);
-    });
+    runDeferredTask('telemetry_init', () => initializeTelemetry(config));
   }
 
   if (config.isInteractive()) {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2189,7 +2189,14 @@ export class Config {
       this.telemetrySettings.enabled &&
       !this.telemetryInitializationDeferred
     ) {
-      initializeTelemetry(this);
+      // Fire-and-forget: the SDK module loads asynchronously (issue #4748),
+      // and spans/logs emitted before it settles are dropped by the
+      // isTelemetrySdkInitialized() gates — same as the deferred TUI path.
+      // Promise.resolve guards against auto-mocked initializeTelemetry
+      // returning undefined in tests.
+      void Promise.resolve(initializeTelemetry(this)).catch((error) => {
+        this.debugLogger.error('Failed to initialize telemetry:', error);
+      });
     }
 
     const proxyUrl = this.getProxy();

--- a/packages/core/src/telemetry/otlp-urls.ts
+++ b/packages/core/src/telemetry/otlp-urls.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Leaf module for OTLP HTTP URL resolution (issue #4748).
+ *
+ * Kept free of `@opentelemetry/*` and any telemetry SDK dependency so both the
+ * light facade (`sdk.ts`) and the heavy implementation (`sdk-impl.ts`) can
+ * import it without forming a cycle between them.
+ */
+
+/**
+ * Standard OTLP HTTP signal-specific paths per the OpenTelemetry specification.
+ * gRPC uses service-based routing so no path appending is needed.
+ */
+const OTLP_SIGNAL_PATHS = {
+  traces: 'v1/traces',
+  logs: 'v1/logs',
+  metrics: 'v1/metrics',
+} as const;
+
+export type OtlpSignal = keyof typeof OTLP_SIGNAL_PATHS;
+
+/**
+ * Resolve the final URL for an HTTP OTLP exporter.
+ *
+ * - If the URL path already ends with the signal-specific path (e.g., /v1/traces),
+ *   use it as-is. This supports explicit full-path configuration.
+ * - Otherwise, append the signal-specific path to the base URL.
+ */
+export function resolveHttpOtlpUrl(
+  baseEndpoint: string,
+  signal: OtlpSignal,
+): string {
+  const signalPath = OTLP_SIGNAL_PATHS[signal];
+  const url = new URL(baseEndpoint);
+  const normalizedPath = url.pathname.replace(/\/+$/, '');
+  if (normalizedPath.endsWith(signalPath)) {
+    return url.href;
+  }
+  // Append the signal path to the URL pathname, preserving query/hash.
+  url.pathname = normalizedPath + '/' + signalPath;
+  return url.href;
+}

--- a/packages/core/src/telemetry/sdk-exporters-grpc.ts
+++ b/packages/core/src/telemetry/sdk-exporters-grpc.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OTLP gRPC exporter chain (issue #7264, follow-up to #4748).
+ *
+ * Owns the gRPC protocol dependencies — @grpc/grpc-js, @grpc/proto-loader,
+ * and protobufjs (~1.1 MiB bundled). It must only ever be loaded via the
+ * dynamic `import()` in `sdk-impl.ts#startTelemetrySdk`, so telemetry-enabled
+ * processes using the HTTP or file exporters skip the gRPC cluster entirely.
+ * Do not import this module statically; `scripts/check-serve-fast-path-bundle.js`
+ * guards the sdk-impl static closure against regressions.
+ */
+
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+
+export interface GrpcExporters {
+  spanExporter: OTLPTraceExporter;
+  logExporter: OTLPLogExporter;
+  metricReader: PeriodicExportingMetricReader;
+}
+
+export function createGrpcExporters(endpoint: string): GrpcExporters {
+  return {
+    spanExporter: new OTLPTraceExporter({
+      url: endpoint,
+      compression: CompressionAlgorithm.GZIP,
+    }),
+    logExporter: new OTLPLogExporter({
+      url: endpoint,
+      compression: CompressionAlgorithm.GZIP,
+    }),
+    metricReader: new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        url: endpoint,
+        compression: CompressionAlgorithm.GZIP,
+      }),
+      exportIntervalMillis: 10000,
+    }),
+  };
+}

--- a/packages/core/src/telemetry/sdk-exporters-http.ts
+++ b/packages/core/src/telemetry/sdk-exporters-http.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OTLP HTTP exporter chain (issue #7264, follow-up to #4748).
+ *
+ * Owns the HTTP protocol exporters and, through them, the shared OTLP
+ * serialization layer (otlp-transformer + otlp-exporter-base, ~0.9 MiB
+ * bundled). It must only ever be loaded via the dynamic `import()` in
+ * `sdk-impl.ts#startTelemetrySdk`, so telemetry-enabled processes using the
+ * gRPC or file exporters skip this chain entirely. Do not import this module
+ * statically.
+ */
+
+import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPLogExporter as OTLPLogExporterHttp } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPMetricExporter as OTLPMetricExporterHttp } from '@opentelemetry/exporter-metrics-otlp-http';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import {
+  LogToSpanProcessor,
+  type LogToSpanDiagnosticsSink,
+} from './log-to-span-processor.js';
+
+export interface HttpExporterOptions {
+  tracesUrl: string | undefined;
+  logsUrl: string | undefined;
+  metricsUrl: string | undefined;
+  logToSpan: {
+    includeSensitiveSpanAttributes: boolean;
+    diagnosticsSink?: LogToSpanDiagnosticsSink;
+  };
+}
+
+export interface HttpExporters {
+  spanExporter: OTLPTraceExporterHttp | undefined;
+  logExporter: OTLPLogExporterHttp | undefined;
+  metricReader: PeriodicExportingMetricReader | undefined;
+  logToSpanProcessor: LogToSpanProcessor | undefined;
+}
+
+export function createHttpExporters(
+  options: HttpExporterOptions,
+): HttpExporters {
+  const { tracesUrl, logsUrl, metricsUrl } = options;
+  let spanExporter: OTLPTraceExporterHttp | undefined;
+  let logExporter: OTLPLogExporterHttp | undefined;
+  let metricReader: PeriodicExportingMetricReader | undefined;
+  let logToSpanProcessor: LogToSpanProcessor | undefined;
+
+  if (tracesUrl) {
+    spanExporter = new OTLPTraceExporterHttp({ url: tracesUrl });
+  }
+  if (logsUrl) {
+    logExporter = new OTLPLogExporterHttp({ url: logsUrl });
+  } else if (tracesUrl) {
+    // Bridge: no logs endpoint but traces endpoint exists.
+    // Convert log records to spans. Use a dedicated trace exporter so the
+    // bridge owns its own forceFlush/shutdown lifecycle.
+    logToSpanProcessor = new LogToSpanProcessor(
+      new OTLPTraceExporterHttp({ url: tracesUrl }),
+      {
+        includeSensitiveSpanAttributes:
+          options.logToSpan.includeSensitiveSpanAttributes,
+        ...(options.logToSpan.diagnosticsSink && {
+          diagnosticsSink: options.logToSpan.diagnosticsSink,
+        }),
+      },
+    );
+  }
+  if (metricsUrl) {
+    metricReader = new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporterHttp({ url: metricsUrl }),
+      exportIntervalMillis: 10000,
+    });
+  }
+
+  return { spanExporter, logExporter, metricReader, logToSpanProcessor };
+}

--- a/packages/core/src/telemetry/sdk-impl.ts
+++ b/packages/core/src/telemetry/sdk-impl.ts
@@ -1,0 +1,496 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Heavy half of the telemetry SDK split (issue #4748).
+ *
+ * This module owns NodeSDK, batch processors, and both instrumentations. It
+ * must only ever be loaded via the dynamic `import()` in
+ * `sdk.ts#initializeTelemetry`, so processes that never enable telemetry (the
+ * default) skip the module-load cost entirely. The six OTLP exporters live
+ * one level further down (issue #7264): `sdk-exporters-grpc.ts` (pulls in
+ * @grpc/grpc-js + protobufjs) and `sdk-exporters-http.ts` (pulls in
+ * otlp-transformer) are dynamically imported per configured protocol, so an
+ * outfile config loads neither chain. Do not import this module statically;
+ * `scripts/check-serve-fast-path-bundle.js` guards the ACP-child and serve
+ * pre-listen closures, and this module's own static closure, against
+ * regressions.
+ */
+
+import { diag } from '@opentelemetry/api';
+import type { Context, TextMapPropagator } from '@opentelemetry/api';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  BatchSpanProcessor,
+  type ReadableSpan,
+  type Span as SdkSpan,
+  type SpanExporter,
+  type SpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+import {
+  BatchLogRecordProcessor,
+  type LogRecordExporter,
+} from '@opentelemetry/sdk-logs';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
+import type { TelemetryRuntimeConfig } from './runtime-config.js';
+import { SERVICE_NAME } from './constants.js';
+import {
+  FileLogExporter,
+  FileMetricExporter,
+  FileSpanExporter,
+} from './file-exporters.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { LogToSpanProcessor } from './log-to-span-processor.js';
+import { getCurrentSessionId } from './session-context.js';
+import { resolveHttpOtlpUrl } from './sdk.js';
+
+/**
+ * `TextMapPropagator` that emits nothing. Installed when
+ * `outboundCorrelation.propagateTraceContext` is false (the default), so
+ * trace context stays internal to the user's OTLP collector and is not
+ * written into outbound `fetch` requests to third-party LLM providers.
+ *
+ * UndiciInstrumentation still creates client HTTP spans — the propagator
+ * only governs whether `propagation.inject()` writes `traceparent` into
+ * the outgoing request's header carrier. With this propagator installed,
+ * inject is a no-op and outbound requests carry no trace headers.
+ * Outbound-wire behavior is split out of telemetry default-on.
+ */
+const NOOP_PROPAGATOR: TextMapPropagator = {
+  inject() {},
+  extract(context: Context): Context {
+    return context;
+  },
+  fields(): string[] {
+    return [];
+  },
+};
+
+function parseOtlpEndpoint(
+  otlpEndpointSetting: string | undefined,
+  protocol: 'grpc' | 'http',
+): string | undefined {
+  if (!otlpEndpointSetting) {
+    return undefined;
+  }
+  // Trim leading/trailing quotes that might come from env variables
+  const trimmedEndpoint = otlpEndpointSetting.replace(/^["']|["']$/g, '');
+
+  try {
+    const url = new URL(trimmedEndpoint);
+    if (protocol === 'grpc') {
+      // OTLP gRPC exporters expect an endpoint in the format scheme://host:port
+      // The `origin` property provides this, stripping any path, query, or hash.
+      return url.origin;
+    }
+    // For http, use the full href.
+    return url.href;
+  } catch (error) {
+    diag.error('Invalid OTLP endpoint URL provided:', trimmedEndpoint, error);
+    return undefined;
+  }
+}
+
+/**
+ * Validate a URL string. Returns the URL if valid http(s), undefined otherwise.
+ * Logs an error for invalid URLs instead of throwing.
+ */
+function validateUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      diag.error(
+        `OTLP endpoint must use http or https, got ${parsed.protocol}`,
+      );
+      return undefined;
+    }
+    if (!parsed.hostname) {
+      diag.error('OTLP endpoint missing hostname');
+      return undefined;
+    }
+    return url;
+  } catch {
+    diag.error('Invalid OTLP signal endpoint URL, skipping:', url);
+    return undefined;
+  }
+}
+
+class SessionIdSpanProcessor implements SpanProcessor {
+  onStart(span: SdkSpan): void {
+    try {
+      if ((span as unknown as ReadableSpan).attributes?.['session.id']) return;
+      const sessionId = getCurrentSessionId();
+      if (sessionId) {
+        span.setAttribute('session.id', sessionId);
+      }
+    } catch {
+      // OTel processor errors must not break span creation
+    }
+  }
+  onEnd(_span: ReadableSpan): void {}
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+export interface StartedTelemetrySdk {
+  sdk: NodeSDK;
+  metricReader: PeriodicExportingMetricReader | undefined;
+}
+
+/**
+ * Assemble (but do not start) the NodeSDK for the given config. Returns
+ * `undefined` on the unsupported gRPC-without-base-endpoint configuration,
+ * matching the historical skip path. Async because the configured OTLP
+ * protocol chain is loaded on demand. The facade (`sdk.ts`) owns `start()`,
+ * initialized-state, and session-context wiring.
+ */
+export async function startTelemetrySdk(
+  config: TelemetryRuntimeConfig,
+): Promise<StartedTelemetrySdk | undefined> {
+  const debugLogger = createDebugLogger('OTEL');
+  // User-provided resource attributes (env + settings, already merged with
+  // RESERVED stripping and OTEL_SERVICE_NAME precedence in the resolver).
+  // We strip service.name/service.version here too as defense-in-depth, then
+  // re-apply runtime-controlled values on top.
+  const userAttrs = config.getTelemetryResourceAttributes() ?? {};
+  const userServiceName = userAttrs['service.name'];
+  // Strip keys we re-inject below (service.name, service.version) plus
+  // session.id, which never belongs on the Resource — Resource attributes
+  // auto-attach to every metric data point, which would bypass the metric
+  // cardinality toggle. The resolver normally drops session.id from user
+  // input already; this destructure is defense-in-depth for callers that
+  // bypass the resolver (e.g. direct Config construction in tests).
+  const {
+    'service.name': _ignoredServiceName,
+    'service.version': _ignoredServiceVersion,
+    'session.id': _ignoredSessionId,
+    ...nonReservedUserAttrs
+  } = userAttrs;
+  const resource = resourceFromAttributes({
+    ...nonReservedUserAttrs,
+    // `.trim() || SERVICE_NAME`: catches both empty string (`""`) and
+    // whitespace-only values (`" "`, `"\t"`) that would otherwise produce
+    // a blank service name on Resource (some backends reject these). Both
+    // settings (no value trimming there) and env (`%20` decodes to `" "`)
+    // can deliver whitespace-only values, so trim at the fallback point.
+    [SemanticResourceAttributes.SERVICE_NAME]:
+      userServiceName?.trim() || SERVICE_NAME,
+    [SemanticResourceAttributes.SERVICE_VERSION]:
+      config.getCliVersion() || 'unknown',
+  });
+
+  // One-time user-visible summary of resource-attribute diagnostics
+  // produced during config resolution. The per-warning `diag.warn` calls
+  // route to the OTel debug log; without this summary, an operator whose
+  // attributes are silently dropped has no console signal that anything
+  // happened. Telemetry init runs before Ink renders, so console output
+  // here does not interleave with the TUI.
+  // `?? []` defends against test mocks (`vi.mock('../config/config.js')`)
+  // that auto-stub Config methods to return undefined.
+  const attrWarnings = config.getTelemetryResourceAttributeWarnings() ?? [];
+  if (attrWarnings.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[qwen-code telemetry] ${attrWarnings.length} resource attribute issue(s):`,
+    );
+    for (const w of attrWarnings) {
+      // eslint-disable-next-line no-console
+      console.warn(`  - ${w}`);
+    }
+  }
+
+  const otlpEndpoint = config.getTelemetryOtlpEndpoint();
+  const otlpProtocol = config.getTelemetryOtlpProtocol();
+  const parsedEndpoint = parseOtlpEndpoint(otlpEndpoint, otlpProtocol);
+  const telemetryOutfile = config.getTelemetryOutfile();
+  const hasPerSignalEndpoint =
+    !!config.getTelemetryOtlpTracesEndpoint() ||
+    !!config.getTelemetryOtlpLogsEndpoint() ||
+    !!config.getTelemetryOtlpMetricsEndpoint();
+  const useOtlp =
+    (!!parsedEndpoint || hasPerSignalEndpoint) && !telemetryOutfile;
+
+  let spanExporter: SpanExporter | undefined;
+  let logExporter: LogRecordExporter | undefined;
+  let metricReader: PeriodicExportingMetricReader | undefined;
+  let logToSpanProcessor: LogToSpanProcessor | undefined;
+
+  if (useOtlp) {
+    if (otlpProtocol === 'http') {
+      const tracesUrl = validateUrl(
+        config.getTelemetryOtlpTracesEndpoint() ??
+          (parsedEndpoint
+            ? resolveHttpOtlpUrl(parsedEndpoint, 'traces')
+            : undefined),
+      );
+      const logsUrl = validateUrl(
+        config.getTelemetryOtlpLogsEndpoint() ??
+          (parsedEndpoint
+            ? resolveHttpOtlpUrl(parsedEndpoint, 'logs')
+            : undefined),
+      );
+      const metricsUrl = validateUrl(
+        config.getTelemetryOtlpMetricsEndpoint() ??
+          (parsedEndpoint
+            ? resolveHttpOtlpUrl(parsedEndpoint, 'metrics')
+            : undefined),
+      );
+
+      debugLogger.debug(
+        `OTLP HTTP endpoints: traces=${tracesUrl ?? 'none'}, logs=${logsUrl ?? 'none'}, metrics=${metricsUrl ?? 'none'}`,
+      );
+
+      if (tracesUrl || logsUrl || metricsUrl) {
+        // The HTTP chain (exporters + shared otlp-transformer serialization
+        // layer) loads only when at least one signal URL survives validation.
+        const { createHttpExporters } = await import('./sdk-exporters-http.js');
+        const httpExporters = createHttpExporters({
+          tracesUrl,
+          logsUrl,
+          metricsUrl,
+          logToSpan: {
+            includeSensitiveSpanAttributes:
+              config.getTelemetryIncludeSensitiveSpanAttributes(),
+            // In interactive (TUI) mode, route bridge diagnostics to the OTEL
+            // debug log file so they don't break out of the Ink render area
+            // via raw stderr. In non-interactive mode, leave the default sink
+            // alone so CI / scripts can still see export failures on stderr
+            // the canonical diagnostic channel for batch runs.
+            //
+            // Caveat for interactive mode: when the user has explicitly
+            // disabled file logging via QWEN_DEBUG_LOG_FILE=0, debugLogger.warn
+            // silently no-ops and bridge diagnostics are fully lost — accepted
+            // trade-off, since falling back to stderr would re-introduce the
+            // TUI pollution this injection was added to prevent.
+            ...(config.isInteractive() && {
+              diagnosticsSink: (message: string) => debugLogger.warn(message),
+            }),
+          },
+        });
+        spanExporter = httpExporters.spanExporter;
+        logExporter = httpExporters.logExporter;
+        metricReader = httpExporters.metricReader;
+        logToSpanProcessor = httpExporters.logToSpanProcessor;
+      }
+    } else {
+      // grpc — per-signal endpoints are not supported with gRPC protocol.
+      if (!parsedEndpoint) {
+        const warning =
+          'Per-signal OTLP endpoints are only supported with HTTP protocol. ' +
+          'Set otlpProtocol to "http" or provide a base otlpEndpoint for gRPC. ' +
+          'Telemetry SDK startup was skipped because no supported gRPC endpoint was configured.';
+        diag.warn(warning);
+        debugLogger.warn(warning);
+        return undefined;
+      } else {
+        // The gRPC chain (@grpc/grpc-js + protobufjs) loads only after the
+        // endpoint check above — a misconfigured gRPC setup imports nothing.
+        const { createGrpcExporters } = await import('./sdk-exporters-grpc.js');
+        const grpcExporters = createGrpcExporters(parsedEndpoint);
+        spanExporter = grpcExporters.spanExporter;
+        logExporter = grpcExporters.logExporter;
+        metricReader = grpcExporters.metricReader;
+      }
+    }
+  } else if (telemetryOutfile) {
+    spanExporter = new FileSpanExporter(telemetryOutfile);
+    logExporter = new FileLogExporter(telemetryOutfile);
+    metricReader = new PeriodicExportingMetricReader({
+      exporter: new FileMetricExporter(telemetryOutfile),
+      exportIntervalMillis: 10000,
+    });
+  }
+  // If no exporter is configured for a signal, it is silently skipped.
+
+  // Build OTLP exporter URL prefixes once. Both HttpInstrumentation (which
+  // patches Node's built-in `http`/`https` — used by the OTLP HTTP exporter)
+  // and UndiciInstrumentation (which patches `fetch` / undici — used by LLM
+  // SDKs but also by some OTLP exporters when configured) must ignore
+  // requests to these endpoints. Otherwise an upload would create a span
+  // that gets exported, creating an infinite feedback loop. Use WHATWG URL
+  // parsing so a parsed prefix is always { origin, pathname } — never the
+  // dangerous bare `"http"` fallback that startsWith would match against
+  // every HTTP URL on the wire.
+  function normalizeOtlpPrefix(
+    raw: string | undefined,
+  ): { origin: string; pathname: string } | undefined {
+    if (!raw) return undefined;
+    // Trim surrounding whitespace + ASCII quotes a user may have placed in
+    // settings.json (`"value"` → `value`). Use the SAME lenient regex as
+    // `parseOtlpEndpoint` (line 109) so any endpoint the exporter accepts
+    // also gets a feedback-loop guard. Asymmetric quotes (e.g. `"value'`)
+    // are almost certainly typos but `parseOtlpEndpoint` strips them too;
+    // mismatching here would let the exporter connect while the guard
+    // returned `undefined`, reintroducing the parasitic-span loop.
+    const s = raw.trim().replace(/^["']|["']$/g, '');
+    try {
+      const u = new URL(s);
+      // Drop ?query and #fragment — they're never part of the request
+      // signature an instrumentation observer sees on outbound requests.
+      // Strip a trailing `/` from path to keep prefix matching tight.
+      const pathname = u.pathname === '/' ? '' : u.pathname.replace(/\/$/, '');
+      return { origin: u.origin, pathname };
+    } catch {
+      // Unparseable URL (e.g. typo, placeholder). Reject entirely rather than
+      // attempt a string-level fallback — a fallback like `"http"` from input
+      // `"http"` would `startsWith`-match every outbound HTTP request and
+      // silently disable all instrumentation. Returning undefined means this
+      // misconfigured endpoint loses its feedback-loop guard, but the rest of
+      // the system stays correct.
+      diag.warn(
+        `Telemetry OTLP endpoint "${raw}" is not a valid URL; instrumentation feedback-loop guard for it is disabled.`,
+      );
+      return undefined;
+    }
+  }
+  const otlpUrlPrefixes = [
+    config.getTelemetryOtlpEndpoint(),
+    config.getTelemetryOtlpTracesEndpoint(),
+    config.getTelemetryOtlpLogsEndpoint(),
+    config.getTelemetryOtlpMetricsEndpoint(),
+  ]
+    .map(normalizeOtlpPrefix)
+    .filter((u): u is { origin: string; pathname: string } => !!u);
+
+  // Boundary-safe URL match. `url.startsWith(prefix)` is unsafe because:
+  //   - port: prefix `http://host:4318` matches `http://host:43180/x`
+  //   - path: prefix `http://host/v1` matches `http://host/v1foo/x`
+  //   - host: prefix `https://otlp.example.com` matches `https://otlp.example.com.evil.net`
+  // Comparing origin exactly + pathname with a path-boundary check avoids all
+  // three. The next char after the prefix pathname must be `/`, `?`, `#`, or
+  // end-of-string.
+  const matchesOtlpPrefix = (origin: string, path: string): boolean => {
+    for (const prefix of otlpUrlPrefixes) {
+      if (origin !== prefix.origin) continue;
+      if (prefix.pathname === '') return true;
+      if (!path.startsWith(prefix.pathname)) continue;
+      const next = path.charAt(prefix.pathname.length);
+      if (next === '' || next === '/' || next === '?' || next === '#') {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Strip ?query / #fragment from a path. `indexOf` (not regex) for CodeQL
+  // ReDoS hygiene.
+  const stripPathSuffix = (path: string): string => {
+    const qIdx = path.indexOf('?');
+    const fIdx = path.indexOf('#');
+    let cut = path.length;
+    if (qIdx !== -1) cut = Math.min(cut, qIdx);
+    if (fIdx !== -1) cut = Math.min(cut, fIdx);
+    return path.slice(0, cut);
+  };
+
+  // Outbound trace-context propagation gate:
+  // by default, install a no-op propagator so `traceparent` does NOT get
+  // written onto outbound `fetch` requests to LLM providers. Operators
+  // who want server-side trace stitching (e.g. ARMS+DashScope) opt in via
+  // `outboundCorrelation.propagateTraceContext: true`, which leaves the
+  // SDK's default W3C composite propagator in place. UndiciInstrumentation
+  // still creates client HTTP spans either way — the propagator only
+  // governs whether trace ids leak onto third-party request streams.
+  const textMapPropagator: TextMapPropagator | undefined =
+    config.getOutboundCorrelationPropagateTraceContext()
+      ? undefined // undefined → NodeSDK keeps its default W3C propagator
+      : NOOP_PROPAGATOR;
+
+  const sdk = new NodeSDK({
+    resource,
+    // Disable async host/process/env resource detectors: they leave attributes
+    // pending and trigger an OTel diag.error on any resource attribute read
+    // before the detectors settle (e.g. during HttpInstrumentation span creation).
+    autoDetectResources: false,
+    ...(textMapPropagator && { textMapPropagator }),
+    spanProcessors: spanExporter
+      ? [new SessionIdSpanProcessor(), new BatchSpanProcessor(spanExporter)]
+      : [],
+    logRecordProcessors: logExporter
+      ? [new BatchLogRecordProcessor(logExporter)]
+      : logToSpanProcessor
+        ? [logToSpanProcessor]
+        : [],
+    ...(metricReader && { metricReader }),
+    instrumentations: [
+      new HttpInstrumentation({
+        // OTLP HTTP exporter uses node:http (patched here, not by undici).
+        // Without this, every OTLP upload batch creates a parasitic client
+        // span that itself gets exported → feedback loop.
+        ignoreOutgoingRequestHook: (req) => {
+          if (otlpUrlPrefixes.length === 0) return false;
+          // Protocol must be known to compare reliably. The previous
+          // `|| 'http'` fallback silently mis-bucketed HTTPS requests as
+          // HTTP when `req.protocol` was unset, so HTTPS OTLP endpoints
+          // wouldn't match their prefix → guard bypassed → feedback loop.
+          // Now: when proto can't be determined, fail open (return false →
+          // request gets instrumented). Worst case is a parasitic client
+          // span for an OTLP request — observable and recoverable, vs. the
+          // unbounded feedback loop the previous default produced.
+          const proto = req.protocol
+            ? String(req.protocol).replace(/:$/, '')
+            : undefined;
+          if (!proto) return false;
+          // `req.host` may already include `:port` (e.g. `"collector:4318"`).
+          // Naively concatenating `:${req.port}` below would yield
+          // `"http://collector:4318:4318"`, which `new URL()` rejects → catch
+          // returns false → silent guard bypass. Currently unreachable because
+          // `@opentelemetry/otlp-exporter-base` always sets `hostname`, but
+          // the fallback exists and must be correct. Strip the port — IPv6
+          // literals like `"[::1]:443"` keep their bracketed host.
+          let host = req.hostname || '';
+          if (!host && req.host) {
+            const h = String(req.host);
+            const bracketEnd = h.indexOf(']');
+            const portIdx =
+              bracketEnd !== -1 ? h.indexOf(':', bracketEnd) : h.indexOf(':');
+            host = portIdx !== -1 ? h.slice(0, portIdx) : h;
+          }
+          const portPart =
+            req.port !== undefined && req.port !== null && String(req.port)
+              ? `:${req.port}`
+              : '';
+          // Route through `URL` so the reconstructed origin gets the same
+          // default-port stripping (`:80` for http, `:443` for https) that
+          // `normalizeOtlpPrefix` applies via `URL.origin`. Without this,
+          // prefix `http://collector` (no explicit port) wouldn't match a
+          // request to `http://collector:80/v1/traces` because `prefix.origin`
+          // strips `:80` while the manually built string keeps it.
+          let origin: string;
+          try {
+            origin = new URL(`${proto}://${host}${portPart}`).origin;
+          } catch {
+            return false;
+          }
+          const path =
+            typeof req.path === 'string' ? stripPathSuffix(req.path) : '';
+          return matchesOtlpPrefix(origin, path);
+        },
+      }),
+      // Modern fetch (`globalThis.fetch` / undici) is the HTTP layer used by
+      // `openai`, `@google/genai`, and `@anthropic-ai/sdk`. Without this
+      // instrumentation, outbound LLM requests carry no `traceparent` header
+      // and the trace tree terminates at the qwen-code process boundary.
+      new UndiciInstrumentation({
+        ignoreRequestHook: (request) => {
+          if (otlpUrlPrefixes.length === 0) return false;
+          const path =
+            typeof request.path === 'string'
+              ? stripPathSuffix(request.path)
+              : '';
+          return matchesOtlpPrefix(request.origin, path);
+        },
+      }),
+    ],
+  });
+
+  return { sdk, metricReader };
+}

--- a/packages/core/src/telemetry/sdk-impl.ts
+++ b/packages/core/src/telemetry/sdk-impl.ts
@@ -49,7 +49,7 @@ import {
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { LogToSpanProcessor } from './log-to-span-processor.js';
 import { getCurrentSessionId } from './session-context.js';
-import { resolveHttpOtlpUrl } from './sdk.js';
+import { resolveHttpOtlpUrl } from './otlp-urls.js';
 
 /**
  * `TextMapPropagator` that emits nothing. Installed when

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -11,9 +11,9 @@ import {
   initializeTelemetry,
   isTelemetrySdkInitialized,
   shutdownTelemetry,
-  resolveHttpOtlpUrl,
   refreshSessionContext,
 } from './sdk.js';
+import { resolveHttpOtlpUrl } from './otlp-urls.js';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
@@ -177,6 +177,66 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK).toHaveBeenCalledWith(
       expect.objectContaining({ autoDetectResources: false }),
     );
+  });
+
+  describe('lazy init lifecycle', () => {
+    it('shares a single in-flight init across concurrent callers', async () => {
+      await Promise.all([
+        initializeTelemetry(mockConfig),
+        initializeTelemetry(mockConfig),
+      ]);
+
+      expect(NodeSDK).toHaveBeenCalledTimes(1);
+      expect(NodeSDK.prototype.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the in-flight promise so a failed init can be retried', async () => {
+      vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
+        throw new Error('start failed');
+      });
+
+      // A failed init must resolve (never reject) and leave telemetry off so a
+      // later call can retry rather than reusing a poisoned single-flight promise.
+      await expect(initializeTelemetry(mockConfig)).resolves.toBeUndefined();
+      expect(isTelemetrySdkInitialized()).toBe(false);
+
+      // The retry succeeds: reaching `initialized === true` requires the
+      // continuation to have run `sdk.start()` again on a fresh SDK.
+      await initializeTelemetry(mockConfig);
+      expect(isTelemetrySdkInitialized()).toBe(true);
+    });
+
+    it('waits for an in-flight init before shutting down', async () => {
+      // Regression guard for the shutdown/init race: shutdown must not no-op
+      // past a not-yet-set `telemetryInitialized` and leak a started SDK whose
+      // buffered spans/logs never flush.
+      const initPromise = initializeTelemetry(mockConfig);
+      const shutdownPromise = shutdownTelemetry();
+
+      await Promise.all([initPromise, shutdownPromise]);
+
+      expect(NodeSDK.prototype.start).toHaveBeenCalledTimes(1);
+      expect(NodeSDK.prototype.shutdown).toHaveBeenCalledTimes(1);
+      expect(isTelemetrySdkInitialized()).toBe(false);
+    });
+
+    it('clears the shutdown promise when it races an init that fails to start', async () => {
+      vi.mocked(NodeSDK.prototype.start).mockImplementationOnce(() => {
+        throw new Error('start failed');
+      });
+
+      const initPromise = initializeTelemetry(mockConfig);
+      const shutdownPromise = shutdownTelemetry();
+      await Promise.all([initPromise, shutdownPromise]);
+      expect(isTelemetrySdkInitialized()).toBe(false);
+
+      // The no-op shutdown above resolved without an SDK; it must not leave a
+      // stale shutdown promise that short-circuits a later real teardown.
+      await initializeTelemetry(mockConfig);
+      await shutdownTelemetry();
+      expect(NodeSDK.prototype.shutdown).toHaveBeenCalledTimes(1);
+      expect(isTelemetrySdkInitialized()).toBe(false);
+    });
   });
 
   it('should route OpenTelemetry diagnostics to debug log instead of console output', async () => {

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -158,8 +158,8 @@ describe('Telemetry SDK', () => {
     await shutdownTelemetry();
   });
 
-  it('should use gRPC exporters when protocol is grpc', () => {
-    initializeTelemetry(mockConfig);
+  it('should use gRPC exporters when protocol is grpc', async () => {
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'http://localhost:4317',
@@ -251,14 +251,14 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should use HTTP exporters with signal-specific paths when protocol is http', () => {
+  it('should use HTTP exporters with signal-specific paths when protocol is http', async () => {
     vi.spyOn(mockConfig, 'getTelemetryEnabled').mockReturnValue(true);
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'http://localhost:4318',
     );
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
       url: 'http://localhost:4318/v1/traces',
@@ -275,22 +275,22 @@ describe('Telemetry SDK', () => {
     );
   });
 
-  it('should parse gRPC endpoint correctly', () => {
+  it('should parse gRPC endpoint correctly', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'https://my-collector.com',
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     expect(OTLPTraceExporter).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'https://my-collector.com' }),
     );
   });
 
-  it('should append signal paths to HTTP endpoint', () => {
+  it('should append signal paths to HTTP endpoint', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'https://my-collector.com',
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'https://my-collector.com/v1/traces' }),
     );
@@ -302,7 +302,7 @@ describe('Telemetry SDK', () => {
     );
   });
 
-  it('should use per-signal endpoint overrides when provided', () => {
+  it('should use per-signal endpoint overrides when provided', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
       'http://default-collector:4318',
@@ -311,7 +311,7 @@ describe('Telemetry SDK', () => {
       'http://traces-collector:4318/v1/traces',
     );
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     // Traces uses the per-signal override
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
@@ -326,7 +326,7 @@ describe('Telemetry SDK', () => {
     });
   });
 
-  it('should use per-signal overrides without base endpoint', () => {
+  it('should use per-signal overrides without base endpoint', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
     vi.spyOn(mockConfig, 'getTelemetryOtlpTracesEndpoint').mockReturnValue(
@@ -337,7 +337,7 @@ describe('Telemetry SDK', () => {
     );
     // logs has no override and no base endpoint
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     // Traces and metrics use per-signal override
     expect(OTLPTraceExporterHttp).toHaveBeenCalledWith({
@@ -355,7 +355,7 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
   });
 
-  it('passes sensitive span attribute config to the log-to-span bridge', () => {
+  it('passes sensitive span attribute config to the log-to-span bridge', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
     vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
     vi.spyOn(mockConfig, 'getTelemetryOtlpTracesEndpoint').mockReturnValue(
@@ -366,7 +366,7 @@ describe('Telemetry SDK', () => {
       'getTelemetryIncludeSensitiveSpanAttributes',
     ).mockReturnValue(true);
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(LogToSpanProcessor).toHaveBeenCalledWith(
       expect.anything(),
@@ -391,7 +391,7 @@ describe('Telemetry SDK', () => {
       process.env['QWEN_DEBUG_LOG_FILE'] = '1';
       setDebugLogSession({ getSessionId: () => 'log-to-span-sink-test' });
 
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       const call = vi.mocked(LogToSpanProcessor).mock.calls.at(-1);
       const opts = call?.[1] as { diagnosticsSink?: (m: string) => void };
@@ -427,7 +427,7 @@ describe('Telemetry SDK', () => {
     );
     vi.spyOn(mockConfig, 'isInteractive').mockReturnValue(false);
 
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     const call = vi.mocked(LogToSpanProcessor).mock.calls.at(-1);
     const opts = call?.[1] as { diagnosticsSink?: (m: string) => void };
@@ -472,7 +472,7 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should warn and skip startup for gRPC per-signal endpoints without base endpoint', () => {
+  it('should warn and skip startup for gRPC per-signal endpoints without base endpoint', async () => {
     const diagWarnSpy = vi.spyOn(diag, 'warn').mockImplementation(() => {});
     try {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('grpc');
@@ -481,7 +481,7 @@ describe('Telemetry SDK', () => {
         'http://traces-host/token/api/otlp/traces',
       );
 
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       expect(diagWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Telemetry SDK startup was skipped'),
@@ -493,11 +493,11 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should not use OTLP exporters when telemetryOutfile is set', () => {
+  it('should not use OTLP exporters when telemetryOutfile is set', async () => {
     vi.spyOn(mockConfig, 'getTelemetryOutfile').mockReturnValue(
       path.join(os.tmpdir(), 'test.log'),
     );
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     expect(OTLPTraceExporter).not.toHaveBeenCalled();
     expect(OTLPLogExporter).not.toHaveBeenCalled();
@@ -511,10 +511,10 @@ describe('Telemetry SDK', () => {
     );
   });
 
-  it('should not register async process shutdown handlers', () => {
+  it('should not register async process shutdown handlers', async () => {
     const processOnSpy = vi.spyOn(process, 'on');
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       expect(processOnSpy).not.toHaveBeenCalledWith(
         'SIGTERM',
@@ -534,15 +534,15 @@ describe('Telemetry SDK', () => {
   });
 
   it('should mark telemetry uninitialized after shutdown', async () => {
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     await shutdownTelemetry();
 
     expect(isTelemetrySdkInitialized()).toBe(false);
   });
 
-  it('should set service.version to the application version, not Node.js version', () => {
-    initializeTelemetry(mockConfig);
+  it('should set service.version to the application version, not Node.js version', async () => {
+    await initializeTelemetry(mockConfig);
 
     const constructorCall = vi.mocked(NodeSDK).mock.calls[0]![0]!;
     const resource = constructorCall.resource as {
@@ -559,7 +559,7 @@ describe('Telemetry SDK', () => {
       .mockReturnValue(new Promise<void>(() => {}));
     const diagWarnSpy = vi.spyOn(diag, 'warn').mockImplementation(() => {});
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       const shutdownPromise = shutdownTelemetry();
 
@@ -584,7 +584,7 @@ describe('Telemetry SDK', () => {
       .spyOn(NodeSDK.prototype, 'shutdown')
       .mockResolvedValue();
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       await shutdownTelemetry();
 
@@ -600,7 +600,7 @@ describe('Telemetry SDK', () => {
       .mockReturnValue(Promise.reject(new Error('shutdown failed')));
     const diagErrorSpy = vi.spyOn(diag, 'error').mockImplementation(() => {});
     try {
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
 
       await shutdownTelemetry();
 
@@ -615,9 +615,9 @@ describe('Telemetry SDK', () => {
     }
   });
 
-  it('should fall back to "unknown" when getCliVersion returns undefined', () => {
+  it('should fall back to "unknown" when getCliVersion returns undefined', async () => {
     vi.spyOn(mockConfig, 'getCliVersion').mockImplementation(() => undefined);
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
 
     const constructorCall = vi.mocked(NodeSDK).mock.calls[0]![0]!;
     const resource = constructorCall.resource as {
@@ -634,67 +634,67 @@ describe('Telemetry SDK', () => {
       ).attributes;
     }
 
-    it('does not place session.id on the Resource', () => {
-      initializeTelemetry(mockConfig);
+    it('does not place session.id on the Resource', async () => {
+      await initializeTelemetry(mockConfig);
       expect(getResourceAttributes()['session.id']).toBeUndefined();
     });
 
-    it('always sets service.name and service.version from runtime', () => {
-      initializeTelemetry(mockConfig);
+    it('always sets service.name and service.version from runtime', async () => {
+      await initializeTelemetry(mockConfig);
       const attrs = getResourceAttributes();
       expect(attrs['service.name']).toBe('qwen-code');
       expect(attrs['service.version']).toBe('1.0.0-test');
     });
 
-    it('attaches user-provided resource attributes', () => {
+    it('attaches user-provided resource attributes', async () => {
       vi.spyOn(mockConfig, 'getTelemetryResourceAttributes').mockReturnValue({
         team: 'platform',
         env: 'prod',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const attrs = getResourceAttributes();
       expect(attrs['team']).toBe('platform');
       expect(attrs['env']).toBe('prod');
     });
 
-    it('user-provided service.name wins over default', () => {
+    it('user-provided service.name wins over default', async () => {
       vi.spyOn(mockConfig, 'getTelemetryResourceAttributes').mockReturnValue({
         'service.name': 'qwen-code-ci',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       expect(getResourceAttributes()['service.name']).toBe('qwen-code-ci');
     });
 
-    it('user-provided service.version is ignored (runtime value wins)', () => {
+    it('user-provided service.version is ignored (runtime value wins)', async () => {
       vi.spyOn(mockConfig, 'getTelemetryResourceAttributes').mockReturnValue({
         'service.version': '99.0.0-fake',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       expect(getResourceAttributes()['service.version']).toBe('1.0.0-test');
     });
 
-    it('empty-string service.name from settings falls back to default', () => {
+    it('empty-string service.name from settings falls back to default', async () => {
       // Reviewer caught: `??` would let "" pass; `||` correctly falls back
       // so backends never see a blank service name.
       vi.spyOn(mockConfig, 'getTelemetryResourceAttributes').mockReturnValue({
         'service.name': '',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       expect(getResourceAttributes()['service.name']).toBe('qwen-code');
     });
 
-    it('whitespace-only service.name from settings falls back to default', () => {
+    it('whitespace-only service.name from settings falls back to default', async () => {
       // Reviewer caught: plain `||` lets `" "` through (truthy). The
       // `.trim() || SERVICE_NAME` fallback covers both empty and
       // whitespace-only values (env path can produce these via `%20`).
       vi.spyOn(mockConfig, 'getTelemetryResourceAttributes').mockReturnValue({
         'service.name': '   ',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       expect(getResourceAttributes()['service.name']).toBe('qwen-code');
     });
 
-    it('emits a console summary when resource-attribute warnings are present', () => {
+    it('emits a console summary when resource-attribute warnings are present', async () => {
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -706,7 +706,7 @@ describe('Telemetry SDK', () => {
           'OTEL_RESOURCE_ATTRIBUTES cannot override reserved key "service.version"; ignoring',
           'Skipping malformed OTEL_RESOURCE_ATTRIBUTES entry: "bogus"',
         ]);
-        initializeTelemetry(mockConfig);
+        await initializeTelemetry(mockConfig);
         const header = consoleWarnSpy.mock.calls[0]?.[0] ?? '';
         expect(header).toContain('2 resource attribute issue');
         expect(
@@ -719,19 +719,19 @@ describe('Telemetry SDK', () => {
       }
     });
 
-    it('no console output when warnings list is empty', () => {
+    it('no console output when warnings list is empty', async () => {
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
       try {
-        initializeTelemetry(mockConfig);
+        await initializeTelemetry(mockConfig);
         expect(consoleWarnSpy).not.toHaveBeenCalled();
       } finally {
         consoleWarnSpy.mockRestore();
       }
     });
 
-    it('user-provided session.id is stripped (defense-in-depth)', () => {
+    it('user-provided session.id is stripped (defense-in-depth)', async () => {
       // Simulates a caller that bypasses resolveTelemetrySettings() and feeds
       // raw user input straight into Config. Resource must still not carry
       // session.id, otherwise it would leak onto every metric data point.
@@ -739,7 +739,7 @@ describe('Telemetry SDK', () => {
         'session.id': 'spoofed',
         team: 'x',
       });
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const attrs = getResourceAttributes();
       expect(attrs['session.id']).toBeUndefined();
       expect(attrs['team']).toBe('x');
@@ -753,12 +753,12 @@ describe('Telemetry SDK', () => {
         .textMapPropagator;
     }
 
-    it('installs a no-op TextMapPropagator by default (propagateTraceContext=false)', () => {
+    it('installs a no-op TextMapPropagator by default (propagateTraceContext=false)', async () => {
       // Default behavior per PR #4390 R4 split: traceparent is NOT written
       // onto outbound wire. The propagator's inject() must be a no-op so
       // UndiciInstrumentation's `propagation.inject(carrier)` call writes
       // nothing into the outgoing request's headers.
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const propagator = getTextMapPropagator() as
         | { inject: (...args: unknown[]) => void; fields: () => string[] }
         | undefined;
@@ -775,12 +775,12 @@ describe('Telemetry SDK', () => {
       expect(carrier).toEqual({ existing: 'h' });
     });
 
-    it('uses the SDK default propagator when propagateTraceContext=true (operator opt-in)', () => {
+    it('uses the SDK default propagator when propagateTraceContext=true (operator opt-in)', async () => {
       vi.spyOn(
         mockConfig,
         'getOutboundCorrelationPropagateTraceContext',
       ).mockReturnValue(true);
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       // textMapPropagator is omitted from NodeSDK options → SDK installs
       // its default `CompositePropagator` (W3CTraceContextPropagator +
       // W3CBaggagePropagator). Test asserts the absence at the constructor
@@ -796,8 +796,8 @@ describe('Telemetry SDK', () => {
       return (constructorCall.instrumentations ?? []) as unknown[];
     }
 
-    it('registers both HttpInstrumentation and UndiciInstrumentation', () => {
-      initializeTelemetry(mockConfig);
+    it('registers both HttpInstrumentation and UndiciInstrumentation', async () => {
+      await initializeTelemetry(mockConfig);
       const instrumentations = getInstrumentations();
       // The mocks make HttpInstrumentation / UndiciInstrumentation auto-mocked
       // classes; instance-of checks against the mocked class still work.
@@ -809,12 +809,12 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('UndiciInstrumentation receives ignoreRequestHook that skips configured OTLP endpoints', () => {
+    it('UndiciInstrumentation receives ignoreRequestHook that skips configured OTLP endpoints', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -834,7 +834,7 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('ignoreRequestHook is a pure no-op when no OTLP endpoint is configured', () => {
+    it('ignoreRequestHook is a pure no-op when no OTLP endpoint is configured', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
       vi.spyOn(mockConfig, 'getTelemetryOtlpTracesEndpoint').mockReturnValue(
         undefined,
@@ -846,7 +846,7 @@ describe('Telemetry SDK', () => {
         undefined,
       );
       vi.spyOn(mockConfig, 'getTelemetryOutfile').mockReturnValue('/tmp/x');
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -860,7 +860,7 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('ignoreRequestHook handles per-signal endpoint configuration', () => {
+    it('ignoreRequestHook handles per-signal endpoint configuration', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue('');
       vi.spyOn(mockConfig, 'getTelemetryOtlpTracesEndpoint').mockReturnValue(
@@ -869,7 +869,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpLogsEndpoint').mockReturnValue(
         'http://logs.example.com:4318/v1/logs',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -896,12 +896,12 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('ignoreRequestHook strips query string from incoming path for matching', () => {
+    it('ignoreRequestHook strips query string from incoming path for matching', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -915,12 +915,12 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('ignoreRequestHook strips #fragment from incoming path for matching', () => {
+    it('ignoreRequestHook strips #fragment from incoming path for matching', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -932,7 +932,7 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('ignoreRequestHook normalizes endpoint config quoted in settings.json', () => {
+    it('ignoreRequestHook normalizes endpoint config quoted in settings.json', async () => {
       // Defense against settings.json `"otlpEndpoint": "\"http://...\""` —
       // quoted strings would otherwise miss the prefix match and reintroduce
       // the feedback loop. Per PR review feedback.
@@ -940,7 +940,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         '"http://collector.example.com:4318"',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -952,12 +952,12 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('ignoreRequestHook strips #fragment from configured endpoint', () => {
+    it('ignoreRequestHook strips #fragment from configured endpoint', async () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318/v1/traces#anchor',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -969,7 +969,7 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('ignoreRequestHook does NOT bleed across port boundary (4318 vs 43180)', () => {
+    it('ignoreRequestHook does NOT bleed across port boundary (4318 vs 43180)', async () => {
       // Defense against the URL prefix boundary collision: a naive
       // `url.startsWith(prefix)` would match `http://host:43180/...` against
       // prefix `http://host:4318`. Origin comparison is exact, so a
@@ -978,7 +978,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -990,7 +990,7 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('ignoreRequestHook does NOT bleed across hostname boundary (otlp vs otlp.evil)', () => {
+    it('ignoreRequestHook does NOT bleed across hostname boundary (otlp vs otlp.evil)', async () => {
       // Defense against the hostname suffix collision: prefix
       // `https://otlp.example.com` must NOT match
       // `https://otlp.example.com.evil.net`. Origin comparison is exact.
@@ -998,7 +998,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'https://otlp.example.com',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -1010,13 +1010,13 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('ignoreRequestHook does NOT bleed across path-segment boundary (/v1 vs /v1foo)', () => {
+    it('ignoreRequestHook does NOT bleed across path-segment boundary (/v1 vs /v1foo)', async () => {
       // Prefix `http://host/v1` must NOT match `http://host/v1foo/x`.
       vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318/v1',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -1035,7 +1035,7 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('normalizeOtlpPrefix rejects unparseable URLs entirely (no dangerous "http" fallback)', () => {
+    it('normalizeOtlpPrefix rejects unparseable URLs entirely (no dangerous "http" fallback)', async () => {
       // Critical fix: previously the catch fallback would let a typo like
       // `"http"` produce the prefix `"http"`, which startsWith-matches every
       // outbound HTTP request → silently disabled all instrumentation. The
@@ -1054,7 +1054,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpMetricsEndpoint').mockReturnValue(
         undefined,
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -1073,7 +1073,7 @@ describe('Telemetry SDK', () => {
       warnSpy.mockRestore();
     });
 
-    it('HttpInstrumentation also receives ignoreOutgoingRequestHook for OTLP exporter', () => {
+    it('HttpInstrumentation also receives ignoreOutgoingRequestHook for OTLP exporter', async () => {
       // The OTLP HTTP exporter uses node:http (patched by HttpInstrumentation,
       // NOT undici). Without this guard, every OTLP upload batch creates a
       // parasitic client span → feedback loop. PR #4390 review feedback.
@@ -1081,7 +1081,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const httpInstrumentationConfig = vi.mocked(HttpInstrumentation).mock
         .calls[0]![0]! as {
         ignoreOutgoingRequestHook: (req: {
@@ -1113,7 +1113,7 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('matches default-port requests against a portless prefix (URL.origin parity)', () => {
+    it('matches default-port requests against a portless prefix (URL.origin parity)', async () => {
       // Regression: `URL.origin` strips `:80` from `http://collector` to give
       // `http://collector`. The hook's manual `${proto}://${host}${portPart}`
       // reconstruction kept `:80`, so prefix and request origin diverged →
@@ -1122,7 +1122,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const httpInstrumentationConfig = vi.mocked(HttpInstrumentation).mock
         .calls[0]![0]! as {
         ignoreOutgoingRequestHook: (req: {
@@ -1144,7 +1144,7 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('fails open when req.protocol is missing (no silent HTTPS guard bypass)', () => {
+    it('fails open when req.protocol is missing (no silent HTTPS guard bypass)', async () => {
       // Regression: previous `|| 'http'` fallback silently mis-bucketed HTTPS
       // requests as HTTP when `req.protocol` was unset, so HTTPS OTLP
       // endpoints never matched their prefix → guard bypassed. Now: missing
@@ -1155,7 +1155,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'https://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const httpInstrumentationConfig = vi.mocked(HttpInstrumentation).mock
         .calls[0]![0]! as {
         ignoreOutgoingRequestHook: (req: {
@@ -1176,7 +1176,7 @@ describe('Telemetry SDK', () => {
       ).toBe(false);
     });
 
-    it('strips port from req.host fallback to avoid `host:port:port` URL reject', () => {
+    it('strips port from req.host fallback to avoid `host:port:port` URL reject', async () => {
       // Defensive: when `req.hostname` is absent and `req.host` already
       // includes `:port` (e.g. `"collector:4318"`), naively appending
       // `:${req.port}` produced `"http://collector:4318:4318"`, which
@@ -1188,7 +1188,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
         'http://collector.example.com:4318',
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const httpInstrumentationConfig = vi.mocked(HttpInstrumentation).mock
         .calls[0]![0]! as {
         ignoreOutgoingRequestHook: (req: {
@@ -1210,7 +1210,7 @@ describe('Telemetry SDK', () => {
       ).toBe(true);
     });
 
-    it('normalizeOtlpPrefix strips asymmetric quotes for parity with parseOtlpEndpoint', () => {
+    it('normalizeOtlpPrefix strips asymmetric quotes for parity with parseOtlpEndpoint', async () => {
       // parseOtlpEndpoint (line 109) uses /^["']|["']$/g which strips
       // asymmetric leading/trailing quotes. Previously normalizeOtlpPrefix
       // only stripped symmetric quotes, so settings.json typos like
@@ -1230,7 +1230,7 @@ describe('Telemetry SDK', () => {
       vi.spyOn(mockConfig, 'getTelemetryOtlpMetricsEndpoint').mockReturnValue(
         undefined,
       );
-      initializeTelemetry(mockConfig);
+      await initializeTelemetry(mockConfig);
       const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
         ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
       };
@@ -1274,8 +1274,8 @@ describe('refreshSessionContext', () => {
     await shutdownTelemetry();
   });
 
-  it('should update session context when telemetry is initialized', () => {
-    initializeTelemetry(mockConfig);
+  it('should update session context when telemetry is initialized', async () => {
+    await initializeTelemetry(mockConfig);
 
     refreshSessionContext('new-session-id');
 
@@ -1294,8 +1294,8 @@ describe('refreshSessionContext', () => {
     expect(setSessionContext).not.toHaveBeenCalled();
   });
 
-  it('should not throw when refreshing session context fails', () => {
-    initializeTelemetry(mockConfig);
+  it('should not throw when refreshing session context fails', async () => {
+    await initializeTelemetry(mockConfig);
     vi.clearAllMocks();
     vi.mocked(createSessionRootContext).mockImplementationOnce(() => {
       throw new Error('session context failed');
@@ -1338,19 +1338,19 @@ describe('shell trace propagation wiring', () => {
     await shutdownTelemetry();
   });
 
-  it('sets shell trace propagation on init based on config', () => {
+  it('sets shell trace propagation on init based on config', async () => {
     const config = {
       ...mockConfig,
       getOutboundCorrelationPropagateTraceContext: () => true,
     } as unknown as Config;
 
-    initializeTelemetry(config);
+    await initializeTelemetry(config);
 
     expect(setShellTracePropagation).toHaveBeenCalledWith(true);
   });
 
   it('resets shell trace propagation on shutdown', async () => {
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     vi.mocked(setShellTracePropagation).mockClear();
 
     await shutdownTelemetry();

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -4,44 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Light facade of the telemetry SDK split (issue #4748).
+ *
+ * Hot-path modules (`loggers.ts`, `session-tracing.ts`) statically gate every
+ * telemetry call on `isTelemetrySdkInitialized()`, so this module must stay
+ * cheap: its only runtime `@opentelemetry/*` dependency is `@opentelemetry/api`.
+ * All heavy SDK assembly (NodeSDK, instrumentations, and — one level further
+ * down, per configured protocol — the OTLP exporter chains) lives in
+ * `sdk-impl.ts` and is loaded via dynamic `import()` only when telemetry is
+ * actually enabled.
+ */
+
 import { DiagLogLevel, diag } from '@opentelemetry/api';
-import type {
-  Context,
-  DiagLogger,
-  TextMapPropagator,
-} from '@opentelemetry/api';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
-import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
-import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/exporter-trace-otlp-http';
-import { OTLPLogExporter as OTLPLogExporterHttp } from '@opentelemetry/exporter-logs-otlp-http';
-import { OTLPMetricExporter as OTLPMetricExporterHttp } from '@opentelemetry/exporter-metrics-otlp-http';
-import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import {
-  BatchSpanProcessor,
-  type ReadableSpan,
-  type Span as SdkSpan,
-  type SpanProcessor,
-} from '@opentelemetry/sdk-trace-node';
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
-import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
+import type { DiagLogger } from '@opentelemetry/api';
+import type { NodeSDK } from '@opentelemetry/sdk-node';
+import type { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import type { TelemetryRuntimeConfig } from './runtime-config.js';
-import { SERVICE_NAME } from './constants.js';
 import { initializeMetrics } from './metrics.js';
-import {
-  FileLogExporter,
-  FileMetricExporter,
-  FileSpanExporter,
-} from './file-exporters.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { createSessionRootContext } from './tracer.js';
-import { getCurrentSessionId, setSessionContext } from './session-context.js';
+import { setSessionContext } from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
 import { endInteractionSpan } from './session-tracing.js';
 
@@ -100,30 +83,9 @@ export function resolveHttpOtlpUrl(
 // (2s) and overall (5s) timeouts, so this value is effectively unreachable there.
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
-/**
- * `TextMapPropagator` that emits nothing. Installed when
- * `outboundCorrelation.propagateTraceContext` is false (the default), so
- * trace context stays internal to the user's OTLP collector and is not
- * written into outbound `fetch` requests to third-party LLM providers.
- *
- * UndiciInstrumentation still creates client HTTP spans — the propagator
- * only governs whether `propagation.inject()` writes `traceparent` into
- * the outgoing request's header carrier. With this propagator installed,
- * inject is a no-op and outbound requests carry no trace headers.
- * Outbound-wire behavior is split out of telemetry default-on.
- */
-const NOOP_PROPAGATOR: TextMapPropagator = {
-  inject() {},
-  extract(context: Context): Context {
-    return context;
-  },
-  fields(): string[] {
-    return [];
-  },
-};
-
 let sdk: NodeSDK | undefined;
 let telemetryInitialized = false;
+let telemetryInitPromise: Promise<void> | undefined;
 let telemetryShutdownPromise: Promise<void> | undefined;
 let activeMetricReader: PeriodicExportingMetricReader | undefined;
 
@@ -131,450 +93,44 @@ export function isTelemetrySdkInitialized(): boolean {
   return telemetryInitialized;
 }
 
-function parseOtlpEndpoint(
-  otlpEndpointSetting: string | undefined,
-  protocol: 'grpc' | 'http',
-): string | undefined {
-  if (!otlpEndpointSetting) {
-    return undefined;
-  }
-  // Trim leading/trailing quotes that might come from env variables
-  const trimmedEndpoint = otlpEndpointSetting.replace(/^["']|["']$/g, '');
-
-  try {
-    const url = new URL(trimmedEndpoint);
-    if (protocol === 'grpc') {
-      // OTLP gRPC exporters expect an endpoint in the format scheme://host:port
-      // The `origin` property provides this, stripping any path, query, or hash.
-      return url.origin;
-    }
-    // For http, use the full href.
-    return url.href;
-  } catch (error) {
-    diag.error('Invalid OTLP endpoint URL provided:', trimmedEndpoint, error);
-    return undefined;
-  }
-}
-
-/**
- * Validate a URL string. Returns the URL if valid http(s), undefined otherwise.
- * Logs an error for invalid URLs instead of throwing.
- */
-function validateUrl(url: string | undefined): string | undefined {
-  if (!url) return undefined;
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      diag.error(
-        `OTLP endpoint must use http or https, got ${parsed.protocol}`,
-      );
-      return undefined;
-    }
-    if (!parsed.hostname) {
-      diag.error('OTLP endpoint missing hostname');
-      return undefined;
-    }
-    return url;
-  } catch {
-    diag.error('Invalid OTLP signal endpoint URL, skipping:', url);
-    return undefined;
-  }
-}
-
-class SessionIdSpanProcessor implements SpanProcessor {
-  onStart(span: SdkSpan): void {
-    try {
-      if ((span as unknown as ReadableSpan).attributes?.['session.id']) return;
-      const sessionId = getCurrentSessionId();
-      if (sessionId) {
-        span.setAttribute('session.id', sessionId);
-      }
-    } catch {
-      // OTel processor errors must not break span creation
-    }
-  }
-  onEnd(_span: ReadableSpan): void {}
-  async shutdown(): Promise<void> {}
-  async forceFlush(): Promise<void> {}
-}
-
-export function initializeTelemetry(config: TelemetryRuntimeConfig): void {
+export function initializeTelemetry(
+  config: TelemetryRuntimeConfig,
+): Promise<void> {
   if (telemetryInitialized || !config.getTelemetryEnabled()) {
-    return;
+    return Promise.resolve();
   }
-
-  const debugLogger = createDebugLogger('OTEL');
-  // User-provided resource attributes (env + settings, already merged with
-  // RESERVED stripping and OTEL_SERVICE_NAME precedence in the resolver).
-  // We strip service.name/service.version here too as defense-in-depth, then
-  // re-apply runtime-controlled values on top.
-  const userAttrs = config.getTelemetryResourceAttributes() ?? {};
-  const userServiceName = userAttrs['service.name'];
-  // Strip keys we re-inject below (service.name, service.version) plus
-  // session.id, which never belongs on the Resource — Resource attributes
-  // auto-attach to every metric data point, which would bypass the metric
-  // cardinality toggle. The resolver normally drops session.id from user
-  // input already; this destructure is defense-in-depth for callers that
-  // bypass the resolver (e.g. direct Config construction in tests).
-  const {
-    'service.name': _ignoredServiceName,
-    'service.version': _ignoredServiceVersion,
-    'session.id': _ignoredSessionId,
-    ...nonReservedUserAttrs
-  } = userAttrs;
-  const resource = resourceFromAttributes({
-    ...nonReservedUserAttrs,
-    // `.trim() || SERVICE_NAME`: catches both empty string (`""`) and
-    // whitespace-only values (`" "`, `"\t"`) that would otherwise produce
-    // a blank service name on Resource (some backends reject these). Both
-    // settings (no value trimming there) and env (`%20` decodes to `" "`)
-    // can deliver whitespace-only values, so trim at the fallback point.
-    [SemanticResourceAttributes.SERVICE_NAME]:
-      userServiceName?.trim() || SERVICE_NAME,
-    [SemanticResourceAttributes.SERVICE_VERSION]:
-      config.getCliVersion() || 'unknown',
-  });
-
-  // One-time user-visible summary of resource-attribute diagnostics
-  // produced during config resolution. The per-warning `diag.warn` calls
-  // route to the OTel debug log; without this summary, an operator whose
-  // attributes are silently dropped has no console signal that anything
-  // happened. Telemetry init runs before Ink renders, so console output
-  // here does not interleave with the TUI.
-  // `?? []` defends against test mocks (`vi.mock('../config/config.js')`)
-  // that auto-stub Config methods to return undefined.
-  const attrWarnings = config.getTelemetryResourceAttributeWarnings() ?? [];
-  if (attrWarnings.length > 0) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[qwen-code telemetry] ${attrWarnings.length} resource attribute issue(s):`,
-    );
-    for (const w of attrWarnings) {
-      // eslint-disable-next-line no-console
-      console.warn(`  - ${w}`);
-    }
-  }
-
-  const otlpEndpoint = config.getTelemetryOtlpEndpoint();
-  const otlpProtocol = config.getTelemetryOtlpProtocol();
-  const parsedEndpoint = parseOtlpEndpoint(otlpEndpoint, otlpProtocol);
-  const telemetryOutfile = config.getTelemetryOutfile();
-  const hasPerSignalEndpoint =
-    !!config.getTelemetryOtlpTracesEndpoint() ||
-    !!config.getTelemetryOtlpLogsEndpoint() ||
-    !!config.getTelemetryOtlpMetricsEndpoint();
-  const useOtlp =
-    (!!parsedEndpoint || hasPerSignalEndpoint) && !telemetryOutfile;
-
-  let spanExporter:
-    | OTLPTraceExporter
-    | OTLPTraceExporterHttp
-    | FileSpanExporter
-    | undefined;
-  let logExporter:
-    | OTLPLogExporter
-    | OTLPLogExporterHttp
-    | FileLogExporter
-    | undefined;
-  let metricReader: PeriodicExportingMetricReader | undefined;
-  let logToSpanProcessor: LogToSpanProcessor | undefined;
-
-  if (useOtlp) {
-    if (otlpProtocol === 'http') {
-      const tracesUrl = validateUrl(
-        config.getTelemetryOtlpTracesEndpoint() ??
-          (parsedEndpoint
-            ? resolveHttpOtlpUrl(parsedEndpoint, 'traces')
-            : undefined),
-      );
-      const logsUrl = validateUrl(
-        config.getTelemetryOtlpLogsEndpoint() ??
-          (parsedEndpoint
-            ? resolveHttpOtlpUrl(parsedEndpoint, 'logs')
-            : undefined),
-      );
-      const metricsUrl = validateUrl(
-        config.getTelemetryOtlpMetricsEndpoint() ??
-          (parsedEndpoint
-            ? resolveHttpOtlpUrl(parsedEndpoint, 'metrics')
-            : undefined),
-      );
-
-      debugLogger.debug(
-        `OTLP HTTP endpoints: traces=${tracesUrl ?? 'none'}, logs=${logsUrl ?? 'none'}, metrics=${metricsUrl ?? 'none'}`,
-      );
-
-      if (tracesUrl) {
-        spanExporter = new OTLPTraceExporterHttp({ url: tracesUrl });
-      }
-      if (logsUrl) {
-        logExporter = new OTLPLogExporterHttp({ url: logsUrl });
-      } else if (tracesUrl) {
-        // Bridge: no logs endpoint but traces endpoint exists.
-        // Convert log records to spans. Use a dedicated trace exporter so the
-        // bridge owns its own forceFlush/shutdown lifecycle.
-        logToSpanProcessor = new LogToSpanProcessor(
-          new OTLPTraceExporterHttp({ url: tracesUrl }),
-          {
-            includeSensitiveSpanAttributes:
-              config.getTelemetryIncludeSensitiveSpanAttributes(),
-            // In interactive (TUI) mode, route bridge diagnostics to the OTEL
-            // debug log file so they don't break out of the Ink render area
-            // via raw stderr. In non-interactive mode, leave the default sink
-            // alone so CI / scripts can still see export failures on stderr
-            // the canonical diagnostic channel for batch runs.
-            //
-            // Caveat for interactive mode: when the user has explicitly
-            // disabled file logging via QWEN_DEBUG_LOG_FILE=0, debugLogger.warn
-            // silently no-ops and bridge diagnostics are fully lost — accepted
-            // trade-off, since falling back to stderr would re-introduce the
-            // TUI pollution this injection was added to prevent.
-            ...(config.isInteractive() && {
-              diagnosticsSink: (message: string) => debugLogger.warn(message),
-            }),
-          },
-        );
-      }
-      if (metricsUrl) {
-        metricReader = new PeriodicExportingMetricReader({
-          exporter: new OTLPMetricExporterHttp({ url: metricsUrl }),
-          exportIntervalMillis: 10000,
-        });
-      }
-    } else {
-      // grpc — per-signal endpoints are not supported with gRPC protocol.
-      if (!parsedEndpoint) {
-        const warning =
-          'Per-signal OTLP endpoints are only supported with HTTP protocol. ' +
-          'Set otlpProtocol to "http" or provide a base otlpEndpoint for gRPC. ' +
-          'Telemetry SDK startup was skipped because no supported gRPC endpoint was configured.';
-        diag.warn(warning);
-        debugLogger.warn(warning);
-        return;
-      } else {
-        spanExporter = new OTLPTraceExporter({
-          url: parsedEndpoint,
-          compression: CompressionAlgorithm.GZIP,
-        });
-        logExporter = new OTLPLogExporter({
-          url: parsedEndpoint,
-          compression: CompressionAlgorithm.GZIP,
-        });
-        metricReader = new PeriodicExportingMetricReader({
-          exporter: new OTLPMetricExporter({
-            url: parsedEndpoint,
-            compression: CompressionAlgorithm.GZIP,
-          }),
-          exportIntervalMillis: 10000,
-        });
-      }
-    }
-  } else if (telemetryOutfile) {
-    spanExporter = new FileSpanExporter(telemetryOutfile);
-    logExporter = new FileLogExporter(telemetryOutfile);
-    metricReader = new PeriodicExportingMetricReader({
-      exporter: new FileMetricExporter(telemetryOutfile),
-      exportIntervalMillis: 10000,
-    });
-  }
-  // If no exporter is configured for a signal, it is silently skipped.
-
-  // Build OTLP exporter URL prefixes once. Both HttpInstrumentation (which
-  // patches Node's built-in `http`/`https` — used by the OTLP HTTP exporter)
-  // and UndiciInstrumentation (which patches `fetch` / undici — used by LLM
-  // SDKs but also by some OTLP exporters when configured) must ignore
-  // requests to these endpoints. Otherwise an upload would create a span
-  // that gets exported, creating an infinite feedback loop. Use WHATWG URL
-  // parsing so a parsed prefix is always { origin, pathname } — never the
-  // dangerous bare `"http"` fallback that startsWith would match against
-  // every HTTP URL on the wire.
-  function normalizeOtlpPrefix(
-    raw: string | undefined,
-  ): { origin: string; pathname: string } | undefined {
-    if (!raw) return undefined;
-    // Trim surrounding whitespace + ASCII quotes a user may have placed in
-    // settings.json (`"value"` → `value`). Use the SAME lenient regex as
-    // `parseOtlpEndpoint` (line 109) so any endpoint the exporter accepts
-    // also gets a feedback-loop guard. Asymmetric quotes (e.g. `"value'`)
-    // are almost certainly typos but `parseOtlpEndpoint` strips them too;
-    // mismatching here would let the exporter connect while the guard
-    // returned `undefined`, reintroducing the parasitic-span loop.
-    const s = raw.trim().replace(/^["']|["']$/g, '');
+  // Single-flight: concurrent callers share one in-flight init. The promise
+  // is cleared in `finally` so a failed dynamic import can be retried, while
+  // a successful init keeps returning early via `telemetryInitialized`.
+  telemetryInitPromise ??= (async () => {
+    // The heavy SDK assembly is loaded on demand so disabled-telemetry
+    // processes — notably the ACP child on the daemon cold-start path —
+    // never pay the module-load cost. `startTelemetrySdk` in turn loads
+    // only the configured OTLP protocol chain (issue #7264).
+    const { startTelemetrySdk } = await import('./sdk-impl.js');
+    if (telemetryInitialized) return;
+    const started = await startTelemetrySdk(config);
+    if (!started) return;
+    sdk = started.sdk;
+    const debugLogger = createDebugLogger('OTEL');
     try {
-      const u = new URL(s);
-      // Drop ?query and #fragment — they're never part of the request
-      // signature an instrumentation observer sees on outbound requests.
-      // Strip a trailing `/` from path to keep prefix matching tight.
-      const pathname = u.pathname === '/' ? '' : u.pathname.replace(/\/$/, '');
-      return { origin: u.origin, pathname };
-    } catch {
-      // Unparseable URL (e.g. typo, placeholder). Reject entirely rather than
-      // attempt a string-level fallback — a fallback like `"http"` from input
-      // `"http"` would `startsWith`-match every outbound HTTP request and
-      // silently disable all instrumentation. Returning undefined means this
-      // misconfigured endpoint loses its feedback-loop guard, but the rest of
-      // the system stays correct.
-      diag.warn(
-        `Telemetry OTLP endpoint "${raw}" is not a valid URL; instrumentation feedback-loop guard for it is disabled.`,
+      sdk.start();
+      debugLogger.debug('OpenTelemetry SDK started successfully.');
+      telemetryInitialized = true;
+      activeMetricReader = started.metricReader;
+      const sessionId = config.getSessionId();
+      setSessionContext(createSessionRootContext(sessionId), sessionId);
+      setShellTracePropagation(
+        config.getOutboundCorrelationPropagateTraceContext(),
       );
-      return undefined;
+      initializeMetrics(config);
+    } catch (error) {
+      debugLogger.error('Error starting OpenTelemetry SDK:', error);
     }
-  }
-  const otlpUrlPrefixes = [
-    config.getTelemetryOtlpEndpoint(),
-    config.getTelemetryOtlpTracesEndpoint(),
-    config.getTelemetryOtlpLogsEndpoint(),
-    config.getTelemetryOtlpMetricsEndpoint(),
-  ]
-    .map(normalizeOtlpPrefix)
-    .filter((u): u is { origin: string; pathname: string } => !!u);
-
-  // Boundary-safe URL match. `url.startsWith(prefix)` is unsafe because:
-  //   - port: prefix `http://host:4318` matches `http://host:43180/x`
-  //   - path: prefix `http://host/v1` matches `http://host/v1foo/x`
-  //   - host: prefix `https://otlp.example.com` matches `https://otlp.example.com.evil.net`
-  // Comparing origin exactly + pathname with a path-boundary check avoids all
-  // three. The next char after the prefix pathname must be `/`, `?`, `#`, or
-  // end-of-string.
-  const matchesOtlpPrefix = (origin: string, path: string): boolean => {
-    for (const prefix of otlpUrlPrefixes) {
-      if (origin !== prefix.origin) continue;
-      if (prefix.pathname === '') return true;
-      if (!path.startsWith(prefix.pathname)) continue;
-      const next = path.charAt(prefix.pathname.length);
-      if (next === '' || next === '/' || next === '?' || next === '#') {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  // Strip ?query / #fragment from a path. `indexOf` (not regex) for CodeQL
-  // ReDoS hygiene.
-  const stripPathSuffix = (path: string): string => {
-    const qIdx = path.indexOf('?');
-    const fIdx = path.indexOf('#');
-    let cut = path.length;
-    if (qIdx !== -1) cut = Math.min(cut, qIdx);
-    if (fIdx !== -1) cut = Math.min(cut, fIdx);
-    return path.slice(0, cut);
-  };
-
-  // Outbound trace-context propagation gate:
-  // by default, install a no-op propagator so `traceparent` does NOT get
-  // written onto outbound `fetch` requests to LLM providers. Operators
-  // who want server-side trace stitching (e.g. ARMS+DashScope) opt in via
-  // `outboundCorrelation.propagateTraceContext: true`, which leaves the
-  // SDK's default W3C composite propagator in place. UndiciInstrumentation
-  // still creates client HTTP spans either way — the propagator only
-  // governs whether trace ids leak onto third-party request streams.
-  const textMapPropagator: TextMapPropagator | undefined =
-    config.getOutboundCorrelationPropagateTraceContext()
-      ? undefined // undefined → NodeSDK keeps its default W3C propagator
-      : NOOP_PROPAGATOR;
-
-  sdk = new NodeSDK({
-    resource,
-    // Disable async host/process/env resource detectors: they leave attributes
-    // pending and trigger an OTel diag.error on any resource attribute read
-    // before the detectors settle (e.g. during HttpInstrumentation span creation).
-    autoDetectResources: false,
-    ...(textMapPropagator && { textMapPropagator }),
-    spanProcessors: spanExporter
-      ? [new SessionIdSpanProcessor(), new BatchSpanProcessor(spanExporter)]
-      : [],
-    logRecordProcessors: logExporter
-      ? [new BatchLogRecordProcessor(logExporter)]
-      : logToSpanProcessor
-        ? [logToSpanProcessor]
-        : [],
-    ...(metricReader && { metricReader }),
-    instrumentations: [
-      new HttpInstrumentation({
-        // OTLP HTTP exporter uses node:http (patched here, not by undici).
-        // Without this, every OTLP upload batch creates a parasitic client
-        // span that itself gets exported → feedback loop.
-        ignoreOutgoingRequestHook: (req) => {
-          if (otlpUrlPrefixes.length === 0) return false;
-          // Protocol must be known to compare reliably. The previous
-          // `|| 'http'` fallback silently mis-bucketed HTTPS requests as
-          // HTTP when `req.protocol` was unset, so HTTPS OTLP endpoints
-          // wouldn't match their prefix → guard bypassed → feedback loop.
-          // Now: when proto can't be determined, fail open (return false →
-          // request gets instrumented). Worst case is a parasitic client
-          // span for an OTLP request — observable and recoverable, vs. the
-          // unbounded feedback loop the previous default produced.
-          const proto = req.protocol
-            ? String(req.protocol).replace(/:$/, '')
-            : undefined;
-          if (!proto) return false;
-          // `req.host` may already include `:port` (e.g. `"collector:4318"`).
-          // Naively concatenating `:${req.port}` below would yield
-          // `"http://collector:4318:4318"`, which `new URL()` rejects → catch
-          // returns false → silent guard bypass. Currently unreachable because
-          // `@opentelemetry/otlp-exporter-base` always sets `hostname`, but
-          // the fallback exists and must be correct. Strip the port — IPv6
-          // literals like `"[::1]:443"` keep their bracketed host.
-          let host = req.hostname || '';
-          if (!host && req.host) {
-            const h = String(req.host);
-            const bracketEnd = h.indexOf(']');
-            const portIdx =
-              bracketEnd !== -1 ? h.indexOf(':', bracketEnd) : h.indexOf(':');
-            host = portIdx !== -1 ? h.slice(0, portIdx) : h;
-          }
-          const portPart =
-            req.port !== undefined && req.port !== null && String(req.port)
-              ? `:${req.port}`
-              : '';
-          // Route through `URL` so the reconstructed origin gets the same
-          // default-port stripping (`:80` for http, `:443` for https) that
-          // `normalizeOtlpPrefix` applies via `URL.origin`. Without this,
-          // prefix `http://collector` (no explicit port) wouldn't match a
-          // request to `http://collector:80/v1/traces` because `prefix.origin`
-          // strips `:80` while the manually built string keeps it.
-          let origin: string;
-          try {
-            origin = new URL(`${proto}://${host}${portPart}`).origin;
-          } catch {
-            return false;
-          }
-          const path =
-            typeof req.path === 'string' ? stripPathSuffix(req.path) : '';
-          return matchesOtlpPrefix(origin, path);
-        },
-      }),
-      // Modern fetch (`globalThis.fetch` / undici) is the HTTP layer used by
-      // `openai`, `@google/genai`, and `@anthropic-ai/sdk`. Without this
-      // instrumentation, outbound LLM requests carry no `traceparent` header
-      // and the trace tree terminates at the qwen-code process boundary.
-      new UndiciInstrumentation({
-        ignoreRequestHook: (request) => {
-          if (otlpUrlPrefixes.length === 0) return false;
-          const path =
-            typeof request.path === 'string'
-              ? stripPathSuffix(request.path)
-              : '';
-          return matchesOtlpPrefix(request.origin, path);
-        },
-      }),
-    ],
+  })().finally(() => {
+    telemetryInitPromise = undefined;
   });
-
-  try {
-    sdk.start();
-    debugLogger.debug('OpenTelemetry SDK started successfully.');
-    telemetryInitialized = true;
-    activeMetricReader = metricReader;
-    const sessionId = config.getSessionId();
-    setSessionContext(createSessionRootContext(sessionId), sessionId);
-    setShellTracePropagation(
-      config.getOutboundCorrelationPropagateTraceContext(),
-    );
-    initializeMetrics(config);
-  } catch (error) {
-    debugLogger.error('Error starting OpenTelemetry SDK:', error);
-  }
+  return telemetryInitPromise;
 }
 
 /**

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -44,40 +44,6 @@ function createTelemetryDiagLogger(): DiagLogger {
 // surfaced in user-visible UI. Keep diagnostics in the debug log instead.
 diag.setLogger(createTelemetryDiagLogger(), DiagLogLevel.WARN);
 
-/**
- * Standard OTLP HTTP signal-specific paths per the OpenTelemetry specification.
- * gRPC uses service-based routing so no path appending is needed.
- */
-const OTLP_SIGNAL_PATHS = {
-  traces: 'v1/traces',
-  logs: 'v1/logs',
-  metrics: 'v1/metrics',
-} as const;
-
-type OtlpSignal = keyof typeof OTLP_SIGNAL_PATHS;
-
-/**
- * Resolve the final URL for an HTTP OTLP exporter.
- *
- * - If the URL path already ends with the signal-specific path (e.g., /v1/traces),
- *   use it as-is. This supports explicit full-path configuration.
- * - Otherwise, append the signal-specific path to the base URL.
- */
-export function resolveHttpOtlpUrl(
-  baseEndpoint: string,
-  signal: OtlpSignal,
-): string {
-  const signalPath = OTLP_SIGNAL_PATHS[signal];
-  const url = new URL(baseEndpoint);
-  const normalizedPath = url.pathname.replace(/\/+$/, '');
-  if (normalizedPath.endsWith(signalPath)) {
-    return url.href;
-  }
-  // Append the signal path to the URL pathname, preserving query/hash.
-  url.pathname = normalizedPath + '/' + signalPath;
-  return url.href;
-}
-
 // Ceiling for sdk.shutdown() when called directly (e.g. non-interactive mode).
 // In interactive mode, runExitCleanup() imposes its own tighter per-function
 // (2s) and overall (5s) timeouts, so this value is effectively unreachable there.
@@ -103,17 +69,19 @@ export function initializeTelemetry(
   // is cleared in `finally` so a failed dynamic import can be retried, while
   // a successful init keeps returning early via `telemetryInitialized`.
   telemetryInitPromise ??= (async () => {
-    // The heavy SDK assembly is loaded on demand so disabled-telemetry
-    // processes — notably the ACP child on the daemon cold-start path —
-    // never pay the module-load cost. `startTelemetrySdk` in turn loads
-    // only the configured OTLP protocol chain (issue #7264).
-    const { startTelemetrySdk } = await import('./sdk-impl.js');
-    if (telemetryInitialized) return;
-    const started = await startTelemetrySdk(config);
-    if (!started) return;
-    sdk = started.sdk;
     const debugLogger = createDebugLogger('OTEL');
     try {
+      // The heavy SDK assembly is loaded on demand so disabled-telemetry
+      // processes — notably the ACP child on the daemon cold-start path —
+      // never pay the module-load cost. `startTelemetrySdk` in turn loads
+      // only the configured OTLP protocol chain (issue #7264). Both dynamic
+      // imports stay inside the try so a chunk-load failure degrades telemetry
+      // rather than rejecting — the daemon runtime awaits this without a catch.
+      const { startTelemetrySdk } = await import('./sdk-impl.js');
+      if (telemetryInitialized) return;
+      const started = await startTelemetrySdk(config);
+      if (!started) return;
+      sdk = started.sdk;
       sdk.start();
       debugLogger.debug('OpenTelemetry SDK started successfully.');
       telemetryInitialized = true;
@@ -147,17 +115,33 @@ export function refreshSessionContext(sessionId: string): void {
   }
 }
 
-export async function shutdownTelemetry(): Promise<void> {
+export function shutdownTelemetry(): Promise<void> {
   if (telemetryShutdownPromise) {
     return telemetryShutdownPromise;
   }
-  if (!telemetryInitialized || !sdk) {
-    return;
+  // A fire-and-forget init (config bootstrap, startup prefetch) may still be
+  // in flight. When nothing is initializing and nothing is initialized this is
+  // a no-op; otherwise wait for that init inside the shutdown promise so we
+  // tear down — and flush — whatever it registers, instead of racing past the
+  // synchronous `telemetryInitialized` flag and leaking a started SDK.
+  const pendingInit = telemetryInitPromise;
+  if (!pendingInit && (!telemetryInitialized || !sdk)) {
+    return Promise.resolve();
   }
-  endInteractionSpan('cancelled');
-  const currentSdk = sdk;
-  const debugLogger = createDebugLogger('OTEL');
   telemetryShutdownPromise = (async () => {
+    if (pendingInit) {
+      await pendingInit.catch(() => {});
+    }
+    if (!telemetryInitialized || !sdk) {
+      // The awaited init did not finish initializing (telemetry disabled, no
+      // usable exporter, or `sdk.start()` threw). Clear the promise we just set
+      // so a later real shutdown isn't short-circuited by this stale no-op.
+      telemetryShutdownPromise = undefined;
+      return;
+    }
+    endInteractionSpan('cancelled');
+    const currentSdk = sdk;
+    const debugLogger = createDebugLogger('OTEL');
     let timer: ReturnType<typeof setTimeout> | undefined;
     let timedOut = false;
     try {

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -48,14 +48,14 @@ describe('telemetry', () => {
     }
   });
 
-  it('should initialize the telemetry service', () => {
-    initializeTelemetry(mockConfig);
+  it('should initialize the telemetry service', async () => {
+    await initializeTelemetry(mockConfig);
     expect(NodeSDK).toHaveBeenCalled();
     expect(mockNodeSdk.start).toHaveBeenCalled();
   });
 
   it('should shutdown the telemetry service', async () => {
-    initializeTelemetry(mockConfig);
+    await initializeTelemetry(mockConfig);
     await shutdownTelemetry();
 
     expect(mockNodeSdk.shutdown).toHaveBeenCalled();

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -44,6 +44,19 @@ const ACP_RUNTIME_ROOT = {
   ],
 };
 
+// The telemetry protocol split (issue #7264) keeps the OTLP exporter chains
+// behind dynamic import()s inside sdk-impl.ts itself. Its static closure may
+// keep NodeSDK and the instrumentations, but must not reach the gRPC cluster
+// or the shared OTLP serialization layer, which only the protocol modules
+// (sdk-exporters-grpc.ts / sdk-exporters-http.ts) are allowed to load.
+const SDK_IMPL_ROOT = {
+  label: 'telemetry sdk-impl',
+  suffixes: [
+    'packages/core/src/telemetry/sdk-impl.ts',
+    'packages/core/dist/src/telemetry/sdk-impl.js',
+  ],
+};
+
 const FORBIDDEN_SOURCE_INPUTS = [
   {
     label: 'Gemini runtime',
@@ -129,6 +142,55 @@ const FORBIDDEN_ACP_UI_PACKAGES = [
   { label: 'React runtime', packageName: 'react' },
   { label: 'React reconciler runtime', packageName: 'react-reconciler' },
   { label: 'Yoga layout runtime', packageName: 'yoga-layout' },
+];
+
+// Heavy telemetry SDK packages must stay behind the dynamic import() in
+// packages/core/src/telemetry/sdk.ts (issue #4748). Cheap packages that are
+// legitimately eager (@opentelemetry/api, semantic-conventions, core,
+// resources, api-logs) are intentionally NOT listed.
+//
+// The protocol-chain subset is additionally forbidden from the sdk-impl
+// static closure (issue #7264): @opentelemetry/otlp-transformer sits in the
+// shared serialization layer both the HTTP and gRPC exporter packages pull
+// in, so it catches a static re-import of either protocol module.
+const FORBIDDEN_OTLP_PROTOCOL_PACKAGES = [
+  { label: 'gRPC runtime', packageName: '@grpc/grpc-js' },
+  { label: 'gRPC proto loader', packageName: '@grpc/proto-loader' },
+  { label: 'protobufjs runtime', packageName: 'protobufjs' },
+  {
+    label: 'OTLP transformer',
+    packageName: '@opentelemetry/otlp-transformer',
+  },
+  {
+    label: 'OTLP gRPC trace exporter',
+    packageName: '@opentelemetry/exporter-trace-otlp-grpc',
+  },
+  {
+    label: 'OTLP gRPC log exporter',
+    packageName: '@opentelemetry/exporter-logs-otlp-grpc',
+  },
+  {
+    label: 'OTLP gRPC metric exporter',
+    packageName: '@opentelemetry/exporter-metrics-otlp-grpc',
+  },
+];
+
+const FORBIDDEN_ACP_TELEMETRY_PACKAGES = [
+  ...FORBIDDEN_OTLP_PROTOCOL_PACKAGES,
+  { label: 'OTel NodeSDK', packageName: '@opentelemetry/sdk-node' },
+  {
+    label: 'OTel HTTP instrumentation',
+    packageName: '@opentelemetry/instrumentation-http',
+  },
+  {
+    label: 'OTel undici instrumentation',
+    packageName: '@opentelemetry/instrumentation-undici',
+  },
+];
+
+const FORBIDDEN_ACP_PACKAGES = [
+  ...FORBIDDEN_ACP_UI_PACKAGES,
+  ...FORBIDDEN_ACP_TELEMETRY_PACKAGES,
 ];
 
 export function normalizeMetafilePath(filePath) {
@@ -235,16 +297,28 @@ function buildImportPath(entryOutputs, outputPath, parent) {
 }
 
 export function findAcpImportBoundaryOffenders(metafile) {
+  return findRootClosureOffenders(
+    metafile,
+    ACP_RUNTIME_ROOT,
+    FORBIDDEN_ACP_PACKAGES,
+  );
+}
+
+export function findSdkImplProtocolOffenders(metafile) {
+  return findRootClosureOffenders(
+    metafile,
+    SDK_IMPL_ROOT,
+    FORBIDDEN_OTLP_PROTOCOL_PACKAGES,
+  );
+}
+
+function findRootClosureOffenders(metafile, root, forbiddenPackages) {
   const outputs = normalizeOutputs(metafile);
   let entryOutput;
 
   for (const [outputPath, output] of outputs) {
     const inputs = Object.keys(output.inputs ?? {});
-    if (
-      inputs.some((input) =>
-        inputMatchesAnySuffix(input, ACP_RUNTIME_ROOT.suffixes),
-      )
-    ) {
+    if (inputs.some((input) => inputMatchesAnySuffix(input, root.suffixes))) {
       entryOutput = outputPath;
       break;
     }
@@ -252,8 +326,8 @@ export function findAcpImportBoundaryOffenders(metafile) {
 
   if (!entryOutput) {
     throw new Error(
-      `Could not find bundled output for ${ACP_RUNTIME_ROOT.label} ` +
-        `(${ACP_RUNTIME_ROOT.suffixes.join(' or ')}).\n` +
+      `Could not find bundled output for ${root.label} ` +
+        `(${root.suffixes.join(' or ')}).\n` +
         `Run \`${METAFILE_BUILD_COMMAND}\` to produce the metafile.`,
     );
   }
@@ -266,7 +340,7 @@ export function findAcpImportBoundaryOffenders(metafile) {
   for (const outputPath of closure) {
     const output = outputs.get(outputPath);
     for (const input of Object.keys(output?.inputs ?? {})) {
-      const match = FORBIDDEN_ACP_UI_PACKAGES.find(({ packageName }) =>
+      const match = forbiddenPackages.find(({ packageName }) =>
         inputMatchesPackage(input, packageName),
       );
       if (!match) continue;
@@ -353,9 +427,7 @@ export function formatServeFastPathBundleOffenders(offenders) {
     .join('\n');
 }
 
-export function checkServeFastPathBundle({
-  metafilePath = DEFAULT_METAFILE_PATH,
-} = {}) {
+function readMetafile(metafilePath) {
   if (!existsSync(metafilePath)) {
     throw new Error(
       `Missing esbuild metafile at ${metafilePath}. ` +
@@ -363,9 +435,8 @@ export function checkServeFastPathBundle({
     );
   }
 
-  let metafile;
   try {
-    metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
+    return JSON.parse(readFileSync(metafilePath, 'utf8'));
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -373,32 +444,28 @@ export function checkServeFastPathBundle({
         `Run \`${METAFILE_BUILD_COMMAND}\` to regenerate it.`,
     );
   }
-  const offenders = findServeFastPathBundleOffenders(metafile);
+}
+
+export function checkServeFastPathBundle({
+  metafilePath = DEFAULT_METAFILE_PATH,
+} = {}) {
+  const offenders = findServeFastPathBundleOffenders(
+    readMetafile(metafilePath),
+  );
   return { ok: offenders.length === 0, offenders };
 }
 
 export function checkAcpImportBoundary({
   metafilePath = DEFAULT_METAFILE_PATH,
 } = {}) {
-  if (!existsSync(metafilePath)) {
-    throw new Error(
-      `Missing esbuild metafile at ${metafilePath}. ` +
-        `Run \`${METAFILE_BUILD_COMMAND}\` to produce it.`,
-    );
-  }
+  const offenders = findAcpImportBoundaryOffenders(readMetafile(metafilePath));
+  return { ok: offenders.length === 0, offenders };
+}
 
-  let metafile;
-  try {
-    metafile = JSON.parse(readFileSync(metafilePath, 'utf8'));
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Invalid esbuild metafile at ${metafilePath}: ${reason}. ` +
-        `Run \`${METAFILE_BUILD_COMMAND}\` to regenerate it.`,
-    );
-  }
-
-  const offenders = findAcpImportBoundaryOffenders(metafile);
+export function checkSdkImplProtocolBoundary({
+  metafilePath = DEFAULT_METAFILE_PATH,
+} = {}) {
+  const offenders = findSdkImplProtocolOffenders(readMetafile(metafilePath));
   return { ok: offenders.length === 0, offenders };
 }
 
@@ -422,7 +489,16 @@ function main() {
       process.exitCode = 1;
     }
 
-    if (serveResult.ok && acpResult.ok) {
+    const sdkImplResult = checkSdkImplProtocolBoundary();
+    if (!sdkImplResult.ok) {
+      console.error(
+        'Telemetry sdk-impl static closure includes OTLP protocol chain modules:\n' +
+          formatServeFastPathBundleOffenders(sdkImplResult.offenders),
+      );
+      process.exitCode = 1;
+    }
+
+    if (serveResult.ok && acpResult.ok && sdkImplResult.ok) {
       console.log('Startup bundle closure checks passed.');
     }
   } catch (error) {

--- a/scripts/check-serve-fast-path-bundle.js
+++ b/scripts/check-serve-fast-path-bundle.js
@@ -150,9 +150,11 @@ const FORBIDDEN_ACP_UI_PACKAGES = [
 // resources, api-logs) are intentionally NOT listed.
 //
 // The protocol-chain subset is additionally forbidden from the sdk-impl
-// static closure (issue #7264): @opentelemetry/otlp-transformer sits in the
-// shared serialization layer both the HTTP and gRPC exporter packages pull
-// in, so it catches a static re-import of either protocol module.
+// static closure (issue #7264). Both the gRPC and HTTP exporter packages are
+// listed explicitly so the guard is self-describing and survives upstream
+// dependency restructuring; @opentelemetry/otlp-transformer (the serialization
+// layer both chains share) and @opentelemetry/otlp-exporter-base stay listed as
+// belt-and-suspenders for a static re-import of either protocol module.
 const FORBIDDEN_OTLP_PROTOCOL_PACKAGES = [
   { label: 'gRPC runtime', packageName: '@grpc/grpc-js' },
   { label: 'gRPC proto loader', packageName: '@grpc/proto-loader' },
@@ -160,6 +162,10 @@ const FORBIDDEN_OTLP_PROTOCOL_PACKAGES = [
   {
     label: 'OTLP transformer',
     packageName: '@opentelemetry/otlp-transformer',
+  },
+  {
+    label: 'OTLP exporter base',
+    packageName: '@opentelemetry/otlp-exporter-base',
   },
   {
     label: 'OTLP gRPC trace exporter',
@@ -172,6 +178,18 @@ const FORBIDDEN_OTLP_PROTOCOL_PACKAGES = [
   {
     label: 'OTLP gRPC metric exporter',
     packageName: '@opentelemetry/exporter-metrics-otlp-grpc',
+  },
+  {
+    label: 'OTLP HTTP trace exporter',
+    packageName: '@opentelemetry/exporter-trace-otlp-http',
+  },
+  {
+    label: 'OTLP HTTP log exporter',
+    packageName: '@opentelemetry/exporter-logs-otlp-http',
+  },
+  {
+    label: 'OTLP HTTP metric exporter',
+    packageName: '@opentelemetry/exporter-metrics-otlp-http',
   },
 ];
 

--- a/scripts/sdk-node-exporter-stub.js
+++ b/scripts/sdk-node-exporter-stub.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared logic for the esbuild plugin that stubs the OTLP exporter packages
+ * `@opentelemetry/sdk-node` eagerly require()s for env-based auto-configuration
+ * (issue #7264). Extracted from esbuild.config.js so the resolve decision — the
+ * security-critical part that keeps both protocol chains out of the sdk-impl
+ * static closure — is unit-testable without running a full bundle.
+ */
+
+// Exporter packages sdk-node eagerly require()s: the three OTLP signals across
+// grpc/http/proto transports, plus zipkin and prometheus.
+export const SDK_NODE_STUBBED_EXPORTERS = new RegExp(
+  '^@opentelemetry/(' +
+    [
+      'exporter-trace-otlp-(grpc|http|proto)',
+      'exporter-logs-otlp-(grpc|http|proto)',
+      'exporter-metrics-otlp-(grpc|http|proto)',
+      'exporter-zipkin',
+      'exporter-prometheus',
+    ].join('|') +
+    ')$',
+);
+
+/**
+ * Decide whether an esbuild import should resolve to the loud stub.
+ *
+ * True only when a stubbed exporter package is imported *by sdk-node itself* —
+ * our own protocol modules keep resolving the real packages. The importer path
+ * is normalized to forward slashes so the match holds on Windows (where esbuild
+ * emits backslash-separated paths) as well as POSIX.
+ */
+export function isStubbedSdkNodeExporterImport(importPath, importer) {
+  if (!SDK_NODE_STUBBED_EXPORTERS.test(importPath)) return false;
+  if (typeof importer !== 'string' || importer.length === 0) return false;
+  const normalizedImporter = importer.replace(/\\/g, '/');
+  return normalizedImporter.includes('@opentelemetry/sdk-node');
+}

--- a/scripts/tests/sdk-node-exporter-stub.test.js
+++ b/scripts/tests/sdk-node-exporter-stub.test.js
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  SDK_NODE_STUBBED_EXPORTERS,
+  isStubbedSdkNodeExporterImport,
+} from '../sdk-node-exporter-stub.js';
+
+// Importer paths as esbuild reports them, per OS. sdk-node lives one level up
+// from the exporter package inside node_modules; the decision must hold
+// regardless of the path separator (Windows is the ⚠️ platform in the matrix).
+const POSIX_SDK_NODE_IMPORTER =
+  '/repo/node_modules/@opentelemetry/sdk-node/build/src/sdk.js';
+const WINDOWS_SDK_NODE_IMPORTER =
+  'C:\\repo\\node_modules\\@opentelemetry\\sdk-node\\build\\src\\sdk.js';
+const POSIX_OWN_MODULE_IMPORTER =
+  '/repo/packages/core/src/telemetry/sdk-exporters-grpc.ts';
+const WINDOWS_OWN_MODULE_IMPORTER =
+  'C:\\repo\\packages\\core\\src\\telemetry\\sdk-exporters-http.ts';
+
+describe('SDK_NODE_STUBBED_EXPORTERS', () => {
+  it('matches the OTLP exporter packages across every transport', () => {
+    for (const signal of ['trace', 'logs', 'metrics']) {
+      for (const transport of ['grpc', 'http', 'proto']) {
+        expect(
+          SDK_NODE_STUBBED_EXPORTERS.test(
+            `@opentelemetry/exporter-${signal}-otlp-${transport}`,
+          ),
+        ).toBe(true);
+      }
+    }
+    expect(
+      SDK_NODE_STUBBED_EXPORTERS.test('@opentelemetry/exporter-zipkin'),
+    ).toBe(true);
+    expect(
+      SDK_NODE_STUBBED_EXPORTERS.test('@opentelemetry/exporter-prometheus'),
+    ).toBe(true);
+  });
+
+  it('does not match non-exporter or unrelated packages', () => {
+    expect(SDK_NODE_STUBBED_EXPORTERS.test('@opentelemetry/sdk-node')).toBe(
+      false,
+    );
+    expect(SDK_NODE_STUBBED_EXPORTERS.test('@opentelemetry/api')).toBe(false);
+    // Subpath imports must not match — the anchor is end-of-string.
+    expect(
+      SDK_NODE_STUBBED_EXPORTERS.test(
+        '@opentelemetry/exporter-trace-otlp-grpc/build/src/index.js',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isStubbedSdkNodeExporterImport', () => {
+  it('stubs a stubbed exporter imported by sdk-node on POSIX and Windows', () => {
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-trace-otlp-grpc',
+        POSIX_SDK_NODE_IMPORTER,
+      ),
+    ).toBe(true);
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-metrics-otlp-http',
+        WINDOWS_SDK_NODE_IMPORTER,
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves the real package for our own protocol modules', () => {
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-trace-otlp-grpc',
+        POSIX_OWN_MODULE_IMPORTER,
+      ),
+    ).toBe(false);
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-metrics-otlp-http',
+        WINDOWS_OWN_MODULE_IMPORTER,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not stub non-exporter packages even when sdk-node imports them', () => {
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/otlp-transformer',
+        POSIX_SDK_NODE_IMPORTER,
+      ),
+    ).toBe(false);
+  });
+
+  it('is safe against a missing or empty importer', () => {
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-trace-otlp-grpc',
+        undefined,
+      ),
+    ).toBe(false);
+    expect(
+      isStubbedSdkNodeExporterImport(
+        '@opentelemetry/exporter-trace-otlp-grpc',
+        '',
+      ),
+    ).toBe(false);
+  });
+});

--- a/scripts/tests/serve-fast-path-bundle-check.test.js
+++ b/scripts/tests/serve-fast-path-bundle-check.test.js
@@ -12,8 +12,10 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   checkAcpImportBoundary,
+  checkSdkImplProtocolBoundary,
   checkServeFastPathBundle,
   findAcpImportBoundaryOffenders,
+  findSdkImplProtocolOffenders,
   findServeFastPathBundleOffenders,
   formatServeFastPathBundleOffenders,
   normalizeMetafilePath,
@@ -37,6 +39,9 @@ function makeMetafile(outputs) {
       }),
       'dist/chunks/acp-agent.js': output({
         inputs: ['packages/cli/src/acp-integration/acpAgent.ts'],
+      }),
+      'dist/chunks/sdk-impl.js': output({
+        inputs: ['packages/core/src/telemetry/sdk-impl.ts'],
       }),
       ...outputs,
     },
@@ -488,6 +493,145 @@ describe('ACP import boundary check', () => {
           }),
         ],
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('telemetry sdk-impl protocol boundary check', () => {
+  it('reports gRPC cluster packages reached through static imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/sdk-impl.js': output({
+        inputs: ['packages/core/src/telemetry/sdk-impl.ts'],
+        imports: [staticImport('dist/chunks/grpc-chain.js')],
+      }),
+      'dist/chunks/grpc-chain.js': output({
+        inputs: [
+          'node_modules/@grpc/grpc-js/build/src/index.js',
+          'node_modules/protobufjs/index.js',
+          'node_modules/@opentelemetry/exporter-trace-otlp-grpc/build/esm/index.js',
+        ],
+      }),
+    });
+
+    expect(findSdkImplProtocolOffenders(metafile)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'gRPC runtime' }),
+        expect.objectContaining({ label: 'protobufjs runtime' }),
+        expect.objectContaining({ label: 'OTLP gRPC trace exporter' }),
+      ]),
+    );
+  });
+
+  it('reports the shared OTLP serialization layer reached statically', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/sdk-impl.js': output({
+        inputs: [
+          'packages/core/src/telemetry/sdk-impl.ts',
+          'node_modules/@opentelemetry/otlp-transformer/build/esm/index.js',
+        ],
+      }),
+    });
+
+    expect(findSdkImplProtocolOffenders(metafile)).toEqual([
+      expect.objectContaining({
+        label: 'OTLP transformer',
+        matchedInput:
+          'node_modules/@opentelemetry/otlp-transformer/build/esm/index.js',
+      }),
+    ]);
+  });
+
+  it('allows protocol chains behind dynamic imports', () => {
+    const metafile = makeMetafile({
+      'dist/chunks/sdk-impl.js': output({
+        inputs: ['packages/core/src/telemetry/sdk-impl.ts'],
+        imports: [
+          dynamicImport('dist/chunks/grpc-chain.js'),
+          dynamicImport('dist/chunks/http-chain.js'),
+        ],
+      }),
+      'dist/chunks/grpc-chain.js': output({
+        inputs: ['node_modules/@grpc/grpc-js/build/src/index.js'],
+      }),
+      'dist/chunks/http-chain.js': output({
+        inputs: [
+          'node_modules/@opentelemetry/otlp-transformer/build/esm/index.js',
+        ],
+      }),
+    });
+
+    expect(findSdkImplProtocolOffenders(metafile)).toEqual([]);
+  });
+
+  it('throws when the sdk-impl chunk is missing', () => {
+    const metafile = {
+      outputs: {
+        'dist/chunks/unrelated.js': output({
+          inputs: ['packages/cli/src/unrelated.ts'],
+        }),
+      },
+    };
+
+    expect(() => findSdkImplProtocolOffenders(metafile)).toThrow(
+      /Could not find bundled output for telemetry sdk-impl/,
+    );
+  });
+
+  it('reads a metafile path and returns sdk-impl boundary offenders', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'sdk-impl-boundary-'));
+    try {
+      const metafilePath = writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/chunks/sdk-impl.js': output({
+            inputs: [
+              'packages/core/src/telemetry/sdk-impl.ts',
+              'node_modules/@grpc/grpc-js/build/src/index.js',
+            ],
+          }),
+        }),
+      );
+
+      expect(checkSdkImplProtocolBoundary({ metafilePath })).toEqual({
+        ok: false,
+        offenders: [
+          expect.objectContaining({
+            label: 'gRPC runtime',
+            matchedInput: 'node_modules/@grpc/grpc-js/build/src/index.js',
+          }),
+        ],
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits non-zero with CLI diagnostics for sdk-impl offenders', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'sdk-impl-boundary-'));
+    try {
+      writeMetafile(
+        tempDir,
+        makeMetafile({
+          'dist/chunks/sdk-impl.js': output({
+            inputs: [
+              'packages/core/src/telemetry/sdk-impl.ts',
+              'node_modules/@grpc/grpc-js/build/src/index.js',
+            ],
+          }),
+        }),
+      );
+
+      expect(() =>
+        execFileSync(process.execPath, [checkScriptPath], {
+          cwd: tempDir,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }),
+      ).toThrow(
+        /Telemetry sdk-impl static closure includes OTLP protocol chain modules/,
+      );
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What this PR does

Makes telemetry SDK loading lazy, in two stages. First, the telemetry entry point is split into a light facade and a heavy implementation half: processes that never enable telemetry (the default) no longer parse and compile the OpenTelemetry NodeSDK, instrumentations, or any exporter — the heavy half is loaded on demand, behind a single-flight dynamic import, only when telemetry is actually enabled. Second, the OTLP exporter chains are split by protocol: the gRPC chain (including the gRPC transport stack and protobuf runtime) and the HTTP chain (including the shared OTLP serialization layer) each live in their own dynamically imported module, so a process loads at most the one chain its configuration needs — file-based telemetry output loads neither, and a misconfigured gRPC setup without an endpoint loads nothing before it skips.

Two supporting changes keep the split honest in the bundled CLI. The bundler now stubs the exporter packages that the OpenTelemetry NodeSDK eagerly requires for env-var-based auto-configuration (an unsupported configuration surface here), because those eager requires would otherwise drag both protocol chains back into the static closure; the stubs fail loudly if ever constructed. And the existing bundle-closure guard gains a third check that fails CI if either protocol chain ever becomes statically reachable from the implementation half again.

## Why it's needed

Daemon cold start (#4748) paid roughly 2.1 MiB of telemetry module parse/compile cost in every ACP child process, including the default case where telemetry is disabled. On a 2C4G reference machine this was worth about 144 ms P50 (-7.5%) of process-to-first-session latency for default configurations. The protocol split then targets the remaining cost for users who do enable telemetry (#7264): both protocol chains loaded even though a configuration uses at most one, and on small machines that extra module loading contended with config construction and bootstrap on the CPU, adding back ~50 ms. With the split, telemetry-enabled cold start improved by a further ~51 ms P50 on the same reference machine, with config-construction time cut in half.

## Reviewer Test Plan

### How to verify

- Default configuration (telemetry disabled): startup behaves as before; no OpenTelemetry SDK modules load. The bundle guard proves this statically: `npm run build && cross-env DEV=true npm run bundle && node scripts/check-serve-fast-path-bundle.js` passes three closure checks.
- Telemetry enabled with an outfile: spans/logs/metrics land in the outfile as before; neither OTLP protocol chain loads.
- Telemetry enabled with OTLP HTTP: exporters connect and per-signal endpoint overrides, URL validation, and the logs-to-spans bridge behave as before; the gRPC stack never loads.
- Telemetry enabled with OTLP gRPC: exporters connect with gzip compression as before; the HTTP exporters never load. Without a base endpoint, startup is skipped with the same warning as before, and no protocol module loads.
- Unit tests: `cd packages/core && npx vitest run src/telemetry` (671 tests) and `npm run test:scripts` (guard tests including six new boundary cases).
- Edge case: in the bundled CLI, setting `OTEL_METRICS_EXPORTER=otlp` (env-based exporter auto-configuration, never a supported configuration surface here) now fails loudly inside SDK start — caught and logged by the existing error handling — instead of silently exporting to a default localhost endpoint.

### Evidence (Before & After)

N/A (no UI change). Paired benchmark on a 2C4G Linux host, 30 pairs per scenario, P50:

- Telemetry disabled (default): process→first-session −144.4 ms (−7.5%).
- Telemetry enabled (outfile), cold start: process→first-session −50.8 ms (1957.6 → 1906.8); channel initialize −37.7 ms; config construction 45.4 → 23.9 ms; bootstrap config init 160.1 → 124.1 ms.
- Telemetry enabled (outfile), preheated: channel initialize −71.6 ms; first-session latency unchanged (~71 ms, session path untouched).
- Functional checks in the same run: concurrency, telemetry-disabled (zero records), and legacy single-session all pass with no residual processes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS: unit tests, typecheck, lint, bundle guards, and runtime smoke tests against the bundled CLI. Linux (2C4G): paired cold/preheated benchmarks against the bundled CLI.

## Risk & Scope

- Main risk or tradeoff: in the bundled CLI, env-var-based exporter auto-configuration through the NodeSDK now throws loudly (caught by existing error handling) instead of silently working; this was never a documented or supported configuration surface, and source/dev mode is unaffected. Telemetry initialization is now asynchronous end to end; call sites were already async or fire-and-forget, and events emitted before initialization settle are dropped by the existing initialized gates, same as before.
- Not validated / out of scope: gRPC export against a live collector (exporter assembly is covered by unit tests and runtime smoke checks); the other five lazy-loading candidates listed in #7264.
- Breaking changes / migration notes: none for documented configuration surfaces.

## Linked Issues

Part of #4748. Implements the first candidate (per-protocol exporter split) from #7264.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 telemetry SDK 的加载改为两级懒加载。第一级：把 telemetry 入口拆分为轻量 facade 和重量实现两半——默认不开启 telemetry 的进程（绝大多数）不再解析和编译 OpenTelemetry NodeSDK、instrumentation 及任何 exporter；重的那一半只在 telemetry 真正开启时通过单飞动态 import 按需加载。第二级：把 OTLP exporter 链按协议拆分——gRPC 链（含 gRPC 传输栈和 protobuf 运行时）与 HTTP 链（含共享的 OTLP 序列化层）各自独立成动态导入模块，进程最多只加载配置所需的那一条链：文件输出模式两条链都不加载；gRPC 缺少 endpoint 的错误配置在加载任何协议模块之前就跳过。

两项配套改动保证拆分在打包后的 CLI 中真实生效。打包器现在会对 NodeSDK 为环境变量自动配置而急切 require 的 exporter 包打桩（这从来不是本项目支持的配置面），否则这些急切 require 会把两条协议链重新拖回静态闭包；桩一旦被构造会响亮报错。同时现有的 bundle 闭包守卫新增第三项检查：若任一协议链重新静态可达实现半，CI 直接失败。

## 为什么需要

Daemon 冷启动（#4748）中每个 ACP 子进程都要支付约 2.1 MiB 的 telemetry 模块解析/编译成本，包括默认关闭 telemetry 的场景。在 2C4G 参考机器上，默认配置的进程到首 session 延迟因此高出约 144 ms P50（-7.5%）。协议拆分进一步针对开启 telemetry 的用户（#7264）：配置最多用到一条协议链却加载了两条，且在小机器上这些额外的模块加载与 config 构建、bootstrap 抢占 CPU，额外增加约 50 ms。拆分后，同一参考机器上开启 telemetry 的冷启动再降约 51 ms P50，config 构建耗时减半。

## 评审验证计划

### 如何验证

- 默认配置（telemetry 关闭）：启动行为不变；不加载任何 OpenTelemetry SDK 模块。bundle 守卫静态证明这一点：`npm run build && cross-env DEV=true npm run bundle && node scripts/check-serve-fast-path-bundle.js` 三项闭包检查全过。
- 开启 telemetry 且配置 outfile：spans/logs/metrics 照常写入文件；两条 OTLP 协议链都不加载。
- 开启 telemetry 且配置 OTLP HTTP：exporter 正常连接，per-signal endpoint 覆盖、URL 校验、logs 转 spans 桥行为不变；gRPC 栈永不加载。
- 开启 telemetry 且配置 OTLP gRPC：exporter 照常以 gzip 压缩连接；HTTP exporter 永不加载。缺少 base endpoint 时以与之前相同的警告跳过启动，且不加载任何协议模块。
- 单元测试：`cd packages/core && npx vitest run src/telemetry`（671 个）以及 `npm run test:scripts`（守卫测试含六个新边界用例）。
- 边界情况：打包后的 CLI 中设置 `OTEL_METRICS_EXPORTER=otlp`（基于环境变量的 exporter 自动配置，从来不是支持的配置面）现在会在 SDK 启动时响亮失败——被现有错误处理捕获并记录——而不是静默导出到默认 localhost 端点。

### 证据（前后对比）

N/A（无 UI 变化）。2C4G Linux 机器成对基准，每场景 30 对，P50：

- Telemetry 关闭（默认）：进程→首 session −144.4 ms（−7.5%）。
- Telemetry 开启（outfile）冷启动：进程→首 session −50.8 ms（1957.6 → 1906.8）；channel initialize −37.7 ms；config 构建 45.4 → 23.9 ms；bootstrap config init 160.1 → 124.1 ms。
- Telemetry 开启（outfile）预热：channel initialize −71.6 ms；首 session 延迟不变（约 71 ms，session 路径未改动）。
- 同一轮的功能检查：并发、telemetry 关闭（零记录）、legacy 单 session 全部通过，无残留进程。

### 测试平台

macOS：单元测试、typecheck、lint、bundle 守卫、针对打包 CLI 的运行时冒烟。Linux（2C4G）：针对打包 CLI 的成对冷启动/预热基准。

## 风险与范围

- 主要风险/权衡：打包后的 CLI 中，通过 NodeSDK 的环境变量 exporter 自动配置现在会响亮抛错（被现有错误处理捕获），不再静默生效；这从来不是文档化或受支持的配置面，源码/开发模式不受影响。telemetry 初始化现在端到端异步；调用方原本就是 async 或 fire-and-forget，初始化完成前产生的事件由现有的已初始化门控丢弃，与之前一致。
- 未验证/超出范围：对真实 collector 的 gRPC 导出（exporter 组装已由单测和运行时冒烟覆盖）；#7264 中列出的其余五个懒加载候选。
- 破坏性变更/迁移说明：对文档化配置面无。

## 关联 Issue

属于 #4748 的一部分。实现了 #7264 中的第一个候选项（按协议拆分 exporter）。

</details>
