### PR TITLE
fix(ci): create remote-tracking ref for fork PRs in autofix verify gate

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2111,6 +2111,10 @@ jobs:
               exit 0
             fi
             git checkout -B "${BRANCH}" FETCH_HEAD
+            # Create the remote-tracking ref so the verification gate's
+            # `git diff --quiet "origin/${BRANCH}...${BRANCH}"` works for
+            # fork PRs the same way it does for same-repo branches.
+            git update-ref "refs/remotes/origin/${BRANCH}" "${BRANCH}"
             # Allow-edits pushes ride the classic-PAT grant — GITHUB_TOKEN
             # and fine-grained PATs are documented as NOT receiving it.
             # Prove push access NOW, before an agent round is spent, instead


### PR DESCRIPTION
## Motivation

The autofix `review-address` verification gate fails on every fork PR. The gate runs `git diff --quiet "origin/${BRANCH}...${BRANCH}"` to detect whether the agent produced new commits, but fork branches are fetched via URL into `FETCH_HEAD` and checked out locally — the remote-tracking ref `origin/${BRANCH}` is never created. The resulting `fatal: ambiguous argument` is misread as "branch changed", and the gate then fails because `address-summary.md` is absent (the agent correctly wrote `no-action.md`).

Observed in [run 29718309973, job 88279014933](https://github.com/QwenLM/qwen-code/actions/runs/29718309973/job/88279014933) for PR #7265 (`fix/wake-repaint` from `wenshao/qwen-code`).

## Changes

Add `git update-ref "refs/remotes/origin/${BRANCH}" "${BRANCH}"` immediately after the fork checkout, so the verification gate's no-change detection works identically for fork and same-repo branches.

## How to verify

Trigger an autofix `review-address` run against any fork PR where the agent writes `no-action.md`. The gate should detect "no new commits" and exit with `outcome=noop` instead of failing.
