### PR TITLE
feat(autofix): resolve the review threads whose findings it implemented

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2315,7 +2315,7 @@ jobs:
               | select((.created_at // "") > $wm)
               | select((.user.login // "") != $ab)
               | select(((.author_association // "") | IN($trust[])) or (.user.login // "") == $rb)
-              | "- \(.path // "?"):\(.line // "?") @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
+              | "- [rc:\(.id)] \(.path // "?"):\(.line // "?") @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/rc.json"
             echo
             echo "## Issue-level comments"
@@ -2544,7 +2544,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md handoff.md pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md resolved-comments.txt pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               cat "${WORKDIR}/${f}"
@@ -2616,6 +2616,42 @@ jobs:
               git push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${HEAD_REPO}.git" HEAD:"${BRANCH}"
             else
               git push --no-verify origin "${BRANCH}"
+            fi
+            # Resolve the review threads whose findings the agent actually
+            # IMPLEMENTED, so a human re-reviewing sees only what is still open
+            # instead of re-reading every thread to work out what was handled.
+            # The agent cannot do this itself - its sandbox carries no token -
+            # so it records the inline-comment ids it implemented and this step,
+            # which already holds the PAT, maps each to its thread. Findings it
+            # DECLINED or deferred are deliberately left open. Best-effort
+            # throughout: a resolve failure must never fail a good push.
+            if [[ -s "${WORKDIR}/resolved-comments.txt" ]]; then
+              THREADS_JSON="$(gh api graphql -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
+                query($owner:String!,$name:String!,$pr:Int!){
+                  repository(owner:$owner,name:$name){
+                    pullRequest(number:$pr){
+                      reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{databaseId}}}}
+                    }
+                  }
+                }' --jq '.data.repository.pullRequest.reviewThreads.nodes' 2> /dev/null || echo '[]')"
+              RESOLVED_N=0
+              while IFS= read -r rc_id || [[ -n "${rc_id}" ]]; do
+                [[ "${rc_id}" =~ ^[0-9]+$ ]] || continue
+                thread_id="$(jq -r --argjson id "${rc_id}" \
+                  'map(select(.isResolved | not)
+                     | select(any(.comments.nodes[]; .databaseId == $id)))
+                   | .[0].id // ""' <<< "${THREADS_JSON}")"
+                [[ -n "${thread_id}" ]] || continue
+                if gh api graphql -f threadId="${thread_id}" -f query='
+                  mutation($threadId:ID!){
+                    resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}
+                  }' > /dev/null 2>&1; then
+                  RESOLVED_N=$(( RESOLVED_N + 1 ))
+                else
+                  echo "::warning::could not resolve the review thread for comment ${rc_id}"
+                fi
+              done < "${WORKDIR}/resolved-comments.txt"
+              echo "🧵 resolved ${RESOLVED_N} review thread(s) the agent implemented"
             fi
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on:"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2713,22 +2713,32 @@ jobs:
             # DECLINED or deferred are deliberately left open. Best-effort
             # throughout: a resolve failure must never fail a good push.
             if [[ -s "${WORKDIR}/resolved-comments.txt" ]]; then
-              THREADS_JSON="$(gh api graphql -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
+              # first-100 page cap: threads beyond this page are not resolved
+              THREADS_RAW="$(gh api graphql -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
                 query($owner:String!,$name:String!,$pr:Int!){
                   repository(owner:$owner,name:$name){
                     pullRequest(number:$pr){
-                      reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{databaseId}}}}
+                      reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{databaseId}}} pageInfo{hasNextPage}}
                     }
                   }
-                }' --jq '.data.repository.pullRequest.reviewThreads.nodes' 2> /dev/null || echo '[]')"
+                }' --jq '(.data.repository.pullRequest.reviewThreads // {nodes:[]})' 2> /dev/null || echo '{"nodes":[]}')"
+              THREADS_JSON="$(jq '.nodes' <<< "${THREADS_RAW}")"
+              if [[ "$(jq -r '.pageInfo.hasNextPage // false' <<< "${THREADS_RAW}")" == "true" ]]; then
+                echo "::warning::PR has more than 100 review threads; threads past the first page will not be resolved"
+              fi
               RESOLVED_N=0
               while IFS= read -r rc_id || [[ -n "${rc_id}" ]]; do
+                rc_id="${rc_id%$'\r'}"
+                rc_id="${rc_id#rc:}"
                 [[ "${rc_id}" =~ ^[0-9]+$ ]] || continue
                 thread_id="$(jq -r --argjson id "${rc_id}" \
                   'map(select(.isResolved | not)
                      | select(any(.comments.nodes[]; .databaseId == $id)))
                    | .[0].id // ""' <<< "${THREADS_JSON}")"
-                [[ -n "${thread_id}" ]] || continue
+                if [[ -z "${thread_id}" ]]; then
+                  echo "::warning::comment ${rc_id} matched no open review thread"
+                  continue
+                fi
                 if gh api graphql -f threadId="${thread_id}" -f query='
                   mutation($threadId:ID!){
                     resolveReviewThread(input:{threadId:$threadId}){thread{isResolved}}

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -167,6 +167,13 @@ Finish with exactly one outcome:
   the regenerated schema, if a settings source changed), commit once only after
   they pass, then write `<workdir>/address-summary.md` with each feedback point,
   decision, changes, conflict notes, and verification results (bilingual per
-  Shared Rules).
+  Shared Rules). Also write `<workdir>/resolved-comments.txt`: one inline
+  comment id per line — the `rc:<id>` handle shown in `feedback.md` — for each
+  finding you IMPLEMENTED. The workflow resolves exactly those review threads
+  after the push, so a human re-reviewing sees only what is still open. List an
+  id ONLY when you actually made the change: a finding you declined or deferred
+  must stay unresolved so its recorded reason gets read. Omit the file (or
+  leave it empty) when you implemented nothing that came from an inline
+  comment.
 - No change: write `<workdir>/no-action.md` (bilingual per Shared Rules).
 - Cannot confidently proceed: write `<workdir>/failure.md` and do not commit.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3430,23 +3430,26 @@ describe('qwen-autofix workflow', () => {
     writeFileSync(resolvedLog, '');
     writeFileSync(
       join(dir, 'threads.json'),
-      JSON.stringify([
-        {
-          id: 'T_open_1',
-          isResolved: false,
-          comments: { nodes: [{ databaseId: 111 }] },
-        },
-        {
-          id: 'T_open_2',
-          isResolved: false,
-          comments: { nodes: [{ databaseId: 222 }] },
-        },
-        {
-          id: 'T_done',
-          isResolved: true,
-          comments: { nodes: [{ databaseId: 333 }] },
-        },
-      ]),
+      JSON.stringify({
+        nodes: [
+          {
+            id: 'T_open_1',
+            isResolved: false,
+            comments: { nodes: [{ databaseId: 111 }] },
+          },
+          {
+            id: 'T_open_2',
+            isResolved: false,
+            comments: { nodes: [{ databaseId: 222 }] },
+          },
+          {
+            id: 'T_done',
+            isResolved: true,
+            comments: { nodes: [{ databaseId: 333 }] },
+          },
+        ],
+        pageInfo: { hasNextPage: false },
+      }),
     );
     writeFileSync(
       join(bin, 'gh'),
@@ -3462,8 +3465,8 @@ describe('qwen-autofix workflow', () => {
     chmodSync(join(bin, 'gh'), 0o755);
     // 111 was implemented; 333's thread is already resolved; 999 matches
     // nothing. 222 was DECLINED, so it is deliberately absent and must stay open.
-    writeFileSync(join(dir, 'resolved-comments.txt'), '111\n333\n999\n');
-    const out = execFileSync('bash', ['-c', `set -uo pipefail\n${block}`], {
+    writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:111\r\n333\n999\n');
+    const out = execFileSync('bash', ['-c', `set -euo pipefail\n${block}`], {
       env: {
         ...process.env,
         PATH: `${bin}:${process.env.PATH}`,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3114,6 +3114,86 @@ describe('qwen-autofix workflow', () => {
     ).toBe(0);
   });
 
+  it('resolves only the review threads whose findings it implemented', () => {
+    // A human re-reviewing should see what is still OPEN, not re-read every
+    // thread to work out what the bot handled. The agent cannot resolve threads
+    // itself (its sandbox carries no token), so it records the inline-comment
+    // ids it implemented and the push step maps each to its thread.
+    const lines = workflow.split('\n');
+    const i = lines.findIndex((l) =>
+      l.includes('resolved-comments.txt" ]]; then'),
+    );
+    const j = lines.findIndex(
+      (l, k) => k > i && l.trim().startsWith('echo "🧵 resolved'),
+    );
+    expect(i).toBeGreaterThan(-1);
+    const block = lines.slice(i, j + 2).join('\n');
+    // feedback.md must carry the handle the agent echoes back.
+    expect(workflow).toContain('- [rc:\\(.id)]');
+
+    const dir = mkdtempSync(join(tmpdir(), 'resolve-'));
+    const bin = join(dir, 'bin');
+    mkdirSync(bin);
+    const resolvedLog = join(dir, 'resolved.log');
+    writeFileSync(resolvedLog, '');
+    writeFileSync(
+      join(dir, 'threads.json'),
+      JSON.stringify([
+        {
+          id: 'T_open_1',
+          isResolved: false,
+          comments: { nodes: [{ databaseId: 111 }] },
+        },
+        {
+          id: 'T_open_2',
+          isResolved: false,
+          comments: { nodes: [{ databaseId: 222 }] },
+        },
+        {
+          id: 'T_done',
+          isResolved: true,
+          comments: { nodes: [{ databaseId: 333 }] },
+        },
+      ]),
+    );
+    writeFileSync(
+      join(bin, 'gh'),
+      [
+        '#!/usr/bin/env bash',
+        'if [[ "$*" == *mutation* ]]; then',
+        '  for a in "$@"; do [[ "$a" == threadId=* ]] && printf "%s\\n" "${a#threadId=}" >> "$RESOLVED_LOG"; done',
+        '  exit 0',
+        'fi',
+        'cat "$THREADS_FIXTURE"',
+      ].join('\n'),
+    );
+    chmodSync(join(bin, 'gh'), 0o755);
+    // 111 was implemented; 333's thread is already resolved; 999 matches
+    // nothing. 222 was DECLINED, so it is deliberately absent and must stay open.
+    writeFileSync(join(dir, 'resolved-comments.txt'), '111\n333\n999\n');
+    const out = execFileSync('bash', ['-c', `set -uo pipefail\n${block}`], {
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        WORKDIR: dir,
+        REPO: 'QwenLM/qwen-code',
+        PR: '7308',
+        RESOLVED_LOG: resolvedLog,
+        THREADS_FIXTURE: join(dir, 'threads.json'),
+      },
+      encoding: 'utf8',
+    });
+    const resolved = readFileSync(resolvedLog, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    expect(resolved).toEqual(['T_open_1']);
+    expect(resolved).not.toContain('T_open_2'); // declined stays open
+    expect(resolved).not.toContain('T_done'); // already resolved
+    expect(out).toContain('resolved 1 review thread');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it('replays the handoff decision and terminal-round transitions under bash', () => {
     // The agent step is bounded below the 120-minute job timeout so a runaway
     // agent fails the STEP, not the job, leaving the always() report step time to


### PR DESCRIPTION
## What this PR does

Makes the autofix loop **resolve the review threads whose findings it actually implemented**, so a human re-reviewing a managed PR sees only what is still open.

## Why it's needed

Today a reviewer has to re-read every thread to work out what the bot already handled. **#7308** shows the cost: **17 review threads, 13 still open**, with no way to tell which of those were fixed and which were declined.

The agent already decides per finding — `address-summary.md` records each one as implemented or declined with a reason. What was missing was any way to *act* on that decision:

- the agent's sandbox carries **no GitHub token**, so it cannot resolve anything itself, and
- `feedback.md` gave it **no stable handle** to point at even if it could.

## How

Three small pieces close the loop:

1. **`feedback.md` carries the handle.** Each inline comment now renders as `- [rc:<id>] path:line @author: body`.
2. **The SKILL asks the agent to declare what it fixed.** It writes `resolved-comments.txt`, one id per line, **for findings it IMPLEMENTED only** — a declined or deferred finding must stay unresolved so its recorded reason actually gets read.
3. **The push step resolves them.** After a successful push, the step that already holds the PAT maps each id to its review thread and resolves it.

Deliberately narrow: only threads the agent claims it implemented, only ones not already resolved, and entirely best-effort — a resolve failure warns and never fails a good push.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 68/68. The **real extracted resolve block** is driven with a stubbed `gh` over fixture threads:

   | fixture | listed as implemented? | outcome |
   | --- | --- | --- |
   | open thread, comment `111` | yes | **resolved** |
   | open thread, comment `222` | no (declined) | **left open** |
   | already-resolved thread, `333` | yes | skipped |
   | id `999` | yes | matches nothing |

   Mutation-verified: dropping the `isResolved` guard turns it red.
2. Static (run locally with the exact CI toolchain): `js-yaml` parses; all 36 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
3. Post-merge smoke: on the next round of a managed PR, the threads the bot fixed show as resolved and the ones it declined stay open with their reason.

### Evidence (Before & After)

```
BEFORE  bot implements 4 of 6 findings, pushes, comments a summary
        -> all 6 threads stay open
        -> reviewer re-reads every thread to find the 2 that still matter
           (#7308: 17 threads, 13 open)

AFTER   bot implements 4, declines 2 with reasons
        -> the 4 threads resolve, the 2 declined stay open
        -> reviewer sees exactly what is left
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: the agent could claim it implemented something it did not, resolving a thread that still deserves attention. Bounded by the same trust already placed in `address-summary.md` (which claims the same thing in prose), and it fails in the visible direction — the summary comment still lists every finding and its decision, so an over-claim is auditable in the same place it is made.
- Not validated / out of scope: only **inline review comments** get handles; review-level and issue-level comments have no thread to resolve. Threads on outdated lines are resolved the same as any other.
- Breaking changes / migration notes: none.

## Linked Issues

Raised from #7308's unresolved-thread pile. Part of the autofix reliability line: #7330, #7350, #7351, #7354, #7355, #7358.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix 在**确实实现了某条评审意见后 resolve 对应的 review thread**,这样人来复查时只会看到**还没处理完**的部分。

## 为什么需要

现在复查者必须把每个 thread 重读一遍,才能弄清 bot 已经处理了什么。**#7308** 就是代价:**17 个 review thread,13 个仍然打开**,而且无法分辨其中哪些已修、哪些是被婉拒的。

agent 本来就是逐条决策的 —— `address-summary.md` 会记录每条是"已实现"还是"婉拒并附理由"。缺的是把这个决策**落到实处**的通路:

- agent 的沙箱**没有 GitHub token**,它自己无法 resolve;
- 而且 `feedback.md` 也**没给它任何稳定句柄**可指。

## 怎么做

三个小环节闭合:

1. **`feedback.md` 带上句柄**:每条 inline 评论渲染为 `- [rc:<id>] path:line @author: body`。
2. **SKILL 要求 agent 声明它修了什么**:写 `resolved-comments.txt`,每行一个 id,**且仅限"确实实现了"的**——被婉拒或延后的必须保持未解决,好让它记录的理由真的被读到。
3. **推送步骤执行 resolve**:推送成功后,本就持有 PAT 的那一步把每个 id 映射到 thread 并 resolve。

刻意收窄:只处理 agent 声称已实现的、且尚未解决的 thread;并且全程 best-effort —— resolve 失败只告警,绝不让一次成功的推送失败。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 68/68。**真实提取的 resolve 块**用 stub 的 `gh` 在夹具 thread 上驱动:已实现的开放 thread **被 resolve**;**被婉拒的保持打开**;已解决的跳过;未知 id 不匹配任何东西。变异验证:去掉 `isResolved` 守卫即变红。
2. 静态(均用 CI 一致工具):YAML 可解析;全部 36 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
3. 合并后冒烟:被托管 PR 的下一轮里,bot 修掉的 thread 显示为已解决,婉拒的保持打开并附理由。

## 风险与范围

- 主要权衡:agent 可能声称实现了其实没做的事,从而 resolve 掉仍需关注的 thread。这与已经赋予 `address-summary.md` 的信任同级(它本就以散文形式作同样声明),且失败方向是**可见的**——摘要评论仍会列出每条意见及其决策,过度声称可在同一处被审计。
- 不在范围内:只有 **inline review 评论**有句柄;review 级与 issue 级评论没有可 resolve 的 thread。
- 破坏性变更:无。

## 关联 Issue

由 #7308 的未解决 thread 堆积引出。属于 autofix 可靠性主线:#7330、#7350、#7351、#7354、#7355、#7358。

</details>
