### PR TITLE
fix: ask when Auto Mode classifier is unavailable

### DIFF
--- a/docs/design/auto-classifier-unavailable-fallback.md
+++ b/docs/design/auto-classifier-unavailable-fallback.md
@@ -1,0 +1,87 @@
+# Auto classifier unavailable fallback
+
+## Problem
+
+Auto Mode currently converts every classifier infrastructure failure into an execution denial. A network error, timeout, invalid structured response, unavailable fast model, or context overflow therefore fails the pending tool call before the standard confirmation flow can ask the user what to do.
+
+This behavior conflates two different outcomes:
+
+- A classifier policy block is a safety verdict and should continue to deny the action.
+- A classifier unavailable result means no verdict was produced and should let the user make the decision manually.
+
+The existing consecutive-unavailable fallback only opens a confirmation after two failed classifier calls. The first failures still terminate their tool calls, and the prompt does not explain the infrastructure problem or offer a direct recovery path.
+
+## Goals
+
+- Route the first classifier unavailable result into the standard manual confirmation flow.
+- Explain in the confirmation that Auto Mode could not classify the action.
+- Offer an explicit option that approves the current action once and switches the session to Default Mode.
+- Keep CLI and ACP permission behavior aligned.
+- Preserve policy blocks, explicit deny rules, deterministic destructive-command guards, and user cancellation behavior.
+
+## Non-goals
+
+- Persisting Default Mode to user or workspace settings.
+- Automatically switching modes without a user selection.
+- Changing the policy classifier's allow/block rules.
+- Making non-interactive or background sessions capable of presenting a prompt when they have no approval surface.
+
+## Proposed behavior
+
+When the classifier returns `unavailable: true`, the permission layer will still record the unavailable event, but it will return a manual-fallback outcome instead of a blocked outcome. The pending call will continue through the existing PermissionRequest and confirmation paths.
+
+The generated confirmation will carry Auto Mode fallback metadata and suppress persistent “always allow” choices. The confirmation will show that the classifier is unavailable and recommend Default Mode if failures continue. Its choices will include:
+
+- Allow once.
+- Switch to Default Mode and allow once.
+- Reject.
+
+The switch choice is intentionally combined with an explicit one-time approval. A mode-only label would leave the disposition of the already pending action ambiguous.
+
+| Classifier result | Current behavior        | New behavior            |
+| ----------------- | ----------------------- | ----------------------- |
+| Allow             | Execute automatically   | Unchanged               |
+| Policy block      | Deny with policy reason | Unchanged               |
+| Unavailable       | Deny the tool call      | Ask for manual approval |
+
+## Core permission flow
+
+`applyAutoModeDecision` will record unavailable counters and return a fallback reason dedicated to classifier unavailability. Because the outcome is no longer blocked, PermissionDenied hooks will not fire for infrastructure failures; the normal PermissionRequest hook will run before the prompt instead.
+
+Unavailable counters remain useful. Approving a fallback resets the consecutive counters, while rejecting it preserves them. If repeated failures reach the existing threshold, later classifier-eligible calls can bypass the known-broken classifier and go directly to manual confirmation.
+
+Confirmation details will gain optional Auto Mode fallback metadata shared across edit, execute, info, MCP, and other confirmation shapes. A new approval outcome will represent “proceed once and switch to Default.” The CLI scheduler will switch the runtime session mode and normalize that outcome to ordinary `ProceedOnce` before invoking tool-specific confirmation callbacks or recording the tool decision.
+
+`Config.setApprovalMode` already provides the required session transition: it restores rules temporarily stripped on Auto Mode entry, resets denial counters, and increments the approval-mode revision. No settings file is changed.
+
+## CLI presentation
+
+The TUI confirmation component will render the fallback notice before the action details and add the switch option before Reject. Full and compact confirmation layouts will both expose the option. Height accounting must reserve space for the added warning and option so small terminals continue to show actionable choices.
+
+## ACP presentation
+
+ACP permission requests will include the fallback notice as text content and expose the same switch-and-allow-once option. When selected, the session will normalize the tool approval to `ProceedOnce`, switch the runtime mode to Default, and publish the existing current-mode update notification.
+
+ACP clients that only choose Allow or Reject continue to use the existing protocol behavior.
+
+## Failure boundaries
+
+- User cancellation of the classifier request remains an abort and does not become an approval prompt.
+- Explicit permission denies and deterministic destructive-command blocks remain errors.
+- Non-interactive calls without a permission transport and background agents that cannot prompt still deny through their existing manual-confirmation fallback handling.
+- A failed policy review in classifier Stage 2 is considered unavailable and therefore asks the user; a completed Stage 2 policy block remains denied.
+
+## Files affected
+
+- `packages/core/src/permissions/autoMode.ts` and tests: unavailable-to-fallback mapping, metadata, and hook gating.
+- `packages/core/src/tools/tools.ts`: fallback confirmation metadata and switch approval outcome.
+- `packages/core/src/core/coreToolScheduler.ts` and tests: decorate confirmations, track fallback resolution, switch modes, and normalize the approval.
+- `packages/core/src/telemetry/tool-call-decision.ts` and tests: classify the new approval-shaped outcome.
+- `packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx` and tests: notice and option rendering.
+- `packages/cli/src/acp-integration/session/permissionUtils.ts` and tests: ACP content and option mapping.
+- `packages/cli/src/acp-integration/session/Session.ts` and tests: ACP fallback, mode transition, and notification.
+- `docs/users/features/auto-mode.md`: document immediate manual fallback and the Default Mode recovery option.
+
+## Open questions
+
+None. The switch is session-only and explicitly approves the pending action once.

--- a/docs/users/features/auto-mode.md
+++ b/docs/users/features/auto-mode.md
@@ -175,8 +175,8 @@ This is useful for production or high-security environments where you
 want defense-in-depth: even seemingly harmless commands are reviewed by
 the classifier before execution. The trade-off is added latency (~300ms
 per read-only shell call) and reliance on classifier availability — if
-the classifier API is unreachable, read-only shell commands will also be
-blocked (fail-closed).
+the classifier API is unreachable, read-only shell commands will also require
+manual approval.
 
 > [!note]
 >
@@ -187,18 +187,13 @@ blocked (fail-closed).
 
 ## Reading the decision
 
-When the classifier blocks an action, the tool call fails with one of
-the following error texts:
+When the classifier blocks an action, the tool call fails with:
 
 - **`Blocked by auto mode policy: <reason>`** —
   the classifier judged the action unsafe. The reason comes from Stage
   2 of the classifier.
-- **`Auto mode classifier unavailable; action blocked for safety`** —
-  the classifier API was unreachable, timed out, or returned an
-  un-parseable response. This is fail-closed behavior: when in doubt,
-  block.
 
-Both messages are followed by a trailing guidance line telling the agent
+This message is followed by a trailing guidance line telling the agent
 that the **denied action specifically** must not be completed through
 another tool, shell indirection, generated script, alias, symlink,
 config change, hook, command file, MCP configuration, encoded payload,
@@ -219,16 +214,24 @@ want non-English reasons, add a hint like
 
 Auto Mode protects you from getting stuck:
 
+- If the classifier API is unreachable, times out, exceeds its context window,
+  or returns an invalid response, the current action immediately falls back to
+  manual approval. The confirmation recommends Default Mode and offers
+  **Switch to Default Mode and allow once** alongside Allow once and Reject.
+  Switching affects only the current runtime session; it does not change your
+  saved settings.
+
 - After **3 consecutive policy blocks** the next tool call falls back to
   the standard manual-approval prompt. This catches the case where the
   agent keeps trying minor variants of a forbidden command.
-- After **2 consecutive unavailable** results (classifier API failures)
-  the next tool call also falls back. This avoids waiting on a broken
-  classifier.
+- After **2 consecutive unavailable** results (classifier API failures),
+  later calls skip the known-broken classifier and go directly to manual
+  approval. The first unavailable result already asks; the threshold avoids
+  repeatedly waiting for classifier retries.
 
-The session itself stays in Auto Mode — only the single fallback call
-goes through manual approval. The counters reset when you approve the
-fallback call or switch modes.
+The session stays in Auto Mode unless you explicitly select the switch option.
+Only the fallback call goes through manual approval. The counters reset when
+you approve the fallback call or switch modes.
 
 If you find yourself constantly hitting fallback, the most likely causes
 are an outage on the classifier API or hints that need tuning. Switch to

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -11364,6 +11364,158 @@ describe('Session', () => {
       );
     });
 
+    it('asks when the AUTO classifier is unavailable and can switch to Default', async () => {
+      const cwd = '/repo';
+      const command = "echo '{}' > .qwen/settings.json";
+      let approvalMode = ApprovalMode.AUTO;
+      let denialState = {
+        consecutiveBlock: 0,
+        consecutiveUnavailable: 0,
+        totalBlock: 0,
+        totalUnavailable: 0,
+      };
+      const baseLlmClient = {
+        generateJson: vi.fn().mockRejectedValue(new Error('classifier 503')),
+      };
+      const getHistoryTail = vi.fn().mockReturnValue([]);
+      const permissionManager = new core.PermissionManager({
+        getPermissionsAllow: () => ['Bash(*)'],
+        getPermissionsAsk: () => [],
+        getPermissionsDeny: () => [],
+        getCoreTools: () => undefined,
+        getApprovalMode: () => ApprovalMode.DEFAULT,
+        getProjectRoot: () => cwd,
+        getCwd: () => cwd,
+      });
+      permissionManager.initialize();
+      const executeSpy = vi.fn().mockResolvedValue({
+        llmContent: 'ok',
+        returnDisplay: 'ok',
+      });
+      const onConfirmSpy = vi.fn().mockResolvedValue(undefined);
+      const invocation = {
+        params: { command },
+        getDefaultPermission: vi.fn().mockResolvedValue('ask'),
+        getConfirmationDetails: vi.fn().mockResolvedValue({
+          type: 'exec',
+          title: 'Confirm shell command',
+          command,
+          rootCommand: 'echo',
+          onConfirm: onConfirmSpy,
+        }),
+        getDescription: vi.fn().mockReturnValue('Run shell command'),
+        toolLocations: vi.fn().mockReturnValue([]),
+        execute: executeSpy,
+      };
+      const tool = {
+        name: core.ToolNames.SHELL,
+        kind: core.Kind.Execute,
+        build: vi.fn().mockReturnValue(invocation),
+      };
+
+      mockToolRegistry.getTool.mockReturnValue(tool);
+      mockConfig.getApprovalMode = vi
+        .fn()
+        .mockImplementation(() => approvalMode);
+      mockConfig.setApprovalMode = vi.fn().mockImplementation((mode) => {
+        approvalMode = mode;
+      });
+      mockConfig.getTargetDir = vi.fn().mockReturnValue(cwd);
+      mockConfig.getCwd = vi.fn().mockReturnValue(cwd);
+      mockConfig.getPermissionManager = vi
+        .fn()
+        .mockReturnValue(permissionManager);
+      mockConfig.getAutoModeDenialState = vi
+        .fn()
+        .mockImplementation(() => denialState);
+      mockConfig.setAutoModeDenialState = vi
+        .fn()
+        .mockImplementation((next: typeof denialState) => {
+          denialState = next;
+        });
+      mockConfig.getBaseLlmClient = vi.fn().mockReturnValue(baseLlmClient);
+      mockConfig.getGeminiClient = vi
+        .fn()
+        .mockReturnValue({ ...mockGeminiClient, getHistoryTail });
+      mockConfig.getAutoModeSettings = vi.fn().mockReturnValue({});
+      mockConfig.getModel = vi.fn().mockReturnValue('test-model');
+      mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(true);
+      mockConfig.getMessageBus = vi.fn().mockReturnValue(undefined);
+      vi.mocked(mockClient.requestPermission).mockResolvedValueOnce({
+        outcome: {
+          outcome: 'selected',
+          optionId: core.ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+        },
+      });
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              functionCalls: [
+                {
+                  id: 'call-classifier-unavailable',
+                  name: core.ToolNames.SHELL,
+                  args: { command },
+                },
+              ],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'run shell command' }],
+      });
+
+      expect(mockClient.requestPermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: [
+            expect.objectContaining({
+              optionId: core.ToolConfirmationOutcome.ProceedOnce,
+            }),
+            expect.objectContaining({
+              optionId:
+                core.ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+              name: expect.stringContaining('recommended'),
+            }),
+            expect.objectContaining({
+              optionId: core.ToolConfirmationOutcome.Cancel,
+            }),
+          ],
+          toolCall: expect.objectContaining({
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                content: expect.objectContaining({
+                  text: expect.stringContaining(
+                    "Auto Mode couldn't classify this action",
+                  ),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+      expect(onConfirmSpy).toHaveBeenCalledWith(
+        core.ToolConfirmationOutcome.ProceedOnce,
+        { answers: undefined },
+      );
+      expect(mockConfig.setApprovalMode).toHaveBeenCalledWith(
+        ApprovalMode.DEFAULT,
+      );
+      expect(approvalMode).toBe(ApprovalMode.DEFAULT);
+      expect(executeSpy).toHaveBeenCalled();
+      expect(mockClient.sessionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: 'current_mode_update',
+            currentModeId: ApprovalMode.DEFAULT,
+          }),
+        }),
+      );
+    });
+
     it('resets AUTO denial counters when the user approves a denialTracking fallback prompt', async () => {
       const executeSpy = vi.fn().mockResolvedValue({
         llmContent: 'ok',
@@ -11619,7 +11771,7 @@ describe('Session', () => {
           );
         });
 
-        it('forwards classifier_unavailable reasons to PermissionDenied hooks', async () => {
+        it('does not fire PermissionDenied hooks for classifier unavailability', async () => {
           const hookSystem = {
             firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
           };
@@ -11637,9 +11789,9 @@ describe('Session', () => {
               durationMs: 3000,
             },
             {
-              kind: 'blocked',
-              errorMessage: 'blocked',
+              kind: 'fallback',
               reason: 'classifier_unavailable',
+              message: 'Classifier unavailable.',
             },
             core.ToolNames.SHELL,
             { command: 'rm -rf /tmp/example' },
@@ -11647,14 +11799,7 @@ describe('Session', () => {
             new AbortController().signal,
           );
 
-          expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
-            core.ToolNames.SHELL,
-            { command: 'rm -rf /tmp/example' },
-            'auto-denied-acp',
-            'classifier_unavailable',
-            expect.any(AbortSignal),
-            'auto-denied-acp',
-          );
+          expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
         });
 
         it('continues AUTO block handling when PermissionDenied hook fails', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -104,6 +104,7 @@ import {
   getStopHookContinuationReason,
   formatStopHookBlockingCapWarning,
   applyAutoModeDecision,
+  decorateClassifierUnavailableConfirmation,
   evaluateAutoMode,
   getAutoModePermissionDeniedReason,
   isApproveOutcome,
@@ -6217,8 +6218,8 @@ export class Session implements SessionContext {
 
           // Explicit allow (user rule matched, or tool's L3 default is 'allow')
           // is authoritative for ordinary calls. In AUTO, protected
-          // self-modification writes must still reach the classifier/fail-closed
-          // path so allow rules cannot bypass AUTO mode's safety boundary.
+          // self-modification writes must still reach the classifier/manual
+          // fallback path so allow rules cannot bypass AUTO mode review.
           // Also resets the denialTracking streak so a following
           // classifier-eligible call doesn't surprise the user with a manual
           // prompt right after an allow-rule call just worked.
@@ -6244,7 +6245,8 @@ export class Session implements SessionContext {
               recordAllow(this.config.getAutoModeDenialState()),
             );
           }
-          let wasAutoModeDenialFallback = false;
+          let wasAutoModeManualFallback = false;
+          let autoModeFallbackMessage: string | undefined;
 
           // ── L5: AUTO mode three-layer filter (duplicated from
           // coreToolScheduler.ts; ACP routes through this Session path).
@@ -6313,10 +6315,11 @@ export class Session implements SessionContext {
                 );
               case 'fallback':
                 // Drop through to the manual-approval flow below.
-                wasAutoModeDenialFallback = isDenialFallbackReason(
-                  outcome.reason,
-                );
-                if (wasAutoModeDenialFallback) {
+                wasAutoModeManualFallback =
+                  isDenialFallbackReason(outcome.reason) ||
+                  outcome.reason === 'classifier_unavailable';
+                autoModeFallbackMessage = outcome.message;
+                if (wasAutoModeManualFallback) {
                   debugLogger.warn(
                     `Auto mode fallback to manual approval (${outcome.reason}): ` +
                       formatDenialStateLog(denialState),
@@ -6335,12 +6338,12 @@ export class Session implements SessionContext {
           const recordAutoModeFallbackResolution = (
             outcome: ToolConfirmationOutcome,
           ) => {
-            // Reset AUTO-mode fallback counters when approval resolves a prompt
-            // raised because denialTracking forced fallback. This covers both ACP
-            // requestPermission and PermissionRequest hook approvals.
+            // Reset AUTO-mode fallback counters when approval resolves a
+            // recovery prompt. This covers both ACP requestPermission and
+            // PermissionRequest hook approvals.
             if (
               approvalMode === ApprovalMode.AUTO &&
-              wasAutoModeDenialFallback &&
+              wasAutoModeManualFallback &&
               isApproveOutcome(outcome)
             ) {
               const before = this.config.getAutoModeDenialState();
@@ -6372,6 +6375,13 @@ export class Session implements SessionContext {
             confirmationDetails = await invocation.getConfirmationDetails(
               activeToolAbortSignal,
             );
+
+            if (autoModeFallbackMessage) {
+              confirmationDetails = decorateClassifierUnavailableConfirmation(
+                confirmationDetails,
+                autoModeFallbackMessage,
+              );
+            }
 
             if (planShellDecision.classification !== 'not-applicable') {
               const preDisplayPlanShellError =
@@ -6662,6 +6672,12 @@ export class Session implements SessionContext {
                 outcome = approval.outcome;
                 confirmationPayload = approval.payload;
               }
+              const shouldSwitchToDefault =
+                outcome ===
+                ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault;
+              if (shouldSwitchToDefault) {
+                outcome = ToolConfirmationOutcome.ProceedOnce;
+              }
               recordAutoModeFallbackResolution(outcome);
 
               try {
@@ -6678,6 +6694,11 @@ export class Session implements SessionContext {
                   error,
                 );
                 return stopAfterPermissionCancel();
+              }
+
+              if (shouldSwitchToDefault) {
+                this.config.setApprovalMode(ApprovalMode.DEFAULT);
+                await this.sendCurrentModeUpdateNotification();
               }
 
               // Persist permission rules when user explicitly chose "Always Allow".
@@ -6707,6 +6728,10 @@ export class Session implements SessionContext {
               }
 
               switch (outcome) {
+                case ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault:
+                  throw new Error(
+                    'Switch-to-Default outcome must be normalized before execution.',
+                  );
                 case ToolConfirmationOutcome.Cancel:
                   // Route through earlyErrorResponse so spanError carries the
                   // cancellation reason (plain errorResponse leaves it unset,

--- a/packages/cli/src/acp-integration/session/permissionUtils.test.ts
+++ b/packages/cli/src/acp-integration/session/permissionUtils.test.ts
@@ -99,6 +99,36 @@ describe('permissionUtils', () => {
         }),
       );
     });
+
+    it('offers switch-to-Default before Reject and hides persistent choices', () => {
+      const options = toPermissionOptions({
+        type: 'exec',
+        title: 'Confirm Shell Command',
+        command: 'touch /tmp/marker',
+        rootCommand: 'touch',
+        autoModeFallback: {
+          reason: 'classifier_unavailable',
+          message: 'Classifier unavailable.',
+        },
+        onConfirm: async () => undefined,
+      });
+
+      expect(options).toEqual([
+        expect.objectContaining({
+          optionId: ToolConfirmationOutcome.ProceedOnce,
+          kind: 'allow_once',
+        }),
+        {
+          optionId: ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+          name: 'Switch to Default Mode and allow once (recommended)',
+          kind: 'allow_once',
+        },
+        expect.objectContaining({
+          optionId: ToolConfirmationOutcome.Cancel,
+          kind: 'reject_once',
+        }),
+      ]);
+    });
   });
 
   describe('interactionMetaFields', () => {
@@ -156,6 +186,35 @@ describe('permissionUtils', () => {
     ]);
     expect(content[0]).toMatchObject({
       content: { text: 'Unknown safety' },
+    });
+  });
+
+  it('places classifier fallback guidance before other content', () => {
+    const content = buildPermissionRequestContent({
+      type: 'edit',
+      title: 'Confirm edit',
+      fileName: 'a.txt',
+      filePath: '/tmp/a.txt',
+      fileDiff: 'diff',
+      originalContent: 'a',
+      newContent: 'b',
+      warnings: ['Existing warning'],
+      autoModeFallback: {
+        reason: 'classifier_unavailable',
+        message: 'Classifier unavailable. Default Mode is recommended.',
+      },
+      onConfirm: async () => undefined,
+    });
+
+    expect(content.map((item) => item.type)).toEqual([
+      'content',
+      'content',
+      'diff',
+    ]);
+    expect(content[0]).toMatchObject({
+      content: {
+        text: 'Classifier unavailable. Default Mode is recommended.',
+      },
     });
   });
 

--- a/packages/cli/src/acp-integration/session/permissionUtils.ts
+++ b/packages/cli/src/acp-integration/session/permissionUtils.ts
@@ -43,11 +43,28 @@ function filterAlwaysAllowOptions(
 ): PermissionOption[] {
   const hideAlwaysAllow =
     forceHideAlwaysAllow ||
+    confirmation.autoModeFallback !== undefined ||
     (supportsHideAlwaysAllow(confirmation) &&
       confirmation.hideAlwaysAllow === true);
-  return hideAlwaysAllow
+  const visibleOptions = hideAlwaysAllow
     ? options.filter((option) => option.kind !== 'allow_always')
     : options;
+  if (!confirmation.autoModeFallback) return visibleOptions;
+
+  const switchOption: PermissionOption = {
+    optionId: ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+    name: 'Switch to Default Mode and allow once (recommended)',
+    kind: 'allow_once',
+  };
+  const rejectIndex = visibleOptions.findIndex(
+    (option) => option.kind === 'reject_once',
+  );
+  if (rejectIndex === -1) return [...visibleOptions, switchOption];
+  return [
+    ...visibleOptions.slice(0, rejectIndex),
+    switchOption,
+    ...visibleOptions.slice(rejectIndex),
+  ];
 }
 
 function formatExecPermissionScopeLabel(
@@ -87,6 +104,16 @@ export function buildPermissionRequestContent(
   confirmation: ToolCallConfirmationDetails,
 ): ToolCallContent[] {
   const content: ToolCallContent[] = [];
+
+  if (confirmation.autoModeFallback) {
+    content.push({
+      type: 'content',
+      content: {
+        type: 'text',
+        text: confirmation.autoModeFallback.message,
+      },
+    });
+  }
 
   const warnings =
     confirmation.type === 'exec' || confirmation.type === 'edit'

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.test.tsx
@@ -132,6 +132,47 @@ describe('ToolConfirmationMessage', () => {
     expect(lastFrame() ?? '').not.toContain('command substitution');
   });
 
+  it('renders classifier fallback guidance and the Default Mode option', async () => {
+    const onConfirm = vi.fn();
+    const confirmationDetails: ToolCallConfirmationDetails = {
+      type: 'exec',
+      title: 'Confirm Shell Command',
+      command: 'touch /tmp/marker',
+      rootCommand: 'touch',
+      hideAlwaysAllow: true,
+      autoModeFallback: {
+        reason: 'classifier_unavailable',
+        message:
+          "Auto Mode couldn't classify this action. Switching to Default Mode is recommended.",
+      },
+      onConfirm,
+    };
+
+    const { lastFrame, stdin } = renderWithProviders(
+      <ToolConfirmationMessage
+        confirmationDetails={confirmationDetails}
+        config={mockConfig}
+        availableTerminalHeight={12}
+        contentWidth={80}
+      />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain("Auto Mode couldn't classify this action");
+    expect(frame).toContain(
+      'Switch to Default Mode and allow once (recommended)',
+    );
+    expect(frame).not.toContain('Always allow');
+
+    stdin.write('\x1b[B');
+    stdin.write('\r');
+    await vi.waitFor(() =>
+      expect(onConfirm).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+      ),
+    );
+  });
+
   // Regression coverage for the round-1 review on PR #4386 (PR #4386 round-2
   // self-review SR-1): the warnings block sits outside the MaxSizedBox
   // cap, so its footprint has to be reserved from `bodyContentHeight`
@@ -753,6 +794,41 @@ describe('ToolConfirmationMessage', () => {
   });
 
   describe('compactMode', () => {
+    it('keeps classifier fallback guidance and all choices visible', () => {
+      const confirmationDetails: ToolCallConfirmationDetails = {
+        type: 'exec',
+        title: 'Confirm Execution',
+        command: 'touch /tmp/marker',
+        rootCommand: 'touch',
+        hideAlwaysAllow: true,
+        autoModeFallback: {
+          reason: 'classifier_unavailable',
+          message:
+            "Auto Mode couldn't classify this action. Switching to Default Mode is recommended.",
+        },
+        onConfirm: vi.fn(),
+      };
+
+      const { lastFrame } = renderWithProviders(
+        <ToolConfirmationMessage
+          confirmationDetails={confirmationDetails}
+          config={mockConfig}
+          availableTerminalHeight={10}
+          contentWidth={80}
+          compactMode={true}
+        />,
+      );
+
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain("Auto Mode couldn't classify this action");
+      expect(frame).toContain('Yes, allow once');
+      expect(frame).toContain(
+        'Switch to Default Mode and allow once (recommended)',
+      );
+      expect(frame).toContain('No');
+      expect(frame).not.toContain('Allow always');
+    });
+
     it('renders the command and exec-specific question for exec confirmations', () => {
       const confirmationDetails: ToolCallConfirmationDetails = {
         type: 'exec',

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -61,6 +61,7 @@ export const ToolConfirmationMessage: React.FC<
   compactMode = false,
 }) => {
   const { onConfirm } = confirmationDetails;
+  const autoModeFallback = confirmationDetails.autoModeFallback;
 
   const settings = useSettings();
   const preferredEditor = settings.merged.general?.preferredEditor as
@@ -182,14 +183,23 @@ export const ToolConfirmationMessage: React.FC<
     const MARGIN_BODY_BOTTOM = compactMode ? 0 : 1;
     const HEIGHT_QUESTION = 1;
     const MARGIN_QUESTION_BOTTOM = compactMode ? 0 : 1;
-    const HEIGHT_OPTIONS = compactMode ? 3 : options.length;
+    const HEIGHT_OPTIONS = compactMode
+      ? 3
+      : options.length + (autoModeFallback ? 1 : 0);
+    const AUTO_MODE_FALLBACK_HEIGHT = autoModeFallback
+      ? wrapAnsi(`⚠ ${autoModeFallback.message}`, warningContentWidth, {
+          trim: false,
+          hard: true,
+        }).split('\n').length + 1
+      : 0;
 
     const surroundingElementsHeight =
       PADDING_OUTER_Y +
       MARGIN_BODY_BOTTOM +
       HEIGHT_QUESTION +
       MARGIN_QUESTION_BOTTOM +
-      HEIGHT_OPTIONS;
+      HEIGHT_OPTIONS +
+      AUTO_MODE_FALLBACK_HEIGHT;
     return Math.max(availableTerminalHeight - surroundingElementsHeight, 1);
   }
 
@@ -644,6 +654,32 @@ export const ToolConfirmationMessage: React.FC<
     });
   }
 
+  if (autoModeFallback) {
+    const cancelIndex = options.findIndex(
+      (option) => option.value === ToolConfirmationOutcome.Cancel,
+    );
+    const switchOption: RadioSelectItem<ToolConfirmationOutcome> = {
+      key: 'switch-default-and-proceed-once',
+      label: t('Switch to Default Mode and allow once (recommended)'),
+      value: ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+    };
+    options.splice(
+      cancelIndex === -1 ? options.length : cancelIndex,
+      0,
+      switchOption,
+    );
+    bodyContent = (
+      <Box flexDirection="column">
+        <Box paddingX={1} marginLeft={1} marginBottom={1}>
+          <Text color={theme.status.warning}>
+            ⚠ {autoModeFallback.message}
+          </Text>
+        </Box>
+        {bodyContent}
+      </Box>
+    );
+  }
+
   // For exec/mcp confirmations the type-specific question text would
   // restate what the body already shows (the full command, or the labeled
   // server + tool). Use the generic prompt so the question line acts as a
@@ -666,6 +702,17 @@ export const ToolConfirmationMessage: React.FC<
             label: t('Yes, allow once'),
             value: ToolConfirmationOutcome.ProceedOnce,
           },
+          ...(autoModeFallback
+            ? [
+                {
+                  key: 'switch-default-and-proceed-once',
+                  label: t(
+                    'Switch to Default Mode and allow once (recommended)',
+                  ),
+                  value: ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+                },
+              ]
+            : []),
           ...(!confirmationDetails.hideAlwaysAllow
             ? [
                 {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -706,6 +706,7 @@ describe('CoreToolScheduler', () => {
       totalUnavailable: number;
     };
     setAutoModeDenialState?: ReturnType<typeof vi.fn>;
+    setApprovalMode?: ReturnType<typeof vi.fn>;
     onAllToolCallsComplete?: ReturnType<typeof vi.fn>;
     onToolCallsUpdate?: ReturnType<typeof vi.fn>;
     memoryMonitor?: { scheduleCheck: () => void };
@@ -741,6 +742,7 @@ describe('CoreToolScheduler', () => {
         getUsageStatisticsEnabled: () => true,
         getDebugMode: () => false,
         getApprovalMode: () => options.approvalMode ?? ApprovalMode.YOLO,
+        setApprovalMode: options.setApprovalMode ?? vi.fn(),
         getPermissionsAllow: () => [],
         getPermissionsDeny: options.getPermissionsDeny ?? (() => undefined),
         getContentGeneratorConfig: () => ({
@@ -2663,21 +2665,29 @@ describe('CoreToolScheduler', () => {
     }
   });
 
-  it('fires PermissionDenied hooks for AUTO classifier unavailable blocks', async () => {
+  it('asks on AUTO classifier unavailable and can switch to Default', async () => {
     runSideQueryMock
       .mockResolvedValueOnce({ shouldBlock: true })
       .mockRejectedValueOnce(new Error('classifier timed out'));
     const execute = vi.fn().mockResolvedValue({
-      llmContent: 'should not execute',
-      returnDisplay: 'should not execute',
+      llmContent: 'executed',
+      returnDisplay: 'executed',
     });
+    const originalOnConfirm = vi.fn().mockResolvedValue(undefined);
     const toolsByName = new Map<string, MockTool>([
       [
         ToolNames.SHELL,
         new MockTool({
           name: ToolNames.SHELL,
           getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
-          getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+          getConfirmationDetails: () =>
+            Promise.resolve({
+              type: 'exec',
+              title: 'Confirm shell',
+              command: 'touch /tmp/example',
+              rootCommand: 'touch',
+              onConfirm: originalOnConfirm,
+            }),
           execute,
         }),
       ],
@@ -2685,12 +2695,16 @@ describe('CoreToolScheduler', () => {
     const hookSystem = {
       firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
     };
+    const setApprovalMode = vi.fn();
+    const onToolCallsUpdate = vi.fn();
     const { scheduler, onAllToolCallsComplete } =
       createSchedulerForLegacyToolTests({
         toolsByName,
         approvalMode: ApprovalMode.AUTO,
         hookSystem,
         disableHooks: false,
+        setApprovalMode,
+        onToolCallsUpdate,
       });
     const abortController = new AbortController();
 
@@ -2699,7 +2713,7 @@ describe('CoreToolScheduler', () => {
         {
           callId: 'auto-unavailable',
           name: ToolNames.SHELL,
-          args: { command: 'rm -rf /tmp/example' },
+          args: { command: 'touch /tmp/example' },
           isClientInitiated: false,
           prompt_id: 'prompt-auto-unavailable',
         },
@@ -2707,18 +2721,33 @@ describe('CoreToolScheduler', () => {
       abortController.signal,
     );
 
+    const waiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    expect(waiting.confirmationDetails).toMatchObject({
+      hideAlwaysAllow: true,
+      autoModeFallback: {
+        reason: 'classifier_unavailable',
+        message: expect.stringContaining('Switching to Default Mode'),
+      },
+    });
+    expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+
+    await waiting.confirmationDetails.onConfirm(
+      ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+    );
+
     await vi.waitFor(() => {
       expect(onAllToolCallsComplete).toHaveBeenCalled();
     });
-    expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
-      ToolNames.SHELL,
-      { command: 'rm -rf /tmp/example' },
-      'auto-unavailable',
-      'classifier_unavailable',
-      abortController.signal,
-      'auto-unavailable',
+    expect(originalOnConfirm).toHaveBeenCalledWith(
+      ToolConfirmationOutcome.ProceedOnce,
+      undefined,
     );
-    expect(execute).not.toHaveBeenCalled();
+    expect(setApprovalMode).toHaveBeenCalledWith(ApprovalMode.DEFAULT);
+    expect(execute).toHaveBeenCalledOnce();
   });
 
   it('skips PermissionDenied hooks when hooks are disabled', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -95,6 +95,7 @@ import {
 } from './plan-mode-entry-policy.js';
 import {
   applyAutoModeDecision,
+  decorateClassifierUnavailableConfirmation,
   evaluateAutoMode,
   getAutoModePermissionDeniedReason,
   shouldClassifyAllShellForAutoMode,
@@ -2547,6 +2548,7 @@ export class CoreToolScheduler {
           // Grep, LS, in-cwd Edit, …) short-circuit even in a denial-streak
           // fallback state — otherwise every trivially safe tool would
           // force manual approval until the user toggles modes.
+          let autoModeFallbackMessage: string | undefined;
           if (
             !requiresUserInteraction &&
             shouldRunAutoModeForCall(approvalMode, canonicalName)
@@ -2626,11 +2628,14 @@ export class CoreToolScheduler {
               case 'fallback':
                 // Drop through to the manual-approval flow below. The
                 // pending dialog tells the user what's being asked;
-                // operators see the cause in the debug log (only when
-                // fallback was specifically armed by denialTracking —
-                // a pmForcedAsk fallback isn't an audit-worthy event).
-                if (isDenialFallbackReason(outcome.reason)) {
+                // operators see recovery fallbacks in the debug log. A
+                // pmForcedAsk fallback isn't an audit-worthy event.
+                if (
+                  isDenialFallbackReason(outcome.reason) ||
+                  outcome.reason === 'classifier_unavailable'
+                ) {
                   this.autoModeFallbackCallIds.add(reqInfo.callId);
+                  autoModeFallbackMessage = outcome.message;
                   debugLogger.warn(
                     `Auto mode fallback to manual approval (${outcome.reason}): ` +
                       formatDenialStateLog(denialState),
@@ -2668,6 +2673,13 @@ export class CoreToolScheduler {
           } else {
             confirmationDetails =
               await invocation.getConfirmationDetails(signal);
+
+            if (autoModeFallbackMessage) {
+              confirmationDetails = decorateClassifierUnavailableConfirmation(
+                confirmationDetails,
+                autoModeFallbackMessage,
+              );
+            }
 
             if (planShellDecision.classification !== 'not-applicable') {
               const preDisplayPlanShellError =
@@ -3262,7 +3274,17 @@ export class CoreToolScheduler {
     signal: AbortSignal,
     payload?: ToolConfirmationPayload,
   ): Promise<void> {
-    await originalOnConfirm(outcome, payload);
+    const shouldSwitchToDefault =
+      outcome === ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault;
+    const normalizedOutcome = shouldSwitchToDefault
+      ? ToolConfirmationOutcome.ProceedOnce
+      : outcome;
+
+    await originalOnConfirm(normalizedOutcome, payload);
+    if (shouldSwitchToDefault) {
+      this.config.setApprovalMode(ApprovalMode.DEFAULT);
+    }
+    outcome = normalizedOutcome;
 
     if (
       outcome === ToolConfirmationOutcome.ProceedAlways ||
@@ -3415,12 +3437,11 @@ export class CoreToolScheduler {
   ): void {
     const wasAutoModeFallback = this.autoModeFallbackCallIds.delete(callId);
 
-    // AUTO-mode denialTracking recovery: when the user manually approves a
-    // call that fell back because denialTracking was armed, clear the armed
-    // counters so subsequent calls return to classifier flow. Ordinary AUTO
-    // approvals for ask rules must not clear cumulative denial totals.
-    // Cancel / abort do NOT reset — spec §9.1.4 treats rejection as a
-    // signal that the classifier was correct to block.
+    // AUTO-mode recovery: when the user manually approves a call that fell
+    // back because denialTracking was armed or the classifier was unavailable,
+    // clear the counters so subsequent calls return to classifier flow.
+    // Ordinary AUTO approvals for ask rules must not clear cumulative totals.
+    // Cancel / abort do not reset because the user declined the action.
     if (
       this.config.getApprovalMode() === ApprovalMode.AUTO &&
       wasAutoModeFallback &&
@@ -5310,10 +5331,23 @@ export class CoreToolScheduler {
               break;
             }
             case 'fallback':
-              if (fallback.fallback) {
+              if (
+                isDenialFallbackReason(outcome.reason) ||
+                outcome.reason === 'classifier_unavailable'
+              ) {
                 this.autoModeFallbackCallIds.add(pendingTool.request.callId);
+                if (outcome.message) {
+                  this.setStatusInternal(
+                    pendingTool.request.callId,
+                    'awaiting_approval',
+                    decorateClassifierUnavailableConfirmation(
+                      pendingTool.confirmationDetails,
+                      outcome.message,
+                    ),
+                  );
+                }
                 debugLogger.warn(
-                  `Auto mode fallback for pending tool (${fallback.reason}): consecutiveBlock=${denialState.consecutiveBlock}, consecutiveUnavailable=${denialState.consecutiveUnavailable}`,
+                  `Auto mode fallback for pending tool (${outcome.reason}): consecutiveBlock=${denialState.consecutiveBlock}, consecutiveUnavailable=${denialState.consecutiveUnavailable}`,
                 );
               }
               break;

--- a/packages/core/src/permissions/autoMode.test.ts
+++ b/packages/core/src/permissions/autoMode.test.ts
@@ -11,8 +11,10 @@ import path from 'node:path';
 import {
   SAFE_TOOL_ALLOWLIST,
   applyAutoModeDecision,
+  decorateClassifierUnavailableConfirmation,
   evaluateAutoMode,
   formatClassifierBlockMessage,
+  formatClassifierUnavailableFallbackMessage,
   getAutoModePermissionDeniedReason,
   isAutoModeProtectedWritePath,
   isInSafeToolAllowlist,
@@ -1141,7 +1143,7 @@ describe('applyAutoModeDecision — blocked reason mapping', () => {
     });
   });
 
-  it('maps classifier infrastructure failures to classifier_unavailable', () => {
+  it('routes classifier infrastructure failures to manual approval', () => {
     const setAutoModeDenialState = vi.fn();
     const result = applyAutoModeDecision(
       {
@@ -1157,8 +1159,9 @@ describe('applyAutoModeDecision — blocked reason mapping', () => {
     );
 
     expect(result).toMatchObject({
-      kind: 'blocked',
+      kind: 'fallback',
       reason: 'classifier_unavailable',
+      message: expect.stringContaining('Switching to Default Mode'),
     });
     expect(setAutoModeDenialState).toHaveBeenCalledWith({
       consecutiveBlock: 0,
@@ -1234,29 +1237,47 @@ describe('formatClassifierBlockMessage', () => {
       'Blocked by auto mode policy: Irreversible filesystem destruction\nDo not try to complete the denied action through another tool, shell indirection, generated script, alias, symlink, config change, hook, command file, MCP configuration, encoded payload, or equivalent path. If that action is required, stop and ask the user for explicit approval. You may continue with unrelated safe work or a genuinely safer alternative that does not accomplish the denied action.',
     );
   });
+});
 
-  it('renders an unavailable message with cause when reason is present', () => {
+describe('classifier unavailable confirmation', () => {
+  const baseDecision = {
+    via: 'classifier' as const,
+    shouldBlock: true,
+    stage: 'thinking' as const,
+    durationMs: 100,
+    unavailable: true,
+  };
+
+  it('renders a manual fallback message with the cause and recommendation', () => {
     expect(
-      formatClassifierBlockMessage({
+      formatClassifierUnavailableFallbackMessage({
         ...baseDecision,
         reason: 'Conversation transcript exceeds classifier context window',
-        unavailable: true,
       }),
     ).toBe(
-      'Auto mode classifier unavailable (Conversation transcript exceeds classifier context window); action blocked for safety\nDo not try to complete the denied action through another tool, shell indirection, generated script, alias, symlink, config change, hook, command file, MCP configuration, encoded payload, or equivalent path. If that action is required, stop and ask the user for explicit approval. You may continue with unrelated safe work or a genuinely safer alternative that does not accomplish the denied action.',
+      "Auto Mode couldn't classify this action (Conversation transcript exceeds classifier context window). Review it manually. Switching to Default Mode is recommended if you want to continue without the classifier.",
     );
   });
 
-  it('falls back to a bare unavailable message when reason is empty', () => {
-    expect(
-      formatClassifierBlockMessage({
-        ...baseDecision,
-        reason: '',
-        unavailable: true,
-      }),
-    ).toBe(
-      'Auto mode classifier unavailable; action blocked for safety\nDo not try to complete the denied action through another tool, shell indirection, generated script, alias, symlink, config change, hook, command file, MCP configuration, encoded payload, or equivalent path. If that action is required, stop and ask the user for explicit approval. You may continue with unrelated safe work or a genuinely safer alternative that does not accomplish the denied action.',
+  it('decorates the confirmation and suppresses persistent approval', () => {
+    const confirmation = decorateClassifierUnavailableConfirmation(
+      {
+        type: 'exec',
+        title: 'Run command',
+        command: 'touch marker',
+        rootCommand: 'touch',
+        onConfirm: vi.fn(),
+      },
+      'Classifier unavailable.',
     );
+
+    expect(confirmation).toMatchObject({
+      hideAlwaysAllow: true,
+      autoModeFallback: {
+        reason: 'classifier_unavailable',
+        message: 'Classifier unavailable.',
+      },
+    });
   });
 });
 
@@ -1285,6 +1306,17 @@ describe('PermissionDenied hook gating', () => {
       shouldFirePermissionDeniedForAutoMode(
         { ...classifierBlock, shouldBlock: false },
         { kind: 'approved' },
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldFirePermissionDeniedForAutoMode(
+        { ...classifierBlock, unavailable: true },
+        {
+          kind: 'fallback',
+          reason: 'classifier_unavailable',
+          message: 'Classifier unavailable.',
+        },
       ),
     ).toBe(false);
 

--- a/packages/core/src/permissions/autoMode.ts
+++ b/packages/core/src/permissions/autoMode.ts
@@ -28,6 +28,7 @@ import {
 import type { PermissionDeniedReason } from '../hooks/types.js';
 export type { PermissionDeniedReason } from '../hooks/types.js';
 import { ToolNames } from '../tools/tool-names.js';
+import type { ToolCallConfirmationDetails } from '../tools/tools.js';
 import { normalizeMonitorCommand } from '../utils/shell-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { classifyAction, type ClassifierResult } from './classifier.js';
@@ -514,6 +515,7 @@ export type FallbackToAskReason =
   | 'ask_rule'
   | 'plan_mode_floor'
   | 'org_ask_ceiling'
+  | 'classifier_unavailable'
   | DenialFallbackReason;
 
 /** Outcome of {@link applyAutoModeDecision}. */
@@ -524,7 +526,11 @@ export type AutoModeOutcome =
       errorMessage: string;
       reason: PermissionDeniedReason;
     }
-  | { kind: 'fallback'; reason: FallbackToAskReason };
+  | {
+      kind: 'fallback';
+      reason: FallbackToAskReason;
+      message?: string;
+    };
 
 /**
  * Apply an AUTO decision and denial-tracking update. Shared by the scheduler
@@ -549,17 +555,19 @@ export function applyAutoModeDecision(
       };
     case 'classifier':
       if (decision.shouldBlock) {
-        config.setAutoModeDenialState(
-          decision.unavailable
-            ? recordUnavailable(denialState)
-            : recordBlock(denialState),
-        );
+        if (decision.unavailable) {
+          config.setAutoModeDenialState(recordUnavailable(denialState));
+          return {
+            kind: 'fallback',
+            reason: 'classifier_unavailable',
+            message: formatClassifierUnavailableFallbackMessage(decision),
+          };
+        }
+        config.setAutoModeDenialState(recordBlock(denialState));
         return {
           kind: 'blocked',
           errorMessage: formatClassifierBlockMessage(decision),
-          reason: decision.unavailable
-            ? 'classifier_unavailable'
-            : 'classifier_blocked',
+          reason: 'classifier_blocked',
         };
       }
       config.setAutoModeDenialState(recordAllow(denialState));
@@ -598,21 +606,41 @@ export function getAutoModePermissionDeniedReason(
 }
 
 /**
- * Trailing guidance appended to every classifier-denial tool-result message.
+ * Trailing guidance appended to classifier policy-denial tool results.
  * Centralised so the policy boundary (no silent retries, no equivalent-path
- * workarounds, stop and ask the user) is identical for "blocked" and
- * "unavailable" verdicts and stays in sync with the main system prompt's
- * Denied Tool Calls rule.
+ * workarounds, stop and ask the user) stays in sync with the main system
+ * prompt's Denied Tool Calls rule.
  */
 export const AUTO_MODE_DENIAL_GUIDANCE =
   'Do not try to complete the denied action through another tool, shell indirection, generated script, alias, symlink, config change, hook, command file, MCP configuration, encoded payload, or equivalent path. If that action is required, stop and ask the user for explicit approval. You may continue with unrelated safe work or a genuinely safer alternative that does not accomplish the denied action.';
 
+export function formatClassifierUnavailableFallbackMessage(
+  decision: Extract<AutoModeDecision, { via: 'classifier' }>,
+): string {
+  const detail = decision.reason ? ` (${decision.reason})` : '';
+  return `Auto Mode couldn't classify this action${detail}. Review it manually. Switching to Default Mode is recommended if you want to continue without the classifier.`;
+}
+
+export function decorateClassifierUnavailableConfirmation(
+  confirmation: ToolCallConfirmationDetails,
+  message: string,
+): ToolCallConfirmationDetails {
+  return {
+    ...confirmation,
+    ...(confirmation.type === 'ask_user_question'
+      ? {}
+      : { hideAlwaysAllow: true }),
+    autoModeFallback: {
+      reason: 'classifier_unavailable',
+      message,
+    },
+  } as ToolCallConfirmationDetails;
+}
+
 /**
- * Build the tool-error message the scheduler / ACP session returns when
- * the classifier blocks or is unavailable. Shared between
- * `coreToolScheduler.ts` and `acp-integration/session/Session.ts` so the
- * CLI and ACP paths surface identical diagnostic signal to operators
- * (context overflow vs API timeout vs construction failure).
+ * Build the tool-error message the scheduler / ACP session returns when the
+ * classifier supplies a policy block. Keeping it here gives both paths the
+ * same denial guidance.
  *
  * Callers are responsible for only invoking this on classifier verdicts —
  * `decision.via === 'classifier'` with `decision.shouldBlock === true`.
@@ -620,12 +648,6 @@ export const AUTO_MODE_DENIAL_GUIDANCE =
 export function formatClassifierBlockMessage(
   decision: Extract<AutoModeDecision, { via: 'classifier' }>,
 ): string {
-  if (decision.unavailable) {
-    const message = decision.reason
-      ? `Auto mode classifier unavailable (${decision.reason}); action blocked for safety`
-      : `Auto mode classifier unavailable; action blocked for safety`;
-    return `${message}\n${AUTO_MODE_DENIAL_GUIDANCE}`;
-  }
   return `Blocked by auto mode policy: ${decision.reason}\n${AUTO_MODE_DENIAL_GUIDANCE}`;
 }
 

--- a/packages/core/src/permissions/classifier.test.ts
+++ b/packages/core/src/permissions/classifier.test.ts
@@ -131,14 +131,14 @@ describe('classifyAction — stage 1 escalates to stage 2', () => {
   });
 });
 
-describe('classifyAction — fail-closed on stage 1 failure', () => {
+describe('classifyAction — unavailable on stage 1 failure', () => {
   it('returns unavailable=true when stage 1 throws an API error', async () => {
     runSideQueryMock.mockRejectedValueOnce(new Error('API 500'));
     const result = await classifyAction(makeInput());
     expect(result.shouldBlock).toBe(true);
     expect(result.unavailable).toBe(true);
     expect(result.stage).toBe('fast');
-    expect(result.reason).toMatch(/blocked for safety/);
+    expect(result.reason).toBe('Classifier stage 1 unavailable');
   });
 
   it('surfaces a context-overflow reason when stage 1 fails with that error', async () => {
@@ -163,7 +163,7 @@ describe('classifyAction — fail-closed on stage 1 failure', () => {
   });
 });
 
-describe('classifyAction — fail-closed on stage 2 failure', () => {
+describe('classifyAction — unavailable on stage 2 failure', () => {
   it('honors stage 1 block when stage 2 fails (unavailable=true)', async () => {
     runSideQueryMock
       .mockResolvedValueOnce({ shouldBlock: true })

--- a/packages/core/src/permissions/classifier.ts
+++ b/packages/core/src/permissions/classifier.ts
@@ -35,10 +35,10 @@ import { buildClassifierContents } from './classifier-transcript.js';
 // the underlying API / timeout / context-overflow error.
 const debugLogger = createDebugLogger('CLASSIFIER');
 
-// A timeout is fail-closed (action BLOCKED as "unavailable"), so too tight a
-// budget turns transient slowness into spurious blocks. The fast model's p99
-// is ~1.5s but the tail is long under load, so budgets are kept generous —
-// better to wait than fail closed on a healthy call.
+// A timeout yields an unavailable result and manual fallback downstream, so
+// too tight a budget turns transient slowness into repeated prompts. The fast
+// model's p99 is ~1.5s but the tail is long under load, so budgets are kept
+// generous.
 /** Stage-1 timeout: generous headroom over the fast model's p99 (~1.5s). */
 export const STAGE1_TIMEOUT_MS = 10_000;
 /** Stage-2 timeout: review stage runs a larger prompt; cap infra failure. */
@@ -133,7 +133,7 @@ const STAGE2_SCHEMA: Record<string, unknown> = {
  *
  * Returns a `ClassifierResult` describing the verdict. Throws `AbortError`
  * only when the user-supplied `input.signal` is aborted; all other failures
- * are converted into `unavailable=true` block results (fail-closed).
+ * are converted into `unavailable=true` results for downstream fallback.
  */
 export async function classifyAction(
   input: ClassifierInput,
@@ -143,7 +143,7 @@ export async function classifyAction(
   // buildClassifierContents and buildClassifierSystemPrompt are wrapped so
   // any pathological input (a tool returning a circular projected-args
   // structure that crashes JSON.stringify, a registry lookup error, etc.)
-  // is converted to a fail-closed unavailable verdict instead of crashing
+  // is converted to an unavailable result instead of crashing
   // the tool-execution loop with an uncaught exception.
   let contents;
   let baseSystemPrompt: string;
@@ -155,7 +155,7 @@ export async function classifyAction(
     );
     baseSystemPrompt = buildClassifierSystemPrompt(input.config);
   } catch (err) {
-    return failClosed(
+    return failUnavailable(
       'Classifier prompt construction failed',
       err,
       'fast',
@@ -194,7 +194,7 @@ export async function classifyAction(
     })) as Stage1Response;
   } catch (err) {
     if (input.signal.aborted) throw err;
-    return failClosed(
+    return failUnavailable(
       'Classifier stage 1 unavailable',
       err,
       'fast',
@@ -239,7 +239,7 @@ export async function classifyAction(
         temperature: 0,
         maxOutputTokens: 4096,
         // API thinking stays off by default: this gate is latency-sensitive
-        // and a reasoning budget can worsen fail-closed timeouts. The
+        // and a reasoning budget can worsen unavailable-result timeouts. The
         // `thinking` output field still carries the model's plain-text
         // reasoning unless API thinking is explicitly enabled.
         thinkingConfig: {
@@ -356,7 +356,7 @@ export function sanitizeClassifierReason(raw: string): string {
   );
 }
 
-function failClosed(
+function failUnavailable(
   baseMessage: string,
   err: unknown,
   stage: 'fast' | 'thinking',
@@ -365,13 +365,13 @@ function failClosed(
 ): ClassifierResult {
   const reason = isContextLengthExceededError(err)
     ? 'Conversation transcript exceeds classifier context window'
-    : `${baseMessage} - blocked for safety`;
+    : baseMessage;
   // Log the underlying error so operators can distinguish timeout / API /
   // schema-validation / context-overflow failure modes when AUTO mode
-  // starts silently blocking every call. The public `ClassifierResult`
+  // starts routing every call to manual approval. The public `ClassifierResult`
   // only carries the sanitized `reason` and `unavailable` flag.
   debugLogger.warn(
-    `failClosed stage=${stage} durationMs=${Date.now() - startedAt} ` +
+    `failUnavailable stage=${stage} durationMs=${Date.now() - startedAt} ` +
       `reason="${reason}" cause="${errMessage(err)}"`,
   );
   return {

--- a/packages/core/src/permissions/denialTracking.ts
+++ b/packages/core/src/permissions/denialTracking.ts
@@ -190,6 +190,7 @@ export function recordFallbackApprove(
 export function isApproveOutcome(outcome: string): boolean {
   return (
     outcome === 'proceed_once' ||
+    outcome === 'proceed_once_and_switch_to_default' ||
     outcome === 'proceed_always' ||
     outcome === 'proceed_always_project' ||
     outcome === 'proceed_always_user' ||

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -12,8 +12,10 @@ export { extractShellOperations } from './shell-semantics.js';
 export type { ShellOperation } from './shell-semantics.js';
 export {
   applyAutoModeDecision,
+  decorateClassifierUnavailableConfirmation,
   evaluateAutoMode,
   formatClassifierBlockMessage,
+  formatClassifierUnavailableFallbackMessage,
   type AutoModeUnavailableReason,
   getAutoModePermissionDeniedReason,
   type AutoModeDecision,

--- a/packages/core/src/telemetry/tool-call-decision.test.ts
+++ b/packages/core/src/telemetry/tool-call-decision.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ToolConfirmationOutcome } from '../tools/tools.js';
+import {
+  getDecisionFromOutcome,
+  ToolCallDecision,
+} from './tool-call-decision.js';
+
+describe('getDecisionFromOutcome', () => {
+  it('records switch-to-Default approval as a one-time acceptance', () => {
+    expect(
+      getDecisionFromOutcome(
+        ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault,
+      ),
+    ).toBe(ToolCallDecision.ACCEPT);
+  });
+});

--- a/packages/core/src/telemetry/tool-call-decision.ts
+++ b/packages/core/src/telemetry/tool-call-decision.ts
@@ -18,6 +18,7 @@ export function getDecisionFromOutcome(
 ): ToolCallDecision {
   switch (outcome) {
     case ToolConfirmationOutcome.ProceedOnce:
+    case ToolConfirmationOutcome.ProceedOnceAndSwitchToDefault:
     case ToolConfirmationOutcome.RestorePrevious:
       return ToolCallDecision.ACCEPT;
     case ToolConfirmationOutcome.ProceedAlways:

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -875,13 +875,22 @@ export interface ToolInfoConfirmationDetails {
   permissionRules?: string[];
 }
 
-export type ToolCallConfirmationDetails =
+export interface AutoModeFallbackConfirmation {
+  reason: 'classifier_unavailable';
+  message: string;
+}
+
+export type ToolCallConfirmationDetails = (
   | ToolEditConfirmationDetails
   | ToolExecuteConfirmationDetails
   | ToolMcpConfirmationDetails
   | ToolInfoConfirmationDetails
   | ToolPlanConfirmationDetails
-  | ToolAskUserQuestionConfirmationDetails;
+  | ToolAskUserQuestionConfirmationDetails
+) & {
+  /** Explains why an AUTO-mode call was routed to manual confirmation. */
+  autoModeFallback?: AutoModeFallbackConfirmation;
+};
 
 export interface ToolPlanConfirmationDetails {
   type: 'plan';
@@ -925,6 +934,8 @@ export interface ToolAskUserQuestionConfirmationDetails {
  */
 export enum ToolConfirmationOutcome {
   ProceedOnce = 'proceed_once',
+  /** Approve this call once and change the runtime session to Default mode. */
+  ProceedOnceAndSwitchToDefault = 'proceed_once_and_switch_to_default',
   ProceedAlways = 'proceed_always',
   /** @deprecated Use ProceedAlwaysProject or ProceedAlwaysUser instead. */
   ProceedAlwaysServer = 'proceed_always_server',


### PR DESCRIPTION
## What this PR does

When Auto Mode cannot obtain a classifier verdict because of an API outage, timeout, invalid response, or context overflow, the pending action now falls back immediately to manual approval instead of being denied as unsafe.

The confirmation explains the infrastructure failure, recommends Default Mode, and offers Allow once, Switch to Default Mode and allow once, or Reject. Persistent approval choices are hidden for this recovery prompt. Selecting the recommended option approves only the pending action and switches the current runtime session to Default Mode without changing saved settings. The terminal UI and ACP permission flow expose the same behavior.

Completed classifier policy blocks and deterministic destructive-command guards remain denied.

## Why it's needed

Classifier unavailability means no safety verdict was produced, but the previous fail-closed path treated it like a policy rejection and ended the tool call without asking the user. This made Auto Mode unusable during transient classifier failures and gave users no direct way to continue in Default Mode.

## Reviewer Test Plan

### How to verify

1. Start Qwen Code in Auto Mode against an endpoint that serves ordinary model responses but returns HTTP 503 for classifier requests, then ask it to invoke a shell command.
2. Confirm that the first unavailable result opens a manual prompt containing the failure reason and exactly the one-time Allow, recommended switch-and-allow, and Reject choices.
3. Select the recommended option and confirm that the pending command runs once and the session changes from Auto Mode to Default Mode.
4. Repeat with Reject and confirm that the command does not run and the session stays in Auto Mode.
5. Confirm that a completed policy block and the deterministic destructive-command guard still deny execution.

Automated checks: `npm run build`, `npm run typecheck`, `npm run lint`, 409 focused Core tests, and 422 focused CLI tests.

### Evidence (Before & After)

Before: Qwen Code 0.19.11 received eight mocked classifier HTTP 503 responses, ended the call with `Auto mode classifier unavailable ... action blocked for safety`, showed no confirmation, and did not create the isolated marker.

After: the local 0.20.0 bundle showed the unavailable explanation and three intended choices on the first failure. Selecting the recommended option created the isolated marker once and changed the footer from `Auto mode` to `Ask permissions`. In a separate rejection run, the marker remained absent and the footer stayed in Auto Mode.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundled CLI in Safe Mode, exercised interactively through tmux against an isolated OpenAI-compatible mock endpoint.

## Risk & Scope

- Main risk or tradeoff: classifier infrastructure failures now delegate the pending decision to the user; the dedicated approval outcome is normalized to an ordinary one-time approval before tool-specific callbacks run.
- Not validated / out of scope: Windows and Linux interactive rendering were not tested locally. Non-interactive and background sessions without an approval surface retain their existing denial behavior.
- Breaking changes / migration notes: none. Switching to Default Mode is session-only and does not modify configuration files.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 Auto Mode 因 API 故障、超时、无效响应或上下文溢出而无法获得分类器结论时，待执行操作现在会立即回退到人工确认，而不再被当作不安全操作直接拒绝。

确认框会说明基础设施故障、推荐切换到 Default Mode，并提供“仅允许一次”“切换到 Default Mode 并仅允许一次”或“拒绝”。该恢复提示不会提供持久允许选项。选择推荐项只会批准当前待执行操作，并将当前运行时会话切换到 Default Mode，不会修改已保存的设置。终端 UI 和 ACP 权限流程提供一致行为。

分类器已经完成的策略阻止和确定性的破坏性命令防护仍会拒绝执行。

## 为什么需要它

分类器不可用意味着没有产出安全结论，但原来的 fail-closed 路径会把它当成策略拒绝，在不询问用户的情况下终止工具调用。这会让 Auto Mode 在分类器短暂故障期间无法使用，也没有为用户提供直接切换到 Default Mode 继续操作的途径。

## Reviewer 测试计划

### 如何验证

1. 让 Qwen Code 以 Auto Mode 连接一个能返回普通模型响应、但对分类器请求返回 HTTP 503 的端点，然后要求它调用 shell 命令。
2. 确认第一次不可用结果就会打开人工确认，包含故障原因，并且只显示单次允许、推荐的切换并允许以及拒绝三个选项。
3. 选择推荐项，确认待执行命令只运行一次，并且会话从 Auto Mode 切换到 Default Mode。
4. 重新运行并选择拒绝，确认命令不会执行且会话仍保持 Auto Mode。
5. 确认已经完成的策略阻止和确定性的破坏性命令防护仍会拒绝执行。

自动检查：`npm run build`、`npm run typecheck`、`npm run lint`、409 个 Core focused tests 和 422 个 CLI focused tests。

### 证据（Before & After）

Before：Qwen Code 0.19.11 收到八次模拟的分类器 HTTP 503 响应后，以 `Auto mode classifier unavailable ... action blocked for safety` 结束调用，没有显示确认框，也没有创建隔离 marker。

After：本地 0.20.0 bundle 在第一次失败时显示了不可用说明和三个预期选项。选择推荐项后只创建一次隔离 marker，footer 从 `Auto mode` 变为 `Ask permissions`。在单独的拒绝测试中，marker 保持不存在，footer 仍为 Auto Mode。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地 bundle CLI，以 Safe Mode 运行，通过 tmux 对隔离的 OpenAI-compatible mock endpoint 进行真实交互测试。

## 风险与范围

- 主要风险或权衡：分类器基础设施故障现在会把待执行决策交给用户；专用批准结果会在工具自身的确认回调运行前归一化为普通的单次批准。
- 未验证或不在范围内：没有在本地测试 Windows 和 Linux 的交互渲染。没有确认界面的非交互和后台会话保留现有拒绝行为。
- Breaking changes / migration notes：无。切换到 Default Mode 仅影响当前会话，不会修改配置文件。

## 关联 Issue

N/A

</details>
