### PR TITLE
fix(ci): stop a slow patrol classifier from killing every flaky rerun

### DIFF
--- a/.github/workflows/qwen-ci-flaky-rerun.yml
+++ b/.github/workflows/qwen-ci-flaky-rerun.yml
@@ -107,14 +107,17 @@ jobs:
         if: "${{ steps.scan.outputs.target_found == 'true' }}"
         run: |-
           # No decisions is a legitimate outcome now that the classifier can
-          # time out without taking the job with it. Report it and let the run
-          # finish cleanly so the next tick retries, rather than failing the
-          # patrol and skipping the act job that reruns real flakes.
-          if [[ -s "${WORKDIR}/ci-flaky-decisions.json" ]]; then
+          # time out without taking the job with it. A timeout can also kill
+          # the process mid-write, leaving a non-empty but unparseable file,
+          # so validate JSON syntax alongside the size check. Report the
+          # result and let the run finish cleanly so the next tick retries,
+          # rather than failing the patrol and skipping the act job that
+          # reruns real flakes.
+          if [[ -s "${WORKDIR}/ci-flaky-decisions.json" ]] && node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "${WORKDIR}/ci-flaky-decisions.json" 2>/dev/null; then
             echo 'has_decisions=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'has_decisions=false' >> "${GITHUB_OUTPUT}"
-            echo "::warning::patrol classifier produced no decisions this cycle; nothing to act on"
+            echo "::warning::patrol classifier produced no valid decisions this cycle; nothing to act on"
           fi
 
       - name: 'Upload patrol input and decisions'

--- a/.github/workflows/qwen-ci-flaky-rerun.yml
+++ b/.github/workflows/qwen-ci-flaky-rerun.yml
@@ -32,6 +32,7 @@ jobs:
       bot_login: '${{ steps.identity.outputs.bot_login }}'
       target_found: '${{ steps.scan.outputs.target_found }}'
       input_sha: '${{ steps.scan.outputs.input_sha }}'
+      has_decisions: '${{ steps.decisions.outputs.has_decisions }}'
     steps:
       - name: 'Resolve patrol identity'
         id: 'identity'
@@ -70,6 +71,16 @@ jobs:
 
       - name: 'Classify with ci-flaky-patrol skill'
         if: "${{ steps.scan.outputs.target_found == 'true' }}"
+        # The model can outlast the WHOLE job budget when it is under load:
+        # across a busy 9-hour window every scheduled patrol spent ~9m40s in
+        # this step and was killed by the 10-minute job timeout, so Validate
+        # and Upload never ran, `act` was skipped, and nothing was ever re-run
+        # (28 of 30 runs cancelled; the 2 that passed took ~2 minutes at 00:0x
+        # when the model was idle). Bounding the STEP below the job turns a
+        # slow model into one wasted cycle instead of a dead patrol - the next
+        # tick simply tries again.
+        timeout-minutes: 5
+        continue-on-error: true
         env:
           GH_TOKEN: ''
           GITHUB_TOKEN: ''
@@ -92,11 +103,22 @@ jobs:
             Read ci-flaky-input.json and write ci-flaky-decisions.json.
 
       - name: 'Validate patrol decisions'
+        id: 'decisions'
         if: "${{ steps.scan.outputs.target_found == 'true' }}"
-        run: 'test -s "${WORKDIR}/ci-flaky-decisions.json"'
+        run: |-
+          # No decisions is a legitimate outcome now that the classifier can
+          # time out without taking the job with it. Report it and let the run
+          # finish cleanly so the next tick retries, rather than failing the
+          # patrol and skipping the act job that reruns real flakes.
+          if [[ -s "${WORKDIR}/ci-flaky-decisions.json" ]]; then
+            echo 'has_decisions=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'has_decisions=false' >> "${GITHUB_OUTPUT}"
+            echo "::warning::patrol classifier produced no decisions this cycle; nothing to act on"
+          fi
 
       - name: 'Upload patrol input and decisions'
-        if: "${{ steps.scan.outputs.target_found == 'true' }}"
+        if: "${{ steps.decisions.outputs.has_decisions == 'true' }}"
         uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
         with:
           name: 'ci-flaky-patrol-decisions'
@@ -109,7 +131,7 @@ jobs:
   act:
     name: 'Act on classified PR failures'
     needs: 'classify'
-    if: "${{ needs.classify.result == 'success' }}"
+    if: "${{ needs.classify.result == 'success' && needs.classify.outputs.has_decisions == 'true' }}"
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     # GitHub writes use CI_BOT_PAT; keep the generated GITHUB_TOKEN read-only.

--- a/scripts/tests/ci-flaky-rerun-workflow.test.js
+++ b/scripts/tests/ci-flaky-rerun-workflow.test.js
@@ -1,4 +1,7 @@
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
 
@@ -20,6 +23,76 @@ describe('ci failure patrol workflow', () => {
     expect(yml.env.MAX_CANDIDATES_PER_RUN).toBe('5');
     expect(workflow).toContain('--active-days "${ACTIVE_DAYS}"');
     expect(workflow).toContain('--max-candidates "${MAX_CANDIDATES_PER_RUN}"');
+  });
+
+  it('bounds the classifier step below the job so a slow model cannot kill the patrol', () => {
+    // Observed: across a busy 9-hour window EVERY scheduled patrol spent ~9m40s
+    // in the classifier and was killed by the 10-minute job timeout, so
+    // Validate and Upload never ran, `act` was skipped, and nothing was ever
+    // re-run - 28 of 30 runs cancelled. The two that passed took ~2 minutes,
+    // at 00:0x, when the model was idle.
+    const classify = yml.jobs.classify;
+    const step = classify.steps.find(
+      (s) => s.name === 'Classify with ci-flaky-patrol skill',
+    );
+    expect(step).toBeTruthy();
+    expect(step['timeout-minutes']).toBeLessThan(classify['timeout-minutes']);
+    // A slow model must cost one cycle, not the whole job.
+    expect(step['continue-on-error']).toBe(true);
+
+    // An empty classifier result is a no-op cycle, not a patrol failure.
+    const validate = classify.steps.find(
+      (s) => s.name === 'Validate patrol decisions',
+    );
+    expect(validate.id).toBe('decisions');
+    expect(validate.run).not.toContain('test -s');
+
+    // Downstream work is gated on decisions EXISTING, not merely on the job
+    // having survived - otherwise a no-decision cycle looks actionable.
+    expect(classify.outputs.has_decisions).toBe(
+      '${{ steps.decisions.outputs.has_decisions }}',
+    );
+    const upload = classify.steps.find(
+      (s) => s.name === 'Upload patrol input and decisions',
+    );
+    expect(upload.if).toContain(
+      "steps.decisions.outputs.has_decisions == 'true'",
+    );
+    expect(yml.jobs.act.if).toContain(
+      "needs.classify.outputs.has_decisions == 'true'",
+    );
+  });
+
+  it('reports an empty classifier result instead of failing the patrol', () => {
+    const validate = yml.jobs.classify.steps.find(
+      (s) => s.name === 'Validate patrol decisions',
+    );
+    const run = (writeDecisions) => {
+      const dir = mkdtempSync(join(tmpdir(), 'patrol-'));
+      const out = join(dir, 'gh_output');
+      writeFileSync(out, '');
+      if (writeDecisions) {
+        writeFileSync(join(dir, 'ci-flaky-decisions.json'), '{"decisions":[]}');
+      }
+      let status = 0;
+      try {
+        execFileSync('bash', ['-c', `set -eo pipefail\n${validate.run}`], {
+          env: { ...process.env, WORKDIR: dir, GITHUB_OUTPUT: out },
+          encoding: 'utf8',
+        });
+      } catch (e) {
+        status = e.status;
+      }
+      const result = readFileSync(out, 'utf8');
+      rmSync(dir, { recursive: true, force: true });
+      return { status, result };
+    };
+    // Decisions present -> act downstream.
+    expect(run(true)).toMatchObject({ status: 0 });
+    expect(run(true).result).toContain('has_decisions=true');
+    // Classifier timed out and wrote nothing -> still exit 0, just no work.
+    expect(run(false)).toMatchObject({ status: 0 });
+    expect(run(false).result).toContain('has_decisions=false');
   });
 
   it('keeps classifier credentials isolated and PAT writes explicit', () => {

--- a/scripts/tests/ci-flaky-rerun-workflow.test.js
+++ b/scripts/tests/ci-flaky-rerun-workflow.test.js
@@ -46,6 +46,9 @@ describe('ci failure patrol workflow', () => {
     );
     expect(validate.id).toBe('decisions');
     expect(validate.run).not.toContain('test -s');
+    // A timeout kill can leave a non-empty but unparseable file; the validate
+    // step must reject it so the act job never receives corrupt JSON.
+    expect(validate.run).toContain('JSON.parse');
 
     // Downstream work is gated on decisions EXISTING, not merely on the job
     // having survived - otherwise a no-decision cycle looks actionable.
@@ -63,16 +66,16 @@ describe('ci failure patrol workflow', () => {
     );
   });
 
-  it('reports an empty classifier result instead of failing the patrol', () => {
+  it('reports an empty or corrupt classifier result instead of failing the patrol', () => {
     const validate = yml.jobs.classify.steps.find(
       (s) => s.name === 'Validate patrol decisions',
     );
-    const run = (writeDecisions) => {
+    const run = (content) => {
       const dir = mkdtempSync(join(tmpdir(), 'patrol-'));
       const out = join(dir, 'gh_output');
       writeFileSync(out, '');
-      if (writeDecisions) {
-        writeFileSync(join(dir, 'ci-flaky-decisions.json'), '{"decisions":[]}');
+      if (content !== null) {
+        writeFileSync(join(dir, 'ci-flaky-decisions.json'), content);
       }
       let status = 0;
       try {
@@ -88,11 +91,15 @@ describe('ci failure patrol workflow', () => {
       return { status, result };
     };
     // Decisions present -> act downstream.
-    expect(run(true)).toMatchObject({ status: 0 });
-    expect(run(true).result).toContain('has_decisions=true');
+    expect(run('{"decisions":[]}')).toMatchObject({ status: 0 });
+    expect(run('{"decisions":[]}').result).toContain('has_decisions=true');
     // Classifier timed out and wrote nothing -> still exit 0, just no work.
-    expect(run(false)).toMatchObject({ status: 0 });
-    expect(run(false).result).toContain('has_decisions=false');
+    expect(run(null)).toMatchObject({ status: 0 });
+    expect(run(null).result).toContain('has_decisions=false');
+    // Classifier killed mid-write -> partial JSON is not actionable.
+    const partial = run('{"decisions": [{"pr": 123, "action": "rer');
+    expect(partial).toMatchObject({ status: 0 });
+    expect(partial.result).toContain('has_decisions=false');
   });
 
   it('keeps classifier credentials isolated and PAT writes explicit', () => {


### PR DESCRIPTION
## What this PR does

Stops one slow step from taking down the entire CI Failure Patrol, which has been effectively offline for hours at a time.

## Why it's needed

**The patrol is not running.** Across the last 30 scheduled runs, **28 were cancelled and only 2 succeeded** — and both survivors ran at `00:0x`, in ~2 minutes, when the model was idle.

Step timings show exactly why:

| Step | Duration |
| --- | --- |
| Set up job → Scan stale PR failures (steps 1–5) | **28 seconds** ✅ |
| **Classify with ci-flaky-patrol skill** | **9m39s → killed by the 10-minute job timeout** ❌ |
| Validate patrol decisions | skipped |
| Upload patrol input and decisions | skipped |

Because the job dies in the model step, `Validate` and `Upload` never run, the `act` job is skipped on `classify.result != 'success'`, and **nothing is ever re-run**. That repeated on every single cycle from 07:38 to 16:59.

That is why **#7333** still carries a red `web-shell E2E Smoke` whose failure is `No space left on device` — a textbook infra flake, inside the patrol's own `TARGET_WORKFLOW`, that the patrol never got far enough to re-run. (The autofix agent separately looked at the same failure and correctly concluded "not attributable to this PR" — the judgement was right, there was simply nothing left to *act*.)

## How

- **The classifier step is bounded at 5 minutes**, below the job's 10, and marked `continue-on-error`. A slow model now costs one patrol cycle instead of the patrol; the next tick simply tries again.
- **An empty classifier result is reported** (`has_decisions=false`) instead of failing the job, so the run finishes cleanly rather than looking like a broken patrol.
- **Upload and `act` are gated on decisions actually existing**, not merely on the classify job having survived — otherwise a no-decision cycle would look actionable.

The 2-minute survivors show the model does answer well inside a 5-minute budget when it is not saturated, so this converts "never runs" into "runs whenever the model responds at all".

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/ci-flaky-rerun-workflow.test.js scripts/tests/ci-flaky-rerun.test.js` — 40/40. New coverage:
   - The classifier step's `timeout-minutes` is asserted **strictly below** the job's, plus its `continue-on-error`, plus the `has_decisions` gating on both `Upload` and the `act` job.
   - The `Validate patrol decisions` bash is **replayed for real**, with and without a decisions file, asserting exit 0 and the right flag in both cases.
2. Mutation-verified: removing the step bound, or the `decisions` step id, turns the test red.
3. Static (run locally with the exact CI toolchain): `js-yaml` parses; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: the next scheduled `Qwen CI Failure Patrol` run should reach `Validate` (conclusion `success`) instead of being cancelled at ~10 minutes.

### Evidence (Before & After)

```
BEFORE  classify step runs 9m39s -> job timeout at 10m -> job cancelled
        -> Validate/Upload skipped -> act skipped -> zero reruns
        (28 of the last 30 runs cancelled; #7333's ENOSPC never re-run)

AFTER   classify step capped at 5m, continue-on-error
        -> model answered  : decisions -> Upload -> act -> reruns as designed
        -> model too slow  : has_decisions=false, run ends green, next tick retries
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: a model that needs 5–10 minutes will now be cut off where it previously had ~9m40s before being killed anyway. Since the job died at 10 minutes regardless, no cycle that used to produce decisions stops producing them; cycles that used to die now end cleanly.
- Not validated / out of scope: this restores the patrol's ability to *complete*; it does not make it independent of the model. Failures with an unambiguous infra signature (`No space left on device`, runner crash) could be classified deterministically in `scan` and re-run without the model at all — the natural follow-up, and the thing that would guarantee an ENOSPC rerun even when the model is down. Also unchanged: `review-pr` failures are outside `TARGET_WORKFLOW` and remain out of the patrol's scope.
- Breaking changes / migration notes: none.

## Linked Issues

Found while asking why #7333's build failures were never handled. Part of the autofix/CI reliability line: #7330, #7350, #7351, #7354, #7355.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

阻止单个慢步骤拖垮整个 CI Failure Patrol —— 它已经成片地处于离线状态。

## 为什么需要

**巡逻根本没在跑。** 最近 30 次定时运行中,**28 次被取消,仅 2 次成功**;而这 2 次都发生在 `00:0x`、耗时约 2 分钟,当时模型空闲。

步骤耗时给出了确切原因:

| 步骤 | 耗时 |
| --- | --- |
| Set up job → Scan stale PR failures(第 1–5 步) | **28 秒** ✅ |
| **Classify with ci-flaky-patrol skill** | **9分39秒 → 被 10 分钟 job 超时杀死** ❌ |
| Validate patrol decisions | 跳过 |
| Upload patrol input and decisions | 跳过 |

由于 job 在模型步骤死掉,`Validate` 与 `Upload` 从未执行,`act` 因 `classify.result != 'success'` 被跳过,**没有任何重跑**。从 07:38 到 16:59 每一个周期都如此。

这正是 **#7333** 至今挂着红色 `web-shell E2E Smoke` 的原因 —— 其失败是 `No space left on device`,一个教科书级的基础设施 flake,且就在巡逻自己的 `TARGET_WORKFLOW` 范围内,而巡逻从未走到能重跑它的那一步。(autofix agent 另行看过同一失败并正确判定"不可归因于本 PR" —— 判断没错,只是没有任何环节去**执行**。)

## 怎么做

- **分类器步骤限时 5 分钟**(低于 job 的 10 分钟),并标记 `continue-on-error`。慢模型现在只损失一个巡逻周期,而不是整个巡逻;下一个 tick 会自然重试。
- **分类器无产出时如实上报**(`has_decisions=false`)而非让 job 失败,运行得以干净结束,而不是看起来像巡逻坏了。
- **Upload 与 `act` 改为按"决策确实存在"设门**,而不仅仅是"classify job 活下来了" —— 否则一个无决策周期会被误认为可执行。

那 2 次约 2 分钟的成功说明:模型不饱和时完全能在 5 分钟预算内作答。本 PR 把"从不运行"变成"只要模型有响应就运行"。

## 评审验证

1. `npx vitest run scripts/tests/ci-flaky-rerun-workflow.test.js scripts/tests/ci-flaky-rerun.test.js` —— 40/40。新增覆盖:断言分类器步骤的 `timeout-minutes` **严格小于** job 的、其 `continue-on-error`、以及 `Upload` 与 `act` 上的 `has_decisions` 门控;并**真实回放** `Validate patrol decisions` 的 bash(有/无决策文件两种),断言两种情况都 exit 0 且标志正确。
2. 变异验证:去掉步骤限时、或去掉 `decisions` 步骤 id,测试各自变红。
3. 静态(均用 CI 一致工具):YAML 可解析;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:下一次定时 `Qwen CI Failure Patrol` 应能走到 `Validate`(结论 `success`),而不是在约 10 分钟处被取消。

## 风险与范围

- 主要权衡:需要 5–10 分钟的模型现在会被提前截断,而此前它虽有约 9分40秒、最终也一样被杀。由于 job 本就在 10 分钟处死亡,原本能产出决策的周期不会因此失去决策;原本会死掉的周期现在能干净结束。
- 不在范围内:本 PR 恢复的是巡逻**跑完**的能力,并未让它摆脱对模型的依赖。签名明确的基础设施失败(`No space left on device`、runner 崩溃)可以在 `scan` 阶段确定性判定并直接重跑、完全不经模型 —— 这是自然的后续,也是"模型宕机时仍能保证 ENOSPC 被重跑"的关键。另外不变:`review-pr` 的失败在 `TARGET_WORKFLOW` 之外,仍不属巡逻覆盖范围。
- 破坏性变更:无。

## 关联 Issue

在追问"#7333 的构建错误为什么没被处理"时发现。属于 autofix/CI 可靠性主线:#7330、#7350、#7351、#7354、#7355。

</details>
