### PR TITLE
fix(dingtalk): cap media download size to 50MB to match feishu

### DIFF
--- a/packages/channels/dingtalk/src/media.test.ts
+++ b/packages/channels/dingtalk/src/media.test.ts
@@ -64,8 +64,9 @@ describe('downloadMedia (DingTalk)', () => {
     expect(result?.mimeType).toBe('image/png');
   });
 
-  it('rejects a Content-Length exceeding 50MB', async () => {
+  it('rejects a Content-Length exceeding 50MB and releases the connection', async () => {
     const largeSize = 60 * 1024 * 1024; // 60 MB
+    const bodyCancel = vi.fn();
     const fileResp = {
       ok: true,
       headers: {
@@ -73,6 +74,7 @@ describe('downloadMedia (DingTalk)', () => {
           key === 'content-length' ? largeSize.toString() : null,
       },
       body: {
+        cancel: bodyCancel,
         getReader: () => ({
           read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
           cancel: vi.fn(),
@@ -87,6 +89,7 @@ describe('downloadMedia (DingTalk)', () => {
     const result = await downloadMedia('code', 'robot', 'token');
 
     expect(result).toBeNull();
+    expect(bodyCancel).toHaveBeenCalled();
   });
 
   it('rejects a stream exceeding 50MB with no Content-Length header', async () => {

--- a/packages/channels/dingtalk/src/media.test.ts
+++ b/packages/channels/dingtalk/src/media.test.ts
@@ -1,0 +1,134 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
+import { downloadMedia } from './media.js';
+
+describe('downloadMedia (DingTalk)', () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  // First fetch is the DingTalk download-code API that returns a downloadUrl;
+  // the second fetch is the actual file download that the size cap guards.
+  function mockApiResponse(
+    downloadUrl = 'https://dl.dingtalk.example/file',
+  ): Response {
+    return {
+      ok: true,
+      json: vi.fn().mockResolvedValue({ downloadUrl }),
+    } as unknown as Response;
+  }
+
+  it('downloads a file within the size limit', async () => {
+    const mockData = new Uint8Array([1, 2, 3, 4]);
+    const fileResp = {
+      ok: true,
+      headers: {
+        get: (key: string) => {
+          if (key === 'content-length') return '4';
+          if (key === 'content-type') return 'image/png';
+          return null;
+        },
+      },
+      body: {
+        getReader: () => ({
+          read: vi
+            .fn()
+            .mockResolvedValueOnce({ done: false, value: mockData })
+            .mockResolvedValueOnce({ done: true, value: undefined }),
+          cancel: vi.fn(),
+        }),
+      },
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce(mockApiResponse())
+      .mockResolvedValueOnce(fileResp as unknown as Response);
+
+    const result = await downloadMedia('code', 'robot', 'token');
+
+    expect(result).not.toBeNull();
+    expect(result?.buffer).toEqual(Buffer.from(mockData));
+    expect(result?.mimeType).toBe('image/png');
+  });
+
+  it('rejects a Content-Length exceeding 50MB', async () => {
+    const largeSize = 60 * 1024 * 1024; // 60 MB
+    const fileResp = {
+      ok: true,
+      headers: {
+        get: (key: string) =>
+          key === 'content-length' ? largeSize.toString() : null,
+      },
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+          cancel: vi.fn(),
+        }),
+      },
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce(mockApiResponse())
+      .mockResolvedValueOnce(fileResp as unknown as Response);
+
+    const result = await downloadMedia('code', 'robot', 'token');
+
+    expect(result).toBeNull();
+  });
+
+  it('rejects a stream exceeding 50MB with no Content-Length header', async () => {
+    const chunkSize = 10 * 1024 * 1024; // 10 MB per chunk
+    const mockData = new Uint8Array(chunkSize);
+    const cancelMock = vi.fn();
+    const fileResp = {
+      ok: true,
+      headers: {
+        get: () => null, // no content-length → must be caught while streaming
+      },
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockResolvedValue({ done: false, value: mockData }), // never ends
+          cancel: cancelMock,
+        }),
+      },
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce(mockApiResponse())
+      .mockResolvedValueOnce(fileResp as unknown as Response);
+
+    const result = await downloadMedia('code', 'robot', 'token');
+
+    expect(result).toBeNull();
+    expect(cancelMock).toHaveBeenCalled();
+  });
+
+  it('returns null when the file response body is null', async () => {
+    const fileResp = {
+      ok: true,
+      headers: { get: () => null },
+      body: null,
+    };
+
+    fetchSpy
+      .mockResolvedValueOnce(mockApiResponse())
+      .mockResolvedValueOnce(fileResp as unknown as Response);
+
+    const result = await downloadMedia('code', 'robot', 'token');
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/channels/dingtalk/src/media.ts
+++ b/packages/channels/dingtalk/src/media.ts
@@ -71,9 +71,39 @@ export async function downloadMedia(
       return null;
     }
 
+    const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+    const contentLength = fileResp.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > MAX_DOWNLOAD_BYTES) {
+      process.stderr.write(
+        `[DingTalk] downloadMedia rejected: size ${contentLength} exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
+      );
+      return null;
+    }
+
     const mimeType =
       fileResp.headers.get('content-type') || 'application/octet-stream';
-    const buffer = Buffer.from(await fileResp.arrayBuffer());
+
+    // Stream-read with size enforcement (handles chunked transfer without Content-Length)
+    const reader = fileResp.body?.getReader();
+    if (!reader) {
+      return null;
+    }
+    const chunks: Buffer[] = [];
+    let totalSize = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalSize += value.byteLength;
+      if (totalSize > MAX_DOWNLOAD_BYTES) {
+        reader.cancel();
+        process.stderr.write(
+          `[DingTalk] downloadMedia rejected: actual size exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
+        );
+        return null;
+      }
+      chunks.push(Buffer.from(value));
+    }
+    const buffer = Buffer.concat(chunks);
 
     return { buffer, mimeType };
   } catch (err) {

--- a/packages/channels/dingtalk/src/media.ts
+++ b/packages/channels/dingtalk/src/media.ts
@@ -62,8 +62,12 @@ export async function downloadMedia(
       return null;
     }
 
-    // Step 2: Download the actual file
-    const fileResp = await fetch(downloadUrl);
+    // Step 2: Download the actual file. Bound the request so a stalled CDN
+    // connection can't hang the streaming loop below indefinitely (matches
+    // the Feishu adapter).
+    const fileResp = await fetch(downloadUrl, {
+      signal: AbortSignal.timeout(30_000),
+    });
     if (!fileResp.ok) {
       process.stderr.write(
         `[DingTalk] downloadMedia file fetch failed: HTTP ${fileResp.status}\n`,
@@ -74,6 +78,9 @@ export async function downloadMedia(
     const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
     const contentLength = fileResp.headers.get('content-length');
     if (contentLength && parseInt(contentLength, 10) > MAX_DOWNLOAD_BYTES) {
+      // Release the connection instead of letting the unread body pin it
+      // until GC.
+      await fileResp.body?.cancel();
       process.stderr.write(
         `[DingTalk] downloadMedia rejected: size ${contentLength} exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
       );

--- a/packages/channels/dingtalk/src/media.ts
+++ b/packages/channels/dingtalk/src/media.ts
@@ -102,7 +102,10 @@ export async function downloadMedia(
       if (done) break;
       totalSize += value.byteLength;
       if (totalSize > MAX_DOWNLOAD_BYTES) {
-        reader.cancel();
+        // Await the cancel so a stream error during teardown surfaces here
+        // instead of becoming an unhandled rejection (matches the body.cancel
+        // above).
+        await reader.cancel();
         process.stderr.write(
           `[DingTalk] downloadMedia rejected: actual size exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
         );


### PR DESCRIPTION
## What this PR does

Brings the DingTalk media download path to parity with the Feishu adapter: a 50 MB size cap (`Content-Length` check plus streaming enforcement), connection release on rejection, and a 30s download timeout. Previously `downloadMedia()` read the whole response into memory via `Buffer.from(await fileResp.arrayBuffer())` with no size or time bound at all.

## Why it's needed

This is a concrete consistency gap with the sibling adapter, not hypothetical hardening. `packages/channels/feishu/src/media.ts` already enforces exactly this — a 50 MB cap, a streaming size check that also covers chunked responses with no `Content-Length`, and `AbortSignal.timeout(30_000)` on the download fetch. DingTalk's `downloadMedia()` was the outlier with none of it: a large response is read fully into daemon memory, and a stalled CDN connection can hang the read indefinitely. Bringing the two adapters to parity closes that gap and keeps their behavior aligned for the same class of input.

## Reviewer Test Plan

### How to verify

```
npx vitest run --root packages/channels/dingtalk src/media.test.ts
```

`media.test.ts` (mirroring `feishu/media.test.ts`) covers: a within-limit download succeeds; a `Content-Length` above 50 MB is rejected, returns null, and the response body is cancelled (connection released); a chunked stream with no `Content-Length` that exceeds 50 MB is rejected and `reader.cancel()` is called; a null body returns null. Each test pins a specific guard — removing the `Content-Length` check fails the first rejection test, removing the streaming check fails the second, removing the body cancel fails the connection-release assertion.

### Evidence (Before & After)

N/A — non-user-visible parity fix. Evidence is the unit tests.

```
✓ src/media.test.ts (4 tests)
[DingTalk] downloadMedia rejected: size 62914560 exceeds 52428800 byte limit
[DingTalk] downloadMedia rejected: actual size exceeds 52428800 byte limit
Test Files  4 passed (4) | Tests  123 passed (123)   (full dingtalk suite)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest); `fetch` is mocked.

## Risk & Scope

- Main risk or tradeoff: The download path switches from `arrayBuffer()` to a streaming reader with a 30s timeout — the same approach Feishu already uses. Behavior for normal-sized files is unchanged; the new outcomes are rejecting downloads over 50 MB and aborting a stalled connection.
- Not validated / out of scope: The ~30 lines of size-capped streaming are now duplicated between the DingTalk and Feishu adapters. The cleaner end-state is a shared `downloadWithSizeCap` helper in `packages/channels/base/`; I've kept this PR scoped to bringing DingTalk to parity (matching Feishu line-for-line, including `Buffer.from(value)` + `Buffer.concat`) and would do the extraction as a focused follow-up rather than refactor the working Feishu path here. The 50 MB threshold matches Feishu's constant; not made configurable, for consistency. Not exercised against the live DingTalk API.
- Breaking changes / migration notes: None. Legitimate media (well under 50 MB) downloads exactly as before.

## Linked Issues

N/A — found by source review comparing the DingTalk and Feishu media paths; no existing issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 DingTalk 媒体下载路径与 Feishu 适配器达到一致：50 MB 大小上限（`Content-Length` 检查加流式强制）、拒绝时释放连接，以及 30 秒下载超时。此前 `downloadMedia()` 通过 `Buffer.from(await fileResp.arrayBuffer())` 将整个响应读入内存，没有任何大小或时间限制。

## 为什么需要它

这是与同级适配器之间一个具体的一致性缺口，而非假设性加固。`packages/channels/feishu/src/media.ts` 已经实现了这一切——50 MB 上限、也能覆盖无 `Content-Length` 分块响应的流式大小检查，以及下载 fetch 上的 `AbortSignal.timeout(30_000)`。DingTalk 的 `downloadMedia()` 是那个什么都没有的例外：大响应会被完整读入守护进程内存，而停滞的 CDN 连接会使读取无限期挂起。让两个适配器达到一致就能关闭这个缺口，并使它们对同类输入的行为保持一致。

## Reviewer Test Plan

### 如何验证

```
npx vitest run --root packages/channels/dingtalk src/media.test.ts
```

`media.test.ts`（对照 `feishu/media.test.ts`）覆盖：限额内的下载成功；`Content-Length` 超过 50 MB 被拒绝、返回 null 且响应 body 被取消（释放连接）；无 `Content-Length` 的分块流超过 50 MB 被拒绝且调用 `reader.cancel()`；body 为 null 返回 null。每个测试都锁定一个具体守卫——移除 `Content-Length` 检查会使第一个拒绝测试失败，移除流式检查会使第二个失败，移除 body cancel 会使连接释放断言失败。

### 证据（Before & After）

N/A——非用户可见的一致性修复。证据为单元测试。

```
✓ src/media.test.ts (4 tests)
[DingTalk] downloadMedia rejected: size 62914560 exceeds 52428800 byte limit
[DingTalk] downloadMedia rejected: actual size exceeds 52428800 byte limit
Test Files  4 passed (4) | Tests  123 passed (123)   （dingtalk 完整测试套件）
```

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅单元测试（vitest）；`fetch` 被 mock。

## 风险与范围

- 主要风险或权衡：下载路径从 `arrayBuffer()` 改为带 30 秒超时的流式 reader——与 Feishu 已采用的方式相同。正常大小文件的行为不变；新增的结果是拒绝超过 50 MB 的下载以及中止停滞的连接。
- 未验证／超出范围：约 30 行的大小限制流式逻辑现在在 DingTalk 与 Feishu 适配器之间重复。更清晰的最终形态是在 `packages/channels/base/` 中提供一个共享的 `downloadWithSizeCap` 助手；我将本 PR 限定为让 DingTalk 达到一致（与 Feishu 逐行一致，包括 `Buffer.from(value)` + `Buffer.concat`），并倾向于将抽取作为一个专门的后续 PR，而不是在此改动工作正常的 Feishu 路径。50 MB 阈值与 Feishu 的常量一致；为保持一致未做成可配置。未针对真实 DingTalk API 验证。
- 破坏性变更／迁移说明：无。合法媒体（远小于 50 MB）的下载与之前完全一致。

## 关联 Issue

N/A——通过对比 DingTalk 与 Feishu 媒体路径的源码审查发现，无现有 issue。

</details>
