### PR TITLE
fix(core): bound web-fetch post-processing and preserve fetched content on failure

### DIFF
--- a/packages/core/src/tools/web-fetch.test.ts
+++ b/packages/core/src/tools/web-fetch.test.ts
@@ -12,6 +12,7 @@ import {
   WebFetchTool,
   clearWebFetchCache,
   rewriteGitHubBlobUrl,
+  sideQueryTimeoutMs,
 } from './web-fetch.js';
 import type { Config } from '../config/config.js';
 import { ApprovalMode } from '../config/config.js';
@@ -89,6 +90,7 @@ describe('WebFetchTool', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     fs.rmSync(toolResultsDir, { recursive: true, force: true });
   });
 
@@ -160,14 +162,19 @@ describe('WebFetchTool', () => {
       expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
     });
 
-    it('should return WEB_FETCH_FALLBACK_FAILED on API processing failure', async () => {
+    it('should fall back to raw content when side-query processing fails', async () => {
       vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
       mockGenerateContent.mockRejectedValue(new Error('API error'));
       const tool = new WebFetchTool(mockConfig);
       const params = { url: 'https://public.ip', prompt: 'summarize this' };
       const invocation = tool.build(params);
       const result = await invocation.execute(new AbortController().signal);
-      expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Content processing failed');
+      expect(result.llmContent).toContain('Test content');
+      expect(result.returnDisplay).toContain(
+        'processing failed, raw content returned',
+      );
     });
 
     it('should return an error result for non-2xx statuses', async () => {
@@ -568,7 +575,7 @@ describe('WebFetchTool', () => {
       expect(result.llmContent).toContain('Content-Type: text/html');
       expect(result.llmContent).toContain('A summary.');
       expect(result.returnDisplay).toMatch(
-        /^Received 28 bytes \(200 OK\) from example\.com$/,
+        /^Received 28 bytes \(200 OK\) from example\.com in \d+\.\ds$/,
       );
     });
 
@@ -605,6 +612,185 @@ describe('WebFetchTool', () => {
       expect(result.llmContent).toContain(
         'The processing model returned no content',
       );
+    });
+  });
+
+  describe('side-query processing', () => {
+    it('should stream on the fast model with maxAttempts 1 and a combined abort signal', async () => {
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      vi.mocked(mockConfig.getFastModel).mockReturnValue('qwen-flash');
+      let received: {
+        stream?: boolean;
+        model?: string;
+        maxAttempts?: number;
+        abortSignal?: AbortSignal;
+      } = {};
+      mockGenerateContent.mockImplementation((options) => {
+        received = options;
+        return Promise.resolve({ text: 'Summary' });
+      });
+
+      const controller = new AbortController();
+      await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(controller.signal);
+
+      expect(received.stream).toBe(true);
+      expect(received.model).toBe('qwen-flash');
+      expect(received.maxAttempts).toBe(1);
+      // Combined signal: not the tool signal itself, but aborts with it.
+      expect(received.abortSignal).not.toBe(controller.signal);
+      expect(received.abortSignal?.aborted).toBe(false);
+      controller.abort();
+      expect(received.abortSignal?.aborted).toBe(true);
+    });
+
+    it('should use the main model when no fast model is configured', async () => {
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      let receivedModel: string | undefined;
+      mockGenerateContent.mockImplementation((options) => {
+        receivedModel = options.model;
+        return Promise.resolve({ text: 'Summary' });
+      });
+
+      await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(new AbortController().signal);
+
+      expect(receivedModel).toBe('qwen-coder');
+    });
+
+    it('should keep the persisted PDF and its extracted text when processing fails', async () => {
+      const pdfBytes = Buffer.concat([
+        Buffer.from('%PDF-1.4\n'),
+        Buffer.from([0xe2, 0xe3, 0xcf, 0xd3, 0x00, 0x01, 0x02]),
+      ]);
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(
+        okResponse({ contentType: 'application/pdf', body: pdfBytes }),
+      );
+      mockExtractPDFText.mockResolvedValue({
+        success: true,
+        text: 'Bid item 24Z010: $1,234.56',
+      });
+      mockGenerateContent.mockRejectedValue(new Error('Request timed out.'));
+
+      const result = await new WebFetchTool(mockConfig)
+        .build({
+          url: 'https://example.com/doc.pdf',
+          prompt: 'list ALL bid items',
+        })
+        .execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Content processing failed');
+      expect(result.llmContent).toContain('Bid item 24Z010: $1,234.56');
+      expect(result.resultFilePaths).toHaveLength(1);
+      expect(result.llmContent).toContain('saved to');
+    });
+
+    it('should fall back with raw content when the processing backstop fires, without aborting the tool signal', async () => {
+      vi.stubEnv('QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS', '50');
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      // Hangs until the composed signal (carrying the backstop timeout)
+      // aborts it — simulating a stalled provider stream.
+      mockGenerateContent.mockImplementation(
+        ({ abortSignal }: { abortSignal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            abortSignal.addEventListener('abort', () =>
+              reject(new Error('Request was aborted.')),
+            );
+          }),
+      );
+
+      const controller = new AbortController();
+      const result = await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(controller.signal);
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('Content processing failed');
+      expect(result.llmContent).toContain('Test content');
+      expect(controller.signal.aborted).toBe(false);
+    });
+
+    it('should not return a late side-query success after the user aborts', async () => {
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      const controller = new AbortController();
+      // The final stream chunk can already be queued when the user aborts:
+      // the side query then resolves successfully despite the abort.
+      mockGenerateContent.mockImplementation(() => {
+        controller.abort();
+        return Promise.resolve({ text: 'Late success' });
+      });
+
+      const result = await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(controller.signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
+      expect(result.llmContent).not.toContain('Late success');
+      expect(result.llmContent).not.toContain('Test content');
+    });
+
+    it.each([
+      ['unset', undefined, 300_000],
+      ['empty', '', 300_000],
+      ['fraction', '0.5', 300_000],
+      ['scientific notation', '1e3', 300_000],
+      ['hexadecimal', '0x32', 300_000],
+      ['zero', '0', 300_000],
+      ['negative', '-5', 300_000],
+      ['non-numeric', 'abc', 300_000],
+      ['timer overflow', '2147483648', 300_000],
+      ['max timer delay', '2147483647', 2_147_483_647],
+      ['valid decimal', '50', 50],
+    ])(
+      'should resolve the backstop timeout for %s env values',
+      (_label, envValue, expected) => {
+        if (envValue === undefined) {
+          vi.stubEnv('QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS', '');
+          delete process.env['QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS'];
+        } else {
+          vi.stubEnv('QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS', envValue);
+        }
+        expect(sideQueryTimeoutMs()).toBe(expected);
+      },
+    );
+
+    it('should return a proper error result when aborted with a non-Error reason', async () => {
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      const controller = new AbortController();
+      // Session.ts aborts with a plain string reason; throwIfAborted rethrows
+      // it as-is, so the error path must not assume an Error instance.
+      mockGenerateContent.mockImplementation(() => {
+        controller.abort('qwen:user-cancel');
+        return Promise.resolve({ text: 'Late success' });
+      });
+
+      const result = await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(controller.signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
+      expect(result.llmContent).toContain('qwen:user-cancel');
+      expect(result.llmContent).not.toContain('undefined');
+      expect(result.llmContent).not.toContain('Late success');
+    });
+
+    it('should propagate a user abort instead of fabricating a raw-content result', async () => {
+      vi.spyOn(fetchUtils, 'fetchWithPolicy').mockResolvedValue(okResponse());
+      const controller = new AbortController();
+      mockGenerateContent.mockImplementation(() => {
+        controller.abort();
+        return Promise.reject(new Error('Request was aborted.'));
+      });
+
+      const result = await new WebFetchTool(mockConfig)
+        .build({ url: 'https://example.com', prompt: 'summarize' })
+        .execute(controller.signal);
+
+      expect(result.error?.type).toBe(ToolErrorType.WEB_FETCH_FALLBACK_FAILED);
+      expect(result.llmContent).not.toContain('Test content');
     });
   });
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -37,9 +37,29 @@ import { BaseDeclarativeTool, BaseToolInvocation, Kind } from './tools.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import { isPreapprovedUrl } from './web-fetch-preapproved.js';
 import { createDebugLogger, type DebugLogger } from '../utils/debugLogger.js';
+import { parsePositiveIntegerEnv } from '../utils/env.js';
+import { getErrorMessage } from '../utils/errors.js';
 
 // Full-transfer budget: headers AND body must complete within this window.
 const FETCH_TIMEOUT_MS = 60_000;
+// Backstop for the post-fetch summarization side query. Deliberately above
+// the 240s stream idle watchdog so the watchdog's more specific error fires
+// first on a hung stream; this only catches pathological slow-drip streams.
+// Expiry does NOT fail the tool — executeDirectFetch falls back to returning
+// the raw fetched content.
+const SIDE_QUERY_TIMEOUT_MS = 300_000;
+// Deployment/test knob (same convention as QWEN_STREAM_IDLE_TIMEOUT_MS):
+// override the processing backstop without code changes. Malformed or
+// non-positive values fall back to the default. Values above the max timer
+// delay (2^31-1 ms) are rejected rather than clamped — Node truncates larger
+// delays to 1ms, which would disable processing instead of extending it.
+export function sideQueryTimeoutMs(): number {
+  const value = parsePositiveIntegerEnv(
+    process.env['QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS'],
+    SIDE_QUERY_TIMEOUT_MS,
+  );
+  return value > 2_147_483_647 ? SIDE_QUERY_TIMEOUT_MS : value;
+}
 // Truncation applies to converted/decoded text, never to raw HTML — cutting
 // markup before conversion silently destroys content deep in large pages.
 const MAX_CONTENT_CHARS = 100_000;
@@ -342,6 +362,7 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       },
     };
 
+    const networkStart = Date.now();
     let result;
     let usedHttpFallback = false;
     try {
@@ -364,6 +385,8 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       }
     }
 
+    const networkMs = Date.now() - networkStart;
+
     if (result.kind === 'cross-host-redirect') {
       // Never cached; the caller converts it into a redirect ToolResult.
       return result;
@@ -376,6 +399,7 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       );
     }
 
+    const extractStart = Date.now();
     const contentType = response.contentType;
     const sniff = sniffFileKind(
       response.body,
@@ -482,6 +506,10 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       content = truncateText(response.body.toString('utf-8'));
     }
 
+    this.debugLogger.debug(
+      `[WebFetchTool] network_ms=${networkMs} extract_ms=${Date.now() - extractStart}`,
+    );
+
     const entry: CacheEntry = {
       fetchedAt: Date.now(),
       status: response.status,
@@ -507,11 +535,18 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
   }
 
   private async executeDirectFetch(signal: AbortSignal): Promise<ToolResult> {
+    const startMs = Date.now();
+    const elapsedSuffix = () =>
+      ` in ${((Date.now() - startMs) / 1000).toFixed(1)}s`;
     try {
       const entry = await this.fetchAndProcess(signal);
       // CacheEntry has no 'kind' discriminant — this narrows to the redirect.
       if ('kind' in entry) {
-        return this.buildRedirectResult(entry);
+        const redirect = this.buildRedirectResult(entry);
+        return {
+          ...redirect,
+          returnDisplay: `${redirect.returnDisplay}${elapsedSuffix()}`,
+        };
       }
 
       const header = this.buildMetadataHeader(entry);
@@ -526,7 +561,7 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       if (entry.persistedPath && !entry.content) {
         return {
           llmContent: `${header}\n\n[No text could be extracted from this binary content.]${binaryNote}`,
-          returnDisplay: displaySummary,
+          returnDisplay: `${displaySummary}${elapsedSuffix()}`,
           resultFilePaths: [entry.persistedPath],
         };
       }
@@ -548,7 +583,7 @@ Status: ${entry.status} ${entry.statusText || 'OK'} | Content-Type: ${entry.cont
       ) {
         return {
           llmContent: `${header}\n\n${entry.content}${binaryNote}`,
-          returnDisplay: displaySummary,
+          returnDisplay: `${displaySummary}${elapsedSuffix()}`,
           ...(entry.persistedPath
             ? { resultFilePaths: [entry.persistedPath] }
             : {}),
@@ -566,21 +601,58 @@ Please use the following content to answer the user's request.
 ${entry.content}
 ---`;
 
-      const result = await runSideQuery(this.config, {
-        purpose: 'web-fetch',
-        // Pin to the main model — fast model loses too much fidelity on
-        // long, rich source material.
-        model: this.config.getModel(),
-        // Best-effort: the outer catch already converts processing failures
-        // into a tool error; retrying 7× just delays that fallback.
-        maxAttempts: 1,
-        contents: [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
-        systemInstruction:
-          'Extract and summarize the requested information from the provided web content. ' +
-          'Be concise and accurate. Respond only with the requested information.',
-        abortSignal: signal,
-      });
-      let resultText = (result.text || '').trim();
+      const sideQueryStart = Date.now();
+      let resultText: string;
+      try {
+        // Runs on the fast model (runSideQuery's default) like claw-code's
+        // Haiku summarizer.
+        const result = await runSideQuery(this.config, {
+          purpose: 'web-fetch',
+          // Best-effort: a failure falls back to raw content below; retrying
+          // 7× just delays that fallback.
+          maxAttempts: 1,
+          contents: [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
+          systemInstruction:
+            'Extract and summarize the requested information from the provided web content. ' +
+            'Be concise and accurate. Respond only with the requested information.',
+          // Stream so the provider SDK's whole-request timeout only bounds
+          // connect + first chunk: an exhaustive extraction can legitimately
+          // generate for >120s, and a non-streaming call dies at that SDK
+          // deadline and is then re-fired by SDK-internal retries (which
+          // maxAttempts does not govern).
+          stream: true,
+          abortSignal: AbortSignal.any([
+            signal,
+            AbortSignal.timeout(sideQueryTimeoutMs()),
+          ]),
+        });
+        // The stream can deliver its final chunk after the user aborts — a
+        // cancelled turn must not surface that late success as a result.
+        signal.throwIfAborted();
+        resultText = (result.text || '').trim();
+        this.debugLogger.debug(
+          `[WebFetchTool] side_query_ms=${Date.now() - sideQueryStart}`,
+        );
+      } catch (error) {
+        // A cancelled turn must not fabricate a result.
+        if (signal.aborted) {
+          throw error;
+        }
+        this.debugLogger.error(
+          `[WebFetchTool] side_query_ms=${Date.now() - sideQueryStart} (failed); returning raw content`,
+          error,
+        );
+        // The fetch succeeded; only post-fetch processing failed. Return the
+        // normalized raw content instead of discarding the transfer (and, for
+        // binaries, orphaning the persisted file).
+        return {
+          llmContent: `${header}\n\n[Content processing failed (${getErrorMessage(error)}). The raw fetched content follows.]\n\n${entry.content}${binaryNote}`,
+          returnDisplay: `${displaySummary}${elapsedSuffix()} — processing failed, raw content returned`,
+          ...(entry.persistedPath
+            ? { resultFilePaths: [entry.persistedPath] }
+            : {}),
+        };
+      }
       if (!resultText) {
         resultText =
           '[The processing model returned no content. The fetch itself succeeded — see the metadata above.]';
@@ -588,18 +660,19 @@ ${entry.content}
 
       return {
         llmContent: `${header}\n\n${resultText}${binaryNote}`,
-        returnDisplay: displaySummary,
+        returnDisplay: `${displaySummary}${elapsedSuffix()}`,
         ...(entry.persistedPath
           ? { resultFilePaths: [entry.persistedPath] }
           : {}),
       };
     } catch (e) {
-      const error = e as Error;
-      const errorMessage = `Error during fetch for ${this.params.url}: ${error.message}`;
-      this.debugLogger.error(`[WebFetchTool] ${errorMessage}`, error);
+      // e may be a non-Error abort reason (throwIfAborted rethrows whatever
+      // the aborting caller passed — e.g. a plain string, or null).
+      const errorMessage = `Error during fetch for ${this.params.url}: ${getErrorMessage(e)}`;
+      this.debugLogger.error(`[WebFetchTool] ${errorMessage}`, e);
       return {
         llmContent: `Error: ${errorMessage}`,
-        returnDisplay: `Error: ${errorMessage}`,
+        returnDisplay: `Error: ${errorMessage}${elapsedSuffix()}`,
         error: {
           message: errorMessage,
           type: ToolErrorType.WEB_FETCH_FALLBACK_FAILED,

--- a/packages/core/src/utils/sideQuery.ts
+++ b/packages/core/src/utils/sideQuery.ts
@@ -24,8 +24,7 @@ export interface SideQueryJsonOptions<TResponse> {
    * `config.getFastModel?.() ?? config.getModel() ?? DEFAULT_QWEN_MODEL`
    * — side queries run on the fast model when one is configured, including
    * fast models registered under a different authType than the main session.
-   * Pass an explicit value to pin to the main model (e.g. long-form
-   * summarization in web-fetch).
+   * Pass an explicit value to pin a specific model.
    */
   model?: string;
   systemInstruction?: string | Part | Part[] | Content;
@@ -72,8 +71,7 @@ export interface SideQueryTextOptions {
    * `config.getFastModel?.() ?? config.getModel() ?? DEFAULT_QWEN_MODEL`
    * — side queries run on the fast model when one is configured, including
    * fast models registered under a different authType than the main session.
-   * Pass an explicit value to pin to the main model (e.g. long-form
-   * summarization in web-fetch).
+   * Pass an explicit value to pin a specific model.
    */
   model?: string;
   systemInstruction?: string | Part | Part[] | Content;


### PR DESCRIPTION
## What this PR does

Web fetch processes downloaded content through a secondary model call that extracts what the prompt asked for. This PR hardens that processing step:

- **Fast model**: the processing call now runs on the configured fast model instead of being pinned to the main model, matching the reference implementation's design where summarization is a cheap, fast filter.
- **Streaming**: the call now streams its response, so an extraction that legitimately takes minutes to generate keeps its connection alive instead of being killed by the client's whole-request timeout and then transparently re-run by SDK-internal retries.
- **Bounded processing**: a five-minute backstop (tunable through an environment variable) sits above the existing stream-inactivity watchdog.
- **Fetch preserved on failure** — the most important change: a processing failure no longer destroys the work already done; the tool now returns the fetch metadata together with the raw normalized content, and for binary downloads it keeps the saved-file path, instead of collapsing the whole call into an error.
- **Timing visibility**: the result display gains an elapsed-time suffix, and the debug log records per-phase timings (network, extraction, processing).

## Why it's needed

This is a follow-up to the web-fetch overhaul in #7146. A benchmark audit of the first release containing that overhaul confirmed the transport and content fixes but traced the remaining large end-to-end failures to the processing step this PR hardens:

- Provider wire logs showed extraction requests that completed successfully on the server after 350–375 seconds being timed out client-side at 120 seconds and silently re-run as eleven identical attempts — turning one web fetch into a 23-minute failure that then discarded the successfully downloaded content, forcing the agent to re-download the same file by shell to make progress.
- Across the audited run, roughly half of all fetch observations were error blanks, and affected jobs averaged 34% longer wall time.
- The failure needs no exotic conditions: any extraction whose output takes longer to generate than the client timeout can never succeed under the old design, and any processing error at all destroyed an already-successful fetch.

## Reviewer Test Plan

### How to verify

- **Fast model + streaming**: configure a fast model (`fastModel` in settings, backed by a matching provider entry) distinct from the main model, then fetch any HTML page with a question prompt. The answer should come back normally; with request logging enabled, the processing request should name the fast model and be a streaming request, where previously it named the main model and was non-streaming.
- **Raw-content fallback**: point the CLI at an environment where the processing call fails (a mock provider returning 500 for the processing request, or any provider/model mismatch — run this scenario with a clean configuration that has no fast model set, otherwise the processing request routes to the real fast-model provider and escapes the mock). The tool result should be a success whose display ends with "processing failed, raw content returned", and the model-visible content should carry the fetch metadata header followed by the raw page or file text — previously the same scenario produced a hard tool error containing no content at all.
- **Binary downloads**: fetching a PDF in that failing configuration should still report the saved-file path.
- **Cancellation**: a user cancel during processing must still surface as a cancelled tool call, not a success.
- **Backstop**: set `QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS` to a very small value (e.g. 50 ms); the call should return the raw-content fallback after roughly that long instead of hanging.

### Evidence (Before & After)

- **Before (audited release, real trace)**: a Treasury CSV fetch spent 1,377,723 ms in processing and returned `Failed to generate text content (side-query:web-fetch): Request timed out.` with no content; the agent re-downloaded the file with Python in 763 ms.
- **After (this branch, same request class)**: the identical exhaustive-extraction prompt completes in 147.8 s with the full 252-row table.
- **After (forced processing failure)**: returns `Received 69 bytes (200 OK) from 127.0.0.1 in 3.0s — processing failed, raw content returned` with the raw CSV rows delivered to the model verbatim.
- Full before/after matrix (3 test groups × baseline/fixed) will be posted as a PR comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundle (`npm run build && npm run bundle`, `node dist/cli.js`) against DashScope (OpenAI-compatible) and a scripted mock OpenAI server; unit tests via vitest.

## Risk & Scope

- Main risk or tradeoff: extraction fidelity on long, dense sources may differ on the fast model versus the main model; the reference implementation made the same tradeoff deliberately, and a failure now degrades to raw content rather than an error. Deployments without a configured fast model keep the main model, so their only behavior change is streaming, the backstop, and the fallback.
- Not validated / out of scope: replacing the external search path, chunked extraction of documents beyond the existing 100k-character head truncation, and agent-level final-verification behavior — all tracked separately in the design doc. Also out of scope: the general side-query failure mode where the resolved model rejects requests with thinking disabled (e.g. a main model that requires thinking enabled and no usable fast model configured — a restriction of this kind surfaced during verification); this is pre-existing behavior common to all side queries, and this PR only ensures web fetch degrades to raw content instead of erroring when it occurs.
- Breaking changes / migration notes: none. New optional environment variable `QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS` (milliseconds, strict positive decimal integer, capped at 2^31−1; invalid values fall back to the 300 s default).

## Linked Issues

Follow-up to #7146 (web-fetch overhaul). No issue to close — this originates from a benchmark audit rather than a filed issue.

<details>
<summary>中文说明</summary>

## 本 PR 的内容

Web fetch 会把下载的内容交给一个二级模型调用来提取 prompt 所要求的信息。本 PR 从以下几个方面加固了这一处理步骤:

- **Fast model**:处理调用现在运行在配置的 fast model 上,而不再固定使用主模型,与参考实现"摘要是一个廉价、快速的过滤器"的设计保持一致。
- **流式响应**:该调用现在以流式方式接收响应,因此一个合理地需要数分钟生成的提取任务可以保持连接存活,而不会被客户端的整请求超时杀死、再被 SDK 内部重试机制透明地重复执行。
- **处理超时兜底**:处理阶段增加了一个五分钟的兜底超时(可通过环境变量调节),位于现有流式空闲看门狗之上。
- **失败时保留抓取结果**——也是最重要的改动:处理失败不再摧毁已完成的工作;工具现在会返回抓取元数据和归一化后的原始内容,对于二进制下载还会保留已保存文件的路径,而不是把整个调用坍缩成一个错误。
- **耗时可观测性**:结果显示增加了耗时后缀,调试日志会记录分阶段耗时(网络、提取、处理)。

## 为什么需要

本 PR 是 web-fetch 整体改造 #7146 的后续。对首个包含该改造的版本的基准测试审计确认了传输与内容层修复的效果,但将剩余的大量端到端失败追溯到了本 PR 所加固的处理步骤:

- Provider 侧的线上日志显示:提取请求在服务端 350–375 秒后成功完成,却在客户端 120 秒处被超时、并被静默重复执行——共产生 11 次相同的完整请求,把一次 web fetch 变成了 23 分钟的失败,然后还丢弃了已经成功下载的内容,agent 不得不用 shell 重新下载同一个文件才能继续。
- 在被审计的整组运行中,约一半的抓取观测是错误空白,受影响的任务平均墙钟时间长 34%。
- 这个失败不需要任何特殊条件:在旧设计下,任何输出生成时间超过客户端超时的提取任务都永远不可能成功,而任何处理错误都会摧毁一次已经成功的抓取。

## 审阅者测试计划

### 如何验证

- **Fast model + 流式**:配置一个与主模型不同的 fast model(settings 中的 `fastModel`,并有对应的 provider 条目),然后抓取任意 HTML 页面并附带一个问题 prompt。应能正常得到答案;开启请求日志后,处理请求应使用 fast model 且为流式请求,而之前它使用主模型且为非流式。
- **原始内容回退**:将 CLI 指向一个处理调用会失败的环境(mock provider 对处理请求返回 500,或任意 provider/模型不匹配——此场景需使用未配置 fast model 的干净配置运行,否则处理请求会路由到真实的 fast model provider、绕过 mock)。工具结果应为成功,其显示以 "processing failed, raw content returned" 结尾,模型可见内容应包含抓取元数据头及其后的原始页面或文件文本——之前同样的场景会产生一个不含任何内容的硬性工具错误。
- **二进制下载**:在该失败配置下抓取 PDF 仍应报告已保存文件的路径。
- **取消**:处理期间的用户取消必须仍然表现为被取消的工具调用,而不是成功。
- **兜底超时**:将 `QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS` 设为极小值(如 50 毫秒);调用应在大约该时长后返回原始内容回退,而不是挂起。

### 证据(Before & After)

- **Before(被审计版本,真实 trace)**:一次 Treasury CSV 抓取在处理阶段耗费 1,377,723 毫秒后返回 `Failed to generate text content (side-query:web-fetch): Request timed out.` 且不含任何内容;agent 用 Python 在 763 毫秒内重新下载了该文件。
- **After(本分支,同类请求)**:同样的穷举提取 prompt 在 147.8 秒内完成并返回完整的 252 行表格。
- **After(强制处理失败)**:返回 `Received 69 bytes (200 OK) from 127.0.0.1 in 3.0s — processing failed, raw content returned`,原始 CSV 行逐字送达模型。
- 完整的 before/after 矩阵(3 个测试组 × 基线/修复)将以 PR 评论形式发布。

### 已测试平台

macOS ✅;Windows ⚠️;Linux ⚠️。

### 环境(可选)

本地 bundle(`npm run build && npm run bundle`,`node dist/cli.js`),对接 DashScope(OpenAI 兼容)及脚本化的 mock OpenAI server;单元测试使用 vitest。

## 风险与范围

- 主要风险或权衡:在长而密集的源内容上,fast model 的提取保真度可能与主模型不同;参考实现有意做了同样的权衡,且失败现在会降级为原始内容而不是错误。未配置 fast model 的部署仍使用主模型,其唯一行为变化是流式、兜底超时和回退机制。
- 未验证/超出范围:替换外部搜索路径、超出现有 10 万字符头部截断的分块提取、以及 agent 层面的最终校验行为——均在设计文档中单独跟踪。另一项超出范围的问题:side query 的一般性失败模式——当最终解析到的模型拒绝关闭 thinking 的请求时(例如主模型要求开启 thinking 且未配置可用的 fast model——验证过程中曾遇到此类限制),side query 会整体失败;这是所有 side query 共有的既有行为,本 PR 仅保证 web fetch 在该情况发生时降级为返回原始内容而不是报错。
- 破坏性变更/迁移说明:无。新增可选环境变量 `QWEN_WEB_FETCH_PROCESSING_TIMEOUT_MS`(毫秒,严格正十进制整数,上限 2^31−1;无效值回退到 300 秒默认值)。

## 关联 Issue

本 PR 是 #7146(web-fetch 整体改造)的后续。无需关闭的 issue——本 PR 源于基准测试审计而非已提交的 issue。

</details>
