### PR TITLE
feat(serve): manage skills per workspace runtime

### DIFF
--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -313,7 +313,6 @@ The workspace projection response is:
       "version": "1.2.3",
       "defaultActivation": "enabled",
       "workspaceActivation": "disabled",
-      "effectiveActivation": "disabled",
       "activationSource": "workspace_override"
     }
   ]
@@ -354,10 +353,12 @@ Location: /extensions/operations/<operation-id>
 Retry-After: 1
 Content-Type: application/json
 
-{"accepted":true,"operationId":"<operation-id>"}
+{"accepted":true,"operationId":"<operation-id>","deadlineAt":1750000600000}
 ```
 
 Workspace-qualified mutations use the same global `/extensions/operations/:operationId` polling path. Operation history is process-local, keeps only a bounded number of terminal entries, and is lost on daemon restart; clients must re-read the catalog or workspace projection and compare generations when an operation id disappears.
+
+`deadlineAt` is the server-owned absolute Unix timestamp for the operation. Clients may use an earlier local deadline, but must not extend this value or reset the budget on each poll.
 
 An operation snapshot has this shape:
 
@@ -370,6 +371,7 @@ An operation snapshot has this shape:
   "phase": "preparing",
   "createdAt": 1750000000000,
   "updatedAt": 1750000000100,
+  "deadlineAt": 1750000600000,
   "source": "owner/repository",
   "name": "demo"
 }
@@ -534,7 +536,7 @@ Response shape:
     "compactedReplayMaxBytes": 4194304,
     "promptDeadlineMs": null,
     "writerIdleTimeoutMs": null,
-    "channelIdleTimeoutMs": 0,
+    "channelIdleTimeoutMs": null,
     "sessionIdleTimeoutMs": 1800000,
     "acpConnectionCap": 64
   },
@@ -1121,6 +1123,72 @@ canonicalizing it. Current daemons emit it for every skill, while clients must
 tolerate its absence from older v1 daemons. Skill bodies, hooks, `skillRoot`,
 and other skill configuration remain excluded. `errors` is omitted when
 discovery succeeds.
+
+### Workspace module management APIs
+
+Extensions, MCP, and Skill management is available without creating or loading
+a Session. Configuration and installation use `/config`; live discovery and
+control use `/runtime`:
+
+| Scope                          | Primary workspace                 | Selected registered workspace                 |
+| ------------------------------ | --------------------------------- | --------------------------------------------- |
+| Runtime preparation and status | `/workspace/runtime/*`            | `/workspaces/:workspace/runtime/*`            |
+| Extension management           | `/workspace/config/extensions/*`  | `/workspaces/:workspace/config/extensions/*`  |
+| MCP server configuration       | `/workspace/config/mcp/servers/*` | `/workspaces/:workspace/config/mcp/servers/*` |
+| MCP server enablement          | `/workspace/config/mcp/:server/*` | `/workspaces/:workspace/config/mcp/:server/*` |
+| Skill management               | `/workspace/config/skills/*`      | `/workspaces/:workspace/config/skills/*`      |
+
+Selected-workspace MCP configuration accepts only `scope: "workspace"`;
+process-global user configuration remains on the primary endpoint. Qualified
+routes resolve the selected `WorkspaceRuntime` and never fall back to the
+primary runtime. Read-only daemon-local configuration inventory is available
+for an untrusted workspace; runtime commands and sensitive workspace mutations
+require trust. Configuration operations commit without starting ACP. The
+no-argument runtime ensure command and explicit domain commands may start or
+reuse that workspace's ACP child, but they do not create a hidden
+Session. The daemon keeps an idle child for the lifetime of its WorkspaceRuntime
+by default. Closing the last Session or finishing a management operation does
+not stop it; later runtime operations reuse the same child and epoch. An
+explicit positive `channelIdleTimeoutMs` enables delayed compatibility
+auto-reaping; `0` is rejected. The
+`/runtime/status` snapshot reports `null` when no timeout is configured; it
+remains side-effect free and does not start or retain a child.
+Runtime ensure and domain-command responses project their status after releasing the
+outer control lease, so a child exit during release is reported as `stopping`
+or `cold` instead of returning a stale live snapshot.
+
+Runtime routes are additive; the legacy `/workspace/mcp`, `/workspace/skills`,
+and related primary-workspace routes keep their existing behavior.
+
+| Operation                                      | Primary workspace                                      | Selected registered workspace                                      |
+| ---------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------ |
+| Ensure the complete standard Workspace Runtime | `POST /workspace/runtime/ensure`                       | `POST /workspaces/:workspace/runtime/ensure`                       |
+| Read coordinator state                         | `GET /workspace/runtime/status`                        | `GET /workspaces/:workspace/runtime/status`                        |
+| Read MCP discovery state                       | `GET /workspace/runtime/mcp`                           | `GET /workspaces/:workspace/runtime/mcp`                           |
+| Reload MCP configuration                       | `POST /workspace/runtime/mcp/reload`                   | `POST /workspaces/:workspace/runtime/mcp/reload`                   |
+| Enable or disable one MCP server               | `POST /workspace/config/mcp/:server/{enable,disable}`  | `POST /workspaces/:workspace/config/mcp/:server/{enable,disable}`  |
+| Read one MCP server's tools/resources          | `GET /workspace/runtime/mcp/:server/{tools,resources}` | `GET /workspaces/:workspace/runtime/mcp/:server/{tools,resources}` |
+| Manage one MCP server                          | `POST /workspace/runtime/mcp/:server/:action`          | `POST /workspaces/:workspace/runtime/mcp/:server/:action`          |
+| List active MCP operations                     | `GET /workspace/runtime/operations`                    | `GET /workspaces/:workspace/runtime/operations`                    |
+| Poll an MCP operation                          | `GET /workspace/runtime/operations/:operationId`       | `GET /workspaces/:workspace/runtime/operations/:operationId`       |
+| Read Skills or built-in Tools                  | `GET /workspace/runtime/{skills,tools}`                | `GET /workspaces/:workspace/runtime/{skills,tools}`                |
+
+Runtime MCP management actions are `approve`, `authenticate`, and `clear-auth`.
+The legacy `/workspace(s)/.../mcp` control route continues accepting `enable`
+and `disable` with its historical persistence behavior, while new clients use
+the configuration route. Runtime MCP management responses
+include an `operationId` and authoritative `deadlineAt`; OAuth authentication
+can move from `running` to
+`waiting_for_input` and then to `succeeded` or `failed`.
+The active-operation collection and by-id status retain the OAuth `authUrl` so
+a client can resume observing after navigation without restarting authentication.
+Operation history is workspace-local, bounded, and process-local. Built-in tool
+catalogs exclude MCP tools; MCP tools are read from the server-qualified route.
+MCP configuration mutations return `activation: "deferred" | "reconciling"`.
+`deferred` means every affected runtime was cold and will consume the persisted
+configuration on its next preparation; `reconciling` means at least one live
+runtime has started applying it. Clients observe completion through
+`/runtime/status`, not through Session events.
 
 ### `GET /workspace/providers`
 

--- a/packages/cli/src/serve/routes/workspace-skills.test.ts
+++ b/packages/cli/src/serve/routes/workspace-skills.test.ts
@@ -6,10 +6,11 @@ import express, {
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import type { WorkspaceRuntime } from '../workspace-registry.js';
+import { getWorkspaceRuntimeCoordinator } from '../workspace-runtime-coordinator.js';
 import { WorkspaceSkillManagementError } from '../workspace-skill-management.js';
 import { registerWorkspaceSkillsRoutes } from './workspace-skills.js';
 
-function createHarness() {
+function createHarness(trusted = true) {
   const installWorkspaceSkill = vi.fn().mockResolvedValue({
     skillName: 'demo-skill',
     scope: 'workspace',
@@ -20,26 +21,134 @@ function createHarness() {
     scope: 'global',
     deleted: true,
   });
+  const setWorkspaceSkillEnabled = vi.fn().mockResolvedValue({
+    skillName: 'demo-skill',
+    enabled: false,
+  });
+  const getWorkspaceSkillsConfigStatus = vi.fn().mockResolvedValue({
+    v: 1,
+    workspaceCwd: '/workspace',
+    initialized: true,
+    source: 'config',
+    skills: [{ name: 'demo-skill', status: 'ok' }],
+  });
+  const invalidateWorkspaceSkillsStatus = vi.fn();
+  const invalidateSecondarySkillsStatus = vi.fn();
+  const refreshSecondarySkills = vi.fn(async () => ({
+    sessionsRefreshed: 0,
+    sessionsFailed: 0,
+  }));
+  let secondaryLive = false;
+  const primaryRuntime = {
+    workspaceCwd: '/workspace',
+    trusted,
+    bridge: {
+      isChannelLive: () => false,
+      publishWorkspaceEvent: vi.fn(),
+    },
+    workspaceService: {
+      installWorkspaceSkill,
+      deleteWorkspaceSkill,
+      setWorkspaceSkillEnabled,
+      getWorkspaceSkillsConfigStatus,
+      invalidateWorkspaceSkillsStatus,
+    },
+  } as unknown as WorkspaceRuntime;
+  const secondaryRuntime = {
+    workspaceCwd: '/secondary',
+    trusted: true,
+    bridge: {
+      isChannelLive: () => secondaryLive,
+      getRuntimeEpoch: () => (secondaryLive ? 1 : 0),
+      invokeWorkspaceCommand: refreshSecondarySkills,
+      publishWorkspaceEvent: vi.fn(),
+    },
+    workspaceService: {
+      invalidateWorkspaceSkillsStatus: invalidateSecondarySkillsStatus,
+      getWorkspaceSkillsStatus: vi.fn(async () => ({
+        v: 1,
+        workspaceCwd: '/secondary',
+        initialized: true,
+        source: 'live',
+        runtimeEpoch: 1,
+        skills: [],
+      })),
+    },
+  } as unknown as WorkspaceRuntime;
   const app = express();
   app.use(express.json({ limit: '10mb' }));
   registerWorkspaceSkillsRoutes(app, {
-    workspaceRuntime: {
-      workspaceCwd: '/workspace',
-      trusted: true,
-      workspaceService: {
-        installWorkspaceSkill,
-        deleteWorkspaceSkill,
-      },
-    } as unknown as WorkspaceRuntime,
+    workspaceRuntime: primaryRuntime,
+    workspaceRegistry: {
+      list: () => [primaryRuntime],
+      listManaged: () => [primaryRuntime, secondaryRuntime],
+    } as never,
     mutate: () => (_req: Request, _res: Response, next: NextFunction) => next(),
     safeBody: (req) => req.body as Record<string, unknown>,
     sendBridgeError: vi.fn(),
     parseAndValidateClientId: () => 'client-1',
   });
-  return { app, installWorkspaceSkill, deleteWorkspaceSkill };
+  return {
+    app,
+    installWorkspaceSkill,
+    deleteWorkspaceSkill,
+    setWorkspaceSkillEnabled,
+    getWorkspaceSkillsConfigStatus,
+    invalidateWorkspaceSkillsStatus,
+    invalidateSecondarySkillsStatus,
+    refreshSecondarySkills,
+    secondaryRuntime,
+    setSecondaryLive: (value: boolean) => {
+      secondaryLive = value;
+    },
+  };
 }
 
 describe('workspace Skill management routes', () => {
+  it('keeps global config available when the primary workspace is untrusted', async () => {
+    const harness = createHarness(false);
+    const body = {
+      name: 'demo-skill',
+      scope: 'global',
+      source: { type: 'folder', path: '/tmp/demo-skill' },
+    } as const;
+
+    const inventory = await request(harness.app).get(
+      '/workspace/config/skills',
+    );
+    const install = await request(harness.app)
+      .post('/workspace/config/skills/install')
+      .send(body);
+    const legacyInstall = await request(harness.app)
+      .post('/workspace/skills/install')
+      .send(body);
+
+    expect(inventory.status).toBe(200);
+    expect(install.status).toBe(200);
+    expect(legacyInstall.status).toBe(403);
+    expect(legacyInstall.body).toMatchObject({ code: 'untrusted_workspace' });
+    expect(harness.installWorkspaceSkill).toHaveBeenCalledOnce();
+    expect(harness.installWorkspaceSkill).toHaveBeenCalledWith(
+      expect.not.objectContaining({ originatorClientId: expect.anything() }),
+      body,
+    );
+  });
+
+  it('reads the daemon-local config inventory without a runtime command', async () => {
+    const harness = createHarness();
+
+    const response = await request(harness.app).get('/workspace/config/skills');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      source: 'config',
+      skills: [{ name: 'demo-skill' }],
+    });
+    expect(harness.getWorkspaceSkillsConfigStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceCwd: '/workspace' }),
+    );
+  });
+
   it('forwards an install request to the workspace service', async () => {
     const harness = createHarness();
     const body = {
@@ -63,6 +172,120 @@ describe('workspace Skill management routes', () => {
       }),
       body,
     );
+  });
+
+  it('keeps the legacy workspace toggle route available', async () => {
+    const harness = createHarness();
+
+    const response = await request(harness.app)
+      .post('/workspace/skills/demo-skill/enable')
+      .send({ enabled: false });
+
+    expect(response.status).toBe(200);
+    expect(harness.setWorkspaceSkillEnabled).toHaveBeenCalledWith(
+      expect.objectContaining({ originatorClientId: 'client-1' }),
+      'demo-skill',
+      false,
+    );
+  });
+
+  it('uses the global config route without a client identity', async () => {
+    const harness = createHarness();
+    const body = {
+      name: 'demo-skill',
+      scope: 'global',
+      source: { type: 'folder', path: '/tmp/demo-skill' },
+    };
+
+    const response = await request(harness.app)
+      .post('/workspace/config/skills/install')
+      .send(body);
+
+    expect(response.status).toBe(200);
+    expect(harness.installWorkspaceSkill).toHaveBeenCalledWith(
+      expect.not.objectContaining({ originatorClientId: expect.anything() }),
+      body,
+    );
+  });
+
+  it('rejects workspace mutations through singular config routes', async () => {
+    const harness = createHarness();
+    const expectedError = {
+      error:
+        'Workspace Skill scope must be changed through /workspaces/:workspace/config/skills',
+      code: 'workspace_scope_requires_qualified_workspace',
+    };
+
+    const install = await request(harness.app)
+      .post('/workspace/config/skills/install')
+      .send({
+        name: 'demo-skill',
+        scope: 'workspace',
+        source: { type: 'folder', path: '/tmp/demo-skill' },
+      });
+    const remove = await request(harness.app).delete(
+      '/workspace/config/skills/demo-skill?scope=workspace',
+    );
+    expect(install.status).toBe(400);
+    expect(install.body).toEqual(expectedError);
+    expect(remove.status).toBe(400);
+    expect(remove.body).toEqual(expectedError);
+    expect(harness.installWorkspaceSkill).not.toHaveBeenCalled();
+    expect(harness.deleteWorkspaceSkill).not.toHaveBeenCalled();
+    expect(harness.setWorkspaceSkillEnabled).not.toHaveBeenCalled();
+  });
+
+  it('invalidates cached inventories in active and draining workspaces after global changes', async () => {
+    const harness = createHarness();
+    harness.setSecondaryLive(true);
+    const secondaryCoordinator = getWorkspaceRuntimeCoordinator(
+      harness.secondaryRuntime,
+    );
+    secondaryCoordinator.beginDrain();
+    const body = {
+      name: 'demo-skill',
+      scope: 'global',
+      source: { type: 'folder', path: '/tmp/demo-skill' },
+    };
+
+    const install = await request(harness.app)
+      .post('/workspace/config/skills/install')
+      .send(body);
+    const remove = await request(harness.app).delete(
+      '/workspace/config/skills/demo-skill?scope=global',
+    );
+
+    expect(install.status).toBe(200);
+    expect(remove.status).toBe(200);
+    expect(harness.invalidateWorkspaceSkillsStatus).toHaveBeenCalledTimes(2);
+    expect(harness.invalidateSecondarySkillsStatus).toHaveBeenCalledTimes(2);
+    expect(harness.refreshSecondarySkills).not.toHaveBeenCalled();
+
+    secondaryCoordinator.cancelDrain();
+    await vi.waitFor(() => {
+      expect(harness.refreshSecondarySkills).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('keeps a durable global install successful when runtime invalidation fails', async () => {
+    const harness = createHarness();
+    harness.invalidateSecondarySkillsStatus.mockImplementationOnce(() => {
+      throw new Error('runtime removed');
+    });
+
+    const response = await request(harness.app)
+      .post('/workspace/config/skills/install')
+      .send({
+        name: 'demo-skill',
+        scope: 'global',
+        source: { type: 'folder', path: '/tmp/demo-skill' },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      skillName: 'demo-skill',
+      activation: 'deferred',
+    });
   });
 
   it('forwards delete scope and rejects invalid scopes', async () => {

--- a/packages/cli/src/serve/routes/workspace-skills.ts
+++ b/packages/cli/src/serve/routes/workspace-skills.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceRegistry,
   WorkspaceRuntime,
 } from '../workspace-registry.js';
+import { getWorkspaceRuntimeCoordinator } from '../workspace-runtime-coordinator.js';
 import {
   MAX_WORKSPACE_SKILL_NAME_LENGTH,
   WorkspaceSkillManagementError,
@@ -28,6 +29,7 @@ import {
 
 interface RegisterWorkspaceSkillsRoutesDeps {
   workspaceRuntime: WorkspaceRuntime;
+  workspaceRegistry?: WorkspaceRegistry;
   mutate: (opts?: { strict?: boolean }) => RequestHandler;
   safeBody: (req: Request) => Record<string, unknown>;
   sendBridgeError: SendBridgeError;
@@ -35,6 +37,76 @@ interface RegisterWorkspaceSkillsRoutesDeps {
     req: Request,
     res: Response,
   ) => string | undefined | null;
+}
+
+type WorkspaceSkillActivation = 'deferred' | 'reconciling';
+
+function scheduleSkillsConfiguration(
+  runtimes: readonly WorkspaceRuntime[],
+): WorkspaceSkillActivation {
+  let reconciling = false;
+  for (const runtime of runtimes) {
+    try {
+      if (
+        getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).reconcileSkillsConfiguration() === 'reconciling'
+      ) {
+        reconciling = true;
+      }
+    } catch {
+      // Durable configuration is already committed; activation is best-effort.
+    }
+  }
+  return reconciling ? 'reconciling' : 'deferred';
+}
+
+function affectedSkillRuntimes(
+  runtime: WorkspaceRuntime,
+  scope: WorkspaceSkillScope,
+  registry?: WorkspaceRegistry,
+): readonly WorkspaceRuntime[] {
+  return scope === 'global'
+    ? (registry?.listManaged() ?? [runtime])
+    : [runtime];
+}
+
+function invalidateSkillsInventory(
+  runtimes: readonly WorkspaceRuntime[],
+): void {
+  for (const runtime of runtimes) {
+    try {
+      runtime.workspaceService.invalidateWorkspaceSkillsStatus();
+    } catch {
+      // Durable configuration is already committed; invalidation is best-effort.
+    }
+  }
+}
+
+function rejectQualifiedGlobalScope(
+  scope: WorkspaceSkillScope,
+  res: Response,
+): boolean {
+  if (scope !== 'global') return false;
+  res.status(400).json({
+    error:
+      'Global Skill scope must be changed through /workspace/config/skills',
+    code: 'global_scope_requires_singular_owner',
+  });
+  return true;
+}
+
+function rejectSingularWorkspaceScope(
+  scope: WorkspaceSkillScope,
+  res: Response,
+): boolean {
+  if (scope !== 'workspace') return false;
+  res.status(400).json({
+    error:
+      'Workspace Skill scope must be changed through /workspaces/:workspace/config/skills',
+    code: 'workspace_scope_requires_qualified_workspace',
+  });
+  return true;
 }
 
 function parseSkillToggleRequest(
@@ -164,6 +236,20 @@ export function registerWorkspaceSkillsRoutes(
   const buildWorkspaceCtx = createBuildWorkspaceCtx(
     deps.workspaceRuntime.workspaceCwd,
   );
+  app.get('/workspace/config/skills', async (_req, res) => {
+    const configRoute = 'GET /workspace/config/skills';
+    try {
+      res
+        .status(200)
+        .json(
+          await deps.workspaceRuntime.workspaceService.getWorkspaceSkillsConfigStatus(
+            buildWorkspaceCtx(configRoute),
+          ),
+        );
+    } catch (error) {
+      deps.sendBridgeError(res, error, { route: configRoute });
+    }
+  });
   const route = 'POST /workspace/skills/:name/enable';
   app.post(
     '/workspace/skills/install',
@@ -181,7 +267,18 @@ export function registerWorkspaceSkillsRoutes(
             buildWorkspaceCtx(installRoute, clientId),
             input,
           );
-        res.status(200).json(result);
+        const runtimes = affectedSkillRuntimes(
+          deps.workspaceRuntime,
+          input.scope,
+          deps.workspaceRegistry,
+        );
+        if (input.scope === 'global') {
+          invalidateSkillsInventory(runtimes);
+        }
+        res.status(200).json({
+          ...result,
+          activation: scheduleSkillsConfiguration(runtimes),
+        });
       } catch (err) {
         if (!sendSkillManagementError(res, err))
           deps.sendBridgeError(res, err, { route: installRoute });
@@ -213,7 +310,18 @@ export function registerWorkspaceSkillsRoutes(
             skillName,
             scope,
           );
-        res.status(200).json(result);
+        const runtimes = affectedSkillRuntimes(
+          deps.workspaceRuntime,
+          scope,
+          deps.workspaceRegistry,
+        );
+        if (scope === 'global') {
+          invalidateSkillsInventory(runtimes);
+        }
+        res.status(200).json({
+          ...result,
+          activation: scheduleSkillsConfiguration(runtimes),
+        });
       } catch (err) {
         if (!sendSkillManagementError(res, err))
           deps.sendBridgeError(res, err, { route: deleteRoute });
@@ -236,9 +344,86 @@ export function registerWorkspaceSkillsRoutes(
             input.skillName,
             input.enabled,
           );
-        res.status(200).json(result);
+        res.status(200).json({
+          ...result,
+          activation: scheduleSkillsConfiguration([deps.workspaceRuntime]),
+        });
       } catch (err) {
         deps.sendBridgeError(res, err, { route });
+      }
+    },
+  );
+
+  app.post(
+    '/workspace/config/skills/install',
+    deps.mutate({ strict: true }),
+    async (req, res) => {
+      const input = parseSkillInstallRequest(req, res, deps.safeBody);
+      if (!input) return;
+      if (rejectSingularWorkspaceScope(input.scope, res)) return;
+      const installRoute = 'POST /workspace/config/skills/install';
+      try {
+        const result =
+          await deps.workspaceRuntime.workspaceService.installWorkspaceSkill(
+            buildWorkspaceCtx(installRoute),
+            input,
+          );
+        const runtimes = affectedSkillRuntimes(
+          deps.workspaceRuntime,
+          input.scope,
+          deps.workspaceRegistry,
+        );
+        if (input.scope === 'global') {
+          invalidateSkillsInventory(runtimes);
+        }
+        res.status(200).json({
+          ...result,
+          activation: scheduleSkillsConfiguration(runtimes),
+        });
+      } catch (err) {
+        if (!sendSkillManagementError(res, err))
+          deps.sendBridgeError(res, err, { route: installRoute });
+      }
+    },
+  );
+  app.delete(
+    '/workspace/config/skills/:name',
+    deps.mutate({ strict: true }),
+    async (req, res) => {
+      const rawSkillName = req.params['name'];
+      const scope = parseDeleteScope(req, res);
+      if (!rawSkillName || !scope) return;
+      if (rejectSingularWorkspaceScope(scope, res)) return;
+      let skillName: string;
+      try {
+        skillName = validateWorkspaceSkillName(rawSkillName);
+      } catch (error) {
+        sendSkillManagementError(res, error);
+        return;
+      }
+      const deleteRoute = 'DELETE /workspace/config/skills/:name';
+      try {
+        const result =
+          await deps.workspaceRuntime.workspaceService.deleteWorkspaceSkill(
+            buildWorkspaceCtx(deleteRoute),
+            skillName,
+            scope,
+          );
+        const runtimes = affectedSkillRuntimes(
+          deps.workspaceRuntime,
+          scope,
+          deps.workspaceRegistry,
+        );
+        if (scope === 'global') {
+          invalidateSkillsInventory(runtimes);
+        }
+        res.status(200).json({
+          ...result,
+          activation: scheduleSkillsConfiguration(runtimes),
+        });
+      } catch (err) {
+        if (!sendSkillManagementError(res, err))
+          deps.sendBridgeError(res, err, { route: deleteRoute });
       }
     },
   );
@@ -251,6 +436,26 @@ export function registerWorkspaceQualifiedSkillsRoutes(
     'mutate' | 'safeBody' | 'sendBridgeError'
   > & { workspaceRegistry: WorkspaceRegistry },
 ): void {
+  app.get('/workspaces/:workspace/config/skills', async (req, res) => {
+    const runtime = resolveWorkspaceRuntimeFromParam(
+      deps.workspaceRegistry,
+      req,
+      res,
+    );
+    if (!runtime) return;
+    const configRoute = 'GET /workspaces/:workspace/config/skills';
+    try {
+      res
+        .status(200)
+        .json(
+          await runtime.workspaceService.getWorkspaceSkillsConfigStatus(
+            createBuildWorkspaceCtx(runtime.workspaceCwd)(configRoute),
+          ),
+        );
+    } catch (error) {
+      deps.sendBridgeError(res, error, { route: configRoute });
+    }
+  });
   const route = 'POST /workspaces/:workspace/skills/:name/enable';
   app.post(
     '/workspaces/:workspace/skills/install',
@@ -264,6 +469,7 @@ export function registerWorkspaceQualifiedSkillsRoutes(
       if (!runtime || !requireTrustedWorkspaceRuntime(runtime, res)) return;
       const input = parseSkillInstallRequest(req, res, deps.safeBody);
       if (!input) return;
+      if (rejectQualifiedGlobalScope(input.scope, res)) return;
       const clientId = parseAndValidateWorkspaceClientId(
         req,
         res,
@@ -272,10 +478,22 @@ export function registerWorkspaceQualifiedSkillsRoutes(
       if (clientId === null) return;
       const installRoute = 'POST /workspaces/:workspace/skills/install';
       try {
-        const result = await runtime.workspaceService.installWorkspaceSkill(
-          createBuildWorkspaceCtx(runtime.workspaceCwd)(installRoute, clientId),
-          input,
-        );
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const installed =
+            await runtime.workspaceService.installWorkspaceSkill(
+              createBuildWorkspaceCtx(runtime.workspaceCwd)(
+                installRoute,
+                clientId,
+              ),
+              input,
+            );
+          return {
+            ...installed,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
         res.status(200).json(result);
       } catch (err) {
         if (!sendSkillManagementError(res, err))
@@ -296,6 +514,7 @@ export function registerWorkspaceQualifiedSkillsRoutes(
       const rawSkillName = req.params['name'];
       const scope = parseDeleteScope(req, res);
       if (!rawSkillName || !scope) return;
+      if (rejectQualifiedGlobalScope(scope, res)) return;
       let skillName: string;
       try {
         skillName = validateWorkspaceSkillName(rawSkillName);
@@ -311,11 +530,22 @@ export function registerWorkspaceQualifiedSkillsRoutes(
       if (clientId === null) return;
       const deleteRoute = 'DELETE /workspaces/:workspace/skills/:name';
       try {
-        const result = await runtime.workspaceService.deleteWorkspaceSkill(
-          createBuildWorkspaceCtx(runtime.workspaceCwd)(deleteRoute, clientId),
-          skillName,
-          scope,
-        );
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const deleted = await runtime.workspaceService.deleteWorkspaceSkill(
+            createBuildWorkspaceCtx(runtime.workspaceCwd)(
+              deleteRoute,
+              clientId,
+            ),
+            skillName,
+            scope,
+          );
+          return {
+            ...deleted,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
         res.status(200).json(result);
       } catch (err) {
         if (!sendSkillManagementError(res, err))
@@ -342,14 +572,139 @@ export function registerWorkspaceQualifiedSkillsRoutes(
       );
       if (clientId === null) return;
       try {
-        const result = await runtime.workspaceService.setWorkspaceSkillEnabled(
-          createBuildWorkspaceCtx(runtime.workspaceCwd)(route, clientId),
-          input.skillName,
-          input.enabled,
-        );
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const updated =
+            await runtime.workspaceService.setWorkspaceSkillEnabled(
+              createBuildWorkspaceCtx(runtime.workspaceCwd)(route, clientId),
+              input.skillName,
+              input.enabled,
+            );
+          return {
+            ...updated,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
         res.status(200).json(result);
       } catch (err) {
         deps.sendBridgeError(res, err, { route });
+      }
+    },
+  );
+
+  app.post(
+    '/workspaces/:workspace/config/skills/install',
+    deps.mutate({ strict: true }),
+    async (req, res) => {
+      const runtime = resolveWorkspaceRuntimeFromParam(
+        deps.workspaceRegistry,
+        req,
+        res,
+      );
+      if (!runtime || !requireTrustedWorkspaceRuntime(runtime, res)) return;
+      const input = parseSkillInstallRequest(req, res, deps.safeBody);
+      if (!input) return;
+      if (rejectQualifiedGlobalScope(input.scope, res)) return;
+      const configRoute = 'POST /workspaces/:workspace/config/skills/install';
+      try {
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const installed =
+            await runtime.workspaceService.installWorkspaceSkill(
+              createBuildWorkspaceCtx(runtime.workspaceCwd)(configRoute),
+              input,
+            );
+          return {
+            ...installed,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
+        res.status(200).json(result);
+      } catch (err) {
+        if (!sendSkillManagementError(res, err)) {
+          deps.sendBridgeError(res, err, { route: configRoute });
+        }
+      }
+    },
+  );
+  app.delete(
+    '/workspaces/:workspace/config/skills/:name',
+    deps.mutate({ strict: true }),
+    async (req, res) => {
+      const runtime = resolveWorkspaceRuntimeFromParam(
+        deps.workspaceRegistry,
+        req,
+        res,
+      );
+      if (!runtime || !requireTrustedWorkspaceRuntime(runtime, res)) return;
+      const rawSkillName = req.params['name'];
+      const scope = parseDeleteScope(req, res);
+      if (!rawSkillName || !scope) return;
+      if (rejectQualifiedGlobalScope(scope, res)) return;
+      let skillName: string;
+      try {
+        skillName = validateWorkspaceSkillName(rawSkillName);
+      } catch (error) {
+        sendSkillManagementError(res, error);
+        return;
+      }
+      const configRoute = 'DELETE /workspaces/:workspace/config/skills/:name';
+      try {
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const deleted = await runtime.workspaceService.deleteWorkspaceSkill(
+            createBuildWorkspaceCtx(runtime.workspaceCwd)(configRoute),
+            skillName,
+            scope,
+          );
+          return {
+            ...deleted,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
+        res.status(200).json(result);
+      } catch (err) {
+        if (!sendSkillManagementError(res, err)) {
+          deps.sendBridgeError(res, err, { route: configRoute });
+        }
+      }
+    },
+  );
+  app.post(
+    '/workspaces/:workspace/config/skills/:name/enable',
+    deps.mutate({ strict: true }),
+    async (req, res) => {
+      const runtime = resolveWorkspaceRuntimeFromParam(
+        deps.workspaceRegistry,
+        req,
+        res,
+      );
+      if (!runtime || !requireTrustedWorkspaceRuntime(runtime, res)) return;
+      const input = parseSkillToggleRequest(req, res, deps.safeBody);
+      if (!input) return;
+      const configRoute =
+        'POST /workspaces/:workspace/config/skills/:name/enable';
+      try {
+        const result = await getWorkspaceRuntimeCoordinator(
+          runtime,
+        ).runManagementOperation(async () => {
+          const updated =
+            await runtime.workspaceService.setWorkspaceSkillEnabled(
+              createBuildWorkspaceCtx(runtime.workspaceCwd)(configRoute),
+              input.skillName,
+              input.enabled,
+            );
+          return {
+            ...updated,
+            activation: scheduleSkillsConfiguration([runtime]),
+          };
+        });
+        res.status(200).json(result);
+      } catch (err) {
+        deps.sendBridgeError(res, err, { route: configRoute });
       }
     },
   );

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -1550,6 +1550,7 @@ export function createServeApp(
   });
   registerWorkspaceSkillsRoutes(app, {
     workspaceRuntime: primaryRuntime,
+    workspaceRegistry,
     mutate,
     safeBody,
     sendBridgeError,

--- a/packages/cli/src/serve/workspace-qualified-rest.test.ts
+++ b/packages/cli/src/serve/workspace-qualified-rest.test.ts
@@ -22,6 +22,7 @@ import {
   type WorkspaceRuntime,
 } from './workspace-registry.js';
 import type { AcpSessionBridge } from './acp-session-bridge.js';
+import { getWorkspaceRuntimeCoordinator } from './workspace-runtime-coordinator.js';
 import {
   WorkspaceSkillNotFoundError,
   type DaemonWorkspaceService,
@@ -155,6 +156,13 @@ function makeWorkspaceService(label: string): DaemonWorkspaceService {
       v: 1,
       workspaceCwd: ctx.workspaceCwd,
       skills: [],
+    })),
+    getWorkspaceSkillsConfigStatus: vi.fn(async (ctx) => ({
+      v: 1,
+      workspaceCwd: ctx.workspaceCwd,
+      initialized: true,
+      source: 'config' as const,
+      skills: [{ name: label }],
     })),
     getWorkspaceProvidersStatus: vi.fn(async (ctx) => ({
       v: 1,
@@ -623,6 +631,172 @@ describe('workspace-qualified core REST', () => {
     }
   });
 
+  it('routes workspace-qualified MCP configuration without a session client', async () => {
+    const h = await makeHarness({ token: 'secret' });
+    try {
+      const base = `/workspaces/${encodeURIComponent(h.secondaryId)}/config/mcp/servers`;
+      const get = await request(h.app)
+        .get(base)
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host());
+      expect(get.status).toBe(200);
+      expect(get.body).toMatchObject({
+        v: 1,
+        effective: {},
+        user: {},
+        workspace: {},
+        disabledServers: expect.any(Array),
+      });
+
+      const put = await request(h.app)
+        .put(`${base}/docs`)
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host())
+        .send({
+          scope: 'workspace',
+          config: { command: 'node', args: ['server.js'] },
+        });
+      expect(put.status).toBe(200);
+      expect(put.body).toMatchObject({
+        name: 'docs',
+        scope: 'workspace',
+        activation: 'deferred',
+      });
+      expect(h.persistSetting).toHaveBeenCalledWith(
+        h.secondaryCwd,
+        expect.any(String),
+        'mcpServers',
+        expect.objectContaining({ docs: expect.any(Object) }),
+      );
+
+      vi.mocked(h.secondaryBridge.publishWorkspaceEvent).mockClear();
+      const disable = await request(h.app)
+        .post(
+          `/workspaces/${encodeURIComponent(h.secondaryId)}/config/mcp/docs/disable`,
+        )
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host());
+      expect(disable.status).toBe(200);
+      expect(disable.body.activation).toBe('deferred');
+      expect(h.secondaryBridge.publishWorkspaceEvent).toHaveBeenCalledWith({
+        type: 'settings_changed',
+        data: {
+          key: 'mcp.excluded',
+          value: ['docs'],
+          scope: 'workspace',
+        },
+      });
+
+      const badScope = await request(h.app)
+        .put(`${base}/docs`)
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host())
+        .send({ scope: 'user', config: { command: 'node' } });
+      expect(badScope.status).toBe(400);
+      expect(badScope.body.code).toBe('invalid_scope');
+
+      const primaryReconcile = vi
+        .spyOn(
+          getWorkspaceRuntimeCoordinator(h.primaryRuntime),
+          'reconcileMcpConfiguration',
+        )
+        .mockReturnValue('deferred');
+      const secondaryReconcile = vi
+        .spyOn(
+          getWorkspaceRuntimeCoordinator(h.secondaryRuntime),
+          'reconcileMcpConfiguration',
+        )
+        .mockReturnValue('deferred');
+      const genericMutation = await request(h.app)
+        .post(`/workspaces/${encodeURIComponent(h.secondaryId)}/settings`)
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host())
+        .send({
+          scope: 'workspace',
+          key: 'mcpServers',
+          value: { command: 'node' },
+          mcpServerMutation: { operation: 'set', name: 'generic' },
+        });
+      expect(genericMutation.status).toBe(200);
+      expect(genericMutation.body.activation).toBe('deferred');
+      expect(secondaryReconcile).toHaveBeenCalledOnce();
+      expect(primaryReconcile).not.toHaveBeenCalled();
+    } finally {
+      await fsp.rm(h.scratch, { recursive: true, force: true });
+    }
+  });
+
+  it('allows untrusted config reads while trust-gating MCP and Skill writes', async () => {
+    const h = await makeHarness({
+      secondaryTrusted: false,
+      token: 'secret',
+    });
+    const headers = { Authorization: 'Bearer secret', Host: host() };
+    const mcpBase = `/workspaces/${encodeURIComponent(h.secondaryId)}/config/mcp`;
+    const skillsBase = `/workspaces/${encodeURIComponent(h.secondaryId)}/config/skills`;
+    try {
+      const mcpInventory = await request(h.app)
+        .get(`${mcpBase}/servers`)
+        .set(headers);
+      expect(mcpInventory.status).toBe(200);
+
+      const mcpWrite = await request(h.app)
+        .put(`${mcpBase}/servers/docs`)
+        .set(headers)
+        .send({
+          scope: 'workspace',
+          config: { command: 'node', args: ['server.js'] },
+        });
+      const mcpDelete = await request(h.app)
+        .delete(`${mcpBase}/servers/docs?scope=workspace`)
+        .set(headers);
+      const mcpDisable = await request(h.app)
+        .post(`${mcpBase}/docs/disable`)
+        .set(headers);
+
+      const skillsInventory = await request(h.app).get(skillsBase).set(headers);
+      expect(skillsInventory.status).toBe(200);
+      expect(skillsInventory.body).toMatchObject({
+        workspaceCwd: h.secondaryCwd,
+        source: 'config',
+      });
+
+      const skillInstall = await request(h.app)
+        .post(`${skillsBase}/install`)
+        .set(headers)
+        .send({
+          name: 'review',
+          scope: 'workspace',
+          source: { type: 'folder', path: '/tmp/review' },
+        });
+      const skillDelete = await request(h.app)
+        .delete(`${skillsBase}/review?scope=workspace`)
+        .set(headers);
+      const skillEnable = await request(h.app)
+        .post(`${skillsBase}/review/enable`)
+        .set(headers)
+        .send({ enabled: true });
+
+      for (const response of [
+        mcpWrite,
+        mcpDelete,
+        mcpDisable,
+        skillInstall,
+        skillDelete,
+        skillEnable,
+      ]) {
+        expect(response.status).toBe(403);
+        expect(response.body).toMatchObject({ code: 'untrusted_workspace' });
+      }
+      expect(h.persistSetting).not.toHaveBeenCalled();
+      expect(
+        h.secondaryWorkspaceService.setWorkspaceSkillEnabled,
+      ).not.toHaveBeenCalled();
+    } finally {
+      await fsp.rm(h.scratch, { recursive: true, force: true });
+    }
+  });
+
   it('routes workspace-qualified permissions and rejects non-workspace scope', async () => {
     const h = await makeHarness({ token: 'secret' });
     try {
@@ -948,6 +1122,19 @@ describe('workspace-qualified core REST', () => {
         sessionsFailed: 0,
       });
 
+      const configToggle = await request(h.app)
+        .post(
+          `/workspaces/${encodeURIComponent(h.secondaryId)}/config/skills/review/enable`,
+        )
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host())
+        .send({ enabled: true });
+      expect(configToggle.status).toBe(200);
+      expect(configToggle.body).toMatchObject({
+        skillName: 'review',
+        enabled: true,
+      });
+
       vi.mocked(
         h.secondaryWorkspaceService.setWorkspaceSkillEnabled,
       ).mockRejectedValueOnce(new WorkspaceSkillNotFoundError('missing'));
@@ -991,6 +1178,30 @@ describe('workspace-qualified core REST', () => {
       expect(res.body.code).toBe('untrusted_workspace');
     } finally {
       await fsp.rm(untrusted.scratch, { recursive: true, force: true });
+    }
+  });
+
+  it('reads Skills config inventory from the selected workspace', async () => {
+    const h = await makeHarness({ token: 'secret' });
+    try {
+      const response = await request(h.app)
+        .get(`/workspaces/${encodeURIComponent(h.secondaryId)}/config/skills`)
+        .set('Authorization', 'Bearer secret')
+        .set('Host', host());
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        workspaceCwd: h.secondaryCwd,
+        source: 'config',
+        skills: [{ name: 'secondary' }],
+      });
+      expect(
+        h.secondaryWorkspaceService.getWorkspaceSkillsConfigStatus,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceCwd: h.secondaryCwd }),
+      );
+    } finally {
+      await fsp.rm(h.scratch, { recursive: true, force: true });
     }
   });
 

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -724,6 +724,37 @@ describe('createDaemonWorkspaceService', () => {
       );
     });
 
+    it('reads Skills config inventory locally even while a child is live', async () => {
+      const queryWorkspaceStatus = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        source: 'live',
+        skills: [{ kind: 'skill', status: 'ok', name: 'runtime-only' }],
+      });
+      const workspaceSkillsStatusProvider = vi.fn().mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/ws',
+        initialized: true,
+        skills: [{ kind: 'skill', status: 'ok', name: 'configured' }],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus,
+          workspaceSkillsStatusProvider,
+          isChannelLive: () => true,
+          boundWorkspace: '/ws',
+        }),
+      );
+
+      const result = await svc.getWorkspaceSkillsConfigStatus(makeCtx());
+
+      expect(result.source).toBe('config');
+      expect(result.skills.map((skill) => skill.name)).toEqual(['configured']);
+      expect(workspaceSkillsStatusProvider).toHaveBeenCalledWith('/ws');
+      expect(queryWorkspaceStatus).not.toHaveBeenCalled();
+    });
+
     it('getWorkspaceSkillsStatus idle fallback returns correct envelope', async () => {
       const queryWorkspaceStatus = vi
         .fn()
@@ -749,6 +780,8 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/ws',
         initialized: true,
+        runtimeEpoch: 3,
+        source: 'live' as const,
         skills: [
           {
             kind: 'skill',
@@ -773,6 +806,8 @@ describe('createDaemonWorkspaceService', () => {
       // Channel live: authoritative skills from the ACP child, cached.
       const first = await svc.getWorkspaceSkillsStatus(makeCtx());
       expect(first.initialized).toBe(true);
+      expect(first.runtimeEpoch).toBe(3);
+      expect(first.source).toBe('live');
       expect(first.skills.map((s) => s.name)).toEqual(['review']);
 
       // Channel reaped: queryWorkspaceStatus falls back to the empty idle
@@ -781,6 +816,8 @@ describe('createDaemonWorkspaceService', () => {
       channelLive = false;
       const second = await svc.getWorkspaceSkillsStatus(makeCtx());
       expect(second.initialized).toBe(true);
+      expect(second.runtimeEpoch).toBe(3);
+      expect(second.source).toBe('cache');
       expect(second.skills.map((s) => s.name)).toEqual(['review']);
     });
 
@@ -790,12 +827,14 @@ describe('createDaemonWorkspaceService', () => {
           v: 1,
           workspaceCwd: '/ws',
           initialized: true,
+          source: 'live' as const,
           skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
         },
         {
           v: 1,
           workspaceCwd: '/ws',
           initialized: true,
+          source: 'live' as const,
           skills: [
             { kind: 'skill', status: 'ok', name: 'review' },
             { kind: 'skill', status: 'ok', name: 'plan' },
@@ -820,6 +859,7 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/ws',
         initialized: true,
+        source: 'live' as const,
         skills: [
           {
             kind: 'skill',
@@ -844,9 +884,11 @@ describe('createDaemonWorkspaceService', () => {
         .mockImplementation((_m: string, idle: () => unknown) =>
           Promise.resolve(channelLive ? liveStatus : idle()),
         );
-      const workspaceSkillsStatusProvider = vi
-        .fn()
-        .mockResolvedValue(localStatus);
+      const invalidate = vi.fn();
+      const workspaceSkillsStatusProvider = Object.assign(
+        vi.fn().mockResolvedValue(localStatus),
+        { invalidate },
+      );
       const svc = createDaemonWorkspaceService(
         makeDeps({
           queryWorkspaceStatus,
@@ -861,6 +903,7 @@ describe('createDaemonWorkspaceService', () => {
 
       const result = await svc.getWorkspaceSkillsStatus(makeCtx());
       expect(result.skills).toEqual([]);
+      expect(invalidate).toHaveBeenCalledWith('/ws');
       expect(workspaceSkillsStatusProvider).toHaveBeenCalledWith('/ws');
     });
 
@@ -905,6 +948,7 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/ws',
         initialized: true,
+        source: 'live' as const,
         skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
       };
       let channelLive = true;
@@ -940,6 +984,7 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/ws',
         initialized: true,
+        source: 'live' as const,
         skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
       };
       const queryWorkspaceStatus = vi.fn().mockResolvedValue(liveStatus);
@@ -963,6 +1008,7 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/ws',
         initialized: true,
+        source: 'live' as const,
         skills: [{ kind: 'skill', status: 'ok', name: 'review' }],
       };
       let shouldThrow = false;
@@ -1329,14 +1375,34 @@ describe('createDaemonWorkspaceService', () => {
         v: 1,
         workspaceCwd: '/workspace',
         initialized: true,
+        source: 'live',
         skills: [skill],
       });
-
-    it('uses the canonical skill name and refreshes every active session', async () => {
-      const invalidate = vi.fn();
-      const workspaceSkillsStatusProvider = Object.assign(vi.fn(), {
-        invalidate,
+    const makeSkillDeps = (
+      overrides: Partial<DaemonWorkspaceServiceDeps> = {},
+      skills: Array<Record<string, unknown>> = [skillStatus()],
+    ) =>
+      makeDeps({
+        workspaceSkillsStatusProvider: vi.fn().mockResolvedValue({
+          v: 1,
+          workspaceCwd: '/workspace',
+          initialized: true,
+          skills,
+        }),
+        ...overrides,
       });
+
+    it('uses the canonical skill name and leaves activation to the coordinator', async () => {
+      const invalidate = vi.fn();
+      const workspaceSkillsStatusProvider = Object.assign(
+        vi.fn().mockResolvedValue({
+          v: 1,
+          workspaceCwd: '/workspace',
+          initialized: true,
+          skills: [skillStatus()],
+        }),
+        { invalidate },
+      );
       const persistDisabledSkills = vi.fn().mockResolvedValue({
         changed: true,
         disabled: ['review'],
@@ -1347,7 +1413,7 @@ describe('createDaemonWorkspaceService', () => {
       });
       const publishWorkspaceEvent = vi.fn();
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           workspaceSkillsStatusProvider,
           persistDisabledSkills,
@@ -1369,16 +1435,13 @@ describe('createDaemonWorkspaceService', () => {
         false,
       );
       expect(invalidate).toHaveBeenCalledWith('/workspace');
-      expect(invokeWorkspaceCommand).toHaveBeenCalledWith(
-        'qwen/control/workspace/skills/refresh',
-        { cwd: '/workspace' },
-      );
+      expect(invokeWorkspaceCommand).not.toHaveBeenCalled();
       expect(result).toEqual({
         skillName: 'review',
         enabled: false,
         changed: true,
-        activation: 'applied',
-        sessionsRefreshed: 2,
+        activation: 'deferred',
+        sessionsRefreshed: 0,
         sessionsFailed: 0,
       });
       expect(publishWorkspaceEvent).toHaveBeenCalledWith({
@@ -1392,10 +1455,37 @@ describe('createDaemonWorkspaceService', () => {
       });
     });
 
+    it('validates mutations against config when the live Catalog is stale', async () => {
+      const queryWorkspaceStatus = statusQuery(
+        skillStatus({ name: 'old-runtime-skill' }),
+      );
+      const persistDisabledSkills = vi.fn().mockResolvedValue({
+        changed: true,
+        disabled: ['review'],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeSkillDeps({
+          queryWorkspaceStatus,
+          persistDisabledSkills,
+          isChannelLive: () => true,
+        }),
+      );
+
+      await expect(
+        svc.setWorkspaceSkillEnabled(makeCtx(), 'review', false),
+      ).resolves.toMatchObject({ skillName: 'review', changed: true });
+      expect(persistDisabledSkills).toHaveBeenCalledWith(
+        '/workspace',
+        'review',
+        false,
+      );
+      expect(queryWorkspaceStatus).not.toHaveBeenCalled();
+    });
+
     it('publishes the reduced disabled list when enabling a skill', async () => {
       const publishWorkspaceEvent = vi.fn();
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
@@ -1415,7 +1505,7 @@ describe('createDaemonWorkspaceService', () => {
       ).resolves.toMatchObject({
         skillName: 'review',
         enabled: true,
-        activation: 'applied',
+        activation: 'deferred',
       });
       expect(publishWorkspaceEvent).toHaveBeenCalledWith({
         type: 'settings_changed',
@@ -1428,9 +1518,9 @@ describe('createDaemonWorkspaceService', () => {
       });
     });
 
-    it('reports partial activation when a session refresh fails', async () => {
+    it('does not infer activation from session refresh results', async () => {
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
@@ -1447,16 +1537,16 @@ describe('createDaemonWorkspaceService', () => {
       await expect(
         svc.setWorkspaceSkillEnabled(makeCtx(), 'review', false),
       ).resolves.toMatchObject({
-        activation: 'partial',
-        sessionsRefreshed: 1,
-        sessionsFailed: 1,
+        activation: 'deferred',
+        sessionsRefreshed: 0,
+        sessionsFailed: 0,
       });
     });
 
     it('defers refresh when no child exists or the child closes mid-refresh', async () => {
       const noChildCommand = vi.fn();
       const noChild = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
@@ -1476,7 +1566,7 @@ describe('createDaemonWorkspaceService', () => {
       expect(noChildCommand).not.toHaveBeenCalled();
 
       const closedChild = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
@@ -1501,7 +1591,7 @@ describe('createDaemonWorkspaceService', () => {
 
     it('defers refresh when the child reports no session', async () => {
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
@@ -1523,17 +1613,18 @@ describe('createDaemonWorkspaceService', () => {
       });
     });
 
-    it('reports partial activation on an unexpected refresh error', async () => {
+    it('does not call the ACP refresh path from the persistence service', async () => {
+      const invokeWorkspaceCommand = vi
+        .fn()
+        .mockRejectedValue(new Error('network timeout'));
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: true,
             disabled: ['review'],
           }),
-          invokeWorkspaceCommand: vi
-            .fn()
-            .mockRejectedValue(new Error('network timeout')),
+          invokeWorkspaceCommand,
           isChannelLive: () => true,
         }),
       );
@@ -1541,17 +1632,18 @@ describe('createDaemonWorkspaceService', () => {
       await expect(
         svc.setWorkspaceSkillEnabled(makeCtx(), 'review', false),
       ).resolves.toMatchObject({
-        activation: 'partial',
+        activation: 'deferred',
         sessionsRefreshed: 0,
-        sessionsFailed: 1,
+        sessionsFailed: 0,
       });
+      expect(invokeWorkspaceCommand).not.toHaveBeenCalled();
     });
 
     it('does not refresh or publish an idempotent mutation', async () => {
       const invokeWorkspaceCommand = vi.fn();
       const publishWorkspaceEvent = vi.fn();
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi.fn().mockResolvedValue({
             changed: false,
@@ -1565,7 +1657,7 @@ describe('createDaemonWorkspaceService', () => {
 
       await expect(
         svc.setWorkspaceSkillEnabled(makeCtx(), 'review', false),
-      ).resolves.toMatchObject({ changed: false, activation: 'applied' });
+      ).resolves.toMatchObject({ changed: false, activation: 'deferred' });
       expect(invokeWorkspaceCommand).not.toHaveBeenCalled();
       expect(publishWorkspaceEvent).not.toHaveBeenCalled();
     });
@@ -1573,7 +1665,7 @@ describe('createDaemonWorkspaceService', () => {
     it('rejects unknown, hidden, and inactive extension skills before persisting', async () => {
       const persistDisabledSkills = vi.fn();
       const unknown = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills,
         }),
@@ -1583,12 +1675,15 @@ describe('createDaemonWorkspaceService', () => {
       ).rejects.toBeInstanceOf(WorkspaceSkillNotFoundError);
 
       const hidden = createDaemonWorkspaceService(
-        makeDeps({
-          queryWorkspaceStatus: statusQuery(
-            skillStatus({ userInvocable: false }),
-          ),
-          persistDisabledSkills,
-        }),
+        makeSkillDeps(
+          {
+            queryWorkspaceStatus: statusQuery(
+              skillStatus({ userInvocable: false }),
+            ),
+            persistDisabledSkills,
+          },
+          [skillStatus({ userInvocable: false })],
+        ),
       );
       await expect(
         hidden.setWorkspaceSkillEnabled(makeCtx(), 'review', false),
@@ -1597,16 +1692,25 @@ describe('createDaemonWorkspaceService', () => {
       });
 
       const inactive = createDaemonWorkspaceService(
-        makeDeps({
-          queryWorkspaceStatus: statusQuery(
+        makeSkillDeps(
+          {
+            queryWorkspaceStatus: statusQuery(
+              skillStatus({
+                status: 'disabled',
+                level: 'extension',
+                extensionName: 'review-ext',
+              }),
+            ),
+            persistDisabledSkills,
+          },
+          [
             skillStatus({
               status: 'disabled',
               level: 'extension',
               extensionName: 'review-ext',
             }),
-          ),
-          persistDisabledSkills,
-        }),
+          ],
+        ),
       );
       await expect(
         inactive.setWorkspaceSkillEnabled(makeCtx(), 'review', true),
@@ -1620,7 +1724,7 @@ describe('createDaemonWorkspaceService', () => {
       const invokeWorkspaceCommand = vi.fn();
       const publishWorkspaceEvent = vi.fn();
       const svc = createDaemonWorkspaceService(
-        makeDeps({
+        makeSkillDeps({
           queryWorkspaceStatus: statusQuery(),
           persistDisabledSkills: vi
             .fn()
@@ -1720,7 +1824,7 @@ describe('createDaemonWorkspaceService', () => {
       });
     });
 
-    it('returns ready without preheating when the channel is already live', async () => {
+    it('renews the idle window when the channel is already live', async () => {
       const preheatAcpChild = vi.fn().mockResolvedValue(undefined);
       const svc = createDaemonWorkspaceService(
         makeDeps({ isChannelLive: () => true, preheatAcpChild }),
@@ -1729,7 +1833,7 @@ describe('createDaemonWorkspaceService', () => {
       const result = await svc.preheatAcpChild(makeCtx());
 
       expect(result).toMatchObject({ ready: true, channelLive: true });
-      expect(preheatAcpChild).not.toHaveBeenCalled();
+      expect(preheatAcpChild).toHaveBeenCalledOnce();
     });
 
     it('returns an error when ACP preheat is unavailable', async () => {

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -19,7 +19,6 @@ import * as path from 'node:path';
 import {
   SERVE_STATUS_EXT_METHODS,
   SERVE_CONTROL_EXT_METHODS,
-  BridgeChannelClosedError,
   STATUS_SCHEMA_VERSION,
   createIdleWorkspaceMcpStatus,
   createIdleWorkspaceSkillsStatus,
@@ -30,7 +29,6 @@ import {
   createIdleAcpPreflightCells,
   mapDomainErrorToErrorKind,
   type ServeWorkspacePreflightStatus,
-  type ServeWorkspaceSkillsRefreshResult,
   type ServeWorkspaceSkillsStatus,
 } from '@qwen-code/acp-bridge/status';
 
@@ -234,6 +232,31 @@ export function createDaemonWorkspaceService(
   let lastWorkspaceSkillsStatus: ServeWorkspaceSkillsStatus | undefined;
   let inFlightAcpPreheat: Promise<void> | undefined;
 
+  const invalidateWorkspaceSkillsStatus = (): void => {
+    lastWorkspaceSkillsStatus = undefined;
+    workspaceSkillsStatusProvider?.invalidate?.(boundWorkspace);
+  };
+
+  const getWorkspaceSkillsConfigStatus =
+    async (): Promise<ServeWorkspaceSkillsStatus> => {
+      if (workspaceSkillsStatusProvider) {
+        try {
+          return {
+            ...(await workspaceSkillsStatusProvider(boundWorkspace)),
+            source: 'config',
+          };
+        } catch (err) {
+          writeStderrLine(
+            `qwen serve: getWorkspaceSkillsConfigStatus local provider failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      return {
+        ...createIdleWorkspaceSkillsStatus(boundWorkspace),
+        source: 'config',
+      };
+    };
+
   const getWorkspaceSkillsStatus =
     async (): Promise<ServeWorkspaceSkillsStatus> => {
       let status: ServeWorkspaceSkillsStatus;
@@ -253,51 +276,28 @@ export function createDaemonWorkspaceService(
         );
         status = createIdleWorkspaceSkillsStatus(boundWorkspace);
       }
-      if (status.initialized) {
-        lastWorkspaceSkillsStatus = status;
-        return status;
+      if (
+        status.initialized &&
+        (status.source === 'live' ||
+          (status.source === undefined && (isChannelLive?.() ?? false)))
+      ) {
+        const liveStatus = { ...status, source: 'live' as const };
+        lastWorkspaceSkillsStatus = liveStatus;
+        return liveStatus;
       }
       // Live child unavailable. Prefer the last answer it produced (keeps the
       // full, extension-aware list available across a reap)...
-      if (lastWorkspaceSkillsStatus) return lastWorkspaceSkillsStatus;
+      if (lastWorkspaceSkillsStatus) {
+        return { ...lastWorkspaceSkillsStatus, source: 'cache' };
+      }
       // ...then fall back to daemon-local enumeration, so a child that has not
       // answered even once (e.g. a preheat that times out under `npm run dev`)
       // still yields the on-disk skills — `/review` included. The provider
       // handles its own errors, but it is injected, so guard the call too and
       // degrade to the idle placeholder rather than failing the request —
       // matching getWorkspaceEnvStatus / getWorkspacePreflightStatus.
-      if (workspaceSkillsStatusProvider) {
-        try {
-          return await workspaceSkillsStatusProvider(boundWorkspace);
-        } catch (err) {
-          writeStderrLine(
-            `qwen serve: getWorkspaceSkillsStatus local provider failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }
-      return status;
+      return getWorkspaceSkillsConfigStatus();
     };
-
-  const refreshWorkspaceSkillsAfterMutation = async (): Promise<void> => {
-    lastWorkspaceSkillsStatus = undefined;
-    workspaceSkillsStatusProvider?.invalidate?.(boundWorkspace);
-    if (!(isChannelLive?.() ?? false)) return;
-    try {
-      await invokeWorkspaceCommand<ServeWorkspaceSkillsRefreshResult>(
-        SERVE_CONTROL_EXT_METHODS.workspaceSkillsRefresh,
-        { cwd: boundWorkspace },
-      );
-    } catch (err) {
-      if (
-        !(err instanceof SessionNotFoundError) &&
-        !(err instanceof BridgeChannelClosedError)
-      ) {
-        writeStderrLine(
-          `qwen serve: workspace skill refresh after mutation failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }
-  };
 
   // -- Facade --
   return {
@@ -314,13 +314,17 @@ export function createDaemonWorkspaceService(
       // SkillManager (including extension-provided skills). `queryWorkspaceStatus`
       // returns the idle placeholder (`initialized: false`, empty `skills`)
       // whenever no child channel is live — before the first session, after
-      // the child is reaped on session close (`--channel-idle-timeout-ms`
-      // defaults to an immediate kill), and when a cold-start preheat times
-      // out before the child ever answers. In those windows the Web Shell's
+      // workspace removal, a child crash, or an explicit restart, and when a
+      // cold-start preheat times out before the child ever answers. In those
+      // windows the Web Shell's
       // pre-first-prompt slash-command list would otherwise drop every skill,
       // so `/rev` stops autocompleting `/review`. `initialized` cleanly
       // separates a real child answer (always `true`) from the placeholder.
       return getWorkspaceSkillsStatus();
+    },
+
+    async getWorkspaceSkillsConfigStatus(_ctx: WorkspaceRequestContext) {
+      return getWorkspaceSkillsConfigStatus();
     },
 
     async getWorkspaceProvidersStatus(_ctx: WorkspaceRequestContext) {
@@ -721,7 +725,7 @@ export function createDaemonWorkspaceService(
       enabled: boolean,
     ): Promise<WorkspaceSkillToggleResult> {
       const normalizedName = requestedSkillName.trim().toLowerCase();
-      const status = await getWorkspaceSkillsStatus();
+      const status = await getWorkspaceSkillsConfigStatus();
       const skill = status.skills.find(
         (candidate) => candidate.name.trim().toLowerCase() === normalizedName,
       );
@@ -756,42 +760,9 @@ export function createDaemonWorkspaceService(
         skill.name,
         enabled,
       );
-      const channelLive = isChannelLive?.() ?? false;
-      let activation: WorkspaceSkillToggleResult['activation'] = channelLive
-        ? 'applied'
-        : 'deferred';
-      let sessionsRefreshed = 0;
-      let sessionsFailed = 0;
 
       if (persisted.changed) {
-        lastWorkspaceSkillsStatus = undefined;
-        workspaceSkillsStatusProvider?.invalidate?.(boundWorkspace);
-        if (channelLive) {
-          try {
-            const refreshed =
-              await invokeWorkspaceCommand<ServeWorkspaceSkillsRefreshResult>(
-                SERVE_CONTROL_EXT_METHODS.workspaceSkillsRefresh,
-                { cwd: boundWorkspace },
-              );
-            sessionsRefreshed = refreshed.sessionsRefreshed;
-            sessionsFailed = refreshed.sessionsFailed;
-            if (sessionsFailed > 0) activation = 'partial';
-          } catch (err) {
-            if (
-              err instanceof SessionNotFoundError ||
-              err instanceof BridgeChannelClosedError
-            ) {
-              activation = 'deferred';
-            } else {
-              activation = 'partial';
-              sessionsFailed = 1;
-              writeStderrLine(
-                `qwen serve: workspace skill refresh failed: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            }
-          }
-        }
-
+        invalidateWorkspaceSkillsStatus();
         publishWorkspaceEvent({
           type: 'settings_changed',
           data: {
@@ -808,9 +779,9 @@ export function createDaemonWorkspaceService(
         skillName: skill.name,
         enabled,
         changed: persisted.changed,
-        activation,
-        sessionsRefreshed,
-        sessionsFailed,
+        activation: 'deferred',
+        sessionsRefreshed: 0,
+        sessionsFailed: 0,
       };
     },
 
@@ -823,7 +794,7 @@ export function createDaemonWorkspaceService(
         request,
         skillInstallEnv?.['GH_TOKEN'] ?? skillInstallEnv?.['GITHUB_TOKEN'],
       );
-      await refreshWorkspaceSkillsAfterMutation();
+      invalidateWorkspaceSkillsStatus();
       return result;
     },
 
@@ -833,7 +804,7 @@ export function createDaemonWorkspaceService(
       scope: WorkspaceSkillScope,
     ): Promise<WorkspaceSkillMutationResult> {
       const normalizedName = requestedSkillName.trim().toLowerCase();
-      const status = await getWorkspaceSkillsStatus();
+      const status = await getWorkspaceSkillsConfigStatus();
       const skill = status.skills.find(
         (candidate) => candidate.name.trim().toLowerCase() === normalizedName,
       );
@@ -852,7 +823,7 @@ export function createDaemonWorkspaceService(
         skill.name,
         skill.installedPath,
       );
-      await refreshWorkspaceSkillsAfterMutation();
+      invalidateWorkspaceSkillsStatus();
       return result;
     },
 
@@ -1196,7 +1167,7 @@ export function createDaemonWorkspaceService(
     },
 
     invalidateWorkspaceSkillsStatus() {
-      lastWorkspaceSkillsStatus = undefined;
+      invalidateWorkspaceSkillsStatus();
     },
 
     async refreshExtensionsForAllSessions() {

--- a/packages/cli/src/serve/workspace-service/types.ts
+++ b/packages/cli/src/serve/workspace-service/types.ts
@@ -125,6 +125,11 @@ export interface DaemonWorkspaceService {
     ctx: WorkspaceRequestContext,
   ): Promise<ServeWorkspaceSkillsStatus>;
 
+  /** Daemon-local configured Skill inventory for the bound workspace. */
+  getWorkspaceSkillsConfigStatus(
+    ctx: WorkspaceRequestContext,
+  ): Promise<ServeWorkspaceSkillsStatus>;
+
   /** Model-provider status for the bound workspace. */
   getWorkspaceProvidersStatus(
     ctx: WorkspaceRequestContext,
@@ -239,7 +244,7 @@ export interface DaemonWorkspaceService {
   /** Reload all settings (env + model + permissions + tools + memory). */
   reload(ctx: WorkspaceRequestContext): Promise<ReloadResponse>;
 
-  /** Drop cached skill status so extension skill changes are re-enumerated. */
+  /** Drop both runtime Skill snapshots and daemon-local config inventory. */
   invalidateWorkspaceSkillsStatus(): void;
 
   /** Broadcast extension refresh to all active sessions (fire-and-forget). */
@@ -332,7 +337,11 @@ export interface WorkspaceVoiceSettingsUpdate {
   voiceModel?: string;
 }
 
-export type WorkspaceSkillToggleActivation = 'applied' | 'deferred' | 'partial';
+export type WorkspaceSkillToggleActivation =
+  | 'applied'
+  | 'deferred'
+  | 'reconciling'
+  | 'partial';
 
 export interface WorkspaceSkillToggleResult {
   skillName: string;

--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -59,7 +59,9 @@ const rootDir = join(__dirname, '..');
 // Bumped from 161KB to 165KB for the Web Shell git-diff REST helpers
 // (workspaceGitDiff / workspaceGitDiffFile on both client classes) and the
 // ChatRecord transcript projection in the default UI API.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 165 * 1024;
+// Bumped from 165KB to 171KB for workspace-qualified, sessionless Extension,
+// MCP, Skill, and built-in Tool runtime management APIs.
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 171 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -2975,6 +2975,27 @@ export class DaemonClient {
     );
   }
 
+  installWorkspaceConfigSkill(
+    request: DaemonSkillInstallRequest & { scope: 'global' },
+  ): Promise<DaemonSkillMutationResult> {
+    return this.jsonRequest('/workspace/config/skills/install', 'Skill', {
+      method: 'POST',
+      body: request,
+      mode: 'rest',
+    });
+  }
+
+  deleteWorkspaceConfigSkill(
+    skillName: string,
+    scope: 'global',
+  ): Promise<DaemonSkillMutationResult> {
+    return this.jsonRequest(
+      `/workspace/config/skills/${urlEncode(skillName)}?scope=${urlEncode(scope)}`,
+      'Skill',
+      { method: 'DELETE', mode: 'rest' },
+    );
+  }
+
   async workspaceSettings(opts?: {
     clientId?: string;
   }): Promise<DaemonWorkspaceSettingsStatus> {
@@ -4570,6 +4591,39 @@ export class WorkspaceDaemonClient {
 
   workspaceSkills(): Promise<DaemonWorkspaceSkillsStatus> {
     return this.get('/skills', 'GET /workspaces/:workspace/skills');
+  }
+
+  installWorkspaceConfigSkill(
+    request: DaemonSkillInstallRequest & { scope: 'workspace' },
+  ): Promise<DaemonSkillMutationResult> {
+    return this.restPost(
+      '/config/skills/install',
+      'POST /workspaces/:workspace/config/skills/install',
+      request,
+    );
+  }
+
+  deleteWorkspaceConfigSkill(
+    skillName: string,
+    scope: 'workspace',
+  ): Promise<DaemonSkillMutationResult> {
+    return this.client.workspaceJsonRequest(
+      this.workspaceSelector,
+      `/config/skills/${urlEncode(skillName)}?scope=${urlEncode(scope)}`,
+      'DELETE /workspaces/:workspace/config/skills/:name',
+      { method: 'DELETE', mode: 'rest' },
+    );
+  }
+
+  setWorkspaceConfigSkillEnabled(
+    skillName: string,
+    enabled: boolean,
+  ): Promise<DaemonSkillToggleResult> {
+    return this.restPost(
+      `/config/skills/${urlEncode(skillName)}/enable`,
+      'POST /workspaces/:workspace/config/skills/:name/enable',
+      { enabled },
+    );
   }
 
   workspaceProviders(): Promise<DaemonWorkspaceProvidersStatus> {

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -2233,7 +2233,11 @@ export interface DaemonToolToggleResult {
   enabled: boolean;
 }
 
-export type DaemonSkillToggleActivation = 'applied' | 'deferred' | 'partial';
+export type DaemonSkillToggleActivation =
+  | 'applied'
+  | 'reconciling'
+  | 'deferred'
+  | 'partial';
 
 export interface DaemonSkillToggleResult {
   skillName: string;
@@ -2262,6 +2266,7 @@ export interface DaemonSkillMutationResult {
   scope: DaemonSkillScope;
   installedPath?: string;
   deleted?: boolean;
+  activation?: DaemonSkillToggleActivation;
 }
 
 export interface DaemonSettingDescriptor {

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -748,6 +748,50 @@ describe('DaemonClient', () => {
       ]);
     });
 
+    it('uses workspace-qualified config routes for managed modules', async () => {
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, {}));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      const workspace = client.workspaceById('workspace/id');
+
+      await workspace.workspaceMcpConfig();
+      await workspace.setWorkspaceMcpConfig('docs/server', {
+        command: 'node',
+      });
+      await workspace.removeWorkspaceMcpConfig('docs/server');
+      await workspace.workspaceConfigExtensions();
+      await workspace.workspaceConfigSkills();
+      await workspace.activeWorkspaceConfigExtensionOperations();
+      await workspace.setWorkspaceConfigSkillEnabled('review/skill', true);
+
+      expect(calls.map((call) => [call.method, call.url])).toEqual([
+        ['GET', 'http://daemon/workspaces/workspace%2Fid/config/mcp/servers'],
+        [
+          'PUT',
+          'http://daemon/workspaces/workspace%2Fid/config/mcp/servers/docs%2Fserver',
+        ],
+        [
+          'DELETE',
+          'http://daemon/workspaces/workspace%2Fid/config/mcp/servers/docs%2Fserver?scope=workspace',
+        ],
+        ['GET', 'http://daemon/workspaces/workspace%2Fid/config/extensions'],
+        ['GET', 'http://daemon/workspaces/workspace%2Fid/config/skills'],
+        [
+          'GET',
+          'http://daemon/workspaces/workspace%2Fid/config/extensions/operations',
+        ],
+        [
+          'POST',
+          'http://daemon/workspaces/workspace%2Fid/config/skills/review%2Fskill/enable',
+        ],
+      ]);
+      expect(calls[1]?.body).toBe(
+        JSON.stringify({
+          scope: 'workspace',
+          config: { command: 'node' },
+        }),
+      );
+    });
+
     it('reads primary and workspace-qualified Git status over REST', async () => {
       const primary = {
         v: 1 as const,
@@ -4609,6 +4653,25 @@ describe('DaemonClient', () => {
       expect(polls).toBe(0);
     });
 
+    it('does not let a client timeout extend the server operation deadline', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(500, { error: 'should not poll' }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await expect(
+        client.waitForExtensionOperation(
+          {
+            accepted: true,
+            operationId: 'op-expired',
+            deadlineAt: Date.now() - 1,
+          },
+          { timeoutMs: Number.POSITIVE_INFINITY },
+        ),
+      ).rejects.toThrow('server operation was not cancelled');
+      expect(calls).toHaveLength(0);
+    });
+
     it('aborts an in-flight poll when the operation deadline expires', async () => {
       let pollSignal: AbortSignal | null | undefined;
       const { fetch } = recordingFetch(
@@ -4906,6 +4969,96 @@ describe('DaemonClient', () => {
         ['POST', 'http://daemon/workspaces/%2Fwork%2Fa/extensions/refresh'],
       ]);
       expect(transportFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workspace runtime management', () => {
+    it('uses REST for runtime and management routes with an ACP transport', async () => {
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, {}));
+      const transportFetch = vi.fn(async () =>
+        jsonResponse(500, { error: 'transport should not be used' }),
+      );
+      const transport: DaemonTransport = {
+        type: 'acp-http',
+        supportsReplay: true,
+        connected: true,
+        fetch: transportFetch,
+        async *subscribeEvents() {},
+        dispose() {},
+      };
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch,
+        transport,
+      });
+      const workspace = client.workspaceByCwd('/work/a');
+
+      await workspace.ensureWorkspaceRuntime();
+      await workspace.workspaceRuntimeStatus();
+      await workspace.workspaceRuntimeOperation('op-1');
+      await workspace.activeWorkspaceRuntimeOperations();
+      await workspace.workspaceRuntimeExtensions();
+      await workspace.workspaceRuntimeMcp();
+      await workspace.workspaceMcpConfig();
+      await workspace.workspaceRuntimeSkills();
+      await workspace.workspaceRuntimeTools();
+      await workspace.workspaceConfigSkills();
+      await workspace.workspaceConfigExtensions();
+      await workspace.setWorkspaceConfigSkillEnabled('review', true);
+      await client.installWorkspaceConfigSkill({
+        name: 'global-review',
+        scope: 'global',
+        source: { type: 'github', url: 'owner/repo' },
+      });
+
+      expect(calls.map((call) => [call.method, call.url])).toEqual([
+        ['POST', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/ensure'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/status'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/operations/op-1'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/operations'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/extensions'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/mcp'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/config/mcp/servers'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/skills'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/runtime/tools'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/config/skills'],
+        ['GET', 'http://daemon/workspaces/%2Fwork%2Fa/config/extensions'],
+        [
+          'POST',
+          'http://daemon/workspaces/%2Fwork%2Fa/config/skills/review/enable',
+        ],
+        ['POST', 'http://daemon/workspace/config/skills/install'],
+      ]);
+      expect(JSON.parse(calls[0]?.body ?? 'null')).toEqual({});
+      expect(transportFetch).not.toHaveBeenCalled();
+    });
+
+    it('persists MCP enablement through the owning configuration route', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          serverName: 'docs',
+          action: 'disable',
+          ok: true,
+          activation: 'deferred',
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+      await expect(
+        client
+          .workspaceByCwd('/work/a')
+          .setWorkspaceConfigMcpServerEnabled('docs', false),
+      ).resolves.toMatchObject({ activation: 'deferred' });
+      await expect(
+        client.setUserConfigMcpServerEnabled('docs', true),
+      ).resolves.toMatchObject({ activation: 'deferred' });
+      expect(calls.map((call) => [call.method, call.url])).toEqual([
+        [
+          'POST',
+          'http://daemon/workspaces/%2Fwork%2Fa/config/mcp/docs/disable',
+        ],
+        ['POST', 'http://daemon/workspace/config/mcp/docs/enable'],
+      ]);
     });
   });
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -44,6 +44,7 @@ type ChatEditorTestProps = {
   placeholderText?: string;
   workspaces?: Array<{ id: string; cwd: string }>;
   atWorkspaceCwd?: string;
+  onSelectWorkspace?: (cwd: string | undefined) => void;
 };
 
 const {
@@ -62,6 +63,9 @@ const {
   editorFocus,
   editorInsertText,
   settingsReload,
+  workspaceRuntimeStatus,
+  ensureWorkspaceRuntime,
+  workspaceRuntimeSkills,
 } = vi.hoisted(() => {
   const connection: MockConnection = {
     status: 'connected',
@@ -79,10 +83,21 @@ const {
     catchingUp: false,
   };
   const loadSkillsStatus = vi.fn().mockResolvedValue({ skills: [] });
+  const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+    runtimeLive: true,
+    capabilities: { skills: { state: 'ready' } },
+  });
+  const ensureWorkspaceRuntime = vi.fn().mockResolvedValue({
+    capabilities: { skills: { state: 'ready' } },
+  });
+  const workspaceRuntimeSkills = vi.fn(() => loadSkillsStatus());
   const workspaceClient = {
     workspaceByCwd: vi.fn(() => ({
       workspaceGit: vi.fn().mockResolvedValue({ branch: 'main' }),
       workspaceSkills: loadSkillsStatus,
+      workspaceRuntimeStatus,
+      ensureWorkspaceRuntime,
+      workspaceRuntimeSkills,
     })),
     sessionStatus: vi.fn(() => Promise.resolve({})),
   };
@@ -115,6 +130,7 @@ const {
       client: workspaceClient,
     },
     mockWorkspaceActions: {
+      ensureRuntime: vi.fn().mockResolvedValue({}),
       loadSkillsStatus,
       loadProviders: vi.fn().mockResolvedValue({ current: null }),
       loadPreflight: vi.fn().mockResolvedValue(null),
@@ -124,15 +140,21 @@ const {
       loadMcpResources: vi.fn().mockResolvedValue([]),
     },
     mockMcp: {
+      status: undefined,
       initialize: vi.fn().mockResolvedValue({ accepted: true }),
       reloadConfig: vi.fn().mockResolvedValue({ accepted: true }),
       reload: vi.fn(),
+      loadStatus: vi.fn(),
+      loadConfig: vi.fn(),
+      waitForRuntime: vi.fn(),
       loadTools: vi.fn(),
       loadResources: vi.fn(),
       restartServer: vi.fn(),
       manageServer: vi.fn(),
-      addServer: vi.fn(),
-      removeServer: vi.fn(),
+      operationStatus: vi.fn(),
+      activeOperations: vi.fn().mockResolvedValue({ v: 1, operations: [] }),
+      setConfig: vi.fn(),
+      removeConfig: vi.fn(),
       loading: false,
       error: undefined,
     },
@@ -172,6 +194,7 @@ const {
         onCreateGoal?: (condition: string) => Promise<void>;
         onOpenSession?: (sessionId: string) => void;
       } | null,
+      workspaceActionOwners: [] as Array<string | undefined>,
     },
     sidebarTokens: [] as Array<number | undefined>,
     rawEnqueuePrompt: vi.fn(() => true),
@@ -180,6 +203,9 @@ const {
     editorFocus: vi.fn(),
     editorInsertText: vi.fn(),
     settingsReload: vi.fn().mockResolvedValue(undefined),
+    workspaceRuntimeStatus,
+    ensureWorkspaceRuntime,
+    workspaceRuntimeSkills,
   };
 });
 
@@ -218,7 +244,10 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   }),
   useTranscriptStore: () => mockStore,
   useWorkspace: () => mockWorkspace,
-  useWorkspaceActions: () => mockWorkspaceActions,
+  useWorkspaceActions: (workspaceCwd?: string) => {
+    testState.workspaceActionOwners.push(workspaceCwd);
+    return mockWorkspaceActions;
+  },
   useMcp: () => mockMcp,
   useWorkspaceEventSignals: () => ({
     artifactsVersion: 0,
@@ -922,6 +951,19 @@ beforeEach(() => {
     workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
   };
   mockWorkspace.client.workspaceByCwd.mockClear();
+  workspaceRuntimeStatus.mockClear();
+  workspaceRuntimeStatus.mockResolvedValue({
+    runtimeLive: true,
+    capabilities: { skills: { state: 'ready' } },
+  });
+  ensureWorkspaceRuntime.mockClear();
+  ensureWorkspaceRuntime.mockResolvedValue({
+    capabilities: { skills: { state: 'ready' } },
+  });
+  workspaceRuntimeSkills.mockReset();
+  workspaceRuntimeSkills.mockImplementation(() =>
+    mockWorkspaceActions.loadSkillsStatus(),
+  );
   testState.prompt = 'hello';
   testState.inputAnnotations = undefined;
   testState.promptImages = undefined;
@@ -933,6 +975,7 @@ beforeEach(() => {
   testState.latestAskUserQuestionKeyboardActive = null;
   testState.latestScheduledTasksProps = null;
   testState.latestGoalsProps = null;
+  testState.workspaceActionOwners.length = 0;
   sidebarTokens.length = 0;
   rawEnqueuePrompt.mockClear();
   editorClear.mockClear();
@@ -967,6 +1010,8 @@ beforeEach(() => {
   mockStore.reset.mockClear();
   mockStore.dispatch.mockClear();
   mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({ skills: [] });
+  mockWorkspaceActions.ensureRuntime.mockClear();
+  mockWorkspaceActions.ensureRuntime.mockResolvedValue({});
   mockWorkspaceActions.loadProviders.mockResolvedValue({ current: null });
   mockWorkspaceActions.loadPreflight.mockResolvedValue(null);
   mockWorkspaceActions.loadEnv.mockResolvedValue(null);
@@ -978,6 +1023,17 @@ beforeEach(() => {
   mockMcp.reloadConfig.mockClear();
   mockMcp.reloadConfig.mockResolvedValue({ accepted: true });
   mockMcp.reload.mockReset();
+  mockMcp.reload.mockResolvedValue(undefined);
+  mockMcp.loadStatus.mockReset();
+  mockMcp.loadConfig.mockReset();
+  mockMcp.loadConfig.mockResolvedValue({
+    v: 1,
+    effective: {},
+    user: {},
+    workspace: {},
+    disabledServers: [],
+  });
+  mockMcp.waitForRuntime.mockReset();
   mockMcp.loadTools.mockReset();
   mockMcp.loadResources.mockReset();
   mockMcp.restartServer.mockReset();
@@ -987,6 +1043,11 @@ beforeEach(() => {
     durationMs: 1,
   });
   mockMcp.manageServer.mockReset();
+  mockMcp.operationStatus.mockReset();
+  mockMcp.activeOperations.mockReset();
+  mockMcp.activeOperations.mockResolvedValue({ v: 1, operations: [] });
+  mockMcp.setConfig.mockReset();
+  mockMcp.removeConfig.mockReset();
   vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
@@ -1000,6 +1061,14 @@ afterEach(() => {
 });
 
 describe('App session callbacks', () => {
+  it('scopes workspace actions to the connected session workspace', () => {
+    mockConnection.workspaceCwd = '/work/secondary';
+
+    renderApp();
+
+    expect(testState.workspaceActionOwners).toContain('/work/secondary');
+  });
+
   it('submits through a disconnected session when prompt SSE restart is enabled', async () => {
     mockConnection.status = 'disconnected';
     renderApp({ restartSseOnPrompt: true });
@@ -1063,9 +1132,10 @@ describe('App session callbacks', () => {
   });
 
   it('reloads skills from the target workspace when starting a new session', async () => {
-    const { container } = renderApp({
+    const props = {
       lockedWorkspaceCwd: '/work/secondary',
-    });
+    };
+    const { container, rerender } = renderApp(props);
     await flush();
     mockWorkspace.client.workspaceByCwd.mockClear();
 
@@ -1075,6 +1145,9 @@ describe('App session callbacks', () => {
         ?.click();
       await Promise.resolve();
     });
+    mockConnection.sessionId = undefined;
+    rerender(props);
+    await flush();
 
     expect(mockWorkspace.client.workspaceByCwd).toHaveBeenCalledWith(
       '/work/secondary',
@@ -1193,7 +1266,7 @@ describe('App session callbacks', () => {
     mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({
       skills: [{ name: 'review', description: 'Review', status: 'ok' }],
     });
-    const { container } = renderApp();
+    const { container, rerender } = renderApp();
     await flush();
     expect(testState.latestChatEditorProps?.skills).toEqual([
       { name: 'review', description: 'Review' },
@@ -1211,29 +1284,33 @@ describe('App session callbacks', () => {
         ?.click();
       await Promise.resolve();
     });
+    mockConnection.sessionId = undefined;
+    rerender();
+    await flush();
+    await flush();
 
     expect(testState.latestChatEditorProps?.skills).toEqual([]);
     expect(testState.latestChatEditorProps?.commands).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ name: 'review' })]),
     );
-    expect(mockWorkspaceActions.loadSkillsStatus).toHaveBeenCalledTimes(2);
+    expect(workspaceRuntimeSkills).toHaveBeenCalledTimes(1);
   });
 
-  it('adds an enabled skill command when starting a new session', async () => {
+  it('adds a runtime-loaded skill command when starting a new session', async () => {
     mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({
       skills: [{ name: 'review', description: 'Review', status: 'disabled' }],
     });
-    const { container } = renderApp();
+    const { container, rerender } = renderApp();
     await flush();
     expect(testState.latestChatEditorProps?.commands).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ name: 'review' })]),
     );
 
-    mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({
+    workspaceRuntimeSkills.mockResolvedValue({
       skills: [
         {
-          name: 'review',
-          description: 'Review',
+          name: 'design',
+          description: 'Design',
           argumentHint: '<path>',
           status: 'ok',
         },
@@ -1245,14 +1322,47 @@ describe('App session callbacks', () => {
         ?.click();
       await Promise.resolve();
     });
+    mockConnection.sessionId = undefined;
+    rerender();
+    await flush();
+    await flush();
 
     expect(testState.latestChatEditorProps?.commands).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: 'review',
+          name: 'design',
           argumentHint: '<path>',
           source: 'skill',
         }),
+      ]),
+    );
+  });
+
+  it('waits for runtime initialization before refreshing new-task skills', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspaceActions.loadSkillsStatus.mockResolvedValue({
+      skills: [{ name: 'review', description: 'Review', status: 'disabled' }],
+    });
+    workspaceRuntimeStatus.mockResolvedValue({
+      runtimeLive: false,
+      capabilities: { skills: { state: 'not_started' } },
+    });
+    mockWorkspaceActions.ensureRuntime.mockResolvedValue({
+      capabilities: { skills: { state: 'ready' } },
+    });
+    workspaceRuntimeSkills.mockResolvedValue({
+      skills: [{ name: 'design', description: 'Design', status: 'ok' }],
+    });
+
+    renderApp();
+    await flush();
+    await flush();
+
+    expect(mockWorkspaceActions.ensureRuntime).toHaveBeenCalledOnce();
+    expect(workspaceRuntimeSkills).toHaveBeenCalledOnce();
+    expect(testState.latestChatEditorProps?.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'design', source: 'skill' }),
       ]),
     );
   });
@@ -2384,6 +2494,7 @@ describe('App session callbacks', () => {
     expect(
       container.querySelector('[data-testid="extensions-manager-page"]'),
     ).not.toBeNull();
+    expect(mockWorkspaceActions.ensureRuntime).toHaveBeenCalledOnce();
     const backButton = container.querySelector(
       '[data-testid="extensions-manager-back"]',
     );
@@ -2405,6 +2516,81 @@ describe('App session callbacks', () => {
       container.querySelector('[data-testid="extensions-manager-page"]'),
     ).toBeNull();
     expect(editorFocus).toHaveBeenCalled();
+  });
+
+  it('reloads MCP status when the selected workspace changes', async () => {
+    mockConnection.sessionId = undefined;
+    mockWorkspace.capabilities = {
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true },
+        { id: 'secondary', cwd: '/work/secondary', primary: false },
+      ],
+    };
+    mockWorkspaceActions.loadMcpStatus
+      .mockResolvedValueOnce({
+        workspaceCwd: '/workspace',
+        initialized: true,
+        discoveryState: 'completed',
+        servers: [],
+      })
+      .mockResolvedValueOnce({
+        workspaceCwd: '/work/secondary',
+        initialized: true,
+        discoveryState: 'completed',
+        servers: [],
+      });
+    const { container } = renderApp();
+    await flush();
+
+    testState.prompt = '/mcp';
+    await clickSubmit(container);
+    await flush();
+    expect(mockWorkspaceActions.loadMcpStatus).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSelectWorkspace?.('/work/secondary');
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(mockWorkspaceActions.loadMcpStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes new-task skills after returning from a management page', async () => {
+    mockConnection.sessionId = undefined;
+    const { container } = renderApp();
+    await flush();
+    await flush();
+
+    testState.prompt = '/extensions manage';
+    await clickSubmit(container);
+    await flush();
+
+    workspaceRuntimeSkills.mockResolvedValue({
+      skills: [
+        {
+          name: 'design',
+          description: 'Design',
+          status: 'ok',
+        },
+      ],
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="extensions-manager-back"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    await flush();
+    await flush();
+
+    expect(testState.latestChatEditorProps?.commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'design', source: 'skill' }),
+      ]),
+    );
   });
 
   it.each(['/skills', '/skills detail', '/skills details'])(
@@ -2456,6 +2642,7 @@ describe('App session callbacks', () => {
     ]);
     expect(extensionsTab?.getAttribute('aria-selected')).toBe('true');
     expect(document.activeElement).toBe(extensionsTab);
+    expect(mockWorkspaceActions.ensureRuntime).toHaveBeenCalledOnce();
 
     await act(async () => {
       tabs?.[2]?.focus();
@@ -2467,12 +2654,19 @@ describe('App session callbacks', () => {
         ?.querySelectorAll<HTMLButtonElement>('button[role="tab"]')[2]
         ?.getAttribute('aria-selected'),
     ).toBe('true');
+    expect(mockWorkspaceActions.ensureRuntime).toHaveBeenCalledOnce();
   });
 
-  it('only shows server startup progress during MCP discovery', async () => {
+  it('shows the configured server with explicit runtime startup state', async () => {
     mockWorkspaceActions.loadMcpStatus.mockResolvedValue({
       initialized: true,
       discoveryState: 'starting',
+      workspaceCwd: '/workspace',
+      source: 'live',
+      runtimeEpoch: 1,
+      runtimeState: 'starting',
+      coordinatorRuntimeEpoch: 1,
+      capabilityRuntimeEpoch: 1,
       servers: [
         {
           name: 'filesystem',
@@ -2483,6 +2677,13 @@ describe('App session callbacks', () => {
         },
       ],
     });
+    mockMcp.loadConfig.mockResolvedValue({
+      v: 1,
+      effective: { filesystem: { command: 'filesystem' } },
+      user: {},
+      workspace: { filesystem: { command: 'filesystem' } },
+      disabledServers: [],
+    });
     const { container } = renderApp();
     await flush();
 
@@ -2490,12 +2691,40 @@ describe('App session callbacks', () => {
     await clickSubmit(container);
     await flush();
 
-    expect(container.textContent).toContain(
-      'MCP servers are starting up (1 initializing)',
-    );
+    expect(container.textContent).toContain('Workspace runtime starting');
     expect(container.textContent).not.toContain('Loading MCP tools...');
     expect(
       container.querySelector('[role="button"][aria-label="filesystem"]'),
+    ).toHaveProperty('tabIndex', 0);
+  });
+
+  it('opens MCP configuration when the workspace runtime is unavailable', async () => {
+    mockWorkspaceActions.loadMcpStatus.mockRejectedValue(
+      new Error('Workspace is not trusted'),
+    );
+    mockMcp.initialize.mockRejectedValue(new Error('Workspace is not trusted'));
+    mockMcp.loadConfig.mockResolvedValue({
+      v: 1,
+      effective: { docs: { command: 'docs-server' } },
+      user: {},
+      workspace: { docs: { command: 'docs-server' } },
+      disabledServers: [],
+    });
+    const { container } = renderApp();
+    await flush();
+
+    testState.prompt = '/mcp';
+    await clickSubmit(container);
+    await flush();
+
+    expect(
+      container
+        .querySelector('[data-testid="inline-panel"]')
+        ?.getAttribute('aria-label'),
+    ).toBe('MCP Servers');
+    expect(container.textContent).toContain('Workspace is not trusted');
+    expect(
+      container.querySelector('[role="button"][aria-label="docs"]'),
     ).toHaveProperty('tabIndex', 0);
   });
 
@@ -2504,6 +2733,11 @@ describe('App session callbacks', () => {
       initialized: true,
       discoveryState: 'completed',
       workspaceCwd: '/workspace',
+      source: 'live',
+      runtimeEpoch: 1,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 1,
+      capabilityRuntimeEpoch: 1,
       servers: [
         {
           name: 'filesystem',
@@ -2516,12 +2750,29 @@ describe('App session callbacks', () => {
         },
       ],
     });
+    mockMcp.loadConfig.mockResolvedValue({
+      v: 1,
+      effective: { filesystem: { command: 'filesystem' } },
+      user: {},
+      workspace: { filesystem: { command: 'filesystem' } },
+      disabledServers: [],
+    });
     mockMcp.loadTools.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
       serverName: 'filesystem',
+      initialized: true,
+      runtimeEpoch: 1,
+      acpChannelLive: true,
       tools: [{ name: 'read_file', description: 'Read a file' }],
     });
     mockMcp.loadResources.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
       serverName: 'filesystem',
+      initialized: true,
+      runtimeEpoch: 1,
+      acpChannelLive: true,
       resources: [{ uri: 'file:///README.md', name: 'README' }],
     });
     const { container } = renderApp();
@@ -2569,7 +2820,7 @@ describe('App session callbacks', () => {
     expect(mockMcp.restartServer).toHaveBeenCalledWith('filesystem');
   });
 
-  it('polls workspace MCP status until browser authentication completes', async () => {
+  it('polls the workspace MCP operation until browser authentication completes', async () => {
     vi.useFakeTimers();
     const disconnectedServer = {
       name: 'yuque',
@@ -2584,6 +2835,11 @@ describe('App session callbacks', () => {
       initialized: true,
       discoveryState: 'completed',
       workspaceCwd: '/workspace',
+      source: 'live',
+      runtimeEpoch: 1,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 1,
+      capabilityRuntimeEpoch: 1,
       servers: [disconnectedServer],
     });
     mockMcp.loadTools.mockResolvedValue({ serverName: 'yuque', tools: [] });
@@ -2592,31 +2848,54 @@ describe('App session callbacks', () => {
       action: 'authenticate',
       ok: true,
       pending: true,
+      operationId: 'op-auth',
+      deadlineAt: '2099-01-01T00:00:00.000Z',
       messages: ['Open the browser to authenticate.'],
       authUrl: 'https://example.com/oauth',
     });
-    mockMcp.reload
+    const authenticationOperation = {
+      v: 1 as const,
+      operationId: 'op-auth',
+      workspaceCwd: '/workspace',
+      kind: 'mcp' as const,
+      action: 'authenticate',
+      target: 'yuque',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      deadlineAt: '2099-01-01T00:00:00.000Z',
+      authUrl: 'https://example.com/oauth',
+    };
+    mockMcp.operationStatus
       .mockResolvedValueOnce({
-        initialized: true,
-        discoveryState: 'completed',
-        workspaceCwd: '/workspace',
-        servers: [
-          { ...disconnectedServer, authenticationState: 'pending' as const },
-        ],
+        ...authenticationOperation,
+        state: 'waiting_for_input' as const,
       })
       .mockResolvedValueOnce({
-        initialized: true,
-        discoveryState: 'completed',
-        workspaceCwd: '/workspace',
-        servers: [
-          {
-            ...disconnectedServer,
-            mcpStatus: 'connected' as const,
-            hasOAuthTokens: true,
-            authenticationState: 'succeeded' as const,
-          },
-        ],
+        ...authenticationOperation,
+        state: 'waiting_for_input' as const,
+      })
+      .mockResolvedValueOnce({
+        ...authenticationOperation,
+        state: 'succeeded' as const,
       });
+    mockMcp.loadStatus.mockResolvedValue({
+      initialized: true,
+      discoveryState: 'completed',
+      workspaceCwd: '/workspace',
+      source: 'live',
+      runtimeEpoch: 1,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 1,
+      capabilityRuntimeEpoch: 1,
+      servers: [
+        {
+          ...disconnectedServer,
+          mcpStatus: 'connected' as const,
+          hasOAuthTokens: true,
+          authenticationState: 'succeeded' as const,
+        },
+      ],
+    });
     const { container } = renderApp();
     await flush();
 
@@ -2654,19 +2933,24 @@ describe('App session callbacks', () => {
     expect(container.textContent).toContain(
       'Open the browser to authenticate.',
     );
-    expect(mockMcp.reload).not.toHaveBeenCalled();
+    expect(mockMcp.operationStatus).toHaveBeenCalledTimes(1);
+    expect(mockMcp.loadStatus).not.toHaveBeenCalled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_500);
     });
-    expect(mockMcp.reload).toHaveBeenCalledTimes(1);
-    expect(container.textContent).toContain('Authenticating');
+    expect(mockMcp.operationStatus).toHaveBeenCalledTimes(2);
+    expect(mockMcp.loadStatus).not.toHaveBeenCalled();
+    expect(container.textContent).toContain(
+      "Starting OAuth authentication for MCP server 'yuque'",
+    );
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_500);
     });
     await flush();
-    expect(mockMcp.reload).toHaveBeenCalledTimes(2);
+    expect(mockMcp.operationStatus).toHaveBeenCalledTimes(3);
+    expect(mockMcp.loadStatus).toHaveBeenCalledOnce();
     expect(container.textContent).toContain('Authenticate complete.');
   });
 
@@ -2690,6 +2974,11 @@ describe('App session callbacks', () => {
     mockWorkspaceActions.loadMcpStatus.mockResolvedValue({
       initialized: true,
       discoveryState: 'completed',
+      source: 'live',
+      runtimeEpoch: 1,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 1,
+      capabilityRuntimeEpoch: 1,
       servers: [],
     });
     const { container } = renderApp();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2191,28 +2191,59 @@ export function App({
   const [loadedSkillsReady, setLoadedSkillsReady] = useState(false);
   const loadedSkillsRequestRef = useRef(0);
   const reloadLoadedSkills = useCallback(
-    async (workspaceCwd?: string) => {
+    async (workspaceCwd?: string, options?: { reconcileRuntime?: boolean }) => {
       const request = ++loadedSkillsRequestRef.current;
+      const workspaceClient =
+        workspaceCwd && workspace.client
+          ? workspace.client.workspaceByCwd(workspaceCwd)
+          : undefined;
       try {
-        const status =
-          workspaceCwd && workspace.client
-            ? await workspace.client
-                .workspaceByCwd(workspaceCwd)
-                .workspaceSkills()
-            : await workspaceActions.loadSkillsStatus();
+        const status = workspaceClient
+          ? await workspaceClient.workspaceSkills()
+          : await workspaceActions.loadSkillsStatus();
         if (request !== loadedSkillsRequestRef.current) return;
         setLoadedSkills(availableSkillInfos(status));
         setLoadedSkillsReady(true);
       } catch {
         return;
       }
+      if (!options?.reconcileRuntime || !workspaceClient) return;
+      void (async () => {
+        try {
+          const runtime = await workspaceClient.workspaceRuntimeStatus();
+          if (request !== loadedSkillsRequestRef.current) return;
+          if (
+            !runtime.runtimeLive ||
+            runtime.capabilities.skills?.state !== 'ready'
+          ) {
+            const prepared = await workspaceActions.ensureRuntime();
+            if (
+              request !== loadedSkillsRequestRef.current ||
+              prepared.capabilities.skills?.state !== 'ready'
+            ) {
+              return;
+            }
+          }
+          const refreshed = await workspaceClient.workspaceRuntimeSkills();
+          if (request !== loadedSkillsRequestRef.current) return;
+          setLoadedSkills(availableSkillInfos(refreshed));
+          setLoadedSkillsReady(true);
+        } catch (error) {
+          console.warn(
+            '[WebShell] failed to refresh new-task skills from workspace runtime:',
+            error,
+          );
+        }
+      })();
     },
     [workspace.client, workspaceActions],
   );
   useEffect(() => {
-    if (!connected) return;
-    void reloadLoadedSkills(connection.workspaceCwd);
-  }, [connected, connection.workspaceCwd, reloadLoadedSkills]);
+    if (!connected || !activeWorkspaceCwd) return;
+    void reloadLoadedSkills(activeWorkspaceCwd, {
+      reconcileRuntime: !connection.sessionId,
+    });
+  }, [activeWorkspaceCwd, connected, connection.sessionId, reloadLoadedSkills]);
 
   const [modelDialogMode, setModelDialogMode] =
     useState<ModelDialogMode | null>(null);
@@ -2296,6 +2327,27 @@ export function App({
     activePanel === 'mcp' ||
     activePanel === 'skills' ||
     activePanel === 'plugins';
+  const previousManagementPanelActiveRef = useRef(managementPanelActive);
+  useEffect(() => {
+    const wasManagementPanelActive = previousManagementPanelActiveRef.current;
+    previousManagementPanelActiveRef.current = managementPanelActive;
+    if (
+      !wasManagementPanelActive ||
+      managementPanelActive ||
+      connection.sessionId ||
+      !connected ||
+      !activeWorkspaceCwd
+    ) {
+      return;
+    }
+    void reloadLoadedSkills(activeWorkspaceCwd, { reconcileRuntime: true });
+  }, [
+    activeWorkspaceCwd,
+    connected,
+    connection.sessionId,
+    managementPanelActive,
+    reloadLoadedSkills,
+  ]);
   const [managementRuntimeState, setManagementRuntimeState] = useState<{
     status: 'idle' | 'initializing' | 'ready' | 'error';
     error?: string;
@@ -4004,7 +4056,10 @@ export function App({
        */
       opts?: { keepView?: boolean; worktree?: { slug?: string } },
     ) => {
-      const targetWorkspaceCwd = lockedWorkspaceCwd ?? workspaceCwd;
+      const targetWorkspaceCwd =
+        lockedWorkspaceCwd ??
+        workspaceCwd ??
+        workspaces.find((entry) => entry.primary)?.cwd;
       selectedWorkspaceCwdRef.current = targetWorkspaceCwd;
       setSelectedWorkspaceCwd(targetWorkspaceCwd);
       pendingWorktreeRef.current = opts?.worktree;
@@ -4022,10 +4077,7 @@ export function App({
           sessionActions as typeof sessionActions & SessionActionsWithCreate
         ).clearSession();
         focusRequest = scheduleComposerFocus();
-        await Promise.all([
-          clearPromise,
-          reloadLoadedSkills(targetWorkspaceCwd),
-        ]);
+        await clearPromise;
         // Clear after successful clearSession — if it rejects, the old
         // session's worktree state is preserved.
         setSessionWorktree(undefined);
@@ -4043,9 +4095,9 @@ export function App({
       closePanel,
       lockedWorkspaceCwd,
       reportError,
-      reloadLoadedSkills,
       scheduleComposerFocus,
       sessionActions,
+      workspaces,
     ],
   );
   useEffect(
@@ -6779,25 +6831,42 @@ export function App({
                       <DaemonStatusDialog />
                     ) : activePanel === 'extensions' ? (
                       <ExtensionsManagerPage
+                        key={`extensions-${activeWorkspaceCwd ?? 'primary'}`}
                         onClose={closePanel}
+                        workspaceCwd={activeWorkspaceCwd}
                         initialFocusRef={panelHeadingRef}
                       />
                     ) : activePanel === 'mcp' && mcpDialogMessage ? (
                       <McpManagerPage
+                        key={`mcp-${activeWorkspaceCwd ?? 'primary'}`}
                         message={mcpDialogMessage}
+                        workspaceCwd={activeWorkspaceCwd}
                         onClose={() => {
                           clearMcpDialogMessage();
                           closePanel();
                         }}
                       />
+                    ) : activePanel === 'mcp' ? (
+                      <div
+                        className={styles.managementRuntimeState}
+                        role="status"
+                      >
+                        <Spinner />
+                        <span>{t('mcp.discovery.initializing')}</span>
+                      </div>
                     ) : activePanel === 'skills' ? (
                       <SkillsManagerPage
+                        key={`skills-${activeWorkspaceCwd ?? 'primary'}`}
                         onClose={closePanel}
                         onUseSkill={handleUseSkill}
+                        workspaceCwd={activeWorkspaceCwd}
+                        runtimeReady
                       />
                     ) : activePanel === 'plugins' ? (
                       <PluginManagerPage
+                        key={`plugins-${activeWorkspaceCwd ?? 'primary'}`}
                         mcpMessage={mcpDialogMessage}
+                        workspaceCwd={activeWorkspaceCwd}
                         loadMcpMessage={async () => {
                           try {
                             await loadMcpManagerMessage();

--- a/packages/web-shell/client/components/plugins/PluginManagerPage.tsx
+++ b/packages/web-shell/client/components/plugins/PluginManagerPage.tsx
@@ -25,6 +25,7 @@ interface PluginManagerPageProps {
   loadMcpMessage: () => Promise<void>;
   onClose: () => void;
   onUseSkill: (name: string) => void;
+  workspaceCwd?: string;
   initialFocusRef?: Ref<HTMLButtonElement>;
 }
 
@@ -33,6 +34,7 @@ export function PluginManagerPage({
   loadMcpMessage,
   onClose,
   onUseSkill,
+  workspaceCwd,
   initialFocusRef,
 }: PluginManagerPageProps) {
   const { t } = useI18n();
@@ -88,16 +90,19 @@ export function PluginManagerPage({
       <TabsContent value={activeTab} className="mt-0">
         {activeTab === 'extensions' ? (
           <ExtensionsManagerPage
-            key={`extensions-${pageRevision}`}
+            key={`extensions-${workspaceCwd ?? 'primary'}-${pageRevision}`}
             onClose={onClose}
+            workspaceCwd={workspaceCwd}
             embedded={embedded}
           />
         ) : activeTab === 'skills' ? (
           <SkillsManagerPage
-            key={`skills-${pageRevision}`}
+            key={`skills-${workspaceCwd ?? 'primary'}-${pageRevision}`}
             onClose={onClose}
             onUseSkill={onUseSkill}
+            workspaceCwd={workspaceCwd}
             embedded={embedded}
+            runtimeReady
           />
         ) : mcpLoadError ? (
           <Alert variant="destructive" className="mt-4">
@@ -111,9 +116,10 @@ export function PluginManagerPage({
           </Alert>
         ) : mcpMessage && mcpLoaded ? (
           <McpManagerPage
-            key={`mcp-${pageRevision}`}
+            key={`mcp-${workspaceCwd ?? 'primary'}-${pageRevision}`}
             message={mcpMessage}
             onClose={onClose}
+            workspaceCwd={workspaceCwd}
             embedded={embedded}
           />
         ) : (

--- a/packages/web-shell/client/components/skills/SkillsManagerPage.tsx
+++ b/packages/web-shell/client/components/skills/SkillsManagerPage.tsx
@@ -18,11 +18,17 @@ import {
 import { useI18n } from '../../i18n';
 import {
   filterSkills,
+  isSkillInConfigInventory,
+  isSkillRuntimeConfirmed,
+  mergeSkillsInventory,
   preserveSkillSelection,
+  skillMutationActivationPresentation,
   type SkillLevelFilter,
+  type SkillMutationActivation,
   type SkillStatusFilter,
 } from './skills-manager-logic';
 import { Alert, AlertDescription } from '../ui/alert';
+import { ManagementNotice } from '../ui/management-notice';
 import { Badge } from '../ui/badge';
 import {
   Breadcrumb,
@@ -81,7 +87,9 @@ import styles from './SkillsManagerPage.module.css';
 interface SkillsManagerPageProps {
   onClose: () => void;
   onUseSkill: (name: string) => void;
+  workspaceCwd?: string;
   embedded?: EmbeddedManagerPage;
+  runtimeReady?: boolean;
 }
 
 function skillLevelLabel(
@@ -158,20 +166,35 @@ function ManualReferenceBadge({ compact = false }: { compact?: boolean }) {
 export function SkillsManagerPage({
   onClose,
   onUseSkill,
+  workspaceCwd,
   embedded,
+  runtimeReady = false,
 }: SkillsManagerPageProps) {
   const { t } = useI18n();
   const workspace = useWorkspace();
   const {
     status,
-    skills,
+    configStatus,
+    runtimeStatus,
+    skills: fallbackSkills,
     loading,
     error,
-    reload,
+    warning,
+    reloadConfig,
+    reloadRuntime,
+    ensureRuntime,
     setEnabled,
     install,
     remove,
-  } = useSkills({ autoLoad: true });
+  } = useSkills({ autoLoad: true }, workspaceCwd);
+  const skills = useMemo(
+    () =>
+      mergeSkillsInventory(
+        configStatus?.skills ?? fallbackSkills,
+        runtimeStatus,
+      ),
+    [configStatus?.skills, fallbackSkills, runtimeStatus],
+  );
   const canToggleSkills =
     workspace.capabilities?.features.includes('workspace_skill_toggle') ===
     true;
@@ -189,11 +212,16 @@ export function SkillsManagerPage({
   const [busySkill, setBusySkill] = useState<string | null>(null);
   const [installOpen, setInstallOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [listNotice, setListNotice] = useState<string | null>(null);
+  const [listNotice, setListNotice] = useState<{
+    text: string;
+    error: boolean;
+    success?: boolean;
+  } | null>(null);
   const [notice, setNotice] = useState<{
     skillName: string;
     text: string;
     error: boolean;
+    success?: boolean;
   } | null>(null);
   const displayedSkills = useMemo(
     () =>
@@ -207,6 +235,9 @@ export function SkillsManagerPage({
     () => displayedSkills.find((skill) => skill.name === selectedName),
     [displayedSkills, selectedName],
   );
+  const selectedSkillConfigured =
+    selectedSkill !== undefined &&
+    isSkillInConfigInventory(selectedSkill.name, configStatus?.skills ?? []);
   const filteredSkills = useMemo(
     () => filterSkills(displayedSkills, query, levelFilter, statusFilter),
     [displayedSkills, levelFilter, query, statusFilter],
@@ -215,6 +246,7 @@ export function SkillsManagerPage({
     (skill) => skill.status === 'disabled',
   ).length;
   const message = error?.message ?? status?.errors?.[0]?.error;
+  const warningMessage = warning?.message;
   const levelOptions: Array<{
     value: SkillLevelFilter;
     label: string;
@@ -229,6 +261,10 @@ export function SkillsManagerPage({
   useEffect(() => {
     setSelectedName((name) => preserveSkillSelection(name, displayedSkills));
   }, [displayedSkills]);
+
+  useEffect(() => {
+    if (runtimeReady) void reloadRuntime();
+  }, [reloadRuntime, runtimeReady]);
 
   useEffect(() => {
     setStatusOverrides((current) => {
@@ -248,21 +284,89 @@ export function SkillsManagerPage({
     embedded?.onDetailChange(Boolean(selectedSkill));
   }, [embedded, selectedSkill]);
 
+  async function reloadAfterMutation(
+    activation: SkillMutationActivation | undefined,
+  ) {
+    const configReload = reloadConfig();
+    if (activation !== 'applied' && activation !== 'partial') {
+      try {
+        await configReload;
+        return { refreshedRuntime: undefined, refreshError: undefined };
+      } catch (refreshError) {
+        return { refreshedRuntime: undefined, refreshError };
+      }
+    }
+    const [configResult, runtimeResult] = await Promise.allSettled([
+      configReload,
+      reloadRuntime(),
+    ]);
+    return {
+      refreshedRuntime:
+        runtimeResult.status === 'fulfilled' ? runtimeResult.value : undefined,
+      refreshError:
+        configResult.status === 'rejected'
+          ? configResult.reason
+          : runtimeResult.status === 'rejected'
+            ? runtimeResult.reason
+            : undefined,
+    };
+  }
+
+  function refreshFailureMessage(refreshError: unknown): string {
+    return t('skills.refreshAfterMutationFailed', {
+      error:
+        refreshError instanceof Error
+          ? refreshError.message
+          : String(refreshError),
+    });
+  }
+
+  async function refreshSkills(): Promise<void> {
+    await Promise.all([reloadConfig(), ensureRuntime()]);
+  }
+
   async function toggleSkill(skill: DaemonWorkspaceSkillStatus) {
+    if (!isSkillInConfigInventory(skill.name, configStatus?.skills ?? [])) {
+      return;
+    }
     const enabled = skill.status === 'disabled';
     setBusySkill(skill.name);
     setNotice(null);
     try {
-      await setEnabled(skill.name, enabled);
+      const mutation = await setEnabled(skill.name, enabled);
       setStatusOverrides((current) => ({
         ...current,
         [skill.name]: enabled ? 'ok' : 'disabled',
       }));
-      await reload();
+      const { refreshedRuntime, refreshError } = await reloadAfterMutation(
+        mutation.activation,
+      );
+      let presentation = skillMutationActivationPresentation(
+        mutation.activation,
+      );
+      if (
+        refreshError === undefined &&
+        mutation.activation === 'applied' &&
+        !isSkillRuntimeConfirmed(refreshedRuntime, skill.name, enabled)
+      ) {
+        presentation = {
+          messageKey: 'skills.runtimeNotConfirmed',
+          error: true,
+        };
+      }
+      const refreshMessage =
+        refreshError === undefined
+          ? ''
+          : ` ${refreshFailureMessage(refreshError)}`;
+      const error = presentation.error || refreshError !== undefined;
       setNotice({
         skillName: skill.name,
-        text: t(enabled ? 'skills.enabled' : 'skills.disabled'),
-        error: false,
+        text: `${t(enabled ? 'skills.enabled' : 'skills.disabled')} ${t(
+          presentation.messageKey,
+          { activation: mutation.activation ?? 'unknown' },
+        )}${refreshMessage}`,
+        error,
+        success: !error && mutation.activation !== 'deferred',
       });
     } catch (toggleError) {
       setNotice({
@@ -279,9 +383,30 @@ export function SkillsManagerPage({
     request: Parameters<typeof install>[0],
   ): Promise<void> {
     setListNotice(null);
-    await install(request);
-    setListNotice(t('skills.install.succeeded', { name: request.name.trim() }));
-    await reload().catch(() => undefined);
+    const mutation = await install(request);
+    const presentation = skillMutationActivationPresentation(
+      mutation.activation,
+    );
+    setListNotice({
+      text: `${t('skills.install.succeeded', {
+        name: request.name.trim(),
+      })} ${t(presentation.messageKey, {
+        activation: mutation.activation ?? 'unknown',
+      })}`,
+      error: presentation.error,
+      success: !presentation.error && mutation.activation === 'applied',
+    });
+    void reloadAfterMutation(mutation.activation).then(({ refreshError }) => {
+      if (refreshError === undefined) return;
+      setListNotice({
+        text: `${t('skills.install.succeeded', {
+          name: request.name.trim(),
+        })} ${t(presentation.messageKey, {
+          activation: mutation.activation ?? 'unknown',
+        })} ${refreshFailureMessage(refreshError)}`,
+        error: true,
+      });
+    });
   }
 
   async function deleteSkill(): Promise<void> {
@@ -289,11 +414,32 @@ export function SkillsManagerPage({
     const scope = selectedSkill.level === 'project' ? 'workspace' : 'global';
     setBusySkill(selectedSkill.name);
     try {
-      await remove(selectedSkill.name, scope);
+      const mutation = await remove(selectedSkill.name, scope);
+      const presentation = skillMutationActivationPresentation(
+        mutation.activation,
+      );
       setDeleteOpen(false);
       setSelectedName(null);
-      setListNotice(t('skills.delete.succeeded', { name: selectedSkill.name }));
-      await reload().catch(() => undefined);
+      setListNotice({
+        text: `${t('skills.delete.succeeded', {
+          name: selectedSkill.name,
+        })} ${t(presentation.messageKey, {
+          activation: mutation.activation ?? 'unknown',
+        })}`,
+        error: presentation.error,
+        success: !presentation.error && mutation.activation === 'applied',
+      });
+      const { refreshError } = await reloadAfterMutation(mutation.activation);
+      if (refreshError !== undefined) {
+        setListNotice({
+          text: `${t('skills.delete.succeeded', {
+            name: selectedSkill.name,
+          })} ${t(presentation.messageKey, {
+            activation: mutation.activation ?? 'unknown',
+          })} ${refreshFailureMessage(refreshError)}`,
+          error: true,
+        });
+      }
     } catch (deleteError) {
       setDeleteOpen(false);
       setNotice({
@@ -311,7 +457,6 @@ export function SkillsManagerPage({
 
   function returnToList(): void {
     setSelectedName(null);
-    void reload();
   }
 
   const standaloneNavigation = (
@@ -412,77 +557,90 @@ export function SkillsManagerPage({
               <PlayIcon data-icon="inline-start" />
               {t('skills.run')}
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  disabled={busySkill !== null}
-                  aria-label={t('skills.actions')}
-                  data-testid="skill-actions"
-                >
-                  {busySkill === selectedSkill.name ? (
-                    <Spinner />
-                  ) : (
-                    <EllipsisVerticalIcon />
-                  )}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                onCloseAutoFocus={(event) => event.preventDefault()}
-              >
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    disabled={
-                      busySkill !== null ||
-                      !canToggleSkills ||
-                      selectedSkill.userInvocable === false
-                    }
-                    title={
-                      !canToggleSkills
-                        ? t('skills.toggleUnsupported')
-                        : selectedSkill.userInvocable === false
-                          ? t('skills.notToggleable')
-                          : undefined
-                    }
-                    onSelect={() => void toggleSkill(selectedSkill)}
+            {selectedSkillConfigured ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    disabled={busySkill !== null}
+                    aria-label={t('skills.actions')}
+                    data-testid="skill-actions"
                   >
-                    {t(
-                      selectedSkill.status === 'disabled'
-                        ? 'skills.enable'
-                        : 'skills.disable',
+                    {busySkill === selectedSkill.name ? (
+                      <Spinner />
+                    ) : (
+                      <EllipsisVerticalIcon />
                     )}
-                  </DropdownMenuItem>
-                  {canManageSkills &&
-                  (selectedSkill.level === 'project' ||
-                    selectedSkill.level === 'user') ? (
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  onCloseAutoFocus={(event) => event.preventDefault()}
+                >
+                  <DropdownMenuGroup>
                     <DropdownMenuItem
-                      variant="destructive"
-                      disabled={busySkill !== null}
-                      onSelect={() => setDeleteOpen(true)}
+                      disabled={
+                        busySkill !== null ||
+                        !canToggleSkills ||
+                        selectedSkill.userInvocable === false
+                      }
+                      title={
+                        !canToggleSkills
+                          ? t('skills.toggleUnsupported')
+                          : selectedSkill.userInvocable === false
+                            ? t('skills.notToggleable')
+                            : undefined
+                      }
+                      onSelect={() => void toggleSkill(selectedSkill)}
                     >
-                      {t('skills.delete.action')}
+                      {t(
+                        selectedSkill.status === 'disabled'
+                          ? 'skills.enable'
+                          : 'skills.disable',
+                      )}
                     </DropdownMenuItem>
-                  ) : null}
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                    {canManageSkills &&
+                    (selectedSkill.level === 'project' ||
+                      selectedSkill.level === 'user') ? (
+                      <DropdownMenuItem
+                        variant="destructive"
+                        disabled={busySkill !== null}
+                        onSelect={() => setDeleteOpen(true)}
+                      >
+                        {t('skills.delete.action')}
+                      </DropdownMenuItem>
+                    ) : null}
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
           </div>
 
           {notice?.skillName === selectedSkill.name ? (
-            <Alert variant={notice.error ? 'destructive' : 'default'}>
-              {notice.error ? <AlertCircleIcon /> : <InfoIcon />}
-              <AlertDescription>{notice.text}</AlertDescription>
+            <ManagementNotice
+              tone={
+                notice.error ? 'error' : notice.success ? 'success' : 'info'
+              }
+              noticeKey={notice.text}
+              closeLabel={t('common.close')}
+              onDismiss={() => setNotice(null)}
+            >
+              {notice.text}
+            </ManagementNotice>
+          ) : null}
+
+          {selectedSkill.error ? (
+            <Alert variant="destructive">
+              <AlertCircleIcon />
+              <AlertDescription>{selectedSkill.error}</AlertDescription>
             </Alert>
           ) : null}
 
-          {message || selectedSkill.error ? (
-            <Alert variant="destructive">
-              <AlertCircleIcon />
-              <AlertDescription>
-                {selectedSkill.error || message}
-              </AlertDescription>
+          {warningMessage ? (
+            <Alert>
+              <InfoIcon />
+              <AlertDescription>{warningMessage}</AlertDescription>
             </Alert>
           ) : null}
 
@@ -580,6 +738,11 @@ export function SkillsManagerPage({
                 disabled: disabledCount,
               })}
             </p>
+            {runtimeStatus?.source && runtimeStatus.source !== 'live' ? (
+              <Badge variant="secondary" className="mt-2">
+                {t(`skills.source.${runtimeStatus.source}`)}
+              </Badge>
+            ) : null}
           </div>
           <div className="flex gap-2">
             {canManageSkills ? (
@@ -591,7 +754,7 @@ export function SkillsManagerPage({
             <Button
               variant="outline"
               disabled={loading}
-              onClick={() => void reload()}
+              onClick={() => void refreshSkills()}
             >
               {loading ? (
                 <Spinner data-icon="inline-start" />
@@ -610,11 +773,37 @@ export function SkillsManagerPage({
           </Alert>
         ) : null}
 
-        {listNotice ? (
+        {warningMessage ? (
           <Alert>
             <InfoIcon />
-            <AlertDescription>{listNotice}</AlertDescription>
+            <AlertDescription>{warningMessage}</AlertDescription>
           </Alert>
+        ) : null}
+
+        {runtimeStatus?.source && runtimeStatus.source !== 'live' ? (
+          <Alert>
+            <InfoIcon />
+            <AlertDescription>
+              {t(`skills.source.${runtimeStatus.source}.description`)}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {listNotice ? (
+          <ManagementNotice
+            tone={
+              listNotice.error
+                ? 'error'
+                : listNotice.success
+                  ? 'success'
+                  : 'info'
+            }
+            noticeKey={listNotice.text}
+            closeLabel={t('common.close')}
+            onDismiss={() => setListNotice(null)}
+          >
+            {listNotice.text}
+          </ManagementNotice>
         ) : null}
 
         <div className="relative">

--- a/packages/web-shell/client/components/skills/skills-manager-logic.test.ts
+++ b/packages/web-shell/client/components/skills/skills-manager-logic.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { DaemonWorkspaceSkillStatus } from '@qwen-code/webui/daemon-react-sdk';
-import { filterSkills, preserveSkillSelection } from './skills-manager-logic';
+import {
+  filterSkills,
+  isSkillInConfigInventory,
+  isSkillRuntimeConfirmed,
+  isSkillsRuntimeCurrent,
+  mergeSkillsInventory,
+  preserveSkillSelection,
+  skillMutationActivationPresentation,
+} from './skills-manager-logic';
 
 const skills: DaemonWorkspaceSkillStatus[] = [
   {
@@ -54,5 +62,131 @@ describe('skills manager logic', () => {
   it('preserves only a selection that still exists', () => {
     expect(preserveSkillSelection('review', skills)).toBe('review');
     expect(preserveSkillSelection('removed', skills)).toBeNull();
+  });
+
+  it('only treats Skills present in config inventory as mutable', () => {
+    const configuredSkills = skills.slice(1);
+    expect(isSkillInConfigInventory('ReViEw', configuredSkills)).toBe(true);
+    expect(isSkillInConfigInventory('frontend-design', configuredSkills)).toBe(
+      false,
+    );
+  });
+
+  it('only confirms toggles from the live runtime catalog', () => {
+    const currentRuntime = {
+      v: 1 as const,
+      workspaceCwd: '/ws',
+      initialized: true,
+      runtimeEpoch: 7,
+      source: 'live' as const,
+      skills,
+      runtimeState: 'ready' as const,
+      coordinatorRuntimeEpoch: 7,
+      capabilityRuntimeEpoch: 7,
+      runtimeCatalogEpoch: 7,
+      runtimeCatalogInitialized: true,
+      runtimeCatalogSource: 'live' as const,
+      runtimeSkills: skills,
+    };
+    expect(isSkillRuntimeConfirmed(currentRuntime, 'review', true)).toBe(true);
+    expect(
+      isSkillRuntimeConfirmed(
+        {
+          ...currentRuntime,
+          capabilityRuntimeEpoch: 6,
+        },
+        'review',
+        true,
+      ),
+    ).toBe(false);
+    expect(isSkillRuntimeConfirmed(undefined, 'review', true)).toBe(false);
+  });
+
+  it('requires a ready, initialized Catalog from the current epoch', () => {
+    const status = {
+      v: 1 as const,
+      workspaceCwd: '/ws',
+      initialized: true,
+      source: 'live' as const,
+      skills,
+      runtimeState: 'ready' as const,
+      coordinatorRuntimeEpoch: 9,
+      capabilityRuntimeEpoch: 9,
+      runtimeCatalogEpoch: 9,
+      runtimeCatalogInitialized: true,
+      runtimeCatalogSource: 'live' as const,
+      runtimeSkills: skills,
+    };
+
+    expect(isSkillsRuntimeCurrent(status)).toBe(true);
+    expect(isSkillsRuntimeCurrent({ ...status, runtimeCatalogEpoch: 8 })).toBe(
+      false,
+    );
+    expect(
+      isSkillsRuntimeCurrent({ ...status, runtimeCatalogInitialized: false }),
+    ).toBe(false);
+    expect(isSkillsRuntimeCurrent({ ...status, runtimeState: 'stale' })).toBe(
+      false,
+    );
+  });
+
+  it('keeps config activation authoritative when merging a live Catalog', () => {
+    const configured = [
+      {
+        ...skills[1],
+        installedPath: '/home/user/.qwen/skills/review/SKILL.md',
+      },
+    ];
+    const currentRuntime = {
+      v: 1 as const,
+      workspaceCwd: '/ws',
+      initialized: true,
+      source: 'live' as const,
+      skills,
+      runtimeState: 'ready' as const,
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+      runtimeCatalogEpoch: 4,
+      runtimeCatalogInitialized: true,
+      runtimeCatalogSource: 'live' as const,
+      runtimeSkills: [{ ...skills[1], status: 'disabled' as const }, skills[0]],
+    };
+
+    expect(
+      mergeSkillsInventory(configured, {
+        ...currentRuntime,
+        runtimeState: 'stale',
+      }),
+    ).toEqual(configured);
+    expect(mergeSkillsInventory(configured, currentRuntime)).toEqual([
+      {
+        ...skills[1],
+        installedPath: '/home/user/.qwen/skills/review/SKILL.md',
+      },
+      skills[0],
+    ]);
+  });
+
+  it('distinguishes durable skill mutations from runtime activation', () => {
+    expect(skillMutationActivationPresentation('applied')).toEqual({
+      messageKey: 'skills.activation.applied',
+      error: false,
+    });
+    expect(skillMutationActivationPresentation('reconciling')).toEqual({
+      messageKey: 'skills.activation.reconciling',
+      error: false,
+    });
+    expect(skillMutationActivationPresentation('deferred')).toEqual({
+      messageKey: 'skills.activation.deferred',
+      error: false,
+    });
+    expect(skillMutationActivationPresentation('partial')).toEqual({
+      messageKey: 'skills.activation.partial',
+      error: true,
+    });
+    expect(skillMutationActivationPresentation(undefined)).toEqual({
+      messageKey: 'skills.runtimeNotConfirmed',
+      error: true,
+    });
   });
 });

--- a/packages/web-shell/client/components/skills/skills-manager-logic.ts
+++ b/packages/web-shell/client/components/skills/skills-manager-logic.ts
@@ -1,7 +1,36 @@
-import type { DaemonWorkspaceSkillStatus } from '@qwen-code/webui/daemon-react-sdk';
+import type {
+  DaemonWorkspaceActions,
+  DaemonWorkspaceSkillStatus,
+} from '@qwen-code/webui/daemon-react-sdk';
+
+type SkillsStatus = Awaited<
+  ReturnType<DaemonWorkspaceActions['loadSkillsStatus']>
+>;
 
 export type SkillLevelFilter = 'all' | DaemonWorkspaceSkillStatus['level'];
 export type SkillStatusFilter = 'all' | 'enabled' | 'disabled';
+export type SkillMutationActivation = NonNullable<
+  Awaited<
+    ReturnType<DaemonWorkspaceActions['installWorkspaceSkill']>
+  >['activation']
+>;
+
+export function skillMutationActivationPresentation(
+  activation: SkillMutationActivation | undefined,
+): { messageKey: string; error: boolean } {
+  switch (activation) {
+    case 'applied':
+      return { messageKey: 'skills.activation.applied', error: false };
+    case 'reconciling':
+      return { messageKey: 'skills.activation.reconciling', error: false };
+    case 'deferred':
+      return { messageKey: 'skills.activation.deferred', error: false };
+    case 'partial':
+      return { messageKey: 'skills.activation.partial', error: true };
+    default:
+      return { messageKey: 'skills.runtimeNotConfirmed', error: true };
+  }
+}
 
 export function filterSkills(
   skills: readonly DaemonWorkspaceSkillStatus[],
@@ -24,4 +53,63 @@ export function preserveSkillSelection(
   skills: readonly DaemonWorkspaceSkillStatus[],
 ): string | null {
   return name && skills.some((skill) => skill.name === name) ? name : null;
+}
+
+export function isSkillInConfigInventory(
+  skillName: string,
+  configuredSkills: readonly DaemonWorkspaceSkillStatus[],
+): boolean {
+  const normalizedName = skillName.trim().toLowerCase();
+  return configuredSkills.some(
+    (skill) => skill.name.trim().toLowerCase() === normalizedName,
+  );
+}
+
+export function isSkillsRuntimeCurrent(
+  status: SkillsStatus | undefined,
+): boolean {
+  const epoch = status?.coordinatorRuntimeEpoch;
+  return (
+    status?.runtimeState === 'ready' &&
+    epoch !== undefined &&
+    status.capabilityRuntimeEpoch === epoch &&
+    status.runtimeCatalogEpoch === epoch &&
+    status.runtimeCatalogInitialized === true &&
+    status.runtimeCatalogSource === 'live'
+  );
+}
+
+export function mergeSkillsInventory(
+  configuredSkills: readonly DaemonWorkspaceSkillStatus[],
+  runtimeStatus: SkillsStatus | undefined,
+): DaemonWorkspaceSkillStatus[] {
+  if (!isSkillsRuntimeCurrent(runtimeStatus)) return [...configuredSkills];
+
+  const runtimeSkills = runtimeStatus?.runtimeSkills ?? [];
+  const runtimeByName = new Map(
+    runtimeSkills.map((skill) => [skill.name.toLowerCase(), skill]),
+  );
+  const merged = configuredSkills.map((configured) => {
+    const runtime = runtimeByName.get(configured.name.toLowerCase());
+    if (!runtime) return configured;
+    runtimeByName.delete(configured.name.toLowerCase());
+    return {
+      ...runtime,
+      ...configured,
+      installedPath: configured.installedPath ?? runtime.installedPath,
+    };
+  });
+  return [...merged, ...runtimeByName.values()];
+}
+
+export function isSkillRuntimeConfirmed(
+  status: SkillsStatus | undefined,
+  skillName: string,
+  enabled: boolean,
+): boolean {
+  if (!isSkillsRuntimeCurrent(status)) return false;
+  const skill = status?.runtimeSkills?.find(
+    (candidate) => candidate.name === skillName,
+  );
+  return skill !== undefined && (skill.status !== 'disabled') === enabled;
 }

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -96,6 +96,15 @@ interface MockSession {
   }) => AsyncGenerator<DaemonEvent, void, unknown>;
 }
 
+interface MockWorkspaceClient {
+  workspaceProviders: () => Promise<unknown>;
+  workspaceSkills: () => Promise<unknown>;
+  workspaceRuntimeSkills: () => Promise<unknown>;
+  workspaceRuntimeStatus: () => Promise<unknown>;
+  ensureWorkspaceRuntime: () => Promise<unknown>;
+  workspaceGit: () => Promise<unknown>;
+}
+
 interface MockClient {
   createOrAttachSession: (req: unknown) => Promise<MockSession>;
   capabilities: () => Promise<unknown>;
@@ -110,7 +119,7 @@ interface MockClient {
   workspaceAcpStatus: () => Promise<unknown>;
   workspaceAcpPreheat: () => Promise<unknown>;
   workspaceGit: () => Promise<unknown>;
-  workspaceByCwd: (workspaceCwd: string) => Pick<MockClient, 'workspaceGit'>;
+  workspaceByCwd: (workspaceCwd: string) => MockWorkspaceClient;
   workspaceTools: () => Promise<unknown>;
   setWorkspaceToolEnabled: () => Promise<unknown>;
   workspaceMemory: () => Promise<unknown>;
@@ -148,6 +157,7 @@ const sdkMocks = vi.hoisted(() => {
   const sessions: MockSession[] = [];
   const capabilities = vi.fn();
   const workspaceProviders = vi.fn();
+  const singularWorkspaceProviders = vi.fn();
   const listWorkspaceSessions = vi.fn();
   const closeSession = vi.fn();
   const setSessionApprovalMode = vi.fn();
@@ -155,10 +165,21 @@ const sdkMocks = vi.hoisted(() => {
   const workspaceMcpTools = vi.fn();
   const restartMcpServer = vi.fn();
   const workspaceSkills = vi.fn();
+  const singularWorkspaceSkills = vi.fn();
+  const workspaceRuntimeStatus = vi.fn();
+  const ensureWorkspaceRuntime = vi.fn();
   const workspaceAcpStatus = vi.fn();
   const workspaceAcpPreheat = vi.fn();
   const workspaceGit = vi.fn();
-  const workspaceByCwd = vi.fn((_workspaceCwd: string) => ({ workspaceGit }));
+  const singularWorkspaceGit = vi.fn();
+  const workspaceByCwd = vi.fn((_workspaceCwd: string) => ({
+    workspaceProviders,
+    workspaceSkills,
+    workspaceRuntimeSkills: workspaceSkills,
+    workspaceRuntimeStatus,
+    ensureWorkspaceRuntime,
+    workspaceGit,
+  }));
   const workspaceTools = vi.fn();
   const setWorkspaceToolEnabled = vi.fn();
   const workspaceMemory = vi.fn();
@@ -180,17 +201,17 @@ const sdkMocks = vi.hoisted(() => {
       MockDaemonSessionClient.createOrAttach(this, req),
     );
     capabilities = capabilities;
-    workspaceProviders = workspaceProviders;
+    workspaceProviders = singularWorkspaceProviders;
     listWorkspaceSessions = listWorkspaceSessions;
     closeSession = closeSession;
     setSessionApprovalMode = setSessionApprovalMode;
     workspaceMcp = workspaceMcp;
     workspaceMcpTools = workspaceMcpTools;
     restartMcpServer = restartMcpServer;
-    workspaceSkills = workspaceSkills;
+    workspaceSkills = singularWorkspaceSkills;
     workspaceAcpStatus = workspaceAcpStatus;
     workspaceAcpPreheat = workspaceAcpPreheat;
-    workspaceGit = workspaceGit;
+    workspaceGit = singularWorkspaceGit;
     workspaceByCwd = workspaceByCwd;
     workspaceTools = workspaceTools;
     setWorkspaceToolEnabled = setWorkspaceToolEnabled;
@@ -234,10 +255,15 @@ const sdkMocks = vi.hoisted(() => {
     sessions,
     capabilities,
     workspaceProviders,
+    singularWorkspaceProviders,
     workspaceSkills,
+    singularWorkspaceSkills,
+    workspaceRuntimeStatus,
+    ensureWorkspaceRuntime,
     workspaceAcpStatus,
     workspaceAcpPreheat,
     workspaceGit,
+    singularWorkspaceGit,
     workspaceByCwd,
     MockDaemonClient,
     MockDaemonSessionClient,
@@ -260,6 +286,7 @@ const sdkMocks = vi.hoisted(() => {
         initialized: true,
         providers: [],
       });
+      singularWorkspaceProviders.mockReset();
       listWorkspaceSessions.mockReset();
       listWorkspaceSessions.mockResolvedValue([]);
       closeSession.mockReset();
@@ -286,7 +313,38 @@ const sdkMocks = vi.hoisted(() => {
         v: 1,
         workspaceCwd: '/mock-workspace',
         initialized: true,
+        source: 'live',
+        runtimeEpoch: 1,
         skills: [],
+      });
+      singularWorkspaceSkills.mockReset();
+      workspaceRuntimeStatus.mockReset();
+      workspaceRuntimeStatus.mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/mock-workspace',
+        state: 'idle',
+        runtimeLive: true,
+        runtimeEpoch: 1,
+        capabilities: {
+          skills: {
+            state: 'ready',
+            runtimeEpoch: 1,
+          },
+        },
+      });
+      ensureWorkspaceRuntime.mockReset();
+      ensureWorkspaceRuntime.mockResolvedValue({
+        v: 1,
+        workspaceCwd: '/mock-workspace',
+        state: 'idle',
+        runtimeLive: true,
+        runtimeEpoch: 1,
+        capabilities: {
+          skills: {
+            state: 'ready',
+            runtimeEpoch: 1,
+          },
+        },
       });
       workspaceAcpStatus.mockReset();
       workspaceAcpStatus.mockResolvedValue({ channelLive: true });
@@ -302,8 +360,14 @@ const sdkMocks = vi.hoisted(() => {
         workspaceCwd: '/mock-workspace',
         branch: 'main',
       });
+      singularWorkspaceGit.mockReset();
       workspaceByCwd.mockReset();
       workspaceByCwd.mockImplementation((_workspaceCwd: string) => ({
+        workspaceProviders,
+        workspaceSkills,
+        workspaceRuntimeSkills: workspaceSkills,
+        workspaceRuntimeStatus,
+        ensureWorkspaceRuntime,
         workspaceGit,
       }));
       workspaceTools.mockReset();
@@ -511,6 +575,8 @@ describe('DaemonSessionProvider', () => {
       v: 1,
       workspaceCwd: '/mock-workspace',
       initialized: true,
+      source: 'live',
+      runtimeEpoch: 1,
       skills: [
         {
           kind: 'skill',
@@ -532,12 +598,16 @@ describe('DaemonSessionProvider', () => {
     await renderWithProvider(<Harness />, {
       autoConnect: true,
       sessionId: undefined,
+      workspaceCwd: '/secondary-workspace',
     });
 
     expect(
       sdkMocks.MockDaemonSessionClient.createOrAttach,
     ).not.toHaveBeenCalled();
-    expect(connection?.status).toBe('connected');
+    expect(connection).toMatchObject({
+      status: 'connected',
+      workspaceCwd: '/secondary-workspace',
+    });
     expect(connection).not.toHaveProperty('sessionId');
     expect(connection?.skills).toEqual(['review']);
     expect(connection?.commands).toEqual([
@@ -546,19 +616,54 @@ describe('DaemonSessionProvider', () => {
         description: 'Review a GitHub pull request',
       }),
     ]);
+    expect(sdkMocks.workspaceByCwd).toHaveBeenCalledWith(
+      '/secondary-workspace',
+    );
+    expect(sdkMocks.workspaceProviders).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceSkills).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceRuntimeStatus).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceGit).toHaveBeenCalledOnce();
+    expect(sdkMocks.singularWorkspaceProviders).not.toHaveBeenCalled();
+    expect(sdkMocks.singularWorkspaceSkills).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
+    expect(sdkMocks.singularWorkspaceGit).not.toHaveBeenCalled();
   });
 
-  it('preheats ACP and refreshes deferred skills when ACP is not running', async () => {
-    sdkMocks.capabilities.mockResolvedValue({
+  it('prepares the workspace runtime and refreshes deferred skills', async () => {
+    sdkMocks.workspaceRuntimeStatus.mockResolvedValue({
+      v: 1,
       workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+      state: 'cold',
+      runtimeLive: false,
+      runtimeEpoch: 1,
+      capabilities: {
+        skills: {
+          state: 'not_started',
+          runtimeEpoch: 1,
+        },
+      },
     });
-    sdkMocks.workspaceAcpStatus.mockResolvedValue({ channelLive: false });
+    sdkMocks.ensureWorkspaceRuntime.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      state: 'idle',
+      runtimeLive: true,
+      runtimeEpoch: 2,
+      capabilities: {
+        skills: {
+          state: 'ready',
+          runtimeEpoch: 2,
+        },
+      },
+    });
     sdkMocks.workspaceSkills
       .mockResolvedValueOnce({
         v: 1,
         workspaceCwd: '/mock-workspace',
         initialized: true,
+        source: 'config',
+        runtimeEpoch: 1,
         skills: [
           {
             kind: 'skill',
@@ -574,6 +679,8 @@ describe('DaemonSessionProvider', () => {
         v: 1,
         workspaceCwd: '/mock-workspace',
         initialized: true,
+        source: 'live',
+        runtimeEpoch: 2,
         skills: [
           {
             kind: 'skill',
@@ -609,22 +716,47 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
-    expect(sdkMocks.workspaceAcpPreheat).toHaveBeenCalledWith(5000);
+    expect(sdkMocks.ensureWorkspaceRuntime).toHaveBeenCalledWith();
     expect(sdkMocks.workspaceSkills).toHaveBeenCalledTimes(2);
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
     expect(connection?.skills).toEqual(['review', 'pdf']);
   });
 
-  it('clears deferred skills when ACP refresh returns an empty list', async () => {
-    sdkMocks.capabilities.mockResolvedValue({
+  it('clears deferred skills when the prepared runtime returns an empty list', async () => {
+    sdkMocks.workspaceRuntimeStatus.mockResolvedValue({
+      v: 1,
       workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat', 'workspace_acp_status'],
+      state: 'cold',
+      runtimeLive: false,
+      runtimeEpoch: 1,
+      capabilities: {
+        skills: {
+          state: 'not_started',
+          runtimeEpoch: 1,
+        },
+      },
     });
-    sdkMocks.workspaceAcpStatus.mockResolvedValue({ channelLive: false });
+    sdkMocks.ensureWorkspaceRuntime.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      state: 'idle',
+      runtimeLive: true,
+      runtimeEpoch: 2,
+      capabilities: {
+        skills: {
+          state: 'ready',
+          runtimeEpoch: 2,
+        },
+      },
+    });
     sdkMocks.workspaceSkills
       .mockResolvedValueOnce({
         v: 1,
         workspaceCwd: '/mock-workspace',
         initialized: true,
+        source: 'config',
+        runtimeEpoch: 1,
         skills: [
           {
             kind: 'skill',
@@ -640,6 +772,8 @@ describe('DaemonSessionProvider', () => {
         v: 1,
         workspaceCwd: '/mock-workspace',
         initialized: true,
+        source: 'live',
+        runtimeEpoch: 2,
         skills: [],
       });
     let connection: DaemonConnectionState | undefined;
@@ -698,10 +832,14 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
   });
 
-  it('preheats without probing status when only preheat is advertised', async () => {
-    sdkMocks.capabilities.mockResolvedValue({
+  it('prepares the runtime without using legacy ACP feature routes', async () => {
+    sdkMocks.workspaceRuntimeStatus.mockResolvedValue({
+      v: 1,
       workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat'],
+      state: 'cold',
+      runtimeLive: false,
+      runtimeEpoch: 1,
+      capabilities: { skills: { state: 'not_started', runtimeEpoch: 1 } },
     });
 
     function Harness() {
@@ -717,16 +855,13 @@ describe('DaemonSessionProvider', () => {
       await flushPromises();
     });
 
+    expect(sdkMocks.workspaceRuntimeStatus).toHaveBeenCalledOnce();
+    expect(sdkMocks.ensureWorkspaceRuntime).toHaveBeenCalledOnce();
     expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
-    expect(sdkMocks.workspaceAcpPreheat).toHaveBeenCalledWith(5000);
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
   });
 
-  it('does not preheat when the advertised ACP status is live', async () => {
-    sdkMocks.capabilities.mockResolvedValue({
-      workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat', 'workspace_acp_status'],
-    });
-
+  it('does not ensure the runtime when Skills are already ready', async () => {
     function Harness() {
       useDaemonConnection();
       return null;
@@ -737,18 +872,16 @@ describe('DaemonSessionProvider', () => {
       sessionId: undefined,
     });
 
-    expect(sdkMocks.workspaceAcpStatus).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceRuntimeStatus).toHaveBeenCalledOnce();
+    expect(sdkMocks.ensureWorkspaceRuntime).not.toHaveBeenCalled();
+    expect(sdkMocks.workspaceAcpStatus).not.toHaveBeenCalled();
     expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
   });
 
-  it('still preheats when the advertised ACP status request fails', async () => {
+  it('still ensures the runtime when its status request fails', async () => {
     const statusError = new Error('status unavailable');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    sdkMocks.capabilities.mockResolvedValue({
-      workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat', 'workspace_acp_status'],
-    });
-    sdkMocks.workspaceAcpStatus.mockRejectedValue(statusError);
+    sdkMocks.workspaceRuntimeStatus.mockRejectedValue(statusError);
 
     function Harness() {
       useDaemonConnection();
@@ -764,20 +897,25 @@ describe('DaemonSessionProvider', () => {
     });
 
     expect(warn).toHaveBeenCalledWith(
-      '[DaemonSessionProvider] workspaceAcpStatus failed in deferred connect:',
+      '[DaemonSessionProvider] workspaceRuntimeStatus failed in deferred connect:',
       statusError,
     );
-    expect(sdkMocks.workspaceAcpPreheat).toHaveBeenCalledWith(5000);
+    expect(sdkMocks.ensureWorkspaceRuntime).toHaveBeenCalledOnce();
+    expect(sdkMocks.workspaceAcpPreheat).not.toHaveBeenCalled();
   });
 
-  it('keeps the deferred connection usable when preheat fails', async () => {
-    const preheatError = new Error('preheat unavailable');
+  it('keeps the deferred connection usable when runtime preparation fails', async () => {
+    const prepareError = new Error('runtime unavailable');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    sdkMocks.capabilities.mockResolvedValue({
+    sdkMocks.workspaceRuntimeStatus.mockResolvedValue({
+      v: 1,
       workspaceCwd: '/mock-workspace',
-      features: ['workspace_acp_preheat'],
+      state: 'cold',
+      runtimeLive: false,
+      runtimeEpoch: 1,
+      capabilities: { skills: { state: 'not_started', runtimeEpoch: 1 } },
     });
-    sdkMocks.workspaceAcpPreheat.mockRejectedValue(preheatError);
+    sdkMocks.ensureWorkspaceRuntime.mockRejectedValue(prepareError);
     let connection: DaemonConnectionState | undefined;
 
     function Harness() {
@@ -799,8 +937,8 @@ describe('DaemonSessionProvider', () => {
     });
     expect(connection).not.toHaveProperty('sessionId');
     expect(warn).toHaveBeenCalledWith(
-      '[DaemonSessionProvider] ACP preheat for workspace skills failed:',
-      preheatError,
+      '[DaemonSessionProvider] workspace runtime prepare for skills failed:',
+      prepareError,
     );
   });
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -123,8 +123,6 @@ export interface DaemonTranscriptHistory {
 }
 
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
-const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
-const WORKSPACE_ACP_STATUS_FEATURE = 'workspace_acp_status';
 
 function assistantDoneFromTurnEvent(
   event: DaemonEvent,
@@ -292,7 +290,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   workspaceCapabilitiesRef.current = workspace?.capabilities;
   const workspaceGetCapabilitiesRef = useRef(workspace?.getCapabilities);
   workspaceGetCapabilitiesRef.current = workspace?.getCapabilities;
-  const workspaceAcpPreheatInFlightRef = useRef(false);
+  const workspaceSkillsPrepareInFlightRef = useRef(false);
   const initialRestoreSessionIdRef = useRef(sessionId);
   const initialRestoreSessionId = initialRestoreSessionIdRef.current;
   // Captured once at mount: if the host did not provide an initial session,
@@ -629,15 +627,6 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               resolvedWorkspaceCwdRef.current ??
               caps.workspaceCwd;
             activeWorkspaceCwdRef.current = effectWorkspaceCwd;
-            const capabilityFeatures = Array.isArray(caps.features)
-              ? caps.features
-              : [];
-            const canPreheatPrimaryWorkspace =
-              effectWorkspaceCwd === caps.workspaceCwd &&
-              capabilityFeatures.includes(WORKSPACE_ACP_PREHEAT_FEATURE);
-            const canReadPrimaryAcpStatus =
-              canPreheatPrimaryWorkspace &&
-              capabilityFeatures.includes(WORKSPACE_ACP_STATUS_FEATURE);
             if (
               (shouldDeferInitialSessionCreation ||
                 manualSessionClearRef.current) &&
@@ -645,6 +634,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               !reconnectSessionId &&
               !shouldCreateFreshSession
             ) {
+              if (!effectWorkspaceCwd) {
+                throw new Error('Daemon workspace is not connected');
+              }
+              const workspaceClient = client.workspaceByCwd(effectWorkspaceCwd);
               // Fetch skills alongside providers so skill-backed slash
               // commands (e.g. /review) can autocomplete before the first
               // prompt. Both are session-less workspace queries; the
@@ -653,14 +646,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               // creates a session.
               const [providerResult, skillsResult, acpStatusResult, gitResult] =
                 await Promise.allSettled([
-                  client.workspaceProviders(),
-                  client.workspaceSkills(),
-                  canReadPrimaryAcpStatus
-                    ? client.workspaceAcpStatus()
-                    : Promise.resolve(undefined),
-                  effectWorkspaceCwd
-                    ? client.workspaceByCwd(effectWorkspaceCwd).workspaceGit()
-                    : client.workspaceGit(),
+                  workspaceClient.workspaceProviders(),
+                  workspaceClient.workspaceSkills(),
+                  workspaceClient.workspaceRuntimeStatus(),
+                  workspaceClient.workspaceGit(),
                 ]);
               if (providerResult.status === 'rejected') {
                 console.warn(
@@ -674,12 +663,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   skillsResult.reason,
                 );
               }
-              if (
-                canReadPrimaryAcpStatus &&
-                acpStatusResult.status === 'rejected'
-              ) {
+              if (acpStatusResult.status === 'rejected') {
                 console.warn(
-                  '[DaemonSessionProvider] workspaceAcpStatus failed in deferred connect:',
+                  '[DaemonSessionProvider] workspaceRuntimeStatus failed in deferred connect:',
                   acpStatusResult.reason,
                 );
               }
@@ -722,30 +708,34 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   : deferredSkills,
               }));
               if (
-                canPreheatPrimaryWorkspace &&
-                !(
-                  acpStatusResult.status === 'fulfilled' &&
-                  acpStatusResult.value?.channelLive === true
-                ) &&
-                !workspaceAcpPreheatInFlightRef.current
+                (acpStatusResult.status !== 'fulfilled' ||
+                  !acpStatusResult.value.runtimeLive ||
+                  acpStatusResult.value.capabilities.skills?.state !==
+                    'ready') &&
+                !workspaceSkillsPrepareInFlightRef.current
               ) {
-                workspaceAcpPreheatInFlightRef.current = true;
+                workspaceSkillsPrepareInFlightRef.current = true;
                 void (async () => {
                   try {
-                    const preheat = await client.workspaceAcpPreheat(5_000);
+                    const prepared =
+                      await workspaceClient.ensureWorkspaceRuntime();
                     if (
                       disposed ||
                       abort.signal.aborted ||
-                      !preheat.ready ||
+                      prepared.capabilities.skills?.state !== 'ready' ||
                       connectionRef.current.sessionId
                     ) {
                       return;
                     }
-                    const refreshed = await client.workspaceSkills();
+                    const refreshed =
+                      await workspaceClient.workspaceRuntimeSkills();
                     if (
                       disposed ||
                       abort.signal.aborted ||
-                      connectionRef.current.sessionId
+                      connectionRef.current.sessionId ||
+                      refreshed.initialized !== true ||
+                      refreshed.source !== 'live' ||
+                      refreshed.runtimeEpoch !== prepared.runtimeEpoch
                     ) {
                       return;
                     }
@@ -757,11 +747,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                     );
                   } catch (error) {
                     console.warn(
-                      '[DaemonSessionProvider] ACP preheat for workspace skills failed:',
+                      '[DaemonSessionProvider] workspace runtime prepare for skills failed:',
                       error,
                     );
                   } finally {
-                    workspaceAcpPreheatInFlightRef.current = false;
+                    workspaceSkillsPrepareInFlightRef.current = false;
                   }
                 })();
               }
@@ -1127,16 +1117,17 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               connectionRef.current.skills !== undefined &&
               connectionRef.current.supportedCommands !== undefined &&
               connectionRef.current.context !== undefined);
+          const activeWorkspaceClient = client.workspaceByCwd(
+            activeSession.workspaceCwd,
+          );
           const gitPromise = skipMetadataRefreshThisIteration
             ? Promise.resolve({ branch: connectionRef.current.gitBranch })
-            : activeSession.workspaceCwd
-              ? client.workspaceByCwd(activeSession.workspaceCwd).workspaceGit()
-              : client.workspaceGit();
+            : activeWorkspaceClient.workspaceGit();
           const [providerResult, commandResult, contextResult, gitResult] =
             await Promise.allSettled([
               canReuseSessionMetadata
                 ? Promise.resolve(undefined)
-                : client.workspaceProviders(),
+                : activeWorkspaceClient.workspaceProviders(),
               canReuseSessionMetadata
                 ? Promise.resolve(undefined)
                 : activeSession.supportedCommands(),

--- a/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.test.tsx
+++ b/packages/webui/src/daemon/workspace/DaemonWorkspaceProvider.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DaemonWorkspaceProvider,
   useDaemonWorkspace,
+  useDaemonWorkspaceActions,
   useOptionalDaemonWorkspace,
   type DaemonWorkspaceActions,
   type DaemonWorkspaceContextValue,
@@ -44,22 +45,40 @@ const sdkMocks = vi.hoisted(() => {
   const deleteSessionsData = vi.fn();
   const exportSession = vi.fn();
   const daemonStatus = vi.fn();
+  const workspaceByCwd = vi.fn();
 
   class MockDaemonClient {
     constructor(_opts: unknown) {}
+
+    workspaceByCwd(workspaceCwd: string) {
+      workspaceByCwd(workspaceCwd);
+      return this;
+    }
 
     capabilities = capabilities;
     workspaceMcp = workspaceMcp;
     workspaceMcpTools = workspaceMcpTools;
     workspaceMcpResources = workspaceMcpResources;
     restartMcpServer = restartMcpServer;
+    workspaceRuntimeMcp = workspaceMcp;
+    workspaceRuntimeMcpTools = workspaceMcpTools;
+    workspaceRuntimeMcpResources = workspaceMcpResources;
+    restartWorkspaceRuntimeMcpServer = restartMcpServer;
     workspaceSkills = workspaceSkills;
     setWorkspaceSkillEnabled = setWorkspaceSkillEnabled;
     installWorkspaceSkill = installWorkspaceSkill;
     deleteWorkspaceSkill = deleteWorkspaceSkill;
+    workspaceConfigSkills = workspaceSkills;
+    workspaceRuntimeSkills = workspaceSkills;
+    setWorkspaceConfigSkillEnabled = setWorkspaceSkillEnabled;
+    installWorkspaceConfigSkill = installWorkspaceSkill;
+    deleteWorkspaceConfigSkill = deleteWorkspaceSkill;
     workspaceAcpStatus = workspaceAcpStatus;
     workspaceAcpPreheat = workspaceAcpPreheat;
+    workspaceRuntimeStatus = workspaceAcpStatus;
+    ensureWorkspaceRuntime = workspaceAcpPreheat;
     workspaceTools = workspaceTools;
+    workspaceRuntimeTools = workspaceTools;
     setWorkspaceToolEnabled = setWorkspaceToolEnabled;
     workspaceMemory = workspaceMemory;
     readWorkspaceFile = readWorkspaceFile;
@@ -103,6 +122,7 @@ const sdkMocks = vi.hoisted(() => {
     deleteSessionsData,
     exportSession,
     daemonStatus,
+    workspaceByCwd,
     reset() {
       capabilities.mockReset();
       capabilities.mockResolvedValue({
@@ -228,6 +248,7 @@ const sdkMocks = vi.hoisted(() => {
         status: 'ok',
         issues: [],
       });
+      workspaceByCwd.mockReset();
     },
   };
 });
@@ -265,14 +286,17 @@ describe('DaemonWorkspaceProvider', () => {
     vi.unstubAllGlobals();
   });
 
-  function renderWithProvider(children: ReactNode) {
+  function renderWithProvider(children: ReactNode, workspaceCwd?: string) {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
     return new Promise<void>((resolve) => {
       act(() => {
         root?.render(
-          <DaemonWorkspaceProvider baseUrl="http://127.0.0.1:4170">
+          <DaemonWorkspaceProvider
+            baseUrl="http://127.0.0.1:4170"
+            workspaceCwd={workspaceCwd}
+          >
             {children}
           </DaemonWorkspaceProvider>,
         );
@@ -297,6 +321,40 @@ describe('DaemonWorkspaceProvider', () => {
     expect(context).toBeDefined();
     expect(context?.baseUrl).toBe('http://127.0.0.1:4170');
     expect(context?.workspaceCwd).toBe('/mock-workspace');
+  });
+
+  it('keeps an explicit workspace owner instead of replacing it with primary capabilities', async () => {
+    let context: DaemonWorkspaceContextValue | undefined;
+
+    function Harness() {
+      context = useOptionalDaemonWorkspace();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, '/other-workspace');
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(context?.workspaceCwd).toBe('/other-workspace');
+  });
+
+  it('creates actions for an explicit workspace owner', async () => {
+    let actions: DaemonWorkspaceActions | undefined;
+
+    function Harness() {
+      actions = useDaemonWorkspaceActions('/other-workspace');
+      return null;
+    }
+
+    await renderWithProvider(<Harness />);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await actions?.loadSkillsConfigStatus();
+    });
+
+    expect(sdkMocks.workspaceByCwd).toHaveBeenCalledWith('/other-workspace');
+    expect(sdkMocks.workspaceSkills).toHaveBeenCalledOnce();
   });
 
   it('refreshCapabilities re-fetches and updates capabilities state', async () => {
@@ -379,9 +437,11 @@ describe('DaemonWorkspaceProvider', () => {
     });
 
     expect(actions).toBeDefined();
+    expect(typeof actions?.ensureRuntime).toBe('function');
     expect(typeof actions?.loadMcpStatus).toBe('function');
     expect(typeof actions?.reloadMcp).toBe('function');
     expect(typeof actions?.loadSkillsStatus).toBe('function');
+    expect(typeof actions?.loadSkillsConfigStatus).toBe('function');
     expect(typeof actions?.setWorkspaceSkillEnabled).toBe('function');
     expect(typeof actions?.installWorkspaceSkill).toBe('function');
     expect(typeof actions?.deleteWorkspaceSkill).toBe('function');
@@ -416,7 +476,7 @@ describe('DaemonWorkspaceProvider', () => {
     expect(context).toBeUndefined();
   });
 
-  it('returns MCP tools fallback for older daemons', async () => {
+  it('surfaces MCP tools loading errors', async () => {
     sdkMocks.workspaceMcpTools.mockRejectedValueOnce(
       new Error('missing route'),
     );
@@ -438,21 +498,9 @@ describe('DaemonWorkspaceProvider', () => {
     const workspaceActions = actions;
 
     await act(async () => {
-      await expect(workspaceActions.loadMcpTools('server-a')).resolves.toEqual({
-        v: 1,
-        workspaceCwd: '',
-        serverName: 'server-a',
-        initialized: false,
-        acpChannelLive: false,
-        tools: [],
-        errors: [
-          {
-            kind: 'mcp_tools',
-            status: 'error',
-            error: 'The connected daemon does not expose MCP tool details.',
-          },
-        ],
-      });
+      await expect(workspaceActions.loadMcpTools('server-a')).rejects.toThrow(
+        'missing route',
+      );
     });
   });
 
@@ -492,7 +540,7 @@ describe('DaemonWorkspaceProvider', () => {
     expect(sdkMocks.workspaceMcpResources).toHaveBeenCalledWith('docs');
   });
 
-  it('returns MCP resources fallback for older daemons', async () => {
+  it('surfaces MCP resources loading errors', async () => {
     sdkMocks.workspaceMcpResources.mockRejectedValueOnce(
       new Error('missing route'),
     );
@@ -515,21 +563,7 @@ describe('DaemonWorkspaceProvider', () => {
     await act(async () => {
       await expect(
         workspaceActions.loadMcpResources('server-a'),
-      ).resolves.toEqual({
-        v: 1,
-        workspaceCwd: '',
-        serverName: 'server-a',
-        initialized: false,
-        acpChannelLive: false,
-        resources: [],
-        errors: [
-          {
-            kind: 'mcp_resources',
-            status: 'error',
-            error: 'The connected daemon does not expose MCP resource details.',
-          },
-        ],
-      });
+      ).rejects.toThrow('missing route');
     });
   });
 

--- a/packages/webui/src/daemon/workspace/actions.test.ts
+++ b/packages/webui/src/daemon/workspace/actions.test.ts
@@ -112,12 +112,22 @@ describe('workspace actions', () => {
   });
 
   it('loads active extension operations from the daemon client', async () => {
-    const activeExtensionOperations = vi
+    const activePrimaryExtensionOperations = vi
+      .fn()
+      .mockResolvedValue({ v: 1, operations: [] });
+    const activeWorkspaceExtensionOperations = vi
       .fn()
       .mockResolvedValue({ v: 1, operations: [] });
     const actions = createDaemonWorkspaceActions({
       getClient: () =>
-        ({ activeExtensionOperations }) as unknown as DaemonClient,
+        ({
+          activeWorkspaceConfigExtensionOperations:
+            activePrimaryExtensionOperations,
+          workspaceByCwd: vi.fn(() => ({
+            activeWorkspaceConfigExtensionOperations:
+              activeWorkspaceExtensionOperations,
+          })),
+        }) as unknown as DaemonClient,
       getWorkspaceCwd: () => '/workspace',
       baseUrl: 'http://daemon',
     });
@@ -126,28 +136,850 @@ describe('workspace actions', () => {
       v: 1,
       operations: [],
     });
-    expect(activeExtensionOperations).toHaveBeenCalledOnce();
+    expect(activePrimaryExtensionOperations).toHaveBeenCalledOnce();
+    expect(activeWorkspaceExtensionOperations).toHaveBeenCalledOnce();
   });
 
-  it('reloads MCP settings through the daemon client', async () => {
-    const reloadWorkspaceMcp = vi.fn().mockResolvedValue({ accepted: true });
+  it('loads extension configuration without reading or starting the runtime', async () => {
+    const ensureWorkspaceRuntime = vi.fn(
+      () => new Promise<never>(() => undefined),
+    );
+    const workspaceConfigExtensions = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      extensions: [],
+    });
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+      runtimeEpoch: 7,
+      capabilities: {
+        extensions: {
+          state: 'starting',
+          desiredGeneration: 4,
+          appliedGeneration: 3,
+          runtimeEpoch: 7,
+          appliedEpoch: 7,
+        },
+      },
+    });
     const actions = createDaemonWorkspaceActions({
-      getClient: () => ({ reloadWorkspaceMcp }) as unknown as DaemonClient,
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            ensureWorkspaceRuntime,
+            workspaceConfigExtensions,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
       getWorkspaceCwd: () => '/workspace',
       baseUrl: 'http://daemon',
     });
 
-    await expect(actions.reloadMcp()).resolves.toEqual({ accepted: true });
-    expect(reloadWorkspaceMcp).toHaveBeenCalledOnce();
+    await expect(actions.loadExtensionsStatus()).resolves.toMatchObject({
+      extensions: [],
+    });
+    expect(ensureWorkspaceRuntime).not.toHaveBeenCalled();
+    expect(workspaceRuntimeStatus).not.toHaveBeenCalled();
+    expect(workspaceConfigExtensions).toHaveBeenCalledOnce();
+  });
+
+  it('ensures the selected workspace runtime without capability parameters', async () => {
+    const ensured = {
+      v: 1 as const,
+      workspaceCwd: '/workspace/secondary',
+      state: 'idle' as const,
+      runtimeLive: true,
+      runtimeEpoch: 4,
+      capabilities: {
+        extensions: { state: 'ready' },
+        mcp: { state: 'ready' },
+        skills: { state: 'ready' },
+        tools: { state: 'ready' },
+      },
+    };
+    const ensureWorkspaceRuntime = vi.fn().mockResolvedValue(ensured);
+    const workspaceByCwd = vi.fn(() => ({ ensureWorkspaceRuntime }));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () => ({ workspaceByCwd }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.ensureRuntime()).resolves.toEqual(ensured);
+    expect(workspaceByCwd).toHaveBeenCalledWith('/workspace/secondary');
+    expect(ensureWorkspaceRuntime).toHaveBeenCalledWith();
+  });
+
+  it('polls the unified runtime status when ensure is still starting', async () => {
+    vi.useFakeTimers();
+    const starting = {
+      v: 1 as const,
+      workspaceCwd: '/workspace',
+      state: 'starting' as const,
+      runtimeLive: true,
+      runtimeEpoch: 4,
+      capabilities: {
+        extensions: { state: 'ready' as const },
+        mcp: { state: 'starting' as const },
+        skills: { state: 'ready' as const },
+        tools: { state: 'ready' as const },
+      },
+    };
+    const ready = {
+      ...starting,
+      state: 'idle' as const,
+      capabilities: {
+        ...starting.capabilities,
+        mcp: { state: 'ready' as const },
+      },
+    };
+    const ensureWorkspaceRuntime = vi.fn().mockResolvedValue(starting);
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue(ready);
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: () => ({
+            ensureWorkspaceRuntime,
+            workspaceRuntimeStatus,
+          }),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    const result = actions.ensureRuntime();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toMatchObject({
+      state: 'idle',
+    });
+    expect(ensureWorkspaceRuntime).toHaveBeenCalledWith();
+    expect(workspaceRuntimeStatus).toHaveBeenCalledOnce();
+  });
+
+  it('loads extension activation from the original configuration inventory', async () => {
+    const entry = {
+      kind: 'extension' as const,
+      id: 'extension-id',
+      name: 'demo',
+      version: '1.0.0',
+      isActive: false,
+      defaultActivation: 'enabled' as const,
+      workspaceActivation: 'disabled' as const,
+      path: '/extensions/demo',
+      capabilities: {
+        mcpServerCount: 0,
+        skillCount: 0,
+        agentCount: 0,
+        hookCount: 0,
+        commandCount: 0,
+        contextFileCount: 0,
+        channelCount: 0,
+        hasSettings: false,
+      },
+    };
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            workspaceConfigExtensions: vi.fn().mockResolvedValue({
+              v: 1,
+              workspaceCwd: '/workspace',
+              initialized: true,
+              extensions: [entry],
+            }),
+            workspaceRuntimeStatus: vi
+              .fn()
+              .mockRejectedValue(new Error('runtime unavailable')),
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadExtensionsStatus()).resolves.toMatchObject({
+      extensions: [entry],
+    });
+  });
+
+  it('uses the original scoped extension enable and disable routes', async () => {
+    const enableWorkspaceConfigExtension = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'enable-operation',
+    });
+    const disableWorkspaceConfigExtension = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'disable-operation',
+    });
+    const workspaceEnable = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'workspace-enable-operation',
+    });
+    const workspaceDisable = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'workspace-disable-operation',
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          enableWorkspaceConfigExtension,
+          disableWorkspaceConfigExtension,
+          workspaceByCwd: vi.fn(() => ({
+            enableWorkspaceConfigExtension: workspaceEnable,
+            disableWorkspaceConfigExtension: workspaceDisable,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(
+      actions.enableExtension('demo', { scope: 'user' }),
+    ).resolves.toMatchObject({ operationId: 'enable-operation' });
+    await expect(
+      actions.disableExtension('demo', { scope: 'workspace' }),
+    ).resolves.toMatchObject({ operationId: 'workspace-disable-operation' });
+
+    expect(enableWorkspaceConfigExtension).toHaveBeenCalledWith('demo', {
+      scope: 'user',
+    });
+    expect(workspaceDisable).toHaveBeenCalledWith('demo', {
+      scope: 'workspace',
+    });
+    expect(disableWorkspaceConfigExtension).not.toHaveBeenCalled();
+    expect(workspaceEnable).not.toHaveBeenCalled();
+  });
+
+  it('updates global and workspace extension activation independently', async () => {
+    const setExtensionDefaultActivation = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'default-operation',
+    });
+    const setExtensionActivation = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'workspace-operation',
+    });
+    const clearExtensionActivation = vi.fn().mockResolvedValue({
+      accepted: true,
+      operationId: 'inherit-operation',
+    });
+    const extensionOperation = vi.fn().mockResolvedValue({
+      operationId: 'workspace-operation',
+      status: 'succeeded',
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          setExtensionDefaultActivation,
+          extensionOperation,
+          workspaceByCwd: vi.fn(() => ({
+            setExtensionActivation,
+            clearExtensionActivation,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await actions.setExtensionActivation('extension-id', {
+      scope: 'user',
+      state: 'disabled',
+    });
+    await actions.setExtensionActivation('extension-id', {
+      scope: 'workspace',
+      state: 'enabled',
+    });
+    await actions.extensionOperationStatus('workspace-operation');
+    await actions.setExtensionActivation('extension-id', {
+      scope: 'workspace',
+      state: 'inherit',
+    });
+
+    expect(setExtensionDefaultActivation).toHaveBeenCalledWith(
+      'extension-id',
+      'disabled',
+    );
+    expect(setExtensionActivation).toHaveBeenCalledWith(
+      'extension-id',
+      'enabled',
+    );
+    expect(extensionOperation).toHaveBeenCalledWith('workspace-operation');
+    expect(clearExtensionActivation).toHaveBeenCalledWith('extension-id');
+  });
+
+  it('returns extension configuration without depending on runtime status', async () => {
+    const workspaceConfigExtensions = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      desiredGeneration: 4,
+      appliedGeneration: 3,
+      extensions: [],
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            workspaceConfigExtensions,
+            workspaceRuntimeStatus: vi
+              .fn()
+              .mockRejectedValue(new Error('runtime unavailable')),
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadExtensionsStatus()).resolves.toEqual({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      desiredGeneration: 4,
+      appliedGeneration: 3,
+      extensions: [],
+    });
+  });
+
+  it('reads the Skills runtime snapshot without starting the runtime', async () => {
+    const ensureWorkspaceRuntime = vi
+      .fn()
+      .mockRejectedValue(new Error('ACP unavailable'));
+    const workspaceRuntimeSkills = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: false,
+      source: 'config',
+      skills: [{ name: 'review', status: 'ok' }],
+    });
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      state: 'cold',
+      runtimeLive: false,
+      runtimeEpoch: 3,
+      capabilities: {
+        skills: {
+          state: 'stale',
+          runtimeEpoch: 2,
+        },
+      },
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            ensureWorkspaceRuntime,
+            workspaceRuntimeSkills,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadSkillsStatus()).resolves.toMatchObject({
+      source: 'config',
+      skills: [{ name: 'review' }],
+      runtimeState: 'stale',
+      coordinatorRuntimeEpoch: 3,
+      capabilityRuntimeEpoch: 2,
+      runtimeCatalogInitialized: false,
+      runtimeCatalogSource: 'config',
+    });
+    expect(ensureWorkspaceRuntime).not.toHaveBeenCalled();
+    expect(workspaceRuntimeSkills).toHaveBeenCalledOnce();
+  });
+
+  it('reuses a prepared runtime status when loading Skills', async () => {
+    const workspaceRuntimeSkills = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      runtimeEpoch: 4,
+      source: 'live',
+      skills: [{ name: 'review', status: 'ok' }],
+    });
+    const workspaceRuntimeStatus = vi.fn();
+    const preparedStatus = {
+      v: 1 as const,
+      workspaceCwd: '/workspace',
+      state: 'idle' as const,
+      runtimeLive: true,
+      runtimeEpoch: 4,
+      capabilities: {
+        skills: { state: 'ready' as const, runtimeEpoch: 4 },
+      },
+    };
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            workspaceRuntimeSkills,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(
+      actions.loadSkillsStatus(preparedStatus),
+    ).resolves.toMatchObject({
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+      runtimeCatalogSource: 'live',
+    });
+    expect(workspaceRuntimeSkills).toHaveBeenCalledOnce();
+    expect(workspaceRuntimeStatus).not.toHaveBeenCalled();
+  });
+
+  it('loads the Skills config inventory without preparing the runtime', async () => {
+    const ensureWorkspaceRuntime = vi.fn();
+    const workspaceConfigSkills = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      source: 'config',
+      skills: [{ name: 'review', status: 'disabled' }],
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            ensureWorkspaceRuntime,
+            workspaceConfigSkills,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadSkillsConfigStatus()).resolves.toMatchObject({
+      source: 'config',
+      skills: [{ name: 'review', status: 'disabled' }],
+    });
+    expect(workspaceConfigSkills).toHaveBeenCalledOnce();
+    expect(ensureWorkspaceRuntime).not.toHaveBeenCalled();
+  });
+
+  it('loads Tools from the selected workspace runtime', async () => {
+    const ensureWorkspaceRuntime = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace/secondary',
+      state: 'active',
+      runtimeLive: true,
+      runtimeEpoch: 9,
+      capabilities: {
+        tools: { state: 'ready', runtimeEpoch: 9 },
+      },
+    });
+    const workspaceRuntimeTools = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace/secondary',
+      initialized: true,
+      runtimeEpoch: 9,
+      acpChannelLive: true,
+      tools: [],
+    });
+    const workspaceByCwd = vi.fn(() => ({
+      ensureWorkspaceRuntime,
+      workspaceRuntimeTools,
+    }));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () => ({ workspaceByCwd }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadToolsStatus()).resolves.toMatchObject({
+      workspaceCwd: '/workspace/secondary',
+      runtimeEpoch: 9,
+    });
+    expect(workspaceByCwd).toHaveBeenCalledWith('/workspace/secondary');
+    expect(ensureWorkspaceRuntime).toHaveBeenCalledWith();
+    expect(workspaceRuntimeTools).toHaveBeenCalledOnce();
+  });
+
+  it('reloads MCP settings through the daemon client', async () => {
+    const reloadWorkspaceRuntimeMcp = vi.fn().mockResolvedValue({
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({ reloadWorkspaceRuntimeMcp })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.reloadMcp()).resolves.toMatchObject({
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    expect(reloadWorkspaceRuntimeMcp).toHaveBeenCalledWith(65_000);
+  });
+
+  it('polls runtime status until a starting MCP capability is ready', async () => {
+    vi.useFakeTimers();
+    const ensureWorkspaceRuntime = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      state: 'starting',
+      runtimeLive: true,
+      capabilities: { mcp: { state: 'starting' } },
+    });
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      state: 'active',
+      runtimeLive: true,
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            ensureWorkspaceRuntime,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    const result = actions.initializeMcp();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toMatchObject({
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    expect(ensureWorkspaceRuntime).toHaveBeenCalledWith();
+    expect(workspaceRuntimeStatus).toHaveBeenCalledWith(64_500);
+  });
+
+  it('uses one deadline across the prepare request and status polling', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const ensureWorkspaceRuntime = vi.fn(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                v: 1,
+                workspaceCwd: '/workspace',
+                state: 'starting',
+                runtimeLive: true,
+                capabilities: {
+                  mcp: { state: 'starting' },
+                },
+              }),
+            64_000,
+          ),
+        ),
+    );
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      state: 'active',
+      runtimeLive: true,
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            ensureWorkspaceRuntime,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    const result = actions.initializeMcp();
+    await vi.advanceTimersByTimeAsync(64_500);
+
+    await expect(result).resolves.toMatchObject({
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    expect(ensureWorkspaceRuntime).toHaveBeenCalledWith();
+    expect(workspaceRuntimeStatus).toHaveBeenCalledWith(500);
+  });
+
+  it('waits for selected workspace MCP reconciliation', async () => {
+    vi.useFakeTimers();
+    const workspaceRuntimeStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        capabilities: { mcp: { state: 'starting' } },
+      })
+      .mockResolvedValueOnce({
+        capabilities: { mcp: { state: 'ready' } },
+      });
+    const workspaceByCwd = vi.fn(() => ({ workspaceRuntimeStatus }));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () => ({ workspaceByCwd }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    const result = actions.waitForMcpRuntime();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(result).resolves.toMatchObject({
+      capabilities: { mcp: { state: 'ready' } },
+    });
+    expect(workspaceByCwd).toHaveBeenCalledWith('/workspace/secondary');
+    expect(workspaceRuntimeStatus).toHaveBeenNthCalledWith(1, 65_000);
+    expect(workspaceRuntimeStatus).toHaveBeenNthCalledWith(2, 64_500);
+  });
+
+  it('writes workspace MCP config through the selected workspace client', async () => {
+    const setWorkspaceMcpConfig = vi.fn().mockResolvedValue({
+      name: 'docs',
+      scope: 'workspace',
+      activation: 'reconciling',
+    });
+    const setPrimaryMcpConfig = vi.fn();
+    const workspaceByCwd = vi.fn(() => ({ setWorkspaceMcpConfig }));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd,
+          setWorkspaceMcpConfig: setPrimaryMcpConfig,
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(
+      actions.setMcpConfig('docs', 'workspace', { command: 'node' }),
+    ).resolves.toMatchObject({ activation: 'reconciling' });
+    expect(workspaceByCwd).toHaveBeenCalledWith('/workspace/secondary');
+    expect(setWorkspaceMcpConfig).toHaveBeenCalledWith('docs', {
+      command: 'node',
+    });
+    expect(setPrimaryMcpConfig).not.toHaveBeenCalled();
+  });
+
+  it('keeps global skill installation in the daemon control plane', async () => {
+    const installWorkspaceConfigSkill = vi.fn().mockResolvedValue({
+      skillName: 'review',
+      scope: 'global',
+      activation: 'reconciling',
+    });
+    const installQualifiedSkill = vi.fn();
+    const workspaceByCwd = vi.fn(() => ({
+      installWorkspaceConfigSkill: installQualifiedSkill,
+    }));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd,
+          installWorkspaceConfigSkill,
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+    const request = {
+      name: 'review',
+      scope: 'global' as const,
+      source: { type: 'github' as const, url: 'owner/repo' },
+    };
+
+    await expect(actions.installWorkspaceSkill(request)).resolves.toMatchObject(
+      { activation: 'reconciling' },
+    );
+    expect(installWorkspaceConfigSkill).toHaveBeenCalledWith(request);
+    expect(workspaceByCwd).not.toHaveBeenCalled();
+    expect(installQualifiedSkill).not.toHaveBeenCalled();
+  });
+
+  it('routes runtime management through the selected workspace client', async () => {
+    const workspaceRuntimeMcp = vi.fn().mockResolvedValue({
+      servers: [],
+      runtimeEpoch: 4,
+      source: 'live',
+      initialized: true,
+      discoveryState: 'completed',
+    });
+    const workspaceRuntimeStatus = vi.fn().mockResolvedValue({
+      runtimeEpoch: 4,
+      capabilities: {
+        mcp: { state: 'ready', runtimeEpoch: 4 },
+      },
+    });
+    const workspaceByCwd = vi.fn(() => ({
+      workspaceRuntimeMcp,
+      workspaceRuntimeStatus,
+    }));
+    const singularWorkspaceRuntimeMcp = vi.fn();
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd,
+          workspaceRuntimeMcp: singularWorkspaceRuntimeMcp,
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadMcpStatus()).resolves.toMatchObject({
+      servers: [],
+      runtimeEpoch: 4,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+    });
+    expect(workspaceByCwd).toHaveBeenCalledWith('/workspace/secondary');
+    expect(workspaceRuntimeMcp).toHaveBeenCalledWith(undefined);
+    expect(workspaceRuntimeStatus).toHaveBeenCalledWith(undefined);
+    expect(singularWorkspaceRuntimeMcp).not.toHaveBeenCalled();
+  });
+
+  it('does not claim current MCP state when coordinator status is unavailable', async () => {
+    const workspaceRuntimeMcp = vi.fn().mockResolvedValue({
+      servers: [],
+      runtimeEpoch: 4,
+      source: 'live',
+      initialized: true,
+      discoveryState: 'completed',
+    });
+    const workspaceRuntimeStatus = vi
+      .fn()
+      .mockRejectedValue(new Error('runtime unavailable'));
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            workspaceRuntimeMcp,
+            workspaceRuntimeStatus,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace/secondary',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.loadMcpStatus()).resolves.toMatchObject({
+      servers: [],
+      runtimeEpoch: 4,
+      runtimeState: undefined,
+      coordinatorRuntimeEpoch: undefined,
+      capabilityRuntimeEpoch: undefined,
+    });
+  });
+
+  it('loads MCP operation status from the selected workspace runtime', async () => {
+    const workspaceRuntimeOperation = vi.fn().mockResolvedValue({
+      operationId: 'op-1',
+      state: 'waiting_for_input',
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({ workspaceRuntimeOperation })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.mcpOperationStatus('op-1')).resolves.toMatchObject({
+      state: 'waiting_for_input',
+    });
+    expect(workspaceRuntimeOperation).toHaveBeenCalledWith('op-1', undefined);
+  });
+
+  it('loads active MCP operations from the selected workspace runtime', async () => {
+    const activeWorkspaceRuntimeOperations = vi.fn().mockResolvedValue({
+      v: 1,
+      operations: [{ operationId: 'op-1', state: 'waiting_for_input' }],
+    });
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            activeWorkspaceRuntimeOperations,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(actions.activeMcpOperations()).resolves.toMatchObject({
+      operations: [{ operationId: 'op-1' }],
+    });
+    expect(activeWorkspaceRuntimeOperations).toHaveBeenCalledWith(undefined);
+  });
+
+  it('persists MCP enablement through the configuration client', async () => {
+    const setWorkspaceConfigMcpServerEnabled = vi.fn().mockResolvedValue({
+      serverName: 'docs',
+      action: 'disable',
+      ok: true,
+      activation: 'deferred',
+    });
+    const manageWorkspaceRuntimeMcpServer = vi.fn();
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          workspaceByCwd: vi.fn(() => ({
+            setWorkspaceConfigMcpServerEnabled,
+            manageWorkspaceRuntimeMcpServer,
+          })),
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(
+      actions.manageMcpServer('docs', 'disable', 'workspace'),
+    ).resolves.toMatchObject({ activation: 'deferred' });
+    expect(setWorkspaceConfigMcpServerEnabled).toHaveBeenCalledWith(
+      'docs',
+      false,
+    );
+    expect(manageWorkspaceRuntimeMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('persists user MCP enablement through the primary config route', async () => {
+    const setUserConfigMcpServerEnabled = vi.fn().mockResolvedValue({
+      serverName: 'docs',
+      action: 'enable',
+      ok: true,
+      activation: 'deferred',
+    });
+    const workspaceByCwd = vi.fn();
+    const actions = createDaemonWorkspaceActions({
+      getClient: () =>
+        ({
+          setUserConfigMcpServerEnabled,
+          workspaceByCwd,
+        }) as unknown as DaemonClient,
+      getWorkspaceCwd: () => '/workspace',
+      baseUrl: 'http://daemon',
+    });
+
+    await expect(
+      actions.manageMcpServer('docs', 'enable', 'user'),
+    ).resolves.toMatchObject({ activation: 'deferred' });
+    expect(setUserConfigMcpServerEnabled).toHaveBeenCalledWith('docs', true);
+    expect(workspaceByCwd).not.toHaveBeenCalled();
   });
 
   it('forwards an extension interaction response to the daemon client', async () => {
-    const respondToExtensionInteraction = vi
+    const respondToWorkspaceConfigExtensionInteraction = vi
       .fn()
       .mockResolvedValue({ accepted: true });
     const actions = createDaemonWorkspaceActions({
       getClient: () =>
-        ({ respondToExtensionInteraction }) as unknown as DaemonClient,
+        ({
+          respondToWorkspaceConfigExtensionInteraction,
+          workspaceByCwd: vi.fn(() => ({
+            respondToWorkspaceConfigExtensionInteraction: vi.fn(),
+          })),
+        }) as unknown as DaemonClient,
       getWorkspaceCwd: () => '/workspace',
       baseUrl: 'http://daemon',
     });
@@ -160,11 +992,10 @@ describe('workspace actions', () => {
         'client-1',
       ),
     ).resolves.toEqual({ accepted: true });
-    expect(respondToExtensionInteraction).toHaveBeenCalledWith(
+    expect(respondToWorkspaceConfigExtensionInteraction).toHaveBeenCalledWith(
       'op-1',
       'interaction-1',
       { value: 'answer' },
-      'client-1',
     );
   });
 

--- a/packages/webui/src/daemon/workspace/actions.ts
+++ b/packages/webui/src/daemon/workspace/actions.ts
@@ -396,36 +396,81 @@ export function createDaemonWorkspaceActions({
       );
     },
 
-    async loadSkillsStatus() {
-      const client = requireClient(getClient, 'Load skills failed');
+    async loadSkillsConfigStatus() {
+      const client = requireWorkspaceClient(
+        getClient,
+        getWorkspaceCwd,
+        'Load skills configuration failed',
+      );
       return withActionTimeout(
-        client.workspaceSkills(),
-        'Load skills timed out',
+        client.workspaceConfigSkills(),
+        'Load skills configuration timed out',
       );
     },
 
+    async loadSkillsStatus(runtimeStatus) {
+      const client = requireWorkspaceClient(
+        getClient,
+        getWorkspaceCwd,
+        'Load skills failed',
+      );
+      const [catalog, runtime] = await withActionTimeout(
+        Promise.all([
+          client.workspaceRuntimeSkills(),
+          runtimeStatus
+            ? Promise.resolve(runtimeStatus)
+            : client.workspaceRuntimeStatus().catch(() => undefined),
+        ]),
+        'Load skills timed out',
+      );
+      const capability = runtime?.capabilities.skills;
+      return {
+        ...catalog,
+        runtimeState: capability?.state,
+        coordinatorRuntimeEpoch: runtime?.runtimeEpoch,
+        capabilityRuntimeEpoch: capability?.runtimeEpoch,
+        runtimeCatalogEpoch: catalog.runtimeEpoch,
+        runtimeCatalogInitialized: catalog.initialized,
+        runtimeCatalogSource: catalog.source,
+        runtimeSkills: catalog.skills,
+      };
+    },
+
     async setWorkspaceSkillEnabled(skillName, enabled) {
-      const client = requireClient(getClient, 'Set skill enabled failed');
+      const client = requireWorkspaceClient(
+        getClient,
+        getWorkspaceCwd,
+        'Set skill enabled failed',
+      );
       return withActionTimeout(
-        client.setWorkspaceSkillEnabled(skillName, enabled),
+        client.setWorkspaceConfigSkillEnabled(skillName, enabled),
         'Set skill enabled timed out',
       );
     },
 
     async installWorkspaceSkill(request) {
       const client = requireClient(getClient, 'Install skill failed');
-      return withActionTimeout(
-        client.installWorkspaceSkill(request),
-        'Install skill timed out',
-      );
+      const operation =
+        request.scope === 'workspace'
+          ? client
+              .workspaceByCwd(requireWorkspaceCwd(getWorkspaceCwd))
+              .installWorkspaceConfigSkill({ ...request, scope: 'workspace' })
+          : client.installWorkspaceConfigSkill({
+              ...request,
+              scope: 'global',
+            });
+      return withActionTimeout(operation, 'Install skill timed out');
     },
 
     async deleteWorkspaceSkill(skillName, scope) {
       const client = requireClient(getClient, 'Delete skill failed');
-      return withActionTimeout(
-        client.deleteWorkspaceSkill(skillName, scope),
-        'Delete skill timed out',
-      );
+      const operation =
+        scope === 'workspace'
+          ? client
+              .workspaceByCwd(requireWorkspaceCwd(getWorkspaceCwd))
+              .deleteWorkspaceConfigSkill(skillName, 'workspace')
+          : client.deleteWorkspaceConfigSkill(skillName, scope);
+      return withActionTimeout(operation, 'Delete skill timed out');
     },
 
     async loadExtensionsStatus() {
@@ -441,12 +486,28 @@ export function createDaemonWorkspaceActions({
     },
 
     async loadToolsStatus() {
-      const client = requireClient(getClient, 'Load tools failed');
-      return withActionTimeout(client.workspaceTools(), 'Load tools timed out');
+      const client = requireWorkspaceClient(
+        getClient,
+        getWorkspaceCwd,
+        'Load tools failed',
+      );
+      await withActionTimeout(
+        ensureRuntimeCapability(client, 'tools'),
+        'Prepare tools timed out',
+        WORKSPACE_RUNTIME_ACTION_TIMEOUT_MS,
+      );
+      return withActionTimeout(
+        client.workspaceRuntimeTools(),
+        'Load tools timed out',
+      );
     },
 
     async setWorkspaceToolEnabled(toolName, enabled) {
-      const client = requireClient(getClient, 'Set tool enabled failed');
+      const client = requireWorkspaceClient(
+        getClient,
+        getWorkspaceCwd,
+        'Set tool enabled failed',
+      );
       return withActionTimeout(
         client.setWorkspaceToolEnabled(toolName, enabled),
         'Set tool enabled timed out',

--- a/packages/webui/src/daemon/workspace/hooks/useDaemonSkills.test.tsx
+++ b/packages/webui/src/daemon/workspace/hooks/useDaemonSkills.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loadSkillsConfigStatus, loadSkillsStatus, ensureRuntime, actions } =
+  vi.hoisted(() => {
+    const loadConfig = vi.fn();
+    const loadRuntime = vi.fn();
+    const prepareRuntime = vi.fn();
+    return {
+      loadSkillsConfigStatus: loadConfig,
+      loadSkillsStatus: loadRuntime,
+      ensureRuntime: prepareRuntime,
+      actions: {
+        loadSkillsConfigStatus: loadConfig,
+        loadSkillsStatus: loadRuntime,
+        ensureRuntime: prepareRuntime,
+        setWorkspaceSkillEnabled: vi.fn(),
+        installWorkspaceSkill: vi.fn(),
+        deleteWorkspaceSkill: vi.fn(),
+      },
+    };
+  });
+
+vi.mock('../DaemonWorkspaceProvider.js', () => ({
+  useDaemonWorkspaceActions: () => actions,
+}));
+vi.mock('../../session/DaemonSessionProvider.js', () => ({
+  useDaemonWorkspaceEventSignals: () => undefined,
+}));
+
+const { useDaemonSkills } = await import('./useDaemonSkills.js');
+
+describe('useDaemonSkills', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    loadSkillsConfigStatus.mockReset();
+    loadSkillsStatus.mockReset();
+    ensureRuntime.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('loads only the config inventory on mount', async () => {
+    loadSkillsConfigStatus.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: true,
+      source: 'config',
+      skills: [{ name: 'review', status: 'ok' }],
+    });
+    let result: ReturnType<typeof useDaemonSkills> | undefined;
+
+    function TestComponent() {
+      result = useDaemonSkills({ autoLoad: true });
+      return null;
+    }
+
+    await act(async () => {
+      root.render((<TestComponent />) as ReactNode);
+      await Promise.resolve();
+    });
+
+    expect(result?.configStatus?.source).toBe('config');
+    expect(result?.skills).toEqual([{ name: 'review', status: 'ok' }]);
+    expect(result?.runtimeStatus).toBeUndefined();
+    expect(result?.loading).toBe(false);
+    expect(ensureRuntime).not.toHaveBeenCalled();
+    expect(loadSkillsStatus).not.toHaveBeenCalled();
+  });
+
+  it('ensures only when explicitly requested and reuses its runtime status', async () => {
+    const staleCatalog = {
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: false,
+      runtimeEpoch: 2,
+      source: 'config',
+      skills: [{ name: 'review', status: 'disabled' }],
+    };
+    const liveCatalog = {
+      ...staleCatalog,
+      initialized: true,
+      runtimeEpoch: 4,
+      source: 'live',
+      skills: [{ name: 'review', status: 'ok' }],
+    };
+    const liveRuntime = {
+      v: 1 as const,
+      workspaceCwd: '/workspace',
+      state: 'idle',
+      runtimeLive: true,
+      runtimeEpoch: 4,
+      capabilities: {
+        skills: {
+          state: 'ready',
+          runtimeEpoch: 4,
+        },
+      },
+    };
+    loadSkillsConfigStatus.mockResolvedValue(staleCatalog);
+    loadSkillsStatus.mockResolvedValue({
+      ...liveCatalog,
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+      runtimeCatalogEpoch: 4,
+      runtimeCatalogInitialized: true,
+      runtimeCatalogSource: 'live',
+      runtimeSkills: liveCatalog.skills,
+    });
+    ensureRuntime.mockResolvedValue(liveRuntime);
+    let result: ReturnType<typeof useDaemonSkills> | undefined;
+
+    function TestComponent() {
+      result = useDaemonSkills({ autoLoad: true });
+      return null;
+    }
+
+    await act(async () => {
+      root.render((<TestComponent />) as ReactNode);
+    });
+
+    expect(result?.runtimeStatus).toBeUndefined();
+    expect(ensureRuntime).not.toHaveBeenCalled();
+
+    let prepared:
+      | Awaited<ReturnType<ReturnType<typeof useDaemonSkills>['ensureRuntime']>>
+      | undefined;
+    await act(async () => {
+      prepared = await result?.ensureRuntime();
+    });
+
+    expect(ensureRuntime).toHaveBeenCalledOnce();
+    expect(loadSkillsStatus).toHaveBeenCalledOnce();
+    expect(loadSkillsStatus).toHaveBeenCalledWith(liveRuntime);
+    expect(prepared).toMatchObject({
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+      runtimeCatalogEpoch: 4,
+      runtimeCatalogInitialized: true,
+      runtimeCatalogSource: 'live',
+    });
+    expect(result?.runtimeStatus).toMatchObject({
+      runtimeState: 'ready',
+      coordinatorRuntimeEpoch: 4,
+      capabilityRuntimeEpoch: 4,
+    });
+  });
+
+  it('keeps an ensure warning visible when the config fallback loads', async () => {
+    const fallback = {
+      v: 1 as const,
+      workspaceCwd: '/workspace',
+      initialized: false,
+      source: 'config' as const,
+      skills: [],
+      runtimeState: 'error' as const,
+    };
+    ensureRuntime.mockResolvedValue({
+      v: 1,
+      workspaceCwd: '/workspace',
+      state: 'error',
+      runtimeLive: false,
+      runtimeEpoch: 0,
+      capabilities: {
+        skills: {
+          state: 'error',
+          error: { code: 'skills_prepare_failed', message: 'ACP unavailable' },
+        },
+      },
+    });
+    loadSkillsStatus.mockResolvedValue(fallback);
+    let result: ReturnType<typeof useDaemonSkills> | undefined;
+
+    function TestComponent() {
+      result = useDaemonSkills();
+      return null;
+    }
+
+    await act(async () => root.render((<TestComponent />) as ReactNode));
+    await act(async () => {
+      await result?.ensureRuntime();
+    });
+
+    expect(result?.warning?.message).toBe('ACP unavailable');
+    expect(result?.error).toBeUndefined();
+  });
+
+  it('keeps ordinary config and snapshot reloads read-only', async () => {
+    const catalog = {
+      v: 1,
+      workspaceCwd: '/workspace',
+      initialized: false,
+      runtimeEpoch: 2,
+      source: 'config',
+      skills: [],
+    };
+    loadSkillsConfigStatus.mockResolvedValue(catalog);
+    loadSkillsStatus.mockResolvedValue(catalog);
+    let result: ReturnType<typeof useDaemonSkills> | undefined;
+
+    function TestComponent() {
+      result = useDaemonSkills({ autoLoad: true });
+      return null;
+    }
+
+    await act(async () => {
+      root.render((<TestComponent />) as ReactNode);
+    });
+    await act(async () => {
+      await result?.reloadConfig();
+      await result?.reload();
+    });
+
+    expect(loadSkillsConfigStatus).toHaveBeenCalledTimes(3);
+    expect(loadSkillsStatus).toHaveBeenCalledOnce();
+    expect(ensureRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webui/src/daemon/workspace/hooks/useDaemonSkills.ts
+++ b/packages/webui/src/daemon/workspace/hooks/useDaemonSkills.ts
@@ -4,22 +4,106 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import type { DaemonWorkspaceRuntimeStatus } from '@qwen-code/sdk/daemon';
+import { useDaemonWorkspaceEventSignals } from '../../session/DaemonSessionProvider.js';
 import { useDaemonWorkspaceActions } from '../DaemonWorkspaceProvider.js';
-import type { DaemonResourceOptions } from '../types.js';
+import type {
+  DaemonResourceOptions,
+  DaemonWorkspaceSkillsViewStatus,
+} from '../types.js';
 import { useDaemonResource } from './useDaemonResource.js';
+import { useWorkspaceEventReload } from './useWorkspaceEventReload.js';
 
-export function useDaemonSkills(options: DaemonResourceOptions = {}) {
-  const workspaceActions = useDaemonWorkspaceActions();
-  const load = useCallback(
-    () => workspaceActions.loadSkillsStatus(),
+export function useDaemonSkills(
+  options: DaemonResourceOptions = {},
+  workspaceCwdOverride?: string,
+) {
+  const workspaceActions = useDaemonWorkspaceActions(workspaceCwdOverride);
+  const preparedRuntimeStatusRef = useRef<
+    DaemonWorkspaceRuntimeStatus | undefined
+  >(undefined);
+  const [preparing, setPreparing] = useState(false);
+  const [prepareError, setPrepareError] = useState<Error | undefined>();
+  const [prepareWarning, setPrepareWarning] = useState<Error | undefined>();
+  const loadConfig = useCallback(
+    () => workspaceActions.loadSkillsConfigStatus(),
     [workspaceActions],
   );
-  const result = useDaemonResource(load, options);
+  const loadRuntime =
+    useCallback(async (): Promise<DaemonWorkspaceSkillsViewStatus> => {
+      const preparedStatus = preparedRuntimeStatusRef.current;
+      preparedRuntimeStatusRef.current = undefined;
+      return await workspaceActions.loadSkillsStatus(preparedStatus);
+    }, [workspaceActions]);
+  const config = useDaemonResource(loadConfig, options);
+  const runtime = useDaemonResource(loadRuntime, {
+    ...options,
+    autoLoad: false,
+  });
+  const reloadConfig = config.reload;
+  const reloadRuntime = runtime.reload;
+  const reload = useCallback(async () => {
+    const [, runtimeStatus] = await Promise.all([
+      reloadConfig(),
+      reloadRuntime(),
+    ]);
+    return runtimeStatus;
+  }, [reloadConfig, reloadRuntime]);
+  const ensureRuntime = useCallback(async () => {
+    setPreparing(true);
+    setPrepareError(undefined);
+    setPrepareWarning(undefined);
+    try {
+      const preparedStatus = await workspaceActions.ensureRuntime();
+      preparedRuntimeStatusRef.current = preparedStatus;
+      const refreshedStatus = await reloadRuntime();
+      if (
+        preparedStatus.capabilities.skills?.state === 'error' &&
+        refreshedStatus?.runtimeState !== 'ready'
+      ) {
+        setPrepareWarning(
+          new Error(
+            preparedStatus.capabilities.skills.error?.message ??
+              'Workspace skills runtime failed',
+          ),
+        );
+      }
+      return refreshedStatus;
+    } catch (error) {
+      setPrepareError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return undefined;
+    } finally {
+      setPreparing(false);
+    }
+  }, [reloadRuntime, workspaceActions]);
+  const signals = useDaemonWorkspaceEventSignals();
+  const version = signals
+    ? signals.settingsVersion + signals.extensionsVersion
+    : undefined;
+  useWorkspaceEventReload(
+    version,
+    reloadConfig,
+    options.autoLoad === true || config.data !== undefined,
+  );
+  useWorkspaceEventReload(version, reloadRuntime, runtime.data !== undefined);
+  const status = config.data ?? runtime.data;
   return {
-    ...result,
-    status: result.data,
-    skills: result.data?.skills ?? [],
+    data: status,
+    status,
+    configStatus: config.data,
+    runtimeStatus: runtime.data,
+    skills: config.data?.skills ?? runtime.data?.skills ?? [],
+    loading: config.loading || runtime.loading || preparing,
+    error: config.error ?? runtime.error ?? prepareError,
+    warning:
+      runtime.data?.runtimeState === 'ready' ? undefined : prepareWarning,
+    reload,
+    reloadConfig,
+    reloadRuntime,
+    ensureRuntime,
     setEnabled: workspaceActions.setWorkspaceSkillEnabled,
     install: workspaceActions.installWorkspaceSkill,
     remove: workspaceActions.deleteWorkspaceSkill,

--- a/packages/webui/src/daemon/workspace/types.ts
+++ b/packages/webui/src/daemon/workspace/types.ts
@@ -394,7 +394,10 @@ export interface DaemonWorkspaceActions {
   }): Promise<DaemonUsageDashboard>;
 
   // Skills
-  loadSkillsStatus(): Promise<DaemonWorkspaceSkillsStatus>;
+  loadSkillsConfigStatus(): Promise<DaemonWorkspaceSkillsStatus>;
+  loadSkillsStatus(
+    runtimeStatus?: DaemonWorkspaceRuntimeStatus,
+  ): Promise<DaemonWorkspaceSkillsViewStatus>;
   setWorkspaceSkillEnabled(
     skillName: string,
     enabled: boolean,


### PR DESCRIPTION
## What this PR does

This PR moves Skills configuration and live validation onto the selected workspace runtime, refreshes new-task Skills and slash commands after management changes, and completes the shared management-page workspace scoping.

This is stack 4/4 and contains one commit on top of `codex/workspace-runtime-extensions`.

## Why it's needed

Skills shown in management and new-task flows must reflect the selected workspace even when no session exists. Configuration should load immediately, while runtime validation can reconcile in the background without blocking the page.

## Reviewer Test Plan

### How to verify

Open Skills management without a session, verify configuration appears before background runtime reconciliation completes, then install, remove, enable, or disable a Skill. Open a new task and confirm the latest Skills and slash commands are available.

### Evidence (Before & After)

Before: Skills and slash commands could remain stale until a session refreshed them. After: configuration loads immediately and workspace runtime reconciliation refreshes live validation and new-task commands.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local npm workspace. CLI, SDK, Web UI, and Web Shell type checks passed; 129 CLI Skills tests, 221 Web UI tests, and 149 Web Shell tests passed. End-to-end validation was not run.

## Risk & Scope

- Main risk or tradeoff: configuration and live runtime catalogs are intentionally loaded on separate timelines and merged in the UI.
- Not validated / out of scope: full browser end-to-end validation.
- Breaking changes / migration notes: Skills management uses workspace-runtime-scoped APIs; persisted Skills configuration remains compatible.

## Linked Issues

Stack 4/4: #7308 Runtime foundation → #7309 MCP → #7310 Extensions → **#7311 Skills**.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将 Skills 配置和实时校验迁移到所选 Workspace Runtime，在管理页面变更后刷新新建任务的 Skills 和斜杠命令，并完成管理页面共享的工作区作用域处理。

这是堆叠 PR 的第 4/4 个，仅包含基于 `codex/workspace-runtime-extensions` 的一个 commit。

## 为什么需要

即使没有 Session，管理页和新建任务流程展示的 Skills 也必须反映所选工作区。配置应立即加载，Runtime 校验则可以在后台协调而不阻塞页面。

## 审查测试计划

### 如何验证

在没有 Session 时打开 Skills 管理页，确认配置会先于后台 Runtime 协调显示，然后安装、删除、启用或禁用 Skill。打开新建任务，确认最新 Skills 和斜杠命令可用。

### 前后对比证据

改动前：Skills 和斜杠命令可能一直过期，直到 Session 刷新。改动后：配置立即加载，Workspace Runtime 协调会刷新实时校验和新建任务命令。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

本地 npm workspace。CLI、SDK、Web UI 和 Web Shell 类型检查通过；129 个 CLI Skills 测试、221 个 Web UI 测试和 149 个 Web Shell 测试通过；未执行端到端验证。

## 风险与范围

- 主要风险或取舍：配置清单和实时 Runtime 清单有意按不同时间线加载，并在 UI 中合并。
- 未验证或不在范围内：完整浏览器端到端验证。
- 破坏性改动或迁移说明：Skills 管理使用 Workspace Runtime 作用域接口；已有 Skills 配置保持兼容。

## 关联事项

堆叠 PR 第 4/4 个：#7308 Runtime 基础架构 → #7309 MCP → #7310 拓展 → **#7311 Skills**。

</details>
