### PR TITLE
fix: worktree sessions unopenable in Web Shell while actively running

### DIFF
--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1648,9 +1648,10 @@ export function registerSessionRoutes(
                 // timeout), making the session unopenable in the Web
                 // Shell. Skip the cwd relocation in that case.
                 // Invariant: hasActivePrompt implies a live bridge entry
-                // that was spawned directly in the worktree cwd, so
-                // relocation is unnecessary. A cold-restored session
-                // cannot have an in-flight prompt.
+                // that was relocated into the worktree cwd at creation
+                // (before any prompt could run), so relocation is
+                // unnecessary. A cold-restored session cannot have an
+                // in-flight prompt.
                 if (!session.hasActivePrompt) {
                   await runtime.bridge.changeSessionCwd(sessionId, {
                     path: wt.path,

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1643,12 +1643,14 @@ export function registerSessionRoutes(
               try {
                 // changeSessionCwd chains onto the prompt queue and
                 // blocks until any in-flight prompt finishes. When the
-                // session is actively running a task this would hang the
-                // HTTP response indefinitely, making the session
-                // unopenable in the Web Shell. Skip the cwd relocation
-                // in that case — the bridge entry already has the
-                // correct cwd from the original spawn, and the metadata
-                // is enough for the UI to show the worktree badge/chip.
+                // session is actively running a task this would stall the
+                // HTTP response (bounded by the ~30s changeSessionCwd
+                // timeout), making the session unopenable in the Web
+                // Shell. Skip the cwd relocation in that case.
+                // Invariant: hasActivePrompt implies a live bridge entry
+                // that was spawned directly in the worktree cwd, so
+                // relocation is unnecessary. A cold-restored session
+                // cannot have an in-flight prompt.
                 if (!session.hasActivePrompt) {
                   await runtime.bridge.changeSessionCwd(sessionId, {
                     path: wt.path,

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -1641,10 +1641,20 @@ export function registerSessionRoutes(
                 branch: sidecar.worktreeBranch,
               };
               try {
-                await runtime.bridge.changeSessionCwd(sessionId, {
-                  path: wt.path,
-                  allowedRoots: candidateRoots,
-                });
+                // changeSessionCwd chains onto the prompt queue and
+                // blocks until any in-flight prompt finishes. When the
+                // session is actively running a task this would hang the
+                // HTTP response indefinitely, making the session
+                // unopenable in the Web Shell. Skip the cwd relocation
+                // in that case — the bridge entry already has the
+                // correct cwd from the original spawn, and the metadata
+                // is enough for the UI to show the worktree badge/chip.
+                if (!session.hasActivePrompt) {
+                  await runtime.bridge.changeSessionCwd(sessionId, {
+                    path: wt.path,
+                    allowedRoots: candidateRoots,
+                  });
+                }
                 runtime.bridge.setSessionWorktree(sessionId, wt);
                 session.worktree = wt;
               } catch (restoreErr) {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1347,8 +1347,9 @@ export function App({
         }
       })
       .catch(() => {
-        // Non-live sessions 404 here; the sidecar-enriched session list
-        // in the sidebar still shows the worktree badge.
+        if (worktreeSessionIdRef.current === sid) {
+          setSessionWorktree(undefined);
+        }
       });
   }, [connection.sessionId, workspace.client]);
   // Active workspace: the connected session's workspace, else the workspace

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1321,27 +1321,28 @@ export function App({
   const [sessionWorktree, setSessionWorktree] = useState<
     { slug: string; path: string; branch: string } | undefined
   >(undefined);
-  // Bumped on every user-initiated session switch so the async worktree
-  // restore can tell apart "user switched away" from "connection.sessionId
-  // transiently cycled through other sessions during the reconnect loop".
-  const worktreeGenRef = useRef(0);
+  // Tracks the session id from the latest effect run. In-flight fetches
+  // compare their captured sid against this ref on resolve: a match means
+  // the response is still relevant and may set OR clear the worktree state;
+  // a mismatch means connection.sessionId moved on (reconnect cycling or a
+  // user-initiated switch) and the stale response is dropped.
+  const worktreeSessionIdRef = useRef<string | undefined>(undefined);
   // Restore worktree info from the server when switching to an existing
   // session. The effect intentionally does NOT cancel in-flight fetches on
   // cleanup: connection.sessionId can cycle through several sessions during
   // the DaemonSessionProvider reconnection loop, and cancelling would
-  // discard the one response we actually need. Instead, the generation
-  // counter guards against stale writes after a user-initiated switch.
+  // discard the one response we actually need.
   useEffect(() => {
     const sid = connection.sessionId;
+    worktreeSessionIdRef.current = sid;
     if (!sid) {
       setSessionWorktree(undefined);
       return;
     }
-    const gen = worktreeGenRef.current;
     workspace.client
       .sessionStatus(sid)
       .then((summary) => {
-        if (worktreeGenRef.current === gen && summary.worktree) {
+        if (worktreeSessionIdRef.current === sid) {
           setSessionWorktree(summary.worktree);
         }
       })
@@ -3968,7 +3969,6 @@ export function App({
         ]);
         // Clear after successful clearSession — if it rejects, the old
         // session's worktree state is preserved.
-        worktreeGenRef.current += 1;
         setSessionWorktree(undefined);
         return true;
       } catch (error) {
@@ -4179,7 +4179,6 @@ export function App({
       setSidebarSwitchingSessionId(sessionId);
       pendingWorktreeRef.current = undefined;
       setWorktreePending(false);
-      worktreeGenRef.current += 1;
       setSessionWorktree(undefined);
       // Close the drawer before awaiting the load; the transcript clears
       // immediately and shows its loading skeleton for the selected session.

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1321,25 +1321,34 @@ export function App({
   const [sessionWorktree, setSessionWorktree] = useState<
     { slug: string; path: string; branch: string } | undefined
   >(undefined);
-  // Restore worktree info from the server when switching to an existing session.
+  // Bumped on every user-initiated session switch so the async worktree
+  // restore can tell apart "user switched away" from "connection.sessionId
+  // transiently cycled through other sessions during the reconnect loop".
+  const worktreeGenRef = useRef(0);
+  // Restore worktree info from the server when switching to an existing
+  // session. The effect intentionally does NOT cancel in-flight fetches on
+  // cleanup: connection.sessionId can cycle through several sessions during
+  // the DaemonSessionProvider reconnection loop, and cancelling would
+  // discard the one response we actually need. Instead, the generation
+  // counter guards against stale writes after a user-initiated switch.
   useEffect(() => {
     const sid = connection.sessionId;
     if (!sid) {
       setSessionWorktree(undefined);
       return;
     }
-    let cancelled = false;
+    const gen = worktreeGenRef.current;
     workspace.client
       .sessionStatus(sid)
       .then((summary) => {
-        if (!cancelled) setSessionWorktree(summary.worktree);
+        if (worktreeGenRef.current === gen && summary.worktree) {
+          setSessionWorktree(summary.worktree);
+        }
       })
       .catch(() => {
-        if (!cancelled) setSessionWorktree(undefined);
+        // Non-live sessions 404 here; the sidecar-enriched session list
+        // in the sidebar still shows the worktree badge.
       });
-    return () => {
-      cancelled = true;
-    };
   }, [connection.sessionId, workspace.client]);
   // Active workspace: the connected session's workspace, else the workspace
   // picked for the next session (locked / selected / primary). Computed once
@@ -3959,6 +3968,7 @@ export function App({
         ]);
         // Clear after successful clearSession — if it rejects, the old
         // session's worktree state is preserved.
+        worktreeGenRef.current += 1;
         setSessionWorktree(undefined);
         return true;
       } catch (error) {
@@ -4169,6 +4179,7 @@ export function App({
       setSidebarSwitchingSessionId(sessionId);
       pendingWorktreeRef.current = undefined;
       setWorktreePending(false);
+      worktreeGenRef.current += 1;
       setSessionWorktree(undefined);
       // Close the drawer before awaiting the load; the transcript clears
       // immediately and shows its loading skeleton for the selected session.


### PR DESCRIPTION
## What this PR does

Fixes two related issues with worktree sessions in the daemon Web Shell:

1. Active worktree sessions could not be opened — clicking them in the sidebar stalled for ~30s (the `changeSessionCwd` timeout) because the load/resume endpoint blocked on the prompt queue waiting for the in-flight prompt to complete before relocating the working directory. The HTTP response was only sent after this relocation, so curl and the Web Shell SDK timed out before the server responded.

2. The composer git branch chip showed the workspace root branch (e.g. `main`) instead of the worktree branch. The `connection.sessionId` transiently cycles through several sessions during the DaemonSessionProvider reconnection loop, and the old effect cancelled flag discarded the worktree session status response before it could land.

## Why it is needed

Users running long tasks in worktree-isolated sessions could not view or interact with those sessions through the Web Shell. The sidebar showed the session but clicking it produced no response within any reasonable timeout. Additionally, even when a worktree session was open, the git chip displayed misleading branch and change information from the workspace root.

## Reviewer Test Plan

### How to verify

1. Start the daemon (`npm run dev serve --port 4170 --workspace .`)
2. Create a worktree session via the Web Shell sidebar
3. Send a long-running prompt in that session
4. While the prompt is still running, navigate away and then click back on the worktree session in the sidebar
5. **Before**: the session load stalls ~30s then returns without worktree metadata. **After**: loads in ~40ms with correct worktree metadata
6. Confirm the composer git chip shows the worktree branch (e.g. `worktree-eager-leaf-e9384f`), not the workspace root branch

### Evidence (Before & After)

**Before** — `POST /session/:id/load` for an active worktree session:

```
curl --max-time 10 ... /session/f769a069-.../load
# Operation timed out after 10003 milliseconds with 0 bytes received
```

**After** — same request:

```
SUCCESS! sessionId: f769a069-d598-4a
worktree: {"slug":"eager-leaf-e9384f","path":"...","branch":"worktree-eager-leaf-e9384f"}
hasActivePrompt: True
real    0m0.042s
```

Tested on: macOS