### PR TITLE
fix(core): record auto-memory index reads in FileReadCache

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import type { ConfigParameters, SandboxConfig } from './config.js';
 import {
   Config,
@@ -65,8 +65,8 @@ import {
 import { loadServerHierarchicalMemory } from '../utils/memoryDiscovery.js';
 import type { LoadServerHierarchicalMemoryOptions } from '../utils/memoryDiscovery.js';
 import {
-  readAutoMemoryIndex,
-  readUserAutoMemoryIndex,
+  readAutoMemoryIndexWithStats,
+  readUserAutoMemoryIndexWithStats,
 } from '../memory/store.js';
 import {
   clearAutoMemoryRootCache,
@@ -92,6 +92,7 @@ import {
 } from '../services/session-writer-lease.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import { checkPriorRead } from '../tools/priorReadEnforcement.js';
+import { ToolErrorType } from '../tools/tool-error.js';
 
 function createToolMock(toolName: string) {
   const ToolMock = vi.fn();
@@ -179,8 +180,8 @@ vi.mock('../utils/memoryDiscovery.js', () => ({
 }));
 
 vi.mock('../memory/store.js', () => ({
-  readAutoMemoryIndex: vi.fn().mockResolvedValue(null),
-  readUserAutoMemoryIndex: vi.fn().mockResolvedValue(null),
+  readAutoMemoryIndexWithStats: vi.fn().mockResolvedValue(null),
+  readUserAutoMemoryIndexWithStats: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('../memory/indexer.js', async (importActual) => ({
   // Keep the real exports (notably TeamMemoryRootSecurityError, which the sync
@@ -366,6 +367,19 @@ const MEMORY_PRESSURE_ENV_KEYS = [
   'QWEN_MEMORY_PRESSURE_CRITICAL',
 ];
 
+let mockAutoMemoryInode = 1;
+function mockAutoMemoryIndexRead(content: string) {
+  return {
+    content,
+    stats: {
+      dev: 1,
+      ino: mockAutoMemoryInode++,
+      mtimeMs: 1,
+      size: Buffer.byteLength(content),
+    } as fs.Stats,
+  };
+}
+
 vi.mock('../core/baseLlmClient.js');
 // Mock fireNotificationHook from toolHookTriggers
 vi.mock('../core/toolHookTriggers.js', () => ({
@@ -493,6 +507,7 @@ describe('Server Config (config.ts)', () => {
   beforeEach(() => {
     // Reset mocks if necessary
     vi.clearAllMocks();
+    mockAutoMemoryInode = 1;
     for (const envName of MEMORY_PRESSURE_ENV_KEYS) {
       delete process.env[envName];
     }
@@ -3908,8 +3923,10 @@ describe('Server Config (config.ts)', () => {
       conditionalRules: [],
       projectRoot: '/tmp',
     });
-    vi.mocked(readAutoMemoryIndex).mockResolvedValue(
-      '# Managed Auto-Memory Index\n\n- [Project Memory](project.md)',
+    vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValue(
+      mockAutoMemoryIndexRead(
+        '# Managed Auto-Memory Index\n\n- [Project Memory](project.md)',
+      ),
     );
 
     await config.refreshHierarchicalMemory();
@@ -3951,12 +3968,14 @@ describe('Server Config (config.ts)', () => {
         conditionalRules: [],
         projectRoot,
       });
-      vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(
-        '# managed memory\n',
-      );
-      vi.mocked(readUserAutoMemoryIndex).mockResolvedValueOnce(
-        '# user memory\n',
-      );
+      vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValueOnce({
+        content: '# managed memory\n',
+        stats: await stat(managedIndexPath),
+      });
+      vi.mocked(readUserAutoMemoryIndexWithStats).mockResolvedValueOnce({
+        content: '# user memory\n',
+        stats: await stat(userIndexPath),
+      });
 
       await config.refreshHierarchicalMemory();
 
@@ -3970,6 +3989,71 @@ describe('Server Config (config.ts)', () => {
       await expect(
         checkPriorRead(config.getFileReadCache(), userIndexPath, 'overwriting'),
       ).resolves.toEqual({ ok: true });
+    } finally {
+      if (originalMemoryBaseDir === undefined) {
+        delete process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+      } else {
+        process.env['QWEN_CODE_MEMORY_BASE_DIR'] = originalMemoryBaseDir;
+      }
+      clearAutoMemoryRootCache();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshHierarchicalMemory records the stats captured with the auto-memory index read', async () => {
+    const originalMemoryBaseDir = process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+    const tempDir = await mkdtemp(
+      path.join(os.tmpdir(), 'auto-memory-cache-race-'),
+    );
+    const projectRoot = path.join(tempDir, 'project');
+    const memoryBaseDir = path.join(tempDir, 'memory-base');
+
+    await mkdir(projectRoot, { recursive: true });
+    process.env['QWEN_CODE_MEMORY_BASE_DIR'] = memoryBaseDir;
+    clearAutoMemoryRootCache();
+
+    const managedIndexPath = getAutoMemoryIndexPath(projectRoot);
+
+    await mkdir(path.dirname(managedIndexPath), { recursive: true });
+    await writeFile(managedIndexPath, '# old managed memory\n', 'utf-8');
+    const oldStats = await stat(managedIndexPath);
+    await writeFile(
+      managedIndexPath,
+      '# newer managed memory with extra bytes\n',
+      'utf-8',
+    );
+
+    try {
+      const config = new Config({
+        ...baseParams,
+        cwd: projectRoot,
+        targetDir: projectRoot,
+      });
+
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValueOnce({
+        memoryContent: '--- Context from: QWEN.md ---\nProject rules',
+        fileCount: 1,
+        ruleCount: 0,
+        conditionalRules: [],
+        projectRoot,
+      });
+      vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValueOnce({
+        content: '# old managed memory\n',
+        stats: oldStats,
+      });
+
+      await config.refreshHierarchicalMemory();
+
+      await expect(
+        checkPriorRead(
+          config.getFileReadCache(),
+          managedIndexPath,
+          'overwriting',
+        ),
+      ).resolves.toMatchObject({
+        ok: false,
+        type: ToolErrorType.FILE_CHANGED_SINCE_READ,
+      });
     } finally {
       if (originalMemoryBaseDir === undefined) {
         delete process.env['QWEN_CODE_MEMORY_BASE_DIR'];
@@ -4168,8 +4252,10 @@ describe('Server Config (config.ts)', () => {
       conditionalRules: [],
       projectRoot: '/tmp',
     });
-    vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(
-      '# Managed Auto-Memory Index\n\n' + 'remember this '.repeat(80),
+    vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValueOnce(
+      mockAutoMemoryIndexRead(
+        '# Managed Auto-Memory Index\n\n' + 'remember this '.repeat(80),
+      ),
     );
 
     await config.refreshHierarchicalMemory();
@@ -4247,7 +4333,7 @@ describe('Server Config (config.ts)', () => {
       conditionalRules: [],
       projectRoot: '/tmp',
     });
-    vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(null);
+    vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValueOnce(null);
 
     await config.refreshHierarchicalMemory();
 
@@ -4680,7 +4766,7 @@ describe('Server Config (config.ts)', () => {
       conditionalRules: [],
       projectRoot: '/tmp',
     });
-    vi.mocked(readAutoMemoryIndex).mockResolvedValue(null);
+    vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValue(null);
 
     await config.refreshHierarchicalMemory();
 
@@ -4702,13 +4788,13 @@ describe('Server Config (config.ts)', () => {
       conditionalRules: [],
       projectRoot: '/tmp',
     });
-    vi.mocked(readAutoMemoryIndex).mockResolvedValue(null);
+    vi.mocked(readAutoMemoryIndexWithStats).mockResolvedValue(null);
 
     await config.refreshHierarchicalMemory();
 
     expect(config.getUserMemory()).toContain('Project rules');
     expect(config.getUserMemory()).not.toContain('# auto memory');
-    expect(readAutoMemoryIndex).not.toHaveBeenCalled();
+    expect(readAutoMemoryIndexWithStats).not.toHaveBeenCalled();
   });
 
   it('refreshHierarchicalMemory should only use explicit inputs in bare mode', async () => {
@@ -4730,7 +4816,7 @@ describe('Server Config (config.ts)', () => {
     const lastCall = vi.mocked(loadServerHierarchicalMemory).mock.calls.at(-1);
     expect(lastCall?.at(-1)).toMatchObject({ explicitOnly: true });
     expect(lastCall?.[1]).toEqual([]);
-    expect(readAutoMemoryIndex).not.toHaveBeenCalled();
+    expect(readAutoMemoryIndexWithStats).not.toHaveBeenCalled();
     expect(config.getUserMemory()).toContain('Project rules');
     expect(config.getUserMemory()).not.toContain('# auto memory');
   });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import type { ConfigParameters, SandboxConfig } from './config.js';
 import {
   Config,
@@ -64,7 +64,15 @@ import {
 } from '../confirmation-bus/types.js';
 import { loadServerHierarchicalMemory } from '../utils/memoryDiscovery.js';
 import type { LoadServerHierarchicalMemoryOptions } from '../utils/memoryDiscovery.js';
-import { readAutoMemoryIndex } from '../memory/store.js';
+import {
+  readAutoMemoryIndex,
+  readUserAutoMemoryIndex,
+} from '../memory/store.js';
+import {
+  clearAutoMemoryRootCache,
+  getAutoMemoryIndexPath,
+  getUserAutoMemoryIndexPath,
+} from '../memory/paths.js';
 import {
   rebuildTeamAutoMemoryIndex,
   TeamMemoryRootSecurityError,
@@ -83,6 +91,7 @@ import {
   SessionWriterLease,
 } from '../services/session-writer-lease.js';
 import * as jsonl from '../utils/jsonl-utils.js';
+import { checkPriorRead } from '../tools/priorReadEnforcement.js';
 
 function createToolMock(toolName: string) {
   const ToolMock = vi.fn();
@@ -3908,6 +3917,68 @@ describe('Server Config (config.ts)', () => {
     expect(config.getUserMemory()).toContain('Project rules');
     expect(config.getUserMemory()).toContain('# auto memory');
     expect(config.getUserMemory()).toContain('[Project Memory](project.md)');
+  });
+
+  it('refreshHierarchicalMemory seeds the FileReadCache for project and user MEMORY.md indexes', async () => {
+    const originalMemoryBaseDir = process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'auto-memory-cache-'));
+    const projectRoot = path.join(tempDir, 'project');
+    const memoryBaseDir = path.join(tempDir, 'memory-base');
+
+    await mkdir(projectRoot, { recursive: true });
+    process.env['QWEN_CODE_MEMORY_BASE_DIR'] = memoryBaseDir;
+    clearAutoMemoryRootCache();
+
+    const managedIndexPath = getAutoMemoryIndexPath(projectRoot);
+    const userIndexPath = getUserAutoMemoryIndexPath();
+
+    await mkdir(path.dirname(managedIndexPath), { recursive: true });
+    await mkdir(path.dirname(userIndexPath), { recursive: true });
+    await writeFile(managedIndexPath, '# managed memory\n', 'utf-8');
+    await writeFile(userIndexPath, '# user memory\n', 'utf-8');
+
+    try {
+      const config = new Config({
+        ...baseParams,
+        cwd: projectRoot,
+        targetDir: projectRoot,
+      });
+
+      vi.mocked(loadServerHierarchicalMemory).mockResolvedValueOnce({
+        memoryContent: '--- Context from: QWEN.md ---\nProject rules',
+        fileCount: 1,
+        ruleCount: 0,
+        conditionalRules: [],
+        projectRoot,
+      });
+      vi.mocked(readAutoMemoryIndex).mockResolvedValueOnce(
+        '# managed memory\n',
+      );
+      vi.mocked(readUserAutoMemoryIndex).mockResolvedValueOnce(
+        '# user memory\n',
+      );
+
+      await config.refreshHierarchicalMemory();
+
+      await expect(
+        checkPriorRead(
+          config.getFileReadCache(),
+          managedIndexPath,
+          'overwriting',
+        ),
+      ).resolves.toEqual({ ok: true });
+      await expect(
+        checkPriorRead(config.getFileReadCache(), userIndexPath, 'overwriting'),
+      ).resolves.toEqual({ ok: true });
+    } finally {
+      if (originalMemoryBaseDir === undefined) {
+        delete process.env['QWEN_CODE_MEMORY_BASE_DIR'];
+      } else {
+        process.env['QWEN_CODE_MEMORY_BASE_DIR'] = originalMemoryBaseDir;
+      }
+      clearAutoMemoryRootCache();
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('refreshHierarchicalMemory should not load team memory from untrusted workspaces', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -212,7 +212,9 @@ import {
 } from '../utils/debugLogger.js';
 import {
   getAutoMemoryRoot,
+  getAutoMemoryIndexPath,
   getTeamAutoMemoryRoot,
+  getUserAutoMemoryIndexPath,
   getUserAutoMemoryRoot,
 } from '../memory/paths.js';
 import {
@@ -3149,6 +3151,16 @@ export class Config {
         readAutoMemoryIndex(this.getProjectRoot()),
         readUserAutoMemoryIndex().catch(() => null),
       ]);
+      await Promise.all([
+        this.recordAutoMemoryIndexRead(
+          getAutoMemoryIndexPath(this.getProjectRoot()),
+          managedAutoMemoryIndex,
+        ),
+        this.recordAutoMemoryIndexRead(
+          getUserAutoMemoryIndexPath(),
+          userAutoMemoryIndex,
+        ),
+      ]);
       // Always surface the user-level section so the main assistant knows the
       // dir exists and can route ad-hoc "remember this cross-project" saves
       // there. When empty the prompt builder emits a "MEMORY.md is currently
@@ -3179,6 +3191,28 @@ export class Config {
       conditionalRules,
       projectRoot,
     );
+  }
+
+  private async recordAutoMemoryIndexRead(
+    indexPath: string,
+    indexContent: string | null,
+  ): Promise<void> {
+    if (indexContent === null || this.getFileReadCacheDisabled()) {
+      return;
+    }
+
+    try {
+      const stats = await fsPromises.stat(indexPath);
+      this.getFileReadCache().recordRead(indexPath, stats, {
+        full: true,
+        cacheable: true,
+      });
+    } catch (error) {
+      this.debugLogger.warn(
+        `Failed to seed FileReadCache for auto-memory index ${indexPath}`,
+        error,
+      );
+    }
   }
 
   private buildMemoryContextWarning(memoryContent: string): string | undefined {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -218,8 +218,9 @@ import {
   getUserAutoMemoryRoot,
 } from '../memory/paths.js';
 import {
-  readAutoMemoryIndex,
-  readUserAutoMemoryIndex,
+  type AutoMemoryIndexRead,
+  readAutoMemoryIndexWithStats,
+  readUserAutoMemoryIndexWithStats,
 } from '../memory/store.js';
 import {
   rebuildTeamAutoMemoryIndex,
@@ -3147,20 +3148,22 @@ export class Config {
           }
         }
       }
-      const [managedAutoMemoryIndex, userAutoMemoryIndex] = await Promise.all([
-        readAutoMemoryIndex(this.getProjectRoot()),
-        readUserAutoMemoryIndex().catch(() => null),
-      ]);
-      await Promise.all([
-        this.recordAutoMemoryIndexRead(
-          getAutoMemoryIndexPath(this.getProjectRoot()),
-          managedAutoMemoryIndex,
-        ),
-        this.recordAutoMemoryIndexRead(
-          getUserAutoMemoryIndexPath(),
-          userAutoMemoryIndex,
-        ),
-      ]);
+      const [managedAutoMemoryIndexRead, userAutoMemoryIndexRead] =
+        await Promise.all([
+          readAutoMemoryIndexWithStats(this.getProjectRoot()),
+          readUserAutoMemoryIndexWithStats().catch(() => null),
+        ]);
+      this.recordAutoMemoryIndexRead(
+        getAutoMemoryIndexPath(this.getProjectRoot()),
+        managedAutoMemoryIndexRead,
+      );
+      this.recordAutoMemoryIndexRead(
+        getUserAutoMemoryIndexPath(),
+        userAutoMemoryIndexRead,
+      );
+      const managedAutoMemoryIndex =
+        managedAutoMemoryIndexRead?.content ?? null;
+      const userAutoMemoryIndex = userAutoMemoryIndexRead?.content ?? null;
       // Always surface the user-level section so the main assistant knows the
       // dir exists and can route ad-hoc "remember this cross-project" saves
       // there. When empty the prompt builder emits a "MEMORY.md is currently
@@ -3193,26 +3196,18 @@ export class Config {
     );
   }
 
-  private async recordAutoMemoryIndexRead(
+  private recordAutoMemoryIndexRead(
     indexPath: string,
-    indexContent: string | null,
-  ): Promise<void> {
-    if (indexContent === null || this.getFileReadCacheDisabled()) {
+    indexRead: AutoMemoryIndexRead | null,
+  ): void {
+    if (indexRead === null || this.getFileReadCacheDisabled()) {
       return;
     }
 
-    try {
-      const stats = await fsPromises.stat(indexPath);
-      this.getFileReadCache().recordRead(indexPath, stats, {
-        full: true,
-        cacheable: true,
-      });
-    } catch (error) {
-      this.debugLogger.warn(
-        `Failed to seed FileReadCache for auto-memory index ${indexPath}`,
-        error,
-      );
-    }
+    this.getFileReadCache().recordRead(indexPath, indexRead.stats, {
+      full: true,
+      cacheable: true,
+    });
   }
 
   private buildMemoryContextWarning(memoryContent: string): string | undefined {

--- a/packages/core/src/memory/store.test.ts
+++ b/packages/core/src/memory/store.test.ts
@@ -22,6 +22,7 @@ import {
   createDefaultAutoMemoryMetadata,
   ensureAutoMemoryScaffold,
   readAutoMemoryIndex,
+  readAutoMemoryIndexWithStats,
 } from './store.js';
 import { Storage } from '../config/storage.js';
 import { sanitizeCwd } from '../utils/paths.js';
@@ -291,5 +292,25 @@ describe('auto-memory storage scaffold', () => {
   it('reads the managed auto-memory index after scaffold creation', async () => {
     await ensureAutoMemoryScaffold(projectRoot);
     await expect(readAutoMemoryIndex(projectRoot)).resolves.toBe('');
+  });
+
+  it('returns content and stats for an existing auto-memory index', async () => {
+    await ensureAutoMemoryScaffold(projectRoot);
+    const indexContent = '# Existing Index\n\n- keep me\n';
+    await fs.writeFile(
+      getAutoMemoryIndexPath(projectRoot),
+      indexContent,
+      'utf-8',
+    );
+
+    const result = await readAutoMemoryIndexWithStats(projectRoot);
+
+    expect(result?.content).toBe(indexContent);
+    expect(result?.stats.size).toBe(Buffer.byteLength(indexContent));
+    expect(result?.stats.mtimeMs).toBeGreaterThan(0);
+  });
+
+  it('returns null when reading auto-memory index with stats before creation', async () => {
+    await expect(readAutoMemoryIndexWithStats(projectRoot)).resolves.toBeNull();
   });
 });

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs/promises';
+import type { Stats } from 'node:fs';
 import {
   AUTO_MEMORY_INDEX_FILENAME,
   getAutoMemoryExtractCursorPath,
@@ -41,6 +42,11 @@ export function createDefaultAutoMemoryExtractCursor(
 
 export function createDefaultAutoMemoryIndex(): string {
   return '';
+}
+
+export interface AutoMemoryIndexRead {
+  content: string;
+  stats: Stats;
 }
 
 async function writeFileIfMissing(
@@ -95,6 +101,28 @@ export async function readAutoMemoryIndex(
   }
 }
 
+async function readMemoryIndexWithStats(
+  indexPath: string,
+): Promise<AutoMemoryIndexRead | null> {
+  try {
+    const stats = await fs.stat(indexPath);
+    const content = await fs.readFile(indexPath, 'utf-8');
+    return { content, stats };
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function readAutoMemoryIndexWithStats(
+  projectRoot: string,
+): Promise<AutoMemoryIndexRead | null> {
+  return readMemoryIndexWithStats(getAutoMemoryIndexPath(projectRoot));
+}
+
 /**
  * Ensure the user-level (cross-project) auto-memory dir + empty index exist.
  * Unlike the per-project scaffold, this does NOT seed meta.json or
@@ -118,6 +146,10 @@ export async function readUserAutoMemoryIndex(): Promise<string | null> {
     }
     throw error;
   }
+}
+
+export async function readUserAutoMemoryIndexWithStats(): Promise<AutoMemoryIndexRead | null> {
+  return readMemoryIndexWithStats(getUserAutoMemoryIndexPath());
 }
 
 export { AUTO_MEMORY_INDEX_FILENAME };


### PR DESCRIPTION
## What this PR does

Registers project-level and user-level auto-memory `MEMORY.md` reads in the session `FileReadCache` when those indexes are loaded into the system prompt.

## Why it's needed

The model already sees these index files through the auto-memory prompt, but the prior-read guard did not know that. As a result, the first `write_file` update to `MEMORY.md` in a fresh session was rejected until the model spent an extra `read_file` round-trip.

## Reviewer Test Plan

### How to verify

Run `npm test --workspace=@qwen-code/qwen-code-core -- src/config/config.test.ts`. The regression test creates project-level and user-level `MEMORY.md` files, refreshes hierarchical memory, and verifies that `checkPriorRead()` allows overwriting both index files without an explicit `read_file` call.

The test also uses a temporary memory base directory and restores the environment after completion, so it does not touch a real user memory directory.

### Evidence (Before & After)

N/A — non-user-visible core behavior and regression test change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local npm workspace on Windows. `config.test.ts` passed with 419 tests. Changed files also passed ESLint and Prettier checks.

## Risk & Scope

- Main risk or tradeoff: if the file disappears or `stat` fails after the prompt-loading read, the cache entry is not seeded and the existing prior-read protection remains in effect; the refresh itself continues without failing.
- Not validated / out of scope: `QWEN.md`, `AGENTS.md`, team-memory indexes, and broader system-prompt file tracking.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7287

<details>
<summary>中文说明</summary>

## What this PR does

当项目级和用户级自动记忆 `MEMORY.md` 被加载到 system prompt 时，将这两次读取登记到当前 session 的 `FileReadCache` 中。

## Why it's needed

模型实际上已经通过 auto-memory prompt 看到了这些索引文件，但 prior-read guard 并不知道这次读取。因此，在全新 session 中第一次使用 `write_file` 更新 `MEMORY.md` 时，必须额外调用一次 `read_file`，否则写入会被拒绝。

## Reviewer Test Plan

### How to verify

运行 `npm test --workspace=@qwen-code/qwen-code-core -- src/config/config.test.ts`。回归测试会创建项目级和用户级 `MEMORY.md`，刷新 hierarchical memory，并验证 `checkPriorRead()` 可以在没有显式调用 `read_file` 的情况下允许覆盖这两个索引文件。

测试使用临时 memory base directory，并在结束后恢复环境变量，不会修改真实用户 memory 目录。

### Evidence (Before & After)

不适用：这是不可见的 core 行为和回归测试改动。

### Tested on

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### Environment (optional)

Windows 本地 npm workspace。`config.test.ts` 的 419 个测试全部通过，改动文件也通过了 ESLint 和 Prettier 检查。

## Risk & Scope

- 主要风险或取舍：如果 prompt 加载后文件消失或 `stat` 失败，cache 不会登记该文件，但原有 prior-read 保护仍然生效；refresh 本身不会失败。
- 未验证或不在范围内：`QWEN.md`、`AGENTS.md`、team-memory 索引以及更广泛的 system-prompt 文件追踪。
- 破坏性改动或迁移说明：无。

## Linked Issues

Fixes #7287

</details>