### PR TITLE
fix(cli): Preserve cancellation during permission prompts

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -10397,6 +10397,16 @@ describe('Session', () => {
       const rawCommand = "python -c 'print(1)'";
       const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
       const executeSpy = vi.fn();
+      const internals = session as unknown as {
+        midTurnRecoveredMessages: Array<{
+          kind: 'text';
+          message: string;
+        }>;
+      };
+      internals.midTurnRecoveredMessages.push({
+        kind: 'text',
+        message: 'recovered before cancellation',
+      });
       const invocation = {
         params: { command: rawCommand },
         getDefaultPermission: vi.fn().mockResolvedValue('allow'),
@@ -10454,6 +10464,31 @@ describe('Session', () => {
       );
       expect(mockClient.extMethod).not.toHaveBeenCalled();
       expect(executeSpy).not.toHaveBeenCalled();
+      expect(internals.midTurnRecoveredMessages).toHaveLength(0);
+      expect(mockChat.addHistory).toHaveBeenCalledWith({
+        role: 'user',
+        parts: [
+          expect.objectContaining({
+            functionResponse: expect.objectContaining({
+              id: 'call-plan-approval-cancelled',
+              name: core.ToolNames.SHELL,
+            }),
+          }),
+          {
+            text: '\n[User message received during tool execution]: recovered before cancellation',
+          },
+        ],
+      });
+      expect(
+        mockChatRecordingService.recordMidTurnUserMessage,
+      ).toHaveBeenCalledWith(
+        [
+          {
+            text: '\n[User message received during tool execution]: recovered before cancellation',
+          },
+        ],
+        'recovered before cancellation',
+      );
     });
 
     it('rejects permission-hook rewrites of unknown Plan shell commands', async () => {
@@ -12954,6 +12989,11 @@ describe('Session', () => {
         ]);
       }
 
+      async function* createAbortingEmptyStream() {
+        await session.cancelPendingPrompt();
+        yield* createEmptyStream();
+      }
+
       it('waits for pending rewrites before ending after cancelled ask_user_question', async () => {
         let releaseRewrite!: () => void;
         const flushTurn = vi.fn().mockResolvedValue(undefined);
@@ -13215,6 +13255,44 @@ describe('Session', () => {
         expect(execute).not.toHaveBeenCalled();
       });
 
+      it('reports cancellation when abort lands between Stop-hook iterations', async () => {
+        const messageBus = {
+          request: vi.fn().mockResolvedValueOnce({
+            success: true,
+            output: {
+              decision: 'block',
+              reason: 'Continue after Stop hook',
+            },
+          }),
+        };
+        mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
+        mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+        mockConfig.hasHooksForEvent = vi
+          .fn()
+          .mockImplementation((eventName: string) => eventName === 'Stop');
+        mockChat.getHistory = vi
+          .fn()
+          .mockReturnValue([
+            { role: 'model', parts: [{ text: 'response text' }] },
+          ]);
+        mockChat.getLastModelMessageText = vi
+          .fn()
+          .mockReturnValue('response text');
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(createAbortingEmptyStream());
+
+        await expect(
+          session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'hello' }],
+          }),
+        ).resolves.toEqual({ stopReason: 'cancelled' });
+        expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(2);
+        expect(messageBus.request).toHaveBeenCalledTimes(1);
+      });
+
       it('ends background notification processing after cancelled ask_user_question', async () => {
         const execute = vi.fn();
         mockToolRegistry.getTool.mockReturnValue(
@@ -13314,6 +13392,40 @@ describe('Session', () => {
           );
         });
         expect(execute).not.toHaveBeenCalled();
+      });
+
+      it('reports cancellation when a background stream ends after abort', async () => {
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(createAbortingEmptyStream());
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'start background work' }],
+        });
+
+        const callback = mockBackgroundTaskRegistry.setNotificationCallback.mock
+          .calls[0][0] as (
+          displayText: string,
+          modelText: string,
+          meta: { agentId: string; status: string; toolUseId?: string },
+        ) => void;
+        callback('done', '<task-notification />', {
+          agentId: 'agent-1',
+          status: 'completed',
+        });
+
+        await vi.waitFor(() => {
+          expect(mockClient.extNotification).toHaveBeenCalledWith(
+            '_qwencode/end_turn',
+            {
+              sessionId: 'test-session-id',
+              reason: 'cancelled',
+              source: 'background_notification',
+            },
+          );
+        });
       });
     });
   });
@@ -15868,7 +15980,7 @@ describe('Session', () => {
       );
     });
 
-    it('preserves the feature-off Stop-loop result when cancellation arrives before it starts', async () => {
+    it('reports cancellation before a feature-off Stop loop starts', async () => {
       let enterWait!: () => void;
       const waitStarted = new Promise<void>((resolve) => {
         enterWait = resolve;
@@ -15893,7 +16005,7 @@ describe('Session', () => {
       await session.cancelPendingPrompt();
       releaseWait();
 
-      await expect(prompt).resolves.toEqual({ stopReason: 'end_turn' });
+      await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
     });
 
     it('runs exactly two continuations and emits replayable status', async () => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -10452,6 +10452,7 @@ describe('Session', () => {
       expect(onConfirmSpy).toHaveBeenCalledWith(
         core.ToolConfirmationOutcome.Cancel,
       );
+      expect(mockClient.extMethod).not.toHaveBeenCalled();
       expect(executeSpy).not.toHaveBeenCalled();
     });
 
@@ -13167,8 +13168,9 @@ describe('Session', () => {
       });
 
       it('preserves parent cancellation during Stop-hook permission', async () => {
+        const execute = vi.fn();
         mockToolRegistry.getTool.mockReturnValue(
-          mockConfirmingTool(core.ToolNames.ASK_USER_QUESTION, vi.fn()),
+          mockConfirmingTool(core.ToolNames.ASK_USER_QUESTION, execute),
         );
         vi.mocked(mockClient.requestPermission).mockImplementationOnce(
           () => new Promise(() => {}),
@@ -13210,6 +13212,7 @@ describe('Session', () => {
         await session.cancelPendingPrompt();
 
         await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
+        expect(execute).not.toHaveBeenCalled();
       });
 
       it('ends background notification processing after cancelled ask_user_question', async () => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -10393,6 +10393,68 @@ describe('Session', () => {
       );
     });
 
+    it('preserves parent cancellation while unknown Plan shell approval is pending', async () => {
+      const rawCommand = "python -c 'print(1)'";
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const executeSpy = vi.fn();
+      const invocation = {
+        params: { command: rawCommand },
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell',
+          command: rawCommand,
+          rootCommand: 'python',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue(rawCommand),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      mockToolRegistry.getTool.mockReturnValue({
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      });
+      mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+      mockConfig.getApprovalModeRevision = vi.fn().mockReturnValue(2);
+      mockConfig.getPermissionManager = vi.fn().mockReturnValue(null);
+      vi.mocked(mockClient.requestPermission).mockImplementationOnce(
+        () => new Promise(() => {}),
+      );
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-plan-approval-cancelled',
+                  name: core.ToolNames.SHELL,
+                  args: { command: rawCommand },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      const prompt = session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'inspect through wrapper' }],
+      });
+      await vi.waitFor(() => {
+        expect(mockClient.requestPermission).toHaveBeenCalledOnce();
+      });
+      await session.cancelPendingPrompt();
+
+      await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.Cancel,
+      );
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
     it('rejects permission-hook rewrites of unknown Plan shell commands', async () => {
       const rawCommand = "python -c 'print(1)'";
       const hookSpy = vi
@@ -13104,6 +13166,52 @@ describe('Session', () => {
         });
       });
 
+      it('preserves parent cancellation during Stop-hook permission', async () => {
+        mockToolRegistry.getTool.mockReturnValue(
+          mockConfirmingTool(core.ToolNames.ASK_USER_QUESTION, vi.fn()),
+        );
+        vi.mocked(mockClient.requestPermission).mockImplementationOnce(
+          () => new Promise(() => {}),
+        );
+        const messageBus = {
+          request: vi.fn().mockResolvedValueOnce({
+            success: true,
+            output: {
+              decision: 'block',
+              reason: 'Continue after Stop hook',
+            },
+          }),
+        };
+        mockConfig.getMessageBus = vi.fn().mockReturnValue(messageBus);
+        mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+        mockConfig.hasHooksForEvent = vi
+          .fn()
+          .mockImplementation((eventName: string) => eventName === 'Stop');
+        mockChat.getHistory = vi
+          .fn()
+          .mockReturnValue([
+            { role: 'model', parts: [{ text: 'response text' }] },
+          ]);
+        mockChat.getLastModelMessageText = vi
+          .fn()
+          .mockReturnValue('response text');
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(createAskUserQuestionResponseStream());
+
+        const prompt = session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'hello' }],
+        });
+        await vi.waitFor(() => {
+          expect(mockClient.requestPermission).toHaveBeenCalledOnce();
+        });
+        await session.cancelPendingPrompt();
+
+        await expect(prompt).resolves.toEqual({ stopReason: 'cancelled' });
+      });
+
       it('ends background notification processing after cancelled ask_user_question', async () => {
         const execute = vi.fn();
         mockToolRegistry.getTool.mockReturnValue(
@@ -13157,6 +13265,52 @@ describe('Session', () => {
             }),
           ],
         });
+      });
+
+      it('reports cancellation while a background notification awaits permission', async () => {
+        const execute = vi.fn();
+        mockToolRegistry.getTool.mockReturnValue(
+          mockConfirmingTool(core.ToolNames.ASK_USER_QUESTION, execute),
+        );
+        vi.mocked(mockClient.requestPermission).mockImplementationOnce(
+          () => new Promise(() => {}),
+        );
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(createEmptyStream())
+          .mockResolvedValueOnce(createAskUserQuestionResponseStream());
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'start background work' }],
+        });
+
+        const callback = mockBackgroundTaskRegistry.setNotificationCallback.mock
+          .calls[0][0] as (
+          displayText: string,
+          modelText: string,
+          meta: { agentId: string; status: string; toolUseId?: string },
+        ) => void;
+        callback('done', '<task-notification />', {
+          agentId: 'agent-1',
+          status: 'completed',
+        });
+        await vi.waitFor(() => {
+          expect(mockClient.requestPermission).toHaveBeenCalledOnce();
+        });
+        await session.cancelPendingPrompt();
+
+        await vi.waitFor(() => {
+          expect(mockClient.extNotification).toHaveBeenCalledWith(
+            '_qwencode/end_turn',
+            {
+              sessionId: 'test-session-id',
+              reason: 'cancelled',
+              source: 'background_notification',
+            },
+          );
+        });
+        expect(execute).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -334,6 +334,7 @@ type AutoCompressionSendResult =
 function getAbortAwareEndTurnStopReason(
   signal: AbortSignal,
 ): PromptResponse['stopReason'] {
+  // Parent cancellation wins over a simultaneous terminal path.
   return signal.aborted ? 'cancelled' : 'end_turn';
 }
 
@@ -2738,7 +2739,7 @@ export class Session implements SessionContext {
     while (true) {
       if (pendingSend.signal.aborted) {
         this.todoStopGuard.suspend();
-        return { stopReason: 'end_turn' };
+        return { stopReason: 'cancelled' };
       }
 
       if (this.config.getApprovalMode() === ApprovalMode.PLAN) {
@@ -3675,10 +3676,14 @@ export class Session implements SessionContext {
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
   ): Promise<void> {
-    // Leave queued input with the host instead of delaying the required
-    // cancellation response on a mid-turn drain that may time out.
+    // Leave host-queued input in place, but preserve messages already removed
+    // by a prior timed-out drain before returning the cancellation response.
     const midTurnParts = abortSignal.aborted
-      ? []
+      ? await this.#buildMidTurnParts(
+          this.#takeRecoveredMidTurnMessages(),
+          abortSignal,
+          { preserveFallbackOnAbort: true },
+        )
       : await this.#drainMidTurnUserMessages(abortSignal);
     this.#preserveUnsentMessageHistory(
       {
@@ -3856,11 +3861,7 @@ export class Session implements SessionContext {
 
     if (this.midTurnDrainUnavailable) {
       return {
-        parts: await this.#buildMidTurnParts(
-          recovered,
-          abortSignal,
-          options.onFullTurnModel,
-        ),
+        parts: await this.#buildMidTurnParts(recovered, abortSignal, options),
         hasQueuedPrompt: false,
       };
     }
@@ -3891,7 +3892,7 @@ export class Session implements SessionContext {
         parts: await this.#buildMidTurnParts(
           [...recovered, ...parseMidTurnDrainResponse(response)],
           abortSignal,
-          options.onFullTurnModel,
+          options,
         ),
         hasQueuedPrompt:
           isRecord(response) && response['hasQueuedPrompt'] === true,
@@ -3946,11 +3947,7 @@ export class Session implements SessionContext {
       // Even on a failed/timed-out drain, still inject anything recovered from
       // an EARLIER timeout so a transient stall never strands those messages.
       return {
-        parts: await this.#buildMidTurnParts(
-          recovered,
-          abortSignal,
-          options.onFullTurnModel,
-        ),
+        parts: await this.#buildMidTurnParts(recovered, abortSignal, options),
         hasQueuedPrompt: false,
       };
     }
@@ -4018,7 +4015,10 @@ export class Session implements SessionContext {
   async #buildMidTurnParts(
     messages: DrainedMidTurnMessage[],
     abortSignal: AbortSignal,
-    onFullTurnModel?: (model: string) => boolean,
+    options: {
+      onFullTurnModel?: (model: string) => boolean;
+      preserveFallbackOnAbort?: boolean;
+    } = {},
   ): Promise<Part[]> {
     const parts: Part[] = [];
     for (const message of messages) {
@@ -4034,13 +4034,19 @@ export class Session implements SessionContext {
                 MID_TURN_QUEUE_RESOLVE_TIMEOUT_MS,
                 (signal) =>
                   this.#resolvePrompt(message.content, signal, {
-                    onFullTurnModel,
+                    onFullTurnModel: options.onFullTurnModel,
                   }),
               );
       } catch (messageError) {
-        if (abortSignal.aborted) return parts;
-        const errorMessage = this.#formatError(messageError);
-        debugLogger.warn(`Failed to resolve mid-turn message: ${errorMessage}`);
+        if (abortSignal.aborted && !options.preserveFallbackOnAbort) {
+          return parts;
+        }
+        if (!abortSignal.aborted) {
+          const errorMessage = this.#formatError(messageError);
+          debugLogger.warn(
+            `Failed to resolve mid-turn message: ${errorMessage}`,
+          );
+        }
         rawParts = [{ text: displayText }];
         if (
           message.kind === 'structured' &&
@@ -5001,7 +5007,9 @@ export class Session implements SessionContext {
               )
             ).stopReason;
           }
-          await this.#emitBackgroundNotificationEndTurn(stopReason);
+          await this.#emitBackgroundNotificationEndTurn(
+            ac.signal.aborted ? 'cancelled' : stopReason,
+          );
         } catch (error) {
           if (ac.signal.aborted) {
             this.todoStopGuard.suspend();

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -331,6 +331,12 @@ type AutoCompressionSendResult =
   | { responseStream: AsyncGenerator<StreamEvent>; stopReason?: never }
   | { responseStream: null; stopReason: PromptResponse['stopReason'] };
 
+function getAbortAwareEndTurnStopReason(
+  signal: AbortSignal,
+): PromptResponse['stopReason'] {
+  return signal.aborted ? 'cancelled' : 'end_turn';
+}
+
 type RunToolResult = {
   parts: Part[];
   stopAfterPermissionCancel: boolean;
@@ -2650,9 +2656,9 @@ export class Session implements SessionContext {
                       pendingSend.signal,
                     );
                     return {
-                      stopReason: pendingSend.signal.aborted
-                        ? 'cancelled'
-                        : 'end_turn',
+                      stopReason: getAbortAwareEndTurnStopReason(
+                        pendingSend.signal,
+                      ),
                     };
                   }
                   const nextAfterTools =
@@ -2668,7 +2674,11 @@ export class Session implements SessionContext {
                       toolRun,
                       pendingSend.signal,
                     );
-                    return { stopReason: 'end_turn' };
+                    return {
+                      stopReason: getAbortAwareEndTurnStopReason(
+                        pendingSend.signal,
+                      ),
+                    };
                   }
                 }
               }
@@ -3320,10 +3330,7 @@ export class Session implements SessionContext {
           await this.#preserveStoppedToolRun(toolRun, pendingSend.signal);
           return {
             kind: 'terminal',
-            stopReason:
-              toolRun.stopAfterPermissionCancel && pendingSend.signal.aborted
-                ? 'cancelled'
-                : 'end_turn',
+            stopReason: getAbortAwareEndTurnStopReason(pendingSend.signal),
             ...(supersededAutomaticContinuation
               ? { supersededAutomaticContinuation: true }
               : {}),
@@ -3668,6 +3675,11 @@ export class Session implements SessionContext {
     toolRun: RunToolResult,
     abortSignal: AbortSignal,
   ): Promise<void> {
+    // Leave queued input with the host instead of delaying the required
+    // cancellation response on a mid-turn drain that may time out.
+    const midTurnParts = abortSignal.aborted
+      ? []
+      : await this.#drainMidTurnUserMessages(abortSignal);
     this.#preserveUnsentMessageHistory(
       {
         role: 'user',
@@ -3676,7 +3688,7 @@ export class Session implements SessionContext {
           ...(toolRun.loopDetected
             ? [{ text: LOOP_DETECTED_CONTEXT_MESSAGE }]
             : []),
-          ...(await this.#drainMidTurnUserMessages(abortSignal)),
+          ...midTurnParts,
         ],
       },
       true,
@@ -4953,7 +4965,7 @@ export class Session implements SessionContext {
                 this.todoStopGuard.suspend();
                 await this.#preserveStoppedToolRun(toolRun, ac.signal);
                 await this.#emitBackgroundNotificationEndTurn(
-                  ac.signal.aborted ? 'cancelled' : 'end_turn',
+                  getAbortAwareEndTurnStopReason(ac.signal),
                 );
                 return;
               }
@@ -4965,7 +4977,9 @@ export class Session implements SessionContext {
               if (toolRun.loopDetected) {
                 this.todoStopGuard.suspend();
                 await this.#preserveStoppedToolRun(toolRun, ac.signal);
-                await this.#emitBackgroundNotificationEndTurn('end_turn');
+                await this.#emitBackgroundNotificationEndTurn(
+                  getAbortAwareEndTurnStopReason(ac.signal),
+                );
                 return;
               }
             }

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -2649,7 +2649,11 @@ export class Session implements SessionContext {
                       toolRun,
                       pendingSend.signal,
                     );
-                    return { stopReason: 'end_turn' };
+                    return {
+                      stopReason: pendingSend.signal.aborted
+                        ? 'cancelled'
+                        : 'end_turn',
+                    };
                   }
                   const nextAfterTools =
                     await this.#buildNextMessageAfterToolRun(
@@ -3316,7 +3320,10 @@ export class Session implements SessionContext {
           await this.#preserveStoppedToolRun(toolRun, pendingSend.signal);
           return {
             kind: 'terminal',
-            stopReason: 'end_turn',
+            stopReason:
+              toolRun.stopAfterPermissionCancel && pendingSend.signal.aborted
+                ? 'cancelled'
+                : 'end_turn',
             ...(supersededAutomaticContinuation
               ? { supersededAutomaticContinuation: true }
               : {}),
@@ -4945,7 +4952,9 @@ export class Session implements SessionContext {
               if (toolRun.stopAfterPermissionCancel) {
                 this.todoStopGuard.suspend();
                 await this.#preserveStoppedToolRun(toolRun, ac.signal);
-                await this.#emitBackgroundNotificationEndTurn('end_turn');
+                await this.#emitBackgroundNotificationEndTurn(
+                  ac.signal.aborted ? 'cancelled' : 'end_turn',
+                );
                 return;
               }
               const nextAfterTools = await this.#buildNextMessageAfterToolRun(


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one long line.
-->

## What this PR does

This PR preserves ACP parent-turn cancellation when a permission request is pending. The ordinary prompt loop, Stop-hook continuation loop, and background-notification loop now report `cancelled` when their owning abort signal has fired; an ordinary permission rejection, host-side permission failure, or tool-loop stop continues to report `end_turn`. An already-cancelled turn also skips the optional host mid-turn-input drain, leaving queued input for the next turn instead of delaying cancellation by up to the drain timeout.

It also adds focused regressions for an unknown Plan-mode shell command, a Stop-hook continuation, and a background notification that are each cancelled while waiting for permission.

## Why it's needed

Local end-to-end validation of #6949 found that cancelling an ACP prompt while a one-off Plan-mode shell approval was pending correctly prevented command execution but returned `end_turn`. That loses the parent cancellation reason at the permission boundary, so ACP hosts cannot distinguish a completed turn from a cancelled or superseded turn. The permission cancellation already stopped the tool; this change preserves the protocol-level reason without changing the behavior of user rejection or permission errors.

## Reviewer Test Plan

### How to verify

Start a prompt that reaches an ACP permission request, cancel or supersede the parent prompt before answering, and confirm that the prompt settles promptly with `stopReason: cancelled` and the tool is not executed. Repeat through a Stop-hook continuation and a background notification; the background `_qwencode/end_turn` notification should likewise carry `reason: cancelled`. Then reject a permission request normally and confirm it still ends with `end_turn`.

The focused session suite passes 378 tests. A built-bundle harness also passed 14 direct and real local `qwen serve` HTTP/SSE scenarios covering Plan entry boundaries, read-only/write/unknown shell handling, Plan exit approval, rejection, and parent cancellation. The final daemon cancellation scenario settled in 218 ms, returned `cancelled`, and created no marker file. `npm run build`, `npm run bundle`, `npm run lint`, and `npm run typecheck` all pass.

### Evidence (Before & After)

Before: cancelling the parent ACP turn while its Plan-mode shell permission request was pending stopped the command but returned `stopReason: end_turn`.

After: the same local daemon scenario returns `stopReason: cancelled` in 218 ms, emits one permission request, and does not create the command's marker file.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js v22.22.3 and npm 10.9.8; validation used the production bundle and a real local `qwen serve` daemon over HTTP/SSE.

## Risk & Scope

- Main risk or tradeoff: A tool stop that races with an already-aborted parent now reports the abort as authoritative; non-aborted permission and loop stops retain their previous `end_turn` result. Mid-turn input is intentionally not drained into an already-cancelled turn and remains available to the host for the next turn.
- Not validated / out of scope: The managed public-cloud ACP deployment, host permission UI, and stitched managed traces remain to be validated after deployment. This PR does not change Plan routing, approval choices, permission wording, or tool execution policy.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #6949. The issue remains open for managed-host ACP validation after deployment.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 在权限请求等待期间保留 ACP 父轮次的取消语义。普通提示循环、Stop-hook 续跑循环和后台通知循环现在会在各自所属的中止信号已经触发时报告 `cancelled`；普通权限拒绝、宿主侧权限失败或工具循环停止仍继续报告 `end_turn`。已经取消的轮次还会跳过可选的宿主中途输入抽取，让排队输入留给下一轮，而不是让取消响应最多等待一次 drain 超时。

同时增加了三个聚焦回归测试，分别覆盖未知的 Plan 模式 shell 命令、Stop-hook 续跑和后台通知在等待权限时被取消的情况。

## 为什么需要

对 #6949 的本地端到端验证发现：当一次性 Plan 模式 shell 审批仍在等待时取消 ACP 提示，命令执行虽然被正确阻止，但返回的是 `end_turn`。这会在权限边界丢失父轮次的取消原因，使 ACP 宿主无法区分正常完成的轮次与被取消或被新轮次取代的轮次。权限取消原本就会停止工具；本次改动只保留协议层原因，不改变用户拒绝或权限错误的行为。

## Reviewer Test Plan

### 验证方法

启动一个会进入 ACP 权限请求的提示，在回答前取消或用新提示取代父提示，确认提示会迅速以 `stopReason: cancelled` 结束且工具没有执行。对 Stop-hook 续跑和后台通知重复验证；后台 `_qwencode/end_turn` 通知也应携带 `reason: cancelled`。随后正常拒绝一次权限请求，确认它仍以 `end_turn` 结束。

聚焦的 Session 测试套件共 378 项全部通过。基于生产 bundle 的测试工具还通过了 14 个直接路径和真实本地 `qwen serve` HTTP/SSE 场景，覆盖 Plan 进入边界、只读/写入/未知 shell 处理、Plan 退出审批、拒绝和父轮次取消。最终守护进程取消场景在 218 ms 内结束，返回 `cancelled`，且没有创建标记文件。`npm run build`、`npm run bundle`、`npm run lint` 和 `npm run typecheck` 均通过。

### 证据（修改前后）

修改前：在 Plan 模式 shell 权限请求等待期间取消父 ACP 轮次，命令会停止，但返回 `stopReason: end_turn`。

修改后：相同的本地守护进程场景在 218 ms 内返回 `stopReason: cancelled`，发出一次权限请求，并且没有创建该命令的标记文件。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS，Node.js v22.22.3，npm 10.9.8；验证使用生产 bundle，并通过 HTTP/SSE 连接真实的本地 `qwen serve` 守护进程。

## 风险与范围

- 主要风险或权衡：当工具停止与已经中止的父轮次发生竞态时，现在以父轮次中止为权威结果；未中止的权限停止和循环停止保留原有 `end_turn` 结果。中途输入不会再被抽取到已经取消的轮次中，而是有意留在宿主侧供下一轮处理。
- 未验证 / 不在范围内：托管公有云 ACP 部署、宿主权限 UI 和托管链路追踪仍需在部署后验证。本 PR 不改变 Plan 路由、审批选项、权限文案或工具执行策略。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #6949。该 issue 会继续保持打开，等待部署后的托管宿主 ACP 验证。

</details>
