### PR TITLE
fix(web-shell): respect voice enabled setting

### DIFF
--- a/docs/design/webshell-voice-button-visibility.md
+++ b/docs/design/webshell-voice-button-visibility.md
@@ -1,0 +1,17 @@
+# WebShell Voice Button Visibility
+
+## Summary
+
+The WebShell voice button is visible only when the workspace explicitly enables voice, the embedding host allows the voice toolbar action, and the daemon advertises the `voice_transcribe` capability.
+
+## Decision
+
+The host toolbar filter remains the outer gate. When the host allows voice, `VoiceButton` reads the existing `/workspace/voice` status and accepts only `enabled: true`. A missing capability avoids the status request entirely.
+
+The status is fail-closed: the button stays hidden while the request is pending or after it fails. Each settings event invalidates the previous result and starts a fresh request. Results are tied to the workspace client and settings version so a late response cannot re-enable a stale configuration.
+
+## Boundaries
+
+Voice model selection, available model discovery, and voice mode do not affect button visibility. Invalid model configuration continues to use the existing capture error path after the user clicks the button.
+
+This change does not add a WebShell prop, daemon endpoint, SDK type, or configuration field.

--- a/docs/design/webshell-voice-button-visibility.md
+++ b/docs/design/webshell-voice-button-visibility.md
@@ -10,6 +10,8 @@ The host toolbar filter remains the outer gate. When the host allows voice, `Voi
 
 The status is fail-closed: the button stays hidden while the request is pending or after it fails. Each settings event invalidates the previous result and starts a fresh request. Results are tied to the workspace client and settings version so a late response cannot re-enable a stale configuration.
 
+If a previously enabled gate becomes invalid during an active capture, the capture is aborted before the control remains hidden so the microphone and voice connection are released.
+
 ## Boundaries
 
 Voice model selection, available model discovery, and voice mode do not affect button visibility. Invalid model configuration continues to use the existing capture error path after the user clicks the button.

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -118,6 +118,10 @@ vi.mock('../hooks/useComposerCore', async (importOriginal) => {
   };
 });
 
+vi.mock('../voice/VoiceButton', () => ({
+  VoiceButton: () => <span data-testid="voice-button" />,
+}));
+
 const mounted: Array<{
   root: Root;
   container: HTMLDivElement;
@@ -198,6 +202,24 @@ function renderChatEditor(props: {
 
   return container;
 }
+
+describe('ChatEditor voice toolbar integration', () => {
+  it('mounts voice only when the host toolbar allows it', () => {
+    expect(
+      renderChatEditor({}).querySelector('[data-testid="voice-button"]'),
+    ).not.toBeNull();
+    expect(
+      renderChatEditor({
+        visibleToolbarActions: ['voice'],
+      }).querySelector('[data-testid="voice-button"]'),
+    ).not.toBeNull();
+    expect(
+      renderChatEditor({
+        visibleToolbarActions: [],
+      }).querySelector('[data-testid="voice-button"]'),
+    ).toBeNull();
+  });
+});
 
 describe('ChatEditor composer tag icons', () => {
   it('renders built-in icons for top composer tags', () => {

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -44,6 +44,7 @@ export interface WebShellDaemonScenario {
   providers: DaemonWorkspaceProvidersStatus;
   skills: DaemonWorkspaceSkillsStatus;
   settings: DaemonWorkspaceSettingsStatus;
+  voice: DaemonWorkspaceVoiceStatus;
   extensions: DaemonWorkspaceExtensionsStatus;
   extensionOperations: ExtensionActiveOperations;
   extensionUpdateCheck: ExtensionUpdateCheckResponse;
@@ -71,6 +72,7 @@ type ScenarioOverrides = Partial<
     | 'providers'
     | 'skills'
     | 'settings'
+    | 'voice'
     | 'extensions'
     | 'extensionOperations'
     | 'extensionUpdateCheck'
@@ -83,6 +85,7 @@ type ScenarioOverrides = Partial<
   providers?: Partial<DaemonWorkspaceProvidersStatus>;
   skills?: Partial<DaemonWorkspaceSkillsStatus>;
   settings?: Partial<DaemonWorkspaceSettingsStatus>;
+  voice?: Partial<DaemonWorkspaceVoiceStatus>;
   extensions?: Partial<DaemonWorkspaceExtensionsStatus>;
   extensionOperations?: Partial<ExtensionActiveOperations>;
   extensionUpdateCheck?: Partial<ExtensionUpdateCheckResponse>;
@@ -230,6 +233,17 @@ export function createWebShellDaemonScenario(
     ...(overrides.settings ?? {}),
   };
 
+  const voice: DaemonWorkspaceVoiceStatus = {
+    v: 1,
+    workspaceCwd,
+    enabled: false,
+    mode: 'hold',
+    language: 'en',
+    voiceModel: null,
+    availableVoiceModels: [],
+    ...(overrides.voice ?? {}),
+  };
+
   const extensions: DaemonWorkspaceExtensionsStatus = {
     v: 1,
     workspaceCwd,
@@ -282,6 +296,7 @@ export function createWebShellDaemonScenario(
     providers,
     skills,
     settings,
+    voice,
     extensions,
     extensionOperations,
     extensionUpdateCheck,
@@ -934,15 +949,7 @@ function workspaceTools(
 function workspaceVoice(
   scenario: WebShellDaemonScenario,
 ): DaemonWorkspaceVoiceStatus {
-  return {
-    v: 1,
-    workspaceCwd: scenario.workspaceCwd,
-    enabled: false,
-    mode: 'hold',
-    language: 'en',
-    voiceModel: null,
-    availableVoiceModels: [],
-  };
+  return scenario.voice;
 }
 
 async function json(route: Route, body: unknown, status = 200): Promise<void> {

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -217,6 +217,32 @@ test('opens slash menu, resume dialog, model dialog, and theme dialog @smoke', a
   await expect(page.locator('[data-web-shell-theme-dialog]')).toHaveCount(0);
 });
 
+test('gates voice dictation on the workspace voice setting @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    voice: {
+      enabled: false,
+    },
+  });
+  scenario.capabilities.features = [
+    ...scenario.capabilities.features,
+    'voice_transcribe',
+  ];
+  const daemon = await installScenario(page, scenario, testInfo);
+  const voiceButton = page.getByRole('button', {
+    name: 'Start voice dictation',
+  });
+
+  await gotoSession(page, scenario, daemon);
+  await expect(voiceButton).toHaveCount(0);
+
+  scenario.voice.enabled = true;
+  await page.reload();
+  await completeReplay(page, daemon);
+  await expect(voiceButton).toBeVisible();
+});
+
 for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
   test(`grows long text to the responsive composer cap at ${viewportHeight}px @smoke`, async ({
     page,

--- a/packages/web-shell/client/voice/VoiceButton.test.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.test.tsx
@@ -92,7 +92,9 @@ const click = (button: HTMLButtonElement) => {
 beforeEach(() => {
   mocks.settingsVersion = 0;
   mocks.workspace.capabilities.features = ['voice_transcribe'];
-  mocks.workspace.client.workspaceVoice = mocks.workspaceVoice;
+  mocks.workspace.client = {
+    workspaceVoice: mocks.workspaceVoice,
+  };
   mocks.workspaceVoice.mockReset();
   mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
   mocks.capture.status = 'idle';
@@ -196,6 +198,55 @@ describe('VoiceButton', () => {
       await Promise.resolve();
     });
     expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('waits for the current workspace client voice status', async () => {
+    const { root, container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    let resolveNext: (value: ReturnType<typeof voiceStatus>) => void = () =>
+      undefined;
+    const workspaceVoice = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof voiceStatus>>((resolve) => {
+          resolveNext = resolve;
+        }),
+    );
+    mocks.workspace.client = { workspaceVoice };
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(workspaceVoice).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveNext(voiceStatus(true));
+      await Promise.resolve();
+    });
+    expect(container.querySelector('button')).not.toBeNull();
+  });
+
+  it('aborts active capture when the voice gate reloads', async () => {
+    const { root, container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    mocks.capture.status = 'recording';
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+    expect(mocks.capture.abort).not.toHaveBeenCalled();
+
+    mocks.settingsVersion = 1;
+    mocks.workspaceVoice.mockReturnValue(new Promise(() => undefined));
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(mocks.capture.abort).toHaveBeenCalledOnce();
   });
 
   it('lets a disabled composer stop active dictation', async () => {

--- a/packages/web-shell/client/voice/VoiceButton.test.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.test.tsx
@@ -11,10 +11,15 @@ import type { UseVoiceCaptureReturn } from './useVoiceCapture';
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
+  settingsVersion: 0,
+  workspaceVoice: vi.fn(),
   workspace: {
     baseUrl: 'http://127.0.0.1:1234',
     token: undefined as string | undefined,
     capabilities: { features: ['voice_transcribe'] },
+    client: {
+      workspaceVoice: vi.fn(),
+    },
   },
   capture: {
     status: 'idle' as UseVoiceCaptureReturn['status'],
@@ -29,6 +34,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useWorkspace: () => mocks.workspace,
+  useWorkspaceEventSignals: () => ({
+    settingsVersion: mocks.settingsVersion,
+  }),
 }));
 
 vi.mock('./useVoiceCapture', () => ({
@@ -38,7 +46,19 @@ vi.mock('./useVoiceCapture', () => ({
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
 
-function render(disabled: boolean): HTMLButtonElement {
+function voiceStatus(enabled: boolean) {
+  return {
+    v: 1 as const,
+    workspaceCwd: '/tmp/workspace',
+    enabled,
+    mode: 'hold' as const,
+    language: 'en',
+    voiceModel: null,
+    availableVoiceModels: [],
+  };
+}
+
+function mount(disabled: boolean) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -46,6 +66,18 @@ function render(disabled: boolean): HTMLButtonElement {
     root.render(<VoiceButton disabled={disabled} onInsert={() => {}} />);
   });
   mounted.push({ root, container });
+  return { root, container };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function render(disabled: boolean): Promise<HTMLButtonElement> {
+  const { container } = mount(disabled);
+  await flush();
   const button = container.querySelector('button');
   if (!button) throw new Error('VoiceButton did not render');
   return button;
@@ -58,6 +90,11 @@ const click = (button: HTMLButtonElement) => {
 };
 
 beforeEach(() => {
+  mocks.settingsVersion = 0;
+  mocks.workspace.capabilities.features = ['voice_transcribe'];
+  mocks.workspace.client.workspaceVoice = mocks.workspaceVoice;
+  mocks.workspaceVoice.mockReset();
+  mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
   mocks.capture.status = 'idle';
   mocks.capture.interimText = '';
   mocks.capture.audioLevel = 0;
@@ -75,9 +112,95 @@ afterEach(() => {
 });
 
 describe('VoiceButton', () => {
-  it('lets a disabled composer stop active dictation', () => {
+  it('renders only when workspace voice is enabled', async () => {
+    expect(await render(false)).not.toBeNull();
+
+    mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
+    const { container } = mount(false);
+    await flush();
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('stays hidden while the workspace voice request is pending or fails', async () => {
+    let rejectVoice: (reason?: unknown) => void = () => undefined;
+    mocks.workspaceVoice.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectVoice = reject;
+      }),
+    );
+    const { container } = mount(false);
+
+    expect(container.querySelector('button')).toBeNull();
+
+    await act(async () => {
+      rejectVoice(new Error('voice status unavailable'));
+      await Promise.resolve();
+    });
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('does not request workspace voice without the daemon capability', async () => {
+    mocks.workspace.capabilities.features = [];
+    const { container } = mount(false);
+    await flush();
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(mocks.workspaceVoice).not.toHaveBeenCalled();
+  });
+
+  it('reloads workspace voice when settings change', async () => {
+    mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
+    const { root, container } = mount(false);
+    await flush();
+    expect(container.querySelector('button')).toBeNull();
+
+    mocks.settingsVersion = 1;
+    mocks.workspaceVoice.mockResolvedValue(voiceStatus(true));
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+    expect(container.querySelector('button')).toBeNull();
+    await flush();
+    expect(container.querySelector('button')).not.toBeNull();
+
+    mocks.settingsVersion = 2;
+    mocks.workspaceVoice.mockResolvedValue(voiceStatus(false));
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+    expect(container.querySelector('button')).toBeNull();
+    await flush();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('ignores a stale workspace voice response', async () => {
+    let resolveFirst: (value: ReturnType<typeof voiceStatus>) => void = () =>
+      undefined;
+    mocks.workspaceVoice.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    const { root, container } = mount(false);
+
+    mocks.settingsVersion = 1;
+    mocks.workspaceVoice.mockResolvedValueOnce(voiceStatus(false));
+    act(() => {
+      root.render(<VoiceButton disabled={false} onInsert={() => {}} />);
+    });
+    await flush();
+
+    await act(async () => {
+      resolveFirst(voiceStatus(true));
+      await Promise.resolve();
+    });
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('lets a disabled composer stop active dictation', async () => {
     mocks.capture.status = 'recording';
-    const button = render(true);
+    const button = await render(true);
 
     expect(button.disabled).toBe(false);
     click(button);
@@ -85,9 +208,9 @@ describe('VoiceButton', () => {
     expect(mocks.capture.stop).toHaveBeenCalledOnce();
   });
 
-  it('lets a disabled composer abort a connecting dictation', () => {
+  it('lets a disabled composer abort a connecting dictation', async () => {
     mocks.capture.status = 'connecting';
-    const button = render(true);
+    const button = await render(true);
 
     expect(button.disabled).toBe(false);
     click(button);
@@ -95,8 +218,8 @@ describe('VoiceButton', () => {
     expect(mocks.capture.abort).toHaveBeenCalledOnce();
   });
 
-  it('keeps disabled idle dictation from starting', () => {
-    const button = render(true);
+  it('keeps disabled idle dictation from starting', async () => {
+    const button = await render(true);
 
     expect(button.disabled).toBe(true);
 

--- a/packages/web-shell/client/voice/VoiceButton.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.tsx
@@ -6,7 +6,10 @@
 
 import type React from 'react';
 import { useEffect, useState } from 'react';
-import { useWorkspace } from '@qwen-code/webui/daemon-react-sdk';
+import {
+  useWorkspace,
+  useWorkspaceEventSignals,
+} from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../i18n';
 import { useVoiceCapture } from './useVoiceCapture';
 import styles from './VoiceButton.module.css';
@@ -59,8 +62,52 @@ export function VoiceButton({
   disabled,
 }: VoiceButtonProps): React.JSX.Element | null {
   const workspace = useWorkspace();
+  const settingsVersion = useWorkspaceEventSignals()?.settingsVersion;
   const { t } = useI18n();
   const features = workspace.capabilities?.features ?? [];
+  const hasVoiceCapability = features.includes(VOICE_FEATURE);
+  const [voiceGate, setVoiceGate] = useState<{
+    client: typeof workspace.client;
+    settingsVersion: number | undefined;
+    enabled: boolean;
+  }>(() => ({
+    client: workspace.client,
+    settingsVersion,
+    enabled: false,
+  }));
+
+  useEffect(() => {
+    let current = true;
+    setVoiceGate({
+      client: workspace.client,
+      settingsVersion,
+      enabled: false,
+    });
+    if (!hasVoiceCapability) return undefined;
+
+    void workspace.client
+      .workspaceVoice()
+      .then((voice) => {
+        if (current) {
+          setVoiceGate({
+            client: workspace.client,
+            settingsVersion,
+            enabled: voice.enabled === true,
+          });
+        }
+      })
+      .catch(() => undefined);
+
+    return () => {
+      current = false;
+    };
+  }, [hasVoiceCapability, settingsVersion, workspace.client]);
+
+  const voiceEnabled =
+    hasVoiceCapability &&
+    voiceGate.client === workspace.client &&
+    voiceGate.settingsVersion === settingsVersion &&
+    voiceGate.enabled;
   // Surfaced when a recording finalizes with no transcript (e.g. silence).
   const [noticeMessage, setNoticeMessage] = useState<string | undefined>(
     undefined,
@@ -111,8 +158,7 @@ export function VoiceButton({
     return () => clearInterval(id);
   }, [isRecording]);
 
-  // Only render when the daemon advertises a usable voice model.
-  if (!features.includes(VOICE_FEATURE)) return null;
+  if (!voiceEnabled) return null;
 
   const isConnecting = status === 'connecting';
   const isTranscribing = status === 'transcribing';

--- a/packages/web-shell/client/voice/VoiceButton.tsx
+++ b/packages/web-shell/client/voice/VoiceButton.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   useWorkspace,
   useWorkspaceEventSignals,
@@ -157,6 +157,21 @@ export function VoiceButton({
     );
     return () => clearInterval(id);
   }, [isRecording]);
+
+  const voiceWasEnabled = useRef(voiceEnabled);
+  useEffect(() => {
+    const wasEnabled = voiceWasEnabled.current;
+    voiceWasEnabled.current = voiceEnabled;
+    if (
+      wasEnabled &&
+      !voiceEnabled &&
+      (status === 'recording' ||
+        status === 'connecting' ||
+        status === 'transcribing')
+    ) {
+      abort();
+    }
+  }, [abort, status, voiceEnabled]);
 
   if (!voiceEnabled) return null;
 


### PR DESCRIPTION
## What this PR does

This change makes the WebShell voice dictation button visible only when voice is explicitly enabled for the workspace, the embedding host allows the voice toolbar action, and the daemon advertises voice transcription capability. Workspace setting updates trigger a fail-closed refresh, and late responses from an older setting version are ignored.

## Why it's needed

The button was previously gated only by daemon capability and host toolbar configuration, so a host could surface voice dictation even when `general.voice.enabled` was missing or disabled. Treating the workspace setting as the primary product gate keeps unsupported or disabled voice entry points hidden.

## Reviewer Test Plan

### How to verify

1. Allow the host voice toolbar action and advertise `voice_transcribe`, then return `enabled: false` from the workspace voice status. Confirm that the voice button is absent.
2. Keep the same host and capability configuration, return `enabled: true`, and confirm that the voice button appears.
3. Remove `voice_transcribe` and confirm that the button stays absent without requesting workspace voice status.
4. Exclude `voice` from the host toolbar configuration and confirm that the voice component is not mounted.
5. Change workspace voice from disabled to enabled and back. Confirm that the button hides during each refresh and reflects only the latest settings version.
6. While dictation is recording or connecting, disable the composer and confirm that the user can still stop or abort the active capture.

### Evidence (Before & After)

Before: advertising `voice_transcribe` was sufficient to display the voice button even when workspace voice status returned `enabled: false`.

After: `enabled: false` keeps the button absent, while `enabled: true` displays it only when the host and capability gates also pass. The focused unit suite passed 27/27 tests, and the WebShell smoke suite passed 16/16 scenarios including the disabled-to-enabled workspace voice transition.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace install with the WebShell Vitest and Playwright mock-daemon harnesses.

## Risk & Scope

- Main risk or tradeoff: The button intentionally stays hidden while workspace voice status is loading or unavailable, favoring a fail-closed experience.
- Not validated / out of scope: Voice model selection, available model discovery, `general.voice.mode`, and physical microphone capture are unchanged and out of scope.
- Breaking changes / migration notes: None. No public props, daemon endpoints, SDK contracts, or configuration schema changed.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本次修改让 WebShell 语音听写按钮只在三个条件同时满足时显示：工作区显式启用语音、宿主允许语音工具栏动作、daemon 声明语音转写能力。工作区设置更新会触发失败关闭式刷新，旧设置版本的延迟响应会被忽略。

## 为什么需要

此前按钮只受 daemon capability 和宿主工具栏配置控制，因此即使 `general.voice.enabled` 缺失或关闭，宿主仍可能展示语音听写入口。将工作区设置作为首要产品门槛，可以隐藏不受支持或已关闭的语音入口。

## Reviewer Test Plan

### 如何验证

1. 宿主允许语音工具栏动作并声明 `voice_transcribe`，然后让工作区语音状态返回 `enabled: false`，确认语音按钮不存在。
2. 保持相同宿主与 capability 配置，让状态返回 `enabled: true`，确认语音按钮出现。
3. 移除 `voice_transcribe`，确认按钮保持隐藏且不会请求工作区语音状态。
4. 从宿主工具栏配置中排除 `voice`，确认语音组件不挂载。
5. 将工作区语音从关闭改为开启，再改回关闭；确认每次刷新期间按钮先隐藏，且只反映最新设置版本。
6. 在听写处于录音或连接状态时禁用 composer，确认用户仍能停止或中断当前采集。

### 前后对比证据

修改前：只要声明 `voice_transcribe`，即使工作区语音状态返回 `enabled: false`，语音按钮仍会显示。

修改后：`enabled: false` 时按钮不存在；只有 `enabled: true` 且宿主与 capability 门槛同时通过时按钮才显示。聚焦单元测试 27/27 通过，WebShell smoke 测试 16/16 通过，其中包含工作区语音从关闭到开启的场景。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 工作区安装环境，使用 WebShell Vitest 与 Playwright mock-daemon harness 验证。

## 风险与范围

- 主要风险或取舍：工作区语音状态加载中或不可用时，按钮会按预期保持隐藏，采用失败关闭体验。
- 未验证或范围外：语音模型选择、可用模型发现、`general.voice.mode` 和真实物理麦克风采集均未修改且不在本次范围内。
- 破坏性变更或迁移说明：无。未修改公开 props、daemon endpoint、SDK contract 或配置 schema。

## 关联 Issue

无

</details>
