### PR TITLE
fix(core): make fork subagents discoverable

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -311,6 +311,15 @@ describe('AgentTool', () => {
       expect(interactiveTool.description).toContain("Don't race");
       expect(interactiveTool.description).toContain('Writing a fork prompt');
       expect(interactiveTool.description).toContain(
+        'result arrives through a completion notification',
+      );
+      expect(interactiveTool.description).not.toContain(
+        'does NOT come back to you',
+      );
+      expect(interactiveTool.description).not.toContain(
+        "won't need the result back",
+      );
+      expect(interactiveTool.description).toContain(
         'forks inherit all or the selected recent window',
       );
     });
@@ -358,6 +367,9 @@ describe('AgentTool', () => {
 
       expect(tool.description).toContain('background by default');
       expect(tool.description).toContain('run_in_background: false');
+      expect(tool.description).toContain(
+        'foreground regular agent returns its result inline',
+      );
     });
 
     it('explains how to continue reusable background agents', async () => {
@@ -404,19 +416,22 @@ describe('AgentTool', () => {
   });
 
   describe('schema generation', () => {
-    it('should generate schema with subagent names as enum', () => {
+    it('keeps subagent_type open when named subagents are available', () => {
       const schema = agentTool.schema;
       const properties = schema.parametersJsonSchema as {
         properties: {
           subagent_type: {
+            type?: string;
+            description?: string;
             enum?: string[];
           };
         };
       };
-      expect(properties.properties.subagent_type.enum).toEqual([
-        'file-search',
-        'code-review',
-      ]);
+      expect(properties.properties.subagent_type.type).toBe('string');
+      expect(properties.properties.subagent_type.description).toContain(
+        '"fork" to inherit',
+      );
+      expect(properties.properties.subagent_type.enum).toBeUndefined();
     });
 
     it('declares the background default and foreground opt-out', () => {
@@ -432,6 +447,9 @@ describe('AgentTool', () => {
       expect(properties.properties.run_in_background.default).toBe(true);
       expect(properties.properties.run_in_background.description).toContain(
         'Set to false',
+      );
+      expect(properties.properties.run_in_background.description).toContain(
+        'interactive fork',
       );
     });
 
@@ -471,30 +489,6 @@ describe('AgentTool', () => {
       expect(properties.properties.working_dir.description).not.toContain(
         'Mutually exclusive',
       );
-    });
-
-    it('does not advertise "fork" in the enum, even when interactive', async () => {
-      // `fork` is intentionally omitted from the enum so the model is not
-      // steered to fork result-bearing work; it stays valid via validation.
-      (config as unknown as Record<string, unknown>)['isInteractive'] = vi
-        .fn()
-        .mockReturnValue(true);
-      const interactiveTool = new AgentTool(config);
-      await vi.runAllTimersAsync();
-
-      const schema = interactiveTool.schema;
-      const properties = schema.parametersJsonSchema as {
-        properties: {
-          subagent_type: {
-            enum?: string[];
-          };
-        };
-      };
-      expect(properties.properties.subagent_type.enum).toEqual([
-        'file-search',
-        'code-review',
-      ]);
-      expect(properties.properties.subagent_type.enum).not.toContain('fork');
     });
 
     it('does not expose teammate name when teams are disabled', () => {
@@ -3014,6 +3008,7 @@ describe('AgentTool', () => {
       vi.mocked(
         config.isInteractive as ReturnType<typeof vi.fn>,
       ).mockReturnValue(false);
+      vi.mocked(mockAgent.getFinalText).mockReturnValue('headless fork result');
       (mockAgent as unknown as Record<string, unknown>)['getCore'] = vi
         .fn()
         .mockReturnValue({
@@ -3045,6 +3040,7 @@ describe('AgentTool', () => {
         config as unknown as {
           getBackgroundTaskRegistry: () => {
             register: ReturnType<typeof vi.fn>;
+            complete: ReturnType<typeof vi.fn>;
           };
         }
       ).getBackgroundTaskRegistry();
@@ -3083,6 +3079,11 @@ describe('AgentTool', () => {
       );
 
       await vi.runAllTimersAsync();
+      expect(stubRegistry.complete).toHaveBeenCalledWith(
+        expect.any(String),
+        'headless fork result',
+        expect.anything(),
+      );
       expect(mockStartSubagentSpan).toHaveBeenCalledWith(
         expect.objectContaining({
           invocationKind: 'fork',

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -760,7 +760,8 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
         },
         subagent_type: {
           type: 'string',
-          description: 'The type of specialized agent to use for this task',
+          description:
+            'The named agent type to use, or "fork" to inherit the parent conversation context',
         },
         fork_turns: {
           oneOf: [
@@ -780,7 +781,7 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
           type: 'boolean',
           default: true,
           description:
-            'Defaults to true for top-level regular subagents. Set to false to run in the foreground and return the result inline. Nested agents run in the foreground. Caller-owned working_dir launches default to foreground and cannot run in the background.',
+            'Defaults to true for top-level regular subagents. Set to false to run a regular agent in the foreground and return its result inline. Set to true for an interactive fork to receive its completion notification; headless forks always run in the background. Nested agents run in the foreground. Caller-owned working_dir launches default to foreground and cannot run in the background.',
         },
         ...(config.isAgentTeamEnabled()
           ? {
@@ -876,7 +877,7 @@ The Agent tool launches specialized agents (subprocesses) that autonomously hand
 Available agent types and the tools they have access to:
 ${subagentDescriptions}
 
-When using the Agent tool, specify a subagent_type to select which agent type to use. If omitted, the general-purpose agent is used. Top-level regular subagents run in the background by default and report their results through a completion notification; set \`run_in_background: false\` when you need the result inline before continuing. A fork (\`subagent_type: "fork"\`) runs detached and fire-and-forget — its result does NOT come back to you, so use it ONLY for work whose output you won't need. Forks inherit the full parent conversation by default; set \`fork_turns\` to a positive integer string to limit inheritance to that many recent real user turns. When you need the agent's findings back (review, audit, aggregation, verification), use a regular subagent, never a fork.
+When using the Agent tool, specify a subagent_type to select which agent type to use. If omitted, the general-purpose agent is used. Top-level regular subagents run in the background by default and report their results through a completion notification; set \`run_in_background: false\` when you need a regular subagent's result inline before continuing. A fork (\`subagent_type: "fork"\`) inherits the parent conversation context. A background fork's result arrives through a completion notification. Forks inherit the full parent conversation by default; set \`fork_turns\` to a positive integer string to limit inheritance to that many recent real user turns.
 
 When NOT to use the Agent tool:
 - If you want to read a specific file path, use the ${ToolNames.READ_FILE} tool or the ${ToolNames.GLOB} tool instead of the ${ToolNames.AGENT} tool, to find the match more quickly
@@ -892,7 +893,7 @@ Usage notes:
 - Keep immediate critical-path work local when your next action depends on it.
 - Do not duplicate work between the parent and subagents.
 - Run agents concurrently only when their tasks are independent. For code changes, give concurrent agents disjoint write scopes; launch them in a single message with multiple tool uses.
-- A background agent reports its result through a completion notification in a later turn. A foreground agent returns its result inline. Agent results are not visible to the user, so relay the relevant outcome in your response.
+- A background agent reports its result through a completion notification in a later turn. A foreground regular agent returns its result inline. Agent results are not visible to the user, so relay the relevant outcome in your response.
 - While background agents run, continue meaningful non-overlapping work. Wait for an agent only when its result blocks the next required step.
 - Reuse an existing background agent for related follow-up work instead of launching a duplicate: call ${ToolNames.SEND_MESSAGE} with the \`agentId\` from its launch result as its \`task_id\`. Running agents receive the message at the next tool-round boundary; paused agents resume with it as their first continuation instruction; completed agents are revived from their retained transcript. If the task is no longer retained or cannot be resumed or revived, launch a new agent.
 - Provide clear, detailed prompts so the agent can work autonomously and return exactly the information you need.
@@ -905,15 +906,15 @@ Usage notes:
 - You can optionally set \`isolation: "worktree"\` to run the agent in a temporary git worktree, giving it an isolated copy of the repository. The worktree is automatically cleaned up if the agent makes no changes; if changes are made, the worktree path and branch are returned in the result so you can review or merge them.
 ## When to fork
 
-A fork (\`subagent_type: "fork"\`) runs detached and fire-and-forget: it inherits your full context by default, but its findings do NOT come back to you in a form you can act on. Set \`fork_turns\` to a positive integer string only when a bounded recent window is sufficient. **Never fork work whose output you need** — reviews, audits, parallel investigations you must aggregate, verification, anything where you have to read or combine the results. For all of that, launch regular subagents instead (omit \`subagent_type\` for general-purpose, or name a specific type). Regular top-level subagents report through background completion notifications by default; set \`run_in_background: false\` when you need the result inline in the current turn. Omitting \`subagent_type\` does NOT fork.
+A fork (\`subagent_type: "fork"\`) inherits your full context by default. Set \`fork_turns\` to a positive integer string only when a bounded recent window is sufficient. A background fork reports its result through a completion notification; set \`run_in_background: true\` in interactive sessions when you need that result. Headless forks always use this background path. Omitting \`subagent_type\` does NOT fork.
 
-Fork only when you genuinely won't need the result back — a detached background chore the user asked you to kick off and move on from. The criterion is qualitative: "will I need to read this output?" If yes, don't fork.
+Choose a fork when the task needs substantial context from the parent conversation. Use a regular subagent when a fresh prompt provides enough context.
 
 Forks are cheap because they share your prompt cache. Don't set \`model\` on a fork — a different model can't reuse the parent's cache. Pass a short \`name\` (one or two words, lowercase) so the user can track the fork.
 
-**Don't peek.** The tool result includes an output — do not read or tail it unless the user explicitly asks for a progress check. You get a completion notification; trust it. Reading the transcript mid-flight pulls the fork's tool noise into your context, which defeats the point of forking.
+**Don't peek.** For a background fork, do not read or tail its output unless the user explicitly asks for a progress check. You get a completion notification; trust it. Reading the transcript mid-flight pulls the fork's tool noise into your context, which defeats the point of forking.
 
-**Don't race.** After launching, you know nothing about what the fork found. Never fabricate or predict fork results in any format — not as prose, summary, or structured output. The notification arrives as a user-role message in a later turn; it is never something you write yourself. If the user asks a follow-up before the notification lands, tell them the fork is still running — give status, not a guess.
+**Don't race.** After launching a background fork, you know nothing about what it found. Never fabricate or predict fork results in any format — not as prose, summary, or structured output. The notification arrives as a user-role message in a later turn; it is never something you write yourself. If the user asks a follow-up before the notification lands, tell them the fork is still running — give status, not a guess.
 
 **Writing a fork prompt.** With the default full history, the prompt is a *directive* — what to do, not what the situation is. When \`fork_turns\` limits history, include any older context the fork still needs. Be specific about scope: what's in, what's out, what another agent is handling.
 
@@ -960,32 +961,13 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
     // Update description using object property assignment since it's readonly
     (this as { description: string }).description = baseDescription;
 
-    // Generate dynamic schema with enum of available subagent names
-    const subagentNames = this.availableSubagents.map((s) => s.name);
-
     // Update the parameter schema by modifying the existing object
     const schema = this.parameterSchema as {
       properties?: {
-        subagent_type?: {
-          enum?: string[];
-        };
         name?: typeof TEAM_AGENT_NAME_PROPERTY;
         plan_mode_required?: typeof TEAM_AGENT_PLAN_REQUIRED_PROPERTY;
       };
     };
-    if (schema.properties && schema.properties.subagent_type) {
-      // Only real, loadable subagents are advertised in the enum. `fork` is a
-      // deliberate pseudo-type, NOT listed here: dangling it as a casual option
-      // led the model to fork result-bearing work (e.g. review agents), whose
-      // findings a fork never returns. Forking stays reachable for intentional
-      // use — validation accepts `subagent_type: "fork"` and `/fork` passes it
-      // directly — it just isn't offered as a default pick.
-      if (subagentNames.length > 0) {
-        schema.properties.subagent_type.enum = subagentNames;
-      } else {
-        delete schema.properties.subagent_type.enum;
-      }
-    }
     if (schema.properties) {
       if (this.config.isAgentTeamEnabled()) {
         schema.properties.name = TEAM_AGENT_NAME_PROPERTY;


### PR DESCRIPTION
## What this PR does

- Keeps `subagent_type` as an open string so named agents and the special `fork` type can coexist without contradictory schema constraints.
- Defines a fork by its inherited parent context and explains when its result arrives through a background completion notification.
- Adds regression coverage for schema discoverability and headless fork completion.

## Why it's needed

The runtime already supports `subagent_type: "fork"`, but the generated schema enumerates only named agents. In headless mode, models therefore reject `fork` as an invalid value before invoking the tool. The existing guidance also incorrectly says fork results never return, even though background and headless forks report through completion notifications. This resolves #7421 by making the schema and guidance match the existing runtime behavior.

## Reviewer Test Plan

### How to verify

- In safe-mode headless execution, provide a unique marker in the parent conversation and request one explicit background fork whose tool prompt omits that marker. Expect the model to invoke the Agent tool with `subagent_type: "fork"`, receive a completion notification, and report the inherited marker.
- Inspect the exposed Agent tool schema. Expect `subagent_type` to remain a string without an enum, with its description explicitly documenting `fork`.
- Check regular-agent guidance. Expect foreground inline-result behavior to remain scoped to regular agents, while interactive forks that need a result are instructed to run in the background.

### Evidence (Before & After)

- **Before:** The headless model refuses the requested call because `fork` is absent from the allowed `subagent_type` enum, listing only the installed named agents.
- **After:** The packaged CLI makes exactly one background fork call, the fork recovers a marker available only in inherited parent context, and its completion notification arrives before the parent reports the answer.

### Tested on

| OS      | Status                  |
| ------- | ----------------------- |
| macOS   | ✅                      |
| Windows | ⚠️ Not tested           |
| Linux   | ⚠️ Not tested           |

### Environment (optional)

- Node.js 24.18.0
- Qwen Code 0.20.0
- `qwen3.8-max-preview`
- Safe mode with stream JSON output

## Risk & Scope

- Main risk or tradeoff: Removing the schema enum moves typo detection for named agent types from JSON-schema validation to the existing runtime lookup and error path.
- Not validated / out of scope: The legacy interactive non-background fork path still returns its existing asynchronous placeholder; callers that need the fork result are directed to use the background path.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #7421

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 保持 `subagent_type` 为开放字符串，让具名 agent 与特殊的 `fork` 类型在没有 schema 冲突的情况下共存。
- 将 fork 定义为继承父对话上下文，并准确说明后台 completion notification 的结果返回方式。
- 补充 schema 可发现性和 headless fork completion 的回归测试。

## 为什么需要

运行时已经支持 `subagent_type: "fork"`，但生成的 schema 只枚举具名 agent。因此在 headless 模式下，模型会在调用工具前把 `fork` 判断为非法值。现有提示词还错误地声称 fork 结果永远不会返回，而后台和 headless fork 实际会通过 completion notification 报告结果。本 PR 让 schema 与提示词和已有运行时行为保持一致，并修复 #7421。

## Reviewer 测试计划

### 如何验证

- 在 safe-mode headless 执行中，在父对话提供一个唯一标记，并要求进行一次显式后台 fork，且工具 prompt 不包含该标记。预期模型使用 `subagent_type: "fork"` 调用 Agent 工具，收到 completion notification，并报告继承到的标记。
- 检查暴露的 Agent 工具 schema。预期 `subagent_type` 是没有 enum 的字符串，并在描述中明确说明 `fork`。
- 检查普通 agent 的说明。预期前台 inline result 只针对普通 agent；交互式 fork 如果需要结果，应使用后台路径。

### 证据（Before & After）

- **Before：** headless 模型拒绝请求，因为允许的 `subagent_type` enum 中没有 `fork`，只列出了已安装的具名 agent。
- **After：** 本地打包 CLI 恰好发起一次后台 fork；fork 从父上下文继承到工具 prompt 中没有出现的标记；completion notification 到达后，父 agent 才报告结果。

### 测试平台

| 操作系统 | 状态        |
| -------- | ----------- |
| macOS    | ✅          |
| Windows  | ⚠️ 未测试   |
| Linux    | ⚠️ 未测试   |

### 环境（可选）

- Node.js 24.18.0
- Qwen Code 0.20.0
- `qwen3.8-max-preview`
- Safe mode 与 stream JSON 输出

## 风险与范围

- 主要风险或取舍：移除 schema enum 后，具名 agent 类型拼写错误会从 JSON schema 校验转移到现有运行时查找与错误路径。
- 未验证 / 范围外：旧的交互式非后台 fork 路径仍返回原有异步占位结果；需要 fork 结果的调用方会被提示使用后台路径。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Closes #7421

</details>
