### PR TITLE
fix(acp-bridge): close prompt-terminal follow-ups from the PR #7400 self-review

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6821,6 +6821,13 @@ describe('createAcpSessionBridge', () => {
       await new Promise((r) => setTimeout(r, 60));
       expect(terminalsFor(events, 'prompt-queued-deadline')).toHaveLength(1);
 
+      // A queued prompt never ran, so its deadline terminal must not
+      // advertise a session-level turnError nor arm the retry path — those
+      // belong to the ACTIVE turn only.
+      expect(
+        bridge.getSessionSummary(session.sessionId).turnError,
+      ).toBeUndefined();
+
       await bridge.shutdown();
       // Shutdown flushed the still-wedged head prompt exactly once, and the
       // queued prompt's residual FIFO abort stayed latched.
@@ -6831,6 +6838,11 @@ describe('createAcpSessionBridge', () => {
       expect((headTerms[0]?.data as { code?: string }).code).toBe(
         'daemon_shutdown',
       );
+      // The caller sees the same typed rejection as a running-prompt expiry
+      // — the pre-dispatch abort check (reached once shutdown released the
+      // wedged head) propagates the deadline reason instead of a generic
+      // AbortError.
+      await expect(p2).rejects.toBeInstanceOf(PromptDeadlineExceededError);
     });
 
     it('keeps a detached session draining until the last pending prompt settles (DAEMON-005)', async () => {
@@ -6931,6 +6943,53 @@ describe('createAcpSessionBridge', () => {
         // on promptId observe the turn ending before the session vanishes.
         expect(events.indexOf(terms[0]!)).toBeLessThan(closedIdx);
       }
+      await bridge.shutdown();
+    });
+
+    it('still publishes a terminal for a removed RUNNING prompt when the session closes before the agent cooperates', async () => {
+      const handle = wedgeChannel();
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'wedge' }],
+        },
+        undefined,
+        { promptId: 'prompt-removed-running' },
+      );
+      p1.catch(() => {});
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Remove the RUNNING prompt — the wedged agent ignores the cancel,
+      // so no terminal has been published yet.
+      expect(
+        bridge.removePendingPrompt(session.sessionId, 'prompt-removed-running'),
+      ).toEqual({ removed: true });
+      // The API no longer shows the prompt…
+      expect(bridge.getPendingPrompts(session.sessionId)).toHaveLength(0);
+      // …and a repeat removal is a no-op.
+      expect(
+        bridge.removePendingPrompt(session.sessionId, 'prompt-removed-running'),
+      ).toEqual({ removed: false });
+      expect(terminalsFor(events, 'prompt-removed-running')).toHaveLength(0);
+
+      // Session closes before the agent ever settles: the teardown flush
+      // must still see the removed-but-unsettled prompt and publish its
+      // terminal before the bus closes.
+      await bridge.closeSession(session.sessionId);
+
+      const closedIdx = events.findIndex((e) => e.type === 'session_closed');
+      expect(closedIdx).toBeGreaterThan(-1);
+      const terms = terminalsFor(events, 'prompt-removed-running');
+      expect(terms).toHaveLength(1);
+      expect(terms[0]?.type).toBe('turn_error');
+      expect((terms[0]?.data as { code?: string }).code).toBe('session_closed');
+      expect(events.indexOf(terms[0]!)).toBeLessThan(closedIdx);
       await bridge.shutdown();
     });
 

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6993,6 +6993,98 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('does not publish a duplicate completed event when a promoted-then-removed running prompt settles', async () => {
+      let releaseFirst: (() => void) | undefined;
+      const firstDone = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      let releaseSecond: (() => void) | undefined;
+      const secondDone = new Promise<void>((r) => {
+        releaseSecond = r;
+      });
+      const handle = makeChannel({
+        promptImpl: async (req: PromptRequest) => {
+          const text = (req.prompt[0] as { text?: string }).text;
+          if (text === 'blocker') await firstDone;
+          if (text === 'queued then running') await secondDone;
+          return { stopReason: 'end_turn' } as PromptResponse;
+        },
+      });
+      const bridge = makeBridge({ channelFactory: async () => handle.channel });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const events: BridgeEvent[] = [];
+      subscribe(bridge, session.sessionId, events);
+
+      // Prompt 1 starts running immediately; prompt 2 queues behind it.
+      const p1 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'blocker' }],
+        },
+        undefined,
+        { promptId: 'prompt-blocker' },
+      );
+      const p2 = bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: 'queued then running' }],
+        },
+        undefined,
+        { promptId: 'prompt-promoted' },
+      );
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Prompt 2 is queued behind prompt 1.
+      expect(
+        bridge
+          .getPendingPrompts(session.sessionId)
+          .find((p) => p.promptId === 'prompt-promoted')?.state,
+      ).toBe('queued');
+
+      // Release prompt 1 so prompt 2 promotes to running.
+      releaseFirst!();
+      await p1;
+      await new Promise((r) => setTimeout(r, 20));
+      expect(
+        bridge
+          .getPendingPrompts(session.sessionId)
+          .find((p) => p.promptId === 'prompt-promoted')?.state,
+      ).toBe('running');
+
+      // Remove the now-running prompt 2.
+      expect(
+        bridge.removePendingPrompt(session.sessionId, 'prompt-promoted'),
+      ).toEqual({ removed: true });
+
+      // Let prompt 2 settle cooperatively.
+      releaseSecond!();
+      await p2;
+      await new Promise((r) => setTimeout(r, 20));
+
+      // Exactly one pending_prompt_completed for prompt-promoted: the
+      // 'removed' one from removePendingPrompt. The result.finally path
+      // must NOT publish a second 'completed' event because the
+      // isQueued && !pendingEntry.removed guard suppresses it.
+      const completedForPromoted = events.filter(
+        (e) =>
+          e.type === 'pending_prompt_completed' &&
+          (e as BridgeEvent & { data: { promptId: string } }).data.promptId ===
+            'prompt-promoted',
+      );
+      expect(completedForPromoted).toHaveLength(1);
+      expect(
+        (completedForPromoted[0] as BridgeEvent & { data: { state: string } })
+          .data.state,
+      ).toBe('removed');
+
+      // The formal terminal is still published exactly once.
+      expect(terminalsFor(events, 'prompt-promoted')).toHaveLength(1);
+
+      await bridge.shutdown();
+    });
+
     it('flushes error terminals for active and queued prompts before session_died on killSession (DAEMON-005)', async () => {
       const handle = wedgeChannel();
       const bridge = makeBridge({ channelFactory: async () => handle.channel });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1086,6 +1086,7 @@ function broadcastTurnError(
   err: unknown,
   promptId: string | undefined,
   originatorClientId: string | undefined,
+  mutateTurnState: boolean,
 ): void {
   const message = extractErrorMessage(err);
   const code = extractErrorCode(err);
@@ -1099,12 +1100,20 @@ function broadcastTurnError(
         (promptId ? ` promptId=${JSON.stringify(promptId)}` : ''),
     );
   }
-  entry.retryAllowed = true;
-  entry.turnError = {
-    message,
-    ...(code ? { code } : {}),
-    ...(errorKind ? { errorKind } : {}),
-  };
+  // Session-scoped turn state (`turnError` is surfaced by the summary,
+  // `retryAllowed` is consumed by the retry-admission check) must only
+  // reflect the ACTIVE turn's failure. A queued prompt's terminal (deadline
+  // expiry, teardown flush) publishes the event alone — otherwise a queued
+  // failure would advertise a `turnError` for a turn that never ran and
+  // arm a retry the active prompt didn't earn.
+  if (mutateTurnState) {
+    entry.retryAllowed = true;
+    entry.turnError = {
+      message,
+      ...(code ? { code } : {}),
+      ...(errorKind ? { errorKind } : {}),
+    };
+  }
   try {
     entry.events.publish({
       type: 'turn_error',
@@ -1149,7 +1158,10 @@ function publishPromptTerminal(
   terminal: PromptTerminal,
 ): void {
   if (pendingEntry.terminalPublished) {
-    writeStderrLine(
+    // Dedup here is the designed steady state, not an anomaly: deadline
+    // expiry, queued removal, and teardown flush each race the prompt's
+    // natural settle, so the loser lands here on every such turn.
+    writeServeDebugLine(
       `publishPromptTerminal: suppressed duplicate ${terminal.kind} terminal ` +
         `for prompt ${pendingEntry.promptId} (session ${entry.sessionId})`,
     );
@@ -1180,6 +1192,13 @@ function publishPromptTerminal(
       terminal.err,
       pendingEntry.promptId,
       originatorClientId,
+      // Only a running prompt's failure is the active turn's failure. The
+      // `state === 'running'` gate (not `activePromptId`) is deliberate:
+      // on the normal settle path `settleActivePromptState` runs in
+      // `promptPromise.finally` BEFORE the terminal is published, so
+      // `activePromptId` is already cleared when a genuine active failure
+      // lands here.
+      pendingEntry.state === 'running',
     );
   }
 }
@@ -1191,7 +1210,10 @@ function publishPromptTerminal(
  * check instead of being promoted to running. Must run before
  * `entry.events.close()` — the bus swallows publishes afterwards. Any
  * later settle of the same prompts re-enters `publishPromptTerminal` and
- * is deduped by the latch.
+ * is deduped by the latch. For a running prompt the abort fires the
+ * existing `onAbort` listener while the bus is still open, so a trailing
+ * `prompt_cancelled` after the terminal frame is expected — consumers
+ * settling on the terminal by `promptId` are unaffected.
  */
 function flushPromptTerminals(
   entry: SessionEntry,
@@ -5020,7 +5042,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // racing the (possibly wedged) `promptPromise`, and the agent is
       // best-effort cancelled through the existing abort path. The channel
       // is NOT killed — it may be shared by other sessions; reclaiming a
-      // wedged agent's channel is a tracked follow-up.
+      // wedged agent's channel is a tracked follow-up. Releasing the FIFO
+      // while the wedged call is still outstanding also means the next
+      // prompt overlaps it on the same ACP session: an agent that ignored
+      // `cancel()` but keeps streaming will interleave its stale
+      // `session/update`s with the new turn's output. Accepted trade-off —
+      // the alternative (poisoning the session until the old call settles)
+      // would give up the "follow-up prompt dispatches normally" recovery
+      // property the deadline exists to provide.
       const deadlineMs = context?.deadlineMs;
       const hasDeadline =
         typeof deadlineMs === 'number' &&
@@ -5108,6 +5137,14 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           // already aborted this entry, skip the running transition and
           // the `pending_prompt_started` event entirely.
           if (pendingAbort.signal.aborted) {
+            // A deadline that expired while this prompt was still queued
+            // aborted with the typed error; surface it to the caller so
+            // queued and running expiry reject identically.
+            if (
+              pendingAbort.signal.reason instanceof PromptDeadlineExceededError
+            ) {
+              throw pendingAbort.signal.reason;
+            }
             throw new DOMException('Prompt aborted', 'AbortError');
           }
           // If this prompt was queued behind another, promote it to
@@ -5357,6 +5394,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           }
         }),
       );
+      // Do not reorder — this `result.then` must stay registered before the
+      // `result.finally` below: handlers on the same promise run in
+      // registration order and the broadcasts are synchronous, which is what
+      // guarantees the terminal frame precedes the deferred
+      // close-on-prompt-complete in `result.finally`.
       result.then(
         (promptResult) => {
           publishPromptTerminal(entry, pendingEntry, {
@@ -5388,8 +5430,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
           // Remove this prompt from the pending list and publish a
           // completed event so SSE subscribers can update their queue view.
-          // If `removePendingPrompt` already spliced this entry and
-          // published its own terminal event, skip to avoid a duplicate.
+          // A removed RUNNING prompt is still on the list (see
+          // `removePendingPrompt`) — splice it now, but skip the `completed`
+          // event: its `pending_prompt_completed{state:'removed'}` already
+          // announced the queue-view change.
           const listIdx = entry.pendingPromptList.indexOf(pendingEntry);
           if (listIdx !== -1) {
             entry.pendingPromptList.splice(listIdx, 1);
@@ -5397,7 +5441,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
             // (and thus had an `added` event). The first prompt on an idle
             // session starts immediately without `added`, so publishing
             // `completed` would produce an unpaired event.
-            if (isQueued) {
+            if (isQueued && !pendingEntry.removed) {
               try {
                 entry.events.publish({
                   type: 'pending_prompt_completed',
@@ -7037,15 +7081,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       if (!entry) throw new SessionNotFoundError(sessionId);
       // Authorize the caller against this session — mirrors /prompt.
       resolveTrustedClientId(entry, context?.clientId);
-      return entry.pendingPromptList.map((p) => ({
-        promptId: p.promptId,
-        text: p.text,
-        queuedAt: p.queuedAt,
-        state: p.state,
-        ...(p.originatorClientId !== undefined
-          ? { originatorClientId: p.originatorClientId }
-          : {}),
-      }));
+      return entry.pendingPromptList
+        .filter((p) => !p.removed)
+        .map((p) => ({
+          promptId: p.promptId,
+          text: p.text,
+          queuedAt: p.queuedAt,
+          state: p.state,
+          ...(p.originatorClientId !== undefined
+            ? { originatorClientId: p.originatorClientId }
+            : {}),
+        }));
     },
 
     removePendingPrompt(sessionId, promptId, context) {
@@ -7058,6 +7104,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       );
       if (idx === -1) return { removed: false };
       const target = entry.pendingPromptList[idx];
+      // A running prompt already removed once is invisible to the API —
+      // repeat removals are no-ops.
+      if (target.removed) return { removed: false };
       writeStderrLine(
         `[pending-prompt] session=${sessionId} removing promptId=${promptId} state=${target.state}`,
       );
@@ -7067,8 +7116,20 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       target.abortController.abort(
         new DOMException('Prompt removed by user', 'AbortError'),
       );
-      // Remove from the list immediately so the API reflects the change.
-      entry.pendingPromptList.splice(idx, 1);
+      if (target.state === 'queued') {
+        // A queued prompt never dispatches once aborted — safe to drop
+        // from the list immediately.
+        entry.pendingPromptList.splice(idx, 1);
+      } else {
+        // A RUNNING prompt must stay on the list (hidden from
+        // `getPendingPrompts` via the `removed` flag) until it settles
+        // through `result.finally`. Splicing it here would make it
+        // invisible to `flushPromptTerminals`: if the session then closes
+        // before the agent cooperates with the cancel, the prompt's
+        // terminal would be published into an already-closed bus and
+        // silently dropped.
+        target.removed = true;
+      }
       // Keep the admission slot until this prompt's FIFO node reaches the head
       // and settles through the original result.finally() path. Otherwise a
       // client could enqueue/delete queued prompts repeatedly while one turn is

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -599,6 +599,13 @@ export interface PendingPromptEntry {
    * later publish attempts for the same prompt are suppressed.
    */
   terminalPublished?: boolean;
+  /**
+   * Set when `removePendingPrompt` cancels a RUNNING prompt. The entry
+   * stays on `pendingPromptList` (hidden from `getPendingPrompts`) until
+   * the prompt settles, so the teardown flush can still publish its
+   * terminal if the session closes before the agent cooperates.
+   */
+  removed?: boolean;
 }
 
 /**

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -227,10 +227,8 @@ export {
   resolveBoundWorkspacesFromIdeEnv,
   resolveBridgeFsFactory,
 } from './server/fs-factory.js';
-export {
-  PromptDeadlineExceededError,
-  resolvePromptDeadlineMs,
-} from './server/prompt-deadline.js';
+export { PromptDeadlineExceededError } from './acp-session-bridge.js';
+export { resolvePromptDeadlineMs } from './server/prompt-deadline.js';
 export { detectFromLoopback } from './server/request-helpers.js';
 export {
   InvalidCursorError,

--- a/packages/cli/src/serve/server/prompt-deadline.ts
+++ b/packages/cli/src/serve/server/prompt-deadline.ts
@@ -5,14 +5,6 @@
  */
 
 /**
- * Rejected by the bridge's `sendPrompt` when a prompt exceeds its
- * wallclock deadline. The class itself lives in the acp-bridge package
- * (the bridge owns the deadline race since DAEMON-003); re-exported here
- * so existing `server.ts` / test imports keep working.
- */
-export { PromptDeadlineExceededError } from '../acp-session-bridge.js';
-
-/**
  * Resolve the effective per-prompt wallclock from the server flag +
  * an optional request body override. Returns `undefined` when no
  * deadline applies. The request override may SHORTEN the deadline but


### PR DESCRIPTION
## What this PR does

Closes the post-merge self-review follow-ups from PR https://github.com/QwenLM/qwen-code/pull/7400 (the daemon prompt-terminal exactly-once work). Four behavioral fixes plus documentation hardening:

1. **A removed RUNNING prompt no longer loses its terminal.** Removing a running prompt via the API now keeps it on the pending list (hidden from the pending-prompts API by a flag, and idempotent on repeat removal) until it actually settles. If the session closes, is killed, or crashes before the agent cooperates with the cancel, the teardown flush can still see the prompt and publishes its terminal before the event bus closes — previously the terminal was published into an already-closed bus and silently dropped, hanging any SSE consumer waiting on that prompt. (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090277)
2. **A queued prompt's failure no longer pollutes session-level turn state.** The turn-error broadcast now only mutates the session's `turnError` / `retryAllowed` when the failing prompt was actually running. A queued prompt's terminal (deadline expiry, teardown flush) publishes the event alone, so the session summary no longer advertises an error for a turn that never ran, and the retry path isn't armed by it. The gate is the prompt's own running state rather than the session's active-prompt id, because on the normal settle path the active-prompt id is already cleared before the terminal publishes — gating on it would misclassify genuine active-turn failures. (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090289)
3. **Queued deadline expiry now rejects with the typed error.** A prompt whose deadline expires while still queued previously rejected the caller with a generic `AbortError`; the pre-dispatch abort check now propagates the typed `PromptDeadlineExceededError`, so queued and running expiry reject identically as the PR #7400 description promised. (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090297)
4. **The prompt-deadline module is a pure leaf again.** Dropped the re-export that made a small helper module transitively pull in the entire bridge; the error class is re-exported from the server barrel via the bridge boundary instead. Existing import sites are unchanged. (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090342)

Documentation/nit follow-ups in the same pass: the deadline comment now spells out the accepted trade-off that releasing the FIFO lets the next prompt overlap a still-wedged call on the same ACP session (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090293); the duplicate-terminal dedup log moved to the debug channel since dedup is the designed steady state, not an anomaly (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090305); the teardown-flush doc notes the expected trailing `prompt_cancelled` after a running prompt's terminal (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090313); and the load-bearing registration order of the terminal broadcast before the deferred close now has a do-not-reorder comment (https://github.com/QwenLM/qwen-code/pull/7400#discussion_r3622090336).

## Why it's needed

These items were flagged in the PR #7400 self-review as "will fix" but the PR merged first. The first three are real behavioral defects: a hung SSE consumer on session teardown after removing a running prompt, a misleading session summary plus an unearned retry arm after a queued failure, and an untyped rejection that makes deadline expiry indistinguishable from user removal for programmatic callers.

## Reviewer Test Plan

### How to verify

- Removed-running-prompt terminal: start a prompt against an agent that ignores cancellation, remove it via the pending-prompt DELETE API (observe it disappear from the pending-prompts GET and a repeat DELETE report not-removed), then close the session. Expect exactly one `turn_error{code:'session_closed'}` terminal for that promptId on the session event stream, ordered before the `session_closed` frame. Before this fix the terminal never arrived.
- Queued-failure turn state: let a queued prompt's deadline expire behind a wedged head prompt. Expect the session summary's `turnError` to stay unset, while the queued prompt still gets its exactly-once deadline terminal and the caller's promise rejects with `PromptDeadlineExceededError` (previously a generic `AbortError`).
- Unit coverage: `cd packages/acp-bridge && npx vitest run src/bridge.test.ts` — 429 tests pass, including a new removed-running-prompt teardown test and extended queued-deadline assertions covering both fixes above.
- `npm run build` and `npm run typecheck` pass.

### Evidence (Before & After)

N/A — daemon/bridge internals, no TUI change. Test output:

```
 Test Files  1 passed (1)
      Tests  429 passed (429)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via vitest; no sandbox.

## Risk & Scope

- Main risk or tradeoff: a removed running prompt now stays on the internal pending list until it settles. All internal consumers were audited — queue-depth accounting and the stop-guard scan count only queued entries, the pending-prompts API filters the flag, and the settle path splices the entry while skipping the duplicate completed event — but any future code iterating the raw list must be aware removed entries can be present.
- Not validated / out of scope: reclaiming a wedged agent's channel (tracked separately in PR #7400); the stale `session/update` interleave after a deadline release is documented as an accepted trade-off, not changed.
- Breaking changes / migration notes: none. The queued-expiry rejection type changes from `AbortError` to `PromptDeadlineExceededError`, matching the documented contract from PR #7400.

## Linked Issues

Fixes #7451

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

闭环 PR https://github.com/QwenLM/qwen-code/pull/7400（daemon prompt 终态 exactly-once 工作）合并后 self-review 中标记的待修项。四项行为修复加文档加固：

1. **被移除的运行中 prompt 不再丢失终态。** 通过 API 移除运行中的 prompt 后，该条目现在保留在待处理列表上（通过标志对 pending-prompts API 隐藏，重复移除幂等返回未移除），直到真正结算。如果会话在 agent 配合取消之前关闭、被杀或崩溃，teardown flush 仍能看到该 prompt 并在事件总线关闭前发布其终态——此前终态会被发布进已关闭的总线并被静默丢弃，导致等待该 prompt 的 SSE 消费者永久挂起。
2. **排队 prompt 的失败不再污染会话级 turn 状态。** turn-error 广播现在仅在失败的 prompt 确实处于运行状态时才修改会话的 `turnError` / `retryAllowed`。排队 prompt 的终态（deadline 过期、teardown flush）只发布事件本身，因此会话摘要不再为一个从未运行的 turn 报告错误，retry 路径也不会被它武装。门控使用 prompt 自身的运行状态而非会话的 active-prompt id，因为正常结算路径上 active-prompt id 在终态发布前已被清空——用它做门控会误判真实的活跃 turn 失败。
3. **排队中 deadline 过期现在以类型化错误拒绝。** 此前 deadline 在排队期间过期的 prompt 会以通用 `AbortError` 拒绝调用方；pre-dispatch abort 检查现在传播类型化的 `PromptDeadlineExceededError`，使排队与运行中的过期拒绝行为一致，符合 PR #7400 描述的承诺。
4. **prompt-deadline 模块恢复为纯叶子模块。** 删除了使这个小工具模块传递性拉入整个 bridge 的 re-export；错误类改为经由 bridge 边界从 server barrel 导出。现有导入点不变。

同批文档/nit 跟进：deadline 注释现在明确说明释放 FIFO 会让下一个 prompt 与仍然卡死的调用在同一 ACP 会话上重叠这一已接受的权衡；重复终态去重日志移至 debug 通道（去重是设计内的稳态而非异常）；teardown-flush 文档注明运行中 prompt 终态帧之后出现尾随 `prompt_cancelled` 属预期；终态广播先于延迟关闭的注册顺序这一承重不变式现在有 do-not-reorder 注释保护。

## 为什么需要

这些项在 PR #7400 self-review 中标记为"将修复"，但 PR 先合并了。前三项是真实的行为缺陷：移除运行中 prompt 后会话 teardown 时 SSE 消费者挂起、排队失败后会话摘要误导且 retry 被无端武装、无类型拒绝使程序化调用方无法区分 deadline 过期与用户移除。

## 审阅者测试计划

### 如何验证

- 被移除运行中 prompt 的终态：对一个无视取消的 agent 启动 prompt，通过 pending-prompt DELETE API 移除它（观察它从 pending-prompts GET 消失、重复 DELETE 报告未移除），然后关闭会话。预期该 promptId 在会话事件流上恰有一条 `turn_error{code:'session_closed'}` 终态，且排序在 `session_closed` 帧之前。修复前该终态永远不会到达。
- 排队失败的 turn 状态：让排队 prompt 的 deadline 在卡死的队头 prompt 后过期。预期会话摘要的 `turnError` 保持未设置，同时排队 prompt 仍获得 exactly-once 的 deadline 终态，调用方 promise 以 `PromptDeadlineExceededError` 拒绝（此前是通用 `AbortError`）。
- 单元覆盖：`cd packages/acp-bridge && npx vitest run src/bridge.test.ts` —— 429 个测试通过，包括新增的移除运行中 prompt 的 teardown 测试与覆盖上述两项修复的扩展排队 deadline 断言。
- `npm run build` 与 `npm run typecheck` 通过。

### 证据（前后对比）

N/A —— daemon/bridge 内部改动，无 TUI 变化。

### 风险与范围

- 主要风险或权衡：被移除的运行中 prompt 现在保留在内部待处理列表上直到结算。所有内部消费方已审计——队列深度统计与 stop-guard 扫描只计数排队条目，pending-prompts API 过滤该标志，结算路径在跳过重复 completed 事件的同时移除条目——但未来任何遍历原始列表的代码需注意可能存在已移除条目。
- 未验证/范围外：回收卡死 agent 的 channel（PR #7400 中单独跟踪）；deadline 释放后的陈旧 `session/update` 交错已记录为已接受的权衡，未改变。
- 破坏性变更/迁移说明：无。排队过期的拒绝类型从 `AbortError` 变为 `PromptDeadlineExceededError`，与 PR #7400 记录的契约一致。

## 关联 Issue

Fixes #7451

</details>
