### PR TITLE
fix(ci): serialise the two workflows that push to a PR head branch

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2073,8 +2073,26 @@ jobs:
       max-parallel: 3
       matrix:
         target: '${{ fromJSON(needs.review-scan.outputs.targets) }}'
+    # Serialises every writer of THIS PR's head branch, across workflows.
+    # GitHub concurrency groups are repository-scoped, so sharing one name with
+    # qwen-code-pr-review.yml's resolve-pr job is what makes the two mutually
+    # exclusive — a per-workflow name only guards against itself.
+    # Without this, a `@qwen-code /resolve` and this job's own conflict path
+    # both merge the base branch and both push. Observed on #7355: /resolve
+    # pushed at 03:51, this job pushed at 04:05 and was rejected `fetch first`,
+    # discarding a full agent run and leaving no marker to show for it.
+    # Serialising is strictly better than racing: this job fetches the head by
+    # NAME at job start, so the second run reads the winner's result instead of
+    # a stale base — its work is usable and its push lands, rather than being
+    # rejected and thrown away. It may still spend an agent run: the
+    # address-time recheck re-verifies lifecycle and consent (state, labels,
+    # author, base, head branch) but not whether the conflict is still there.
+    # The prefix is a LITERAL on both sides: job-level `concurrency` cannot read
+    # the `env` context, so the two files cannot share a constant. A test pins
+    # them equal instead, because a rename in one file alone silently unlocks
+    # the race again with nothing failing.
     concurrency:
-      group: 'qwen-autofix-review-${{ matrix.target.pr }}'
+      group: 'qwen-pr-head-write-${{ matrix.target.pr }}'
       cancel-in-progress: false
     env:
       REPO: '${{ github.repository }}'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -932,8 +932,15 @@ jobs:
     # ephemeral, which suits the sandboxed conflict-resolution job.
     runs-on: 'ubuntu-latest'
     timeout-minutes: 120
+    # Shared with qwen-autofix.yml's review-address job — see the rationale
+    # there. GitHub concurrency groups are repository-scoped, so the identical
+    # prefix is what serialises the two workflows against each other; both
+    # merge the base branch and push to this PR's head, and racing them costs a
+    # whole agent run on the loser (observed on #7355). The prefix must stay
+    # byte-identical in both files; a test pins that, because renaming one side
+    # alone re-opens the race with nothing failing.
     concurrency:
-      group: 'qwen-resolve-${{ github.event.issue.number || github.event.inputs.pr_number }}'
+      group: 'qwen-pr-head-write-${{ github.event.issue.number || github.event.inputs.pr_number }}'
       cancel-in-progress: false
     # Least-privilege: every write in this job (push, PR comments, the
     # acknowledge reaction) uses an explicit PAT, so the implicit GITHUB_TOKEN

--- a/scripts/tests/qwen-resolve-workflow.test.js
+++ b/scripts/tests/qwen-resolve-workflow.test.js
@@ -113,6 +113,47 @@ describe('qwen resolve workflow', () => {
     'utf8',
   );
 
+  it('serialises /resolve against the autofix conflict path on the same PR head', () => {
+    // Both jobs merge the base branch and push to the PR's head. They live in
+    // different workflows, so a per-workflow concurrency name guards each only
+    // against itself. Observed on #7355: /resolve pushed at 03:51, the autofix
+    // leg pushed at 04:05 and was rejected `fetch first`, throwing away a full
+    // agent run. GitHub concurrency groups are repository-scoped, so an
+    // IDENTICAL prefix in both files is what makes them mutually exclusive.
+    const autofix = readFileSync(
+      path.join(repoRoot, '.github/workflows/qwen-autofix.yml'),
+      'utf8',
+    );
+    const groupOf = (text, jobName) =>
+      job(text, jobName).match(
+        /\n {4}concurrency:\n {6}group: '([a-z-]+?)-\$\{\{/,
+      )?.[1];
+
+    const resolveLock = groupOf(workflow, 'resolve-pr');
+    const autofixLock = groupOf(autofix, 'review-address');
+    expect(resolveLock).toBeTruthy();
+    // The invariant: renaming one side alone silently re-opens the race, and
+    // nothing else in the suite would notice.
+    expect(autofixLock).toBe(resolveLock);
+
+    // Each side must still key the group on the PR number — a shared prefix
+    // with a per-run suffix would serialise nothing.
+    expect(job(workflow, 'resolve-pr')).toContain(
+      `group: '${resolveLock}-\${{ github.event.issue.number || github.event.inputs.pr_number }}'`,
+    );
+    expect(job(autofix, 'review-address')).toContain(
+      `group: '${autofixLock}-\${{ matrix.target.pr }}'`,
+    );
+    // Queue, never cancel: the loser of the race must run after the winner and
+    // re-check, not be discarded (or discard the winner's in-flight work).
+    for (const [text, name] of [
+      [workflow, 'resolve-pr'],
+      [autofix, 'review-address'],
+    ]) {
+      expect(job(text, name)).toContain('cancel-in-progress: false');
+    }
+  });
+
   it('uses the existing PR command workflow', () => {
     expect(
       existsSync(


### PR DESCRIPTION
## What this PR does

Makes the two workflows that push to a PR's head branch take turns instead of racing.

## Why it's needed

Two independent jobs resolve conflicts on the same branch:

| job | workflow | concurrency group (before) |
| --- | --- | --- |
| `review-address` (autofix's `conflict=true` path) | `qwen-autofix.yml` | `qwen-autofix-review-<pr>` |
| `resolve-pr` (`@qwen-code /resolve`) | `qwen-code-pr-review.yml` | `qwen-resolve-<pr>` |

Both merge the base branch and push. Different group names means **neither guards against the other** — each only serialises against itself.

Observed on **#7355**:

```
03:43  autofix scan selects #7355 (conflict=true) -> review-address starts
03:47  @qwen-code /resolve issued on the same PR
03:51  /resolve pushes 84fbb3d13                              ← winner
04:05  review-address pushes -> ! [rejected] (fetch first)    ← loser
```

The loser had already spent its agent run. Its job died in `Push and report`, so it wrote **no eval marker** — the round is simply gone, and from outside the PR just looks idle. This is the same failure I had previously mis-filed as a generic "push race"; #7262's was a merge race, but this one is two owners with no lock.

## How

GitHub concurrency groups are **repository-scoped**, not workflow-scoped, so two jobs in different workflows sharing a group name do serialise. Both now use `qwen-pr-head-write-<pr>`, keeping `cancel-in-progress: false` so the loser **queues** rather than being discarded.

`issue-autofix` is deliberately left out: it pushes a branch it created for a new PR, so it has no contender.

The prefix is a literal in both files because **job-level `concurrency` cannot read the `env` context**, so the two cannot share a constant. A test pins them equal instead — renaming one side alone would re-open the race with nothing failing.

## What this does and does not buy

`review-address` fetches the head **by name** at job start (`git fetch … refs/heads/${BRANCH}` → `git checkout -B "${BRANCH}" FETCH_HEAD`), so the second run reads the winner's result rather than a stale base: its work is usable and its push lands.

It may still spend an agent run. The address-time recheck re-verifies lifecycle and consent (state, labels, author, base, head branch) but **not** whether the conflict is still there, so the loser does the work and finds little to do rather than discarding for free. Making the recheck re-test the trigger condition is the natural follow-up and is deliberately not in this PR.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-resolve-workflow.test.js` — 26/26. The new test reads **both** workflow files, extracts each job's group prefix by regex, and asserts they are equal, that each still keys on the PR number, and that both queue rather than cancel.
2. Mutation-verified, three reverts each turning it red:

   | mutation | result |
   | --- | --- |
   | rename the autofix side back to `qwen-autofix-review-` | `expected 'qwen-autofix-review' to be 'qwen-pr-head-write'` |
   | keep the prefix but key on `github.run_id` (shared name, serialises nothing) | red |
   | flip `resolve-pr` to `cancel-in-progress: true` | red |

3. Static, run locally with the exact CI toolchain: both files parse under `js-yaml`; all 37 + 17 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean on both; the added lines are prettier-clean.
4. Post-merge smoke: issue `@qwen-code /resolve` on a PR while an autofix `review-address` leg is running for it — the resolve job should sit **queued** and start only after the leg finishes.

### Evidence (Before & After)

```
BEFORE  group: qwen-autofix-review-7355   |  group: qwen-resolve-7355
        two groups -> both run -> both push -> loser rejected,
        agent run discarded, no marker written

AFTER   group: qwen-pr-head-write-7355    |  group: qwen-pr-head-write-7355
        one group -> second queues -> starts on the winner's head -> push lands
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: a maintainer's `/resolve` can now sit queued behind a `review-address` leg for that PR, whose timeout cap is 120 minutes. That is the intended semantics — the alternative is the current wasted run — but it is a real latency change, and GitHub shows nothing to the commenter while a job is pending. If that proves annoying, the follow-up above (cheap early discard) reduces how long the lock is held rather than removing it.
- Only one queued run is kept per group: a second `/resolve` arriving while one is pending cancels the pending one, which is latest-intent and correct here.
- Pre-existing and unrelated: running `qwen-resolve-workflow`, `qwen-autofix-workflow` and `qwen-pr-review-workflow` together reliably fails `eligibility recheck` and `takeover-command toggle` — a load flake. A/B on this machine: **unmodified `main` fails the same two, twice, in the same combined run**, and both pass in isolation. Not introduced here.
- Not validated / out of scope: no attempt to detect a race that spans repositories (fork head pushes) beyond what the shared group already covers, since both jobs key on the PR number.
- Breaking changes / migration notes: none.

## Linked Issues

Found while analysing the takeover fleet's operating state — #7355's round-6 work had vanished with no marker. Part of the autofix-reliability line: #7330, #7350, #7351, #7354, #7355, #7358, #7364.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让两个会向 PR head 分支推送的 workflow 排队,而不是互相竞争。

## 为什么需要

有两个互不相识的作业在解同一个分支的冲突:

| 作业 | workflow | 原 concurrency 组 |
| --- | --- | --- |
| `review-address`(autofix 的 `conflict=true` 路径) | `qwen-autofix.yml` | `qwen-autofix-review-<pr>` |
| `resolve-pr`(`@qwen-code /resolve`) | `qwen-code-pr-review.yml` | `qwen-resolve-<pr>` |

两者都会合并 base 分支并推送。组名不同,意味着**谁也拦不住谁** —— 各自只与自己互斥。

在 **#7355** 上实测到(见上方英文时间线):03:43 扫描选中 → 03:47 有人发 `/resolve` → 03:51 `/resolve` 推送成功 → 04:05 autofix 推送被 `fetch first` 拒绝。

输的一方**已经把 agent 运行花掉了**。它的 job 死在 `Push and report`,因此**没有写下任何 eval 标记** —— 这一轮就这么消失了,从 PR 外面看只是"没动静"。这也是我此前笼统归类为"推送竞态"的两例中真正的那一类;#7262 是合并竞态,而这一例是两个主人、没有锁。

## 怎么做

GitHub 的 concurrency 组是**仓库级**而非 workflow 级,因此不同 workflow 的两个作业只要组名相同就会串行。两者现在统一使用 `qwen-pr-head-write-<pr>`,并保持 `cancel-in-progress: false`,让输的一方**排队**而不是被丢弃。

`issue-autofix` 刻意不纳入:它推送的是自己为新 PR 创建的分支,不存在竞争者。

前缀在两个文件里都是字面量,因为 **job 级 `concurrency` 读不到 `env` 上下文**,两边无法共享常量。改由测试钉住两者相等 —— 只改一边会让竞态悄悄复活且无人报警。

## 它买到了什么、没买到什么

`review-address` 在作业开始时**按分支名**拉取 head(`git fetch … refs/heads/${BRANCH}` → `git checkout -B`),因此第二个运行读到的是赢家的结果而非陈旧的 base:它的工作可用,推送也能落地。

但它仍可能花掉一次 agent 运行。address 阶段的复核只重验生命周期与授权(state、labels、author、base、head 分支),**不**重验冲突是否还在,所以输的一方会照常干活、然后发现没什么可做,而不是免费丢弃。让复核重验触发条件是自然的后续,刻意不放进本 PR。

## 评审验证

1. `npx vitest run scripts/tests/qwen-resolve-workflow.test.js` —— 26/26。新测试同时读取**两个** workflow 文件,用正则提取各自作业的组前缀并断言相等,同时断言两边仍以 PR 号为 key、且都是排队而非取消。
2. 变异验证,三处回退各自令其变红(见上方英文表格:把 autofix 一侧改回旧名 / 前缀相同但改用 `github.run_id` 作 key / 把 `resolve-pr` 改成 `cancel-in-progress: true`)。
3. 静态(均用 CI 一致工具):两个文件均可被 `js-yaml` 解析;37 + 17 个 `run:` 块全过 `bash -n`;actionlint 1.7.12 对两者均 clean;新增行本身符合 prettier。
4. 合并后冒烟:在某 PR 的 `review-address` 腿正在运行时对它发 `@qwen-code /resolve`,该 resolve 作业应处于 **queued**,待那条腿结束后才启动。

## 风险与范围

- 主要权衡:维护者的 `/resolve` 现在可能排在该 PR 的 `review-address` 腿之后,后者超时上限为 120 分钟。这正是预期语义 —— 替代方案是现在这种白跑一轮 —— 但它确实改变了延迟,且作业处于 pending 时 GitHub 不会给评论者任何提示。若实际体验不佳,上文的后续(让复核提前廉价丢弃)可缩短持锁时间,而非移除锁。
- 每个组只保留一个排队中的运行:在已有一个 pending 时再发一次 `/resolve` 会取消前一个 pending,这里属于"最新意图优先",是正确的。
- 既有且无关:把 `qwen-resolve-workflow`、`qwen-autofix-workflow`、`qwen-pr-review-workflow` 三个套件一起跑时,`eligibility recheck` 与 `takeover-command toggle` 会稳定变红 —— 这是负载 flake。本机 A/B:**未修改的 `main` 在同样的组合运行下同样红这两个,两次皆然**,而单独跑均通过。并非本 PR 引入。
- 不在范围内:未额外处理跨仓库(fork head 推送)层面的竞态,超出共享组已覆盖的范围;两个作业都以 PR 号为 key。
- 破坏性变更:无。

## 关联 Issue

在盘点接管机群运行状况时发现 —— #7355 的第 6 轮工作连标记都没留下就消失了。属 autofix 可靠性主线:#7330、#7350、#7351、#7354、#7355、#7358、#7364。

</details>
