### PR TITLE
fix(agent): ignore empty working_dir placeholders

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -653,6 +653,28 @@ describe('AgentTool', () => {
       ).toMatch(/working_dir/i);
     });
 
+    it('treats an empty working_dir as unset when isolation is set', () => {
+      const params = {
+        ...validParams,
+        isolation: 'worktree' as const,
+        working_dir: '',
+      };
+
+      expect(agentTool.validateToolParams(params)).toBeNull();
+      expect(params.working_dir).toBeUndefined();
+    });
+
+    it('treats a whitespace-only working_dir as unset when isolation is set', () => {
+      const params = {
+        ...validParams,
+        isolation: 'worktree' as const,
+        working_dir: '   ',
+      };
+
+      expect(agentTool.validateToolParams(params)).toBeNull();
+      expect(params.working_dir).toBeUndefined();
+    });
+
     it('rejects working_dir combined with isolation', () => {
       expect(
         agentTool.validateToolParams({

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -635,22 +635,24 @@ describe('AgentTool', () => {
       ).toBeNull();
     });
 
-    it('rejects an empty working_dir', () => {
-      expect(
-        agentTool.validateToolParams({
-          ...validParams,
-          working_dir: '',
-        }),
-      ).toMatch(/working_dir/i);
+    it('treats an empty working_dir as unset', () => {
+      const params = {
+        ...validParams,
+        working_dir: '',
+      };
+
+      expect(agentTool.validateToolParams(params)).toBeNull();
+      expect(params.working_dir).toBeUndefined();
     });
 
-    it('rejects a whitespace-only working_dir', () => {
-      expect(
-        agentTool.validateToolParams({
-          ...validParams,
-          working_dir: '   ',
-        }),
-      ).toMatch(/working_dir/i);
+    it('treats a whitespace-only working_dir as unset', () => {
+      const params = {
+        ...validParams,
+        working_dir: '   ',
+      };
+
+      expect(agentTool.validateToolParams(params)).toBeNull();
+      expect(params.working_dir).toBeUndefined();
     });
 
     it('treats an empty working_dir as unset when isolation is set', () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1028,6 +1028,15 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
         }
       }
     }
+    // Some models emit an empty placeholder for the unused optional field.
+    // With isolation selected, normalize it away before downstream routing.
+    if (
+      (typeof params.working_dir === 'string' &&
+        params.working_dir.trim().length === 0) ||
+      params.working_dir === null
+    ) {
+      params.working_dir = undefined;
+    }
 
     if (params.isolation !== undefined) {
       if (params.isolation !== 'worktree') {


### PR DESCRIPTION
## What this PR does

Normalizes empty and whitespace-only `working_dir` values to an omitted value before Agent parameter routing. This lets subagent calls continue when an OpenAI-compatible model emits an empty placeholder for the optional field, including isolated worktree launches. Non-empty `working_dir` values continue through the existing validation and mutual-exclusion checks.

## Why it's needed

Some OpenAI-compatible models emit every declared tool property even when the property is optional. For Agent calls, this can produce `working_dir: ""`, which is rejected before an otherwise valid launch can proceed. This change provides a narrow compatibility path for empty placeholders while leaving non-empty path validation intact.

## Reviewer Test Plan

### How to verify

Run the focused Agent tool test and confirm empty and whitespace-only `working_dir` values are removed, calls with `isolation: "worktree"` are no longer rejected solely because of an empty placeholder, and non-empty `working_dir` plus `isolation` remains rejected as mutually exclusive.

```bash
cd packages/core && npx vitest run src/tools/agent/agent.test.ts
```

Also confirm the repository builds and type-checks:

```bash
npm run build
npm run typecheck
```

### Evidence (Before & After)

Before: a generated Agent tool call containing `working_dir: ""` failed with `Parameter "working_dir" must be a non-empty string when set.`

After: empty and whitespace-only placeholders are treated as omitted; existing validation still applies to non-empty paths.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js development environment using the repository workspace. Verified with the focused 169-test Agent suite, full build, and full typecheck.

## Risk & Scope

- Main risk or tradeoff: callers that intentionally pass an empty `working_dir` now receive the same behavior as callers that omit it.
- Not validated / out of scope: models that emit a non-empty unwanted `working_dir`, broader OpenAI-compatible schema conversion behavior, macOS, and Windows runtime behavior.
- Breaking changes / migration notes: none.

## Linked Issues

Addresses part of #7315.

<details>
<summary>中文说明</summary>

## 此 PR 的改动

在 Agent 参数路由前，将空字符串及仅含空白字符的 `working_dir` 归一化为未传值。如此，当 OpenAI 兼容模型为可选字段输出空占位时，子代理调用仍可继续，包括隔离 worktree 启动。非空 `working_dir` 仍沿用现有校验与互斥检查。

## 为什么需要

部分 OpenAI 兼容模型会输出工具 schema 中声明的所有属性，即使属性并非必填。Agent 调用因此可能带有 `working_dir: ""`，导致原本有效的调用在启动前被拒绝。本改动仅兼容空占位，不放宽非空路径校验。

## Reviewer Test Plan

### 如何验证

运行 Agent 工具定向测试，确认空字符串与纯空白 `working_dir` 会被移除，带 `isolation: "worktree"` 的调用不再仅因空占位而失败，且非空 `working_dir` 与 `isolation` 同时出现时仍以互斥错误拒绝。

```bash
cd packages/core && npx vitest run src/tools/agent/agent.test.ts
```

并确认全仓构建与类型检查通过：

```bash
npm run build
npm run typecheck
```

### 前后证据

修改前：Agent tool call 若包含 `working_dir: ""`，会报 `Parameter "working_dir" must be a non-empty string when set.`。

修改后：空字符串及纯空白占位按未传处理；非空路径仍执行原有校验。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境

使用仓库工作区的 Node.js 开发环境。已验证 Agent 定向测试 169 项、全仓构建及全仓类型检查。

## 风险与范围

- 主要风险或权衡：调用方若有意传入空 `working_dir`，现会得到与省略该字段相同的行为。
- 未验证或范围外：模型输出非空但非预期的 `working_dir`、更广泛的 OpenAI 兼容 schema 转换问题、macOS 与 Windows 运行行为。
- 破坏性变更或迁移说明：无。

## 关联 Issue

处理 #7315 的部分问题。

</details>
