### PR TITLE
fix(acp-bridge): make detachClient idempotent via per-clientId attach-ref ledger

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -12229,12 +12229,13 @@ describe('createAcpSessionBridge', () => {
     });
 
     it('duplicate detach with same clientId decrements attachCount only once (DAEMON-006)', async () => {
-      // A spawns (owner, attachCount stays 0); B attaches
-      // (attachCount: 1). B's detach arrives TWICE (e.g. route
+      // A spawns (owner, attachCount stays 0); B and C attach
+      // (attachCount: 2). B's detach arrives TWICE (e.g. route
       // handler + disconnect reaper both firing). The second detach
-      // finds no attach-ref in the ledger and must NOT decrement,
-      // otherwise A's requireZeroAttaches kill would see 0 and reap
-      // a session A still owns.
+      // finds no attach-ref in the ledger and must NOT decrement —
+      // otherwise it steals C's ref, attachCount hits 0 with C still
+      // connected, and A's requireZeroAttaches kill reaps a session
+      // C is actively using.
       const factory: ChannelFactory = async () => makeChannel().channel;
       const bridge = makeBridge({
         channelFactory: factory,
@@ -12243,13 +12244,13 @@ describe('createAcpSessionBridge', () => {
       const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       expect(b.attached).toBe(true);
-      await bridge.detachClient(b.sessionId, b.clientId);
-      await bridge.detachClient(b.sessionId, b.clientId);
-      // attachCount must have gone 1→0 exactly once — but the
-      // duplicate must not have poisoned anything: a fresh attacher
-      // bumps it back to 1 and the owner's zero-attaches kill bails.
       const c = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
       expect(c.attached).toBe(true);
+      expect(c.clientId).not.toBe(b.clientId);
+      await bridge.detachClient(b.sessionId, b.clientId);
+      await bridge.detachClient(b.sessionId, b.clientId);
+      // attachCount must still be 1 (C's ref intact): the owner's
+      // zero-attaches kill bails and C's session survives.
       await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
       expect(bridge.sessionCount).toBe(1);
       await bridge.shutdown();

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -12194,7 +12194,7 @@ describe('createAcpSessionBridge', () => {
       expect(b.attached).toBe(true);
       expect(bridge.sessionCount).toBe(1);
       // B disconnects — but A is alive. detachClient must NOT reap.
-      await bridge.detachClient(b.sessionId);
+      await bridge.detachClient(b.sessionId, b.clientId);
       // Session survives — A would have 404'd on every subsequent
       // request otherwise.
       expect(bridge.sessionCount).toBe(1);
@@ -12223,7 +12223,151 @@ describe('createAcpSessionBridge', () => {
       expect(bridge.sessionCount).toBe(1); // bailed, no reap
       // B disconnects: detachClient decrements attachCount→0 AND
       // sees the tombstone → completes the deferred reap.
+      await bridge.detachClient(b.sessionId, b.clientId);
+      expect(bridge.sessionCount).toBe(0);
+      await bridge.shutdown();
+    });
+
+    it('duplicate detach with same clientId decrements attachCount only once (DAEMON-006)', async () => {
+      // A spawns (owner, attachCount stays 0); B attaches
+      // (attachCount: 1). B's detach arrives TWICE (e.g. route
+      // handler + disconnect reaper both firing). The second detach
+      // finds no attach-ref in the ledger and must NOT decrement,
+      // otherwise A's requireZeroAttaches kill would see 0 and reap
+      // a session A still owns.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
+      await bridge.detachClient(b.sessionId, b.clientId);
+      await bridge.detachClient(b.sessionId, b.clientId);
+      // attachCount must have gone 1→0 exactly once — but the
+      // duplicate must not have poisoned anything: a fresh attacher
+      // bumps it back to 1 and the owner's zero-attaches kill bails.
+      const c = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(c.attached).toBe(true);
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1);
+      await bridge.shutdown();
+    });
+
+    it('detach with unknown clientId does not decrement attachCount (DAEMON-006)', async () => {
+      // A stray DELETE with a bogus X-Qwen-Client-Id must not steal
+      // B's attach ref: the owner's requireZeroAttaches kill must
+      // still bail on attachCount === 1.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
+      await bridge.detachClient(b.sessionId, 'client_does-not-exist');
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1);
+      await bridge.shutdown();
+    });
+
+    it('anonymous detach (no clientId) does not decrement attachCount (DAEMON-006)', async () => {
+      // A DELETE without X-Qwen-Client-Id returns 204 but releases
+      // nothing — attach/spawn responses always hand out a clientId,
+      // and clients that lost theirs are reaped by the idle backstop.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
       await bridge.detachClient(b.sessionId);
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1);
+      await bridge.shutdown();
+    });
+
+    it('spawn owner detaching itself does not steal an attacher ref (DAEMON-006)', async () => {
+      // Owner registrations never contribute to attachCount, so the
+      // owner's own DELETE detach must leave B's ref intact — while
+      // still dropping the owner's registration so close-on-last-
+      // detach stays reachable.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
+      // Owner says goodbye with its own clientId.
+      await bridge.detachClient(a.sessionId, a.clientId);
+      expect(bridge.sessionCount).toBe(1);
+      // attachCount must still be 1 (B's ref survived the owner
+      // detach): the zero-attaches kill bails.
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1);
+      // Owner's registration WAS removed: once B leaves too, the
+      // deferred-reap tombstone completes and the session closes.
+      await bridge.detachClient(b.sessionId, b.clientId);
+      expect(bridge.sessionCount).toBe(0);
+      await bridge.shutdown();
+    });
+
+    it('deferred reap fires exactly on the real last attacher detach (DAEMON-006 regression)', async () => {
+      // With the tombstone set, noise detaches (unknown/anonymous)
+      // must NOT complete the reap early; the genuine last attacher's
+      // clientId-bearing detach must.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1); // bailed, tombstone set
+      // Noise: neither of these releases B's ledger ref.
+      await bridge.detachClient(b.sessionId, 'client_unknown');
+      await bridge.detachClient(b.sessionId);
+      expect(bridge.sessionCount).toBe(1);
+      // The real last attacher leaves → deferred reap completes.
+      await bridge.detachClient(b.sessionId, b.clientId);
+      expect(bridge.sessionCount).toBe(0);
+      await bridge.shutdown();
+    });
+
+    it('repeated attach under one clientId detaches ref-by-ref (DAEMON-006)', async () => {
+      // Echoing the same clientId on a second attach refcounts the
+      // ledger entry; each detach releases exactly one ref, and the
+      // deferred reap fires only when the LAST ref is gone.
+      const factory: ChannelFactory = async () => makeChannel().channel;
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'single',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(b.attached).toBe(true);
+      const c = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        clientId: b.clientId,
+      });
+      expect(c.attached).toBe(true);
+      expect(c.clientId).toBe(b.clientId); // echoed id was honored
+      // attachCount is now 2; tombstone the owner's kill.
+      await bridge.killSession(a.sessionId, { requireZeroAttaches: true });
+      expect(bridge.sessionCount).toBe(1);
+      // First detach releases one ref → attachCount 2→1, no reap.
+      await bridge.detachClient(b.sessionId, b.clientId);
+      expect(bridge.sessionCount).toBe(1);
+      // Second detach releases the last ref → attachCount 0 → reap.
+      await bridge.detachClient(b.sessionId, b.clientId);
       expect(bridge.sessionCount).toBe(0);
       await bridge.shutdown();
     });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -590,6 +590,17 @@ interface SessionEntry {
    */
   attachCount: number;
   /**
+   * Per-clientId attach reference ledger. Every `attachCount`
+   * contribution that materialized into a registered clientId is
+   * recorded here; `detachClient` may only decrement `attachCount`
+   * by releasing a ref from this ledger. Owner-style registrations
+   * (spawn owner, restore initiator) never contribute to
+   * `attachCount` and are deliberately absent, so a detach with an
+   * owner clientId — or a duplicate/unknown/anonymous detach —
+   * cannot steal another attacher's count.
+   */
+  attachRefs: Map<string, number>;
+  /**
    * BkwQP: tombstone for the spawn-owner-disconnect path. When the
    * spawn owner's HTTP response can't be written and they call
    * `killSession({ requireZeroAttaches: true })` but the bail
@@ -1816,12 +1827,44 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     }
   };
 
+  // Record one attach-ref for `clientId` in the entry's ledger. Call
+  // only at sites where the registered clientId corresponds to an
+  // `attachCount` contribution (a direct `++` or a pre-folded coalesce
+  // reservation) — never for owner-style registrations.
+  const recordAttachRef = (entry: SessionEntry, clientId: string): void => {
+    entry.attachRefs.set(clientId, (entry.attachRefs.get(clientId) ?? 0) + 1);
+  };
+
+  // Release one attach-ref for `clientId`. Returns true only when a
+  // ledger ref was actually released; callers must gate every
+  // `attachCount` decrement on that result so duplicate, unknown or
+  // owner-clientId detaches cannot steal another attacher's count.
+  const releaseAttachRef = (entry: SessionEntry, clientId: string): boolean => {
+    const refs = entry.attachRefs.get(clientId);
+    if (refs === undefined || refs <= 0) return false;
+    if (refs === 1) {
+      entry.attachRefs.delete(clientId);
+    } else {
+      entry.attachRefs.set(clientId, refs - 1);
+    }
+    return true;
+  };
+
   const rollbackAttachRegistration = async (
     entry: SessionEntry,
     clientId: string,
     attachCountDelta = 1,
   ): Promise<void> => {
-    entry.attachCount = Math.max(0, entry.attachCount - attachCountDelta);
+    // The initiator's own contribution is only rolled back if it was
+    // actually recorded in the attach ledger; the remaining
+    // `attachCountDelta - 1` covers coalesce reservations that never
+    // registered a clientId (their promise rejects), so they carry no
+    // ledger entry to release.
+    const released = releaseAttachRef(entry, clientId) ? 1 : 0;
+    entry.attachCount = Math.max(
+      0,
+      entry.attachCount - (released + (attachCountDelta - 1)),
+    );
     unregisterClient(entry, clientId);
     if (
       entry.spawnOwnerWantedKill &&
@@ -3502,6 +3545,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       clientIds: new Map(),
       clientLastSeenAt: new Map(),
       attachCount: 0,
+      attachRefs: new Map(),
       spawnOwnerWantedKill: false,
       promptActive: false,
       retryAllowed: false,
@@ -3816,6 +3860,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     if (existing) {
       existing.attachCount++;
       const clientId = registerClient(existing, req.clientId);
+      recordAttachRef(existing, clientId);
       if (req.approvalMode) {
         await applyApprovalModeForAttach(existing, req.approvalMode, clientId);
       }
@@ -3886,6 +3931,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // ACP state propagates to coalesced waiters (BQ9tV-equivalent
       // for restore waiter consistency).
       const clientId = registerClient(entry, req.clientId);
+      // This coalescer's attachCount contribution was pre-folded via
+      // `coalesceState.count`, so only the ledger is updated here.
+      recordAttachRef(entry, clientId);
       if (req.approvalMode) {
         await applyApprovalModeForAttach(entry, req.approvalMode, clientId);
       }
@@ -4049,6 +4097,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         // (they read it off the registered entry on the next tick).
         racedEntry.attachCount += 1 + coalesceState.count;
         const clientId = registerClient(racedEntry, req.clientId);
+        recordAttachRef(racedEntry, clientId);
         if (req.approvalMode) {
           try {
             await applyApprovalMode(
@@ -4524,6 +4573,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           // microtask," which is what we get here.
           existing.attachCount++;
           const clientId = registerClient(existing, req.clientId);
+          recordAttachRef(existing, clientId);
           // If the caller passed a modelServiceId on attach, the session
           // may currently be running a DIFFERENT model. Honor the request
           // by issuing setSessionModel — same call we'd use on
@@ -4601,6 +4651,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             );
           }
           const clientId = registerClient(attachedEntry, req.clientId);
+          recordAttachRef(attachedEntry, clientId);
           if (req.modelServiceId) {
             // Same swallow as above — we picked up an in-flight
             // spawn, the session is real, model-switch failure
@@ -7584,7 +7635,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // without sending a detach request.
       const entry = byId.get(sessionId);
       if (!entry) return;
-      if (entry.attachCount > 0) entry.attachCount--;
+      // Only a detach that releases a recorded attach-ref may decrement
+      // `attachCount`. Duplicate detaches, unknown/anonymous clientIds
+      // and owner-style registrations (spawn owner, restore initiator)
+      // carry no ledger ref, so they can no longer steal another
+      // attacher's count and trigger a premature kill. The
+      // registration ref is still dropped unconditionally below —
+      // unregisterClient is idempotent and an owner's explicit goodbye
+      // must keep the close-on-last-detach path reachable.
+      if (clientId !== undefined && releaseAttachRef(entry, clientId)) {
+        if (entry.attachCount > 0) entry.attachCount--;
+      }
       unregisterClient(entry, clientId);
       if (
         entry.spawnOwnerWantedKill &&


### PR DESCRIPTION
## What this PR does

Makes `detachClient` idempotent by introducing a per-clientId attach reference ledger (`attachRefs`) on each session entry. Every attach that contributes to `attachCount` records one ledger ref for the registered clientId; `detachClient` may only decrement `attachCount` by releasing a ref from that ledger. Detaches that hold no ref — duplicates, unknown clientIds, anonymous requests, and owner-style registrations (spawn owner, restore initiator) — leave the counter untouched, while the client registration itself is still dropped unconditionally (that operation is idempotent, and an owner's explicit goodbye must keep the close-on-last-detach path reachable). `rollbackAttachRegistration` is updated to the same ledger discipline so restore-initiator rollbacks and coalesce-reservation rollbacks each subtract exactly what they contributed.

## Why it's needed

`detachClient` unconditionally decremented `attachCount`, fully decoupled from whether the detach released a real attach reference. A duplicate detach, a stray or anonymous `DELETE`, or the spawn owner detaching with its own clientId all stole another attacher's count. Once the counter was stolen down to 0 while real attachers were still connected, the `spawnOwnerWantedKill` deferred reap or the close-on-last-detach path killed a session that still had live clients, and every subsequent request from those clients 404'd. Fixes #7385.

## Reviewer Test Plan

### How to verify

Run `cd packages/acp-bridge && npx vitest run src/bridge.test.ts`. Six new tests cover the failure modes end-to-end: duplicate detach decrements only once; unknown-clientId and anonymous detaches don't decrement; a spawn owner detaching itself doesn't steal an attacher's ref (while its registration is still removed); the deferred reap fires exactly on the real last attacher's detach and not on noise detaches; and repeated attaches under one echoed clientId detach ref-by-ref. Two existing detach tests now pass the clientId, matching all six production call sites of `detachClient` (acp-http index, dispatch, session routes), which all forward a concrete id.

### Evidence (Before & After)

N/A (daemon-internal counter semantics; covered by unit tests — 416/416 passing in `bridge.test.ts`, plus `npm run build` and `npm run typecheck` clean at the repo root).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: two deliberate behavior changes. (1) A `DELETE` detach without `X-Qwen-Client-Id` no longer decrements `attachCount` (still returns 204); attach/spawn responses always hand out a clientId, and clients that lost theirs are covered by the idle-reaper backstop already documented at the detach site. (2) A spawn owner's `DELETE` detach no longer affects `attachCount`, but its registration is still removed.
- Not validated / out of scope: a pre-existing issue where the restore IIFE assigns `entry.attachCount = coalesceState.count` (assignment, not accumulation), which can swallow concurrent attacher bumps during the restore window — unrelated to this fix and left for a follow-up. Also out of scope: under a shared clientId, an adversarial duplicate detach can still strip one extra `clientIds` refcount layer (no `attachCount` impact, no premature kill); fully eliminating that would require a detach idempotency key, i.e. a protocol change.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7385

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

通过在每个 session entry 上引入按 clientId 记账的 attach 引用账本（`attachRefs`），使 `detachClient` 幂等化。每次对 `attachCount` 有贡献的 attach 都会为注册的 clientId 记录一份账本引用；`detachClient` 只有在成功释放一份账本引用时才允许递减 `attachCount`。不持有引用的 detach——重复 detach、未知 clientId、匿名请求、以及 owner 型注册（spawn owner、restore 发起者）——不再影响计数，但客户端注册本身仍无条件移除（该操作本身幂等，且 owner 的显式告别必须保持 close-on-last-detach 路径可达）。`rollbackAttachRegistration` 也改为同一账本纪律，使 restore 发起者回滚与 coalesce 预留回滚各自精确扣除自己贡献的部分。

## 为什么需要

`detachClient` 原先无条件递减 `attachCount`，与该 detach 是否真实释放了一份 attach 引用完全解耦。重复 detach、伪造或匿名的 `DELETE`、以及 spawn owner 用自身 clientId 的 detach 都会偷减其他 attacher 的计数。一旦计数在仍有真实 attacher 在线时被偷减到 0，`spawnOwnerWantedKill` 延迟回收或 close-on-last-detach 路径就会杀掉仍有存活客户端的 session，这些客户端之后的所有请求都会 404。修复 #7385。

## 审阅者验证方案

运行 `cd packages/acp-bridge && npx vitest run src/bridge.test.ts`。六个新增用例端到端覆盖各失败模式：重复 detach 只递减一次；未知 clientId 与匿名 detach 不递减；spawn owner 自 detach 不偷减 attacher 引用（其注册仍被移除）；延迟回收精确地在真实最后一个 attacher detach 时触发、不被噪声 detach 提前触发；同一回显 clientId 多次 attach 后逐份引用释放。两个现有 detach 用例改为传 clientId，与 `detachClient` 全部六处生产调用点（acp-http index、dispatch、session routes）一致——它们都传递具体 id。

证据：daemon 内部计数语义，由单元测试覆盖——`bridge.test.ts` 416/416 通过，仓库根 `npm run build` 与 `npm run typecheck` 干净。本地在 macOS 验证。

## 风险与范围

- 主要风险/权衡：两个刻意的行为变更。（1）不带 `X-Qwen-Client-Id` 的 `DELETE` detach 不再递减 `attachCount`（仍返回 204）；attach/spawn 响应始终下发 clientId，丢失 id 的客户端由 detach 站点已注明的 idle reaper 兜底。（2）spawn owner 的 `DELETE` detach 不再影响 `attachCount`，但其注册仍被移除。
- 未验证/范围外：restore IIFE 中 `entry.attachCount = coalesceState.count` 为赋值而非累加的既有问题（可能吞掉 restore 窗口内并发 attacher 的递增），与本修复无关，留待后续处理。同样范围外：共享 clientId 下攻击性的重复 detach 仍可多剥一层 `clientIds` refcount（不影响 `attachCount`、无提前 kill）；彻底消除需要 detach 幂等键，即协议变更。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7385

</details>
