### PR TITLE
fix(web-shell): proxy extension APIs without intercepting modules

### DIFF
--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -10,6 +10,14 @@ const daemonProxy: ProxyOptions = {
   changeOrigin: true,
   bypass: (req) => {
     if (req.url?.startsWith('/api/')) return undefined;
+    // `/extensions/*` is both a daemon API and a client source directory.
+    if (
+      req.method === 'GET' &&
+      req.url?.startsWith('/extensions/') &&
+      /\.(?:[cm]?[jt]sx?|css|map)(?:\?|$)/.test(req.url)
+    ) {
+      return req.url;
+    }
     const fetchMode = req.headers['sec-fetch-mode'];
     const fetchDest = req.headers['sec-fetch-dest'];
     const accept = req.headers.accept ?? '';
@@ -77,6 +85,7 @@ export default defineConfig(({ command }) => ({
       '/session': daemonProxy,
       '/permission': daemonProxy,
       '/workspace': daemonProxy,
+      '/extensions': daemonProxy,
       '/file': daemonProxy,
       '/stat': daemonProxy,
       '/list': daemonProxy,


### PR DESCRIPTION
## What this PR does

Adds the daemon `/extensions` API to the Web Shell development proxy while bypassing the proxy for GET requests that clearly target Vite-served JavaScript, TypeScript, CSS, or source-map modules under the same path.

## Why it's needed

Extension management API requests otherwise fall through to the SPA and return 404, while blindly proxying the whole prefix causes client modules such as `/extensions/inputHighlight.ts` to be sent to the authenticated daemon and return 401. The development server must distinguish API traffic from source-module traffic sharing this prefix.

## Reviewer Test Plan

### How to verify

Run the Web Shell development server with a daemon. Open the Extension page and confirm `/extensions/.../activation` requests reach the daemon. Reload the page and confirm Vite serves `/extensions/*.ts`, `/extensions/*.tsx`, CSS, and source maps locally without 401 responses. Confirm document navigation behavior is unchanged.

### Evidence (Before & After)

Before: either the activation API returns 404 or Extension source modules return 401, depending on proxy coverage. After: API requests are proxied and source modules remain local to Vite.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ included in full build and typecheck |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Node.js 22; local workspace build. Manual browser end-to-end validation was not run.

## Risk & Scope

- Main risk or tradeoff: The bypass relies on method and file extension; future daemon API routes ending in source-like extensions would need an explicit routing rule.
- Not validated / out of scope: Manual browser traffic inspection.
- Breaking changes / migration notes: Development-server behavior only; production routing is unchanged.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 daemon 的 `/extensions` API 加入 Web Shell 开发代理，同时对该路径下明显由 Vite 提供的 JavaScript、TypeScript、CSS 和 source map GET 请求绕过代理。

## 为什么需要

扩展管理 API 若未代理会落入 SPA 并返回 404；但直接代理整个前缀，又会把 `/extensions/inputHighlight.ts` 等客户端模块发给需要认证的 daemon，返回 401。开发服务器需要区分共享同一前缀的 API 流量和源码模块流量。

## Reviewer Test Plan

### 如何验证

同时运行 Web Shell 开发服务器和 daemon。打开扩展页面，确认 `/extensions/.../activation` 请求到达 daemon。刷新页面，确认 `/extensions/*.ts`、`*.tsx`、CSS 和 source map 仍由 Vite 本地提供，不出现 401。确认页面导航行为不变。

### 证据（前后对比）

改动前：根据代理覆盖方式，activation API 返回 404，或扩展源码模块返回 401。改动后：API 请求被代理，源码模块保留在 Vite 本地。

### 测试平台

macOS 已包含在完整 build 和 typecheck 中；Windows、Linux 未测试。

### 环境

Node.js 22，本地工作区构建。按当前约定未执行手动浏览器端到端验证。

## 风险与范围

- 主要风险或权衡：绕过规则依赖请求方法和扩展名；未来若 daemon API 以源码类扩展名结尾，需要增加明确规则。
- 未验证或范围外：手动浏览器流量检查。
- 破坏性变更或迁移说明：仅影响开发服务器；生产路由不变。

## 关联 Issue

N/A

</details>
