### PR TITLE
fix(mcp): add opt-in model payload filtering

### DIFF
--- a/.github/workflows/cd-cua-driver.yml
+++ b/.github/workflows/cd-cua-driver.yml
@@ -25,7 +25,7 @@ on:
       version:
         description: 'Version to release (without v prefix)'
         required: true
-        default: '0.7.2'
+        default: '0.7.3'
       notarize:
         description: 'Codesign + notarize the macOS artifacts (false to skip during
           iteration)'
@@ -60,6 +60,10 @@ jobs:
             echo "::error::Release version $VERSION does not match Cargo version $CARGO_VERSION"
             exit 1
           fi
+      - uses: 'dtolnay/rust-toolchain@stable'
+      - name: 'Test model payload filtering'
+        working-directory: 'packages/cua-driver/rust'
+        run: 'cargo test -p cua-driver-core --locked model_payload'
 
   # ── Linux (x86_64 + arm64) ───────────────────────────────────────────────
   # Built inside debian:11 (glibc 2.31) so binaries run on Debian 11+,
@@ -367,6 +371,7 @@ jobs:
         uses: 'softprops/action-gh-release@v2'
         with:
           tag_name: '${{ steps.version.outputs.tag }}'
+          target_commitish: '${{ github.sha }}'
           name: 'cua-driver-rs v${{ steps.version.outputs.version }}'
           files: 'release-upload/**/*'
           prerelease: true
@@ -381,6 +386,9 @@ jobs:
 
             Enable relative coordinates: `CUA_DRIVER_RS_COORDINATE_SPACE=1`
             (default `0` = off; optional `CUA_DRIVER_RS_COORDINATE_SCALE=1000`).
+
+            Enable textual MCP payload filtering for affected model API routes:
+            `MCP_MODEL_PAYLOAD_FILTER=1` (default off).
 
   sync-installer-version:
     name: 'Sync installer version to main'

--- a/.github/workflows/cd-mobile-mcp.yml
+++ b/.github/workflows/cd-mobile-mcp.yml
@@ -8,6 +8,7 @@ on:
       version:
         description: 'Version to publish (without v prefix, e.g. 0.1.0)'
         required: true
+        default: '0.1.5'
       dry_run:
         description: 'Dry run (build only, no publish)'
         required: false
@@ -56,7 +57,12 @@ jobs:
 
       - name: 'Test'
         working-directory: 'packages/mobile-mcp'
-        run: 'npx playwright test test/coord-norm.test.ts test/mobile-ui-dump.test.ts'
+        run: >-
+          npx playwright test
+          test/coord-norm.test.ts
+          test/mobile-ui-dump.test.ts
+          test/payload-filter.test.ts
+          test/server-payload-filter.test.ts
 
       - name: 'Publish'
         if: '${{ !inputs.dry_run }}'

--- a/docs/design/mcp-payload-filter.md
+++ b/docs/design/mcp-payload-filter.md
@@ -1,0 +1,66 @@
+# MCP model-payload filtering
+
+## Goal
+
+Prevent `packages/cua-driver` and `packages/mobile-mcp` from returning known
+vendor terms in textual MCP payloads while preserving the real local values
+needed to operate apps, windows, devices, and packages.
+
+Filtering is opt-in and disabled by default. Set
+`MCP_MODEL_PAYLOAD_FILTER=1` in the MCP server environment for API routes that
+reject these terms. Users on other routes retain the original payloads.
+
+The initial case-insensitive ASCII terms are `qwen`, `dashscope`, `alibaba`,
+`aliyun`, `aliyuncs`, `alicloud`, `tongyi`, `qianwen`, `antgroup`, `bailian`,
+`modelscope`, `damo`, `lingma`, `wanx`, `alipay`, `antfin`, `yuque`,
+`dingtalk`, `taobao`, `tmall`, `qoder`, and `maxcompute`. Chinese terms are
+matched exactly: `通义`, `千问`, `阿里`, `百炼`, `魔搭`, `达摩`, `灵码`,
+`万相`, `支付宝`, `蚂蚁`, `语雀`, `钉钉`, `淘宝`, and `天猫`.
+Separator variants are also matched for multi-part names, such as `q-wen`,
+`dash_scope`, `ali cloud`, `qian-wen`, and `ant_group`.
+
+## Encoding
+
+Each matched substring is replaced with a stateless token containing its UTF-8
+hex bytes. For example, a filtered app name remains readable around the token,
+and returning that value to the same MCP server restores the exact original
+substring before tool validation and execution. This avoids a session map and
+keeps app/package/path round trips working after process restarts.
+
+JSON-RPC ids and methods are never transformed. Object keys and textual values
+inside result, error, and notification payloads are transformed recursively.
+Image and audio `data` fields are preserved byte-for-byte.
+
+## Component boundaries
+
+In cua-driver, `Response::ok` and `Response::error` are the shared model-facing
+boundary for direct stdio, HTTP, and daemon-proxy MCP responses. Tool-call names
+and arguments are decoded in `Request::tool_call` before dispatch. Both
+directions apply the transform only when `MCP_MODEL_PAYLOAD_FILTER=1`.
+
+In mobile-mcp, a transport wrapper encodes outgoing JSON-RPC payloads and
+decodes incoming payloads before the SDK performs schema validation. A small
+`McpServer` subclass applies the wrapper to stdio, SSE, in-memory tests, and
+future transports when `MCP_MODEL_PAYLOAD_FILTER=1`; otherwise it connects the
+original transport unchanged.
+
+## Non-goals
+
+This does not rename installed apps, processes, bundles, npm packages, signing
+identities, repositories, or distribution URLs. It does not transform stderr,
+telemetry, or build logs. Image bytes are preserved, so OCR-based filtering is
+outside this textual-payload guarantee.
+
+Aliases are decoded only when returned to the same MCP component. Passing an
+alias to a shell or another server does not recover the local value.
+
+## Verification
+
+- Unit-test every term, mixed case, Chinese text, nested objects and keys,
+  invalid tokens, exact round trips, and binary-content preservation.
+- Verify that the model-facing boundary is unchanged by default and filtered
+  only when `MCP_MODEL_PAYLOAD_FILTER=1` is present.
+- Exercise real MCP initialize, tools/list, success, structured success, and
+  error responses for both components.
+- Re-run the observed cua permission, health, app, and window payloads and the
+  deterministic mobile error echo.

--- a/packages/cua-driver/README.md
+++ b/packages/cua-driver/README.md
@@ -22,12 +22,12 @@ irm https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/
 
 ```bash
 # macOS / Linux
-CUA_DRIVER_RS_VERSION=0.7.2 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/scripts/install.sh)"
+CUA_DRIVER_RS_VERSION=0.7.3 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/scripts/install.sh)"
 ```
 
 ```powershell
 # Windows
-$env:CUA_DRIVER_RS_VERSION = "0.7.2"
+$env:CUA_DRIVER_RS_VERSION = "0.7.3"
 irm https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/scripts/install.ps1 | iex
 ```
 
@@ -37,7 +37,7 @@ irm https://raw.githubusercontent.com/QwenLM/qwen-code/main/packages/cua-driver/
 
 ```bash
 qwen-cua-driver --version
-# Expected: cua-driver 0.7.2
+# Expected: cua-driver 0.7.3
 ```
 
 ### macOS permissions
@@ -144,6 +144,31 @@ Or get the generic `mcpServers` JSON shape:
 ```bash
 qwen-cua-driver mcp-config
 ```
+
+## Model API payload filtering
+
+Some model API routes reject requests whose textual conversation history
+contains known vendor names. To filter those names at the cua-driver MCP
+boundary, set `MCP_MODEL_PAYLOAD_FILTER=1` in the server environment:
+
+```json
+{
+  "mcpServers": {
+    "cua-computer-use": {
+      "command": "qwen-cua-driver",
+      "args": ["mcp"],
+      "env": {
+        "MCP_MODEL_PAYLOAD_FILTER": "1"
+      }
+    }
+  }
+}
+```
+
+The filter is disabled by default. When enabled, it rewrites matching text in
+MCP responses to reversible aliases and decodes those aliases when they are
+passed back to cua-driver. An alias passed to a shell or another MCP server is
+not decoded there.
 
 ## Relative-coordinate mode
 

--- a/packages/cua-driver/rust/Cargo.lock
+++ b/packages/cua-driver/rust/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-testkit"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde_json",
  "windows 0.61.3",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "image",
@@ -939,7 +939,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focus-monitor-win"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "windows 0.58.0",
 ]
@@ -1892,7 +1892,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1946,7 +1946,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "platform-linux"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/packages/cua-driver/rust/Cargo.toml
+++ b/packages/cua-driver/rust/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["trycua"]
 license = "MIT"

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/lib.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod element_token;
 pub mod ffmpeg_install;
 pub mod health_report;
 pub mod image_utils;
+mod model_payload;
 pub mod page;
 pub mod pip_hook;
 pub mod protocol;

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/model_payload.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/model_payload.rs
@@ -1,0 +1,443 @@
+//! Reversible filtering for text crossing the model-facing MCP boundary.
+
+use std::borrow::Cow;
+use std::ffi::OsStr;
+
+use serde_json::{Map, Value};
+
+const TOKEN_PREFIX: &str = "__cuaf_";
+const TOKEN_SUFFIX: &str = "__";
+
+const FILTER_ENV: &str = "MCP_MODEL_PAYLOAD_FILTER";
+
+pub(crate) fn is_enabled() -> bool {
+    is_enabled_value(std::env::var_os(FILTER_ENV).as_deref())
+}
+
+fn is_enabled_value(value: Option<&OsStr>) -> bool {
+    value == Some(OsStr::new("1"))
+}
+
+const ASCII_TERMS: &[&str] = &[
+    "qwen",
+    "dashscope",
+    "alibaba",
+    "aliyun",
+    "aliyuncs",
+    "alicloud",
+    "tongyi",
+    "qianwen",
+    "bailian",
+    "modelscope",
+    "damo",
+    "lingma",
+    "wanx",
+    "alipay",
+    "antfin",
+    "yuque",
+    "dingtalk",
+    "taobao",
+    "tmall",
+    "qoder",
+    "maxcompute",
+];
+
+const CHINESE_TERMS: &[&str] = &[
+    "通义",
+    "千问",
+    "阿里",
+    "百炼",
+    "魔搭",
+    "达摩",
+    "灵码",
+    "万相",
+    "支付宝",
+    "蚂蚁",
+    "语雀",
+    "钉钉",
+    "淘宝",
+    "天猫",
+];
+
+const SEPARATOR_PATTERNS: &[(&str, &str)] = &[
+    ("q", "wen"),
+    ("dash", "scope"),
+    ("ali", "baba"),
+    ("ali", "yun"),
+    ("ali", "cloud"),
+    ("tong", "yi"),
+    ("qian", "wen"),
+    ("ant", "group"),
+];
+
+/// Encode filtered substrings without hiding the surrounding text. The token
+/// contains only a reserved prefix plus hexadecimal UTF-8 bytes, so it can be
+/// returned as a later tool argument and decoded without process-local state.
+pub(crate) fn encode_text(input: &str) -> Cow<'_, str> {
+    let mut output: Option<String> = None;
+    let mut offset = 0;
+
+    while offset < input.len() {
+        let tail = &input[offset..];
+        let matched_len = if tail.starts_with(TOKEN_PREFIX) {
+            Some(TOKEN_PREFIX.len())
+        } else {
+            filtered_match_len(tail)
+        };
+
+        if let Some(len) = matched_len {
+            let out = output.get_or_insert_with(|| {
+                let mut out = String::with_capacity(input.len() + 16);
+                out.push_str(&input[..offset]);
+                out
+            });
+            push_token(out, &input.as_bytes()[offset..offset + len]);
+            offset += len;
+            continue;
+        }
+
+        let ch = tail.chars().next().expect("non-empty tail");
+        if let Some(out) = output.as_mut() {
+            out.push(ch);
+        }
+        offset += ch.len_utf8();
+    }
+
+    match output {
+        Some(output) => Cow::Owned(output),
+        None => Cow::Borrowed(input),
+    }
+}
+
+/// Decode aliases previously produced by [`encode_text`]. Malformed tokens
+/// remain literal text. Decoding is deliberately one pass: an escaped literal
+/// token prefix must be restored as data, not interpreted a second time.
+pub(crate) fn decode_text(input: &str) -> Cow<'_, str> {
+    let mut output: Option<String> = None;
+    let mut copied_through = 0;
+    let mut search_from = 0;
+
+    while let Some(relative_start) = input[search_from..].find(TOKEN_PREFIX) {
+        let start = search_from + relative_start;
+        let hex_start = start + TOKEN_PREFIX.len();
+        let Some(relative_end) = input[hex_start..].find(TOKEN_SUFFIX) else {
+            break;
+        };
+        let hex_end = hex_start + relative_end;
+        let token_end = hex_end + TOKEN_SUFFIX.len();
+
+        let Some(decoded) = decode_hex(&input[hex_start..hex_end]) else {
+            search_from = hex_start;
+            continue;
+        };
+
+        let out = output.get_or_insert_with(|| String::with_capacity(input.len()));
+        out.push_str(&input[copied_through..start]);
+        out.push_str(&decoded);
+        copied_through = token_end;
+        search_from = token_end;
+    }
+
+    match output {
+        Some(mut output) => {
+            output.push_str(&input[copied_through..]);
+            Cow::Owned(output)
+        }
+        None => Cow::Borrowed(input),
+    }
+}
+
+/// Encode every textual key and value in an MCP result. Base64 media data is
+/// opaque and must stay byte-for-byte identical.
+pub(crate) fn encode_value(value: &mut Value) {
+    transform_value(value, Direction::Encode).expect("encoding is infallible");
+}
+
+/// Decode aliases in a tool name/argument value before schema validation and
+/// dispatch. A hostile payload can manufacture aliases that collapse two keys;
+/// reject that input instead of silently discarding one value.
+pub(crate) fn decode_value(value: &mut Value) -> Result<(), String> {
+    transform_value(value, Direction::Decode)
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Encode,
+    Decode,
+}
+
+fn transform_value(value: &mut Value, direction: Direction) -> Result<(), String> {
+    match value {
+        Value::String(text) => {
+            let transformed = match direction {
+                Direction::Encode => encode_text(text),
+                Direction::Decode => decode_text(text),
+            };
+            if let Cow::Owned(transformed) = transformed {
+                *text = transformed;
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                transform_value(item, direction)?;
+            }
+        }
+        Value::Object(object) => {
+            let opaque_data = matches!(
+                object.get("type").and_then(Value::as_str),
+                Some("image" | "audio")
+            );
+            let original = std::mem::take(object);
+            let mut transformed = Map::with_capacity(original.len());
+
+            for (key, mut child) in original {
+                let transformed_key = match direction {
+                    Direction::Encode => encode_text(&key).into_owned(),
+                    Direction::Decode => decode_text(&key).into_owned(),
+                };
+                if !(opaque_data && key == "data") {
+                    transform_value(&mut child, direction)?;
+                }
+                if transformed.insert(transformed_key, child).is_some() {
+                    return Err("decoded payload contains duplicate object keys".to_owned());
+                }
+            }
+            *object = transformed;
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+    Ok(())
+}
+
+fn filtered_match_len(tail: &str) -> Option<usize> {
+    let mut longest = None;
+
+    for term in ASCII_TERMS.iter().chain(CHINESE_TERMS) {
+        if tail
+            .get(..term.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(term))
+        {
+            longest = Some(longest.map_or(term.len(), |len: usize| len.max(term.len())));
+        }
+    }
+
+    for (first, second) in SEPARATOR_PATTERNS {
+        let Some(first_candidate) = tail.get(..first.len()) else {
+            continue;
+        };
+        if !first_candidate.eq_ignore_ascii_case(first) {
+            continue;
+        }
+
+        let mut second_start = first.len();
+        if matches!(
+            tail.as_bytes().get(second_start).copied(),
+            Some(b'-' | b'_' | b' ')
+        ) {
+            second_start += 1;
+        }
+        let second_end = second_start + second.len();
+        if tail
+            .get(second_start..second_end)
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(second))
+        {
+            longest = Some(longest.map_or(second_end, |len: usize| len.max(second_end)));
+        }
+    }
+
+    longest
+}
+
+fn push_token(output: &mut String, bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    output.push_str(TOKEN_PREFIX);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output.push_str(TOKEN_SUFFIX);
+}
+
+fn decode_hex(hex: &str) -> Option<String> {
+    if hex.is_empty() || hex.len() % 2 != 0 {
+        return None;
+    }
+
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.as_bytes().chunks_exact(2) {
+        let high = hex_nibble(pair[0])?;
+        let low = hex_nibble(pair[1])?;
+        bytes.push((high << 4) | low);
+    }
+    String::from_utf8(bytes).ok()
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn assert_round_trip(input: &str) {
+        let encoded = encode_text(input);
+        assert_ne!(encoded, input, "expected a filtered match in {input:?}");
+        assert_eq!(decode_text(&encoded), input);
+        assert!(
+            !contains_filtered_term(&encoded),
+            "encoded text still contains a filtered term: {encoded}"
+        );
+    }
+
+    fn contains_filtered_term(text: &str) -> bool {
+        let mut offset = 0;
+        while offset < text.len() {
+            let tail = &text[offset..];
+            if filtered_match_len(tail).is_some() {
+                return true;
+            }
+            offset += tail.chars().next().expect("non-empty tail").len_utf8();
+        }
+        false
+    }
+
+    #[test]
+    fn filter_opt_in_requires_exact_one() {
+        assert!(!is_enabled_value(None));
+        for value in ["", "0", "01", "true", "TRUE", "yes", " 1"] {
+            assert!(!is_enabled_value(Some(OsStr::new(value))));
+        }
+        assert!(is_enabled_value(Some(OsStr::new("1"))));
+    }
+
+    #[test]
+    fn filters_every_canonical_term_case_insensitively() {
+        for term in ASCII_TERMS {
+            assert_round_trip(term);
+            assert_round_trip(&term.to_ascii_uppercase());
+        }
+        for term in CHINESE_TERMS {
+            assert_round_trip(term);
+        }
+    }
+
+    #[test]
+    fn filters_supported_separator_variants() {
+        for (first, second) in SEPARATOR_PATTERNS {
+            for separator in ["", "-", "_", " "] {
+                assert_round_trip(&format!("{first}{separator}{second}"));
+            }
+        }
+        assert_round_trip("DaSh_ScOpE");
+        assert_round_trip("QIAN-WEN");
+        assert_round_trip("Ant Group");
+    }
+
+    #[test]
+    fn preserves_surrounding_text_and_multiple_matches() {
+        let input = "Open Q-Wen in 阿里 Cloud, then inspect Dash_Scope.";
+        let encoded = encode_text(input);
+        assert!(encoded.starts_with("Open "));
+        assert!(encoded.contains(" in "));
+        assert!(encoded.ends_with('.'));
+        assert_eq!(decode_text(&encoded), input);
+        assert!(!contains_filtered_term(&encoded));
+    }
+
+    #[test]
+    fn escapes_a_literal_token_prefix() {
+        let input = "literal __cuaf_5177656E__ text";
+        let encoded = encode_text(input);
+        assert_ne!(encoded, input);
+        assert_eq!(decode_text(&encoded), input);
+    }
+
+    #[test]
+    fn leaves_invalid_tokens_literal() {
+        for input in ["__cuaf___", "__cuaf_0__", "__cuaf_ZZ__", "__cuaf_FF__"] {
+            assert_eq!(decode_text(input), input);
+        }
+    }
+
+    #[test]
+    fn recursively_transforms_keys_and_values_but_not_media_data() {
+        let mut value = json!({
+            "QwenKey": {
+                "path": "/Applications/Alibaba Cloud/Qwen.app",
+                "nested": ["通义", { "Dash Scope": "百炼" }]
+            },
+            "content": [
+                {
+                    "type": "image",
+                    "data": "Qwen-DashScope-Alibaba",
+                    "annotations": { "label": "Ali Cloud" }
+                },
+                {
+                    "type": "audio",
+                    "data": "Qwen-DashScope-Alibaba"
+                }
+            ]
+        });
+        let original = value.clone();
+
+        encode_value(&mut value);
+
+        assert!(value.get("QwenKey").is_none());
+        assert_eq!(value["content"][0]["data"], original["content"][0]["data"]);
+        assert_eq!(value["content"][1]["data"], original["content"][1]["data"]);
+        assert_ne!(
+            value["content"][0]["annotations"]["label"],
+            original["content"][0]["annotations"]["label"]
+        );
+
+        decode_value(&mut value).expect("decode");
+        assert_eq!(value, original);
+    }
+
+    #[test]
+    fn decoding_rejects_object_key_collisions() {
+        let encoded_key = encode_text("Qwen").into_owned();
+        let mut value = json!({ "Qwen": 1 });
+        value.as_object_mut().unwrap().insert(encoded_key, json!(2));
+
+        assert!(decode_value(&mut value).is_err());
+    }
+
+    #[test]
+    fn filters_driver_identity_from_observed_windows_apps_and_tree_shapes() {
+        let mut value = json!({
+            "content": [{
+                "type": "text",
+                "text": "[{\"app_name\":\"qwen-cua-driver.exe\"}]"
+            }],
+            "structuredContent": {
+                "windows": [{ "app_name": "qwen-cua-driver.exe" }],
+                "apps": [{ "name": "qwen-cua-driver.exe" }],
+                "processes": [{ "name": "qwen-cua-driver.exe", "pid": 7756 }]
+            }
+        });
+        let original = value.clone();
+
+        encode_value(&mut value);
+
+        let wire = serde_json::to_string(&value).expect("serialize filtered payload");
+        assert!(!wire.to_ascii_lowercase().contains("qwen"));
+        decode_value(&mut value).expect("decode");
+        assert_eq!(value, original);
+    }
+
+    #[test]
+    fn safe_text_is_borrowed_and_unchanged() {
+        let input = "ordinary cua-driver payload";
+        assert!(matches!(encode_text(input), Cow::Borrowed(_)));
+        assert!(matches!(decode_text(input), Cow::Borrowed(_)));
+    }
+}

--- a/packages/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
+++ b/packages/cua-driver/rust/crates/cua-driver-core/src/protocol.rs
@@ -22,16 +22,26 @@ impl Request {
     }
 
     pub fn tool_call(&self) -> anyhow::Result<ToolCall> {
+        self.tool_call_with_filter(crate::model_payload::is_enabled())
+    }
+
+    fn tool_call_with_filter(&self, filter_enabled: bool) -> anyhow::Result<ToolCall> {
         let params = self.params.as_ref().ok_or_else(|| anyhow::anyhow!("missing params"))?;
         let name = params
             .get("name")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("missing tool name"))?
             .to_owned();
-        let args = params
+        let mut args = params
             .get("arguments")
             .cloned()
             .unwrap_or(Value::Object(Default::default()));
+        let name = if filter_enabled {
+            crate::model_payload::decode_value(&mut args).map_err(anyhow::Error::msg)?;
+            crate::model_payload::decode_text(&name).into_owned()
+        } else {
+            name
+        };
         Ok(ToolCall { name, args })
     }
 }
@@ -66,14 +76,42 @@ pub struct RpcError {
 
 impl Response {
     pub fn ok(id: Value, result: Value) -> Self {
-        Self { jsonrpc: "2.0", id, body: ResponseBody::Result { result } }
+        Self::ok_with_filter(id, result, crate::model_payload::is_enabled())
     }
 
-    pub fn error(id: Value, code: i64, message: impl Into<String>) -> Self {
+    fn ok_with_filter(id: Value, mut result: Value, filter_enabled: bool) -> Self {
+        if filter_enabled {
+            crate::model_payload::encode_value(&mut result);
+        }
         Self {
             jsonrpc: "2.0",
             id,
-            body: ResponseBody::Error { error: RpcError { code, message: message.into() } },
+            body: ResponseBody::Result { result },
+        }
+    }
+
+    pub fn error(id: Value, code: i64, message: impl Into<String>) -> Self {
+        Self::error_with_filter(id, code, message, crate::model_payload::is_enabled())
+    }
+
+    fn error_with_filter(
+        id: Value,
+        code: i64,
+        message: impl Into<String>,
+        filter_enabled: bool,
+    ) -> Self {
+        let message = message.into();
+        let message = if filter_enabled {
+            crate::model_payload::encode_text(&message).into_owned()
+        } else {
+            message
+        };
+        Self {
+            jsonrpc: "2.0",
+            id,
+            body: ResponseBody::Error {
+                error: RpcError { code, message },
+            },
         }
     }
 
@@ -142,6 +180,118 @@ impl ToolResult {
     pub fn with_structured(mut self, v: Value) -> Self {
         self.structured_content = Some(v);
         self
+    }
+}
+
+#[cfg(test)]
+mod model_payload_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn filter_is_disabled_by_default_on_both_wire_directions() {
+        let result = json!({
+            "content": [{ "type": "text", "text": "Open Qwen in Alibaba Cloud" }],
+            "structuredContent": { "QwenKey": "Dash Scope" }
+        });
+        let response = Response::ok_with_filter(json!(1), result.clone(), false);
+        let value = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(value["result"], result);
+
+        let response = Response::error_with_filter(json!(2), -32603, "Qwen failed", false);
+        let value = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(value["error"]["message"], "Qwen failed");
+
+        let encoded_name = crate::model_payload::encode_text("Qwen_tool").into_owned();
+        let encoded_key = crate::model_payload::encode_text("AlibabaKey").into_owned();
+        let encoded_value =
+            crate::model_payload::encode_text("/Applications/Qwen.app").into_owned();
+        let request: Request = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": encoded_name,
+                "arguments": { (encoded_key.clone()): encoded_value.clone() }
+            }
+        }))
+        .expect("request");
+
+        let call = request
+            .tool_call_with_filter(false)
+            .expect("tool call");
+        assert_eq!(call.name, encoded_name);
+        assert_eq!(call.args[&encoded_key], encoded_value);
+    }
+
+    #[test]
+    fn filter_enabled_encodes_success_and_error_responses() {
+        let id = json!("Qwen-client-id");
+        let image_data = "Qwen-DashScope-Alibaba";
+        let response = Response::ok_with_filter(
+            id.clone(),
+            json!({
+                "content": [
+                    { "type": "text", "text": "Open Qwen in Alibaba Cloud" },
+                    { "type": "image", "data": image_data, "mimeType": "image/png" }
+                ],
+                "structuredContent": {
+                    "QwenKey": ["Dash Scope", "阿里"]
+                }
+            }),
+            true,
+        );
+
+        let value = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(value["id"], id, "JSON-RPC ids must remain opaque");
+        assert_ne!(
+            value["result"]["content"][0]["text"],
+            "Open Qwen in Alibaba Cloud"
+        );
+        assert_eq!(value["result"]["content"][1]["data"], image_data);
+        assert!(value["result"]["structuredContent"]
+            .get("QwenKey")
+            .is_none());
+
+        let response = Response::error_with_filter(
+            json!(7),
+            -32603,
+            "Qwen daemon failed under /Applications/Alibaba Cloud",
+            true,
+        );
+        let value = serde_json::to_value(response).expect("serialize response");
+        let message = value["error"]["message"].as_str().expect("message");
+
+        assert!(!message.to_ascii_lowercase().contains("qwen"));
+        assert!(!message.to_ascii_lowercase().contains("alibaba"));
+        assert_eq!(
+            crate::model_payload::decode_text(message),
+            "Qwen daemon failed under /Applications/Alibaba Cloud"
+        );
+    }
+
+    #[test]
+    fn filter_enabled_round_trips_tool_name_argument_keys_and_values() {
+        let encoded_name = crate::model_payload::encode_text("Qwen_tool").into_owned();
+        let encoded_key = crate::model_payload::encode_text("AlibabaKey").into_owned();
+        let encoded_value =
+            crate::model_payload::encode_text("/Applications/Qwen.app").into_owned();
+        let request: Request = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": "Qwen-client-id",
+            "method": "tools/call",
+            "params": {
+                "name": encoded_name,
+                "arguments": { (encoded_key): encoded_value }
+            }
+        }))
+        .expect("request");
+
+        let call = request.tool_call_with_filter(true).expect("tool call");
+        assert_eq!(call.name, "Qwen_tool");
+        assert_eq!(call.args["AlibabaKey"], "/Applications/Qwen.app");
+        assert_eq!(request.id, Some(json!("Qwen-client-id")));
+        assert_eq!(request.method, "tools/call");
     }
 }
 

--- a/packages/cua-driver/scripts/_install-rust.sh
+++ b/packages/cua-driver/scripts/_install-rust.sh
@@ -513,7 +513,7 @@ done
 # the baked line hasn't been updated yet (dev / pre-release checkouts).
 #
 # ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
-CUA_DRIVER_RS_BAKED_VERSION="0.7.2"
+CUA_DRIVER_RS_BAKED_VERSION="0.7.3"
 # ~~~ END_BAKED_VERSION ~~~
 
 if [[ -n "${CUA_DRIVER_RS_VERSION:-}" ]]; then

--- a/packages/cua-driver/scripts/install.ps1
+++ b/packages/cua-driver/scripts/install.ps1
@@ -114,7 +114,7 @@ $BinaryName = "qwen-cua-driver.exe"
 # where the baked line hasn't been updated yet.
 #
 # ~~~ BAKED_VERSION: auto-updated by CD workflow after each release — do not edit ~~~
-$Script:CuaDriverRsBakedVersion = "0.7.2"
+$Script:CuaDriverRsBakedVersion = "0.7.3"
 # ~~~ END_BAKED_VERSION ~~~
 
 # ---------- Path resolution ------------------------------------------------

--- a/packages/mobile-mcp/README.md
+++ b/packages/mobile-mcp/README.md
@@ -126,6 +126,29 @@ With relative coordinates enabled:
 }
 ```
 
+Some model API routes reject requests whose textual conversation history
+contains known vendor names. Enable filtering at the mobile-mcp boundary only
+for those routes by adding `MCP_MODEL_PAYLOAD_FILTER=1`:
+
+```json
+{
+  "mcpServers": {
+    "mobile-mcp": {
+      "command": "npx",
+      "args": ["@qwen-code/mobile-mcp"],
+      "env": {
+        "MCP_MODEL_PAYLOAD_FILTER": "1"
+      }
+    }
+  }
+}
+```
+
+The filter is disabled by default. When enabled, matching text in MCP responses
+is replaced with reversible aliases and decoded when passed back to the same
+server. A filtered alias passed to a shell or another MCP server is not decoded
+there.
+
 ### Prerequisites
 
 - **Android**: [Android SDK Platform Tools](https://developer.android.com/tools/releases/platform-tools) (`adb` on PATH)

--- a/packages/mobile-mcp/src/payload-filter.ts
+++ b/packages/mobile-mcp/src/payload-filter.ts
@@ -1,0 +1,248 @@
+import type {
+  JSONRPCMessage,
+  MessageExtraInfo,
+} from '@modelcontextprotocol/sdk/types.js';
+import type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+
+const FILTERED_TERM_SOURCES = [
+  'dash[-_ ]?scope',
+  'ali[-_ ]?baba',
+  'ali[-_ ]?yuncs',
+  'ali[-_ ]?yun',
+  'ali[-_ ]?cloud',
+  'tong[-_ ]?yi',
+  'qian[-_ ]?wen',
+  'ant[-_ ]?group',
+  'modelscope',
+  'maxcompute',
+  'bailian',
+  'dingtalk',
+  'lingma',
+  'alipay',
+  'antfin',
+  'taobao',
+  'qoder',
+  'q[-_ ]?wen',
+  'damo',
+  'yuque',
+  'tmall',
+  'wanx',
+  '通义',
+  '千问',
+  '阿里',
+  '百炼',
+  '魔搭',
+  '达摩',
+  '灵码',
+  '万相',
+  '支付宝',
+  '蚂蚁',
+  '语雀',
+  '钉钉',
+  '淘宝',
+  '天猫',
+];
+
+const TOKEN_PREFIX = '__mcp_ref_';
+const FILTERED_TERM_PATTERN = new RegExp(
+  FILTERED_TERM_SOURCES.join('|'),
+  'giu',
+);
+const TOKEN_PREFIX_PATTERN = /__mcp_ref_/giu;
+const REFERENCE_PATTERN = /__mcp_ref_([0-9a-f]+)__/giu;
+
+const encodeReference = (value: string): string => {
+  const hex = Buffer.from(value, 'utf8').toString('hex');
+  return `${TOKEN_PREFIX}${hex}__`;
+};
+
+export const encodeFilteredText = (value: string): string => {
+  const escaped = value.replace(TOKEN_PREFIX_PATTERN, encodeReference);
+  return escaped.replace(FILTERED_TERM_PATTERN, (match) => {
+    const hex = Buffer.from(match, 'utf8').toString('hex');
+    return `${TOKEN_PREFIX}${hex}__`;
+  });
+};
+
+export const decodeFilteredText = (value: string): string =>
+  value.replace(REFERENCE_PATTERN, (reference, hex: string) => {
+    if (hex.length % 2 !== 0) {
+      return reference;
+    }
+
+    const decoded = Buffer.from(hex, 'hex').toString('utf8');
+    if (Buffer.from(decoded, 'utf8').toString('hex') !== hex.toLowerCase()) {
+      return reference;
+    }
+
+    return decoded;
+  });
+
+type TransformText = (value: string) => string;
+
+class PayloadKeyCollisionError extends Error {}
+
+const transformPayload = (
+  value: unknown,
+  transformText: TransformText,
+): unknown => {
+  if (typeof value === 'string') {
+    return transformText(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => transformPayload(item, transformText));
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  const binaryContent = record.type === 'image' || record.type === 'audio';
+  const transformedEntries: [string, unknown][] = [];
+  const transformedKeys = new Set<string>();
+
+  for (const [key, item] of Object.entries(record)) {
+    const transformedKey = transformText(key);
+    if (transformedKeys.has(transformedKey)) {
+      throw new PayloadKeyCollisionError(
+        'Decoded payload contains duplicate object keys',
+      );
+    }
+    transformedKeys.add(transformedKey);
+    transformedEntries.push([
+      transformedKey,
+      binaryContent && key === 'data'
+        ? item
+        : transformPayload(item, transformText),
+    ]);
+  }
+
+  return Object.fromEntries(transformedEntries);
+};
+
+const transformMessage = (
+  message: JSONRPCMessage,
+  transformText: TransformText,
+): JSONRPCMessage => {
+  const transformed = { ...message } as Record<string, unknown>;
+
+  for (const key of ['params', 'result', 'error']) {
+    if (key in transformed) {
+      transformed[key] = transformPayload(transformed[key], transformText);
+    }
+  }
+
+  return transformed as JSONRPCMessage;
+};
+
+export const encodePayloadMessage = (message: JSONRPCMessage): JSONRPCMessage =>
+  transformMessage(message, encodeFilteredText);
+
+export const decodePayloadMessage = (message: JSONRPCMessage): JSONRPCMessage =>
+  transformMessage(message, decodeFilteredText);
+
+export class PayloadFilteringTransport implements Transport {
+  private readonly inheritedCloseHandler: Transport['onclose'];
+  private readonly inheritedErrorHandler: Transport['onerror'];
+  private closeHandler: Transport['onclose'];
+  private errorHandler: Transport['onerror'];
+  private messageHandler: Transport['onmessage'];
+
+  constructor(private readonly transport: Transport) {
+    this.inheritedCloseHandler = transport.onclose;
+    this.inheritedErrorHandler = transport.onerror;
+  }
+
+  get sessionId(): string | undefined {
+    return this.transport.sessionId;
+  }
+
+  get onclose(): (() => void) | undefined {
+    return this.closeHandler;
+  }
+
+  set onclose(handler: (() => void) | undefined) {
+    this.closeHandler = handler;
+    this.transport.onclose =
+      this.inheritedCloseHandler || handler
+        ? () => {
+            this.inheritedCloseHandler?.();
+            handler?.();
+          }
+        : undefined;
+  }
+
+  get onerror(): ((error: Error) => void) | undefined {
+    return this.errorHandler;
+  }
+
+  set onerror(handler: ((error: Error) => void) | undefined) {
+    this.errorHandler = handler;
+    this.transport.onerror =
+      this.inheritedErrorHandler || handler
+        ? (error) => {
+            this.inheritedErrorHandler?.(error);
+            handler?.(error);
+          }
+        : undefined;
+  }
+
+  get onmessage(): Transport['onmessage'] {
+    return this.messageHandler;
+  }
+
+  set onmessage(handler: Transport['onmessage']) {
+    this.messageHandler = handler;
+    this.transport.onmessage = handler
+      ? <T extends JSONRPCMessage>(message: T, extra?: MessageExtraInfo) => {
+          let decoded: T;
+          try {
+            decoded = decodePayloadMessage(message) as T;
+          } catch (error) {
+            if (!(error instanceof PayloadKeyCollisionError)) {
+              throw error;
+            }
+            if ('method' in message && 'id' in message) {
+              void this.transport
+                .send(
+                  {
+                    jsonrpc: '2.0',
+                    id: message.id,
+                    error: { code: -32602, message: error.message },
+                  },
+                  { relatedRequestId: message.id },
+                )
+                .catch((sendError: Error) => {
+                  this.transport.onerror?.(sendError);
+                });
+            } else {
+              this.transport.onerror?.(error);
+            }
+            return;
+          }
+          handler(decoded, extra);
+        }
+      : undefined;
+  }
+
+  start(): Promise<void> {
+    return this.transport.start();
+  }
+
+  send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
+    return this.transport.send(encodePayloadMessage(message), options);
+  }
+
+  close(): Promise<void> {
+    return this.transport.close();
+  }
+
+  setProtocolVersion(version: string): void {
+    this.transport.setProtocolVersion?.(version);
+  }
+}

--- a/packages/mobile-mcp/src/server.ts
+++ b/packages/mobile-mcp/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -15,6 +16,7 @@ import { isScalingAvailable, Image } from './image-utils';
 import { Mobilecli } from './mobilecli';
 import { MobileDevice } from './mobile-device';
 import { validateOutputPath, validateFileExtension } from './utils';
+import { PayloadFilteringTransport } from './payload-filter';
 import {
   isNormalized,
   coordinateScale,
@@ -50,13 +52,23 @@ interface ActiveRecording {
   startedAt: number;
 }
 
+class PayloadFilteredMcpServer extends McpServer {
+  override connect(transport: Transport): Promise<void> {
+    return super.connect(
+      process.env.MCP_MODEL_PAYLOAD_FILTER === '1'
+        ? new PayloadFilteringTransport(transport)
+        : transport,
+    );
+  }
+}
+
 export const getAgentVersion = (): string => {
   const json = require('../package.json');
   return json.version;
 };
 
 export const createMcpServer = (): McpServer => {
-  const server = new McpServer({
+  const server = new PayloadFilteredMcpServer({
     name: 'mobile-mcp',
     version: getAgentVersion(),
     ...(isNormalized()

--- a/packages/mobile-mcp/test/payload-filter.test.ts
+++ b/packages/mobile-mcp/test/payload-filter.test.ts
@@ -1,0 +1,221 @@
+import { expect, test } from '@playwright/test';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+import {
+  decodeFilteredText,
+  decodePayloadMessage,
+  encodeFilteredText,
+  encodePayloadMessage,
+  PayloadFilteringTransport,
+} from '../src/payload-filter';
+
+const filteredSamples = [
+  'qwen',
+  'Q-WEN',
+  'q_wen',
+  'q wen',
+  'dashscope',
+  'Dash-Scope',
+  'dash_scope',
+  'dash scope',
+  'alibaba',
+  'Ali-Baba',
+  'ali_baba',
+  'ali baba',
+  'aliyun',
+  'Ali-Yun',
+  'ali_yun',
+  'ali yun',
+  'aliyuncs',
+  'alicloud',
+  'Ali-Cloud',
+  'ali_cloud',
+  'ali cloud',
+  'tongyi',
+  'Tong-Yi',
+  'tong_yi',
+  'tong yi',
+  'qianwen',
+  'Qian-Wen',
+  'qian_wen',
+  'qian wen',
+  'antgroup',
+  'Ant-Group',
+  'ant_group',
+  'ant group',
+  'bailian',
+  'modelscope',
+  'damo',
+  'lingma',
+  'wanx',
+  'alipay',
+  'antfin',
+  'yuque',
+  'dingtalk',
+  'taobao',
+  'tmall',
+  'qoder',
+  'maxcompute',
+  '通义',
+  '千问',
+  '阿里',
+  '百炼',
+  '魔搭',
+  '达摩',
+  '灵码',
+  '万相',
+  '支付宝',
+  '蚂蚁',
+  '语雀',
+  '钉钉',
+  '淘宝',
+  '天猫',
+];
+
+test('filtered terms use deterministic exact round-trip references', () => {
+  for (const sample of filteredSamples) {
+    const variants = /^[\x00-\x7f]+$/.test(sample)
+      ? [sample, sample.toUpperCase()]
+      : [sample];
+    for (const variant of variants) {
+      const original = `before/${variant}/after`;
+      const encoded = encodeFilteredText(original);
+
+      expect(encoded, variant).not.toBe(original);
+      expect(encoded, variant).toMatch(/__mcp_ref_[0-9a-f]+__/);
+      expect(decodeFilteredText(encoded), variant).toBe(original);
+      expect(encodeFilteredText(original), variant).toBe(encoded);
+    }
+  }
+});
+
+test('multiple filtered terms preserve mixed case and separators', () => {
+  const original = 'Q-Wen talks to DASH_scope and 阿里';
+  const encoded = encodeFilteredText(original);
+
+  expect(encoded).not.toContain('Q-Wen');
+  expect(encoded).not.toContain('DASH_scope');
+  expect(encoded).not.toContain('阿里');
+  expect(decodeFilteredText(encoded)).toBe(original);
+});
+
+test('invalid and unrelated references are not decoded', () => {
+  const values = ['__mcp_ref_7__', '__mcp_ref_zz__', '__mcp_ref_ff__'];
+
+  for (const value of values) {
+    expect(decodeFilteredText(value)).toBe(value);
+  }
+});
+
+test('literal reference tokens survive an encode-decode round trip', () => {
+  const original = 'literal __mcp_ref_7177656e__ and __MCP_REF_zz__';
+  const encoded = encodeFilteredText(original);
+
+  expect(encoded).not.toBe(original);
+  expect(decodeFilteredText(encoded)).toBe(original);
+});
+
+test('message transformation preserves envelopes and binary data', () => {
+  const message = {
+    jsonrpc: '2.0',
+    id: 'qwen-id',
+    method: 'qwen-method',
+    params: {
+      'qwen-key': 'Alibaba Cloud',
+      content: [
+        { type: 'text', text: 'DashScope result' },
+        { type: 'image', data: 'qwen', mimeType: 'image/qwen' },
+        { type: 'audio', data: 'alibaba', mimeType: 'audio/alibaba' },
+      ],
+    },
+  } satisfies JSONRPCMessage;
+
+  const encoded = encodePayloadMessage(message) as typeof message;
+
+  expect(encoded.id).toBe('qwen-id');
+  expect(encoded.method).toBe('qwen-method');
+  expect(encoded.jsonrpc).toBe('2.0');
+  expect(encoded.params).not.toHaveProperty('qwen-key');
+  expect(encoded.params.content[0].text).not.toContain('DashScope');
+  expect(encoded.params.content[1].data).toBe('qwen');
+  expect(encoded.params.content[1].mimeType).not.toContain('qwen');
+  expect(encoded.params.content[2].data).toBe('alibaba');
+  expect(encoded.params.content[2].mimeType).not.toContain('alibaba');
+  expect(decodePayloadMessage(encoded)).toEqual(message);
+});
+
+test('message transformation preserves special object keys', () => {
+  const message = JSON.parse(
+    '{"jsonrpc":"2.0","id":1,"result":{"__proto__":"Qwen"}}',
+  ) as JSONRPCMessage;
+
+  const encoded = encodePayloadMessage(message) as Record<string, unknown>;
+  const result = encoded.result as Record<string, unknown>;
+
+  expect(Object.hasOwn(result, '__proto__')).toBe(true);
+  expect(result.__proto__).not.toBe('Qwen');
+  expect(decodePayloadMessage(encoded)).toEqual(message);
+});
+
+test('transport chains callbacks installed before wrapping', () => {
+  const events: string[] = [];
+  const transport: Transport = {
+    onclose: () => events.push('inherited-close'),
+    onerror: () => events.push('inherited-error'),
+    start: async () => {},
+    send: async () => {},
+    close: async () => {},
+  };
+  const filtered = new PayloadFilteringTransport(transport);
+  filtered.onclose = () => events.push('server-close');
+  filtered.onerror = () => events.push('server-error');
+
+  transport.onclose?.();
+  transport.onerror?.(new Error('test'));
+
+  expect(events).toEqual([
+    'inherited-close',
+    'server-close',
+    'inherited-error',
+    'server-error',
+  ]);
+});
+
+test('transport rejects decoded key collisions before dispatch', () => {
+  const sent: JSONRPCMessage[] = [];
+  const transport: Transport = {
+    start: async () => {},
+    send: async (message) => {
+      sent.push(message);
+    },
+    close: async () => {},
+  };
+  const filtered = new PayloadFilteringTransport(transport);
+  let dispatched = false;
+  filtered.onmessage = () => {
+    dispatched = true;
+  };
+
+  transport.onmessage?.({
+    jsonrpc: '2.0',
+    id: 7,
+    method: 'tools/call',
+    params: {
+      name: 'probe',
+      arguments: { device: 'first', __mcp_ref_646576696365__: 'second' },
+    },
+  });
+
+  expect(dispatched).toBe(false);
+  expect(sent).toEqual([
+    {
+      jsonrpc: '2.0',
+      id: 7,
+      error: {
+        code: -32602,
+        message: 'Decoded payload contains duplicate object keys',
+      },
+    },
+  ]);
+});

--- a/packages/mobile-mcp/test/server-payload-filter.test.ts
+++ b/packages/mobile-mcp/test/server-payload-filter.test.ts
@@ -1,0 +1,286 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { z } from 'zod';
+
+import { AndroidDeviceManager, AndroidRobot } from '../src/android';
+import { IosManager } from '../src/ios';
+import { Mobilecli } from '../src/mobilecli';
+import { encodeFilteredText } from '../src/payload-filter';
+import { ActionableError } from '../src/robot';
+import { createMcpServer } from '../src/server';
+
+const FILTERED_TEXT_PATTERN =
+  /q[-_ ]?wen|dash[-_ ]?scope|ali[-_ ]?baba|ali[-_ ]?yun|ali[-_ ]?cloud|tong[-_ ]?yi|qian[-_ ]?wen|ant[-_ ]?group|bailian|modelscope|damo|lingma|wanx|alipay|antfin|yuque|dingtalk|taobao|tmall|qoder|maxcompute|通义|千问|阿里|百炼|魔搭|达摩|灵码|万相|支付宝|蚂蚁|语雀|钉钉|淘宝|天猫/iu;
+
+const expectTextPayloadSafe = (value: unknown): void => {
+  if (typeof value === 'string') {
+    expect(value).not.toMatch(FILTERED_TEXT_PATTERN);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      expectTextPayloadSafe(item);
+    }
+    return;
+  }
+
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  const binaryContent = record.type === 'image' || record.type === 'audio';
+  for (const [key, item] of Object.entries(record)) {
+    expect(key).not.toMatch(FILTERED_TEXT_PATTERN);
+    if (!(binaryContent && key === 'data')) {
+      expectTextPayloadSafe(item);
+    }
+  }
+};
+
+test('MCP boundary preserves payloads when filtering is disabled', async () => {
+  const originalPayloadFilter = process.env.MCP_MODEL_PAYLOAD_FILTER;
+  delete process.env.MCP_MODEL_PAYLOAD_FILTER;
+
+  const server = createMcpServer();
+  server.registerTool(
+    'payload_unfiltered_probe',
+    {
+      description: 'Qwen talks to Alibaba through Dash-Scope',
+      inputSchema: {},
+    },
+    async () => ({
+      content: [{ type: 'text', text: 'Qwen result from Alibaba' }],
+      structuredContent: { 'Alibaba-key': 'DashScope value' },
+    }),
+  );
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const tools = await client.listTools();
+    const probe = tools.tools.find(
+      ({ name }) => name === 'payload_unfiltered_probe',
+    );
+    expect(probe?.description).toBe('Qwen talks to Alibaba through Dash-Scope');
+
+    const result = await client.callTool({
+      name: 'payload_unfiltered_probe',
+      arguments: {},
+    });
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: 'Qwen result from Alibaba' }],
+      structuredContent: { 'Alibaba-key': 'DashScope value' },
+    });
+  } finally {
+    await client.close();
+    await server.close();
+    if (originalPayloadFilter === undefined) {
+      delete process.env.MCP_MODEL_PAYLOAD_FILTER;
+    } else {
+      process.env.MCP_MODEL_PAYLOAD_FILTER = originalPayloadFilter;
+    }
+  }
+});
+
+test('MCP boundary filters lists, successes, errors, and preserves round trips', async () => {
+  const originalGetVersion = Mobilecli.prototype.getVersion;
+  const originalListIosDevices = IosManager.prototype.listDevices;
+  const originalGetAndroidDevices =
+    AndroidDeviceManager.prototype.getConnectedDevices;
+  const originalListApps = AndroidRobot.prototype.listApps;
+  const originalLaunchApp = AndroidRobot.prototype.launchApp;
+  const originalGetScreenSize = AndroidRobot.prototype.getScreenSize;
+  const originalTelemetry = process.env.MOBILEMCP_ENABLE_TELEMETRY;
+  const originalPayloadFilter = process.env.MCP_MODEL_PAYLOAD_FILTER;
+
+  const packageName = 'com.alibaba.qwen';
+  let launchedPackage: string | undefined;
+  let validatedValue: string | undefined;
+
+  Mobilecli.prototype.getVersion = () => '1.0.0';
+  IosManager.prototype.listDevices = () => [];
+  AndroidDeviceManager.prototype.getConnectedDevices = () => [
+    { deviceId: 'test-device', deviceType: 'mobile' },
+  ];
+  AndroidRobot.prototype.listApps = async () => [
+    { appName: 'Q-Wen Dashboard', packageName },
+  ];
+  AndroidRobot.prototype.launchApp = async (value) => {
+    if (value.endsWith('.failure')) {
+      throw new ActionableError(`Qwen could not launch ${value}`);
+    }
+    launchedPackage = value;
+  };
+  AndroidRobot.prototype.getScreenSize = async () => {
+    throw new Error('Alibaba screenshot setup failed');
+  };
+  delete process.env.MOBILEMCP_ENABLE_TELEMETRY;
+  process.env.MCP_MODEL_PAYLOAD_FILTER = '1';
+
+  const server = createMcpServer();
+  server.registerTool(
+    'payload_success_probe',
+    {
+      description: 'Qwen talks to Alibaba through Dash-Scope',
+      inputSchema: { value: z.string() },
+    },
+    async ({ value }) => ({
+      content: [{ type: 'text', text: `Qian-Wen success: ${value}` }],
+      structuredContent: {
+        'Alibaba-key': 'Tong Yi and 阿里',
+      },
+    }),
+  );
+  server.registerTool(
+    'payload_error_probe',
+    {
+      description: 'Return a test error',
+      inputSchema: {},
+    },
+    async () => {
+      throw new Error('DashScope failed for Alibaba Cloud');
+    },
+  );
+  server.registerTool(
+    'payload_validation_probe',
+    {
+      description: 'Reject a value during schema validation',
+      inputSchema: {
+        value: z.string().superRefine((value, context) => {
+          validatedValue = value;
+          context.addIssue({
+            code: 'custom',
+            message: `Qwen rejected ${value}`,
+          });
+        }),
+      },
+    },
+    async () => ({ content: [{ type: 'text', text: 'unreachable' }] }),
+  );
+  server.registerTool(
+    'payload_image_probe',
+    {
+      description: 'Return binary and textual content',
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        { type: 'image', data: 'qwen', mimeType: 'image/png' },
+        { type: 'text', text: 'Alibaba image description' },
+      ],
+    }),
+  );
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    expectTextPayloadSafe(client.getServerVersion());
+    expectTextPayloadSafe(client.getInstructions());
+
+    const tools = await client.listTools();
+    expectTextPayloadSafe(tools);
+
+    const success = await client.callTool({
+      name: 'payload_success_probe',
+      arguments: { value: 'ModelScope' },
+    });
+    expectTextPayloadSafe(success);
+    expect(success.structuredContent).not.toHaveProperty('Alibaba-key');
+
+    const failure = await client.callTool({
+      name: 'payload_error_probe',
+      arguments: {},
+    });
+    expect(failure.isError).toBe(true);
+    expectTextPayloadSafe(failure);
+
+    const validation = await client.callTool({
+      name: 'payload_validation_probe',
+      arguments: { value: encodeFilteredText('Q-Wen') },
+    });
+    expect(validatedValue).toBe('Q-Wen');
+    expect(validation.isError).toBe(true);
+    expectTextPayloadSafe(validation);
+
+    const image = await client.callTool({
+      name: 'payload_image_probe',
+      arguments: {},
+    });
+    expect(image.content).toContainEqual({
+      type: 'image',
+      data: 'qwen',
+      mimeType: 'image/png',
+    });
+    expectTextPayloadSafe(image);
+
+    const apps = await client.callTool({
+      name: 'mobile_list_apps',
+      arguments: { device: 'test-device' },
+    });
+    expectTextPayloadSafe(apps);
+    expect(apps.content).toContainEqual({
+      type: 'text',
+      text: expect.stringContaining(encodeFilteredText(packageName)),
+    });
+
+    const launch = await client.callTool({
+      name: 'mobile_launch_app',
+      arguments: {
+        device: 'test-device',
+        packageName: encodeFilteredText(packageName),
+      },
+    });
+    expect(launchedPackage).toBe(packageName);
+    expectTextPayloadSafe(launch);
+
+    const actionableFailure = await client.callTool({
+      name: 'mobile_launch_app',
+      arguments: {
+        device: 'test-device',
+        packageName: encodeFilteredText('com.alibaba.failure'),
+      },
+    });
+    expect(actionableFailure.isError).toBeUndefined();
+    expectTextPayloadSafe(actionableFailure);
+
+    const screenshotFailure = await client.callTool({
+      name: 'mobile_take_screenshot',
+      arguments: { device: 'test-device' },
+    });
+    expect(screenshotFailure.isError).toBe(true);
+    expectTextPayloadSafe(screenshotFailure);
+  } finally {
+    await client.close();
+    await server.close();
+    Mobilecli.prototype.getVersion = originalGetVersion;
+    IosManager.prototype.listDevices = originalListIosDevices;
+    AndroidDeviceManager.prototype.getConnectedDevices =
+      originalGetAndroidDevices;
+    AndroidRobot.prototype.listApps = originalListApps;
+    AndroidRobot.prototype.launchApp = originalLaunchApp;
+    AndroidRobot.prototype.getScreenSize = originalGetScreenSize;
+    if (originalTelemetry === undefined) {
+      delete process.env.MOBILEMCP_ENABLE_TELEMETRY;
+    } else {
+      process.env.MOBILEMCP_ENABLE_TELEMETRY = originalTelemetry;
+    }
+    if (originalPayloadFilter === undefined) {
+      delete process.env.MCP_MODEL_PAYLOAD_FILTER;
+    } else {
+      process.env.MCP_MODEL_PAYLOAD_FILTER = originalPayloadFilter;
+    }
+  }
+});


### PR DESCRIPTION
## What this PR does

This PR adds an opt-in `MCP_MODEL_PAYLOAD_FILTER=1` mode to cua-driver and mobile-mcp. When enabled, configured vendor terms are reversibly encoded at the model-facing MCP boundary across textual response keys and values, then decoded when the model returns those aliases as tool arguments. Binary image and audio payloads, JSON-RPC routing fields, and the default unfiltered behavior are preserved.

It also adds regression coverage and release-workflow checks for both components, prepares cua-driver 0.7.3, and sets the next mobile-mcp publishing workflow default to 0.1.5.

## Why it's needed

Some model API routes reject an entire request when any configured vendor term appears anywhere in the accumulated payload. Desktop and mobile automation tools can legitimately expose those terms through app names, process names, package identifiers, window metadata, accessibility trees, tool descriptions, or error text; once recorded in conversation history, later requests and retries can continue to be rejected.

Renaming or hiding the real local identifiers would break automation. A reversible filter at the MCP boundary keeps model payloads acceptable while preserving the exact values required to operate the corresponding local app, window, process, device, or package.

## Reviewer Test Plan

### How to verify

1. Run each MCP server without `MCP_MODEL_PAYLOAD_FILTER`; initialize, tool discovery, success results, structured results, errors, and incoming arguments should remain byte-for-byte compatible with the previous behavior.
2. Run each server with `MCP_MODEL_PAYLOAD_FILTER=1`; configured terms should be absent case-insensitively from textual model-facing payloads, including nested object keys and values.
3. Return an encoded app, process, package, or path value to the same MCP server as a tool argument; the tool should receive the exact original local value.
4. Confirm that invalid aliases remain literal, object-key collisions are rejected safely, and image/audio data is not transformed.

### Evidence (Before & After)

Before: the reported production trajectory recorded driver identity in window, app, and accessibility-tree tool results, and the proxy subsequently logged an `AC-001` request rejection for a configured term.

After: with filtering enabled, a real cua-driver stdio session exercised initialize, app listing, window listing, and accessibility-tree responses across 73,976 response bytes with zero configured-term matches. A deterministic mobile-mcp error-path session produced 458 response bytes with zero matches. Default-off behavior and exact round trips were also verified.

Validation completed:

- cua-driver core library suite: 167 passed.
- cua-driver check and release build: passed.
- mobile-mcp build and package dry-run: passed.
- mobile-mcp focused suite: 32 passed.
- [cua-driver 0.7.3 cross-platform CD dry-run](https://github.com/QwenLM/qwen-code/actions/runs/29816280306): payload-filter tests plus Linux x86_64/arm64, Windows x86_64/arm64, and macOS universal release builds passed; release publication was skipped as intended.
- [mobile-mcp 0.1.5 CD dry-run](https://github.com/QwenLM/qwen-code/actions/runs/29816280256): install, version injection, build, and tests passed; npm publication was skipped as intended.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ local build, tests, and real stdio MCP |
| 🪟 Windows | ⚠️ release build and packaging in GitHub Actions; runtime replay not completed |
|  🐧 Linux  | ⚠️ release build and packaging in GitHub Actions; runtime replay not completed |

### Environment (optional)

Local macOS validation used the Rust release binary and the built mobile-mcp stdio server. Cross-platform packaging used the linked GitHub Actions dry-runs at commit `a00ea00d4422f953fae6086c7799f2bce38f84cd`.

## Risk & Scope

- Main risk or tradeoff: filtering changes model-visible text when explicitly enabled, and reversible aliases are meaningful only when returned to the same MCP component.
- Not validated / out of scope: the supplied AP job was macOS while the supplied rejection evidence came from a different Windows job; the macOS job also failed on private-repository authentication before reaching model execution. Production AP replay, final macOS signing/notarization, OCR inside images, stderr/telemetry/build logs, and output from unrelated shell tools are not covered by this filter.
- Breaking changes / migration notes: none by default. Existing users see no behavior change unless they set `MCP_MODEL_PAYLOAD_FILTER=1`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 为 cua-driver 和 mobile-mcp 增加了可选的 `MCP_MODEL_PAYLOAD_FILTER=1` 模式。启用后，配置的厂商词会在面向模型的 MCP 边界上，对文本响应的键和值进行可逆编码；当模型把这些别名作为工具参数返回时，再恢复为原始值。图片和音频二进制内容、JSON-RPC 路由字段以及默认的不过滤行为都保持不变。

同时增加了两个组件的回归测试和发布工作流校验，准备 cua-driver 0.7.3，并将下一次 mobile-mcp 发布工作流的默认版本设为 0.1.5。

## 为什么需要这个改动

部分模型 API 路由会在累计 payload 的任意位置出现配置的厂商词时拒绝整个请求。桌面和移动自动化工具可能通过应用名、进程名、包标识、窗口元数据、无障碍树、工具说明或错误文本合法地暴露这些词；一旦写入对话历史，后续请求和重试可能持续被拒绝。

重命名或隐藏真实本地标识会破坏自动化。在 MCP 边界进行可逆过滤，可以让模型 payload 满足接口要求，同时保留操作对应本地应用、窗口、进程、设备或包所需的精确值。

## Reviewer 测试计划

### 如何验证

1. 不设置 `MCP_MODEL_PAYLOAD_FILTER` 分别运行两个 MCP server；initialize、工具发现、成功结果、结构化结果、错误和传入参数应与之前的行为逐字节兼容。
2. 设置 `MCP_MODEL_PAYLOAD_FILTER=1` 分别运行两个 server；面向模型的文本 payload 中不应以任意大小写出现配置词，包括嵌套对象的键和值。
3. 将编码后的应用、进程、包或路径值作为工具参数返回同一个 MCP server；工具应收到完全一致的原始本地值。
4. 确认无效别名保持原样、对象键冲突被安全拒绝，并且图片和音频数据不被转换。

### 前后证据

改动前：用户反馈的生产轨迹在窗口、应用和无障碍树工具结果中记录了 driver 身份，随后代理日志记录到配置词触发的 `AC-001` 请求拒绝。

改动后：启用过滤后，真实 cua-driver stdio 会话覆盖了 initialize、应用列表、窗口列表和无障碍树响应，共 73,976 字节响应内容，配置词命中数为零。mobile-mcp 的确定性错误路径会话产生 458 字节响应内容，命中数同样为零。默认关闭行为和精确往返恢复也完成了验证。

已完成验证：

- cua-driver core library 测试：167 个通过。
- cua-driver check 和 release build：通过。
- mobile-mcp build 和打包 dry-run：通过。
- mobile-mcp 定向测试：32 个通过。
- [cua-driver 0.7.3 跨平台 CD dry-run](https://github.com/QwenLM/qwen-code/actions/runs/29816280306)：payload-filter 测试以及 Linux x86_64/arm64、Windows x86_64/arm64、macOS universal release build 均通过；发布步骤按预期跳过。
- [mobile-mcp 0.1.5 CD dry-run](https://github.com/QwenLM/qwen-code/actions/runs/29816280256)：安装、版本注入、构建和测试均通过；npm 发布步骤按预期跳过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 本地构建、测试和真实 stdio MCP |
| 🪟 Windows | ⚠️ GitHub Actions release 构建和打包通过；未完成运行时复跑 |
|  🐧 Linux  | ⚠️ GitHub Actions release 构建和打包通过；未完成运行时复跑 |

### 环境（可选）

本地 macOS 验证使用 Rust release binary 和构建后的 mobile-mcp stdio server。跨平台打包使用上面链接的 GitHub Actions dry-run，对应提交为 `a00ea00d4422f953fae6086c7799f2bce38f84cd`。

## 风险与范围

- 主要风险或权衡：显式启用时会改变模型可见文本，可逆别名只有返回同一个 MCP 组件时才有意义。
- 未验证或范围外：提供的 AP job 是 macOS，但提供的拒绝证据来自另一条 Windows job；该 macOS job 还在进入模型执行前因私有仓库认证失败。生产 AP 复跑、最终 macOS 签名和公证、图片内 OCR、stderr/遥测/构建日志以及无关 shell 工具的输出不在本过滤器覆盖范围内。
- 破坏性变更或迁移说明：默认没有。除非设置 `MCP_MODEL_PAYLOAD_FILTER=1`，现有用户不会看到行为变化。

## 关联 Issue

无

</details>
