### PR TITLE
test(feishu): enforce markdown chunk limit assertion

### DIFF
--- a/packages/channels/feishu/src/markdown.test.ts
+++ b/packages/channels/feishu/src/markdown.test.ts
@@ -158,7 +158,7 @@ describe('Feishu markdown utilities', () => {
       const chunks = splitChunks(text);
       expect(chunks.length).toBeGreaterThan(1);
       chunks.forEach((chunk) => {
-        expect(chunk.length).toBeLessThanOrEqual(4100);
+        expect(chunk.length).toBeLessThanOrEqual(4000);
       });
     });
 


### PR DESCRIPTION
## What this PR does

Tightens the Feishu markdown chunking test so every produced chunk must stay at or below the production 4000-character limit.

## Why it's needed

The production splitter documents and uses a 4000-character chunk limit, but one regression test allowed chunks up to 4100 characters. That slack meant a regression producing oversized chunks could still pass.

## Reviewer Test Plan

### How to verify

Run `cd packages/channels/feishu && npx vitest run src/markdown.test.ts` and confirm the Feishu markdown utility tests pass.

### Evidence (Before & After)

Before: the long-text chunking assertion allowed `chunk.length <= 4100`. After: the assertion matches the production limit, `chunk.length <= 4000`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v26.2.0 via nvm, npm 11.13.0, local dependencies installed with `npm install`.

## Risk & Scope

- Main risk or tradeoff: Very low; this changes only a test assertion.
- Not validated / out of scope: No Windows or Linux local run.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

收紧 Feishu markdown 分块测试，要求每个 chunk 都不超过生产代码使用的 4000 字符限制。

## Why it's needed

生产分块器文档和实现都使用 4000 字符限制，但一个回归测试允许 chunk 达到 4100 字符。这 100 字符余量会让超限 chunk 的回归仍然通过测试。

## Reviewer Test Plan

### How to verify

运行 `cd packages/channels/feishu && npx vitest run src/markdown.test.ts`，确认 Feishu markdown 工具测试通过。

### Evidence (Before & After)

Before：长文本分块断言允许 `chunk.length <= 4100`。After：断言与生产限制一致，为 `chunk.length <= 4000`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

通过 nvm 使用 Node v26.2.0，npm 11.13.0，本地依赖通过 `npm install` 安装。

## Risk & Scope

- Main risk or tradeoff: 风险很低；只修改测试断言。
- Not validated / out of scope: 未在 Windows 或 Linux 本地运行。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
