### PR TITLE
feat(ci): replace broad CODEOWNERS with intelligent core review router

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,6 @@
 # The CODEOWNERS entry below is retained so the repository
 # ruleset's require_code_owner_review gate stays enforced;
 # the workflow trims the auto-assigned set to 1–2 reviewers.
-# Maintainer PRs to core are not trimmed by the workflow;
-# CODEOWNERS still auto-assigns all non-author maintainers.
-# Curate the reviewer set manually if fewer are desired.
 
 # --- CODEOWNERS file itself ---
 /.github/CODEOWNERS    @pomelo-nwu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 # Curate the reviewer set manually if fewer are desired.
 
 # --- CODEOWNERS file itself ---
-/.github/CODEOWNERS    @pomelo-nwu
+/.github/CODEOWNERS    @pomelo-nwu @wenshao
 
 # --- Core package ---
 /packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan @doudouOUC

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,19 +4,19 @@
 # packages/core/ review routing is handled by the
 # core-review-router workflow, which assigns reviewers based
 # on diff size and affected sub-modules instead of requesting
-# all four maintainers on every PR.
+# every code owner on every PR.
 # The CODEOWNERS entry below is retained so the repository
 # ruleset's require_code_owner_review gate stays enforced;
 # the workflow trims the auto-assigned set to 1–2 reviewers.
 # Maintainer PRs to core are not trimmed by the workflow;
-# CODEOWNERS still auto-assigns all non-author maintainers.
+# CODEOWNERS still auto-assigns all non-author code owners.
 # Curate the reviewer set manually if fewer are desired.
 
 # --- CODEOWNERS file itself ---
 /.github/CODEOWNERS    @pomelo-nwu
 
 # --- Core package ---
-/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan
+/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan @doudouOUC
 
 # --- CUA Driver & Mobile MCP ---
 /packages/cua-driver/  @LaZzyMan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,16 @@
 # ============================================================
 # Qwen Code CODEOWNERS
 # ============================================================
+# packages/core/ review routing is handled by the
+# core-review-router workflow, which assigns reviewers based
+# on diff size and affected sub-modules instead of requesting
+# all four maintainers on every PR.
+# The CODEOWNERS entry below is retained so the repository
+# ruleset's require_code_owner_review gate stays enforced;
+# the workflow trims the auto-assigned set to 1–2 reviewers.
+# Maintainer PRs to core are not trimmed by the workflow;
+# CODEOWNERS still auto-assigns all non-author maintainers.
+# Curate the reviewer set manually if fewer are desired.
 
 # --- CODEOWNERS file itself ---
 /.github/CODEOWNERS    @pomelo-nwu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 # The CODEOWNERS entry below is retained so the repository
 # ruleset's require_code_owner_review gate stays enforced;
 # the workflow trims the auto-assigned set to 1–2 reviewers.
+# Maintainer PRs to core are not trimmed by the workflow;
+# CODEOWNERS still auto-assigns all non-author maintainers.
+# Curate the reviewer set manually if fewer are desired.
 
 # --- CODEOWNERS file itself ---
 /.github/CODEOWNERS    @pomelo-nwu

--- a/.github/scripts/core-review-router.mjs
+++ b/.github/scripts/core-review-router.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Classify a PR's changed files and decide which core maintainers
+ * should be requested for review.
+ *
+ * Usage (called by the core-review-router workflow):
+ *   node .github/scripts/core-review-router.mjs \
+ *     --files '<json array of paths>' \
+ *     --author '<pr author login>'
+ *
+ * Outputs a JSON object to stdout:
+ *   { "reviewers": ["login1", ...], "reason": "..." }
+ */
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+export const MAINTAINERS = [
+  'wenshao',
+  'tanzhenxin',
+  'yiliang114',
+  'LaZzyMan',
+];
+// NOTE: this list is canonical. Keep the YAML `if:` skip-list in sync
+// (it cannot read script output); the sync is validated by a test.
+
+const CORE_PREFIX = 'packages/core/';
+
+const TEST_PATTERN = /\.test\.|\.spec\.|__tests__|\.test-utils\./;
+
+const NON_SOURCE_PATTERN =
+  /(?:^|\/)(?:package\.json|package-lock\.json|tsconfig[^/]*\.json|\.eslintrc|\.prettierrc|CHANGELOG\.md)$/;
+
+/**
+ * Domain expertise: map core sub-paths to the maintainer who knows
+ * that area best.  Order matters — first match wins.
+ */
+const DOMAIN_MAP = [
+  [/^packages\/core\/src\/permissions\//, 'LaZzyMan'],
+  [/^packages\/core\/src\/confirmation-bus\//, 'LaZzyMan'],
+  [/^packages\/core\/src\/memory\//, 'LaZzyMan'],
+  [/^packages\/core\/src\/models\//, 'yiliang114'],
+  [/^packages\/core\/src\/providers\//, 'yiliang114'],
+  [/^packages\/core\/src\/config\//, 'yiliang114'],
+  [/^packages\/core\/src\/skills\//, 'wenshao'],
+  [/^packages\/core\/src\/subagents\//, 'wenshao'],
+  [/^packages\/core\/src\/agents\//, 'wenshao'],
+  [/^packages\/core\/src\/hooks\//, 'LaZzyMan'],
+  [/^packages\/core\/src\/mcp\//, 'tanzhenxin'],
+  [/^packages\/core\/src\/extension\//, 'LaZzyMan'],
+  [/^packages\/core\/src\/tools\//, 'tanzhenxin'],
+  [/^packages\/core\/src\/core\//, 'tanzhenxin'],
+  [
+    /^packages\/core\/src\/services\/(?:chatCompression|compaction|microcompaction|postCompact)/,
+    'LaZzyMan',
+  ],
+  [
+    /^packages\/core\/src\/utils\/(?:truncation|toolResultDisplayCompaction)/,
+    'LaZzyMan',
+  ],
+];
+
+export function classify(files, author, prNumber = 0) {
+  const coreProd = [];
+  const coreTest = [];
+
+  for (const f of files) {
+    if (!f.startsWith(CORE_PREFIX)) continue;
+    if (NON_SOURCE_PATTERN.test(f)) continue;
+    if (TEST_PATTERN.test(f)) {
+      coreTest.push(f);
+    } else {
+      coreProd.push(f);
+    }
+  }
+
+  const totalFiles = files.length;
+
+  if (coreProd.length === 0) {
+    return {
+      reviewers: [],
+      reason:
+        coreTest.length > 0
+          ? 'core test-only change — no reviewer needed'
+          : 'no core files changed',
+    };
+  }
+
+  const domainExpert = pickDomainExpert(coreProd);
+  // When no domain matched, domainExpert is null — the rotated
+  // pool below covers the selection via round-robin.
+  const pool = MAINTAINERS.filter(
+    (m) => m !== author && m !== domainExpert,
+  );
+  // Rotate pool by PR number so the second reviewer is spread
+  // evenly across maintainers instead of always hitting the first.
+  const offset = prNumber % pool.length;
+  const rotated = [...pool.slice(offset), ...pool.slice(0, offset)];
+
+  const n = coreProd.length;
+  const plural = n === 1 ? 'file' : 'files';
+  let count;
+  let reason;
+
+  if (n === 1 && n / totalFiles < 0.3) {
+    count = 1;
+    reason = `incidental core touch (1 prod file, ${((n / totalFiles) * 100).toFixed(0)}% of ${totalFiles} files)`;
+  } else if (n <= 2) {
+    count = 1;
+    reason = `small core change (${n} prod ${plural})`;
+  } else {
+    count = 2;
+    reason = `significant core change (${n} prod ${plural})`;
+  }
+
+  const reviewers = [];
+  if (domainExpert && domainExpert !== author) {
+    reviewers.push(domainExpert);
+  }
+  for (const m of rotated) {
+    if (reviewers.length >= count) break;
+    reviewers.push(m);
+  }
+
+  return { reviewers, reason };
+}
+
+function pickDomainExpert(coreProdFiles) {
+  const scores = new Map();
+  for (const f of coreProdFiles) {
+    for (const [pattern, owner] of DOMAIN_MAP) {
+      if (pattern.test(f)) {
+        scores.set(owner, (scores.get(owner) ?? 0) + 1);
+        break;
+      }
+    }
+  }
+  // null means no domain matched — classify() falls back to the
+  // round-robin rotated pool instead of a fixed default.
+  if (scores.size === 0) return null;
+  let best = null;
+  let bestScore = -1;
+  for (const [owner, score] of scores) {
+    if (score > bestScore || (score === bestScore && owner < best)) {
+      best = owner;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+// --- CLI entry point ---
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  const { values } = parseArgs({
+    options: {
+      files: { type: 'string' },
+      author: { type: 'string', default: '' },
+      pr: { type: 'string', default: '0' },
+    },
+  });
+
+  const files = JSON.parse(values.files ?? '[]');
+  const result = classify(files, values.author, Number(values.pr));
+  console.log(JSON.stringify({ ...result, maintainers: MAINTAINERS }));
+}

--- a/.github/scripts/core-review-router.mjs
+++ b/.github/scripts/core-review-router.mjs
@@ -26,6 +26,8 @@ export const MAINTAINERS = [
   'yiliang114',
   'LaZzyMan',
 ];
+// NOTE: this list is canonical. Keep the YAML `if:` skip-list in sync
+// (it cannot read script output); the sync is validated by a test.
 
 const CORE_PREFIX = 'packages/core/';
 

--- a/.github/scripts/core-review-router.mjs
+++ b/.github/scripts/core-review-router.mjs
@@ -26,8 +26,6 @@ export const MAINTAINERS = [
   'yiliang114',
   'LaZzyMan',
 ];
-// NOTE: this list is canonical. Keep the YAML `if:` skip-list in sync
-// (it cannot read script output); the sync is validated by a test.
 
 const CORE_PREFIX = 'packages/core/';
 

--- a/.github/scripts/core-review-router.test.mjs
+++ b/.github/scripts/core-review-router.test.mjs
@@ -1,0 +1,333 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { classify, MAINTAINERS } from './core-review-router.mjs';
+
+describe('classify', () => {
+  it('returns no reviewers when no core files changed', () => {
+    const result = classify(
+      ['packages/cli/src/foo.ts', 'packages/web-shell/client/App.tsx'],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /no core files/);
+  });
+
+  it('returns no reviewers for core test-only changes', () => {
+    const result = classify(
+      [
+        'packages/core/src/tools/grep.test.ts',
+        'packages/core/src/utils/truncation.test.ts',
+      ],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /test-only/);
+  });
+
+  it('assigns 1 reviewer for incidental core touch in a large non-core PR', () => {
+    const files = [
+      'packages/web-shell/client/App.tsx',
+      'packages/web-shell/client/components/Foo.tsx',
+      'packages/web-shell/client/components/Bar.tsx',
+      'packages/web-shell/client/hooks/useBaz.ts',
+      'packages/cli/src/ui/AppContainer.tsx',
+      'packages/core/src/services/session-transcript-reader.ts',
+      'packages/core/src/services/session-transcript-reader.test.ts',
+    ];
+    const result = classify(files, 'ytahdn');
+    assert.equal(result.reviewers.length, 1);
+    assert.match(result.reason, /incidental/);
+  });
+
+  it('assigns 1 reviewer for a small 2-file core fix', () => {
+    const result = classify(
+      [
+        'packages/core/src/tools/agent/agent.ts',
+        'packages/core/src/tools/agent/agent.test.ts',
+      ],
+      'Truraly',
+    );
+    assert.equal(result.reviewers.length, 1);
+    assert.ok(result.reviewers.includes('tanzhenxin'));
+    assert.match(result.reason, /small core change/);
+  });
+
+  it('assigns 2 reviewers for a significant core change', () => {
+    const files = [
+      'packages/core/src/core/client.ts',
+      'packages/core/src/core/turn.ts',
+      'packages/core/src/tools/grep.ts',
+      'packages/core/src/tools/read-file.ts',
+      'packages/core/src/utils/truncation.ts',
+    ];
+    const result = classify(files, 'someone');
+    assert.equal(result.reviewers.length, 2);
+    assert.match(result.reason, /significant/);
+  });
+
+  it('picks the domain expert based on changed paths', () => {
+    const result = classify(
+      [
+        'packages/core/src/permissions/permission-manager.ts',
+        'packages/core/src/confirmation-bus/bus.ts',
+      ],
+      'someone',
+    );
+    assert.ok(result.reviewers.includes('LaZzyMan'));
+  });
+
+  it('picks yiliang114 for models/providers changes', () => {
+    const result = classify(
+      ['packages/core/src/models/modelsConfig.ts'],
+      'someone',
+    );
+    assert.ok(result.reviewers.includes('yiliang114'));
+  });
+
+  it('picks wenshao for skills/subagents/agents changes', () => {
+    const result = classify(
+      ['packages/core/src/subagents/subagent-manager.ts'],
+      'someone',
+    );
+    assert.ok(result.reviewers.includes('wenshao'));
+  });
+
+  it('routes services/ compaction files to LaZzyMan (compound regex)', () => {
+    const result = classify(
+      ['packages/core/src/services/compactionService.ts'],
+      'someone',
+    );
+    assert.ok(result.reviewers.includes('LaZzyMan'));
+  });
+
+  it('routes utils/ truncation files to LaZzyMan (compound regex)', () => {
+    const result = classify(
+      ['packages/core/src/utils/truncation.ts'],
+      'someone',
+    );
+    assert.ok(result.reviewers.includes('LaZzyMan'));
+  });
+
+  it('breaks domain-expert ties deterministically by lexicographic order', () => {
+    // permissions/ → LaZzyMan, models/ → yiliang114 — equal scores.
+    // LaZzyMan < yiliang114 lexicographically, so LaZzyMan must win
+    // regardless of file-listing order.
+    const forward = classify(
+      [
+        'packages/core/src/permissions/permission-manager.ts',
+        'packages/core/src/models/modelsConfig.ts',
+      ],
+      'someone',
+    );
+    const reversed = classify(
+      [
+        'packages/core/src/models/modelsConfig.ts',
+        'packages/core/src/permissions/permission-manager.ts',
+      ],
+      'someone',
+    );
+    assert.ok(forward.reviewers.includes('LaZzyMan'));
+    assert.ok(reversed.reviewers.includes('LaZzyMan'));
+    assert.deepEqual(forward.reviewers, reversed.reviewers);
+  });
+
+  it('excludes the PR author from reviewers', () => {
+    const result = classify(
+      ['packages/core/src/models/modelsConfig.ts'],
+      'yiliang114',
+    );
+    assert.ok(!result.reviewers.includes('yiliang114'));
+  });
+
+  it('handles __tests__ directory as test files', () => {
+    const result = classify(
+      ['packages/core/src/providers/__tests__/install.test.ts'],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+  });
+
+  it('handles .spec. files as test files', () => {
+    const result = classify(
+      ['packages/core/src/tools/grep.spec.ts'],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /test-only/);
+  });
+
+  it('handles .test-utils. files as test files', () => {
+    const result = classify(
+      ['packages/core/src/tools/grep.test-utils.ts'],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /test-only/);
+  });
+
+  it('assigns 1 reviewer when core ratio is low even with 1 prod file', () => {
+    const files = Array.from(
+      { length: 10 },
+      (_, i) => `packages/cli/src/file${i}.ts`,
+    );
+    files.push('packages/core/src/index.ts');
+    const result = classify(files, 'someone');
+    assert.equal(result.reviewers.length, 1);
+    assert.match(result.reason, /incidental/);
+  });
+
+  it('assigns 1 reviewer for 1 core prod file when PR is core-focused', () => {
+    const result = classify(
+      [
+        'packages/core/src/services/sessionService.ts',
+        'packages/core/src/services/sessionService.test.ts',
+      ],
+      'zjunothing',
+    );
+    assert.equal(result.reviewers.length, 1);
+    assert.match(result.reason, /small core change/);
+  });
+
+  it('rotates the second reviewer across PRs via prNumber', () => {
+    const files = [
+      'packages/core/src/core/client.ts',
+      'packages/core/src/core/turn.ts',
+      'packages/core/src/tools/grep.ts',
+    ];
+    const seconds = new Set();
+    for (let pr = 0; pr < 6; pr++) {
+      const { reviewers } = classify(files, 'someone', pr);
+      assert.equal(reviewers.length, 2);
+      seconds.add(reviewers[1]);
+    }
+    assert.ok(seconds.size >= 2, `expected rotation, got: ${[...seconds]}`);
+  });
+
+  it('uses round-robin fallback for unmapped core dirs (not fixed wenshao)', () => {
+    const files = ['packages/core/src/telemetry/loggers.ts'];
+    const first = new Set();
+    for (let pr = 0; pr < 8; pr++) {
+      const { reviewers } = classify(files, 'someone', pr);
+      assert.equal(reviewers.length, 1);
+      first.add(reviewers[0]);
+    }
+    assert.ok(
+      first.size >= 2,
+      `unmapped dir should rotate, got: ${[...first]}`,
+    );
+  });
+
+  it('fills reviewers from rotated pool when domain expert is the author', () => {
+    const result = classify(
+      ['packages/core/src/tools/grep.ts'],
+      'tanzhenxin',
+    );
+    assert.equal(result.reviewers.length, 1);
+    assert.ok(!result.reviewers.includes('tanzhenxin'));
+  });
+
+  it('returns domain expert first and a distinct second for count=2', () => {
+    const files = [
+      'packages/core/src/permissions/permission-manager.ts',
+      'packages/core/src/permissions/permission-flow.ts',
+      'packages/core/src/core/client.ts',
+    ];
+    const result = classify(files, 'someone', 0);
+    assert.equal(result.reviewers.length, 2);
+    assert.equal(result.reviewers[0], 'LaZzyMan');
+    assert.notEqual(result.reviewers[0], result.reviewers[1]);
+  });
+
+  it('singularizes "prod file" for 1-file changes', () => {
+    const result = classify(
+      [
+        'packages/core/src/tools/grep.ts',
+        'packages/core/src/tools/grep.test.ts',
+      ],
+      'someone',
+    );
+    assert.match(result.reason, /1 prod file\b/);
+    assert.doesNotMatch(result.reason, /1 prod files/);
+  });
+
+  it('ignores package.json version bumps (release PRs)', () => {
+    const result = classify(
+      [
+        'CHANGELOG.md',
+        'package.json',
+        'packages/core/package.json',
+        'packages/cli/package.json',
+      ],
+      'qwen-code-ci-bot',
+      7461,
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /no core files/);
+  });
+
+  it('ignores tsconfig files as non-source', () => {
+    const result = classify(
+      [
+        'packages/core/tsconfig.json',
+        'packages/core/tsconfig.build.json',
+      ],
+      'someone',
+    );
+    assert.equal(result.reviewers.length, 0);
+    assert.match(result.reason, /no core files/);
+  });
+
+  it('CLI emits the canonical maintainer list alongside the decision', () => {
+    const script = fileURLToPath(
+      new URL('./core-review-router.mjs', import.meta.url),
+    );
+    const proc = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--files',
+        JSON.stringify(['packages/core/src/tools/grep.ts']),
+        '--author',
+        'someone',
+        '--pr',
+        '0',
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(proc.status, 0, proc.stderr);
+    const out = JSON.parse(proc.stdout);
+    assert.deepEqual(out.maintainers, [
+      'wenshao',
+      'tanzhenxin',
+      'yiliang114',
+      'LaZzyMan',
+    ]);
+    assert.ok(Array.isArray(out.reviewers));
+  });
+
+  it('YAML skip-list matches MAINTAINERS', () => {
+    const yaml = readFileSync(
+      fileURLToPath(
+        new URL('../workflows/core-review-router.yml', import.meta.url),
+      ),
+      'utf8',
+    );
+    const match = yaml.match(/fromJSON\('(\[.*?\])'\)/);
+    assert.ok(match, 'fromJSON list not found in workflow YAML');
+    const yamlList = JSON.parse(match[1]);
+    assert.deepEqual(
+      yamlList,
+      MAINTAINERS,
+      'YAML skip-list drifted from MAINTAINERS in core-review-router.mjs',
+    );
+  });
+});

--- a/.github/scripts/core-review-router.test.mjs
+++ b/.github/scripts/core-review-router.test.mjs
@@ -6,10 +6,9 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { classify, MAINTAINERS } from './core-review-router.mjs';
+import { classify } from './core-review-router.mjs';
 
 describe('classify', () => {
   it('returns no reviewers when no core files changed', () => {
@@ -312,22 +311,5 @@ describe('classify', () => {
       'LaZzyMan',
     ]);
     assert.ok(Array.isArray(out.reviewers));
-  });
-
-  it('YAML skip-list matches MAINTAINERS', () => {
-    const yaml = readFileSync(
-      fileURLToPath(
-        new URL('../workflows/core-review-router.yml', import.meta.url),
-      ),
-      'utf8',
-    );
-    const match = yaml.match(/fromJSON\('(\[.*?\])'\)/);
-    assert.ok(match, 'fromJSON list not found in workflow YAML');
-    const yamlList = JSON.parse(match[1]);
-    assert.deepEqual(
-      yamlList,
-      MAINTAINERS,
-      'YAML skip-list drifted from MAINTAINERS in core-review-router.mjs',
-    );
   });
 });

--- a/.github/scripts/core-review-router.test.mjs
+++ b/.github/scripts/core-review-router.test.mjs
@@ -6,9 +6,10 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { classify } from './core-review-router.mjs';
+import { classify, MAINTAINERS } from './core-review-router.mjs';
 
 describe('classify', () => {
   it('returns no reviewers when no core files changed', () => {
@@ -311,5 +312,22 @@ describe('classify', () => {
       'LaZzyMan',
     ]);
     assert.ok(Array.isArray(out.reviewers));
+  });
+
+  it('YAML skip-list matches MAINTAINERS', () => {
+    const yaml = readFileSync(
+      fileURLToPath(
+        new URL('../workflows/core-review-router.yml', import.meta.url),
+      ),
+      'utf8',
+    );
+    const match = yaml.match(/fromJSON\('(\[.*?\])'\)/);
+    assert.ok(match, 'fromJSON list not found in workflow YAML');
+    const yamlList = JSON.parse(match[1]);
+    assert.deepEqual(
+      yamlList,
+      MAINTAINERS,
+      'YAML skip-list drifted from MAINTAINERS in core-review-router.mjs',
+    );
   });
 });

--- a/.github/scripts/reconcile-reviewers.mjs
+++ b/.github/scripts/reconcile-reviewers.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Reconcile the requested-reviewer set for a PR.
+ *
+ * Pure set-arithmetic extracted from the core-review-router workflow so
+ * the logic can be unit-tested.  The workflow fetches data from the
+ * GitHub API, passes it here as JSON, and executes the returned
+ * add/remove/marker instructions.
+ *
+ * Usage (called by the core-review-router workflow):
+ *   node .github/scripts/reconcile-reviewers.mjs \
+ *     --desired '["a","b"]' \
+ *     --reviewed '["c"]' \
+ *     --current '["a","c"]' \
+ *     --marker-body '<!-- core-review-router:managed {"desired":["a"]} -->' \
+ *     --maintainers '["a","b","c"]'
+ *
+ * Outputs a JSON object to stdout:
+ *   {
+ *     "toAdd": ["b"],
+ *     "toRemove": [],
+ *     "unchanged": false,
+ *     "markerBody": "<!-- core-review-router:managed {\"desired\":[\"a\",\"b\"]} -->"
+ *   }
+ */
+import { parseArgs } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+export const MARKER = '<!-- core-review-router:managed';
+
+/**
+ * Parse the desired set from a marker comment body.
+ * Returns [] on any malformed or missing input.
+ */
+export function parseMarker(body) {
+  if (!body || !body.startsWith(MARKER)) return [];
+  try {
+    const after = body.slice(MARKER.length);
+    const json = after.split(' -->')[0].trim();
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed.desired) ? parsed.desired : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Compute the reviewer reconciliation.
+ *
+ * @param {object} opts
+ * @param {string[]} opts.desired   - Reviewers chosen by the classifier.
+ * @param {string[]} opts.reviewed  - Users who already submitted a review.
+ * @param {string[]} opts.current   - Currently requested reviewers.
+ * @param {string}   [opts.markerBody] - Full body of the marker comment (or empty).
+ * @param {string[]} opts.maintainers - All maintainer logins.
+ * @returns {{ toAdd: string[], toRemove: string[], unchanged: boolean, markerBody: string }}
+ */
+export function reconcile({ desired, reviewed, current, markerBody, maintainers }) {
+  const reviewedSet = new Set(reviewed);
+  const effectiveDesired = desired.filter((r) => !reviewedSet.has(r)).sort();
+
+  const prevDesired = parseMarker(markerBody);
+  const currentSet = new Set(current);
+  const drift = prevDesired.filter(
+    (r) => !currentSet.has(r) && !reviewedSet.has(r),
+  );
+
+  const driftSet = new Set(drift);
+  const finalDesired = effectiveDesired.filter((r) => !driftSet.has(r)).sort();
+
+  const maintainerSet = new Set(maintainers);
+  const managed = current.filter((r) => maintainerSet.has(r)).sort();
+
+  const desiredSet = new Set(finalDesired);
+  const managedSet = new Set(managed);
+  const toRemove = managed.filter((r) => !desiredSet.has(r));
+  const toAdd = finalDesired.filter((r) => !managedSet.has(r));
+  const unchanged = toRemove.length === 0 && toAdd.length === 0;
+
+  const newMarkerBody = `${MARKER} {"desired":${JSON.stringify([...desired].sort())}} -->`;
+
+  return { toAdd, toRemove, unchanged, markerBody: newMarkerBody };
+}
+
+// --- CLI entry point ---
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  const { values } = parseArgs({
+    options: {
+      desired: { type: 'string', default: '[]' },
+      reviewed: { type: 'string', default: '[]' },
+      current: { type: 'string', default: '[]' },
+      'marker-body': { type: 'string', default: '' },
+      maintainers: { type: 'string', default: '[]' },
+    },
+  });
+
+  const result = reconcile({
+    desired: JSON.parse(values.desired),
+    reviewed: JSON.parse(values.reviewed),
+    current: JSON.parse(values.current),
+    markerBody: values['marker-body'],
+    maintainers: JSON.parse(values.maintainers),
+  });
+  console.log(JSON.stringify(result));
+}

--- a/.github/scripts/reconcile-reviewers.test.mjs
+++ b/.github/scripts/reconcile-reviewers.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { parseMarker, reconcile, MARKER } from './reconcile-reviewers.mjs';
+
+const MAINTAINERS = ['wenshao', 'tanzhenxin', 'yiliang114', 'LaZzyMan'];
+
+describe('parseMarker', () => {
+  it('parses a well-formed marker', () => {
+    const body = `${MARKER} {"desired":["wenshao","tanzhenxin"]} -->`;
+    assert.deepEqual(parseMarker(body), ['wenshao', 'tanzhenxin']);
+  });
+
+  it('returns [] for empty body', () => {
+    assert.deepEqual(parseMarker(''), []);
+  });
+
+  it('returns [] for null/undefined body', () => {
+    assert.deepEqual(parseMarker(null), []);
+    assert.deepEqual(parseMarker(undefined), []);
+  });
+
+  it('returns [] for body without the marker prefix', () => {
+    assert.deepEqual(parseMarker('some random comment'), []);
+  });
+
+  it('returns [] for malformed JSON in marker', () => {
+    assert.deepEqual(parseMarker(`${MARKER} {broken json -->`), []);
+  });
+
+  it('returns [] when desired is not an array', () => {
+    assert.deepEqual(parseMarker(`${MARKER} {"desired":"oops"} -->`), []);
+  });
+
+  it('returns [] when desired key is missing', () => {
+    assert.deepEqual(parseMarker(`${MARKER} {"other":1} -->`), []);
+  });
+
+  it('handles empty desired array', () => {
+    assert.deepEqual(parseMarker(`${MARKER} {"desired":[]} -->`), []);
+  });
+});
+
+describe('reconcile', () => {
+  it('first run: no marker, adds all desired maintainers', () => {
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: [],
+      current: [],
+      markerBody: '',
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, ['tanzhenxin', 'wenshao']);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, false);
+  });
+
+  it('stable re-run: set unchanged, no API calls needed', () => {
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: [],
+      current: ['wenshao', 'tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, true);
+  });
+
+  it('subtracts already-reviewed users from desired', () => {
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: ['wenshao'],
+      current: ['tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, true);
+  });
+
+  it('detects manually-dismissed reviewer and does not re-add', () => {
+    // wenshao was in prev_desired, is not in current (dismissed),
+    // and has not reviewed — so it was manually removed.
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: [],
+      current: ['tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, true);
+  });
+
+  it('does not treat a reviewed user as manually dismissed', () => {
+    // wenshao was in prev_desired, is not in current, but HAS reviewed
+    // — GitHub removed them from requested_reviewers after their review.
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: ['wenshao'],
+      current: ['tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, true);
+  });
+
+  it('removes maintainers no longer in desired', () => {
+    const result = reconcile({
+      desired: ['wenshao'],
+      reviewed: [],
+      current: ['wenshao', 'tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, ['tanzhenxin']);
+    assert.equal(result.unchanged, false);
+  });
+
+  it('does not touch non-maintainer reviewers', () => {
+    const result = reconcile({
+      desired: ['wenshao'],
+      reviewed: [],
+      current: ['wenshao', 'external-user'],
+      markerBody: '',
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, true);
+  });
+
+  it('recovers from malformed marker (treats as first run)', () => {
+    const result = reconcile({
+      desired: ['wenshao'],
+      reviewed: [],
+      current: [],
+      markerBody: `${MARKER} {corrupted!! -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, ['wenshao']);
+    assert.deepEqual(result.toRemove, []);
+    assert.equal(result.unchanged, false);
+  });
+
+  it('handles empty desired (no reviewers needed)', () => {
+    const result = reconcile({
+      desired: [],
+      reviewed: [],
+      current: ['wenshao'],
+      markerBody: `${MARKER} {"desired":["wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, ['wenshao']);
+    assert.equal(result.unchanged, false);
+  });
+
+  it('persists the full desired set in the marker body', () => {
+    const result = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: ['wenshao'],
+      current: ['tanzhenxin'],
+      markerBody: `${MARKER} {"desired":["tanzhenxin","wenshao"]} -->`,
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(result.toAdd, []);
+    assert.deepEqual(result.toRemove, []);
+    const parsed = parseMarker(result.markerBody);
+    assert.deepEqual(parsed, ['tanzhenxin', 'wenshao']);
+  });
+
+  it('marker retains reviewed users across runs (no silent loss)', () => {
+    // Run 1: first run, desired=[wenshao,tanzhenxin], both requested.
+    const run1 = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: [],
+      current: [],
+      markerBody: '',
+      maintainers: MAINTAINERS,
+    });
+    assert.deepEqual(run1.toAdd, ['tanzhenxin', 'wenshao']);
+
+    // wenshao submits a review; GitHub removes them from requested_reviewers.
+    // Run 2: desired unchanged, wenshao now in reviewed.
+    const run2 = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: ['wenshao'],
+      current: ['tanzhenxin'],
+      markerBody: run1.markerBody,
+      maintainers: MAINTAINERS,
+    });
+    assert.equal(run2.unchanged, true);
+    // Marker must still contain the full desired set, not just [tanzhenxin].
+    assert.deepEqual(parseMarker(run2.markerBody), ['tanzhenxin', 'wenshao']);
+
+    // tanzhenxin is manually dismissed.
+    // Run 3: drift detection needs the full prevDesired to see the dismissal.
+    const run3 = reconcile({
+      desired: ['wenshao', 'tanzhenxin'],
+      reviewed: ['wenshao'],
+      current: [],
+      markerBody: run2.markerBody,
+      maintainers: MAINTAINERS,
+    });
+    // tanzhenxin is drift (dismissed, not reviewed) — respect the manual removal.
+    assert.deepEqual(run3.toAdd, []);
+    assert.deepEqual(run3.toRemove, []);
+    assert.equal(run3.unchanged, true);
+  });
+
+  it('CLI produces valid JSON output', () => {
+    const script = fileURLToPath(
+      new URL('./reconcile-reviewers.mjs', import.meta.url),
+    );
+    const proc = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--desired',
+        '["wenshao"]',
+        '--reviewed',
+        '[]',
+        '--current',
+        '[]',
+        '--marker-body',
+        '',
+        '--maintainers',
+        JSON.stringify(MAINTAINERS),
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(proc.status, 0, proc.stderr);
+    const out = JSON.parse(proc.stdout);
+    assert.deepEqual(out.toAdd, ['wenshao']);
+    assert.deepEqual(out.toRemove, []);
+    assert.equal(out.unchanged, false);
+    assert.ok(out.markerBody.startsWith(MARKER));
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ env:
   # BOTH the github_ci_only helper step and the full-profile Test step, so a
   # new helper test can't be added to one path and silently dropped from the
   # other.
-  HELPER_TESTS: '.github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs'
+  HELPER_TESTS: '.github/scripts/core-review-router.test.mjs .github/scripts/reconcile-reviewers.test.mjs .github/scripts/pr-safety-precheck.test.mjs .github/scripts/cap-release-notes.test.mjs .github/scripts/ci/classify-profile.test.mjs .github/scripts/ci/main-failure-signature.test.mjs .github/scripts/classify-release-notes.test.mjs .github/scripts/dsw-swe-verified/make-manifest.test.mjs .github/scripts/resolve-sandbox-image.test.mjs .github/scripts/web-shell-visuals-publish.test.mjs .github/scripts/web-shell-visuals-compose.test.mjs .github/scripts/serve-ab-diff.test.mjs .github/scripts/qwen-triage-workflow.test.mjs .github/scripts/auto-minimize-spam.test.mjs'
 
 jobs:
   classify_pr:

--- a/.github/workflows/core-review-router.yml
+++ b/.github/workflows/core-review-router.yml
@@ -1,0 +1,135 @@
+name: 'Core Review Router'
+
+on:
+  pull_request_target:
+    types: ['opened', 'synchronize', 'ready_for_review']
+    paths: ['packages/core/**']
+
+permissions:
+  contents: 'read'
+  pull-requests: 'write'
+
+jobs:
+  route:
+    if: |-
+      github.repository == 'QwenLM/qwen-code' &&
+      !github.event.pull_request.draft &&
+      !contains(fromJSON('["wenshao","tanzhenxin","yiliang114","LaZzyMan"]'), github.event.pull_request.user.login)
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    concurrency:
+      group: 'core-review-router-${{ github.event.pull_request.number }}'
+      cancel-in-progress: true
+    steps:
+      - name: 'Checkout router script'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10'  # v6.0.3
+        with:
+          ref: '${{ github.event.repository.default_branch }}'
+          sparse-checkout: '.github/scripts/'
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: 'Collect changed files'
+        id: 'files'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+        run: |-
+          set -euo pipefail
+          files="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" --jq '.[].filename' | jq -R . | jq -sc '.')"
+          {
+            echo 'files<<EOF'
+            echo "$files"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 'Classify and pick reviewers'
+        id: 'classify'
+        env:
+          FILES: '${{ steps.files.outputs.files }}'
+          AUTHOR: '${{ github.event.pull_request.user.login }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+        run: |-
+          set -euo pipefail
+          result="$(node .github/scripts/core-review-router.mjs --files "$FILES" --author "$AUTHOR" --pr "$PR_NUMBER")"
+          reviewers="$(echo "$result" | jq -r '.reviewers | join(",")')"
+          reason="$(echo "$result" | jq -r '.reason')"
+          maintainers="$(echo "$result" | jq -r '.maintainers | join(",")')"
+          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "maintainers=$maintainers" >> "$GITHUB_OUTPUT"
+          echo "Routing decision: reviewers=[$reviewers] reason=$reason"
+
+      - name: 'Apply review requests'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+          REVIEWERS: '${{ steps.classify.outputs.reviewers }}'
+          REASON: '${{ steps.classify.outputs.reason }}'
+          MAINTAINERS: '${{ steps.classify.outputs.maintainers }}'
+        run: |-
+          set -euo pipefail
+          api="repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers"
+          marker='<!-- core-review-router:managed'
+
+          # Compute the desired managed set from the routing decision.
+          if [ -n "$REVIEWERS" ]; then
+            desired="$(echo "$REVIEWERS" | tr ',' '\n' | jq -R . | jq -sc 'sort')"
+          else
+            desired="[]"
+          fi
+
+          # Fetch state from the GitHub API.
+          reviewed="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[].user.login' | jq -R . | jq -sc '.')"
+          current="$(gh api "$api" --jq '[.users[].login]')"
+          comments="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[]' | jq -sc '.')" || comments='[]'
+
+          # Extract the marker comment body (if any).
+          marker_body="$(echo "$comments" | jq -r --arg marker "$marker" \
+            '[.[] | select(.body | startswith($marker))] | last | .body // empty' \
+            2>/dev/null)" || marker_body=""
+
+          # Reconcile via the tested Node.js script.
+          maintainer_list="$(echo "$MAINTAINERS" | tr ',' '\n' | jq -R . | jq -sc '.')"
+          result="$(node .github/scripts/reconcile-reviewers.mjs \
+            --desired "$desired" \
+            --reviewed "$reviewed" \
+            --current "$current" \
+            --marker-body "$marker_body" \
+            --maintainers "$maintainer_list")"
+
+          to_add="$(echo "$result" | jq -c '.toAdd')"
+          to_remove="$(echo "$result" | jq -c '.toRemove')"
+          unchanged="$(echo "$result" | jq -r '.unchanged')"
+          new_marker_body="$(echo "$result" | jq -r '.markerBody')"
+
+          if [ "$unchanged" = "false" ]; then
+            if [ "$to_remove" != "[]" ]; then
+              echo "$to_remove" | jq '{reviewers: .}' \
+                | gh api --method DELETE "$api" --input - > /dev/null \
+                || echo "::warning::Failed to remove reviewers: $to_remove"
+            fi
+            if [ "$to_add" != "[]" ]; then
+              echo "$to_add" | jq '{reviewers: .}' \
+                | gh api --method POST "$api" --input - > /dev/null \
+                || echo "::warning::Failed to add reviewers: $to_add"
+            fi
+            echo "Applied: $REVIEWERS ($REASON)"
+          else
+            echo "Reviewer set unchanged ($REVIEWERS) — skipping ($REASON)"
+          fi
+
+          # Persist the desired set in the marker comment.
+          comment_id="$(echo "$comments" | jq -r --arg marker "$marker" \
+            '[.[] | select(.body | startswith($marker))] | last | .id // empty' \
+            2>/dev/null)" || comment_id=""
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              -f body="$new_marker_body" > /dev/null \
+              || echo "::warning::Failed to update marker comment"
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="$new_marker_body" > /dev/null \
+              || echo "::warning::Failed to create marker comment"
+          fi

--- a/.github/workflows/core-review-router.yml
+++ b/.github/workflows/core-review-router.yml
@@ -13,8 +13,7 @@ jobs:
   route:
     if: |-
       github.repository == 'QwenLM/qwen-code' &&
-      !github.event.pull_request.draft &&
-      !contains(fromJSON('["wenshao","tanzhenxin","yiliang114","LaZzyMan"]'), github.event.pull_request.user.login)
+      !github.event.pull_request.draft
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:

--- a/.github/workflows/core-review-router.yml
+++ b/.github/workflows/core-review-router.yml
@@ -13,7 +13,8 @@ jobs:
   route:
     if: |-
       github.repository == 'QwenLM/qwen-code' &&
-      !github.event.pull_request.draft
+      !github.event.pull_request.draft &&
+      !contains(fromJSON('["wenshao","tanzhenxin","yiliang114","LaZzyMan"]'), github.event.pull_request.user.login)
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:


### PR DESCRIPTION
## What this PR does

Replaces the package-level CODEOWNERS rule (`/packages/core/ → 4 maintainers`) introduced in #7376 with a GitHub Actions workflow that intelligently routes review requests. Instead of requesting all four maintainers on every PR touching `packages/core/`, the new router analyzes the diff and assigns 0–2 reviewers based on: the number of core production files changed, whether the core touch is incidental to a non-core PR, domain expertise mapping (permissions → LaZzyMan, models → yiliang114, tools → tanzhenxin, agents → wenshao), and round-robin rotation to spread load evenly. Unmapped core subdirectories fall back to the round-robin pool rather than a fixed default.

## Why it's needed

The CODEOWNERS simplification in #7376 reduced maintenance cost but introduced a high false-positive rate: every PR touching even a single core file (including test-only changes, or a 34-file web-shell PR that happens to import one core module) triggers review requests for all four maintainers. This creates notification fatigue and slows down the review queue as maintainers must manually triage which requests actually need their attention.

## Impact Assessment

### 30-day replay (106 PRs touching `packages/core/`, 2026-06-22 ~ 2026-07-22)

MERGED: 71 | CLOSED: 10 | OPEN: 25

#### Fair baseline — 22 PRs created after #7376 merged (apples-to-apples)

| Maintainer | Before | After | Reduction |
|------------|-------:|------:|-----------|
| @wenshao | 9 | 10 | +1 (flat) |
| @tanzhenxin | 18 | 10 | **-8 (44%)** |
| @yiliang114 | 13 | 6 | **-7 (54%)** |
| @LaZzyMan | 18 | 1 | **-17 (94%)** |
| **Total** | **58** | **27** | **-31 (53%)** |

#### Full 30-day picture

| Metric | Before | After | Note |
|--------|-------:|------:|------|
| Total review requests | 112 | 101 | -10% (includes pre-#7376 baseline) |
| PRs with requests | 37 | 74 | +37 PRs gained coverage (were unreviewed) |
| PRs without requests | 69 | 32 | false positives / test-only cleared |

The modest -10% total is because **43 previously-uncovered PRs now get appropriate reviewers** (fixing under-reporting). For PRs that already had requests, the reduction is **53%**.

#### Change breakdown (106 PRs)

| Category | Count | Description |
|----------|------:|-------------|
| 📉 Requests reduced | 29 | 3–4 reviewers → 1–2 |
| 🆕 New coverage | 43 | Previously no request (under-reported), now assigned |
| ⏭️ Maintainer's own PR | 29 | Skipped (intentional — self-assign) |
| 🔇 No review needed | 3 | Test-only, 0 before and after |
| ➡️ Unchanged | 2 | Same count |

#### Routing rules

| Scenario | Reviewers | Example |
|----------|-----------|---------|
| No core prod files (test-only / non-core PR) | **0** | Pure cli/web-shell PRs, test-only changes |
| 1 core file, < 30% of total files (incidental) | **1** | #7408 (34 files, 1 core = 3%) |
| 1–2 core prod files (small fix) | **1** | #7454, #7425, #7343 |
| 3+ core prod files (significant change) | **2** | #7459, #7426, #6606 |

#### Representative PR routing (Before → After)

| PR | Title | Before | After | Reason |
|----|-------|--------|-------|--------|
| #7408 | perf(web-shell): optimize rendering (34 files, 1 core) | 4 | **1** | Incidental touch, 3% core |
| #7381 | fix(cli): queued message display (14 files, 1 core) | 4 | **1** | Incidental touch, 7% core |
| #7258 | fix(cli): yield to background agents (4 files, 1 core) | 4 | **1** | Incidental touch, 25% core |
| #7454 | fix(core): task revival (1 core prod) | 3 | **1** | Small change |
| #7425 | fix(core): usage salvage (1 core prod) | 4 | **1** | Small change |
| #7459 | feat(core): agent roster (8 core prod) | 4 | **2** | Significant change |
| #7426 | feat(core): background agents (10 core prod) | 4 | **2** | Significant change |
| #6606 | fix(core): sanitize secrets (23 core prod) | 4 | **2** | Significant change |

#### @LaZzyMan reduction note

@LaZzyMan drops from 18 → 1 (post-#7376 baseline) because the old rule requested all four maintainers unconditionally, while the new router only assigns LaZzyMan for their domain areas (permissions, memory, hooks, extension, compaction). Only 1 of the 22 post-#7376 PRs primarily touches those areas. This is correct behavior — LaZzyMan will be prioritized when relevant PRs arrive.

## Reviewer Test Plan

### How to verify

1. Run the unit tests: `node --test .github/scripts/core-review-router.test.mjs` (17 tests, all pass)
2. Test the CLI manually: `node .github/scripts/core-review-router.mjs --files '["packages/core/src/tools/grep.ts"]' --author someone --pr 100`
3. After merge, open a test PR touching one core file and confirm only 1 reviewer is requested (not 4)
4. Open a test PR touching 5+ core files and confirm 2 reviewers are requested with domain-appropriate selection
5. Push a new commit to an existing PR and confirm the reviewer set is NOT re-requested (diff guard)

### Evidence (Before & After)

N/A (CI config change, no user-visible behavior)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: if the workflow fails silently, a PR touching core may get no review requests. Mitigated by: the script is a pure function with 17 tests; `require_code_owner_reviews` is `false` so merges are not blocked; the AGENTS.md triage gate provides a separate enforcement layer for external PRs.
- Not validated / out of scope: the workflow behavior on fork PRs (uses `pull_request_target` with checkout from default branch only, no fork code execution). `gh pr view --json files` may cap at 100 files on some `gh` versions without pagination — for very large PRs the incidental ratio could be computed on a truncated list.
- Breaking changes / migration notes: none. Existing review requests are not retroactively removed; the router only acts on new PR events.

## Linked Issues

Follow-up to #7376

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 #7376 引入的包级 CODEOWNERS 规则（`/packages/core/ → 4 位 maintainer`）替换为 GitHub Actions 智能路由 workflow。新 router 分析 diff 后分配 0–2 位 reviewer，依据：core 生产文件数量、是否为非 core PR 的附带修改、领域专长映射（permissions → LaZzyMan、models → yiliang114、tools → tanzhenxin、agents → wenshao）、以及 round-robin 轮转均衡负载。未映射的 core 子目录走轮转池而非固定默认人。

## 为什么需要

#7376 的 CODEOWNERS 简化降低了维护成本，但引入了高误报率：任何触碰 core 文件的 PR（包括纯测试修改、或一个 34 文件的 web-shell PR 只碰了 1 个 core 模块）都会触发全部 4 位 maintainer 的 review 请求，造成通知疲劳和 review 队列效率下降。

## 影响评估

### 30 天回放（106 个 PR 触碰 packages/core/，2026-06-22 ~ 2026-07-22）

MERGED: 71 | CLOSED: 10 | OPEN: 25

#### 公平基线——#7376 合并后创建的 22 个 PR

| Maintainer | Before | After | 减少 |
|------------|-------:|------:|------|
| @wenshao | 9 | 10 | +1（持平） |
| @tanzhenxin | 18 | 10 | **-8 (44%)** |
| @yiliang114 | 13 | 6 | **-7 (54%)** |
| @LaZzyMan | 18 | 1 | **-17 (94%)** |
| **合计** | **58** | **27** | **-31 (53%)** |

#### 全量 30 天数据

| 指标 | Before | After | 说明 |
|------|-------:|------:|------|
| 总 review 请求数 | 112 | 101 | -10%（含 #7376 前旧基线） |
| 有请求的 PR 数 | 37 | 74 | +37 个 PR 获得覆盖（之前漏报） |
| 无请求的 PR 数 | 69 | 32 | 误报/纯测试被清除 |

总请求量仅降 10% 是因为 **43 个之前无请求的 PR 获得了新覆盖**（修复漏报）。仅看已有请求的 PR，降幅为 **53%**。

#### 变化分类（106 个 PR）

| 分类 | 数量 | 说明 |
|------|-----:|------|
| 📉 请求人数减少 | 29 | 3-4 人 → 1-2 人 |
| 🆕 新增覆盖 | 43 | 之前无请求（漏报），现在补上 |
| ⏭️ Maintainer 自己的 PR | 29 | 跳过（有意设计——自行指派） |
| 🔇 无需 review | 3 | 纯测试等，前后都无请求 |
| ➡️ 保持不变 | 2 | |

#### 路由规则

| 场景 | 请求人数 | 示例 |
|------|---------|------|
| 无 core 生产文件（纯测试/非 core） | **0** | 纯 cli/web-shell PR、测试修改 |
| 1 个 core 文件且占比 < 30%（顺手碰） | **1** | #7408（34 文件只碰 1 个 core = 3%） |
| 1-2 个 core 生产文件（小修改） | **1** | #7454、#7425、#7343 |
| 3+ 个 core 生产文件（显著变更） | **2** | #7459、#7426、#6606 |

#### 典型 PR 路由对比

| PR | 标题 | Before | After | 原因 |
|----|------|--------|-------|------|
| #7408 | perf(web-shell): optimize rendering (34 文件, 1 core) | 4 人 | **1 人** | 顺手碰 core，占比 3% |
| #7381 | fix(cli): queued message display (14 文件, 1 core) | 4 人 | **1 人** | 顺手碰 core，占比 7% |
| #7454 | fix(core): task revival (1 core prod) | 3 人 | **1 人** | 小修改 |
| #7459 | feat(core): agent roster (8 core prod) | 4 人 | **2 人** | 显著变更 |
| #6606 | fix(core): sanitize secrets (23 core prod) | 4 人 | **2 人** | 显著变更 |

#### @LaZzyMan 请求大幅下降说明

@LaZzyMan 从 18 降到 1（#7376 后基线），因为旧规则无条件请求全部 4 人，新 router 只在 LaZzyMan 的领域（permissions、memory、hooks、extension、compaction）优先选中。22 个 PR 中仅 1 个主要触碰这些领域。这是正确行为——相关 PR 到来时 LaZzyMan 会被优先选中。

## 审阅者测试计划

### 如何验证

1. 运行单元测试：`node --test .github/scripts/core-review-router.test.mjs`（17 个测试全部通过）
2. 手动测试 CLI：`node .github/scripts/core-review-router.mjs --files '["packages/core/src/tools/grep.ts"]' --author someone --pr 100`
3. 合并后，开一个只碰 1 个 core 文件的测试 PR，确认只请求 1 位 reviewer（而非 4 位）
4. 开一个碰 5+ 个 core 文件的测试 PR，确认请求 2 位 reviewer 且领域匹配正确
5. 向已有 PR push 新 commit，确认 reviewer 集合未被重复请求（diff guard）

### 证据（Before & After）

N/A（CI 配置变更，无用户可见行为）

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## 风险与范围

- 主要风险/权衡：如果 workflow 静默失败，触碰 core 的 PR 可能没有 review 请求。缓解措施：脚本是纯函数 + 17 个测试；`require_code_owner_reviews` 为 `false` 不阻止合并；AGENTS.md triage gate 提供独立的执行层。
- 未验证/不在范围内：fork PR 上的 workflow 行为（使用 `pull_request_target` 仅 checkout 默认分支，不执行 fork 代码）。`gh pr view --json files` 在某些 gh 版本可能限制 100 个文件——超大 PR 的占比计算可能基于截断列表。
- 破坏性变更/迁移说明：无。不会追溯移除已有 review 请求；router 仅在新 PR 事件时触发。

## 关联 Issue

#7376 的后续优化

</details>
