### PR TITLE
test(cli): pin the record_artifact workspacePath round trip

### DIFF
--- a/packages/cli/src/serve/routes/workspace-file-read.test.ts
+++ b/packages/cli/src/serve/routes/workspace-file-read.test.ts
@@ -10,7 +10,11 @@ import * as path from 'node:path';
 import { createHash, randomBytes } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import request from 'supertest';
-import { Ignore } from '@qwen-code/qwen-code-core';
+import {
+  buildRecordArtifactReminder,
+  Ignore,
+  type Config,
+} from '@qwen-code/qwen-code-core';
 import { createServeApp } from '../server.js';
 import { workspaceRelative } from './workspace-file-read.js';
 import {
@@ -547,6 +551,117 @@ describe('capability advertisement', () => {
       expect(res.body.features).toContain('workspace_file_read');
       expect(res.body.features).toContain('workspace_file_bytes');
       expect(res.body.features).toContain('workspace_file_write');
+    } finally {
+      await teardown(h);
+    }
+  });
+});
+
+// The `record_artifact` hint that `write_file` appends to a successful write
+// names a `workspacePath`, and the model hands that exact string back to this
+// route. Producer and consumer live in different packages, each with its own
+// notion of what the path is relative to — `write_file` starts from the session
+// cwd, the route resolves against the bound workspace root. They agree for an
+// ordinary session and drifted apart for a worktree one, where every artifact
+// preview 404'd. Neither side's unit tests could catch that: both were
+// internally consistent. These pin the round trip instead, over real HTTP.
+describe('record_artifact workspacePath contract (write_file ⇄ GET /file)', () => {
+  const ARTIFACT = '<!doctype html><h1>Quarterly Chart</h1>';
+
+  /** The workspacePath the model is told to send, from the real producer. */
+  function emittedWorkspacePath(sessionCwd: string, filePath: string): string {
+    const reminder = buildRecordArtifactReminder(
+      {
+        isRecordArtifactEnabled: () => true,
+        getTargetDir: () => sessionCwd,
+      } as unknown as Config,
+      filePath,
+    );
+    const match = /workspacePath "([^"]+)"/.exec(reminder ?? '');
+    if (!match?.[1]) {
+      throw new Error(`no workspacePath in reminder: ${reminder ?? 'null'}`);
+    }
+    return match[1];
+  }
+
+  it('round-trips an artifact written by an ordinary session', async () => {
+    const h = await makeHarness();
+    try {
+      const filePath = path.join(h.workspace, 'report.html');
+      await fsp.writeFile(filePath, ARTIFACT);
+
+      const workspacePath = emittedWorkspacePath(h.workspace, filePath);
+      expect(workspacePath).toBe('report.html');
+
+      const res = await request(h.app)
+        .get('/file')
+        .query({ path: workspacePath })
+        .set('Host', loopbackHost());
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe(ARTIFACT);
+    } finally {
+      await teardown(h);
+    }
+  });
+
+  it('round-trips an artifact written inside a worktree session', async () => {
+    const h = await makeHarness();
+    try {
+      // A worktree session's cwd is <workspace>/.qwen/worktrees/<slug>, but the
+      // route only ever resolves against <workspace>. A path relative to the
+      // session cwd ("report.html") would resolve to <workspace>/report.html —
+      // a different file, or none at all.
+      const sessionCwd = path.join(
+        h.workspace,
+        '.qwen',
+        'worktrees',
+        'my-feature',
+      );
+      await fsp.mkdir(sessionCwd, { recursive: true });
+      const filePath = path.join(sessionCwd, 'report.html');
+      await fsp.writeFile(filePath, ARTIFACT);
+
+      const workspacePath = emittedWorkspacePath(sessionCwd, filePath);
+      expect(workspacePath).toBe('.qwen/worktrees/my-feature/report.html');
+
+      const res = await request(h.app)
+        .get('/file')
+        .query({ path: workspacePath })
+        .set('Host', loopbackHost());
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe(ARTIFACT);
+    } finally {
+      await teardown(h);
+    }
+  });
+
+  it('does not silently read a same-named file at the workspace root', async () => {
+    const h = await makeHarness();
+    try {
+      // The failure this guards is worse than a 404: with an unrelated
+      // report.html sitting at the root, a session-cwd-relative path resolves
+      // to it and the preview shows the WRONG artifact with a 200.
+      await fsp.writeFile(
+        path.join(h.workspace, 'report.html'),
+        '<!doctype html><h1>UNRELATED ROOT FILE</h1>',
+      );
+      const sessionCwd = path.join(
+        h.workspace,
+        '.qwen',
+        'worktrees',
+        'my-feature',
+      );
+      await fsp.mkdir(sessionCwd, { recursive: true });
+      const filePath = path.join(sessionCwd, 'report.html');
+      await fsp.writeFile(filePath, ARTIFACT);
+
+      const res = await request(h.app)
+        .get('/file')
+        .query({ path: emittedWorkspacePath(sessionCwd, filePath) })
+        .set('Host', loopbackHost());
+      expect(res.status).toBe(200);
+      expect(res.body.content).toBe(ARTIFACT);
+      expect(res.body.content).not.toContain('UNRELATED ROOT FILE');
     } finally {
       await teardown(h);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -196,6 +196,10 @@ export type {
   WebSearchSettings,
 } from './tools/web-search.js';
 export type { WriteFileTool, WriteFileToolParams } from './tools/write-file.js';
+// Exported for the cross-package contract test in packages/cli (see the
+// function's own doc comment) — the daemon's file-read route must resolve the
+// workspacePath this produces.
+export { buildRecordArtifactReminder } from './tools/write-file.js';
 export type {
   ArtifactTool,
   ArtifactToolParams,

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -643,7 +643,18 @@ class WriteFileToolInvocation extends BaseToolInvocation<
   }
 }
 
-function buildRecordArtifactReminder(
+/**
+ * Builds the `record_artifact` hint appended to a successful write.
+ *
+ * Exported because the string it produces is a CONTRACT with the daemon's
+ * `GET /file` route: the `workspacePath` computed here is later resolved by
+ * `resolveWithinWorkspace` against the bound workspace root. The two sides live
+ * in different packages and drifted apart once already (a worktree session
+ * emitted a worktree-relative path that the route resolved against the
+ * workspace root, so every artifact preview 404'd). `workspace-file-read.test.ts`
+ * pins the round-trip; keep this exported so it can keep doing so.
+ */
+export function buildRecordArtifactReminder(
   config: Config,
   filePath: string,
 ): string | null {


### PR DESCRIPTION
## What this PR does

Pins the `record_artifact` `workspacePath` round trip with three tests that drive the real producer and the real `GET /file` route over HTTP, and exports `buildRecordArtifactReminder` so the consuming package can reach it.

Follow-up to #7429, which merged before this landed on its branch.

## Why it's needed

The `workspacePath` that `write_file` hands the model is resolved by the daemon's `GET /file` route, but the two live in different packages and disagreed about what the path is relative to: `write_file` measured from the session cwd, the route resolves against the bound workspace root. For an ordinary session those coincide, so nothing caught the drift until a worktree session made them differ and every artifact preview 404'd. #7429 fixed the drift.

What it could not add was a test that catches the next one. Neither side's unit tests could have caught this one — each was internally consistent — and #7429's producer test asserts only the literal string it emits (`workspacePath ".qwen/worktrees/my-feature/report.html"`). Nothing proves that string resolves to the file. The consumer side is worse off: `packages/cli/src/serve/` contains no file, source or test, that mentions worktrees at all.

So this pins the contract itself: take the real reminder from `buildRecordArtifactReminder`, pull `workspacePath` out of it, and fetch that over real HTTP through the route — the automated form of the manual `404 → 200` check on #7429.

Three cases:

| Case | What it protects |
| --- | --- |
| ordinary session | the common path can't be quietly broken by a future fix to the worktree path |
| worktree session | #7429's fix |
| worktree session **with a same-named file at the workspace root** | the failure that isn't a 404 |

The third is the one worth naming. With an unrelated `report.html` at the workspace root, the pre-fix path does not 404 — it returns **200 with the wrong file's contents**, so the artifact panel renders an unrelated artifact and looks like it worked. A test that only asserted "not 404" would pass against that.

## Reviewer Test Plan

### How to verify

```
npx vitest run packages/cli/src/serve/routes/workspace-file-read.test.ts   # 35 passed
npx vitest run packages/core/src/tools/write-file.test.ts                  # 57 passed
```

To confirm the tests are load-bearing rather than tautological, revert only the anchoring in `buildRecordArtifactReminder` — replace `path.relative(baseDir, filePath)` with `path.relative(config.getTargetDir(), filePath)` and drop the `wtMatch` lines — then re-run. The ordinary-session case must still pass and both worktree cases must fail.

### Evidence (Before & After)

**With the fix on main (this PR's tests, unmodified source):**

```
 ✓ src/serve/routes/workspace-file-read.test.ts (35 tests) 203ms
   Tests  35 passed (35)
```

**After reverting only the anchoring in `write-file.ts`:**

```
 ✓ record_artifact workspacePath contract > round-trips an artifact written by an ordinary session
 × record_artifact workspacePath contract > round-trips an artifact written inside a worktree session
 × record_artifact workspacePath contract > does not silently read a same-named file at the workspace root
   Tests  2 failed | 33 passed (35)
```

The ordinary-session case surviving the revert is the part that matters: it shows the two worktree failures are caused by the reverted logic specifically, not by the harness.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx vitest run` against the workspace; the route tests use `supertest` against the real express app built by `createServeApp`, with a real temp workspace on disk. No daemon or network needed.

## Risk & Scope

- **Main risk or tradeoff:** `buildRecordArtifactReminder` becomes a public export of `@qwen-code/qwen-code-core`. It is exported specifically because the string it builds is a cross-package contract that the consuming package has to honour, and the doc comment says so — but it is new public surface, and an alternative would be to duplicate the tool-level mock scaffolding in the cli test instead (~35 mock fields, cast through `as unknown as Config`).
- **Not validated / out of scope:** the anchoring regex matches `<projectRoot>/.qwen/worktrees/<slug>`, which is the layout used by `enter_worktree` and the web-shell worktree sessions. `GitWorktreeService` also maintains `<base>/<sessionId>/worktrees/<name>` (default base `~/.qwen/worktrees`, replaceable via `customBaseDir`) for Arena agents, which the regex does not match. I did not verify whether an Arena agent's artifact ever reaches this route with the same bound workspace, so these tests deliberately do not assert anything about that layout. Raised on #7429 for a decision.
- **Breaking changes / migration notes:** none. One added export; no behaviour change.

## Linked Issues

Follow-up to #7429.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

用三个测试锁住 `record_artifact` 的 `workspacePath` 往返契约 —— 驱动真实的生产端和真实的 `GET /file` 路由走真实 HTTP,并导出 `buildRecordArtifactReminder` 让消费方所在的包能拿到它。

这是 #7429 的后续 —— 那个 PR 在这部分推上分支之前就已经合入了。

## 为什么需要

`write_file` 交给模型的 `workspacePath` 由 daemon 的 `GET /file` 路由解析,但两者分属不同的包,且对"相对于什么"的理解不一致:`write_file` 从会话 cwd 起算,路由按绑定的 workspace 根解析。普通会话下两者恰好重合,所以这个漂移一直没被发现,直到 worktree 会话让它们分叉,artifact 预览全部 404。#7429 修好了这次漂移。

但它没能加上一个能拦住**下一次**漂移的测试。两端的单测都抓不到这次问题 —— 各自都是自洽的 —— 而 #7429 的生产端测试只断言了它吐出的字面量字符串,没有任何东西证明这个字符串能解析到文件。消费端更糟:`packages/cli/src/serve/` 下没有任何一个文件(源码或测试)提到过 worktree。

所以这里锁的是契约本身:取 `buildRecordArtifactReminder` 的真实输出,抽出 `workspacePath`,再通过真实 HTTP 打到路由上 —— 就是 #7429 上那次手工 `404 → 200` 验证的自动化版本。

三个用例分别护住:普通会话(以后修 worktree 路径时不会悄悄破坏常规路径)、worktree 会话(#7429 的修复),以及**workspace 根目录下存在同名文件的 worktree 会话**。

第三个最值得点名:根目录下有个无关的 `report.html` 时,修复前的路径**不会 404,而是返回 200 加上错误文件的内容** —— artifact 面板会渲染一个无关的产物,看起来像是成功了。一个只断言"不是 404"的测试会在这种情况下通过。

## 如何验证

见上文英文部分的命令(`35 passed` / `57 passed`)。要确认这些测试是承重的而非同义反复,只回退 `buildRecordArtifactReminder` 里的锚定逻辑再跑一遍:普通会话用例必须仍然通过,两个 worktree 用例必须挂掉(实测 `2 failed | 33 passed`)。普通会话用例在回退后依然通过,这一点才是关键 —— 它说明那两个失败是被回退的那段逻辑导致的,而不是测试脚手架本身的问题。

## 风险与范围

- **主要取舍:** `buildRecordArtifactReminder` 成为 core 的公开导出。导出的理由是它构造的字符串本身就是一个跨包契约,消费方必须遵守,函数的文档注释也写明了这点 —— 但这确实是新增的公开面。替代方案是在 cli 测试里复制工具级的 mock 脚手架(约 35 个字段,`as unknown as Config` 强转)。
- **不在范围内:** 锚定正则匹配的是 `<projectRoot>/.qwen/worktrees/<slug>`,即 `enter_worktree` 和 web-shell worktree 会话使用的布局。`GitWorktreeService` 还维护着 `<base>/<sessionId>/worktrees/<name>`(默认 base 为 `~/.qwen/worktrees`,可通过 `customBaseDir` 整体替换)供 Arena agent 使用,正则不匹配这一套。我没有验证 Arena agent 的 artifact 是否会走到同一个路由、绑定同一个 workspace,因此这些测试刻意没有对那套布局做任何断言。已在 #7429 上提出待决策。
- **破坏性改动:** 无。仅新增一个导出,行为无变化。

</details>
