### PR TITLE
chore: simplify CODEOWNERS to package-level rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,86 +1,13 @@
 # ============================================================
-# Qwen Code Core Harness CODEOWNERS
-# 涉及模型效果的核心模块变更，需对应 maintainer review
+# Qwen Code CODEOWNERS
 # ============================================================
 
 # --- CODEOWNERS file itself ---
-/.github/CODEOWNERS                                    @pomelo-nwu
+/.github/CODEOWNERS    @pomelo-nwu
 
-# --- Tier 1: Agent Loop & System Prompt ---
-/packages/core/src/core/                               @tanzhenxin @yiliang114
+# --- Core package ---
+/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan
 
-# --- Tier 1: API Message Serialization ---
-# (overrides the core/ catch-all above via last-match-wins)
-/packages/core/src/core/openaiContentGenerator/         @tanzhenxin @yiliang114
-/packages/core/src/core/anthropicContentGenerator/      @tanzhenxin @yiliang114
-/packages/core/src/core/geminiContentGenerator/         @tanzhenxin @yiliang114
-/packages/core/src/utils/schemaConverter.ts             @tanzhenxin @yiliang114
-
-# --- Tier 1: Tool Definitions & Schemas ---
-/packages/core/src/tools/                               @tanzhenxin @LaZzyMan
-
-# --- Tier 1: Extension Security ---
-/packages/core/src/extension/                           @tanzhenxin @LaZzyMan
-
-# --- Tier 1: Context Assembly ---
-/packages/core/src/utils/environmentContext.ts          @LaZzyMan @tanzhenxin
-
-# --- Tier 1: Context Dependencies ---
-/packages/core/src/services/tokenEstimation.ts          @tanzhenxin @LaZzyMan
-/packages/core/src/services/image-payload-references.ts @tanzhenxin @LaZzyMan
-/packages/core/src/services/memoryPressureMonitor.ts    @tanzhenxin @LaZzyMan
-/packages/core/src/services/visionBridge/               @tanzhenxin @LaZzyMan
-
-# --- Tier 1: Compaction & Truncation ---
-/packages/core/src/services/chatCompressionService.ts   @tanzhenxin @LaZzyMan
-/packages/core/src/services/postCompactAttachments.ts   @tanzhenxin @LaZzyMan
-/packages/core/src/services/compactionInputSlimming.ts  @tanzhenxin @LaZzyMan
-/packages/core/src/services/microcompaction/            @tanzhenxin @LaZzyMan
-/packages/core/src/utils/truncation.ts                  @tanzhenxin @LaZzyMan
-/packages/core/src/utils/toolResultDisplayCompaction.ts @tanzhenxin @LaZzyMan
-
-# --- Tier 1: Model & Provider Configuration ---
-/packages/core/src/models/                              @yiliang114 @tanzhenxin
-/packages/core/src/providers/                           @yiliang114 @tanzhenxin
-/packages/core/src/config/models.ts                     @yiliang114 @tanzhenxin
-
-# --- Tier 1: MCP ---
-/packages/core/src/mcp/                                 @tanzhenxin @LaZzyMan
-/packages/core/src/prompts/prompt-registry.ts           @tanzhenxin @LaZzyMan
-/packages/core/src/resources/resource-registry.ts       @tanzhenxin @LaZzyMan
-
-# --- Tier 2: Permission System ---
-# (permission-helpers/permissionFlow override the core/ catch-all)
-/packages/core/src/permissions/                         @LaZzyMan @qqqys
-/packages/core/src/core/permission-helpers.ts           @LaZzyMan @qqqys
-/packages/core/src/core/permissionFlow.ts               @LaZzyMan @qqqys
-/packages/core/src/confirmation-bus/                    @LaZzyMan @qqqys
-
-# --- Tier 2: Memory System ---
-/packages/core/src/memory/                              @LaZzyMan @qqqys
-
-# --- Tier 2: Loop Detection ---
-/packages/core/src/services/loopDetectionService.ts     @tanzhenxin @LaZzyMan
-
-# --- Tier 2: Skills / Subagents / Agents ---
-# (individual runtime files; skills/bundled/ content is intentionally excluded)
-/packages/core/src/skills/index.ts                      @wenshao @tanzhenxin
-/packages/core/src/skills/skill-activation.ts           @wenshao @tanzhenxin
-/packages/core/src/skills/skill-load.ts                 @wenshao @tanzhenxin
-/packages/core/src/skills/skill-manager.ts              @wenshao @tanzhenxin
-/packages/core/src/skills/skill-paths.ts                @wenshao @tanzhenxin
-/packages/core/src/skills/symlinkScope.ts               @wenshao @tanzhenxin
-/packages/core/src/skills/types.ts                      @wenshao @tanzhenxin
-/packages/core/src/subagents/                           @wenshao @tanzhenxin
-/packages/core/src/agents/                              @wenshao @tanzhenxin
-
-# --- Tier 2: Hooks ---
-/packages/core/src/hooks/                               @DennisYu07 @qqqys
-
-# --- Tier 2: Master Config ---
-/packages/core/src/config/config.ts                     @tanzhenxin @yiliang114
-/packages/core/src/config/approval-mode.ts              @tanzhenxin @LaZzyMan
-
-# --- Tier 2: CUA Driver & Mobile MCP ---
-/packages/cua-driver/                                   @LaZzyMan
-/packages/mobile-mcp/                                   @LaZzyMan
+# --- CUA Driver & Mobile MCP ---
+/packages/cua-driver/  @LaZzyMan
+/packages/mobile-mcp/  @LaZzyMan


### PR DESCRIPTION
## What this PR does

Consolidates the 80-line granular CODEOWNERS (30+ per-directory/per-file rules with Tier 1/Tier 2 splits) into a single package-level rule: all of `packages/core/` is owned by the four core maintainers (@wenshao @tanzhenxin @yiliang114 @LaZzyMan). CUA Driver and Mobile MCP keep their existing single-owner rule.

## Why it's needed

Qwen Code iteration is about to enter autopilot mode. The core package needs core maintainer approval to stay stable, while everything else should iterate fast. The previous fine-grained rules were expensive to maintain and didn't meaningfully improve review quality — any change inside `packages/core` ultimately needs the same set of people to sign off.

## Reviewer Test Plan

### How to verify

Confirm the new CODEOWNERS file correctly assigns `packages/core/` to the four maintainers by checking the file diff. GitHub will enforce ownership on the next PR touching that path.

### Evidence (Before & After)

N/A (config-only change, no user-visible behavior)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: all `packages/core/` changes now require approval from any of the four maintainers instead of the previous per-module two-person pairs — slightly broader reviewer pool per PR.
- Not validated / out of scope: `packages/cli`, `packages/web-shell`, and other packages remain without CODEOWNERS rules (intentional — they iterate freely).
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将原来 80 行、30+ 条按目录/文件细分的 CODEOWNERS 规则（Tier 1/Tier 2 分层）合并为一条包级规则：`packages/core/` 整体由四位核心 maintainer（@wenshao @tanzhenxin @yiliang114 @LaZzyMan）负责。CUA Driver 和 Mobile MCP 保持原有单 owner 规则不变。

## 为什么需要

Qwen Code 的迭代即将进入自动驾驶阶段。核心包需要核心 maintainer 审批以保持稳定，其余部分快速迭代即可。之前按子目录细分的规则维护成本高，且实际上并没有提升 review 质量——`packages/core` 内的任何改动最终都需要同一批人签字。

## 审阅者测试计划

### 如何验证

检查文件 diff，确认新的 CODEOWNERS 正确将 `packages/core/` 分配给四位 maintainer。GitHub 会在下一个触碰该路径的 PR 上自动执行 ownership 检查。

### 证据（Before & After）

N/A（纯配置变更，无用户可见行为）

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## 风险与范围

- 主要风险/权衡：`packages/core/` 的所有变更现在需要四位 maintainer 中任一人批准，而非之前按模块的两人组合——每个 PR 的 reviewer 池略宽。
- 未验证/不在范围内：`packages/cli`、`packages/web-shell` 等其他包保持无 CODEOWNERS 规则（有意为之——它们自由迭代）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A

</details>
