### PR TITLE
feat(core): add memory recall delivery telemetry

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -5303,6 +5303,123 @@ hello
       expect(discardCalls).toHaveLength(0);
     });
 
+    it('should discard prefetch when ModelFallback resets hasToolCalls', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      // ToolCallRequest sets hasToolCalls, then ModelFallback resets it →
+      // end-of-turn sees no tool calls and discards the prefetch.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-1',
+              name: 'foo',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+          yield {
+            type: 'model_fallback',
+            fromModel: 'test-model',
+            toModel: 'fallback-model',
+            fallbackIndex: 1,
+          };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'model fallback resets tool calls' }],
+        new AbortController().signal,
+        'prompt-id-model-fallback-reset',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'no_safe_delivery_point',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+      expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
+    it('should preserve prefetch when ToolCallRequest follows ModelFallback', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      // ToolCallRequest → ModelFallback (resets) → ToolCallRequest (re-sets) →
+      // end-of-turn sees hasToolCalls=true and preserves the prefetch.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-1',
+              name: 'foo',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+          yield {
+            type: 'model_fallback',
+            fromModel: 'test-model',
+            toModel: 'fallback-model',
+            fallbackIndex: 1,
+          };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-2',
+              name: 'bar',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'model fallback then tool call' }],
+        new AbortController().signal,
+        'prompt-id-model-fallback-then-tool',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(client['pendingMemoryPrefetch']).toBeDefined();
+      const discardCalls = vi
+        .mocked(logMemoryRecallDelivery)
+        .mock.calls.filter(
+          ([, event]) => event.discard_reason === 'no_safe_delivery_point',
+        );
+      expect(discardCalls).toHaveLength(0);
+    });
+
     it('should log abort discard telemetry when arena cancels with a pending prefetch', async () => {
       mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4709,7 +4709,7 @@ hello
       );
       const [, deliveryEvent] = vi.mocked(logMemoryRecallDelivery).mock
         .calls[0];
-      expect(deliveryEvent.discard_reason).toBeUndefined();
+      expect(deliveryEvent.discard_reason).toBe('no_relevant_results');
     });
 
     it('should inject auto-memory on first ToolResult when recall settles after UserQuery', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -5004,6 +5004,128 @@ hello
       );
     });
 
+    it('should log discard telemetry when pending auto-memory is shut down', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getHistoryLength: vi.fn().mockReturnValue(0),
+      } as unknown as GeminiChat;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'first' }],
+        new AbortController().signal,
+        'prompt-id-shutdown-telemetry',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      client.requestShutdown();
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'shutdown',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+    });
+
+    it('should log abort discard telemetry when caller signal is already aborted', async () => {
+      mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {
+        expect(opts.abortSignal?.aborted).toBe(true);
+        return new Promise(() => {});
+      });
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      const callerController = new AbortController();
+      callerController.abort();
+      const stream = client.sendMessageStream(
+        [{ text: 'already aborted' }],
+        callerController.signal,
+        'prompt-id-pre-aborted',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'abort',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+    });
+
+    it('should log only one terminal event for the same prefetch handle', () => {
+      const result = {
+        prompt: '## Relevant memory\n\nOne-shot.',
+        selectedDocs: [],
+        strategy: 'model' as const,
+      };
+      const handle = {
+        promise: Promise.resolve(result),
+        settledAt: Date.now(),
+        result,
+        consumed: false,
+        terminalLogged: false,
+        firedAt: Date.now(),
+        controller: new AbortController(),
+      };
+      const privateClient = client as unknown as {
+        logMemoryPrefetchDelivery: (
+          memoryHandle: typeof handle,
+          deliveryPoint: 'initial' | 'tool_result' | 'discarded',
+          recallResult: typeof result,
+          discardReason?: 'reset',
+        ) => void;
+      };
+
+      privateClient.logMemoryPrefetchDelivery(handle, 'initial', result);
+      privateClient.logMemoryPrefetchDelivery(
+        handle,
+        'discarded',
+        result,
+        'reset',
+      );
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledTimes(1);
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          delivery_point: 'initial',
+          strategy: 'model',
+        }),
+      );
+    });
+
     it('should abort the pending prefetch when LoopDetected fires mid-stream', async () => {
       let abortHandlerInvoked = false;
       mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -51,6 +51,7 @@ import {
   type ServerGeminiStreamEvent,
 } from './turn.js';
 import { LoopType } from '../telemetry/types.js';
+import { logMemoryRecallDelivery } from '../telemetry/index.js';
 
 type MockSessionStartProfiler = {
   time: Mock;
@@ -318,6 +319,7 @@ const mockUiTelemetryService = vi.hoisted(() => ({
   resetSession: vi.fn(),
   addEvent: vi.fn(),
 }));
+const mockLogMemoryRecallDelivery = vi.hoisted(() => vi.fn());
 vi.mock('../telemetry/tracer.js', () => ({
   API_CALL_ABORTED_SPAN_STATUS_MESSAGE: 'API call aborted',
   API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
@@ -328,6 +330,7 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
   return {
     ...actual,
     uiTelemetryService: mockUiTelemetryService,
+    logMemoryRecallDelivery: mockLogMemoryRecallDelivery,
     // We keep the real implementations of logChatCompression, etc.
     // but we can spy on QwenLogger if needed
   };
@@ -4610,13 +4613,121 @@ hello
       );
     });
 
+    it('should log initial delivery when auto-memory is injected on UserQuery', async () => {
+      mockMemoryManager.recall.mockResolvedValue({
+        prompt: '## Relevant memory\n\nInitial memory result.',
+        selectedDocs: [
+          {
+            type: 'user',
+            filePath: '/test/project/root/.qwen/memory/user.md',
+            relativePath: 'user.md',
+            filename: 'user.md',
+            title: 'User Memory',
+            description: 'User preferences',
+            body: '- User prefers terse responses.',
+            mtimeMs: 1,
+          },
+        ],
+        strategy: 'model',
+      });
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Quick question' }],
+        new AbortController().signal,
+        'prompt-id-initial-memory-delivery',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'initial',
+          strategy: 'model',
+          docs_selected: 1,
+          latency_ms: expect.any(Number),
+        }),
+      );
+    });
+
+    it('should log discard telemetry when auto-memory selects no docs', async () => {
+      mockMemoryManager.recall.mockResolvedValue({
+        prompt: '',
+        selectedDocs: [],
+        strategy: 'none',
+      });
+
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Quick question' }],
+        new AbortController().signal,
+        'prompt-id-empty-memory-discard',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'test-model',
+        expect.not.arrayContaining([
+          expect.stringContaining('Relevant memory'),
+        ]),
+        expect.any(AbortSignal),
+      );
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+      const [, deliveryEvent] = vi.mocked(logMemoryRecallDelivery).mock
+        .calls[0];
+      expect(deliveryEvent.discard_reason).toBeUndefined();
+    });
+
     it('should inject auto-memory on first ToolResult when recall settles after UserQuery', async () => {
       // Controllable promise — recall stays pending across the UserQuery turn
       // and only settles before the ToolResult turn runs.
       let resolveRecall:
         | ((value: {
             prompt: string;
-            selectedDocs: never[];
+            selectedDocs: Array<{
+              type: 'user';
+              filePath: string;
+              relativePath: string;
+              filename: string;
+              title: string;
+              description: string;
+              body: string;
+              mtimeMs: number;
+            }>;
             strategy: 'model';
           }) => void)
         | undefined;
@@ -4659,7 +4770,18 @@ hello
       // Recall settles between turns
       resolveRecall!({
         prompt: '## Relevant memory\n\nDeferred memory result.',
-        selectedDocs: [],
+        selectedDocs: [
+          {
+            type: 'user',
+            filePath: '/test/project/root/.qwen/memory/user.md',
+            relativePath: 'user.md',
+            filename: 'user.md',
+            title: 'User Memory',
+            description: 'User preferences',
+            body: '- User prefers terse responses.',
+            mtimeMs: 1,
+          },
+        ],
         strategy: 'model',
       });
       // Drain microtasks so the settledAt finally() callback runs
@@ -4694,6 +4816,16 @@ hello
       );
       expect(functionResponseIdx).toBeGreaterThanOrEqual(0);
       expect(memoryIdx).toBeGreaterThan(functionResponseIdx);
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'tool_result',
+          strategy: 'model',
+          docs_selected: 1,
+          latency_ms: expect.any(Number),
+        }),
+      );
     });
 
     it('should abort the pending prefetch when the caller signal aborts', async () => {
@@ -4783,6 +4915,17 @@ hello
       expect(abortSignals.length).toBe(2);
       expect(abortSignals[0].aborted).toBe(true);
       expect(abortSignals[1].aborted).toBe(false);
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'new_query',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
     });
 
     it('should abort the pending prefetch on resetChat', async () => {
@@ -4820,6 +4963,45 @@ hello
       await client.resetChat();
       expect(abortHandlerInvoked).toBe(true);
       expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
+    it('should log discard telemetry when pending auto-memory is reset', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        getHistoryLength: vi.fn().mockReturnValue(0),
+      } as unknown as GeminiChat;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'first' }],
+        new AbortController().signal,
+        'prompt-id-reset-telemetry',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      await client.resetChat();
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'reset',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
     });
 
     it('should abort the pending prefetch when LoopDetected fires mid-stream', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4737,8 +4737,20 @@ hello
         }),
       );
 
+      // The model requests a tool call so pendingToolCalls is non-empty and
+      // the prefetch is preserved for the subsequent ToolResult turn.
       const mockStream = (async function* () {
         yield { type: 'content', value: 'Hello' };
+        yield {
+          type: 'tool_call_request',
+          value: {
+            callId: 'call-1',
+            name: 'foo',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-user-query',
+          },
+        };
       })();
       mockTurnRunFn.mockReturnValue(mockStream);
 
@@ -4828,6 +4840,46 @@ hello
       );
     });
 
+    it('should discard pending prefetch with no_safe_delivery_point on a no-tool turn', async () => {
+      // Recall stays pending — never settles before the turn completes.
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      // Model responds without tool calls → pendingToolCalls is empty.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })(),
+      );
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'no tool calls here' }],
+        new AbortController().signal,
+        'prompt-id-no-tool-turn',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'no_safe_delivery_point',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+      expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
     it('should abort the pending prefetch when the caller signal aborts', async () => {
       let abortHandlerInvoked = false;
       mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {
@@ -4845,6 +4897,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
 
@@ -4880,6 +4942,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
 
@@ -4900,6 +4972,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello again' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
       const stream2 = client.sendMessageStream(
@@ -4946,6 +5028,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
 
@@ -4976,6 +5068,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
 
@@ -5015,6 +5117,16 @@ hello
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-keep-alive',
+              name: 'noop',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
         })(),
       );
 
@@ -5355,6 +5467,16 @@ hello
         () =>
           (async function* () {
             yield { type: 'content', value: 'reply' };
+            yield {
+              type: 'tool_call_request',
+              value: {
+                callId: 'call-keep-alive',
+                name: 'noop',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: 'test',
+              },
+            };
           })() as unknown as AsyncGenerator<ServerGeminiStreamEvent>,
       );
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -5196,6 +5196,192 @@ hello
       );
     });
 
+    it('should discard prefetch when Retry resets hasToolCalls', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      // ToolCallRequest sets hasToolCalls, then Retry resets it → end-of-turn
+      // sees no tool calls and discards the prefetch.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-1',
+              name: 'foo',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+          yield { type: 'retry' };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'retry resets tool calls' }],
+        new AbortController().signal,
+        'prompt-id-retry-reset',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'no_safe_delivery_point',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+      expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
+    it('should preserve prefetch when ToolCallRequest follows Retry', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      // ToolCallRequest → Retry (resets) → ToolCallRequest (re-sets) →
+      // end-of-turn sees hasToolCalls=true and preserves the prefetch.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-1',
+              name: 'foo',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+          yield { type: 'retry' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-2',
+              name: 'bar',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'retry then tool call' }],
+        new AbortController().signal,
+        'prompt-id-retry-then-tool',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      expect(client['pendingMemoryPrefetch']).toBeDefined();
+      const discardCalls = vi
+        .mocked(logMemoryRecallDelivery)
+        .mock.calls.filter(
+          ([, event]) => event.discard_reason === 'no_safe_delivery_point',
+        );
+      expect(discardCalls).toHaveLength(0);
+    });
+
+    it('should log abort discard telemetry when arena cancels with a pending prefetch', async () => {
+      mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
+
+      const mockArenaAgentClient = {
+        checkControlSignal: vi
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({ type: 'cancel', reason: 'stop' }),
+        reportCancelled: vi.fn().mockResolvedValue(undefined),
+        reportCompleted: vi.fn().mockResolvedValue(undefined),
+        reportError: vi.fn().mockResolvedValue(undefined),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(mockConfig.getArenaAgentClient).mockReturnValue(
+        mockArenaAgentClient as unknown as ReturnType<
+          Config['getArenaAgentClient']
+        >,
+      );
+
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      } as unknown as GeminiChat;
+
+      // Turn 1: prefetch fires, tool call preserves it past end-of-turn.
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: 'content', value: 'Hello' };
+          yield {
+            type: 'tool_call_request',
+            value: {
+              callId: 'call-1',
+              name: 'foo',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'test',
+            },
+          };
+        })(),
+      );
+
+      const stream1 = client.sendMessageStream(
+        [{ text: 'first turn' }],
+        new AbortController().signal,
+        'prompt-id-arena-prefetch-1',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream1) {
+        // consume
+      }
+
+      expect(client['pendingMemoryPrefetch']).toBeDefined();
+
+      // Turn 2: arena control signal cancels before the turn runs.
+      const stream2 = client.sendMessageStream(
+        [{ text: 'tool result' }],
+        new AbortController().signal,
+        'prompt-id-arena-prefetch-2',
+        { type: SendMessageType.ToolResult },
+      );
+      for await (const _ of stream2) {
+        // consume
+      }
+
+      expect(mockArenaAgentClient.reportCancelled).toHaveBeenCalled();
+      expect(logMemoryRecallDelivery).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'abort',
+          strategy: 'none',
+          docs_selected: 0,
+          latency_ms: expect.any(Number),
+        }),
+      );
+      expect(client['pendingMemoryPrefetch']).toBeUndefined();
+    });
+
     it('should log only one terminal event for the same prefetch handle', () => {
       const result = {
         prompt: '## Relevant memory\n\nOne-shot.',

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -715,7 +715,7 @@ export class GeminiClient {
   }
 
   private cancelPendingMemoryPrefetch(
-    discardReason: MemoryRecallDiscardReason = 'superseded',
+    discardReason: MemoryRecallDiscardReason,
   ): void {
     const handle = this.pendingMemoryPrefetch;
     if (!handle) return;
@@ -751,7 +751,12 @@ export class GeminiClient {
       }
       this.logMemoryPrefetchDelivery(handle, deliveryPoint, result);
     } else {
-      this.logMemoryPrefetchDelivery(handle, 'discarded', result);
+      this.logMemoryPrefetchDelivery(
+        handle,
+        'discarded',
+        result,
+        'no_relevant_results',
+      );
     }
     return result;
   }
@@ -2553,6 +2558,11 @@ export class GeminiClient {
         for await (const event of resultStream) {
           if (event.type === GeminiEventType.ToolCallRequest) {
             hasToolCalls = true;
+          } else if (
+            event.type === GeminiEventType.Retry ||
+            event.type === GeminiEventType.ModelFallback
+          ) {
+            hasToolCalls = false;
           }
           if (messageDisplay && event.type === GeminiEventType.Content) {
             messageDisplay.addChunk(event.value);

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2548,8 +2548,12 @@ export class GeminiClient {
 
       const resultStream = turn.run(model, requestToSend, signal);
       let didUpdateIdeContextState = false;
+      let hasToolCalls = false;
       try {
         for await (const event of resultStream) {
+          if (event.type === GeminiEventType.ToolCallRequest) {
+            hasToolCalls = true;
+          }
           if (messageDisplay && event.type === GeminiEventType.Content) {
             messageDisplay.addChunk(event.value);
           }
@@ -3068,9 +3072,14 @@ export class GeminiClient {
       if (isTopLevelInteraction) {
         endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
       }
-      // Reached the bottom of the try — this turn ended cleanly. Preserve
-      // any still-pending memory prefetch so the next ToolResult turn can
-      // consume it (the whole point of the fire-and-forget design).
+      // Reached the bottom of the try — this turn ended cleanly. If the
+      // model did not request tool calls, no future ToolResult will arrive
+      // to consume the prefetch, so close it out now. When tool calls ARE
+      // pending, preserve the handle so the next ToolResult turn can
+      // consume it (the fire-and-forget design).
+      if (!hasToolCalls) {
+        this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
+      }
       normalCompletion = true;
       return turn;
     } finally {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -79,11 +79,17 @@ import { ToolNames } from '../tools/tool-names.js';
 import {
   NextSpeakerCheckEvent,
   logNextSpeakerCheck,
+  logMemoryRecallDelivery,
   startInteractionSpan,
   endInteractionSpan,
   getActiveInteractionSpan,
   addUserPromptAttributes,
+  MemoryRecallDeliveryEvent,
 } from '../telemetry/index.js';
+import type {
+  MemoryRecallDeliveryPoint,
+  MemoryRecallDiscardReason,
+} from '../telemetry/types.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 
 // Forked agent cache
@@ -218,8 +224,13 @@ type MemoryPrefetchHandle = {
   promise: Promise<RelevantAutoMemoryPromptResult>;
   /** Set by promise.finally(). null until the promise settles. */
   settledAt: number | null;
+  /** Set when the promise resolves, even if the consume point never runs. */
+  result: RelevantAutoMemoryPromptResult | null;
   /** True after memory has been injected — prevents double-inject. */
   consumed: boolean;
+  /** True after delivery/discard telemetry has recorded the terminal outcome. */
+  terminalLogged: boolean;
+  firedAt: number;
   controller: AbortController;
 };
 
@@ -657,6 +668,7 @@ export class GeminiClient {
    */
   requestShutdown(): void {
     this.shutdownRequested = true;
+    this.cancelPendingMemoryPrefetch('shutdown');
   }
 
   /**
@@ -669,12 +681,48 @@ export class GeminiClient {
    * hadn't run yet), the settled result is discarded — logged at debug so
    * operators can diagnose missing-memory scenarios.
    */
-  private cancelPendingMemoryPrefetch(): void {
+  private logMemoryPrefetchDelivery(
+    handle: MemoryPrefetchHandle,
+    deliveryPoint: MemoryRecallDeliveryPoint,
+    result: RelevantAutoMemoryPromptResult,
+    discardReason?: MemoryRecallDiscardReason,
+  ): void {
+    if (handle.terminalLogged) return;
+    handle.terminalLogged = true;
+    logMemoryRecallDelivery(
+      this.config,
+      new MemoryRecallDeliveryEvent({
+        phase: 'refined',
+        delivery_point: deliveryPoint,
+        discard_reason: discardReason,
+        strategy: result.strategy,
+        docs_selected: result.selectedDocs.length,
+        latency_ms: Date.now() - handle.firedAt,
+      }),
+    );
+  }
+
+  private logMemoryPrefetchDiscard(
+    handle: MemoryPrefetchHandle,
+    discardReason: MemoryRecallDiscardReason,
+  ): void {
+    this.logMemoryPrefetchDelivery(
+      handle,
+      'discarded',
+      handle.result ?? EMPTY_RELEVANT_AUTO_MEMORY_RESULT,
+      discardReason,
+    );
+  }
+
+  private cancelPendingMemoryPrefetch(
+    discardReason: MemoryRecallDiscardReason = 'superseded',
+  ): void {
     const handle = this.pendingMemoryPrefetch;
     if (!handle) return;
     if (handle.settledAt !== null && !handle.consumed) {
       debugLogger.debug('Discarding settled but unconsumed memory prefetch.');
     }
+    this.logMemoryPrefetchDiscard(handle, discardReason);
     handle.controller.abort();
     this.pendingMemoryPrefetch = undefined;
   }
@@ -687,7 +735,9 @@ export class GeminiClient {
    * Centralises the consume-and-mark dance so the UserQuery and ToolResult
    * inject sites can't drift on the guard logic.
    */
-  private async tryConsumeMemoryPrefetch(): Promise<RelevantAutoMemoryPromptResult | null> {
+  private async tryConsumeMemoryPrefetch(
+    deliveryPoint: Exclude<MemoryRecallDeliveryPoint, 'discarded'>,
+  ): Promise<RelevantAutoMemoryPromptResult | null> {
     const handle = this.pendingMemoryPrefetch;
     if (!handle || handle.settledAt === null || handle.consumed) {
       return null;
@@ -699,6 +749,9 @@ export class GeminiClient {
       for (const doc of result.selectedDocs) {
         this.surfacedRelevantAutoMemoryPaths.add(doc.filePath);
       }
+      this.logMemoryPrefetchDelivery(handle, deliveryPoint, result);
+    } else {
+      this.logMemoryPrefetchDelivery(handle, 'discarded', result);
     }
     return result;
   }
@@ -732,7 +785,7 @@ export class GeminiClient {
     this.config.getBaseLlmClient().clearPerModelGeneratorCache();
     // Abort any in-flight auto-memory recall so the stale controller
     // does not leak into the next session.
-    this.cancelPendingMemoryPrefetch();
+    this.cancelPendingMemoryPrefetch('reset');
     // Drop any deferred tools revealed this session so /clear really gives
     // a clean slate. We don't clear inside startChat itself because that path
     // is also taken by compression (which preserves the session), and
@@ -2052,7 +2105,7 @@ export class GeminiClient {
           // A previous recall may still be pending (slow side-query, new user
           // turn arrived before it settled). Abort it before installing the
           // new handle so the orphan doesn't keep running indefinitely.
-          this.cancelPendingMemoryPrefetch();
+          this.cancelPendingMemoryPrefetch('new_query');
           const controller = new AbortController();
           // Bridge the caller's signal into the prefetch controller so a user
           // abort (Ctrl-C / Esc) on the parent turn also terminates the
@@ -2060,7 +2113,10 @@ export class GeminiClient {
           // up after firing; we still call removeEventListener on the promise's
           // finally to cover the normal-completion case so a long-lived parent
           // signal doesn't accumulate listeners across many turns.
-          const onParentAbort = () => controller.abort();
+          const onParentAbort = () => {
+            controller.abort();
+            this.cancelPendingMemoryPrefetch('abort');
+          };
           if (signal.aborted) {
             controller.abort();
           } else {
@@ -2097,9 +2153,15 @@ export class GeminiClient {
           const handle: MemoryPrefetchHandle = {
             promise,
             settledAt: null,
+            result: null,
             consumed: false,
+            terminalLogged: false,
+            firedAt: Date.now(),
             controller,
           };
+          void promise.then((result) => {
+            handle.result = result;
+          });
           void promise.finally(() => {
             handle.settledAt = Date.now();
             signal.removeEventListener('abort', onParentAbort);
@@ -2189,7 +2251,7 @@ export class GeminiClient {
           this.config.getMaxSessionTurns() > 0 &&
           this.sessionTurnCount > this.config.getMaxSessionTurns()
         ) {
-          this.cancelPendingMemoryPrefetch();
+          this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
           yield { type: GeminiEventType.MaxSessionTurns };
           if (isTopLevelInteraction)
             endInteractionSpan('error', {
@@ -2202,7 +2264,7 @@ export class GeminiClient {
       // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
       const boundedTurns = Math.min(turns, MAX_TURNS);
       if (!boundedTurns) {
-        this.cancelPendingMemoryPrefetch();
+        this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
         if (isTopLevelInteraction)
           endInteractionSpan('error', { errorMessage: 'max turns exhausted' });
         return new Turn(this.getChat(), prompt_id);
@@ -2243,7 +2305,7 @@ export class GeminiClient {
         const lastPromptTokenCount =
           uiTelemetryService.getLastPromptTokenCount();
         if (lastPromptTokenCount > sessionTokenLimit) {
-          this.cancelPendingMemoryPrefetch();
+          this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
           yield {
             type: GeminiEventType.SessionTokenLimitExceeded,
             value: {
@@ -2302,7 +2364,7 @@ export class GeminiClient {
             `Arena control signal received: ${controlSignal.type} - ${controlSignal.reason}`,
           );
           await arenaAgentClient.reportCancelled();
-          this.cancelPendingMemoryPrefetch();
+          this.cancelPendingMemoryPrefetch('abort');
           if (isTopLevelInteraction) endInteractionSpan('cancelled');
           return new Turn(this.getChat(), prompt_id);
         }
@@ -2398,7 +2460,7 @@ export class GeminiClient {
         // after any await prior to this point — flatMapTextParts above is
         // the natural drain.) If still not settled, skip — the ToolResult
         // inject point will retry on the next turn.
-        const userQueryMemory = await this.tryConsumeMemoryPrefetch();
+        const userQueryMemory = await this.tryConsumeMemoryPrefetch('initial');
         if (userQueryMemory?.prompt) {
           // Unshift to the front of systemReminders: on a UserQuery turn
           // requestToSend leads with user text, so positioning memory at
@@ -2412,7 +2474,8 @@ export class GeminiClient {
       }
 
       if (messageType === SendMessageType.ToolResult) {
-        const toolResultMemory = await this.tryConsumeMemoryPrefetch();
+        const toolResultMemory =
+          await this.tryConsumeMemoryPrefetch('tool_result');
         if (toolResultMemory?.prompt) {
           // Append (not prepend): on a ToolResult turn, requestToSend leads
           // with functionResponse parts that must immediately follow the
@@ -2514,7 +2577,7 @@ export class GeminiClient {
             this.lastApiCompletionTimestamp = Date.now();
             if (isTopLevelInteraction)
               endInteractionSpan('error', { errorMessage: 'loop detected' });
-            this.cancelPendingMemoryPrefetch();
+            this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
             return turn;
           }
 
@@ -2545,7 +2608,7 @@ export class GeminiClient {
               endInteractionSpan('error', { errorMessage: 'loop detected' });
             // finally cleanup catches this, but cancel explicitly to match
             // the cleanup pattern at other early-return sites.
-            this.cancelPendingMemoryPrefetch();
+            this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
             return turn;
           }
           // Update arena status on Finished events — stats are derived
@@ -2609,7 +2672,7 @@ export class GeminiClient {
             }
             // finally cleanup catches this, but cancel explicitly to match
             // the cleanup pattern at other early-return sites.
-            this.cancelPendingMemoryPrefetch();
+            this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
             return turn;
           }
         }
@@ -3017,7 +3080,9 @@ export class GeminiClient {
       // `return turn`. Catches uncaught exceptions and guards against
       // future early-return sites that forget to call cancel.
       if (!normalCompletion) {
-        this.cancelPendingMemoryPrefetch();
+        this.cancelPendingMemoryPrefetch(
+          signal?.aborted ? 'abort' : 'no_safe_delivery_point',
+        );
       }
       if (isTopLevelInteraction) {
         endInteractionSpan(signal?.aborted ? 'cancelled' : 'error', {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -2113,11 +2113,14 @@ export class GeminiClient {
           // up after firing; we still call removeEventListener on the promise's
           // finally to cover the normal-completion case so a long-lived parent
           // signal doesn't accumulate listeners across many turns.
+          let prefetchAbortReason: MemoryRecallDiscardReason | null = null;
           const onParentAbort = () => {
+            prefetchAbortReason = 'abort';
             controller.abort();
             this.cancelPendingMemoryPrefetch('abort');
           };
           if (signal.aborted) {
+            prefetchAbortReason = 'abort';
             controller.abort();
           } else {
             signal.addEventListener('abort', onParentAbort, { once: true });
@@ -2167,6 +2170,9 @@ export class GeminiClient {
             signal.removeEventListener('abort', onParentAbort);
           });
           this.pendingMemoryPrefetch = handle;
+          if (prefetchAbortReason) {
+            this.cancelPendingMemoryPrefetch(prefetchAbortReason);
+          }
         }
 
         // Track prompt count for commit attribution. Only the user typing a

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -81,6 +81,7 @@ export const EVENT_PERFORMANCE_REGRESSION = 'qwen-code.performance.regression';
 export const EVENT_MEMORY_EXTRACT = 'qwen-code.memory.extract';
 export const EVENT_MEMORY_DREAM = 'qwen-code.memory.dream';
 export const EVENT_MEMORY_RECALL = 'qwen-code.memory.recall';
+export const EVENT_MEMORY_RECALL_DELIVERY = 'qwen-code.memory.recall.delivery';
 
 // Session Tracing Span Names
 export const SPAN_INTERACTION = 'qwen-code.interaction';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -62,6 +62,7 @@ export {
   logMemoryExtract,
   logMemoryDream,
   logMemoryRecall,
+  logMemoryRecallDelivery,
 } from './loggers.js';
 export type { SlashCommandEvent, ChatCompressionEvent } from './types.js';
 export {
@@ -91,6 +92,7 @@ export {
   MemoryExtractEvent,
   MemoryDreamEvent,
   MemoryRecallEvent,
+  MemoryRecallDeliveryEvent,
 } from './types.js';
 export { makeSlashCommandEvent, makeChatCompressionEvent } from './types.js';
 export type {
@@ -137,6 +139,7 @@ export {
   recordMemoryDreamMetrics,
   recordMemoryRecallMetrics,
   recordChannelMemoryRecallMetrics,
+  recordMemoryRecallDeliveryMetrics,
   // Performance monitoring types
   PerformanceMetricType,
   MemoryMetricType,

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -223,6 +223,7 @@ describe('loggers', () => {
       expect(mockLogger.emit).toHaveBeenCalledWith({
         body: 'Memory recall delivery: phase=refined. delivery_point=discarded. Selected 2 doc(s).',
         attributes: {
+          'session.id': 'test-session-id',
           'event.name': EVENT_MEMORY_RECALL_DELIVERY,
           'event.timestamp': '2025-01-01T00:00:00.000Z',
           phase: 'refined',
@@ -233,8 +234,9 @@ describe('loggers', () => {
           latency_ms: 123,
         },
       });
-      expect(mockLogger.emit.mock.calls[0][0].attributes).not.toHaveProperty(
+      expect(mockLogger.emit.mock.calls[0][0].attributes).toHaveProperty(
         'session.id',
+        'test-session-id',
       );
       expect(metrics.recordMemoryRecallDeliveryMetrics).toHaveBeenCalledWith(
         config,
@@ -247,7 +249,7 @@ describe('loggers', () => {
         },
       );
       expect(JSON.stringify(mockLogger.emit.mock.calls[0])).not.toMatch(
-        /query|hash|content|filePath|projectPath|session|message|raw_error|secret/i,
+        /query|hash|content|filePath|projectPath|message|raw_error|secret/i,
       );
     });
 

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -40,6 +40,7 @@ import {
   EVENT_EXTENSION_UNINSTALL,
   EVENT_TOOL_OUTPUT_TRUNCATED,
   EVENT_PROTOCOL_TAG_SANITIZED,
+  EVENT_MEMORY_RECALL_DELIVERY,
 } from './constants.js';
 import {
   logApiRequest,
@@ -62,6 +63,7 @@ import {
   logApiError,
   logApiRetry,
   logProtocolTagSanitized,
+  logMemoryRecallDelivery,
 } from './loggers.js';
 import * as metrics from './metrics.js';
 import { apiActivityTracker } from './api-activity-tracker.js';
@@ -90,6 +92,7 @@ import {
   ApiErrorEvent,
   ApiRetryEvent,
   ProtocolTagSanitizedEvent,
+  MemoryRecallDeliveryEvent,
 } from './types.js';
 import { FileOperation } from './metrics.js';
 import type {
@@ -195,6 +198,57 @@ describe('loggers', () => {
       });
       expect(JSON.stringify(mockLogger.emit.mock.calls[0])).not.toMatch(
         /response_text|reasoning|tool_name|arguments/,
+      );
+    });
+  });
+
+  describe('logMemoryRecallDelivery', () => {
+    beforeEach(() => {
+      vi.spyOn(metrics, 'recordMemoryRecallDeliveryMetrics');
+    });
+
+    it('emits low-cardinality delivery telemetry without memory content or paths', () => {
+      const config = makeFakeConfig({ sessionId: 'test-session-id' });
+      const event = new MemoryRecallDeliveryEvent({
+        phase: 'refined',
+        delivery_point: 'discarded',
+        discard_reason: 'reset',
+        strategy: 'model',
+        docs_selected: 2,
+        latency_ms: 123,
+      });
+
+      logMemoryRecallDelivery(config, event);
+
+      expect(mockLogger.emit).toHaveBeenCalledWith({
+        body: 'Memory recall delivery: phase=refined. delivery_point=discarded. Selected 2 doc(s).',
+        attributes: {
+          'event.name': EVENT_MEMORY_RECALL_DELIVERY,
+          'event.timestamp': '2025-01-01T00:00:00.000Z',
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'reset',
+          strategy: 'model',
+          docs_selected: 2,
+          latency_ms: 123,
+        },
+      });
+      expect(mockLogger.emit.mock.calls[0][0].attributes).not.toHaveProperty(
+        'session.id',
+      );
+      expect(metrics.recordMemoryRecallDeliveryMetrics).toHaveBeenCalledWith(
+        config,
+        123,
+        {
+          phase: 'refined',
+          delivery_point: 'discarded',
+          discard_reason: 'reset',
+          strategy: 'model',
+          docs_selected: 2,
+        },
+      );
+      expect(JSON.stringify(mockLogger.emit.mock.calls[0])).not.toMatch(
+        /query|hash|content|filePath|projectPath|session|message|raw_error|secret/i,
       );
     });
   });

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -251,6 +251,30 @@ describe('loggers', () => {
         /query|hash|content|filePath|projectPath|session|message|raw_error|secret/i,
       );
     });
+
+    it('omits discard_reason from metrics payload for delivered memory', () => {
+      const config = makeFakeConfig({ sessionId: 'test-session-id' });
+      const event = new MemoryRecallDeliveryEvent({
+        phase: 'refined',
+        delivery_point: 'tool_result',
+        strategy: 'model',
+        docs_selected: 2,
+        latency_ms: 123,
+      });
+
+      logMemoryRecallDelivery(config, event);
+
+      expect(metrics.recordMemoryRecallDeliveryMetrics).toHaveBeenCalledWith(
+        config,
+        123,
+        {
+          phase: 'refined',
+          delivery_point: 'tool_result',
+          strategy: 'model',
+          docs_selected: 2,
+        },
+      );
+    });
   });
 
   describe('logCliConfiguration', () => {

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -244,7 +244,6 @@ describe('loggers', () => {
           delivery_point: 'discarded',
           discard_reason: 'reset',
           strategy: 'model',
-          docs_selected: 2,
         },
       );
       expect(JSON.stringify(mockLogger.emit.mock.calls[0])).not.toMatch(
@@ -271,7 +270,6 @@ describe('loggers', () => {
           phase: 'refined',
           delivery_point: 'tool_result',
           strategy: 'model',
-          docs_selected: 2,
         },
       );
     });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -1413,7 +1413,7 @@ export function logMemoryRecallDelivery(
   recordMemoryRecallDeliveryMetrics(config, event.latency_ms, {
     phase: event.phase,
     delivery_point: event.delivery_point,
-    discard_reason: event.discard_reason,
+    ...(event.discard_reason ? { discard_reason: event.discard_reason } : {}),
     strategy: event.strategy,
     docs_selected: event.docs_selected,
   });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -1393,6 +1393,7 @@ export function logMemoryRecallDelivery(
   if (!isTelemetrySdkInitialized()) return;
 
   const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
     'event.name': EVENT_MEMORY_RECALL_DELIVERY,
     'event.timestamp': event['event.timestamp'],
     phase: event.phase,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -54,6 +54,7 @@ import {
   EVENT_MEMORY_EXTRACT,
   EVENT_MEMORY_DREAM,
   EVENT_MEMORY_RECALL,
+  EVENT_MEMORY_RECALL_DELIVERY,
   EVENT_TOOL_OUTPUT_TRUNCATED,
 } from './constants.js';
 import {
@@ -75,6 +76,7 @@ import {
   recordMemoryExtractMetrics,
   recordMemoryDreamMetrics,
   recordMemoryRecallMetrics,
+  recordMemoryRecallDeliveryMetrics,
 } from './metrics.js';
 import { QwenLogger } from './qwen-logger/qwen-logger.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
@@ -125,6 +127,7 @@ import type {
   MemoryExtractEvent,
   MemoryDreamEvent,
   MemoryRecallEvent,
+  MemoryRecallDeliveryEvent,
 } from './types.js';
 import type { HookCallEvent } from './types.js';
 import type { UiEvent } from './uiTelemetry.js';
@@ -1378,6 +1381,39 @@ export function logMemoryRecall(
     attributes,
   });
   recordMemoryRecallMetrics(config, event.duration_ms, {
+    strategy: event.strategy,
+    docs_selected: event.docs_selected,
+  });
+}
+
+export function logMemoryRecallDelivery(
+  config: Config,
+  event: MemoryRecallDeliveryEvent,
+): void {
+  if (!isTelemetrySdkInitialized()) return;
+
+  const attributes: LogAttributes = {
+    'event.name': EVENT_MEMORY_RECALL_DELIVERY,
+    'event.timestamp': event['event.timestamp'],
+    phase: event.phase,
+    delivery_point: event.delivery_point,
+    strategy: event.strategy,
+    docs_selected: event.docs_selected,
+    latency_ms: event.latency_ms,
+  };
+  if (event.discard_reason) {
+    attributes['discard_reason'] = event.discard_reason;
+  }
+
+  const logger = logs.getLogger(SERVICE_NAME);
+  logger.emit({
+    body: `Memory recall delivery: phase=${event.phase}. delivery_point=${event.delivery_point}. Selected ${event.docs_selected} doc(s).`,
+    attributes,
+  });
+  recordMemoryRecallDeliveryMetrics(config, event.latency_ms, {
+    phase: event.phase,
+    delivery_point: event.delivery_point,
+    discard_reason: event.discard_reason,
     strategy: event.strategy,
     docs_selected: event.docs_selected,
   });

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -1415,6 +1415,5 @@ export function logMemoryRecallDelivery(
     delivery_point: event.delivery_point,
     ...(event.discard_reason ? { discard_reason: event.discard_reason } : {}),
     strategy: event.strategy,
-    docs_selected: event.docs_selected,
   });
 }

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -859,7 +859,6 @@ describe('Telemetry Metrics', () => {
         delivery_point: 'discarded',
         discard_reason: 'reset',
         strategy: 'model',
-        docs_selected: 3,
       });
 
       const expectedAttrs = {

--- a/packages/core/src/telemetry/metrics.test.ts
+++ b/packages/core/src/telemetry/metrics.test.ts
@@ -81,6 +81,7 @@ describe('Telemetry Metrics', () => {
   let recordPerformanceRegressionModule: typeof import('./metrics.js').recordPerformanceRegression;
   let recordBaselineComparisonModule: typeof import('./metrics.js').recordBaselineComparison;
   let recordChannelMemoryRecallMetricsModule: typeof import('./metrics.js').recordChannelMemoryRecallMetrics;
+  let recordMemoryRecallDeliveryMetricsModule: typeof import('./metrics.js').recordMemoryRecallDeliveryMetrics;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -110,6 +111,8 @@ describe('Telemetry Metrics', () => {
     recordBaselineComparisonModule = metricsJsModule.recordBaselineComparison;
     recordChannelMemoryRecallMetricsModule =
       metricsJsModule.recordChannelMemoryRecallMetrics;
+    recordMemoryRecallDeliveryMetricsModule =
+      metricsJsModule.recordMemoryRecallDeliveryMetrics;
 
     const otelApiModule = await import('@opentelemetry/api');
 
@@ -845,6 +848,30 @@ describe('Telemetry Metrics', () => {
   });
 
   describe('metric attribute cardinality controls', () => {
+    it('records memory recall delivery with low-cardinality attributes', () => {
+      const config = makeFakeConfig({ sessionId: 'cardinality-test' });
+      initializeMetricsModule(config);
+      mockCounterAddFn.mockClear();
+      mockHistogramRecordFn.mockClear();
+
+      recordMemoryRecallDeliveryMetricsModule(config, 42, {
+        phase: 'refined',
+        delivery_point: 'discarded',
+        discard_reason: 'reset',
+        strategy: 'model',
+        docs_selected: 3,
+      });
+
+      const expectedAttrs = {
+        phase: 'refined',
+        delivery_point: 'discarded',
+        discard_reason: 'reset',
+        strategy: 'model',
+      };
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, expectedAttrs);
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(42, expectedAttrs);
+    });
+
     it('omits session.id from metric attributes by default', () => {
       const config = makeFakeConfig({ sessionId: 'cardinality-test' });
       initializeMetricsModule(config);

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -58,6 +58,8 @@ const MEMORY_RECALL_DURATION = `${SERVICE_NAME}.memory.recall.duration`;
 const CHANNEL_MEMORY_RECALL_COUNT = `${SERVICE_NAME}.channel.memory.recall.count`;
 const CHANNEL_MEMORY_RECALL_DURATION = `${SERVICE_NAME}.channel.memory.recall.duration`;
 const CHANNEL_MEMORY_RECALL_SELECTED_COUNT = `${SERVICE_NAME}.channel.memory.recall.selected_count`;
+const MEMORY_RECALL_DELIVERY_COUNT = `${SERVICE_NAME}.memory.recall.delivery.count`;
+const MEMORY_RECALL_DELIVERY_LATENCY = `${SERVICE_NAME}.memory.recall.delivery.latency`;
 
 const baseMetricDefinition = {
   // session.id on metrics is opt-in: each session is a new value, so
@@ -406,6 +408,8 @@ let memoryRecallDurationHistogram: Histogram | undefined;
 let channelMemoryRecallCounter: Counter | undefined;
 let channelMemoryRecallDurationHistogram: Histogram | undefined;
 let channelMemoryRecallSelectedCountHistogram: Histogram | undefined;
+let memoryRecallDeliveryCounter: Counter | undefined;
+let memoryRecallDeliveryLatencyHistogram: Histogram | undefined;
 
 let isMetricsInitialized = false;
 let isPerformanceMonitoringEnabled = false;
@@ -534,6 +538,23 @@ export function initializeMetrics(config: TelemetryRuntimeConfig): void {
     CHANNEL_MEMORY_RECALL_SELECTED_COUNT,
     {
       description: 'Number of channel memory entries selected per attempt.',
+      valueType: ValueType.INT,
+    },
+  );
+  memoryRecallDeliveryCounter = meter.createCounter(
+    MEMORY_RECALL_DELIVERY_COUNT,
+    {
+      description:
+        'Counts auto-memory recall delivery outcomes, tagged by phase and delivery point.',
+      valueType: ValueType.INT,
+    },
+  );
+  memoryRecallDeliveryLatencyHistogram = meter.createHistogram(
+    MEMORY_RECALL_DELIVERY_LATENCY,
+    {
+      description:
+        'Latency from auto-memory recall prefetch start to delivery or discard.',
+      unit: 'ms',
       valueType: ValueType.INT,
     },
   );
@@ -1086,4 +1107,35 @@ export function recordChannelMemoryRecallMetrics(observation: {
     observation.selectedCount,
     attributes,
   );
+}
+
+export function recordMemoryRecallDeliveryMetrics(
+  config: Config,
+  latencyMs: number,
+  attrs: {
+    phase: 'fast' | 'refined';
+    delivery_point: 'initial' | 'tool_result' | 'discarded';
+    discard_reason?:
+      | 'not_ready'
+      | 'no_safe_delivery_point'
+      | 'new_query'
+      | 'reset'
+      | 'abort'
+      | 'shutdown'
+      | 'superseded';
+    strategy: 'none' | 'heuristic' | 'model';
+    docs_selected: number;
+  },
+): void {
+  if (!isMetricsInitialized) return;
+  const common = baseMetricDefinition.getCommonAttributes(config);
+  const metricAttributes = {
+    ...common,
+    phase: attrs.phase,
+    delivery_point: attrs.delivery_point,
+    strategy: attrs.strategy,
+    ...(attrs.discard_reason ? { discard_reason: attrs.discard_reason } : {}),
+  };
+  memoryRecallDeliveryCounter?.add(1, metricAttributes);
+  memoryRecallDeliveryLatencyHistogram?.record(latencyMs, metricAttributes);
 }

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -1116,7 +1116,6 @@ export function recordMemoryRecallDeliveryMetrics(
     phase: 'fast' | 'refined';
     delivery_point: 'initial' | 'tool_result' | 'discarded';
     discard_reason?:
-      | 'not_ready'
       | 'no_safe_delivery_point'
       | 'new_query'
       | 'reset'

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -9,7 +9,12 @@ import { diag, metrics, ValueType } from '@opentelemetry/api';
 import { SERVICE_NAME, EVENT_CHAT_COMPRESSION } from './constants.js';
 import type { Config } from '../config/config.js';
 import type { TelemetryRuntimeConfig } from './runtime-config.js';
-import type { ModelSlashCommandEvent } from './types.js';
+import type {
+  ModelSlashCommandEvent,
+  MemoryRecallDeliveryPhase,
+  MemoryRecallDeliveryPoint,
+  MemoryRecallDiscardReason,
+} from './types.js';
 
 const TOOL_CALL_COUNT = `${SERVICE_NAME}.tool.call.count`;
 const TOOL_CALL_LATENCY = `${SERVICE_NAME}.tool.call.latency`;
@@ -1113,15 +1118,9 @@ export function recordMemoryRecallDeliveryMetrics(
   config: Config,
   latencyMs: number,
   attrs: {
-    phase: 'fast' | 'refined';
-    delivery_point: 'initial' | 'tool_result' | 'discarded';
-    discard_reason?:
-      | 'no_safe_delivery_point'
-      | 'new_query'
-      | 'reset'
-      | 'abort'
-      | 'shutdown'
-      | 'superseded';
+    phase: MemoryRecallDeliveryPhase;
+    delivery_point: MemoryRecallDeliveryPoint;
+    discard_reason?: MemoryRecallDiscardReason;
     strategy: 'none' | 'heuristic' | 'model';
     docs_selected: number;
   },

--- a/packages/core/src/telemetry/metrics.ts
+++ b/packages/core/src/telemetry/metrics.ts
@@ -1122,7 +1122,6 @@ export function recordMemoryRecallDeliveryMetrics(
     delivery_point: MemoryRecallDeliveryPoint;
     discard_reason?: MemoryRecallDiscardReason;
     strategy: 'none' | 'heuristic' | 'model';
-    docs_selected: number;
   },
 ): void {
   if (!isMetricsInitialized) return;

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1473,7 +1473,7 @@ export type MemoryRecallDiscardReason =
   | 'reset'
   | 'abort'
   | 'shutdown'
-  | 'superseded';
+  | 'no_relevant_results';
 
 export class MemoryRecallDeliveryEvent implements BaseTelemetryEvent {
   'event.name': 'qwen-code.memory.recall.delivery';

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1464,3 +1464,43 @@ export class MemoryRecallEvent implements BaseTelemetryEvent {
     this.duration_ms = params.duration_ms;
   }
 }
+
+export type MemoryRecallDeliveryPhase = 'fast' | 'refined';
+export type MemoryRecallDeliveryPoint = 'initial' | 'tool_result' | 'discarded';
+export type MemoryRecallDiscardReason =
+  | 'not_ready'
+  | 'no_safe_delivery_point'
+  | 'new_query'
+  | 'reset'
+  | 'abort'
+  | 'shutdown'
+  | 'superseded';
+
+export class MemoryRecallDeliveryEvent implements BaseTelemetryEvent {
+  'event.name': 'qwen-code.memory.recall.delivery';
+  'event.timestamp': string;
+  phase: MemoryRecallDeliveryPhase;
+  delivery_point: MemoryRecallDeliveryPoint;
+  discard_reason?: MemoryRecallDiscardReason;
+  strategy: 'none' | 'heuristic' | 'model';
+  docs_selected: number;
+  latency_ms: number;
+
+  constructor(params: {
+    phase: MemoryRecallDeliveryPhase;
+    delivery_point: MemoryRecallDeliveryPoint;
+    discard_reason?: MemoryRecallDiscardReason;
+    strategy: 'none' | 'heuristic' | 'model';
+    docs_selected: number;
+    latency_ms: number;
+  }) {
+    this['event.name'] = 'qwen-code.memory.recall.delivery';
+    this['event.timestamp'] = new Date().toISOString();
+    this.phase = params.phase;
+    this.delivery_point = params.delivery_point;
+    this.discard_reason = params.discard_reason;
+    this.strategy = params.strategy;
+    this.docs_selected = params.docs_selected;
+    this.latency_ms = params.latency_ms;
+  }
+}

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1468,7 +1468,6 @@ export class MemoryRecallEvent implements BaseTelemetryEvent {
 export type MemoryRecallDeliveryPhase = 'fast' | 'refined';
 export type MemoryRecallDeliveryPoint = 'initial' | 'tool_result' | 'discarded';
 export type MemoryRecallDiscardReason =
-  | 'not_ready'
   | 'no_safe_delivery_point'
   | 'new_query'
   | 'reset'


### PR DESCRIPTION
## What this PR does

Adds terminal delivery telemetry for managed auto-memory recall. The existing recall selection telemetry tells us which memories were selected, but not whether those selected memories were actually delivered to the main model. This PR adds a new `qwen-code.memory.recall.delivery` event plus count and latency metrics, and records terminal outcomes when recall is injected into the initial prompt, injected at a ToolResult continuation point, discarded because no memory was selected, or cancelled by reset, shutdown, abort, new query, or another no-safe-delivery-point exit.

The current single auto-memory prefetch path is reported as `phase: "refined"` to preserve the current behavior and leave room for the planned Fast/Refined split in follow-up PRs. This PR does not change recall selection behavior or introduce Fast/Refined delivery logic.

## Why it's needed

Issue #7040 needs reliable observability for auto-memory recall delivery. Today we can see that recall selected memories, but we cannot tell whether those memories reached the model prompt, arrived later at a safe continuation point, or were dropped because the turn ended first. That makes it hard to evaluate first-turn delivery, late delivery, and cancellation behavior before changing the recall pipeline.

This PR adds the missing delivery/discard signal with low-cardinality fields only. The event intentionally does not include query text, query hashes, memory content, file paths, project paths, session/message ids, raw errors, or secrets.

## Reviewer Test Plan

### How to verify

Run the focused telemetry and client tests. Confirm that delivery telemetry is emitted for initial prompt injection, ToolResult injection, empty recall results, reset cancellation, and new-query supersession, and that metrics only carry low-cardinality attributes.

```bash
cd packages/core && npx vitest run src/telemetry/loggers.test.ts src/telemetry/metrics.test.ts
cd packages/core && mkdir -p coverage/.tmp && npx vitest run src/core/client.test.ts
npm run build && npm run typecheck
```

For E2E, run the CLI in a tmux session with `QWEN_CODE_MEMORY_LOCAL=1` and telemetry file export enabled. Seed a local `.qwen/memory/` file with a unique keyword such as `ultraviolet parsnip`, ask a prompt that recalls that memory, and inspect the telemetry outfile for `qwen-code.memory.recall.delivery`, `qwen-code.memory.recall.delivery.count`, and `qwen-code.memory.recall.delivery.latency`. Confirm each delivery event has one terminal outcome and does not include query, memory content, paths, session/message ids, raw errors, or secrets.

### Evidence (Before & After)

Before: auto-memory recall telemetry reported selection outcome only, so a selected memory could not be distinguished from a delivered, late-delivered, or discarded memory.

After: tmux E2E on `/tmp/pr1-memory-test` produced `qwen-code.memory.recall.delivery` events and delivery metrics. Verified normal recall, ToolResult delivery, and abort discard. `new_query` and `reset` were timing-limited in real TUI because recall completed before cancellation, but those cancellation paths are covered by unit tests.

### Tested on

|     OS     |   Status   |
| :--------: | :--------: |
|  macOS     |   tested   |
|  Windows   | not tested |
|  Linux     | not tested |

### Environment (optional)

Local worktree on macOS, built bundle and ran focused Vitest tests plus tmux-based CLI E2E with telemetry outfile export.

## Risk & Scope

- Main risk or tradeoff: This adds telemetry to the recall lifecycle and cancellation paths, so the main risk is duplicate or missing terminal events. The implementation guards each prefetch with a terminal-logged flag and tests the key delivery/discard paths.
- Not validated / out of scope: This PR does not implement Fast/Refined recall, bounded first-turn waiting, scorer fixes, multilingual recall, or the 200-cap candidate changes. Real TUI E2E could not reliably trigger `new_query` and `reset` discard reasons due to timing, but unit tests cover them.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #7040

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 为 managed auto-memory recall 增加终态投递遥测。现有 recall selection telemetry 能说明选中了哪些 memory，但不能说明这些 memory 是否真的送进了主模型。这个 PR 新增 `qwen-code.memory.recall.delivery` 事件，以及 count 和 latency metrics，并在 recall 注入首轮 prompt、注入 ToolResult continuation、安全点缺失导致丢弃、reset、shutdown、abort、新 query 顶替等路径记录终态。

当前代码只有单一 auto-memory prefetch 路径，所以本 PR 统一记录为 `phase: "refined"`，保持现有行为，并为后续 Fast/Refined 拆分预留字段。本 PR 不改变 recall selection 行为，也不实现 Fast/Refined 投递逻辑。

## 为什么需要

Issue #7040 需要可靠观察 auto-memory recall 是否真正交付。现在只能看到 recall 选中了 memory，但看不到它是否进入主模型 prompt、是否晚到后在安全 continuation 点投递，或者是否因为 turn 结束而被丢弃。缺少这个信号，就很难评估 first-turn delivery、late delivery 和 cancellation 行为。

这个 PR 补上 delivery/discard 信号，并且只记录低基数字段。事件不会包含 query 文本、query hash、memory 内容、文件路径、project path、session/message id、raw error 或 secret。

## Reviewer Test Plan

### 如何验证

运行聚焦的 telemetry 和 client 测试。确认 initial prompt 注入、ToolResult 注入、空 recall 结果、reset 取消、新 query 顶替都会产生 delivery telemetry，并确认 metrics 只携带低基数字段。

```bash
cd packages/core && npx vitest run src/telemetry/loggers.test.ts src/telemetry/metrics.test.ts
cd packages/core && mkdir -p coverage/.tmp && npx vitest run src/core/client.test.ts
npm run build && npm run typecheck
```

E2E 可以用 tmux 启动 CLI，设置 `QWEN_CODE_MEMORY_LOCAL=1` 并开启 telemetry outfile。准备一个本地 `.qwen/memory/` 文件，包含 `ultraviolet parsnip` 这类唯一关键词，然后询问相关 memory。检查 telemetry outfile 中是否有 `qwen-code.memory.recall.delivery`、`qwen-code.memory.recall.delivery.count` 和 `qwen-code.memory.recall.delivery.latency`。确认每条 delivery event 只有一个终态，并且不包含 query、memory 内容、路径、session/message id、raw error 或 secret。

### 证据 Before & After

Before：auto-memory recall telemetry 只记录 selection 结果，无法区分 selected memory 是已投递、晚投递，还是最终被丢弃。

After：在 `/tmp/pr1-memory-test` 的 tmux E2E 中观察到了 `qwen-code.memory.recall.delivery` 事件和 delivery metrics。已验证正常 recall、ToolResult delivery 和 abort discard。`new_query` 和 `reset` 在真实 TUI 中受时序限制，recall 完成太快，未稳定复现，但对应取消路径已有单测覆盖。

### Tested on

|     OS     |   Status   |
| :--------: | :--------: |
|  macOS     |   tested   |
|  Windows   | not tested |
|  Linux     | not tested |

### Environment

macOS 本地 worktree，构建 bundle 后运行聚焦 Vitest 测试，并用 tmux 进行 CLI E2E，telemetry 通过 outfile 落盘。

## Risk & Scope

- Main risk or tradeoff: 这个 PR 在 recall 生命周期和取消路径中增加 telemetry，主要风险是终态事件重复或遗漏。实现中通过 terminal-logged 标记保证同一个 prefetch 只记录一次终态，并用测试覆盖关键 delivery/discard 路径。
- Not validated / out of scope: 本 PR 不实现 Fast/Refined recall、首轮 bounded wait、scorer 修复、多语言召回或 200 cap candidate 变更。真实 TUI E2E 未稳定触发 `new_query` 和 `reset` discard reason，因为 recall 完成太快，但单测已覆盖这些路径。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #7040

</details>
