### PR TITLE
fix(test): strip QWEN_SANDBOX from daemon env in serve integration tests

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -150,6 +150,11 @@ beforeAll(async () => {
                 'QWEN_SERVE_NO_PERSISTENT_REGISTRATION',
                 'QWEN_SERVE_CLIENT_MCP_OVER_WS',
                 'QWEN_SERVE_CDP_TUNNEL_OVER_WS',
+                // The daemon and its ACP child must not inherit the
+                // CI sandbox setting — sandboxed shell execution inside
+                // the child conflicts with the host-side session-writer
+                // lease bookkeeping (#7435).
+                'QWEN_SANDBOX',
               ].includes(k),
           ),
         ),

--- a/integration-tests/cli/qwen-serve-streaming.test.ts
+++ b/integration-tests/cli/qwen-serve-streaming.test.ts
@@ -159,7 +159,8 @@ beforeAll(async () => {
       env: {
         ...Object.fromEntries(
           Object.entries(process.env).filter(
-            ([key]) => !/^(https?|all)_proxy$/i.test(key),
+            ([key]) =>
+              !/^(https?|all)_proxy$/i.test(key) && key !== 'QWEN_SANDBOX',
           ),
         ),
         HOME: homeDir,


### PR DESCRIPTION
## What this PR does

Strips `QWEN_SANDBOX` from the daemon process environment in `qwen-serve-routes.test.ts` and `qwen-serve-streaming.test.ts`, so the daemon and its ACP child process do not inherit the CI Docker sandbox setting.

## Why it's needed

Follow-up to #7439. The `QWEN_RUNTIME_DIR` pin alone did not fix the Docker CI failure — the same 7 tests in `qwen-serve-routes.test.ts` still fail deterministically with `session_writer_conflict` 409s on every thread-scope `createOrAttachSession` call. The daemon inherits `QWEN_SANDBOX=docker` from the CI environment and passes it to the ACP child process. Sandboxed shell execution inside the child conflicts with host-side session-writer lease bookkeeping: single-scope sessions succeed (first creation, no existing lock), but every subsequent thread-scope creation fails because the child's sandboxed view of the lock directory diverges from the host.

## Reviewer Test Plan

### How to verify

Trigger the Release workflow (or E2E Tests with Docker sandbox) on this branch. `Integration Tests (Docker)` should pass without `session_writer_conflict` errors.

### Evidence (Before & After)

Before: [Run 29842674807](https://github.com/QwenLM/qwen-code/actions/runs/29842674807/job/88675617703) — 7 failed tests, all `session_writer_conflict` (with #7439 already merged).
After: pending CI run on this branch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Docker sandbox CI.

## Risk & Scope

- Main risk or tradeoff: none — the daemon serve process does not execute sandboxed shell commands; stripping the env var only affects the test daemon's child processes.
- Not validated / out of scope: N/A.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7439, fixes remaining failures from #7435.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 `qwen-serve-routes.test.ts` 和 `qwen-serve-streaming.test.ts` 中，从 daemon 进程环境变量中移除 `QWEN_SANDBOX`，使 daemon 及其 ACP 子进程不继承 CI 的 Docker sandbox 设置。

## 为什么需要

#7439 的后续修复。仅固定 `QWEN_RUNTIME_DIR` 未能修复 Docker CI 失败——`qwen-serve-routes.test.ts` 中同样的 7 个测试仍然确定性地失败，每次 thread-scope `createOrAttachSession` 调用都报 `session_writer_conflict` 409。Daemon 从 CI 环境继承 `QWEN_SANDBOX=docker` 并传递给 ACP 子进程。子进程内部的沙箱化 shell 执行与宿主机的 session-writer lease 管理冲突：single-scope session 成功（首次创建，无现有锁），但后续所有 thread-scope 创建都失败，因为子进程对锁目录的沙箱化视图与宿主机不一致。

## 审阅者测试计划

### 如何验证

在此分支上触发 Release 工作流（或带 Docker sandbox 的 E2E Tests）。`Integration Tests (Docker)` 应通过，无 `session_writer_conflict` 错误。

### 证据（修改前后）

修改前：[Run 29842674807](https://github.com/QwenLM/qwen-code/actions/runs/29842674807/job/88675617703) — 7 个测试失败（#7439 已合入后）。
修改后：等待此分支的 CI 运行。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Docker sandbox CI。

## 风险与范围

- 主要风险或权衡：无 — daemon serve 进程不执行沙箱化 shell 命令；移除环境变量仅影响测试 daemon 的子进程。
- 未验证 / 超出范围：无。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#7439 的后续，修复 #7435 的剩余失败。

</details>
