### PR TITLE
fix(web-shell): persist the daemon bearer token per-tab so it survives refresh

### DIFF
--- a/packages/web-shell/client/config/daemon.test.ts
+++ b/packages/web-shell/client/config/daemon.test.ts
@@ -98,6 +98,9 @@ describe('getAllowedDaemonOrigin (via getDaemonBaseUrl)', () => {
 describe('getDaemonToken', () => {
   beforeEach(() => {
     vi.resetModules();
+    // The token now persists per-tab (#7301); isolate tests from each
+    // other's persisted copies.
+    window.sessionStorage.clear();
   });
 
   function setupToken(search: string, hash: string) {
@@ -130,6 +133,59 @@ describe('getDaemonToken', () => {
     setupToken('', '');
     const mod = await import('./daemon');
     expect(mod.getDaemonToken()).toBeUndefined();
+  });
+
+  // Regression for #7301: removeDaemonTokenFromUrl() strips the fragment
+  // for history hygiene, so a refreshed page has no token in the URL at
+  // all. The first load must persist the token per-tab and later loads
+  // must fall back to it.
+  it('survives a page refresh via the per-tab persisted copy', async () => {
+    setupToken('', '#token=frag-secret');
+    const first = await import('./daemon');
+    expect(first.getDaemonToken()).toBe('frag-secret');
+
+    // Simulate the refresh: fresh module state (in-memory cache gone),
+    // URL already cleaned — sessionStorage is all that remains.
+    vi.resetModules();
+    setupToken('', '#/chat');
+    const second = await import('./daemon');
+    expect(second.getDaemonToken()).toBe('frag-secret');
+    expect(second.getDaemonAuthHeaders()).toEqual({
+      Authorization: 'Bearer frag-secret',
+    });
+  });
+
+  it('prefers a fresh URL token over a stale persisted one', async () => {
+    window.sessionStorage.setItem('qwen-daemon-token', 'stale-secret');
+    setupToken('', '#token=new-secret');
+    const mod = await import('./daemon');
+    expect(mod.getDaemonToken()).toBe('new-secret');
+    // The persisted copy is refreshed for the next reload.
+    expect(window.sessionStorage.getItem('qwen-daemon-token')).toBe(
+      'new-secret',
+    );
+  });
+
+  it('degrades gracefully when sessionStorage throws', async () => {
+    const original = window.sessionStorage;
+    Object.defineProperty(window, 'sessionStorage', {
+      get() {
+        throw new Error('storage disabled');
+      },
+      configurable: true,
+    });
+    try {
+      setupToken('', '#token=frag-secret');
+      const mod = await import('./daemon');
+      // Same-load behavior is unaffected; only refresh persistence is lost.
+      expect(mod.getDaemonToken()).toBe('frag-secret');
+    } finally {
+      Object.defineProperty(window, 'sessionStorage', {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    }
   });
 });
 

--- a/packages/web-shell/client/config/daemon.ts
+++ b/packages/web-shell/client/config/daemon.ts
@@ -10,6 +10,27 @@ export function getDaemonBaseUrl(): string {
 let cachedDaemonToken: string | undefined;
 const DAEMON_AUTH_MESSAGE_TYPE = 'qwen-daemon-auth';
 const DEFAULT_TOKEN_MESSAGE_TIMEOUT_MS = 2500;
+const DAEMON_TOKEN_STORAGE_KEY = 'qwen-daemon-token';
+
+// sessionStorage access can throw (privacy modes, storage-disabled
+// embeds); the token flow must degrade to the pre-persistence behavior
+// rather than break page load.
+function readStoredDaemonToken(): string | undefined {
+  try {
+    return window.sessionStorage.getItem(DAEMON_TOKEN_STORAGE_KEY) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function persistDaemonToken(token: string): void {
+  try {
+    window.sessionStorage.setItem(DAEMON_TOKEN_STORAGE_KEY, token);
+  } catch {
+    // Storage unavailable — the token still works for this load via the
+    // in-memory cache; a refresh will lose it, matching the old behavior.
+  }
+}
 
 export function getDaemonToken(): string | undefined {
   if (cachedDaemonToken) return cachedDaemonToken;
@@ -23,10 +44,21 @@ export function getDaemonToken(): string | undefined {
   const fromHash = new URLSearchParams(
     window.location.hash.replace(/^#/, ''),
   ).get('token');
-  cachedDaemonToken =
-    fromHash ||
-    new URLSearchParams(window.location.search).get('token') ||
-    undefined;
+  const fromUrl =
+    fromHash || new URLSearchParams(window.location.search).get('token') || '';
+  if (fromUrl) {
+    // Persist per-tab so the token survives a page refresh (#7301):
+    // removeDaemonTokenFromUrl() deliberately strips it from the URL for
+    // history hygiene, which previously left a refreshed page with no
+    // credential at all. sessionStorage (not localStorage) keeps the token
+    // scoped to this tab and cleared when the tab closes.
+    persistDaemonToken(fromUrl);
+    cachedDaemonToken = fromUrl;
+    return cachedDaemonToken;
+  }
+  // Refresh path: the URL was already cleaned on the first load — fall
+  // back to the per-tab persisted copy.
+  cachedDaemonToken = readStoredDaemonToken();
   return cachedDaemonToken;
 }
 


### PR DESCRIPTION
## What this PR does

Persists the daemon bearer token per-tab in the Web Shell: on first load `getDaemonToken()` now writes the token it reads from the URL (`#token=` fragment, or the legacy `?token=` query) to `sessionStorage`, and on later loads where the URL carries no token it falls back to that stored copy. A fresh URL token always wins over a stale persisted one, storage failures (privacy modes, storage-disabled embeds) degrade gracefully to the previous memory-only behavior, and `removeDaemonTokenFromUrl()`'s history-hygiene stripping is unchanged. `sessionStorage` (not `localStorage`) keeps the token scoped to the tab and cleared when it closes, matching the triage's recommendation.

## Why it's needed

#7301: `qwen serve --token "xxx" --open` opens the browser at `#token=xxx`, the token is read into a module-level cache, and the fragment is then deliberately stripped from the URL so the credential stays out of browser history. Because nothing persisted it, a page refresh (Ctrl+R / F5) loaded the app with no credential at all — every token-gated API call returned 401 until the user manually re-appended `#token=xxx`. The triage confirmed the mechanism from source (no SPA-router involvement; the strip is intentional, the missing piece is persistence) and proposed exactly this fix.

## Reviewer Test Plan

### How to verify

1. `qwen serve --token "123456" --open`, use the Web Shell normally, then hard-refresh the page. Before this PR: the address bar no longer carries the token and every token-gated call 401s. After: the session keeps working — requests still carry `Authorization: Bearer`.
2. Close the tab and open a fresh one at the bare URL (no `#token=`): still unauthenticated, as before — the persistence is per-tab by design.
3. `npx vitest run client/config/daemon.test.ts` (packages/web-shell): 19/19, including the refresh regression (module reset + cleaned URL → token restored from the per-tab copy), fresh-token-beats-stale, and a storage-throws degradation case.

### Evidence (Before & After)

Real-browser E2E — a real `qwen serve --token` daemon plus Playwright Chromium, with a hard reload between phases, recording whether daemon API requests carry `Authorization` and probing a token-gated endpoint from inside the page:

| | before fix | after fix |
| --- | --- | --- |
| initial load | 15/15 requests authorized | 15/15 requests authorized |
| after reload | **0/2 requests authorized** ❌ | **16/16 requests authorized** ✅ |
| in-page probe after reload | `sessionStorage` empty · `/capabilities` → **401** ❌ | token present · `/capabilities` → **200** ✅ |
| URL after first load | token stripped (hygiene) | token stripped (unchanged) ✅ |

![verification](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7301/verify-7301.png)

The jsdom refresh regression test fails on the unpatched source (verified via `git stash`; the before-phase E2E above is the same unpatched build served by the real daemon).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; Playwright Chromium against a real `qwen serve --token` daemon serving the built Web Shell, plus vitest/jsdom unit tests. `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: the token now rests in `sessionStorage`, where same-origin script can read it — but the pre-existing in-memory copy was equally readable by any script that could run in the page (patching `fetch` reveals the header), so this adds no materially new exposure; per-tab scoping avoids the cross-tab/lingering-credential surface `localStorage` would open. Tokens are also invalidated server-side whenever the daemon restarts with a new `--token`, and a stale persisted token simply yields the same 401s as no token.
- Not validated / out of scope: the extension-iframe token path (`waitForDaemonTokenMessage`) is untouched — the embedding extension re-messages the token on every load, so it needs no persistence; multi-tab sharing (deliberately not provided) and remembering tokens across tab closes are out of scope.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7301

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 的 daemon bearer token 改为按标签页持久化：首次加载时 `getDaemonToken()` 把从 URL（`#token=` 或兼容的 `?token=`）读到的 token 写入 `sessionStorage`；后续加载 URL 无 token 时回退读取。新 URL token 始终覆盖旧持久化副本；存储异常（隐私模式、禁存储嵌入）优雅退化为原先的仅内存行为；`removeDaemonTokenFromUrl()` 的历史卫生剥离保持不变。选 `sessionStorage` 而非 `localStorage`——token 按标签页隔离、关标签即清，与 triage 建议一致。

## 为什么需要

#7301：`qwen serve --token --open` 以 `#token=xxx` 打开浏览器，token 读入模块级缓存后 fragment 被有意从 URL 剥离（避免进浏览器历史）。因从未持久化，刷新后页面完全无凭据——所有 token 门控 API 返回 401，除非手动重拼 URL。triage 已从源码确认机制（无 SPA 路由参与；剥离是有意的，缺的是持久化）并给出了正是本 PR 的修复方向。

## 审阅测试计划

### 如何验证

1. `qwen serve --token "123456" --open` 正常使用后硬刷新：本 PR 之前地址栏无 token、门控调用全 401；之后会话持续可用，请求仍带 `Authorization: Bearer`；
2. 关标签后开新标签访问裸 URL：仍未鉴权（按设计不跨标签持久化）；
3. `daemon.test.ts` 19/19，含刷新回归（模块重置+已清理 URL → 从每标签副本恢复）、新 token 覆盖旧副本、存储抛错退化用例。

### 证据（Before & After）

真浏览器 E2E（真实 `qwen serve --token` + Playwright Chromium，中间硬刷新，记录 daemon API 请求是否带 Authorization 并在页内探测门控端点）：修复前刷新后 0/2 请求带鉴权、探针 401；修复后 16/16 带鉴权、探针 200；两种情况下首次加载后 URL 均无 token（卫生保持）。jsdom 刷新回归测试在未修复源码上失败（git stash 验证；上表 before 阶段即真实 daemon 服务的未修复构建）。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；Playwright Chromium + 真实 daemon + vitest/jsdom；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：token 落入 `sessionStorage` 后同源脚本可读——但原先的内存副本对页内任意脚本同样可得（patch `fetch` 即见头），无实质新增暴露面；按标签页隔离避免了 `localStorage` 的跨标签/滞留凭据面。daemon 换 `--token` 重启后旧副本自然失效（与无 token 一样 401）。
- 未验证/超出范围：扩展 iframe 的 token 路径（`waitForDaemonTokenMessage`）未动——嵌入方每次加载重发消息，无需持久化；跨标签共享与跨关闭记忆（有意不做）超出范围。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7301

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
