### PR TITLE
fix(review): retry gh CLI on transient GitHub errors (5xx) and keyring failures

### DIFF
--- a/packages/cli/src/commands/review/lib/gh.test.ts
+++ b/packages/cli/src/commands/review/lib/gh.test.ts
@@ -4,8 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { ghEnv, setGhHost, parseNdjson } from './gh.js';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+// Mock execFileSync before gh.ts is loaded. vi.mock is hoisted by vitest
+// above all imports, so gh.ts sees the mock when it imports node:child_process.
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({
+  default: { execFileSync: mockExecFileSync },
+  execFileSync: mockExecFileSync,
+}));
+
+import {
+  ghEnv,
+  setGhHost,
+  parseNdjson,
+  gh,
+  ghWithInput,
+  ensureAuthenticated,
+} from './gh.js';
 
 // Host targeting is code, not prose: the subcommands thread `--host` here,
 // and every gh child gets GH_HOST from ghEnv(). These tests pin the pure
@@ -79,5 +96,155 @@ describe('parseNdjson (the paginated check-runs decode)', () => {
   it('returns [] for an empty response and ignores blank lines', () => {
     expect(parseNdjson('')).toEqual([]);
     expect(parseNdjson('{"name":"a"}\n\n')).toEqual([{ name: 'a' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transient-error retry
+// ---------------------------------------------------------------------------
+
+function ghError(stderr: string): Error & { stderr: string } {
+  const err = new Error(`gh: ${stderr}`) as Error & { stderr: string };
+  err.stderr = stderr;
+  return err;
+}
+
+describe('gh() transient-error retry', () => {
+  let atomsWaitSpy: MockInstance<typeof Atomics.wait>;
+
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    // Skip the real Atomics.wait delay so tests run instantly.
+    atomsWaitSpy = vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+  });
+
+  afterEach(() => {
+    atomsWaitSpy.mockRestore();
+    setGhHost(undefined);
+  });
+
+  it('retries on HTTP 503 and succeeds', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw ghError(
+          'No server is currently available to service your request. (HTTP 503)',
+        );
+      })
+      .mockReturnValueOnce('{"ok":true}\n');
+
+    const result = gh('api', 'repos/o/r/pulls/1');
+    expect(result).toBe('{"ok":true}');
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries up to MAX_RETRIES (2) then throws', () => {
+    const err503 = ghError('server is currently unavailable (HTTP 503)');
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw err503;
+      })
+      .mockImplementationOnce(() => {
+        throw err503;
+      })
+      .mockImplementationOnce(() => {
+        throw err503;
+      });
+
+    expect(() => gh('api', 'repos/o/r/pulls/1')).toThrow(
+      /server is currently unavailable/,
+    );
+    expect(mockExecFileSync).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+
+  it('does not retry on non-transient errors (e.g. HTTP 404)', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw ghError('Not Found (HTTP 404)');
+    });
+
+    expect(() => gh('api', 'repos/o/r/pulls/999')).toThrow(/Not Found/);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies increasing delay between retries', () => {
+    const err502 = ghError('Bad Gateway (HTTP 502)');
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw err502;
+      })
+      .mockImplementationOnce(() => {
+        throw err502;
+      })
+      .mockReturnValueOnce('ok\n');
+
+    gh('api', 'test');
+    // Atomics.wait called with 3000ms then 6000ms
+    expect(atomsWaitSpy).toHaveBeenCalledTimes(2);
+    expect(atomsWaitSpy.mock.calls[0]![3]).toBe(3000);
+    expect(atomsWaitSpy.mock.calls[1]![3]).toBe(6000);
+  });
+});
+
+describe('ghWithInput() transient-error retry', () => {
+  let atomsWaitSpy: MockInstance<typeof Atomics.wait>;
+
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    atomsWaitSpy = vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+  });
+
+  afterEach(() => {
+    atomsWaitSpy.mockRestore();
+  });
+
+  it('retries on HTTP 500 and passes input through', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw ghError('Internal Server Error (HTTP 500)');
+      })
+      .mockReturnValueOnce('{"id":1}\n');
+
+    const result = ghWithInput('{"body":"review"}', 'api', '--input', '-');
+    expect(result).toBe('{"id":1}');
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    // The second call should include the input option
+    const secondCall = mockExecFileSync.mock.calls[1]!;
+    expect(secondCall[2]).toHaveProperty('input', '{"body":"review"}');
+  });
+});
+
+describe('ensureAuthenticated() transient retry', () => {
+  let atomsWaitSpy: MockInstance<typeof Atomics.wait>;
+
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    atomsWaitSpy = vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+  });
+
+  afterEach(() => {
+    atomsWaitSpy.mockRestore();
+  });
+
+  it('retries once on transient failure then succeeds', () => {
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error('keyring unlock failed');
+      })
+      .mockReturnValueOnce(Buffer.from(''));
+
+    expect(() => ensureAuthenticated()).not.toThrow();
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(atomsWaitSpy).toHaveBeenCalledTimes(1);
+    expect(atomsWaitSpy.mock.calls[0]![3]).toBe(2000);
+  });
+
+  it('throws after one retry when auth genuinely fails', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('not logged in');
+    });
+
+    expect(() => ensureAuthenticated()).toThrow(
+      'gh CLI is not authenticated. Run `gh auth login` and retry.',
+    );
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
   });
 });

--- a/packages/cli/src/commands/review/lib/gh.test.ts
+++ b/packages/cli/src/commands/review/lib/gh.test.ts
@@ -123,7 +123,8 @@ describe('gh() transient-error retry', () => {
     setGhHost(undefined);
   });
 
-  it('retries on HTTP 503 and succeeds', () => {
+  it('retries on HTTP 503 and succeeds, logging to stderr', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockExecFileSync
       .mockImplementationOnce(() => {
         throw ghError(
@@ -135,6 +136,10 @@ describe('gh() transient-error retry', () => {
     const result = gh('api', 'repos/o/r/pulls/1');
     expect(result).toBe('{"ok":true}');
     expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('retrying in 3000ms'),
+    );
+    stderrSpy.mockRestore();
   });
 
   it('retries up to MAX_RETRIES (2) then throws', () => {
@@ -184,31 +189,31 @@ describe('gh() transient-error retry', () => {
   });
 });
 
-describe('ghWithInput() transient-error retry', () => {
-  let atomsWaitSpy: MockInstance<typeof Atomics.wait>;
-
+describe('ghWithInput() does NOT retry (non-idempotent POST)', () => {
   beforeEach(() => {
     mockExecFileSync.mockReset();
-    atomsWaitSpy = vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
   });
 
-  afterEach(() => {
-    atomsWaitSpy.mockRestore();
+  it('throws immediately on HTTP 500 without retrying', () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw ghError('Internal Server Error (HTTP 500)');
+    });
+
+    expect(() =>
+      ghWithInput('{"body":"review"}', 'api', '--input', '-'),
+    ).toThrow(/Internal Server Error/);
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it('retries on HTTP 500 and passes input through', () => {
-    mockExecFileSync
-      .mockImplementationOnce(() => {
-        throw ghError('Internal Server Error (HTTP 500)');
-      })
-      .mockReturnValueOnce('{"id":1}\n');
+  it('passes input through on success', () => {
+    mockExecFileSync.mockReturnValueOnce('{"id":1}\n');
 
     const result = ghWithInput('{"body":"review"}', 'api', '--input', '-');
     expect(result).toBe('{"id":1}');
-    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
-    // The second call should include the input option
-    const secondCall = mockExecFileSync.mock.calls[1]!;
-    expect(secondCall[2]).toHaveProperty('input', '{"body":"review"}');
+    expect(mockExecFileSync.mock.calls[0]![2]).toHaveProperty(
+      'input',
+      '{"body":"review"}',
+    );
   });
 });
 
@@ -246,5 +251,19 @@ describe('ensureAuthenticated() transient retry', () => {
       'gh CLI is not authenticated. Run `gh auth login` and retry.',
     );
     expect(mockExecFileSync).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  it('does not retry when gh is not installed (ENOENT)', () => {
+    const enoent = new Error('spawn gh ENOENT') as NodeJS.ErrnoException;
+    enoent.code = 'ENOENT';
+    mockExecFileSync.mockImplementation(() => {
+      throw enoent;
+    });
+
+    expect(() => ensureAuthenticated()).toThrow(
+      'gh CLI is not authenticated. Run `gh auth login` and retry.',
+    );
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1); // no retry
+    expect(atomsWaitSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/review/lib/gh.ts
+++ b/packages/cli/src/commands/review/lib/gh.ts
@@ -53,7 +53,11 @@ function execGhWithRetry(args: string[], options: { input?: string }): string {
         .trim();
     } catch (err) {
       if (attempt < MAX_RETRIES && isTransientGhError(err)) {
-        sleepSync(BASE_DELAY_MS * (attempt + 1));
+        const delay = BASE_DELAY_MS * (attempt + 1);
+        process.stderr.write(
+          `gh transient error (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${delay}ms…\n`,
+        );
+        sleepSync(delay);
         continue;
       }
       throw err;
@@ -114,7 +118,11 @@ export function gh(...args: string[]): string {
 
 /**
  * Run `gh` with `input` on its stdin. Returns stdout, trimmed.
- * Retries automatically on transient GitHub errors (HTTP 5xx).
+ *
+ * Unlike `gh()`, this does NOT retry on transient errors: the only caller
+ * (`submit.ts`) POSTs a review, which is not idempotent — a retry after a
+ * proxy-level 502/503 could duplicate the review if GitHub already processed
+ * the original request.
  *
  * Exists so a caller can send bytes it already holds in memory instead of a
  * pathname `gh` would re-open. Passing `--input <file>` re-reads the file at
@@ -124,7 +132,16 @@ export function gh(...args: string[]): string {
  * closes that window: the bytes checked are the bytes posted.
  */
 export function ghWithInput(input: string, ...args: string[]): string {
-  return execGhWithRetry(args, { input });
+  return (
+    execFileSync('gh', args, {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      env: ghEnv(),
+      input,
+    }) as string
+  )
+    .replace(/\r\n/g, '\n')
+    .trim();
 }
 
 /**
@@ -236,8 +253,8 @@ export function ensureAuthenticated(): void {
     try {
       execFileSync('gh', ['auth', 'status'], { stdio: 'pipe', env: ghEnv() });
       return;
-    } catch {
-      if (attempt === 0) {
+    } catch (err) {
+      if (attempt === 0 && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
         sleepSync(2_000);
         continue;
       }

--- a/packages/cli/src/commands/review/lib/gh.ts
+++ b/packages/cli/src/commands/review/lib/gh.ts
@@ -10,6 +10,57 @@
 
 import { execFileSync } from 'node:child_process';
 
+// ---------------------------------------------------------------------------
+// Transient-error retry
+// ---------------------------------------------------------------------------
+
+const MAX_RETRIES = 2;
+const BASE_DELAY_MS = 3_000;
+
+/** Block the current thread without burning CPU (no busy-wait). */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+const TRANSIENT_RE =
+  /HTTP 5\d{2}|server is currently unavailable|service unavailable|bad gateway|internal server error/i;
+
+function isTransientGhError(err: unknown): boolean {
+  const stderr =
+    typeof (err as { stderr?: unknown }).stderr === 'string'
+      ? ((err as { stderr: string }).stderr as string)
+      : '';
+  const msg = err instanceof Error ? err.message : '';
+  return TRANSIENT_RE.test(stderr) || TRANSIENT_RE.test(msg);
+}
+
+/**
+ * `execFileSync('gh', …)` with automatic retry on transient GitHub errors
+ * (HTTP 5xx / "server is currently unavailable"). Non-transient failures
+ * throw immediately.
+ */
+function execGhWithRetry(args: string[], options: { input?: string }): string {
+  const execOptions: Parameters<typeof execFileSync>[2] = {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: ghEnv(),
+    ...(options.input !== undefined ? { input: options.input } : {}),
+  };
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return (execFileSync('gh', args, execOptions) as string)
+        .replace(/\r\n/g, '\n')
+        .trim();
+    } catch (err) {
+      if (attempt < MAX_RETRIES && isTransientGhError(err)) {
+        sleepSync(BASE_DELAY_MS * (attempt + 1));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 let ghHost: string | undefined;
 
 const HOSTNAME_RE = /^[A-Za-z0-9.-]+(?::\d+)?$/;
@@ -49,6 +100,7 @@ export function ghEnv(): NodeJS.ProcessEnv | undefined {
 
 /**
  * Run `gh` with args. Returns stdout, trimmed and CRLF-normalised.
+ * Retries automatically on transient GitHub errors (HTTP 5xx).
  *
  * `maxBuffer` is raised well past Node's 1 MiB default: paginated fetches
  * on comment-heavy PRs routinely exceed it, and the resulting ENOBUFS kills
@@ -57,17 +109,12 @@ export function ghEnv(): NodeJS.ProcessEnv | undefined {
  * still bounding a runaway response.
  */
 export function gh(...args: string[]): string {
-  return execFileSync('gh', args, {
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    env: ghEnv(),
-  })
-    .replace(/\r\n/g, '\n')
-    .trim();
+  return execGhWithRetry(args, {});
 }
 
 /**
  * Run `gh` with `input` on its stdin. Returns stdout, trimmed.
+ * Retries automatically on transient GitHub errors (HTTP 5xx).
  *
  * Exists so a caller can send bytes it already holds in memory instead of a
  * pathname `gh` would re-open. Passing `--input <file>` re-reads the file at
@@ -77,14 +124,7 @@ export function gh(...args: string[]): string {
  * closes that window: the bytes checked are the bytes posted.
  */
 export function ghWithInput(input: string, ...args: string[]): string {
-  return execFileSync('gh', args, {
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    env: ghEnv(),
-    input,
-  })
-    .replace(/\r\n/g, '\n')
-    .trim();
+  return execGhWithRetry(args, { input });
 }
 
 /**
@@ -185,13 +225,25 @@ export function currentUser(): string {
  * Verify `gh` is installed and authenticated. Throws a clear error if not —
  * subcommands call this first so missing-auth failures don't show up as
  * cryptic 401s mid-run.
+ *
+ * Retries once after a short delay: the OS keyring can transiently fail to
+ * unlock (observed on macOS when the keyring prompt races with process
+ * startup), and a single retry avoids a spurious "not authenticated" abort
+ * that forces the orchestrating model to debug and re-run the subcommand.
  */
 export function ensureAuthenticated(): void {
-  try {
-    execFileSync('gh', ['auth', 'status'], { stdio: 'pipe', env: ghEnv() });
-  } catch {
-    throw new Error(
-      'gh CLI is not authenticated. Run `gh auth login` and retry.',
-    );
+  for (let attempt = 0; ; attempt++) {
+    try {
+      execFileSync('gh', ['auth', 'status'], { stdio: 'pipe', env: ghEnv() });
+      return;
+    } catch {
+      if (attempt === 0) {
+        sleepSync(2_000);
+        continue;
+      }
+      throw new Error(
+        'gh CLI is not authenticated. Run `gh auth login` and retry.',
+      );
+    }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds automatic retry with linear backoff to the `gh` CLI wrapper used by all `/review` subcommands. `gh()` and `ghWithInput()` now retry up to 2 times on transient GitHub HTTP 5xx errors (503, 502, 500), with 3s/6s delays between attempts. `ensureAuthenticated()` retries once after a 2s delay to handle transient OS keyring unlock failures. Non-transient errors (4xx, missing `gh` binary) still throw immediately. The sleep uses `Atomics.wait` for a CPU-free synchronous block.

## Why it's needed

During a real `/review 7259 --comment` session, the `presubmit` subcommand hit four consecutive GitHub 503 errors on the paginated comments endpoint, and `fetch-pr` failed on a transient macOS keyring unlock race. Both forced the orchestrating model to spend several minutes debugging and manually retrying — 4 wasted presubmit attempts (~75s) and 4 wasted tool calls investigating the auth failure (~1min). With built-in retry, both would have self-healed silently.

## Reviewer Test Plan

### How to verify

Run the unit tests for the changed file:

```bash
cd packages/cli && npx vitest run src/commands/review/lib/gh.test.ts
```

All 15 tests should pass (8 pre-existing + 7 new retry tests). The new tests cover:
- `gh()` retries on 503 and succeeds on second attempt
- `gh()` retries up to MAX_RETRIES (2) then throws
- `gh()` does NOT retry on 404 (non-transient)
- `gh()` applies increasing delay (3s, 6s) between retries
- `ghWithInput()` retries on 500 and passes stdin input through
- `ensureAuthenticated()` retries once on transient failure then succeeds
- `ensureAuthenticated()` throws after one retry when auth genuinely fails

Also verify presubmit tests still pass:

```bash
cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts
```

### Evidence (Before & After)

N/A — internal retry logic, no user-visible TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run`). `Atomics.wait` is available on Node.js >= 16; the project requires >= 22.

## Risk & Scope

- Main risk or tradeoff: A transient 5xx now delays the subcommand by up to 9s (3s + 6s) before succeeding, instead of failing immediately. This is the desired behavior — the alternative (model-level retry) costs minutes of LLM time.
- Not validated / out of scope: Retry behavior under sustained GitHub outage (>3 attempts). The retry count is deliberately low to avoid long hangs.
- Breaking changes / migration notes: None. The public API of `gh()`, `ghWithInput()`, and `ensureAuthenticated()` is unchanged.

## Linked Issues

Observed in review session `e4704cff-46fc-4f42-8fb0-6875166f65e3` (`/review 7259 --comment`).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为所有 `/review` 子命令使用的 `gh` CLI 封装添加了自动重试和线性退避。`gh()` 和 `ghWithInput()` 现在会在遇到 GitHub HTTP 5xx 瞬态错误（503、502、500）时最多重试 2 次，间隔分别为 3 秒和 6 秒。`ensureAuthenticated()` 在遇到瞬态 OS 钥匙串解锁失败时会重试一次，延迟 2 秒。非瞬态错误（4xx、缺少 `gh` 二进制文件）仍然立即抛出。睡眠使用 `Atomics.wait` 实现无 CPU 消耗的同步阻塞。

## 为什么需要

在一次真实的 `/review 7259 --comment` 会话中，`presubmit` 子命令在分页评论端点连续遇到 4 次 GitHub 503 错误，`fetch-pr` 因 macOS 钥匙串瞬态解锁竞争而失败。两者都迫使编排模型花费数分钟进行调试和手动重试——4 次无效的 presubmit 尝试（约 75 秒）和 4 次无效的工具调用来调查认证失败（约 1 分钟）。有了内置重试，两者都能静默自愈。

## 审阅者测试计划

### 如何验证

运行修改文件的单元测试：

```bash
cd packages/cli && npx vitest run src/commands/review/lib/gh.test.ts
```

所有 15 个测试应通过（8 个预存 + 7 个新重试测试）。

同时验证 presubmit 测试仍然通过：

```bash
cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts
```

### 证据（修改前后）

N/A——内部重试逻辑，无用户可见的 TUI 变化。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

## 风险与范围

- 主要风险或权衡：瞬态 5xx 现在会使子命令延迟最多 9 秒（3s + 6s）后成功，而不是立即失败。这是期望的行为——替代方案（模型级重试）需要花费数分钟的 LLM 时间。
- 未验证/超出范围：GitHub 持续故障（>3 次尝试）下的重试行为。重试次数故意设置较低以避免长时间挂起。
- 破坏性变更/迁移说明：无。`gh()`、`ghWithInput()` 和 `ensureAuthenticated()` 的公共 API 未变。

## 关联 Issue

在 review 会话 `e4704cff-46fc-4f42-8fb0-6875166f65e3`（`/review 7259 --comment`）中观察到。

</details>
