### PR TITLE
fix(web-shell): localize extension tag labels

### DIFF
--- a/packages/cli/src/serve/routes/workspace-extensions-controller.test.ts
+++ b/packages/cli/src/serve/routes/workspace-extensions-controller.test.ts
@@ -4,14 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ExtensionManager } from '@qwen-code/qwen-code-core';
 import type { Response } from 'express';
 import type { AcpSessionBridge } from '../acp-session-bridge.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
+import { resolveLanguageSetting } from '../../i18n/index.js';
 import { createExtensionsController } from './workspace-extensions-controller.js';
 
+vi.mock('../../i18n/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../i18n/index.js')>();
+  return {
+    ...actual,
+    resolveLanguageSetting: vi.fn().mockReturnValue('en'),
+  };
+});
+
 describe('createExtensionsController', () => {
+  beforeEach(() => {
+    vi.mocked(resolveLanguageSetting).mockReturnValue('en');
+  });
+
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -157,6 +173,65 @@ describe('createExtensionsController', () => {
     await controller.buildLocalExtensionsStatus();
 
     expect(refreshCache).toHaveBeenCalledOnce();
+  });
+
+  it('normalizes the current language when resolving extension metadata', async () => {
+    vi.mocked(resolveLanguageSetting).mockImplementation((language) =>
+      language === 'zh_TW' ? 'zh_TW' : 'en',
+    );
+    const extensionDir = await mkdtemp(
+      join(tmpdir(), 'qwen-localized-extension-'),
+    );
+
+    try {
+      await mkdir(join(extensionDir, '.qwen'));
+      await writeFile(
+        join(extensionDir, '.qwen', 'settings.json'),
+        JSON.stringify({ general: { language: 'zh_TW' } }),
+      );
+      await writeFile(
+        join(extensionDir, 'qwen-extension.json'),
+        JSON.stringify({
+          name: 'localized-extension',
+          displayName: { en: 'English name', 'zh-TW': '繁體名稱' },
+        }),
+      );
+      const controller = createExtensionsController({
+        boundWorkspace: extensionDir,
+        bridge: {} as AcpSessionBridge,
+        workspace: {} as DaemonWorkspaceService,
+      });
+
+      const config = controller
+        .createExtensionManager(extensionDir, true)
+        .loadExtensionConfig({ extensionDir });
+
+      expect(config.displayName).toBe('繁體名稱');
+      expect(resolveLanguageSetting).toHaveBeenCalledWith('zh_TW');
+    } finally {
+      await rm(extensionDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates the status cache when the current language changes', async () => {
+    const refreshCache = vi
+      .spyOn(ExtensionManager.prototype, 'refreshCache')
+      .mockResolvedValue(undefined);
+    vi.spyOn(ExtensionManager.prototype, 'getLoadedExtensions').mockReturnValue(
+      [],
+    );
+    const controller = createExtensionsController({
+      boundWorkspace: '/work/bound',
+      bridge: {} as AcpSessionBridge,
+      workspace: {} as DaemonWorkspaceService,
+    });
+
+    await controller.buildLocalExtensionsStatus();
+    await controller.buildLocalExtensionsStatus();
+    vi.mocked(resolveLanguageSetting).mockReturnValue('zh');
+    await controller.buildLocalExtensionsStatus();
+
+    expect(refreshCache).toHaveBeenCalledTimes(2);
   });
 
   it('reports an accepted operation as running while its cache refreshes', async () => {

--- a/packages/cli/src/serve/routes/workspace-extensions-controller.ts
+++ b/packages/cli/src/serve/routes/workspace-extensions-controller.ts
@@ -15,6 +15,11 @@ import {
 import type { Request, Response } from 'express';
 import { loadSettings } from '../../config/settings.js';
 import { getWorkspaceTrustStatus } from '../../config/trustedFolders.js';
+import {
+  detectSystemLanguage,
+  resolveLanguageSetting,
+} from '../../i18n/index.js';
+import { resolveSupportedLanguage } from '../../i18n/languages.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import type { AcpSessionBridge } from '../acp-session-bridge.js';
 import { parseAndValidateWorkspaceClientId } from '../server/request-helpers.js';
@@ -52,6 +57,17 @@ export const redactExtensionDisplaySource = (source: string): string => {
 const EXTENSION_PREPARATION_CONCURRENCY = 2;
 const EXTENSION_REFRESH_TIMEOUT_MS = 30_000;
 const RECONCILE_SLOW_MS = 30_000;
+
+const resolveExtensionLocale = (workspaceDir: string): string => {
+  const configuredLanguage = loadSettings(workspaceDir).merged.general
+    ?.language as string | undefined;
+  const requestedLocale = resolveLanguageSetting(configuredLanguage);
+  if (requestedLocale === 'auto') {
+    return detectSystemLanguage();
+  }
+
+  return resolveSupportedLanguage(requestedLocale) ?? requestedLocale;
+};
 
 /**
  * Thrown by the per-workspace install queue when it is saturated, and matched
@@ -259,6 +275,7 @@ export function createExtensionsController(
   ) =>
     new ExtensionManager({
       workspaceDir,
+      locale: resolveExtensionLocale(workspaceDir),
       isWorkspaceTrusted:
         trustedOverride ??
         getWorkspaceTrustStatus(loadSettings(workspaceDir).merged, workspaceDir)
@@ -364,7 +381,11 @@ export function createExtensionsController(
   };
 
   let extensionsStatusCache:
-    | { expiresAt: number; value: ServeWorkspaceExtensionsStatus }
+    | {
+        locale: string;
+        expiresAt: number;
+        value: ServeWorkspaceExtensionsStatus;
+      }
     | undefined;
 
   const refreshExtensionsForAllSessions = async (): Promise<{
@@ -927,8 +948,12 @@ export function createExtensionsController(
 
   const buildLocalExtensionsStatus =
     async (): Promise<ServeWorkspaceExtensionsStatus> => {
+      const locale = resolveExtensionLocale(boundWorkspace);
       const now = Date.now();
-      if (extensionsStatusCache && extensionsStatusCache.expiresAt > now) {
+      if (
+        extensionsStatusCache?.locale === locale &&
+        extensionsStatusCache.expiresAt > now
+      ) {
         return extensionsStatusCache.value;
       }
       const extensionManager = createExtensionManager();
@@ -1003,6 +1028,7 @@ export function createExtensionsController(
         extensions: entries,
       };
       extensionsStatusCache = {
+        locale,
         expiresAt: Date.now() + 2_000,
         value: status,
       };

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
@@ -326,7 +326,7 @@ describe('ScheduledTasksDialog editing', () => {
         {
           id: 'ext-1',
           name: 'alibabacloud-compute-suite',
-          displayName: 'Alibaba Cloud',
+          displayName: '\u001b[31mAlibaba Cloud\u001b[0m\u202e\u0007',
           description: '',
           version: '1.0.0',
           isActive: true,
@@ -374,8 +374,12 @@ describe('ScheduledTasksDialog editing', () => {
     click(findButtonContaining('repo-tools'));
     await flush();
 
-    expect(document.querySelector('[role="textbox"]')?.textContent).toContain(
-      'alibabacloud-compute-suite',
+    const extensionTag = document.querySelector<HTMLElement>(
+      '[data-prompt-tag-serialized="@ext:alibabacloud-compute-suite"]',
+    );
+    expect(extensionTag?.textContent).toBe('Alibaba Cloud');
+    expect(extensionTag?.dataset.promptTagSerialized).toBe(
+      '@ext:alibabacloud-compute-suite',
     );
 
     click(findButton('Create'));
@@ -542,7 +546,6 @@ describe('ScheduledTasksDialog editing', () => {
         {
           id: 'ext-1',
           name: 'alibabacloud-compute-suite',
-          displayName: 'Alibaba Cloud',
           description: '',
           version: '1.0.0',
           isActive: true,
@@ -565,6 +568,11 @@ describe('ScheduledTasksDialog editing', () => {
     await flush();
     click(findButtonContaining('alibabacloud-compute-suite'));
     await flush();
+
+    const extensionTag = prompt.querySelector<HTMLElement>(
+      '[data-prompt-tag-serialized="@ext:alibabacloud-compute-suite"]',
+    );
+    expect(extensionTag?.textContent).toBe('alibabacloud-compute-suite');
 
     click(findButton('Create'));
     await flush();

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -24,6 +24,7 @@ import type {
   DaemonWorkspaceMcpServerStatus,
   DaemonWorkspaceSkillStatus,
 } from '@qwen-code/sdk/daemon';
+import { sanitizeDisplayText } from '../../hooks/useAtMentionMenu';
 import { useI18n } from '../../i18n';
 import { getComposerTagIconUrl } from '../../utils/composerTag';
 import { cssUrlValue } from '../../utils/cssUrlVar';
@@ -141,6 +142,7 @@ interface PromptReferenceItem {
   id: string;
   kind: PromptTagKind;
   label: string;
+  tagLabel?: string;
   description?: string;
   insertText: string;
 }
@@ -313,7 +315,7 @@ function makePromptTagElement(item: PromptReferenceItem): HTMLElement {
 
   const value = document.createElement('span');
   value.className = styles.promptTagValue;
-  value.textContent = item.label;
+  value.textContent = item.tagLabel ?? item.label;
   tag.appendChild(value);
   return tag;
 }
@@ -730,6 +732,9 @@ export function ScheduledTasksDialog({
               id: extension.id || extension.name,
               kind,
               label: extension.name,
+              tagLabel:
+                sanitizeDisplayText(extension.displayName ?? '') ||
+                extension.name,
               description: extensionDescription(extension),
               insertText: `@ext:${escapeAtReferenceText(extension.name)} `,
             }));

--- a/packages/web-shell/client/hooks/useAtMentionMenu.test.tsx
+++ b/packages/web-shell/client/hooks/useAtMentionMenu.test.tsx
@@ -274,7 +274,15 @@ describe('useAtMentionMenu', () => {
     act(() => latest!.enterCategory(1));
     await runDebounce();
 
-    expect(latest!.state?.items[0]?.description).toBe('Reviewtxt中文');
+    expect(latest!.state?.items[0]).toMatchObject({
+      description: 'Reviewtxt中文',
+      composerTag: {
+        id: 'extension:@ext:review',
+        kind: 'extension',
+        value: 'Reviewtxt中文',
+        serialized: '@ext:review',
+      },
+    });
   });
 
   it('filters cached extension provider data while searching', async () => {
@@ -716,57 +724,63 @@ describe('useAtMentionMenu', () => {
     });
   });
 
-  it('decorates accepted extension refs as inline composer tags', async () => {
-    vi.useFakeTimers();
-    const inlineTagEffect = StateEffect.define<{
-      from: number;
-      to: number;
-      tag: WebShellComposerTag;
-    }>();
-    const view = makeView('@');
-    mount({
-      view,
-      createInlineTagEffect: (range) => inlineTagEffect.of(range),
-      actions: {
-        loadExtensionsStatus: vi.fn().mockResolvedValue({
-          extensions: [
-            {
-              name: 'review',
-              displayName: 'Review',
-              isActive: true,
-            },
-          ],
-        }),
-      },
-    });
+  it.each([
+    ['localized displayName', 'Review', 'Review'],
+    ['extension name fallback', undefined, 'review'],
+  ])(
+    'decorates accepted extension refs using the %s',
+    async (_case, displayName, expectedValue) => {
+      vi.useFakeTimers();
+      const inlineTagEffect = StateEffect.define<{
+        from: number;
+        to: number;
+        tag: WebShellComposerTag;
+      }>();
+      const view = makeView('@');
+      mount({
+        view,
+        createInlineTagEffect: (range) => inlineTagEffect.of(range),
+        actions: {
+          loadExtensionsStatus: vi.fn().mockResolvedValue({
+            extensions: [
+              {
+                name: 'review',
+                ...(displayName ? { displayName } : {}),
+                isActive: true,
+              },
+            ],
+          }),
+        },
+      });
 
-    act(() => latest!.refreshForView(view));
-    act(() => latest!.enterCategory(1));
-    await runDebounce();
-    act(() => {
-      expect(latest!.accept()).toBe(true);
-    });
+      act(() => latest!.refreshForView(view));
+      act(() => latest!.enterCategory(1));
+      await runDebounce();
+      act(() => {
+        expect(latest!.accept()).toBe(true);
+      });
 
-    const spec = vi.mocked(view.dispatch).mock.calls[0]?.[0];
-    expect(spec).toMatchObject({
-      changes: { from: 0, to: 1, insert: '@ext:review ' },
-      selection: { anchor: 12 },
-      scrollIntoView: true,
-    });
-    expect(Array.isArray(spec?.effects)).toBe(true);
-    const effect = Array.isArray(spec?.effects) ? spec.effects[0] : undefined;
-    expect(effect?.is(inlineTagEffect)).toBe(true);
-    expect(effect?.value).toEqual({
-      from: 0,
-      to: 11,
-      tag: {
-        id: 'extension:@ext:review',
-        kind: 'extension',
-        value: 'review',
-        serialized: '@ext:review',
-      },
-    });
-  });
+      const spec = vi.mocked(view.dispatch).mock.calls[0]?.[0];
+      expect(spec).toMatchObject({
+        changes: { from: 0, to: 1, insert: '@ext:review ' },
+        selection: { anchor: 12 },
+        scrollIntoView: true,
+      });
+      expect(Array.isArray(spec?.effects)).toBe(true);
+      const effect = Array.isArray(spec?.effects) ? spec.effects[0] : undefined;
+      expect(effect?.is(inlineTagEffect)).toBe(true);
+      expect(effect?.value).toEqual({
+        from: 0,
+        to: 11,
+        tag: {
+          id: 'extension:@ext:review',
+          kind: 'extension',
+          value: expectedValue,
+          serialized: '@ext:review',
+        },
+      });
+    },
+  );
 
   it('clears a pending provider search when closing from items', async () => {
     vi.useFakeTimers();

--- a/packages/web-shell/client/hooks/useAtMentionMenu.ts
+++ b/packages/web-shell/client/hooks/useAtMentionMenu.ts
@@ -724,6 +724,7 @@ function createExtensionProvider(
             const insertName = escapeAtReferenceText(
               sanitizeInsertText(ext.name),
             );
+            const serialized = `@ext:${insertName}`;
             const displayName = sanitizeDisplayText(ext.displayName ?? '');
             const description = sanitizeDisplayText(ext.description ?? '');
             return {
@@ -737,7 +738,13 @@ function createExtensionProvider(
                 displayName && description
                   ? `${displayName} - ${description}`
                   : (displayName ?? description),
-              insertText: `@ext:${insertName} `,
+              composerTag: {
+                id: `extension:${serialized}`,
+                kind: 'extension',
+                value: displayName || label,
+                serialized,
+              },
+              insertText: `${serialized} `,
             };
           })
           .filter((ext) => {


### PR DESCRIPTION
## What this PR does

Extension metadata now resolves with the daemon's current configured language, and the short-lived Extension status cache is scoped to that language so a locale change cannot reuse stale labels. Newly selected Extension tags in both the main Composer and Scheduled Tasks show the resolved `displayName`, with `name` as the fallback, while their identity, inserted text, submitted content, and saved prompt remain `@ext:<name>`.

## Why it's needed

Extensions already support localized display names, but the daemon previously loaded their metadata with the default English locale and both built-in tag pickers rendered the internal Extension name. This exposed implementation identifiers in localized UI and made the visible chip inconsistent with the metadata users had configured.

## Reviewer Test Plan

### How to verify

Create an active Extension whose `displayName` contains English and Chinese values. Start the Web Shell in each locale and confirm the workspace Extension status returns the matching value. Select the Extension from the main Composer and Scheduled Tasks pickers: each new chip should show the localized display name, or the internal name when `displayName` is absent. Submit the Composer message and create the scheduled task, then confirm both persisted references remain exactly `@ext:<name>`.

### Evidence (Before & After)

Before: the installed baseline binary did not bundle Web Shell assets, so it could not expose either UI entry; its Chinese daemon response also returned the English display name. After: the final local bundle returned `Localized Extension` for English and `本地化扩展` for Chinese. Both main Composer tags used those labels while copying the editor still produced `@ext:localized-extension-fixture`. Both Scheduled Tasks picker rows used the localized labels; selection and unchanged persistence are covered by the focused DOM unit test because the in-app browser's pointer activation reached the Time control underneath the picker instead of activating its option.

Focused tests cover locale propagation and cache invalidation, localized labels, missing-label fallback, control-character sanitization, and unchanged tag IDs, inserted text, serialization, and scheduled prompt payloads.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 22.17.0, an isolated temporary `QWEN_HOME`, and the locally built daemon/Web Shell without a sandbox.

## Risk & Scope

- Main risk or tradeoff: visible text and stable serialized references now intentionally differ, relying on the existing tag annotation and prompt serialization paths.
- Not validated / out of scope: existing or historical tags keep their snapshot label; reopening a saved Scheduled Task from a plain `@ext:<name>` token still shows `name`; Windows and Linux UI E2E were not run.
- Breaking changes / migration notes: none; no SDK or REST contract changes.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

Extension 元数据现在会按 Daemon 当前配置的 `general.language` 解析，并且短时 Extension 状态缓存会按语言隔离，因此切换语言后不会复用旧语言的标签。主 Composer 和 Scheduled Tasks 中新选择的 Extension tag 都会展示解析后的 `displayName`，缺省时回退到 `name`；与此同时，tag 的稳定身份、插入文本、提交内容和保存后的 prompt 仍保持为 `@ext:<name>`。

## 为什么需要

Extension 已经支持本地化 display name，但 Daemon 之前会使用默认英文 locale 加载元数据，两个内建 tag 选择入口也一直展示内部 Extension name。这会在本地化界面中暴露实现标识，并让用户看到的 chip 与 Extension 已配置的元数据不一致。

## Reviewer 测试计划

### 验证方式

创建一个启用状态的 Extension，并为其 `displayName` 配置英文和中文值。分别以两种语言启动 Web Shell，确认 workspace Extension 状态返回对应语言的值。从主 Composer 和 Scheduled Tasks 的选择器中选择该 Extension：新 tag 应显示本地化名称；没有 `displayName` 时应显示内部 name。随后提交 Composer 消息并创建 Scheduled Task，确认两处持久化的引用都严格保持为 `@ext:<name>`。

### 证据（修复前与修复后）

修复前：已安装的基线 binary 未包含 Web Shell 静态资源，因此无法打开两个 UI 入口；其中文 Daemon 响应也仍返回英文 display name。修复后：最终本地 bundle 在英文环境返回 `Localized Extension`，在中文环境返回 `本地化扩展`；主 Composer 的 tag 分别显示对应名称，而复制后的文本仍是 `@ext:localized-extension-fixture`。Scheduled Tasks 的两个 picker 行也显示对应的本地化名称；选择后的标签与保存值由聚焦 DOM 单测覆盖，因为内置浏览器中的指针激活落到了 picker 下方的 Time 控件，未能触发 option。

聚焦测试覆盖 locale 传递、缓存失效、本地化标签、缺省回退、控制字符清洗，以及 tag ID、插入文本、序列化值和 Scheduled prompt payload 保持不变。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js 22.17.0、隔离的临时 `QWEN_HOME`，使用本地构建的 Daemon/Web Shell，未启用 sandbox。

## 风险与范围

- 主要风险或取舍：可见文本与稳定序列化引用现在有意分离，并继续依赖现有 tag annotation 与 prompt serialization 链路。
- 未验证 / 不在范围内：已插入或历史 tag 保持快照名称；仅从纯 `@ext:<name>` token 重新打开已保存 Scheduled Task 时仍显示 `name`；未运行 Windows 和 Linux UI E2E。
- 破坏性变更 / 迁移说明：无；未修改 SDK 或 REST contract。

## 关联 Issue

无

</details>
