### PR TITLE
fix(cli): narrow update-check error classification

### DIFF
--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -649,6 +649,16 @@ describe('classifyUpdateCheckError', () => {
     );
   });
 
+  it('classifies execFile timeouts as timeout', () => {
+    const error = Object.assign(new Error('Command failed: npm view'), {
+      code: null,
+      killed: true,
+      signal: 'SIGTERM',
+    });
+
+    expect(classifyUpdateCheckError(error)).toBe('timeout');
+  });
+
   it.each([
     'ENOTFOUND',
     'ECONNREFUSED',

--- a/packages/cli/src/ui/utils/updateCheck.test.ts
+++ b/packages/cli/src/ui/utils/updateCheck.test.ts
@@ -649,31 +649,17 @@ describe('classifyUpdateCheckError', () => {
     );
   });
 
-  it('classifies execFile timeouts as timeout', () => {
-    const error = Object.assign(new Error('Command failed: npm view'), {
-      code: null,
-      killed: true,
-      signal: 'SIGTERM',
-    });
-
-    expect(classifyUpdateCheckError(error)).toBe('timeout');
+  it.each([
+    'ENOTFOUND',
+    'ECONNREFUSED',
+    'EAI_AGAIN',
+    'ETIMEDOUT',
+    'ENETUNREACH',
+  ])('classifies %s errors as offline', (code) => {
+    const error = new Error(`request failed`) as NodeJS.ErrnoException;
+    error.code = code;
+    expect(classifyUpdateCheckError(error)).toBe('offline');
   });
-
-  it('classifies ETIMEDOUT errors as timeout', () => {
-    const error = new Error('request failed') as NodeJS.ErrnoException;
-    error.code = 'ETIMEDOUT';
-
-    expect(classifyUpdateCheckError(error)).toBe('timeout');
-  });
-
-  it.each(['ENOTFOUND', 'ECONNREFUSED', 'EAI_AGAIN', 'ENETUNREACH'])(
-    'classifies %s errors as offline',
-    (code) => {
-      const error = new Error(`request failed`) as NodeJS.ErrnoException;
-      error.code = code;
-      expect(classifyUpdateCheckError(error)).toBe('offline');
-    },
-  );
 
   it('classifies network codes embedded in the message as offline', () => {
     // npm child-process failures surface the code inside stderr text only.

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -68,6 +68,14 @@ export function classifyUpdateCheckError(
 ): UpdateCheckFailureReason {
   if (error instanceof UpdateCheckTimeoutError) return 'timeout';
   if (error instanceof Error) {
+    if (
+      'killed' in error &&
+      error.killed === true &&
+      'signal' in error &&
+      error.signal === 'SIGTERM'
+    ) {
+      return 'timeout';
+    }
     const errors = [error];
     if (error.cause instanceof Error) errors.push(error.cause);
     const matchesCode = (code: string) =>

--- a/packages/cli/src/ui/utils/updateCheck.ts
+++ b/packages/cli/src/ui/utils/updateCheck.ts
@@ -52,6 +52,7 @@ const NETWORK_ERROR_CODES = [
   'ENOTFOUND',
   'ECONNREFUSED',
   'EAI_AGAIN',
+  'ETIMEDOUT',
   'ENETUNREACH',
 ];
 
@@ -65,6 +66,7 @@ const NETWORK_ERROR_CODES = [
 export function classifyUpdateCheckError(
   error: unknown,
 ): UpdateCheckFailureReason {
+  if (error instanceof UpdateCheckTimeoutError) return 'timeout';
   if (error instanceof Error) {
     const errors = [error];
     if (error.cause instanceof Error) errors.push(error.cause);
@@ -75,16 +77,6 @@ export function classifyUpdateCheckError(
           error.message.includes(code),
       );
 
-    if (
-      errors.some((error) => error instanceof UpdateCheckTimeoutError) ||
-      ('killed' in error &&
-        error.killed === true &&
-        'signal' in error &&
-        error.signal === 'SIGTERM') ||
-      matchesCode('ETIMEDOUT')
-    ) {
-      return 'timeout';
-    }
     if (NETWORK_ERROR_CODES.some(matchesCode)) return 'offline';
   }
   return 'registry';


### PR DESCRIPTION
## What this PR does

This narrows the update-check classifier change merged in #7428 to the behavior reproduced through the complete user path. It keeps direct `error.cause` inspection for Node 22 fetch failures, removes the `killed`/`SIGTERM` child-process special case, and restores `ETIMEDOUT` to the existing offline bucket.

## Why it's needed

Post-merge tmux testing exercised a real temporary global npm installation against a local registry that accepted requests but never responded. Both the #7409 baseline and #7428 rendered `registry did not respond within 5s`. The outer `fetchInfoWithTimeout` and inner npm child-process timeout both use 5000 ms; the outer typed timeout surfaces before the killed child's rejection propagates. The direct child-process unit test bypassed that real wrapper and therefore did not demonstrate the claimed user-visible fix.

The nested fetch cause remains a real issue: Node 22 reports DNS failure as `TypeError: fetch failed` with `ENOTFOUND` on `error.cause.code`. A real startup TUI run changes from `registry error` on the #7409 baseline to `registry unreachable` with that fix.

## Reviewer Test Plan

### How to verify

- Run `cd packages/cli && npx vitest run src/ui/utils/updateCheck.test.ts`; all 40 tests should pass.
- Start the bundled interactive CLI with an isolated home and `npm_config_registry=http://this-host-does-not-exist-zzz.invalid`; the background warning should report `registry unreachable`.
- As a regression control, run a temporary global npm installation against a registry that accepts but never responds; the warning should remain `registry did not respond within 5s`.

### Evidence (Before & After)

The corrected real-startup tmux evidence and the no-differential global-npm timeout control are posted as a separate PR comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 15.1.1, Node.js v22.22.0, tmux 3.5a. Windows and Linux are left to CI.

## Risk & Scope

- Main risk or tradeoff: none beyond restoring #7409's prior timeout classifications; the reproduced nested fetch fix is unchanged.
- Not validated / out of scope: recursive or aggregate error-cause traversal and manual Windows/Linux TUI verification.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7428

Related to #7423 and #7409

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将 #7428 的更新检查分类改动收窄到完整用户路径中真实复现的部分：保留 Node 22 fetch 失败的直接 `error.cause` 检查，删除 `killed`/`SIGTERM` 子进程特判，并把 `ETIMEDOUT` 恢复到原有的离线分类。

## 为什么需要

合并后的 tmux 测试使用真实的临时全局 npm 安装，并连接到一个接受请求但永不响应的本地 registry。#7409 baseline 与 #7428 都显示 `registry did not respond within 5s`。外层 `fetchInfoWithTimeout` 与内层 npm 子进程超时都使用 5000 ms，外层类型化超时会在被杀子进程的 rejection 传播前返回。原来的直接子进程单元测试绕过了真实包装层，不能证明所声称的用户可见修复。

嵌套 fetch cause 则是真实问题：Node 22 将 DNS 失败报告为 `TypeError: fetch failed`，并把 `ENOTFOUND` 放在 `error.cause.code`。真实启动 TUI 从 #7409 baseline 的 `registry error` 正确变为 `registry unreachable`。

## 验证

- 目标单元测试 40/40 通过。
- ESLint、Prettier、CLI typecheck 和 CLI build 通过。
- 真实启动 tmux Before/After 与 global-npm timeout 无差异控制证据见独立评论。

## 风险与范围

恢复 #7409 原有 timeout 分类，已复现的 nested fetch 修复保持不变。递归/聚合 cause 遍历以及 Windows/Linux 手动 TUI 验证不在本 PR 范围内。

</details>
