### PR TITLE
fix(ci): tell a triage action crash apart from a silent agent

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -295,10 +295,25 @@ jobs:
         shell: 'bash'
         env:
           RESPONSE: '${{ steps.triage.outputs.summary }}'
+          # Tells the two no-response causes apart. They need OPPOSITE
+          # responses, and the old message ("check the step stderr") pointed at
+          # diagnostics that do not exist: the action installs the CLI with
+          # `npm --silent`, so an install failure prints nothing but an exit
+          # code. Observed on a PR whose triage died at exit 243 during that
+          # install, with the error telling the maintainer to read an empty log.
+          TRIAGE_OUTCOME: '${{ steps.triage.outcome }}'
         run: |-
           set -uo pipefail
           if [[ -z "${RESPONSE}" || "${RESPONSE}" == "null" ]]; then
-            echo "::error title=Triage silent failure::Qwen Code exited without a response. Check the 'Run Qwen Triage' step stderr above for diagnostics."
+            if [[ "${TRIAGE_OUTCOME}" != 'success' ]]; then
+              # The action itself failed: no model call was ever made, so
+              # nothing about this PR can explain it. Retry is the fix.
+              echo "::error title=Triage did not start::The Qwen Code action failed before producing any response, so no triage ran. The usual cause is the global CLI install, which runs under \`npm --silent\` and prints nothing on failure. This is infrastructure, not this PR — re-run the failed job."
+            else
+              # The action succeeded but returned nothing: the agent ran and
+              # produced no summary. That IS worth reading the step output for.
+              echo "::error title=Triage silent failure::Qwen Code ran to completion but returned an empty response — a model or prompt problem, not an install one. Check the 'Run Qwen Triage' step output above."
+            fi
             exit 1
           fi
           echo "Triage response received (${#RESPONSE} chars)."

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
@@ -122,6 +123,53 @@ describe('qwen-triage tmux workflow', () => {
       'RESPONSE="${{ steps.triage.outputs.summary }}"',
     );
     expect(checkStep).toContain('if [[ -z "${RESPONSE}"');
+  });
+
+  it('tells an action crash apart from a silent agent, and replays both', () => {
+    const checkStep = step('Check triage response');
+    // The outcome must arrive through env like RESPONSE does — inlining the
+    // expression into the script would be the injection shape this step
+    // already avoids for RESPONSE.
+    expect(checkStep).toContain(
+      "TRIAGE_OUTCOME: '${{ steps.triage.outcome }}'",
+    );
+    expect(checkStep).not.toContain('TRIAGE_OUTCOME="${{');
+
+    const body = checkStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+    expect(body).toBeTruthy();
+    const script = body.replace(/^ {10}/gm, '');
+    const run = (env) => {
+      const proc = spawnSync('bash', ['-c', script], {
+        env: {
+          ...process.env,
+          RESPONSE: '',
+          TRIAGE_OUTCOME: 'success',
+          ...env,
+        },
+        encoding: 'utf8',
+      });
+      return { status: proc.status, out: `${proc.stdout}${proc.stderr}` };
+    };
+
+    // A crashed action: no model call happened, so nothing about the PR can
+    // explain it and the guidance must say "re-run", not "read the log" —
+    // the install runs under `npm --silent`, so there is no log to read.
+    const crashed = run({ TRIAGE_OUTCOME: 'failure' });
+    expect(crashed.status).not.toBe(0);
+    expect(crashed.out).toContain('Triage did not start');
+    expect(crashed.out).toContain('re-run the failed job');
+    expect(crashed.out).not.toContain('Triage silent failure');
+
+    // A completed action with no summary IS worth reading the step output for.
+    const silent = run({ TRIAGE_OUTCOME: 'success' });
+    expect(silent.status).not.toBe(0);
+    expect(silent.out).toContain('Triage silent failure');
+    expect(silent.out).toContain('model or prompt problem');
+    expect(silent.out).not.toContain('Triage did not start');
+
+    // A real response still passes, and 'null' still counts as no response.
+    expect(run({ RESPONSE: 'triaged' }).status).toBe(0);
+    expect(run({ RESPONSE: 'null' }).status).not.toBe(0);
   });
 
   it('notifies the author when a manual triage re-run posts no review', () => {


### PR DESCRIPTION
## What this PR does

Makes the triage failure message say which of two very different things went wrong, instead of giving one piece of advice that is useless for half the cases.

## Why it's needed

Every no-response outcome produced the same error:

```
::error title=Triage silent failure::Qwen Code exited without a response.
Check the 'Run Qwen Triage' step stderr above for diagnostics.
```

For one of the two causes there **are no diagnostics to check**. The action installs the CLI with `npm install --silent`, so a failed install prints an exit code and nothing else:

```
Installing Qwen Code from npm: @qwen-code/qwen-code@latest
##[error]Process completed with exit code 243.
##[error]Qwen Code exited without a response. Check the 'Run Qwen Triage' step stderr above for diagnostics.
```

That is the whole log. A maintainer following the advice finds an empty step and has no way to tell this from a model that answered with nothing — even though the two need opposite responses.

It is not rare, and it is not PR-specific. Of the last 100 triage runs, 19 actually executed and **4 failed**; 3 of those were on unrelated PRs, and one PR (`fix(cli): soften update-check failure`) both succeeded and failed within an hour on the same head. The failures are spread across self-hosted and GitHub-hosted runners alike, so it is not one bad machine.

## How

`steps.triage.outcome` already distinguishes the two, and it is passed through `env:` exactly as `RESPONSE` already is — inlining the expression into the script would be the injection shape this step deliberately avoids.

| state | meaning | message |
| --- | --- | --- |
| outcome ≠ success, no summary | the action died before any model call | *"Triage did not start … infrastructure, not this PR — re-run the failed job"* |
| outcome = success, no summary | the agent ran and returned nothing | *"Triage silent failure … a model or prompt problem, not an install one. Check the step output"* |

Nothing else changes: a real response still passes, and `null` still counts as no response.

The `--silent` itself lives in `QwenLM/qwen-code-action`, a different repository, so it cannot be fixed here — which is exactly why the message on this side has to stop pretending there is a log to read.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-triage-workflow.test.js` — 12/12, run twice. The new test **replays the real extracted script under bash** for all four states:

   | driven state | asserted |
   | --- | --- |
   | `TRIAGE_OUTCOME=failure`, empty response | exit ≠ 0, says *"Triage did not start"* and *"re-run the failed job"*, and **not** the silent-failure text |
   | `TRIAGE_OUTCOME=success`, empty response | exit ≠ 0, says *"Triage silent failure"* and *"model or prompt problem"*, and **not** the crash text |
   | a real response | exit 0 |
   | `RESPONSE=null` | exit ≠ 0 |

2. Mutation-verified, three reverts each turning it red: dropping the `TRIAGE_OUTCOME` env passthrough; inverting the branch condition; making both branches emit the same title.
3. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 14 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; the added lines are prettier-clean.
4. Post-merge smoke: the next triage that dies during install should report *"Triage did not start"* rather than pointing at an empty log.

### Evidence (Before & After)

```
BEFORE  install crashes (exit 243, --silent) -> "check the step stderr"
        -> the step has no stderr; indistinguishable from a silent model

AFTER   install crashes -> "Triage did not start … re-run the failed job"
        agent returns nothing -> "silent failure … check the step output"
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: none functional — this only changes which message is printed on a path that already failed. The exit code is unchanged in every case.
- The crash branch tells maintainers to re-run. That is right when the action genuinely died, and `outcome` is GitHub's own signal for exactly that; it is not inferred from log text.
- Pre-existing and unrelated: `qwen-triage.yml` fails `prettier --check` on `main` over the quote style of two `runs-on:` expressions. Those lines are untouched here, and the repo's `scripts/lint.js --prettier` is a formatter run, not a gate.
- Not validated / out of scope: the `--silent` that hides the npm error lives in `QwenLM/qwen-code-action` and needs a change there. This PR makes the failure legible from this side; it does not recover the lost output.
- Breaking changes / migration notes: none.

## Linked Issues

Found while diagnosing a red `triage` check on #7416 that turned out to be unrelated to the PR.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 triage 的失败信息说清楚是**两件完全不同的事**中的哪一件,而不是给出一条对其中一半情况毫无用处的建议。

## 为什么需要

所有"无响应"结果都产出同一条报错:*"Qwen Code exited without a response. Check the 'Run Qwen Triage' step stderr above for diagnostics."*

而对其中一种成因,**根本没有 stderr 可看**。该 action 用 `npm install --silent` 安装 CLI,安装失败时只留下一个退出码:

```
Installing Qwen Code from npm: @qwen-code/qwen-code@latest
##[error]Process completed with exit code 243.
```

日志到此为止。维护者照着提示去看,只会看到一个空步骤,而且无法把它与"模型跑完但没有输出"区分开 —— 尽管这两者需要**相反**的处理。

它并不罕见,也与具体 PR 无关:最近 100 次 triage 中真正执行 19 次、**失败 4 次**,其中 3 次发生在别人的 PR 上;而 `fix(cli): soften update-check failure` 这个 PR 在同一个 head 上一小时内既成功过也失败过。失败同时出现在自建与 GitHub 托管两类 runner 上,因此不是某台机器坏了。

## 怎么做

`steps.triage.outcome` 本就能区分两者,并且**通过 `env:` 传入**(与 `RESPONSE` 现有做法一致)—— 把表达式内联进脚本正是这一步刻意规避的注入形态。

| 状态 | 含义 | 信息 |
| --- | --- | --- |
| outcome ≠ success 且无响应 | action 在任何模型调用之前就死了 | *"Triage did not start …… 属基础设施问题而非本 PR —— 重跑该作业"* |
| outcome = success 且无响应 | agent 跑完但没有产出 | *"Triage silent failure …… 是模型/提示问题而非安装问题,请查看该步骤输出"* |

其余不变:有真实响应仍然通过,`null` 仍算作无响应。

`--silent` 本身位于 `QwenLM/qwen-code-action`(另一个仓库),这里改不了 —— 这恰恰是本侧的信息必须停止假装"有日志可读"的原因。

## 评审验证

1. `npx vitest run scripts/tests/qwen-triage-workflow.test.js` —— 12/12,连跑两次。新测试**在 bash 下回放真实提取的脚本**,覆盖四种状态(见上方英文表格):崩溃分支必须说"did not start / re-run",且**不得**出现静默失败文案;静默分支反之;有响应退出 0;`null` 退出非 0。
2. 变异验证,三处回退各自变红:去掉 `TRIAGE_OUTCOME` 的 env 传参;反转分支条件;让两个分支输出同一个标题。
3. 静态(均用 CI 一致工具):YAML 可解析;14 个 `run:` 块全过 `bash -n`;actionlint 1.7.12 clean;新增行符合 prettier。
4. 合并后冒烟:下一次在安装阶段死掉的 triage 应报告 *"Triage did not start"*,而不再指向一个空日志。

## 风险与范围

- 主要风险:功能上无 —— 本改动只影响一条**本就已失败**的路径上打印哪条信息,各种情况下的退出码完全不变。
- 崩溃分支建议维护者重跑。当 action 确实死掉时这是正确处置,而 `outcome` 是 GitHub 自身给出的信号,并非从日志文本推断。
- 既有且无关:`qwen-triage.yml` 在 `main` 上就通不过 `prettier --check`(两处 `runs-on:` 表达式的引号风格)。这两行未被触碰,且仓库的 `scripts/lint.js --prettier` 是格式化运行而非门禁。
- 不在范围内:隐藏 npm 错误的 `--silent` 位于 `QwenLM/qwen-code-action`,需在那边修改。本 PR 让失败在本侧变得可读,但不能找回已经丢失的输出。
- 破坏性变更:无。

## 关联 Issue

在排查 #7416 上一个与该 PR 无关的红色 `triage` 检查时发现。

</details>
