### PR TITLE
fix(core): allow restricted git config for extension installs

### DIFF
--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -284,6 +284,10 @@ describe('git extension helpers', () => {
           'protocol.allow=never',
           'protocol.https.allow=always',
         ],
+        unsafe: {
+          allowUnsafeConfigPaths: true,
+          allowUnsafeProtocolOverride: true,
+        },
       });
       expect(mockGit.env).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -591,6 +595,10 @@ describe('git extension helpers', () => {
           'protocol.allow=never',
           'protocol.https.allow=always',
         ],
+        unsafe: {
+          allowUnsafeConfigPaths: true,
+          allowUnsafeProtocolOverride: true,
+        },
       });
       expect(mockGit.listRemote).toHaveBeenCalledWith([
         'https://github.com/owner/repo.git',

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -184,7 +184,15 @@ export async function cloneFromGit(
     const git = restrictGitEnvironment(
       simpleGit(destination, {
         ...(signal ? { abort: signal } : {}),
-        ...(networkConfig.length > 0 ? { config: networkConfig } : {}),
+        ...(networkConfig.length > 0
+          ? {
+              config: networkConfig,
+              unsafe: {
+                allowUnsafeConfigPaths: true,
+                allowUnsafeProtocolOverride: true,
+              },
+            }
+          : {}),
       }),
       installMetadata.networkPolicy,
     );
@@ -452,7 +460,15 @@ export async function checkForExtensionUpdate(
       const git = restrictGitEnvironment(
         simpleGit(extension.path, {
           ...(signal ? { abort: signal } : {}),
-          ...(networkConfig.length > 0 ? { config: networkConfig } : {}),
+          ...(networkConfig.length > 0
+            ? {
+                config: networkConfig,
+                unsafe: {
+                  allowUnsafeConfigPaths: true,
+                  allowUnsafeProtocolOverride: true,
+                },
+              }
+            : {}),
         }),
         installMetadata.networkPolicy,
       );


### PR DESCRIPTION
## What this PR does

Allows simple-git to apply the explicitly constructed per-command protocol policy and the isolated global-config path used for public Extension Git installs and update checks. The unsafe flags only authorize simple-git's validation layer; Git still receives the existing restrictive configuration that disables system/global configuration, denies protocols by default, and permits only the pinned HTTPS path.

## Why it's needed

Public Git Extension installs currently fail before Git runs because simple-git rejects `protocol.allow` and `GIT_CONFIG_GLOBAL`. Users see errors such as “Configuring protocol.allow is not permitted” or “Use of GIT_CONFIG_GLOBAL is not permitted” even for ordinary HTTPS GitHub repositories.

## Reviewer Test Plan

### How to verify

Install or check updates for a public HTTPS Git Extension that resolves through the pinned network policy. Confirm simple-git accepts the restricted command configuration, cloning succeeds, and the environment still excludes inherited system/global Git configuration. Confirm non-public install paths are unchanged.

### Evidence (Before & After)

Before: public Git installs fail in simple-git validation. After: the existing restricted Git policy is allowed to execute.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ build, typecheck, 86 extension Git tests |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Node.js 22; local workspace build.

## Risk & Scope

- Main risk or tradeoff: The simple-git options are security-sensitive; the allowance must remain limited to commands that also receive the pinned public-network configuration.
- Not validated / out of scope: Live cloning from GitHub in an end-to-end run.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

允许 simple-git 使用公共扩展 Git 安装和更新检查中明确构造的命令级协议策略，以及隔离的全局配置路径。这些 unsafe 标志只放行 simple-git 自身的参数校验；Git 仍然使用原有的严格配置：禁用系统/全局配置，默认拒绝协议，只允许固定的 HTTPS 路径。

## 为什么需要

公共 Git 扩展安装目前会在 Git 执行前被 simple-git 拒绝。即使是普通 HTTPS GitHub 仓库，用户也会看到 “Configuring protocol.allow is not permitted” 或 “Use of GIT_CONFIG_GLOBAL is not permitted”。

## Reviewer Test Plan

### 如何验证

安装或检查一个通过固定网络策略解析的公共 HTTPS Git 扩展。确认 simple-git 接受受限命令配置，克隆可以执行，并且环境仍不会继承系统/用户 Git 配置。确认非公共安装路径不受影响。

### 证据（前后对比）

改动前：公共 Git 安装在 simple-git 校验阶段失败。改动后：已有的受限 Git 策略可以实际执行。

### 测试平台

macOS 已完成 build、typecheck 和 86 个扩展 Git 测试；Windows、Linux 未测试。

### 环境

Node.js 22，本地工作区构建。

## 风险与范围

- 主要风险或权衡：simple-git 选项涉及安全，放行必须仅限于同时传入固定公共网络配置的命令。
- 未验证或范围外：真实 GitHub 克隆端到端测试。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
