### PR TITLE
test(core): Cover Shell truncation without an artifact

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -2725,6 +2725,32 @@ describe('ShellTool', () => {
       expect(result.error?.type).toBe(ToolErrorType.SHELL_EXECUTE_ERROR);
     });
 
+    it('retains shell truncation without an artifact and records the persistence decision', async () => {
+      const originalOutput = 'A'.repeat(30_001);
+      const shortenedContent =
+        'Tool output was too large and has been truncated.\n[mocked truncated body]\n[Note: Could not save full output to file]';
+      const truncationModule = await import('../utils/truncation.js');
+      const spy = vi
+        .spyOn(truncationModule, 'truncateToolOutput')
+        .mockResolvedValue({ content: shortenedContent });
+
+      try {
+        const invocation = shellTool.build({
+          command: 'large-output-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        resolveShellExecution({ output: originalOutput, exitCode: 0 });
+        const result = await promise;
+
+        expect(result.llmContent).toContain(shortenedContent);
+        expect(result.llmContent).not.toContain(originalOutput);
+        expect(result.persistedOutputFiles).toEqual([]);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
     describe('long-running foreground hint', () => {
       // Auto-bg advisory. Threshold = effectiveTimeout / 2 — for the
       // default 120s timeout that's 60_000ms, which the tests below

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -493,8 +493,14 @@ export interface ToolResult {
   llmContent: PartListUnion;
 
   /**
-   * Producer output artifacts persisted before final aggregation.
-   * Internal runtimes use these paths to avoid writing the same output again.
+   * Internal runtime metadata recording the producer persistence decision
+   * before final aggregation.
+   * `undefined` means no decision was made; `[]` means a decision was made but
+   * no reusable artifact exists; a non-empty array lists reusable producer
+   * artifact paths. Downstream finalization treats any defined value as a
+   * completed decision for this producer output and does not persist it again.
+   * Other artifact channels remain independent and may still be aggregated
+   * later.
    */
   persistedOutputFiles?: string[];
 


### PR DESCRIPTION
## What this PR does

This PR adds regression coverage for Shell producer truncation when the model-facing content is shortened but persistence produces no artifact. It also clarifies the internal three-state contract for persisted output metadata so downstream finalization can distinguish an undecided producer from a completed decision with or without reusable artifacts.

## Why it's needed

When saving complete Shell output fails, the truncation helper still returns a bounded preview without an output file. Shell must retain that preview and return an empty artifact list rather than omitting the metadata; otherwise the finalizer can treat the producer decision as unhandled and retry persistence. The production behavior is already correct, but this failure branch lacked direct producer-level regression coverage and the type documentation did not explain the empty-array sentinel.

## Reviewer Test Plan

### How to verify

Run the focused Shell test and confirm that an over-budget result whose truncation returns no artifact keeps the shortened preview, removes the original oversized model content, and records an empty artifact list. Run the complete Shell and finalizer unit test files and confirm all 300 tests pass. Formatting, targeted ESLint, the repository build, and workspace type checking should also complete successfully.

### Evidence (Before & After)

N/A — test and type documentation only; no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS, Node.js v24.12.0, npm 10.9.8, sandbox N/A.

## Risk & Scope

- Main risk or tradeoff: Minimal test-maintenance risk from a mocked truncation boundary; the assertions intentionally avoid coupling to helper call counts, complete response formatting, or display text.
- Not validated / out of scope: No local Windows or Linux run; wire-level observability, display budgeting, artifact lifecycle, and other Phase 2–4 work remain out of scope.
- Breaking changes / migration notes: None. Runtime behavior, public type shape, serialization, and configuration are unchanged.

## Linked Issues

Refs #7306

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 为 Shell 生产者截断增加回归覆盖，针对模型侧内容已经缩短但持久化未生成 artifact 的情况。同时补充持久化输出元数据的内部三态契约，使下游 finalizer 能区分生产者尚未作出决定，以及已经完成但有或没有可复用 artifact 的决定。

## 为什么需要

完整 Shell 输出保存失败时，截断 helper 仍会返回有界预览，但不会返回输出文件。Shell 必须保留该预览并返回空 artifact 数组，而不是省略元数据；否则 finalizer 可能把生产者决定视为未处理并再次尝试持久化。当前生产行为已经正确，但这个失败分支缺少直接的生产者级回归测试，类型文档也没有解释空数组哨兵。

## Reviewer 测试计划

### 如何验证

运行聚焦的 Shell 测试，确认超预算结果在截断未生成 artifact 时保留缩短预览、从模型内容中移除原始超长正文，并记录空 artifact 数组。运行完整 Shell 与 finalizer 单测文件，确认 300 个测试全部通过。格式检查、目标 ESLint、仓库构建和 workspace 类型检查也应全部成功。

### 前后证据

N/A——仅测试和类型文档变更，没有用户可见或 TUI 变化。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    | ✅ 已测试 |
| 🪟 Windows   | ⚠️ 本地未测试 |
|  🐧 Linux    | ⚠️ 本地未测试 |

### 环境

macOS、Node.js v24.12.0、npm 10.9.8，sandbox 不适用。

## 风险与范围

- 主要风险或取舍：仅有极小的测试维护风险，测试 mock 截断边界，并刻意避免绑定 helper 调用次数、完整响应格式或展示文案。
- 未验证或范围外：未在本地运行 Windows 或 Linux；wire-level 可观测性、展示预算、artifact 生命周期以及其他 Phase 2–4 工作均不在范围内。
- 破坏性变更或迁移说明：无。运行时行为、公共类型结构、序列化和配置均未改变。

## 关联 Issue

Refs #7306

</details>
