### PR TITLE
fix(autofix): refuse a non-main takeover out loud instead of only in the job log

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -205,6 +205,7 @@ jobs:
       pr_number: '${{ steps.decide.outputs.pr_number }}'
       takeover_ack: '${{ steps.decide.outputs.takeover_ack }}'
       ack_pr: '${{ steps.decide.outputs.ack_pr }}'
+      ack_base: '${{ steps.decide.outputs.ack_base }}'
       takeover_cmd: '${{ steps.decide.outputs.takeover_cmd }}'
       retry_pr: '${{ steps.decide.outputs.retry_pr }}'
       cmd_pr: '${{ steps.decide.outputs.cmd_pr }}'
@@ -242,6 +243,7 @@ jobs:
           DO_ISSUE=false
           DO_REVIEW=false
           TAKEOVER_ACK=''
+          ACK_BASE=''
           TAKEOVER_CMD=''
           CMD_PR=''
           RETRY_PR=''
@@ -454,6 +456,14 @@ jobs:
                   elif [[ "${PR_STATE}" != 'open' ]]; then
                     echo "🧭 takeover ignored: PR state '${PR_STATE:-unknown}' is not open"
                   elif [[ "${PR_BASE_REF}" != 'main' ]]; then
+                    # Refuse OUT LOUD. Staying silent here made a labelled
+                    # stacked PR indistinguishable from a managed one: the
+                    # label stuck, the route run went green, and the only
+                    # trace was this log line — so the PR sat unmanaged for
+                    # hours with nobody able to tell without reading the job
+                    # log. The ack job posts the explanation instead.
+                    TAKEOVER_ACK='base-refused'
+                    ACK_BASE="${PR_BASE_REF}"
                     echo "🧭 takeover ignored: PR targets '${PR_BASE_REF}' not 'main'"
                   else
                     DO_REVIEW=true
@@ -531,6 +541,7 @@ jobs:
           echo "pr_number=${ROUTE_PR}" >> "${GITHUB_OUTPUT}"
           echo "takeover_ack=${TAKEOVER_ACK}" >> "${GITHUB_OUTPUT}"
           echo "ack_pr=$(sanitize_number "${PR_NUMBER_EVENT}")" >> "${GITHUB_OUTPUT}"
+          echo "ack_base=${ACK_BASE}" >> "${GITHUB_OUTPUT}"
           echo "takeover_cmd=${TAKEOVER_CMD}" >> "${GITHUB_OUTPUT}"
           echo "retry_pr=${RETRY_PR}" >> "${GITHUB_OUTPUT}"
           echo "cmd_pr=${CMD_PR}" >> "${GITHUB_OUTPUT}"
@@ -1440,6 +1451,10 @@ jobs:
       REPO: '${{ github.repository }}'
       ACK: '${{ needs.route.outputs.takeover_ack }}'
       PR: '${{ needs.route.outputs.ack_pr }}'
+      # The base the ROUTE saw when it refused — naming a live re-read here
+      # could report 'main' for a refusal that was decided against something
+      # else, so the message stays tied to the decision it explains.
+      ACK_BASE: '${{ needs.route.outputs.ack_base }}'
       GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
     steps:
       - name: 'Acknowledge takeover state change'
@@ -1469,13 +1484,23 @@ jobs:
           # ack on a skip-labeled PR during a transient API failure. A red
           # ack job posts nothing — engagement itself is scan-driven and
           # unaffected.
-          if ! PR_STATE_INFO="$(gh pr view "${PR}" --repo "${REPO}" --json labels,author 2> /dev/null)"; then
-            echo "::error::could not read PR #${PR} state for takeover ack"
-            exit 1
+          # A base refusal needs no live state — it is decided entirely by the
+          # route — so it does NOT ride on this read. Making the one ack whose
+          # whole purpose is "say why nothing happened" depend on an unrelated
+          # API call would reintroduce the silence it exists to remove.
+          HAS_SKIP=''
+          PR_AUTHOR_LIVE=''
+          if [[ "${ACK}" != 'base-refused' ]]; then
+            if ! PR_STATE_INFO="$(gh pr view "${PR}" --repo "${REPO}" --json labels,author 2> /dev/null)"; then
+              echo "::error::could not read PR #${PR} state for takeover ack"
+              exit 1
+            fi
+            HAS_SKIP="$(jq -r --arg t "${SKIP_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_STATE_INFO}")"
+            PR_AUTHOR_LIVE="$(jq -r '.author.login // ""' <<< "${PR_STATE_INFO}")"
           fi
-          HAS_SKIP="$(jq -r --arg t "${SKIP_LABEL}" '[.labels[]?.name] | index($t) != null' <<< "${PR_STATE_INFO}")"
-          PR_AUTHOR_LIVE="$(jq -r '.author.login // ""' <<< "${PR_STATE_INFO}")"
-          if [[ "${ACK}" == 'engaged' && "${HAS_SKIP}" == "true" ]]; then
+          if [[ "${ACK}" == 'base-refused' ]]; then
+            BODY="$(printf '🚫 Takeover not engaged: the loop only manages PRs that target `main`, and this one targets `%s`. A stacked PR moves whenever its base branch does, so "new feedback since the last round" and base-conflict resolution are not well defined until the base lands. Two ways forward: retarget this PR to `main` once the base PR merges — the `%s` label is left in place and the scan lists by label, so the next scan engages it with no re-labelling — or take over the base PR instead.\n\n<details>\n<summary>中文说明</summary>\n\n🚫 未接管：循环只管理以 `main` 为 base 的 PR，而本 PR 的 base 是 `%s`。堆叠 PR 会随 base 分支移动，因此“自上一轮以来的新反馈”与 base 冲突处理都无法良定义。两条路：待 base 的 PR 合入后把本 PR 改为面向 `main` —— `%s` 标签予以保留，扫描按标签枚举，下一次扫描即会自动接管，无需重新打标签；或改为接管 base 那个 PR。\n\n</details>\n\n<!-- takeover-ack base-refused -->' "${ACK_BASE}" "${TAKEOVER_LABEL}" "${ACK_BASE}" "${TAKEOVER_LABEL}")"
+          elif [[ "${ACK}" == 'engaged' && "${HAS_SKIP}" == "true" ]]; then
             BODY="$(printf '🚫 Takeover label applied but NOT engaged: this PR carries `%s`, which wins over takeover — the loop will not manage it. Remove `%s` to engage.\n\n<details>\n<summary>中文说明</summary>\n\n🚫 已打接管标签但未生效：本 PR 带有 `%s`，其优先级高于接管，循环不会介入。移除 `%s` 后才会接管。\n\n</details>\n\n<!-- takeover-ack skip-blocked -->' "${SKIP_LABEL}" "${SKIP_LABEL}" "${SKIP_LABEL}" "${SKIP_LABEL}")"
           elif [[ "${ACK}" == 'engaged' ]]; then
             BODY="$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -942,12 +942,13 @@ describe('qwen-autofix workflow', () => {
     // one lost Chinese section against a duplicate elsewhere): engage,
     // honest bot-PR release, skip-labeled bot-PR release, human-PR
     // release, re-arm, fork allow-edits refusal, two skip-blocked refusals,
-    // the cap pause, and the scan-side first-pickup engage ack (fork label
-    // events carry no secrets, so the scan anchors the window itself).
+    // the non-main base refusal, the cap pause, and the scan-side
+    // first-pickup engage ack (fork label events carry no secrets, so the
+    // scan anchors the window itself).
     const ackBodies = workflow.match(
       /printf '[^']*takeover-(?:ack|cap)[^']*'/g,
     );
-    expect(ackBodies).toHaveLength(11);
+    expect(ackBodies).toHaveLength(12);
     for (const body of ackBodies) {
       expect(body).toContain('<summary>中文说明</summary>');
     }
@@ -2020,6 +2021,169 @@ describe('qwen-autofix workflow', () => {
     expect(
       run({ headRepo: FORK, author: 'qwen-code-dev-bot', metaOk: false }),
     ).toContain('DO_REVIEW=false');
+  });
+
+  it('refuses a takeover on a non-main base out loud instead of only in the job log', () => {
+    // Observed: #7368 was labelled autofix/takeover, the pull_request:labeled
+    // route ran GREEN, and the loop never engaged it — because the PR targeted
+    // another PR's branch. The only trace was one line in a job log, so the PR
+    // sat unmanaged for hours looking exactly like a managed one.
+    const block = routeStep.match(
+      /if \[\[ "\$\{EVENT_NAME\}" == 'pull_request' \]\]; then[\s\S]*?\n {14}fi/,
+    )?.[0];
+    expect(block).toBeTruthy();
+
+    const run = ({
+      base = 'main',
+      state = 'open',
+      action = 'labeled',
+      headRepo = 'QwenLM/qwen-code',
+      label = 'autofix/takeover',
+    }) =>
+      // The block also logs its reasoning; only the trailing summary is asserted.
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -uo pipefail',
+            'sanitize_number() { printf "%s" "${1//[^0-9]/}"; }',
+            'DO_ISSUE=true; DO_REVIEW=false; ROUTE_PR=""',
+            "TAKEOVER_ACK=''; ACK_BASE=''",
+            block,
+            'printf "ack=%s base=%s review=%s" "${TAKEOVER_ACK}" "${ACK_BASE}" "${DO_REVIEW}"',
+          ].join('\n'),
+        ],
+        {
+          env: {
+            ...process.env,
+            EVENT_NAME: 'pull_request',
+            EVENT_ACTION: action,
+            REPO: 'QwenLM/qwen-code',
+            TAKEOVER_LABEL: 'autofix/takeover',
+            ISSUE_LABEL: label,
+            PR_HEAD_REPO: headRepo,
+            PR_STATE: state,
+            PR_BASE_REF: base,
+            PR_NUMBER_EVENT: '7368',
+            SENDER_LOGIN: 'wenshao',
+          },
+          encoding: 'utf8',
+        },
+      )
+        .trim()
+        .split('\n')
+        .pop();
+
+    // The regression: a stacked PR now REFUSES audibly and carries the base
+    // it was refused against, rather than falling through silently.
+    expect(run({ base: 'ci/autofix-gate-crash-retry' })).toBe(
+      'ack=base-refused base=ci/autofix-gate-crash-retry review=false',
+    );
+    // Unchanged: a main-targeting in-repo PR still engages, and engagement
+    // carries no base (the field exists only to name a refusal).
+    expect(run({})).toBe('ack=engaged base= review=true');
+    // Still deliberately silent — these were never engaged and a comment on
+    // them would be noise, not information: a closed PR, a fork (whose label
+    // event carries no secrets to comment with), a non-takeover label, and
+    // releasing a PR that never engaged.
+    expect(run({ state: 'closed' })).toBe('ack= base= review=false');
+    expect(run({ headRepo: 'wenshao/qwen-code' })).toBe(
+      'ack= base= review=false',
+    );
+    expect(run({ label: 'kind/bug' })).toBe('ack= base= review=false');
+    expect(
+      run({ action: 'unlabeled', base: 'ci/autofix-gate-crash-retry' }),
+    ).toBe('ack= base= review=false');
+  });
+
+  it('posts the non-main base refusal without depending on any other API call', () => {
+    const ackBlock = workflow
+      .match(
+        /- name: 'Acknowledge takeover state change'\n {8}run: \|-\n([\s\S]*?)(?=\n {2}# ={10})/,
+      )?.[1]
+      ?.split('\n')
+      .map((line) => line.slice(10))
+      .join('\n');
+    expect(ackBlock).toBeTruthy();
+
+    const runAck = ({ ack, base = '', prViewOk = true }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'ack-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      writeFileSync(
+        join(bin, 'gh'),
+        [
+          '#!/usr/bin/env bash',
+          `if [[ "$1" == 'api' ]]; then printf 'qwen-code-dev-bot'; exit 0; fi`,
+          `if [[ "$1" == 'pr' && "$2" == 'view' ]]; then : > ${JSON.stringify(join(dir, 'pr-view-called'))}; ${
+            prViewOk
+              ? `printf '%s' '{"labels":[],"author":{"login":"wenshao"}}'; exit 0`
+              : 'exit 1'
+          }; fi`,
+          `if [[ "$1" == 'pr' && "$2" == 'comment' ]]; then printf '%s' "$7" > ${JSON.stringify(join(dir, 'comment.md'))}; exit 0; fi`,
+          'exit 1',
+        ].join('\n'),
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const proc = spawnSync('bash', ['-e', '-c', ackBlock], {
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          GITHUB_TOKEN: 'pat',
+          AUTOFIX_BOT: 'qwen-code-dev-bot',
+          REPO: 'QwenLM/qwen-code',
+          SKIP_LABEL: 'autofix/skip',
+          TAKEOVER_LABEL: 'autofix/takeover',
+          TAKEOVER_COMMAND: '@qwen-code /takeover',
+          ACK: ack,
+          PR: '7368',
+          ACK_BASE: base,
+        },
+        encoding: 'utf8',
+      });
+      const commentPath = join(dir, 'comment.md');
+      const result = {
+        status: proc.status,
+        body: existsSync(commentPath) ? readFileSync(commentPath, 'utf8') : '',
+        readPr: existsSync(join(dir, 'pr-view-called')),
+      };
+      rmSync(dir, { recursive: true, force: true });
+      return result;
+    };
+
+    const refused = runAck({
+      ack: 'base-refused',
+      base: 'ci/autofix-gate-crash-retry',
+    });
+    expect(refused.status).toBe(0);
+    expect(refused.body).toContain('<!-- takeover-ack base-refused -->');
+    // Names the actual base and stays actionable + bilingual.
+    expect(refused.body).toContain('`ci/autofix-gate-crash-retry`');
+    expect(refused.body).toContain('<summary>中文说明</summary>');
+    // The advice it gives ("retarget, no re-labelling needed") is only true
+    // while the scan enumerates takeover PRs BY LABEL — retargeting emits no
+    // `labeled` event, so a scan that instead required a fresh engage marker
+    // would silently make this message wrong. Pin the fact it depends on.
+    expect(refused.body).toContain('no re-labelling');
+    expect(reviewScanJob).toContain('--label "${TAKEOVER_LABEL}"');
+    expect(reviewScanJob).toContain('--base main');
+    // The one ack whose entire job is to explain silence must not itself be
+    // silenced by an unrelated API call — it reads no live PR state at all,
+    // so it still posts when that read would have failed.
+    expect(refused.readPr).toBe(false);
+    expect(
+      runAck({ ack: 'base-refused', base: 'release', prViewOk: false }).body,
+    ).toContain('<!-- takeover-ack base-refused -->');
+
+    // Unchanged for every other ack: the live read happens and still fails
+    // CLOSED, so a transient API error cannot turn into a wrong ack.
+    const engaged = runAck({ ack: 'engaged' });
+    expect(engaged.readPr).toBe(true);
+    expect(engaged.body).toContain('<!-- takeover-ack engaged -->');
+    const broken = runAck({ ack: 'engaged', prViewOk: false });
+    expect(broken.status).not.toBe(0);
+    expect(broken.body).toBe('');
   });
 
   it('treats Suggestion-level review findings as actionable feedback', () => {


### PR DESCRIPTION
## What this PR does

Makes the autofix loop say why it refused a takeover, instead of refusing silently and leaving the PR looking managed.

## Why it's needed

**#7368 was labelled `autofix/takeover` at `23:24:52` and sat unmanaged for over two hours across five scans.** Nothing was broken — the `pull_request:labeled` route ran and went **green** (run [29787127598](https://github.com/QwenLM/qwen-code/actions/runs/29787127598)). The entire record of the refusal was one line, in a job log:

```
🧭 takeover ignored: PR targets 'ci/autofix-gate-crash-retry' not 'main'
```

#7368 is a stacked PR — it targets another PR's branch, and the loop only manages PRs based on `main`. That is the correct decision. The problem is that **a refused PR is indistinguishable from a managed one from the outside**: the label is present, the run is green, and no comment says otherwise. It was found only by pulling the route job's log by hand while auditing why the fleet had one PR with zero eval markers.

Every other takeover refusal already speaks up — a skip label, a fork without allow-edits, a fork author without write. The non-main base was the one silent path left.

## How

- The route sets `takeover_ack=base-refused` and passes the base it saw through a new `ack_base` output.
- The ack job posts a bilingual comment naming that base and giving both ways forward: retarget once the base PR merges, or take over the base PR instead.
- **The refusal reads no live PR state.** The other acks fetch labels/author and fail closed on an API error; making the one ack whose entire purpose is "explain why nothing happened" depend on an unrelated API call would reintroduce exactly the silence it removes. Every other ack keeps that fail-closed read unchanged.

The base is carried from the route rather than re-read live, so the message names the base the decision was actually made against.

Nothing else changes: `DO_REVIEW` stays false, no label is touched, and closed PRs / forks / non-takeover labels / releases stay deliberately silent (they were never engaged, so a comment there is noise, not information).

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 74/74, run three times clean. Two new tests **replay the real extracted blocks under bash**:

   | driven case | result |
   | --- | --- |
   | labelled, base `ci/autofix-gate-crash-retry` | `ack=base-refused base=ci/autofix-gate-crash-retry review=false` |
   | labelled, base `main` | `ack=engaged base= review=true` |
   | closed / fork / non-takeover label / unlabeled | `ack= base= review=false` (unchanged silence) |
   | ack job, `ACK=base-refused` | posts the marker, **`gh pr view` never called** |
   | ack job, `ACK=base-refused` + failing `gh pr view` | still posts |
   | ack job, `ACK=engaged` + failing `gh pr view` | exit ≠ 0, posts nothing (fail-closed preserved) |

2. Mutation-verified, three separate reverts each turning a test red: dropping `TAKEOVER_ACK='base-refused'` from the route; deleting the `base-refused` body from the ack job; restoring the unconditional `gh pr view`.
3. The message's advice ("retarget — no re-labelling needed") is only true while the scan enumerates takeover PRs **by label**, since retargeting emits no `labeled` event. That dependency is pinned by an assertion on the scan's `--label`/`--base main` listing, so a future change that breaks the advice turns the test red instead of shipping wrong instructions.
4. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
5. Post-merge smoke: apply `autofix/takeover` to any PR not based on `main` and confirm the bot comments the refusal.

### Evidence (Before & After)

```
BEFORE  label applied to a stacked PR
        -> route run: GREEN
        -> comments: none
        -> label: present
        -> PR looks managed; is not. #7368 sat 2h+ across 5 scans.
        (found only by reading the route job log by hand)

AFTER   label applied to a stacked PR
        -> route run: GREEN
        -> bot comments: "🚫 Takeover not engaged: … targets `ci/autofix-…`"
           + what to do next, in both languages
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: one comment per label application on a non-main PR — the same cadence as the existing engage ack. Toggling the label repeatedly repeats the comment. The comment cannot re-trigger the loop: the route's job-level prefilter only admits `@qwen-code /takeover` and `/retry` bodies.
- Pre-existing and unrelated: `behaviorally replays the eligibility recheck` is a load flake. A controlled A/B on this machine — 6 runs of unmodified `origin/main` vs 6 with this change — showed **2 of 5 completed main runs already red**, at a comparable rate to the branch, so this change does not introduce or worsen it.
- Not validated / out of scope: labelling a **closed** PR stays silent by design (a bot comment on a closed PR is noise). Fork label events carry no secrets and so still cannot comment at all — the next scan engages them, which is the existing documented behaviour.
- Breaking changes / migration notes: none.

## Linked Issues

Found while auditing the takeover fleet's operating state — #7368 was the one managed PR with zero eval markers. Part of the autofix-reliability line: #7330, #7350, #7351, #7354, #7355, #7358, #7364, #7368.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 autofix 循环在拒绝接管时**说出原因**,而不是静默拒绝、把 PR 留在"看起来已被接管"的状态。

## 为什么需要

**#7368 在 `23:24:52` 打上 `autofix/takeover`,随后跨越 5 次扫描、两个多小时无人管理。** 而一切"正常"——`pull_request:labeled` 路由跑了,而且是**绿的**(运行 [29787127598](https://github.com/QwenLM/qwen-code/actions/runs/29787127598))。这次拒绝的全部记录,是 job 日志里的一行:

```
🧭 takeover ignored: PR targets 'ci/autofix-gate-crash-retry' not 'main'
```

#7368 是堆叠 PR——它的 base 是另一个 PR 的分支,而循环只管理以 `main` 为 base 的 PR。这个判断本身没错。问题在于:**被拒绝的 PR 从外部看与被接管的 PR 完全无法区分**——标签在、运行是绿的、没有任何评论说明。它是在盘点机群运行状况、发现有一个 PR 的 eval 标记数为零之后,手工翻 route 的 job 日志才找出来的。

其余每一种接管拒绝都已经会出声——skip 标签、未开 allow-edits 的 fork、无 write 权限的 fork 作者。base 非 main 是最后一条静默路径。

## 怎么做

- route 置 `takeover_ack=base-refused`,并通过新增的 `ack_base` 输出传出它当时看到的 base。
- ack 作业发出双语评论,点名该 base,并给出两条出路:待 base 的 PR 合入后改为面向 `main`,或改为接管 base 那个 PR。
- **该拒绝不读取任何实时 PR 状态。** 其余 ack 会拉取 labels/author 并在 API 失败时 fail-closed;而让这个"唯一职责就是解释为何什么都没发生"的 ack 依赖一次无关的 API 调用,等于把它要消除的静默又请回来。其他 ack 的 fail-closed 读取保持不变。

base 由 route 携带而非实时重读,以保证消息点名的正是当初做出该决定所依据的 base。

其余一概不变:`DO_REVIEW` 仍为 false、不改动任何标签;已关闭的 PR、fork、非接管标签、以及释放操作仍**刻意保持静默**(它们从未被接管,在那里发评论是噪音而非信息)。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 74/74,连续三次全绿。两个新测试在 bash 下**回放真实提取的代码块**:

   | 驱动场景 | 结果 |
   | --- | --- |
   | 打标签,base 为 `ci/autofix-gate-crash-retry` | `ack=base-refused base=ci/autofix-gate-crash-retry review=false` |
   | 打标签,base 为 `main` | `ack=engaged base= review=true` |
   | 已关闭 / fork / 非接管标签 / 取消标签 | `ack= base= review=false`(静默不变) |
   | ack 作业,`ACK=base-refused` | 发出标记,且**从未调用 `gh pr view`** |
   | ack 作业,`ACK=base-refused` + `gh pr view` 失败 | 仍然发出 |
   | ack 作业,`ACK=engaged` + `gh pr view` 失败 | 退出码非 0、不发任何评论(fail-closed 保持) |

2. 变异验证,三处分别回退各自令测试变红:去掉 route 的 `TAKEOVER_ACK='base-refused'`;删掉 ack 的 `base-refused` 分支;恢复无条件的 `gh pr view`。
3. 消息里的建议("改 base 即可,无需重新打标签")只有在扫描**按标签枚举**接管 PR 时才成立(改 base 不会触发 `labeled` 事件)。该依赖已用对扫描 `--label` / `--base main` 的断言钉住,将来若有改动使该建议失效,会先变红而不是把错误指引发出去。
4. 静态检查(均用 CI 一致工具):YAML 可解析;全部 37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
5. 合并后冒烟:对任意非 `main` base 的 PR 打上 `autofix/takeover`,确认 bot 发出拒绝说明。

## 风险与范围

- 主要权衡:非 main 的 PR 每被打一次标签就多一条评论,节奏与既有的接管 ack 相同;反复切换标签会重复评论。该评论不会反向触发循环:route 的作业级预过滤只放行 `@qwen-code /takeover` 与 `/retry` 正文。
- 既有且无关:`behaviorally replays the eligibility recheck` 是负载 flake。本机受控 A/B —— 未修改的 `origin/main` 跑 6 次 vs 带本改动跑 6 次 —— 显示 main 已完成的 5 次中**有 2 次为红**,与本分支频率相当,故本改动未引入也未加重它。
- 不在范围内:对**已关闭**的 PR 打标签仍按设计保持静默(在已关闭 PR 上发 bot 评论属噪音)。fork 的标签事件不携带 secrets,因而仍然无法发评论——由下一次扫描接管,这是既有的既定行为。
- 破坏性变更:无。

## 关联 Issue

在盘点接管机群运行状况时发现——#7368 是唯一一个 eval 标记数为零的托管 PR。属 autofix 可靠性主线:#7330、#7350、#7351、#7354、#7355、#7358、#7364、#7368。

</details>
