### PR TITLE
fix(autofix): retry a verification-gate crash instead of burying the agent's fix

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2885,16 +2885,18 @@ jobs:
             if [[ -n "${NEWEST:-}" ]]; then
               MARK_ROUND="$(( ROUND + 1 ))"
               if [[ -z "${DETAIL_FILE}" || "${GATE_CRASHED}" == 'true' ]]; then
-                # Prepare ran (NEWEST is set) but the agent produced NO output
-                # at all — it crashed before writing any verdict (e.g. a staged
-                # runner that fails to boot). It evaluated NOTHING, so the
-                # watermark must NOT advance past this feedback: an advance makes
-                # the next scan see "nothing new" and never retry, stranding the
-                # PR on a transient crash (a deploy, an infra blip, a base-image
-                # bug fixed minutes later). Stamp the sentinel ts (excluded from
-                # EVAL_WM) so the feedback stays live and the next scan retries;
-                # the incremented round still bounds retries to MAX_ROUNDS before
-                # a terminal handoff, so a PERSISTENT crash cannot loop forever.
+                # Prepare ran (NEWEST is set) but no verdict was reached — either
+                # the agent produced NO output at all (crashed before writing any
+                # verdict, e.g. a staged runner that fails to boot), or the gate
+                # crashed after the agent wrote its summary. It evaluated NOTHING,
+                # so the watermark must NOT advance past this feedback: an advance
+                # makes the next scan see "nothing new" and never retry,
+                # stranding the PR on a transient crash (a deploy, an infra blip,
+                # a base-image bug fixed minutes later). Stamp the sentinel ts
+                # (excluded from EVAL_WM) so the feedback stays live and the next
+                # scan retries; the incremented round still bounds retries to
+                # MAX_ROUNDS before a terminal handoff, so a PERSISTENT crash
+                # cannot loop forever.
                 MARK_TS='9999-12-31T23:59:59Z'
                 # Only promise a retry when one will actually happen: at
                 # MARK_ROUND == MAX_ROUNDS the next scan's round-cap gate skips
@@ -2903,8 +2905,9 @@ jobs:
                 # a retry that never comes. No Run log here: the report block
                 # below appends it to every handoff (avoid a duplicate URL).
                 # Name the real cause: a gate crash points the maintainer at
-                # the gate logs (the agent's work may be fine and is preserved
-                # for the retry), while a no-output crash points at the run.
+                # the gate logs (the agent's commit is discarded with the runner,
+                # but the feedback watermark is preserved so the retry re-attempts
+                # the same feedback), while a no-output crash points at the run.
                 if [[ -z "${DETAIL_FILE}" ]]; then
                   CAUSE='crashed before it could evaluate the feedback'
                   LAST_FIX='a human should take over this PR'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2498,10 +2498,22 @@ jobs:
             exit 1
           fi
 
+          # Every check below can legitimately REJECT the agent's attempt, so
+          # each declares that verdict explicitly. That is what lets the handoff
+          # tell a rejection apart from the gate's OWN death: an empty outcome
+          # on a failed job means the gate never reached a verdict (its own bug,
+          # an infra blip), and the agent's work must then be retried rather
+          # than buried by a watermark advance.
+          reject_fix() {
+            echo "❌ ${1}"
+            echo "outcome=failed" >> "${GITHUB_OUTPUT}"
+            exit 1
+          }
+
           echo '🔬 Re-running deterministic checks (independent of the agent)...'
-          npm run build
-          npm run typecheck
-          npm run lint
+          npm run build || reject_fix 'build failed on the agent-committed fix'
+          npm run typecheck || reject_fix 'typecheck failed on the agent-committed fix'
+          npm run lint || reject_fix 'lint failed on the agent-committed fix'
 
           # Test changed/related files for the packages this PR touches.
           # --changed follows the import graph so transitive breakage is caught.
@@ -2532,7 +2544,8 @@ jobs:
                 continue
               fi
               echo "🧪 Testing ${p} (changed files only)..."
-              npm run test --workspace "${p}" --if-present -- --changed origin/main --passWithNoTests
+              npm run test --workspace "${p}" --if-present -- --changed origin/main --passWithNoTests \
+                || reject_fix "tests failed in ${p}"
             done
           fi
           echo "outcome=fixed" >> "${GITHUB_OUTPUT}"
@@ -2769,10 +2782,22 @@ jobs:
             # ISO-8601 date is used (not a bare word) so it is both non-empty AND
             # sorts above any real timestamp in EVAL_WM's max, belt-and-suspenders
             # with the terminal round.
+            # The gate declares its verdict explicitly (failed / noop / fixed).
+            # An EMPTY outcome on a non-success job means it died BEFORE reaching
+            # one - its own crash (a gate bug, an infra blip, a resolver error),
+            # not a judgement on the agent's work. That must retry like any other
+            # pre-verdict crash instead of advancing the watermark: the
+            # nested-package ENOENT that stranded #7329/#7336 looked exactly like
+            # a rejection, so a fix the agent had already written was discarded
+            # and the PR sat idle until a human deleted the marker by hand.
+            GATE_CRASHED=false
+            if [[ -z "${OUTCOME}" && "${JOB_STATUS:-}" != 'success' ]]; then
+              GATE_CRASHED=true
+            fi
             MARK_TS="${NEWEST:-${WATERMARK:-9999-12-31T23:59:59Z}}"
             if [[ -n "${NEWEST:-}" ]]; then
               MARK_ROUND="$(( ROUND + 1 ))"
-              if [[ -z "${DETAIL_FILE}" ]]; then
+              if [[ -z "${DETAIL_FILE}" || "${GATE_CRASHED}" == 'true' ]]; then
                 # Prepare ran (NEWEST is set) but the agent produced NO output
                 # at all — it crashed before writing any verdict (e.g. a staged
                 # runner that fails to boot). It evaluated NOTHING, so the
@@ -2790,10 +2815,20 @@ jobs:
                 # final attempt must say so itself, or the maintainer waits for
                 # a retry that never comes. No Run log here: the report block
                 # below appends it to every handoff (avoid a duplicate URL).
-                if [[ "${MARK_ROUND}" -lt "${MAX_ROUNDS}" ]]; then
-                  HEADLINE="🤖 AutoFix crashed before it could evaluate the feedback (attempt ${MARK_ROUND}/${MAX_ROUNDS}) — it will retry on the next scan."
+                # Name the real cause: a gate crash points the maintainer at
+                # the gate logs (the agent's work may be fine and is preserved
+                # for the retry), while a no-output crash points at the run.
+                if [[ -z "${DETAIL_FILE}" ]]; then
+                  CAUSE='crashed before it could evaluate the feedback'
+                  LAST_FIX='a human should take over this PR'
                 else
-                  HEADLINE="🤖 AutoFix crashed before it could evaluate the feedback (attempt ${MARK_ROUND}/${MAX_ROUNDS}) — this was the last automatic attempt; a human should take over this PR."
+                  CAUSE='hit a verification-gate error before reaching a verdict'
+                  LAST_FIX='a maintainer should check the gate logs, then re-arm'
+                fi
+                if [[ "${MARK_ROUND}" -lt "${MAX_ROUNDS}" ]]; then
+                  HEADLINE="🤖 AutoFix ${CAUSE} (attempt ${MARK_ROUND}/${MAX_ROUNDS}) — it will retry on the next scan."
+                else
+                  HEADLINE="🤖 AutoFix ${CAUSE} (attempt ${MARK_ROUND}/${MAX_ROUNDS}) — this was the last automatic attempt; ${LAST_FIX}."
                 fi
               else
                 HEADLINE="🤖 Could not address the latest feedback automatically (round ${MARK_ROUND}/${MAX_ROUNDS}). A human should take over this PR."

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3114,6 +3114,106 @@ describe('qwen-autofix workflow', () => {
     ).toBe(0);
   });
 
+  it('retries a verification-gate crash instead of burying the fix', () => {
+    // A gate that DECLARES a verdict (outcome=failed) evaluated the agent's
+    // attempt and rejected it - the watermark advances, bounded by MAX_ROUNDS.
+    // A gate that dies WITHOUT a verdict (empty outcome on a failed job) never
+    // judged the work at all; advancing there strands a fix the agent had
+    // already written, which is exactly how the nested-package ENOENT stranded
+    // #7329/#7336 until a human deleted the marker.
+    const decision = reviewAddressReportStep.match(
+      /(GATE_CRASHED=false\n[\s\S]*?\n {12}fi)\n {12}\{/,
+    )?.[1];
+    expect(decision).toBeTruthy();
+    const SENTINEL = '9999-12-31T23:59:59Z';
+    const NEWEST = '2026-07-20T10:00:00Z';
+    const run = (env) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `${decision}\nprintf '%s|%s|%s' "$MARK_TS" "$MARK_ROUND" "$HEADLINE"`,
+        ],
+        {
+          env: {
+            ...process.env,
+            NEWEST,
+            WATERMARK: '2026-07-20T09:00:00Z',
+            ROUND: '1',
+            MAX_ROUNDS: '5',
+            DETAIL_FILE: '/w/address-summary.md',
+            OUTCOME: '',
+            JOB_STATUS: 'failure',
+            ...env,
+          },
+          encoding: 'utf8',
+        },
+      );
+
+    // Declared rejection: the agent was judged -> advance the watermark.
+    const rejected = run({ OUTCOME: 'failed' });
+    expect(rejected.split('|')[0]).toBe(NEWEST);
+    expect(rejected).toContain('Could not address the latest feedback');
+
+    // Gate crash (no verdict): keep the feedback live and retry.
+    const crashed = run({ OUTCOME: '' });
+    expect(crashed.split('|')[0]).toBe(SENTINEL);
+    expect(crashed).toContain(
+      'verification-gate error before reaching a verdict',
+    );
+    expect(crashed).toContain('it will retry on the next scan');
+    expect(crashed.split('|')[1]).toBe('2');
+
+    // A no-output crash keeps its own (pre-existing) wording, still a retry.
+    const noOutput = run({ OUTCOME: '', DETAIL_FILE: '' });
+    expect(noOutput.split('|')[0]).toBe(SENTINEL);
+    expect(noOutput).toContain('crashed before it could evaluate the feedback');
+
+    // At the cap the gate crash names the operator fix rather than promising a
+    // retry the scan's round gate would refuse.
+    const capped = run({ OUTCOME: '', ROUND: '4' });
+    expect(capped).toContain('this was the last automatic attempt');
+    expect(capped).toContain('check the gate logs, then re-arm');
+
+    // A successful job never counts as a crash (dry-run reporting path).
+    expect(run({ OUTCOME: '', JOB_STATUS: 'success' }).split('|')[0]).toBe(
+      NEWEST,
+    );
+  });
+
+  it('makes every known gate rejection declare its verdict', () => {
+    // The retry/advance split above is only sound while each real rejection
+    // writes outcome=failed; an unwired check would read as a gate crash and be
+    // retried instead of reported. Drive the extracted helper for real.
+    const gate = verificationGateSteps[1];
+    for (const check of [
+      "npm run build || reject_fix 'build failed on the agent-committed fix'",
+      "npm run typecheck || reject_fix 'typecheck failed on the agent-committed fix'",
+      "npm run lint || reject_fix 'lint failed on the agent-committed fix'",
+      'reject_fix "tests failed in ${p}"',
+    ]) {
+      expect(gate).toContain(check);
+    }
+    const helper = gate.match(/reject_fix\(\) \{\n[\s\S]*?\n {10}\}/)?.[0];
+    expect(helper).toBeTruthy();
+    const dir = mkdtempSync(join(tmpdir(), 'reject-'));
+    const out = join(dir, 'gh_output');
+    writeFileSync(out, '');
+    let status = 0;
+    try {
+      execFileSync(
+        'bash',
+        ['-c', `set -eo pipefail\n${helper}\nfalse || reject_fix 'boom'`],
+        { env: { ...process.env, GITHUB_OUTPUT: out }, encoding: 'utf8' },
+      );
+    } catch (e) {
+      status = e.status;
+    }
+    expect(status).not.toBe(0);
+    expect(readFileSync(out, 'utf8')).toContain('outcome=failed');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it('replays the handoff decision and terminal-round transitions under bash', () => {
     // The agent step is bounded below the 120-minute job timeout so a runaway
     // agent fails the STEP, not the job, leaving the always() report step time to


### PR DESCRIPTION
## What this PR does

Makes the autofix handoff distinguish a verification-gate **rejection** from the gate's own **crash**, and retry the crash instead of burying the agent's work.

A gate failure had two very different meanings collapsed into one signal:

- The gate **declares a verdict** (`outcome=failed`) — it evaluated the agent's attempt and rejected it. Advancing the feedback watermark is right: the same feedback would reproduce the same rejection, and `MAX_ROUNDS` bounds the loop.
- The gate **dies without a verdict** — it never judged the work at all. Advancing there buries a fix the agent had already written: the next scan sees "nothing new" and the PR sits until a human deletes the marker by hand.

## Why it's needed

This is exactly how the nested-package `ENOENT` stranded **#7329** and **#7336**. Both agents had implemented the review feedback — the handoff comment even quoted the implemented changes — but the gate crashed on its own bug while resolving `packages/channels/*`, the commit was discarded with the runner, and both PRs read as *"Could not address the latest feedback automatically. A human should take over this PR."* They stayed stuck at round 1 until their eval markers were deleted manually.

The gate bug itself is fixed (#7330), but the failure mode is general: any gate-side crash — a future gate bug, a resolver error, an infra blip — silently converts a good fix into a stranded PR.

## How

Two halves, both in the review-address path:

- **The gate declares every rejection it can legitimately reach.** `build`, `typecheck`, `lint` and the per-package tests now each call a `reject_fix` helper that writes `outcome=failed` before exiting. The resolver call is deliberately left undeclared — a resolver error *is* a gate bug, not a judgement on the agent's fix.
- **The handoff treats an empty outcome on a non-success job as the gate's own crash** and routes it to the existing sentinel/retry path, so the feedback stays live and the next scan retries. The round still increments, so a persistently crashing gate is bounded exactly as before, and the headline names the real cause (*"hit a verification-gate error before reaching a verdict"*) and, on the final attempt, points at the gate logs rather than at the agent.

Unchanged: a declared rejection still advances and reads as before; a no-output crash keeps its own wording and its retry; a crash before the feedback was read stays terminal.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 69/69. The **real extracted decision block** is replayed under bash:

   | case | `MARK_TS` | headline |
   | --- | --- | --- |
   | declared rejection (`outcome=failed`) | `NEWEST` (advances) | "Could not address the latest feedback" |
   | **gate crash** (empty outcome, job failed) | **sentinel** (retry), round+1 | "hit a verification-gate error before reaching a verdict … will retry" |
   | no output at all | sentinel (retry) | "crashed before it could evaluate the feedback" (unchanged) |
   | gate crash at the round cap | sentinel | "last automatic attempt … check the gate logs, then re-arm" |
   | successful job | `NEWEST` | never treated as a crash |

   Plus the `reject_fix` helper is driven for real: a failing check writes `outcome=failed` and exits non-zero.
2. Mutation-verified: dropping the crash arm from the retry condition, or unwiring one known rejection (`npm run build`), each turns the corresponding test red.
3. Static (run locally with the exact CI toolchain): `js-yaml` parses; all four affected steps pass `bash -n`; actionlint 1.7.12 clean; prettier clean.

### Evidence (Before & After)

```
BEFORE  agent commits a fix -> gate crashes on its OWN bug (ENOENT)
        -> outcome empty -> handoff advances the watermark
        -> "Could not address the latest feedback automatically"
        -> next scan: "nothing new" -> PR stranded until a human deletes the marker
        (observed on #7329 and #7336)

AFTER   agent commits a fix -> gate crashes on its OWN bug
        -> outcome empty + job failed -> GATE_CRASHED
        -> sentinel ts (feedback stays live), round+1
        -> "AutoFix hit a verification-gate error before reaching a verdict - it will retry"
        -> next scan retries; bounded by MAX_ROUNDS as before

        agent commits a fix -> tests genuinely fail
        -> reject_fix writes outcome=failed -> watermark advances (unchanged)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: if a *future* rejection path is added without declaring `outcome=failed`, it degrades to a retry instead of a report. That is the safe direction (bounded by `MAX_ROUNDS`, and the handoff still posts every attempt), and a test now pins each existing rejection's declaration so an unwired one is caught.
- Not validated / out of scope: only the **review-address** gate is wired — the issue-fix gate opens a fresh PR and never emits `outcome=`, so it has no watermark contract to protect.
- Overlaps #7247, which adds a model-API-error arm to the same `if` chain; whichever lands second resolves a few lines in that condition.
- Breaking changes / migration notes: none.

## Linked Issues

Motivated by #7329 / #7336, whose strandings prompted #7330. Same "make the managed-PR loop fail honestly" line as #7229, #7247, #7330.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix 的 handoff 区分验证门的**拒绝**与门**自身的崩溃**,并对崩溃执行重试,而不是把 agent 的成果埋掉。

门失败原本被压成了同一个信号,而它有两种截然不同的含义:

- 门**给出了裁决**(`outcome=failed`)—— 它评判了 agent 的尝试并拒绝。推进反馈水位线是对的:同一批反馈会复现同样的拒绝,且 `MAX_ROUNDS` 有界。
- 门**没给裁决就死了** —— 它根本没评判过这份工作。此时推进就等于埋掉 agent 已经写好的修复:下次扫描看到"无新反馈",PR 就一直卡到有人手工删 marker。

## 为什么需要

**#7329** 和 **#7336** 正是这样被卡住的。两个 agent 都已实现了评审反馈(handoff 评论里甚至引用了已实现的改动),但门在解析 `packages/channels/*` 时因**自身 bug** 崩溃,提交随 runner 丢弃,两个 PR 都显示为"Could not address the latest feedback automatically"。它们停在 round 1,直到 eval marker 被手工删除。

门的那个 bug 已由 #7330 修复,但这个失败模式是通用的:任何门侧崩溃 —— 未来的门 bug、解析器错误、基础设施抖动 —— 都会静默地把一个好修复变成搁置的 PR。

## 怎么做

两半,都在 review-address 路径:

- **门显式声明它能合法给出的每一个拒绝**:`build`、`typecheck`、`lint` 和逐包测试现在各自调用 `reject_fix`,在退出前写 `outcome=failed`。解析器调用**刻意不声明** —— 解析器出错本身就是门的 bug,不是对 agent 修复的裁决。
- **handoff 把"job 非成功 + outcome 为空"视为门自身崩溃**,路由到既有的哨兵/重试路径,反馈保持存活、下次扫描重试。round 仍会 +1,所以持续崩溃的门与此前一样有界;标题写出真实原因("hit a verification-gate error before reaching a verdict"),并在末次尝试时指向门日志而非 agent。

不变:已声明的拒绝仍推进、措辞如旧;无产出崩溃保留自己的措辞与重试;读取反馈前的崩溃仍为终态。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 69/69。**真实提取的决策块**在 bash 下回放:已声明拒绝→推进到 NEWEST;**门崩溃→哨兵 + 重试 + round+1**;无产出→哨兵(措辞不变);门崩溃触顶→"检查门日志后 re-arm";job 成功→绝不判为崩溃。另外 `reject_fix` 被真实驱动:失败检查会写 `outcome=failed` 并非零退出。
2. 变异验证:去掉重试条件里的崩溃臂、或取消某个已知拒绝的声明(`npm run build`),对应测试各自变红。
3. 静态(均用 CI 一致工具):YAML 可解析;四个受影响步骤过 `bash -n`;actionlint 1.7.12 clean;prettier clean。

## 风险与范围

- 主要权衡:若**未来**新增拒绝路径却忘了声明 `outcome=failed`,它会退化为重试而非报告。这是安全方向(有 `MAX_ROUNDS` 上界,且每次尝试仍会发 handoff),并且现在有测试钉住每条既有拒绝的声明,漏接会被抓到。
- 不在范围内:只接线了 **review-address** 门 —— issue-fix 门开的是新 PR、从不发 `outcome=`,没有需要保护的水位线契约。
- 与 #7247 有重叠(它在同一条 `if` 链上新增了模型 API 错误臂);后合入者解决那几行冲突。
- 破坏性变更:无。

## 关联 Issue

由 #7329 / #7336 的搁置驱动(它们也促成了 #7330)。与 #7229、#7247、#7330 同一"让被托管 PR 循环诚实失败"主线。

</details>
