### PR TITLE
feat(autofix): pick up managed fork PRs in real time instead of waiting for the throttled schedule

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -264,21 +264,53 @@ jobs:
               if [[ "${EVENT_NAME}" == 'schedule' ]]; then
                 DO_ISSUE=true
               fi
-              # Real-time review triggers: only process in-repo bot PRs with
-              # reviews from trusted senders (collaborators or the review bot).
-              # This prevents arbitrary commenters from forcing expensive
+              # Real-time review triggers: process the SAME managed set the
+              # scheduled scan does, so feedback is picked up seconds after the
+              # review instead of waiting for a schedule GitHub throttles hard
+              # (the */10 cron actually lands every 40-70min on this repo).
+              # Reviews must come from trusted senders (collaborators or the
+              # review bot) so arbitrary commenters cannot force expensive
               # review-scan runs. Only pull_request_review:submitted triggers
-              # (not per-comment events) to avoid redundant runs on multi-comment
-              # reviews.
+              # (not per-comment events) to avoid redundant runs on
+              # multi-comment reviews.
               if [[ "${EVENT_NAME}" == 'pull_request_review' ]]; then
                 DO_ISSUE=false
-                if [[ "${PR_AUTHOR}" != "${AUTOFIX_BOT}" ]]; then
-                  echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"
-                elif [[ "${PR_HEAD_REPO}" != "${REPO}" ]]; then
-                  echo "🧭 review event ignored: PR is a fork (${PR_HEAD_REPO} != ${REPO})"
-                elif [[ "${PR_BASE_REF}" != "main" ]]; then
+                pr_is_managed=false
+                if [[ "${PR_BASE_REF}" != "main" ]]; then
                   echo "🧭 review event ignored: PR targets '${PR_BASE_REF}' not 'main'"
+                elif [[ "${PR_HEAD_REPO}" == "${REPO}" ]]; then
+                  if [[ "${PR_AUTHOR}" == "${AUTOFIX_BOT}" ]]; then
+                    pr_is_managed=true
+                  else
+                    echo "🧭 review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}"
+                  fi
                 else
+                  # Fork PR. The scheduled scan already admits these for
+                  # takeover, so real-time pickup applies the SAME admission
+                  # (allow-edits on, and either the bot's own fork or an
+                  # explicit TAKEOVER_LABEL) rather than making the takeover
+                  # PRs — the ones a maintainer is actively waiting on — sit
+                  # through a throttled schedule. This event runs in BASE-repo
+                  # context, and review-address independently re-verifies
+                  # allow-edits, a live write+ author and a matching live head
+                  # repo before it touches the branch, so this only decides
+                  # WHEN that same gated work happens, never whether it may.
+                  fork_meta=''
+                  if fork_meta="$(gh pr view "${PR_NUMBER_EVENT}" --repo "${REPO}" --json labels,maintainerCanModify 2> /dev/null)"; then
+                    fork_allows_edits="$(jq -r '.maintainerCanModify == true' <<< "${fork_meta}")"
+                    fork_has_takeover="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${fork_meta}")"
+                    if [[ "${fork_allows_edits}" != 'true' ]]; then
+                      echo "🧭 review event ignored: fork PR #${PR_NUMBER_EVENT} does not allow maintainer edits"
+                    elif [[ "${PR_AUTHOR}" == "${AUTOFIX_BOT}" || "${fork_has_takeover}" == 'true' ]]; then
+                      pr_is_managed=true
+                    else
+                      echo "🧭 review event ignored: fork PR #${PR_NUMBER_EVENT} is neither ${AUTOFIX_BOT}'s own fork nor ${TAKEOVER_LABEL}-labeled"
+                    fi
+                  else
+                    echo "🧭 review event ignored: could not read fork PR #${PR_NUMBER_EVENT} metadata"
+                  fi
+                fi
+                if [[ "${pr_is_managed}" == 'true' ]]; then
                   # Verify the reviewer/commenter is trusted (prompt-injection gate).
                   sender_permission=''
                   sender_is_trusted=false

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1458,15 +1458,44 @@ jobs:
           # input and silently green-no-op'd all forced dispatches.
           if [[ -n "${FORCED_PR}" ]]; then
             META="$(gh pr view "${FORCED_PR}" --repo "${REPO}" \
-              --json number,state,author,headRefName,isCrossRepository,baseRefName,labels 2> /dev/null || echo '{}')"
+              --json number,state,author,headRefName,isCrossRepository,baseRefName,labels,maintainerCanModify 2> /dev/null || echo '{}')"
+            # Same admission as the scheduled scan below. In-repo PRs fail
+            # CLOSED on a missing isCrossRepository field (`.isCrossRepository
+            # == false`, never a `// true | not` default — jq's // treats false
+            # as empty, so that form is false for EVERY input and silently
+            # green-no-op'd all forced dispatches). Fork PRs are admitted under
+            # the scan's OWN fork rules (allow-edits on; the live write+ author
+            # gate runs in the shell case just below, mirroring the scan's
+            # per-candidate permission call) so the real-time route's fork
+            # pickup is not silently discarded here.
             OK="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg take "${TAKEOVER_LABEL}" --arg skip "${SKIP_LABEL}" \
               '(((.state // "") == "OPEN")
                  and (((.author.login // "") == $ab) or ([.labels[]?.name] | index($take) != null))
                  and ([.labels[]?.name] | index($skip) | not)
-                 and (.isCrossRepository == false)
-                 and ((.baseRefName // "") == "main"))' <<< "${META}")"
+                 and ((.baseRefName // "") == "main")
+                 and (if (.isCrossRepository == true)
+                        then (.maintainerCanModify == true)
+                        else (.isCrossRepository == false)
+                      end))' <<< "${META}")"
+            # Fork only: the author must hold write+ RIGHT NOW (the same
+            # live-privilege rule the scan applies per candidate and
+            # review-address re-checks before pushing). In-repo PRs are gated
+            # by author/label alone.
+            if [[ "${OK}" == 'true' && "$(jq -r '.isCrossRepository == true' <<< "${META}")" == 'true' ]]; then
+              FORK_AUTHOR="$(jq -r '.author.login // ""' <<< "${META}")"
+              FPERM="$(gh api "repos/${REPO}/collaborators/${FORK_AUTHOR}/permission" --jq '.permission // ""' 2> /dev/null || echo '')"
+              case "${FPERM}" in
+                admin|maintain|write)
+                  echo "🌿 forced fork PR #${FORCED_PR} admitted (author ${FORK_AUTHOR}=${FPERM})"
+                  ;;
+                *)
+                  echo "🧭 forced fork PR #${FORCED_PR} rejected: author ${FORK_AUTHOR} permission='${FPERM:-none}' below write"
+                  OK='false'
+                  ;;
+              esac
+            fi
             if [[ "${OK}" != "true" ]]; then
-              echo "❌ #${FORCED_PR} is not an open in-repo main-targeting PR owned by ${AUTOFIX_BOT} or labeled ${TAKEOVER_LABEL} (or it carries ${SKIP_LABEL}); fork takeover PRs are engaged by the scheduled scan, not manual dispatch"
+              echo "❌ #${FORCED_PR} is not an open main-targeting PR owned by ${AUTOFIX_BOT} or labeled ${TAKEOVER_LABEL} (or it carries ${SKIP_LABEL}); a fork PR additionally needs maintainer edits allowed and a live write+ author"
               echo "targets=[]" >> "${GITHUB_OUTPUT}"
               echo "has_targets=false" >> "${GITHUB_OUTPUT}"
               exit 0

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -221,7 +221,7 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain("MAX_ROUNDS: '5'");
     expect(workflow).toContain("MAX_OPEN_AUTOFIX_PRS: '5'");
     expect(reviewScanJob).toContain('isCrossRepository');
-    expect(reviewScanJob).toContain('not an open in-repo main-targeting PR');
+    expect(reviewScanJob).toContain('not an open main-targeting PR');
     // Candidates fail CLOSED on the fork field, matching the forced path
     // and the NOTE that documents the jq // false trap.
     expect(reviewScanJob).toContain('select(.isCrossRepository == false)');
@@ -1595,7 +1595,10 @@ describe('qwen-autofix workflow', () => {
   it('behaviorally validates forced targets against author, takeover, and skip', () => {
     // Extract the forced-PR OK predicate VERBATIM and replay it: the bot's
     // own PRs pass; a human PR passes only with the takeover label; skip
-    // vetoes even a takeover-labeled PR; closed and fork PRs never pass.
+    // vetoes even a takeover-labeled PR; closed PRs never pass. A fork PR
+    // passes the structural predicate only with maintainer edits allowed — the
+    // live write+ author gate is a shell step below (asserted separately),
+    // mirroring the scheduled scan's per-candidate fork admission.
     const okProgram = reviewScanJob.match(
       /OK="\$\(jq -r --arg ab "\$\{AUTOFIX_BOT\}" --arg take "\$\{TAKEOVER_LABEL\}" --arg skip "\$\{SKIP_LABEL\}" \\\n\s+'([\s\S]*?)'/,
     )?.[1];
@@ -1636,6 +1639,26 @@ describe('qwen-autofix workflow', () => {
     expect(ok(meta('human', ['autofix/takeover'], { state: 'CLOSED' }))).toBe(
       'false',
     );
+    // Fork PRs: admitted structurally only when maintainer edits are allowed
+    // (the bot's own fork or a takeover-labelled fork). The live write+ author
+    // check is the shell gate asserted below; without allow-edits a fork still
+    // fails closed here.
+    expect(
+      ok(
+        meta('human', ['autofix/takeover'], {
+          isCrossRepository: true,
+          maintainerCanModify: true,
+        }),
+      ),
+    ).toBe('true');
+    expect(
+      ok(
+        meta('qwen-code-dev-bot', [], {
+          isCrossRepository: true,
+          maintainerCanModify: true,
+        }),
+      ),
+    ).toBe('true');
     expect(
       ok(meta('human', ['autofix/takeover'], { isCrossRepository: true })),
     ).toBe('false');
@@ -1648,6 +1671,16 @@ describe('qwen-autofix workflow', () => {
     expect(ok(missing)).toBe('false');
     expect(reviewScanJob).toContain('.isCrossRepository == false');
     expect(reviewScanJob).not.toContain('(.isCrossRepository // true) | not');
+    // The forced path queries maintainerCanModify and re-checks a fork author's
+    // live permission exactly like the scheduled scan's per-candidate gate, so
+    // a fork the route admitted in real time is not silently discarded here.
+    expect(reviewScanJob).toContain(
+      '--json number,state,author,headRefName,isCrossRepository,baseRefName,labels,maintainerCanModify',
+    );
+    expect(reviewScanJob).toContain('forced fork PR #${FORCED_PR} admitted');
+    expect(reviewScanJob).toContain(
+      'gh api "repos/${REPO}/collaborators/${FORK_AUTHOR}/permission"',
+    );
   });
 
   it('exposes exactly one comment command: label-toggle takeover sugar', () => {
@@ -1888,6 +1921,7 @@ describe('qwen-autofix workflow', () => {
       allowEdits = true,
       labels = [],
       perm = 'write',
+      metaOk = true,
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'route-'));
       const bin = join(dir, 'bin');
@@ -1900,7 +1934,9 @@ describe('qwen-autofix workflow', () => {
         join(bin, 'gh'),
         [
           '#!/usr/bin/env bash',
-          `if [[ "$*" == *"--json labels,maintainerCanModify"* ]]; then printf '%s' ${JSON.stringify(meta)}; exit 0; fi`,
+          `if [[ "$*" == *"--json labels,maintainerCanModify"* ]]; then ${
+            metaOk ? `printf '%s' ${JSON.stringify(meta)}; exit 0` : 'exit 1'
+          }; fi`,
           `if [[ "$*" == *permission* ]]; then printf '%s' ${JSON.stringify(perm)}; exit 0; fi`,
           'exit 1',
         ].join('\n'),
@@ -1978,6 +2014,11 @@ describe('qwen-autofix workflow', () => {
         labels: ['autofix/takeover'],
         perm: 'read',
       }),
+    ).toContain('DO_REVIEW=false');
+    // A metadata read failure fails CLOSED: the event is ignored rather than
+    // admitting a fork whose allow-edits/labels could not be verified.
+    expect(
+      run({ headRepo: FORK, author: 'qwen-code-dev-bot', metaOk: false }),
     ).toContain('DO_REVIEW=false');
   });
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -731,20 +731,27 @@ describe('qwen-autofix workflow', () => {
     );
   });
 
-  it('routes submitted review events only for trusted in-repo bot PRs', () => {
+  it('routes submitted review events only for trusted managed PRs', () => {
     expect(routeStep).toContain('PR_AUTHOR');
     expect(routeStep).toContain('PR_NUMBER_EVENT');
     expect(routeStep).toContain(
       'if [[ "${EVENT_NAME}" == \'pull_request_review\' ]]; then',
     );
-    expect(routeStep).toContain('"${PR_AUTHOR}" != "${AUTOFIX_BOT}"');
-    expect(routeStep).toContain('"${PR_HEAD_REPO}" != "${REPO}"');
+    // In-repo PRs are managed only when the bot authored them; forks only
+    // under the scan's takeover rules (allow-edits + bot fork or the label).
+    expect(routeStep).toContain('"${PR_AUTHOR}" == "${AUTOFIX_BOT}"');
+    expect(routeStep).toContain('"${PR_HEAD_REPO}" == "${REPO}"');
     expect(routeStep).toContain('"${PR_BASE_REF}" != "main"');
+    expect(routeStep).toContain('.maintainerCanModify == true');
+    expect(routeStep).toContain('index($t) != null');
     expect(routeStep).toContain(
       'ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")',
     );
     expect(routeStep).toContain(
       "review event ignored: PR author '${PR_AUTHOR}' is not ${AUTOFIX_BOT}",
+    );
+    expect(routeStep).toContain(
+      'review event ignored: fork PR #${PR_NUMBER_EVENT} does not allow maintainer edits',
     );
   });
 
@@ -1829,16 +1836,19 @@ describe('qwen-autofix workflow', () => {
   });
 
   it('gates real-time review triggers on bot author, trusted sender, and in-repo PR', () => {
-    // Route step must check PR author against AUTOFIX_BOT for review events.
-    expect(routeStep).toContain('"${PR_AUTHOR}" != "${AUTOFIX_BOT}"');
+    // Route step must check PR author against AUTOFIX_BOT for review events
+    // (an in-repo PR is managed only when the bot authored it).
+    expect(routeStep).toContain('"${PR_AUTHOR}" == "${AUTOFIX_BOT}"');
     // Must verify sender is trusted (collaborator or review bot).
     expect(routeStep).toContain('"${SENDER_LOGIN}" == "${REVIEW_BOT}"');
     expect(routeStep).toContain(
       'gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission"',
     );
-    // Must reject fork PRs and non-main targets.
-    expect(routeStep).toContain('"${PR_HEAD_REPO}" != "${REPO}"');
+    // Non-main targets are rejected; forks are admitted only under the scan's
+    // own takeover rules (allow-edits + bot fork or takeover label).
     expect(routeStep).toContain('"${PR_BASE_REF}" != "main"');
+    expect(routeStep).toContain('"${PR_HEAD_REPO}" == "${REPO}"');
+    expect(routeStep).toContain('--json labels,maintainerCanModify');
     // Must set ROUTE_PR from the event payload.
     expect(routeStep).toContain(
       'ROUTE_PR="$(sanitize_number "${PR_NUMBER_EVENT}")"',
@@ -1856,6 +1866,119 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain(
       "ref: '${{ github.event.repository.default_branch }}'",
     );
+  });
+
+  it('admits managed fork PRs to the real-time review trigger, not just in-repo bot PRs', () => {
+    // The */10 schedule is throttled to 40-70min on this repo, so a takeover PR
+    // that only the scan could pick up waited up to an hour for feedback the
+    // event already carried. Real-time pickup now applies the scan's OWN fork
+    // admission (allow-edits + the bot's own fork or an explicit takeover
+    // label); review-address still re-verifies allow-edits, a live write+
+    // author and a matching head repo before touching the branch.
+    const block = routeStep.match(
+      /if \[\[ "\$\{EVENT_NAME\}" == 'pull_request_review' \]\]; then[\s\S]*?\n {14}fi/,
+    )?.[0];
+    expect(block).toBeTruthy();
+
+    const run = ({
+      headRepo,
+      author,
+      base = 'main',
+      sender = 'alice',
+      allowEdits = true,
+      labels = [],
+      perm = 'write',
+    }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'route-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      const meta = JSON.stringify({
+        maintainerCanModify: allowEdits,
+        labels: labels.map((name) => ({ name })),
+      });
+      writeFileSync(
+        join(bin, 'gh'),
+        [
+          '#!/usr/bin/env bash',
+          `if [[ "$*" == *"--json labels,maintainerCanModify"* ]]; then printf '%s' ${JSON.stringify(meta)}; exit 0; fi`,
+          `if [[ "$*" == *permission* ]]; then printf '%s' ${JSON.stringify(perm)}; exit 0; fi`,
+          'exit 1',
+        ].join('\n'),
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const out = execFileSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -uo pipefail',
+            'sanitize_number() { printf "%s" "${1//[^0-9]/}"; }',
+            'DO_ISSUE=true; DO_REVIEW=false; ROUTE_PR=""',
+            block,
+            'printf "DO_REVIEW=%s ROUTE_PR=%s" "${DO_REVIEW}" "${ROUTE_PR}"',
+          ].join('\n'),
+        ],
+        {
+          env: {
+            ...process.env,
+            PATH: `${bin}:${process.env.PATH}`,
+            EVENT_NAME: 'pull_request_review',
+            REPO: 'QwenLM/qwen-code',
+            AUTOFIX_BOT: 'qwen-code-dev-bot',
+            REVIEW_BOT: 'qwen-code-ci-bot',
+            TAKEOVER_LABEL: 'autofix/takeover',
+            PR_NUMBER_EVENT: '7259',
+            PR_HEAD_REPO: headRepo,
+            PR_AUTHOR: author,
+            PR_BASE_REF: base,
+            SENDER_LOGIN: sender,
+          },
+          encoding: 'utf8',
+        },
+      );
+      rmSync(dir, { recursive: true, force: true });
+      return out;
+    };
+
+    const IN_REPO = 'QwenLM/qwen-code';
+    const FORK = 'wenshao/qwen-code';
+    // Unchanged: an in-repo bot PR is admitted, a human in-repo PR is not.
+    expect(run({ headRepo: IN_REPO, author: 'qwen-code-dev-bot' })).toContain(
+      'DO_REVIEW=true',
+    );
+    expect(run({ headRepo: IN_REPO, author: 'someone' })).toContain(
+      'DO_REVIEW=false',
+    );
+    // NEW: the bot's own fork, and a takeover-labelled human fork, are admitted
+    // in real time and route to that exact PR.
+    expect(run({ headRepo: FORK, author: 'qwen-code-dev-bot' })).toContain(
+      'DO_REVIEW=true',
+    );
+    expect(
+      run({ headRepo: FORK, author: 'wenshao', labels: ['autofix/takeover'] }),
+    ).toContain('DO_REVIEW=true');
+    expect(run({ headRepo: FORK, author: 'qwen-code-dev-bot' })).toContain(
+      'ROUTE_PR=7259',
+    );
+    // Still rejected: no allow-edits, an unlabelled human fork, a non-main
+    // base, and an untrusted sender.
+    expect(
+      run({ headRepo: FORK, author: 'qwen-code-dev-bot', allowEdits: false }),
+    ).toContain('DO_REVIEW=false');
+    expect(run({ headRepo: FORK, author: 'wenshao' })).toContain(
+      'DO_REVIEW=false',
+    );
+    expect(
+      run({ headRepo: IN_REPO, author: 'qwen-code-dev-bot', base: 'release' }),
+    ).toContain('DO_REVIEW=false');
+    expect(
+      run({
+        headRepo: FORK,
+        author: 'wenshao',
+        labels: ['autofix/takeover'],
+        perm: 'read',
+      }),
+    ).toContain('DO_REVIEW=false');
   });
 
   it('treats Suggestion-level review findings as actionable feedback', () => {


### PR DESCRIPTION
## What this PR does

Lets the autofix loop pick up feedback on **managed fork PRs** the moment a review is submitted, instead of leaving them to the scheduled scan.

The `pull_request_review` trigger already exists and already routes feedback straight to the PR it arrived on — but it admitted **only in-repo bot PRs**. Every fork under takeover (`autofix/takeover`, or the bot's own fork) fell through to the scheduled scan. Real-time pickup now applies the **same admission the scan itself uses for a fork**: allow-edits on, and either the bot's own fork or an explicit `autofix/takeover` label.

## Why it's needed

The scheduled scan is much slower than its cron suggests. `qwen-autofix.yml` declares `*/10 * * * *`, but GitHub throttles scheduled events on this repo hard enough that the observed spacing between scheduled runs is **40–70 minutes** (measured across the last 30 scheduled runs; it was 20–25 min the previous evening and has been degrading). In the same window, `pull_request_review` fired **17 times** while `schedule` fired **once** — the event path is reliable, the cron is not.

The practical result was backwards: takeover PRs — the ones a maintainer is actively iterating on and explicitly opted into — were the ones waiting longest for their feedback to be picked up, because they were the only managed PRs with no real-time path.

## Why it's safe

This changes **when** work happens, never **whether** it may:

- `pull_request_review` runs in **base-repo context**; a fork PR adds no capability the scheduled scan does not already have when it admits the same PR.
- The trusted-sender gate is unchanged — the review must come from the review bot or a write/maintain/admin collaborator, so arbitrary commenters still cannot force a scan.
- `review-address` independently re-verifies allow-edits, a **live** write+ author and a matching **live** head repo before it touches the branch. The route-side check is a fast filter, not the security boundary.
- Still ignored: non-`main` targets, untrusted senders, human in-repo PRs, and forks that are neither the bot's own nor takeover-labelled. Only `pull_request_review:submitted` triggers (not per-comment events).

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 68/68. The new behavioural test drives the **real extracted route block** under bash with a stubbed `gh`, across eight cases:

   | case | expected |
   | --- | --- |
   | in-repo, bot author | admitted |
   | in-repo, human author | ignored |
   | **fork, bot's own, allow-edits** | **admitted (new)** |
   | **fork, human + `autofix/takeover`, allow-edits** | **admitted (new)** |
   | fork admitted → `ROUTE_PR` | routes to that PR number |
   | fork, allow-edits off | ignored |
   | fork, human, no takeover label | ignored |
   | non-`main` base / untrusted sender | ignored |

   Mutation-verified: restoring the blanket fork rejection turns the test red.
2. Static (run locally with the exact CI toolchain): `js-yaml` parses the workflow; the route step passes `bash -n`; actionlint 1.7.12 clean; prettier clean.
3. Post-merge smoke: submit a review on a takeover fork PR (e.g. #7259) and confirm a `pull_request_review` autofix run starts within seconds rather than at the next scheduled scan.

### Evidence (Before & After)

```
BEFORE  review submitted on a takeover fork PR
        → route: "review event ignored: PR is a fork"
        → waits for the scheduled scan (observed 40-70 min spacing)

AFTER   review submitted on a takeover fork PR (allow-edits + label/bot fork)
        → route: DO_REVIEW=true, ROUTE_PR=<that PR>  (seconds)
        → review-address re-verifies allow-edits + live write+ author as before
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: a trusted review on a managed fork now starts a run immediately, so a burst of reviews can start more runs than before. The route concurrency group and the scan's in-flight/busy skip already collapse these, and each run still exits early when the address side finds nothing new.
- Not validated / out of scope: the schedule throttling itself (a GitHub-side behaviour) — this PR routes around it for the review path rather than fixing the cron. The other pickup gaps (re-armed PRs after a marker reset, inline-comment-only feedback, failed-check feedback) still rely on the scan.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7213 / #7243 (fork takeover) and #7330 (verify gate). Motivated by measured scheduled-scan latency while triaging #7208 / #7259 / #7262.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix 在 review 提交的**瞬间**拾起**被托管的 fork PR** 的反馈,而不是把它们丢给定时扫描。

`pull_request_review` 触发器本就存在、也本就能把反馈直接路由到对应 PR —— 但它只准入 **in-repo 的 bot PR**。所有处于托管的 fork(`autofix/takeover` 标签,或 bot 自己的 fork)都只能等定时扫描。现在实时拾起采用**与扫描自身完全相同的 fork 准入规则**:勾选 allow-edits,且要么是 bot 自己的 fork、要么带显式 `autofix/takeover` 标签。

## 为什么需要

定时扫描远比它的 cron 慢。`qwen-autofix.yml` 写的是 `*/10 * * * *`,但 GitHub 对本仓库的定时事件限流严重,实测最近 30 次定时运行的间隔是 **40–70 分钟**(前一晚还是 20–25 分钟,在持续劣化)。同一时间窗内 `pull_request_review` 触发了 **17 次**,而 `schedule` 只有 **1 次** —— 事件路径可靠,cron 不可靠。

结果是反的:**托管 fork PR ——** 维护者正在积极迭代、且显式选择加入的那些 —— 反而因为没有实时路径,等得最久。

## 为什么安全

本 PR 改变的是**何时**执行,而非**是否允许**执行:

- `pull_request_review` 在**基座仓库上下文**运行;当扫描准入同一个 PR 时,fork 并不带来任何扫描不具备的能力。
- 可信 sender 门不变 —— review 必须来自 review bot 或 write/maintain/admin 协作者,任意评论者仍无法强制触发扫描。
- `review-address` 在动分支前会**独立重新校验** allow-edits、**实时** write+ 作者、以及**实时** head 仓库匹配。route 侧只是快速过滤,不是安全边界。
- 仍然忽略:非 `main` 目标、不可信 sender、人类 in-repo PR、以及既非 bot 自有也无 takeover 标签的 fork;且只有 `pull_request_review:submitted` 触发(非逐条评论事件)。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 68/68。新增行为测试用 stub 的 `gh` 在 bash 下驱动**真实提取的 route 块**,覆盖 8 种场景:in-repo bot 准入、in-repo 人类拒绝、**bot fork 与 takeover 标签 fork 准入(新)**、准入后路由到该 PR 号、无 allow-edits / 无标签人类 fork / 非 main / 不可信 sender 全部拒绝。变异验证:改回一刀切拒绝 fork 即变红。
2. 静态(均用 CI 一致工具本地跑):YAML 可解析;route 步骤过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
3. 合并后冒烟:在一个 takeover fork PR(如 #7259)上提交 review,确认 `pull_request_review` 运行在数秒内启动,而非等到下一次定时扫描。

## 风险与范围

- 主要权衡:对被托管 fork 的可信 review 现在会立即启动运行,因此短时间内大量 review 会启动更多运行。route 的 concurrency 组与扫描的 in-flight/busy 跳过已会合并这些,且每次运行在 address 侧发现"无新反馈"时仍会尽早退出。
- 不在范围内:定时限流本身(GitHub 侧行为)—— 本 PR 是为 review 路径绕开它,而非修复 cron。其余拾起缺口(marker 重置后的重新武装、仅 inline 评论的反馈、失败检查反馈)仍依赖扫描。
- 破坏性变更:无。

## 关联 Issue

#7213 / #7243(fork 托管)与 #7330(验证门)的后续。由排查 #7208 / #7259 / #7262 时实测到的定时扫描延迟驱动。

</details>
