### PR TITLE
fix(autofix): keep a still-red check visible until its head is judged

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2495,14 +2495,17 @@ jobs:
           # QUEUES the duplicate rather than discarding it — but that queueing
           # is exactly what makes this check sound: address jobs for one PR run
           # strictly one at a time, so by the time the duplicate runs here, the
-          # first job's eval marker is posted and visible. Two duplicate
+          # first job's eval marker is posted and visible. Three duplicate
           # signatures: (a) a sibling evaluated through a NEWER live ts than
           # our matrix watermark; (b) a conflict-only sibling resolved and
           # marked at the SAME ts — with no newer feedback its marker keeps
           # ts=watermark while its ROUND advances past ours (ours is the max
-          # round observed at scan time). Either way, if there is no live
-          # conflict left and nothing newer than the live watermark, this run
-          # is a stale duplicate and discards itself.
+          # round observed at scan time); (c) a no-op sibling judged THIS exact
+          # head (its redcheck marker matches CHECKED_OUT_HEAD) while keeping
+          # BOTH ts and round unchanged — neither (a) nor (b) fires, but
+          # re-running would post a duplicate report for the same head. Either
+          # way, if there is no live conflict left and nothing newer than the
+          # live watermark, this run is a stale duplicate and discards itself.
           STALE='false'
           LIVE_MARKS="$(jq -r --arg ab "${AUTOFIX_BOT}" '
             [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
@@ -2526,6 +2529,16 @@ jobs:
                     or ((.body // "") | contains("<!-- autofix-rearm -->")))
               | .created_at ] | max // "none"' "${WORKDIR}/ic.json")"
           LIVE_MAX_ROUND="$(jq -r --arg key "${LIVE_REARM_KEY}" 'map(select(.win == $key)) | map(.round) | max // 0' <<< "${LIVE_MARKS}")"
+          # The head a sibling last judged, mirrored from the scan's RED_HEAD
+          # parse. A no-op sibling records this marker while leaving BOTH ts and
+          # round UNCHANGED — so the watermark/round triggers below never fire,
+          # yet a second same-watermark target for the same head would otherwise
+          # run the agent again and post a duplicate report for that head.
+          LIVE_RED_HEAD="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+            [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
+              | [ scan("<!-- autofix-redcheck head=([0-9a-f]+) -->") ] | .[]
+              | {sha: .[0], at: ($c.created_at // "")} ]
+            | sort_by(.at) | last | .sha // ""' "${WORKDIR}/ic.json")"
           # A re-arm SUPERSEDES every job selected under the old window key:
           # the maintainer asked for a fresh start, so a queued old-window job
           # must discard instead of finishing and stamping an old-sequence
@@ -2535,7 +2548,8 @@ jobs:
             echo "🫥 window superseded: selected under key '${WINDOW:-none}' but the live window is '${LIVE_REARM_KEY}' (re-armed while queued) — discarding without action or marker"
           fi
           if [[ -n "${LIVE_EVAL_WM}" && "${CONFLICT}" != "true" ]] \
-            && { [[ "${LIVE_EVAL_WM}" > "${WATERMARK}" ]] || [[ "${LIVE_MAX_ROUND}" -gt "${ROUND}" ]]; }; then
+            && { [[ "${LIVE_EVAL_WM}" > "${WATERMARK}" ]] || [[ "${LIVE_MAX_ROUND}" -gt "${ROUND}" ]] \
+              || { [[ -n "${LIVE_RED_HEAD}" ]] && [[ "${LIVE_RED_HEAD}" == "${CHECKED_OUT_HEAD}" ]]; }; }; then
             LIVE_NEW="$(jq -rs \
               --arg wm "${LIVE_EVAL_WM}" --arg rb "${REVIEW_BOT}" --arg ab "${AUTOFIX_BOT}" \
               --argjson trust "${TRUSTED_ASSOC}" '

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1238,6 +1238,12 @@ jobs:
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
         run: |-
+          # The head the reds were evaluated against. Taken from the REMOTE,
+          # not local HEAD: after a rejected push the two differ, and
+          # recording a sha that never landed would suppress the still-red
+          # checks on the head that actually exists. Empty on failure, which
+          # matches no marker and therefore keeps them visible — fail-open.
+          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
           {
@@ -1744,7 +1750,7 @@ jobs:
             # (the watermark floor below), and labels (the effective round
             # cap) — avoids extra round-trips per candidate PR.
             PR_META="$(gh pr view "${PR}" --repo "${REPO}" \
-              --json headRefName,statusCheckRollup,createdAt,labels,isCrossRepository,headRepositoryOwner,headRepository 2> /dev/null || echo '{}')"
+              --json headRefName,headRefOid,statusCheckRollup,createdAt,labels,isCrossRepository,headRepositoryOwner,headRepository 2> /dev/null || echo '{}')"
             HEAD_REPO_FULL="${REPO}"
             if [[ "$(jq -r '.isCrossRepository // false' <<< "${PR_META}")" == "true" ]]; then
               HR_OWNER="$(jq -r '.headRepositoryOwner.login // ""' <<< "${PR_META}")"
@@ -1902,6 +1908,16 @@ jobs:
               [ .[] | select((.user.login // "") == $ab)
                 | select((.body // "") | contains("<!-- autofix-rearm -->"))
                 | .created_at ] | max // ""' "${WORKDIR}/ic.json")"
+            # The head this PR's red checks were last reported against. Carried
+            # as its OWN marker inside the eval comment rather than a new field
+            # on autofix-eval, so none of the ts/acted/round parsers change —
+            # and the comment still matches the eval filter, so the agent never
+            # sees it as feedback.
+            RED_HEAD="$(jq -r --arg ab "${AUTOFIX_BOT}" '
+              [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
+                | [ scan("<!-- autofix-redcheck head=([0-9a-f]+) -->") ] | .[]
+                | {sha: .[0], at: ($c.created_at // "")} ]
+              | sort_by(.at) | last | .sha // ""' "${WORKDIR}/ic.json")"
             # A maintainer '@qwen-code /retry' posts that marker to say
             # "evaluate this feedback again": markers written BEFORE it stop
             # holding the watermark down. This is the sanctioned exception to
@@ -1995,6 +2011,28 @@ jobs:
                 | select((.completedAt // .updatedAt // "") > $wm) ]
               | length
             ' <<< "${CHECKS_JSON}")"
+            # A red check is a persistent STATE, not the instant it turned red.
+            # Counting only "failed since the watermark" made a still-failing PR
+            # invisible the moment the watermark passed the failure: measured on
+            # #6451 (3 reds, all completed 09:30-09:51, watermark 10:55),
+            # #7357 (red 07:59, watermark 09:18) and #7390 (red and watermark
+            # both 11:27:37, so a strict `>` hid it the instant it appeared) —
+            # all three sat red for hours while every scan logged "nothing new".
+            #
+            # So: a currently-red check counts as feedback until the head it ran
+            # against has been evaluated. The address job records the head it
+            # reported on; a PR whose recorded head still matches is left alone,
+            # which bounds this to ONE look per head instead of every scan.
+            LIVE_HEAD="$(jq -r '.headRefOid // ""' <<< "${PR_META}")"
+            N_RED_NOW=0
+            if [[ -n "${LIVE_HEAD}" && "${RED_HEAD}" != "${LIVE_HEAD}" ]]; then
+              N_RED_NOW="$(jq '
+                [ .[]
+                  | select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED"))
+                  | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address")))) ]
+                | length
+              ' <<< "${CHECKS_JSON}")"
+            fi
 
             gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate > "${WORKDIR}/rv.json"
             gh api "repos/${REPO}/pulls/${PR}/comments" --paginate > "${WORKDIR}/rc.json"
@@ -2049,14 +2087,14 @@ jobs:
             HAS_CONFLICT='false'
             if [[ "${MERGEABLE}" == "CONFLICTING" ]]; then HAS_CONFLICT='true'; fi
 
-            if [[ "${N_REVIEWS}" -eq 0 && "${N_COMMENTS}" -eq 0 && "${N_ISSUE_COMMENTS}" -eq 0 && "${N_FAILED_CHECKS}" -eq 0 && "${HAS_CONFLICT}" != "true" ]]; then
+            if [[ "${N_REVIEWS}" -eq 0 && "${N_COMMENTS}" -eq 0 && "${N_ISSUE_COMMENTS}" -eq 0 && "${N_FAILED_CHECKS}" -eq 0 && "${N_RED_NOW}" -eq 0 && "${HAS_CONFLICT}" != "true" ]]; then
               echo "✅ #${PR}: nothing new since ${EFF_WM} (conflict=${HAS_CONFLICT})"
               fleet_row "${PR}" 'idle' "nothing new since ${EFF_WM} (round ${ROUND}/${EFF_MAX_ROUNDS}, conflict=${HAS_CONFLICT})"
               continue
             fi
 
-            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} issue comment(s) + ${N_FAILED_CHECKS} failed check(s) new, conflict=${HAS_CONFLICT}, round=${ROUND}"
-            fleet_row "${PR}" 'SELECTED' "${N_REVIEWS} review + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} comment + ${N_FAILED_CHECKS} failed-check new (round ${ROUND}/${EFF_MAX_ROUNDS}, conflict=${HAS_CONFLICT})"
+            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} issue comment(s) + ${N_FAILED_CHECKS} failed check(s) new + ${N_RED_NOW} still-red on ${LIVE_HEAD:0:9}, conflict=${HAS_CONFLICT}, round=${ROUND}"
+            fleet_row "${PR}" 'SELECTED' "${N_REVIEWS} review + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} comment + ${N_FAILED_CHECKS} failed-check new + ${N_RED_NOW} still-red (round ${ROUND}/${EFF_MAX_ROUNDS}, conflict=${HAS_CONFLICT})"
             TARGETS="$(jq -c \
               --arg pr "${PR}" --arg branch "${BRANCH}" --arg issue "${ISSUE}" \
               --arg round "${ROUND}" --arg wm "${EFF_WM}" --arg mr "${EFF_MAX_ROUNDS}" \
@@ -2906,6 +2944,12 @@ jobs:
           # variable (not a secret), already the agent's OPENAI_MODEL.
           MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
+          # The head the reds were evaluated against. Taken from the REMOTE,
+          # not local HEAD: after a rejected push the two differ, and
+          # recording a sha that never landed would suppress the still-red
+          # checks on the head that actually exists. Empty on failure, which
+          # matches no marker and therefore keeps them visible — fail-open.
+          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
           # Prepare may have adopted a sibling's live round; the matrix value
           # would double-write that round's marker.
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
@@ -3011,6 +3055,7 @@ jobs:
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=true round=${NEXT_ROUND} win=${WINDOW:-none} -->"
+              echo "<!-- autofix-redcheck head=${REPORT_HEAD} -->"
             } > "${WORKDIR}/report.md"
             STATUS="pushed (round ${NEXT_ROUND}/${MAX_ROUNDS})"
           else
@@ -3027,6 +3072,7 @@ jobs:
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${NEWEST} acted=false round=${ROUND} win=${WINDOW:-none} -->"
+              echo "<!-- autofix-redcheck head=${REPORT_HEAD} -->"
             } > "${WORKDIR}/report.md"
             STATUS="no action needed"
           fi
@@ -3313,6 +3359,7 @@ jobs:
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${MARK_TS} acted=false round=${MARK_ROUND} win=${WINDOW:-none} -->"
+              echo "<!-- autofix-redcheck head=${REPORT_HEAD} -->"
             } > "${WORKDIR}/report.md"
             gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || echo "::warning::Failed to post handoff comment on PR #${PR}"
           fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2017,6 +2017,8 @@ jobs:
             # against has been evaluated. The address job records the head it
             # reported on; a PR whose recorded head still matches is left alone,
             # which bounds this to ONE look per head instead of every scan.
+            # Empty LIVE_HEAD → N_RED_NOW stays 0: fail-closed (no head → cannot judge → do not act),
+            # unlike the recording side where an empty REPORT_HEAD keeps reds visible.
             LIVE_HEAD="$(jq -r '.headRefOid // ""' <<< "${PR_META}")"
             N_RED_NOW=0
             if [[ -n "${LIVE_HEAD}" && "${RED_HEAD}" != "${LIVE_HEAD}" ]]; then

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2436,6 +2436,12 @@ jobs:
             git checkout -B "${BRANCH}" "origin/${BRANCH}"
           fi
 
+          # The exact SHA the agent will evaluate. Captured HERE, before any
+          # agent mutation, so the marker records what was actually looked at —
+          # not the report-time remote head, which can move during the run.
+          CHECKED_OUT_HEAD="$(git rev-parse HEAD)"
+          echo "checked_out_head=${CHECKED_OUT_HEAD}" >> "${GITHUB_OUTPUT}"
+
           # Does the branch conflict with base? merge-tree computes the merge
           # without touching the tree; exit 1 means conflicts. UNKNOWN/errors are
           # treated as no-conflict so we never block on a transient state.
@@ -2631,6 +2637,20 @@ jobs:
               | select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED"))
               | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
               | select((.completedAt // .updatedAt // "") > $wm)
+              | "- \(((.name // .workflowName) // "external check") | gsub("[^A-Za-z0-9 _./()-]"; "") | .[0:80]): \(.conclusion // .state // "?")"' \
+              "${WORKDIR}/checks.json"
+            # Checks that turned red BEFORE the watermark and are STILL red.
+            # The section above only shows checks that failed AFTER the
+            # watermark, so a persistent red (the exact case the scan's
+            # N_RED_NOW gate selects) would leave the agent with an empty
+            # "Failed checks" section and no check name to reproduce.
+            echo
+            echo "## Still-red checks (persisting from before the last evaluation)"
+            jq -r --arg wm "${WATERMARK}" '
+              .[]
+              | select((.conclusion // .state // "") | IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED"))
+              | select(((.workflowName // "") != "Qwen Autofix") or (((.name // "") | startswith("review-address"))))
+              | select((.completedAt // .updatedAt // "") <= $wm)
               | "- \(((.name // .workflowName) // "external check") | gsub("[^A-Za-z0-9 _./()-]"; "") | .[0:80]): \(.conclusion // .state // "?")"' \
               "${WORKDIR}/checks.json"
             # If the LAST round ended in a gate rejection, show the agent WHY.
@@ -2939,13 +2959,13 @@ jobs:
           # Surfaced in the report footer for diagnosis + attribution; a repo
           # variable (not a secret), already the agent's OPENAI_MODEL.
           MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
+          CHECKED_OUT_HEAD: '${{ steps.prepare.outputs.checked_out_head }}'
         run: |-
-          # The head the reds were evaluated against. Taken from the REMOTE,
-          # not local HEAD: after a rejected push the two differ, and
-          # recording a sha that never landed would suppress the still-red
-          # checks on the head that actually exists. Empty on failure, which
-          # matches no marker and therefore keeps them visible — fail-open.
-          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
+          # The head the agent actually evaluated — captured in prepare before
+          # any mutation, not the report-time remote head (which can move
+          # during the run). Empty when prepare exited early, which matches
+          # no marker and keeps reds visible — fail-open.
+          REPORT_HEAD="${CHECKED_OUT_HEAD}"
           # Prepare may have adopted a sibling's live round; the matrix value
           # would double-write that round's marker.
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
@@ -3103,13 +3123,13 @@ jobs:
           STALE: '${{ steps.prepare.outputs.stale }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
           MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
+          CHECKED_OUT_HEAD: '${{ steps.prepare.outputs.checked_out_head }}'
         run: |-
-          # The head the reds were evaluated against. Taken from the REMOTE,
-          # not local HEAD: after a rejected push the two differ, and
-          # recording a sha that never landed would suppress the still-red
-          # checks on the head that actually exists. Empty on failure, which
-          # matches no marker and therefore keeps them visible — fail-open.
-          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
+          # The head the agent actually evaluated — captured in prepare before
+          # any mutation, not the report-time remote head (which can move
+          # during the run). Empty when prepare exited early, which matches
+          # no marker and keeps reds visible — fail-open.
+          REPORT_HEAD="${CHECKED_OUT_HEAD}"
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
           MODEL_DISPLAY="${MODEL:-default}"
           SUFFIX=''
@@ -3361,7 +3381,14 @@ jobs:
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
               echo
               echo "<!-- autofix-eval ts=${MARK_TS} acted=false round=${MARK_ROUND} win=${WINDOW:-none} -->"
-              echo "<!-- autofix-redcheck head=${REPORT_HEAD} -->"
+              # A sentinel ts means the agent evaluated NOTHING (crash, API
+              # error, gate crash) and the next scan must retry. Recording a
+              # judged head here would make RED_HEAD == LIVE_HEAD, so the
+              # retry scan sees N_RED_NOW=0 and goes idle despite the handoff
+              # promising a retry.
+              if [[ "${MARK_TS}" != '9999-12-31T23:59:59Z' ]]; then
+                echo "<!-- autofix-redcheck head=${REPORT_HEAD} -->"
+              fi
             } > "${WORKDIR}/report.md"
             gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || echo "::warning::Failed to post handoff comment on PR #${PR}"
           fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1238,12 +1238,6 @@ jobs:
           DRY_RUN: '${{ needs.route.outputs.dry_run }}'
           OUTCOME: '${{ steps.verify.outputs.outcome }}'
         run: |-
-          # The head the reds were evaluated against. Taken from the REMOTE,
-          # not local HEAD: after a rejected push the two differ, and
-          # recording a sha that never landed would suppress the still-red
-          # checks on the head that actually exists. Empty on failure, which
-          # matches no marker and therefore keeps them visible — fail-open.
-          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
           SUFFIX=''
           [[ "${DRY_RUN}" == "true" ]] && SUFFIX=' (dry-run, nothing pushed)'
           {
@@ -2093,8 +2087,8 @@ jobs:
               continue
             fi
 
-            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} issue comment(s) + ${N_FAILED_CHECKS} failed check(s) new + ${N_RED_NOW} still-red on ${LIVE_HEAD:0:9}, conflict=${HAS_CONFLICT}, round=${ROUND}"
-            fleet_row "${PR}" 'SELECTED' "${N_REVIEWS} review + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} comment + ${N_FAILED_CHECKS} failed-check new + ${N_RED_NOW} still-red (round ${ROUND}/${EFF_MAX_ROUNDS}, conflict=${HAS_CONFLICT})"
+            echo "🔎 #${PR}: ${N_REVIEWS} review(s) + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} issue comment(s) + ${N_FAILED_CHECKS} failed check(s) new, ${N_RED_NOW} still-red on ${LIVE_HEAD:0:9}, conflict=${HAS_CONFLICT}, round=${ROUND}"
+            fleet_row "${PR}" 'SELECTED' "${N_REVIEWS} review + ${N_COMMENTS} inline + ${N_ISSUE_COMMENTS} comment + ${N_FAILED_CHECKS} failed-check new, ${N_RED_NOW} still-red (round ${ROUND}/${EFF_MAX_ROUNDS}, conflict=${HAS_CONFLICT})"
             TARGETS="$(jq -c \
               --arg pr "${PR}" --arg branch "${BRANCH}" --arg issue "${ISSUE}" \
               --arg round "${ROUND}" --arg wm "${EFF_WM}" --arg mr "${EFF_MAX_ROUNDS}" \
@@ -3108,6 +3102,12 @@ jobs:
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
           MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
         run: |-
+          # The head the reds were evaluated against. Taken from the REMOTE,
+          # not local HEAD: after a rejected push the two differ, and
+          # recording a sha that never landed would suppress the still-red
+          # checks on the head that actually exists. Empty on failure, which
+          # matches no marker and therefore keeps them visible — fail-open.
+          REPORT_HEAD="$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha // ""' 2> /dev/null || echo '')"
           ROUND="${EFFECTIVE_ROUND:-${ROUND}}"
           MODEL_DISPLAY="${MODEL:-default}"
           SUFFIX=''

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -445,6 +445,10 @@ describe('qwen-autofix workflow', () => {
     // Green stays green.
     expect(run([], '', 'abc123')).toBe('0');
     expect(run(['a', 'b', 'c'], '', 'abc123')).toBe('3');
+    // Empty LIVE_HEAD → fail-closed regardless of RED_HEAD. Without this,
+    // a simplified guard (removing -n) would select a PR with no evaluable head.
+    expect(run(['Test'], '', '')).toBe('0');
+    expect(run(['Test'], 'abc123', '')).toBe('0');
 
     // The count must actually GATE selection — computing it and then not
     // consulting it is the whole bug, and every other assertion here still

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -481,16 +481,96 @@ describe('qwen-autofix workflow', () => {
       const emits = body.includes(
         '<!-- autofix-redcheck head=${REPORT_HEAD} -->',
       );
-      const defines = body.includes('REPORT_HEAD="$(gh api');
+      const defines = body.includes('REPORT_HEAD="${CHECKED_OUT_HEAD}"');
       expect(emits).toBe(defines);
       if (emits) emitterSteps += 1;
     }
     expect(emitterSteps).toBe(2);
-    // Taken from the REMOTE head: after a rejected push local HEAD is ahead of
-    // what landed, and recording a sha that never existed would suppress the
-    // reds on the head that does. Empty on failure — matches no marker, so the
-    // reds stay visible.
-    expect(workflow).not.toContain('REPORT_HEAD="$(git rev-parse HEAD)"');
+    // The head is captured in prepare (before agent mutations) and forwarded
+    // via a step output — not re-fetched from the API at report time, which
+    // could return a DIFFERENT head if the branch moved during the run.
+    expect(prepareBranchAndFeedbackStep).toContain(
+      'CHECKED_OUT_HEAD="$(git rev-parse HEAD)"',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain(
+      'checked_out_head=${CHECKED_OUT_HEAD}',
+    );
+    expect(workflow).not.toContain('REPORT_HEAD="$(gh api');
+    // The handoff step must NOT stamp the redcheck marker when the agent
+    // evaluated nothing (sentinel ts): doing so would make RED_HEAD ==
+    // LIVE_HEAD and the retry scan would see N_RED_NOW=0, going idle
+    // despite the handoff promising a retry.
+    expect(reviewAddressReportStep).toContain(
+      'if [[ "${MARK_TS}" != \'9999-12-31T23:59:59Z\' ]]; then',
+    );
+  });
+
+  it('renders persistent red checks into the agent feedback', () => {
+    // The scan selects a PR via N_RED_NOW (currently-red, head unjudged),
+    // but the prepare step's "Failed checks" renderer only shows checks
+    // that completed AFTER the watermark. In the exact case N_RED_NOW
+    // targets (red completed before/equal to the watermark), the agent
+    // would receive an empty "Failed checks" section with no check name
+    // to reproduce. The "Still-red checks" section closes that gap.
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '## Still-red checks (persisting from before the last evaluation)',
+    );
+    // The still-red section must use <= (complement of the > in "Failed
+    // checks") so the two sections partition the red checks without overlap
+    // or gap.
+    const stillRedBlock = prepareBranchAndFeedbackStep.match(
+      /Still-red checks[\s\S]*?checks\.json"/,
+    )?.[0];
+    expect(stillRedBlock).toBeTruthy();
+    expect(stillRedBlock).toContain('<= $wm');
+    // Must carry the same conclusion filter as N_RED_NOW (no CANCELLED:
+    // a cancelled check is not a persistent red state).
+    expect(stillRedBlock).toContain(
+      'IN("FAILURE", "FAILED", "ERROR", "TIMED_OUT", "ACTION_REQUIRED")',
+    );
+    expect(stillRedBlock).not.toContain('CANCELLED');
+    // Must carry the address-check carve-out, same as every other
+    // failed-check selector.
+    expect(stillRedBlock).toContain('startswith("review-address")');
+
+    // Behavioral: the jq filter renders a persistent red check that the
+    // "Failed checks" section (completedAt > wm) would miss.
+    const jqFilter = stillRedBlock.match(
+      /jq -r --arg wm.*?'([\s\S]*?)'\s*\\/,
+    )?.[1];
+    expect(jqFilter).toBeTruthy();
+    const checksJson = JSON.stringify([
+      {
+        name: 'Test / unit',
+        conclusion: 'FAILURE',
+        workflowName: 'CI',
+        completedAt: '2026-01-01T09:00:00Z',
+      },
+      {
+        name: 'Lint',
+        conclusion: 'SUCCESS',
+        workflowName: 'CI',
+        completedAt: '2026-01-01T09:00:00Z',
+      },
+      {
+        name: 'Build',
+        conclusion: 'FAILURE',
+        workflowName: 'CI',
+        completedAt: '2026-01-01T11:00:00Z',
+      },
+    ]);
+    const result = execFileSync(
+      'jq',
+      ['-r', '--arg', 'wm', '2026-01-01T10:00:00Z', jqFilter],
+      { encoding: 'utf8', input: checksJson },
+    );
+    // Test / unit completed BEFORE the watermark: shown in still-red.
+    expect(result).toContain('Test / unit: FAILURE');
+    // Build completed AFTER the watermark: NOT in still-red (it is in
+    // "Failed checks" instead).
+    expect(result).not.toContain('Build');
+    // Green check: never shown.
+    expect(result).not.toContain('Lint');
   });
 
   it('bounds fleet-wide simultaneity below the per-scan target budget', () => {
@@ -2456,13 +2536,13 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain(
       '.[3] | map(select((.conclusion // .state // "")',
     );
-    // Three sites: the NEWEST computation, the live-watermark revalidation,
-    // and the feedback rendering — all must share the same address-check
-    // carve-out.
+    // Four sites: the NEWEST computation, the live-watermark revalidation,
+    // the "Failed checks" rendering, and the "Still-red checks" rendering
+    // — all must share the same address-check carve-out.
     expect(
       prepareBranchAndFeedbackStep.match(/startswith\("review-address"\)/g) ??
         [],
-    ).toHaveLength(3);
+    ).toHaveLength(4);
     expect(prepareBranchAndFeedbackStep).toContain(
       'gsub("[^A-Za-z0-9 _./()-]"; "") | .[0:80]',
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -627,6 +627,9 @@ describe('qwen-autofix workflow', () => {
       // Default: the job was selected under the CURRENT window (the latest
       // ack, or 'none' before any takeover) — the normal, non-raced case.
       window = undefined,
+      // The head this job checked out (CHECKED_OUT_HEAD). The no-op same-head
+      // duplicate signature compares the live redcheck marker against it.
+      head = 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111',
     }) => {
       const effWindow =
         window ?? (acks.length ? acks[acks.length - 1] : 'none');
@@ -638,7 +641,7 @@ describe('qwen-autofix workflow', () => {
             ...marks.map((m) => ({
               user: { login: 'qwen-code-dev-bot' },
               created_at: m.at ?? '2026-07-18T09:00:00Z',
-              body: `eval <!-- autofix-eval ts=${m.ts} acted=${m.acted ?? 'true'} round=${m.round}${m.win ? ` win=${m.win}` : ''} -->`,
+              body: `eval <!-- autofix-eval ts=${m.ts} acted=${m.acted ?? 'true'} round=${m.round}${m.win ? ` win=${m.win}` : ''} -->${m.head ? `\n<!-- autofix-redcheck head=${m.head} -->` : ''}`,
             })),
             ...acks.map((at) => ({
               user: { login: 'qwen-code-dev-bot' },
@@ -674,6 +677,7 @@ describe('qwen-autofix workflow', () => {
               CONFLICT: conflict,
               MAX_ROUNDS: '5',
               WINDOW: effWindow,
+              CHECKED_OUT_HEAD: head,
               AUTOFIX_BOT: 'qwen-code-dev-bot',
               REVIEW_BOT: 'qwen-code-ci-bot',
               TRUSTED_ASSOC: '["OWNER","MEMBER","COLLABORATOR"]',
@@ -851,6 +855,51 @@ describe('qwen-autofix workflow', () => {
         commands: ['2026-07-18T08:45:00Z'],
       }).stale,
     ).toBe(true);
+    // No-op same-head duplicate (signature c): two scans both emit the PR with
+    // watermark W; the first serialized job ends in a no-op, recording a
+    // redcheck marker for head H while keeping ts=W and round UNCHANGED.
+    // Neither the watermark nor the round trigger fires, so without the
+    // redcheck re-check the second job would run the agent again and post a
+    // duplicate report for the same head.
+    const H = 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111';
+    expect(
+      runStaleGate({
+        marks: [{ ts: W, round: 2, acted: 'false', head: H }],
+        conflict: 'false',
+        round: 2,
+        head: H,
+      }).stale,
+    ).toBe(true);
+    // A new commit moved the head: the sibling judged a DIFFERENT head, so
+    // this target is real work, not a duplicate.
+    expect(
+      runStaleGate({
+        marks: [{ ts: W, round: 2, acted: 'false', head: H }],
+        conflict: 'false',
+        round: 2,
+        head: 'bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222',
+      }).stale,
+    ).toBe(false);
+    // Same head, but trusted feedback arrived after the watermark the no-op
+    // sibling evaluated through: the queued job has real work and proceeds.
+    expect(
+      runStaleGate({
+        marks: [{ ts: W, round: 2, acted: 'false', head: H }],
+        conflict: 'false',
+        round: 2,
+        head: H,
+        reviews: [F2],
+      }).stale,
+    ).toBe(false);
+    // Same head, but a live conflict is actionable regardless of the redcheck.
+    expect(
+      runStaleGate({
+        marks: [{ ts: W, round: 2, acted: 'false', head: H }],
+        conflict: 'true',
+        round: 2,
+        head: H,
+      }).stale,
+    ).toBe(false);
   });
 
   it('behaviorally replays the eligibility recheck across lifecycle and label states', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -462,14 +462,34 @@ describe('qwen-autofix workflow', () => {
     expect(
       workflow.match(/<!-- autofix-redcheck head=\$\{REPORT_HEAD\} -->/g) ?? [],
     ).toHaveLength(3);
+    // Every step that EMITS the marker must define REPORT_HEAD itself — a
+    // shell variable does not cross step boundaries — and no step may define
+    // it without emitting. Counting the two kinds separately missed exactly
+    // this: one assignment had landed in `issue-autofix`, which emits no
+    // marker and has no ${PR} in scope, while review-address's handoff step
+    // emitted the marker with the variable unset. Both counts were "right";
+    // the pairing was not.
+    // Checked PER STEP BLOCK, not by step name: `Report dry-run / failure`
+    // exists in BOTH issue-autofix and review-address, so a name-keyed set
+    // merges them and the misplacement stays invisible — that is how the
+    // first version of this assertion passed while the bug was live.
+    let emitterSteps = 0;
+    for (const m of workflow.matchAll(
+      /\n {6}- name: '(?:[^']+)'\n([\s\S]*?)(?=\n {6}- name: '|\n {2}[a-z][a-z0-9-]*:\n|$)/g,
+    )) {
+      const body = m[1];
+      const emits = body.includes(
+        '<!-- autofix-redcheck head=${REPORT_HEAD} -->',
+      );
+      const defines = body.includes('REPORT_HEAD="$(gh api');
+      expect(emits).toBe(defines);
+      if (emits) emitterSteps += 1;
+    }
+    expect(emitterSteps).toBe(2);
     // Taken from the REMOTE head: after a rejected push local HEAD is ahead of
     // what landed, and recording a sha that never existed would suppress the
     // reds on the head that does. Empty on failure — matches no marker, so the
     // reds stay visible.
-    expect(
-      workflow.match(/REPORT_HEAD="\$\(gh api "repos\/\$\{REPO\}\/pulls/g) ??
-        [],
-    ).toHaveLength(2);
     expect(workflow).not.toContain('REPORT_HEAD="$(git rev-parse HEAD)"');
   });
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -294,9 +294,16 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain('.conclusion // .state // ""');
     expect(reviewScanJob).toContain('.workflowName // ""');
     expect(reviewScanJob).toContain('startswith("review-address")');
+    // Every failed-check selector must carry the address-check carve-out, or
+    // the loop reads its OWN runs as feedback about the PR. Asserting the
+    // property rather than the count lets a new selector be added, but not
+    // one that forgets the carve-out.
+    const scanCheckSelectors =
+      reviewScanJob.match(/IN\("(?:FAILURE|QUEUED)"/g) ?? [];
+    expect(scanCheckSelectors.length).toBeGreaterThanOrEqual(3);
     expect(
       reviewScanJob.match(/startswith\("review-address"\)/g) ?? [],
-    ).toHaveLength(2);
+    ).toHaveLength(scanCheckSelectors.length);
     expect(reviewScanJob).toContain('"${N_FAILED_CHECKS}" -eq 0');
     expect(reviewScanJob).toContain('${N_FAILED_CHECKS} failed check(s) new');
     expect(reviewScanJob).toContain('.completedAt // .updatedAt // ""');
@@ -392,6 +399,78 @@ describe('qwen-autofix workflow', () => {
     expect(run([llm, build])).toBe('true');
     // Unchanged: the branch-mutating sibling in the same workflow still blocks.
     expect(run([{ ...llm, name: 'resolve-pr' }])).toBe('true');
+  });
+
+  it('keeps a still-red check visible, but only once per head', () => {
+    // A red check is a STATE, not the instant it turned red. Counting only
+    // "failed since the watermark" made a still-failing PR invisible the
+    // moment the watermark passed the failure. Measured: #6451 (3 reds
+    // completed 09:30-09:51, watermark 10:55), #7357 (red 07:59, watermark
+    // 09:18), #7390 (red and watermark BOTH 11:27:37, so a strict `>` hid it
+    // the instant it appeared) — all three sat red for hours while every scan
+    // logged "nothing new".
+    const block = reviewScanJob.match(
+      /LIVE_HEAD="\$\(jq -r[\s\S]*?\n {12}fi\n/,
+    )?.[0];
+    expect(block).toBeTruthy();
+    const script = block.replace(/^ {12}/gm, '');
+    const run = (reds, redHead, liveHead) =>
+      execFileSync(
+        'bash',
+        ['-c', `set -uo pipefail\n${script}\nprintf '%s' "$N_RED_NOW"`],
+        {
+          env: {
+            ...process.env,
+            PR_META: JSON.stringify({ headRefOid: liveHead }),
+            CHECKS_JSON: JSON.stringify(
+              reds.map((name) => ({
+                name,
+                conclusion: 'FAILURE',
+                workflowName: 'CI',
+              })),
+            ),
+            RED_HEAD: redHead,
+          },
+          encoding: 'utf8',
+        },
+      );
+
+    // Never evaluated: the red is visible however old it is.
+    expect(run(['Test'], '', 'abc123')).toBe('1');
+    // Already evaluated on THIS head: left alone. This is what bounds it to
+    // one look per head instead of re-selecting the PR every single scan.
+    expect(run(['Test'], 'abc123', 'abc123')).toBe('0');
+    // A new commit re-opens it — the reds now belong to a head nobody judged.
+    expect(run(['Test'], 'old999', 'abc123')).toBe('1');
+    // Green stays green.
+    expect(run([], '', 'abc123')).toBe('0');
+    expect(run(['a', 'b', 'c'], '', 'abc123')).toBe('3');
+
+    // The count must actually GATE selection — computing it and then not
+    // consulting it is the whole bug, and every other assertion here still
+    // passes without this line.
+    const idleGate = reviewScanJob.match(
+      /if \[\[ "\$\{N_REVIEWS\}" -eq 0[^\n]*\]\]; then/,
+    )?.[0];
+    expect(idleGate).toBeTruthy();
+    expect(idleGate).toContain('"${N_RED_NOW}" -eq 0');
+
+    // The head is recorded by its OWN marker inside the eval comment, so no
+    // ts/acted/round parser changes — and the comment still matches the eval
+    // filter, so the agent never sees it as feedback.
+    expect(reviewScanJob).toContain('autofix-redcheck head=([0-9a-f]+)');
+    expect(
+      workflow.match(/<!-- autofix-redcheck head=\$\{REPORT_HEAD\} -->/g) ?? [],
+    ).toHaveLength(3);
+    // Taken from the REMOTE head: after a rejected push local HEAD is ahead of
+    // what landed, and recording a sha that never existed would suppress the
+    // reds on the head that does. Empty on failure — matches no marker, so the
+    // reds stay visible.
+    expect(
+      workflow.match(/REPORT_HEAD="\$\(gh api "repos\/\$\{REPO\}\/pulls/g) ??
+        [],
+    ).toHaveLength(2);
+    expect(workflow).not.toContain('REPORT_HEAD="$(git rev-parse HEAD)"');
   });
 
   it('bounds fleet-wide simultaneity below the per-scan target budget', () => {
@@ -1379,7 +1458,7 @@ describe('qwen-autofix workflow', () => {
       ).length - 1,
     ).toBe(2);
     expect(reviewScanJob).toContain(
-      '--json headRefName,statusCheckRollup,createdAt,labels',
+      '--json headRefName,headRefOid,statusCheckRollup,createdAt,labels',
     );
     // Command-style comments are instructions, not feedback — excluded at
     // ALL FOUR feedback sites (scan count via $cf; NEWEST, LIVE_NEW, and


### PR DESCRIPTION
## What this PR does

Makes a still-failing check visible to the scan, instead of only at the instant it turned red — while keeping it to one look per head so a permanently-red PR is not re-selected forever.

## Why it's needed

The scan counts a failed check as feedback only when it `completedAt > watermark`. But a red check is a **persistent state**, not an event: once the watermark passes the failure, the PR is red and invisible at the same time.

Measured on the live fleet:

| PR | watermark | red checks | visible? |
| --- | --- | --- | --- |
| #6451 | `10:55:16` | 3, completed `09:30:00` / `09:30:12` / `09:51:05` | no |
| #7357 | `09:18:06` | 1, completed `07:59:46` | no |
| #7390 | `11:27:37` | 1, completed `11:27:37` — equal, and the test is a strict `>` | no, from the instant it appeared |
| #6506 | `09:22:56` | none | n/a (clean control) |

All three sat red for hours while every scan logged `✅ nothing new`. #6451 wrote **two consecutive no-ops** whose reasoning mentions reviews only — correctly, because the three failures were never in its feedback file. Its log holds a one-command fix:

```
Error: NOTICES.txt is out of date.
Please run: npm run generate:notices --workspace=qwen-code-vscode-ide-companion
```

## How

A currently-red check counts as feedback **until the head it ran against has been evaluated**:

- The scan reads the live `headRefOid` and compares it with the head recorded on the PR.
- The address job records that head in its own `<!-- autofix-redcheck head=… -->` marker, emitted at all three report sites (pushed / no-action / handoff).

The marker is separate from `autofix-eval` on purpose: it rides **inside the same comment**, so no `ts`/`acted`/`round` parser changes, and the comment still matches the existing bot-comment filter — the agent never sees it as feedback.

**The head comes from the remote, not local HEAD.** After a rejected push (three happened today: #7262, #7355, #7395) the two differ, and recording a sha that never landed would suppress the reds on the head that actually exists. On failure it is empty, which matches no marker — so the reds stay visible. Fail-open.

**Why this does not churn:** the recorded head only changes when someone pushes. A permanently-red PR with no new commits is examined exactly once and then goes quiet again, which is the behaviour today minus the initial blind spot.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 90/90 (a run in three hits the pre-existing load flakes; see Risk). The new test **replays the real extracted decision block**:

   | recorded head | live head | reds | counted |
   | --- | --- | --- | --- |
   | *(none)* | `abc123` | 1 | **1** — an old red is still visible |
   | `abc123` | `abc123` | 1 | **0** — already judged on this head |
   | `old999` | `abc123` | 1 | **1** — a new commit re-opens it |
   | *(none)* | `abc123` | 0 | 0 |
   | *(none)* | `abc123` | 3 | 3 |

2. Mutation-verified, four reverts each turning it red:

   | mutation | why it matters |
   | --- | --- |
   | drop the head comparison | every scan re-selects a red PR forever |
   | record local `git rev-parse HEAD` | a rejected push suppresses the real head's reds |
   | omit one of the three marker sites | that path silently never records a head |
   | drop `N_RED_NOW` from the idle gate | the count is computed and then ignored — the whole bug |

   The last one was **not** caught by my first version of the test; every other assertion passed without the gate. It is the reason the test now extracts and asserts the gate itself.

3. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: the next scan should select #6451 with `… + 3 still-red on <sha>`, and the scan after that should leave it alone.

### Evidence (Before & After)

```
BEFORE  #6451: red since 09:30, watermark 10:55
        scan → ✅ nothing new since 10:55   (× every tick, for hours)

AFTER   scan → 🔎 … + 3 still-red on 57af64577
        agent gets the failures in its feedback; next scan is quiet again
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main risk or tradeoff: on the first scan after merge, every managed PR that is currently red gets one evaluation. That is a one-off burst bounded by the fleet size (8 PRs today, 3 of them red), and each costs one round. Thereafter it is one look per head.
- `CANCELLED` is deliberately **excluded** from the still-red set although the watermark-based counter includes it: a cancelled check is usually a superseded run (41% of `review-pr` runs are cancelled by concurrency), and treating that as persistent feedback would wake the loop on ordinary churn.
- Pre-existing and unrelated: `eligibility recheck`, `takeover-command toggle` and `classifies permanent API failures` are subprocess load flakes — an earlier controlled A/B showed unmodified `main` failing the same ones at a comparable rate, and all pass in isolation.
- Not validated / out of scope: this makes the failure **visible**; it does not put the check's log into the feedback. The agent reproduces failures locally today (#7357 diagnosed a 17-test failure by checking out `main`'s files and re-running), so log-forwarding is a separate question, not a prerequisite.
- Breaking changes / migration notes: none. PRs with no `autofix-redcheck` marker simply get their first look.

## Linked Issues

Found by tracking why three managed PRs stayed red for hours while the scan reported them idle. Part of the autofix-reliability line: #7330, #7350, #7351, #7354, #7392, #7396, #7412, #7416.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让**仍然红着**的检查对扫描可见,而不是只在它刚变红的那一瞬间可见;同时限定"每个 head 只看一次",避免长期红的 PR 被反复选中。

## 为什么需要

扫描只在 `completedAt > 水位线` 时把失败检查计为反馈。但红检查是**持续状态**而非事件:水位线一旦越过该失败,PR 就同时处于"红着"和"不可见"。

实测(见上方英文表格):#6451 水位线 10:55,3 个红完成于 09:30/09:30/09:51;#7357 水位线 09:18,红完成于 07:59;#7390 水位线与红检查**完全相等**(11:27:37),而判定用严格 `>`,因此它诞生即不可见。对照组 #6506 无红,也无此问题。

三者都红了数小时,而每次扫描都记录 `✅ nothing new`。#6451 连写**两次 no-op**,理由只谈评审 —— 这是正确的,因为那三个失败根本不在它的反馈文件里。而它的日志里躺着一条命令就能修的问题(见上方英文代码块)。

## 怎么做

当前为红的检查会一直计为反馈,**直到它所在的 head 被评估过**:扫描读取实时 `headRefOid` 与 PR 上记录的 head 比较;address 作业在三个报告出口(已推送 / 无需改动 / 交接)都写下 `<!-- autofix-redcheck head=… -->`。

该标记刻意独立于 `autofix-eval`,但**寄生在同一条评论里**:因此 `ts`/`acted`/`round` 的解析器一律不动,评论也仍然命中既有的 bot 评论过滤器 —— agent 永远不会把它当成反馈。

**head 取自远端而非本地 HEAD。** 推送被拒时两者不同(今天就发生了三次:#7262、#7355、#7395),记录一个从未落地的 sha 会把真实 head 上的红压掉。取值失败时为空,匹配不上任何标记,红保持可见 —— 失败方向是安全的。

**为什么不会空转**:记录的 head 只在有人推送时改变。长期红且无新提交的 PR 只会被检查一次,随后重新安静。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 90/90。新测试**回放真实提取的判定块**,覆盖五种组合(见上方英文表格)。
2. 变异验证,四处回退各自变红:去掉 head 比较(红 PR 每次扫描都被重选)、改用本地 `git rev-parse HEAD`(推送被拒时压掉真实 head 的红)、少写一处标记(该路径静默不记录)、以及**从 idle 判定里去掉 `N_RED_NOW`**(算出来却不用 —— 正是整个 bug)。最后这一条**没有**被我第一版测试抓到:其余断言在缺少该判定时全部照过。这正是测试现在直接提取并断言该判定本身的原因。
3. 静态(均用 CI 一致工具):YAML 可解析;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:下一次扫描应以 `… + 3 still-red on <sha>` 选中 #6451,再下一次则应重新安静。

## 风险与范围

- 主要权衡:合并后的第一次扫描,所有当前为红的托管 PR 各获得一次评估。这是一次性脉冲,规模受机群大小约束(今天 8 个 PR、其中 3 个红),每个消耗一轮。此后即为"每 head 一次"。
- `CANCELLED` **刻意不计入**"仍然红"的集合,尽管基于水位线的旧计数包含它:被取消的检查通常是被取代的运行(`review-pr` 有 41% 因 concurrency 被取消),把它当作持续反馈会让循环被日常抖动唤醒。
- 既有且无关:`eligibility recheck`、`takeover-command toggle`、`classifies permanent API failures` 是子进程负载 flake;此前受控 A/B 显示未修改的 `main` 以相当频率红同样用例,单独跑均通过。
- 不在范围内:本 PR 让失败**可见**,并不把检查日志放进反馈。agent 今天已能在本地复现失败(#7357 通过 checkout `main` 的文件重跑,诊断出 17 个测试失败),因此"喂日志"是另一个独立问题,而非本改动的前提。
- 破坏性变更:无。没有 `autofix-redcheck` 标记的 PR 只是获得它的第一次检查。

## 关联 Issue

在追查"三个托管 PR 红了数小时而扫描一直报 idle"时发现。属 autofix 可靠性主线:#7330、#7350、#7351、#7354、#7392、#7396、#7412、#7416。

</details>
