### PR TITLE
perf(autofix): raise fleet simultaneity from 3 to 5

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2095,7 +2095,16 @@ jobs:
       contents: 'read'
     strategy:
       fail-fast: false
-      max-parallel: 3
+      # Simultaneity bound for the whole fleet — the ONLY place different PRs
+      # wait on each other (the per-scan target budget and the inspection
+      # budget are both far from binding at the current pool size).
+      # Measured at 3, on the scan that selected 7 PRs: the legs started
+      # 3-at-a-time and each new one began 3-4s after a slot freed, so the
+      # 7th PR waited 81 minutes for a slot it could have had immediately.
+      # 5 halves that tail while staying a real bound — the point of the cap
+      # is that a backlog cannot open an unbounded number of agent runs at
+      # once, not the specific number.
+      max-parallel: 5
       matrix:
         target: '${{ fromJSON(needs.review-scan.outputs.targets) }}'
     concurrency:

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -231,7 +231,12 @@ describe('qwen-autofix workflow', () => {
     // older PRs for hours whenever cron ticks were sparse.
     expect(reviewScanJob).not.toContain('break # one PR per scheduled scan');
     expect(reviewScanJob).toContain('Fan out: emit EVERY eligible PR');
-    expect(workflow).toContain('max-parallel: 3');
+    // A simultaneity bound must exist — without one, a backlog opens an agent
+    // run per selected PR at once. The VALUE is a tuning knob; the invariant
+    // that it exists AND still binds below MAX_TARGETS_PER_SCAN is pinned by
+    // 'bounds fleet-wide simultaneity below the per-scan target budget'.
+    // Asserting the literal number here only detected edits, not breakage.
+    expect(workflow).toMatch(/max-parallel: \d+/);
     // Pathological-backlog bound: the budget BREAKS the candidate loop (so it
     // bounds runtime and API usage, not just matrix size), the deferral is
     // LOGGED, and the next scan picks up the remainder.
@@ -308,6 +313,33 @@ describe('qwen-autofix workflow', () => {
     // A failed metadata fetch (empty branch) must skip the candidate, not fall
     // through to an address job that fails on `git checkout -B "" origin/`.
     expect(reviewScanJob).toContain('could not fetch PR metadata');
+  });
+
+  it('bounds fleet-wide simultaneity below the per-scan target budget', () => {
+    // max-parallel is the ONE place different PRs wait on each other: the scan
+    // emits every eligible PR (up to MAX_TARGETS_PER_SCAN) and the matrix
+    // decides how many run at once. Measured at 3 on a scan that selected 7,
+    // the 7th leg started 81 minutes late, each new leg beginning 3-4 seconds
+    // after a slot freed.
+    //
+    // The number is a tuning knob and deliberately NOT pinned here. What is
+    // pinned is that a bound exists and still binds: dropping the key, or
+    // raising it to the target budget, both let one backlog open every agent
+    // run at once — which is the thing the cap exists to prevent, and neither
+    // would fail any other test.
+    // review-address is the last job in the file, so there is no trailing
+    // `# ====` separator to anchor on — match to EOF.
+    const addressJob =
+      workflow.match(/\n {2}review-address:[\s\S]*$/)?.[0] ?? '';
+    expect(addressJob).toContain('matrix:');
+    const parallel = Number(addressJob.match(/max-parallel: (\d+)/)?.[1]);
+    const targetBudget = Number(
+      workflow.match(/MAX_TARGETS_PER_SCAN: '(\d+)'/)?.[1],
+    );
+    expect(Number.isInteger(parallel)).toBe(true);
+    expect(parallel).toBeGreaterThan(0);
+    expect(Number.isInteger(targetBudget)).toBe(true);
+    expect(parallel).toBeLessThan(targetBudget);
   });
 
   it('behaviorally replays the stale-duplicate revalidation, including the conflict-only transition', () => {


### PR DESCRIPTION
## What this PR does

Raises the autofix fleet's simultaneity bound from 3 to 5, and replaces the test that pinned the literal number with the invariant it was standing in for.

## Why it's needed

`max-parallel` on the `review-address` matrix is the **only** place different PRs wait on each other. The other two caps are nowhere near binding at the current fleet size:

| bound | value | actual |
| --- | --- | --- |
| `MAX_TARGETS_PER_SCAN` | 10 | scans selected 1–7 |
| `MAX_CANDIDATE_INSPECTIONS` | 60 | candidate pool is 15 |
| **`max-parallel`** | **3** | **binding** |

Measured on the scan that selected 7 PRs — the legs form a perfect staircase, each new one starting within 3–4 seconds of a slot freeing:

```
#7350  00:52:59 → 00:58:24  ┐
#7369  00:52:59 → 00:58:57  ├ 3 start together
#7367  00:53:01 → 01:14:11  ┘
#7364  00:58:27  ← 3s after 00:58:24 freed
#7355  00:59:00  ← 3s after 00:58:57 freed
#7308  01:12:43  ← 4s after 01:12:39 freed
#7365  01:14:15  ← 4s after 01:14:11 freed
```

The 7th PR waited **81 minutes** for a slot. Nothing about that PR was blocked — its feedback, its checks and its branch were all ready at 00:52.

## How

`max-parallel: 3` → `5`. Everything that prevents *duplicate* work on the *same* PR is untouched: the per-PR concurrency group, the busy-PR skip in the scan, and the address-time eligibility recheck.

The existing test asserted the literal `max-parallel: 3`. That is a change-detector: it fires on any tuning edit, and it would **not** fire on the actual regression — deleting the key entirely, which lets one backlog open an agent run per selected PR at once. It is replaced by a test that reads both numbers and asserts a bound exists and still binds below the per-scan target budget, so the value stays tunable without touching tests.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 79/79, run three times (one hit the pre-existing `eligibility recheck` load flake).
2. Mutation-verified, and deliberately including a case that must **pass**:

   | mutation | expected | result |
   | --- | --- | --- |
   | delete the `max-parallel` key | red — this is the real regression | red |
   | raise it to 10 (= `MAX_TARGETS_PER_SCAN`, so it never binds) | red | red |
   | set it to 9 (a different but still-binding bound) | **pass** — not a change-detector | pass |

3. Static, run locally with the exact CI toolchain: `js-yaml` parses and reports `max-parallel = 5`; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: on the next scan that selects more than 3 PRs, five `review-address` legs should start together instead of three.

### Evidence (Before & After)

```
BEFORE  7 selected -> 3 slots -> tail PR starts +81 min
AFTER   7 selected -> 5 slots -> tail PR starts ≈ +1 leg duration
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- **Main risk: model-side concurrency.** Each leg is a full agent run, and today's dominant failure is a model transport blip — one `[API Error: terminated (cause: read ECONNRESET)]` took out #7308 and #7365 in the *same* run, while three legs were in flight. Five concurrent legs press harder on that. The mitigation is #7247 (classify transport errors as retryable), which is **not merged yet**; until it is, a blip costs a round rather than being retried. Worth watching the next few scans that select >3, and reverting to 3 is a one-line change if transport failures rise.
- Runner minutes rise in bursts, not in total: the same PRs run either way, just less staggered.
- Not validated / out of scope: the other pacing factors are untouched — the cron cadence (observed 40–70 min, not `*/10`) and the per-PR "wait for checks to settle" gate, which is the larger throughput ceiling and is CI-bound rather than loop-bound.
- Breaking changes / migration notes: none.

## Linked Issues

Found while tracing why 13 managed PRs were producing only 2–4 processed per scan. Part of the autofix-reliability line: #7247, #7330, #7350, #7351, #7354, #7358, #7364, #7392.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 autofix 机群的同时性上界从 3 提到 5,并把"钉住字面数字"的那条测试换成它本应表达的不变量。

## 为什么需要

`review-address` 矩阵上的 `max-parallel` 是**唯一**一处不同 PR 会互相等待的地方。另外两个上限在当前规模下远未触顶:

| 上界 | 值 | 实际 |
| --- | --- | --- |
| `MAX_TARGETS_PER_SCAN` | 10 | 各次扫描选中 1–7 |
| `MAX_CANDIDATE_INSPECTIONS` | 60 | 候选池只有 15 |
| **`max-parallel`** | **3** | **在起作用** |

在那次选中 7 个 PR 的扫描上实测,各腿是一条完美的楼梯,每条新腿都在有槽位释放后 3–4 秒内启动(见上方英文时间线)。

第 7 个 PR 为等槽位等了 **81 分钟**。它本身没有任何东西被阻塞 —— 反馈、检查、分支在 00:52 时就都就绪了。

## 怎么做

`max-parallel: 3` → `5`。所有防止**同一个 PR**重复处理的机制一概未动:按 PR 的 concurrency 组、扫描里的 busy 跳过、以及 address 阶段的资格复核。

既有测试断言的是字面量 `max-parallel: 3`。那是一个变更检测器:任何调参都会让它变红,而**真正的回归 —— 整个键被删掉、使一次积压可以为每个选中的 PR 同时开一次 agent 运行 —— 它反而抓不到**。现改为读取两个数字并断言"上界存在且仍然小于每次扫描的目标预算",使该值可调而无需改测试。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 79/79,连跑三次(其中一次命中既有的 `eligibility recheck` 负载 flake)。
2. 变异验证,并**刻意包含一个必须通过的用例**:删掉 `max-parallel` 键 → 红(这才是真回归);提到 10(等于 `MAX_TARGETS_PER_SCAN`,上界永不生效)→ 红;设为 9(不同但仍有效的上界)→ **通过**,证明它不是数字变更检测器。
3. 静态(均用 CI 一致工具):`js-yaml` 可解析并报告 `max-parallel = 5`;全部 37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:下一次选中超过 3 个 PR 的扫描,应有 5 条 `review-address` 腿同时启动而非 3 条。

## 风险与范围

- **主要风险:模型侧并发。** 每条腿都是一次完整 agent 运行,而今天的头号故障正是模型传输层抖动 —— 一次 `[API Error: terminated (cause: read ECONNRESET)]` 在**同一次运行**里同时打掉 #7308 与 #7365,当时正是 3 条腿在飞。5 条并发会加大这个压力。缓解手段是 #7247(把传输层错误判为可重试),但它**尚未合入**;在此之前,一次抖动会烧掉一轮而不是被重试。建议观察接下来几次选中 >3 的扫描;若传输失败上升,退回 3 只是一行改动。
- runner 分钟数是在时间上更集中而非总量增加:同样这些 PR 本来也要跑,只是不再错峰。
- 不在范围内:其余定速因素未动 —— cron 实际节奏(观测为 40–70 分钟,并非 `*/10`),以及按 PR 的"等检查结束"闸门 —— 后者才是更大的吞吐天花板,且受制于 CI 而非循环本身。
- 破坏性变更:无。

## 关联 Issue

在追查"13 个托管 PR 为何每次扫描只处理 2–4 个"时发现。属 autofix 可靠性主线:#7247、#7330、#7350、#7351、#7354、#7358、#7364、#7392。

</details>
