### PR TITLE
fix(core): Advertise completed task revival

### DIFF
--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -254,7 +254,7 @@ export class SendMessageTool extends BaseDeclarativeTool<
     super(
       SendMessageTool.Name,
       ToolDisplayNames.SEND_MESSAGE,
-      'Send a message to a teammate (use "to") or to a running background task (use "task_id"). ' +
+      'Send a message to a teammate (use "to") or to a running, paused, or completed background task (use "task_id"); completed tasks are revived. ' +
         'For teams, set "to" to a bare teammate name (no @) or "*" to broadcast. ' +
         'For background tasks, set "task_id" to the id from the launch response, a recovered paused task, or a completed task to revive. ' +
         'Running tasks receive it at the next tool-round boundary; paused recovered tasks are resumed with the message as their first continuation instruction; a completed task is revived from its transcript and continued with your message. ' +

--- a/packages/core/src/utils/environmentContext.test.ts
+++ b/packages/core/src/utils/environmentContext.test.ts
@@ -38,6 +38,7 @@ import {
 import { prependToFirstTextPart } from './partUtils.js';
 import type { Config } from '../config/config.js';
 import type { ToolRegistry } from '../tools/tool-registry.js';
+import { SendMessageTool } from '../tools/send-message.js';
 import { getFolderStructure } from './getFolderStructure.js';
 import { collectAvailableSkillEntries } from '../tools/skill-utils.js';
 import type { AvailableSkillEntry } from '../tools/skill-utils.js';
@@ -517,6 +518,22 @@ describe('startup reminder builders', () => {
     expect(reminder).toContain('### MCP servers');
     expect(reminder).toContain('#### schedule-server');
     expect(reminder).toContain('- "cron_list": "List scheduled jobs."');
+  });
+
+  it('keeps completed-task revival visible in the send_message summary', () => {
+    const tool = new SendMessageTool({} as Config);
+    const reminder = buildDeferredToolsReminder(
+      registry({
+        getDeferredToolSummary: vi
+          .fn()
+          .mockReturnValue([
+            { name: tool.name, description: tool.description },
+          ]),
+      }),
+    );
+
+    expect(reminder).toContain('completed background task');
+    expect(reminder).toContain('completed tasks are revived');
   });
 
   it('JSON-encodes deferred tool metadata before rendering', () => {


### PR DESCRIPTION
## What this PR does

This PR makes the initially visible `send_message` summary state that running, paused, and completed background tasks are supported and that completed tasks are revived. It also adds a regression test that renders the real tool metadata through the deferred-tool summary limit and verifies that the completed-task guidance remains visible.

## Why it's needed

The full tool schema already documented completed-task revival, and the runtime already implemented it, but deferred tools expose only the first 160 characters of their descriptions at session startup. The revival guidance appeared after that boundary, so an agent that had not called `tool_search` could incorrectly conclude that completed subagents could not be reused and launch a redundant replacement. Keeping the capability in the initial summary lets the agent reuse prior context without an avoidable discovery round trip.

## Reviewer Test Plan

### How to verify

Start a fresh session where `send_message` is deferred and ask, without allowing `tool_search` or another tool call, whether `send_message` can revive a completed background task. Confirm that the initial summary explicitly includes completed background tasks and states that completed tasks are revived, and that the model answers yes without launching a replacement agent.

### Evidence (Before & After)

Before: Qwen Code 0.20.0 answered **No** with zero tool calls and cited the visible summary's wording that only mentioned a "running background task."

After: the patched local bundle answered **Yes** with zero tool calls and cited: "running, paused, or completed background task ... completed tasks are revived."

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundle in safe mode, Node.js v24.18.0, Qwen Code 0.20.0, model `qwen3.8-max-preview`.

## Risk & Scope

- Main risk or tradeoff: The concise revival guidance now takes priority within the 160-character startup summary, so detailed team-routing guidance is truncated slightly earlier; the full schema remains unchanged and available through `tool_search`.
- Not validated / out of scope: Model behavior was not manually tested on Windows or Linux, and this change does not alter task lifecycle or revival runtime behavior.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #7450

<details>
<summary>中文说明</summary>

## 此 PR 的改动

此 PR 让初始可见的 `send_message` 摘要明确说明其支持运行中、暂停和已完成的后台任务，并说明已完成任务会被唤醒。同时新增回归测试，将真实工具元数据经过 deferred-tool 摘要长度限制渲染，并验证已完成任务的说明仍然可见。

## 为什么需要此改动

完整工具 schema 已经说明了已完成任务可被唤醒，运行时也已经实现该能力，但 deferred 工具在会话启动时只暴露描述的前 160 个字符。原先唤醒能力的说明位于该边界之后，因此尚未调用 `tool_search` 的 agent 可能错误地认为已完成的子代理无法复用，并启动一个冗余的新代理。把该能力放入初始摘要后，agent 可以直接复用之前的上下文，不再需要一次可避免的工具发现往返。

## Reviewer 测试计划

### 验证方法

启动一个 `send_message` 仍为 deferred 工具的新会话，在不允许调用 `tool_search` 或其他工具的情况下，询问 `send_message` 是否能唤醒已完成的后台任务。确认初始摘要明确包含已完成的后台任务并说明已完成任务会被唤醒，同时模型回答“可以”且不会启动替代代理。

### 证据（修复前后）

修复前：Qwen Code 0.20.0 在零工具调用下回答 **No**，并引用了只提到“running background task”的可见摘要。

修复后：本地修复 bundle 在零工具调用下回答 **Yes**，并引用了“running, paused, or completed background task ... completed tasks are revived”。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 bundle safe mode、Node.js v24.18.0、Qwen Code 0.20.0、模型 `qwen3.8-max-preview`。

## 风险与范围

- 主要风险或取舍：简洁的唤醒说明现在优先占用 160 字符启动摘要，因此详细的团队路由说明会更早被截断；完整 schema 保持不变，仍可通过 `tool_search` 获取。
- 未验证 / 范围外：未在 Windows 或 Linux 上手动验证模型行为；此改动不修改任务生命周期或唤醒运行时逻辑。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7450

</details>
