### PR TITLE
fix(mobile-mcp): use process.platform for adb executable name on Windows

### DIFF
--- a/packages/mobile-mcp/src/android.ts
+++ b/packages/mobile-mcp/src/android.ts
@@ -41,8 +41,8 @@ interface UiAutomatorXml {
   };
 }
 
-const getAdbPath = (): string => {
-  const exeName = process.env.platform === 'win32' ? 'adb.exe' : 'adb';
+export const getAdbPath = (): string => {
+  const exeName = process.platform === 'win32' ? 'adb.exe' : 'adb';
   if (process.env.ANDROID_HOME) {
     return path.join(process.env.ANDROID_HOME, 'platform-tools', exeName);
   }

--- a/packages/mobile-mcp/test/adb-path.test.ts
+++ b/packages/mobile-mcp/test/adb-path.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { getAdbPath } from '../src/android';
+
+// getAdbPath must key off `process.platform` (the real runtime platform),
+// not `process.env.platform` (an env var that is essentially never set, so
+// it always fell through to the non-Windows 'adb' name). On Windows with
+// ANDROID_HOME set that produced a `.../platform-tools/adb` path with no
+// `.exe`, which execFileSync cannot resolve (PATHEXT is not applied),
+// breaking Android automation on Windows.
+
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', {
+      value: original,
+      configurable: true,
+    });
+  }
+}
+
+function withAndroidHome(value: string, fn: () => void): void {
+  const original = process.env.ANDROID_HOME;
+  process.env.ANDROID_HOME = value;
+  try {
+    fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env.ANDROID_HOME;
+    } else {
+      process.env.ANDROID_HOME = original;
+    }
+  }
+}
+
+test('resolves adb.exe under ANDROID_HOME on win32', () => {
+  withAndroidHome(path.join('C:', 'Android', 'Sdk'), () => {
+    withPlatform('win32', () => {
+      const resolved = getAdbPath();
+      expect(resolved.endsWith('adb.exe')).toBe(true);
+    });
+  });
+});
+
+test('resolves plain adb (no .exe) under ANDROID_HOME on non-win32', () => {
+  withAndroidHome('/opt/android-sdk', () => {
+    withPlatform('linux', () => {
+      const resolved = getAdbPath();
+      expect(resolved.endsWith('adb.exe')).toBe(false);
+      expect(resolved.endsWith('adb')).toBe(true);
+    });
+  });
+});

--- a/packages/mobile-mcp/test/adb-path.test.ts
+++ b/packages/mobile-mcp/test/adb-path.test.ts
@@ -10,7 +10,10 @@ import { getAdbPath } from '../src/android';
 // breaking Android automation on Windows.
 
 function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
-  const original = process.platform;
+  // Capture the full original descriptor so the restore preserves its
+  // attributes (enumerable/writable), rather than leaving behind a plain
+  // { configurable, value } descriptor that would leak to later tests.
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
   Object.defineProperty(process, 'platform', {
     value: platform,
     configurable: true,
@@ -18,10 +21,11 @@ function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
   try {
     fn();
   } finally {
-    Object.defineProperty(process, 'platform', {
-      value: original,
-      configurable: true,
-    });
+    if (original) {
+      Object.defineProperty(process, 'platform', original);
+    } else {
+      delete (process as unknown as { platform?: NodeJS.Platform }).platform;
+    }
   }
 }
 

--- a/packages/mobile-mcp/test/adb-path.test.ts
+++ b/packages/mobile-mcp/test/adb-path.test.ts
@@ -57,3 +57,22 @@ test('resolves plain adb (no .exe) under ANDROID_HOME on non-win32', () => {
     });
   });
 });
+
+test('resolves adb.exe on the win32 fallthrough (no ANDROID_HOME, no LOCALAPPDATA)', () => {
+  // With neither ANDROID_HOME nor LOCALAPPDATA set, getAdbPath falls through
+  // to `return exeName`, which must be 'adb.exe' on win32 — guards the bare
+  // executable name the fix produces on that path.
+  const originalLocalAppData = process.env.LOCALAPPDATA;
+  delete process.env.LOCALAPPDATA;
+  try {
+    withAndroidHome('', () => {
+      withPlatform('win32', () => {
+        expect(getAdbPath()).toBe('adb.exe');
+      });
+    });
+  } finally {
+    if (originalLocalAppData !== undefined) {
+      process.env.LOCALAPPDATA = originalLocalAppData;
+    }
+  }
+});


### PR DESCRIPTION
## What this PR does

Fixes Android device detection on Windows in the vendored `mobile-mcp` package. `getAdbPath()` picked the executable name from `process.env.platform` — an environment variable, not the runtime platform — so it always chose `adb`. It now keys off `process.platform`, matching every other platform check in the file and the sibling Windows branch that already hardcodes `adb.exe`.

## Why it's needed

`process.env.platform` is essentially never set, so the Windows branch was dead: on Windows with `ANDROID_HOME` configured, `getAdbPath()` returned a path ending in `adb` instead of `adb.exe`. `execFileSync` does not apply `PATHEXT`, so it fails with `ENOENT` and Android automation is broken on Windows for the common `ANDROID_HOME` case.

## Reviewer Test Plan

### How to verify

```
cd packages/mobile-mcp
npx playwright test test/adb-path.test.ts
```

New regression tests assert `getAdbPath()` resolves `adb.exe` under `ANDROID_HOME` on `win32` and plain `adb` on non-Windows.

### Evidence (Before & After)

N/A — non-user-visible fix. Evidence is the unit tests. Clean fail-before / pass-after (logic bug reintroduced with the export intact):

```
Before: ✘ resolves adb.exe under ANDROID_HOME on win32   Expected: true  Received: false
        ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
After:  ✓ resolves adb.exe under ANDROID_HOME on win32
        ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `adb-path` suite green, `tsc --noEmit` clean. Windows is the platform the fix targets but I could not run the suite there; the change is a one-line correction matching the file's other `process.platform` checks.

### Environment (optional)

`packages/mobile-mcp` playwright test runner (pure-node test, no device required).

## Risk & Scope

- Main risk or tradeoff: Only changes behavior on Windows, toward the documented `adb.exe` name.
- Not validated / out of scope: Not run on real Windows (the package is vendored and not part of the main CI test loop); verified by unit test and by matching the sibling code. `getAdbPath` is now exported to make it unit-testable.
- Breaking changes / migration notes: None.

## Linked Issues

N/A — found by source review; no existing issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 vendored `mobile-mcp` 包中 Windows 上的 Android 设备检测。`getAdbPath()` 从 `process.env.platform`（一个环境变量，而非运行时平台）选择可执行文件名，因此总是选到 `adb`。现改为基于 `process.platform`，与文件中其它所有平台判断以及已硬编码 `adb.exe` 的同级 Windows 分支保持一致。

## 为什么需要它

`process.env.platform` 基本上从不会被设置，因此 Windows 分支形同虚设：在配置了 `ANDROID_HOME` 的 Windows 上，`getAdbPath()` 返回以 `adb` 而非 `adb.exe` 结尾的路径。`execFileSync` 不应用 `PATHEXT`，因此会以 `ENOENT` 失败，导致常见的 `ANDROID_HOME` 场景下 Windows 上的 Android 自动化被破坏。

## Reviewer Test Plan

### 如何验证

```
cd packages/mobile-mcp
npx playwright test test/adb-path.test.ts
```

新增回归测试断言 `getAdbPath()` 在 `win32` 且设置 `ANDROID_HOME` 时解析为 `adb.exe`，在非 Windows 上解析为 `adb`。

### 证据（Before & After）

N/A——非用户可见的修复。证据为单元测试。干净的 fail-before / pass-after（在保留 export 的情况下重新引入逻辑 bug）：

```
之前: ✘ resolves adb.exe under ANDROID_HOME on win32   Expected: true  Received: false
      ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
之后: ✓ resolves adb.exe under ANDROID_HOME on win32
      ✓ resolves plain adb (no .exe) under ANDROID_HOME on non-win32
```

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`adb-path` 套件通过，`tsc --noEmit` 干净。Windows 是修复所针对的平台，但我无法在该平台运行测试；该修复是一行更正，与文件中其它 `process.platform` 判断一致。

### 环境（可选）

`packages/mobile-mcp` playwright 测试运行器（纯 node 测试，无需设备）。

## 风险与范围

- 主要风险或权衡：仅在 Windows 上改变行为，趋向文档记载的 `adb.exe` 名称。
- 未验证／超出范围：未在真实 Windows 上运行（该包为 vendored，不在主 CI 测试回路中）；通过单元测试和与同级代码的一致性来验证。`getAdbPath` 现已导出以便单元测试。
- 破坏性变更／迁移说明：无。

## 关联 Issue

N/A——通过源码审查发现，无现有 issue。

</details>
