### PR TITLE
fix(deps): regenerate the ink@7.0.3 patch so it applies on a clean install

### DIFF
--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -1,25 +1,3 @@
-diff --git a/node_modules/ink/package.json b/node_modules/ink/package.json
---- a/node_modules/ink/package.json
-+++ b/node_modules/ink/package.json
-@@ -11,8 +11,16 @@
- 	},
- 	"type": "module",
- 	"exports": {
--		"types": "./build/index.d.ts",
--		"default": "./build/index.js"
-+		".": {
-+			"types": "./build/index.d.ts",
-+			"default": "./build/index.js"
-+		},
-+		"./dom": {
-+			"default": "./build/dom.js"
-+		},
-+		"./components/CursorContext": {
-+			"default": "./build/components/CursorContext.js"
-+		}
- 	},
- 	"engines": {
- 		"node": ">=22"
 diff --git a/node_modules/ink/build/frame-controller.d.ts b/node_modules/ink/build/frame-controller.d.ts
 new file mode 100644
 index 0000000..fe4821e
@@ -126,7 +104,7 @@ index cc849f0..25d6b33 100644
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/node_modules/ink/build/ink.js b/node_modules/ink/build/ink.js
-index ef659f3..fbba275 100644
+index ef659f3..cbdb068 100644
 --- a/node_modules/ink/build/ink.js
 +++ b/node_modules/ink/build/ink.js
 @@ -17,6 +17,7 @@ import { hideCursorEscape, showCursorEscape } from './cursor-helpers.js';
@@ -167,7 +145,7 @@ index ef659f3..fbba275 100644
 +        const { output, outputHeight, staticOutput, cells } = render(this.rootNode, this.isScreenReaderEnabled, selection);
 +        if (cells && this.frameController) {
 +            this.frameController.publishFrame({
-+                width: cells.reduce((width, row) => Math.max(width, row.length), 0),
++                width: cells[0]?.length ?? 0,
 +                height: cells.length,
 +                cells,
 +            });
@@ -175,14 +153,6 @@ index ef659f3..fbba275 100644
          this.options.onRender?.({ renderTime: performance.now() - startTime });
          // If <Static> output isn't empty, it means new children have been added to it
          const hasStaticOutput = staticOutput && staticOutput !== '\n';
-@@ -642,6 +658,7 @@ export default class Ink {
-         this.alternateScreen = this.resolveAlternateScreenOption(enabled, this.interactive);
-         if (this.alternateScreen) {
-             this.writeBestEffort(this.options.stdout, ansiEscapes.enterAlternativeScreen);
-+            this.writeBestEffort(this.options.stdout, ansiEscapes.clearTerminal);
-             this.writeBestEffort(this.options.stdout, hideCursorEscape);
-         }
-     }
 diff --git a/node_modules/ink/build/output.d.ts b/node_modules/ink/build/output.d.ts
 index 0f4523f..1ceda6a 100644
 --- a/node_modules/ink/build/output.d.ts


### PR DESCRIPTION
## What this PR does

Regenerates `patches/ink+7.0.3.patch` so patch-package applies it cleanly on a fresh `npm install` / `npm ci`.

## Why it's needed

The committed patch no longer applies to the `ink@7.0.3` tarball the lockfile pins. I confirmed the lockfile-pinned integrity and the current registry integrity are byte-identical (`sha512-5kxHkIj9…`), and that `git apply --check` fails against a pristine `ink@7.0.3` on `package.json`, `build/index.js`, `build/ink.js`, `build/output.js`, and `build/renderer.js` — the patch was cut against a different ink build than the one that ships. On a clean install the `postinstall` patch-package step therefore fails, `ink` is left without the text-selection exports added for VP mouse selection (`getFrameController` / `FrameController` / `ReadonlyFrame` / `ScreenSelection` / `FrameCell`), and `packages/cli/src/ui/selection/*` fails to build with `TS2305: Module '"ink"' has no exported member …`. Existing checkouts keep working only because they still carry an already-patched `node_modules/ink` from when the patch last applied, so this is invisible until someone installs from scratch (fresh clone, new worktree, or CI without a warm `node_modules`).

The regenerated patch reproduces the exact ink state the project already runs on and drops three hunks that no longer apply and are not needed: the `package.json` subpath exports (`./dom`, `./components/CursorContext` — not imported by any source file), a `clearTerminal` write on alternate-screen enter (redundant with the per-render clear at `ink.js` render time), and a frame-width calc the published build already expresses differently (`cells[0]?.length` vs `cells.reduce(max)` — equivalent for the rectangular cell grid). Net change is 2 insertions / 32 deletions; the selection feature the patch exists for is unchanged.

## Reviewer Test Plan

### How to verify

1. From a clean state (no `node_modules`), run `npm ci`.
2. **Before** (on `main`): `postinstall` patch-package reports `**ERROR** Failed to apply patch for package ink`, and the build fails with `src/ui/selection/*.ts … error TS2305: Module '"ink"' has no exported member 'getFrameController'` (and siblings).
3. **After** (this branch): `npm ci` completes, patch-package applies, and the build passes.
4. Optionally confirm the patch is well-formed against a pristine dep: `npm install ink@7.0.3` in a scratch dir, then `git apply -p1 --check patches/ink+7.0.3.patch` exits 0.

### Evidence (Before & After)

Verified on a fresh worktree checked out from `origin/main` (empty `node_modules`):

- `git apply -p1 --check` of the old patch against a pristine `ink@7.0.3`: fails (`patch does not apply` on package.json / index.js / ink.js / output.js / renderer.js).
- `git apply -p1 --check` of the regenerated patch against a pristine `ink@7.0.3`: exit 0.
- Full `npm ci` on this branch: exit 0 (postinstall patch applies, prepare build passes).
- After install, `node_modules/ink/build/frame-controller.js` exists and `node_modules/ink/build/index.js` exports `getFrameController` / `ScreenSelection`.
- `npm run build --workspace=packages/cli`: exit 0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

`npm ci` + `git apply --check` on macOS (darwin), Node 22. Windows/Linux covered by CI.

## Risk & Scope

- Main risk or tradeoff: the regenerated patch reproduces the ink modifications the project already runs on, expressed against the pinned `ink@7.0.3`; it is not a behavior change for anyone whose `node_modules/ink` was already patched. The only observable change is that a clean install now succeeds instead of failing.
- Not validated / out of scope: this does not touch the VP UX fixes tracked separately. The dropped `clearTerminal`-on-alt-enter hunk is not present in the ink the project currently runs, so this PR does not change VP rendering behavior.
- Breaking changes / migration notes: none. If a machine has a stale already-patched `node_modules/ink`, a normal `npm ci` (or deleting `node_modules/ink` and reinstalling) picks up the corrected patch.

## Follow-up

This regeneration is intentionally minimal: it restores the text-selection exports so a clean `npm install` builds. The original patch also carried a `clearTerminal`-on-alternate-screen-enter line (VP-mode rendering) that no longer applies to the published ink and is not reinstated here — reinstating it on the current ink anchors content to the top but clips the top row and breaks scrolling, because the published ink's incremental renderer has diverged. Restoring that behavior in a renderer-compatible way (which also fixes the VP-mode "blank top / content anchored low" symptom) is deferred to a separate VP-rendering follow-up that needs interactive verification in a real terminal.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

重新生成 `patches/ink+7.0.3.patch`,使其在全新 `npm install` / `npm ci` 时能被 patch-package 干净应用。

## 为什么需要

已提交的补丁对 lockfile pin 的 `ink@7.0.3` tarball 已经打不上了。我确认了 lockfile pin 的 integrity 与 registry 当前 integrity 完全一致(`sha512-5kxHkIj9…`),并且 `git apply --check` 对 pristine `ink@7.0.3` 在 `package.json`、`build/index.js`、`build/ink.js`、`build/output.js`、`build/renderer.js` 上全部失败——补丁是对着与发布版不同的 ink build 生成的。于是全新安装时 `postinstall` 的 patch-package 步骤失败,ink 缺少 VP 鼠标选择所需的导出(`getFrameController` / `FrameController` / `ReadonlyFrame` / `ScreenSelection` / `FrameCell`),`packages/cli/src/ui/selection/*` 以 `TS2305` 编译失败。已有 checkout 之所以还能用,只是因为它们仍保留着补丁上次能应用时打好的 `node_modules/ink`,所以只有从零安装(全新 clone、新 worktree、无缓存 CI)才会暴露。

重新生成的补丁复现了项目本就在跑的 ink 状态,并删掉三处已不适用且不需要的 hunk:`package.json` 子路径导出(`./dom`、`./components/CursorContext`——没有任何源码 import)、alternate-screen 进入时的 `clearTerminal` 写入(与每帧渲染时的清屏冗余)、以及一处发布版已用不同写法表达的帧宽计算(`cells[0]?.length` vs `cells.reduce(max)`——对矩形 cell 网格等价)。净变更 2 增 32 删;补丁存在的意义(选择功能)不变。

## 评审测试计划

### 如何验证

1. 从干净状态(无 `node_modules`)执行 `npm ci`。
2. **修复前**(在 `main`):`postinstall` 的 patch-package 报 `**ERROR** Failed to apply patch for package ink`,build 以 `src/ui/selection/*.ts … error TS2305: Module '"ink"' has no exported member 'getFrameController'`(及同类)失败。
3. **修复后**(本分支):`npm ci` 通过,补丁应用成功,build 通过。
4. 可选:在临时目录 `npm install ink@7.0.3`,再 `git apply -p1 --check patches/ink+7.0.3.patch`,退出码为 0。

### 证据(修复前后)

在从 `origin/main` 全新检出(空 `node_modules`)的 worktree 上验证:

- 旧补丁对 pristine `ink@7.0.3` 做 `git apply -p1 --check`:失败(package.json / index.js / ink.js / output.js / renderer.js 上 `patch does not apply`)。
- 新补丁对 pristine `ink@7.0.3` 做 `git apply -p1 --check`:退出码 0。
- 本分支完整 `npm ci`:退出码 0(postinstall 补丁应用,prepare build 通过)。
- 安装后 `node_modules/ink/build/frame-controller.js` 存在,`node_modules/ink/build/index.js` 导出 `getFrameController` / `ScreenSelection`。
- `npm run build --workspace=packages/cli`:退出码 0。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

macOS(darwin)/Node 22 上跑了 `npm ci` 与 `git apply --check`;Windows/Linux 由 CI 覆盖。

## 风险与范围

- 主要风险或权衡:重新生成的补丁复现项目本就在跑的 ink 修改,只是改成对着 pin 的 `ink@7.0.3` 表达;对于 `node_modules/ink` 已打过补丁的人不构成行为变化。唯一可观察的变化是全新安装从失败变成成功。
- 未验证 / 超出范围:不涉及单独跟踪的 VP UX 修复。被删掉的 `clearTerminal`-on-alt-enter hunk 在项目当前运行的 ink 里本就不存在,所以本 PR 不改变 VP 渲染行为。
- 破坏性变更 / 迁移说明:无。若某机器上有过时的已打补丁 `node_modules/ink`,正常 `npm ci`(或删掉 `node_modules/ink` 重装)即可拿到修正后的补丁。

## 后续跟进(Follow-up)

本次重生成是有意最小化的:只恢复文本选中导出,让全新 `npm install` 能构建。原补丁还带有一行进备用屏后的 `clearTerminal`(VP 模式渲染),它对已发布 ink 已打不上,这里也未恢复——在当前 ink 上加回它会把内容顶到顶部但裁掉顶行并破坏滚动,因为已发布 ink 的增量渲染器已变化。以与渲染器兼容的方式恢复该行为(同时也修复 VP 模式「上半空白 / 内容偏下」现象)留到单独的 VP 渲染 follow-up,需要在真机终端交互式验证。

## 关联 Issue

无。

</details>

