### PR TITLE
fix(feishu): await stream cancels in media download teardown

### DIFF
--- a/packages/channels/feishu/src/media.test.ts
+++ b/packages/channels/feishu/src/media.test.ts
@@ -101,8 +101,9 @@ describe('downloadMedia', () => {
     expect(result).toBeNull();
   });
 
-  it('should reject Content-Length exceeding 50MB', async () => {
+  it('should reject Content-Length exceeding 50MB and release the body', async () => {
     const largeSize = 60 * 1024 * 1024; // 60 MB
+    const bodyCancel = vi.fn();
     const mockResponse = {
       ok: true,
       headers: {
@@ -112,6 +113,7 @@ describe('downloadMedia', () => {
         },
       },
       body: {
+        cancel: bodyCancel,
         getReader: () => ({
           read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
           cancel: vi.fn(),
@@ -124,6 +126,9 @@ describe('downloadMedia', () => {
     const result = await downloadMedia('om_msg', 'file_key', 'file', 'token');
 
     expect(result).toBeNull();
+    // The oversized body is cancelled to release the connection instead of
+    // being left dangling until GC.
+    expect(bodyCancel).toHaveBeenCalled();
   });
 
   it('should reject stream exceeding 50MB', async () => {
@@ -149,6 +154,49 @@ describe('downloadMedia', () => {
 
     expect(result).toBeNull();
     expect(cancelMock).toHaveBeenCalled();
+  });
+
+  it('awaits reader.cancel() so a failing stream teardown is caught, not leaked', async () => {
+    const chunkSize = 10 * 1024 * 1024; // 10 MB per read; crosses 50MB on the 6th
+    const mockData = new Uint8Array(chunkSize);
+    // A stream whose cancel() rejects during teardown. Because the fixed code
+    // AWAITS reader.cancel(), this rejection propagates into downloadMedia's
+    // own catch (logging "downloadMedia error: …"). With the previous
+    // un-awaited call the rejection floated free as an unhandled rejection and
+    // the code instead ran the "rejected: actual size exceeds" branch — so
+    // asserting on which branch logged deterministically pins the await.
+    const cancelMock = vi
+      .fn()
+      .mockRejectedValue(new Error('reader teardown failed'));
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: () => null, // no content-length -> exercise the stream-size path
+      },
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockResolvedValue({ done: false, value: mockData }),
+          cancel: cancelMock,
+        }),
+      },
+    };
+
+    fetchSpy.mockResolvedValueOnce(mockResponse as unknown as Response);
+
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    try {
+      const result = await downloadMedia('om_msg', 'file_key', 'file', 'token');
+
+      expect(result).toBeNull();
+      expect(cancelMock).toHaveBeenCalledTimes(1);
+      const logged = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(logged).toContain('downloadMedia error');
+      expect(logged).toContain('reader teardown failed');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it('should return null when response body is null', async () => {

--- a/packages/channels/feishu/src/media.test.ts
+++ b/packages/channels/feishu/src/media.test.ts
@@ -131,6 +131,51 @@ describe('downloadMedia', () => {
     expect(bodyCancel).toHaveBeenCalled();
   });
 
+  it('awaits body.cancel() so a failing Content-Length teardown is caught, not leaked', async () => {
+    const largeSize = 60 * 1024 * 1024; // 60 MB
+    // Mirror of the reader.cancel() test below, for the Content-Length path:
+    // a body whose cancel() rejects (e.g. the connection was already reset).
+    // Because the call is AWAITED, the rejection lands in downloadMedia's own
+    // catch ("downloadMedia error: …") instead of escaping as an unhandled
+    // rejection — asserting on which branch logged pins the await.
+    const bodyCancel = vi
+      .fn()
+      .mockRejectedValue(new Error('body teardown failed'));
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: (key: string) => {
+          if (key === 'content-length') return largeSize.toString();
+          return null;
+        },
+      },
+      body: {
+        cancel: bodyCancel,
+        getReader: () => ({
+          read: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+          cancel: vi.fn(),
+        }),
+      },
+    };
+
+    fetchSpy.mockResolvedValueOnce(mockResponse as unknown as Response);
+
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    try {
+      const result = await downloadMedia('om_msg', 'file_key', 'file', 'token');
+
+      expect(result).toBeNull();
+      expect(bodyCancel).toHaveBeenCalledTimes(1);
+      const logged = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(logged).toContain('downloadMedia error');
+      expect(logged).toContain('body teardown failed');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('should reject stream exceeding 50MB', async () => {
     const chunkSize = 10 * 1024 * 1024; // 10 MB per chunk
     const mockData = new Uint8Array(chunkSize);

--- a/packages/channels/feishu/src/media.ts
+++ b/packages/channels/feishu/src/media.ts
@@ -61,6 +61,9 @@ export async function downloadMedia(
     const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
     const contentLength = resp.headers.get('content-length');
     if (contentLength && parseInt(contentLength, 10) > MAX_DOWNLOAD_BYTES) {
+      // Release the connection instead of letting the unread body pin it
+      // until GC.
+      await resp.body?.cancel();
       process.stderr.write(
         `[Feishu] downloadMedia rejected: size ${contentLength} exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
       );
@@ -82,7 +85,10 @@ export async function downloadMedia(
       if (done) break;
       totalSize += value.byteLength;
       if (totalSize > MAX_DOWNLOAD_BYTES) {
-        reader.cancel();
+        // Await the cancel so a stream error during teardown surfaces here
+        // instead of becoming an unhandled rejection (matches the body.cancel
+        // above).
+        await reader.cancel();
         process.stderr.write(
           `[Feishu] downloadMedia rejected: actual size exceeds ${MAX_DOWNLOAD_BYTES} byte limit\n`,
         );


### PR DESCRIPTION
## What this PR does

Feishu's media downloader left its stream teardown unawaited on both size-reject paths. This awaits them, matching the fix already merged for the sibling DingTalk downloader in #7361. Two small changes in `downloadMedia`: the oversize-stream path now `await`s `reader.cancel()`, and the Content-Length-too-large path now cancels the response body before returning.

## Why it's needed

When a download is rejected for exceeding the 50 MB cap, the stream has to be torn down. On the streamed byte-count path, `reader.cancel()` was called without `await`, so if that cancel rejected during teardown the rejection escaped `downloadMedia` entirely and became an unhandled rejection — fatal under Node's default `--unhandled-rejections=throw`. On the Content-Length path, the function returned without cancelling `resp.body` at all, leaving the connection pinned until GC. The sibling DingTalk downloader had the identical two gaps and fixed them in #7361 (which was itself modelled on this Feishu code, so the streaming logic — and the bug — originated here); this brings Feishu to parity with the merged fix.

## Reviewer Test Plan

### How to verify

- From `packages/channels/feishu`: `npx vitest run src/media.test.ts` → 11/11.
- The new test `awaits reader.cancel() so a failing stream teardown is caught, not leaked` pins the fix: it feeds an oversize stream whose `cancel()` rejects, and asserts the rejection is routed into `downloadMedia`'s own catch (logs `downloadMedia error: …`) instead of escaping. Reverting just the `await` on `reader.cancel()` flips execution onto the `rejected: actual size exceeds` branch and the test fails with `expected '…downloadMedia rejected: actu…' to contain 'downloadMedia error'`.
- The updated Content-Length test additionally asserts the oversized body is cancelled (`bodyCancel` called) — behavior the pre-fix code never performed.

### Evidence (Before & After)

Non–user-visible robustness fix; verified by the deterministic unit tests above.

- Before: `reader.cancel()` (un-awaited) → a cancel error during teardown becomes an unhandled rejection; the Content-Length reject path returns without releasing `resp.body`.
- After: `await reader.cancel()` → a teardown error is caught by `downloadMedia`; `await resp.body?.cancel()` on the Content-Length path releases the connection instead of pinning it until GC.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: the Feishu media suite passes locally (11 tests), with proven fail-before/pass-after by reverting the awaits. The logic is platform-independent and the assertions are deterministic (mocked `fetch`/reader), so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/channel-feishu` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: the change only adds `await` to two already-present stream-cancel calls on the reject paths (plus the body cancel the DingTalk sibling already does). The success path is untouched and every existing Feishu media test still passes.
- Not validated / out of scope: other channels' downloaders — weixin's `media.ts` buffers the whole response via `arrayBuffer()` with no streaming size cap and is a different shape, so it is intentionally not touched here.
- Breaking changes / migration notes: none.

## Linked Issues

Mirrors the sibling DingTalk fix in #7361 (no separate issue to close).

<details>
<summary>中文说明</summary>

## 本 PR 的作用

Feishu 的媒体下载在两条「超限拒绝」路径上都没有 `await` 流的清理（cancel）。本 PR 补上这两个 `await`，与已合并的同级 DingTalk 下载器修复 #7361 保持一致。`downloadMedia` 中的两处小改动：超大流路径现在 `await reader.cancel()`；Content-Length 超限路径在返回前先取消响应体。

## 为什么需要

当下载因超过 50 MB 上限而被拒绝时，需要拆除（tear down）流。在按字节计数的流式路径上，`reader.cancel()` 未被 `await`，因此若该 cancel 在清理期间被 reject，该 rejection 会完全逃出 `downloadMedia`，变成一个未处理的 rejection——在 Node 默认的 `--unhandled-rejections=throw` 下是致命的。在 Content-Length 路径上，函数直接返回、完全没有取消 `resp.body`，使连接一直被占用直到 GC。同级的 DingTalk 下载器有着完全相同的两个缺口，并已在 #7361 中修复（该下载器正是以这份 Feishu 代码为模板，所以流式逻辑——以及这个 bug——最初就源于此）；本 PR 使 Feishu 与已合并的修复对齐。

## 复核测试计划

### 如何验证

- 在 `packages/channels/feishu` 目录下：`npx vitest run src/media.test.ts` → 11/11 通过。
- 新增测试 `awaits reader.cancel() so a failing stream teardown is caught, not leaked` 用于锁定该修复：它构造一个 `cancel()` 会 reject 的超大流，并断言该 rejection 被路由进 `downloadMedia` 自身的 catch（日志出现 `downloadMedia error: …`），而非逃逸。仅还原 `reader.cancel()` 上的 `await`，执行就会走到 `rejected: actual size exceeds` 分支，测试随即失败：`expected '…downloadMedia rejected: actu…' to contain 'downloadMedia error'`。
- 更新后的 Content-Length 测试还断言超大响应体被取消（`bodyCancel` 被调用）——这是修复前代码从未做的。

### 证据（修复前后对比）

非用户可见的健壮性修复；由上述确定性单元测试验证。

- 修复前：`reader.cancel()`（未 await）→ 清理期间的 cancel 错误变成未处理的 rejection；Content-Length 拒绝路径返回时未释放 `resp.body`。
- 修复后：`await reader.cancel()` → 清理错误被 `downloadMedia` 捕获；Content-Length 路径上的 `await resp.body?.cancel()` 释放连接，而非占用到 GC。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：Feishu 媒体测试套件本地通过（11 个测试），并通过还原 await 验证了 fail-before/pass-after。该逻辑与平台无关，断言是确定性的（mock 的 `fetch`/reader），因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/channel-feishu` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：本改动仅为拒绝路径上两处已存在的流取消调用补上 `await`（外加 DingTalk 同级已有的 body 取消）。成功路径不变，所有既有 Feishu 媒体测试仍全部通过。
- 未验证 / 范围之外：其他 channel 的下载器——weixin 的 `media.ts` 通过 `arrayBuffer()` 一次性缓冲整个响应、没有流式大小上限，形态不同，故本 PR 有意不改动它。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

对齐同级 DingTalk 修复 #7361（无需关闭单独的 issue）。

</details>
