### PR TITLE
fix(ci): tell a visuals coverage gap apart from "no visual change"

### DIFF
--- a/.github/scripts/web-shell-visuals-publish.mjs
+++ b/.github/scripts/web-shell-visuals-publish.mjs
@@ -17,7 +17,7 @@
  * `buildComment`) are exported and tested. The file also runs as a CLI for the
  * workflow:
  *   node web-shell-visuals-publish.mjs stage   <screenshotsDir> <gifsDir> <stageDir>
- *   node web-shell-visuals-publish.mjs comment <stageDir> <rawBase> <shortSha> <runUrl> <bodyFile>
+ *   node web-shell-visuals-publish.mjs comment <stageDir> <rawBase> <shortSha> <runUrl> <bodyFile> [changedPathsFile]
  */
 
 import {
@@ -26,6 +26,7 @@ import {
   mkdirSync,
   openSync,
   readdirSync,
+  readFileSync,
   readSync,
   statSync,
   writeFileSync,
@@ -115,6 +116,60 @@ export function selectImages(candidates, opts = {}) {
   return { accepted, warnings };
 }
 
+/**
+ * Directories that feed the rendered bundle. Kept in sync with the `paths:`
+ * trigger in .github/workflows/web-shell-visuals.yml — that trigger decides
+ * whether we render at all; this decides whether a "nothing changed" RESULT
+ * deserves a second look.
+ */
+const RENDER_SHAPING_PREFIXES = [
+  'packages/web-shell/client/',
+  'packages/webui/src/',
+];
+
+/**
+ * Extensions that change what a view LOOKS like. Deliberately narrow: a `.ts`
+ * hook/util/type edit routinely lands with no visual delta, and flagging those
+ * would train everyone to ignore the prompt. `.css` covers `.module.css`; every
+ * `.svg` under the render surface is a bundled UI icon (client/assets/icons),
+ * so a changed icon that moves no pixel is the same coverage signal.
+ */
+const RENDER_SHAPING_EXT = /\.(tsx|css|svg)$/i;
+
+/** Test + scenario code DRIVES the preview; it is not the UI under preview. */
+const NOT_PRODUCT_UI =
+  /(^|\/)(__tests__|__mocks__|e2e)\/|\.(test|spec)\.[jt]sx?$/i;
+
+/** How many paths to name before collapsing the rest into a count. */
+export const MAX_LISTED_PATHS = 8;
+
+/**
+ * Pick the changed paths that shape rendering, from the PR's full file list.
+ * Returns `{ files, total }` — `files` capped at `maxListed`, `total` the full
+ * count, so the caller can say "and N more" without re-deriving it.
+ *
+ * This exists because "no view changed" is ambiguous: it means either "this
+ * change genuinely has no visual effect" or "no scenario renders this UI at
+ * all". The second is a COVERAGE gap that has shipped silently three times
+ * (#7035 primary label, #7221 worktree badge, #7365 empty-state toggle), each
+ * time caught only because a human happened to notice the missing image.
+ */
+export function selectRenderShapingFiles(paths, opts = {}) {
+  const maxListed = opts.maxListed ?? MAX_LISTED_PATHS;
+  const matched = [];
+  for (const raw of paths ?? []) {
+    const p = String(raw).trim();
+    if (!p) continue;
+    if (!RENDER_SHAPING_PREFIXES.some((prefix) => p.startsWith(prefix)))
+      continue;
+    if (!RENDER_SHAPING_EXT.test(p)) continue;
+    if (NOT_PRODUCT_UI.test(p)) continue;
+    matched.push(p);
+  }
+  matched.sort();
+  return { files: matched.slice(0, maxListed), total: matched.length };
+}
+
 /** Self-defending HTML escaping for interpolated values. */
 export const esc = (s) =>
   String(s)
@@ -127,8 +182,17 @@ export const pretty = (s) =>
   s.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 
 /**
+ * Render a path inside a code span without letting it escape. Backticks would
+ * close the span (and let the rest of the path inject markdown/HTML), so they
+ * go; `esc` then neutralises the remainder. Both are no-ops for real paths.
+ */
+const codePath = (p) => `\`${esc(String(p).replace(/[`\r\n]/g, ''))}\``;
+
+/**
  * Pure comment builder. `files` is the list of staged filenames (png + gif).
- * `ctx` is `{ rawBase, shortSha, runUrl }`. Returns the markdown body.
+ * `ctx` is `{ rawBase, shortSha, runUrl, changedPaths }`, where `changedPaths`
+ * is the PR's full changed-file list (used only to triage an empty preview).
+ * Returns the markdown body.
  */
 export function buildComment(files, ctx = {}) {
   const rawBase = ctx.rawBase ?? '';
@@ -161,8 +225,31 @@ export function buildComment(files, ctx = {}) {
       out.push('');
     }
   } else {
-    out.push('✅ _No screenshot changes against the PR base._');
-    out.push('');
+    // An empty preview is ambiguous, so say WHICH of the two things it means.
+    // "No view changed" is only a clean bill of health if nothing that shapes a
+    // view was touched; when render-shaping files DID change, the same result
+    // may instead mean no scenario renders them — a coverage gap that reads as
+    // reassurance if we print a bare green check (see selectRenderShapingFiles).
+    const shaping = selectRenderShapingFiles(ctx.changedPaths);
+    if (shaping.total > 0) {
+      const noun = shaping.total === 1 ? 'file' : 'files';
+      out.push(
+        `ℹ️ _No screenshot changed against the PR base_ — but this PR edits ${shaping.total} render-shaping ${noun}:`,
+      );
+      out.push('');
+      for (const f of shaping.files) out.push(`- ${codePath(f)}`);
+      if (shaping.total > shaping.files.length) {
+        out.push(`- _…and ${shaping.total - shaping.files.length} more._`);
+      }
+      out.push('');
+      out.push(
+        'Either the change has no visual effect (logic, plumbing, a state the scenarios never reach), or **no scenario renders this UI** — in which case the preview cannot see it, and an empty result is a coverage gap rather than a clean bill of health. To make it visible, add a scenario to `packages/web-shell/client/e2e/visuals/screenshots.spec.ts` that seeds whatever state the UI is gated on; it then appears here as a head-only (NEW) capture.',
+      );
+      out.push('');
+    } else {
+      out.push('✅ _No screenshot changes against the PR base._');
+      out.push('');
+    }
   }
 
   if (gifs.length > 0) {
@@ -246,14 +333,26 @@ function stageCli(screenshotsDir, gifsDir, stageDir) {
   process.stdout.write(`${accepted.length}\n`);
 }
 
-function commentCli(stageDir, rawBase, shortSha, runUrl, bodyFile) {
+function commentCli(stageDir, rawBase, shortSha, runUrl, bodyFile, pathsFile) {
   let files = [];
   try {
     files = readdirSync(stageDir);
   } catch {
     // Missing stage dir → empty preview body.
   }
-  const body = buildComment(files, { rawBase, shortSha, runUrl });
+  // Newline-delimited changed paths, via a file rather than argv: a PR can
+  // change thousands of files, and paths are attacker-influenced (fork PRs).
+  // Best-effort — if the workflow's API call failed the file is absent/empty,
+  // and the comment falls back to the plain "no screenshot changes" line.
+  let changedPaths = [];
+  if (pathsFile) {
+    try {
+      changedPaths = readFileSync(pathsFile, 'utf8').split('\n');
+    } catch {
+      // Unreadable → treat as "unknown", not as "nothing changed".
+    }
+  }
+  const body = buildComment(files, { rawBase, shortSha, runUrl, changedPaths });
   writeFileSync(bodyFile, body);
   process.stderr.write(`Comment body: ${body.split('\n').length} lines.\n`);
 }
@@ -263,7 +362,7 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   if (cmd === 'stage') {
     stageCli(rest[0], rest[1], rest[2]);
   } else if (cmd === 'comment') {
-    commentCli(rest[0], rest[1], rest[2], rest[3], rest[4]);
+    commentCli(rest[0], rest[1], rest[2], rest[3], rest[4], rest[5]);
   } else {
     process.stderr.write(`unknown command: ${cmd ?? '(none)'}\n`);
     process.exit(2);

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -16,6 +16,7 @@ import {
   MAX_SCREENSHOTS,
   sanitizeName,
   selectImages,
+  selectRenderShapingFiles,
 } from './web-shell-visuals-publish.mjs';
 
 const PNG = '89504e470d0a1a0a';
@@ -159,4 +160,126 @@ test('buildComment lists a lone composite as one wide image (no light/dark table
   assert.doesNotMatch(body, /<table>/); // composites are a flat list now
   // A lone light shot no longer needs a dark-pair placeholder cell.
   assert.doesNotMatch(body, /<td>/);
+});
+
+// --- Empty-preview triage (coverage gap vs. genuinely no visual effect) ---
+
+test('selectRenderShapingFiles keeps rendered .tsx/.css/.svg and drops logic/test/other-package edits', () => {
+  const { files, total } = selectRenderShapingFiles([
+    'packages/web-shell/client/components/WelcomeScreen.tsx',
+    'packages/web-shell/client/components/worktree.module.css',
+    'packages/webui/src/ui/button.tsx',
+    'packages/web-shell/client/assets/icons/plan.svg',
+    // Dropped: not a rendered extension...
+    'packages/web-shell/client/hooks/useWorktree.ts',
+    'packages/web-shell/client/types.d.ts',
+    // ...not the rendered surface...
+    'packages/core/src/utils/gitDiff.ts',
+    'packages/web-shell/server/routes.tsx',
+    'docs/web-shell.md',
+    // ...or test/scenario code, which DRIVES the preview rather than being it.
+    'packages/web-shell/client/e2e/visuals/screenshots.spec.ts',
+    'packages/web-shell/client/components/Sidebar.test.tsx',
+    'packages/web-shell/client/components/__tests__/Chip.tsx',
+    // Blank lines from a trailing newline in the paths file.
+    '',
+    '   ',
+  ]);
+  assert.deepEqual(files, [
+    'packages/web-shell/client/assets/icons/plan.svg',
+    'packages/web-shell/client/components/WelcomeScreen.tsx',
+    'packages/web-shell/client/components/worktree.module.css',
+    'packages/webui/src/ui/button.tsx',
+  ]);
+  assert.equal(total, 4);
+});
+
+test('selectRenderShapingFiles caps the listed paths but reports the true total', () => {
+  const many = Array.from(
+    { length: 12 },
+    (_, i) => `packages/web-shell/client/c/F${String(i).padStart(2, '0')}.tsx`,
+  );
+  const { files, total } = selectRenderShapingFiles(many, { maxListed: 3 });
+  assert.equal(total, 12);
+  assert.equal(files.length, 3);
+  assert.equal(files[0], 'packages/web-shell/client/c/F00.tsx');
+});
+
+test('selectRenderShapingFiles tolerates a missing/undefined list', () => {
+  assert.deepEqual(selectRenderShapingFiles(undefined), {
+    files: [],
+    total: 0,
+  });
+  assert.deepEqual(selectRenderShapingFiles([]), { files: [], total: 0 });
+});
+
+test('buildComment flags a possible COVERAGE GAP when UI changed but no view did', () => {
+  const body = buildComment([], {
+    shortSha: 'abc1234',
+    changedPaths: [
+      'packages/web-shell/client/components/WelcomeScreen.tsx',
+      'packages/web-shell/client/hooks/useWorktree.ts', // logic — not listed
+    ],
+  });
+  // The bare green check would read as "nothing broke"; it must not appear.
+  assert.doesNotMatch(body, /✅/);
+  assert.match(body, /1 render-shaping file:/); // singular
+  assert.match(
+    body,
+    /`packages\/web-shell\/client\/components\/WelcomeScreen\.tsx`/,
+  );
+  assert.doesNotMatch(body, /useWorktree\.ts/);
+  assert.match(body, /no scenario renders this UI/);
+  assert.match(body, /screenshots\.spec\.ts/); // tells you where to fix it
+});
+
+test('buildComment keeps the green check when only non-rendering files changed', () => {
+  const body = buildComment([], {
+    shortSha: 'abc1234',
+    changedPaths: [
+      'packages/web-shell/client/hooks/useWorktree.ts',
+      'packages/core/src/index.ts',
+    ],
+  });
+  // A logic-only PR with no visual delta is EXPECTED — prompting here would
+  // train everyone to ignore the prompt when it matters.
+  assert.match(body, /✅ _No screenshot changes against the PR base\._/);
+  assert.doesNotMatch(body, /coverage gap/);
+});
+
+test('buildComment does not triage when screenshots DID change', () => {
+  const body = buildComment(['home-dark.png'], {
+    rawBase: 'r',
+    changedPaths: ['packages/web-shell/client/components/WelcomeScreen.tsx'],
+  });
+  assert.match(body, /<img /);
+  assert.doesNotMatch(body, /coverage gap/);
+  assert.doesNotMatch(body, /render-shaping/);
+});
+
+test('buildComment summarises the overflow instead of listing every path', () => {
+  const body = buildComment([], {
+    changedPaths: Array.from(
+      { length: 10 },
+      (_, i) =>
+        `packages/web-shell/client/c/F${String(i).padStart(2, '0')}.tsx`,
+    ),
+  });
+  assert.match(body, /10 render-shaping files:/); // plural
+  assert.match(body, /_…and 2 more\._/); // 10 - MAX_LISTED_PATHS(8)
+  assert.equal(body.split('\n').filter((l) => /^- `/.test(l)).length, 8);
+});
+
+test('buildComment neutralises a path that tries to break out of its code span', () => {
+  const body = buildComment([], {
+    changedPaths: [
+      'packages/web-shell/client/`<img src=x onerror=alert(1)>`.tsx',
+    ],
+  });
+  assert.doesNotMatch(body, /<img /); // the injected tag never becomes HTML
+  assert.match(body, /&lt;img src=x/); // escaped, inside the code span
+  // Exactly one path bullet, and it opens and closes its own span.
+  const bullets = body.split('\n').filter((l) => /^- `/.test(l));
+  assert.equal(bullets.length, 1);
+  assert.equal((bullets[0].match(/`/g) ?? []).length, 2);
 });

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -228,6 +228,19 @@ jobs:
             RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_SHA}/imgs"
           fi
 
+          # --- Changed paths, for triaging an EMPTY preview ------------------
+          # "No view changed" means either "no visual effect" or "no scenario
+          # renders this UI"; the script tells those apart by looking at which
+          # files the PR touched (see selectRenderShapingFiles). Read here rather
+          # than in the render job because that one runs untrusted PR code.
+          # Best-effort: on API failure the list stays empty and the comment
+          # falls back to the plain "no screenshot changes" line.
+          CHANGED_PATHS_FILE="${RUNNER_TEMP}/visuals-changed-paths.txt"
+          : > "${CHANGED_PATHS_FILE}"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" \
+            --paginate --jq '.[].filename' > "${CHANGED_PATHS_FILE}" 2>/dev/null \
+            || echo "::warning::Could not list changed files for PR #${PR}; the preview will not flag coverage gaps."
+
           # --- Build the comment body ---------------------------------------
           # Delegated to the same unit-tested script (light/dark pairing, flow
           # labels, and HTML escaping live in web-shell-visuals-publish.mjs).
@@ -235,7 +248,8 @@ jobs:
           node .github/scripts/web-shell-visuals-publish.mjs comment \
             "${STAGE}" \
             "${RAW_BASE}" \
-            "${SHORT_SHA}" "${RUN_URL}" "${BODY_FILE}"
+            "${SHORT_SHA}" "${RUN_URL}" "${BODY_FILE}" \
+            "${CHANGED_PATHS_FILE}"
 
           # --- Post or update the PR comment --------------------------------
           # Dedup only against OUR OWN prior comment (bot author + marker), and


### PR DESCRIPTION
## What this PR does

When the web-shell visual preview finds that no view changed, it now checks which files the PR actually touched before declaring victory. If any of them shape what a view looks like, the comment says the result is ambiguous and lists them, instead of printing a green check. If nothing render-shaping changed, the green check stays exactly as it is today.

## Why it's needed

An empty preview means one of two opposite things: the change genuinely moves no pixel, or **no scenario renders the UI it touches**. The bot printed the same `✅ _No screenshot changes against the PR base._` for both — so the second case, where the preview literally cannot see the feature, read as a clean bill of health.

That is not hypothetical. It has happened three times, each caught only because a maintainer noticed the missing image and asked about it:

| PR | New UI | Why no view changed |
| --- | --- | --- |
| #7035 | Primary-workspace label | needs ≥2 workspaces; every scenario had one |
| #7221 | Worktree session badge | needs `session.worktree` metadata; no scenario set it |
| #7365 | New-session worktree toggle | lives at `/`; every scenario goes to `/session/:id` |

The signal needed to tell the two cases apart already existed and was simply unused: the render workflow only triggers on `packages/web-shell/client/**` and `packages/webui/src/**`, so an empty preview is *by construction* "UI code changed, yet nothing rendered differently". That is worth a second look, and nobody was taking it.

The prompt is deliberately narrow, because a warning everyone learns to skip is worse than no warning. Only `.tsx` / `.css` / `.svg` under the rendered surface count — `.ts` hooks, utils and types routinely land with no visual delta, and test/scenario code drives the preview rather than being previewed. Every `.svg` under that surface is a bundled UI icon (`client/assets/icons/`), so a changed icon that moves no pixel is the same signal.

## Reviewer Test Plan

### How to verify

Unit tests cover the classifier and both comment branches:

```
node --test .github/scripts/web-shell-visuals-publish.test.mjs
# tests 19 / pass 19 / fail 0
```

The whole CI helper set still passes (`88/88`), and `actionlint` is clean on the modified workflow.

To see the real output, drive the CLI the way the workflow does — an empty stage dir plus a changed-paths file:

```bash
printf '%s\n' \
  'packages/web-shell/client/components/WelcomeScreen.tsx' \
  'packages/web-shell/client/components/WorktreeWelcomeToggle.module.css' \
  'packages/web-shell/client/hooks/useWorktreeToggle.ts' \
  'packages/web-shell/client/e2e/visuals/screenshots.spec.ts' \
  'packages/core/src/config.ts' > /tmp/paths.txt
mkdir -p /tmp/stage
node .github/scripts/web-shell-visuals-publish.mjs comment \
  /tmp/stage '' abc1234 https://run.example/1 /tmp/body.md /tmp/paths.txt
cat /tmp/body.md
```

Confirm it names only the `.tsx` and the `.css` — the `.ts` hook, the spec file and the `packages/core` change are all correctly ignored. Then re-run with only `useThing.ts` in the paths file and confirm the green check comes back unchanged.

### Evidence (Before & After)

**Before** — what the bot posted on #7365, a PR whose entire point was new UI ([real comment](https://github.com/QwenLM/qwen-code/pull/7365#issuecomment-5028115039)):

```
#### Screenshots · before / after

✅ _No screenshot changes against the PR base._
```

**After** — same run, same zero images:

```
#### Screenshots · before / after

ℹ️ _No screenshot changed against the PR base_ — but this PR edits 2 render-shaping files:

- `packages/web-shell/client/components/WelcomeScreen.tsx`
- `packages/web-shell/client/components/WorktreeWelcomeToggle.module.css`

Either the change has no visual effect (logic, plumbing, a state the scenarios never reach), or **no scenario renders this UI** — in which case the preview cannot see it, and an empty result is a coverage gap rather than a clean bill of health. To make it visible, add a scenario to `packages/web-shell/client/e2e/visuals/screenshots.spec.ts` that seeds whatever state the UI is gated on; it then appears here as a head-only (NEW) capture.
```

**Control — a logic-only PR is left alone.** With only `packages/web-shell/client/hooks/useThing.ts` changed, the output is byte-identical to today's:

```
✅ _No screenshot changes against the PR base._
```

**Control — the API call failing does not break the comment.** With no changed-paths file at all (what happens if the `pulls/:n/files` request fails), the output is again today's green check. The workflow logs a `::warning::` and carries on.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`node --test` for the helper tests, `actionlint` for the workflow, plus the CLI invocation above. No daemon or browser needed — the changed code is a pure comment builder plus one `gh api` call.

## Risk & Scope

- **Main risk or tradeoff:** false prompts on PRs that touch a `.tsx`/`.css`/`.svg` with no visual delta — a prop rename, a comment, dead-code removal. The wording leads with "either the change has no visual effect", and the file list makes it a one-glance dismissal, but the rate is not knowable until it runs on real traffic. If it turns out noisy, narrowing to added/renamed files or gating on an additions threshold is a small follow-up.
- **Not validated / out of scope:** this does not detect the gap, it only asks the question — nothing here proves a given component is unrendered. A real coverage map (which components each scenario mounts) would answer it directly and is a much larger change. The two path prefixes are duplicated from the render workflow's `paths:` trigger and must stay in sync by hand; a comment on each side flags this.
- **Breaking changes / migration notes:** none. Comment text only; no change to when the preview runs, what it renders, or how assets are hosted.

## Linked Issues

Follow-up to #6880 (the preview bot), #6963 (before/after compositor), #7041 (animation freeze) and #7210 (cluster denoise). Motivated by the coverage gaps in #7035, #7221 and #7365.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 web-shell 视觉预览发现没有任何视图变化时,先看这个 PR 到底改了哪些文件,再决定怎么说。如果改动里有影响渲染的文件,评论会说明这个结果是有歧义的并列出这些文件,而不是打一个绿勾。如果没有改到渲染相关的文件,绿勾保持原样。

## 为什么需要

空预览意味着两件完全相反的事:改动确实不产生任何像素差异,或者**根本没有场景渲染到它所改的 UI**。而 bot 对两种情况打印的是同一句 `✅ _No screenshot changes against the PR base._`——于是第二种情况(预览压根看不见这个功能)被读成了"一切正常"。

这不是假设。已经发生三次了,每次都只是因为维护者碰巧注意到少了配图才问出来:

| PR | 新 UI | 为什么没有视图变化 |
| --- | --- | --- |
| #7035 | Primary workspace 标签 | 需要 ≥2 个 workspace,而所有场景都只有 1 个 |
| #7221 | Worktree 会话徽章 | 需要 `session.worktree` 元数据,没有场景设置过 |
| #7365 | 新建会话的 worktree 开关 | 位于 `/`,而所有场景都进 `/session/:id` |

区分这两种情况所需的信号其实早就存在、只是没被用起来:渲染工作流只在 `packages/web-shell/client/**` 和 `packages/webui/src/**` 改动时才触发,所以一个空预览按构造必然是"改了 UI 代码,却没有任何东西渲染得不一样"。这值得看第二眼,而此前没有人去看。

提示的触发面刻意收窄,因为一个所有人都学会忽略的警告比没有警告更糟。只有渲染面下的 `.tsx` / `.css` / `.svg` 算数——`.ts` 的 hook、工具函数和类型经常正常地不带视觉差异,而测试与场景代码是驱动预览的,本身不是被预览的对象。该目录下的 `.svg` 全部是打包进 bundle 的 UI 图标(`client/assets/icons/`),所以图标改了却零像素差,是同一个信号。

## 如何验证

单元测试覆盖了分类器和评论的两个分支:`node --test .github/scripts/web-shell-visuals-publish.test.mjs` → 19/19 通过。整套 CI helper 测试仍然全绿(88/88),`actionlint` 对改动的工作流无告警。

想看真实输出,就按工作流的方式跑 CLI(空的 stage 目录 + 一个改动路径文件),见上文英文部分的命令。确认它只列出 `.tsx` 和 `.css`——`.ts` hook、spec 文件、`packages/core` 的改动都被正确忽略。然后把路径文件换成只有 `useThing.ts`,确认绿勾原样返回。

## 风险与范围

- **主要风险/取舍:** 对那些改了 `.tsx`/`.css`/`.svg` 但确实没有视觉差异的 PR(改个 prop 名、改注释、删死代码)会误报。文案以"要么这个改动没有视觉影响"开头,加上文件列表,一眼就能排除,但真实误报率要跑过真实流量才知道。如果确实噪音大,收窄到"新增/重命名的文件"或加一个新增行数阈值,都是很小的后续改动。
- **未验证/不在范围内:** 这个改动不检测缺口,只是把问题问出来——它并不能证明某个组件确实没被渲染。真正的覆盖率地图(每个场景挂载了哪些组件)可以直接回答,但那是大得多的改动。两个路径前缀是从渲染工作流的 `paths:` 触发器手工复制过来的,需要人工保持同步,两边都加了注释标注这一点。
- **破坏性改动:** 无。只改评论文案,不改预览何时运行、渲染什么、以及资源如何托管。

</details>
