### PR TITLE
test(weixin): cover exported AES key parser

### DIFF
--- a/packages/channels/weixin/src/media.test.ts
+++ b/packages/channels/weixin/src/media.test.ts
@@ -1,28 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { createDecipheriv, createCipheriv } from 'node:crypto';
-import { encryptAesEcb, computeMd5 } from './media.js';
+import { encryptAesEcb, computeMd5, parseAesKey } from './media.js';
 
 /**
  * Test the AES key parsing and decryption logic used in media.ts.
- * We test the pure crypto functions by reimplementing them here
- * since they're not exported, but the behavior must match.
+ * decryptAesEcb remains private, so keep only that helper here.
  */
-
-function parseAesKey(aesKeyBase64: string): Buffer {
-  const decoded = Buffer.from(aesKeyBase64, 'base64');
-  if (decoded.length === 16) {
-    return decoded;
-  }
-  if (
-    decoded.length === 32 &&
-    /^[0-9a-fA-F]{32}$/.test(decoded.toString('ascii'))
-  ) {
-    return Buffer.from(decoded.toString('ascii'), 'hex');
-  }
-  throw new Error(
-    `Invalid aes_key: expected 16 raw bytes or 32 hex chars, got ${decoded.length} bytes`,
-  );
-}
 
 function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
   const decipher = createDecipheriv('aes-128-ecb', key, null);


### PR DESCRIPTION
## What this PR does

Updates the Weixin media crypto test to import and exercise the production AES key parser directly instead of keeping a duplicate parser inside the test.

## Why it's needed

The parser is already exported by the media module, but the test reimplemented it locally. A regression in the exported parser could pass because the test was checking its own copy instead of the production code.

## Reviewer Test Plan

### How to verify

Run `cd packages/channels/weixin && npx vitest run src/media.test.ts` and confirm the Weixin media crypto tests pass.

### Evidence (Before & After)

Before: `parseAesKey` test cases called a duplicate helper in the test file. After: those same cases call the exported parser from the media module.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node v26.2.0 via nvm, npm 11.13.0, local dependencies installed with `npm install`.

## Risk & Scope

- Main risk or tradeoff: Very low; this changes only test code and removes a duplicate helper.
- Not validated / out of scope: No Windows or Linux local run.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

更新 Weixin media crypto 测试，直接 import 并覆盖生产代码导出的 AES key parser，而不是在测试中保留重复 parser。

## Why it's needed

media 模块已经导出了 parser，但测试本地重新实现了一份。这样生产导出的 parser 即使回归，测试也可能因为只检查本地副本而继续通过。

## Reviewer Test Plan

### How to verify

运行 `cd packages/channels/weixin && npx vitest run src/media.test.ts`，确认 Weixin media crypto 测试通过。

### Evidence (Before & After)

Before：`parseAesKey` 测试用例调用测试文件中的重复 helper。After：相同测试用例调用 media 模块导出的 parser。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

通过 nvm 使用 Node v26.2.0，npm 11.13.0，本地依赖通过 `npm install` 安装。

## Risk & Scope

- Main risk or tradeoff: 风险很低；只修改测试代码并删除重复 helper。
- Not validated / out of scope: 未在 Windows 或 Linux 本地运行。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
