### PR TITLE
fix(ci): tighten API error detection to avoid false positive on review prose

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -795,7 +795,7 @@ jobs:
               return
             fi
             case "$RESULT_TEXT" in
-              *"[API Error"*)
+              *"[API Error: "[0-9]*)
                 if printf '%s' "$RESULT_TEXT" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
                   OUTCOME='quota'
                   KIND='quota'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -729,7 +729,7 @@ jobs:
           # loop below can try once more; a QUOTA-exhausted 429 is NOT retried
           # in-run (its reset is typically hours away — burning a runner on it
           # helps nobody), and a real timeout or a hard/config failure never
-          # retries. Same detection as before; only the disposition is new.
+          # retries.
           OUTCOME=''
           REASON=''
           KIND=''
@@ -794,13 +794,19 @@ jobs:
               REASON="Qwen review ended in an error result (subtype=${RESULT_SUBTYPE}, is_error=${RESULT_IS_ERROR})."
               return
             fi
-            case "$RESULT_TEXT" in
-              *"[API Error: "[0-9]*)
-                if printf '%s' "$RESULT_TEXT" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
+            # An aborted run renders the API error as (or at the very end of)
+            # the result text; a successful review that merely *discusses* API
+            # errors quotes them mid-prose. Anchor on the tail so prose quotes
+            # don't trip the detector. 600 bytes covers the longest real error
+            # (~200 bytes for a 429 + rate-limit suffix) with headroom.
+            RESULT_TAIL="$(printf '%s' "$RESULT_TEXT" | tail -c 600)"
+            case "$RESULT_TAIL" in
+              *"[API Error: "*)
+                if printf '%s' "$RESULT_TAIL" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
                   OUTCOME='quota'
                   KIND='quota'
                   local detail
-                  detail="$(printf '%s' "$RESULT_TEXT" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
+                  detail="$(printf '%s' "$RESULT_TAIL" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
                   REASON="Qwen review stopped: the model API quota is exhausted${detail:+ (${detail})}."
                 else
                   OUTCOME='retryable'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -794,27 +794,29 @@ jobs:
               REASON="Qwen review ended in an error result (subtype=${RESULT_SUBTYPE}, is_error=${RESULT_IS_ERROR})."
               return
             fi
-            # An aborted run renders the API error as (or at the very end of)
-            # the result text; a successful review that merely *discusses* API
-            # errors quotes them mid-prose. Anchor on the tail so prose quotes
-            # don't trip the detector. 600 bytes covers the longest real error
-            # (~200 bytes for a 429 + rate-limit suffix) with headroom.
+            # An aborted run renders the API error as the entire result or at
+            # its very end; a successful review that merely *discusses* API
+            # errors quotes them mid-prose. Two checks cover both shapes:
+            # whole-result match (length-independent) and tail match (catches
+            # errors appended to a partial review). 600 bytes covers the
+            # longest common error (~200 bytes for a 429 + rate-limit suffix).
+            IS_ABORT=0
+            case "$RESULT_TEXT" in "[API Error: "*) IS_ABORT=1 ;; esac
             RESULT_TAIL="$(printf '%s' "$RESULT_TEXT" | tail -c 600)"
-            case "$RESULT_TAIL" in
-              *"[API Error: "*)
-                if printf '%s' "$RESULT_TAIL" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
-                  OUTCOME='quota'
-                  KIND='quota'
-                  local detail
-                  detail="$(printf '%s' "$RESULT_TAIL" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
-                  REASON="Qwen review stopped: the model API quota is exhausted${detail:+ (${detail})}."
-                else
-                  OUTCOME='retryable'
-                  REASON="Qwen review aborted with an API error before posting comments."
-                fi
-                return
-                ;;
-            esac
+            case "$RESULT_TAIL" in *"[API Error: "*) IS_ABORT=1 ;; esac
+            if [ "$IS_ABORT" -eq 1 ]; then
+              if printf '%s' "$RESULT_TEXT" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
+                OUTCOME='quota'
+                KIND='quota'
+                local detail
+                detail="$(printf '%s' "$RESULT_TEXT" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
+                REASON="Qwen review stopped: the model API quota is exhausted${detail:+ (${detail})}."
+              else
+                OUTCOME='retryable'
+                REASON="Qwen review aborted with an API error before posting comments."
+              fi
+              return
+            fi
             OUTCOME='success'
           }
 

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -794,29 +794,35 @@ jobs:
               REASON="Qwen review ended in an error result (subtype=${RESULT_SUBTYPE}, is_error=${RESULT_IS_ERROR})."
               return
             fi
-            # An aborted run renders the API error as the entire result or at
-            # its very end; a successful review that merely *discusses* API
-            # errors quotes them mid-prose. Two checks cover both shapes:
-            # whole-result match (length-independent) and tail match (catches
-            # errors appended to a partial review). 600 bytes covers the
-            # longest common error (~200 bytes for a 429 + rate-limit suffix).
-            IS_ABORT=0
-            case "$RESULT_TEXT" in "[API Error: "*) IS_ABORT=1 ;; esac
-            RESULT_TAIL="$(printf '%s' "$RESULT_TEXT" | tail -c 600)"
-            case "$RESULT_TAIL" in *"[API Error: "*) IS_ABORT=1 ;; esac
-            if [ "$IS_ABORT" -eq 1 ]; then
-              if printf '%s' "$RESULT_TEXT" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
-                OUTCOME='quota'
-                KIND='quota'
-                local detail
-                detail="$(printf '%s' "$RESULT_TEXT" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
-                REASON="Qwen review stopped: the model API quota is exhausted${detail:+ (${detail})}."
-              else
-                OUTCOME='retryable'
-                REASON="Qwen review aborted with an API error before posting comments."
-              fi
-              return
-            fi
+            # The stream-json adapter appends the formatted API error last
+            # (BaseJsonOutputAdapter appendText), so an aborted run's result
+            # ENDS with "[API Error: …]" — optionally followed by a rate-limit
+            # guidance suffix. A review that merely *discusses* API errors
+            # quotes them mid-prose and keeps writing afterwards. Strip the
+            # known suffixes, rtrim, then check the trailing shape.
+            BODY="$RESULT_TEXT"
+            for S in \
+              'Possible quota limitations in place or slow response times detected. Please wait and try again later.' \
+              'Please wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method' \
+              'Please wait and try again later. To increase your limits, request a quota increase through Vertex, or switch to another /auth method'; do
+              BODY="${BODY%"$S"}"
+            done
+            BODY="${BODY%"${BODY##*[![:space:]]}"}"
+            case "$BODY" in
+              *"[API Error: "*"]")
+                if printf '%s' "$RESULT_TEXT" | grep -qiE 'quota.*(exhaust|exceed|limit|reset)'; then
+                  OUTCOME='quota'
+                  KIND='quota'
+                  local detail
+                  detail="$(printf '%s' "$RESULT_TEXT" | grep -oiE 'reset at [^]]*' | head -n1 || true)"
+                  REASON="Qwen review stopped: the model API quota is exhausted${detail:+ (${detail})}."
+                else
+                  OUTCOME='retryable'
+                  REASON="Qwen review aborted with an API error before posting comments."
+                fi
+                return
+                ;;
+            esac
             OUTCOME='success'
           }
 

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -79,7 +79,10 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         '  transient_persist) r success false "[API Error: 503 upstream overloaded]" ;;',
         '  quota) r success false "[API Error: 429 Your token-plan quota has been exhausted. The quota will reset at 07-19 13:17:00 UTC.]" ;;',
         '  quota_noreset) r success false "[API Error: 429 Your quota has been exhausted.]" ;;',
-        '  success_mentions_api_error) r success false "Review of [API Error: ...] handling — quota and rate.?limit keywords look correct." ;;',
+        '  abort_no_status) r success false "[API Error: Connection error.]" ;;',
+        '  abort_status_suffix) r success false "[API Error: Rate limit exceeded (Status: RESOURCE_EXHAUSTED)]" ;;',
+        '  success_mentions_api_error) PAD=$(printf "x%.0s" $(seq 1 600)); r success false "This PR detects the [API Error: ...] pattern and routes to retry. quota and rate.?limit keywords cover the common messages. ${PAD} Review complete: COMMENT posted (0 Critical, 1 Suggestion inline)." ;;',
+        '  success_quotes_status_code) PAD=$(printf "x%.0s" $(seq 1 700)); r success false "This PR adds retry for [API Error: 429 quota exceeded] and similar. ${PAD} Verdict: COMMENT, 0 Critical." ;;',
         '  errresult) r error true "connection dropped mid-review" ;;',
         '  hardexit) exit 3 ;;',
         'esac',
@@ -159,12 +162,34 @@ describe('qwen pr review transient retry', () => {
     expect(r.attempts).toBe(1);
   });
 
+  it('retries an abort with no status code in the message', () => {
+    const r = runScenario('abort_no_status');
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[quota]');
+    expect(r.attempts).toBe(2);
+  });
+
+  it('retries an abort with status at the end (Status: …) shape', () => {
+    const r = runScenario('abort_status_suffix');
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[quota]');
+    expect(r.attempts).toBe(2);
+  });
+
   it('does NOT misclassify a successful review that mentions [API Error: ...] in its summary', () => {
     // A review of PR #7247 (API error retry) quoted "[API Error: ...]" and
     // "quota … limit" in its result text. The old pattern *"[API Error"*
     // matched the prose and the quota grep hit "quota … limit", falsely
     // reporting quota exhaustion on a successful review.
     const r = runScenario('success_mentions_api_error');
+    expect(r.line).toContain('OK outcome=success');
+    expect(r.attempts).toBe(1);
+  });
+
+  it('does NOT misclassify prose quoting a real status code mid-body', () => {
+    // A long review (>600 bytes) that quotes "[API Error: 429 quota
+    // exceeded]" early in the body must not trip the tail-anchored detector.
+    const r = runScenario('success_quotes_status_code');
     expect(r.line).toContain('OK outcome=success');
     expect(r.attempts).toBe(1);
   });

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -82,6 +82,9 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         '  abort_no_status) r success false "[API Error: Connection error.]" ;;',
         '  abort_status_suffix) r success false "[API Error: Rate limit exceeded (Status: RESOURCE_EXHAUSTED)]" ;;',
         '  abort_long_body) EPAD=$(printf "A%.0s" $(seq 1 750)); r success false "[API Error: upstream returned an unparseable error body: ${EPAD}]" ;;',
+        '  abort_appended) r success false "Partial review text streamed before the connection dropped.[API Error: Connection error.]" ;;',
+        '  abort_appended_long) EPAD=$(printf "A%.0s" $(seq 1 750)); r success false "Partial review text streamed before the error.[API Error: upstream returned an unparseable error body: ${EPAD}]" ;;',
+        '  abort_with_suffix) r success false "[API Error: Rate limit exceeded]\\nPossible quota limitations in place or slow response times detected. Please wait and try again later." ;;',
         '  success_mentions_api_error) PAD=$(printf "x%.0s" $(seq 1 600)); r success false "This PR detects the [API Error: ...] pattern and routes to retry. quota and rate.?limit keywords cover the common messages. ${PAD} Review complete: COMMENT posted (0 Critical, 1 Suggestion inline)." ;;',
         '  success_quotes_status_code) PAD=$(printf "x%.0s" $(seq 1 700)); r success false "This PR adds retry for [API Error: 429 quota exceeded] and similar. ${PAD} Verdict: COMMENT, 0 Critical." ;;',
         '  errresult) r error true "connection dropped mid-review" ;;',
@@ -178,12 +181,34 @@ describe('qwen pr review transient retry', () => {
   });
 
   it('detects an abort whose error body exceeds the 600-byte tail window', () => {
-    // The [API Error: prefix falls outside tail -c 600, but the
-    // whole-result check still catches it.
     const r = runScenario('abort_long_body');
     expect(r.line).toContain('FAIL');
     expect(r.line).not.toContain('kind=[quota]');
     expect(r.attempts).toBe(2);
+  });
+
+  it('detects the production abort shape: error appended to partial review', () => {
+    // BaseJsonOutputAdapter appendText puts the error last, after any
+    // partial review text the model already streamed.
+    const r = runScenario('abort_appended');
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[quota]');
+    expect(r.attempts).toBe(2);
+  });
+
+  it('detects a long error appended to partial review (exceeds any fixed window)', () => {
+    const r = runScenario('abort_appended_long');
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[quota]');
+    expect(r.attempts).toBe(2);
+  });
+
+  it('detects an abort with a rate-limit guidance suffix after the ]', () => {
+    // "Rate limit exceeded" + "quota limitations" in the suffix → quota
+    // bucket → no retry (1 attempt).
+    const r = runScenario('abort_with_suffix');
+    expect(r.line).toContain('FAIL kind=[quota]');
+    expect(r.attempts).toBe(1);
   });
 
   it('does NOT misclassify a successful review that mentions [API Error: ...] in its summary', () => {

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -81,6 +81,7 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         '  quota_noreset) r success false "[API Error: 429 Your quota has been exhausted.]" ;;',
         '  abort_no_status) r success false "[API Error: Connection error.]" ;;',
         '  abort_status_suffix) r success false "[API Error: Rate limit exceeded (Status: RESOURCE_EXHAUSTED)]" ;;',
+        '  abort_long_body) EPAD=$(printf "A%.0s" $(seq 1 750)); r success false "[API Error: upstream returned an unparseable error body: ${EPAD}]" ;;',
         '  success_mentions_api_error) PAD=$(printf "x%.0s" $(seq 1 600)); r success false "This PR detects the [API Error: ...] pattern and routes to retry. quota and rate.?limit keywords cover the common messages. ${PAD} Review complete: COMMENT posted (0 Critical, 1 Suggestion inline)." ;;',
         '  success_quotes_status_code) PAD=$(printf "x%.0s" $(seq 1 700)); r success false "This PR adds retry for [API Error: 429 quota exceeded] and similar. ${PAD} Verdict: COMMENT, 0 Critical." ;;',
         '  errresult) r error true "connection dropped mid-review" ;;',
@@ -171,6 +172,15 @@ describe('qwen pr review transient retry', () => {
 
   it('retries an abort with status at the end (Status: …) shape', () => {
     const r = runScenario('abort_status_suffix');
+    expect(r.line).toContain('FAIL');
+    expect(r.line).not.toContain('kind=[quota]');
+    expect(r.attempts).toBe(2);
+  });
+
+  it('detects an abort whose error body exceeds the 600-byte tail window', () => {
+    // The [API Error: prefix falls outside tail -c 600, but the
+    // whole-result check still catches it.
+    const r = runScenario('abort_long_body');
     expect(r.line).toContain('FAIL');
     expect(r.line).not.toContain('kind=[quota]');
     expect(r.attempts).toBe(2);

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -79,6 +79,7 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         '  transient_persist) r success false "[API Error: 503 upstream overloaded]" ;;',
         '  quota) r success false "[API Error: 429 Your token-plan quota has been exhausted. The quota will reset at 07-19 13:17:00 UTC.]" ;;',
         '  quota_noreset) r success false "[API Error: 429 Your quota has been exhausted.]" ;;',
+        '  success_mentions_api_error) r success false "Review of [API Error: ...] handling — quota and rate.?limit keywords look correct." ;;',
         '  errresult) r error true "connection dropped mid-review" ;;',
         '  hardexit) exit 3 ;;',
         'esac',
@@ -155,6 +156,16 @@ describe('qwen pr review transient retry', () => {
     const r = runScenario('quota_noreset');
     expect(r.line).toContain('FAIL kind=[quota]');
     expect(r.line).not.toContain('reset at');
+    expect(r.attempts).toBe(1);
+  });
+
+  it('does NOT misclassify a successful review that mentions [API Error: ...] in its summary', () => {
+    // A review of PR #7247 (API error retry) quoted "[API Error: ...]" and
+    // "quota … limit" in its result text. The old pattern *"[API Error"*
+    // matched the prose and the quota grep hit "quota … limit", falsely
+    // reporting quota exhaustion on a successful review.
+    const r = runScenario('success_mentions_api_error');
+    expect(r.line).toContain('OK outcome=success');
     expect(r.attempts).toBe(1);
   });
 

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -87,6 +87,7 @@ function runScenario(scenario, { timeoutMinutes = 180 } = {}) {
         '  abort_with_suffix) r success false "[API Error: Rate limit exceeded]\\nPossible quota limitations in place or slow response times detected. Please wait and try again later." ;;',
         '  success_mentions_api_error) PAD=$(printf "x%.0s" $(seq 1 600)); r success false "This PR detects the [API Error: ...] pattern and routes to retry. quota and rate.?limit keywords cover the common messages. ${PAD} Review complete: COMMENT posted (0 Critical, 1 Suggestion inline)." ;;',
         '  success_quotes_status_code) PAD=$(printf "x%.0s" $(seq 1 700)); r success false "This PR adds retry for [API Error: 429 quota exceeded] and similar. ${PAD} Verdict: COMMENT, 0 Critical." ;;',
+        '  success_ends_with_bracket) r success false "Review of [API Error: 429 quota exhausted] handling. Checklist: - [x]" ;;',
         '  errresult) r error true "connection dropped mid-review" ;;',
         '  hardexit) exit 3 ;;',
         'esac',
@@ -269,5 +270,30 @@ describe('qwen pr review transient retry', () => {
     ).run;
     expect(fallback).toContain('"$FAILURE_KIND" = "quota"');
     expect(fallback).toContain('model quota exhausted');
+  });
+
+  it('keeps the workflow rate-limit suffix list in sync with errorParsing.ts', () => {
+    const src = readFileSync(
+      'packages/core/src/utils/errorParsing.ts',
+      'utf8',
+    );
+    const blk = src.slice(
+      src.indexOf('RATE_LIMIT_MESSAGE_BY_AUTH = {'),
+      src.indexOf('} as const;'),
+    );
+    const suffixes = [...blk.matchAll(/'\\n([^']+)'/g)].map((m) => m[1]);
+    expect(suffixes).toHaveLength(3);
+    for (const s of suffixes) expect(workflow).toContain(s);
+  });
+
+  // Known limitation: a successful review that quotes "[API Error: …]" and
+  // ends with "]" (e.g. a "- [x]" checklist or a "[1]" ref link) trips the
+  // ends-with gate. The current review template ends with </details> + a
+  // <sub> footer, which accidentally protects us. Accepted trade-off; the
+  // durable fix is checking that the bot comment actually landed (§5).
+  it('KNOWN: prose ending with ] after quoting the pattern is a false positive', () => {
+    const r = runScenario('success_ends_with_bracket');
+    expect(r.line).toContain('FAIL kind=[quota]');
+    expect(r.attempts).toBe(1);
   });
 });


### PR DESCRIPTION
## Motivation

The `review-pr` job in [run 29727094401](https://github.com/QwenLM/qwen-code/actions/runs/29727094401) failed even though the review completed successfully and posted its comment to PR #7247.

The result-text classifier uses a `case` pattern `*"[API Error"*` to detect aborted reviews. When reviewing a PR about API error handling, the review summary naturally quotes the pattern (e.g. "detecting the `[API Error: ...]` pattern") and mentions regex keywords like `` `quota` and `rate.?limit` ``. The broad `case` matched the prose, then the quota grep (`quota.*(exhaust|exceed|limit|reset)`) hit the coincidental "quota … limit" substring, falsely classifying a successful review as a quota exhaustion failure.

## Changes

Tighten the `case` glob from `*"[API Error"*` to `*"[API Error: "[0-9]*` so only real API error messages (which always carry a 3-digit status code, e.g. `[API Error: 429 …]`) trigger the failure path. Review prose that quotes the pattern without a status code no longer matches.

## How to verify

- The new test scenario `success_mentions_api_error` feeds a result text containing `[API Error: ...]` and "quota … limit" in prose — it must classify as `success`, not `quota`.
- All existing scenarios (real `[API Error: 503 …]`, `[API Error: 429 … quota exhausted]`, etc.) still classify correctly.
- `npx vitest run scripts/tests/qwen-pr-review-workflow.test.js` — 11/11 pass.

<details>
<summary>中文说明</summary>

## 动机

[run 29727094401](https://github.com/QwenLM/qwen-code/actions/runs/29727094401) 中 `review-pr` job 失败了，但 review 实际上已成功完成并在 PR #7247 上发布了评论。

result-text 分类器使用 `case` 模式 `*"[API Error"*` 来检测中断的 review。当 review 一个关于 API 错误处理的 PR 时，review 总结自然会引用该模式（如 "detecting the `[API Error: ...]` pattern"），并提及 `` `quota` and `rate.?limit` `` 等正则关键词。宽泛的 `case` 匹配到了正文，随后 quota grep（`quota.*(exhaust|exceed|limit|reset)`）命中了偶然出现的 "quota … limit" 子串，将一次成功的 review 误判为配额耗尽。

## 改动

将 `case` glob 从 `*"[API Error"*` 收紧为 `*"[API Error: "[0-9]*`，要求冒号后跟数字状态码（真正的 API 错误格式如 `[API Error: 429 …]`），review 散文中不带状态码的引用不再触发失败路径。

## 验证方式

- 新增测试场景 `success_mentions_api_error`：result text 包含 `[API Error: ...]` 和 "quota … limit" 散文——必须分类为 `success` 而非 `quota`。
- 所有已有场景（真实的 `[API Error: 503 …]`、`[API Error: 429 … quota exhausted]` 等）分类仍然正确。
- `npx vitest run scripts/tests/qwen-pr-review-workflow.test.js` — 11/11 通过。

</details>