### PR TITLE
feat(autofix): raise the strict round cap from 5 to 10

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -106,8 +106,13 @@ env:
   # hostile commenter cannot steer the agent.
   TRUSTED_ASSOC: '["OWNER", "MEMBER", "COLLABORATOR"]'
   # Hard cap on automated review-address rounds per PR. After this the bot stops
-  # and leaves the PR for a human.
-  MAX_ROUNDS: '5'
+  # and leaves the PR for a human. Raised from 5: across the last 40 bot PRs
+  # only 3 ever reached the cap and all 3 merged AT it (one having spent two of
+  # its five rounds on the verify-gate ENOENT that #7330 fixed), so the ceiling
+  # was near enough to bind on a bad day without any headroom for one. The cap
+  # exists to stop an unproductive LOOP, not to ration ordinary iteration —
+  # a genuinely stuck PR still stops, just later.
+  MAX_ROUNDS: '10'
   # An auth/access model error (401/402/403, "no access"/"does not exist")
   # never self-heals - only a maintainer can fix the key - and every retry
   # costs an agent run AND a PR comment. Cap those attempts far below

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -218,7 +218,21 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain(
       'AUTOFIX_BOT: "${{ vars.AUTOFIX_BOT_LOGIN || \'qwen-code-dev-bot\' }}"',
     );
-    expect(workflow).toContain("MAX_ROUNDS: '5'");
+    // The round budgets are tuning knobs; what must hold is their ORDERING.
+    // Asserting the literal numbers only detected edits — it would not catch
+    // a cap that stopped binding, which is the failure that matters.
+    const num = (key) =>
+      Number(workflow.match(new RegExp(`${key}: '(\\d+)'`))?.[1]);
+    const strictRounds = num('MAX_ROUNDS');
+    const takeoverRounds = num('TAKEOVER_MAX_ROUNDS');
+    const authRounds = num('API_AUTH_MAX_ROUNDS');
+    // A strict cap at or above the takeover cap makes the takeover label a
+    // no-op; an auth sub-cap at or above the strict cap stops short-circuiting
+    // the retries only a maintainer can fix, which is what it exists for.
+    expect(strictRounds).toBeGreaterThan(0);
+    expect(strictRounds).toBeLessThan(takeoverRounds);
+    expect(authRounds).toBeGreaterThan(0);
+    expect(authRounds).toBeLessThan(strictRounds);
     expect(workflow).toContain("MAX_OPEN_AUTOFIX_PRS: '5'");
     expect(reviewScanJob).toContain('isCrossRepository');
     expect(reviewScanJob).toContain('not an open main-targeting PR');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -222,7 +222,7 @@ describe('qwen-autofix workflow', () => {
     // Asserting the literal numbers only detected edits — it would not catch
     // a cap that stopped binding, which is the failure that matters.
     const num = (key) =>
-      Number(workflow.match(new RegExp(`${key}: '(\\d+)'`))?.[1]);
+      Number(workflow.match(new RegExp(`\\b${key}: '(\\d+)'`))?.[1]);
     const strictRounds = num('MAX_ROUNDS');
     const takeoverRounds = num('TAKEOVER_MAX_ROUNDS');
     const authRounds = num('API_AUTH_MAX_ROUNDS');


### PR DESCRIPTION
## What this PR does

Raises `MAX_ROUNDS` — the strict per-PR cap on automated review-address rounds — from 5 to 10, and replaces the test that pinned the literal number with the ordering the round budgets must satisfy.

## Why it's needed

Measured across the last 40 bot-authored PRs:

| max round reached | PRs | outcome |
| --- | --- | --- |
| 0 | 17 | mostly merged straight through |
| 1 | 12 | |
| 2 | 4 | |
| 3 | 2 | |
| 4 | 1 | |
| **5 (the cap)** | **3** | **all three merged** |

The three that reached it:

- **#7246** — round 5 was `acted=true`; it finished the work on the final round and merged. Rounds 1 and 2 were `Could not address`, both spent on the verify-gate ENOENT that #7330 has since fixed.
- **#7113** — round 5 `acted=true`, merged.
- **#7208** — already under takeover, so 5/100; not governed by this cap.

So the ceiling has never actually stopped a PR. What it has done is sit close enough to bind on a bad day with **zero headroom** — #7246 merged on its last available round, and would not have if two of its rounds had not been refunded by a bug fix.

## How

`MAX_ROUNDS: '5'` → `'10'`. Nothing else changes.

**Deliberately not larger.** Retries for a transient model or gate failure increment the same counter (that is by design — see #7247 and #7351), so this cap also bounds how much one bad provider window can spend: 10 agent runs and 10 comments instead of 5. `API_AUTH_MAX_ROUNDS` stays at 3 and still short-circuits the errors only a maintainer can fix, well below the new ceiling. `TAKEOVER_MAX_ROUNDS` stays at 100, so the takeover label remains a meaningful escalation.

The existing test asserted the literal `MAX_ROUNDS: '5'`. That is a change-detector — it fires on any tuning edit, and it would **not** fire on the failure that matters: a cap that stops binding. It is replaced by the ordering these three numbers must satisfy.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 87/87 (one run in three hit the pre-existing `eligibility recheck` / `takeover-command toggle` load flakes; see Risk).
2. Mutation-verified, including a case that must **pass**:

   | mutation | expected | result |
   | --- | --- | --- |
   | `MAX_ROUNDS: 100` (= `TAKEOVER_MAX_ROUNDS`, making the takeover label a no-op) | red | red |
   | `MAX_ROUNDS: 3` (= `API_AUTH_MAX_ROUNDS`, so the auth sub-cap stops binding) | red | red |
   | `MAX_ROUNDS: 20` (different value, ordering still valid) | **pass** — not a change-detector | pass |

3. Static, run locally with the exact CI toolchain: `js-yaml` parses and reports `MAX_ROUNDS=10 API_AUTH_MAX_ROUNDS=3 TAKEOVER_MAX_ROUNDS=100`; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: the next handoff comment on a non-takeover bot PR reads `attempt N/10`.

### Evidence (Before & After)

```
BEFORE  #7246: rounds 1-2 lost to the #7330 gate bug, merged on round 5/5
        -> the cap was reached by 3 of 40 PRs, with no margin left
AFTER   same PRs finish in the same number of rounds; the difference is
        only what happens on a bad day
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: a genuinely unproductive PR now burns up to 10 agent runs and posts up to 10 comments before handing off, instead of 5. That is the cost of the headroom; the sub-cap for non-self-healing (auth) errors is unchanged at 3, which is where the worst of that cost used to come from.
- Not a throughput change: PRs that converge in 1–3 rounds (33 of 40) are unaffected.
- Pre-existing and unrelated: `eligibility recheck`, `takeover-command toggle` and `classifies permanent API failures` are subprocess load flakes; an earlier controlled A/B in this repo showed unmodified `main` failing the same tests at a comparable rate, and all pass in isolation.
- Not validated / out of scope: the deeper issue is that a **retry** round and a **work** round share one counter, so infrastructure flakiness spends the PR's iteration budget (#7246 lost two rounds that way). Separating them is the more targeted fix and is deliberately left out of this change.
- Breaking changes / migration notes: none.

## Linked Issues

Part of the autofix-reliability line: #7247, #7330, #7350, #7351, #7354, #7392, #7396.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 `MAX_ROUNDS`(每个 PR 自动处理评审的严格轮次上限)从 5 提到 10,并把"钉住字面数字"的测试换成这几个轮次预算之间必须成立的**大小关系**。

## 为什么需要

对最近 40 个 bot 创建的 PR 实测(分布见上方英文表格):17 个在 0 轮结束、12 个 1 轮、4 个 2 轮、2 个 3 轮、1 个 4 轮,**只有 3 个触到上限 5,而且三个全部合入**。

逐个看:

- **#7246** —— 第 5 轮是 `acted=true`,在最后一轮把活干完并合入。而它的第 1、2 轮是 `Could not address`,都消耗在 **#7330 已修复的验证门 ENOENT** 上。
- **#7113** —— 第 5 轮 `acted=true`,合入。
- **#7208** —— 当时已在 takeover 下(5/100),不受本上限约束。

所以这个天花板**从未真正拦下过 PR**;它的问题是**一点余量都不剩** —— #7246 是在最后一轮可用额度上合入的,如果不是有两轮后来被 bug 修复"退款",它就撞上了。

## 怎么做

`MAX_ROUNDS: '5'` → `'10'`,其余不变。

**刻意不调得更大。** 传输/门故障的重试会递增同一个计数器(这是 #7247、#7351 的既定设计),因此该上限同时约束着"一次糟糕的服务商窗口最多花掉多少" —— 10 次 agent 运行 + 10 条评论,而非 5 次。`API_AUTH_MAX_ROUNDS` 保持 3,仍然远低于新上限,继续短路那些只有维护者能修的错误。`TAKEOVER_MAX_ROUNDS` 保持 100,使 takeover 标签仍是有意义的升级手段。

既有测试断言的是字面量 `MAX_ROUNDS: '5'` —— 那是变更检测器:任何调参都让它变红,而**真正要紧的失败(某个上限不再生效)它反而抓不到**。现改为断言三者的大小关系。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 87/87(三次中有一次命中既有的负载 flake,见风险段)。
2. 变异验证,含一个**必须通过**的用例:`MAX_ROUNDS: 100`(等于接管上限,使 takeover 标签失效)→ 红;`MAX_ROUNDS: 3`(等于 auth 子上限,使其不再生效)→ 红;`MAX_ROUNDS: 20`(取值不同但顺序仍合法)→ **通过**,证明它不是数字变更检测器。
3. 静态(均用 CI 一致工具):`js-yaml` 解析并报告 `MAX_ROUNDS=10 API_AUTH_MAX_ROUNDS=3 TAKEOVER_MAX_ROUNDS=100`;37 个 `run:` 块全过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:下一条非 takeover 的 bot PR handoff 评论应显示 `attempt N/10`。

## 风险与范围

- 主要权衡:一个真正陷入无效循环的 PR 现在最多烧 10 次 agent 运行、发 10 条评论才交人,而非 5 次。这是余量的代价;而这部分代价此前最主要的来源(不会自愈的认证类错误)其子上限仍为 3,未变。
- 不是吞吐改动:1–3 轮就收敛的 PR(40 个里的 33 个)完全不受影响。
- 既有且无关:`eligibility recheck`、`takeover-command toggle`、`classifies permanent API failures` 是子进程负载 flake;此前在本仓库做过的受控 A/B 显示未修改的 `main` 以相当的频率红同样的用例,且单独跑均通过。
- 不在范围内:更深层的问题是**重试轮与工作轮共用一个计数器**,导致基础设施抖动会吃掉 PR 的迭代额度(#7246 就这样丢了两轮)。把两者拆开是更对症的修法,刻意不放进本次改动。
- 破坏性变更:无。

## 关联 Issue

属 autofix 可靠性主线:#7247、#7330、#7350、#7351、#7354、#7392、#7396。

</details>
