### PR TITLE
perf(autofix): stop the feedback gate waiting on the LLM review check

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -114,6 +114,16 @@ env:
   # MAX_ROUNDS so the actionable "check the model key" message lands in an
   # hour instead of a day. Transient (429/5xx) errors keep the full budget.
   API_AUTH_MAX_ROUNDS: '3'
+  # Checks the "wait for checks to settle" gate does NOT wait for. The gate
+  # exists so a FAILED check can be read as feedback, which is why build/test/
+  # lint are still waited for. `review-pr` is the LLM code review: its output
+  # is a REVIEW, delivered by its own real-time pull_request_review trigger and
+  # counted by the review path — the check conclusion carries nothing the loop
+  # acts on. Blocking on it bought nothing and cost a median 49 minutes per
+  # round (p90 123, max 158, over 32 completed runs), during which the PR was
+  # invisible to the scan even when it already had unaddressed feedback.
+  # Names must match job ids in qwen-code-pr-review.yml; a test pins that.
+  NON_BLOCKING_CHECKS: '["review-pr"]'
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'
@@ -1775,10 +1785,12 @@ jobs:
             # startedAt is the only staleness clock: a check blocks only if it
             # started within the bound; one with no startedAt (queued, not yet
             # running) is not blocking (the next scan re-checks once it starts).
-            HAS_PENDING_CHECKS="$(jq -r --arg cut "${PENDING_CUTOFF}" '
+            HAS_PENDING_CHECKS="$(jq -r --arg cut "${PENDING_CUTOFF}" \
+              --argjson nonblocking "${NON_BLOCKING_CHECKS}" '
               [ .[]
                 | select((.status // .state // "") | IN("QUEUED", "IN_PROGRESS", "PENDING", "WAITING", "REQUESTED"))
                 | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
+                | select((.name // "") as $n | ($nonblocking | index($n)) == null)
                 | select((.startedAt // $cut) > $cut) ]
               | length > 0
             ' <<< "${CHECKS_JSON}")"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -315,6 +315,71 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('could not fetch PR metadata');
   });
 
+  it('does not block the feedback gate on the LLM review check', () => {
+    // The gate waits for checks so a FAILED one can be read as feedback. The
+    // LLM review's conclusion carries nothing the loop acts on — its output is
+    // a review, delivered by the pull_request_review trigger — so waiting for
+    // it only hid the PR for a median 49 minutes per round (p90 123, max 158,
+    // measured over 32 completed runs).
+    const nonBlocking = JSON.parse(
+      workflow.match(/NON_BLOCKING_CHECKS: '(\[[^\n]*\])'/)?.[1] ?? 'null',
+    );
+    expect(nonBlocking).toEqual(['review-pr']);
+    // Cross-file invariant: each excluded name must still be a real job id in
+    // the review workflow. A rename there would silently restore the wait,
+    // with nothing failing — the same trap as the shared concurrency group.
+    const reviewWorkflow = readFileSync(
+      '.github/workflows/qwen-code-pr-review.yml',
+      'utf8',
+    );
+    for (const name of nonBlocking) {
+      expect(reviewWorkflow).toContain(`\n  ${name}:\n`);
+    }
+
+    // Replay the REAL extracted filter over a rollup fixture.
+    const filter = reviewScanJob.match(
+      /HAS_PENDING_CHECKS="\$\(jq -r[\s\S]*?<<< "\$\{CHECKS_JSON\}"\)"/,
+    )?.[0];
+    expect(filter).toBeTruthy();
+    const run = (checks) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `CHECKS_JSON='${JSON.stringify(checks)}'\n${filter}\nprintf '%s' "$HAS_PENDING_CHECKS"`,
+        ],
+        {
+          env: {
+            ...process.env,
+            PENDING_CUTOFF: '2026-07-21T00:00:00Z',
+            NON_BLOCKING_CHECKS: JSON.stringify(nonBlocking),
+          },
+          encoding: 'utf8',
+        },
+      );
+    const started = '2026-07-21T09:00:00Z';
+    const llm = {
+      name: 'review-pr',
+      workflowName: '🧐 Qwen Pull Request Review',
+      status: 'IN_PROGRESS',
+      startedAt: started,
+    };
+    const build = {
+      name: 'Test (ubuntu-latest, Node 22.x)',
+      workflowName: 'CI',
+      status: 'IN_PROGRESS',
+      startedAt: started,
+    };
+    // The LLM review alone no longer blocks…
+    expect(run([llm])).toBe('false');
+    // …but a real correctness check still does, alone or alongside it — a
+    // failed build IS feedback, so the gate must not race it.
+    expect(run([build])).toBe('true');
+    expect(run([llm, build])).toBe('true');
+    // Unchanged: the branch-mutating sibling in the same workflow still blocks.
+    expect(run([{ ...llm, name: 'resolve-pr' }])).toBe('true');
+  });
+
   it('bounds fleet-wide simultaneity below the per-scan target budget', () => {
     // max-parallel is the ONE place different PRs wait on each other: the scan
     // emits every eligible PR (up to MAX_TARGETS_PER_SCAN) and the matrix
@@ -4340,14 +4405,26 @@ describe('qwen-autofix workflow', () => {
     // Behaviorally replay the pending-staleness jq filter against sample checks so
     // a flipped comparison (which would age out live checks → double-processing)
     // is caught, not just string-matched.
+    // The `--arg cut …` line may carry further jq arguments (the non-blocking
+    // check list), so anchor on the program's quotes rather than assuming it
+    // follows `cut` immediately.
     const jqFilter = reviewScanJob.match(
-      /--arg cut "\$\{PENDING_CUTOFF\}" '([\s\S]*?)' <<< "\$\{CHECKS_JSON\}"/,
+      /--arg cut "\$\{PENDING_CUTOFF\}"[\s\S]*?'([\s\S]*?)' <<< "\$\{CHECKS_JSON\}"/,
     )?.[1];
     expect(jqFilter).toBeTruthy();
     const runStaleness = (checks) =>
       execFileSync(
         'jq',
-        ['-r', '--arg', 'cut', '2026-07-16T00:00:00Z', jqFilter],
+        [
+          '-r',
+          '--arg',
+          'cut',
+          '2026-07-16T00:00:00Z',
+          '--argjson',
+          'nonblocking',
+          '[]',
+          jqFilter,
+        ],
         { input: JSON.stringify(checks), encoding: 'utf8' },
       ).trim();
     // Started AFTER the cutoff (recent) → active → blocks.


### PR DESCRIPTION
## What this PR does

Stops the scan's "wait for checks to settle" gate from waiting on the LLM code-review check. Correctness checks still block.

## Why it's needed

The gate skips any PR with checks in flight, and it exists for a good reason: a **failed** check is feedback the agent should act on, so acting before checks report would race it.

`review-pr` is not that kind of check. Its output is a **review**, delivered by its own real-time `pull_request_review` trigger (#7350) and counted by the review path. Its check *conclusion* carries nothing the loop acts on — yet the PR stayed invisible to the scan for its entire runtime.

Measured over **32 completed `review-pr` runs**:

| | duration |
| --- | --- |
| min | 22 min |
| p25 | 38 min |
| **p50** | **49 min** |
| p75 | 78 min |
| **p90** | **123 min** |
| max | **158 min** |

(Of 61 sampled runs, 32 completed, 4 failed, 25 were cancelled by concurrency at ~0 min.)

So a PR with feedback already waiting sat untouched for a median 49 minutes — and one round in ten for over two hours — on a check whose result the loop never reads. This is the dominant reason a 12-PR fleet was producing only 2–4 processed PRs per scan, with `active checks in flight` as the overwhelming skip reason.

## How

A new `NON_BLOCKING_CHECKS: '["review-pr"]'` is applied in the pending-check filter.

Deliberately **only `review-pr`**, not the whole review workflow:

- **build / test / lint still block** — a failed one is feedback, and racing it would make the agent work from an unknown state.
- **`resolve-pr` still blocks** — it mutates the head branch. #7392's shared concurrency group would serialise them anyway, but queueing an address job behind it would hold a matrix slot for nothing.

The list is matched by check **name**, so a rename in `qwen-code-pr-review.yml` would silently restore the wait. A test pins each excluded name to a real job id in that file — the same cross-file trap as the shared concurrency group, guarded the same way.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 88/88 (a run in three hits the pre-existing load flakes; see Risk). The new test **replays the real extracted jq filter**:

   | pending checks | blocks? |
   | --- | --- |
   | `review-pr` alone | **no** |
   | a CI test job | yes |
   | `review-pr` + a CI test job | yes |
   | `resolve-pr` | yes |

2. Mutation-verified, three reverts each turning it red: deleting the exclusion clause (restores the wait); adding `resolve-pr` to the list (would let the loop race a branch mutation); pointing a name at a job that does not exist (the cross-file guard).
3. **The behavioural replay caught a real bug before it shipped.** The first version wrote `$nonblocking | index(.name // "")` — inside that pipe `.` is already the array, so `.name` indexed the wrong object and jq errored out, leaving `HAS_PENDING_CHECKS` empty. A string-matching test would have passed. The fix binds the name first: `(.name // "") as $n | ($nonblocking | index($n)) == null`.
4. One sibling test needed retargeting: it extracted the jq program by assuming it followed `--arg cut …` immediately, which the new `--argjson` line broke. It now anchors on the program's quotes and passes `--argjson nonblocking '[]'`, keeping that test about staleness only.
5. Static, run locally with the exact CI toolchain: `js-yaml` parses and reports `NON_BLOCKING_CHECKS = ["review-pr"]`; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
6. Post-merge smoke: a PR whose only in-flight check is `review-pr` should appear in the scan as `SELECTED` or `nothing new`, never as `active checks in flight`.

### Evidence (Before & After)

```
BEFORE  bot pushes -> CI + review-pr start
        -> gate blocks on review-pr for a median 49 min (p90 123)
        -> PR invisible to the scan even with feedback already waiting

AFTER   gate blocks only until build/test/lint report
        -> review lands separately on the pull_request_review trigger
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- **Main tradeoff: fewer, larger rounds become more, smaller rounds.** Today the loop often waits for `review-pr`, then addresses that review together with whatever else was pending, in one round. Now it may act on the pending feedback first and address the review in a following round. That trades agent runs for latency. It is affordable because #7412 raised the strict cap from 5 to 10, and the watermark guarantees the later review is still picked up — but if round consumption rises noticeably, this is the change to look at first.
- No correctness risk from racing a build: those checks still block.
- Pre-existing and unrelated: `eligibility recheck`, `takeover-command toggle` and `classifies permanent API failures` are subprocess load flakes — an earlier controlled A/B showed unmodified `main` failing the same ones at a comparable rate, and all pass in isolation.
- Not validated / out of scope: the other pacing factor is untouched — the schedule cron, observed at 40–70 minutes rather than the configured `*/10`.
- Breaking changes / migration notes: none.

## Linked Issues

Found by measuring why a 12-PR managed fleet processed only 2–4 PRs per scan. Part of the autofix-reliability line: #7247, #7330, #7350, #7351, #7354, #7392, #7396, #7412.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让扫描的"等检查结束"闸门不再等待 LLM 代码评审那个检查。与正确性相关的检查仍然照等。

## 为什么需要

闸门跳过任何有检查在飞的 PR,这本身有充分理由:**失败的检查**是 agent 应当处理的反馈,在检查出结果前动手会与之抢跑。

但 `review-pr` 不是这类检查。它的产出是一条**评审**,由它自己的实时 `pull_request_review` 触发器(#7350)送达、并由评审计数路径统计;它的**检查结论**里没有任何循环会读取的东西 —— 然而 PR 在它整个运行期间对扫描完全不可见。

对 **32 次跑完的 `review-pr`** 实测:最短 22、p25 38、**中位 49**、p75 78、**p90 123**、最长 **158** 分钟。(61 个样本中 32 成功、4 失败、25 被 concurrency 取消于约 0 分钟。)

也就是说:一个已经有反馈在等的 PR,会因为一个循环根本不读结果的检查,平均枯坐 49 分钟,每十轮有一轮超过两小时。这正是 12 个 PR 的机群每次扫描只处理 2–4 个、且 `active checks in flight` 压倒性地成为跳过原因的主因。

## 怎么做

新增 `NON_BLOCKING_CHECKS: '["review-pr"]'`,在挂起检查过滤器中生效。

**刻意只排除 `review-pr`**,而非整个评审 workflow:

- **build / test / lint 仍然阻塞** —— 它们失败即是反馈,抢跑会让 agent 在未知状态上工作。
- **`resolve-pr` 仍然阻塞** —— 它会改写 head 分支。虽然 #7392 的共享 concurrency 组本就会把两者串行,但让 address 作业排在它后面会白占一个矩阵槽位。

该列表按检查**名字**匹配,因此 `qwen-code-pr-review.yml` 里改名会悄悄恢复等待。测试把每个被排除的名字钉到该文件中真实存在的 job id —— 与共享 concurrency 组同一类跨文件陷阱,用同样的方式设防。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 88/88。新测试**回放真实提取的 jq 过滤器**:仅 `review-pr` 挂起 → **不阻塞**;CI 测试作业挂起 → 阻塞;两者同时 → 阻塞;`resolve-pr` → 阻塞。
2. 变异验证,三处回退各自变红:删掉排除子句(恢复等待)、把 `resolve-pr` 加入列表(会让循环与分支改写抢跑)、把名字指向不存在的 job(跨文件保护)。
3. **行为回放在上线前抓到了一个真 bug。** 初版写的是 `$nonblocking | index(.name // "")` —— 在该管道中 `.` 已经是数组本身,`.name` 取错了对象、jq 直接报错,会导致 `HAS_PENDING_CHECKS` 为空、什么都不跳过。纯字符串匹配的测试会放它过去。修法是先绑定名字:`(.name // "") as $n | ($nonblocking | index($n)) == null`。
4. 有一个既有测试需要重新定位:它假设 jq 程序紧跟在 `--arg cut …` 之后来提取,被新增的 `--argjson` 行打断。现改为锚定程序自身的引号,并传入 `--argjson nonblocking '[]'`,使该测试仍然只考察陈旧性判定。
5. 静态(均用 CI 一致工具):`js-yaml` 解析并报告 `NON_BLOCKING_CHECKS = ["review-pr"]`;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
6. 合并后冒烟:一个仅剩 `review-pr` 在飞的 PR,应在扫描中显示为 `SELECTED` 或 `nothing new`,而不再是 `active checks in flight`。

## 风险与范围

- **主要权衡:"少而大的轮次"会变成"多而小的轮次"。** 现在循环常常等到 `review-pr` 出结果,再把它和其余待办一并在一轮内处理;改后它可能先处理已有反馈,把评审留到下一轮。这是用 agent 运行次数换延迟。可以承受,因为 #7412 已把严格上限从 5 提到 10,且水位线保证后到的评审仍会被拾起 —— 但若轮次消耗明显上升,应首先回看本改动。
- 不存在与构建抢跑的正确性风险:那些检查仍然阻塞。
- 既有且无关:`eligibility recheck`、`takeover-command toggle`、`classifies permanent API failures` 是子进程负载 flake;此前的受控 A/B 显示未修改的 `main` 以相当频率红同样用例,单独跑均通过。
- 不在范围内:另一个定速因素未动 —— 定时扫描的实际节奏为 40–70 分钟,而非配置的 `*/10`。
- 破坏性变更:无。

## 关联 Issue

在量化"12 个托管 PR 为何每次扫描只处理 2–4 个"时发现。属 autofix 可靠性主线:#7247、#7330、#7350、#7351、#7354、#7392、#7396、#7412。

</details>
