### PR TITLE
feat(prompts): allow overriding core identity via QWEN_SYSTEM_IDENTITY_MD

### DIFF
--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -44,6 +44,7 @@ describe('Core System Prompt (prompts.ts)', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.stubEnv('QWEN_SYSTEM_MD', undefined);
+    vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', undefined);
     vi.stubEnv('QWEN_WRITE_SYSTEM_MD', undefined);
   });
 
@@ -360,6 +361,112 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
       expect(prompt).toBe('custom system prompt');
     });
+  });
+
+  describe('QWEN_SYSTEM_IDENTITY_MD environment variable', () => {
+    const defaultIdentity =
+      'You are Qwen Code, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.';
+    const customIdentity =
+      'You are Acme Code, an interactive CLI agent for Acme Corp.';
+
+    it('should keep default prompt byte-identical when identity env is unset', () => {
+      const prompt = getCoreSystemPrompt();
+      expect(prompt.startsWith(defaultIdentity)).toBe(true);
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should replace only the identity sentence when identity env points to a file', () => {
+      const identityPath = path.resolve('/custom/identity.md');
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => path.resolve(String(p)) === identityPath,
+      );
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (path.resolve(String(p)) === identityPath) {
+          return customIdentity;
+        }
+        throw new Error(`unexpected read: ${String(p)}`);
+      });
+
+      const withOverride = getCoreSystemPrompt();
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', undefined);
+      const baseline = getCoreSystemPrompt();
+
+      expect(withOverride.startsWith(customIdentity)).toBe(true);
+      expect(withOverride).not.toContain('You are Qwen Code');
+      expect(withOverride.slice(customIdentity.length)).toBe(
+        baseline.slice(defaultIdentity.length),
+      );
+    });
+
+    it('should ignore identity env when QWEN_SYSTEM_MD is set', () => {
+      const systemPath = path.resolve('/custom/system.md');
+      const identityPath = path.resolve('/custom/identity.md');
+      vi.stubEnv('QWEN_SYSTEM_MD', systemPath);
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (path.resolve(String(p)) === systemPath) {
+          return 'full system override';
+        }
+        throw new Error(`identity file should not be read: ${String(p)}`);
+      });
+
+      const prompt = getCoreSystemPrompt();
+      expect(prompt).toBe('full system override');
+      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync).toHaveBeenCalledWith(systemPath, 'utf8');
+    });
+
+    it('should not inject identity when QWEN_SYSTEM_MD points to an empty file', () => {
+      const systemPath = path.resolve('/custom/empty-system.md');
+      const identityPath = path.resolve('/custom/identity.md');
+      vi.stubEnv('QWEN_SYSTEM_MD', systemPath);
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (path.resolve(String(p)) === systemPath) {
+          return '';
+        }
+        throw new Error(`identity file should not be read: ${String(p)}`);
+      });
+
+      const prompt = getCoreSystemPrompt();
+      expect(prompt).toBe('');
+      expect(prompt).not.toContain(customIdentity);
+      expect(prompt).not.toContain('You are Qwen Code');
+    });
+
+    it('should throw when identity env points to a missing file', () => {
+      const identityPath = path.resolve('/missing/identity.md');
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      expect(() => getCoreSystemPrompt()).toThrow(
+        `missing system identity file '${identityPath}'`,
+      );
+    });
+
+    it('should throw when identity env points to an empty or whitespace-only file', () => {
+      const identityPath = path.resolve('/custom/blank-identity.md');
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('  \n\t  ');
+
+      expect(() => getCoreSystemPrompt()).toThrow(
+        `empty system identity file '${identityPath}'`,
+      );
+    });
+
+    it.each(['0', 'false', '1', 'true'] as const)(
+      'should not override identity when env is switch value %s',
+      (switchValue) => {
+        vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', switchValue);
+        const prompt = getCoreSystemPrompt();
+        expect(prompt.startsWith(defaultIdentity)).toBe(true);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('QWEN_WRITE_SYSTEM_MD environment variable', () => {

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -364,18 +364,25 @@ describe('Core System Prompt (prompts.ts)', () => {
   });
 
   describe('QWEN_SYSTEM_IDENTITY_MD environment variable', () => {
-    const defaultIdentity =
-      'You are Qwen Code, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.';
     const customIdentity =
       'You are Acme Code, an interactive CLI agent for Acme Corp.';
 
+    /** Sample the default identity from the live prompt to avoid drift. */
+    const sampleDefaultIdentity = (): string => {
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', undefined);
+      vi.stubEnv('QWEN_SYSTEM_MD', undefined);
+      return getCoreSystemPrompt().split('\n\n', 1)[0];
+    };
+
     it('should keep default prompt byte-identical when identity env is unset', () => {
+      const defaultIdentity = sampleDefaultIdentity();
       const prompt = getCoreSystemPrompt();
       expect(prompt.startsWith(defaultIdentity)).toBe(true);
       expect(fs.readFileSync).not.toHaveBeenCalled();
     });
 
     it('should replace only the identity sentence when identity env points to a file', () => {
+      const defaultIdentity = sampleDefaultIdentity();
       const identityPath = path.resolve('/custom/identity.md');
       vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', identityPath);
       vi.mocked(fs.existsSync).mockImplementation(
@@ -383,7 +390,7 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
       vi.mocked(fs.readFileSync).mockImplementation((p) => {
         if (path.resolve(String(p)) === identityPath) {
-          return customIdentity;
+          return `${customIdentity}  \n\n`;
         }
         throw new Error(`unexpected read: ${String(p)}`);
       });
@@ -394,6 +401,7 @@ describe('Core System Prompt (prompts.ts)', () => {
 
       expect(withOverride.startsWith(customIdentity)).toBe(true);
       expect(withOverride).not.toContain('You are Qwen Code');
+      // trimEnd() strips trailing spaces/newlines from the identity file.
       expect(withOverride.slice(customIdentity.length)).toBe(
         baseline.slice(defaultIdentity.length),
       );
@@ -458,9 +466,21 @@ describe('Core System Prompt (prompts.ts)', () => {
       );
     });
 
+    it('should throw when a ~/ identity path cannot resolve the home directory', () => {
+      vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', '~/identity.md');
+      vi.spyOn(os, 'homedir').mockImplementation(() => {
+        throw new Error('homedir unavailable');
+      });
+
+      expect(() => getCoreSystemPrompt()).toThrow(
+        `failed to resolve system identity path '~/identity.md'`,
+      );
+    });
+
     it.each(['0', 'false', '1', 'true'] as const)(
       'should not override identity when env is switch value %s',
       (switchValue) => {
+        const defaultIdentity = sampleDefaultIdentity();
         vi.stubEnv('QWEN_SYSTEM_IDENTITY_MD', switchValue);
         const prompt = getCoreSystemPrompt();
         expect(prompt.startsWith(defaultIdentity)).toBe(true);

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -88,23 +88,39 @@ function getInteractiveInteractionModePrompt(): {
  * Factored out so `QWEN_SYSTEM_IDENTITY_MD` can replace this single unit
  * without fragile splicing of the large base-prompt template.
  */
-export function getDefaultCoreIdentitySentence(role: string): string {
+function getDefaultCoreIdentitySentence(role: string): string {
   return `You are Qwen Code, ${role} developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.`;
 }
 
 /**
  * Resolve an opt-in identity override from `QWEN_SYSTEM_IDENTITY_MD`.
- * Only a real file path enables the override (unlike `QWEN_SYSTEM_MD`, there
- * is no default identity file, so switch values like `1`/`true` are ignored).
- * Missing or empty/whitespace-only files fail loud.
+ *
+ * This is a **trusted distributor-level** system-prompt fragment: the file is
+ * inserted verbatim as the leading identity paragraph of the default core
+ * prompt (not a sanitized branding field). Only a real file path enables it
+ * (unlike `QWEN_SYSTEM_MD`, there is no default identity file, so switch
+ * values like `1`/`true` are ignored). Missing files, empty/whitespace-only
+ * files, and path-resolution failures fail loud.
  */
 function resolveCoreIdentityOverride(): string | null {
-  const resolution = resolvePathFromEnv(
-    process.env['QWEN_SYSTEM_IDENTITY_MD'],
-  );
-  // Unset, whitespace, or boolean-like switches → no override.
-  if (!resolution.value || resolution.isSwitch) {
+  const rawEnv = process.env['QWEN_SYSTEM_IDENTITY_MD'];
+  const trimmed = rawEnv?.trim();
+  // Unset or whitespace → no override.
+  if (!trimmed) {
     return null;
+  }
+
+  const resolution = resolvePathFromEnv(rawEnv);
+  // Boolean-like switches → no override (no default identity file).
+  if (resolution.isSwitch) {
+    return null;
+  }
+
+  // Env was set to a path-like value but resolution produced no path
+  // (e.g. `~/...` when `os.homedir()` fails). Do not silently fall back to
+  // the default Qwen identity when an explicit override was configured.
+  if (!resolution.value) {
+    throw new Error(`failed to resolve system identity path '${trimmed}'`);
   }
 
   const identityPath = resolution.value;
@@ -117,9 +133,9 @@ function resolveCoreIdentityOverride(): string | null {
     throw new Error(`empty system identity file '${identityPath}'`);
   }
 
-  // Preserve file contents as the identity paragraph (trim trailing newline
-  // so the following blank line in the template stays a single separator).
-  return contents.replace(/\n+$/, '');
+  // Trim trailing whitespace/newlines so the blank line before
+  // `# Core Mandates` stays a clean paragraph separator.
+  return contents.trimEnd();
 }
 
 export function resolvePathFromEnv(envVar?: string): {
@@ -251,12 +267,14 @@ export function getCoreSystemPrompt(
   //
   // `QWEN_SYSTEM_IDENTITY_MD` only applies on the default-prompt branch and is
   // ignored whenever `QWEN_SYSTEM_MD` is in effect (including empty-file clear).
-  const coreIdentity =
-    (!systemMdEnabled ? resolveCoreIdentityOverride() : null) ??
-    getDefaultCoreIdentitySentence(interaction.role);
-  const basePrompt = systemMdEnabled
-    ? fs.readFileSync(systemMdPath, 'utf8')
-    : `
+  let basePrompt: string;
+  if (systemMdEnabled) {
+    basePrompt = fs.readFileSync(systemMdPath, 'utf8');
+  } else {
+    const coreIdentity =
+      resolveCoreIdentityOverride() ??
+      getDefaultCoreIdentitySentence(interaction.role);
+    basePrompt = `
 ${coreIdentity}
 
 # Core Mandates
@@ -406,6 +424,7 @@ Your core function is efficient and safe assistance. Balance conciseness with th
 
 Interaction mode reminder: ${interaction.questions}
 `.trim();
+  }
 
   // if QWEN_WRITE_SYSTEM_MD is set (and not 0|false), write base system prompt to file
   const writeSystemMdResolution = resolvePathFromEnv(

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -83,6 +83,45 @@ function getInteractiveInteractionModePrompt(): {
   };
 }
 
+/**
+ * Default leading identity sentence of the core system prompt.
+ * Factored out so `QWEN_SYSTEM_IDENTITY_MD` can replace this single unit
+ * without fragile splicing of the large base-prompt template.
+ */
+export function getDefaultCoreIdentitySentence(role: string): string {
+  return `You are Qwen Code, ${role} developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.`;
+}
+
+/**
+ * Resolve an opt-in identity override from `QWEN_SYSTEM_IDENTITY_MD`.
+ * Only a real file path enables the override (unlike `QWEN_SYSTEM_MD`, there
+ * is no default identity file, so switch values like `1`/`true` are ignored).
+ * Missing or empty/whitespace-only files fail loud.
+ */
+function resolveCoreIdentityOverride(): string | null {
+  const resolution = resolvePathFromEnv(
+    process.env['QWEN_SYSTEM_IDENTITY_MD'],
+  );
+  // Unset, whitespace, or boolean-like switches → no override.
+  if (!resolution.value || resolution.isSwitch) {
+    return null;
+  }
+
+  const identityPath = resolution.value;
+  if (!fs.existsSync(identityPath)) {
+    throw new Error(`missing system identity file '${identityPath}'`);
+  }
+
+  const contents = fs.readFileSync(identityPath, 'utf8');
+  if (!contents.trim()) {
+    throw new Error(`empty system identity file '${identityPath}'`);
+  }
+
+  // Preserve file contents as the identity paragraph (trim trailing newline
+  // so the following blank line in the template stays a single separator).
+  return contents.replace(/\n+$/, '');
+}
+
 export function resolvePathFromEnv(envVar?: string): {
   isSwitch: boolean;
   value: string | null;
@@ -209,10 +248,16 @@ export function getCoreSystemPrompt(
   // purpose of the override. Custom prompts are responsible for their own mode
   // awareness (e.g. not instructing the model to ask questions in headless
   // runs). `appendInstruction` below still applies in both branches.
+  //
+  // `QWEN_SYSTEM_IDENTITY_MD` only applies on the default-prompt branch and is
+  // ignored whenever `QWEN_SYSTEM_MD` is in effect (including empty-file clear).
+  const coreIdentity =
+    (!systemMdEnabled ? resolveCoreIdentityOverride() : null) ??
+    getDefaultCoreIdentitySentence(interaction.role);
   const basePrompt = systemMdEnabled
     ? fs.readFileSync(systemMdPath, 'utf8')
     : `
-You are Qwen Code, ${interaction.role} developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+${coreIdentity}
 
 # Core Mandates
 


### PR DESCRIPTION
## Summary
- Add opt-in `QWEN_SYSTEM_IDENTITY_MD` env (file path) to replace only the leading identity sentence of the default core system prompt.
- Keep `QWEN_SYSTEM_MD` as the higher-precedence whole-prompt override; identity env is ignored when it is in effect (including empty-file clear).
- Factor the default identity sentence into `getDefaultCoreIdentitySentence` and fail loud on missing/empty identity files; switch values (`0`/`1`/`true`/`false`) do not enable the override.

Closes #7436

## Test plan
- [x] `vitest run src/core/prompts.test.ts` in `packages/core` (84 tests passed)
- [ ] Verify no env → prompt unchanged vs previous default identity
- [ ] Verify identity file replaces only the first paragraph
- [ ] Verify `QWEN_SYSTEM_MD` wins over identity env
