### PR TITLE
fix(release): exclude mobile-mcp from core version bump

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -37,8 +37,8 @@ if (!versionType) {
 run(`npm version ${versionType} --no-git-tag-version --allow-same-version`);
 
 // 3. Get all workspaces and filter out the one we don't want to version.
-// We intend to maintain sdk version independently.
-const workspacesToExclude = ['@qwen-code/sdk'];
+// We intend to maintain sdk and mobile-mcp versions independently.
+const workspacesToExclude = ['@qwen-code/sdk', '@qwen-code/mobile-mcp'];
 let lsOutput;
 try {
   lsOutput = JSON.parse(


### PR DESCRIPTION
## What this PR does

Excludes `@qwen-code/mobile-mcp` from the core release version bump in `scripts/version.js`, following the same pattern already used for `@qwen-code/sdk`. After this change, running `npm run version` will no longer touch `packages/mobile-mcp/package.json`.

## Why it's needed

Every core release PR (e.g. #7461) bumps all workspace `package.json` versions, including `packages/mobile-mcp/package.json`. Since CODEOWNERS assigns `/packages/mobile-mcp/` to @LaZzyMan only, every routine release PR requires an extra approval from LaZzyMan even though the mobile-mcp change is just a version number bump. This adds unnecessary review overhead. mobile-mcp has its own release cadence and should be versioned independently, like the SDK.

## Reviewer Test Plan

### How to verify

1. Run `npm run version patch --no-git-tag-version` on this branch
2. Confirm `packages/mobile-mcp/package.json` version is **unchanged**
3. Confirm all other workspace packages are bumped as expected
4. mobile-mcp can still be bumped manually: `npm version patch --workspace @qwen-code/mobile-mcp --no-git-tag-version`

### Evidence (Before & After)

N/A — non-UI change (build script modification).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

N/A — only affects the `npm run version` script.

## Risk & Scope

- Main risk or tradeoff: mobile-mcp version will drift from core version. This is intentional and matches the SDK pattern.
- Not validated / out of scope: mobile-mcp's own release/publish workflow (unchanged).
- Breaking changes / migration notes: None. mobile-mcp can still be bumped manually when needed.

## Linked Issues

Closes #7462

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `scripts/version.js` 中将 `@qwen-code/mobile-mcp` 加入 `workspacesToExclude`，使 core 发版时不再自动 bump mobile-mcp 的版本号。与 `@qwen-code/sdk` 的处理方式一致。

## 为什么需要

每次 core 发版 PR（如 #7461）会批量 bump 所有 workspace 的 `package.json` 版本号，包括 `packages/mobile-mcp/package.json`。由于 CODEOWNERS 将 `/packages/mobile-mcp/` 分配给 @LaZzyMan，每次常规发版都需要 LaZzyMan 额外审批，即使 mobile-mcp 的改动只是版本号。mobile-mcp 有自己的发布节奏，应该像 SDK 一样独立管理版本。

## 审查测试计划

### 如何验证

1. 在此分支运行 `npm run version patch --no-git-tag-version`
2. 确认 `packages/mobile-mcp/package.json` 版本号**未变**
3. 确认其他 workspace 包版本号正常 bump
4. mobile-mcp 仍可手动 bump：`npm version patch --workspace @qwen-code/mobile-mcp --no-git-tag-version`

### 证据（前后对比）

N/A — 非 UI 变更（构建脚本修改）。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

N/A — 仅影响 `npm run version` 脚本。

## 风险与范围

- 主要风险或权衡：mobile-mcp 版本号将与 core 版本号不同步。这是预期行为，与 SDK 模式一致。
- 未验证 / 超出范围：mobile-mcp 自身的发布流程（未改动）。
- 破坏性变更 / 迁移说明：无。mobile-mcp 仍可在需要时手动 bump。

## 关联 Issue

Closes #7462

</details>