### PR TITLE
test(autofix): sync workflow assertions with split model vars

### DIFF
--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2219,7 +2219,9 @@ describe('qwen-autofix workflow', () => {
       reviewAddressReportStep,
       publishPrStep,
     ]) {
-      expect(step).toContain("MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'");
+      expect(step).toContain(
+        "MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'",
+      );
       expect(step).toContain('MODEL_DISPLAY="${MODEL:-default}"');
       expect(step).toContain(footer);
     }
@@ -2360,7 +2362,10 @@ describe('qwen-autofix workflow', () => {
       ),
     );
     expect(prepareBranchAndFeedbackStep).not.toContain('git clean');
-    expect(prepareBranchAndFeedbackStep).not.toContain('git diff --quiet');
+    // The prepare step must not gate the unconditional build-output restore on
+    // a diff check; `git diff --quiet` only appears in a comment documenting
+    // the verification gate, never as an executed guard here.
+    expect(prepareBranchAndFeedbackStep).not.toContain('if git diff --quiet');
   });
 
   it('clears persistent autofix workdirs before agent steps run', () => {


### PR DESCRIPTION
## What this PR does

This realigns two autofix workflow test assertions with the workflow as it stands today. The model assertion now expects the autofix-specific model variable with its review-model fallback, matching what every reporting step actually plumbs in. The build-output assertion now only rejects an executed diff-quiet short-circuit in the prepare step, so a documentation comment that describes the verification gate no longer trips it. The original intent of both checks is preserved: reports must still name the running model, and the prepare step must still restore build output unconditionally rather than gating it on a diff.

## Why it's needed

The autofix workflow changed after the model variables were split and a fork-PR remote-tracking ref was added, but these two assertions were not updated alongside it. As a result they fail on any branch that carries the current main, turning CI red for changes that are otherwise unrelated to autofix. Syncing the assertions clears that false failure.

## Reviewer Test Plan

### How to verify

Run the autofix workflow test suite and confirm the two previously failing cases — the running-model footer check and the build-output-restore check — now pass, with no other case regressing:

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t "surfaces the running model"
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t "clears tracked build output"
```

Both pass locally. Prettier and ESLint are clean on the changed file.

### Evidence (Before & After)

N/A — test-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`).

## Risk & Scope

- Main risk or tradeoff: the build-output assertion is slightly narrower (it now matches `if git diff --quiet` instead of any `git diff --quiet`), but that is exactly the executed-guard form it was meant to catch; the comment occurrence is intentionally allowed.
- Not validated / out of scope: Windows and Linux were not run locally; CI covers them.
- Breaking changes / migration notes: none — test-only.

## Linked Issues

Relates to the CI failure observed on #7251.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 把 autofix workflow 的两条测试断言重新对齐到当前 workflow 的实际内容。model 断言现在期望 autofix 专用的 model 变量及其 review-model 兜底，与每个 report 步骤实际注入的内容一致。build-output 断言现在只拒绝 prepare 步骤里真正执行的 diff-quiet 短路，因此描述 verification gate 的那行文档注释不会再误触发它。两条检查的原始意图都保留了：report 仍然必须标出运行所用的模型，prepare 步骤仍然必须无条件恢复构建产物、而不是依据 diff 来决定是否恢复。

## 为什么需要

在 model 变量被拆分、以及新增了 fork PR 的 remote-tracking ref 之后，autofix workflow 发生了变化，但这两条断言没有同步更新。于是任何携带当前 main 的分支上它们都会失败，让本来与 autofix 无关的改动 CI 变红。同步这两条断言可以消除这个误报。

## 评审验证计划

### 如何验证

跑 autofix workflow 测试套件，确认之前失败的两个用例——运行模型 footer 检查和 build-output 恢复检查——现在通过，且没有其它用例回归：

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t "surfaces the running model"
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js -t "clears tracked build output"
```

两条本地均通过。改动文件的 Prettier 和 ESLint 均干净。

### 证据（前后对比）

N/A——仅测试改动，无用户可见行为。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试（`vitest`）。

## 风险与范围

- 主要风险或权衡：build-output 断言稍微收窄了（现在匹配 `if git diff --quiet` 而非任意 `git diff --quiet`），但这正是它原本要抓的「真正执行的短路」形式；注释里的出现是被有意放行的。
- 未验证 / 不在范围内：Windows 和 Linux 未在本地运行，由 CI 覆盖。
- 破坏性变更 / 迁移说明：无——仅测试。

## 关联 Issue

与 #7251 上观察到的 CI 失败相关。

</details>
