### PR TITLE
fix(web-shell): polish embedded shell interactions

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1852,7 +1852,7 @@ describe('App session callbacks', () => {
     }
 
     it('shows the toggle in the empty state for a trusted git workspace', async () => {
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await waitForToggle(container);
     });
 
@@ -1862,7 +1862,7 @@ describe('App session callbacks', () => {
           { id: 'primary', cwd: '/workspace', primary: true, trusted: false },
         ],
       };
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await flush();
       await flush();
       expect(container.querySelector(toggleSelector)).toBeNull();
@@ -1873,14 +1873,14 @@ describe('App session callbacks', () => {
         workspaceGit: vi.fn().mockRejectedValue(new Error('not a git repo')),
         workspaceSkills: mockWorkspaceActions.loadSkillsStatus,
       }));
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await flush();
       await flush();
       expect(container.querySelector(toggleSelector)).toBeNull();
     });
 
     it('toggles the pending badge on and off', async () => {
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await waitForToggle(container);
 
       await clickButton(container, toggleSelector);
@@ -1893,7 +1893,7 @@ describe('App session callbacks', () => {
     });
 
     it('creates the session with worktree when the toggle is enabled', async () => {
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await waitForToggle(container);
       await clickButton(container, toggleSelector);
 
@@ -1910,7 +1910,7 @@ describe('App session callbacks', () => {
     });
 
     it('creates the session without worktree when the toggle is off', async () => {
-      renderApp();
+      renderApp({ showWorktreeToggle: true });
       await flush();
 
       await act(async () => {
@@ -1926,7 +1926,7 @@ describe('App session callbacks', () => {
     });
 
     it('clears the pending worktree intent when starting a new session from the sidebar', async () => {
-      const { container } = renderApp();
+      const { container } = renderApp({ showWorktreeToggle: true });
       await waitForToggle(container);
       await clickButton(container, toggleSelector);
       expect(container.textContent).toContain(badgeDesc);

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -8042,6 +8042,7 @@ export function App({
                     error={artifactsError}
                     onSelectTab={setActiveArtifactPanelTabId}
                     onCloseTab={closeArtifactPanelTab}
+                    onOpenFilePreview={openFilePreview}
                     onClose={closeArtifactPanel}
                     variant="drawer"
                   />

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -570,6 +570,8 @@ export interface WebShellProps {
   renderToolHeaderExtra?: ToolHeaderExtraRenderer;
   /** Custom renderer for the welcome header. Receives version, cwd, model, and mode. */
   renderWelcomeHeader?: WelcomeHeaderRenderer;
+  /** Show the worktree-isolation action in the empty welcome state. Defaults to false. */
+  showWorktreeToggle?: boolean;
   /** Custom renderer shown below the chat composer in the empty welcome state. */
   renderWelcomeFooter?: WelcomeFooterRenderer;
   /**
@@ -1058,6 +1060,7 @@ export function App({
   composerTagIcons,
   renderToolHeaderExtra,
   renderWelcomeHeader,
+  showWorktreeToggle = false,
   renderWelcomeFooter,
   mobileWelcomeFooterMiddle = false,
   parseUserMessageContent,
@@ -6369,7 +6372,8 @@ export function App({
   // session would land in is trusted and is a git repository — the daemon
   // rejects worktree creation otherwise. Mirrors the sidebar entry's gating.
   const worktreeToggleEligible = Boolean(
-    workspaces.find((entry) => entry.cwd === activeWorkspaceCwd)?.trusted &&
+    showWorktreeToggle &&
+      workspaces.find((entry) => entry.cwd === activeWorkspaceCwd)?.trusted &&
       selectedWorkspaceGitStatus?.branch,
   );
   const worktreeToggleRef = useRef<HTMLButtonElement>(null);
@@ -6385,6 +6389,11 @@ export function App({
     setWorktreePending(false);
     worktreeFocusTarget.current = 'toggle';
   }, []);
+  useEffect(() => {
+    if (showWorktreeToggle) return;
+    pendingWorktreeRef.current = undefined;
+    setWorktreePending(false);
+  }, [showWorktreeToggle]);
   useEffect(() => {
     if (!worktreeFocusTarget.current) return;
     const target = worktreeFocusTarget.current;
@@ -6403,7 +6412,7 @@ export function App({
         ) : (
           <WelcomeHeader {...welcomeHeaderProps} />
         )}
-        {worktreePending ? (
+        {showWorktreeToggle && worktreePending ? (
           <div className={styles.worktreeWelcomeBadge}>
             <span className={styles.worktreeBadgeIcon}>
               <GitForkIcon size={18} strokeWidth={1.8} />
@@ -6454,6 +6463,7 @@ export function App({
     ),
     [
       renderWelcomeHeader,
+      showWorktreeToggle,
       welcomeHeaderProps,
       worktreePending,
       worktreeToggleEligible,

--- a/packages/web-shell/client/components/ChatEditor.module.css
+++ b/packages/web-shell/client/components/ChatEditor.module.css
@@ -190,14 +190,8 @@
 }
 
 :global([data-web-shell-slash-menu]) {
-  width: min(
-    max(
-      240px,
-      calc(
-        var(--slash-command-col) + var(--slash-desc-col) +
-          var(--slash-column-gap) + 20px
-      )
-    ),
+  width: 620px;
+  max-width: min(
     calc(var(--radix-popover-trigger-width) - 32px),
     var(--radix-popover-content-available-width),
     calc(100vw - 24px)
@@ -208,11 +202,7 @@
 
 :global([data-web-shell-slash-detail]) {
   z-index: calc(var(--web-shell-popover-z-index, 1000) + 1);
-  width: min(
-    320px,
-    var(--radix-popover-content-available-width),
-    calc(100vw - 24px)
-  );
+  width: min(320px, calc(100vw - 24px));
   max-height: min(200px, var(--radix-popover-content-available-height));
   overflow: hidden;
 }
@@ -303,8 +293,8 @@
   width: 100%;
   min-width: 0;
   grid-template-columns:
-    minmax(0, 2fr)
-    minmax(0, 3fr);
+    minmax(0, 220px)
+    minmax(0, 1fr);
   column-gap: 8px;
   align-items: baseline;
   padding: 5px 8px;
@@ -379,6 +369,7 @@
   font-size: 12px;
   font-weight: 400;
   line-height: 20px;
+  text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -695,18 +686,6 @@
   font-size: 12px;
 }
 
-@container (max-width: 699px) {
-  .slashList {
-    width: 100%;
-  }
-
-  .slashItem {
-    width: 100%;
-    grid-template-columns: minmax(0, 1fr);
-    row-gap: 2px;
-  }
-}
-
 .attachments {
   display: flex;
   min-height: 0;
@@ -958,14 +937,12 @@
   border: 0;
   background: transparent;
   cursor: pointer;
-  font: inherit;
-  color: inherit;
-  padding: 0;
   margin: 0;
 }
 
 .gitBranchChipButton:hover {
-  background: var(--subtle-bg);
+  background: var(--chat-editor-bg-tertiary);
+  color: var(--chat-editor-text-primary);
 }
 
 .gitBranchChipButton:focus-visible {

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import type { CSSProperties, ReactNode, RefObject } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { Tooltip as TooltipPrimitive } from 'radix-ui';
 import { DAEMON_APPROVAL_MODES } from '@qwen-code/webui/daemon-react-sdk';
 import type { CommandInfo } from '../adapters/types';
@@ -838,6 +838,7 @@ function SlashCommandPanel({
   const [hoverDetail, setHoverDetail] = useState<{
     label: string;
     detail: string;
+    side: 'top' | 'right' | 'bottom' | 'left';
   } | null>(null);
 
   useEffect(() => {
@@ -885,25 +886,6 @@ function SlashCommandPanel({
   }, []);
 
   const rowPlans = planSlashSectionRows(menu.items, menu.kind);
-  const maxLabelLength = Math.max(
-    ...menu.items.map((item) => Array.from(item.label).length),
-    0,
-  );
-  const maxDetailLength = Math.max(
-    ...menu.items.map((item) => Array.from(item.detail ?? '').length),
-    0,
-  );
-  const hasDetailColumn = maxDetailLength > 0;
-  const panelStyle = {
-    '--slash-command-col': `${Math.min(
-      Math.max(maxLabelLength + 1, 10),
-      24,
-    )}ch`,
-    '--slash-desc-col': hasDetailColumn
-      ? `${Math.min(Math.max(maxDetailLength + 1, 18), 36)}ch`
-      : '0px',
-    '--slash-column-gap': hasDetailColumn ? '2ch' : '0px',
-  } as CSSProperties;
 
   return (
     <>
@@ -924,11 +906,12 @@ function SlashCommandPanel({
           align="start"
           alignOffset={16}
           sideOffset={8}
+          avoidCollisions={false}
           collisionPadding={12}
           collisionBoundary={collisionBoundary ?? undefined}
+          className="duration-0 data-open:animate-none data-closed:animate-none"
           role="listbox"
           data-web-shell-slash-menu
-          style={panelStyle}
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
           onInteractOutside={(event) => {
@@ -1001,9 +984,29 @@ function SlashCommandPanel({
                             return;
                           }
                           hoverAnchorRef.current = event.currentTarget;
+                          const rowRect =
+                            event.currentTarget.getBoundingClientRect();
+                          const boundaryRect =
+                            collisionBoundary?.getBoundingClientRect();
+                          const left = boundaryRect?.left ?? 0;
+                          const right =
+                            boundaryRect?.right ?? window.innerWidth;
+                          const top = boundaryRect?.top ?? 0;
+                          const bottom =
+                            boundaryRect?.bottom ?? window.innerHeight;
+                          const detailWidth = Math.min(320, right - left - 24);
+                          const side =
+                            right - rowRect.right >= detailWidth + 8
+                              ? 'right'
+                              : rowRect.left - left >= detailWidth + 8
+                                ? 'left'
+                                : rowRect.top - top >= bottom - rowRect.bottom
+                                  ? 'top'
+                                  : 'bottom';
                           setHoverDetail({
                             label: item.label,
                             detail: item.detail,
+                            side,
                           });
                         }}
                         onMouseDown={(event) => {
@@ -1043,11 +1046,12 @@ function SlashCommandPanel({
         {hoverDetail && (
           <PopoverContent
             ref={detailRef}
-            side="right"
+            side={hoverDetail.side}
             align="start"
             sideOffset={8}
             collisionPadding={12}
             collisionBoundary={collisionBoundary ?? undefined}
+            className="duration-0 data-open:animate-none data-closed:animate-none"
             data-web-shell-slash-detail
             onOpenAutoFocus={(event) => event.preventDefault()}
             onCloseAutoFocus={(event) => event.preventDefault()}

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -376,6 +376,10 @@ export function ChatPane({
   const handleRightPanelOpen = useCallback(
     (request: TurnOutputOpenRequest) => {
       if (!onRightPanelOpen) return;
+      if (request.kind === 'subagent') {
+        onRightPanelOpen(request);
+        return;
+      }
       onRightPanelOpen({ ...request, workspaceActions });
     },
     [onRightPanelOpen, workspaceActions],

--- a/packages/web-shell/client/components/WorkspaceSelector.tsx
+++ b/packages/web-shell/client/components/WorkspaceSelector.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { FolderClosedIcon, FolderPlusIcon, LockIcon } from 'lucide-react';
 import { useI18n } from '../i18n';
 import {
@@ -12,6 +13,12 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
 
 export interface WorkspaceSelectorOption {
   id: string;
@@ -51,6 +58,10 @@ export function WorkspaceSelector({
   onOpenExistingFolder,
 }: WorkspaceSelectorProps) {
   const { t } = useI18n();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const menuOpenRef = useRef(false);
+  const suppressTooltipRef = useRef(false);
   const selected = workspaces.find((workspace) =>
     selectedWorkspaceCwd
       ? workspace.cwd === selectedWorkspaceCwd
@@ -60,68 +71,109 @@ export function WorkspaceSelector({
   if (workspaces.length <= 1 && !canCreate) return null;
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild disabled={disabled || busy}>
-        <button
-          type="button"
-          className={className}
-          aria-label={t('sidebar.workspaceSelectLabel')}
-          title={selected?.cwd}
-        >
-          <FolderClosedIcon size={16} strokeWidth={1.2} />
-          <span data-slot="select-value">{selected?.label ?? ''}</span>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-56">
-        <DropdownMenuRadioGroup
-          value={selected?.id}
-          onValueChange={(id) => {
-            const next = workspaces.find((workspace) => workspace.id === id);
-            if (!next?.trusted) return;
-            onSelectWorkspace(next.primary ? undefined : next.cwd);
+    <TooltipProvider delayDuration={300}>
+      <DropdownMenu
+        open={menuOpen}
+        onOpenChange={(open) => {
+          menuOpenRef.current = open;
+          setMenuOpen(open);
+          if (open) {
+            suppressTooltipRef.current = true;
+            setTooltipOpen(false);
+          }
+        }}
+      >
+        <Tooltip
+          open={tooltipOpen}
+          onOpenChange={(open) => {
+            if (open && (menuOpen || suppressTooltipRef.current)) {
+              return;
+            }
+            setTooltipOpen(open);
           }}
         >
-          {workspaces.map((workspace) => (
-            <DropdownMenuRadioItem
-              key={workspace.id}
-              value={workspace.id}
-              disabled={!workspace.trusted}
-              title={workspace.cwd}
-            >
-              <span className="min-w-0 flex-1 truncate">{workspace.label}</span>
-              {!workspace.trusted && (
-                <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <LockIcon />
-                  {t('sidebar.workspaceUntrusted')}
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild disabled={disabled || busy}>
+              <button
+                type="button"
+                className={className}
+                aria-label={t('sidebar.workspaceSelectLabel')}
+                onPointerEnter={() => {
+                  if (!menuOpenRef.current) {
+                    suppressTooltipRef.current = false;
+                  }
+                }}
+                onPointerLeave={() => {
+                  suppressTooltipRef.current = false;
+                  setTooltipOpen(false);
+                }}
+                onBlur={() => {
+                  if (!menuOpenRef.current) {
+                    suppressTooltipRef.current = false;
+                    setTooltipOpen(false);
+                  }
+                }}
+              >
+                <FolderClosedIcon size={16} strokeWidth={1.2} />
+                <span data-slot="select-value">{selected?.label ?? ''}</span>
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top">{selected?.label}</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" className="min-w-56">
+          <DropdownMenuRadioGroup
+            value={selected?.id}
+            onValueChange={(id) => {
+              const next = workspaces.find((workspace) => workspace.id === id);
+              if (!next?.trusted) return;
+              onSelectWorkspace(next.primary ? undefined : next.cwd);
+            }}
+          >
+            {workspaces.map((workspace) => (
+              <DropdownMenuRadioItem
+                key={workspace.id}
+                value={workspace.id}
+                disabled={!workspace.trusted}
+                title={workspace.cwd}
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {workspace.label}
                 </span>
-              )}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-        {canCreate && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger disabled={busy}>
-                <FolderPlusIcon />
-                {t('sidebar.newWorkspace')}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {scratchSupported && (
-                  <DropdownMenuItem onSelect={onCreateScratch}>
-                    {t('sidebar.startFromScratch')}
-                  </DropdownMenuItem>
+                {!workspace.trusted && (
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <LockIcon />
+                    {t('sidebar.workspaceUntrusted')}
+                  </span>
                 )}
-                {existingFolderSupported && (
-                  <DropdownMenuItem onSelect={onOpenExistingFolder}>
-                    {t('sidebar.useExistingFolder')}
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+          {canCreate && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger disabled={busy}>
+                  <FolderPlusIcon />
+                  {t('sidebar.newWorkspace')}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {scratchSupported && (
+                    <DropdownMenuItem onSelect={onCreateScratch}>
+                      {t('sidebar.startFromScratch')}
+                    </DropdownMenuItem>
+                  )}
+                  {existingFolderSupported && (
+                    <DropdownMenuItem onSelect={onOpenExistingFolder}>
+                      {t('sidebar.useExistingFolder')}
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
   );
 }

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -138,7 +138,9 @@ export function ArtifactPanel({
   const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
   const defaultWorkspaceActions = useWorkspaceActions();
   const activeWorkspaceActions =
-    activeTab?.workspaceActions ?? defaultWorkspaceActions;
+    activeTab && 'workspaceActions' in activeTab
+      ? (activeTab.workspaceActions ?? defaultWorkspaceActions)
+      : defaultWorkspaceActions;
 
   return (
     <aside

--- a/packages/web-shell/client/components/ui/tooltip.tsx
+++ b/packages/web-shell/client/components/ui/tooltip.tsx
@@ -31,7 +31,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 8,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -42,13 +42,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          'z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          "relative z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground before:pointer-events-none before:absolute before:size-2.5 before:rotate-45 before:rounded-[2px] before:bg-popover before:border-border before:content-[''] has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:before:-top-[5px] data-[side=bottom]:before:left-1/2 data-[side=bottom]:before:-translate-x-1/2 data-[side=bottom]:before:border-t data-[side=bottom]:before:border-l data-[side=left]:before:top-1/2 data-[side=left]:before:-right-[5px] data-[side=left]:before:-translate-y-1/2 data-[side=left]:before:border-t data-[side=left]:before:border-r data-[side=right]:before:top-1/2 data-[side=right]:before:-left-[5px] data-[side=right]:before:-translate-y-1/2 data-[side=right]:before:border-b data-[side=right]:before:border-l data-[side=top]:before:-bottom-[6px] data-[side=top]:before:left-1/2 data-[side=top]:before:-translate-x-1/2 data-[side=top]:before:border-r data-[side=top]:before:border-b data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=instant-open]:animate-in data-[state=instant-open]:fade-in-0 data-[state=instant-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] fill-popover" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/web-shell/client/hooks/useSessionArtifacts.ts
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.ts
@@ -73,13 +73,9 @@ export function useSessionArtifacts(): SessionArtifactsState {
       loadedSessionIdRef.current = sessionId;
       setArtifacts(result.artifacts);
       setError(null);
-    } catch (err) {
+    } catch {
       if (requestIdRef.current !== requestId) return;
-      if (isSessionDisconnectedError(err)) {
-        setError(null);
-        return;
-      }
-      setError(err instanceof Error ? err.message : String(err));
+      setError(null);
     } finally {
       if (requestIdRef.current === requestId) {
         setLoading(false);
@@ -119,9 +115,4 @@ export function useSessionArtifacts(): SessionArtifactsState {
   );
 
   return { artifacts, artifactById, loading, error, refresh };
-}
-
-function isSessionDisconnectedError(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes('session is not connected');
 }

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -172,6 +172,7 @@ function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
             onLanguageChange: handleLanguageChange,
             onSessionIdChange: handleSessionIdChange,
             sidebar: true,
+            showWorktreeToggle: true,
             compactThinking: true,
             markdownTableMode: 'advanced',
           }}

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -1207,25 +1207,9 @@ export function createDaemonSessionActions({
     },
 
     async loadArtifacts(): Promise<DaemonSessionArtifactsEnvelope> {
-      const session = requireSessionForAction(
-        addNotice,
-        sessionRef.current,
-        'Load artifacts failed',
-        'load_artifacts',
-      );
-      try {
-        return await withActionTimeout(
-          session.artifacts(),
-          'Load artifacts timed out',
-        );
-      } catch (error) {
-        throw dispatchActionError(
-          addNotice,
-          'Load artifacts failed',
-          error,
-          'load_artifacts',
-        );
-      }
+      const session = sessionRef.current;
+      if (!session) throw new Error('Daemon session is not connected');
+      return withActionTimeout(session.artifacts(), 'Load artifacts timed out');
     },
 
     async respondToGlobalPermission(


### PR DESCRIPTION
## What this PR does

This PR polishes several Web Shell interactions: tooltips use a consistent white bordered surface and no longer reopen after dismissing the workspace menu, the slash-command panel stays above the composer with a stable two-column layout and adaptive detail placement, and the Git control matches the surrounding toolbar. Artifact discovery failures are now passive instead of producing global error notifications. Embedded consumers can opt into the empty-state worktree action with `showWorktreeToggle`, while the standalone shell keeps it enabled. It also completes the recently added rendered-file preview wiring for drawer and split-pane paths.

## Why it's needed

The affected controls had inconsistent hover styling, unstable overlay placement on narrow screens, repeated passive artifact errors, and standalone-only worktree behavior leaking into embedded integrations. The rendered-file preview follow-up prevents missing callbacks in the mobile drawer and keeps workspace-scoped actions attached only to compatible panel requests.

## Reviewer Test Plan

### How to verify

- Open the standalone Web Shell with an empty trusted Git workspace and confirm the worktree-isolation action remains visible; render Web Shell as a component without `showWorktreeToggle` and confirm the action is hidden.
- Hover the workspace, approval, model, and Git controls and confirm the white bordered tooltip, arrow, spacing, and animation are consistent. Open and close the workspace menu and confirm its tooltip does not reopen until the trigger is hovered or focused again.
- Open the slash-command menu on wide and narrow layouts and confirm it remains above the composer, keeps a fixed two-column structure, and places long command details on an available side without squeezing the detail card.
- Make artifact discovery fail and confirm no global toast or inline artifact error is shown while any previously loaded artifacts remain available.
- In a narrow/mobile layout, open a rendered HTML or Markdown file from the drawer and confirm preview routing works. Open a subagent panel from a split pane and confirm it does not inherit unrelated workspace actions.

### Evidence (Before & After)

Before: tooltip arrows and toolbar hover states were inconsistent, the slash menu could flip below the composer or squeeze its detail card, passive artifact refresh failures surfaced errors, and embedded shells exposed the worktree action by default. After: overlays have stable placement and styling, passive artifact loads fail silently, worktree isolation is opt-in for embedded consumers, and rendered-file preview paths are fully wired.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Validated with package lint, TypeScript type checking, and production builds for WebUI and Web Shell. UI automation was not run.

## Risk & Scope

- Main risk or tradeoff: tooltip arrows are drawn as part of the tooltip surface for synchronized animation, so collision-shifted tooltips keep the arrow centered on the surface instead of independently offsetting it toward the trigger.
- Not validated / out of scope: UI automation and the broader Git status polling strategy.
- Breaking changes / migration notes: none; `showWorktreeToggle` is optional and defaults to false for embedded consumers, while the standalone entry explicitly enables it.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 优化了多处 Web Shell 交互：Tooltip 统一为白底描边样式，关闭 workspace 菜单后不会自动重新弹出；斜杠命令面板固定在输入框上方，使用稳定的左右两列布局，并根据可用空间放置详情；Git 控件的样式与周围工具栏保持一致。Artifacts 被动加载失败不再产生全局错误通知。嵌入方可以通过 `showWorktreeToggle` 选择是否展示空状态 Worktree 入口，独立 Web Shell 则继续启用。PR 同时补齐了最近新增的文件渲染预览在 Drawer 和分屏路径中的接线。

## 为什么需要

相关控件此前存在 hover 样式不一致、窄屏浮层位置不稳定、被动 artifacts 请求反复报错，以及独立模式的 Worktree 功能默认泄漏到嵌入接入等问题。文件预览的补充修复可以避免移动端 Drawer 缺少回调，并确保 workspace actions 只附加到兼容的面板请求。

## Reviewer 测试计划

### 验证方式

- 在可信 Git workspace 的空会话中打开独立 Web Shell，确认 Worktree 隔离入口仍然展示；将 Web Shell 作为组件使用且不传 `showWorktreeToggle`，确认该入口隐藏。
- Hover workspace、权限、模型和 Git 控件，确认 Tooltip 的白底、边框、箭头、间距和动画一致。打开并关闭 workspace 菜单，确认 Tooltip 不会自动重新出现，直到再次 hover 或 focus trigger。
- 在宽屏和窄屏下打开斜杠命令菜单，确认它始终位于输入框上方、保持固定左右结构，并能把长详情放到有空间的一侧且不会挤压详情卡片。
- 让 artifacts 加载失败，确认不会出现全局 toast 或面板内错误，并保留此前已加载的 artifacts。
- 在窄屏或移动布局中从 Drawer 打开 HTML 或 Markdown 渲染预览，确认预览路由正常；从分屏打开 subagent 面板，确认不会继承无关的 workspace actions。

### 前后对比证据

修改前：Tooltip 箭头和工具栏 hover 样式不一致，斜杠菜单可能翻转到输入框下方或挤压详情卡片，被动 artifacts 刷新失败会展示错误，嵌入组件默认出现 Worktree 入口。修改后：浮层定位与样式稳定，被动 artifacts 加载静默失败，嵌入方需显式开启 Worktree 隔离，文件渲染预览路径完整接通。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

已通过 WebUI 和 Web Shell 的包级 lint、TypeScript 类型检查及生产构建。未运行 UI 自动化测试。

## 风险与范围

- 主要风险或取舍：Tooltip 箭头现在作为气泡表面的一部分绘制，以保证动画同步；发生碰撞位移时，箭头保持在气泡中间，不再单独向 trigger 偏移。
- 未验证或超出范围：UI 自动化，以及更广泛的 Git 状态轮询策略。
- 破坏性变更或迁移说明：无；`showWorktreeToggle` 为可选参数，嵌入方默认 false，独立入口会显式开启。

## 关联 Issue

N/A

</details>
