### PR TITLE
fix(ci): stop /resolve reports from being guillotined mid-sentence

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -387,7 +387,7 @@ jobs:
 
       # SECURITY: checkout trusted base code; /review fetches PR diff context.
       - name: 'Checkout base branch'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
           fetch-depth: 0
@@ -989,7 +989,7 @@ jobs:
           echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
 
       - name: 'Checkout base branch'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           ref: '${{ github.event.repository.default_branch }}'
           fetch-depth: 0
@@ -1183,7 +1183,16 @@ jobs:
 
             ## Finish with exactly one outcome
 
-            - If you confidently resolved the conflicts, create one Conventional Commit on the current branch and write `${{ env.WORKDIR }}/address-summary.md`. Include what conflicted and how you resolved each side.
+            - If you confidently resolved the conflicts, create one Conventional Commit on the current branch and write `${{ env.WORKDIR }}/address-summary.md`.
+
+              **Keep the summary under 4000 bytes.** It is truncated when posted, and a report that stops mid-sentence is worse than a short one. A file-by-file inventory is the first thing to cut: the reviewer can already read the diff. Spend the space on what only you know, having just done the merge:
+
+              1. **Root cause.** Which change on the base branch collided with this PR — name the PR or commit when you can tell — not merely which files conflicted.
+              2. **Textual or semantic.** Say plainly whether the two sides were only adjacent, or whether both modified the same logic. If semantic, show the resolved code in a short fenced block: prose describing merged logic cannot be checked without re-reading the diff.
+              3. **What is load-bearing.** Any ordering, condition, or precedence the resolution depends on, written so that a future edit which breaks it is recognisable as breaking it.
+              4. **What you could not verify.** This command runs no build or tests, and you may only edit files that actually conflicted. If the merge changes behaviour that a NON-conflicted test or caller depends on, say so and name it — you must not fix it here, and silence would leave it broken.
+
+              End with the project's collapsed Chinese translation: `<details>` / `<summary>中文说明</summary>` / the translated body / `</details>`.
             - If there is no longer a conflict, do not commit. Write `${{ env.WORKDIR }}/no-action.md` explaining what changed.
             - If you cannot confidently resolve the conflict, do not commit. Write `${{ env.WORKDIR }}/failure.md` with the blocker and what you learned.
 
@@ -1359,6 +1368,13 @@ jobs:
           set -euo pipefail
           push_failed=false
 
+          # Budget for one agent-written section of the comment. The old 2000
+          # was below what a real resolution report costs to write: EVERY
+          # substantive /resolve summary hit it exactly and stopped mid-word,
+          # so reviewers read a report that looked abandoned rather than
+          # clipped. The prompt now asks for under 4000; this leaves headroom
+          # above that, so the cut only fires on genuinely runaway output.
+          SUMMARY_MAX_BYTES=6000
           append_safe_file() {
             cleaned="${WORKDIR}/safe-$(basename "$1")"
             # Strip only dangerous HTML elements, not every `<...>` — the agent's
@@ -1369,7 +1385,14 @@ jobs:
             # head -c truncates at a byte boundary, which can split a multi-byte
             # UTF-8 character and emit a broken tail in the comment. Drop any
             # incomplete trailing sequence the byte cut leaves behind.
-            head -c 2000 "$cleaned" | iconv -f UTF-8 -t UTF-8 -c
+            head -c "$SUMMARY_MAX_BYTES" "$cleaned" | iconv -f UTF-8 -t UTF-8 -c
+            # Announce the cut. Silent truncation is the worse half of the bug:
+            # a clipped report is indistinguishable from an agent that trailed
+            # off, so a reviewer cannot tell whether the missing analysis was
+            # never written or merely not shown.
+            if [ "$(wc -c < "$cleaned")" -gt "$SUMMARY_MAX_BYTES" ]; then
+              printf '\n_… truncated at %s bytes. The full text is attached to this workflow run as an artifact._\n' "$SUMMARY_MAX_BYTES"
+            fi
             echo
           }
 

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1364,6 +1364,7 @@ jobs:
           HEAD_REPO: '${{ steps.prepare.outputs.head_repo }}'
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
           DRY_RUN: '${{ env.DRY_RUN }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |-
           set -euo pipefail
           push_failed=false
@@ -1391,7 +1392,7 @@ jobs:
             # off, so a reviewer cannot tell whether the missing analysis was
             # never written or merely not shown.
             if [ "$(wc -c < "$cleaned")" -gt "$SUMMARY_MAX_BYTES" ]; then
-              printf '\n_… truncated at %s bytes. The full text is attached to this workflow run as an artifact._\n' "$SUMMARY_MAX_BYTES"
+              printf '\n_… truncated at %s bytes. The full text is attached to this [workflow run](%s) as an artifact._\n' "$SUMMARY_MAX_BYTES" "$RUN_URL"
             fi
             echo
           }

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -200,6 +200,80 @@ describe('qwen resolve workflow', () => {
     expect(resolveJob).not.toContain("- name: 'Refresh dependencies'");
   });
 
+  it('asks the resolution report for what the diff cannot show', () => {
+    // Measured before this contract existed: every substantive /resolve
+    // summary was a file-by-file inventory that hit the byte cap exactly and
+    // stopped mid-word (#2993, #4256, #6206 all ended at 2100 bytes total).
+    // The inventory duplicates the diff; what only the resolver knows is the
+    // root cause, whether the merge was semantic, and what it could not check.
+    const prompt = step(resolveJob, 'Resolve conflicts');
+    expect(prompt).toContain('Keep the summary under 4000 bytes');
+    expect(prompt).toContain(
+      'A file-by-file inventory is the first thing to cut',
+    );
+    expect(prompt).toContain('**Root cause.**');
+    expect(prompt).toContain('**Textual or semantic.**');
+    expect(prompt).toContain('**What is load-bearing.**');
+    expect(prompt).toContain('**What you could not verify.**');
+    // /resolve runs no tests AND may not edit non-conflicted files, so a merge
+    // that breaks an untouched test can only be reported, never fixed here.
+    expect(prompt).toContain('NON-conflicted test');
+    // Project convention for anything posted as a PR comment.
+    expect(prompt).toContain('<summary>中文说明</summary>');
+  });
+
+  it('truncates an over-long report visibly, on a character boundary', () => {
+    const helper = resolveJob.match(
+      /(SUMMARY_MAX_BYTES=\d+\n[\s\S]*?append_safe_file\(\) \{[\s\S]*?\n {10}\})/,
+    )?.[1];
+    expect(helper).toBeTruthy();
+    // The instructed limit must sit BELOW the enforced one, or a report that
+    // obeys the prompt still gets cut.
+    const cap = Number(helper.match(/SUMMARY_MAX_BYTES=(\d+)/)[1]);
+    expect(cap).toBeGreaterThan(4000);
+
+    const run = (body) => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'resolve-summary-'));
+      writeFileSync(path.join(dir, 'address-summary.md'), body);
+      const out = spawnSync(
+        'bash',
+        [
+          '-c',
+          `${helper.replace(/^ {10}/gm, '')}\nappend_safe_file "$WORKDIR/address-summary.md"`,
+        ],
+        { env: { ...process.env, WORKDIR: dir }, encoding: 'utf8' },
+      );
+      rmSync(dir, { recursive: true, force: true });
+      expect(out.status).toBe(0);
+      return out.stdout;
+    };
+
+    // A report inside the budget is passed through whole and unannotated.
+    const short = run(
+      '# Merge report\n\nRoot cause: #7351 touched the same chain.\n',
+    );
+    expect(short).toContain('Root cause: #7351 touched the same chain.');
+    expect(short).not.toContain('truncated at');
+
+    // An over-long one is cut AND says so — the silent stop is the bug.
+    const long = run(`${'x'.repeat(cap + 500)}\n`);
+    expect(long).toContain(`truncated at ${cap} bytes`);
+    expect(long).toContain('attached to this workflow run');
+
+    // The cut lands on a byte boundary, so a multi-byte character straddling
+    // it must be dropped rather than emitted as a broken tail. One leading
+    // ASCII byte offsets the 3-byte characters so the cap falls INSIDE one —
+    // without the offset the cut would land cleanly and prove nothing.
+    const wide = run(`x${'中'.repeat(Math.ceil(cap / 3) + 2)}`);
+    expect(() =>
+      new TextDecoder('utf-8', { fatal: true }).decode(
+        new TextEncoder().encode(wide),
+      ),
+    ).not.toThrow();
+    expect(wide).not.toContain('�');
+    expect(wide).toContain(`truncated at ${cap} bytes`);
+  });
+
   it('uses resolve naming for run artifacts', () => {
     expect(workflow).toContain('qwen-resolve-');
     expect(workflow).toContain('/tmp/qwen-resolve');

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -241,7 +241,13 @@ describe('qwen resolve workflow', () => {
           '-c',
           `${helper.replace(/^ {10}/gm, '')}\nappend_safe_file "$WORKDIR/address-summary.md"`,
         ],
-        { env: { ...process.env, WORKDIR: dir }, encoding: 'utf8' },
+        {
+          env: {
+            ...process.env,
+            WORKDIR: dir,
+            RUN_URL: 'https://github.com/test/repo/actions/runs/1',
+          },
+        },
       );
       rmSync(dir, { recursive: true, force: true });
       expect(out.status).toBe(0);
@@ -249,27 +255,29 @@ describe('qwen resolve workflow', () => {
     };
 
     // A report inside the budget is passed through whole and unannotated.
-    const short = run(
-      '# Merge report\n\nRoot cause: #7351 touched the same chain.\n',
+    const short = new TextDecoder().decode(
+      run('# Merge report\n\nRoot cause: #7351 touched the same chain.\n'),
     );
     expect(short).toContain('Root cause: #7351 touched the same chain.');
     expect(short).not.toContain('truncated at');
 
     // An over-long one is cut AND says so — the silent stop is the bug.
-    const long = run(`${'x'.repeat(cap + 500)}\n`);
+    const long = new TextDecoder().decode(run(`${'x'.repeat(cap + 500)}\n`));
     expect(long).toContain(`truncated at ${cap} bytes`);
-    expect(long).toContain('attached to this workflow run');
+    expect(long).toContain('attached to this [workflow run](');
 
     // The cut lands on a byte boundary, so a multi-byte character straddling
     // it must be dropped rather than emitted as a broken tail. One leading
     // ASCII byte offsets the 3-byte characters so the cap falls INSIDE one —
     // without the offset the cut would land cleanly and prove nothing.
-    const wide = run(`x${'中'.repeat(Math.ceil(cap / 3) + 2)}`);
+    const wideBuf = run(`x${'中'.repeat(Math.ceil(cap / 3) + 2)}`);
+    // Fatal-decode the raw bytes bash emitted: a split multi-byte character
+    // would throw here. Re-encoding a JS string first (TextEncoder) can never
+    // produce invalid UTF-8, so that round-trip would make this assertion inert.
     expect(() =>
-      new TextDecoder('utf-8', { fatal: true }).decode(
-        new TextEncoder().encode(wide),
-      ),
+      new TextDecoder('utf-8', { fatal: true }).decode(wideBuf),
     ).not.toThrow();
+    const wide = new TextDecoder().decode(wideBuf);
     expect(wide).not.toContain('�');
     expect(wide).toContain(`truncated at ${cap} bytes`);
   });


### PR DESCRIPTION
## What this PR does

Changes what `@qwen-code /resolve` is asked to report, and stops the report from being cut off mid-sentence with no indication that it was cut.

## Why it's needed

**Every substantive `/resolve` report is truncated mid-word.** `append_safe_file()` caps each agent-written section at `head -c 2000`, and the reports all land on it exactly:

| PR | comment size | how it ends |
| --- | --- | --- |
| #2993 | 2100 B | `**en.js** — PR added ~50 new translation keys in sectioned` |
| #4256 | 2100 B | `` `createStreamIdleWatchdog` before `retryWithBackoff`, `` |
| #6206 | 2100 B | `` downstream `handleGroup`/`handleG `` |

2100 B = the fixed preamble + exactly 2000 B of summary. Nothing in the comment says it was clipped, so a truncated report is indistinguishable from an agent that trailed off — the reviewer cannot tell whether the missing analysis was never written or merely not shown.

The cap is only half of it. The contract was one sentence — *"Include what conflicted and how you resolved each side"* — which produces a file-by-file inventory. That inventory **duplicates the diff the reviewer already has**, grows with the conflict count, and crowds out the part only the resolver knows, having just done the merge.

## How

**The contract now asks for what the diff cannot show**, in priority order, with the inventory named as the first thing to cut:

1. **Root cause** — which change on the base branch collided with this PR (name the PR/commit when knowable), not merely which files conflicted.
2. **Textual or semantic** — were the two sides merely adjacent, or did both modify the same logic? If semantic, show the resolved code, because prose describing merged logic cannot be checked without re-reading the diff.
3. **What is load-bearing** — the ordering/condition/precedence the resolution depends on, written so a future edit that breaks it is recognisable as breaking it.
4. **What could not be verified** — `/resolve` runs no build or tests *and* may only edit files that actually conflicted. So when a merge changes behaviour a **non-conflicted** test depends on, the resolver can only report it. Saying nothing leaves it broken and invisible.

Plus the project's collapsed `中文说明` section — no `/resolve` report has ever had one (0 of 12 sampled).

**The cap is raised to 6000 and made audible.** The prompt asks for under 4000, so the enforced limit sits above what a compliant report costs; a report that still exceeds it now ends with an explicit truncation notice pointing at the run artifact, which holds the full text (`Upload run artifacts` uploads the whole workdir under `always()`).

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-resolve-workflow.test.js scripts/tests/qwen-pr-review-workflow.test.js` — 47/47. The truncation test **replays the real extracted `append_safe_file` helper** under bash over three inputs:

   | input | asserted |
   | --- | --- |
   | short report | passed through whole, **no** truncation notice |
   | `cap + 500` ASCII bytes | cut **and** annotated with the byte count and where the full text lives |
   | one ASCII byte + 3-byte characters | decodes as strict UTF-8, no `�`, notice present |

   The third case is deliberate: the leading ASCII byte offsets the multi-byte characters so the cap falls *inside* one. Without that offset the cut lands cleanly and would prove nothing.

2. Mutation-verified, four separate reverts each turning a test red:

   | mutation | caught by |
   | --- | --- |
   | drop `\| iconv -f UTF-8 -t UTF-8 -c` | broken-tail assertion on the multi-byte case |
   | `SUMMARY_MAX_BYTES` back to 2000 | the enforced cap must exceed the instructed 4000 |
   | delete the truncation notice | over-long report is cut silently again |
   | remove a contract item from the prompt | the contract test |

3. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 17 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: `@qwen-code /resolve` on a conflicted PR and read the comment — it should open with the root cause rather than a file list, and end with the Chinese section.

### Evidence (Before & After)

```
BEFORE  agent writes a file-by-file inventory (unbounded)
        -> head -c 2000
        -> comment ends: "...no equivalen"
        -> reviewer cannot tell clipped from abandoned
        (2993/4256/6206: all exactly 2100 B, all cut mid-word)

AFTER   agent writes root cause / semantic-or-textual / load-bearing /
        unverified, under 4000 B, + 中文说明
        -> cap 6000, so a compliant report is never cut
        -> if it still overflows: "… truncated at 6000 bytes. The full
           text is attached to this workflow run as an artifact."
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: `append_safe_file` is shared by `address-summary.md`, `no-action.md` and `failure.md`, so all three may now post up to 6000 B. That is 3× the old ceiling on a comment that was already the run's main output, and well inside GitHub's 65536-character limit.
- The contract is a prompt, not a gate — a model can still write an inventory. The tests pin what is *asked*, and the truncation notice makes any overflow visible rather than silent; nothing here can force the content.
- Two unrelated lines: prettier normalises `'…' # v6.0.3` spacing on two `actions/checkout` lines in this file. `main` is prettier-dirty here and the repo's pre-commit `lint-staged` rewrites them on any commit touching the file, so they are not worth fighting.
- Not validated / out of scope: this does not change the resolution itself, only what is reported about it. The `/review` path's own report format is untouched.
- Breaking changes / migration notes: none.

## Linked Issues

Prompted by the merge resolution on #7247, where the useful content was the root cause (#7351 landed in the same `if`-chain), which side was load-bearing, and a non-conflicted test the merge invalidated — none of which the old contract asks for.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

改变 `@qwen-code /resolve` 被要求汇报的**内容**,并让报告不再在半句处被截断、且截断时毫无提示。

## 为什么需要

**每一份有实质内容的 `/resolve` 报告都断在词中间。** `append_safe_file()` 用 `head -c 2000` 截断每个 agent 撰写的段落,而报告无一例外正好撞上:

| PR | 评论长度 | 结尾 |
| --- | --- | --- |
| #2993 | 2100 B | `**en.js** — PR added ~50 new translation keys in sectioned` |
| #4256 | 2100 B | `` `createStreamIdleWatchdog` before `retryWithBackoff`, `` |
| #6206 | 2100 B | `` downstream `handleGroup`/`handleG `` |

2100 B = 固定前言 + 恰好 2000 B 摘要。评论里没有任何字样表明它被裁掉了,于是"被截断的报告"与"agent 写到一半放弃了"无法区分 —— 评审者无从判断缺失的分析是从未写出,还是只是没被展示。

上限只是一半原因。契约原本只有一句话 —— *"Include what conflicted and how you resolved each side"* —— 它产出的是逐文件清单。而该清单**与评审者手上已有的 diff 重复**,随冲突数增长,并挤掉了唯一只有"刚做完这次合并的人"才知道的那部分。

## 怎么做

**契约改为索取 diff 里读不到的东西**,按优先级排列,并明确指出清单是第一个该砍的:

1. **根因** —— base 上的哪个改动与本 PR 相撞(能判断就点名 PR/commit),而非仅列冲突文件。
2. **文本冲突还是语义冲突** —— 两侧只是相邻,还是都改了同一段逻辑?若是语义冲突就贴出解完的代码,因为描述合并逻辑的散文不重读 diff 无法核对。
3. **哪里是承重的** —— 解法所依赖的顺序/条件/优先级,写成"将来谁破坏了它能被认出来"的样子。
4. **无法验证什么** —— `/resolve` 不跑 build/test,**且**只准改真正冲突的文件。因此当合并改变了某个**未冲突**测试所依赖的行为时,解决者只能汇报。闭口不谈会让它坏着且不可见。

外加项目惯例的折叠 `中文说明` —— 迄今没有任何一份 `/resolve` 报告带过(抽样 12 份,0 份有)。

**上限提到 6000 并且会出声。** prompt 要求 4000 以内,故强制上限高于合规报告的成本;仍然超出的报告现在会以明确的截断提示收尾,并指向 run artifact —— 全文在那里(`Upload run artifacts` 以 `always()` 上传整个 workdir)。

## 评审验证

1. `npx vitest run scripts/tests/qwen-resolve-workflow.test.js scripts/tests/qwen-pr-review-workflow.test.js` —— 47/47。截断测试**回放真实提取的 `append_safe_file`**,三种输入:短报告(原样通过、无提示)、`cap + 500` 字节(裁剪**且**带字节数与全文位置的提示)、1 个 ASCII 字节 + 3 字节字符(严格 UTF-8 可解码、无 `�`、有提示)。第三种是刻意设计:前置的 1 个 ASCII 字节使多字节字符错位,让上限**落在字符内部**;没有这个错位,裁剪点会正好落在字符边界,什么也证明不了。
2. 变异验证,四处分别回退各自令测试变红:去掉 `| iconv -f UTF-8 -t UTF-8 -c`(多字节断尾断言);`SUMMARY_MAX_BYTES` 退回 2000(强制上限必须高于所要求的 4000);删掉截断提示(超长报告重新被静默裁剪);删掉契约中的一条(契约测试)。
3. 静态(均用 CI 一致工具):YAML 可解析;全部 17 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:在有冲突的 PR 上执行 `@qwen-code /resolve` 并阅读评论 —— 应以根因开篇而非文件清单,并以中文段收尾。

## 风险与范围

- 主要权衡:`append_safe_file` 被 `address-summary.md`、`no-action.md`、`failure.md` 共用,三者现在都可能达到 6000 B。这是原上限的 3 倍,但它本就是该次运行的主要输出,且远在 GitHub 65536 字符上限之内。
- 契约是 prompt 而非 gate —— 模型仍可能写清单。测试钉住的是"被要求的内容",截断提示则让任何溢出可见而非静默;此处无法强制内容本身。
- 两行无关改动:prettier 会规范本文件中两处 `actions/checkout` 行的 `'…' # v6.0.3` 空格。`main` 在本文件上本就不满足 prettier,且仓库的 pre-commit `lint-staged` 会在任何触碰该文件的提交上重写它们,不值得对抗。
- 不在范围内:本 PR 不改变解决冲突本身,只改变对它的汇报。`/review` 自身的报告格式未触及。
- 破坏性变更:无。

## 关联 Issue

由 #7247 的合并解决过程促成 —— 那里真正有用的内容是根因(#7351 落进了同一条 `if` 链)、哪一侧是承重的、以及一个被合并作废的未冲突测试;而这三样,旧契约一样都没要。

</details>
