### PR TITLE
fix(mobile-mcp): fail closed when ImageMagick is unavailable

### DIFF
--- a/packages/mobile-mcp/src/image-utils.ts
+++ b/packages/mobile-mcp/src/image-utils.ts
@@ -125,6 +125,21 @@ export class ImageTransformer {
       input: this.buffer,
     });
 
+    // Mirror toBufferWithSips: fail loudly so toBuffer()'s catch can surface
+    // the "Image scaling unavailable" fallback. On a missing binary spawnSync
+    // reports proc.error (ENOENT) with a null status and undefined stdout;
+    // returning that empty/undefined value would crash callers that read
+    // `.length`/`.toString()` on the result.
+    if (proc.error) {
+      throw proc.error;
+    }
+    if (proc.status !== 0) {
+      throw new Error(`ImageMagick failed with status ${proc.status}`);
+    }
+    if (!proc.stdout || proc.stdout.length === 0) {
+      throw new Error('ImageMagick produced no output');
+    }
+
     return proc.stdout;
   }
 }


### PR DESCRIPTION
## What this PR does

Makes the ImageMagick scaling path in the vendored `mobile-mcp` package fail closed. `toBufferWithImageMagick()` returned `spawnSync(...).stdout` without inspecting the outcome; it now throws on `proc.error`, a non-zero exit status, or empty output — mirroring the sibling `toBufferWithSips()`.

## Why it's needed

`toBuffer()` is written to catch a throw from `toBufferWithImageMagick()` and surface a clear `Image scaling unavailable (requires Sips or ImageMagick)` error. Because the method swallowed failures and returned empty `stdout` (on a missing `magick` binary, ENOENT gives a null status and undefined stdout), that fallback never fired — instead callers (`mobile_take_screenshot`, `server.ts`) received an empty/undefined buffer typed as `Buffer` and crashed downstream on `.length`/`.toString()`. The sibling `toBufferWithSips()` already checks `proc.status !== 0`; this brings the two paths into line.

## Reviewer Test Plan

### How to verify

With no `magick` binary on `PATH` and Sips unavailable, `Image.fromBuffer(buf).resize(w).toBuffer()` now throws `Image scaling unavailable (requires Sips or ImageMagick)` instead of returning empty and crashing the caller — matching the behavior of the already-tested Sips path when `sips` fails.

`cd packages/mobile-mcp && npx tsc --noEmit -p tsconfig.json` is clean.

### Evidence (Before & After)

N/A — non-user-visible robustness fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `tsc --noEmit` clean; existing pure-logic suites unaffected.

### Environment (optional)

`packages/mobile-mcp`.

## Risk & Scope

- Main risk or tradeoff: Turns silent failure into a thrown error that `toBuffer()` already catches and converts to the intended user-facing message — strictly more correct, no new failure surface for the success path (valid output is returned unchanged).
- Not validated / out of scope: No dedicated unit test — the package's `@playwright/test` harness has no `spawnSync` mocking, and forcing a real ImageMagick absence is environment-dependent; the change mirrors the already-tested `toBufferWithSips()` status check exactly. The package is vendored and not part of the main CI test loop.
- Breaking changes / migration notes: None.

## Linked Issues

N/A — found by source review; no existing issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 vendored `mobile-mcp` 包中的 ImageMagick 缩放路径 fail closed。`toBufferWithImageMagick()` 直接返回 `spawnSync(...).stdout` 而不检查执行结果；现在在 `proc.error`、非零退出状态或空输出时抛出异常——与同级 `toBufferWithSips()` 保持一致。

## 为什么需要它

`toBuffer()` 的设计是捕获 `toBufferWithImageMagick()` 抛出的异常并给出清晰的 `Image scaling unavailable (requires Sips or ImageMagick)` 错误。由于该方法吞掉了失败并返回空 `stdout`（在 `magick` 二进制缺失时，ENOENT 会给出 null 状态和 undefined stdout），这个回退从未触发——调用方（`mobile_take_screenshot`、`server.ts`）反而收到被标注为 `Buffer` 的空/undefined 值，并在后续 `.length`/`.toString()` 上崩溃。同级 `toBufferWithSips()` 已经检查了 `proc.status !== 0`；本次改动让两条路径保持一致。

## Reviewer Test Plan

### 如何验证

在 `PATH` 上没有 `magick` 且 Sips 不可用时，`Image.fromBuffer(buf).resize(w).toBuffer()` 现在抛出 `Image scaling unavailable (requires Sips or ImageMagick)`，而不是返回空值并使调用方崩溃——与已有测试覆盖的 Sips 路径在 `sips` 失败时的行为一致。

`cd packages/mobile-mcp && npx tsc --noEmit -p tsconfig.json` 干净。

### 证据（Before & After）

N/A——非用户可见的健壮性修复。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`tsc --noEmit` 干净；现有纯逻辑测试套件不受影响。

### 环境（可选）

`packages/mobile-mcp`。

## 风险与范围

- 主要风险或权衡：将静默失败转为抛出异常，而 `toBuffer()` 本就会捕获并转换为预期的用户可见信息——严格来说更正确，成功路径不引入新的失败面（有效输出原样返回）。
- 未验证／超出范围：没有专门的单元测试——该包的 `@playwright/test` 测试框架无法 mock `spawnSync`，且强制真实的 ImageMagick 缺失依赖具体环境；该改动与已被测试覆盖的 `toBufferWithSips()` 状态检查完全一致。该包为 vendored，不在主 CI 测试回路中。
- 破坏性变更／迁移说明：无。

## 关联 Issue

N/A——通过源码审查发现，无现有 issue。

</details>
