### PR TITLE
fix(core): require subagent result integration

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -371,6 +371,9 @@ describe('AgentTool', () => {
       expect(tool.description).toContain(
         "Treat the agent's output as evidence, not as automatically correct",
       );
+      expect(tool.description).toContain(
+        'Never treat launched work as complete merely because it is still running in the background',
+      );
       expect(tool.description).not.toContain(
         "The agent's outputs should generally be trusted",
       );

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -876,6 +876,7 @@ Usage notes:
 - Run agents concurrently only when their tasks are independent. For code changes, give concurrent agents disjoint write scopes; launch them in a single message with multiple tool uses.
 - A background agent reports its result through a completion notification in a later turn. A foreground agent returns its result inline. Agent results are not visible to the user, so relay the relevant outcome in your response.
 - While background agents run, continue meaningful non-overlapping work. Wait for an agent only when its result blocks the next required step.
+- Before finalizing a dependent artifact or responding to the user, account for every required subagent result: wait for it, review it, and integrate or explicitly reject it. Never treat launched work as complete merely because it is still running in the background.
 - Provide clear, detailed prompts so the agent can work autonomously and return exactly the information you need.
 - Treat the agent's output as evidence, not as automatically correct. Verify factual claims, review code changes, and run relevant checks before integrating or relaying the result.
 - Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent


### PR DESCRIPTION
## What this PR does

This change strengthens subagent delegation guidance with an explicit completion gate: before finalizing any dependent artifact or responding to the user, the parent agent must account for every required subagent result by waiting for it, reviewing it, and either integrating or explicitly rejecting it. Background execution alone must not be treated as completed work.

## Why it's needed

Agent Platform badcase analysis found repeated fire-and-forget behavior in which the parent launched a research subagent, continued building the deliverable with assumptions or substitute data, and finalized the task before the subagent returned. The existing guidance already covers bounded tasks, critical-path work, non-duplication, and result verification, but it does not state the finalization dependency strongly enough for models that have not internalized that workflow. This patch makes the missing join-and-integrate step explicit without changing subagent runtime behavior. The unreleased patch has not been evaluated.

## Reviewer Test Plan

### How to verify

The author did not execute verification under the experiment policy. A reviewer should inspect the rendered Agent tool description and confirm that it tells the parent agent not to finalize dependent artifacts or the user response until every required subagent result has been received, reviewed, and integrated or explicitly rejected. The reviewer should also confirm that the static description assertion covers the new fire-and-forget guardrail and that unrelated delegation guidance remains unchanged.

### Evidence (Before & After)

N/A — no local reproduction, replay, screenshots, or post-patch AP evidence was collected.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

N/A — no local runtime was invoked.

## Risk & Scope

- Main risk or tradeoff: The stronger wording may make the parent agent more conservative about finalizing work and may reduce some useful background parallelism when it classifies a subagent result as required.
- Not validated / out of scope: No local tests, build, typecheck, lint, formatting command, E2E, reproduction, replay, benchmark, or AP rerun was performed. AP cannot target this unreleased Qwen Code branch.
- Breaking changes / migration notes: N/A.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本次改动为 subagent 委派指引增加了明确的完成门槛：在定稿任何依赖 subagent 的交付物或回复用户之前，主 agent 必须处理每一个必需的 subagent 结果，包括等待结果返回、审阅结果，并将其整合进交付物或明确拒绝该结果。仅仅让任务在后台运行，不能被视为工作已经完成。

## 为什么需要此改动

Agent Platform badcase 分析发现了多次 fire-and-forget 行为：主 agent 启动研究型 subagent 后，使用假设或替代数据继续生成交付物，并在 subagent 返回之前完成任务。现有指引已经覆盖任务边界、关键路径、本地不重复和结果核验，但对于尚未内化这套工作流的模型，它没有足够明确地表达最终交付的依赖关系。本补丁在不改变 subagent 运行时行为的前提下，明确补上等待并整合结果的步骤。这个尚未发布的补丁没有经过评测。

## Reviewer 测试计划

### 如何验证

根据实验策略，作者没有执行验证。Reviewer 应检查渲染后的 Agent 工具描述，确认其中要求主 agent 在所有必需的 subagent 结果完成返回、审阅并被整合或明确拒绝之前，不得定稿依赖这些结果的交付物或最终回复。Reviewer 还应确认静态描述断言覆盖了新的 fire-and-forget 防护规则，并且其他 delegation 指引保持不变。

### 证据（改动前后）

不适用——未收集本地复现、回放、截图或修改后的 AP 证据。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      | ⚠️ 未测试 |
|    🪟 Windows     | ⚠️ 未测试 |
|      🐧 Linux     | ⚠️ 未测试 |

### 环境（可选）

不适用——未启动本地运行环境。

## 风险与范围

- 主要风险或权衡：更强的措辞可能让主 agent 在完成工作时更加保守，并且在它将 subagent 结果判断为必需时，可能减少一部分有价值的后台并行执行。
- 未验证 / 超出范围：未执行本地测试、构建、类型检查、lint、格式化命令、E2E、复现、回放、benchmark 或 AP 重跑。AP 无法使用这个尚未发布的 Qwen Code 分支。
- 破坏性变更 / 迁移说明：不适用。

## 关联 Issue

不适用。

</details>
