### PR TITLE
fix(web-shell): restore context tags in queued and recalled prompts

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1186,6 +1186,7 @@ export const ChatEditor = memo(
       renderComposerTag,
       renderComposerTagTooltip,
       onComposerTagClick,
+      parseUserMessageContent,
     } = useWebShellCustomization();
 
     const core = useComposerCore({
@@ -1213,6 +1214,7 @@ export const ChatEditor = memo(
       atProviders,
       atWorkspaceCwd,
       composerTagIcons,
+      parseUserMessageContent,
       renderComposerTag,
       renderComposerTagTooltip,
       onComposerTagClick,
@@ -1551,6 +1553,7 @@ export const ChatEditor = memo(
       searchInputRef,
       searchUiRef,
       closeSearch,
+      restoreSearchMatch,
       handleSearchKeyDown,
       handleSearchInput,
       handleSearchCompositionEnd,
@@ -1864,7 +1867,11 @@ export const ChatEditor = memo(
                         }`}
                         onMouseDown={(event) => {
                           event.preventDefault();
-                          core.replaceEditorText(match);
+                          if (restoreSearchMatch) {
+                            restoreSearchMatch(match);
+                          } else {
+                            core.replaceEditorText(match);
+                          }
                           closeSearch(false);
                         }}
                       >

--- a/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
@@ -178,6 +178,37 @@ describe('QueuedPromptDisplay', () => {
     expect(container.textContent).not.toContain(serialized);
   });
 
+  it('truncates a text-only queued prompt at the visible preview budget', () => {
+    const text = 'x'.repeat(300);
+    const { container } = setup({ prompts: [{ id: 1, text }] });
+
+    expect(
+      container.querySelector('[class*="queuedPromptText"]')?.textContent,
+    ).toBe(`${text.slice(0, 240)}...`);
+  });
+
+  it('truncates trailing text after an atomic tag consumes the visible preview budget', () => {
+    const visibleTag = 'x'.repeat(240);
+    const serialized = `<context>${visibleTag}</context>`;
+    const trailingText = ' explain the table';
+    const { container } = setup(
+      { prompts: [{ id: 1, text: `${serialized}${trailingText}` }] },
+      {
+        parseUserMessageContent: () => [
+          {
+            type: 'tag',
+            tag: { id: 'orders', value: visibleTag, serialized },
+          },
+          { type: 'text', text: trailingText },
+        ],
+      },
+    );
+
+    expect(
+      container.querySelector('[class*="queuedPromptText"]')?.textContent,
+    ).toBe(`${visibleTag}...`);
+  });
+
   it('falls back to raw queued text when parsing throws', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { container } = setup(

--- a/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
@@ -2,6 +2,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import {
+  WebShellCustomizationProvider,
+  type WebShellCustomization,
+  type UserMessageContentParser,
+} from '../customization';
 import { getTranslator } from '../i18n';
 import { QueuedPromptDisplay, type QueuedPrompt } from './QueuedPromptDisplay';
 
@@ -30,6 +35,7 @@ afterEach(() => {
 
 function setup(
   overrides: Partial<React.ComponentProps<typeof QueuedPromptDisplay>> = {},
+  customization: WebShellCustomization = {},
 ) {
   const handlers = {
     onDelete: vi.fn(),
@@ -43,12 +49,14 @@ function setup(
         { id: 2, text: '排队消息二' },
       ];
   const container = render(
-    <QueuedPromptDisplay
-      prompts={prompts}
-      t={t}
-      {...handlers}
-      {...overrides}
-    />,
+    <WebShellCustomizationProvider value={customization}>
+      <QueuedPromptDisplay
+        prompts={prompts}
+        t={t}
+        {...handlers}
+        {...overrides}
+      />
+    </WebShellCustomizationProvider>,
   );
   return { container, handlers };
 }
@@ -63,6 +71,127 @@ describe('QueuedPromptDisplay', () => {
     const { container } = setup();
     expect(container.textContent).toContain('排队消息一');
     expect(container.textContent).toContain('排队消息二');
+  });
+
+  it('renders queued reference annotations as tags', () => {
+    const serialized = '<context id="orders">orders</context>';
+    const text = `inspect ${serialized} now`;
+    const start = text.indexOf(serialized);
+    const { container } = setup({
+      prompts: [
+        {
+          id: 1,
+          text,
+          inputAnnotations: [
+            {
+              type: 'reference',
+              start,
+              end: start + serialized.length,
+              text: serialized,
+              reference: {
+                id: 'orders',
+                kind: 'data-table',
+                label: 'Table',
+                value: 'orders',
+                serialized,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(container.textContent).toContain('inspect');
+    expect(container.textContent).toContain('Table');
+    expect(container.textContent).toContain('orders');
+    expect(container.textContent).not.toContain(serialized);
+  });
+
+  it('parses the complete legacy queued prompt before rendering its tag', () => {
+    const serialized = `<context>${'x'.repeat(300)}</context>`;
+    const text = `${serialized} explain the table`;
+    const parser = vi.fn(() => [
+      {
+        type: 'tag' as const,
+        tag: { id: 'orders', value: 'orders', serialized },
+      },
+      { type: 'text' as const, text: ' explain the table' },
+    ]);
+    const { container } = setup(
+      { prompts: [{ id: 1, text }] },
+      { parseUserMessageContent: parser },
+    );
+
+    expect(parser).toHaveBeenCalledWith(text);
+    expect(container.textContent).toContain('orders');
+    expect(container.textContent).not.toContain(serialized);
+  });
+
+  it('falls back to raw queued text when parser output cannot recreate it', () => {
+    const text = '<context id="orders">orders</context>';
+    const { container } = setup(
+      { prompts: [{ id: 1, text }] },
+      {
+        parseUserMessageContent: () => [
+          { type: 'text', text: 'different content' },
+        ],
+      },
+    );
+
+    expect(container.textContent).toContain(text);
+    expect(container.textContent).not.toContain('different content');
+  });
+
+  it('falls back to raw queued text when a tag field is malformed', () => {
+    const text = '<context id="orders">orders</context>';
+    const malformedParser = (() => [
+      {
+        type: 'tag',
+        tag: { id: 'orders', serialized: 1 },
+      },
+    ]) as unknown as UserMessageContentParser;
+    const { container } = setup(
+      { prompts: [{ id: 1, text }] },
+      { parseUserMessageContent: malformedParser },
+    );
+
+    expect(container.textContent).toContain(text);
+  });
+
+  it('omits an atomic tag that exceeds the visible preview budget', () => {
+    const visibleTag = 'x'.repeat(241);
+    const serialized = `<context>${visibleTag}</context>`;
+    const { container } = setup(
+      { prompts: [{ id: 1, text: serialized }] },
+      {
+        parseUserMessageContent: () => [
+          {
+            type: 'tag',
+            tag: { id: 'orders', value: visibleTag, serialized },
+          },
+        ],
+      },
+    );
+
+    expect(container.textContent).toContain('...');
+    expect(container.textContent).not.toContain(visibleTag);
+    expect(container.textContent).not.toContain(serialized);
+  });
+
+  it('falls back to raw queued text when parsing throws', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = setup(
+      { prompts: [{ id: 1, text: 'raw <broken /> content' }] },
+      {
+        parseUserMessageContent: () => {
+          throw new Error('bad host payload');
+        },
+      },
+    );
+
+    expect(container.textContent).toContain('raw <broken /> content');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('passes the prompt id to per-row delete', () => {

--- a/packages/web-shell/client/components/QueuedPromptDisplay.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.tsx
@@ -6,16 +6,118 @@
 
 import type { PromptImage } from '../adapters/promptTypes';
 import type { DaemonInputAnnotation } from '@qwen-code/sdk/daemon';
+import { Fragment } from 'react';
 import deleteIconUrl from '../assets/icons/delete.svg';
 import editIconUrl from '../assets/icons/edit.svg';
 import insertIconUrl from '../assets/icons/insert.svg';
 import queueIconUrl from '../assets/icons/queue.svg';
 import type { getTranslator } from '../i18n';
+import {
+  useWebShellCustomization,
+  type UserMessageContentParser,
+  type WebShellComposerTag,
+} from '../customization';
+import {
+  parseUserMessageContentSafely,
+  splitComposerTagContentByAnnotations,
+} from '../utils/composerTag';
 import { cssUrlVar } from '../utils/cssUrlVar';
 import { isCommandPrompt } from '../utils/localCommandQueue';
+import { ReadonlyComposerTag } from './messages/UserMessage';
 import styles from '../App.module.css';
 
 const MAX_QUEUED_PROMPT_PREVIEW_CHARS = 240;
+
+type QueuedPromptPreviewPart =
+  | { type: 'text'; text: string }
+  | {
+      type: 'tag';
+      tag: WebShellComposerTag;
+      preserveCustomKindLabel: boolean;
+    };
+
+function getTagDisplayText(tag: WebShellComposerTag): string {
+  return tag.value?.trim() || tag.label?.trim() || tag.id;
+}
+
+function getQueuedPromptParts(
+  prompt: QueuedPrompt,
+  parser: UserMessageContentParser | undefined,
+): QueuedPromptPreviewPart[] {
+  if (prompt.inputAnnotations && prompt.inputAnnotations.length > 0) {
+    return splitComposerTagContentByAnnotations(
+      prompt.text,
+      prompt.inputAnnotations,
+    ).map((segment) =>
+      segment.type === 'text'
+        ? segment
+        : {
+            type: 'tag',
+            tag: segment.tag,
+            preserveCustomKindLabel: true,
+          },
+    );
+  }
+
+  const parsed = parseUserMessageContentSafely(
+    prompt.text,
+    parser,
+    '[WebShell] failed to parse queued prompt content',
+    { requireSourcePreservation: true },
+  );
+  if (!parsed) return [{ type: 'text', text: prompt.text }];
+  return parsed.map((part) =>
+    part.type === 'text'
+      ? part
+      : { type: 'tag', tag: part.tag, preserveCustomKindLabel: false },
+  );
+}
+
+function truncateQueuedPromptParts(parts: readonly QueuedPromptPreviewPart[]): {
+  parts: QueuedPromptPreviewPart[];
+  truncated: boolean;
+} {
+  const preview: QueuedPromptPreviewPart[] = [];
+  let remaining = MAX_QUEUED_PROMPT_PREVIEW_CHARS;
+  let truncated = false;
+
+  for (const part of parts) {
+    if (part.type === 'tag') {
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      const visibleLength = getTagDisplayText(part.tag).length;
+      if (visibleLength > remaining) {
+        truncated = true;
+        break;
+      }
+      preview.push(part);
+      remaining -= visibleLength;
+      continue;
+    }
+
+    let text = part.text.replace(/\s+/g, ' ');
+    if (preview.length === 0) text = text.trimStart();
+    if (!text) continue;
+    if (text.length > remaining) {
+      if (remaining > 0)
+        preview.push({ type: 'text', text: text.slice(0, remaining) });
+      truncated = true;
+      break;
+    }
+    preview.push({ type: 'text', text });
+    remaining -= text.length;
+  }
+
+  const last = preview[preview.length - 1];
+  if (last?.type === 'text') {
+    const text = last.text.trimEnd();
+    if (text) last.text = text;
+    else preview.pop();
+  }
+  return { parts: preview, truncated };
+}
 
 export interface QueuedPrompt {
   id: number;
@@ -43,16 +145,21 @@ export function QueuedPromptDisplay({
   onInsert: (id: number) => void;
   onEdit: (id: number) => void;
 }) {
+  const {
+    parseUserMessageContent,
+    composerTagIcons,
+    renderComposerTag,
+    renderComposerTagTooltip,
+    onComposerTagClick,
+  } = useWebShellCustomization();
   if (prompts.length === 0) return null;
 
   return (
     <div className={styles.queuedPrompts}>
       {prompts.map((prompt) => {
-        const normalizedPreview = prompt.text.replace(/\s+/g, ' ').trim();
-        const preview =
-          normalizedPreview.length > MAX_QUEUED_PROMPT_PREVIEW_CHARS
-            ? `${normalizedPreview.slice(0, MAX_QUEUED_PROMPT_PREVIEW_CHARS)}...`
-            : normalizedPreview;
+        const preview = truncateQueuedPromptParts(
+          getQueuedPromptParts(prompt, parseUserMessageContent),
+        );
         const imageCount = prompt.images?.length ?? 0;
         const isCommand = isCommandPrompt(prompt.text);
         const isSubmitting = prompt.serverState === 'submitting';
@@ -82,7 +189,22 @@ export function QueuedPromptDisplay({
               />
             </span>
             <span className={styles.queuedPromptText}>
-              {preview}
+              {preview.parts.map((part, index) =>
+                part.type === 'text' ? (
+                  <Fragment key={index}>{part.text}</Fragment>
+                ) : (
+                  <ReadonlyComposerTag
+                    key={`${part.tag.id}:${index}`}
+                    tag={part.tag}
+                    composerTagIcons={composerTagIcons}
+                    renderComposerTag={renderComposerTag}
+                    renderComposerTagTooltip={renderComposerTagTooltip}
+                    onComposerTagClick={onComposerTagClick}
+                    preserveCustomKindLabel={part.preserveCustomKindLabel}
+                  />
+                ),
+              )}
+              {preview.truncated ? '...' : null}
               {imageCount > 0
                 ? ` ${t('queue.imageCount', { count: imageCount })}`
                 : ''}

--- a/packages/web-shell/client/components/messages/UserMessage.tsx
+++ b/packages/web-shell/client/components/messages/UserMessage.tsx
@@ -13,6 +13,7 @@ import {
   getComposerTagIconUrl,
   getComposerTagViewModel,
   isBuiltinComposerTagIconUrl,
+  parseUserMessageContentSafely,
   splitComposerTagContentByAnnotations,
 } from '../../utils/composerTag';
 import type { DaemonInputAnnotation } from '@qwen-code/sdk/daemon';
@@ -23,7 +24,6 @@ import type {
   ComposerTagRenderer,
   WebShellComposerTag,
   WebShellComposerTagIconMap,
-  WebShellUserMessagePart,
 } from '../../customization';
 import {
   getComposerTagDisplay,
@@ -74,7 +74,7 @@ function DefaultUserMessageContent({
         segment.type === 'text' ? (
           <Fragment key={index}>{segment.text}</Fragment>
         ) : (
-          <UserMessageTag
+          <ReadonlyComposerTag
             composerTagIcons={composerTagIcons}
             key={`${segment.tag.id}:${index}`}
             onComposerTagClick={onComposerTagClick}
@@ -127,18 +127,16 @@ export const UserMessage = memo(function UserMessage({
         />
       );
     }
-    let parts: readonly WebShellUserMessagePart[] | undefined | null;
-    try {
-      parts = parseUserMessageContent?.(content);
-    } catch (error) {
-      console.warn('[WebShell] failed to parse user message content', error);
-      return content;
-    }
-    if (!parts || parts.length === 0) return content;
+    const parts = parseUserMessageContentSafely(
+      content,
+      parseUserMessageContent,
+      '[WebShell] failed to parse user message content',
+    );
+    if (!parts) return content;
     return parts.map((part, index) => {
       if (part.type === 'text') return part.text;
       return (
-        <UserMessageTag
+        <ReadonlyComposerTag
           key={`${part.tag.id}-${index}`}
           tag={part.tag}
           composerTagIcons={composerTagIcons}
@@ -248,7 +246,7 @@ function getTagText(tag: WebShellComposerTag): string {
   return getComposerTagDisplay(tag);
 }
 
-function UserMessageTag({
+export function ReadonlyComposerTag({
   tag,
   composerTagIcons,
   renderComposerTag,

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -387,6 +387,51 @@ describe('useComposerCore tags', () => {
     expect(editor.textContent).not.toContain('orders');
   });
 
+  it('restores draft top tags after ArrowDown exits prompt history', async () => {
+    const historyText = 'previous prompt';
+    const draftText = 'draft prompt';
+    const draftTag = {
+      id: 'file:draft.txt',
+      value: 'draft.txt',
+      serialized: '@draft.txt',
+    };
+    await mount();
+
+    act(() => {
+      latest!.setText(historyText);
+      latest!.submitText();
+      latest!.setText(draftText);
+      latest!.addTags([draftTag]);
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    act(() => {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          code: 'ArrowUp',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(latest!.getText()).toBe(historyText);
+    expect(latest!.composerTags).toEqual([]);
+
+    act(() => {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          code: 'ArrowDown',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(latest!.getText()).toBe(draftText);
+    expect(latest!.composerTags).toEqual([draftTag]);
+  });
+
   it('restores tags when Tab or a search-result selection recalls history', async () => {
     const serialized = '<context id="search-orders">orders</context>';
     const prompt = `inspect ${serialized} now`;

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -21,12 +21,18 @@ function Harness({
   renderComposerTag,
   renderComposerTagTooltip,
   parseUserMessageContent,
+  followupState,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit: ReturnType<typeof vi.fn>;
   renderComposerTag?: () => ReactNode;
   renderComposerTagTooltip?: () => ReactNode;
   parseUserMessageContent?: UserMessageContentParser;
+  followupState?: {
+    isVisible: boolean;
+    shownAt: number;
+    suggestion: string | null;
+  };
 }) {
   const composer = useComposerCore({
     onSubmit,
@@ -35,6 +41,7 @@ function Harness({
     renderComposerTag,
     renderComposerTagTooltip,
     parseUserMessageContent,
+    followupState,
     composerInput,
     composerInputVersion: composerInput ? 1 : undefined,
   });
@@ -49,12 +56,18 @@ async function mount({
   renderComposerTag,
   renderComposerTagTooltip,
   parseUserMessageContent,
+  followupState,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit?: ReturnType<typeof vi.fn>;
   renderComposerTag?: () => ReactNode;
   renderComposerTagTooltip?: () => ReactNode;
   parseUserMessageContent?: UserMessageContentParser;
+  followupState?: {
+    isVisible: boolean;
+    shownAt: number;
+    suggestion: string | null;
+  };
 } = {}) {
   container = document.createElement('div');
   document.body.append(container);
@@ -69,6 +82,7 @@ async function mount({
           renderComposerTag={renderComposerTag}
           renderComposerTagTooltip={renderComposerTagTooltip}
           parseUserMessageContent={parseUserMessageContent}
+          followupState={followupState}
         />
       </I18nProvider>,
     );
@@ -79,6 +93,8 @@ async function mount({
 afterEach(() => {
   act(() => root?.unmount());
   container?.remove();
+  localStorage.removeItem('qwen-web-shell-history');
+  localStorage.removeItem('qwen-web-shell-command-history');
   root = null;
   container = null;
   latest = null;
@@ -497,6 +513,34 @@ describe('useComposerCore tags', () => {
           }),
         ],
       },
+    );
+  });
+
+  it('submits the selected plain Ctrl-R history text instead of a visible followup', async () => {
+    const historyText = 'inspect the orders';
+    localStorage.setItem(
+      'qwen-web-shell-history',
+      JSON.stringify([historyText]),
+    );
+    const { onSubmit } = await mount({
+      followupState: {
+        isVisible: true,
+        shownAt: Date.now(),
+        suggestion: 'inspect the orders table and summarize',
+      },
+    });
+
+    act(() => {
+      latest!.setText('draft');
+      latest!.searchState.openHistorySearch();
+      latest!.searchState.submitSearchMatch(historyText);
+    });
+
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      historyText,
+      undefined,
+      expect.any(Function),
+      undefined,
     );
   });
 

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -4,7 +4,10 @@ import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { I18nProvider } from '../i18n';
 import { useComposerCore, type UseComposerCoreReturn } from './useComposerCore';
-import type { WebShellComposerInput } from '../customization';
+import type {
+  UserMessageContentParser,
+  WebShellComposerInput,
+} from '../customization';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
@@ -17,11 +20,13 @@ function Harness({
   onSubmit,
   renderComposerTag,
   renderComposerTagTooltip,
+  parseUserMessageContent,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit: ReturnType<typeof vi.fn>;
   renderComposerTag?: () => ReactNode;
   renderComposerTagTooltip?: () => ReactNode;
+  parseUserMessageContent?: UserMessageContentParser;
 }) {
   const composer = useComposerCore({
     onSubmit,
@@ -29,6 +34,7 @@ function Harness({
     editorTheme: {},
     renderComposerTag,
     renderComposerTagTooltip,
+    parseUserMessageContent,
     composerInput,
     composerInputVersion: composerInput ? 1 : undefined,
   });
@@ -42,11 +48,13 @@ async function mount({
   onSubmit = vi.fn(),
   renderComposerTag,
   renderComposerTagTooltip,
+  parseUserMessageContent,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit?: ReturnType<typeof vi.fn>;
   renderComposerTag?: () => ReactNode;
   renderComposerTagTooltip?: () => ReactNode;
+  parseUserMessageContent?: UserMessageContentParser;
 } = {}) {
   container = document.createElement('div');
   document.body.append(container);
@@ -60,6 +68,7 @@ async function mount({
           onSubmit={onSubmit}
           renderComposerTag={renderComposerTag}
           renderComposerTagTooltip={renderComposerTagTooltip}
+          parseUserMessageContent={parseUserMessageContent}
         />
       </I18nProvider>,
     );
@@ -285,5 +294,299 @@ describe('useComposerCore tags', () => {
         ],
       },
     );
+  });
+
+  it('restores parsed inline tags when arrow keys browse prompt history', async () => {
+    const serialized = '<context id="orders">orders</context>';
+    const prompt = `inspect ${serialized} now`;
+    const parseUserMessageContent: UserMessageContentParser = (content) => {
+      if (content !== prompt) return undefined;
+      return [
+        { type: 'text', text: 'inspect ' },
+        {
+          type: 'tag',
+          tag: { id: 'orders', value: 'orders', serialized },
+        },
+        { type: 'text', text: ' now' },
+      ];
+    };
+    const { onSubmit } = await mount({ parseUserMessageContent });
+
+    act(() => {
+      latest!.setText(prompt);
+      latest!.submitText();
+      latest!.setText('draft');
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    act(() => {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          code: 'ArrowUp',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(editor.textContent).toContain('inspect');
+    expect(editor.textContent).toContain('orders');
+    expect(editor.textContent).not.toContain(serialized);
+
+    act(() => latest!.submitText());
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      prompt,
+      undefined,
+      expect.any(Function),
+      {
+        inputAnnotations: [
+          expect.objectContaining({
+            start: 8,
+            end: 8 + serialized.length,
+            text: serialized,
+            reference: expect.objectContaining({ id: 'orders', serialized }),
+          }),
+        ],
+      },
+    );
+
+    act(() => {
+      latest!.setText('draft');
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          code: 'ArrowUp',
+          bubbles: true,
+        }),
+      );
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          code: 'ArrowDown',
+          bubbles: true,
+        }),
+      );
+    });
+    expect(latest!.getText()).toBe('draft');
+    expect(editor.textContent).not.toContain('orders');
+  });
+
+  it('restores tags when Tab or a search-result selection recalls history', async () => {
+    const serialized = '<context id="search-orders">orders</context>';
+    const prompt = `inspect ${serialized} now`;
+    const parseUserMessageContent: UserMessageContentParser = (content) =>
+      content === prompt
+        ? [
+            { type: 'text', text: 'inspect ' },
+            {
+              type: 'tag',
+              tag: { id: 'orders', value: 'orders', serialized },
+            },
+            { type: 'text', text: ' now' },
+          ]
+        : undefined;
+    const { onSubmit } = await mount({ parseUserMessageContent });
+
+    act(() => {
+      latest!.setText(prompt);
+      latest!.submitText();
+      latest!.setText('draft');
+      latest!.searchState.openHistorySearch();
+    });
+
+    const preventDefault = vi.fn();
+    act(() => {
+      latest!.searchState.handleSearchKeyDown({
+        key: 'Tab',
+        nativeEvent: { isComposing: false },
+        preventDefault,
+      } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    expect(preventDefault).toHaveBeenCalled();
+    expect(editor.textContent).toContain('orders');
+    expect(editor.textContent).not.toContain(serialized);
+
+    act(() => latest!.searchState.restoreSearchMatch?.(prompt));
+    expect(editor.textContent).toContain('orders');
+    expect(editor.textContent).not.toContain(serialized);
+
+    act(() => {
+      latest!.setText('draft');
+      latest!.searchState.openHistorySearch();
+    });
+    act(() => {
+      latest!.searchState.handleSearchKeyDown({
+        key: 'Enter',
+        nativeEvent: { isComposing: false },
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    });
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      prompt,
+      undefined,
+      expect.any(Function),
+      {
+        inputAnnotations: [
+          expect.objectContaining({
+            start: 8,
+            end: 8 + serialized.length,
+            text: serialized,
+            reference: expect.objectContaining({ id: 'orders', serialized }),
+          }),
+        ],
+      },
+    );
+  });
+
+  it('does not prepend stale top tags when Ctrl-R submits a recalled inline tag', async () => {
+    const serialized = '<context id="search-stale-orders">orders</context>';
+    const prompt = `inspect ${serialized} now`;
+    const parseUserMessageContent: UserMessageContentParser = (content) =>
+      content === prompt
+        ? [
+            { type: 'text', text: 'inspect ' },
+            {
+              type: 'tag',
+              tag: { id: 'orders', value: 'orders', serialized },
+            },
+            { type: 'text', text: ' now' },
+          ]
+        : undefined;
+    const { onSubmit } = await mount({ parseUserMessageContent });
+
+    act(() => {
+      latest!.setText(prompt);
+      latest!.submitText();
+    });
+    act(() => {
+      latest!.addTags([
+        {
+          id: 'stale',
+          value: 'stale',
+          serialized: '<context id="stale">stale</context>',
+        },
+      ]);
+    });
+    expect(latest!.composerTags).toHaveLength(1);
+
+    act(() => {
+      latest!.setText('draft');
+      latest!.searchState.openHistorySearch();
+    });
+    act(() => {
+      latest!.searchState.handleSearchKeyDown({
+        key: 'Enter',
+        nativeEvent: { isComposing: false },
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>);
+    });
+
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      prompt,
+      undefined,
+      expect.any(Function),
+      {
+        inputAnnotations: [
+          expect.objectContaining({
+            start: 8,
+            end: 8 + serialized.length,
+            text: serialized,
+            reference: expect.objectContaining({ id: 'orders', serialized }),
+          }),
+        ],
+      },
+    );
+  });
+
+  it('keeps history source text and skips annotations for mismatched parser output', async () => {
+    const prompt = '<context id="orders">orders</context>';
+    const parseUserMessageContent: UserMessageContentParser = (content) =>
+      content === prompt
+        ? [
+            {
+              type: 'tag',
+              tag: {
+                id: 'orders',
+                value: 'orders',
+                serialized: '<context id="other">other</context>',
+              },
+            },
+          ]
+        : undefined;
+    const { onSubmit } = await mount({ parseUserMessageContent });
+
+    act(() => {
+      latest!.setText(prompt);
+      latest!.submitText();
+      latest!.setText('draft');
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    act(() => {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          code: 'ArrowUp',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(editor.textContent).toContain(prompt);
+    act(() => latest!.submitText());
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      prompt,
+      undefined,
+      expect.any(Function),
+      undefined,
+    );
+  });
+
+  it('restores tags when a history search submission is rejected', async () => {
+    const serialized = '<context id="rejected-orders">orders</context>';
+    const prompt = `inspect ${serialized} now`;
+    const parseUserMessageContent: UserMessageContentParser = (content) =>
+      content === prompt
+        ? [
+            { type: 'text', text: 'inspect ' },
+            {
+              type: 'tag',
+              tag: { id: 'orders', value: 'orders', serialized },
+            },
+            { type: 'text', text: ' now' },
+          ]
+        : undefined;
+    const onSubmit = vi
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(false);
+    await mount({ onSubmit, parseUserMessageContent });
+
+    act(() => {
+      latest!.setText(prompt);
+      latest!.submitText();
+      latest!.searchState.submitSearchMatch(prompt);
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      prompt,
+      undefined,
+      expect.any(Function),
+      {
+        inputAnnotations: [
+          expect.objectContaining({
+            start: 8,
+            end: 8 + serialized.length,
+            text: serialized,
+            reference: expect.objectContaining({ id: 'orders', serialized }),
+          }),
+        ],
+      },
+    );
+    expect(editor.textContent).toContain('orders');
+    expect(editor.textContent).not.toContain(serialized);
   });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -387,6 +387,51 @@ describe('useComposerCore tags', () => {
     expect(editor.textContent).not.toContain('orders');
   });
 
+  it('restores shell history as raw command text without parsing tags', async () => {
+    const serialized = '<context id="orders">orders</context>';
+    const command = `echo ${serialized}`;
+    const parseUserMessageContent = vi.fn<UserMessageContentParser>(
+      (content) =>
+        content === command
+          ? [
+              { type: 'text', text: 'echo ' },
+              {
+                type: 'tag',
+                tag: { id: 'orders', value: 'orders', serialized },
+              },
+            ]
+          : undefined,
+    );
+    await mount({ parseUserMessageContent });
+
+    act(() => {
+      latest!.setShellMode(true);
+    });
+    act(() => {
+      latest!.setText(command);
+      latest!.submitText();
+      latest!.setText('draft');
+    });
+
+    const editor = container!.querySelector('.cm-content')!;
+    act(() => {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowUp',
+          code: 'ArrowUp',
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(latest!.getText()).toBe(command);
+    expect(editor.textContent).toBe(command);
+    expect(
+      editor.querySelectorAll('button[aria-label^="Remove "]'),
+    ).toHaveLength(0);
+    expect(parseUserMessageContent).not.toHaveBeenCalled();
+  });
+
   it('restores draft top tags after ArrowDown exits prompt history', async () => {
     const historyText = 'previous prompt';
     const draftText = 'draft prompt';

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -1417,6 +1417,24 @@ export function useComposerCore(
   const [composerTags, setComposerTags] = useState<WebShellComposerTag[]>([]);
   const composerTagsRef = useRef<WebShellComposerTag[]>([]);
   composerTagsRef.current = composerTags;
+  const historyDraftComposerTagsRef = useRef<WebShellComposerTag[] | null>(
+    null,
+  );
+  const rememberPromptHistoryDraftTags = useCallback(() => {
+    if (historyDraftComposerTagsRef.current !== null) return;
+    historyDraftComposerTagsRef.current = [...composerTagsRef.current];
+  }, []);
+  const restorePromptHistoryDraftTags = useCallback(() => {
+    const tags = historyDraftComposerTagsRef.current;
+    if (tags === null) return;
+    historyDraftComposerTagsRef.current = null;
+    const restoredTags = [...tags];
+    composerTagsRef.current = restoredTags;
+    setComposerTags(restoredTags);
+  }, []);
+  const clearPromptHistoryDraftTags = useCallback(() => {
+    historyDraftComposerTagsRef.current = null;
+  }, []);
   const clearRestoredComposerTags = useCallback(() => {
     composerTagsRef.current = [];
     setComposerTags([]);
@@ -1761,10 +1779,13 @@ export function useComposerCore(
     const current = view.state.doc.toString();
     const prev = history.navigateUp(current);
     if (prev !== null) {
+      if (!shellModeRef.current) {
+        rememberPromptHistoryDraftTags();
+      }
       restoreHistoryEntry(view, prev);
     }
     view.focus();
-  }, [restoreHistoryEntry]);
+  }, [rememberPromptHistoryDraftTags, restoreHistoryEntry]);
 
   const navigateNextHistory = useCallback(() => {
     if (disabledRef.current) return;
@@ -1784,10 +1805,15 @@ export function useComposerCore(
       : historyActionsRef.current;
     const next = history.navigateDown();
     if (next !== null) {
+      const returningToPromptDraft =
+        !shellModeRef.current && !history.isNavigating();
       restoreHistoryEntry(view, next);
+      if (returningToPromptDraft) {
+        restorePromptHistoryDraftTags();
+      }
     }
     view.focus();
-  }, [restoreHistoryEntry]);
+  }, [restoreHistoryEntry, restorePromptHistoryDraftTags]);
 
   // ---- Create CodeMirror EditorView ----
   useEffect(() => {
@@ -1922,6 +1948,7 @@ export function useComposerCore(
           historyActionsRef.current.reset();
         }
         historyBrowseActiveRef.current = false;
+        clearPromptHistoryDraftTags();
         setComposerTags([]);
         setPastedImages([]);
         view.dispatch({
@@ -2128,6 +2155,7 @@ export function useComposerCore(
           const current = view.state.doc.toString();
           const prev = history.navigateUp(current);
           if (prev === null) return false;
+          rememberPromptHistoryDraftTags();
           historyBrowseActiveRef.current = true;
           restoreHistoryEntry(view, prev);
           return true;
@@ -2171,8 +2199,12 @@ export function useComposerCore(
           if (next === null) {
             return onFocusFooterRef.current?.() ?? false;
           }
-          historyBrowseActiveRef.current = history.isNavigating();
+          const returningToPromptDraft = !history.isNavigating();
+          historyBrowseActiveRef.current = !returningToPromptDraft;
           restoreHistoryEntry(view, next);
+          if (returningToPromptDraft) {
+            restorePromptHistoryDraftTags();
+          }
           return true;
         },
       },

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -70,12 +70,14 @@ import {
   getComposerTagIconUrl,
   getComposerTagSerialized,
   isBuiltinComposerTagIconUrl,
+  parseUserMessageContentSafely,
 } from '../utils/composerTag';
 import type { DaemonInputAnnotation } from '@qwen-code/sdk/daemon';
 import { isSafeImageSrc } from '../components/messages/Markdown';
 import type {
   ComposerTagClickHandler,
   ComposerTagRenderer,
+  UserMessageContentParser,
   WebShellComposerApi,
   WebShellComposerInput,
   WebShellComposerTag,
@@ -1064,6 +1066,7 @@ export interface UseComposerCoreOptions {
   atProviders?: readonly WebShellAtProvider[];
   atWorkspaceCwd?: string;
   composerTagIcons?: WebShellComposerTagIconMap;
+  parseUserMessageContent?: UserMessageContentParser;
   renderComposerTag?: ComposerTagRenderer;
   renderComposerTagTooltip?: ComposerTagRenderer;
   onComposerTagClick?: ComposerTagClickHandler;
@@ -1081,6 +1084,7 @@ export interface SearchState {
   openHistorySearch: () => void;
   closeSearch: (restoreDraft: boolean, keepFocus?: boolean) => void;
   submitSearchMatch: (match: string) => void;
+  restoreSearchMatch?: (match: string) => void;
   handleSearchKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   handleSearchInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleSearchCompositionEnd: (
@@ -1213,6 +1217,7 @@ export function useComposerCore(
     atProviders,
     atWorkspaceCwd,
     composerTagIcons,
+    parseUserMessageContent,
     renderComposerTag,
     renderComposerTagTooltip,
     onComposerTagClick,
@@ -1301,6 +1306,8 @@ export function useComposerCore(
   }
   const composerTagIconsRef = useRef(composerTagIcons);
   composerTagIconsRef.current = composerTagIcons;
+  const parseUserMessageContentRef = useRef(parseUserMessageContent);
+  parseUserMessageContentRef.current = parseUserMessageContent;
   const renderComposerTagRef = useRef(renderComposerTag);
   renderComposerTagRef.current = renderComposerTag;
   const renderComposerTagTooltipRef = useRef(renderComposerTagTooltip);
@@ -1410,6 +1417,84 @@ export function useComposerCore(
   const [composerTags, setComposerTags] = useState<WebShellComposerTag[]>([]);
   const composerTagsRef = useRef<WebShellComposerTag[]>([]);
   composerTagsRef.current = composerTags;
+  const clearRestoredComposerTags = useCallback(() => {
+    composerTagsRef.current = [];
+    setComposerTags([]);
+  }, []);
+  const restoreRawHistoryEntry = useCallback(
+    (view: EditorView, text: string) => {
+      clearRestoredComposerTags();
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: text },
+        effects: clearInlineTagsEffect.of(),
+        selection: { anchor: text.length },
+      });
+    },
+    [clearRestoredComposerTags],
+  );
+  const restorePromptHistoryEntry = useCallback(
+    (view: EditorView, text: string) => {
+      const parts = parseUserMessageContentSafely(
+        text,
+        parseUserMessageContentRef.current,
+        '[WebShell] failed to parse composer history content',
+        { requireSourcePreservation: true },
+      );
+      const hasTags = parts?.some((part) => part.type === 'tag') ?? false;
+      if (!parts || !hasTags) {
+        restoreRawHistoryEntry(view, text);
+        return;
+      }
+
+      const effects: StateEffect<unknown>[] = [clearInlineTagsEffect.of()];
+      let restoredText = '';
+      for (const part of parts) {
+        if (part.type === 'text') {
+          restoredText += part.text;
+          continue;
+        }
+        const serialized = getComposerTagSerialized(part.tag);
+        const from = restoredText.length;
+        restoredText += serialized;
+        effects.push(
+          addInlineTagEffect.of({
+            from,
+            to: restoredText.length,
+            tag: resolveComposerTagIcon(part.tag),
+          }),
+        );
+      }
+      clearRestoredComposerTags();
+      view.dispatch({
+        changes: {
+          from: 0,
+          to: view.state.doc.length,
+          insert: restoredText,
+        },
+        effects,
+        selection: { anchor: restoredText.length },
+      });
+    },
+    [clearRestoredComposerTags, resolveComposerTagIcon, restoreRawHistoryEntry],
+  );
+  const restoreHistoryEntry = useCallback(
+    (view: EditorView, text: string) => {
+      if (shellModeRef.current) {
+        restoreRawHistoryEntry(view, text);
+        return;
+      }
+      restorePromptHistoryEntry(view, text);
+    },
+    [restorePromptHistoryEntry, restoreRawHistoryEntry],
+  );
+  const restoreSelectedHistoryMatch = useCallback(
+    (text: string) => {
+      const view = viewRef.current;
+      if (!view) return;
+      restoreHistoryEntry(view, text);
+    },
+    [restoreHistoryEntry],
+  );
   const composerInputRef = useRef(composerInput);
   composerInputRef.current = composerInput;
   const submitTextRef = useRef<
@@ -1675,13 +1760,10 @@ export function useComposerCore(
     const current = view.state.doc.toString();
     const prev = history.navigateUp(current);
     if (prev !== null) {
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: prev },
-        selection: { anchor: prev.length },
-      });
+      restoreHistoryEntry(view, prev);
     }
     view.focus();
-  }, []);
+  }, [restoreHistoryEntry]);
 
   const navigateNextHistory = useCallback(() => {
     if (disabledRef.current) return;
@@ -1701,13 +1783,10 @@ export function useComposerCore(
       : historyActionsRef.current;
     const next = history.navigateDown();
     if (next !== null) {
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: next },
-        selection: { anchor: next.length },
-      });
+      restoreHistoryEntry(view, next);
     }
     view.focus();
-  }, []);
+  }, [restoreHistoryEntry]);
 
   // ---- Create CodeMirror EditorView ----
   useEffect(() => {
@@ -2035,10 +2114,7 @@ export function useComposerCore(
             const prev = history.navigateUp(current);
             if (prev === null) return true;
             historyBrowseActiveRef.current = true;
-            view.dispatch({
-              changes: { from: 0, to: view.state.doc.length, insert: prev },
-              selection: { anchor: prev.length },
-            });
+            restoreHistoryEntry(view, prev);
             return true;
           }
           if (queuedMessagesRef.current.length > 0) {
@@ -2050,10 +2126,7 @@ export function useComposerCore(
           const prev = history.navigateUp(current);
           if (prev === null) return false;
           historyBrowseActiveRef.current = true;
-          view.dispatch({
-            changes: { from: 0, to: view.state.doc.length, insert: prev },
-            selection: { anchor: prev.length },
-          });
+          restoreHistoryEntry(view, prev);
           return true;
         },
       },
@@ -2088,10 +2161,7 @@ export function useComposerCore(
             const next = history.navigateDown();
             if (next === null) return true;
             historyBrowseActiveRef.current = history.isNavigating();
-            view.dispatch({
-              changes: { from: 0, to: view.state.doc.length, insert: next },
-              selection: { anchor: next.length },
-            });
+            restoreHistoryEntry(view, next);
             return true;
           }
           const next = history.navigateDown();
@@ -2099,10 +2169,7 @@ export function useComposerCore(
             return onFocusFooterRef.current?.() ?? false;
           }
           historyBrowseActiveRef.current = history.isNavigating();
-          view.dispatch({
-            changes: { from: 0, to: view.state.doc.length, insert: next },
-            selection: { anchor: next.length },
-          });
+          restoreHistoryEntry(view, next);
           return true;
         },
       },
@@ -3050,30 +3117,29 @@ export function useComposerCore(
       const view = viewRef.current;
       if (!view) return;
       closeSearch(false);
+      if (!shellModeRef.current) {
+        restoreSelectedHistoryMatch(match);
+        submitTextRef.current(view);
+        return;
+      }
       const text = match.trim();
       if (!text) return;
       const images = pastedImagesRef.current;
-      const isShellMode = shellModeRef.current;
       const accepted = onSubmitRef.current(
-        isShellMode ? `!${text}` : text,
+        `!${text}`,
         images.length > 0 ? [...images] : undefined,
       );
       if (accepted === false) {
-        replaceEditorText(match);
+        restoreSelectedHistoryMatch(match);
         return;
       }
       onDismissFollowupRef.current?.();
-      if (isShellMode) {
-        shellHistoryActionsRef.current.push(text);
-        shellHistoryActionsRef.current.reset();
-      } else {
-        historyActionsRef.current.push(text);
-        historyActionsRef.current.reset();
-      }
+      shellHistoryActionsRef.current.push(text);
+      shellHistoryActionsRef.current.reset();
       setPastedImages([]);
       replaceEditorText('');
     },
-    [closeSearch, replaceEditorText],
+    [closeSearch, replaceEditorText, restoreSelectedHistoryMatch],
   );
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -3087,7 +3153,7 @@ export function useComposerCore(
       e.preventDefault();
       const match = searchMatches[searchActiveIndex];
       if (match) {
-        replaceEditorText(match);
+        restoreSelectedHistoryMatch(match);
       }
       closeSearch(false);
     } else if (e.key === 'Enter') {
@@ -3219,6 +3285,7 @@ export function useComposerCore(
       openHistorySearch,
       closeSearch,
       submitSearchMatch,
+      restoreSearchMatch: restoreSelectedHistoryMatch,
       handleSearchKeyDown,
       handleSearchInput,
       handleSearchCompositionEnd,

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -1502,6 +1502,7 @@ export function useComposerCore(
       view: EditorView,
       textOverride?: string,
       tagsOverride?: readonly WebShellComposerTag[],
+      suppressFollowupCompletion?: boolean,
     ) => boolean
   >(() => true);
   const autoTriggerRef = useRef<{ text: string; from: number } | null>(null);
@@ -1853,6 +1854,7 @@ export function useComposerCore(
       view: EditorView,
       textOverride?: string,
       tagsOverride?: readonly WebShellComposerTag[],
+      suppressFollowupCompletion = false,
     ) => {
       const inlineTags =
         tagsOverride === undefined ? getInlineComposerTagPlacements(view) : [];
@@ -1860,6 +1862,7 @@ export function useComposerCore(
       const followup = followupStateRef.current;
       const followupCompletion =
         textOverride === undefined &&
+        !suppressFollowupCompletion &&
         inlineTags.length === 0 &&
         followup?.isVisible
           ? getFollowupCompletion(editorText, followup.suggestion)
@@ -3119,7 +3122,7 @@ export function useComposerCore(
       closeSearch(false);
       if (!shellModeRef.current) {
         restoreSelectedHistoryMatch(match);
-        submitTextRef.current(view);
+        submitTextRef.current(view, undefined, undefined, true);
         return;
       }
       const text = match.trim();

--- a/packages/web-shell/client/utils/composerTag.test.ts
+++ b/packages/web-shell/client/utils/composerTag.test.ts
@@ -184,6 +184,17 @@ describe('parseUserMessageContentSafely', () => {
 
     expect(parts).toEqual([{ type: 'text', text: 'rewritten' }]);
   });
+
+  it('rejects valid non-round-tripping parts when source preservation is required', () => {
+    const parts = parseUserMessageContentSafely(
+      'original',
+      () => [{ type: 'text', text: 'rewritten' }],
+      'test warning',
+      { requireSourcePreservation: true },
+    );
+
+    expect(parts).toBeNull();
+  });
 });
 
 describe('composer tag input annotations', () => {

--- a/packages/web-shell/client/utils/composerTag.test.ts
+++ b/packages/web-shell/client/utils/composerTag.test.ts
@@ -4,6 +4,7 @@ import {
   getComposerTagIconUrl,
   getComposerTagViewModel,
   isBuiltinComposerTagIconUrl,
+  parseUserMessageContentSafely,
   splitComposerTagContentByAnnotations,
 } from './composerTag';
 
@@ -134,6 +135,54 @@ describe('getComposerTagViewModel', () => {
       fallback: 'dataset:users',
       iconUrl: undefined,
     });
+  });
+});
+
+describe('parseUserMessageContentSafely', () => {
+  it('rejects an empty parser result', () => {
+    expect(
+      parseUserMessageContentSafely('original', () => [], 'test warning'),
+    ).toBeNull();
+  });
+
+  it('rejects a non-array parser result', () => {
+    const parser = (() => 'not an array') as unknown as Parameters<
+      typeof parseUserMessageContentSafely
+    >[1];
+
+    expect(
+      parseUserMessageContentSafely('original', parser, 'test warning'),
+    ).toBeNull();
+  });
+
+  it('rejects a text part with non-string text', () => {
+    const parser = (() => [{ type: 'text', text: 1 }]) as unknown as Parameters<
+      typeof parseUserMessageContentSafely
+    >[1];
+
+    expect(
+      parseUserMessageContentSafely('original', parser, 'test warning'),
+    ).toBeNull();
+  });
+
+  it('rejects a tag without an id', () => {
+    const parser = (() => [
+      { type: 'tag', tag: { value: 'orders' } },
+    ]) as unknown as Parameters<typeof parseUserMessageContentSafely>[1];
+
+    expect(
+      parseUserMessageContentSafely('original', parser, 'test warning'),
+    ).toBeNull();
+  });
+
+  it('allows valid non-round-tripping parts when source preservation is omitted', () => {
+    const parts = parseUserMessageContentSafely(
+      'original',
+      () => [{ type: 'text', text: 'rewritten' }],
+      'test warning',
+    );
+
+    expect(parts).toEqual([{ type: 'text', text: 'rewritten' }]);
   });
 });
 

--- a/packages/web-shell/client/utils/composerTag.ts
+++ b/packages/web-shell/client/utils/composerTag.ts
@@ -4,10 +4,12 @@ import mcpIconUrl from '../assets/icons/at-mcp.svg';
 import skillIconUrl from '../assets/icons/at-skill.svg';
 import type { DaemonInputAnnotation } from '@qwen-code/sdk/daemon';
 import type {
+  UserMessageContentParser,
   WebShellBuiltinComposerTagKind,
   WebShellComposerTag,
   WebShellComposerTagIconMap,
   WebShellComposerTagKind,
+  WebShellUserMessagePart,
 } from '../customization';
 
 // Shared UI-facing shape for composer tags across React and CodeMirror.
@@ -21,6 +23,69 @@ export interface ComposerTagViewModel {
 export type ComposerTagContentSegment =
   | { type: 'text'; text: string }
   | { type: 'reference'; tag: WebShellComposerTag };
+
+function isValidComposerTag(tag: unknown): tag is WebShellComposerTag {
+  if (!tag || typeof tag !== 'object') return false;
+  const candidate = tag as Record<string, unknown>;
+  return (
+    typeof candidate.id === 'string' &&
+    (candidate.label === undefined || typeof candidate.label === 'string') &&
+    (candidate.value === undefined || typeof candidate.value === 'string') &&
+    (candidate.removable === undefined ||
+      typeof candidate.removable === 'boolean') &&
+    (candidate.kind === undefined || typeof candidate.kind === 'string') &&
+    (candidate.icon === undefined || typeof candidate.icon === 'string') &&
+    (candidate.serialized === undefined ||
+      typeof candidate.serialized === 'string')
+  );
+}
+
+function isValidUserMessagePart(
+  part: unknown,
+): part is WebShellUserMessagePart {
+  if (!part || typeof part !== 'object') return false;
+  const candidate = part as Record<string, unknown>;
+  if (candidate.type === 'text') return typeof candidate.text === 'string';
+  if (candidate.type !== 'tag') return false;
+  return isValidComposerTag(candidate.tag);
+}
+
+export interface ParseUserMessageContentOptions {
+  requireSourcePreservation?: boolean;
+}
+
+export function parseUserMessageContentSafely(
+  content: string,
+  parser: UserMessageContentParser | undefined,
+  warning: string,
+  options: ParseUserMessageContentOptions = {},
+): readonly WebShellUserMessagePart[] | null {
+  if (!parser) return null;
+  try {
+    const parts = parser(content);
+    if (
+      !Array.isArray(parts) ||
+      parts.length === 0 ||
+      !parts.every(isValidUserMessagePart)
+    ) {
+      return null;
+    }
+    if (
+      options.requireSourcePreservation &&
+      parts
+        .map((part) =>
+          part.type === 'text' ? part.text : getComposerTagSerialized(part.tag),
+        )
+        .join('') !== content
+    ) {
+      return null;
+    }
+    return parts;
+  } catch (error) {
+    console.warn(warning, error);
+    return null;
+  }
+}
 
 // Resolves tag kind metadata to asset URLs; it does not render icon components.
 const builtinTagIconUrls: Record<WebShellBuiltinComposerTagKind, string> = {


### PR DESCRIPTION
## What this PR does

This PR keeps host-defined context references rendered as tags after a prompt enters the pending queue and when a user recalls a previous prompt through ArrowUp/ArrowDown or history search. It reuses the existing Web Shell customization contract and readonly tag renderer, validates parser output before using it, preserves the serialized prompt byte-for-byte, and regenerates input annotations through the normal submit path. No package-level API changes are introduced.

## Why it's needed

The host customization added in #6578 renders context tags correctly in the composer and user-message bubbles, but two secondary prompt surfaces still exposed the raw serialized context syntax. Queued prompts displayed the original markup, and recalled prompts restored plain text instead of inline tags. Besides the visual regression, an immediately resubmitted history item could lose annotations or accidentally retain stale top-level tags.

## Reviewer Test Plan

### How to verify

Configure an existing `parseUserMessageContent` customization that maps a serialized context reference to a tag. Submit a prompt while another turn is active and confirm the queued preview renders the context as the host tag rather than raw markup. Recall the same prompt with ArrowUp/ArrowDown and with Ctrl-R using Tab, mouse selection, and Enter; confirm the composer restores inline tags, shell history remains raw, ArrowDown restores the draft, and resubmission preserves the exact serialized source with one matching input annotation. Also exercise a throwing, malformed, or source-mismatching parser and confirm the UI safely falls back to raw text.

### Evidence (Before & After)

Before: pending queue rows and recalled history prompts exposed the host's serialized context markup as plain text. After: both surfaces render the same readonly/inline tag presentation already used by the composer and user-message bubbles, while the serialized prompt remains unchanged for submission. The behavior was manually verified in a real embedding-host debug session on macOS; no screenshot or recording is attached.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Tested locally on macOS with the repository Node/npm setup and an embedding-host debug build. Focused Web Shell tests passed (3 files, 47 tests), the full Web Shell suite passed (119 files, 1,918 tests), and the Web Shell coverage run passed (71.6% statements/lines, 78.3% branches, 61.72% functions). Web Shell lint, typecheck, build, `git diff --check`, and the repository pre-commit hook also passed. The exact root `npm run preflight` completed dependency setup, format, lint, build, and typecheck, then exited in the CLI test workspace on failures outside this seven-file Web Shell patch. Isolated reruns passed all 762 server tests and all 4 extension-list tests with an isolated Qwen home; one current-main AuthDialog assertion remains reproducible because Grok is now listed between DeepSeek and MiniMax while the unchanged test still sends one ArrowDown and expects MiniMax.

## Risk & Scope

- Main risk or tradeoff: Host parser output now participates in queue preview and history restoration, so malformed or non-lossless output must never crash or alter submitted text. The implementation validates parser/tag shapes inside an exception boundary and falls back to raw text when reconstruction does not exactly match the source.
- Not validated / out of scope: Windows and Linux manual UI validation were not run, and no visual capture is attached. The current-main AuthDialog preflight baseline failure described above is not changed by this PR. Host-specific context schemas and workspace policies remain outside Web Shell.
- Breaking changes / migration notes: None. This reuses the existing optional customization API; hosts that do not provide a parser retain the existing plain-text behavior.

## Linked Issues

N/A — this is a follow-up bug fix to the host customization introduced by #6578; no separate issue was supplied.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 让宿主自定义的上下文引用在 prompt 进入待发送队列后，以及用户通过 ArrowUp/ArrowDown 或历史搜索召回旧 prompt 时，仍然以 tag 形式渲染。实现复用了现有的 Web Shell 自定义契约和只读 tag renderer，在使用 parser 输出前进行校验，逐字节保留序列化 prompt，并通过标准提交链路重新生成 input annotations。本次没有引入包级 API 变更。

## Why it's needed

PR #6578 增加的宿主自定义能力已经能在输入框和用户消息气泡中正确渲染上下文 tag，但还有两个次级 prompt 展示面会暴露原始的序列化上下文语法：待发送 prompt 会直接展示原始标记，历史 prompt 被召回时也只会恢复成纯文本而不是内联 tag。除视觉回归外，立即重新提交历史项时还可能丢失 annotations，或者错误带入过期的顶层 tag。

## Reviewer Test Plan

### How to verify

配置一个现有的 `parseUserMessageContent` 自定义实现，把序列化上下文引用映射为 tag。在另一个 turn 正在执行时提交 prompt，确认队列预览展示宿主 tag，而不是原始标记。再通过 ArrowUp/ArrowDown，以及 Ctrl-R 的 Tab、鼠标选择和 Enter 路径召回同一个 prompt；确认输入框恢复内联 tag，shell 历史仍保持原始文本，ArrowDown 能恢复草稿，重新提交时序列化源文本完全一致且只生成一条匹配的 input annotation。还应让 parser 抛错、返回畸形结构或返回无法无损重建源文本的内容，并确认 UI 安全回退为原始文本。

### Evidence (Before & After)

变更前：待发送队列行和召回的历史 prompt 会把宿主的序列化上下文标记直接显示为纯文本。变更后：这两个展示面会使用输入框和用户消息气泡已有的只读/内联 tag 展示，同时提交用的序列化 prompt 保持不变。该行为已在 macOS 上的真实嵌入宿主调试会话中完成人工验证；未附带截图或录屏。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

在 macOS 上使用仓库的 Node/npm 环境和嵌入宿主调试构建完成验证。Web Shell 定向测试通过（3 个文件、47 个测试），完整 Web Shell 测试通过（119 个文件、1,918 个测试），Web Shell coverage 运行通过（statements/lines 71.6%、branches 78.3%、functions 61.72%）。Web Shell lint、typecheck、build、`git diff --check` 和仓库 pre-commit hook 也均通过。精确执行根目录 `npm run preflight` 时，依赖安装、format、lint、build 和 typecheck 均完成，随后在 CLI 测试 workspace 中因本次 7 文件 Web Shell 补丁范围外的失败而退出。隔离复跑后，762 个 server 测试全部通过，并且在隔离 Qwen home 后 4 个 extension-list 测试全部通过；当前主干仍可稳定复现一个 AuthDialog 断言失败，原因是 Grok 现在排在 DeepSeek 与 MiniMax 之间，而未更新的测试仍只发送一次 ArrowDown 就期望选中 MiniMax。

## Risk & Scope

- 主要风险或权衡：宿主 parser 输出现在会参与队列预览和历史恢复，因此畸形或非无损输出不能导致崩溃或改变提交文本。实现会在异常边界内校验 parser/tag 结构，并在重建结果不能与源文本完全一致时回退为原始文本。
- 未验证或范围外：未进行 Windows 和 Linux 的人工 UI 验证，也未附带视觉截图。上面说明的当前主干 AuthDialog preflight 基线失败不在本 PR 修改范围内。宿主特定的上下文 schema 和 workspace 策略仍留在 Web Shell 之外。
- 破坏性变更或迁移说明：无。本次复用现有的可选自定义 API；未提供 parser 的宿主保持原有纯文本行为。

## Linked Issues

N/A — 这是对 #6578 所引入宿主自定义能力的后续 bug 修复；未提供独立 issue。

</details>
