### PR TITLE
fix(cli): soften update-check failure UX — warning instead of error, raise timeout to 5s

### DIFF
--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -43,7 +43,10 @@ const initializeI18n = vi.fn();
 const resolveLanguageSetting = vi.fn((language?: string) => language || 'auto');
 
 vi.mock('../config/settings.js', () => ({ loadSettings }));
-vi.mock('../ui/utils/updateCheck.js', () => ({ checkForUpdatesDetailed }));
+vi.mock('../ui/utils/updateCheck.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/utils/updateCheck.js')>()),
+  checkForUpdatesDetailed,
+}));
 vi.mock('../utils/installationInfo.js', () => ({
   formatUpdateInstructions,
   getInstallationInfo,
@@ -235,7 +238,7 @@ describe('update command', () => {
     await updateCommand.handler(updateArgs);
 
     expect(writeStderrLine).toHaveBeenCalledWith(
-      'Failed to check for updates. Please check your network or registry configuration.',
+      'Failed to check for updates (registry error). Please check your network or registry configuration.',
     );
     expect(process.exitCode).toBe(1);
     expect(getInstallationInfo).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -15,7 +15,7 @@ export const updateCommand: CommandModule = {
   handler: async () => {
     const [
       { loadSettings },
-      { checkForUpdatesDetailed },
+      { checkForUpdatesDetailed, describeUpdateCheckFailure },
       installationInfoModule,
       standaloneUpdate,
       stdioHelpers,
@@ -54,7 +54,8 @@ export const updateCommand: CommandModule = {
     if (updateCheck.status === 'error') {
       writeStderrLine(
         t(
-          'Failed to check for updates. Please check your network or registry configuration.',
+          'Failed to check for updates ({{reason}}). Please check your network or registry configuration.',
+          { reason: describeUpdateCheckFailure(updateCheck.error) },
         ),
       );
       process.exitCode = 1;

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -2098,6 +2098,14 @@ export default {
     'Hi ha una versió nova de Qwen Code disponible! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!':
     'Qwen Code {{version}} està actualitzat!',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    "No s'han pogut comprovar les actualitzacions ({{reason}}). Comproveu la xarxa o la configuració del registre.",
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    "S'ha omès la comprovació d'actualitzacions ({{reason}}) — executeu /update per tornar-ho a provar.",
+  'registry did not respond within {{seconds}}s':
+    'el registre no ha respost en {{seconds}}s',
+  'registry unreachable': 'no es pot accedir al registre',
+  'registry error': 'error del registre',
   'Unable to check for updates: {{reason}}':
     'No es poden comprovar les actualitzacions: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -2098,8 +2098,6 @@ export default {
     'Hi ha una versió nova de Qwen Code disponible! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!':
     'Qwen Code {{version}} està actualitzat!',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    "No s'han pogut comprovar les actualitzacions. Comproveu la xarxa o la configuració del registre.",
   'Unable to check for updates: {{reason}}':
     'No es poden comprovar les actualitzacions: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -2146,6 +2146,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Eine neue Version von Qwen Code ist verfügbar! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} ist aktuell!',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'Suche nach Updates fehlgeschlagen ({{reason}}). Bitte Netzwerk- oder Registry-Konfiguration prüfen.',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'Update-Prüfung übersprungen ({{reason}}) — mit /update erneut versuchen.',
+  'registry did not respond within {{seconds}}s':
+    'Registry hat nicht innerhalb von {{seconds}}s geantwortet',
+  'registry unreachable': 'Registry nicht erreichbar',
+  'registry error': 'Registry-Fehler',
   'Unable to check for updates: {{reason}}':
     'Updates können nicht geprüft werden: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -2146,8 +2146,6 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Eine neue Version von Qwen Code ist verfügbar! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} ist aktuell!',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'Suche nach Updates fehlgeschlagen. Bitte Netzwerk- oder Registry-Konfiguration prüfen.',
   'Unable to check for updates: {{reason}}':
     'Updates können nicht geprüft werden: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -2604,8 +2604,14 @@ export default {
     'A new version of Qwen Code is available! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!':
     'Qwen Code {{version}} is up to date!',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'Failed to check for updates. Please check your network or registry configuration.',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'Failed to check for updates ({{reason}}). Please check your network or registry configuration.',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'Update check skipped ({{reason}}) — run /update to retry.',
+  'registry did not respond within {{seconds}}s':
+    'registry did not respond within {{seconds}}s',
+  'registry unreachable': 'registry unreachable',
+  'registry error': 'registry error',
   'Unable to check for updates: {{reason}}':
     'Unable to check for updates: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -2148,8 +2148,6 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Une nouvelle version de Qwen Code est disponible ! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} est à jour !',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'Échec de la vérification des mises à jour. Vérifiez votre réseau ou la configuration du registre.',
   'Unable to check for updates: {{reason}}':
     'Impossible de vérifier les mises à jour : {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -2148,6 +2148,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Une nouvelle version de Qwen Code est disponible ! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} est à jour !',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'Échec de la vérification des mises à jour ({{reason}}). Vérifiez votre réseau ou la configuration du registre.',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'Vérification des mises à jour ignorée ({{reason}}) — exécutez /update pour réessayer.',
+  'registry did not respond within {{seconds}}s':
+    "le registre n'a pas répondu en {{seconds}}s",
+  'registry unreachable': 'registre inaccessible',
+  'registry error': 'erreur du registre',
   'Unable to check for updates: {{reason}}':
     'Impossible de vérifier les mises à jour : {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1912,8 +1912,6 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Qwen Code の新しいバージョンがあります！{{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} は最新です！',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'アップデートの確認に失敗しました。ネットワークまたはレジストリ設定を確認してください。',
   'Unable to check for updates: {{reason}}':
     'アップデートを確認できません: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1912,6 +1912,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Qwen Code の新しいバージョンがあります！{{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} は最新です！',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'アップデートの確認に失敗しました（{{reason}}）。ネットワークまたはレジストリ設定を確認してください。',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'アップデートの確認をスキップしました（{{reason}}）— /update で再試行できます。',
+  'registry did not respond within {{seconds}}s':
+    'レジストリが {{seconds}} 秒以内に応答しませんでした',
+  'registry unreachable': 'レジストリに接続できません',
+  'registry error': 'レジストリエラー',
   'Unable to check for updates: {{reason}}':
     'アップデートを確認できません: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -2133,8 +2133,6 @@ export default {
     'Uma nova versão do Qwen Code está disponível! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!':
     'Qwen Code {{version}} está atualizado!',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'Falha ao verificar atualizações. Verifique sua rede ou configuração do registro.',
   'Unable to check for updates: {{reason}}':
     'Não foi possível verificar atualizações: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -2133,6 +2133,14 @@ export default {
     'Uma nova versão do Qwen Code está disponível! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!':
     'Qwen Code {{version}} está atualizado!',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'Falha ao verificar atualizações ({{reason}}). Verifique sua rede ou configuração do registro.',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'Verificação de atualização ignorada ({{reason}}) — execute /update para tentar novamente.',
+  'registry did not respond within {{seconds}}s':
+    'o registro não respondeu em {{seconds}}s',
+  'registry unreachable': 'registro inacessível',
+  'registry error': 'erro no registro',
   'Unable to check for updates: {{reason}}':
     'Não foi possível verificar atualizações: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -2120,8 +2120,6 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Доступна новая версия Qwen Code! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} актуален!',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    'Не удалось проверить обновления. Проверьте сеть или настройки registry.',
   'Unable to check for updates: {{reason}}':
     'Невозможно проверить обновления: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -2120,6 +2120,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Доступна новая версия Qwen Code! {{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} актуален!',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    'Не удалось проверить обновления ({{reason}}). Проверьте сеть или настройки registry.',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    'Проверка обновлений пропущена ({{reason}}) — выполните /update для повторной попытки.',
+  'registry did not respond within {{seconds}}s':
+    'registry не ответил за {{seconds}} с',
+  'registry unreachable': 'registry недоступен',
+  'registry error': 'ошибка registry',
   'Unable to check for updates: {{reason}}':
     'Невозможно проверить обновления: {{reason}}',
   'Update successful! The new version will be used on your next run.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -2197,8 +2197,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Qwen Code 有新版本可用！{{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} 已是最新！',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    '檢查更新失敗。請檢查網路或 registry 設定。',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    '檢查更新失敗（{{reason}}）。請檢查網路或 registry 設定。',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    '已略過更新檢查（{{reason}}）— 可執行 /update 重試。',
+  'registry did not respond within {{seconds}}s':
+    'registry 在 {{seconds}} 秒內未回應',
+  'registry unreachable': 'registry 無法連線',
+  'registry error': 'registry 錯誤',
   'Unable to check for updates: {{reason}}': '無法檢查更新：{{reason}}',
   'Update successful! The new version will be used on your next run.':
     '更新成功！新版本將在下次執行時生效。',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -2399,8 +2399,14 @@ export default {
   'A new version of Qwen Code is available! {{current}} → {{latest}}':
     'Qwen Code 有新版本可用！{{current}} → {{latest}}',
   'Qwen Code {{version}} is up to date!': 'Qwen Code {{version}} 已是最新！',
-  'Failed to check for updates. Please check your network or registry configuration.':
-    '检查更新失败。请检查网络或 registry 配置。',
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.':
+    '检查更新失败（{{reason}}）。请检查网络或 registry 配置。',
+  'Update check skipped ({{reason}}) — run /update to retry.':
+    '已跳过更新检查（{{reason}}）— 可运行 /update 重试。',
+  'registry did not respond within {{seconds}}s':
+    'registry 在 {{seconds}} 秒内未响应',
+  'registry unreachable': 'registry 无法连接',
+  'registry error': 'registry 错误',
   'Unable to check for updates: {{reason}}': '无法检查更新：{{reason}}',
   'Update successful! The new version will be used on your next run.':
     '更新成功！新版本将在下次运行时生效。',

--- a/packages/cli/src/startup/startup-prefetch.test.ts
+++ b/packages/cli/src/startup/startup-prefetch.test.ts
@@ -51,7 +51,8 @@ vi.mock('../utils/startupProfiler.js', () => ({
   recordStartupEvent: (...args: unknown[]) => mockRecordStartupEvent(...args),
 }));
 
-vi.mock('../ui/utils/updateCheck.js', () => ({
+vi.mock('../ui/utils/updateCheck.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/utils/updateCheck.js')>()),
   checkForUpdatesDetailed: (...args: unknown[]) =>
     mockCheckForUpdatesDetailed(...args),
 }));
@@ -78,7 +79,12 @@ vi.mock('../utils/updateEventEmitter.js', () => ({
 }));
 
 vi.mock('../i18n/index.js', () => ({
-  t: (key: string) => key,
+  t: (key: string, params?: Record<string, string | number>) =>
+    params
+      ? key.replace(/\{\{(\w+)\}\}/g, (match, name) =>
+          name in params ? String(params[name]) : match,
+        )
+      : key,
 }));
 
 vi.mock('../core/initializer.js', () => ({
@@ -415,7 +421,7 @@ describe('startupPrefetch', () => {
     expect(mockConnectIdeForStartup).toHaveBeenCalledWith(config);
   });
 
-  it('surfaces update check errors through the update event emitter', async () => {
+  it('surfaces update check errors as a warning through the update event emitter', async () => {
     const config = makeConfig();
     mockCheckForUpdatesDetailed.mockResolvedValue({
       status: 'error',
@@ -427,10 +433,50 @@ describe('startupPrefetch', () => {
     await vi.dynamicImportSettled();
 
     expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
-      message:
-        'Failed to check for updates. Please check your network or registry configuration.',
+      message: 'Update check skipped (registry error) — run /update to retry.',
+      severity: 'warning',
     });
     expect(mockRequestUpdateOnExit).not.toHaveBeenCalled();
+  });
+
+  it('reports a timeout-specific reason when the update check times out', async () => {
+    const config = makeConfig();
+    const { UpdateCheckTimeoutError, FETCH_TIMEOUT_MS } = await import(
+      '../ui/utils/updateCheck.js'
+    );
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'error',
+      error: new UpdateCheckTimeoutError(FETCH_TIMEOUT_MS, 'latest'),
+    });
+
+    startPostRenderPrefetches(config, makeSettings());
+
+    await vi.dynamicImportSettled();
+
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
+      message: `Update check skipped (registry did not respond within ${Math.round(FETCH_TIMEOUT_MS / 1000)}s) — run /update to retry.`,
+      severity: 'warning',
+    });
+  });
+
+  it('reports an offline-specific reason when the registry is unreachable', async () => {
+    const config = makeConfig();
+    const error = new Error('getaddrinfo failed') as NodeJS.ErrnoException;
+    error.code = 'ENOTFOUND';
+    mockCheckForUpdatesDetailed.mockResolvedValue({
+      status: 'error',
+      error,
+    });
+
+    startPostRenderPrefetches(config, makeSettings());
+
+    await vi.dynamicImportSettled();
+
+    expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
+      message:
+        'Update check skipped (registry unreachable) — run /update to retry.',
+      severity: 'warning',
+    });
   });
 
   it('requires connectIde option before connecting IDE', async () => {
@@ -657,8 +703,8 @@ describe('startupPrefetch', () => {
 
     expect(mockWarn).toHaveBeenCalledWith('update_check failed:', error);
     expect(mockUpdateEventEmit).toHaveBeenCalledWith('update-failed', {
-      message:
-        'Failed to check for updates. Please check your network or registry configuration.',
+      message: 'Update check skipped (registry error) — run /update to retry.',
+      severity: 'warning',
     });
   });
 

--- a/packages/cli/src/startup/startup-prefetch.ts
+++ b/packages/cli/src/startup/startup-prefetch.ts
@@ -159,7 +159,7 @@ export function startPostRenderPrefetches(
   ) {
     runDeferredTask('update_check', async () => {
       const [
-        { checkForUpdatesDetailed },
+        { checkForUpdatesDetailed, describeUpdateCheckFailure },
         { handleAutoUpdate },
         { getInstallationInfo },
         { updateEventEmitter },
@@ -171,9 +171,13 @@ export function startPostRenderPrefetches(
         import('../utils/updateEventEmitter.js'),
         import('../i18n/index.js'),
       ]);
-      const updateFailedMessage = t(
-        'Failed to check for updates. Please check your network or registry configuration.',
-      );
+      // The startup check is best-effort background work: surface failures as
+      // a soft warning with the concrete reason instead of an alarming error
+      // (#7049), while keeping the failure visible (#6857).
+      const updateCheckSkippedMessage = (error: unknown) =>
+        t('Update check skipped ({{reason}}) — run /update to retry.', {
+          reason: describeUpdateCheckFailure(error),
+        });
       try {
         const result = await checkForUpdatesDetailed();
         if (result.status === 'update') {
@@ -222,12 +226,14 @@ export function startPostRenderPrefetches(
           }
         } else if (result.status === 'error') {
           updateEventEmitter.emit('update-failed', {
-            message: updateFailedMessage,
+            message: updateCheckSkippedMessage(result.error),
+            severity: 'warning',
           });
         }
       } catch (error) {
         updateEventEmitter.emit('update-failed', {
-          message: updateFailedMessage,
+          message: updateCheckSkippedMessage(error),
+          severity: 'warning',
         });
         throw error;
       }

--- a/packages/cli/src/ui/commands/update-command.test.ts
+++ b/packages/cli/src/ui/commands/update-command.test.ts
@@ -36,7 +36,10 @@ const formatUpdateInstructions = vi.fn(
     return ['Manual update required. Please reinstall Qwen Code.'];
   },
 );
-vi.mock('../utils/updateCheck.js', () => ({ checkForUpdatesDetailed }));
+vi.mock('../utils/updateCheck.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/updateCheck.js')>()),
+  checkForUpdatesDetailed,
+}));
 vi.mock('../../utils/processUtils.js', () => ({
   CUSTOM_SANDBOX_IMAGE_ENV_VAR: 'QWEN_CODE_CUSTOM_SANDBOX_IMAGE',
   HOST_UPDATE_RELAUNCH_ENV_VAR: 'QWEN_CODE_HOST_UPDATE_RELAUNCH',
@@ -376,7 +379,7 @@ describe('updateCommand', () => {
       type: 'message',
       messageType: 'error',
       content:
-        'Failed to check for updates. Please check your network or registry configuration.',
+        'Failed to check for updates (registry error). Please check your network or registry configuration.',
     });
     expect(getInstallationInfo).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/ui/commands/update-command.ts
+++ b/packages/cli/src/ui/commands/update-command.ts
@@ -17,7 +17,7 @@ export const updateCommand: SlashCommand = {
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: async (context) => {
     const [
-      { checkForUpdatesDetailed },
+      { checkForUpdatesDetailed, describeUpdateCheckFailure },
       {
         CUSTOM_SANDBOX_IMAGE_ENV_VAR,
         HOST_UPDATE_RELAUNCH_ENV_VAR,
@@ -54,7 +54,8 @@ export const updateCommand: SlashCommand = {
         type: 'message' as const,
         messageType: 'error' as const,
         content: t(
-          'Failed to check for updates. Please check your network or registry configuration.',
+          'Failed to check for updates ({{reason}}). Please check your network or registry configuration.',
+          { reason: describeUpdateCheckFailure(updateCheck.error) },
         ),
       };
     }

--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -8,6 +8,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import {
   checkForUpdates,
   checkForUpdatesDetailed,
+  classifyUpdateCheckError,
   fetchGlobalNpmUpdateInfo,
   FETCH_TIMEOUT_MS,
   isGlobalNpmInstallation,
@@ -632,5 +633,47 @@ describe('checkForUpdates', () => {
         expect(result.error.message).toMatch(/for (nightly|latest)/);
       }
     });
+  });
+
+  describe('timeout budget (#7049)', () => {
+    it('allows at least 5 seconds for slow registries', () => {
+      expect(FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(5000);
+    });
+  });
+});
+
+describe('classifyUpdateCheckError', () => {
+  it('classifies UpdateCheckTimeoutError as timeout', () => {
+    expect(classifyUpdateCheckError(new UpdateCheckTimeoutError(5000))).toBe(
+      'timeout',
+    );
+  });
+
+  it.each([
+    'ENOTFOUND',
+    'ECONNREFUSED',
+    'EAI_AGAIN',
+    'ETIMEDOUT',
+    'ENETUNREACH',
+  ])('classifies %s errors as offline', (code) => {
+    const error = new Error(`request failed`) as NodeJS.ErrnoException;
+    error.code = code;
+    expect(classifyUpdateCheckError(error)).toBe('offline');
+  });
+
+  it('classifies network codes embedded in the message as offline', () => {
+    // npm child-process failures surface the code inside stderr text only.
+    expect(
+      classifyUpdateCheckError(
+        new Error('npm error code ENOTFOUND\nnpm error network'),
+      ),
+    ).toBe('offline');
+  });
+
+  it('classifies other errors as registry', () => {
+    expect(classifyUpdateCheckError(new Error('404 Not Found'))).toBe(
+      'registry',
+    );
+    expect(classifyUpdateCheckError('not-an-error')).toBe('registry');
   });
 });

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -18,7 +18,10 @@ import { t } from '../../i18n/index.js';
 
 const debugLogger = createDebugLogger('UPDATE_CHECK');
 
-export const FETCH_TIMEOUT_MS = 2000;
+// 5s matches comparable CLIs (e.g. Claude Code's autoUpdater uses
+// AbortSignal.timeout(5000)) and gives slow mirrors and corporate proxies a
+// realistic budget. Related: #7049.
+export const FETCH_TIMEOUT_MS = 5000;
 
 /**
  * Sentinel error thrown when `fetchInfo()` does not resolve within
@@ -40,6 +43,60 @@ export class UpdateCheckTimeoutError extends Error {
     super(`update-notifier fetchInfo timed out after ${timeoutMs}ms${suffix}`);
     this.name = 'UpdateCheckTimeoutError';
     this.distTag = distTag;
+  }
+}
+
+export type UpdateCheckFailureReason = 'timeout' | 'offline' | 'registry';
+
+const NETWORK_ERROR_CODES = [
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+];
+
+/**
+ * Buckets an update-check failure so callers can tell the user what actually
+ * happened instead of a generic "check your network" message. Matches error
+ * codes both on the `code` property and inside the message text, because the
+ * global-npm path surfaces network failures only through `npm` child-process
+ * stderr embedded in the error message. Related: #7049.
+ */
+export function classifyUpdateCheckError(
+  error: unknown,
+): UpdateCheckFailureReason {
+  if (error instanceof UpdateCheckTimeoutError) return 'timeout';
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (
+      NETWORK_ERROR_CODES.some(
+        (netCode) => code === netCode || error.message.includes(netCode),
+      )
+    ) {
+      return 'offline';
+    }
+  }
+  return 'registry';
+}
+
+/**
+ * Short human-readable reason for an update-check failure, for embedding in
+ * status messages, e.g. "registry did not respond within 5s".
+ */
+export function describeUpdateCheckFailure(
+  error: unknown,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): string {
+  switch (classifyUpdateCheckError(error)) {
+    case 'timeout':
+      return t('registry did not respond within {{seconds}}s', {
+        seconds: String(Math.round(timeoutMs / 1000)),
+      });
+    case 'offline':
+      return t('registry unreachable');
+    default:
+      return t('registry error');
   }
 }
 

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -489,6 +489,47 @@ describe('setUpdateHandler', () => {
     cleanup();
   });
 
+  it('should render update-failed with warning severity as a warning (#7049)', () => {
+    const isIdleRef = { current: true };
+    const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);
+
+    updateEventEmitter.emit('update-failed', {
+      message:
+        'Update check skipped (registry unreachable) — run /update to retry.',
+      severity: 'warning',
+    });
+
+    expect(addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.WARNING,
+        text: 'Update check skipped (registry unreachable) — run /update to retry.',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
+  it('should keep rendering update-failed as an error when severity is explicit error', () => {
+    const isIdleRef = { current: true };
+    const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);
+
+    updateEventEmitter.emit('update-failed', {
+      message: 'Automatic update failed. Please try updating manually.',
+      severity: 'error',
+    });
+
+    expect(addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.ERROR,
+        text: 'Automatic update failed. Please try updating manually.',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
   it('should defer addItem when not idle (update-success)', () => {
     const isIdleRef = { current: false };
     const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -189,10 +189,16 @@ export function setUpdateHandler(
     }, 60000);
   };
 
-  const handleUpdateFailed = (data?: { message?: string }) => {
+  const handleUpdateFailed = (data?: {
+    message?: string;
+    severity?: 'error' | 'warning';
+  }) => {
     setUpdateInfo(null);
     addItemOrDefer({
-      type: MessageType.ERROR,
+      // Background update-check failures are emitted with severity 'warning'
+      // (#7049); actual update installation failures stay errors.
+      type:
+        data?.severity === 'warning' ? MessageType.WARNING : MessageType.ERROR,
       text: data?.message ?? t(UPDATE_FAILED_MESSAGE),
     });
   };

--- a/packages/cli/src/utils/update-relaunch.test.ts
+++ b/packages/cli/src/utils/update-relaunch.test.ts
@@ -13,12 +13,24 @@ const getInstallationInfo = vi.hoisted(() => vi.fn());
 const performStandaloneUpdate = vi.hoisted(() => vi.fn());
 const writeStderrLine = vi.hoisted(() => vi.fn());
 
-vi.mock('../ui/utils/updateCheck.js', () => ({ checkForUpdatesDetailed }));
+vi.mock('../ui/utils/updateCheck.js', () => ({
+  checkForUpdatesDetailed,
+  // Classification behavior is covered by updateCheck.test.ts; a fixed reason
+  // keeps this suite from importing the real update-notifier chain.
+  describeUpdateCheckFailure: () => 'registry error',
+}));
 vi.mock('./handleAutoUpdate.js', () => ({ handleAutoUpdate }));
 vi.mock('./installationInfo.js', () => ({ getInstallationInfo }));
 vi.mock('./standalone-update.js', () => ({ performStandaloneUpdate }));
 vi.mock('./stdioHelpers.js', () => ({ writeStderrLine }));
-vi.mock('../i18n/index.js', () => ({ t: (message: string) => message }));
+vi.mock('../i18n/index.js', () => ({
+  t: (message: string, params?: Record<string, string | number>) =>
+    params
+      ? message.replace(/\{\{(\w+)\}\}/g, (match, name) =>
+          name in params ? String(params[name]) : match,
+        )
+      : message,
+}));
 
 const { updateBeforeRelaunch } = await import('./update-relaunch.js');
 
@@ -88,7 +100,7 @@ describe('updateBeforeRelaunch', () => {
       true,
     );
     expect(writeStderrLine).toHaveBeenCalledWith(
-      'Failed to check for updates. Please check your network or registry configuration.',
+      'Failed to check for updates (registry error). Please check your network or registry configuration.',
     );
   });
 

--- a/packages/cli/src/utils/update-relaunch.ts
+++ b/packages/cli/src/utils/update-relaunch.ts
@@ -8,7 +8,7 @@ import type { LoadedSettings } from '../config/settings.js';
 import { writeStderrLine } from './stdioHelpers.js';
 
 const UPDATE_CHECK_FAILED_MESSAGE =
-  'Failed to check for updates. Please check your network or registry configuration.';
+  'Failed to check for updates ({{reason}}). Please check your network or registry configuration.';
 const UPDATE_FAILED_MESSAGE =
   'Automatic update failed. Please try updating manually.';
 
@@ -20,7 +20,7 @@ export async function updateBeforeRelaunch(
   let translate = (message: string) => message;
   try {
     const [
-      { checkForUpdatesDetailed },
+      { checkForUpdatesDetailed, describeUpdateCheckFailure },
       { handleAutoUpdate },
       { getInstallationInfo },
       { performStandaloneUpdate },
@@ -73,7 +73,11 @@ export async function updateBeforeRelaunch(
       );
       return success || relaunchOnFailure;
     } else if (result.status === 'error') {
-      writeStderrLine(t(UPDATE_CHECK_FAILED_MESSAGE));
+      writeStderrLine(
+        t(UPDATE_CHECK_FAILED_MESSAGE, {
+          reason: describeUpdateCheckFailure(result.error),
+        }),
+      );
     }
   } catch {
     writeStderrLine(translate(UPDATE_FAILED_MESSAGE));


### PR DESCRIPTION
## What this PR does

Softens how startup update-check failures are presented and gives the check a realistic time budget. On networks where the npm registry is slow or unreachable, Qwen Code used to greet the user with a red `✕ Failed to check for updates. Please check your network or registry configuration.` on every launch — alarming wording for something that is a non-blocking background convenience. With this PR the same situation renders as a calm yellow warning that says what actually happened and how to retry: `△ Update check skipped (registry unreachable) — run /update to retry.`

Three coordinated changes deliver this:

1. **Timeout budget raised from 2s to 5s.** The 2s budget was aggressive for high-latency mirrors and corporate proxies (per #7224, `npm outdated` on Windows consistently takes ~3s). 5s matches comparable CLIs — Claude Code's autoUpdater uses `AbortSignal.timeout(5000)`. The constant is shared by the update-notifier fetch path and the global-npm `npm view` child-process path, so both get the new budget.
2. **Failure severity is now carried on the event.** The `update-failed` event payload gains an optional `severity?: 'error' | 'warning'` field, defaulting to `'error'` so every existing emitter is unaffected. Only the startup background check emits `severity: 'warning'`, which the UI renders as a yellow `△` warning. Genuine update *install* failures keep the red `✕` error, and `/update` — an explicit user action — also keeps error styling.
3. **Failure reasons are classified and surfaced.** A new classifier buckets failures into *timeout* ("registry did not respond within 5s"), *offline* ("registry unreachable" — matching `ENOTFOUND` / `ECONNREFUSED` / `EAI_AGAIN` / `ETIMEDOUT` / `ENETUNREACH`, both on `error.code` and embedded in npm child-process stderr text), and *registry* (anything else). All four call sites — startup check, `/update` slash command, `qwen update` CLI, and the sandbox update-relaunch path — now include the concrete reason in their message.

i18n: the new strings are translated in all nine locales (en, zh, zh-TW, ca, de, fr, ja, pt, ru), reusing each locale's existing registry/update terminology; the now-unused generic key is removed everywhere. `npm run check-i18n` passes.

## Why it's needed

Users on slow or blocked registries (some regions, corporate proxies) see a red error on **every startup** even though the app works normally — issue #7049, with a real-world downstream report in #7044 (China, v0.19.11, "升级就报错"). The failure surfacing itself is correct and recent (#6857 fixed a real false-negative bug, shipped via #6887); what's wrong is the presentation: error-red styling and a generic message for a background check that the user never asked for and that doesn't block anything.

**This is explicitly not a revert of #6857 / #6887.** Failures stay visible ("loud failure"); only the presentation, wording, and time budget change.

## Reviewer Test Plan

### How to verify

Unreachable registry → offline path (startup, TUI):

```bash
npm_config_registry=http://192.0.2.1:1 qwen
# Expected: yellow "△ Update check skipped (registry unreachable) — run /update to retry."
# appears a few seconds after startup; startup itself is not blocked; app fully usable.
```

Unreachable registry → explicit `/update` keeps loud error, now with the reason:

```bash
npm_config_registry=http://192.0.2.1:1 qwen update
# Expected (stderr, exit code 1):
# "Failed to check for updates (registry unreachable). Please check your network or registry configuration."
```

Timeout path (slow-but-reachable registry, e.g. a delaying proxy): expected reason becomes `registry did not respond within 5s`.

No-regression check (#6857): with a normal registry and an older version installed, the update prompt still appears and auto-update still runs.

Unit tests and checks:

```bash
cd packages/cli
npx vitest run src/ui/utils/updateCheck.test.ts src/startup/startup-prefetch.test.ts \
  src/utils/handleAutoUpdate.test.ts src/ui/commands/update-command.test.ts \
  src/commands/update.test.ts src/utils/update-relaunch.test.ts   # 134 pass
npm run check-i18n                                                # passes
```

Key assertions to look at: startup emits `severity: 'warning'` with the per-reason message (both the resolved-error path and the thrown path); `severity: 'warning'` renders `MessageType.WARNING` while absent/explicit-error severity stays `MessageType.ERROR` (install-failure regression guard); classifier tests cover each network code via `error.code` *and* via message text (the global-npm path only surfaces codes in stderr text); a guard test pins `FETCH_TIMEOUT_MS ≥ 5000`.

### Evidence (Before & After)

**Before** (unreachable registry, red `✕`, generic message):

```
✕ Failed to check for updates. Please check your network or registry
  configuration.
```

**After** (same conditions, yellow `△`, concrete reason + retry hint):

```
△ Update check skipped (registry unreachable) — run /update to retry.
```

Live tmux before/after for both the startup TUI and `qwen update` was captured by the triage bot's independent verification run at `b202c0b` (see review comments above). The exact user-facing strings are also asserted verbatim in the updated tests.

Negative control (tests genuinely pin the fix): with the test files kept and the production files reverted to `origin/main`, the six suites fail 17 tests — restoring the fix brings them back to 134/134:

| configuration | result |
| --- | --- |
| patched production code + new tests | 134 pass / 0 fail ✅ |
| `origin/main` production code + new tests | 117 pass / **17 fail** (severity missing, old wording, 2s constant) |

Blast radius (every other test file importing the touched modules): `gemini.test.tsx` ✅, `standalone-update.test.ts` ✅, `installationInfo.test.ts` ✅; `AppContainer.test.tsx` runs 114/121 with 7 failures in the unrelated terminal-title feature that fail identically on unpatched `origin/main` in this environment (TTY-dependent, pre-existing — not introduced by this PR).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux x86_64, Node.js v22, npm workspaces install; verification via the vitest suites, `npm run check-i18n`, and eslint on changed files.

## Risk & Scope

- Main risk or tradeoff: accidentally downgrading *real* failures to warnings. Mitigated by design — `severity` defaults to `'error'`, only the startup check branch opts into `'warning'`, and regression tests assert install failures still render as errors. Secondary tradeoff: on broken networks the (now softer) notice can appear up to 3s later than before; the check runs as a post-render deferred task, so startup latency is unaffected.
- Not validated / out of scope: live TUI runs on macOS/Windows locally (covered by CI matrix); the `skipped` status (`development mode` etc.) keeps its current styling — changing it is out of scope for #7049; no config/setting to customize the timeout (can be a follow-up if maintainers want it).
- Breaking changes / migration notes: none. The event payload extension is backward-compatible (optional field, error default); no public API, settings, or protocol changes.

## Linked Issues

- Fixes #7049
- Downstream user report: #7044
- Context (kept, not reverted): #6857, #6887
- Timing data motivating the 5s budget: #7224

Commits: `b202c0b` (the fix), `a233b5f` (review follow-up — translations for the six locales flagged in the triage review, so all nine locales now carry the new keys).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

软化启动时更新检查失败的呈现方式，并给检查一个更符合现实的时间预算。在 npm registry 缓慢或不可达的网络环境下，Qwen Code 过去每次启动都会显示红色的 `✕ Failed to check for updates. Please check your network or registry configuration.`——对一个非阻塞的后台便利功能来说，这种措辞过于惊吓。本 PR 之后，同样场景会渲染为平和的黄色警告，说明实际发生了什么以及如何重试：`△ Update check skipped (registry unreachable) — run /update to retry.`

三个配套改动：

1. **超时预算从 2 秒提高到 5 秒。** 2 秒对高延迟镜像和公司代理过于激进（#7224 数据显示 Windows 上 `npm outdated` 稳定耗时约 3 秒）。5 秒与同类 CLI 一致——Claude Code 的 autoUpdater 使用 `AbortSignal.timeout(5000)`。该常量同时作用于 update-notifier 路径和 global-npm 的 `npm view` 子进程路径。
2. **失败严重级别随事件携带。** `update-failed` 事件负载新增可选字段 `severity?: 'error' | 'warning'`，默认 `'error'`，所有现有发射点不受影响。只有启动后台检查发出 `severity: 'warning'`，UI 渲染为黄色 `△` 警告。真正的更新*安装*失败保持红色 `✕` 错误；`/update` 作为用户显式操作，同样保持错误样式。
3. **失败原因分类并呈现。** 新的分类器将失败分为*超时*（"registry did not respond within 5s"）、*离线*（"registry unreachable"——匹配 `ENOTFOUND` / `ECONNREFUSED` / `EAI_AGAIN` / `ETIMEDOUT` / `ENETUNREACH`，同时匹配 `error.code` 和 npm 子进程 stderr 文本）和*registry 错误*（其他情况）。四个调用点——启动检查、`/update` 斜杠命令、`qwen update` CLI、沙箱 update-relaunch 路径——的消息现在都包含具体原因。

i18n：新字符串已翻译到全部九个语言（en、zh、zh-TW、ca、de、fr、ja、pt、ru），沿用各语言现有的 registry/更新术语；已无用的旧通用 key 从所有语言中移除。`npm run check-i18n` 通过。

## 为什么需要

慢速或被屏蔽 registry 环境的用户（部分地区、公司代理）**每次启动**都会看到红色错误，尽管应用完全正常——issue #7049，下游真实用户报告见 #7044（中国用户，v0.19.11，"升级就报错"）。失败显式化本身是正确且新近的修复（#6857 修复了真实的假阴性 bug，经 #6887 发布）；问题在于呈现方式：对一个用户未主动请求、也不阻塞任何操作的后台检查使用了错误级红色样式和笼统文案。

**本 PR 明确不是 #6857 / #6887 的回退。** 失败保持可见（"loud failure"）；只改变呈现方式、措辞和时间预算。

## 评审验证方案

### 如何验证

不可达 registry → 离线路径（启动 TUI）：`npm_config_registry=http://192.0.2.1:1 qwen`，预期启动数秒后出现黄色 `△ Update check skipped (registry unreachable) — run /update to retry.`，启动不被阻塞，应用完全可用。

不可达 registry → 显式 `/update` 保持醒目错误并带原因：`npm_config_registry=http://192.0.2.1:1 qwen update`，预期 stderr 输出 `Failed to check for updates (registry unreachable). Please check your network or registry configuration.`，退出码 1。

超时路径（可达但缓慢的 registry，如延迟代理）：预期原因变为 `registry did not respond within 5s`。

无回归检查（#6857）：正常 registry 下安装旧版本，更新提示仍然出现，自动更新仍然执行。

单元测试与检查：`packages/cli` 下运行六个受影响测试文件共 134 个用例全部通过；`npm run check-i18n` 通过。

重点断言：启动路径发出 `severity: 'warning'` 及按原因区分的消息（resolved-error 与 thrown 两条路径）；`severity: 'warning'` 渲染 `MessageType.WARNING`，缺省/显式 error 保持 `MessageType.ERROR`（安装失败回归保护）；分类器测试覆盖每个网络错误码的 `error.code` 与消息文本两种匹配方式；守卫测试锁定 `FETCH_TIMEOUT_MS ≥ 5000`。

### 证据（前后对比）

改动前（不可达 registry，红色 `✕`，笼统消息）与改动后（同等条件，黄色 `△`，具体原因 + 重试提示）见上方英文部分。triage bot 在 `b202c0b` 的独立验证运行中捕获了启动 TUI 和 `qwen update` 的实机 tmux 前后对比（见上方评审评论）。用户可见字符串也在更新后的测试中逐字断言。

### 测试平台

Linux ✅（本地：vitest 套件、check-i18n、changed-files eslint）；macOS / Windows ⚠️（由 CI 矩阵覆盖）。

### 环境（可选）

Linux x86_64，Node.js v22，npm workspaces 安装。

## 风险与范围

- 主要风险/权衡：把*真正的*失败误降级为警告。设计上已规避——`severity` 默认 `'error'`，仅启动检查分支主动选择 `'warning'`，回归测试断言安装失败仍渲染为错误。次要权衡：坏网络下（现已软化的）提示最多比之前晚 3 秒出现；检查在渲染后延迟任务中运行，启动延迟不受影响。
- 未验证/范围外：macOS/Windows 本地实机 TUI（由 CI 矩阵覆盖）；`skipped` 状态（development mode 等）保持现有样式——修改它超出 #7049 范围；未提供超时配置项（若维护者需要可作为后续跟进）。
- 破坏性变更/迁移说明：无。事件负载扩展向后兼容（可选字段、error 默认值）；无公共 API、设置或协议变更。

## 关联 Issue

- Fixes #7049；下游用户报告 #7044；保留（非回退）上下文 #6857、#6887；支撑 5 秒预算的耗时数据 #7224

提交：`b202c0b`（修复本体）、`a233b5f`（评审跟进——补齐 triage 评审指出的六个语言翻译，九个语言现已全部携带新 key）。

补充证据（负向控制）：保留测试文件、将生产代码还原到 `origin/main` 时，六个套件失败 17 个用例（severity 缺失、旧文案、2 秒常量）；恢复修复后回到 134/134 全绿——证明测试确实钉住了修复。波及面：导入被改模块的其余测试文件（`gemini.test.tsx`、`standalone-update.test.ts`、`installationInfo.test.ts`）全部通过；`AppContainer.test.tsx` 114/121 通过，7 个失败位于无关的终端标题功能，在未修复的 `origin/main` 上同样失败（依赖 TTY 的预存环境问题，非本 PR 引入）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
