### PR TITLE
docs(action): fix GitHub Action input names

### DIFF
--- a/docs/users/integration-github-action.md
+++ b/docs/users/integration-github-action.md
@@ -112,32 +112,32 @@ This type of action can be used to invoke a general-purpose, conversational Qwen
 
 <!-- BEGIN_AUTOGEN_INPUTS -->
 
-- <a name="__input_qwen_api_key"></a><a href="#user-content-__input_qwen_api_key"><code>qwen*api_key</code></a>: *(Optional)\_ The API key for the Qwen API.
+- <a name="__input_qwen_api_key"></a><a href="#user-content-__input_qwen_api_key"><code>qwen_api_key</code></a>: _(Optional)_ The API key for the Qwen API.
 
-- <a name="__input_qwen_cli_version"></a><a href="#user-content-__input_qwen_cli_version"><code>qwen*cli_version</code></a>: *(Optional, default: `latest`)\_ The version of the Qwen Code CLI to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit. For more information, see [Qwen Code CLI releases](https://github.com/QwenLM/qwen-code-action/blob/main/docs/releases.md).
+- <a name="__input_qwen_cli_version"></a><a href="#user-content-__input_qwen_cli_version"><code>qwen_cli_version</code></a>: _(Optional, default: `latest`)_ The version of the Qwen Code CLI to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit. For more information, see [Qwen Code CLI releases](https://github.com/QwenLM/qwen-code-action/blob/main/docs/releases.md).
 
-- <a name="__input_qwen_debug"></a><a href="#user-content-__input_qwen_debug"><code>qwen*debug</code></a>: *(Optional)\_ Enable debug logging and output streaming.
+- <a name="__input_qwen_debug"></a><a href="#user-content-__input_qwen_debug"><code>qwen_debug</code></a>: _(Optional)_ Enable debug logging and output streaming.
 
-- <a name="__input_qwen_model"></a><a href="#user-content-__input_qwen_model"><code>qwen*model</code></a>: *(Optional)\_ The model to use with Qwen Code.
+- <a name="__input_qwen_model"></a><a href="#user-content-__input_qwen_model"><code>qwen_model</code></a>: _(Optional)_ The model to use with Qwen Code.
 
 - <a name="__input_prompt"></a><a href="#user-content-__input_prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Qwen Code CLI's [`--prompt` argument](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/configuration.md#command-line-arguments).
 
 - <a name="__input_settings"></a><a href="#user-content-__input_settings"><code>settings</code></a>: _(Optional)_ A JSON string written to `.qwen/settings.json` to configure the CLI's _project_ settings.
   For more details, see the documentation on [settings files](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/configuration.md#settings-files).
 
-- <a name="__input_use_qwen_code_assist"></a><a href="#user-content-__input_use_qwen_code_assist"><code>use*qwen_code_assist</code></a>: *(Optional, default: `false`)\_ Whether to use Code Assist for Qwen Code model access instead of the default Qwen Code API key.
+- <a name="__input_use_qwen_code_assist"></a><a href="#user-content-__input_use_qwen_code_assist"><code>use_qwen_code_assist</code></a>: _(Optional, default: `false`)_ Whether to use Code Assist for Qwen Code model access instead of the default Qwen Code API key.
   For more information, see the [Qwen Code CLI documentation](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/authentication.md).
 
-- <a name="__input_use_vertex_ai"></a><a href="#user-content-__input_use_vertex_ai"><code>use*vertex_ai</code></a>: *(Optional, default: `false`)\_ Whether to use Vertex AI for Qwen Code model access instead of the default Qwen Code API key.
+- <a name="__input_use_vertex_ai"></a><a href="#user-content-__input_use_vertex_ai"><code>use_vertex_ai</code></a>: _(Optional, default: `false`)_ Whether to use Vertex AI for Qwen Code model access instead of the default Qwen Code API key.
   For more information, see the [Qwen Code CLI documentation](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/authentication.md).
 
 - <a name="__input_extensions"></a><a href="#user-content-__input_extensions"><code>extensions</code></a>: _(Optional)_ A list of Qwen Code CLI extensions to install.
 
-- <a name="__input_upload_artifacts"></a><a href="#user-content-__input_upload_artifacts"><code>upload*artifacts</code></a>: *(Optional, default: `false`)\_ Whether to upload artifacts to the github action.
+- <a name="__input_upload_artifacts"></a><a href="#user-content-__input_upload_artifacts"><code>upload_artifacts</code></a>: _(Optional, default: `false`)_ Whether to upload artifacts to the github action.
 
-- <a name="__input_use_pnpm"></a><a href="#user-content-__input_use_pnpm"><code>use*pnpm</code></a>: *(Optional, default: `false`)\_ Whether or not to use pnpm instead of npm to install qwen-code-cli
+- <a name="__input_use_pnpm"></a><a href="#user-content-__input_use_pnpm"><code>use_pnpm</code></a>: _(Optional, default: `false`)_ Whether or not to use pnpm instead of npm to install qwen-code-cli
 
-- <a name="__input_workflow_name"></a><a href="#user-content-__input_workflow_name"><code>workflow*name</code></a>: *(Optional, default: `${{ github.workflow }}`)\_ The GitHub workflow name, used for telemetry purposes.
+- <a name="__input_workflow_name"></a><a href="#user-content-__input_workflow_name"><code>workflow_name</code></a>: _(Optional, default: `${{ github.workflow }}`)_ The GitHub workflow name, used for telemetry purposes.
 
 <!-- END_AUTOGEN_INPUTS -->
 


### PR DESCRIPTION
## What this PR does

Fixes the GitHub Actions integration documentation so the generated input list shows the real action input names with underscores and renders the optional/default marker as normal Markdown emphasis.

## Why it's needed

The current page shows names such as `qwen*api_key`, `use*qwen_code_assist`, and `workflow*name`, which are not valid action inputs. The same lines also render `*(Optional)\_` instead of the intended optional marker, making the reference harder to read.

## Reviewer Test Plan

### How to verify

Open the GitHub Actions integration documentation and confirm the Inputs section shows `qwen_api_key`, `qwen_cli_version`, `qwen_debug`, `qwen_model`, `use_qwen_code_assist`, `use_vertex_ai`, `upload_artifacts`, `use_pnpm`, and `workflow_name`. Confirm the old malformed `qwen*`, `use*`, `workflow*name`, and `*(Optional` forms are absent.

### Evidence (Before & After)

Before: `rg -n -F 'qwen*' docs/users/integration-github-action.md` matched the generated input names. After: `rg -n -F 'qwen*' docs/users/integration-github-action.md; test $? -eq 1`, `rg -n -F 'use*' docs/users/integration-github-action.md; test $? -eq 1`, `rg -n -F 'workflow*name' docs/users/integration-github-action.md; test $? -eq 1`, and `rg -n -F '*(Optional' docs/users/integration-github-action.md; test $? -eq 1` all pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A; documentation-only change verified with grep.

## Risk & Scope

- Main risk or tradeoff: The edited block is marked autogenerated, but no generator exists in this repository for this page, and the current committed Markdown is already malformed.
- Not validated / out of scope: Rebuilding the external action documentation generator, if one exists outside this repository.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

修复 GitHub Actions 集成文档，让生成的输入列表显示真实的下划线参数名，并让 optional/default 标记按正常 Markdown 强调渲染。

## Why it's needed

当前页面显示 `qwen*api_key`、`use*qwen_code_assist`、`workflow*name` 等无效 action 输入名。同一批行还把 `*(Optional)\_` 渲染成异常文本，降低了参考文档可读性。

## Reviewer Test Plan

### How to verify

打开 GitHub Actions 集成文档，确认 Inputs 段显示 `qwen_api_key`、`qwen_cli_version`、`qwen_debug`、`qwen_model`、`use_qwen_code_assist`、`use_vertex_ai`、`upload_artifacts`、`use_pnpm` 和 `workflow_name`。确认旧的异常形态 `qwen*`、`use*`、`workflow*name` 和 `*(Optional` 已不存在。

### Evidence (Before & After)

修复前：`rg -n -F 'qwen*' docs/users/integration-github-action.md` 会匹配生成的输入名。修复后：`rg -n -F 'qwen*' docs/users/integration-github-action.md; test $? -eq 1`、`rg -n -F 'use*' docs/users/integration-github-action.md; test $? -eq 1`、`rg -n -F 'workflow*name' docs/users/integration-github-action.md; test $? -eq 1` 和 `rg -n -F '*(Optional' docs/users/integration-github-action.md; test $? -eq 1` 均通过。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A；纯文档改动，通过 grep 验证。

## Risk & Scope

- Main risk or tradeoff: 修改的段落标记为 autogenerated，但本仓库中没有该页面的生成器，且当前提交的 Markdown 已经是异常内容。
- Not validated / out of scope: 没有重建可能存在于仓库外部的 action 文档生成器。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>
