### PR TITLE
fix(core): salvage session usage into the history before deleting transcripts

### DIFF
--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -5,6 +5,7 @@
  */
 
 import fs from 'node:fs';
+import { persistUsageBeforeTranscriptDeletion } from './usageHistoryService.js';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import {
@@ -38,6 +39,9 @@ import { CompressionStatus } from '../core/turn.js';
 import type { ChatRecord } from './chatRecordingService.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 
+vi.mock('./usageHistoryService.js', () => ({
+  persistUsageBeforeTranscriptDeletion: vi.fn().mockResolvedValue(true),
+}));
 vi.mock('node:path');
 vi.mock('../utils/paths.js');
 vi.mock('../utils/runtimeStatus.js');
@@ -1439,6 +1443,15 @@ describe('SessionService', () => {
 
       expect(result).toBe(true);
       expect(unlinkSyncSpy).toHaveBeenCalled();
+      // #7384: the usage salvage must see the transcript BEFORE it is
+      // unlinked, or the summary is unrecoverable.
+      const salvage = vi.mocked(persistUsageBeforeTranscriptDeletion);
+      expect(salvage).toHaveBeenCalledWith(
+        expect.stringContaining(`${sessionIdA}.jsonl`),
+      );
+      expect(salvage.mock.invocationCallOrder[0]!).toBeLessThan(
+        unlinkSyncSpy.mock.invocationCallOrder[0]!,
+      );
       expect(rmSyncSpy).toHaveBeenCalledWith(
         expect.stringContaining(`file-history/${sessionIdA}`),
         { recursive: true, force: true },

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -5,6 +5,7 @@
  */
 
 import { Storage } from '../config/storage.js';
+import { persistUsageBeforeTranscriptDeletion } from './usageHistoryService.js';
 import { getProjectHash } from '../utils/paths.js';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -1340,6 +1341,10 @@ export class SessionService {
       const activePath = this.getSessionFilePath(sessionId, 'active');
       const active = await this.readProjectSessionHead(sessionId, activePath);
       if (active) {
+        // #7384: the usage-history rebuild reads transcripts, so salvage
+        // the session's usage summary before the file is gone. Never
+        // blocks deletion (the salvage swallows its own errors).
+        await persistUsageBeforeTranscriptDeletion(activePath);
         this.removeFileIfExists(activePath);
         const archivedPath = this.getSessionFilePath(sessionId, 'archived');
         if (fs.existsSync(archivedPath)) {
@@ -1357,6 +1362,7 @@ export class SessionService {
       if (!archived) {
         return false;
       }
+      await persistUsageBeforeTranscriptDeletion(archivedPath);
       this.removeFileIfExists(archivedPath);
       this.removeWorktreeSidecars(sessionId);
       this.removeFileHistoryBackups(sessionId);

--- a/packages/core/src/services/usageHistoryService.test.ts
+++ b/packages/core/src/services/usageHistoryService.test.ts
@@ -14,6 +14,7 @@ import {
   loadUsageHistory,
   loadUsageHistoryWithLive,
   persistSessionUsage,
+  persistUsageBeforeTranscriptDeletion,
 } from './usageHistoryService.js';
 import { ToolCallDecision } from '../telemetry/tool-call-decision.js';
 import type { SessionMetrics } from '../telemetry/uiTelemetry.js';
@@ -774,6 +775,128 @@ describe('loadUsageHistory + persistSessionUsage (issue #4994 regression)', () =
 
     const merged = await loadUsageHistoryWithLive();
     expect(merged.map((r) => r.sessionId)).toEqual(['sess-daemon']);
+  });
+});
+
+// Regression for #7384: deleting a session erased its usage from the
+// rebuild-from-transcript fallback forever. The salvage runs right before
+// transcript deletion.
+describe('persistUsageBeforeTranscriptDeletion (issue #7384)', () => {
+  let tmpHome: string;
+  let originalQwenHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-usage-salvage-'));
+    originalQwenHome = process.env['QWEN_HOME'];
+    process.env['QWEN_HOME'] = path.join(tmpHome, '.qwen');
+    fs.mkdirSync(process.env['QWEN_HOME'], { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalQwenHome === undefined) delete process.env['QWEN_HOME'];
+    else process.env['QWEN_HOME'] = originalQwenHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function plantTranscript(sessionId: string, withTelemetry: boolean): string {
+    const dir = path.join(
+      process.env['QWEN_HOME']!,
+      'projects',
+      'salvage-project',
+      'chats',
+    );
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `${sessionId}.jsonl`);
+    const start = new Date('2026-07-01T00:00:00Z').toISOString();
+    const mid = new Date('2026-07-01T00:01:00Z').toISOString();
+    const records: unknown[] = [
+      {
+        sessionId,
+        cwd: '/salvage/project',
+        uuid: 'u1',
+        parentUuid: null,
+        timestamp: start,
+        type: 'user',
+        message: { role: 'user', content: 'hi' },
+      },
+    ];
+    if (withTelemetry) {
+      records.push({
+        sessionId,
+        cwd: '/salvage/project',
+        uuid: 'u2',
+        parentUuid: 'u1',
+        timestamp: mid,
+        type: 'system',
+        subtype: 'ui_telemetry',
+        systemPayload: {
+          uiEvent: {
+            'event.name': 'qwen-code.api_response',
+            'event.timestamp': mid,
+            response_id: 'r1',
+            model: 'qwen-max',
+            duration_ms: 900,
+            input_token_count: 600,
+            output_token_count: 300,
+            cached_content_token_count: 0,
+            thoughts_token_count: 100,
+            total_token_count: 1000,
+            prompt_id: 'p1',
+          },
+        },
+      });
+    }
+    fs.writeFileSync(
+      filePath,
+      records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+    );
+    return filePath;
+  }
+
+  function usagePath(): string {
+    return path.join(process.env['QWEN_HOME']!, 'usage_record.jsonl');
+  }
+
+  it('writes the session summary before the transcript disappears', async () => {
+    const filePath = plantTranscript('sess-salvage-1', true);
+    await expect(persistUsageBeforeTranscriptDeletion(filePath)).resolves.toBe(
+      true,
+    );
+    const lines = fs
+      .readFileSync(usagePath(), 'utf-8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].sessionId).toBe('sess-salvage-1');
+    expect(lines[0].models['qwen-max'].totalTokens).toBe(1000);
+    expect(lines[0].project).toBe('/salvage/project');
+  });
+
+  it('skips the write when the history already has the session (no #4994 duplicates)', async () => {
+    const filePath = plantTranscript('sess-salvage-2', true);
+    await persistUsageBeforeTranscriptDeletion(filePath);
+    await expect(persistUsageBeforeTranscriptDeletion(filePath)).resolves.toBe(
+      false,
+    );
+    const lines = fs.readFileSync(usagePath(), 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('returns false for a transcript with no telemetry and writes nothing', async () => {
+    const filePath = plantTranscript('sess-salvage-3', false);
+    await expect(persistUsageBeforeTranscriptDeletion(filePath)).resolves.toBe(
+      false,
+    );
+    expect(fs.existsSync(usagePath())).toBe(false);
+  });
+
+  it('never throws for a missing transcript', async () => {
+    await expect(
+      persistUsageBeforeTranscriptDeletion(
+        path.join(tmpHome, 'nope', 'missing.jsonl'),
+      ),
+    ).resolves.toBe(false);
   });
 });
 

--- a/packages/core/src/services/usageHistoryService.ts
+++ b/packages/core/src/services/usageHistoryService.ts
@@ -222,6 +222,98 @@ export function metricsToUsageRecord(
   };
 }
 
+/**
+ * Replays a session transcript's `ui_telemetry` records into a usage
+ * summary. Returns null for an empty transcript; `record` is null when the
+ * transcript has no telemetry events (or unparseable timestamps) — the
+ * sessionId is still reported so callers can dedupe by session.
+ *
+ * Single implementation shared by the rebuild migration and the
+ * pre-deletion salvage (#7384) so the two can never drift.
+ */
+function summarizeTranscript(
+  records: ChatRecord[],
+): { sessionId: string; record: UsageSummaryRecord | null } | null {
+  if (records.length === 0) return null;
+  const firstRecord = records[0]!;
+  const sessionId = firstRecord.sessionId;
+  if (!sessionId) return null;
+  const project = firstRecord.cwd;
+
+  const telemetry = new UiTelemetryService();
+  let hasEvents = false;
+  for (const record of records) {
+    if (record.type === 'system' && record.subtype === 'ui_telemetry') {
+      const payload = record.systemPayload as { uiEvent?: UiEvent } | undefined;
+      if (payload?.uiEvent) {
+        telemetry.addEvent(payload.uiEvent);
+        hasEvents = true;
+      }
+    }
+  }
+  if (!hasEvents) return { sessionId, record: null };
+
+  const startTime = new Date(firstRecord.timestamp).getTime();
+  const endTime = new Date(records[records.length - 1]!.timestamp).getTime();
+  if (isNaN(startTime) || isNaN(endTime)) {
+    return { sessionId, record: null };
+  }
+  return {
+    sessionId,
+    record: metricsToUsageRecord(
+      sessionId,
+      project,
+      startTime,
+      endTime,
+      telemetry.getMetrics(),
+    ),
+  };
+}
+
+/**
+ * Salvages a session's usage summary into `usage_record.jsonl` right before
+ * its transcript is deleted (#7384): the usage-history rebuild reads
+ * transcripts, so deleting a session that was never `/clear`ed or cleanly
+ * exited previously erased its usage from the records forever.
+ *
+ * Never throws — deletion must proceed even when salvage fails — and skips
+ * the write when the persisted history already carries a record for the
+ * session (a `/clear` or exit already wrote the authoritative summary;
+ * duplicating it would re-open #4994). Returns true when a record was
+ * written.
+ */
+export async function persistUsageBeforeTranscriptDeletion(
+  transcriptPath: string,
+): Promise<boolean> {
+  try {
+    const records = await jsonl.read<ChatRecord>(transcriptPath);
+    const summarized = summarizeTranscript(records);
+    if (!summarized?.record) return false;
+
+    const usagePath = getUsageHistoryPath();
+    try {
+      if (fs.existsSync(usagePath)) {
+        const existing = await jsonl.read<UsageSummaryRecord>(usagePath);
+        if (existing.some((r) => r?.sessionId === summarized.sessionId)) {
+          return false;
+        }
+      }
+    } catch (e) {
+      // Unreadable history: write anyway — the read side dedupes by
+      // sessionId (last-wins), so a duplicate is bounded and preferable to
+      // silently losing the session's usage.
+      debugLogger.debug(
+        `persistUsageBeforeTranscriptDeletion: cannot read history: ${e}`,
+      );
+    }
+    jsonl.writeLineSync(usagePath, summarized.record);
+    return true;
+  } catch (e) {
+    debugLogger.debug(`persistUsageBeforeTranscriptDeletion: ${e}`);
+    return false;
+  }
+}
+
 interface RebuildFromSessionJsonlOptions {
   /**
    * Session to exclude from the one-time persistence migration (the caller's
@@ -315,45 +407,12 @@ async function rebuildFromSessionJsonl(
         }
 
         const records = await jsonl.read<ChatRecord>(filePath);
-        if (records.length === 0) continue;
-
-        const firstRecord = records[0]!;
-        const sessionId = firstRecord.sessionId;
-        if (seenSessionIds.has(sessionId)) continue;
-        seenSessionIds.add(sessionId);
-        const project = firstRecord.cwd;
-
-        const telemetry = new UiTelemetryService();
-        let hasEvents = false;
-
-        for (const record of records) {
-          if (record.type === 'system' && record.subtype === 'ui_telemetry') {
-            const payload = record.systemPayload as
-              | { uiEvent?: UiEvent }
-              | undefined;
-            if (payload?.uiEvent) {
-              telemetry.addEvent(payload.uiEvent);
-              hasEvents = true;
-            }
-          }
-        }
-
-        if (!hasEvents) continue;
-
-        const startTime = new Date(firstRecord.timestamp).getTime();
-        const lastRecord = records[records.length - 1]!;
-        const endTime = new Date(lastRecord.timestamp).getTime();
-        if (isNaN(startTime) || isNaN(endTime) || !sessionId) continue;
-
-        results.push(
-          metricsToUsageRecord(
-            sessionId,
-            project,
-            startTime,
-            endTime,
-            telemetry.getMetrics(),
-          ),
-        );
+        const summarized = summarizeTranscript(records);
+        if (!summarized) continue;
+        if (seenSessionIds.has(summarized.sessionId)) continue;
+        seenSessionIds.add(summarized.sessionId);
+        if (!summarized.record) continue;
+        results.push(summarized.record);
       } catch (e) {
         debugLogger.debug(
           `rebuildFromSessionJsonl: failed to process ${file}: ${e}`,


### PR DESCRIPTION
## What this PR does

Adds a `persistUsageBeforeTranscriptDeletion()` salvage to `usageHistoryService` and calls it from `SessionService.removeSessionFiles()` (both the active and the archived branch) right before the transcript JSONL is unlinked. The salvage replays the transcript's `ui_telemetry` records through the same summarization the rebuild migration uses — the per-transcript logic is extracted into a shared `summarizeTranscript()` so the two paths cannot drift — writes the summary to `usage_record.jsonl`, skips the write when the history already carries a record for that session (a `/clear` or clean exit wrote the authoritative one; duplicating it would re-open #4994), and never throws, so deletion always proceeds even when salvage fails.

## Why it's needed

#7384: token usage per session is persisted to `usage_record.jsonl` only on `/clear` and on process exit; for every other session the usage history relies on a rebuild fallback that scans the session transcript JSONLs. `removeSessionFiles()` deleted those transcripts without persisting anything first — so deleting a session that was never `/clear`ed or cleanly exited (the reporter's screenshot case) permanently erased its token usage from the records, making the usage report inaccurate. The triage confirmed both usage systems from source (the global monthly `tokenUsageService` files are unaffected; the per-session `usageHistoryService` is the broken one) and proposed exactly this fix direction.

## Reviewer Test Plan

### How to verify

1. Run a session (without `/clear`), kill it uncleanly or just leave it, then delete it from the session list. Before this PR: its tokens vanish from the usage report (the rebuild has no transcript to read). After: the summary — models, token totals, tools, duration — survives in `usage_record.jsonl`.
2. Delete a session that WAS `/clear`ed: no duplicate record is added (the salvage detects the existing entry and skips).
3. `npx vitest run src/services/usageHistoryService.test.ts src/services/sessionService.test.ts` (packages/core): 150/150.

### Evidence (Before & After)

E2E against the **real compiled services** under a temp `QWEN_HOME`: plant a real transcript containing a `ui_telemetry` record (1000 total tokens), then call the real `SessionService.removeSession()`:

| | before fix | after fix |
| --- | --- | --- |
| session removed / transcript gone | ✅ / ✅ | ✅ / ✅ |
| usage record for the session | **absent — erased forever** ❌ | present, `totalTokens: 1000` ✅ |

![verification](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7384/verify-7384.png)

Unit coverage: the salvage writes the summary from real files, skips when the history already has the session, returns false (writing nothing) for telemetry-less transcripts, and never throws for missing files; the sessionService wiring test pins the salvage running **before** `unlinkSync` via invocation order and fails on the unpatched source (verified via `git stash`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; real compiled `SessionService`/`usageHistoryService` E2E under a temp `QWEN_HOME`, plus vitest unit tests. `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: session deletion now reads the transcript once more (a full JSONL read to replay telemetry) plus one read of `usage_record.jsonl` for the duplicate check — a per-deletion cost bounded by transcript size, on an interactive path where deletion already does multiple file operations. If the current in-progress session were ever deleted, its exit-time `persistSessionUsage` could still produce a duplicate — bounded by the read side's existing last-wins dedupe (`dedupBySessionId`, #4994).
- Not validated / out of scope: bulk cleanup paths that bypass `removeSessionFiles()` (e.g. a user manually deleting `~/.qwen/projects/**`) can still lose usage — out of scope, nothing in-process can salvage an external `rm`. The global monthly `tokenUsageService` files were never affected.
- Breaking changes / migration notes: none — the salvage is additive and silent.

## Linked Issues

Fixes #7384

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`usageHistoryService` 新增 `persistUsageBeforeTranscriptDeletion()`，并在 `SessionService.removeSessionFiles()`（active 与 archived 两个分支）删除 transcript JSONL 前调用。salvage 用与重建迁移相同的汇总逻辑重放 transcript 的 `ui_telemetry` 记录——共用抽取的 `summarizeTranscript()`，两条路径不会漂移——把摘要写入 `usage_record.jsonl`；历史中已有该会话记录时跳过（/clear 或正常退出已写权威记录，重复会重开 #4994）；永不抛错，salvage 失败也不阻塞删除。

## 为什么需要

#7384：会话用量只在 `/clear` 与进程退出时持久化，其余会话依赖「扫描 transcript 重建」的回退。`removeSessionFiles()` 删 transcript 前不持久化任何东西——删除一个从未 `/clear` 或非正常退出的会话（报告者截图场景）会把它的 token 用量从记录中永久抹掉。triage 已从源码确认两套用量系统（全局月度 `tokenUsageService` 不受影响；受影响的是按会话的 `usageHistoryService`）并给出了正是本 PR 的修复方向。

## 审阅测试计划

### 如何验证

1. 跑一个会话（不 /clear）、直接删除：本 PR 之前其 token 从用量报表消失；之后摘要（模型、token 总量、工具、时长）保留在 `usage_record.jsonl`；
2. 删除一个已 `/clear` 的会话：不产生重复记录（salvage 检测到已有条目并跳过）；
3. 两个测试文件 150/150。

### 证据（Before & After）

对**真实编译产物**的 E2E（临时 QWEN_HOME 下种入含 1000 tokens 遥测的真实 transcript，再调真实 `removeSession()`）：修复前会话删除、transcript 消失、用量记录**永久缺失**；修复后用量记录存活且 `totalTokens: 1000`。单测覆盖：真实文件写入、已持久化跳过、无遥测不写、缺文件不抛；接线测试用调用顺序钉死「salvage 在 unlink 之前」，在未修复源码上失败（git stash 验证）。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；临时 QWEN_HOME 下的真实编译类 E2E + vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：删除路径多一次 transcript 全量读取（重放遥测）+ 一次 `usage_record.jsonl` 读取（查重）——按 transcript 大小有界，且删除本就是多文件操作的交互路径。若删除的是进行中的当前会话，退出时的 `persistSessionUsage` 仍可能产生一条重复——由读侧既有的 last-wins 去重（`dedupBySessionId`，#4994）兜底。
- 未验证/超出范围：绕过 `removeSessionFiles()` 的清理（如用户手动 `rm ~/.qwen/projects/**`）仍会丢用量——进程内无法挽救外部删除，超出范围。全局月度 `tokenUsageService` 文件从未受影响。
- 破坏性变更/迁移说明：无——salvage 为静默附加行为。

## 关联 Issue

Fixes #7384

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
