### PR TITLE
fix(test): pin QWEN_RUNTIME_DIR in daemon integration tests

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -155,6 +155,11 @@ beforeAll(async () => {
         ),
         HOME: homeDir,
         QWEN_HOME: path.join(homeDir, '.qwen'),
+        // Pin the runtime dir so session-writer lock files land inside
+        // the per-test temp dir. Without this the locks resolve through
+        // Storage.getRuntimeBaseDir() which can fall outside homeDir in
+        // Docker CI, causing cross-test-file lock conflicts (#7435).
+        QWEN_RUNTIME_DIR: path.join(homeDir, '.qwen'),
         OPENAI_API_KEY: 'fake-key',
         OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
         OPENAI_MODEL: 'fake-model',

--- a/integration-tests/cli/qwen-serve-streaming.test.ts
+++ b/integration-tests/cli/qwen-serve-streaming.test.ts
@@ -164,6 +164,7 @@ beforeAll(async () => {
         ),
         HOME: homeDir,
         QWEN_HOME: path.join(homeDir, '.qwen'),
+        QWEN_RUNTIME_DIR: path.join(homeDir, '.qwen'),
         NO_PROXY: '127.0.0.1,localhost',
         no_proxy: '127.0.0.1,localhost',
         OPENAI_API_KEY: 'fake-key',


### PR DESCRIPTION
## What this PR does

Pins `QWEN_RUNTIME_DIR` alongside `QWEN_HOME` in the daemon env for both `qwen-serve-routes.test.ts` and `qwen-serve-streaming.test.ts`, so session-writer lock files land inside the per-test temp directory instead of resolving through `Storage.getRuntimeBaseDir()` which can fall outside the test's isolated HOME in Docker CI.

## Why it's needed

The Release workflow's Docker integration tests fail intermittently with 7 tests in `qwen-serve-routes.test.ts` all hitting `DaemonHttpError: POST /session: This session is already open in another Qwen process.` (HTTP 409, `session_writer_conflict`). The No-Sandbox variant passes on the same commit. The session-writer lease mechanism stores lock files under `Storage.getRuntimeBaseDir()`, whose resolution priority is `QWEN_RUNTIME_DIR` env > `settings.advanced.runtimeOutputDir` > `Storage.runtimeBaseDir` > `QWEN_HOME`. The tests set `QWEN_HOME` but not `QWEN_RUNTIME_DIR`, so in Docker CI the locks can resolve to a shared location where concurrent or prior test runs leave stale lock files with live PIDs, causing spurious conflicts.

## Reviewer Test Plan

### How to verify

Trigger the Release workflow (or the E2E Tests workflow with Docker sandbox) on this branch. The `Integration Tests (Docker)` job should pass without `session_writer_conflict` errors in `qwen-serve-routes.test.ts`.

### Evidence (Before & After)

Before: [Run 29836149258](https://github.com/QwenLM/qwen-code/actions/runs/29836149258/job/88653237681) — 7 failed tests, all `session_writer_conflict`.
After: pending CI run on this branch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Docker sandbox CI (the only environment where the flake reproduces).

## Risk & Scope

- Main risk or tradeoff: none — the change only adds an env var to the test daemon's environment, narrowing lock file resolution to the already-isolated temp dir.
- Not validated / out of scope: the root cause of why `getRuntimeBaseDir()` escapes `QWEN_HOME` in Docker is not fully traced; this fix sidesteps it by pinning the highest-priority override.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7435

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 `qwen-serve-routes.test.ts` 和 `qwen-serve-streaming.test.ts` 的 daemon 环境变量中， alongside `QWEN_HOME` 一起固定 `QWEN_RUNTIME_DIR`，使 session-writer 锁文件落入每个测试的临时目录内，而不是通过 `Storage.getRuntimeBaseDir()` 解析到 Docker CI 中测试隔离 HOME 之外的位置。

## 为什么需要

Release 工作流的 Docker 集成测试间歇性失败，`qwen-serve-routes.test.ts` 中 7 个测试全部报 `DaemonHttpError: POST /session: This session is already open in another Qwen process.`（HTTP 409，`session_writer_conflict`）。同一 commit 的 No-Sandbox 变体通过。Session-writer lease 机制将锁文件存储在 `Storage.getRuntimeBaseDir()` 下，其解析优先级为 `QWEN_RUNTIME_DIR` env > `settings.advanced.runtimeOutputDir` > `Storage.runtimeBaseDir` > `QWEN_HOME`。测试设置了 `QWEN_HOME` 但未设置 `QWEN_RUNTIME_DIR`，因此在 Docker CI 中锁可能解析到共享位置，并发或先前测试运行留下的带有活跃 PID 的过期锁文件会导致虚假冲突。

## 审阅者测试计划

### 如何验证

在此分支上触发 Release 工作流（或带 Docker sandbox 的 E2E Tests 工作流）。`Integration Tests (Docker)` job 应通过，`qwen-serve-routes.test.ts` 中无 `session_writer_conflict` 错误。

### 证据（修改前后）

修改前：[Run 29836149258](https://github.com/QwenLM/qwen-code/actions/runs/29836149258/job/88653237681) — 7 个测试失败，全部为 `session_writer_conflict`。
修改后：等待此分支的 CI 运行。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Docker sandbox CI（唯一能复现此 flake 的环境）。

## 风险与范围

- 主要风险或权衡：无 — 变更仅向测试 daemon 的环境添加一个环境变量，将锁文件解析收窄到已隔离的临时目录。
- 未验证 / 超出范围：`getRuntimeBaseDir()` 在 Docker 中逃逸 `QWEN_HOME` 的根本原因未完全追踪；此修复通过固定最高优先级覆盖来绕过。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7435

</details>