### PR TITLE
feat(autofix): re-arm a stranded PR with @qwen-code /retry instead of deleting a marker

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -343,9 +343,9 @@ jobs:
                 elif [[ -z "${CMD}" && -z "${RETRY_REQ}" ]]; then
                   echo "🧭 command ignored: body is not an exact command"
                 elif [[ "${ISSUE_STATE}" != 'open' ]]; then
-                  echo "🧭 takeover command ignored: PR is not open"
+                  echo "🧭 command ignored: PR is not open"
                 elif [[ -z "${SENDER_LOGIN}" || "${SENDER_LOGIN}" == "${AUTOFIX_BOT}" ]]; then
-                  echo "🧭 takeover command ignored: sender '${SENDER_LOGIN:-n/a}'"
+                  echo "🧭 command ignored: sender '${SENDER_LOGIN:-n/a}'"
                 else
                   sender_is_authorized=false
                   sender_permission=''
@@ -395,7 +395,7 @@ jobs:
                       echo "🧭 takeover command accepted: ${CMD} ${TAKEOVER_LABEL} on PR #${ISSUE_NUMBER} by ${SENDER_LOGIN} (${sender_permission})"
                     fi
                   else
-                    echo "🧭 takeover command ignored: sender '${SENDER_LOGIN}' permission='${sender_permission:-none}' is not the PR author or write+"
+                    echo "🧭 command ignored: sender '${SENDER_LOGIN}' permission='${sender_permission:-none}' is not the PR author or write+"
                   fi
                 fi
               fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -127,6 +127,12 @@ env:
   # Comment-command sugar over TAKEOVER_LABEL ('<cmd>' applies it, '<cmd>
   # stop' removes it). Matched EXACTLY against the trimmed comment body.
   TAKEOVER_COMMAND: '@qwen-code /takeover'
+  # Re-arm sugar. Recovering a stranded PR previously meant DELETING the
+  # bot's autofix-eval marker comment by hand (undiscoverable, destructive,
+  # and it erases the audit trail). This command instead posts an
+  # 'autofix-rearm' marker that supersedes the earlier evaluation markers:
+  # the scan re-reads the feedback from scratch and the round counter resets.
+  RETRY_COMMAND: '@qwen-code /retry'
   # Round cap while TAKEOVER_LABEL is present. Large managed PRs routinely
   # need dozens of feedback rounds — that is the point of takeover — so the
   # unattended cap (MAX_ROUNDS) would strangle it. The circuit breaker stays
@@ -147,8 +153,10 @@ jobs:
     # gates (exact body match, sender authorization) live in 'Decide phases'.
     # Nuance: a body with LEADING whitespace dies here even though the decide
     # branch would trim it — fail closed, command must start the comment.
+    # Both commands are prefiltered here (/takeover toggles the label, /retry
+    # re-arms a stranded PR); everything else never starts a job.
     if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' && (github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@qwen-code /takeover'))) && (github.event_name != 'pull_request' || github.event.label.name == 'autofix/takeover') }}
+      ${{ github.repository == 'QwenLM/qwen-code' && (github.event_name != 'issue_comment' || (github.event.issue.pull_request && (startsWith(github.event.comment.body, '@qwen-code /takeover') || startsWith(github.event.comment.body, '@qwen-code /retry')))) && (github.event_name != 'pull_request' || github.event.label.name == 'autofix/takeover') }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:
@@ -198,6 +206,7 @@ jobs:
       takeover_ack: '${{ steps.decide.outputs.takeover_ack }}'
       ack_pr: '${{ steps.decide.outputs.ack_pr }}'
       takeover_cmd: '${{ steps.decide.outputs.takeover_cmd }}'
+      retry_pr: '${{ steps.decide.outputs.retry_pr }}'
       cmd_pr: '${{ steps.decide.outputs.cmd_pr }}'
     steps:
       - name: 'Decide phases'
@@ -235,6 +244,7 @@ jobs:
           TAKEOVER_ACK=''
           TAKEOVER_CMD=''
           CMD_PR=''
+          RETRY_PR=''
           DRY_RUN="${DRY_RUN_INPUT:-false}"
           sanitize_number() {
             local value="${1//$'\r'/}"
@@ -323,10 +333,15 @@ jobs:
                 CMD=''
                 [[ "${BODY_TRIMMED}" == "${TAKEOVER_COMMAND}" ]] && CMD='add'
                 [[ "${BODY_TRIMMED}" == "${TAKEOVER_COMMAND} stop" ]] && CMD='remove'
+                # Re-arm shares the takeover command's authorization exactly:
+                # both summon bot activity on a managed PR, so inventing a
+                # second policy would only add surface.
+                RETRY_REQ=''
+                [[ "${BODY_TRIMMED}" == "${RETRY_COMMAND}" ]] && RETRY_REQ='true'
                 if [[ -z "${HAS_PR_URL}" ]]; then
-                  echo "🧭 takeover command ignored: not a PR comment"
-                elif [[ -z "${CMD}" ]]; then
-                  echo "🧭 takeover command ignored: body is not an exact command"
+                  echo "🧭 command ignored: not a PR comment"
+                elif [[ -z "${CMD}" && -z "${RETRY_REQ}" ]]; then
+                  echo "🧭 command ignored: body is not an exact command"
                 elif [[ "${ISSUE_STATE}" != 'open' ]]; then
                   echo "🧭 takeover command ignored: PR is not open"
                 elif [[ -z "${SENDER_LOGIN}" || "${SENDER_LOGIN}" == "${AUTOFIX_BOT}" ]]; then
@@ -371,9 +386,14 @@ jobs:
                     rm -f "${api_error_file}"
                   fi
                   if [[ "${sender_is_authorized}" == 'true' ]]; then
-                    TAKEOVER_CMD="${CMD}"
-                    CMD_PR="$(sanitize_number "${ISSUE_NUMBER}")"
-                    echo "🧭 takeover command accepted: ${CMD} ${TAKEOVER_LABEL} on PR #${ISSUE_NUMBER} by ${SENDER_LOGIN} (${sender_permission})"
+                    if [[ -n "${RETRY_REQ}" ]]; then
+                      RETRY_PR="$(sanitize_number "${ISSUE_NUMBER}")"
+                      echo "🧭 retry command accepted: re-arm PR #${ISSUE_NUMBER} by ${SENDER_LOGIN} (${sender_permission})"
+                    else
+                      TAKEOVER_CMD="${CMD}"
+                      CMD_PR="$(sanitize_number "${ISSUE_NUMBER}")"
+                      echo "🧭 takeover command accepted: ${CMD} ${TAKEOVER_LABEL} on PR #${ISSUE_NUMBER} by ${SENDER_LOGIN} (${sender_permission})"
+                    fi
                   else
                     echo "🧭 takeover command ignored: sender '${SENDER_LOGIN}' permission='${sender_permission:-none}' is not the PR author or write+"
                   fi
@@ -480,6 +500,7 @@ jobs:
           echo "takeover_ack=${TAKEOVER_ACK}" >> "${GITHUB_OUTPUT}"
           echo "ack_pr=$(sanitize_number "${PR_NUMBER_EVENT}")" >> "${GITHUB_OUTPUT}"
           echo "takeover_cmd=${TAKEOVER_CMD}" >> "${GITHUB_OUTPUT}"
+          echo "retry_pr=${RETRY_PR}" >> "${GITHUB_OUTPUT}"
           echo "cmd_pr=${CMD_PR}" >> "${GITHUB_OUTPUT}"
           echo "🧭 phase='${PHASE:-auto}' event='${EVENT_NAME}' issue='#${ISSUE_NUMBER:-n/a}' pr='#${PR_NUMBER_EVENT:-n/a}' schedule='${SCHEDULE:-n/a}' dry_run=${DRY_RUN} → issue=${DO_ISSUE} review=${DO_REVIEW}"
 
@@ -1330,6 +1351,51 @@ jobs:
   # a PR via the takeover label. Label events are explicit user actions, so
   # every toggle acks (no dedup wanted). In-repo PRs only reach this job.
   # ===========================================================================
+  # Re-arm a stranded PR without deleting anything. Recovery previously meant
+  # `gh api -X DELETE` on the bot's own autofix-eval marker comment: raw API
+  # access, an erased audit trail, and undiscoverable unless you had read the
+  # workflow. This posts ONE marker instead — the scan then re-reads the
+  # feedback (the marker releases the watermark those older markers held) and
+  # the round counter resets, because the marker also opens a fresh counting
+  # window exactly like an engage ack.
+  retry-command:
+    needs: 'route'
+    if: |-
+      ${{ needs.route.outputs.retry_pr != '' }}
+    # Queued (never cancelled) per PR so two quick /retry comments cannot
+    # interleave their marker writes.
+    concurrency:
+      group: 'qwen-autofix-retry-cmd-${{ needs.route.outputs.retry_pr }}'
+      cancel-in-progress: false
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    permissions:
+      contents: 'read'
+    env:
+      REPO: '${{ github.repository }}'
+      PR: '${{ needs.route.outputs.retry_pr }}'
+      GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
+    steps:
+      - name: 'Post re-arm marker'
+        run: |-
+          # The marker only counts when the AUTOFIX_BOT authored it (both the
+          # scan and the address-side recheck filter markers by that login), so
+          # a mis-scoped PAT would post a comment that silently does nothing.
+          api_error_file="$(mktemp)"
+          if ! bot_actor="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2>"${api_error_file}")"; then
+            api_error="$(tr '\r\n' ' ' < "${api_error_file}")"
+            rm -f "${api_error_file}"
+            echo "::error::Failed to verify CI_DEV_BOT_PAT identity with gh api user: ${api_error:-unknown error}."
+            exit 1
+          fi
+          rm -f "${api_error_file}"
+          if [[ "${bot_actor}" != "${AUTOFIX_BOT}" ]]; then
+            echo "::error::CI_DEV_BOT_PAT authenticates as '${bot_actor:-unknown}'; expected ${AUTOFIX_BOT}."
+            exit 1
+          fi
+          gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '\U0001F504 AutoFix re-armed. The next scan re-reads this PR'"'"'s feedback from the start and the round counter resets. Nothing was deleted — this marker supersedes the evaluation markers above it.\n\n<details>\n<summary>中文说明</summary>\n\n\U0001F504 已重新武装 AutoFix。下一次扫描会从头重新读取本 PR 的反馈，轮次计数也已重置。未删除任何内容 —— 本标记使其上方的评估标记失效。\n\n</details>\n\n<!-- autofix-rearm -->')"
+          echo "🔄 re-armed PR #${PR}"
+
   takeover-ack:
     needs: 'route'
     if: |-
@@ -1697,9 +1763,9 @@ jobs:
             # Inserting or reordering a field here or at any write site silently
             # corrupts round tracking; keep the `ts= acted= round=` order in lockstep.
             MARKERS="$(jq -c --arg ab "${AUTOFIX_BOT}" '
-              [ .[] | select((.user.login // "") == $ab) | (.body // "")
+              [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
                 | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+)(?: win=([^ ]+))? -->") ] | .[]
-                | {ts: .[0], round: (.[2] | tonumber), win: (.[3] // "none")} ]' "${WORKDIR}/ic.json")"
+                | {ts: .[0], round: (.[2] | tonumber), win: (.[3] // "none"), at: ($c.created_at // "")} ]' "${WORKDIR}/ic.json")"
             # The watermark is GLOBAL across all markers — feedback already
             # evaluated stays evaluated, no matter how counting windows move.
             # The terminal-handoff SENTINEL ts is excluded: it is a flag, not
@@ -1707,7 +1773,19 @@ jobs:
             # filter all future feedback forever — making a re-arm after a
             # terminal handoff dead on arrival (terminal skipping itself is
             # round-based and window-scoped, so re-arm properly clears it).
-            EVAL_WM="$(jq -r 'map(.ts) | map(select(. != "9999-12-31T23:59:59Z")) | max // ""' <<< "${MARKERS}")"
+            REARM_AT="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+              [ .[] | select((.user.login // "") == $ab)
+                | select((.body // "") | contains("<!-- autofix-rearm -->"))
+                | .created_at ] | max // ""' "${WORKDIR}/ic.json")"
+            # A maintainer '@qwen-code /retry' posts that marker to say
+            # "evaluate this feedback again": markers written BEFORE it stop
+            # holding the watermark down. This is the sanctioned exception to
+            # the global rule above, and it replaces the old recovery -
+            # deleting the bot's marker comment by hand, which erased the
+            # audit trail and needed raw API access to do at all.
+            EVAL_WM="$(jq -r --arg rearm "${REARM_AT}" '
+              map(select($rearm == "" or (.at > $rearm)))
+              | map(.ts) | map(select(. != "9999-12-31T23:59:59Z")) | max // ""' <<< "${MARKERS}")"
             # ROUND counting is windowed by KEY EQUALITY, not timestamps: the
             # current window key is the created_at of the latest
             # '<!-- takeover-ack engaged -->' comment ('none' before any
@@ -1721,7 +1799,8 @@ jobs:
             # scan skip regardless of order).
             REARM_KEY="$(jq -r --arg ab "${AUTOFIX_BOT}" '
               [ .[] | select((.user.login // "") == $ab)
-                | select((.body // "") | contains("<!-- takeover-ack engaged -->"))
+                | select(((.body // "") | contains("<!-- takeover-ack engaged -->"))
+                    or ((.body // "") | contains("<!-- autofix-rearm -->")))
                 | .created_at ] | max // "none"' "${WORKDIR}/ic.json")"
             ROUND="$(jq -r --arg key "${REARM_KEY}" 'map(select(.win == $key)) | map(.round) | max // 0' <<< "${MARKERS}")"
 
@@ -1821,7 +1900,7 @@ jobs:
             # bot's own eval markers, and known non-actionable bot comments
             # (triage stages, coverage reports, legacy suggestion summaries,
             # force-push reminders).
-            BOT_COMMENT_FILTER='<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) '
+            BOT_COMMENT_FILTER='<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) '
             # Command-style comments (@qwen-code /takeover, /triage, /review …)
             # are INSTRUCTIONS to tooling, not review feedback on the diff:
             # counting them as actionable burns a full agent cycle to post a
@@ -2185,7 +2264,7 @@ jobs:
             + (.[2] | map(select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-              | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
+              | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not) | .created_at))
             + (.[3] | map(select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED"))
               | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
@@ -2212,17 +2291,25 @@ jobs:
           # is a stale duplicate and discards itself.
           STALE='false'
           LIVE_MARKS="$(jq -r --arg ab "${AUTOFIX_BOT}" '
-            [ .[] | select((.user.login // "") == $ab) | (.body // "")
+            [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
               | [ scan("<!-- autofix-eval ts=([^ ]+) acted=([^ ]+) round=([0-9]+)(?: win=([^ ]+))? -->") ] | .[]
-              | {ts: .[0], round: (.[2] | tonumber), win: (.[3] // "none")} ]' "${WORKDIR}/ic.json")"
-          LIVE_EVAL_WM="$(jq -r 'map(.ts) | map(select(. != "9999-12-31T23:59:59Z")) | max // ""' <<< "${LIVE_MARKS}")"
+              | {ts: .[0], round: (.[2] | tonumber), win: (.[3] // "none"), at: ($c.created_at // "")} ]' "${WORKDIR}/ic.json")"
+          LIVE_REARM_AT="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+            [ .[] | select((.user.login // "") == $ab)
+              | select((.body // "") | contains("<!-- autofix-rearm -->"))
+              | .created_at ] | max // ""' "${WORKDIR}/ic.json")"
+          # Mirrors the scan: a /retry marker releases the watermark it holds.
+          LIVE_EVAL_WM="$(jq -r --arg rearm "${LIVE_REARM_AT}" '
+            map(select($rearm == "" or (.at > $rearm)))
+            | map(.ts) | map(select(. != "9999-12-31T23:59:59Z")) | max // ""' <<< "${LIVE_MARKS}")"
           # Round counting mirrors the scan: keyed to the CURRENT window (the
           # latest engage ack's created_at, 'none' before any takeover), so
           # pre-re-arm markers can neither trip the cap nor inflate the live
           # round here.
           LIVE_REARM_KEY="$(jq -r --arg ab "${AUTOFIX_BOT}" '
             [ .[] | select((.user.login // "") == $ab)
-              | select((.body // "") | contains("<!-- takeover-ack engaged -->"))
+              | select(((.body // "") | contains("<!-- takeover-ack engaged -->"))
+                    or ((.body // "") | contains("<!-- autofix-rearm -->")))
               | .created_at ] | max // "none"' "${WORKDIR}/ic.json")"
           LIVE_MAX_ROUND="$(jq -r --arg key "${LIVE_REARM_KEY}" 'map(select(.win == $key)) | map(.round) | max // 0' <<< "${LIVE_MARKS}")"
           # A re-arm SUPERSEDES every job selected under the old window key:
@@ -2248,7 +2335,7 @@ jobs:
               + (.[2] | map(select((.created_at // "") > $wm)
                 | select((.user.login // "") != $ab)
                 | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-                | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
+                | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)) | length)
               + (.[3] | map(select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED"))
                 | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
@@ -2325,7 +2412,7 @@ jobs:
               | select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-              | select((.body // "") | test("<!-- (autofix-eval|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
+              | select((.body // "") | test("<!-- (autofix-eval|autofix-rearm|qwen-triage|qwen-review-suggestion-summary|pr-force-push|qwen-review-ack) ") | not)
                 | select((.body // "") | test("^\\s*@qwen-code /") | not)
               | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/ic.json"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3114,6 +3114,123 @@ describe('qwen-autofix workflow', () => {
     ).toBe(0);
   });
 
+  it('re-arms a stranded PR from a marker instead of a deleted comment', () => {
+    // Recovery used to mean `gh api -X DELETE` on the bot's own eval marker:
+    // raw API access, an erased audit trail, undiscoverable. `@qwen-code
+    // /retry` posts an autofix-rearm marker instead, which must do BOTH halves
+    // of what the deletion did - release the watermark those older markers
+    // held, and reset the round counter - or the PR stays stuck.
+    const scan =
+      workflow.match(
+        /- name: 'Scan for PRs with new feedback'[\s\S]*?(?=\n {6}- name: )/,
+      )?.[0] ?? '';
+    const block = scan.match(
+      /(MARKERS="\$\(jq[\s\S]*?ROUND="\$\(jq[^\n]*\n)/,
+    )?.[1];
+    expect(block).toBeTruthy();
+
+    const BOT = 'qwen-code-dev-bot';
+    const evalMarker = (at, ts, round) => ({
+      user: { login: BOT },
+      created_at: at,
+      body: `<!-- autofix-eval ts=${ts} acted=false round=${round} win=none -->`,
+    });
+    const run = (comments) => {
+      const dir = mkdtempSync(join(tmpdir(), 'rearm-'));
+      writeFileSync(join(dir, 'ic.json'), JSON.stringify(comments));
+      const out = execFileSync(
+        'bash',
+        [
+          '-c',
+          `set -uo pipefail\n${block}\nprintf '%s|%s|%s' "$EVAL_WM" "$REARM_KEY" "$ROUND"`,
+        ],
+        {
+          env: { ...process.env, WORKDIR: dir, AUTOFIX_BOT: BOT },
+          encoding: 'utf8',
+        },
+      );
+      rmSync(dir, { recursive: true, force: true });
+      return out.split('|');
+    };
+
+    const evaluated = [
+      evalMarker('2026-07-20T08:00:00Z', '2026-07-20T07:00:00Z', 1),
+      evalMarker('2026-07-20T09:00:00Z', '2026-07-20T08:30:00Z', 2),
+    ];
+    // Stranded: the watermark sits at the newest evaluated feedback and the
+    // round has climbed, so the scan reports "nothing new" forever.
+    const [wmBefore, keyBefore, roundBefore] = run(evaluated);
+    expect(wmBefore).toBe('2026-07-20T08:30:00Z');
+    expect(keyBefore).toBe('none');
+    expect(roundBefore).toBe('2');
+
+    // After /retry both halves clear: no marker holds the watermark, and the
+    // marker opens a fresh counting window so the round restarts at 0.
+    const [wmAfter, keyAfter, roundAfter] = run([
+      ...evaluated,
+      {
+        user: { login: BOT },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+    ]);
+    expect(wmAfter).toBe('');
+    expect(keyAfter).toBe('2026-07-20T10:00:00Z');
+    expect(roundAfter).toBe('0');
+
+    // A marker written AFTER the re-arm counts again (the exception is scoped
+    // to the re-arm instant, it does not disable the watermark forever).
+    const [wmNext] = run([
+      ...evaluated,
+      {
+        user: { login: BOT },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+      evalMarker('2026-07-20T11:00:00Z', '2026-07-20T10:30:00Z', 1),
+    ]);
+    expect(wmNext).toBe('2026-07-20T10:30:00Z');
+
+    // A re-arm posted by anyone other than the bot is ignored: both scanners
+    // filter markers by author, so a spoofed comment must not re-arm.
+    const [wmSpoof] = run([
+      ...evaluated,
+      {
+        user: { login: 'someone-else' },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+    ]);
+    expect(wmSpoof).toBe('2026-07-20T08:30:00Z');
+  });
+
+  it('routes @qwen-code /retry through the takeover command authorization', () => {
+    // Prefilter must let the command reach route at all, and the marker must
+    // be a CONTROL comment so the agent never sees it as feedback to address.
+    expect(workflow).toContain(
+      "startsWith(github.event.comment.body, '@qwen-code /retry')",
+    );
+    expect(workflow).toContain("RETRY_COMMAND: '@qwen-code /retry'");
+    expect(workflow).toContain('<!-- autofix-rearm -->');
+    expect(workflow).toContain('<!-- (autofix-eval|autofix-rearm|qwen-triage|');
+    // The re-arm marker is posted by the bot itself (both scanners filter by
+    // that login), so the job verifies the PAT identity before commenting.
+    const job = workflow.match(
+      /- name: 'Post re-arm marker'[\s\S]*?(?=\n {2}[a-z-]+:\n)/,
+    )?.[0];
+    expect(job).toBeTruthy();
+    expect(job).toContain("gh api user --jq '.login'");
+    expect(job).toContain('expected ${AUTOFIX_BOT}');
+    expect(job).toContain('gh pr comment "${PR}"');
+    // Re-arm reuses the takeover command's authorization rather than adding a
+    // second policy: same live permission check, same author rules.
+    expect(routeStep).toContain("RETRY_REQ=''");
+    expect(routeStep).toContain(
+      'RETRY_PR="$(sanitize_number "${ISSUE_NUMBER}")"',
+    );
+    expect(routeStep).toContain('retry_pr=${RETRY_PR}');
+  });
+
   it('replays the handoff decision and terminal-round transitions under bash', () => {
     // The agent step is bounded below the 120-minute job timeout so a runaway
     // agent fails the STEP, not the job, leaving the always() report step time to

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3315,6 +3315,97 @@ describe('qwen-autofix workflow', () => {
     expect(routeStep).toContain('retry_pr=${RETRY_PR}');
   });
 
+  it('behaviorally posts the re-arm marker only after verifying the PAT identity', () => {
+    // The retry-command job's bash is extracted and executed against a stubbed
+    // `gh` so the identity guard and the posted comment body are exercised, not
+    // merely string-matched: a malformed printf body or a broken quote escape
+    // would post a marker the scanners ignore while still printing "re-armed",
+    // and the structural toContain('<!-- autofix-rearm -->') check matches the
+    // marker at several workflow sites so it would not catch a typo in the body.
+    const BOT = 'qwen-code-dev-bot';
+    const rearmStep = workflow.match(
+      /- name: 'Post re-arm marker'\n {8}run: \|-\n {10}([\s\S]*?)\n\n {2}takeover-ack:/,
+    )?.[1];
+    expect(rearmStep).toBeTruthy();
+    const block = rearmStep.replace(/\n {10}/g, '\n');
+
+    const runRearm = ({ actor = BOT, apiFail = false } = {}) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-rearm-'));
+      try {
+        writeFileSync(
+          join(dir, 'gh'),
+          [
+            '#!/bin/bash',
+            `echo "$1 $2" >> '${join(dir, 'calls.log')}'`,
+            'if [[ "$1" == "api" && "$2" == "user" ]]; then',
+            `  if [[ "${apiFail}" == "true" ]]; then echo "HTTP 401: Bad credentials" >&2; exit 1; fi`,
+            `  printf '%s' "${actor}"`,
+            'elif [[ "$1" == "pr" && "$2" == "comment" ]]; then',
+            `  printf '%s' "$7" > '${join(dir, 'body.txt')}'`,
+            'fi',
+          ].join('\n'),
+        );
+        chmodSync(join(dir, 'gh'), 0o755);
+        writeFileSync(join(dir, 'calls.log'), '');
+        const res = spawnSync('bash', ['-c', block], {
+          env: {
+            ...process.env,
+            PATH: `${dir}:${process.env.PATH}`,
+            GITHUB_TOKEN: 'x',
+            PR: '7354',
+            REPO: 'QwenLM/qwen-code',
+            AUTOFIX_BOT: BOT,
+          },
+          encoding: 'utf8',
+        });
+        return {
+          status: res.status,
+          stdout: res.stdout ?? '',
+          calls: readFileSync(join(dir, 'calls.log'), 'utf8'),
+          body: existsSync(join(dir, 'body.txt'))
+            ? readFileSync(join(dir, 'body.txt'), 'utf8')
+            : '',
+        };
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+
+    // Happy path: identity verified via gh api user, then the marker is posted
+    // with the scanner marker line in the bilingual collapsed format.
+    const ok = runRearm({ actor: BOT });
+    expect(ok.status).toBe(0);
+    expect(ok.calls).toContain('api user');
+    expect(ok.calls).toContain('pr comment');
+    expect(ok.stdout).toContain('re-armed PR #7354');
+    expect(ok.body).toContain('AutoFix re-armed');
+    expect(ok.body).toContain('<!-- autofix-rearm -->');
+    expect(ok.body).toContain('<details>');
+    expect(ok.body).toContain('中文说明');
+    // No line may be indented 4+ spaces, or the marker renders as a code block
+    // and the scanners' marker match silently fails.
+    expect(ok.body).not.toMatch(/^ {4,}/m);
+
+    // Actor mismatch: the PAT authenticates as someone else -> the guard exits
+    // non-zero and posts nothing (a mis-scoped PAT must not leave a stranded PR
+    // behind a fake "re-armed" line).
+    const mismatch = runRearm({ actor: 'someone-else' });
+    expect(mismatch.status).toBe(1);
+    expect(mismatch.calls).toContain('api user');
+    expect(mismatch.calls).not.toContain('pr comment');
+    expect(mismatch.body).toBe('');
+    expect(mismatch.stdout).toContain(`expected ${BOT}`);
+
+    // API failure: gh api user fails -> exits non-zero, posts nothing, and
+    // surfaces the captured gh stderr in the error message.
+    const failed = runRearm({ apiFail: true });
+    expect(failed.status).toBe(1);
+    expect(failed.calls).not.toContain('pr comment');
+    expect(failed.body).toBe('');
+    expect(failed.stdout).toContain('Failed to verify CI_DEV_BOT_PAT identity');
+    expect(failed.stdout).toContain('Bad credentials');
+  });
+
   it('replays the handoff decision and terminal-round transitions under bash', () => {
     // The agent step is bounded below the 120-minute job timeout so a runaway
     // agent fails the STEP, not the job, leaving the always() report step time to

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3204,6 +3204,85 @@ describe('qwen-autofix workflow', () => {
     expect(wmSpoof).toBe('2026-07-20T08:30:00Z');
   });
 
+  it('address-side stale check mirrors the scan-side re-arm logic under bash', () => {
+    // The scan-side and address-side jq blocks are copy-pasted (~40 lines
+    // each, 4 jq expressions). Drift between them is the class of bug the
+    // re-arm feature prevents: a queued address job could stamp an
+    // old-sequence eval marker into a fresh window after /retry. This test
+    // runs the address-side block under bash with the same fixtures and
+    // asserts identical outputs.
+    const block = prepareBranchAndFeedbackStep.match(
+      /(LIVE_MARKS="\$\(jq[\s\S]*?LIVE_MAX_ROUND="\$\(jq[^\n]*\n)/,
+    )?.[1];
+    expect(block).toBeTruthy();
+
+    const BOT = 'qwen-code-dev-bot';
+    const evalMarker = (at, ts, round) => ({
+      user: { login: BOT },
+      created_at: at,
+      body: `<!-- autofix-eval ts=${ts} acted=false round=${round} win=none -->`,
+    });
+    const run = (comments) => {
+      const dir = mkdtempSync(join(tmpdir(), 'rearm-live-'));
+      writeFileSync(join(dir, 'ic.json'), JSON.stringify(comments));
+      const out = execFileSync(
+        'bash',
+        [
+          '-c',
+          `set -uo pipefail\n${block}\nprintf '%s|%s|%s' "$LIVE_EVAL_WM" "$LIVE_REARM_KEY" "$LIVE_MAX_ROUND"`,
+        ],
+        {
+          env: { ...process.env, WORKDIR: dir, AUTOFIX_BOT: BOT },
+          encoding: 'utf8',
+        },
+      );
+      rmSync(dir, { recursive: true, force: true });
+      return out.split('|');
+    };
+
+    const evaluated = [
+      evalMarker('2026-07-20T08:00:00Z', '2026-07-20T07:00:00Z', 1),
+      evalMarker('2026-07-20T09:00:00Z', '2026-07-20T08:30:00Z', 2),
+    ];
+    const [wmBefore, keyBefore, roundBefore] = run(evaluated);
+    expect(wmBefore).toBe('2026-07-20T08:30:00Z');
+    expect(keyBefore).toBe('none');
+    expect(roundBefore).toBe('2');
+
+    const [wmAfter, keyAfter, roundAfter] = run([
+      ...evaluated,
+      {
+        user: { login: BOT },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+    ]);
+    expect(wmAfter).toBe('');
+    expect(keyAfter).toBe('2026-07-20T10:00:00Z');
+    expect(roundAfter).toBe('0');
+
+    const [wmNext] = run([
+      ...evaluated,
+      {
+        user: { login: BOT },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+      evalMarker('2026-07-20T11:00:00Z', '2026-07-20T10:30:00Z', 1),
+    ]);
+    expect(wmNext).toBe('2026-07-20T10:30:00Z');
+
+    const [wmSpoof] = run([
+      ...evaluated,
+      {
+        user: { login: 'someone-else' },
+        created_at: '2026-07-20T10:00:00Z',
+        body: '<!-- autofix-rearm -->',
+      },
+    ]);
+    expect(wmSpoof).toBe('2026-07-20T08:30:00Z');
+  });
+
   it('routes @qwen-code /retry through the takeover command authorization', () => {
     // Prefilter must let the command reach route at all, and the marker must
     // be a CONTROL comment so the agent never sees it as feedback to address.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3292,6 +3292,11 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain("RETRY_COMMAND: '@qwen-code /retry'");
     expect(workflow).toContain('<!-- autofix-rearm -->');
     expect(workflow).toContain('<!-- (autofix-eval|autofix-rearm|qwen-triage|');
+    // Verify all four filter sites (scan + 3 address) include autofix-rearm
+    const filterMatches = [
+      ...workflow.matchAll(/autofix-eval\|autofix-rearm\|qwen-triage/g),
+    ];
+    expect(filterMatches.length).toBeGreaterThanOrEqual(4);
     // The re-arm marker is posted by the bot itself (both scanners filter by
     // that login), so the job verifies the PAT identity before commenting.
     const job = workflow.match(


### PR DESCRIPTION
## What this PR does

Adds `@qwen-code /retry` — a one-comment way to re-arm a stranded managed PR, replacing the current recovery of **deleting the bot's own marker comment by hand**.

## Why it's needed

When a PR gets stranded (a falsely-advanced feedback watermark, or a terminal round), the only way back was:

```
gh api -X DELETE repos/QwenLM/qwen-code/issues/comments/<id>
```

That requires raw API access and the comment id, **erases the audit trail**, and is undiscoverable unless you have read the workflow. It came up twice while triaging #7246, #7329 and #7336 — each time a maintainer had to hand-run a destructive API call to un-stick a PR whose fix the agent had already written.

## How

`@qwen-code /retry` posts a single `<!-- autofix-rearm -->` marker. That marker does **both halves** of what the deletion did:

- **Releases the watermark.** The scan ignores eval markers written *before* the newest re-arm, so the feedback those markers buried is read again. The watermark stays global otherwise — this is an explicit, maintainer-issued exception, which is exactly what the deletion was, only recorded instead of destructive.
- **Resets the round.** The marker joins the engage ack in `REARM_KEY`, so it opens a fresh counting window: the round restarts at 0 and a terminal round stops skipping the PR. The existing *"a re-arm supersedes queued old-window jobs"* guard therefore covers `/retry` for free.

The address job's live recheck mirrors both, so a run selected before a re-arm still discards itself instead of stamping an old-sequence marker into the fresh window.

## Why it's safe

- **Authorization is the takeover command's, reused rather than reinvented**: exact body match, live permission lookup, in-repo-only author privilege. Both commands summon bot activity on a managed PR, so a second policy would only add surface.
- The route prefilter (an expression-level gate) now admits the second command; everything else still never starts a job.
- The job **verifies `CI_DEV_BOT_PAT` authenticates as the bot** before commenting — both scanners only count markers authored by it, so a mis-scoped PAT would otherwise post a comment that silently does nothing.
- A re-arm marker from **any other author is ignored** (pinned by a test).
- The marker is registered as a **control comment**, so the agent never sees the re-arm as feedback to address.
- Blast radius: one comment. Nothing is deleted, no label changes, no state outside the marker.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 69/69. The **real extracted scan block** is replayed over synthetic comment fixtures:

   | fixture | `EVAL_WM` | window key | round |
   | --- | --- | --- | --- |
   | two eval markers (stranded) | `…08:30:00Z` (held) | `none` | 2 |
   | **+ `<!-- autofix-rearm -->`** | **`""` (released)** | **re-arm's `created_at`** | **0** |
   | + an eval marker after the re-arm | `…10:30:00Z` (counts again) | — | — |
   | re-arm posted by a non-bot author | `…08:30:00Z` (ignored) | — | — |

   Mutation-verified: dropping the re-arm from the watermark filter, or from the window key, each turns the test red.
2. Static (run locally with the exact CI toolchain): `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
3. Post-merge smoke: comment `@qwen-code /retry` on a stranded PR and confirm the bot posts the re-arm marker and the next scan re-selects the PR at round 0.

### Evidence (Before & After)

```
BEFORE  stranded PR
        -> maintainer finds the marker comment id
        -> gh api -X DELETE …/issues/comments/<id>     (destructive, audit trail gone)
        -> next scan re-selects

AFTER   stranded PR
        -> @qwen-code /retry
        -> bot posts "<!-- autofix-rearm -->"           (nothing deleted)
        -> watermark released + round reset -> next scan re-selects at round 0
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: a maintainer can now re-read feedback the loop had already evaluated, which costs agent runs. That is the point of the command, it is gated to the same senders who can already `/takeover`, and the round cap still bounds what follows.
- Not validated / out of scope: the marker deletion still works (nothing removed) — this adds the safe path rather than closing the old one. The other pickup gaps (inline-comment-only feedback, failed-check feedback) still rely on the scan.
- Breaking changes / migration notes: none.

## Linked Issues

Motivated by the manual recoveries on #7246 / #7329 / #7336. Part of the same autofix-reliability line as #7330, #7350, #7351.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增 `@qwen-code /retry` —— 用一条评论重新武装被搁置的托管 PR,取代现在**手工删除 bot 自己的标记评论**这种恢复方式。

## 为什么需要

当 PR 被搁置(水位线被误推进,或轮次到终态),唯一的复位办法是:

```
gh api -X DELETE repos/QwenLM/qwen-code/issues/comments/<id>
```

它需要裸 API 权限和评论 id、**抹掉审计痕迹**,且不读 workflow 根本无从得知。在排查 #7246、#7329、#7336 时出现了两次 —— 每次都要维护者手工执行破坏性 API 调用,去解救一个 agent 其实早已写好修复的 PR。

## 怎么做

`@qwen-code /retry` 发一条 `<!-- autofix-rearm -->` 标记。该标记完成删除操作的**两半**:

- **释放水位线**:扫描会忽略比最新 re-arm **更早**的 eval 标记,于是被它们埋掉的反馈重新可见。其余情况下水位线仍是全局的 —— 这是一次显式的、由维护者发起的例外,而这正是删除操作原本做的事,只不过现在**有记录、不破坏**。
- **重置轮次**:该标记与 engage ack 一同参与 `REARM_KEY`,因此开启一个新的计数窗口:轮次从 0 重新开始,终态轮次不再让扫描跳过该 PR。既有的"re-arm 使旧窗口已排队作业失效"保护也因此**免费覆盖** `/retry`。

address 作业的实时复核对两者同样镜像,所以在 re-arm 之前被选中的运行会自行丢弃,而不会把旧序列的标记打进新窗口。

## 为什么安全

- **授权直接复用 takeover 命令的**,而非另造一套:精确正文匹配、实时权限查询、仅 in-repo 的作者特权。两个命令都会在托管 PR 上召唤 bot 活动,再造一套策略只会增加攻击面。
- route 的表达式级预过滤现在放行第二个命令;其余评论仍然完全不会启动作业。
- 作业在评论前**校验 `CI_DEV_BOT_PAT` 的身份确为 bot** —— 两个扫描器都只统计由它撰写的标记,PAT 作用域不对会导致评论静默失效。
- **非 bot 作者发的 re-arm 标记会被忽略**(有测试钉住)。
- 该标记被登记为**控制评论**,agent 永远不会把 re-arm 当作待处理反馈。
- 爆炸半径:一条评论。不删除任何内容、不改标签、除标记外无其他状态。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 69/69。**真实提取的扫描块**在合成评论夹具上回放:两条 eval 标记(搁置)→ 水位线保持、round=2;**加入 re-arm 标记** → **水位线释放、窗口键变更、round=0**;re-arm 之后写的标记重新计入;非 bot 作者的 re-arm 被忽略。两半均经变异验证(分别去掉水位线过滤与窗口键中的 re-arm,测试各自变红)。
2. 静态(均用 CI 一致工具):YAML 可解析;全部 37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
3. 合并后冒烟:在搁置的 PR 上评论 `@qwen-code /retry`,确认 bot 发出 re-arm 标记且下一次扫描以 round 0 重新选中该 PR。

## 风险与范围

- 主要权衡:维护者现在可以让循环重读已评估过的反馈,这会消耗 agent 运行。这正是该命令的目的,且它受限于与 `/takeover` 相同的发起人,后续仍有轮次上限约束。
- 不在范围内:删除标记的老办法仍然有效(未移除任何东西)—— 本 PR 是**新增安全路径**,而非封堵旧路径。其余拾起缺口(仅 inline 评论的反馈、失败检查反馈)仍依赖扫描。
- 破坏性变更:无。

## 关联 Issue

由 #7246 / #7329 / #7336 上的手工恢复驱动。与 #7330、#7350、#7351 同属 autofix 可靠性主线。

</details>
