### PR TITLE
fix(core): align stepped day fields with Vixie cron semantics

### DIFF
--- a/packages/core/src/utils/cronParser.test.ts
+++ b/packages/core/src/utils/cronParser.test.ts
@@ -35,6 +35,15 @@ describe('parseCron', () => {
     expect([...fields.minute].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
   });
 
+  it('uses the leading character for Vixie day wildcard flags', () => {
+    expect(parseCron('0 0 */2 * 1').domIsWild).toBe(true);
+    expect(parseCron('0 0 15 * */3').dowIsWild).toBe(true);
+    expect(parseCron('0 0 *,10 * 1').domIsWild).toBe(true);
+    expect(parseCron('0 0 15 * *,3').dowIsWild).toBe(true);
+    expect(parseCron('0 0 1,* * 1').domIsWild).toBe(false);
+    expect(parseCron('0 0 15 * 1,*').dowIsWild).toBe(false);
+  });
+
   it('parses range with step', () => {
     const fields = parseCron('1-10/3 * * * *');
     expect([...fields.minute].sort((a, b) => a - b)).toEqual([1, 4, 7, 10]);
@@ -133,6 +142,12 @@ describe('matches', () => {
     expect(matches('0 10 * * 1', date)).toBe(false);
   });
 
+  it('uses AND logic for day fields that start with a wildcard step', () => {
+    const date = new Date(2025, 0, 1, 0, 0); // Wednesday
+    expect(matches('0 0 */2 * 1', date)).toBe(false);
+    expect(matches('0 0 15 * */3', date)).toBe(false);
+  });
+
   it('matches an N/step minute pattern at every stepped minute', () => {
     // `5/15` fires at :05, :20, :35, :50 — not only :05.
     expect(matches('5/15 * * * *', new Date(2025, 0, 15, 10, 5))).toBe(true);
@@ -200,5 +215,15 @@ describe('nextFireTime', () => {
     const now = new Date(2025, 0, 15, 10, 0, 0); // exactly 10:00:00
     const next = nextFireTime('*/5 * * * *', now);
     expect(next.getTime()).toBeGreaterThan(now.getTime());
+  });
+
+  it('uses AND logic for leading-wildcard day fields', () => {
+    const after = new Date(2024, 11, 31, 23, 59);
+    expect(nextFireTime('0 0 */2 * 1', after)).toEqual(
+      new Date(2025, 0, 13, 0, 0),
+    );
+    expect(nextFireTime('0 0 15 * */3', after)).toEqual(
+      new Date(2025, 0, 15, 0, 0),
+    );
   });
 });

--- a/packages/core/src/utils/cronParser.ts
+++ b/packages/core/src/utils/cronParser.ts
@@ -12,9 +12,9 @@ interface CronFields {
   dayOfMonth: Set<number>;
   month: Set<number>;
   dayOfWeek: Set<number>;
-  /** True when the day-of-month field was literally '*' (unrestricted). */
+  /** True when the day-of-month field starts with '*' (Vixie wildcard flag). */
   domIsWild: boolean;
-  /** True when the day-of-week field was literally '*' (unrestricted). */
+  /** True when the day-of-week field starts with '*' (Vixie wildcard flag). */
   dowIsWild: boolean;
 }
 
@@ -129,17 +129,16 @@ export function parseCron(cronExpr: string): CronFields {
     dayOfMonth: parseField(parts[2]!, FIELD_RANGES[2]![0], FIELD_RANGES[2]![1]),
     month: parseField(parts[3]!, FIELD_RANGES[3]![0], FIELD_RANGES[3]![1]),
     dayOfWeek,
-    domIsWild: parts[2]!.trim() === '*',
-    dowIsWild: parts[4]!.trim() === '*',
+    domIsWild: parts[2]!.trim().startsWith('*'),
+    dowIsWild: parts[4]!.trim().startsWith('*'),
   };
 }
 
 /**
  * Returns true if the given date matches the cron expression.
  *
- * Follows vixie-cron day semantics: when both day-of-month and day-of-week
- * are constrained (neither is `*`), the date matches if EITHER field matches.
- * When only one is constrained, it must match.
+ * Follows vixie-cron day semantics: when neither day field starts with `*`,
+ * the date matches if EITHER field matches. Otherwise, both must match.
  */
 export function matches(cronExpr: string, date: Date): boolean {
   const fields = parseCron(cronExpr);
@@ -155,8 +154,8 @@ export function matches(cronExpr: string, date: Date): boolean {
   const domMatch = fields.dayOfMonth.has(date.getDate());
   const dowMatch = fields.dayOfWeek.has(date.getDay());
 
-  // Vixie-cron: if both day-of-month and day-of-week are restricted,
-  // match if EITHER is satisfied. Otherwise use AND.
+  // Vixie-cron: if neither day field starts with '*', match if EITHER is
+  // satisfied. Otherwise use AND.
   if (!fields.domIsWild && !fields.dowIsWild) {
     return domMatch || dowMatch;
   }
@@ -186,7 +185,8 @@ export function nextFireTime(cronExpr: string, after: Date): Date {
     const domOk = fields.dayOfMonth.has(candidate.getDate());
     const dowOk = fields.dayOfWeek.has(candidate.getDay());
 
-    // Vixie-cron day semantics: OR when both constrained, AND otherwise
+    // Vixie-cron day semantics: OR when neither field starts with '*',
+    // AND otherwise
     const dayOk =
       !fields.domIsWild && !fields.dowIsWild ? domOk || dowOk : domOk && dowOk;
 


### PR DESCRIPTION
## What this PR does

Aligns day-of-month and day-of-week wildcard detection with Vixie cron's leading-character rule. Expressions such as `*/2` now select AND semantics when paired with the other day field, while expressions such as `1,*` remain restricted and select the OR rule. Regression coverage exercises parsing, direct date matching, and next-fire calculation for both day fields.

## Why it's needed

The scheduler previously considered only a lone `*` to be a wildcard day field. As a result, schedules using `*/N` in one day field and a constraint in the other could fire when only the constrained field matched. This restores the documented Vixie behavior and prevents extra or premature task executions.

## Reviewer Test Plan

### How to verify

1. Starting after `2024-12-31 23:59`, evaluate `0 0 */2 * 1`; the next fire time should be `2025-01-13 00:00`, when both the stepped day-of-month and Monday match, rather than `2025-01-01 00:00`.
2. Starting after the same time, evaluate `0 0 15 * */3`; the next fire time should be `2025-01-15 00:00`, when both the fifteenth day and the stepped day-of-week match.
3. Run `cd packages/core && npx vitest run src/utils/cronParser.test.ts` (31 tests passed), the full core test suite (17,121 tests passed and 9 skipped), `npm run build`, and `npm run typecheck`.

### Evidence (Before & After)

N/A — this is a non-UI scheduler semantics fix; the automated before/after cases are covered by the regression tests above.

### Tested on

|     OS     |      Status       |
| :--------: | :---------------: |
|  🍏 macOS  |     ✅ tested      |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS with Node.js v26.5.0 and the npm workspace toolchain.

## Risk & Scope

- Main risk or tradeoff: Schedules whose day field begins with `*` now intentionally use the documented Vixie AND rule, so their fire dates change from the previous incorrect behavior.
- Not validated / out of scope: Windows and Linux were not tested locally. Repository-wide `npm run preflight` reached the test phase but exited on unrelated CLI dialog/workspace-agent failures and Web Shell `localStorage` failures under Node.js 26; the touched full core suite passed, and the workspace-agent failure passed when rerun in isolation.
- Breaking changes / migration notes: None; this is a compatibility correction for the documented cron semantics.

## Linked Issues

Fixes #7452

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将月中日期和星期日期字段的通配符判断与 Vixie cron 的“首字符”规则对齐。像 `*/2` 这样的表达式与另一个日期字段配合时，现在会选择 AND 语义；像 `1,*` 这样的表达式仍视为受约束字段并选择 OR 语义。回归测试覆盖了两个日期字段的解析、直接日期匹配和下次触发时间计算。

## 为什么需要这个改动

调度器此前只有在日期字段恰好为单独的 `*` 时才将其视为通配字段。因此，当一个日期字段使用 `*/N`、另一个日期字段带约束时，只要受约束字段匹配，任务就可能错误触发。此改动恢复了代码所记录的 Vixie 行为，避免任务额外或过早执行。

## 审阅者测试计划

### 验证方法

1. 从 `2024-12-31 23:59` 之后计算 `0 0 */2 * 1`；下次触发时间应为 `2025-01-13 00:00`，此时步进的月中日期与星期一同时匹配，而不应是 `2025-01-01 00:00`。
2. 从同一时间之后计算 `0 0 15 * */3`；下次触发时间应为 `2025-01-15 00:00`，此时每月十五日与步进的星期日期同时匹配。
3. 运行 `cd packages/core && npx vitest run src/utils/cronParser.test.ts`（31 个测试通过）、完整 core 测试套件（17,121 个测试通过、9 个跳过）、`npm run build` 和 `npm run typecheck`。

### 证据（修改前后）

不适用——这是非 UI 的调度语义修复；自动化回归测试已覆盖上述修改前后用例。

### 测试平台

|     操作系统     |      状态       |
| :--------------: | :-------------: |
|    🍏 macOS      |    ✅ 已测试     |
|   🪟 Windows     | ⚠️ 未在本地测试 |
|    🐧 Linux      | ⚠️ 未在本地测试 |

### 环境（可选）

macOS、Node.js v26.5.0 和 npm workspace 工具链。

## 风险与范围

- 主要风险或权衡：日期字段以 `*` 开头的调度现在会按文档所述使用 Vixie AND 规则，因此其触发日期会从此前的错误行为变为正确行为。
- 未验证 / 不在范围内：未在本地测试 Windows 和 Linux。仓库级 `npm run preflight` 进入测试阶段后，因与本修复无关的 CLI 对话框/workspace-agent 失败以及 Node.js 26 下 Web Shell 的 `localStorage` 失败而退出；本次涉及的完整 core 测试套件已通过，workspace-agent 失败单独重跑也已通过。
- 破坏性变更 / 迁移说明：无；这是针对已记录 cron 语义的兼容性修正。

## 关联 Issue

Fixes #7452

</details>
