### PR TITLE
test(telemetry): Cover daemon metrics init ordering and document metricReader asymmetry

### DIFF
--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -1174,6 +1174,46 @@ describe('runQwenServe telemetry validation', () => {
       await handle.close();
     }
   });
+
+  it('awaits telemetry initialization before daemon metrics', async () => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qws-tm-')));
+    const callOrder: string[] = [];
+    vi.spyOn(qwenCore, 'initializeTelemetry').mockImplementation(async () => {
+      callOrder.push('telemetry-start');
+      await Promise.resolve();
+      callOrder.push('telemetry-resolved');
+    });
+    vi.spyOn(qwenCore, 'initializeDaemonMetrics').mockImplementation(() => {
+      callOrder.push('daemon-metrics');
+    });
+    vi.spyOn(qwenCore, 'resolveTelemetrySettings').mockResolvedValue({
+      enabled: true,
+      sensitiveSpanAttributeMaxLength: 1024 * 1024,
+    });
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        bridge: makeRuntimeBridge(),
+        daemonLogBaseDir: path.join(tmpDir, 'debug'),
+      },
+    );
+    try {
+      expect(callOrder).toEqual([
+        'telemetry-start',
+        'telemetry-resolved',
+        'daemon-metrics',
+      ]);
+    } finally {
+      await handle.close();
+    }
+  });
 });
 
 /**

--- a/packages/core/src/telemetry/sdk-impl.ts
+++ b/packages/core/src/telemetry/sdk-impl.ts
@@ -419,6 +419,13 @@ export async function startTelemetrySdk(
       : logToSpanProcessor
         ? [logToSpanProcessor]
         : [],
+    // Metrics uses the singular `metricReader` field because
+    // `@opentelemetry/sdk-node@0.203.0` only accepts one reader; there is no
+    // `metricReaders: []` opt-out. The SDK's `start()` calls
+    // `configureMetricProviderFromEnv()` unconditionally, so env-based readers
+    // are only suppressed when an explicit reader is provided. This is
+    // intentionally asymmetric with `spanProcessors`/`logRecordProcessors`,
+    // where an empty array disables env fallback for those signals.
     ...(metricReader && { metricReader }),
     instrumentations: [
       new HttpInstrumentation({


### PR DESCRIPTION
# test(telemetry): cover daemon metrics init ordering and document metricReader asymmetry

## What this PR does

Two small follow-ups to the lazy telemetry SDK work that merged in #7276, both raised as non-blocking review suggestions there. First, it adds a test asserting that daemon metrics initialization only runs after telemetry initialization has fully settled — the dependency became asynchronous in #7276 and previously had no ordering assertion. Second, it documents why the SDK options use the singular `metricReader` field while traces and logs pass processor arrays: `@opentelemetry/sdk-node@0.203.0` accepts only one metric reader and offers no empty-array opt-out, so env-based reader auto-configuration can only be suppressed by providing an explicit reader — an intentional asymmetry that is easy to "fix" incorrectly.

## Why it's needed

The init-ordering guarantee is load-bearing (metrics recorded before the provider exists are dropped) but was only enforced by code shape, not by a test. The comment prevents a future cleanup from converting `metricReader` to a `metricReaders: []` pattern that the SDK does not support.

## Reviewer Test Plan

### How to verify

- `cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts` — includes the new ordering test (telemetry-start → telemetry-resolved → daemon-metrics).
- The sdk-impl change is comment-only; no behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ➖   |

## Risk & Scope

- Main risk or tradeoff: none — one new test plus a comment.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #7276.
