### PR TITLE
fix(web-shell): stop toasting on failed background artifact refreshes

### DIFF
--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -151,6 +151,42 @@ describe('useSessionArtifacts', () => {
     ]);
   });
 
+  // Regression for #7427: automatic refreshes are silent — the action is
+  // asked not to toast, errors land in local state, and last-good
+  // artifacts stay visible.
+  it('passes silent and keeps last-good artifacts when a refresh fails', async () => {
+    const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await renderHookHost();
+    await act(async () => {
+      initialLoad.resolve({ artifacts: [artifact('kept-artifact')] });
+      await initialLoad.promise;
+    });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'kept-artifact',
+    ]);
+
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Every call is a background refresh and must opt out of the toast.
+    for (const call of sdkMock.actions.loadArtifacts.mock.calls) {
+      expect(call[0]).toEqual({ silent: true });
+    }
+    // The failure lands in local error state; last-good data survives.
+    expect(latestState?.error).toContain('Failed to fetch');
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'kept-artifact',
+    ]);
+    expect(latestState?.loading).toBe(false);
+  });
+
   it('keeps current artifacts visible while refreshing the same session', async () => {
     const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
     const refreshLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();

--- a/packages/web-shell/client/hooks/useSessionArtifacts.ts
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.ts
@@ -68,7 +68,10 @@ export function useSessionArtifacts(): SessionArtifactsState {
     }
     setLoading(true);
     try {
-      const result = await actions.loadArtifacts();
+      // silent: every trigger of this refresh is automatic (mount,
+      // prompt->idle, artifactsVersion); errors land in local state below
+      // and last-good artifacts are preserved — no toast (#7427).
+      const result = await actions.loadArtifacts({ silent: true });
       if (requestIdRef.current !== requestId) return;
       loadedSessionIdRef.current = sessionId;
       setArtifacts(result.artifacts);

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -427,6 +427,43 @@ describe('createDaemonSessionActions', () => {
     }
   });
 
+  // Regression for #7427: background artifact refreshes opt out of the
+  // error toast; the default path keeps it.
+  it('suppresses the failure notice for silent loadArtifacts', async () => {
+    const session = createMockSession('session-a') as ReturnType<
+      typeof createMockSession
+    > & { artifacts?: ReturnType<typeof vi.fn> };
+    session.artifacts = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    const addNotice = vi.fn((notice) => notice);
+    const { actions } = createActionsHarness({ addNotice, session });
+
+    await expect(actions.loadArtifacts({ silent: true })).rejects.toThrow(
+      'Failed to fetch',
+    );
+    expect(addNotice).not.toHaveBeenCalled();
+  });
+
+  it('keeps the failure notice for default loadArtifacts', async () => {
+    const session = createMockSession('session-a') as ReturnType<
+      typeof createMockSession
+    > & { artifacts?: ReturnType<typeof vi.fn> };
+    session.artifacts = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    const addNotice = vi.fn((notice) => notice);
+    const { actions } = createActionsHarness({ addNotice, session });
+
+    await expect(actions.loadArtifacts()).rejects.toThrow('Failed to fetch');
+    expect(addNotice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'daemon.load_artifacts.failed',
+      }),
+    );
+  });
+
   it('rejects attachSession when no session exists', async () => {
     const { actions } = createActionsHarness();
 

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -1172,7 +1172,9 @@ export function createDaemonSessionActions({
       }
     },
 
-    async loadArtifacts(): Promise<DaemonSessionArtifactsEnvelope> {
+    async loadArtifacts(options?: {
+      silent?: boolean;
+    }): Promise<DaemonSessionArtifactsEnvelope> {
       const session = requireSessionForAction(
         addNotice,
         sessionRef.current,
@@ -1185,6 +1187,14 @@ export function createDaemonSessionActions({
           'Load artifacts timed out',
         );
       } catch (error) {
+        // Background refreshes (mount / prompt->idle / artifactsVersion)
+        // opt out of the toast: a transient fetch failure on an automatic
+        // poll is noise the user cannot act on, and the calling hook keeps
+        // its own error state + last-good artifacts (#7427). Same
+        // best-effort-and-silent philosophy as enqueueMidturnMessage.
+        if (options?.silent) {
+          throw error instanceof Error ? error : new Error(String(error));
+        }
         throw dispatchActionError(
           addNotice,
           'Load artifacts failed',

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -412,7 +412,16 @@ export interface DaemonSessionActions {
   ): Promise<{ cancelled: boolean }>;
   clearGoal(): Promise<{ cleared: boolean; condition?: string }>;
   getStats(): Promise<DaemonSessionStatsStatus>;
-  loadArtifacts(): Promise<DaemonSessionArtifactsEnvelope>;
+  /**
+   * Loads the session's artifacts. `silent: true` suppresses the
+   * error-severity notice on failure (the error is still thrown) — for
+   * automatic/background refreshes whose callers handle errors locally
+   * and where a transient fetch failure is not actionable by the user
+   * (#7427).
+   */
+  loadArtifacts(options?: {
+    silent?: boolean;
+  }): Promise<DaemonSessionArtifactsEnvelope>;
   branchSession(
     name?: string,
   ): Promise<{ sessionId: string; displayName: string }>;


### PR DESCRIPTION
## What this PR does

Adds a `{ silent?: boolean }` option to `DaemonSessionActions.loadArtifacts`: when set, the failure path skips `dispatchActionError`'s error-severity notice and re-throws the raw error (the calling hook needs the throw for its local error state). `useSessionArtifacts` — the action's only caller, and a purely automatic one (panel mount, `promptStatus` → idle, the `artifactsVersion` workspace signal) — passes `silent: true`; its existing `catch` already preserves last-good artifacts. User-initiated actions keep their notices, and the change mirrors `enqueueMidturnMessage`'s established best-effort-and-silent philosophy for background-refreshable actions.

## Why it's needed

#7427: the artifact panel repeatedly toasts `Load artifacts failed: Failed to fetch` during transient connectivity hiccups, because every automatic background refresh routes failures through `dispatchActionError`, which unconditionally fires an error toast. The user can't act on a failed background poll, and the panel already keeps its last-good data — the toast is pure noise, reappearing on every retriggered refresh. The triage confirmed the root cause from source and the maintainer endorsed exactly this fix shape (interface option + conditional in the action + call-site update in the hook), including the regression-test design this PR implements.

## Reviewer Test Plan

### How to verify

1. Run `qwen serve`, open the Web Shell with an active session, then briefly interrupt connectivity to the daemon (or block the artifacts endpoint). Before this PR: each automatic refresh pops an error toast. After: no toast; the panel keeps showing the last loaded artifacts; artifacts refresh resumes silently when connectivity returns.
2. `npx vitest run src/daemon/session/actions.test.ts` (packages/webui) 26/26 and `npx vitest run client/hooks/useSessionArtifacts.test.tsx` (packages/web-shell) 3/3.

### Evidence (Before & After)

Regression tests follow the design suggested on the issue, and both fail on the unpatched source (verified via `git stash`):

| test | unpatched | patched |
| --- | --- | --- |
| silent failure dispatches **no** notice, still rejects with the raw error | ❌ (notice fired) | ✅ |
| default (non-silent) failure keeps the `daemon.load_artifacts.failed` notice | ✅ | ✅ (unchanged) |
| the hook passes `{ silent: true }` on **every** refresh; failure lands in local `error` state; last-good artifacts stay visible; `loading` settles | ❌ (no silent arg) | ✅ |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22.23.1; vitest (jsdom for the hook). `npm run typecheck`, eslint `--max-warnings 0`, prettier all clean.

## Risk & Scope

- Main risk or tradeoff: a persistent artifact-endpoint outage no longer surfaces a toast — by design for background polls; the hook still records the error locally, and hard failures of user-initiated actions are unaffected. The maintainer's optional fast-follow (suppress only transient network errors, still toast 401/403/404) is deliberately left out to keep this PR the simple shape endorsed on the issue; happy to do it as a follow-up.
- Not validated / out of scope: `getStats` shares the `dispatchActionError` pattern but is only invoked by the explicit `/stats` command, so it keeps its notice (per the maintainer's note); no other action changes.
- Breaking changes / migration notes: none — the option is additive and optional.

## Linked Issues

Fixes #7427

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 `DaemonSessionActions.loadArtifacts` 增加 `{ silent?: boolean }`：置位时失败路径跳过 `dispatchActionError` 的 error 级 notice、重抛原始错误（调用方 hook 需要 throw 来设置本地 error 状态）。唯一调用方 `useSessionArtifacts` 的刷新完全是自动触发（面板挂载、prompt→idle、artifactsVersion 信号），现传 `silent: true`；其既有 catch 已保留上次成功的 artifacts。用户主动操作保留 notice；与同文件 `enqueueMidturnMessage` 的 best-effort-and-silent 先例一致。

## 为什么需要

#7427：artifact 面板在瞬时连接抖动期间反复弹 `Load artifacts failed: Failed to fetch`——每次自动后台刷新的失败都走 `dispatchActionError` 无条件弹 toast。用户对失败的后台轮询无从行动、面板本就保留旧数据——toast 纯属噪音且随每次重触发反复出现。triage 已源码确认根因，维护者背书了正是本 PR 的修复形状（接口选项 + action 条件 + hook 调用点），包括本 PR 实现的回归测试设计。

## 审阅测试计划

### 如何验证

1. `qwen serve` 开 Web Shell 活跃会话，短暂中断与 daemon 的连接：本 PR 之前每次自动刷新弹错误 toast；之后无 toast、面板保留上次 artifacts、恢复连接后静默恢复刷新；
2. webui actions 26/26 + web-shell hook 3/3。

### 证据（Before & After）

回归测试按 issue 中建议的设计实现，且都在未修复源码上失败（git stash 验证）：silent 失败不派发 notice 仍拒绝；默认路径保留 notice；hook 每次刷新都传 silent、失败落本地 error、旧 artifacts 可见、loading 归位。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22.23.1；vitest（hook 用 jsdom）；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：artifact 端点持续故障不再弹 toast——这正是后台轮询的设计意图；hook 仍本地记录错误，用户主动操作的失败不受影响。维护者提到的可选快跟（仅抑制瞬态网络错误、401/403/404 仍弹）有意留作 follow-up，保持本 PR 为 issue 上背书的简单形状。
- 未验证/超出范围：`getStats` 共享同模式但仅由显式 `/stats` 命令调用，按维护者说明保留 notice；无其它 action 变更。
- 破坏性变更/迁移说明：无——选项为可选新增。

## 关联 Issue

Fixes #7427

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
