### PR TITLE
fix(acp): clear inherited sandboxSessionId for each new ACP session

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -155,11 +155,6 @@ beforeAll(async () => {
         ),
         HOME: homeDir,
         QWEN_HOME: path.join(homeDir, '.qwen'),
-        // Pin the runtime dir so session-writer lock files land inside
-        // the per-test temp dir. Without this the locks resolve through
-        // Storage.getRuntimeBaseDir() which can fall outside homeDir in
-        // Docker CI, causing cross-test-file lock conflicts (#7435).
-        QWEN_RUNTIME_DIR: path.join(homeDir, '.qwen'),
         OPENAI_API_KEY: 'fake-key',
         OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
         OPENAI_MODEL: 'fake-model',

--- a/integration-tests/cli/qwen-serve-streaming.test.ts
+++ b/integration-tests/cli/qwen-serve-streaming.test.ts
@@ -164,7 +164,6 @@ beforeAll(async () => {
         ),
         HOME: homeDir,
         QWEN_HOME: path.join(homeDir, '.qwen'),
-        QWEN_RUNTIME_DIR: path.join(homeDir, '.qwen'),
         NO_PROXY: '127.0.0.1,localhost',
         no_proxy: '127.0.0.1,localhost',
         OPENAI_API_KEY: 'fake-key',

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -9986,6 +9986,11 @@ class QwenAgent implements Agent {
         : { sessionId, resume: undefined };
     const argvForSession = {
       ...this.argv,
+      // Docker sandbox relaunch injects a fixed --sandbox-session-id into
+      // the ACP process argv. Without clearing it, every newSession()
+      // inherits the same ID and the second session collides with the
+      // first's writer lease (#7435).
+      sandboxSessionId: undefined,
       ...sessionArg,
       continue: false,
       ...(chatRecording !== undefined ? { chatRecording } : {}),


### PR DESCRIPTION
## What this PR does

Clears the inherited `sandboxSessionId` in `argvForSession` inside `newSessionConfigInRuntimeContext`, so each ACP sub-session generates its own unique session ID instead of reusing the fixed ID injected by the Docker sandbox relaunch.

## Why it's needed

Docker sandbox relaunch injects `--sandbox-session-id <fixed-uuid>` into the ACP process argv. `newSessionConfigInRuntimeContext` spreads `this.argv` into every sub-session config, and config resolution prioritizes `sandboxSessionId` over `sessionId` (config.ts line ~1989). The first session acquires the writer lease under that fixed ID; every subsequent `newSession()` reuses the same ID and gets a 409 `session_writer_conflict`. This deterministically breaks all thread-scope session creation in Docker CI (7 failures in `qwen-serve-routes.test.ts`, 2 in channel-plugin tests).

Supersedes #7442 (env stripping approach) — this is the root-cause fix at the session creation site.

## Reviewer Test Plan

### How to verify

Trigger the Release workflow (or E2E Tests with Docker sandbox) on this branch. `Integration Tests (Docker)` should pass — both the 7 `qwen-serve-routes.test.ts` failures and the channel-plugin failures should be resolved.

### Evidence (Before & After)

Before: [Run 29842674807](https://github.com/QwenLM/qwen-code/actions/runs/29842674807/job/88675617703) — 7 failed tests, all `session_writer_conflict`.
After: pending CI run on this branch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Docker sandbox CI.

## Risk & Scope

- Main risk or tradeoff: minimal — one line clearing a field that should never propagate to sub-sessions. The sandbox session ID is only meaningful for the initial sandbox relaunch, not for logical sessions created within the ACP process.
- Not validated / out of scope: N/A.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7435. Supersedes #7442.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 `newSessionConfigInRuntimeContext` 的 `argvForSession` 中清除继承的 `sandboxSessionId`，使每个 ACP 子 session 生成自己唯一的 session ID，而不是复用 Docker sandbox relaunch 注入的固定 ID。

## 为什么需要

Docker sandbox relaunch 向 ACP 进程的 argv 注入 `--sandbox-session-id <fixed-uuid>`。`newSessionConfigInRuntimeContext` 将 `this.argv` 展开到每个子 session 的配置中，而配置解析优先使用 `sandboxSessionId`（config.ts 约第 1989 行）。第一个 session 用该固定 ID 获取 writer lease；后续每次 `newSession()` 复用相同 ID，导致 409 `session_writer_conflict`。这在 Docker CI 中确定性地破坏所有 thread-scope session 创建（`qwen-serve-routes.test.ts` 7 个失败，channel-plugin 测试 2 个失败）。

取代 #7442（环境变量过滤方案）——这是 session 创建处的根因修复。

## 审阅者测试计划

### 如何验证

在此分支上触发 Release 工作流（或带 Docker sandbox 的 E2E Tests）。`Integration Tests (Docker)` 应通过——`qwen-serve-routes.test.ts` 的 7 个失败和 channel-plugin 的失败都应解决。

### 证据（修改前后）

修改前：[Run 29842674807](https://github.com/QwenLM/qwen-code/actions/runs/29842674807/job/88675617703) — 7 个测试失败，全部为 `session_writer_conflict`。
修改后：等待此分支的 CI 运行。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Docker sandbox CI。

## 风险与范围

- 主要风险或权衡：极小——仅一行清除不应传播到子 session 的字段。sandbox session ID 仅对初始 sandbox relaunch 有意义，不对 ACP 进程内创建的逻辑 session 有意义。
- 未验证 / 超出范围：无。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7435。取代 #7442。

</details>
