### PR TITLE
fix(ci): inject actual model name into triage signature

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -259,6 +259,16 @@ jobs:
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: 'Inject model name into triage signature'
+        shell: 'bash'
+        env:
+          OPENAI_MODEL: '${{ vars.QWEN_TRIAGE_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
+        run: |-
+          set -euo pipefail
+          if [ -n "${OPENAI_MODEL:-}" ]; then
+            sed -i "s/qwen3\.7-max/${OPENAI_MODEL}/g" .qwen/skills/triage/references/pr-workflow.md
+          fi
+
       - name: 'Run Qwen Triage'
         id: 'triage'
         uses: 'QwenLM/qwen-code-action@6d08e91aa807257b9c8af60edb5bb6bb2d7d951f'


### PR DESCRIPTION
## What this PR does

Adds a prepare step in `qwen-triage.yml` that replaces the hardcoded model name (`qwen3.7-max`) in `.qwen/skills/triage/references/pr-workflow.md` with the actual `OPENAI_MODEL` value (sourced from `QWEN_TRIAGE_MODEL`) before the triage agent runs. This ensures the comment signature line (`— _Qwen Code · <model>_`) always reflects the model actually used.

## Why it's needed

The triage skill template hardcodes `qwen3.7-max` in the signature footer (pr-workflow.md line 61). The workflow correctly reads `QWEN_TRIAGE_MODEL` into `OPENAI_MODEL` for the model call, but the signature template is a separate static string — changing the model variable has no effect on the displayed name. See #7298 comment where the signature shows `qwen3.7-max` regardless of the configured model.

## Reviewer Test Plan

### How to verify

1. Set `QWEN_TRIAGE_MODEL` to a model name different from `qwen3.7-max` (e.g. `qwen3.8-max`)
2. Trigger triage on any issue or PR
3. Confirm the comment signature shows `— _Qwen Code · qwen3.8-max_` instead of `qwen3.7-max`
4. Unset `QWEN_TRIAGE_MODEL` and confirm the fallback `QWEN_PR_REVIEW_MODEL` value is used
5. If neither is set, confirm the step is a no-op and the default `qwen3.7-max` remains

### Evidence (Before & After)

N/A — CI automation change only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

N/A — GitHub Actions workflow change.

## Risk & Scope

- Main risk or tradeoff: the `sed` replacement is global (`/g`); if `qwen3.7-max` appears elsewhere in pr-workflow.md it will also be replaced. Currently it only appears in signature lines, so this is safe.
- Not validated / out of scope: issue-workflow.md may have the same hardcoded name (not changed in this PR).
- Breaking changes / migration notes: None.

## Linked Issues

Ref #7298

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `qwen-triage.yml` 中增加一个准备步骤，在 triage agent 运行前，将 `.qwen/skills/triage/references/pr-workflow.md` 中硬编码的模型名（`qwen3.7-max`）替换为实际的 `OPENAI_MODEL` 值（来源于 `QWEN_TRIAGE_MODEL`）。确保评论签名行始终反映实际使用的模型。

## 为什么需要

triage skill 模板在签名中硬编码了 `qwen3.7-max`（pr-workflow.md 第 61 行）。workflow 虽然正确读取了 `QWEN_TRIAGE_MODEL` 用于模型调用，但签名模板是独立的静态字符串，修改模型变量不会影响显示的名称。

## 审查测试计划

### 如何验证

1. 将 `QWEN_TRIAGE_MODEL` 设为非 `qwen3.7-max` 的模型名
2. 触发任意 issue 或 PR 的 triage
3. 确认评论签名显示实际模型名
4. 不设置 `QWEN_TRIAGE_MODEL`，确认回退到 `QWEN_PR_REVIEW_MODEL`
5. 两者都不设置，确认步骤为空操作，保留默认 `qwen3.7-max`

### 证据（前后对比）

N/A — 仅 CI 自动化变更。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

N/A — GitHub Actions workflow 变更。

## 风险与范围

- 主要风险：`sed` 使用全局替换，如果 `qwen3.7-max` 出现在 pr-workflow.md 的其他位置也会被替换。目前仅出现在签名行，安全。
- 未验证 / 范围外：issue-workflow.md 可能有同样的硬编码（本 PR 未修改）。
- 破坏性变更：无。

## 关联 Issue

Ref #7298

</details>