### PR TITLE
fix(core): harden the usage salvage around session deletion

### DIFF
--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -68,6 +68,9 @@ describe('SessionService', () => {
     });
 
     sessionService = new SessionService('/test/project/root');
+    // Module mocks are not reset by restoreAllMocks; clear the salvage spy
+    // so per-test call/order assertions never read stale invocations.
+    vi.mocked(persistUsageBeforeTranscriptDeletion).mockClear();
 
     readdirSyncSpy = vi.spyOn(fs, 'readdirSync').mockReturnValue([]);
     statSyncSpy = vi.spyOn(fs, 'statSync').mockImplementation(
@@ -1456,6 +1459,19 @@ describe('SessionService', () => {
         expect.stringContaining(`file-history/${sessionIdA}`),
         { recursive: true, force: true },
       );
+    });
+
+    it('still deletes the session when the usage salvage fails', async () => {
+      // Contract: the salvage must never block deletion.
+      vi.mocked(persistUsageBeforeTranscriptDeletion).mockRejectedValueOnce(
+        new Error('salvage exploded'),
+      );
+      vi.mocked(jsonl.readLines).mockResolvedValue([recordA1]);
+
+      await expect(sessionService.removeSession(sessionIdA)).resolves.toBe(
+        true,
+      );
+      expect(unlinkSyncSpy).toHaveBeenCalled();
     });
 
     it('should clear session organization when removing a session', async () => {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -1333,6 +1333,22 @@ export class SessionService {
     return removed;
   }
 
+  /**
+   * Usage salvage wrapper enforcing the "never blocks deletion" contract at
+   * the call site: persistUsageBeforeTranscriptDeletion catches its own
+   * errors, but this second layer keeps the guarantee structural rather
+   * than an implementation detail of another module.
+   */
+  private async salvageUsageBestEffort(transcriptPath: string): Promise<void> {
+    try {
+      await persistUsageBeforeTranscriptDeletion(transcriptPath);
+    } catch (error) {
+      this.warn(
+        `usage salvage failed for ${transcriptPath}: ${error}; deleting anyway`,
+      );
+    }
+  }
+
   private async removeSessionFiles(sessionId: string): Promise<boolean> {
     if (!SESSION_FILE_PATTERN.test(`${sessionId}.jsonl`)) {
       return false;
@@ -1345,10 +1361,16 @@ export class SessionService {
         // #7384: the usage-history rebuild reads transcripts, so salvage
         // the session's usage summary before the file is gone. Never
         // blocks deletion (the salvage swallows its own errors).
-        await persistUsageBeforeTranscriptDeletion(activePath);
+        await this.salvageUsageBestEffort(activePath);
         this.removeFileIfExists(activePath);
         const archivedPath = this.getSessionFilePath(sessionId, 'archived');
         if (fs.existsSync(archivedPath)) {
+          // When both copies co-exist (e.g. an interrupted archive), the
+          // active transcript may hold no telemetry while the archived one
+          // carries the session's history — salvage it too. The dedup
+          // guard inside the salvage makes this a no-op whenever the
+          // active copy already produced a record.
+          await this.salvageUsageBestEffort(archivedPath);
           this.removeFileIfExists(archivedPath);
         }
         this.removeWorktreeSidecars(sessionId);
@@ -1363,7 +1385,7 @@ export class SessionService {
       if (!archived) {
         return false;
       }
-      await persistUsageBeforeTranscriptDeletion(archivedPath);
+      await this.salvageUsageBestEffort(archivedPath);
       this.removeFileIfExists(archivedPath);
       this.removeWorktreeSidecars(sessionId);
       this.removeFileHistoryBackups(sessionId);


### PR DESCRIPTION
## What this PR does

Hardens the usage salvage that #7391 added around session deletion, addressing its three post-merge review findings: (1) the active-branch deletion now salvages the **archived** transcript too before removing it — when both copies co-exist after an interrupted archive and the fresh active transcript carries no telemetry, the archived copy holds the session's usage history and was previously deleted unsalvaged (the salvage's dedup guard makes the extra call a no-op whenever the active copy already wrote a record); (2) the "never blocks deletion" contract is now enforced at the call site via a `salvageUsageBestEffort` wrapper that catches and warns — previously the bare `await` let a salvage rejection escape through `removeSessionFiles`' rethrowing catch, so the guarantee rested entirely on the salvage's internal error handling; (3) the salvage module mock is cleared in `beforeEach` so the wiring test's `invocationCallOrder` assertions can never read stale calls.

## Why it's needed

Post-merge review on #7391 flagged all three: the archived-copy edge loses real usage data in the interrupted-archive scenario; the failure-tolerance contract was documented in a comment but untested and, as the new test proves, not actually structural (a rejecting salvage failed the deletion); and the module-scope mock's monotonically increasing invocation order made the ordering assertion fragile to test reordering.

## Reviewer Test Plan

### How to verify

1. `npx vitest run src/services/sessionService.test.ts src/services/usageHistoryService.test.ts` (packages/core): 151/151.
2. The new failure-tolerance test (`still deletes the session when the usage salvage fails`) fails without the call-site wrapper — verified by running it against the bare-`await` wiring: the mocked rejection propagates and `removeSession` rejects instead of returning true.
3. Interrupted-archive edge: with both transcripts present and a telemetry-less active copy, deletion now writes the archived copy's summary to `usage_record.jsonl`; when the active copy already produced a record, the second salvage is a no-op (dedup guard).

### Evidence (Before & After)

The failure-tolerance contract is the demonstrable delta: with the wrapper removed, the new test fails with the salvage rejection propagating out of `removeSession` (`Error: salvage exploded`), because `removeSessionFiles`' catch rethrows non-ENOENT errors — deletion was blocked exactly the way the #7391 comment claimed it never would be. With the wrapper, deletion succeeds and the failure is downgraded to a warning. The archived-salvage addition reuses the merged salvage function unchanged; its dedup behavior is already pinned by the #7391 suite (150 tests), which passes untouched alongside the new one.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest. `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: deleting a session with both copies present now reads the archived transcript once more; bounded by transcript size, on a path already dominated by file I/O. The wrapper adds a warning line on salvage failure where there was silence.
- Not validated / out of scope: same as #7391 — external deletions bypassing `removeSessionFiles()` cannot be salvaged.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7391 (issue #7384).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

对 #7391 引入的删除前用量 salvage 做三项加固（其合并后 review 的三条发现）：(1) active 分支删除 archived 副本前也执行 salvage——中断的归档会让两份并存，若新的 active transcript 无遥测，archived 副本才是用量历史所在，此前会被无 salvage 删除（salvage 的查重门保证 active 已写记录时第二次调用为 no-op）；(2) 「永不阻塞删除」契约收到调用点——新增 `salvageUsageBestEffort` 包装 catch+warn，此前裸 `await` 会让 salvage 的 rejection 穿透 `removeSessionFiles` 的重抛 catch，契约完全依赖另一模块的内部实现；(3) `beforeEach` 清理 salvage 模块 mock，接线测试的 `invocationCallOrder` 断言不会读到陈旧调用。

## 为什么需要

三条均来自 #7391 的合并后 review：archived 副本边缘会真实丢数据；失败容忍契约写在注释里但未测试、且如新测试所证并非结构性（rejection 会让删除失败）；模块级 mock 的单调递增调用序使顺序断言对测试重排脆弱。

## 审阅测试计划

两套件 151/151；新失败容忍测试在无包装的裸 await 接线上失败（rejection 穿透、removeSession 变 reject）——这正是可演示的 before/after 差异；archived salvage 复用已合并函数，其查重行为由 #7391 原有 150 个测试钉住且原样通过。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

## 风险与范围

- 双副本并存的删除多一次 archived transcript 读取（按大小有界）；salvage 失败从静默变为一条 warning。
- 与 #7391 相同：绕过 `removeSessionFiles()` 的外部删除无法挽救。
- 无破坏性变更。

## 关联 Issue

Follow-up to #7391（issue #7384）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
