### PR TITLE
fix(mobile-mcp): fix Windows adb path detection and fail closed when ImageMagick is unavailable

### DIFF
--- a/packages/mobile-mcp/src/android.ts
+++ b/packages/mobile-mcp/src/android.ts
@@ -41,8 +41,8 @@ interface UiAutomatorXml {
   };
 }
 
-const getAdbPath = (): string => {
-  const exeName = process.env.platform === 'win32' ? 'adb.exe' : 'adb';
+export const getAdbPath = (): string => {
+  const exeName = process.platform === 'win32' ? 'adb.exe' : 'adb';
   if (process.env.ANDROID_HOME) {
     return path.join(process.env.ANDROID_HOME, 'platform-tools', exeName);
   }

--- a/packages/mobile-mcp/src/image-utils.ts
+++ b/packages/mobile-mcp/src/image-utils.ts
@@ -125,6 +125,21 @@ export class ImageTransformer {
       input: this.buffer,
     });
 
+    // Mirror toBufferWithSips: fail loudly so toBuffer()'s catch can surface
+    // the "Image scaling unavailable" fallback. On a missing binary spawnSync
+    // reports proc.error (ENOENT) with a null status and undefined stdout;
+    // returning that empty/undefined value would crash callers that read
+    // `.length`/`.toString()` on the result.
+    if (proc.error) {
+      throw proc.error;
+    }
+    if (proc.status !== 0) {
+      throw new Error(`ImageMagick failed with status ${proc.status}`);
+    }
+    if (!proc.stdout || proc.stdout.length === 0) {
+      throw new Error('ImageMagick produced no output');
+    }
+
     return proc.stdout;
   }
 }

--- a/packages/mobile-mcp/test/adb-path.test.ts
+++ b/packages/mobile-mcp/test/adb-path.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { getAdbPath } from '../src/android';
+
+// getAdbPath must key off `process.platform` (the real runtime platform),
+// not `process.env.platform` (an env var that is essentially never set, so
+// it always fell through to the non-Windows 'adb' name). On Windows with
+// ANDROID_HOME set that produced a `.../platform-tools/adb` path with no
+// `.exe`, which execFileSync cannot resolve (PATHEXT is not applied),
+// breaking Android automation on Windows.
+
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', {
+      value: original,
+      configurable: true,
+    });
+  }
+}
+
+function withAndroidHome(value: string, fn: () => void): void {
+  const original = process.env.ANDROID_HOME;
+  process.env.ANDROID_HOME = value;
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env.ANDROID_HOME;
+    } else {
+      process.env.ANDROID_HOME = original;
+    }
+  }
+}
+
+test('resolves adb.exe under ANDROID_HOME on win32', () => {
+  withAndroidHome(path.join('C:', 'Android', 'Sdk'), () => {
+    withPlatform('win32', () => {
+      const resolved = getAdbPath();
+      expect(resolved.endsWith('adb.exe')).toBe(true);
+    });
+  });
+});
+
+test('resolves plain adb (no .exe) under ANDROID_HOME on non-win32', () => {
+  withAndroidHome('/opt/android-sdk', () => {
+    withPlatform('linux', () => {
+      const resolved = getAdbPath();
+      expect(resolved.endsWith('adb.exe')).toBe(false);
+      expect(resolved.endsWith('adb')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What this PR does

Fixes two independent robustness bugs in the vendored `mobile-mcp` package.

1. **Windows adb path detection.** `getAdbPath()` picked the executable name from `process.env.platform` — an environment variable, not the runtime platform — so it always chose `adb`. When `ANDROID_HOME` is set on Windows it produced a `.../platform-tools/adb` path with no `.exe`. It now keys off `process.platform`, matching every other platform check in the file and the sibling Windows branch that already hardcodes `adb.exe`.

2. **ImageMagick fallback fails closed.** `toBufferWithImageMagick()` returned `spawnSync(...).stdout` without inspecting the outcome. On a missing `magick` binary (ENOENT) or a non-zero exit it returned an empty/undefined value typed as `Buffer`. It now throws on `proc.error`, a non-zero status, or empty output — mirroring the sibling `toBufferWithSips()`.

## Why it's needed

1. `process.env.platform` is essentially never set, so the Windows branch was dead: on Windows with `ANDROID_HOME` configured, `getAdbPath()` returned a path ending in `adb` instead of `adb.exe`. `execFileSync` does not apply `PATHEXT`, so it fails with `ENOENT` and Android automation is broken on Windows for the common `ANDROID_HOME` case.

2. `toBuffer()` is written to catch a throw from `toBufferWithImageMagick()` and surface a clear `Image scaling unavailable (requires Sips or ImageMagick)` error. Because the method swallowed failures and returned empty `stdout`, that fallback never fired — instead callers (`mobile_take_screenshot`, `server.ts`) received an empty/undefined buffer and crashed downstream on `.length`/`.toString()`. The sibling `toBufferWithSips()` already checks `proc.status !== 0`; this brings the two paths into line.

## Reviewer Test Plan

### How to verify

```
cd packages/mobile-mcp
npx playwright test test/adb-path.test.ts
```

New regression tests assert `getAdbPath()` resolves `adb.exe` under `ANDROID_HOME` on `win32` and plain `adb` on non-Windows. They **fail before** this change (win32 resolves `adb`, `Received: false`) and **pass after**. `npx tsc --noEmit -p tsconfig.json` is clean.

For fix (2): with no `magick` binary on `PATH` and Sips unavailable, `Image.fromBuffer(buf).resize(w).toBuffer()` now throws `Image scaling unavailable (requires Sips or ImageMagick)` instead of returning empty and crashing the caller — matching the already-tested Sips path.

### Evidence (Before & After)

N/A — non-user-visible package robustness fix. Evidence is the unit tests above.

Fix (1), clean fail-before / pass-after (logic bug reintroduced with export intact):
```
Before: ✘ resolves adb.exe under ANDROID_HOME on win32   Expected: true  Received: false
        ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
After:  ✓ resolves adb.exe under ANDROID_HOME on win32
        ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: pure-logic suites `adb-path`, `coord-norm`, `strip-ui-bounds` all green (28 passed); `tsc --noEmit` clean. The pre-existing `mobilecli.test.ts` failure (`Could not find mobilecli binary for platform`) is an unrelated missing-prebuilt-binary issue and is untouched by this PR. Windows is the platform the adb fix targets but I could not run the suite there; the fix is a one-line correction matching the file's other `process.platform` checks.

### Environment (optional)

`packages/mobile-mcp` playwright test runner (pure-node tests, no device required).

## Risk & Scope

- Main risk or tradeoff: Fix (2) turns silent failure into a thrown error that `toBuffer()` already catches and converts to the intended user-facing message — strictly more correct, no new failure surface. Fix (1) only changes behavior on Windows, toward the documented `adb.exe` name.
- Not validated / out of scope: Not run on real Windows or against a live ImageMagick/Sips absence in CI (the package is vendored and not part of the main CI test loop); verified by unit tests and by matching the sibling code paths. `getAdbPath` is now exported to make it unit-testable.
- Breaking changes / migration notes: None.

## Linked Issues

N/A — found by source review; no existing issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 vendored `mobile-mcp` 包中的两个独立健壮性 bug。

1. **Windows adb 路径检测。** `getAdbPath()` 从 `process.env.platform`（一个环境变量，而非运行时平台）选择可执行文件名，因此总是选到 `adb`。当 Windows 上设置了 `ANDROID_HOME` 时，它生成的是不带 `.exe` 的 `.../platform-tools/adb` 路径。现改为基于 `process.platform`，与文件中其它所有平台判断以及已硬编码 `adb.exe` 的同级 Windows 分支保持一致。

2. **ImageMagick 回退路径 fail closed。** `toBufferWithImageMagick()` 直接返回 `spawnSync(...).stdout` 而不检查执行结果。在 `magick` 二进制缺失（ENOENT）或非零退出时，它返回一个被标注为 `Buffer` 的空/undefined 值。现在在 `proc.error`、非零状态或空输出时抛出异常——与同级 `toBufferWithSips()` 保持一致。

## 为什么需要它

1. `process.env.platform` 基本上从不会被设置，因此 Windows 分支形同虚设：在配置了 `ANDROID_HOME` 的 Windows 上，`getAdbPath()` 返回以 `adb` 而非 `adb.exe` 结尾的路径。`execFileSync` 不应用 `PATHEXT`，因此会以 `ENOENT` 失败，导致常见的 `ANDROID_HOME` 场景下 Windows 上的 Android 自动化被破坏。

2. `toBuffer()` 的设计是捕获 `toBufferWithImageMagick()` 抛出的异常并给出清晰的 `Image scaling unavailable (requires Sips or ImageMagick)` 错误。由于该方法吞掉了失败并返回空 `stdout`，这个回退从未触发——调用方（`mobile_take_screenshot`、`server.ts`）反而收到空/undefined buffer 并在后续 `.length`/`.toString()` 上崩溃。同级 `toBufferWithSips()` 已经检查了 `proc.status !== 0`；本次改动让两条路径保持一致。

## Reviewer Test Plan

### 如何验证

```
cd packages/mobile-mcp
npx playwright test test/adb-path.test.ts
```

新增回归测试断言 `getAdbPath()` 在 `win32` 且设置 `ANDROID_HOME` 时解析为 `adb.exe`，在非 Windows 上解析为 `adb`。它们在本次改动**之前失败**（win32 解析为 `adb`，`Received: false`），**之后通过**。`npx tsc --noEmit -p tsconfig.json` 干净。

对于修复 (2)：在 `PATH` 上没有 `magick` 且 Sips 不可用时，`Image.fromBuffer(buf).resize(w).toBuffer()` 现在抛出 `Image scaling unavailable (requires Sips or ImageMagick)`，而不是返回空值并使调用方崩溃——与已有测试覆盖的 Sips 路径一致。

### 证据（Before & After）

N/A——非用户可见的包健壮性修复。证据为上述单元测试。

修复 (1)，干净的 fail-before / pass-after（在保留 export 的情况下重新引入逻辑 bug）：
```
之前: ✘ resolves adb.exe under ANDROID_HOME on win32   Expected: true  Received: false
      ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
之后: ✓ resolves adb.exe under ANDROID_HOME on win32
      ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
```

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：纯逻辑测试套件 `adb-path`、`coord-norm`、`strip-ui-bounds` 全部通过（28 passed）；`tsc --noEmit` 干净。已存在的 `mobilecli.test.ts` 失败（`Could not find mobilecli binary for platform`）是无关的缺少预编译二进制问题，本 PR 未触及。Windows 是 adb 修复所针对的平台，但我无法在该平台运行测试；该修复是一行更正，与文件中其它 `process.platform` 判断一致。

### 环境（可选）

`packages/mobile-mcp` playwright 测试运行器（纯 node 测试，无需设备）。

## 风险与范围

- 主要风险或权衡：修复 (2) 将静默失败转为抛出异常，而 `toBuffer()` 本就会捕获并转换为预期的用户可见信息——严格来说更正确，不引入新的失败面。修复 (1) 仅在 Windows 上改变行为，趋向文档记载的 `adb.exe` 名称。
- 未验证／超出范围：未在真实 Windows 上运行，也未在 CI 中针对真实的 ImageMagick/Sips 缺失验证（该包为 vendored，不在主 CI 测试回路中）；通过单元测试和与同级代码路径的一致性来验证。`getAdbPath` 现已导出以便单元测试。
- 破坏性变更／迁移说明：无。

## 关联 Issue

N/A——通过源码审查发现，无现有 issue。

</details>
