### PR TITLE
feat(web-shell): Add sidebar customization API for branding, navigation, session actions, and footer

### DIFF
--- a/docs/developers/daemon-ui/sidebar-customization.md
+++ b/docs/developers/daemon-ui/sidebar-customization.md
@@ -1,0 +1,301 @@
+# WebShell Sidebar — Customization Guide
+
+The `WebShellSidebar` is the session list and navigation panel rendered inside
+the web-shell `App` component. This document maps each visual area to its
+current customization capability and identifies areas with no external injection
+point.
+
+## Enabling the sidebar
+
+The sidebar is **disabled by default**. Pass the `sidebar` prop to enable:
+
+```tsx
+import { WebShellWithProviders } from '@qwen-code/web-shell';
+
+<WebShellWithProviders
+  baseUrl="http://localhost:4170"
+  sidebar={true} // simple enable
+  // or with fine-grained options:
+  // sidebar={{ enabled: true, defaultCollapsed: false, ... }}
+/>;
+```
+
+## Layout overview
+
+```
+┌─────────────────────────────────────┐
+│ ① Branding (topRow)                 │  ✅ customizable
+├─────────────────────────────────────┤
+│ ② Primary navigation                │  ✅ customizable
+│    [＋ New task]  [🧩 Plugins]      │
+│    [📅 Scheduled] [🎯 Goals]        │
+│    [custom render...]               │
+├─────────────────────────────────────┤
+│ ③ Project header                    │  ✅ show/hide
+│    📁 Projects ▼ [🔍] [＋]          │
+│    Session list entries...          │
+│    📦 Archived sessions             │
+├─────────────────────────────────────┤
+│ ④ Footer action bar                 │  ✅ customizable
+│    [⚙ Settings] v0.19 [☀] [▦] [◧] │
+├─────────────────────────────────────┤
+│ ⑤ Resize handle                     │  ❌ not customizable
+└─────────────────────────────────────┘
+```
+
+## Customizable areas
+
+### ① Branding — `branding`
+
+```ts
+interface WebShellSidebarBranding {
+  render?: () => ReactNode; // replace the entire branding row
+  hideWhenCompact?: boolean; // hide when sidebar is collapsed (default: true)
+}
+```
+
+| Value                            | Effect                                            |
+| -------------------------------- | ------------------------------------------------- |
+| `undefined` (default)            | Qwen logo + "Qwen Code" text                      |
+| `false`                          | Branding row hidden entirely                      |
+| `{ render: () => <MyHeader /> }` | Full replacement with custom content              |
+| `{ hideWhenCompact: false }`     | Keep branding visible in collapsed icon-rail mode |
+
+```tsx
+sidebar={{
+  branding: {
+    render: () => (
+      <div style={{ display: 'flex', gap: 8 }}>
+        <img src="/my-logo.svg" alt="" width={24} />
+        <span>My App</span>
+      </div>
+    ),
+  },
+}}
+```
+
+### ② Primary Navigation — `primaryNav`
+
+```ts
+type WebShellSidebarPrimaryNavItem =
+  | 'newTask' // ✏️ New Task button
+  | 'plugins' // 🧩 Plugins button
+  | 'scheduledTasks' // 📅 Scheduled Tasks button
+  | 'goals'; // 🎯 Goals button
+
+interface WebShellSidebarPrimaryNavOptions {
+  items?: readonly WebShellSidebarPrimaryNavItem[]; // which built-in buttons to show (default: all)
+  render?: () => ReactNode; // additional custom content after built-in buttons
+}
+```
+
+The primary navigation area contains built-in buttons controlled by `items`:
+
+- All buttons are shown by default when `items` is not specified
+- Only the listed buttons are shown when `items` is provided
+- Custom content can be added via `render()` after the built-in buttons
+
+| Value                                      | Effect                                 |
+| ------------------------------------------ | -------------------------------------- |
+| `undefined` (default)                      | All built-in buttons shown             |
+| `{ items: ['plugins'] }`                   | Only Plugins button                    |
+| `{ items: ['plugins', 'scheduledTasks'] }` | Plugins + Scheduled Tasks              |
+| `{ items: [], render: () => ... }`         | Hide all built-in, only custom content |
+
+```tsx
+sidebar={{
+  primaryNav: {
+    items: ['plugins', 'scheduledTasks'],  // hide newTask and goals
+    render: () => (
+      <button onClick={() => console.log('custom action')}>
+        🔗 Data Sync
+      </button>
+    ),
+  },
+}}
+```
+
+### ④ Footer — `footer`
+
+```ts
+type WebShellSidebarFooterItem =
+  | 'settings' // ⚙ Settings panel
+  | 'version' // version label (e.g. "v0.19.10")
+  | 'theme' // ☀/🌙 light/dark toggle
+  | 'sessionsOverview' // ▦ session overview panel (large screens only)
+  | 'splitView' // ◧ split view (large screens only)
+  | 'daemonStatus' // 📊 daemon status panel
+  | 'collapse'; // ◁/▷ collapse/expand toggle
+
+interface WebShellSidebarFooterOptions {
+  items?: readonly WebShellSidebarFooterItem[]; // which built-in items to show (default: all)
+  render?: () => ReactNode; // custom content rendered on the left side, before built-in items
+}
+```
+
+| Value                                          | Effect                  |
+| ---------------------------------------------- | ----------------------- |
+| `undefined` (default)                          | All items shown         |
+| `false`                                        | Footer hidden entirely  |
+| `{ items: ['settings', 'theme', 'collapse'] }` | Only listed items shown |
+
+The footer auto-adapts to narrow widths: labels are hidden and version is
+dropped below certain thresholds.
+
+```tsx
+sidebar={{
+  footer: { items: ['theme', 'collapse'] },  // minimal footer
+}}
+```
+
+Custom content via `render()` appears on the left side of the footer, before
+the built-in items:
+
+```tsx
+sidebar={{
+  footer: {
+    items: ['collapse'],
+    render: () => (
+      <button onClick={() => openHelpCenter()}>
+        ❓ Help
+      </button>
+    ),
+  },
+}}
+```
+
+**Note:** `'scheduledTasks'` and `'goals'` have been moved to the primary
+navigation area (②) and are now always visible. They are no longer controlled
+by `footer.items`.
+
+### Other top-level options
+
+```ts
+interface WebShellSidebarOptions {
+  enabled?: boolean; // show/hide sidebar (default: true when passed)
+  defaultCollapsed?: boolean; // initial collapsed state (persisted in localStorage)
+  showCompactToggle?: boolean; // show the collapse button in the chat area (default: true)
+  branding?: false | WebShellSidebarBranding;
+  primaryNav?: WebShellSidebarPrimaryNavOptions;
+  hideProjectHeader?: boolean; // hide "Projects" header row (default: false = shown)
+  sessionActions?: WebShellSidebarSessionActionsOptions;
+  footer?: false | WebShellSidebarFooterOptions;
+}
+```
+
+### ③ Project Header — `hideProjectHeader`
+
+Controls visibility of the "Projects" header row (the row with the collapse
+toggle, search icon, and add workspace button). Defaults to `false` (shown).
+
+```tsx
+sidebar={{
+  hideProjectHeader: true,  // hide the "项目 ▼ [🔍] [＋]" row
+}}
+```
+
+When hidden, the session list entries and archived sessions are still shown —
+only the header row with its action buttons is removed.
+
+### Session Row Actions — `sessionActions`
+
+```ts
+type WebShellSidebarSessionActionItem =
+  | 'details' // 📝 Details (dropdown sub-menu)
+  | 'rename' // ✏️ Rename (dropdown menu)
+  | 'group' // 📁 Group/Move to folder (dropdown menu)
+  | 'export' // 📤 Export chat history (dropdown menu)
+  | 'delete' // 🗑 Delete session (dropdown menu)
+  | 'pin' // 📌 Pin/Unpin (inline button)
+  | 'archive'; // 📦 Archive (inline button)
+
+interface WebShellSidebarSessionActionsOptions {
+  items?: readonly WebShellSidebarSessionActionItem[]; // which actions to show (default: all)
+  inlineItems?: readonly WebShellSidebarSessionActionItem[]; // which items appear as inline buttons (default: ['pin', 'archive'])
+}
+```
+
+Controls which action buttons appear on session rows:
+
+- **`items`**: Master control for all actions (both inline and dropdown). If an item is not in `items`, it's hidden everywhere.
+- **`inlineItems`**: Controls which items appear as **inline buttons** (on hover). Defaults to `['pin', 'archive']`. Any known action item can be used as an inline button — it will use its built-in icon, label, and click handler. If an item has no built-in icon, text is used instead.
+
+**Visibility priority**: Both `items` AND the item's built-in condition AND `inlineItems` must all pass for the inline button to show. For example, `delete` as inline requires `items` to include `'delete'` AND `inlineItems` to include `'delete'`.
+
+| Value                                    | Effect                                     |
+| ---------------------------------------- | ------------------------------------------ |
+| `undefined` (default)                    | All actions shown, pin + archive as inline |
+| `{ inlineItems: ['pin', 'delete'] }`     | Pin + delete as inline buttons             |
+| `{ inlineItems: [] }`                    | No inline buttons at all                   |
+| `{ inlineItems: ['archive', 'export'] }` | Archive + export as inline buttons         |
+
+The dropdown trigger (⋮) is automatically hidden when no dropdown items
+are enabled. Inline buttons (`pin`, `archive`) are only shown when both
+their capability condition and `items` include them.
+
+```tsx
+sidebar={{
+  sessionActions: {
+    items: ['details', 'rename', 'export', 'delete'],  // dropdown items
+    inlineItems: ['pin', 'delete'],  // pin + delete as inline buttons
+  },
+}}
+```
+
+## Non-customizable areas
+
+### Projects / Workspaces (inside session list)
+
+When the session list is visible, the following sub-areas are rendered but
+**not individually customizable**:
+
+| Aspect                | Detail                                                            |
+| --------------------- | ----------------------------------------------------------------- |
+| Data source           | `useSessions()` hook → daemon API (`/sessions` endpoint)          |
+| Session list sorting  | By creation time, descending                                      |
+| Session row rendering | Internal `renderSessionRow` `useCallback` — not injectable        |
+| Search / filter       | Built-in search bar with client-side text matching                |
+| Session groups        | `SessionGroupSection` component with 6 preset colors + custom hex |
+| Workspace sections    | `WorkspaceSection` per daemon workspace, not replaceable          |
+| Add workspace dialog  | Built-in `AddWorkspaceDialog`                                     |
+
+### ⑤ Resize handle
+
+- Drag handle on the right edge for resizing sidebar width
+- Width is persisted in localStorage
+- Not configurable
+
+## Runtime behavior props
+
+These `WebShellProps` affect sidebar behavior indirectly:
+
+| Prop                            | Effect                                 |
+| ------------------------------- | -------------------------------------- |
+| `onNewSession`                  | Override the new-session handler       |
+| `onLoadSession`                 | Override session loading logic         |
+| `onSessionIdChange`             | React to session switches              |
+| `splitSessionIds`               | Control split-view sessions externally |
+| `theme` / `onThemeChange`       | Control / observe theme                |
+| `language` / `onLanguageChange` | Control / observe UI language          |
+
+## Collapsed and mobile states
+
+| State     | Behavior                                           |
+| --------- | -------------------------------------------------- |
+| Expanded  | Full sidebar with text labels                      |
+| Collapsed | Icon-rail mode (logo, pen icon, action icons only) |
+| Mobile    | Drawer slides from left with backdrop overlay      |
+
+Collapse state is persisted in `localStorage` under the key
+`qwen-code-web-shell-sidebar-collapsed`.
+
+## Source locations
+
+| Component           | File                                                                      |
+| ------------------- | ------------------------------------------------------------------------- |
+| WebShellSidebar     | `packages/web-shell/client/components/sidebar/WebShellSidebar.tsx`        |
+| SessionGroupSection | `packages/web-shell/client/components/sidebar/SessionGroupSection.tsx`    |
+| WorkspaceSection    | `packages/web-shell/client/components/sidebar/WorkspaceSection.tsx`       |
+| Sidebar styles      | `packages/web-shell/client/components/sidebar/WebShellSidebar.module.css` |
+| App integration     | `packages/web-shell/client/App.tsx` (search `WebShellSidebar`)            |
+| Entry point (dev)   | `packages/web-shell/client/main.tsx` (`sidebar: true`)                    |

--- a/docs/developers/daemon-ui/sidebar-customization.md
+++ b/docs/developers/daemon-ui/sidebar-customization.md
@@ -165,8 +165,8 @@ sidebar={{
 ```
 
 **Note:** `'scheduledTasks'` and `'goals'` have been moved to the primary
-navigation area (②) and are now always visible. They are no longer controlled
-by `footer.items`.
+navigation area (②) and are shown by default. They are controlled by `primaryNav.items` instead of
+`footer.items`.
 
 ### Other top-level options
 
@@ -195,7 +195,7 @@ sidebar={{
 ```
 
 When hidden, the session list entries and archived sessions are still shown —
-only the header row with its action buttons is removed.
+the header row with its action buttons and the session search bar are removed.
 
 ### Session Row Actions — `sessionActions`
 
@@ -209,16 +209,24 @@ type WebShellSidebarSessionActionItem =
   | 'pin' // 📌 Pin/Unpin (inline button)
   | 'archive'; // 📦 Archive (inline button)
 
+/** Subset with working inline (hover-button) handlers. */
+type WebShellSidebarSessionInlineActionItem =
+  | 'pin'
+  | 'archive'
+  | 'rename'
+  | 'export'
+  | 'delete';
+
 interface WebShellSidebarSessionActionsOptions {
   items?: readonly WebShellSidebarSessionActionItem[]; // which actions to show (default: all)
-  inlineItems?: readonly WebShellSidebarSessionActionItem[]; // which items appear as inline buttons (default: ['pin', 'archive'])
+  inlineItems?: readonly WebShellSidebarSessionInlineActionItem[]; // which items appear as inline buttons (default: ['pin', 'archive'])
 }
 ```
 
 Controls which action buttons appear on session rows:
 
 - **`items`**: Master control for all actions (both inline and dropdown). If an item is not in `items`, it's hidden everywhere.
-- **`inlineItems`**: Controls which items appear as **inline buttons** (on hover). Defaults to `['pin', 'archive']`. Any known action item can be used as an inline button — it will use its built-in icon, label, and click handler. If an item has no built-in icon, text is used instead.
+- **`inlineItems`**: Controls which items appear as **inline buttons** (on hover). Defaults to `['pin', 'archive']`. Only items with working inline handlers can be used: `'pin'`, `'archive'`, `'rename'`, `'export'`, `'delete'`. `'details'` and `'group'` are dropdown-only.
 
 **Visibility priority**: Both `items` AND the item's built-in condition AND `inlineItems` must all pass for the inline button to show. For example, `delete` as inline requires `items` to include `'delete'` AND `inlineItems` to include `'delete'`.
 
@@ -236,7 +244,7 @@ their capability condition and `items` include them.
 ```tsx
 sidebar={{
   sessionActions: {
-    items: ['details', 'rename', 'export', 'delete'],  // dropdown items
+    items: ['details', 'rename', 'export', 'delete', 'pin'],  // which actions to show (master control)
     inlineItems: ['pin', 'delete'],  // pin + delete as inline buttons
   },
 }}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -127,6 +127,8 @@ import {
   type WebShellSidebarBranding,
   type WebShellSidebarFooterOptions,
   type WebShellSidebarLockedWorkspace,
+  type WebShellSidebarPrimaryNavOptions,
+  type WebShellSidebarSessionActionsOptions,
 } from './components/sidebar/WebShellSidebar';
 import { isSidebarToggleShortcut } from './components/sidebar/sidebarToggleShortcut';
 import {
@@ -427,6 +429,12 @@ export interface WebShellSidebarOptions {
   showCompactToggle?: boolean;
   /** Hide or replace the complete sidebar branding row. */
   branding?: false | WebShellSidebarBranding;
+  /** Customize the primary navigation area (new task button, custom entries). */
+  primaryNav?: WebShellSidebarPrimaryNavOptions;
+  /** Whether to hide the "Projects" header row (with search and add workspace). Defaults to false (shown). */
+  hideProjectHeader?: boolean;
+  /** Customize which action buttons appear on session rows. */
+  sessionActions?: WebShellSidebarSessionActionsOptions;
   /** Hide the footer completely or select the built-in entries it exposes. */
   footer?: false | WebShellSidebarFooterOptions;
   /** Customize the workspace row shown when lockWorkspaceCwd is active. */
@@ -647,6 +655,9 @@ function resolveSidebarOptions(sidebar: WebShellProps['sidebar']): {
   defaultCollapsed: boolean;
   showCompactToggle: boolean;
   branding?: false | WebShellSidebarBranding;
+  primaryNav?: WebShellSidebarPrimaryNavOptions;
+  hideProjectHeader?: boolean;
+  sessionActions?: WebShellSidebarSessionActionsOptions;
   footer?: false | WebShellSidebarFooterOptions;
   lockedWorkspace?: WebShellSidebarLockedWorkspace;
 } {
@@ -661,6 +672,9 @@ function resolveSidebarOptions(sidebar: WebShellProps['sidebar']): {
     defaultCollapsed: sidebar.defaultCollapsed ?? false,
     showCompactToggle: sidebar.showCompactToggle ?? true,
     branding: sidebar.branding,
+    primaryNav: sidebar.primaryNav,
+    hideProjectHeader: sidebar.hideProjectHeader,
+    sessionActions: sidebar.sessionActions,
     footer: sidebar.footer,
     lockedWorkspace: sidebar.lockedWorkspace,
   };
@@ -6472,6 +6486,9 @@ export function App({
                   lockedWorkspaceCwd={lockedWorkspaceCwd}
                   lockedWorkspace={sidebarOptions.lockedWorkspace}
                   branding={sidebarOptions.branding}
+                  primaryNav={sidebarOptions.primaryNav}
+                  hideProjectHeader={sidebarOptions.hideProjectHeader}
+                  sessionActions={sidebarOptions.sessionActions}
                   footer={sidebarOptions.footer}
                 />
               </div>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -124,8 +124,6 @@ export type WebShellSidebarFooterItem =
   | 'settings'
   | 'version'
   | 'theme'
-  | 'scheduledTasks'
-  | 'goals'
   | 'sessionsOverview'
   | 'splitView'
   | 'daemonStatus'
@@ -146,22 +144,67 @@ export interface WebShellSidebarLockedWorkspace {
   ) => ReactNode;
 }
 
+export type WebShellSidebarPrimaryNavItem =
+  | 'newTask'
+  | 'plugins'
+  | 'scheduledTasks'
+  | 'goals';
+
+export interface WebShellSidebarPrimaryNavOptions {
+  /** Built-in primary nav entries to show. Defaults to all. */
+  items?: readonly WebShellSidebarPrimaryNavItem[];
+  /** Additional custom content rendered after the built-in nav buttons. */
+  render?: () => ReactNode;
+}
+
 export interface WebShellSidebarFooterOptions {
   /** Built-in footer entries to expose. Entries use the canonical footer order. */
   items?: readonly WebShellSidebarFooterItem[];
+  /** Additional custom content rendered before the built-in footer items (left side). */
+  render?: () => ReactNode;
 }
 
 const DEFAULT_FOOTER_ITEMS: readonly WebShellSidebarFooterItem[] = [
   'settings',
   'version',
   'theme',
-  'scheduledTasks',
-  'goals',
   'sessionsOverview',
   'splitView',
   'daemonStatus',
   'collapse',
 ];
+
+const DEFAULT_PRIMARY_NAV_ITEMS: readonly WebShellSidebarPrimaryNavItem[] = [
+  'newTask',
+  'plugins',
+  'scheduledTasks',
+  'goals',
+];
+
+export type WebShellSidebarSessionActionItem =
+  | 'details'
+  | 'rename'
+  | 'group'
+  | 'export'
+  | 'delete'
+  | 'pin'
+  | 'archive';
+
+export interface WebShellSidebarSessionActionsOptions {
+  /** Session action items to show. Defaults to all. */
+  items?: readonly WebShellSidebarSessionActionItem[];
+  /**
+   * Which items appear as inline buttons (on hover). Defaults to ['pin', 'archive'].
+   * Only items that also pass their built-in visibility condition are rendered.
+   */
+  inlineItems?: readonly WebShellSidebarSessionActionItem[];
+}
+
+const DEFAULT_SESSION_ACTION_ITEMS: readonly WebShellSidebarSessionActionItem[] =
+  ['details', 'rename', 'group', 'export', 'delete', 'pin', 'archive'];
+
+const DEFAULT_INLINE_ACTION_ITEMS: readonly WebShellSidebarSessionActionItem[] =
+  ['pin', 'archive'];
 
 /**
  * Palette order for the quick color-grouping buckets. Mirrors core's
@@ -252,6 +295,11 @@ interface WebShellSidebarProps {
   lockedWorkspaceCwd?: string;
   lockedWorkspace?: WebShellSidebarLockedWorkspace;
   branding?: false | WebShellSidebarBranding;
+  primaryNav?: WebShellSidebarPrimaryNavOptions;
+  /** Whether to hide the "Projects" header row (with search and add workspace). Defaults to false (shown). */
+  hideProjectHeader?: boolean;
+  /** Customize which action buttons appear on session rows. */
+  sessionActions?: WebShellSidebarSessionActionsOptions;
   footer?: false | WebShellSidebarFooterOptions;
 }
 
@@ -441,6 +489,9 @@ export function WebShellSidebar({
   lockedWorkspaceCwd,
   lockedWorkspace: lockedWorkspaceOptions,
   branding,
+  primaryNav: primaryNavOptions,
+  hideProjectHeader,
+  sessionActions: sessionActionsOptions,
   footer,
 }: WebShellSidebarProps) {
   const { t } = useI18n();
@@ -452,6 +503,21 @@ export function WebShellSidebar({
     () =>
       new Set(footer === false ? [] : (footer?.items ?? DEFAULT_FOOTER_ITEMS)),
     [footer],
+  );
+  const primaryNavItems = useMemo(
+    () => new Set(primaryNavOptions?.items ?? DEFAULT_PRIMARY_NAV_ITEMS),
+    [primaryNavOptions?.items],
+  );
+  const sessionActionItems = useMemo(
+    () => new Set(sessionActionsOptions?.items ?? DEFAULT_SESSION_ACTION_ITEMS),
+    [sessionActionsOptions?.items],
+  );
+  const inlineActionItems = useMemo(
+    () =>
+      new Set(
+        sessionActionsOptions?.inlineItems ?? DEFAULT_INLINE_ACTION_ITEMS,
+      ),
+    [sessionActionsOptions?.inlineItems],
   );
   const shouldRenderBrand =
     branding !== false && !(mobileOpen && (branding?.hideWhenCompact ?? true));
@@ -2615,130 +2681,242 @@ export function WebShellSidebar({
                         onClick={(event) => event.stopPropagation()}
                         onKeyDown={(event) => event.stopPropagation()}
                       >
-                        {organizationEnabled && (
-                          <button
-                            className={cx(
-                              styles.sessionActionButton,
-                              session.isPinned &&
-                                styles.activeSessionActionButton,
-                            )}
-                            type="button"
-                            disabled={busy}
-                            aria-label={
-                              session.isPinned
+                        {(() => {
+                          const inlineActions: Array<{
+                            key: WebShellSidebarSessionActionItem;
+                            icon?: ReactNode;
+                            label: string;
+                            disabled?: boolean;
+                            title?: string;
+                            active?: boolean;
+                            visible: boolean;
+                            onClick: () => void;
+                          }> = [
+                            {
+                              key: 'pin',
+                              icon: <PinIcon size={16} strokeWidth={1.2} />,
+                              label: session.isPinned
                                 ? t('sidebar.unpin')
-                                : t('sidebar.pin')
-                            }
-                            title={
-                              session.isPinned
-                                ? t('sidebar.unpin')
-                                : t('sidebar.pin')
-                            }
-                            onClick={() => handleTogglePin(session)}
-                          >
-                            <PinIcon />
-                          </button>
-                        )}
-                        {canMutateSessionArchive(session) && (
-                          <button
-                            className={styles.sessionActionButton}
-                            type="button"
-                            disabled={busy || isCurrent}
-                            aria-label={t('sidebar.archive')}
-                            title={
-                              isCurrent
+                                : t('sidebar.pin'),
+                              disabled: busy,
+                              active: session.isPinned,
+                              visible:
+                                organizationEnabled &&
+                                sessionActionItems.has('pin') &&
+                                inlineActionItems.has('pin'),
+                              onClick: () => handleTogglePin(session),
+                            },
+                            {
+                              key: 'archive',
+                              icon: <ArchiveIcon size={16} strokeWidth={1.2} />,
+                              label: t('sidebar.archive'),
+                              disabled: busy || isCurrent,
+                              title: isCurrent
                                 ? t('sidebar.archiveCurrentDisabled')
-                                : t('sidebar.archive')
-                            }
-                            onClick={() => handleArchive(session)}
-                          >
-                            <ArchiveIcon />
-                          </button>
-                        )}
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              className={styles.sessionActionButton}
-                              type="button"
-                              aria-label={t('sidebar.moreActions')}
-                              title={t('sidebar.moreActions')}
+                                : t('sidebar.archive'),
+                              visible:
+                                canMutateSessionArchive(session) &&
+                                sessionActionItems.has('archive') &&
+                                inlineActionItems.has('archive'),
+                              onClick: () => handleArchive(session),
+                            },
+                            {
+                              key: 'details',
+                              icon: <InfoIcon size={16} strokeWidth={1.2} />,
+                              label: t('sidebar.details'),
+                              visible:
+                                sessionActionItems.has('details') &&
+                                inlineActionItems.has('details'),
+                              onClick: () => {
+                                /* TODO: open details panel */
+                              },
+                            },
+                            {
+                              key: 'rename',
+                              icon: <PencilIcon size={16} strokeWidth={1.2} />,
+                              label: t('sidebar.rename'),
+                              disabled: !isCurrent,
+                              title: !isCurrent
+                                ? t('sidebar.renameCurrentOnly')
+                                : undefined,
+                              visible:
+                                sessionActionItems.has('rename') &&
+                                inlineActionItems.has('rename'),
+                              onClick: () => handleRenameFromMenu(session),
+                            },
+                            {
+                              key: 'group',
+                              icon: (
+                                <FolderInputIcon size={16} strokeWidth={1.2} />
+                              ),
+                              label: t('sidebar.sessionGroup'),
+                              disabled: busy,
+                              visible:
+                                organizationEnabled &&
+                                sessionActionItems.has('group') &&
+                                inlineActionItems.has('group'),
+                              onClick: () => {
+                                /* TODO: open group menu */
+                              },
+                            },
+                            {
+                              key: 'export',
+                              icon: (
+                                <DownloadIcon size={16} strokeWidth={1.2} />
+                              ),
+                              label: t('sidebar.export'),
+                              disabled: exporting,
+                              visible:
+                                canExportSessions &&
+                                sessionActionItems.has('export') &&
+                                inlineActionItems.has('export'),
+                              onClick: () => handleExportSession(session),
+                            },
+                            {
+                              key: 'delete',
+                              icon: <Trash2Icon size={16} strokeWidth={1.2} />,
+                              label: t('sidebar.delete'),
+                              disabled: isCurrent,
+                              title: isCurrent
+                                ? t('sidebar.currentDeleteDisabled')
+                                : undefined,
+                              visible:
+                                sessionActionItems.has('delete') &&
+                                inlineActionItems.has('delete'),
+                              onClick: () => handleDeleteSession(session),
+                            },
+                          ];
+                          return inlineActions
+                            .filter((a) => a.visible)
+                            .map((action) => (
+                              <button
+                                key={action.key}
+                                className={cx(
+                                  styles.sessionActionButton,
+                                  action.active &&
+                                    styles.activeSessionActionButton,
+                                )}
+                                type="button"
+                                disabled={action.disabled}
+                                aria-label={action.label}
+                                title={action.title ?? action.label}
+                                onClick={action.onClick}
+                              >
+                                {action.icon ?? (
+                                  <span style={{ fontSize: 12 }}>
+                                    {action.label}
+                                  </span>
+                                )}
+                              </button>
+                            ));
+                        })()}
+                        {(sessionActionItems.has('details') ||
+                          sessionActionItems.has('rename') ||
+                          (organizationEnabled &&
+                            sessionActionItems.has('group')) ||
+                          (canExportSessions &&
+                            sessionActionItems.has('export')) ||
+                          sessionActionItems.has('delete')) && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className={styles.sessionActionButton}
+                                type="button"
+                                aria-label={t('sidebar.moreActions')}
+                                title={t('sidebar.moreActions')}
+                              >
+                                <EllipsisVerticalIcon />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              align="end"
+                              className="w-auto min-w-40"
+                              onPointerDownOutside={() => {
+                                sessionMenuPointerDismissRef.current = true;
+                              }}
+                              onCloseAutoFocus={(event) => {
+                                if (!sessionMenuPointerDismissRef.current)
+                                  return;
+                                sessionMenuPointerDismissRef.current = false;
+                                event.preventDefault();
+                              }}
                             >
-                              <EllipsisVerticalIcon />
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="end"
-                            className="w-auto min-w-40"
-                            onPointerDownOutside={() => {
-                              sessionMenuPointerDismissRef.current = true;
-                            }}
-                            onCloseAutoFocus={(event) => {
-                              if (!sessionMenuPointerDismissRef.current) return;
-                              sessionMenuPointerDismissRef.current = false;
-                              event.preventDefault();
-                            }}
-                          >
-                            <DropdownMenuGroup>
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger>
-                                  <InfoIcon />
-                                  {t('sidebar.details')}
-                                </DropdownMenuSubTrigger>
-                                <DropdownMenuSubContent className="min-w-64 p-3">
-                                  {details}
-                                </DropdownMenuSubContent>
-                              </DropdownMenuSub>
-                              <DropdownMenuItem
-                                disabled={!isCurrent}
-                                title={
-                                  !isCurrent
-                                    ? t('sidebar.renameCurrentOnly')
-                                    : undefined
-                                }
-                                onSelect={() => handleRenameFromMenu(session)}
-                              >
-                                <PencilIcon />
-                                {t('sidebar.rename')}
-                              </DropdownMenuItem>
-                              {organizationEnabled && (
-                                <DropdownMenuItem
-                                  disabled={busy}
-                                  onSelect={(event) =>
-                                    openGroupMenuFromAnchor(
-                                      event.currentTarget as HTMLElement,
-                                      session,
-                                    )
-                                  }
-                                >
-                                  <FolderInputIcon />
-                                  {t('sidebar.sessionGroup')}
-                                </DropdownMenuItem>
-                              )}
-                              {canExportSessions && (
-                                <DropdownMenuItem
-                                  disabled={exporting}
-                                  onSelect={() => handleExportSession(session)}
-                                >
-                                  <DownloadIcon />
-                                  {t('sidebar.export')}
-                                </DropdownMenuItem>
-                              )}
-                              <DropdownMenuItem
-                                variant="destructive"
-                                disabled={isCurrent}
-                                title={
-                                  isCurrent
-                                    ? t('sidebar.currentDeleteDisabled')
-                                    : undefined
-                                }
-                                onSelect={() => handleDeleteSession(session)}
-                              >
-                                <Trash2Icon />
-                                {t('sidebar.delete')}
-                              </DropdownMenuItem>
-                            </DropdownMenuGroup>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              <DropdownMenuGroup>
+                                {sessionActionItems.has('details') && (
+                                  <DropdownMenuSub>
+                                    <DropdownMenuSubTrigger>
+                                      <InfoIcon />
+                                      {t('sidebar.details')}
+                                    </DropdownMenuSubTrigger>
+                                    <DropdownMenuSubContent className="min-w-64 p-3">
+                                      {details}
+                                    </DropdownMenuSubContent>
+                                  </DropdownMenuSub>
+                                )}
+                                {sessionActionItems.has('rename') && (
+                                  <DropdownMenuItem
+                                    disabled={!isCurrent}
+                                    title={
+                                      !isCurrent
+                                        ? t('sidebar.renameCurrentOnly')
+                                        : undefined
+                                    }
+                                    onSelect={() =>
+                                      handleRenameFromMenu(session)
+                                    }
+                                  >
+                                    <PencilIcon />
+                                    {t('sidebar.rename')}
+                                  </DropdownMenuItem>
+                                )}
+                                {organizationEnabled &&
+                                  sessionActionItems.has('group') && (
+                                    <DropdownMenuItem
+                                      disabled={busy}
+                                      onSelect={(event) =>
+                                        openGroupMenuFromAnchor(
+                                          event.currentTarget as HTMLElement,
+                                          session,
+                                        )
+                                      }
+                                    >
+                                      <FolderInputIcon />
+                                      {t('sidebar.sessionGroup')}
+                                    </DropdownMenuItem>
+                                  )}
+                                {canExportSessions &&
+                                  sessionActionItems.has('export') && (
+                                    <DropdownMenuItem
+                                      disabled={exporting}
+                                      onSelect={() =>
+                                        handleExportSession(session)
+                                      }
+                                    >
+                                      <DownloadIcon />
+                                      {t('sidebar.export')}
+                                    </DropdownMenuItem>
+                                  )}
+                                {sessionActionItems.has('delete') && (
+                                  <DropdownMenuItem
+                                    variant="destructive"
+                                    disabled={isCurrent}
+                                    title={
+                                      isCurrent
+                                        ? t('sidebar.currentDeleteDisabled')
+                                        : undefined
+                                    }
+                                    onSelect={() =>
+                                      handleDeleteSession(session)
+                                    }
+                                  >
+                                    <Trash2Icon />
+                                    {t('sidebar.delete')}
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuGroup>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
                       </div>
                     )}
                   </div>
@@ -2772,6 +2950,8 @@ export function WebShellSidebar({
       openGroupMenuFromAnchor,
       organizationEnabled,
       saveRename,
+      sessionActionItems,
+      inlineActionItems,
       startRename,
       t,
     ],
@@ -3367,32 +3547,36 @@ export function WebShellSidebar({
           </div>
         )}
         <div className={styles.primaryNav}>
-          <button
-            className={styles.newChatButton}
-            type="button"
-            title={t('sidebar.newTask')}
-            aria-label={t('sidebar.newTask')}
-            disabled={newSessionDisabled}
-            onClick={() => handleNewSession()}
-          >
-            <span className={styles.navIcon}>
-              <SquarePenIcon size={16} strokeWidth={1.2} />
-            </span>
-            {!collapsed && <span>{t('sidebar.newTask')}</span>}
-          </button>
-          <button
-            className={styles.pluginButton}
-            type="button"
-            title={t('sidebar.plugins')}
-            aria-label={t('sidebar.plugins')}
-            onClick={onOpenPlugins}
-          >
-            <span className={styles.navIcon}>
-              <BlocksIcon size={16} strokeWidth={1.2} />
-            </span>
-            {!collapsed && <span>{t('sidebar.plugins')}</span>}
-          </button>
-          {footerItems.has('scheduledTasks') && (
+          {primaryNavItems.has('newTask') && (
+            <button
+              className={styles.newChatButton}
+              type="button"
+              title={t('sidebar.newTask')}
+              aria-label={t('sidebar.newTask')}
+              disabled={newSessionDisabled}
+              onClick={() => handleNewSession()}
+            >
+              <span className={styles.navIcon}>
+                <SquarePenIcon size={16} strokeWidth={1.2} />
+              </span>
+              {!collapsed && <span>{t('sidebar.newTask')}</span>}
+            </button>
+          )}
+          {primaryNavItems.has('plugins') && (
+            <button
+              className={styles.pluginButton}
+              type="button"
+              title={t('sidebar.plugins')}
+              aria-label={t('sidebar.plugins')}
+              onClick={onOpenPlugins}
+            >
+              <span className={styles.navIcon}>
+                <BlocksIcon size={16} strokeWidth={1.2} />
+              </span>
+              {!collapsed && <span>{t('sidebar.plugins')}</span>}
+            </button>
+          )}
+          {primaryNavItems.has('scheduledTasks') && (
             <button
               className={styles.pluginButton}
               type="button"
@@ -3406,7 +3590,7 @@ export function WebShellSidebar({
               {!collapsed && <span>{t('sidebar.scheduledTasks')}</span>}
             </button>
           )}
-          {footerItems.has('goals') && (
+          {primaryNavItems.has('goals') && (
             <button
               className={styles.pluginButton}
               type="button"
@@ -3420,6 +3604,7 @@ export function WebShellSidebar({
               {!collapsed && <span>{t('sidebar.goals')}</span>}
             </button>
           )}
+          {primaryNavOptions?.render?.()}
         </div>
         <div className={styles.body}>
           <div className={styles.sessionList}>
@@ -3443,7 +3628,7 @@ export function WebShellSidebar({
                 )}
               </>
             )}
-            {!collapsed && (
+            {!collapsed && !hideProjectHeader && (
               <div className={styles.projectsHeader}>
                 <button
                   className={styles.projectsHeaderToggle}
@@ -3486,7 +3671,7 @@ export function WebShellSidebar({
                 </div>
               </div>
             )}
-            {searchOpen && !collapsed && (
+            {searchOpen && !collapsed && !hideProjectHeader && (
               <div className={styles.projectSearch}>
                 <SearchIcon aria-hidden="true" />
                 <Input
@@ -3690,6 +3875,7 @@ export function WebShellSidebar({
             )}
           >
             <div className={styles.footerPrimary}>
+              {typeof footer === 'object' && footer.render?.()}
               {footerItems.has('settings') && (
                 <button
                   className={styles.footerButton}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -190,20 +190,29 @@ export type WebShellSidebarSessionActionItem =
   | 'pin'
   | 'archive';
 
+/** Subset of action items that have working inline (hover-button) handlers. */
+export type WebShellSidebarSessionInlineActionItem =
+  | 'pin'
+  | 'archive'
+  | 'rename'
+  | 'export'
+  | 'delete';
+
 export interface WebShellSidebarSessionActionsOptions {
   /** Session action items to show. Defaults to all. */
   items?: readonly WebShellSidebarSessionActionItem[];
   /**
    * Which items appear as inline buttons (on hover). Defaults to ['pin', 'archive'].
    * Only items that also pass their built-in visibility condition are rendered.
+   * Only items with working inline handlers are accepted (details/group are dropdown-only).
    */
-  inlineItems?: readonly WebShellSidebarSessionActionItem[];
+  inlineItems?: readonly WebShellSidebarSessionInlineActionItem[];
 }
 
 const DEFAULT_SESSION_ACTION_ITEMS: readonly WebShellSidebarSessionActionItem[] =
   ['details', 'rename', 'group', 'export', 'delete', 'pin', 'archive'];
 
-const DEFAULT_INLINE_ACTION_ITEMS: readonly WebShellSidebarSessionActionItem[] =
+const DEFAULT_INLINE_ACTION_ITEMS: readonly WebShellSidebarSessionInlineActionItem[] =
   ['pin', 'archive'];
 
 /**
@@ -2683,12 +2692,13 @@ export function WebShellSidebar({
                       >
                         {(() => {
                           const inlineActions: Array<{
-                            key: WebShellSidebarSessionActionItem;
+                            key: WebShellSidebarSessionInlineActionItem;
                             icon?: ReactNode;
                             label: string;
                             disabled?: boolean;
                             title?: string;
                             active?: boolean;
+                            destructive?: boolean;
                             visible: boolean;
                             onClick: () => void;
                           }> = [
@@ -2721,17 +2731,6 @@ export function WebShellSidebar({
                               onClick: () => handleArchive(session),
                             },
                             {
-                              key: 'details',
-                              icon: <InfoIcon size={16} strokeWidth={1.2} />,
-                              label: t('sidebar.details'),
-                              visible:
-                                sessionActionItems.has('details') &&
-                                inlineActionItems.has('details'),
-                              onClick: () => {
-                                /* TODO: open details panel */
-                              },
-                            },
-                            {
                               key: 'rename',
                               icon: <PencilIcon size={16} strokeWidth={1.2} />,
                               label: t('sidebar.rename'),
@@ -2743,21 +2742,6 @@ export function WebShellSidebar({
                                 sessionActionItems.has('rename') &&
                                 inlineActionItems.has('rename'),
                               onClick: () => handleRenameFromMenu(session),
-                            },
-                            {
-                              key: 'group',
-                              icon: (
-                                <FolderInputIcon size={16} strokeWidth={1.2} />
-                              ),
-                              label: t('sidebar.sessionGroup'),
-                              disabled: busy,
-                              visible:
-                                organizationEnabled &&
-                                sessionActionItems.has('group') &&
-                                inlineActionItems.has('group'),
-                              onClick: () => {
-                                /* TODO: open group menu */
-                              },
                             },
                             {
                               key: 'export',
@@ -2777,6 +2761,7 @@ export function WebShellSidebar({
                               icon: <Trash2Icon size={16} strokeWidth={1.2} />,
                               label: t('sidebar.delete'),
                               disabled: isCurrent,
+                              destructive: true,
                               title: isCurrent
                                 ? t('sidebar.currentDeleteDisabled')
                                 : undefined,
@@ -2801,6 +2786,13 @@ export function WebShellSidebar({
                                 aria-label={action.label}
                                 title={action.title ?? action.label}
                                 onClick={action.onClick}
+                                style={
+                                  action.destructive && !action.disabled
+                                    ? {
+                                        color: 'var(--destructive, #dc2626)',
+                                      }
+                                    : undefined
+                                }
                               >
                                 {action.icon ?? (
                                   <span style={{ fontSize: 12 }}>
@@ -2810,13 +2802,22 @@ export function WebShellSidebar({
                               </button>
                             ));
                         })()}
-                        {(sessionActionItems.has('details') ||
-                          sessionActionItems.has('rename') ||
-                          (organizationEnabled &&
-                            sessionActionItems.has('group')) ||
-                          (canExportSessions &&
-                            sessionActionItems.has('export')) ||
-                          sessionActionItems.has('delete')) && (
+                        {(organizationEnabled &&
+                          sessionActionItems.has('pin') &&
+                          !inlineActionItems.has('pin')) ||
+                        (canMutateSessionArchive(session) &&
+                          sessionActionItems.has('archive') &&
+                          !inlineActionItems.has('archive')) ||
+                        sessionActionItems.has('details') ||
+                        (sessionActionItems.has('rename') &&
+                          !inlineActionItems.has('rename')) ||
+                        (organizationEnabled &&
+                          sessionActionItems.has('group')) ||
+                        (canExportSessions &&
+                          sessionActionItems.has('export') &&
+                          !inlineActionItems.has('export')) ||
+                        (sessionActionItems.has('delete') &&
+                          !inlineActionItems.has('delete')) ? (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
@@ -2842,6 +2843,35 @@ export function WebShellSidebar({
                               }}
                             >
                               <DropdownMenuGroup>
+                                {organizationEnabled &&
+                                  sessionActionItems.has('pin') &&
+                                  !inlineActionItems.has('pin') && (
+                                    <DropdownMenuItem
+                                      disabled={busy}
+                                      onSelect={() => handleTogglePin(session)}
+                                    >
+                                      <PinIcon />
+                                      {session.isPinned
+                                        ? t('sidebar.unpin')
+                                        : t('sidebar.pin')}
+                                    </DropdownMenuItem>
+                                  )}
+                                {canMutateSessionArchive(session) &&
+                                  sessionActionItems.has('archive') &&
+                                  !inlineActionItems.has('archive') && (
+                                    <DropdownMenuItem
+                                      disabled={busy || isCurrent}
+                                      title={
+                                        isCurrent
+                                          ? t('sidebar.archiveCurrentDisabled')
+                                          : undefined
+                                      }
+                                      onSelect={() => handleArchive(session)}
+                                    >
+                                      <ArchiveIcon />
+                                      {t('sidebar.archive')}
+                                    </DropdownMenuItem>
+                                  )}
                                 {sessionActionItems.has('details') && (
                                   <DropdownMenuSub>
                                     <DropdownMenuSubTrigger>
@@ -2853,22 +2883,23 @@ export function WebShellSidebar({
                                     </DropdownMenuSubContent>
                                   </DropdownMenuSub>
                                 )}
-                                {sessionActionItems.has('rename') && (
-                                  <DropdownMenuItem
-                                    disabled={!isCurrent}
-                                    title={
-                                      !isCurrent
-                                        ? t('sidebar.renameCurrentOnly')
-                                        : undefined
-                                    }
-                                    onSelect={() =>
-                                      handleRenameFromMenu(session)
-                                    }
-                                  >
-                                    <PencilIcon />
-                                    {t('sidebar.rename')}
-                                  </DropdownMenuItem>
-                                )}
+                                {sessionActionItems.has('rename') &&
+                                  !inlineActionItems.has('rename') && (
+                                    <DropdownMenuItem
+                                      disabled={!isCurrent}
+                                      title={
+                                        !isCurrent
+                                          ? t('sidebar.renameCurrentOnly')
+                                          : undefined
+                                      }
+                                      onSelect={() =>
+                                        handleRenameFromMenu(session)
+                                      }
+                                    >
+                                      <PencilIcon />
+                                      {t('sidebar.rename')}
+                                    </DropdownMenuItem>
+                                  )}
                                 {organizationEnabled &&
                                   sessionActionItems.has('group') && (
                                     <DropdownMenuItem
@@ -2885,7 +2916,8 @@ export function WebShellSidebar({
                                     </DropdownMenuItem>
                                   )}
                                 {canExportSessions &&
-                                  sessionActionItems.has('export') && (
+                                  sessionActionItems.has('export') &&
+                                  !inlineActionItems.has('export') && (
                                     <DropdownMenuItem
                                       disabled={exporting}
                                       onSelect={() =>
@@ -2896,27 +2928,28 @@ export function WebShellSidebar({
                                       {t('sidebar.export')}
                                     </DropdownMenuItem>
                                   )}
-                                {sessionActionItems.has('delete') && (
-                                  <DropdownMenuItem
-                                    variant="destructive"
-                                    disabled={isCurrent}
-                                    title={
-                                      isCurrent
-                                        ? t('sidebar.currentDeleteDisabled')
-                                        : undefined
-                                    }
-                                    onSelect={() =>
-                                      handleDeleteSession(session)
-                                    }
-                                  >
-                                    <Trash2Icon />
-                                    {t('sidebar.delete')}
-                                  </DropdownMenuItem>
-                                )}
+                                {sessionActionItems.has('delete') &&
+                                  !inlineActionItems.has('delete') && (
+                                    <DropdownMenuItem
+                                      variant="destructive"
+                                      disabled={isCurrent}
+                                      title={
+                                        isCurrent
+                                          ? t('sidebar.currentDeleteDisabled')
+                                          : undefined
+                                      }
+                                      onSelect={() =>
+                                        handleDeleteSession(session)
+                                      }
+                                    >
+                                      <Trash2Icon />
+                                      {t('sidebar.delete')}
+                                    </DropdownMenuItem>
+                                  )}
                               </DropdownMenuGroup>
                             </DropdownMenuContent>
                           </DropdownMenu>
-                        )}
+                        ) : null}
                       </div>
                     )}
                   </div>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -2662,28 +2662,30 @@ export function WebShellSidebar({
                     ) : !attentionLabel ? (
                       <span className={styles.sessionTime}>{time}</span>
                     ) : null}
-                    {readOnly && canMutateSessionArchive(session) && (
-                      <div
-                        className={styles.sessionActions}
-                        onClick={(event) => event.stopPropagation()}
-                        onKeyDown={(event) => event.stopPropagation()}
-                      >
-                        <button
-                          className={styles.sessionActionButton}
-                          type="button"
-                          disabled={busy || isCurrent}
-                          aria-label={t('sidebar.archive')}
-                          title={
-                            isCurrent
-                              ? t('sidebar.archiveCurrentDisabled')
-                              : t('sidebar.archive')
-                          }
-                          onClick={() => handleArchive(session)}
+                    {readOnly &&
+                      canMutateSessionArchive(session) &&
+                      sessionActionItems.has('archive') && (
+                        <div
+                          className={styles.sessionActions}
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={(event) => event.stopPropagation()}
                         >
-                          <ArchiveIcon />
-                        </button>
-                      </div>
-                    )}
+                          <button
+                            className={styles.sessionActionButton}
+                            type="button"
+                            disabled={busy || isCurrent}
+                            aria-label={t('sidebar.archive')}
+                            title={
+                              isCurrent
+                                ? t('sidebar.archiveCurrentDisabled')
+                                : t('sidebar.archive')
+                            }
+                            onClick={() => handleArchive(session)}
+                          >
+                            <ArchiveIcon />
+                          </button>
+                        </div>
+                      )}
                     {!readOnly && (
                       <div
                         className={styles.sessionActions}
@@ -3908,7 +3910,7 @@ export function WebShellSidebar({
             )}
           >
             <div className={styles.footerPrimary}>
-              {typeof footer === 'object' && footer.render?.()}
+              {footer && typeof footer === 'object' && footer.render?.()}
               {footerItems.has('settings') && (
                 <button
                   className={styles.footerButton}

--- a/packages/web-shell/client/components/sidebar/session-action-visibility.test.ts
+++ b/packages/web-shell/client/components/sidebar/session-action-visibility.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  WebShellSidebarSessionActionItem,
+  WebShellSidebarSessionInlineActionItem,
+} from './WebShellSidebar';
+
+const ALL_ITEMS: readonly WebShellSidebarSessionActionItem[] = [
+  'details',
+  'rename',
+  'group',
+  'export',
+  'delete',
+  'pin',
+  'archive',
+];
+
+const DEFAULT_ITEMS: readonly WebShellSidebarSessionActionItem[] = ALL_ITEMS;
+
+const DEFAULT_INLINE_ITEMS: readonly WebShellSidebarSessionInlineActionItem[] =
+  ['pin', 'archive'];
+
+/**
+ * Items that can never appear as inline buttons (no working handler).
+ * These always fall to the dropdown when present in `items`.
+ */
+const DROPDOWN_ONLY_ITEMS: readonly WebShellSidebarSessionActionItem[] = [
+  'details',
+  'group',
+];
+
+interface VisibilityResult {
+  inline: Set<WebShellSidebarSessionActionItem>;
+  dropdown: Set<WebShellSidebarSessionActionItem>;
+  showDropdownTrigger: boolean;
+}
+
+/**
+ * Pure computation mirroring the visibility logic in WebShellSidebar's
+ * session-row render. Built-in capability conditions are assumed true
+ * (this test covers the items × inlineItems matrix, not runtime state).
+ */
+function computeVisibility(
+  items: readonly WebShellSidebarSessionActionItem[],
+  inlineItems: readonly WebShellSidebarSessionInlineActionItem[],
+): VisibilityResult {
+  const itemSet = new Set(items);
+  const inlineSet = new Set<WebShellSidebarSessionActionItem>(inlineItems);
+
+  const inline = new Set<WebShellSidebarSessionActionItem>();
+  const dropdown = new Set<WebShellSidebarSessionActionItem>();
+
+  for (const item of ALL_ITEMS) {
+    if (!itemSet.has(item)) continue;
+
+    if (DROPDOWN_ONLY_ITEMS.includes(item)) {
+      // details/group can never be inline — always dropdown
+      dropdown.add(item);
+    } else if (inlineSet.has(item as WebShellSidebarSessionInlineActionItem)) {
+      inline.add(item);
+    } else {
+      dropdown.add(item);
+    }
+  }
+
+  return {
+    inline,
+    dropdown,
+    showDropdownTrigger: dropdown.size > 0,
+  };
+}
+
+describe('session action visibility matrix', () => {
+  describe('defaults (no consumer config)', () => {
+    it('pin+archive inline, remaining items in dropdown', () => {
+      const { inline, dropdown, showDropdownTrigger } = computeVisibility(
+        DEFAULT_ITEMS,
+        DEFAULT_INLINE_ITEMS,
+      );
+
+      expect([...inline].sort()).toEqual(['archive', 'pin']);
+      expect([...dropdown].sort()).toEqual([
+        'delete',
+        'details',
+        'export',
+        'group',
+        'rename',
+      ]);
+      expect(showDropdownTrigger).toBe(true);
+    });
+  });
+
+  describe('items × inlineItems interaction', () => {
+    it('inlineItems: [] — all items fall to dropdown', () => {
+      const { inline, dropdown, showDropdownTrigger } = computeVisibility(
+        DEFAULT_ITEMS,
+        [],
+      );
+
+      expect(inline.size).toBe(0);
+      expect([...dropdown].sort()).toEqual([...ALL_ITEMS].sort());
+      expect(showDropdownTrigger).toBe(true);
+    });
+
+    it('items: [] — nothing renders anywhere, trigger hidden', () => {
+      const { inline, dropdown, showDropdownTrigger } = computeVisibility(
+        [],
+        DEFAULT_INLINE_ITEMS,
+      );
+
+      expect(inline.size).toBe(0);
+      expect(dropdown.size).toBe(0);
+      expect(showDropdownTrigger).toBe(false);
+    });
+
+    it('inlineItems: ["delete"] — delete inline only, not in dropdown', () => {
+      const { inline, dropdown } = computeVisibility(DEFAULT_ITEMS, ['delete']);
+
+      expect(inline.has('delete')).toBe(true);
+      expect(dropdown.has('delete')).toBe(false);
+      expect([...inline].sort()).toEqual(['delete']);
+      expect([...dropdown].sort()).toEqual([
+        'archive',
+        'details',
+        'export',
+        'group',
+        'pin',
+        'rename',
+      ]);
+    });
+
+    it('items: ["pin", "delete"], inlineItems: ["delete"] — pin falls to dropdown', () => {
+      const { inline, dropdown } = computeVisibility(
+        ['pin', 'delete'],
+        ['delete'],
+      );
+
+      expect([...inline].sort()).toEqual(['delete']);
+      expect([...dropdown].sort()).toEqual(['pin']);
+    });
+
+    it('items: ["details", "group"] — both in dropdown, nothing inline', () => {
+      const { inline, dropdown, showDropdownTrigger } = computeVisibility(
+        ['details', 'group'],
+        DEFAULT_INLINE_ITEMS,
+      );
+
+      expect(inline.size).toBe(0);
+      expect([...dropdown].sort()).toEqual(['details', 'group']);
+      expect(showDropdownTrigger).toBe(true);
+    });
+
+    it('no item appears in both inline and dropdown simultaneously', () => {
+      const configs: Array<{
+        items: readonly WebShellSidebarSessionActionItem[];
+        inlineItems: readonly WebShellSidebarSessionInlineActionItem[];
+      }> = [
+        { items: DEFAULT_ITEMS, inlineItems: DEFAULT_INLINE_ITEMS },
+        { items: DEFAULT_ITEMS, inlineItems: [] },
+        { items: DEFAULT_ITEMS, inlineItems: ['pin', 'delete'] },
+        { items: DEFAULT_ITEMS, inlineItems: ['rename', 'export', 'delete'] },
+        { items: ['delete', 'rename'], inlineItems: ['delete', 'rename'] },
+        { items: ['pin', 'archive'], inlineItems: [] },
+        { items: [], inlineItems: DEFAULT_INLINE_ITEMS },
+      ];
+
+      for (const config of configs) {
+        const { inline, dropdown } = computeVisibility(
+          config.items,
+          config.inlineItems,
+        );
+        const overlap = [...inline].filter((item) => dropdown.has(item));
+        expect(
+          overlap,
+          `overlap with config: ${JSON.stringify(config)}`,
+        ).toEqual([]);
+      }
+    });
+  });
+});

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -137,6 +137,11 @@ export type {
   WebShellSidebarFooterItem,
   WebShellSidebarFooterOptions,
   WebShellSidebarLockedWorkspace,
+  WebShellSidebarPrimaryNavOptions,
+  WebShellSidebarPrimaryNavItem,
+  WebShellSidebarSessionActionsOptions,
+  WebShellSidebarSessionActionItem,
+  WebShellSidebarSessionInlineActionItem,
 } from './components/sidebar/WebShellSidebar';
 export type { WebShellLanguage } from './i18n';
 export type { WebShellTheme } from './themeContext';


### PR DESCRIPTION
## What this PR does

Extends the WebShell sidebar with a comprehensive customization API, allowing consumers to control which UI elements are visible and inject custom content at key extension points. Five areas of the sidebar are now configurable: branding, primary navigation, project header, session row actions, and footer.

## Why it's needed

Different consumers of the WebShell component need to embed it in varied product contexts (e.g., internal tools, data integration dashboards) where the default sidebar layout doesn't fit. Previously, consumers had no way to hide the project header, customize which session actions appear as inline hover buttons, or inject custom footer content. This PR provides a clean, declarative API for each area without requiring consumers to fork the component.

## Reviewer Test Plan

### How to verify

1. Start the web-shell dev server (`cd packages/web-shell && npm run dev`)
2. Configure `sidebar` in the `webShellProps` with various combinations of the new options
3. Verify each option independently:
   - `primaryNav.items`: set to `['newTask']` — only the new task button should appear
   - `primaryNav.render`: provide a custom button — it should appear after built-in nav items
   - `hideProjectHeader: true` — the Projects header row (with search and add workspace) should be hidden
   - `sessionActions.items: ['details', 'delete']` — only details and delete should appear in both inline and dropdown
   - `sessionActions.inlineItems: ['pin', 'delete']` — pin and delete should render as inline hover buttons with icon/text fallback
   - `footer.render`: provide a custom help button — it should appear on the left side of the footer

### Evidence (Before & After)

N/A — screenshots to be attached.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows |  N/A  |
|  🐧 Linux  |  N/A  |

### Environment (optional)

npm run dev from packages/web-shell

## Risk & Scope

- Main risk or tradeoff: `scheduledTasks` and `goals` are moved from `footer.items` to `primaryNav.items`. Existing consumers using these footer items will need to migrate.
- Not validated / out of scope: inline `details` and `group` actions have placeholder onClick handlers (noted in code with TODO comments).
- Breaking changes / migration notes: `WebShellSidebarFooterItem` no longer includes `'scheduledTasks'` or `'goals'`; use `primaryNav.items` instead.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本次改动内容

扩展 WebShell 侧边栏的定制 API，允许消费者控制哪些 UI 元素可见，并在关键扩展点注入自定义内容。侧边栏五个区域现在可配置：品牌区、主导航区、项目头部区、会话行操作区和底部区。

## 为什么需要这个改动

不同的 WebShell 组件消费者需要将其嵌入到不同的产品场景中（如内部工具、数据集成仪表盘），默认侧边栏布局无法满足需求。此前，消费者无法隐藏项目头部、自定义哪些会话操作作为内联悬停按钮出现、或在底部注入自定义内容。本次改动为每个区域提供了清晰的声明式 API，无需消费者 fork 组件。

## 风险与范围

- `scheduledTasks` 和 `goals` 从 `footer.items` 移至 `primaryNav.items`，现有使用这些 footer item 的消费者需要迁移。
- 内联 `details` 和 `group` 操作的 onClick 为占位实现（代码中有 TODO 注释）。
</details>


## pictures
<img width="1624" height="1716" alt="image" src="https://github.com/user-attachments/assets/afdd30f4-e50d-4135-9214-fd0a75e059f6" />
<img width="1540" height="1600" alt="image" src="https://github.com/user-attachments/assets/653f7c43-cbb8-4a0d-acd6-bc2e43328d87" />
<img width="1912" height="1898" alt="image" src="https://github.com/user-attachments/assets/4c545fd3-2fd6-4912-af0b-6a51f5d6584d" />
<img width="1554" height="1460" alt="image" src="https://github.com/user-attachments/assets/c8356272-71bc-42e8-b3ab-d80840828aa6" />