### PR TITLE
fix(core): hide interaction tools in plain headless mode

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2676,6 +2676,26 @@ describe('Server Config (config.ts)', () => {
       },
     );
 
+    it('registers ask_user_question but not plan tools in SDK mode with interaction support', async () => {
+      // ask_user_question is gated only by the resolved interaction mode, while
+      // enter_plan_mode/exit_plan_mode are additionally gated by !sdkMode. Guard
+      // this asymmetry so a future symmetric `!this.sdkMode` on the question gate
+      // cannot silently drop the tool from SDK-mode interactive sessions.
+      const config = new Config({
+        ...baseParams,
+        interactive: true,
+        sdkMode: true,
+      });
+      await config.initialize();
+
+      const registeredNames = (
+        ToolRegistry.prototype.registerFactory as Mock
+      ).mock.calls.map((call) => call[0]);
+      expect(registeredNames).toContain(ToolNames.ASK_USER_QUESTION);
+      expect(registeredNames).not.toContain(ToolNames.ENTER_PLAN_MODE);
+      expect(registeredNames).not.toContain(ToolNames.EXIT_PLAN_MODE);
+    });
+
     it('does not register user-interaction tools in plain headless sessions', async () => {
       const config = new Config({
         ...baseParams,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -38,6 +38,7 @@ import type {
   ContentGenerator,
   ContentGeneratorConfig,
 } from '../core/contentGenerator.js';
+import { InputFormat } from '../output/types.js';
 import { DEFAULT_DASHSCOPE_BASE_URL } from '../core/openaiContentGenerator/constants.js';
 import {
   AuthType,
@@ -2654,6 +2655,65 @@ describe('Server Config (config.ts)', () => {
         ToolRegistry.prototype.registerFactory as Mock
       ).mock.calls.map((call) => call[0]);
       expect(registeredNames).toContain(ToolNames.READ_MCP_RESOURCE);
+    });
+
+    it.each([
+      ['interactive', { interactive: true }],
+      ['ACP', { experimentalZedIntegration: true }],
+      ['stream-json', { inputFormat: InputFormat.STREAM_JSON }],
+    ] as const)(
+      'registers user-interaction tools in %s sessions',
+      async (_mode, params) => {
+        const config = new Config({ ...baseParams, ...params });
+        await config.initialize();
+
+        const registeredNames = (
+          ToolRegistry.prototype.registerFactory as Mock
+        ).mock.calls.map((call) => call[0]);
+        expect(registeredNames).toContain(ToolNames.ASK_USER_QUESTION);
+        expect(registeredNames).toContain(ToolNames.ENTER_PLAN_MODE);
+        expect(registeredNames).toContain(ToolNames.EXIT_PLAN_MODE);
+      },
+    );
+
+    it('does not register user-interaction tools in plain headless sessions', async () => {
+      const config = new Config({
+        ...baseParams,
+        interactive: false,
+        experimentalZedIntegration: false,
+        inputFormat: InputFormat.TEXT,
+      });
+      await config.initialize();
+
+      const registeredNames = (
+        ToolRegistry.prototype.registerFactory as Mock
+      ).mock.calls.map((call) => call[0]);
+      expect(registeredNames).not.toContain(ToolNames.ASK_USER_QUESTION);
+      expect(registeredNames).not.toContain(ToolNames.ENTER_PLAN_MODE);
+      expect(registeredNames).not.toContain(ToolNames.EXIT_PLAN_MODE);
+    });
+
+    it('keeps exit_plan_mode available for plan-required teammate filtering', async () => {
+      const config = new Config({
+        ...baseParams,
+        interactive: false,
+        experimentalZedIntegration: false,
+        inputFormat: InputFormat.TEXT,
+      });
+      await config.initialize();
+      vi.mocked(ToolRegistry.prototype.registerFactory).mockClear();
+
+      await config.createToolRegistry(undefined, {
+        skipDiscovery: true,
+        forSubAgent: true,
+      });
+
+      const registeredNames = (
+        ToolRegistry.prototype.registerFactory as Mock
+      ).mock.calls.map((call) => call[0]);
+      expect(registeredNames).not.toContain(ToolNames.ASK_USER_QUESTION);
+      expect(registeredNames).not.toContain(ToolNames.ENTER_PLAN_MODE);
+      expect(registeredNames).toContain(ToolNames.EXIT_PLAN_MODE);
     });
 
     it('does not register artifact tools when artifacts are disabled', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -39,6 +39,7 @@ import type { TeamContext } from '../agents/team/types.js';
 // Core
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { GeminiClient } from '../core/client.js';
+import { resolveInteractionMode } from '../core/prompts.js';
 import {
   AuthType,
   createContentGenerator,
@@ -6645,17 +6646,22 @@ export class Config {
       const { TodoWriteTool } = await import('../tools/todoWrite.js');
       return new TodoWriteTool(this);
     });
-    await registerLazy(ToolNames.ASK_USER_QUESTION, async () => {
-      const { AskUserQuestionTool } = await import(
-        '../tools/askUserQuestion.js'
-      );
-      return new AskUserQuestionTool(this);
-    });
-    if (!this.sdkMode) {
+    const supportsUserInteraction = resolveInteractionMode(this) !== 'headless';
+    if (supportsUserInteraction) {
+      await registerLazy(ToolNames.ASK_USER_QUESTION, async () => {
+        const { AskUserQuestionTool } = await import(
+          '../tools/askUserQuestion.js'
+        );
+        return new AskUserQuestionTool(this);
+      });
+    }
+    if (!this.sdkMode && (supportsUserInteraction || options?.forSubAgent)) {
       await registerLazy(ToolNames.EXIT_PLAN_MODE, async () => {
         const { ExitPlanModeTool } = await import('../tools/exitPlanMode.js');
         return new ExitPlanModeTool(this);
       });
+    }
+    if (!this.sdkMode && supportsUserInteraction) {
       await registerLazy(ToolNames.ENTER_PLAN_MODE, async () => {
         const { EnterPlanModeTool } = await import('../tools/enterPlanMode.js');
         return new EnterPlanModeTool(this);


### PR DESCRIPTION
## What this PR does

Aligns the runtime tool registry with the resolved interaction mode. Plain text headless sessions no longer advertise `ask_user_question`, `enter_plan_mode`, or `exit_plan_mode`, while interactive TUI, ACP, and stream-json sessions retain all three tools. Headless subagent registries retain only `exit_plan_mode` so plan-required teammates can still submit plans through the existing filter.

## Why it's needed

The headless system prompt already tells the model that no reply can be received and that it must not ask questions, but the three interaction and plan lifecycle tools were still registered unconditionally. This exposed unusable tools to the model and allowed it to attempt calls that could not complete in a plain single-turn headless session.

## Reviewer Test Plan

### How to verify

1. Create a plain text headless configuration and confirm its tool registry excludes `ask_user_question`, `enter_plan_mode`, and `exit_plan_mode`.
2. Create interactive TUI, ACP, and stream-json configurations and confirm each registry still includes all three tools.
3. Create a headless subagent registry and confirm `ask_user_question` and `enter_plan_mode` are excluded while `exit_plan_mode` remains available for the plan-required teammate policy.
4. Run the focused config and agent-core unit suites and confirm all mode-matrix and downstream filtering tests pass.

### Evidence (Before & After)

Before: a plain headless run with the global Qwen Code 0.19.11 registered and declared all three interaction tools even though its prompt prohibited using them.

After: the registry mode-matrix tests confirm plain headless excludes all three tools, interactive host-mediated modes retain them, and the subagent-specific `exit_plan_mode` path remains intact.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace; baseline reproduced with global Qwen Code 0.19.11; validation used the core Vitest suites, repository build, typecheck, ESLint, and Prettier.

## Risk & Scope

- Main risk or tradeoff: Incorrect interaction-mode classification could hide tools from a host that can relay user responses; the implementation reuses the existing prompt interaction-mode resolver to keep registration and prompting aligned.
- Not validated / out of scope: Manual runtime verification on Windows and Linux.
- Breaking changes / migration notes: Plain text headless sessions intentionally lose three tools that cannot complete there; interactive and host-mediated modes are unchanged.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

让运行时工具注册与解析后的交互模式保持一致。普通文本 headless 会话不再暴露 `ask_user_question`、`enter_plan_mode` 或 `exit_plan_mode`，交互式 TUI、ACP 和 stream-json 会话仍保留这三个工具。Headless 子代理注册表只保留 `exit_plan_mode`，以便要求先提交计划的 teammate 仍能通过现有过滤策略提交计划。

## 为什么需要

Headless 系统提示词已经告诉模型无法接收后续回复且不得提问，但这三个交互和计划生命周期工具仍被无条件注册。这会向模型暴露无法使用的工具，并允许它在普通单轮 headless 会话中尝试无法完成的调用。

## Reviewer 测试计划

### 如何验证

1. 创建普通文本 headless 配置，确认其工具注册表不包含 `ask_user_question`、`enter_plan_mode` 和 `exit_plan_mode`。
2. 创建交互式 TUI、ACP 和 stream-json 配置，确认每种配置的注册表仍包含全部三个工具。
3. 创建 headless 子代理注册表，确认 `ask_user_question` 和 `enter_plan_mode` 被排除，而 `exit_plan_mode` 仍可供要求先提交计划的 teammate 策略使用。
4. 运行针对 config 和 agent-core 的单元测试，确认模式矩阵和下游过滤测试全部通过。

### 证据（修改前后）

修改前：使用全局 Qwen Code 0.19.11 的普通 headless 运行仍会注册并声明全部三个交互工具，尽管其提示词禁止使用这些工具。

修改后：注册表模式矩阵测试确认普通 headless 排除全部三个工具，支持交互的托管模式仍保留它们，并且子代理专用的 `exit_plan_mode` 路径保持完整。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 工作区；使用全局 Qwen Code 0.19.11 复现基线；使用 core Vitest 测试、仓库构建、类型检查、ESLint 和 Prettier 完成验证。

## 风险与范围

- 主要风险或权衡：如果交互模式分类错误，可能会对能够转发用户回复的宿主隐藏工具；实现复用了现有提示词交互模式解析器，使工具注册与提示词保持一致。
- 未验证 / 范围之外：未在 Windows 和 Linux 上进行手工运行时验证。
- 破坏性变更 / 迁移说明：普通文本 headless 会话会按预期失去三个无法在该模式完成的工具；交互式和宿主托管模式不受影响。

## 关联 Issue

无。

</details>
