### PR TITLE
fix(cli): classify nested update-check network errors

### DIFF
--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -649,17 +649,31 @@ describe('classifyUpdateCheckError', () => {
     );
   });
 
-  it.each([
-    'ENOTFOUND',
-    'ECONNREFUSED',
-    'EAI_AGAIN',
-    'ETIMEDOUT',
-    'ENETUNREACH',
-  ])('classifies %s errors as offline', (code) => {
-    const error = new Error(`request failed`) as NodeJS.ErrnoException;
-    error.code = code;
-    expect(classifyUpdateCheckError(error)).toBe('offline');
+  it('classifies execFile timeouts as timeout', () => {
+    const error = Object.assign(new Error('Command failed: npm view'), {
+      code: null,
+      killed: true,
+      signal: 'SIGTERM',
+    });
+
+    expect(classifyUpdateCheckError(error)).toBe('timeout');
   });
+
+  it('classifies ETIMEDOUT errors as timeout', () => {
+    const error = new Error('request failed') as NodeJS.ErrnoException;
+    error.code = 'ETIMEDOUT';
+
+    expect(classifyUpdateCheckError(error)).toBe('timeout');
+  });
+
+  it.each(['ENOTFOUND', 'ECONNREFUSED', 'EAI_AGAIN', 'ENETUNREACH'])(
+    'classifies %s errors as offline',
+    (code) => {
+      const error = new Error(`request failed`) as NodeJS.ErrnoException;
+      error.code = code;
+      expect(classifyUpdateCheckError(error)).toBe('offline');
+    },
+  );
 
   it('classifies network codes embedded in the message as offline', () => {
     // npm child-process failures surface the code inside stderr text only.
@@ -667,6 +681,15 @@ describe('classifyUpdateCheckError', () => {
       classifyUpdateCheckError(
         new Error('npm error code ENOTFOUND\nnpm error network'),
       ),
+    ).toBe('offline');
+  });
+
+  it('classifies network codes from the error cause as offline', () => {
+    const cause = new Error('getaddrinfo failed') as NodeJS.ErrnoException;
+    cause.code = 'ENOTFOUND';
+
+    expect(
+      classifyUpdateCheckError(new TypeError('fetch failed', { cause })),
     ).toBe('offline');
   });
 

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -52,7 +52,6 @@ const NETWORK_ERROR_CODES = [
   'ENOTFOUND',
   'ECONNREFUSED',
   'EAI_AGAIN',
-  'ETIMEDOUT',
   'ENETUNREACH',
 ];
 
@@ -66,16 +65,27 @@ const NETWORK_ERROR_CODES = [
 export function classifyUpdateCheckError(
   error: unknown,
 ): UpdateCheckFailureReason {
-  if (error instanceof UpdateCheckTimeoutError) return 'timeout';
   if (error instanceof Error) {
-    const code = (error as NodeJS.ErrnoException).code;
+    const errors = [error];
+    if (error.cause instanceof Error) errors.push(error.cause);
+    const matchesCode = (code: string) =>
+      errors.some(
+        (error) =>
+          (error as NodeJS.ErrnoException).code === code ||
+          error.message.includes(code),
+      );
+
     if (
-      NETWORK_ERROR_CODES.some(
-        (netCode) => code === netCode || error.message.includes(netCode),
-      )
+      errors.some((error) => error instanceof UpdateCheckTimeoutError) ||
+      ('killed' in error &&
+        error.killed === true &&
+        'signal' in error &&
+        error.signal === 'SIGTERM') ||
+      matchesCode('ETIMEDOUT')
     ) {
-      return 'offline';
+      return 'timeout';
     }
+    if (NETWORK_ERROR_CODES.some(matchesCode)) return 'offline';
   }
   return 'registry';
 }


### PR DESCRIPTION
> [!NOTE]
> Post-merge E2E testing corrected part of the original scope. The direct `error.cause` fix is reproducible through the real startup TUI. The claimed global-npm timeout differential is not: both the #7409 baseline and this PR already render `registry did not respond within 5s` because the outer typed timeout surfaces first. #7431 removes the unsupported child-process special case and restores the prior `ETIMEDOUT` classification.

## What this PR does

This fixes the reproducible Node 22 fetch error shape behind #7423. Network error codes can live on a direct `error.cause`, so the update-check classifier now examines that cause as well as the top-level error.

## Why it's needed

Node's fetch API reports DNS failures as a top-level `TypeError: fetch failed` while keeping `ENOTFOUND` on `error.cause.code`. The previous classifier inspected only the top-level code and message, so a real startup background check fell back to `registry error` instead of `registry unreachable`.

The merged revision also included child-process timeout and `ETIMEDOUT` classification changes. Complete global-npm testing after merge did not reproduce the claimed behavior difference, so those two changes are removed by #7431 rather than retained as speculative handling.

## Reviewer Test Plan

### How to verify

- Run `cd packages/cli && npx vitest run src/ui/utils/updateCheck.test.ts`.
- Build and bundle the CLI, then start the interactive TUI with an isolated Qwen home and `npm_config_registry=http://this-host-does-not-exist-zzz.invalid`; the background warning should report `registry unreachable` instead of `registry error`.

### Evidence (Before & After)

Corrected real-startup tmux evidence and the global-npm timeout control are included in the E2E report comment below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 15.1.1, Node.js v22.22.0, tmux 3.5a. Windows and Linux are left to CI.

## Risk & Scope

- Main risk or tradeoff: only the direct cause is inspected; recursive and aggregate cause traversal remain out of scope.
- Not validated / out of scope: manual Windows/Linux TUI verification.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7423

Related to #7409

Follow-up correction: #7431

<details>
<summary>中文说明</summary>

本 PR 可复现的修复是读取 Node 22 fetch 错误的直接 `error.cause`。真实启动 TUI 中，DNS 失败从 #7409 baseline 的 `registry error` 正确变为 `registry unreachable`。

合并后完成的 global-npm E2E 纠正了原描述中的 timeout 结论：baseline 与本 PR 都已经显示 `registry did not respond within 5s`，因为外层类型化超时会先返回。#7431 删除不受完整路径支持的子进程 timeout 特判，并恢复原有的 `ETIMEDOUT` 分类。

正确的启动 Before/After 图片及 timeout 无差异控制见下方独立测试评论。

</details>
