### PR TITLE
fix(core): relax additionalProperties:false on the OpenAI wire for optional-field schemas

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -5645,6 +5645,66 @@ describe('OpenAIContentConverter', () => {
       });
     });
 
+    // Regression for #7315: the wire schema must not carry
+    // additionalProperties:false on levels with optional properties —
+    // OpenAI-compatible gateways promote every property to required,
+    // forcing mutually exclusive optional fields (Agent working_dir vs
+    // isolation) into every call.
+    it('relaxes additionalProperties:false for schemas with optional fields', async () => {
+      const agentLikeTools = [
+        {
+          functionDeclarations: [
+            {
+              name: 'agent',
+              description: 'Launch a new agent',
+              parametersJsonSchema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                type: 'object',
+                properties: {
+                  description: { type: 'string' },
+                  prompt: { type: 'string' },
+                  working_dir: { type: 'string' },
+                  isolation: { type: 'string', enum: ['worktree'] },
+                },
+                required: ['description', 'prompt'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ] as Tool[];
+
+      const result = await converter.convertGeminiToolsToOpenAI(agentLikeTools);
+      const params = result[0]!.function.parameters as Record<string, unknown>;
+      expect(params['additionalProperties']).toBeUndefined();
+      expect(params['$schema']).toBeUndefined();
+      // Required stays exactly as authored — optional fields remain optional.
+      expect(params['required']).toEqual(['description', 'prompt']);
+    });
+
+    it('keeps additionalProperties:false when every property is required', async () => {
+      const strictTools = [
+        {
+          functionDeclarations: [
+            {
+              name: 'strict_tool',
+              description: 'All fields required',
+              parametersJsonSchema: {
+                type: 'object',
+                properties: { path: { type: 'string' } },
+                required: ['path'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ] as Tool[];
+
+      const result = await converter.convertGeminiToolsToOpenAI(strictTools);
+      const params = result[0]!.function.parameters as Record<string, unknown>;
+      expect(params['additionalProperties']).toBe(false);
+    });
+
     it('should convert MCP tools with parametersJsonSchema field', async () => {
       // MCP tools use parametersJsonSchema which contains plain JSON schema (not Gemini types)
       const mcpTools = [

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -31,6 +31,7 @@ import type { RequestContext, StreamingTextDeltaState } from './types.js';
 import { parseTaggedThinkingText } from './taggedThinkingParser.js';
 import {
   convertSchema,
+  relaxSchemaForFunctionCalling,
   type SchemaComplianceMode,
 } from '../../utils/schemaConverter.js';
 import {
@@ -364,6 +365,13 @@ export async function convertGeminiToolsToOpenAI(
 
           if (parameters) {
             parameters = convertSchema(parameters, schemaCompliance);
+            // #7315: gateways enforcing OpenAI's structured-output contract
+            // promote every property to required when an object level has
+            // `additionalProperties: false` — forcing the model to emit
+            // mutually exclusive optional fields (Agent working_dir vs
+            // isolation). Relax the wire schema; client-side
+            // validateToolParams still enforces the source schema.
+            parameters = relaxSchemaForFunctionCalling(parameters);
           }
 
           openAITools.push({

--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -260,6 +260,7 @@ describe('relaxSchemaForFunctionCalling', () => {
     // called $schema / $id / additionalProperties must survive the walk.
     const schema = {
       $schema: 'http://json-schema.org/draft-07/schema#',
+      $id: 'https://example.com/tool.schema.json',
       type: 'object',
       properties: {
         $schema: { type: 'string' },
@@ -274,13 +275,15 @@ describe('relaxSchemaForFunctionCalling', () => {
     };
     const relaxed = relaxSchemaForFunctionCalling(schema) as {
       $schema?: unknown;
+      $id?: unknown;
       properties: Record<string, unknown>;
       required: string[];
       additionalProperties?: unknown;
       $defs: Record<string, unknown>;
     };
-    // Keyword-level $schema dropped; property-level names all intact.
+    // Keyword-level $schema AND $id dropped; property-level names intact.
     expect(relaxed.$schema).toBeUndefined();
+    expect(relaxed.$id).toBeUndefined();
     expect(Object.keys(relaxed.properties)).toEqual([
       '$schema',
       '$id',

--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { convertSchema } from './schemaConverter.js';
+import {
+  convertSchema,
+  relaxSchemaForFunctionCalling,
+} from './schemaConverter.js';
 
 describe('convertSchema', () => {
   describe('mode: auto (default)', () => {
@@ -142,5 +145,125 @@ describe('convertSchema', () => {
       const expected = { type: 'string' };
       expect(convertSchema(input, 'openapi_30')).toEqual(expected);
     });
+  });
+});
+
+// Regression for #7315: gateways enforcing OpenAI's structured-output
+// contract promote every property to required when an object level carries
+// `additionalProperties: false` — mutually exclusive optional tool fields
+// (Agent working_dir vs isolation) become impossible to satisfy.
+describe('relaxSchemaForFunctionCalling', () => {
+  it('strips additionalProperties:false on levels with optional properties', () => {
+    const agentLike = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        description: { type: 'string' },
+        prompt: { type: 'string' },
+        working_dir: { type: 'string' },
+        isolation: { type: 'string', enum: ['worktree'] },
+      },
+      required: ['description', 'prompt'],
+      additionalProperties: false,
+    };
+    const relaxed = relaxSchemaForFunctionCalling(agentLike);
+    expect(relaxed['additionalProperties']).toBeUndefined();
+    expect(relaxed['$schema']).toBeUndefined();
+    expect(relaxed['required']).toEqual(['description', 'prompt']);
+    expect(Object.keys(relaxed['properties'] as object)).toEqual([
+      'description',
+      'prompt',
+      'working_dir',
+      'isolation',
+    ]);
+  });
+
+  it('keeps additionalProperties:false when every property is required', () => {
+    const strictSchema = {
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+      },
+      required: ['a', 'b'],
+      additionalProperties: false,
+    };
+    expect(
+      relaxSchemaForFunctionCalling(strictSchema)['additionalProperties'],
+    ).toBe(false);
+  });
+
+  it('keeps additionalProperties:false when there are no properties to promote', () => {
+    const empty = { type: 'object', additionalProperties: false };
+    expect(relaxSchemaForFunctionCalling(empty)['additionalProperties']).toBe(
+      false,
+    );
+  });
+
+  it('relaxes nested object levels independently', () => {
+    const nested = {
+      type: 'object',
+      properties: {
+        outerRequired: {
+          type: 'object',
+          properties: {
+            x: { type: 'string' },
+            y: { type: 'string' },
+          },
+          required: ['x'],
+          additionalProperties: false,
+        },
+        strictInner: {
+          type: 'object',
+          properties: { z: { type: 'string' } },
+          required: ['z'],
+          additionalProperties: false,
+        },
+      },
+      required: ['outerRequired', 'strictInner'],
+      additionalProperties: false,
+    };
+    const relaxed = relaxSchemaForFunctionCalling(nested) as {
+      additionalProperties?: unknown;
+      properties: Record<string, { additionalProperties?: unknown }>;
+    };
+    // Top level: all props required -> constraint kept.
+    expect(relaxed.additionalProperties).toBe(false);
+    // Inner with an optional property -> stripped.
+    expect(
+      relaxed.properties['outerRequired']!.additionalProperties,
+    ).toBeUndefined();
+    // Inner fully required -> kept.
+    expect(relaxed.properties['strictInner']!.additionalProperties).toBe(false);
+  });
+
+  it('preserves non-false additionalProperties forms and recurses into them', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      additionalProperties: {
+        type: 'object',
+        properties: { inner: { type: 'string' } },
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const relaxed = relaxSchemaForFunctionCalling(schema) as {
+      additionalProperties: { additionalProperties?: unknown };
+    };
+    expect(typeof relaxed.additionalProperties).toBe('object');
+    expect(relaxed.additionalProperties.additionalProperties).toBeUndefined();
+  });
+
+  it('does not mutate the input schema', () => {
+    const input = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: [],
+      additionalProperties: false,
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    relaxSchemaForFunctionCalling(input);
+    expect(input).toEqual(snapshot);
   });
 });

--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -255,6 +255,48 @@ describe('relaxSchemaForFunctionCalling', () => {
     expect(relaxed.additionalProperties.additionalProperties).toBeUndefined();
   });
 
+  it('never treats property names as schema keywords', () => {
+    // `properties` keys are names, not keywords: a property literally
+    // called $schema / $id / additionalProperties must survive the walk.
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        $schema: { type: 'string' },
+        $id: { type: 'string' },
+        additionalProperties: { type: 'boolean' },
+      },
+      required: ['$schema', '$id', 'additionalProperties'],
+      additionalProperties: false,
+      $defs: {
+        $schema: { type: 'number' },
+      },
+    };
+    const relaxed = relaxSchemaForFunctionCalling(schema) as {
+      $schema?: unknown;
+      properties: Record<string, unknown>;
+      required: string[];
+      additionalProperties?: unknown;
+      $defs: Record<string, unknown>;
+    };
+    // Keyword-level $schema dropped; property-level names all intact.
+    expect(relaxed.$schema).toBeUndefined();
+    expect(Object.keys(relaxed.properties)).toEqual([
+      '$schema',
+      '$id',
+      'additionalProperties',
+    ]);
+    expect(relaxed.required).toEqual([
+      '$schema',
+      '$id',
+      'additionalProperties',
+    ]);
+    // All properties required -> the constraint keyword stays.
+    expect(relaxed.additionalProperties).toBe(false);
+    // $defs is a name map too.
+    expect(Object.keys(relaxed.$defs)).toEqual(['$schema']);
+  });
+
   it('does not mutate the input schema', () => {
     const input = {
       type: 'object',

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -136,3 +136,73 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
 
   return convert(schema) as Record<string, unknown>;
 }
+
+/**
+ * Relaxes a tool-parameter JSON Schema for the OpenAI-compatible wire
+ * format (#7315).
+ *
+ * OpenAI's structured-output contract requires that when an object schema
+ * carries `additionalProperties: false`, every property must be listed in
+ * `required`; several OpenAI-compatible gateways enforce this server-side
+ * by silently promoting ALL properties to required. For tools with
+ * genuinely optional fields the model is then forced to emit every field
+ * on every call — the Agent tool's mutually exclusive `working_dir` and
+ * `isolation` become impossible to satisfy, and the model loops on the
+ * client-side validation error until loop detection kills the run.
+ *
+ * The relaxation is deliberately surgical:
+ * - `additionalProperties: false` is removed ONLY on object levels that
+ *   declare optional properties (some `properties` key missing from
+ *   `required`). Levels where every property is required keep the
+ *   constraint — there is nothing for a gateway to promote.
+ * - `$schema` / `$id` metadata is dropped at every level (some gateways
+ *   reject unknown keywords).
+ * - Everything else passes through untouched; client-side
+ *   `validateToolParams` still enforces the full source schema, so the
+ *   constraint is relaxed on the wire only.
+ *
+ * Pure: returns new objects, never mutates the input.
+ */
+export function relaxSchemaForFunctionCalling(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const relax = (obj: unknown): unknown => {
+    if (typeof obj !== 'object' || obj === null) {
+      return obj;
+    }
+    if (Array.isArray(obj)) {
+      return obj.map(relax);
+    }
+    const source = obj as Record<string, unknown>;
+    const target: Record<string, unknown> = {};
+
+    const properties = source['properties'];
+    const required = Array.isArray(source['required'])
+      ? (source['required'] as unknown[]).filter(
+          (r): r is string => typeof r === 'string',
+        )
+      : [];
+    const hasOptionalProperties =
+      typeof properties === 'object' &&
+      properties !== null &&
+      !Array.isArray(properties) &&
+      Object.keys(properties).some((key) => !required.includes(key));
+
+    for (const [key, value] of Object.entries(source)) {
+      if (key === '$schema' || key === '$id') {
+        continue;
+      }
+      if (
+        key === 'additionalProperties' &&
+        value === false &&
+        hasOptionalProperties
+      ) {
+        continue;
+      }
+      target[key] = relax(value);
+    }
+    return target;
+  };
+
+  return relax(schema) as Record<string, unknown>;
+}

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -199,6 +199,25 @@ export function relaxSchemaForFunctionCalling(
       ) {
         continue;
       }
+      // `properties` / `$defs` / `definitions` are name->schema MAPS: their
+      // keys are property/definition names, not JSON Schema keywords. A
+      // property literally named `$schema` or `additionalProperties` must
+      // survive — only the VALUES are schemas to relax.
+      if (
+        (key === 'properties' || key === '$defs' || key === 'definitions') &&
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        const map: Record<string, unknown> = {};
+        for (const [mapKey, mapValue] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          map[mapKey] = relax(mapValue);
+        }
+        target[key] = map;
+        continue;
+      }
       target[key] = relax(value);
     }
     return target;


### PR DESCRIPTION
## What this PR does

Adds a `relaxSchemaForFunctionCalling` pass to the OpenAI tool-declaration conversion (`convertGeminiToolsToOpenAI`): on the wire, `additionalProperties: false` is removed from object levels that declare optional properties (levels where every property is required keep the constraint — a gateway has nothing to promote there), and `$schema` / `$id` metadata is dropped at every level. The transform is pure and surgical; client-side `validateToolParams` still enforces the full source schema, so the constraint is relaxed on the wire only.

## Why it's needed

#7315 (P1): tool schemas declare `additionalProperties: false` alongside genuinely optional properties — the Agent tool's `working_dir` and `isolation` among them. OpenAI's structured-output contract requires every property to be listed in `required` when that constraint is present, and OpenAI-compatible gateways enforce it server-side by promoting **all** properties to required. The model is then forced to emit both mutually exclusive Agent fields on every call, hits the client-side `Parameters "working_dir" and "isolation" are mutually exclusive` error, retries with identical arguments (the gateway keeps forcing the fields), and eventually trips loop detection. The triage confirmed the mechanism and blast radius (dozens of `additionalProperties: false` occurrences across tool schemas — any tool with optional fields can see models forced to fill them with empty or hallucinated values) and proposed exactly this fix direction.

## Reviewer Test Plan

### How to verify

1. Against an OpenAI-compatible provider that enforces the structured-output required-promotion (the reporter's setup), ask for an Explore subagent in any of the issue's three reproductions. Before this PR: every Agent call carries both `working_dir` and `isolation` and fails mutual exclusion until loop detection. After: optional fields stay optional on the wire, so the model can omit them.
2. Wire-format check anywhere: point the CLI at any request logger and inspect the first request's `tools` array — the `agent` function's parameters must not carry top-level `additionalProperties` while `required` stays exactly `["description", "prompt"]`.
3. `npx vitest run src/utils/schemaConverter.test.ts src/core/openaiContentGenerator/converter.test.ts` (packages/core): 231/231; the full `openaiContentGenerator` directory: 665/665.

### Evidence (Before & After)

Deterministic E2E: a PTY harness drives the real CLI against a local fake OpenAI-compatible server that captures the wire `tools` array of the first `/chat/completions` request:

| | before fix | after fix |
| --- | --- | --- |
| `additionalProperties: false` occurrences across wire tool schemas | **11** | **2** (both on fully-required levels, kept deliberately) |
| `agent.parameters.additionalProperties` | **`false`** ❌ (gateway promotes `working_dir`+`isolation` to required) | absent ✅ |
| `agent.parameters.required` | `["description","prompt"]` | `["description","prompt"]` (unchanged) ✅ |

![verification](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7315/verify-7315.png)

The integration test ("relaxes additionalProperties:false for schemas with optional fields") fails on the unpatched converter — verified via `git stash`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; PTY harness + fake OpenAI-compatible SSE server against `packages/cli/dist`, plus vitest unit/integration tests. `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: providers that genuinely validated `additionalProperties: false` no longer reject unknown keys at optional-field levels on the wire — but client-side `validateToolParams` still enforces the full source schema, so unknown or malformed arguments are rejected exactly as before; the relaxation only stops gateways from forcing optional fields into `required`. Fully-required levels keep the constraint, so the change is the minimum that fixes the forcing behavior.
- Not validated / out of scope: the reporter's exact provider (`gpt-5.6-sol` via an OpenAI-compatible gateway) is not available locally — the E2E proves the wire format, and the gateway behavior follows from OpenAI's documented structured-output contract. Gemini/Anthropic conversion paths are untouched; strict function-calling (if ever adopted) would need the inverse treatment and is out of scope.
- Breaking changes / migration notes: none — `relaxSchemaForFunctionCalling` is a new export; source schemas and client-side validation are unchanged.

## Linked Issues

Fixes #7315

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 OpenAI 工具声明转换（`convertGeminiToolsToOpenAI`）中加入 `relaxSchemaForFunctionCalling`：线上格式中，仅在**声明了可选属性**的对象层级移除 `additionalProperties: false`（全必填层级保留约束——网关无可提升项），并在各层删除 `$schema`/`$id` 元数据。变换是纯函数且外科式的；客户端 `validateToolParams` 仍执行完整源 schema，约束只在线上放宽。

## 为什么需要

#7315（P1）：工具 schema 在存在真可选属性（如 Agent 的 `working_dir`/`isolation`）的同时声明 `additionalProperties: false`。OpenAI 的 structured-output 契约要求此时所有属性都列入 `required`，兼容网关会在服务端把**全部**属性提升为必填——模型被迫每次都同时发出两个互斥字段，撞上客户端互斥校验错误、以相同参数重试（网关持续强制）、最终触发循环检测。triage 已确认机制与波及面（数十处 `additionalProperties: false`，任何带可选字段的工具都可能被迫填空串或幻觉值），并给出了正是本 PR 的修复方向。

## 审阅测试计划

### 如何验证

1. 对执行 required 提升的 OpenAI 兼容 provider（报告者配置），按 issue 三个复现任一发起 Explore 子代理调用：本 PR 之前每次 Agent 调用都带互斥双字段并循环失败；之后可选字段在线上保持可选，模型可以省略；
2. 任意请求记录器检查首个请求的 `tools`：`agent` 参数顶层不得携带 `additionalProperties`，`required` 恰为 `["description","prompt"]`；
3. 两个测试文件 231/231；openaiContentGenerator 目录 665/665。

### 证据（Before & After）

确定性 E2E（PTY + 伪 OpenAI 服务器捕获首个请求的线上 `tools`）：修复前全线 11 处 `additionalProperties:false`、agent 顶层携带（❌ 网关将互斥可选字段提升为必填）；修复后 agent schema 干净、`required` 不变、仅剩 2 处全必填层级保留（✅）。集成测试在未修复 converter 上失败（git stash 验证）。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；PTY harness + 伪 OpenAI SSE 服务器 + vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：真正校验 `additionalProperties: false` 的 provider 在可选字段层级不再于线上拒绝未知键——但客户端 `validateToolParams` 仍按完整源 schema 拒绝未知/畸形参数，行为与之前一致；放宽只阻止网关把可选字段强制进 `required`。全必填层级保留约束，改动是修复强制行为的最小集。
- 未验证/超出范围：报告者的具体 provider（经 OpenAI 兼容网关的 `gpt-5.6-sol`）本地不可得——E2E 证明线上格式，网关行为由 OpenAI 文档化的 structured-output 契约推出。Gemini/Anthropic 转换路径未动；严格函数调用（若未来采用）需要相反处理，超出本 PR 范围。
- 破坏性变更/迁移说明：无——`relaxSchemaForFunctionCalling` 为新导出，源 schema 与客户端校验不变。

## 关联 Issue

Fixes #7315

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
