### PR TITLE
fix(web-shell): isolate component styles from host CSS

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1,3 +1,4 @@
+import './styles/globals.css';
 import {
   createContext,
   useCallback,
@@ -258,7 +259,6 @@ import {
 } from './customization';
 import type { CommandDisplayCategoryOrder } from './utils/commandDisplay';
 import { WebShellPortalRootContext } from './portalRoot';
-import './styles/globals.css';
 import styles from './App.module.css';
 
 export const CompactModeContext = createContext(false);

--- a/packages/web-shell/client/build-artifact.test.ts
+++ b/packages/web-shell/client/build-artifact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import postcss from 'postcss';
+import postcss, { type Rule } from 'postcss';
 
 const DIST_PATH = resolve(__dirname, '../dist/index.js');
 
@@ -15,6 +15,17 @@ function readInjectedCss(): string {
   );
   if (!match?.[1]) throw new Error('Injected component CSS not found');
   return JSON.parse(match[1]) as string;
+}
+
+function enclosingLayer(rule: Rule): string | undefined {
+  let parent = rule.parent;
+  while (parent) {
+    if (parent.type === 'atrule' && parent.name.toLowerCase() === 'layer') {
+      return parent.params;
+    }
+    parent = parent.parent;
+  }
+  return undefined;
 }
 
 describe('build artifact — package boundary', () => {
@@ -88,7 +99,7 @@ describe('build artifact — package boundary', () => {
     });
 
     expect(themeRules).toContain(
-      ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn])',
+      ':is([data-web-shell-root]:where([data-web-shell-shadcn]), [data-web-shell-portal-root]:where([data-web-shell-shadcn]))',
     );
     expect(themeRules).not.toEqual(
       expect.arrayContaining([
@@ -96,6 +107,75 @@ describe('build artifact — package boundary', () => {
         expect.stringContaining(':host'),
       ]),
     );
+  });
+
+  it('keeps component resets and utilities above plain host selectors', () => {
+    const root = postcss.parse(readInjectedCss());
+    const rules: Rule[] = [];
+    root.walkRules((rule) => rules.push(rule));
+
+    const headingIndex = rules.findIndex(
+      (rule) =>
+        rule.selector.includes(':where(h1,h2,h3,h4,h5,h6)') &&
+        rule.nodes.some(
+          (node) =>
+            node.type === 'decl' &&
+            node.prop === 'font' &&
+            node.value === 'inherit',
+        ),
+    );
+    const formControlIndex = rules.findIndex(
+      (rule) =>
+        rule.selector.includes(
+          ':where(button,input,optgroup,select,textarea)',
+        ) &&
+        rule.nodes.some(
+          (node) =>
+            node.type === 'decl' &&
+            node.prop === 'font' &&
+            node.value === 'inherit',
+        ),
+    );
+    const utilityIndex = rules.findIndex((rule) =>
+      rule.selector.includes('.px-2\\.5'),
+    );
+    const cssModuleIndex = rules.findIndex((rule) =>
+      rule.nodes.some(
+        (node) => node.type === 'decl' && node.prop === '--chat-content-width',
+      ),
+    );
+
+    expect(headingIndex).toBeGreaterThanOrEqual(0);
+    expect(formControlIndex).toBeGreaterThanOrEqual(0);
+    expect(utilityIndex).toBeGreaterThan(headingIndex);
+    expect(utilityIndex).toBeGreaterThan(formControlIndex);
+    expect(cssModuleIndex).toBeGreaterThan(utilityIndex);
+
+    const headingRule = rules[headingIndex]!;
+    const formControlRule = rules[formControlIndex]!;
+    const utilityRule = rules[utilityIndex]!;
+    const cssModuleRule = rules[cssModuleIndex]!;
+
+    expect(enclosingLayer(headingRule)).toBeUndefined();
+    expect(enclosingLayer(formControlRule)).toBeUndefined();
+    expect(enclosingLayer(utilityRule)).toBeUndefined();
+    expect(headingRule.selector).toContain(
+      ':is([data-web-shell-root]:where([data-web-shell-shadcn]),[data-web-shell-portal-root]:where([data-web-shell-shadcn]))',
+    );
+    expect(cssModuleRule.selector).toContain(
+      ':where([data-web-shell-root][data-web-shell-shadcn]',
+    );
+    expect(cssModuleRule.selector).not.toContain(':is([data-web-shell-root]');
+
+    const conflictingLayers: string[] = [];
+    root.walkAtRules('layer', (atRule) => {
+      if (
+        ['theme', 'base', 'components', 'utilities'].includes(atRule.params)
+      ) {
+        conflictingLayers.push(atRule.params);
+      }
+    });
+    expect(conflictingLayers).toEqual([]);
   });
 
   it('prefixes global CSS registrations and animations', () => {

--- a/packages/web-shell/client/components/WebShellTranscript.tsx
+++ b/packages/web-shell/client/components/WebShellTranscript.tsx
@@ -1,3 +1,4 @@
+import '../styles/globals.css';
 import {
   useLayoutEffect,
   useMemo,
@@ -41,7 +42,6 @@ import {
   type WebShellTheme,
 } from '../themeContext';
 import { TranscriptRenderModeProvider } from '../transcriptRenderMode';
-import '../styles/globals.css';
 import styles from '../App.module.css';
 
 const DEFAULT_CHAT_MAX_WIDTH = 1000;

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.test.tsx
@@ -56,8 +56,10 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
 
 const { ScheduledTasksDialog } = await import('./ScheduledTasksDialog');
 const { I18nProvider } = await import('../../i18n');
+const { WebShellPortalRootContext } = await import('../../portalRoot');
 
 let container: HTMLDivElement | null = null;
+let portalRoot: HTMLDivElement | null = null;
 let root: Root | null = null;
 
 async function mount(
@@ -84,18 +86,24 @@ async function mount(
     servers: [],
   });
   container = document.createElement('div');
+  portalRoot = document.createElement('div');
+  portalRoot.setAttribute('data-web-shell-portal-root', '');
+  portalRoot.setAttribute('data-web-shell-shadcn', '');
   document.body.appendChild(container);
+  document.body.appendChild(portalRoot);
   root = createRoot(container);
   await act(async () => {
     root!.render(
-      <I18nProvider language="en">
-        <ScheduledTasksDialog
-          onRunPrompt={opts.onRunPrompt ?? vi.fn()}
-          onCreateViaChat={vi.fn()}
-          onOpenSession={opts.onOpenSession}
-          onError={opts.onError ?? vi.fn()}
-        />
-      </I18nProvider>,
+      <WebShellPortalRootContext.Provider value={portalRoot}>
+        <I18nProvider language="en">
+          <ScheduledTasksDialog
+            onRunPrompt={opts.onRunPrompt ?? vi.fn()}
+            onCreateViaChat={vi.fn()}
+            onOpenSession={opts.onOpenSession}
+            onError={opts.onError ?? vi.fn()}
+          />
+        </I18nProvider>
+      </WebShellPortalRootContext.Provider>,
     );
   });
   await flush();
@@ -160,8 +168,10 @@ function dispatchClipboardEvent(
 afterEach(() => {
   act(() => root?.unmount());
   container?.remove();
+  portalRoot?.remove();
   root = null;
   container = null;
+  portalRoot = null;
   vi.clearAllMocks();
 });
 
@@ -516,6 +526,29 @@ describe('ScheduledTasksDialog editing', () => {
     await flush();
     expect(findButtonContaining('review')).toBeTruthy();
     expect(findButtonContaining('alibabacloud-compute-suite')).toBeUndefined();
+  });
+
+  it('renders the reference picker inside the Web Shell portal root', async () => {
+    await mount([]);
+    actions.loadSkillsStatus.mockResolvedValue({
+      skills: [
+        {
+          kind: 'skill',
+          name: 'review',
+          description: 'Review code',
+          level: 'project',
+          modelInvocable: true,
+        },
+      ],
+    });
+
+    click(findButton('New scheduled task'));
+    click(findButtonContaining('Skills'));
+    await flush();
+
+    const picker = document.querySelector('[role="listbox"]');
+    expect(picker).not.toBeNull();
+    expect(portalRoot?.contains(picker)).toBe(true);
   });
 
   it('drops plain text only into the prompt editor', async () => {

--- a/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ScheduledTasksDialog.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@qwen-code/sdk/daemon';
 import { sanitizeDisplayText } from '../../hooks/useAtMentionMenu';
 import { useI18n } from '../../i18n';
+import { useWebShellPortalRoot } from '../../portalRoot';
 import { getComposerTagIconUrl } from '../../utils/composerTag';
 import { cssUrlValue } from '../../utils/cssUrlVar';
 import { workspaceLabel, workspaceLabelForCwd } from '../../utils/workspace';
@@ -532,6 +533,7 @@ export function ScheduledTasksDialog({
 }: ScheduledTasksDialogProps) {
   const { t } = useI18n();
   const actions = useWorkspaceActions();
+  const portalRoot = useWebShellPortalRoot();
 
   // Multi-workspace aggregation. `workspaces` mirrors the daemon capabilities;
   // with more than one the page lists every trusted workspace's tasks together
@@ -1157,7 +1159,7 @@ export function ScheduledTasksDialog({
               ))
             )}
           </div>,
-          document.body,
+          portalRoot ?? document.body,
         )
       : null;
 

--- a/packages/web-shell/client/styles/globals.css
+++ b/packages/web-shell/client/styles/globals.css
@@ -1,7 +1,6 @@
-@layer theme, base, components, utilities;
-
-@import 'tailwindcss/theme.css' layer(theme);
-@import 'tailwindcss/utilities.css' layer(utilities);
+@import './preflight.css';
+@import 'tailwindcss/theme.css';
+@import 'tailwindcss/utilities.css';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 
@@ -32,9 +31,9 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
-:where(
-  [data-web-shell-root][data-web-shell-shadcn],
-  [data-web-shell-portal-root][data-web-shell-shadcn]
+:is(
+  [data-web-shell-root]:where([data-web-shell-shadcn]),
+  [data-web-shell-portal-root]:where([data-web-shell-shadcn])
 ) {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -61,9 +60,9 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
-:where(
-  [data-web-shell-root][data-web-shell-shadcn],
-  [data-web-shell-portal-root][data-web-shell-shadcn]
+:is(
+  [data-web-shell-root]:where([data-web-shell-shadcn]),
+  [data-web-shell-portal-root]:where([data-web-shell-shadcn])
 ).dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
@@ -83,141 +82,4 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-}
-
-@layer base {
-  :where(
-    [data-web-shell-root][data-web-shell-shadcn],
-    [data-web-shell-portal-root][data-web-shell-shadcn]
-  ),
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    *,
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    ::before,
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    ::after,
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    ::backdrop,
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    ::file-selector-button {
-    box-sizing: border-box;
-    border: 0 solid;
-    border-color: var(--border);
-    outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
-  }
-
-  :where(
-    [data-web-shell-root][data-web-shell-shadcn],
-    [data-web-shell-portal-root][data-web-shell-shadcn]
-  ) {
-    -webkit-text-size-adjust: 100%;
-    tab-size: 4;
-    font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
-    line-height: 1.5;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(h1, h2, h3, h4, h5, h6, p, blockquote, figure, dl, dd) {
-    margin: 0;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(ol, ul, menu) {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(button, input, optgroup, select, textarea) {
-    margin: 0;
-    padding: 0;
-    background-color: transparent;
-    color: inherit;
-    font: inherit;
-    font-feature-settings: inherit;
-    font-variation-settings: inherit;
-    letter-spacing: inherit;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    ::file-selector-button {
-    margin: 0;
-    padding: 0;
-    background-color: transparent;
-    color: inherit;
-    font: inherit;
-    font-feature-settings: inherit;
-    font-variation-settings: inherit;
-    letter-spacing: inherit;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(button, select) {
-    text-transform: none;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(button, [type='button'], [type='reset'], [type='submit']) {
-    appearance: button;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(img, svg, video, canvas, audio, iframe, embed, object) {
-    display: block;
-    vertical-align: middle;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    :is(img, video) {
-    max-width: 100%;
-    height: auto;
-  }
-
-  :where(
-      [data-web-shell-root][data-web-shell-shadcn],
-      [data-web-shell-portal-root][data-web-shell-shadcn]
-    )
-    [hidden] {
-    display: none !important;
-  }
 }

--- a/packages/web-shell/client/styles/preflight.css
+++ b/packages/web-shell/client/styles/preflight.css
@@ -1,0 +1,151 @@
+:is(
+  [data-web-shell-root]:where([data-web-shell-shadcn]),
+  [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+),
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  *,
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  ::before,
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  ::after,
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  ::backdrop,
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  ::file-selector-button {
+  box-sizing: border-box;
+  border: 0 solid;
+  border-color: var(--border);
+  outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
+}
+
+:is(
+  [data-web-shell-root]:where([data-web-shell-shadcn]),
+  [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+) {
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+  color: var(--foreground);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: normal;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, dl, dd) {
+  margin: 0;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(h1, h2, h3, h4, h5, h6) {
+  padding: 0;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-align: inherit;
+  text-transform: inherit;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(ol, ul, menu) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(button, input, optgroup, select, textarea) {
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  letter-spacing: inherit;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  ::file-selector-button {
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  letter-spacing: inherit;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(button, select) {
+  text-transform: none;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+  appearance: button;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+  display: block;
+  vertical-align: middle;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  :where(img, video) {
+  max-width: 100%;
+  height: auto;
+}
+
+:is(
+    [data-web-shell-root]:where([data-web-shell-shadcn]),
+    [data-web-shell-portal-root]:where([data-web-shell-shadcn])
+  )
+  [hidden] {
+  display: none !important;
+}

--- a/packages/web-shell/vite.lib.config.ts
+++ b/packages/web-shell/vite.lib.config.ts
@@ -9,7 +9,7 @@ import pkg from './package.json' with { type: 'json' };
 const COMPONENT_SCOPE =
   ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn], [data-web-shell-root][data-web-shell-shadcn] *, [data-web-shell-portal-root][data-web-shell-shadcn] *)';
 const COMPONENT_ROOT_SCOPE =
-  ':where([data-web-shell-root][data-web-shell-shadcn], [data-web-shell-portal-root][data-web-shell-shadcn])';
+  ':is([data-web-shell-root]:where([data-web-shell-shadcn]), [data-web-shell-portal-root]:where([data-web-shell-shadcn]))';
 
 function scopeComponentCss(css: string): string {
   const root = postcss.parse(css);


### PR DESCRIPTION
## What this PR does

This change gives Web Shell-owned UI a scoped baseline with enough specificity to beat ordinary host-page element and universal selectors, while keeping existing CSS Module scoping low-specificity for consumer customization. It also keeps Tailwind utilities out of cascade layers that would otherwise lose to unlayered host CSS and routes the scheduled-task reference picker through the shared Web Shell portal root.

## Why it's needed

When Web Shell is embedded as a component, host rules such as `* { padding: 0 }`, `h2 { ... }`, and `button { ... }` can override Tailwind/shadcn styles even when the component CSS is loaded correctly. This makes Web Shell-owned controls and portal content visually inconsistent with the standalone application.

## Reviewer Test Plan

### How to verify

- Embed the production Web Shell library in a host page, then load ordinary unlayered `*`, `h2`, and `button` rules after the component stylesheet. Confirm representative buttons and headings retain the same padding, margin, box sizing, typography, colors, background, and border radius in both the main root and dialog portal root.
- Open the scheduled-task editor and its skill reference picker. Confirm the picker remains visually styled and is mounted beneath the marked Web Shell portal root.
- Confirm host `!important` rules and higher-specificity class/id rules remain outside the isolation guarantee.

### Evidence (Before & After)

Before: ordinary host universal and element selectors changed computed styles for Web Shell buttons and headings because layered Tailwind rules lost to unlayered host CSS.

After: adding the same hostile host rules after the production component CSS produced no computed-style differences for representative root and portal buttons/headings across padding, margin, box sizing, typography, colors, background, border radius, line height, and height.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Production library build in Chromium, plus focused Vitest coverage for the generated CSS artifact and scheduled-task portal placement.

## Risk & Scope

- Main risk or tradeoff: unlayering Tailwind utilities changes their cascade relationship with host CSS, so the generated artifact locks in reset, utility, and CSS Module ordering.
- Not validated / out of scope: host `!important` declarations, higher-specificity class/id selectors, and arbitrary properties Web Shell does not declare.
- Breaking changes / migration notes: none; component consumers do not need to change props, render callbacks, Tailwind configuration, or stylesheet imports.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本次改动为 Web Shell 自有 UI 增加了带作用域且权重足以压过宿主普通元素选择器和通配选择器的基础样式，同时保持现有 CSS Modules 的低权重作用域，避免影响接入方定制。它还让 Tailwind utilities 不再处于会输给宿主未分层 CSS 的 cascade layer 中，并将定时任务引用选择器统一挂载到 Web Shell 的共享 portal root。

## 为什么需要

当 Web Shell 作为组件嵌入其他页面时，宿主的 `* { padding: 0 }`、`h2 { ... }`、`button { ... }` 等规则可能覆盖 Tailwind/shadcn 样式，即使组件 CSS 已正确加载。结果是 Web Shell 自有控件和 portal 内容的视觉表现与独立应用不一致。

## Reviewer Test Plan

### 如何验证

- 在宿主页面中引入生产版 Web Shell 组件，并在组件样式之后加载普通未分层的 `*`、`h2` 和 `button` 规则。确认主 root 和 dialog portal root 中的代表性按钮、标题在 padding、margin、box sizing、字体、颜色、背景和圆角方面保持不变。
- 打开定时任务编辑器及其技能引用选择器。确认选择器样式正常，并挂载在带标记的 Web Shell portal root 下。
- 确认宿主 `!important` 规则和更高权重的 class/id 规则仍不在本次隔离保证范围内。

### 证据（修改前后）

修改前：由于分层的 Tailwind 规则会输给宿主未分层 CSS，普通宿主通配选择器和元素选择器会改变 Web Shell 按钮和标题的计算样式。

修改后：在生产组件 CSS 之后添加同样的宿主冲突规则，主 root 和 portal 中代表性按钮、标题的计算样式均无差异；核对属性包括 padding、margin、box sizing、字体、颜色、背景、圆角、行高和高度。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

在 Chromium 中验证生产 library build，并使用定向 Vitest 覆盖生成 CSS 产物和定时任务 portal 挂载位置。

## 风险与范围

- 主要风险或取舍：取消 Tailwind utilities 的 layer 会改变其与宿主 CSS 的级联关系，因此生成产物测试固定了 reset、utilities 和 CSS Modules 的顺序。
- 未验证/不在范围内：宿主 `!important` 声明、更高权重的 class/id 选择器，以及 Web Shell 自身未声明的任意属性。
- 破坏性变更/迁移说明：无；组件接入方无需修改 props、render 回调、Tailwind 配置或样式引入方式。

## 关联 Issue

N/A

</details>
