### PR TITLE
fix(acp-bridge): guarantee exactly-once prompt terminal events in daemon serve mode

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -31,6 +31,7 @@ import {
   InvalidSessionMetadataError,
   InvalidSessionScopeError,
   NOT_CURRENTLY_GENERATING_CANCEL_MESSAGE,
+  PromptDeadlineExceededError,
   PromptQueueFullError,
   RestoreInProgressError,
   SessionShellClientRequiredError,
@@ -6589,6 +6590,438 @@ describe('createAcpSessionBridge', () => {
       expect(() => bridge.getPendingPrompts('unknown')).toThrow(
         SessionNotFoundError,
       );
+    });
+  });
+
+  describe('prompt terminal exactly-once (DAEMON-002/003/004/005)', () => {
+    /** All formal turn terminals published for one promptId. */
+    const terminalsFor = (events: BridgeEvent[], promptId: string) =>
+      events.filter(
+        (e) =>
+          (e.type === 'turn_complete' || e.type === 'turn_error') &&
+          e.promptId === promptId,
+      );
+
+    /** Fake agent: prompts whose first text block is 'wedge' hang forever
+     * (agent ignores cancel — FakeAgent's cancel only records the call). */
+    const wedgeChannel = () =>
+      makeChannel({
+        promptImpl: async (req: PromptRequest) => {
+          if ((req.prompt[0] as { text?: string }).text === 'wedge') {
+            await new Promise<never>(() => {});
+          }
+          return { stopReason: 'end_turn' } as PromptResponse;
+        },
+      });
+
+    const subscribe = (
+      bridge: ReturnType<typeof makeBridge>,
+      sessionId: string,
+      events: BridgeEvent[],
+    ) => {
+      const sub = (async () => {
+        for await (const ev of bridge.subscribeEvents(sessionId)) {
+          events.push(ev);
+        }
+      })();
+      sub.catch(() => {});
+      return sub;
+    };
+
+    it('publishes exactly one cancelled terminal when a queued prompt is removed (DAEMON-004)', async () => {
+      let releaseFirst: (() => void) | undefined;
+      const firstDone = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      const handle = makeChannel({
+        promptImpl: async (req: PromptRequest) => {
+          if ((req.prompt[0] as { text?: string }).text === 'blocker') {
+            await firstDone;
+          }
+          return { stopReason: 'end_turn' } as PromptResponse;
+        },
+      });
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'blocker' }],
+        },
+        undefined,
+        { promptId: 'prompt-a' },
+      );
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued victim' }],
+        },
+        undefined,
+        { promptId: 'prompt-b' },
+      );
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(bridge.removePendingPrompt(session.sessionId, 'prompt-b')).toEqual(
+        { removed: true },
+      );
+      // B's terminal arrives immediately — while A is still running — as a
+      // turn_complete{stopReason:'cancelled'} keyed to B's promptId.
+      await vi.waitFor(() => {
+        const terms = terminalsFor(events, 'prompt-b');
+        expect(terms).toHaveLength(1);
+        expect(terms[0]?.type).toBe('turn_complete');
+        expect((terms[0]?.data as { stopReason?: string }).stopReason).toBe(
+          'cancelled',
+        );
+      });
+      // The pending_prompt_completed{removed} bookkeeping event is unchanged.
+      expect(
+        events.some(
+          (e) =>
+            e.type === 'pending_prompt_completed' &&
+            (e.data as { state?: string }).state === 'removed',
+        ),
+      ).toBe(true);
+
+      releaseFirst!();
+      await expect(p1).resolves.toEqual({ stopReason: 'end_turn' });
+      // Caller-facing rejection semantics are unchanged.
+      await expect(p2).rejects.toMatchObject({ name: 'AbortError' });
+      // B's FIFO node reached the head and threw AbortError — the latch
+      // must have swallowed the would-be second terminal.
+      await new Promise((r) => setTimeout(r, 20));
+      expect(terminalsFor(events, 'prompt-b')).toHaveLength(1);
+      expect(terminalsFor(events, 'prompt-a')).toHaveLength(1);
+      expect(terminalsFor(events, 'prompt-a')[0]?.type).toBe('turn_complete');
+      await bridge.shutdown();
+    });
+
+    it('publishes a deadline turn_error, unlocks the FIFO, and clears active state when the agent wedges (DAEMON-003)', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-wedged', deadlineMs: 50 },
+      );
+      await expect(p1).rejects.toBeInstanceOf(PromptDeadlineExceededError);
+
+      await vi.waitFor(() => {
+        const terms = terminalsFor(events, 'prompt-wedged');
+        expect(terms).toHaveLength(1);
+        expect(terms[0]?.type).toBe('turn_error');
+        expect((terms[0]?.data as { code?: string }).code).toBe(
+          'prompt_deadline_exceeded',
+        );
+      });
+      // Active-prompt bookkeeping cleared even though the agent never
+      // settled — otherwise the reaper would skip this session forever.
+      expect(bridge.getSessionSummary(session.sessionId).hasActivePrompt).toBe(
+        false,
+      );
+      // Best-effort cancel reached the (uncooperative) agent.
+      await vi.waitFor(() => {
+        expect(handle.agent.cancelCalls.length).toBeGreaterThan(0);
+      });
+      // FIFO released: a follow-up prompt dispatches and completes.
+      await expect(
+        bridge.sendPrompt(
+          session.sessionId,
+          {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'after the wedge' }],
+          },
+          undefined,
+          { promptId: 'prompt-after' },
+        ),
+      ).resolves.toEqual({ stopReason: 'end_turn' });
+      expect(terminalsFor(events, 'prompt-wedged')).toHaveLength(1);
+      await vi.waitFor(() => {
+        expect(terminalsFor(events, 'prompt-after')).toHaveLength(1);
+      });
+      await bridge.shutdown();
+    });
+
+    it('does not publish a stale deadline terminal for a prompt that completed in time (DAEMON-003)', async () => {
+      const handle = makeChannel({
+        promptImpl: () => ({ stopReason: 'end_turn' }),
+      });
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      await bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'fast' }],
+        },
+        undefined,
+        { promptId: 'prompt-fast', deadlineMs: 60 },
+      );
+      // Wait well past the configured deadline: the timer was cleared (and
+      // the latch guards any straggler), so no second terminal appears.
+      await new Promise((r) => setTimeout(r, 150));
+      const terms = terminalsFor(events, 'prompt-fast');
+      expect(terms).toHaveLength(1);
+      expect(terms[0]?.type).toBe('turn_complete');
+      await bridge.shutdown();
+    });
+
+    it('publishes a deadline terminal for a prompt that expires while still queued (DAEMON-003)', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-head' },
+      );
+      p1.catch(() => {});
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'never dispatches' }],
+        },
+        undefined,
+        { promptId: 'prompt-queued-deadline', deadlineMs: 50 },
+      );
+      p2.catch(() => {});
+
+      await vi.waitFor(() => {
+        const terms = terminalsFor(events, 'prompt-queued-deadline');
+        expect(terms).toHaveLength(1);
+        expect(terms[0]?.type).toBe('turn_error');
+        expect((terms[0]?.data as { code?: string }).code).toBe(
+          'prompt_deadline_exceeded',
+        );
+      });
+      await new Promise((r) => setTimeout(r, 60));
+      expect(terminalsFor(events, 'prompt-queued-deadline')).toHaveLength(1);
+
+      await bridge.shutdown();
+      // Shutdown flushed the still-wedged head prompt exactly once, and the
+      // queued prompt's residual FIFO abort stayed latched.
+      expect(terminalsFor(events, 'prompt-queued-deadline')).toHaveLength(1);
+      const headTerms = terminalsFor(events, 'prompt-head');
+      expect(headTerms).toHaveLength(1);
+      expect(headTerms[0]?.type).toBe('turn_error');
+      expect((headTerms[0]?.data as { code?: string }).code).toBe(
+        'daemon_shutdown',
+      );
+    });
+
+    it('keeps a detached session draining until the last pending prompt settles (DAEMON-005)', async () => {
+      let releaseFirst: (() => void) | undefined;
+      const firstDone = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      const handle = makeChannel({
+        promptImpl: async (req: PromptRequest) => {
+          if ((req.prompt[0] as { text?: string }).text === 'blocker') {
+            await firstDone;
+          }
+          return { stopReason: 'end_turn' } as PromptResponse;
+        },
+      });
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'blocker' }],
+        },
+        undefined,
+        { promptId: 'prompt-a' },
+      );
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued successor' }],
+        },
+        undefined,
+        { promptId: 'prompt-b' },
+      );
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Sole client leaves while A runs and B is queued — the session must
+      // keep draining instead of closing (close would abort B).
+      await bridge.detachClient(session.sessionId, session.clientId);
+      expect(bridge.getSessionSummary(session.sessionId)).toBeDefined();
+
+      releaseFirst!();
+      await expect(p1).resolves.toEqual({ stopReason: 'end_turn' });
+      // B completing proves the session survived the drain window.
+      await expect(p2).resolves.toEqual({ stopReason: 'end_turn' });
+      // …and only then does the deferred close-on-prompt-complete fire.
+      await vi.waitFor(() => {
+        expect(() => bridge.getSessionSummary(session.sessionId)).toThrow(
+          SessionNotFoundError,
+        );
+      });
+      await bridge.shutdown();
+    });
+
+    it('flushes error terminals for active and queued prompts before session_closed (DAEMON-005)', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-a' },
+      );
+      p1.catch(() => {});
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued at close' }],
+        },
+        undefined,
+        { promptId: 'prompt-b' },
+      );
+      p2.catch(() => {});
+      await new Promise((r) => setTimeout(r, 20));
+
+      await bridge.closeSession(session.sessionId);
+
+      const closedIdx = events.findIndex((e) => e.type === 'session_closed');
+      expect(closedIdx).toBeGreaterThan(-1);
+      for (const promptId of ['prompt-a', 'prompt-b']) {
+        const terms = terminalsFor(events, promptId);
+        expect(terms).toHaveLength(1);
+        expect(terms[0]?.type).toBe('turn_error');
+        expect((terms[0]?.data as { code?: string }).code).toBe(
+          'session_closed',
+        );
+        // The terminal precedes the session_closed frame — subscribers keyed
+        // on promptId observe the turn ending before the session vanishes.
+        expect(events.indexOf(terms[0]!)).toBeLessThan(closedIdx);
+      }
+      await bridge.shutdown();
+    });
+
+    it('publishes exactly one terminal per prompt under cancel + remove + deadline races (DAEMON-002)', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-a', deadlineMs: 60 },
+      );
+      p1.catch(() => {});
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued combatant' }],
+        },
+        undefined,
+        { promptId: 'prompt-b', deadlineMs: 60 },
+      );
+      p2.catch(() => {});
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Fire all cancellation paths at once and let the deadline land on
+      // top: the latch must keep every promptId at exactly one terminal.
+      void bridge.cancelSession(session.sessionId).catch(() => {});
+      bridge.removePendingPrompt(session.sessionId, 'prompt-b');
+      await new Promise((r) => setTimeout(r, 150));
+
+      expect(terminalsFor(events, 'prompt-a')).toHaveLength(1);
+      expect(terminalsFor(events, 'prompt-b')).toHaveLength(1);
+      await bridge.shutdown();
+      // Shutdown's flush must also stay latched.
+      expect(terminalsFor(events, 'prompt-a')).toHaveLength(1);
+      expect(terminalsFor(events, 'prompt-b')).toHaveLength(1);
+    });
+
+    it('publishes exactly one turn_error per pending prompt when the channel crashes', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-a' },
+      );
+      p1.catch(() => {});
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued at crash' }],
+        },
+        undefined,
+        { promptId: 'prompt-b' },
+      );
+      p2.catch(() => {});
+      await new Promise((r) => setTimeout(r, 20));
+
+      handle.crash({ exitCode: 1, signalCode: null });
+
+      // NOTE: the flush's `channel_closed` terminal and the transport-race
+      // rejection compete to publish first; the latch only guarantees
+      // exactly-once, not which source wins — so assert type+count only.
+      await vi.waitFor(() => {
+        for (const promptId of ['prompt-a', 'prompt-b']) {
+          const terms = terminalsFor(events, promptId);
+          expect(terms).toHaveLength(1);
+          expect(terms[0]?.type).toBe('turn_error');
+        }
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(terminalsFor(events, 'prompt-a')).toHaveLength(1);
+      expect(terminalsFor(events, 'prompt-b')).toHaveLength(1);
+      await bridge.shutdown();
     });
   });
 
@@ -16160,7 +16593,11 @@ describe('activePromptCount and lastActivityAt', () => {
     if (resultB.ok) {
       throw new Error('queued prompt unexpectedly resolved');
     }
-    expect(resultB.error).toBeInstanceOf(SessionNotFoundError);
+    // The crash-time terminal flush aborts residual FIFO nodes so they
+    // skip at the pre-dispatch check — the caller sees an AbortError
+    // (before DAEMON-005 the node reached `assertLivePromptEntry` after
+    // teardown and rejected with SessionNotFoundError instead).
+    expect((resultB.error as Error).name).toBe('AbortError');
 
     await vi.waitFor(() => {
       expect(bridge.activePromptCount).toBe(0);

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6934,6 +6934,53 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('flushes error terminals for active and queued prompts before session_died on killSession (DAEMON-005)', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-a' },
+      );
+      p1.catch(() => {});
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued at kill' }],
+        },
+        undefined,
+        { promptId: 'prompt-b' },
+      );
+      p2.catch(() => {});
+      await new Promise((r) => setTimeout(r, 20));
+
+      await expect(bridge.killSession(session.sessionId)).resolves.toBe(true);
+
+      const diedIdx = events.findIndex((e) => e.type === 'session_died');
+      expect(diedIdx).toBeGreaterThan(-1);
+      for (const promptId of ['prompt-a', 'prompt-b']) {
+        const terms = terminalsFor(events, promptId);
+        expect(terms).toHaveLength(1);
+        expect(terms[0]?.type).toBe('turn_error');
+        expect((terms[0]?.data as { code?: string }).code).toBe(
+          'session_killed',
+        );
+        // The terminal precedes the session_died frame — a reorder that
+        // flushes after events.close() would drop it into a closed bus.
+        expect(events.indexOf(terms[0]!)).toBeLessThan(diedIdx);
+      }
+      await bridge.shutdown();
+    });
+
     it('publishes exactly one terminal per prompt under cancel + remove + deadline races (DAEMON-002)', async () => {
       const handle = wedgeChannel();
       const bridge = makeBridge({ channelFactory: async () => handle.channel });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -81,6 +81,7 @@ import {
   isNotCurrentlyGeneratingCancelError,
   SessionBusyError,
   InvalidRewindTargetError,
+  PromptDeadlineExceededError,
 } from './bridgeErrors.js';
 import { canonicalizeWorkspace } from './workspacePaths.js';
 import { parseSessionSource } from './session-source.js';
@@ -1106,6 +1107,96 @@ function broadcastTurnError(
   }
 }
 
+/**
+ * The formal terminal outcome of an accepted prompt. Every prompt that was
+ * admitted (202) must observe exactly one of these, published as either a
+ * `turn_complete` (complete / cancelled) or `turn_error` event keyed by
+ * `promptId`.
+ */
+type PromptTerminal =
+  | { kind: 'complete'; result: { stopReason?: string; [k: string]: unknown } }
+  | { kind: 'cancelled' }
+  | { kind: 'error'; err: unknown };
+
+/**
+ * Publish the formal terminal event for an accepted prompt exactly once.
+ * All terminal paths (agent settle, queued removal, deadline, session
+ * close/kill/crash flush) funnel through here; the per-prompt
+ * `terminalPublished` latch suppresses later attempts so consumers keyed
+ * on `promptId` see one and only one `turn_complete`/`turn_error`.
+ * `originatorClientId` is always taken from the pending entry so callers
+ * can't disagree with the admission-time attribution.
+ */
+function publishPromptTerminal(
+  entry: SessionEntry,
+  pendingEntry: PendingPromptEntry,
+  terminal: PromptTerminal,
+): void {
+  if (pendingEntry.terminalPublished) {
+    writeStderrLine(
+      `publishPromptTerminal: suppressed duplicate ${terminal.kind} terminal ` +
+        `for prompt ${pendingEntry.promptId} (session ${entry.sessionId})`,
+    );
+    return;
+  }
+  pendingEntry.terminalPublished = true;
+  const originatorClientId = pendingEntry.originatorClientId;
+  if (terminal.kind === 'complete') {
+    broadcastTurnComplete(
+      entry,
+      entry.sessionId,
+      terminal.result,
+      pendingEntry.promptId,
+      originatorClientId,
+    );
+  } else if (terminal.kind === 'cancelled') {
+    broadcastTurnComplete(
+      entry,
+      entry.sessionId,
+      { stopReason: 'cancelled' },
+      pendingEntry.promptId,
+      originatorClientId,
+    );
+  } else {
+    broadcastTurnError(
+      entry,
+      entry.sessionId,
+      terminal.err,
+      pendingEntry.promptId,
+      originatorClientId,
+    );
+  }
+}
+
+/**
+ * Publish an error terminal for every prompt still pending on a session
+ * that is being torn down (close/kill/channel crash/daemon shutdown), then
+ * abort each prompt so residual FIFO nodes skip at their pre-dispatch
+ * check instead of being promoted to running. Must run before
+ * `entry.events.close()` — the bus swallows publishes afterwards. Any
+ * later settle of the same prompts re-enters `publishPromptTerminal` and
+ * is deduped by the latch.
+ */
+function flushPromptTerminals(
+  entry: SessionEntry,
+  code: string,
+  message: string,
+): void {
+  for (const pending of [...entry.pendingPromptList]) {
+    publishPromptTerminal(entry, pending, {
+      kind: 'error',
+      err: { code, message },
+    });
+    try {
+      pending.abortController.abort(
+        new DOMException('Prompt aborted', 'AbortError'),
+      );
+    } catch {
+      /* listeners must not break teardown */
+    }
+  }
+}
+
 function hasControlCharacter(value: string): boolean {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
@@ -1429,6 +1520,29 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     lastActivityTimestamp = Date.now();
   }
 
+  /**
+   * Idempotently clear a session's active-prompt bookkeeping, but only if
+   * `promptId` still owns it. The ownership gate matters: after a deadline
+   * releases the FIFO, the wedged agent's old `promptPromise` may settle
+   * late — while the NEXT prompt is already active — and must not steal
+   * that prompt's `activePromptId`/`promptActive` state. Called from the
+   * prompt settle path, the echo-failure path, and the deadline path;
+   * without the `promptActive` reset here a wedged agent would pin
+   * `promptActive` true forever and the session reaper would skip the
+   * session indefinitely.
+   */
+  function settleActivePromptState(entry: SessionEntry, promptId: string) {
+    if (entry.activePromptId !== promptId) return;
+    delete entry.activePromptId;
+    delete entry.activePromptOriginatorClientId;
+    if (entry.promptActive) {
+      entry.promptActive = false;
+      activePromptCounter--;
+      entry.sessionLastSeenAt = Date.now();
+      touchActivity();
+    }
+  }
+
   function resolvePositiveFiniteMs(
     raw: number | undefined,
     fallback: number,
@@ -1584,7 +1698,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       if (shuttingDown) return;
       const now = Date.now();
       for (const [id, entry] of byId) {
-        if (entry.promptActive) continue;
+        // `pendingPromptCount` (not `promptActive`): queued prompts and the
+        // FIFO hand-off gap between two prompts must also block the reap.
+        if (entry.pendingPromptCount > 0) continue;
         if (entry.events.subscriberCount > 0) continue;
         // Note: clientIds.size is NOT checked here. Close-on-last-detach
         // handles the normal path (client sends detach → immediate close).
@@ -1877,7 +1993,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     } else if (
       entry.clientIds.size === 0 &&
       entry.events.subscriberCount === 0 &&
-      !entry.promptActive
+      entry.pendingPromptCount === 0
     ) {
       await closeSessionImpl(entry.sessionId, undefined, {
         reason: 'last_client_detached',
@@ -2134,6 +2250,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           const sessEntry = byId.get(sid);
           if (!sessEntry) continue;
           cancelPendingForSession(sid);
+          // DAEMON-002/005: every still-pending prompt owes its formal
+          // terminal before the bus closes below.
+          flushPromptTerminals(
+            sessEntry,
+            'channel_closed',
+            'agent channel exited before the prompt completed',
+          );
           try {
             sessEntry.events.publish({
               type: 'session_died',
@@ -4356,6 +4479,15 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // from the (now-defunct) child can't seed the early-event buffer
     // and leak into a future load/resume of the same persisted id.
     ci?.client.markSessionClosed(sessionId);
+    // DAEMON-002/005: publish the formal terminal for every still-pending
+    // prompt (active AND queued) before `session_closed` and the bus close
+    // below — afterwards the bus swallows publishes and subscribers keyed
+    // on promptId would never see a turn terminal.
+    flushPromptTerminals(
+      entry,
+      'session_closed',
+      'session closed before the prompt completed',
+    );
     try {
       entry.events.publish({
         type: 'session_closed',
@@ -4805,6 +4937,53 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         state: isQueued ? 'queued' : 'running',
       };
       entry.pendingPromptList.push(pendingEntry);
+      // DAEMON-003: absolute wallclock deadline. Armed at admission (the
+      // 202 point) so it covers queue wait AND execution. On expiry the
+      // prompt gets its formal `turn_error{code:'prompt_deadline_exceeded'}`
+      // terminal, the per-session FIFO is released via `deadlineReject`
+      // racing the (possibly wedged) `promptPromise`, and the agent is
+      // best-effort cancelled through the existing abort path. The channel
+      // is NOT killed — it may be shared by other sessions; reclaiming a
+      // wedged agent's channel is a tracked follow-up.
+      const deadlineMs = context?.deadlineMs;
+      const hasDeadline =
+        typeof deadlineMs === 'number' &&
+        Number.isFinite(deadlineMs) &&
+        deadlineMs > 0;
+      let deadlineReject: ((err: unknown) => void) | undefined;
+      let deadlinePromise: Promise<never> | undefined;
+      let deadlineTimer: NodeJS.Timeout | undefined;
+      if (hasDeadline) {
+        deadlinePromise = new Promise<never>((_resolve, reject) => {
+          deadlineReject = reject;
+        });
+        // The race consumer may not be attached yet (or ever, for a queued
+        // prompt that never dispatches) — keep the rejection handled.
+        deadlinePromise.catch(() => {});
+        const onDeadline = () => {
+          if (pendingEntry.terminalPublished) return;
+          const deadlineErr = new PromptDeadlineExceededError(deadlineMs);
+          writeStderrLine(
+            `sendPrompt: prompt ${promptId} exceeded ${deadlineMs}ms deadline ` +
+              `for session ${sessionId}; agent may still be executing`,
+          );
+          publishPromptTerminal(entry, pendingEntry, {
+            kind: 'error',
+            err: {
+              code: 'prompt_deadline_exceeded',
+              message: deadlineErr.message,
+            },
+          });
+          settleActivePromptState(entry, pendingEntry.promptId);
+          // Unlock the dispatch race / FIFO first, then abort so the
+          // existing onAbort path (prompt_cancelled UI signal +
+          // cancelPendingForSession + best-effort connection.cancel) runs.
+          deadlineReject?.(deadlineErr);
+          pendingAbort.abort(deadlineErr);
+        };
+        deadlineTimer = setTimeout(onDeadline, deadlineMs);
+        deadlineTimer.unref();
+      }
       if (isQueued) {
         pendingAbort.signal.addEventListener(
           'abort',
@@ -4975,40 +5154,18 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     );
                   }
                 } catch (echoErr) {
-                  delete entry.activePromptId;
-                  delete entry.activePromptOriginatorClientId;
-                  if (entry.promptActive) {
-                    entry.promptActive = false;
-                    activePromptCounter--;
-                    touchActivity();
-                  }
+                  settleActivePromptState(entry, pendingEntry.promptId);
                   throw echoErr;
                 }
                 const promptPromise = entry.connection
                   .prompt(promptRequest)
                   .finally(() => {
-                    if (entry.promptActive) {
-                      entry.promptActive = false;
-                      activePromptCounter--;
-                      entry.sessionLastSeenAt = Date.now();
-                      touchActivity();
-                    }
-                    delete entry.activePromptId;
-                    delete entry.activePromptOriginatorClientId;
-                    if (
-                      entry.clientIds.size === 0 &&
-                      entry.events.subscriberCount === 0 &&
-                      byId.has(sessionId)
-                    ) {
-                      void closeSessionImpl(sessionId, undefined, {
-                        reason: 'last_client_detached',
-                      }).catch((err) => {
-                        writeStderrLine(
-                          `qwen serve: deferred close-on-prompt-complete failed for ` +
-                            `${JSON.stringify(sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
-                        );
-                      });
-                    }
+                    // Ownership-gated: a late settle after a deadline
+                    // already released the FIFO must not clear the NEXT
+                    // prompt's active state. The deferred
+                    // close-on-prompt-complete lives in `result.finally`
+                    // (after the terminal broadcast), not here.
+                    settleActivePromptState(entry, pendingEntry.promptId);
                   });
 
                 // Race against channel termination: if the underlying transport
@@ -5019,19 +5176,22 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 // queued prompt with an unbounded await. See
                 // `getTransportClosedReject` for the single-listener invariant.
                 //
-                // FIXME(stage-2): no absolute prompt deadline. A buggy agent
-                // that ignores `cancel()` while keeping the channel alive can
-                // hold this race open indefinitely — the abort path fires
-                // `cancel()` and resolves pending permissions, but the
-                // `promptPromise` itself only settles when the agent
-                // cooperates. Stage 2 should add a configurable per-prompt
-                // wall clock (e.g. `--prompt-deadline 30m`) into this race so
-                // a wedged agent can't slow-leak prompt promises. Tracked
-                // as a follow-up.
-                const racedPromise = Promise.race([
-                  promptPromise,
-                  getTransportClosedReject(entry),
-                ]);
+                // The optional `deadlinePromise` (DAEMON-003) joins the same
+                // race: a buggy agent that ignores `cancel()` while keeping
+                // the channel alive can otherwise hold this race open
+                // indefinitely — the deadline rejection settles the raced
+                // promise so the FIFO moves on even though the agent-side
+                // `promptPromise` never resolves.
+                const racedPromise = deadlinePromise
+                  ? Promise.race([
+                      promptPromise,
+                      getTransportClosedReject(entry),
+                      deadlinePromise,
+                    ])
+                  : Promise.race([
+                      promptPromise,
+                      getTransportClosedReject(entry),
+                    ]);
 
                 // The user echo (`echoPromptToSessionBus`) was already published
                 // BEFORE the forward. If the forward itself fails (transport died,
@@ -5045,6 +5205,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                   .then(
                     () => {},
                     (err) => {
+                      if (err instanceof PromptDeadlineExceededError) {
+                        // onDeadline already published the terminal and
+                        // aborted the prompt — the abort listener (onAbort)
+                        // ran synchronously and handled the cancel broadcast
+                        // + connection.cancel. Nothing to compensate.
+                        return;
+                      }
                       if (
                         err instanceof DOMException &&
                         err.name === 'AbortError' &&
@@ -5116,23 +5283,22 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       );
       result.then(
         (promptResult) => {
-          broadcastTurnComplete(
-            entry,
-            sessionId,
-            promptResult,
-            pendingEntry.promptId,
-            originatorClientId,
-          );
+          publishPromptTerminal(entry, pendingEntry, {
+            kind: 'complete',
+            result: promptResult,
+          });
         },
         (err) => {
-          if (err instanceof DOMException && err.name === 'AbortError') return;
-          broadcastTurnError(
-            entry,
-            sessionId,
-            err,
-            pendingEntry.promptId,
-            originatorClientId,
-          );
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            // An aborted prompt (queued removal, caller socket close,
+            // deadline…) still owes its formal terminal — fall back to a
+            // `cancelled` turn_complete. Paths that already published one
+            // (removePendingPrompt, onDeadline, flush) are deduped by the
+            // per-prompt latch inside `publishPromptTerminal`.
+            publishPromptTerminal(entry, pendingEntry, { kind: 'cancelled' });
+            return;
+          }
+          publishPromptTerminal(entry, pendingEntry, { kind: 'error', err });
         },
       );
       // Tail swallows failures so subsequent prompts still run. The caller
@@ -5143,6 +5309,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       );
       result
         .finally(() => {
+          if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
           // Remove this prompt from the pending list and publish a
           // completed event so SSE subscribers can update their queue view.
           // If `removePendingPrompt` already spliced this entry and
@@ -5191,6 +5358,30 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
               `[mid-turn] session=${entry.sessionId} dropped ${entry.midTurnMessageQueue.length} undrained message(s) at idle; browser resends next turn`,
             );
             entry.midTurnMessageQueue.length = 0;
+          }
+          // DAEMON-005: deferred close-on-prompt-complete. Lives here (not
+          // in `promptPromise.finally`) so the terminal broadcast — the
+          // `result.then` registered above on this same promise — runs
+          // before the bus closes. Conditions: nobody attached or
+          // subscribed, no other prompt pending (a queued successor keeps
+          // the session draining and triggers its own close), and this
+          // exact entry is still registered — after killSession's eager
+          // delete the same persisted id can be re-registered as a NEW
+          // entry by `session/load`, which a late settle must not close.
+          if (
+            entry.clientIds.size === 0 &&
+            entry.events.subscriberCount === 0 &&
+            entry.pendingPromptCount === 0 &&
+            byId.get(sessionId) === entry
+          ) {
+            void closeSessionImpl(sessionId, undefined, {
+              reason: 'last_client_detached',
+            }).catch((err) => {
+              writeStderrLine(
+                `qwen serve: deferred close-on-prompt-complete failed for ` +
+                  `${JSON.stringify(sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+              );
+            });
           }
         })
         .catch(() => {});
@@ -6818,6 +7009,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       } catch {
         /* bus may be closed during session teardown */
       }
+      // DAEMON-004: a deleted QUEUED prompt never dispatches, so nothing
+      // downstream would ever emit its formal terminal — publish the
+      // `cancelled` turn_complete now. Running prompts keep the existing
+      // cooperative cancel path (agent returns cancelled → turn_complete);
+      // the FIFO node's later AbortError is deduped by the latch.
+      if (target.state === 'queued') {
+        publishPromptTerminal(entry, target, { kind: 'cancelled' });
+      }
       return { removed: true };
     },
 
@@ -7593,6 +7792,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // `byId.get(...)` returns undefined so the automatic publish
       // at crash time wouldn't fire. SSE subscribers need this
       // terminal frame to know the session is gone.
+      // DAEMON-002/005: pending prompts owe their formal terminal first.
+      flushPromptTerminals(
+        entry,
+        'session_killed',
+        'session killed before the prompt completed',
+      );
       try {
         entry.events.publish({
           type: 'session_died',
@@ -7661,14 +7866,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       } else if (
         entry.clientIds.size === 0 &&
         entry.events.subscriberCount === 0 &&
-        !entry.promptActive
+        entry.pendingPromptCount === 0
       ) {
         // Last registered client left, no SSE subscribers remain, and
-        // no prompt is in flight. Close the session immediately so it
-        // doesn't linger in memory. The JSONL transcript on disk is
+        // no prompt is pending (active OR queued — `pendingPromptCount`
+        // covers the FIFO hand-off gap where `promptActive` is briefly
+        // false between two prompts). Close the session immediately so
+        // it doesn't linger in memory. The JSONL transcript on disk is
         // preserved — session/load or session/resume can restore it
-        // later. When a prompt IS active, skip the close and let the
-        // idle reaper handle it after the prompt completes.
+        // later. When prompts ARE pending, skip the close: the deferred
+        // close in `sendPrompt`'s result.finally fires after the last
+        // one settles (and publishes its terminal).
         await closeSessionImpl(sessionId, undefined, {
           reason: 'last_client_detached',
         }).catch((err) => {
@@ -7772,6 +7980,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             workspaceCwd: e.workspaceCwd,
             reason: shutdownReason,
           });
+          // DAEMON-002/005: pending prompts owe their formal terminal
+          // before the bus closes.
+          flushPromptTerminals(
+            e,
+            'daemon_shutdown',
+            'daemon shut down before the prompt completed',
+          );
           try {
             e.events.publish({
               type: 'session_died',

--- a/packages/acp-bridge/src/bridgeErrors.ts
+++ b/packages/acp-bridge/src/bridgeErrors.ts
@@ -211,6 +211,22 @@ export class PromptQueueFullError extends Error {
 }
 
 /**
+ * Rejected by `sendPrompt` when an accepted prompt exceeds its wallclock
+ * deadline (`BridgeClientRequestContext.deadlineMs`). The bridge publishes a
+ * `turn_error{code:'prompt_deadline_exceeded'}` terminal, releases the FIFO,
+ * and best-effort cancels the agent — the agent may still be executing.
+ * Exported so tests and routes can match on the class identity.
+ */
+export class PromptDeadlineExceededError extends Error {
+  readonly deadlineMs: number;
+  constructor(deadlineMs: number) {
+    super(`prompt exceeded the ${deadlineMs}ms deadline`);
+    this.name = 'PromptDeadlineExceededError';
+    this.deadlineMs = deadlineMs;
+  }
+}
+
+/**
  * Thrown by `spawnOrAttach` when the requested `workspaceCwd` doesn't
  * canonicalize to the bridge's bound workspace. Every bridge instance is bound
  * to exactly one runtime; a multi-workspace daemon selects a bridge before

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -481,6 +481,14 @@ export interface BridgeClientRequestContext {
    * smuggle a continuation through the prompt path.
    */
   continue?: boolean;
+  /**
+   * Absolute wallclock budget (ms) for this prompt, measured from admission
+   * (the 202 semantic point) and covering queue wait. When exceeded, the
+   * bridge publishes a `turn_error{code:'prompt_deadline_exceeded'}` terminal,
+   * releases the FIFO, and best-effort cancels the agent. Populated by the
+   * REST prompt route from `resolvePromptDeadlineMs(serverMs, requestMs)`.
+   */
+  deadlineMs?: number;
 }
 
 /**
@@ -581,6 +589,12 @@ export interface PendingPromptEntry {
   text: string;
   abortController: AbortController;
   state: 'queued' | 'running';
+  /**
+   * Exactly-once latch for the prompt's formal terminal event
+   * (`turn_complete` / `turn_error`). Set by `publishPromptTerminal`;
+   * later publish attempts for the same prompt are suppressed.
+   */
+  terminalPublished?: boolean;
 }
 
 /**

--- a/packages/cli/src/serve/acp-session-bridge.ts
+++ b/packages/cli/src/serve/acp-session-bridge.ts
@@ -109,6 +109,7 @@ export {
   InvalidSessionScopeError,
   SessionLimitExceededError,
   PromptQueueFullError,
+  PromptDeadlineExceededError,
   WorkspaceMismatchError,
   InvalidClientIdError,
   InvalidPermissionOptionError,

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -48,10 +48,7 @@ import {
 } from '../acp-session-bridge.js';
 import type { DaemonLogger } from '../daemon-logger.js';
 import type { SendBridgeError } from '../server/error-response.js';
-import {
-  PromptDeadlineExceededError,
-  resolvePromptDeadlineMs,
-} from '../server/prompt-deadline.js';
+import { resolvePromptDeadlineMs } from '../server/prompt-deadline.js';
 import {
   parseClientIdHeader,
   parseOptionalWorkspaceCwd,
@@ -2329,19 +2326,16 @@ export function registerSessionRoutes(
         };
         res.once('close', onResClose);
         res.once('finish', onResFinish);
+        // The effective deadline (server cap ∩ request override) is passed
+        // to the bridge, which owns the deadline race: it publishes the
+        // formal `turn_error{code:'prompt_deadline_exceeded'}` terminal,
+        // releases the per-session FIFO, and best-effort cancels the agent.
+        // A route-side timer can't do any of that — it could only abort
+        // this request's signal.
         const effectiveDeadlineMs = resolvePromptDeadlineMs(
           promptDeadlineMs,
           requestDeadlineMs,
         );
-        let deadlineTimer: NodeJS.Timeout | undefined;
-        if (effectiveDeadlineMs !== undefined) {
-          deadlineTimer = setTimeout(() => {
-            if (!abort.signal.aborted) {
-              abort.abort(new PromptDeadlineExceededError(effectiveDeadlineMs));
-            }
-          }, effectiveDeadlineMs);
-          deadlineTimer.unref();
-        }
 
         let promptPromise: ReturnType<AcpSessionBridge['sendPrompt']>;
         try {
@@ -2356,10 +2350,12 @@ export function registerSessionRoutes(
             {
               ...(clientId !== undefined ? { clientId } : {}),
               promptId,
+              ...(effectiveDeadlineMs !== undefined
+                ? { deadlineMs: effectiveDeadlineMs }
+                : {}),
             },
           );
         } catch (err) {
-          if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
           res.off('close', onResClose);
           res.off('finish', onResFinish);
           if (daemonLog && err instanceof PromptQueueFullError) {
@@ -2407,9 +2403,6 @@ export function registerSessionRoutes(
               }
             },
           )
-          .finally(() => {
-            if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
-          })
           .catch(() => {});
 
         if (daemonLog) {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -2156,15 +2156,6 @@ describe('detectFromLoopback (#4335 / 3272581557)', () => {
   });
 });
 
-function abortableBridgePromptImpl(): FakeBridgeOpts['promptImpl'] {
-  return (_sid, _req, signal) =>
-    new Promise((resolve) => {
-      const onAbort = () => resolve({ stopReason: 'cancelled' });
-      if (signal?.aborted) onAbort();
-      else signal?.addEventListener('abort', onAbort, { once: true });
-    });
-}
-
 describe('createServeApp', () => {
   it('rejects client-MCP over WS with an injected bridge but no matching sender registry', () => {
     expect(() =>
@@ -22219,20 +22210,15 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
       },
     );
 
-    it('returns cleanly when client disconnects in the same tick the deadline fires (wenshao review #3)', async () => {
-      // Critical regression from wenshao's CHANGES_REQUESTED on #4530:
-      // when `res.writableEnded` was true at the moment the deadline
-      // rejection surfaced, the early code `if (err instanceof
-      // PromptDeadlineExceededError && !res.writableEnded) { ...
-      // return; }` would skip BOTH the body AND the return, fall
-      // through to `sendBridgeError`, and try to write 500 to an
-      // already-ended response → ERR_STREAM_WRITE_AFTER_END.
-      //
-      // We force the race by destroying the client socket
-      // immediately after the bridge starts the prompt, so by the
-      // time the 50ms deadline fires the response is already ended.
-      // The route MUST handle this without throwing — assertion is
-      // implicit: a thrown uncaughtException would fail the test.
+    it('returns cleanly when client disconnects right after admission (wenshao review #3)', async () => {
+      // Historic regression from wenshao's CHANGES_REQUESTED on #4530:
+      // the route-side deadline rejection used to race `res.writableEnded`
+      // and write 500 to an already-ended response →
+      // ERR_STREAM_WRITE_AFTER_END. The deadline timer has since moved
+      // into the bridge (DAEMON-003), but the socket-destroy-after-202
+      // scenario stays as a regression guard: the route MUST handle the
+      // disconnect without throwing — assertion is implicit: a thrown
+      // uncaughtException would fail the test.
       let promptStarted: (() => void) | undefined;
       const promptStartedPromise = new Promise<void>((r) => {
         promptStarted = r;
@@ -22282,10 +22268,11 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         // block to handle the race.
         await new Promise((r) => setTimeout(r, 200));
         expect(bridge.promptCalls).toHaveLength(1);
-        // The bridge's signal MUST still have been aborted with the
-        // typed reason — the cleanup path still runs even though the
-        // response was already ended.
-        expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
+        // The deadline race now lives in the bridge: after admission the
+        // route neither arms a timer nor aborts the signal, it only
+        // forwards the effective deadline via `context.deadlineMs`.
+        expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
+        expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(50);
       } finally {
         await localHandle.close();
       }
@@ -22309,12 +22296,16 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
       expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
     });
 
-    it('fires the server-side deadline and aborts the bridge signal', async () => {
-      // 50ms server deadline + a prompt that resolves only on abort:
-      // the deadline timer must abort the AbortController. With non-
-      // blocking prompt the HTTP response is always 202; the deadline
-      // outcome is delivered via `turn_error` on the SSE bus.
-      const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
+    it('forwards the server-side deadline to the bridge via context.deadlineMs', async () => {
+      // The bridge owns the deadline race (DAEMON-003): the route only
+      // resolves the effective deadline and passes it through the
+      // sendPrompt context. With non-blocking prompt the HTTP response
+      // is always 202; the deadline outcome (`turn_error` with code
+      // `prompt_deadline_exceeded`) is published by the bridge and is
+      // covered by bridge.test.ts.
+      const bridge = fakeBridge({
+        promptImpl: () => new Promise(() => {}),
+      });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 50 },
         undefined,
@@ -22327,13 +22318,9 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
       expect(res.status).toBe(202);
       expect(res.body).toHaveProperty('promptId');
       expect(res.body).toHaveProperty('lastEventId');
-      // Wait for the deadline timer to fire asynchronously.
-      await new Promise((r) => setTimeout(r, 200));
       expect(bridge.promptCalls).toHaveLength(1);
-      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
-      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
-        PromptDeadlineExceededError,
-      );
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(50);
+      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
     });
 
     it('strips route-only deadlineMs before forwarding the prompt body', async () => {
@@ -22367,10 +22354,11 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
     });
 
     it('caps a per-prompt `deadlineMs` override at the server flag', async () => {
-      // Server flag 50ms, request asks for 5000ms — effective deadline
-      // must be 50ms. With non-blocking prompt the HTTP response is
-      // always 202; we verify the abort signal fires within ~50ms.
-      const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
+      // Server flag 50ms, request asks for 5000ms — the effective
+      // deadline forwarded to the bridge must be min(server, request).
+      const bridge = fakeBridge({
+        promptImpl: () => new Promise(() => {}),
+      });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 50 },
         undefined,
@@ -22384,17 +22372,16 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
           deadlineMs: 5_000,
         });
       expect(res.status).toBe(202);
-      await new Promise((r) => setTimeout(r, 200));
-      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
-      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
-        PromptDeadlineExceededError,
-      );
+      expect(bridge.promptCalls).toHaveLength(1);
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(50);
     });
 
     it('uses the per-prompt override when shorter than the server flag', async () => {
       // Server flag 10s, request 30ms — request wins as the tighter
-      // bound. Abort signal should fire within ~30ms.
-      const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
+      // bound; the bridge receives the request value.
+      const bridge = fakeBridge({
+        promptImpl: () => new Promise(() => {}),
+      });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 10_000 },
         undefined,
@@ -22408,17 +22395,15 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
           deadlineMs: 30,
         });
       expect(res.status).toBe(202);
-      await new Promise((r) => setTimeout(r, 200));
-      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
-      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
-        PromptDeadlineExceededError,
-      );
+      expect(bridge.promptCalls).toHaveLength(1);
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(30);
     });
 
-    it('still aborts the signal when the bridge IGNORES the abort (non-cooperative bridge)', async () => {
-      // With non-blocking prompt the HTTP response is always 202. The
-      // deadline timer must still fire and abort the signal so the
-      // bridge can observe it, even if it ignores the abort.
+    it('never aborts the bridge signal from a route-side timer (deadline owned by the bridge)', async () => {
+      // Regression guard for the DAEMON-003 timer migration: even well
+      // past the configured deadline the route must NOT abort the
+      // signal — deadline enforcement (terminal publication, FIFO
+      // release, best-effort agent cancel) is the bridge's job.
       const bridge = fakeBridge({
         promptImpl: () => new Promise(() => {}),
       });
@@ -22433,10 +22418,8 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .send({ prompt: [{ type: 'text', text: 'slow' }] });
       expect(res.status).toBe(202);
       await new Promise((r) => setTimeout(r, 200));
-      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
-      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
-        PromptDeadlineExceededError,
-      );
+      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(50);
     });
 
     it('returns 202 without deadline when the flag is unset', async () => {
@@ -22451,10 +22434,14 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
       expect(res.status).toBe(202);
       expect(res.body).toHaveProperty('promptId');
       expect(res.body).toHaveProperty('lastEventId');
+      expect(bridge.promptCalls).toHaveLength(1);
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBeUndefined();
     });
 
-    it('does not fire the deadline when the prompt resolves promptly', async () => {
-      // 5s deadline + immediate resolve: the timer must not fire.
+    it('forwards the deadline even when the prompt resolves promptly', async () => {
+      // 5s deadline + immediate resolve: the route passes the deadline
+      // through unconditionally; the bridge clears its own timer when
+      // the prompt settles (covered by bridge.test.ts).
       const bridge = fakeBridge({
         promptImpl: async () => ({ stopReason: 'end_turn' }),
       });
@@ -22469,9 +22456,21 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
       expect(res.status).toBe(202);
       expect(res.body).toHaveProperty('promptId');
-      // Give enough time for a timer to fire if it were going to.
+      // Give enough time for a stray route-side timer to fire if one
+      // still existed.
       await new Promise((r) => setTimeout(r, 100));
       expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
+      expect(bridge.promptCalls[0]?.context?.deadlineMs).toBe(5_000);
+    });
+
+    it('keeps re-exporting PromptDeadlineExceededError after the bridge migration', () => {
+      // The class definition moved into acp-bridge (DAEMON-003); the
+      // server module must keep exporting it so SDK consumers and
+      // `instanceof` checks across the package boundary stay intact.
+      const err = new PromptDeadlineExceededError(75);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('PromptDeadlineExceededError');
+      expect(err.deadlineMs).toBe(75);
     });
   });
 

--- a/packages/cli/src/serve/server/prompt-deadline.ts
+++ b/packages/cli/src/serve/server/prompt-deadline.ts
@@ -5,18 +5,12 @@
  */
 
 /**
- * Sentinel passed as `AbortController.abort(reason)` when a prompt
- * exceeds its server-configured wallclock. Exported so tests can
- * match on the class identity.
+ * Rejected by the bridge's `sendPrompt` when a prompt exceeds its
+ * wallclock deadline. The class itself lives in the acp-bridge package
+ * (the bridge owns the deadline race since DAEMON-003); re-exported here
+ * so existing `server.ts` / test imports keep working.
  */
-export class PromptDeadlineExceededError extends Error {
-  readonly deadlineMs: number;
-  constructor(deadlineMs: number) {
-    super(`prompt exceeded the ${deadlineMs}ms deadline`);
-    this.name = 'PromptDeadlineExceededError';
-    this.deadlineMs = deadlineMs;
-  }
-}
+export { PromptDeadlineExceededError } from '../acp-session-bridge.js';
 
 /**
  * Resolve the effective per-prompt wallclock from the server flag +


### PR DESCRIPTION
## What this PR does

This PR makes the daemon serve mode guarantee that every prompt accepted with 202 ends with exactly one formal terminal event — a `turn_complete` or `turn_error` keyed by its `promptId` — on every path a prompt can take. Concretely:

- A per-prompt terminal latch routes all terminal publications through a single publisher, so racing paths (agent settle vs. deadline vs. teardown) produce exactly one terminal instead of zero or duplicates.
- Removing a queued prompt now immediately publishes a `turn_complete` with `stopReason: 'cancelled'` for it, instead of silently discarding the FIFO node.
- The prompt wallclock deadline moves from a route-side timer (which only aborted the request signal) into the bridge's dispatch race, armed at admission so it covers queue wait and execution. On expiry the prompt gets a `turn_error{code:'prompt_deadline_exceeded'}` terminal, the per-session FIFO is released, active-prompt bookkeeping is cleared, and the agent is best-effort cancelled — a wedged agent that ignores `cancel()` can no longer pin the session forever.
- All four teardown paths (session close, kill, channel crash, daemon shutdown) now flush an error terminal for every pending prompt before publishing the `session_closed`/`session_died` frame and closing the event bus, and they abort the flushed prompts' signals.
- Close-on-last-detach, attach rollback, and the idle reaper now gate on the pending prompt count instead of the momentarily-false `promptActive` flag, so queued prompts survive the FIFO hand-off gap; the deferred close-on-prompt-complete additionally requires the session entry to still be live and runs after the terminal broadcast, not before.

The wire protocol is unchanged — no new event types or fields; consumers keyed on `turn_complete`/`turn_error` by `promptId` (SDK `matchTurnEvent`, webui turn settlement) just start receiving the terminals they already expect.

One deliberate semantic change: prompts queued behind a prompt whose session then crashes now reject their caller with `AbortError` (the flush aborts them) instead of `SessionNotFoundError`; their SSE observers get a formal error terminal either way.

## Why it's needed

SSE consumers settle a turn by awaiting a terminal event for their `promptId`. Today several ordinary paths drop that terminal entirely: removing a queued prompt emits nothing; a non-cooperative agent under a deadline leaves the prompt unsettled, permanently wedging the session FIFO and exempting the session from idle reaping (an unbounded leak driven by one bad turn); and every teardown path closes the event bus before pending prompts get a terminal, so their outcomes vanish. Separately, a detach landing in the hand-off gap between two prompts closes the session and destroys queued work that was already accepted with 202. Each of these turns into an indefinite client-side hang or silent data loss. Audited as DAEMON-002/003/004/005 in an external reliability review.

## Reviewer Test Plan

### How to verify

The new test suite `prompt terminal exactly-once (DAEMON-002/003/004/005)` in the acp-bridge package covers each guarantee behaviorally: dedup under racing publishers, queued-removal terminal, deadline expiry against a wedged agent (terminal + FIFO release + follow-up prompt dispatches), teardown flush ordering (terminals strictly before `session_closed`/`session_died`), draining before close-on-last-detach, and the deferred-close-vs-broadcast ordering. Run:

```
cd packages/acp-bridge && npx vitest run src/bridge.test.ts
cd packages/cli && npx vitest run src/serve/server.test.ts -t "prompt deadline"
```

Expected: all green (424 tests in bridge.test.ts locally). For the deadline behavior end-to-end: start a daemon with `--prompt-deadline-ms`, send a prompt to an agent that never settles and ignores cancellation, and observe on the session SSE stream a `turn_error` with `code: 'prompt_deadline_exceeded'` for that `promptId`, after which a follow-up prompt on the same session dispatches normally (previously: no event ever, and the session wedged permanently).

Mutation testing was used to validate test strength: five hand-injected regressions (latch removed, close-path flush removed, deadline race removed, queued-prompt close condition removed, queued-removal terminal removed) were each caught by at least one failing test.

### Evidence (Before & After)

N/A (daemon/SSE behavior, covered by unit tests above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests via vitest; full `npm run build && npm run typecheck` pass.

## Risk & Scope

- Main risk or tradeoff: teardown paths now do extra work (terminal flush) before closing the bus; the flush is snapshot-based and try/catch-wrapped so a bad prompt entry cannot block teardown. The deadline rejection surfaces to `sendPrompt` callers as a typed `PromptDeadlineExceededError`.
- Not validated / out of scope: DAEMON-001/007/008 (recovery-path gaps) and DAEMON-009/010/011 (resource hardening) from the same audit are intentionally not addressed here and will follow separately.
- Breaking changes / migration notes: none on the wire. The queued-prompt-after-crash caller rejection changes from `SessionNotFoundError` to `AbortError` (see above); no in-repo caller depends on the old type.

## Linked Issues

Fixes #7399

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 使 daemon serve 模式保证：每个以 202 被接受的 prompt，在其可能经历的每条路径上，都恰好收到一个以其 `promptId` 为键的正式终态事件（`turn_complete` 或 `turn_error`）。具体包括：

- 引入 per-prompt 终态闩锁，所有终态发布统一经由单一发布函数，竞争路径（agent 正常结束 vs. deadline 到期 vs. 会话销毁）只会产出恰好一个终态，不再是零个或重复。
- 移除排队中的 prompt 时，立即为其发布 `stopReason: 'cancelled'` 的 `turn_complete`，不再静默丢弃 FIFO 节点。
- prompt 的绝对时限从路由侧定时器（只 abort 请求信号）移入 bridge 的派发竞速，在 admission 点武装，覆盖排队等待与执行全程。到期时发布 `turn_error{code:'prompt_deadline_exceeded'}` 终态、释放会话 FIFO、清理 active-prompt 记账并尽力取消 agent——无视 `cancel()` 的卡死 agent 不再能永久钉死会话。
- 四条销毁路径（关闭会话、kill、channel 崩溃、daemon 关停）在发布 `session_closed`/`session_died` 帧和关闭事件总线之前，先为每个未终结 prompt 冲刷一个错误终态，并 abort 这些 prompt 的信号。
- close-on-last-detach、attach 回滚和空闲回收器改为以未终结 prompt 计数为门控，替代瞬时为假的 `promptActive` 标志，排队中的 prompt 得以在 FIFO 交接间隙中存活；延迟关闭额外要求会话条目仍然存活，且在终态广播之后执行而非之前。

线上协议无任何变化——没有新增事件类型或字段；按 `promptId` 等待 `turn_complete`/`turn_error` 的消费者（SDK `matchTurnEvent`、webui 回合结算）只是开始收到它们本就期待的终态。

一处有意的语义变化：排队在崩溃会话后面的 prompt，其调用方现在收到 `AbortError`（由冲刷主动 abort）而非 `SessionNotFoundError`；其 SSE 观察者无论如何都会收到正式的错误终态。

## 为什么需要

SSE 消费者依靠等待自己 `promptId` 的终态事件来结算回合。当前多条常规路径会彻底丢掉这个终态：移除排队 prompt 不发任何事件；配置 deadline 时遇到不配合的 agent 会让 prompt 永不结算，永久钉死会话 FIFO 并使会话豁免于空闲回收（一个坏回合导致无界资源泄漏）；每条销毁路径都在未终结 prompt 拿到终态之前关闭事件总线，其结局凭空消失。另外，detach 落在两个 prompt 的交接间隙时会关闭会话，销毁已被 202 接受的排队工作。上述每一条都会变成客户端的无限等待或静默数据丢失。这些问题在外部可靠性审计中被记录为 DAEMON-002/003/004/005。

## 审阅者测试计划

### 如何验证

acp-bridge 包中新增的测试套件 `prompt terminal exactly-once (DAEMON-002/003/004/005)` 从行为层面覆盖每项保证：竞争发布下的去重、排队移除的终态、deadline 对卡死 agent 的到期处理（终态 + FIFO 释放 + 后续 prompt 正常派发）、销毁路径的冲刷顺序（终态严格先于 `session_closed`/`session_died`）、close-on-last-detach 前的排空、以及延迟关闭与广播的先后顺序。运行：

```
cd packages/acp-bridge && npx vitest run src/bridge.test.ts
cd packages/cli && npx vitest run src/serve/server.test.ts -t "prompt deadline"
```

预期：全部通过（本地 bridge.test.ts 共 424 个测试）。端到端验证 deadline 行为：以 `--prompt-deadline-ms` 启动 daemon，向一个永不结束且无视取消的 agent 发送 prompt，在会话 SSE 流上应观察到该 `promptId` 的 `turn_error`（`code: 'prompt_deadline_exceeded'`），之后同一会话的后续 prompt 正常派发（修复前：永远没有事件，会话永久卡死）。

测试强度经变异测试验证：手工注入五处回归（移除闩锁、移除关闭路径冲刷、移除 deadline 竞速、移除排队 prompt 关闭条件、移除排队移除终态），每处均被至少一个失败测试捕获。

### 证据（Before & After）

N/A（daemon/SSE 行为，由上述单元测试覆盖）。

### 已测试平台

macOS 本地验证通过；Windows/Linux 依赖 CI。

### 环境（可选）

本地 vitest 单元测试；完整 `npm run build && npm run typecheck` 通过。

## 风险与范围

- 主要风险或权衡：销毁路径在关闭总线前多做一步终态冲刷；冲刷基于快照并有 try/catch 包裹，单个异常 prompt 条目不会阻塞销毁流程。deadline 拒绝以类型化的 `PromptDeadlineExceededError` 暴露给 `sendPrompt` 调用方。
- 未验证 / 范围之外：同一审计中的 DAEMON-001/007/008（恢复链路缺口）与 DAEMON-009/010/011（资源硬化）刻意不在本 PR 处理，将另行跟进。
- 破坏性变更 / 迁移说明：线上协议无变化。崩溃后排队 prompt 的调用方拒绝类型从 `SessionNotFoundError` 变为 `AbortError`（见上文）；仓库内无调用方依赖旧类型。

## 关联 Issue

Fixes #7399

</details>
