### PR TITLE
feat(channels): add content-safe memory recall telemetry

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -8612,6 +8612,7 @@ describe('ChannelBase', () => {
 
     it('continues the user prompt and logs bounded metadata when entry listing fails', async () => {
       const channelMemory = createChannelMemory();
+      const channelMemoryRecallObserver = vi.fn();
       channelMemory.listChannelMemoryEntries.mockRejectedValue(
         new Error(`EIO\n${'x'.repeat(400)}`),
       );
@@ -8620,7 +8621,7 @@ describe('ChannelBase', () => {
         .mockImplementation(() => true);
       const ch = createChannel(
         { instructions: 'Use repo conventions.', allowedUsers: ['alice'] },
-        { channelMemory },
+        { channelMemory, channelMemoryRecallObserver },
       );
 
       await ch.handleInbound(envelope({ text: 'ship it', senderId: 'alice' }));
@@ -8635,6 +8636,13 @@ describe('ChannelBase', () => {
       expect(log).not.toContain('EIO');
       expect(log).not.toContain('ship it');
       expect(log.length).toBeLessThan(350);
+      expect(channelMemoryRecallObserver).toHaveBeenCalledOnce();
+      expect(channelMemoryRecallObserver).toHaveBeenCalledWith({
+        cache: 'bypass',
+        durationMs: expect.any(Number),
+        result: 'read_error',
+        selectedCount: 0,
+      });
       writeSpy.mockRestore();
     });
 
@@ -8878,10 +8886,14 @@ describe('ChannelBase', () => {
       const first = { id: 'm-a31f0d82c7e4', text: 'Use staging.' };
       const second = { id: 'm-b82c4e190a6f', text: 'Use production.' };
       const channelMemory = createChannelMemory();
+      const channelMemoryRecallObserver = vi.fn();
       channelMemory.listChannelMemoryEntries
         .mockResolvedValueOnce([first])
         .mockResolvedValueOnce([second]);
-      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, channelMemoryRecallObserver },
+      );
 
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
@@ -8894,6 +8906,24 @@ describe('ChannelBase', () => {
       expect(secondPrompt).toContain(relevantChannelMemoryPrompt([second]));
       expect(channelMemory.listChannelMemoryEntries).toHaveBeenCalledTimes(2);
       expect(channelMemory.readChannelMemory).not.toHaveBeenCalled();
+      expect(channelMemoryRecallObserver).toHaveBeenCalledTimes(2);
+      expect(channelMemoryRecallObserver).toHaveBeenNthCalledWith(1, {
+        cache: 'bypass',
+        durationMs: expect.any(Number),
+        result: 'selected',
+        selectedCount: 1,
+      });
+      expect(
+        Object.keys(channelMemoryRecallObserver.mock.calls[0]![0]).sort(),
+      ).toEqual(['cache', 'durationMs', 'result', 'selectedCount']);
+      expect(
+        Number.isFinite(
+          channelMemoryRecallObserver.mock.calls[0]![0].durationMs,
+        ),
+      ).toBe(true);
+      expect(
+        channelMemoryRecallObserver.mock.calls[0]![0].durationMs,
+      ).toBeGreaterThanOrEqual(0);
     });
 
     it('reuses a prepared recall index while the memory revision is unchanged', async () => {
@@ -8902,7 +8932,11 @@ describe('ChannelBase', () => {
         ...createChannelMemory([relevant]),
         getChannelMemoryRevision: vi.fn().mockResolvedValue('revision-1'),
       };
-      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      const channelMemoryRecallObserver = vi.fn();
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, channelMemoryRecallObserver },
+      );
 
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
@@ -8915,6 +8949,14 @@ describe('ChannelBase', () => {
       );
       expect(promptMock.mock.calls[1]![1]).toContain(
         relevantChannelMemoryPrompt([relevant]),
+      );
+      expect(channelMemoryRecallObserver).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ cache: 'miss', result: 'selected' }),
+      );
+      expect(channelMemoryRecallObserver).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ cache: 'hit', result: 'selected' }),
       );
     });
 
@@ -9020,7 +9062,11 @@ describe('ChannelBase', () => {
           .fn()
           .mockRejectedValue(new Error('revision unavailable')),
       };
-      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      const channelMemoryRecallObserver = vi.fn();
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, channelMemoryRecallObserver },
+      );
 
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
       await ch.handleInbound(envelope({ text: 'deploy', senderId: 'alice' }));
@@ -9033,6 +9079,11 @@ describe('ChannelBase', () => {
       );
       expect(promptMock.mock.calls[1]![1]).toContain(
         relevantChannelMemoryPrompt([relevant]),
+      );
+      expect(channelMemoryRecallObserver).toHaveBeenCalledTimes(2);
+      expect(channelMemoryRecallObserver).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ cache: 'bypass', result: 'selected' }),
       );
     });
 
@@ -9083,7 +9134,11 @@ describe('ChannelBase', () => {
       const stderrSpy = vi
         .spyOn(process.stderr, 'write')
         .mockImplementation(() => true);
-      const ch = createChannel({ allowedUsers: ['alice'] }, { channelMemory });
+      const channelMemoryRecallObserver = vi.fn();
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, channelMemoryRecallObserver },
+      );
 
       await ch.handleInbound(
         envelope({ text: 'deploy secret-project', senderId: 'alice' }),
@@ -9097,6 +9152,12 @@ describe('ChannelBase', () => {
       expect(
         (bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[0]![1],
       ).toContain('Deploy secret-project to staging.');
+      expect(channelMemoryRecallObserver).toHaveBeenCalledWith({
+        cache: 'miss',
+        durationMs: expect.any(Number),
+        result: 'revision_unstable',
+        selectedCount: 1,
+      });
       stderrSpy.mockRestore();
     });
 
@@ -9144,6 +9205,7 @@ describe('ChannelBase', () => {
         ...createChannelMemory(),
         getChannelMemoryRevision: vi.fn().mockResolvedValue('revision-1'),
       };
+      const channelMemoryRecallObserver = vi.fn();
       channelMemory.listChannelMemoryEntries
         .mockReturnValueOnce(firstRead)
         .mockImplementation(async () => entries);
@@ -9155,7 +9217,7 @@ describe('ChannelBase', () => {
       );
       const ch = createChannel(
         { instructions: 'Static instructions.', allowedUsers: ['alice'] },
-        { channelMemory },
+        { channelMemory, channelMemoryRecallObserver },
       );
 
       const first = ch.handleInbound(
@@ -9183,6 +9245,14 @@ describe('ChannelBase', () => {
         relevantChannelMemoryPrompt(entries),
       );
       expect(channelMemory.listChannelMemoryEntries).toHaveBeenCalledTimes(2);
+      expect(channelMemoryRecallObserver).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          cache: 'miss',
+          result: 'stale',
+          selectedCount: 0,
+        }),
+      );
     });
 
     it('preserves a pending normal recall snapshot when another target mutates', async () => {
@@ -9232,19 +9302,70 @@ describe('ChannelBase', () => {
           text: `unrelated ${'x'.repeat(121)}`,
         },
       ]);
-      const ch = createChannel({}, { channelMemory });
+      const channelMemoryRecallObserver = vi.fn();
+      const ch = createChannel(
+        {},
+        { channelMemory, channelMemoryRecallObserver },
+      );
 
       await ch.handleInbound(envelope({ text: 'deploy staging' }));
 
       expect((bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(
         'deploy staging',
       );
+      expect(channelMemoryRecallObserver).toHaveBeenCalledWith({
+        cache: 'bypass',
+        durationMs: expect.any(Number),
+        result: 'empty',
+        selectedCount: 0,
+      });
+    });
+
+    it('bounds the observed selected count to the recall entry budget', async () => {
+      const channelMemory = createChannelMemory(
+        Array.from({ length: 4 }, (_, index) => ({
+          id: `m-${String(index).padStart(12, '0')}`,
+          text: `deploy target ${index}`,
+        })),
+      );
+      const channelMemoryRecallObserver = vi.fn();
+      const ch = createChannel(
+        {},
+        { channelMemory, channelMemoryRecallObserver },
+      );
+
+      await ch.handleInbound(envelope({ text: 'deploy target' }));
+
+      expect(channelMemoryRecallObserver).toHaveBeenCalledWith(
+        expect.objectContaining({ selectedCount: 3 }),
+      );
+    });
+
+    it('ignores channel memory recall observer failures', async () => {
+      const relevant = { id: 'm-a31f0d82c7e4', text: 'Use staging.' };
+      const channelMemory = createChannelMemory([relevant]);
+      const ch = createChannel(
+        {},
+        {
+          channelMemory,
+          channelMemoryRecallObserver: () => {
+            throw new Error('observer unavailable');
+          },
+        },
+      );
+
+      await ch.handleInbound(envelope({ text: 'deploy staging' }));
+
+      expect(
+        (bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[0]![1],
+      ).toContain(relevantChannelMemoryPrompt([relevant]));
     });
 
     it('does not list or inject recall for recognized agent slash commands', async () => {
       const channelMemory = createChannelMemory([
         { id: 'm-a31f0d82c7e4', text: 'Use staging.' },
       ]);
+      const channelMemoryRecallObserver = vi.fn();
       (
         bridge as unknown as {
           availableCommands: Array<{ name: string; description: string }>;
@@ -9252,7 +9373,7 @@ describe('ChannelBase', () => {
       ).availableCommands = [{ name: 'compress', description: 'Compress' }];
       const ch = createChannel(
         { allowedUsers: ['alice'], instructions: 'Static instructions.' },
-        { channelMemory },
+        { channelMemory, channelMemoryRecallObserver },
       );
 
       await ch.handleInbound(
@@ -9261,6 +9382,7 @@ describe('ChannelBase', () => {
 
       expect(channelMemory.listChannelMemoryEntries).not.toHaveBeenCalled();
       expect(channelMemory.readChannelMemory).not.toHaveBeenCalled();
+      expect(channelMemoryRecallObserver).not.toHaveBeenCalled();
       expect((bridge.prompt as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe(
         'Static instructions.\n\n/compress',
       );

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -59,6 +59,7 @@ import {
   type ChannelMemoryIntent,
 } from './channel-memory-intent.js';
 import {
+  CHANNEL_MEMORY_RECALL_MAX_ENTRIES,
   createChannelMemoryRecallIndex,
   selectRelevantChannelMemory,
   selectRelevantChannelMemoryFromIndex,
@@ -163,11 +164,35 @@ interface ChannelMemoryRecallCacheEntry {
   index: ChannelMemoryRecallIndex;
 }
 
+export type ChannelMemoryRecallCacheStatus = 'hit' | 'miss' | 'bypass';
+export type ChannelMemoryRecallResult =
+  | 'selected'
+  | 'empty'
+  | 'stale'
+  | 'read_error'
+  | 'revision_unstable';
+
+export interface ChannelMemoryRecallObservation {
+  durationMs: number;
+  selectedCount: number;
+  cache: ChannelMemoryRecallCacheStatus;
+  result: ChannelMemoryRecallResult;
+}
+
+interface ChannelMemoryRecallSelection {
+  entries: ChannelMemoryEntry[];
+  cache: ChannelMemoryRecallCacheStatus;
+  result?: 'revision_unstable';
+}
+
 export interface ChannelBaseOptions {
   router?: SessionRouter;
   proxy?: string;
   channelMemory?: ChannelMemoryCallbacks;
   memoryIntentClassifier?: ChannelMemoryIntentClassifier;
+  channelMemoryRecallObserver?: (
+    observation: ChannelMemoryRecallObservation,
+  ) => void;
   /**
    * Set when a channel owns a supplied router and should consume bridge
    * events directly.
@@ -308,6 +333,9 @@ export abstract class ChannelBase {
   protected proxy?: string;
   private readonly channelMemory?: ChannelMemoryCallbacks;
   private readonly memoryIntentClassifier?: ChannelMemoryIntentClassifier;
+  private readonly channelMemoryRecallObserver?: (
+    observation: ChannelMemoryRecallObservation,
+  ) => void;
   private groupHistory: GroupHistoryStore;
   private readonly loopController?: ChannelLoopController;
   private readonly observedContacts?: ChannelBaseOptions['observedContacts'];
@@ -502,6 +530,7 @@ export abstract class ChannelBase {
     this.memoryScope = Object.freeze(this.resolveMemoryScope(name, config));
     this.channelMemory = options?.channelMemory;
     this.memoryIntentClassifier = options?.memoryIntentClassifier;
+    this.channelMemoryRecallObserver = options?.channelMemoryRecallObserver;
     this.groupHistory = new GroupHistoryStore(
       options?.groupHistoryPath ??
         join(
@@ -825,13 +854,16 @@ export abstract class ChannelBase {
     envelope: Envelope,
     target: ChannelMemoryTarget,
     read: ChannelMemoryReadToken,
-  ): Promise<ChannelMemoryEntry[]> {
+  ): Promise<ChannelMemoryRecallSelection> {
     const message = envelope.text;
     const channelMemory = this.channelMemory;
-    if (!channelMemory) return [];
+    if (!channelMemory) return { entries: [], cache: 'bypass' };
     if (!channelMemory.getChannelMemoryRevision) {
       const entries = await channelMemory.listChannelMemoryEntries(target);
-      return selectRelevantChannelMemory(message, entries);
+      return {
+        entries: selectRelevantChannelMemory(message, entries),
+        cache: 'bypass',
+      };
     }
 
     let revision: string;
@@ -839,14 +871,20 @@ export abstract class ChannelBase {
       revision = await channelMemory.getChannelMemoryRevision(target);
     } catch {
       const entries = await channelMemory.listChannelMemoryEntries(target);
-      return selectRelevantChannelMemory(message, entries);
+      return {
+        entries: selectRelevantChannelMemory(message, entries),
+        cache: 'bypass',
+      };
     }
 
     let latestEntries: ChannelMemoryEntry[] = [];
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const cached = this.getCachedChannelMemoryRecallIndex(read.key, revision);
       if (cached) {
-        return selectRelevantChannelMemoryFromIndex(message, cached);
+        return {
+          entries: selectRelevantChannelMemoryFromIndex(message, cached),
+          cache: 'hit',
+        };
       }
 
       latestEntries = await channelMemory.listChannelMemoryEntries(target);
@@ -854,10 +892,15 @@ export abstract class ChannelBase {
       try {
         verifiedRevision = await channelMemory.getChannelMemoryRevision(target);
       } catch {
-        return selectRelevantChannelMemory(message, latestEntries);
+        return {
+          entries: selectRelevantChannelMemory(message, latestEntries),
+          cache: 'bypass',
+        };
       }
       if (revision !== verifiedRevision) {
-        if (read.generation !== read.state.generation) return [];
+        if (read.generation !== read.state.generation) {
+          return { entries: [], cache: 'miss' };
+        }
         revision = verifiedRevision;
         continue;
       }
@@ -866,14 +909,42 @@ export abstract class ChannelBase {
       if (read.generation === read.state.generation) {
         this.setCachedChannelMemoryRecallIndex(read.key, revision, index);
       }
-      return selectRelevantChannelMemoryFromIndex(message, index);
+      return {
+        entries: selectRelevantChannelMemoryFromIndex(message, index),
+        cache: 'miss',
+      };
     }
     this.logChannelMemoryError(
       'read',
       envelope,
       'recall revision unstable after retry',
     );
-    return selectRelevantChannelMemory(message, latestEntries);
+    return {
+      entries: selectRelevantChannelMemory(message, latestEntries),
+      cache: 'miss',
+      result: 'revision_unstable',
+    };
+  }
+
+  private observeChannelMemoryRecall(
+    startedAt: number,
+    cache: ChannelMemoryRecallCacheStatus,
+    result: ChannelMemoryRecallResult,
+    selectedCount: number,
+  ): void {
+    try {
+      this.channelMemoryRecallObserver?.({
+        durationMs: Math.max(0, performance.now() - startedAt),
+        selectedCount: Math.min(
+          CHANNEL_MEMORY_RECALL_MAX_ENTRIES,
+          Math.max(0, Math.trunc(selectedCount)),
+        ),
+        cache,
+        result,
+      });
+    } catch {
+      // Telemetry must never affect channel delivery.
+    }
   }
 
   private drainCollectBufferForCurrentPrompt(
@@ -4526,17 +4597,35 @@ export abstract class ChannelBase {
       ) {
         const memoryTarget = this.channelMemoryTarget(envelope);
         recallRead = this.beginChannelMemoryRead(memoryTarget);
+        const recallStartedAt = performance.now();
         try {
-          const relevantEntries = await this.selectRelevantChannelMemory(
+          const selection = await this.selectRelevantChannelMemory(
             envelope,
             memoryTarget,
             recallRead,
+          );
+          const stale = recallRead.generation !== recallRead.state.generation;
+          const relevantEntries = stale ? [] : selection.entries;
+          this.observeChannelMemoryRecall(
+            recallStartedAt,
+            selection.cache,
+            stale
+              ? 'stale'
+              : (selection.result ??
+                  (relevantEntries.length > 0 ? 'selected' : 'empty')),
+            relevantEntries.length,
           );
           if (relevantEntries.length > 0) {
             recallContext =
               this.formatRelevantChannelMemoryContext(relevantEntries);
           }
         } catch {
+          this.observeChannelMemoryRecall(
+            recallStartedAt,
+            'bypass',
+            'read_error',
+            0,
+          );
           this.releaseChannelMemoryRead(recallRead);
           recallRead = undefined;
           this.logChannelMemoryError('read', envelope, 'entry listing failed');

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -29,6 +29,9 @@ export type { BlockStreamerOptions } from './BlockStreamer.js';
 export { ChannelBase } from './ChannelBase.js';
 export type {
   ChannelBaseOptions,
+  ChannelMemoryRecallCacheStatus,
+  ChannelMemoryRecallObservation,
+  ChannelMemoryRecallResult,
   ChannelLoopController,
 } from './ChannelBase.js';
 export { ChannelLoopScheduler } from './ChannelLoopScheduler.js';

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -12,6 +12,7 @@ const mockAddChannelMemoryEntries = vi.hoisted(() => vi.fn());
 const mockUpdateChannelMemoryEntry = vi.hoisted(() => vi.fn());
 const mockRemoveChannelMemoryEntries = vi.hoisted(() => vi.fn());
 const mockClearChannelMemory = vi.hoisted(() => vi.fn());
+const mockRecordChannelMemoryRecallMetrics = vi.hoisted(() => vi.fn());
 const mockRegisterToolCallDispatch = vi.hoisted(() => vi.fn());
 const mockRegisterPermissionRelay = vi.hoisted(() => vi.fn());
 const mockRegisterSessionCleanup = vi.hoisted(() => vi.fn());
@@ -150,6 +151,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   getChannelMemoryRevision: mockGetChannelMemoryRevision,
   listChannelMemoryEntries: mockListChannelMemoryEntries,
   readChannelMemory: mockReadChannelMemory,
+  recordChannelMemoryRecallMetrics: mockRecordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries: mockRemoveChannelMemoryEntries,
   updateChannelMemoryEntry: mockUpdateChannelMemoryEntry,
 }));
@@ -708,6 +710,7 @@ describe('runChannelDaemonWorker', () => {
         memoryIntentClassifier: expect.objectContaining({
           classifyChannelMemoryIntent: expect.any(Function),
         }),
+        channelMemoryRecallObserver: mockRecordChannelMemoryRecallMetrics,
         observedContacts: {
           observe: expect.any(Function),
         },

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -6,6 +6,7 @@ import {
   getChannelMemoryRevision,
   listChannelMemoryEntries,
   readChannelMemory,
+  recordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries,
   updateChannelMemoryEntry,
 } from '@qwen-code/qwen-code-core';
@@ -505,6 +506,7 @@ export async function runChannelDaemonWorker(
               bridgeFacade,
               config.cwd,
             ),
+            channelMemoryRecallObserver: recordChannelMemoryRecallMetrics,
             observedContacts: {
               observe: (channelName, observation) => {
                 observedContacts.observe(channelName, observation);

--- a/packages/cli/src/commands/channel/start.test.ts
+++ b/packages/cli/src/commands/channel/start.test.ts
@@ -20,6 +20,7 @@ const mockAddChannelMemoryEntries = vi.hoisted(() => vi.fn());
 const mockUpdateChannelMemoryEntry = vi.hoisted(() => vi.fn());
 const mockRemoveChannelMemoryEntries = vi.hoisted(() => vi.fn());
 const mockClearChannelMemory = vi.hoisted(() => vi.fn());
+const mockRecordChannelMemoryRecallMetrics = vi.hoisted(() => vi.fn());
 const mockParseCron = vi.hoisted(() => vi.fn());
 const mockNextFireTime = vi.hoisted(() =>
   vi.fn((cron: string) => {
@@ -113,6 +114,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   normalizeProxyUrl: mockNormalizeProxyUrl,
   parseCron: mockParseCron,
   readChannelMemory: mockReadChannelMemory,
+  recordChannelMemoryRecallMetrics: mockRecordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries: mockRemoveChannelMemoryEntries,
   updateChannelMemoryEntry: mockUpdateChannelMemoryEntry,
   Storage: {
@@ -884,6 +886,7 @@ describe('startCommand.handler', () => {
         memoryIntentClassifier: expect.objectContaining({
           classifyChannelMemoryIntent: expect.any(Function),
         }),
+        channelMemoryRecallObserver: mockRecordChannelMemoryRecallMetrics,
       }),
     );
   });
@@ -926,6 +929,7 @@ describe('startCommand.handler', () => {
         memoryIntentClassifier: expect.objectContaining({
           classifyChannelMemoryIntent: expect.any(Function),
         }),
+        channelMemoryRecallObserver: mockRecordChannelMemoryRecallMetrics,
       }),
     );
     expect(mockCreateChannel).toHaveBeenNthCalledWith(

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -7,6 +7,7 @@ import {
   nextFireTime,
   parseCron,
   readChannelMemory,
+  recordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries,
   updateChannelMemoryEntry,
 } from '@qwen-code/qwen-code-core';
@@ -62,7 +63,10 @@ function isFileExistsError(err: unknown): boolean {
 function channelMemoryOptions(
   getBridge: () => AcpBridge,
   cwd: string,
-): Pick<ChannelBaseOptions, 'channelMemory' | 'memoryIntentClassifier'> {
+): Pick<
+  ChannelBaseOptions,
+  'channelMemory' | 'memoryIntentClassifier' | 'channelMemoryRecallObserver'
+> {
   return {
     channelMemory: {
       readChannelMemory,
@@ -77,6 +81,7 @@ function channelMemoryOptions(
       getBridge,
       cwd,
     ),
+    channelMemoryRecallObserver: recordChannelMemoryRecallMetrics,
   };
 }
 

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -136,6 +136,7 @@ export {
   recordMemoryExtractMetrics,
   recordMemoryDreamMetrics,
   recordMemoryRecallMetrics,
+  recordChannelMemoryRecallMetrics,
   // Performance monitoring types
   PerformanceMetricType,
   MemoryMetricType,

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -80,6 +80,7 @@ describe('Telemetry Metrics', () => {
   let recordPerformanceScoreModule: typeof import('./metrics.js').recordPerformanceScore;
   let recordPerformanceRegressionModule: typeof import('./metrics.js').recordPerformanceRegression;
   let recordBaselineComparisonModule: typeof import('./metrics.js').recordBaselineComparison;
+  let recordChannelMemoryRecallMetricsModule: typeof import('./metrics.js').recordChannelMemoryRecallMetrics;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -107,6 +108,8 @@ describe('Telemetry Metrics', () => {
     recordPerformanceRegressionModule =
       metricsJsModule.recordPerformanceRegression;
     recordBaselineComparisonModule = metricsJsModule.recordBaselineComparison;
+    recordChannelMemoryRecallMetricsModule =
+      metricsJsModule.recordChannelMemoryRecallMetrics;
 
     const otelApiModule = await import('@opentelemetry/api');
 
@@ -871,6 +874,66 @@ describe('Telemetry Metrics', () => {
 
       const attrs = mockCounterAddFn.mock.calls[0]?.[1] ?? {};
       expect(attrs['session.id']).toBe('cardinality-test');
+    });
+  });
+
+  describe('recordChannelMemoryRecallMetrics', () => {
+    it('does not record before metrics are initialized', () => {
+      recordChannelMemoryRecallMetricsModule({
+        durationMs: 12,
+        cache: 'hit',
+        result: 'selected',
+        selectedCount: 2,
+      });
+
+      expect(mockCounterAddFn).not.toHaveBeenCalled();
+      expect(mockHistogramRecordFn).not.toHaveBeenCalled();
+    });
+
+    it('records only bounded recall outcome attributes', () => {
+      initializeMetricsModule(makeFakeConfig({ sessionId: 'secret-session' }));
+      mockCounterAddFn.mockClear();
+      mockHistogramRecordFn.mockClear();
+
+      recordChannelMemoryRecallMetricsModule({
+        durationMs: 12.5,
+        cache: 'miss',
+        result: 'revision_unstable',
+        selectedCount: 1,
+      });
+
+      const attributes = {
+        cache: 'miss',
+        result: 'revision_unstable',
+      };
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, attributes);
+      expect(mockHistogramRecordFn).toHaveBeenNthCalledWith(
+        1,
+        12.5,
+        attributes,
+      );
+      expect(mockHistogramRecordFn).toHaveBeenNthCalledWith(2, 1, attributes);
+      expect(Object.keys(mockCounterAddFn.mock.calls[0]![1]!).sort()).toEqual([
+        'cache',
+        'result',
+      ]);
+    });
+
+    it('initializes dedicated channel memory recall instruments', () => {
+      initializeMetricsModule(makeFakeConfig({}));
+
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.channel.memory.recall.count',
+        expect.any(Object),
+      );
+      expect(mockCreateHistogramFn).toHaveBeenCalledWith(
+        'qwen-code.channel.memory.recall.duration',
+        expect.objectContaining({ unit: 'ms' }),
+      );
+      expect(mockCreateHistogramFn).toHaveBeenCalledWith(
+        'qwen-code.channel.memory.recall.selected_count',
+        expect.any(Object),
+      );
     });
   });
 });

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -55,6 +55,9 @@ const MEMORY_DREAM_COUNT = `${SERVICE_NAME}.memory.dream.count`;
 const MEMORY_DREAM_DURATION = `${SERVICE_NAME}.memory.dream.duration`;
 const MEMORY_RECALL_COUNT = `${SERVICE_NAME}.memory.recall.count`;
 const MEMORY_RECALL_DURATION = `${SERVICE_NAME}.memory.recall.duration`;
+const CHANNEL_MEMORY_RECALL_COUNT = `${SERVICE_NAME}.channel.memory.recall.count`;
+const CHANNEL_MEMORY_RECALL_DURATION = `${SERVICE_NAME}.channel.memory.recall.duration`;
+const CHANNEL_MEMORY_RECALL_SELECTED_COUNT = `${SERVICE_NAME}.channel.memory.recall.selected_count`;
 
 const baseMetricDefinition = {
   // session.id on metrics is opt-in: each session is a new value, so
@@ -400,6 +403,9 @@ let memoryDreamCounter: Counter | undefined;
 let memoryDreamDurationHistogram: Histogram | undefined;
 let memoryRecallCounter: Counter | undefined;
 let memoryRecallDurationHistogram: Histogram | undefined;
+let channelMemoryRecallCounter: Counter | undefined;
+let channelMemoryRecallDurationHistogram: Histogram | undefined;
+let channelMemoryRecallSelectedCountHistogram: Histogram | undefined;
 
 let isMetricsInitialized = false;
 let isPerformanceMonitoringEnabled = false;
@@ -502,6 +508,32 @@ export function initializeMetrics(config: TelemetryRuntimeConfig): void {
     {
       description: 'Duration of auto-memory recall operations in milliseconds.',
       unit: 'ms',
+      valueType: ValueType.INT,
+    },
+  );
+  channelMemoryRecallCounter = meter.createCounter(
+    CHANNEL_MEMORY_RECALL_COUNT,
+    {
+      description:
+        'Counts channel memory recall attempts by cache path and bounded result.',
+      valueType: ValueType.INT,
+    },
+  );
+  channelMemoryRecallDurationHistogram = meter.createHistogram(
+    CHANNEL_MEMORY_RECALL_DURATION,
+    {
+      description: 'Duration of channel memory recall attempts.',
+      unit: 'ms',
+      valueType: ValueType.DOUBLE,
+      advice: {
+        explicitBucketBoundaries: [0.1, 0.5, 1, 2, 5, 10, 25, 50, 100, 250],
+      },
+    },
+  );
+  channelMemoryRecallSelectedCountHistogram = meter.createHistogram(
+    CHANNEL_MEMORY_RECALL_SELECTED_COUNT,
+    {
+      description: 'Number of channel memory entries selected per attempt.',
       valueType: ValueType.INT,
     },
   );
@@ -1032,4 +1064,26 @@ export function recordMemoryRecallMetrics(
     ...common,
     strategy: attrs.strategy,
   });
+}
+
+export function recordChannelMemoryRecallMetrics(observation: {
+  durationMs: number;
+  cache: 'hit' | 'miss' | 'bypass';
+  result: 'selected' | 'empty' | 'stale' | 'read_error' | 'revision_unstable';
+  selectedCount: number;
+}): void {
+  if (!isMetricsInitialized) return;
+  const attributes = {
+    cache: observation.cache,
+    result: observation.result,
+  };
+  channelMemoryRecallCounter?.add(1, attributes);
+  channelMemoryRecallDurationHistogram?.record(
+    observation.durationMs,
+    attributes,
+  );
+  channelMemoryRecallSelectedCountHistogram?.record(
+    observation.selectedCount,
+    attributes,
+  );
 }


### PR DESCRIPTION
## What this PR does

Adds one bounded runtime observation for each channel memory recall attempt and records low-cardinality metrics for latency, selected-entry count, cache path, and result. Both foreground channel startup and daemon workers populate the observer. Recall selection, cache invalidation, access control, and prompt output remain unchanged.

The telemetry contract contains only `durationMs`, `selectedCount`, `cache`, and `result`. It does not record message or memory content, entry IDs, sender/chat/thread identifiers, channel names, workspace paths, revisions, or raw errors.

## Why it's needed

The deterministic offline evaluation added earlier can measure retrieval quality, but production traffic has no relevance labels. Operators still need content-safe runtime signals to understand recall latency, cache effectiveness, empty selections, stale reads, and bounded failure paths without exposing user data.

## Reviewer Test Plan

### How to verify

Run the channel-base package tests and confirm cache hits, misses, revision-less bypasses, empty selections, stale reads, read failures, and unstable revisions each emit one bounded observation while slash commands emit none. Run the core telemetry tests and confirm metrics no-op before initialization and use only `cache` and `result` attributes. Run the channel start and daemon-worker tests and confirm both runtime paths provide the recorder. Finally run repository lint, build, and typecheck.

### Evidence (Before & After)

N/A. This is non-user-visible runtime telemetry and does not change channel responses or UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local Node.js workspace with package-level Vitest and repository build tooling.

## Risk & Scope

- Main risk or tradeoff: An observer or metrics backend must not affect channel delivery; observer failures are isolated and metrics are no-ops before telemetry initialization.
- Not validated / out of scope: Online relevance quality, message sampling, semantic retrieval, embeddings, LLM reranking, and storage or access-control changes.
- Breaking changes / migration notes: None. The observer is optional and existing channel integrations remain compatible.

## Linked Issues

Fixes #7335

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为每次 channel memory recall 增加一条有界的运行时观测，并记录延迟、选中条目数、缓存路径和结果状态等低基数指标。前台 channel 启动与 daemon worker 都会注入观测器。召回选择、缓存失效、访问控制和 prompt 输出行为保持不变。

遥测契约只包含 `durationMs`、`selectedCount`、`cache` 和 `result`。不会记录消息或记忆正文、条目 ID、发送者/会话/线程标识、channel 名称、workspace 路径、revision 值或原始错误。

## 为什么需要

此前的确定性离线评估可以衡量检索质量，但生产流量没有相关性标签。运维仍需要不暴露用户数据的运行时信号，用于理解召回延迟、缓存效果、空选择、过期读取和有界失败路径。

## Reviewer 测试计划

### 如何验证

运行 channel-base 包测试，确认缓存命中、未命中、无 revision 的 bypass、空选择、过期读取、读取失败和 revision 不稳定都会各自产生一条有界观测，而 slash command 不产生观测。运行 core telemetry 测试，确认遥测未初始化时为 no-op，且指标属性只有 `cache` 和 `result`。运行 channel start 与 daemon worker 测试，确认两条运行路径都提供 recorder。最后运行仓库 lint、build 和 typecheck。

### 前后证据

N/A。本改动仅增加不可见的运行时遥测，不改变 channel 回复或 UI。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

本地 Node.js workspace，使用包级 Vitest 与仓库构建工具。

## 风险与范围

- 主要风险或取舍：观测器或指标后端不能影响 channel 投递；观测器异常已隔离，遥测未初始化时指标记录为 no-op。
- 未验证或范围外：在线相关性质量、消息采样、语义检索、embedding、LLM rerank，以及存储或访问控制修改。
- 破坏性变更或迁移说明：无。观测器为可选项，现有 channel 集成保持兼容。

## 关联 Issue

Fixes #7335

</details>