### PR TITLE
fix(core): resolve artifact workspacePath against workspace root in worktree sessions

### DIFF
--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -506,6 +506,35 @@ describe('WriteFileTool', () => {
       expect(result.llmContent).not.toContain('record_artifact');
     });
 
+    it('suggests workspace-root-relative path inside a worktree', async () => {
+      mockConfigInternal.isRecordArtifactEnabled.mockReturnValue(true);
+      const worktreeDir = path.join(
+        rootDir,
+        '.qwen',
+        'worktrees',
+        'my-feature',
+      );
+      fs.mkdirSync(worktreeDir, { recursive: true });
+      const originalGetTargetDir = mockConfigInternal.getTargetDir;
+      mockConfigInternal.getTargetDir = () => worktreeDir;
+      try {
+        const filePath = path.join(worktreeDir, 'report.html');
+        const params = {
+          file_path: filePath,
+          content: '<!doctype html><html><body>Report</body></html>',
+        };
+
+        const result = await tool.build(params).execute(abortSignal);
+
+        expect(result.llmContent).toContain('record_artifact');
+        expect(result.llmContent).toContain(
+          'workspacePath ".qwen/worktrees/my-feature/report.html"',
+        );
+      } finally {
+        mockConfigInternal.getTargetDir = originalGetTargetDir;
+      }
+    });
+
     // trackEdit is best-effort: a FileHistoryService failure (disk full,
     // permissions, corrupted state) must never break the write_file tool.
     it('completes the write even when trackEdit throws', async () => {

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -653,7 +653,17 @@ function buildRecordArtifactReminder(
   if (!ARTIFACT_LIKE_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
     return null;
   }
-  const relativePath = path.relative(config.getTargetDir(), filePath);
+  // The daemon's file-read route resolves workspacePath against the
+  // original workspace root, not the session cwd. When the session
+  // runs inside a worktree (<root>/.qwen/worktrees/<slug>), anchor
+  // the relative path at the workspace root so artifact previews
+  // resolve correctly.
+  const targetDir = config.getTargetDir();
+  const wtMatch = targetDir.match(
+    /^(.+)[\\/]\.qwen[\\/]worktrees[\\/][^\\/]+$/,
+  );
+  const baseDir = wtMatch ? wtMatch[1] : targetDir;
+  const relativePath = path.relative(baseDir, filePath);
   if (
     !relativePath ||
     relativePath === '..' ||


### PR DESCRIPTION
## What this PR does

When a session runs inside a git worktree, the write_file tool's artifact reminder suggested a workspacePath relative to the worktree cwd (e.g. "report.html"). However, the daemon's GET /file route resolves paths against the original workspace root, not the session cwd. This mismatch caused artifact HTML previews in Web Shell to fail with a file-not-found error.

This PR anchors the suggested workspacePath at the workspace root when the session cwd is inside a worktree, so the path includes the .qwen/worktrees/slug/ prefix and the daemon resolves it correctly.

## Why it's needed

Users running worktree-isolated sessions cannot preview artifact HTML files in the Web Shell. The artifact panel shows an error because the daemon tries to read <root>/report.html instead of <root>/.qwen/worktrees/<slug>/report.html.

## Reviewer Test Plan

### How to verify

1. Start a daemon-backed Web Shell session with worktree isolation (or use enter_worktree in a CLI session).
2. Ask the model to create an HTML file (e.g. "create a chart.html with a simple bar chart").
3. Confirm the model calls record_artifact with a workspacePath that includes the .qwen/worktrees/<slug>/ prefix.
4. Open the artifact in the Web Shell artifacts panel — the HTML preview should render instead of showing a file-not-found error.

Non-worktree sessions are unaffected: the path resolution logic falls through to the existing behavior when the cwd does not match the worktree pattern.

### Evidence (Before & After)

E2E verified via a worktree sub-session (`enter_worktree` → `write_file` → `record_artifact`):

```
═══ Worktree Artifact Path Fix — E2E Verification ═══

Workspace root : /Users/wenshao/git/qwen-code
Worktree cwd   : /Users/wenshao/git/qwen-code/.qwen/worktrees/artifact-test
File written   : /Users/wenshao/git/qwen-code/.qwen/worktrees/artifact-test/chart.html
File exists    : ✅ YES

── Before fix (relative to worktree cwd) ──
workspacePath  : "chart.html"
Daemon resolves: /Users/wenshao/git/qwen-code/chart.html
File found     : ❌ NO  ← BUG: file not found

── After fix (relative to workspace root) ──
workspacePath  : ".qwen/worktrees/artifact-test/chart.html"
Daemon resolves: /Users/wenshao/git/qwen-code/.qwen/worktrees/artifact-test/chart.html
File found     : ✅ YES ← FIXED
```

The `write_file` tool now suggests `workspacePath ".qwen/worktrees/artifact-test/chart.html"` (with worktree prefix) instead of `"chart.html"`, and `record_artifact` stores the correct path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

npm run dev, typecheck and lint pass. Unit test added but the local test runner has a pre-existing node-pty import failure unrelated to this change.

## Risk & Scope

- Main risk or tradeoff: the worktree detection regex relies on the well-established <root>/.qwen/worktrees/<slug> path convention, already used by enter_worktree for nested-worktree detection.
- Not validated / out of scope: the record_artifact tool itself does not adjust paths — if the model ignores the suggestion and provides its own worktree-relative path, the mismatch persists. This is a model-behavior edge case, not a code path issue.
- Breaking changes / migration notes: none. Non-worktree sessions are unaffected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当会话运行在 git worktree 中时，write_file 工具的 artifact 提醒建议的 workspacePath 是相对于 worktree 工作目录的路径（如 "report.html"）。但 daemon 的 GET /file 路由是相对于原始工作区根目录解析路径的，而非会话的 cwd。这个不匹配导致 Web Shell 中的 artifact HTML 预览因找不到文件而失败。

本 PR 在会话 cwd 位于 worktree 内时，将建议的 workspacePath 锚定到工作区根目录，使路径包含 .qwen/worktrees/<slug>/ 前缀，从而让 daemon 正确解析。

## 为什么需要

运行 worktree 隔离会话的用户无法在 Web Shell 中预览 artifact HTML 文件。artifact 面板会显示错误，因为 daemon 尝试读取 <root>/report.html 而非 <root>/.qwen/worktrees/<slug>/report.html。

## 风险与范围

- 主要风险：worktree 检测正则依赖 <root>/.qwen/worktrees/<slug> 路径约定，该约定已被 enter_worktree 的嵌套检测使用。
- 未验证/不在范围内：record_artifact 工具本身不调整路径——如果模型忽略建议使用自己的 worktree 相对路径，不匹配仍会存在。
- 无破坏性变更。非 worktree 会话不受影响。

</details>

