### PR TITLE
fix(ci): autofix route checks existing labels on non-trigger label events

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -516,7 +516,19 @@ jobs:
                 [[ "${ISSUE_LABEL}" == "${READY_FOR_AGENT_LABEL}" || "${ISSUE_LABEL}" == "${BUG_LABEL}" || "${ISSUE_LABEL}" == "${AUTOFIX_APPROVED_LABEL}" ]] && label_is_trigger=true
                 [[ "${ASSIGNEE_LOGIN}" == "${AUTOFIX_BOT}" ]] && label_is_trigger=true
                 if [[ "${label_is_trigger}" != 'true' ]]; then
-                  echo "🧭 issue event ignored: trigger_label=false label='${ISSUE_LABEL:-n/a}' issue='#${ISSUE_NUMBER:-n/a}'"
+                  # A non-trigger label (e.g. scope/*, priority/*) may arrive
+                  # after the trigger labels and cancel their runs via per-issue
+                  # concurrency. If the issue already carries both required
+                  # labels, proceed anyway — trust was established when the
+                  # trigger labels were applied (both require triage+).
+                  _late_ready="$(jq -r --arg l "${READY_FOR_AGENT_LABEL}" 'index($l) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
+                  _late_approved="$(jq -r --arg l "${AUTOFIX_APPROVED_LABEL}" 'index($l) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
+                  if [[ "${ISSUE_STATE}" == 'open' && "${_late_ready}" == 'true' && "${_late_approved}" == 'true' ]]; then
+                    echo "🧭 non-trigger label '${ISSUE_LABEL:-n/a}' but issue #${ISSUE_NUMBER} already approved+ready → issue phase"
+                    DO_ISSUE=true
+                  else
+                    echo "🧭 issue event ignored: trigger_label=false label='${ISSUE_LABEL:-n/a}' issue='#${ISSUE_NUMBER:-n/a}'"
+                  fi
                 else
                   issue_is_bug="$(jq -r --arg label "${BUG_LABEL}" 'index($label) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
                   issue_is_ready="$(jq -r --arg label "${READY_FOR_AGENT_LABEL}" 'index($label) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -515,15 +515,26 @@ jobs:
                 label_is_trigger=false
                 [[ "${ISSUE_LABEL}" == "${READY_FOR_AGENT_LABEL}" || "${ISSUE_LABEL}" == "${BUG_LABEL}" || "${ISSUE_LABEL}" == "${AUTOFIX_APPROVED_LABEL}" ]] && label_is_trigger=true
                 [[ "${ASSIGNEE_LOGIN}" == "${AUTOFIX_BOT}" ]] && label_is_trigger=true
+                sender_permission=''
+                sender_is_trusted=false
+                if [[ -n "${SENDER_LOGIN}" ]]; then
+                  if ! sender_permission="$(gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission" --jq '.permission // ""' 2>&1)"; then
+                    api_error="${sender_permission}"
+                    sender_permission=''
+                    api_error="${api_error//$'\r'/ }"
+                    api_error="${api_error//$'\n'/ }"
+                    echo "::warning::Permission API call failed for ${SENDER_LOGIN}: ${api_error}"
+                  fi
+                  [[ "${sender_permission}" == 'write' || "${sender_permission}" == 'maintain' || "${sender_permission}" == 'admin' ]] && sender_is_trusted=true
+                fi
                 if [[ "${label_is_trigger}" != 'true' ]]; then
                   # A non-trigger label (e.g. scope/*, priority/*) may arrive
                   # after the trigger labels and cancel their runs via per-issue
                   # concurrency. If the issue already carries both required
-                  # labels, proceed anyway — trust was established when the
-                  # trigger labels were applied (both require triage+).
+                  # labels and the current sender is trusted, proceed anyway.
                   _late_ready="$(jq -r --arg l "${READY_FOR_AGENT_LABEL}" 'index($l) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
                   _late_approved="$(jq -r --arg l "${AUTOFIX_APPROVED_LABEL}" 'index($l) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
-                  if [[ "${ISSUE_STATE}" == 'open' && "${_late_ready}" == 'true' && "${_late_approved}" == 'true' ]]; then
+                  if [[ "${ISSUE_STATE}" == 'open' && "${_late_ready}" == 'true' && "${_late_approved}" == 'true' && "${sender_is_trusted}" == 'true' ]]; then
                     echo "🧭 non-trigger label '${ISSUE_LABEL:-n/a}' but issue #${ISSUE_NUMBER} already approved+ready → issue phase"
                     DO_ISSUE=true
                   else
@@ -532,18 +543,6 @@ jobs:
                 else
                   issue_is_bug="$(jq -r --arg label "${BUG_LABEL}" 'index($label) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
                   issue_is_ready="$(jq -r --arg label "${READY_FOR_AGENT_LABEL}" 'index($label) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
-                  sender_permission=''
-                  sender_is_trusted=false
-                  if [[ -n "${SENDER_LOGIN}" ]]; then
-                    if ! sender_permission="$(gh api "repos/${REPO}/collaborators/${SENDER_LOGIN}/permission" --jq '.permission // ""' 2>&1)"; then
-                      api_error="${sender_permission}"
-                      sender_permission=''
-                      api_error="${api_error//$'\r'/ }"
-                      api_error="${api_error//$'\n'/ }"
-                      echo "::warning::Permission API call failed for ${SENDER_LOGIN}: ${api_error}"
-                    fi
-                    [[ "${sender_permission}" == 'write' || "${sender_permission}" == 'maintain' || "${sender_permission}" == 'admin' ]] && sender_is_trusted=true
-                  fi
                   issue_is_approved="$(jq -r --arg label "${AUTOFIX_APPROVED_LABEL}" 'index($label) != null' <<< "${ISSUE_LABELS_JSON:-[]}")"
                   if [[ "${ISSUE_STATE}" == 'open' && "${issue_is_ready}" == 'true' && "${issue_is_approved}" == 'true' && "${label_is_trigger}" == 'true' && "${sender_is_trusted}" == 'true' ]]; then
                     DO_ISSUE=true

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -1188,6 +1188,15 @@ describe('qwen-autofix workflow', () => {
     expect(workflow).toContain('trigger_label=${label_is_trigger}');
     expect(workflow).toContain('trigger_label=false label=');
     expect(workflow).toContain('sender_trusted=${sender_is_trusted}');
+    expect(workflow).toContain(
+      '_late_ready="$(jq -r --arg l "${READY_FOR_AGENT_LABEL}"',
+    );
+    expect(workflow).toContain(
+      '_late_approved="$(jq -r --arg l "${AUTOFIX_APPROVED_LABEL}"',
+    );
+    expect(workflow).toContain(
+      'if [[ "${ISSUE_STATE}" == \'open\' && "${_late_ready}" == \'true\' && "${_late_approved}" == \'true\' && "${sender_is_trusted}" == \'true\' ]]; then',
+    );
     expect(issueAutofixJob).toContain(
       "group: 'qwen-autofix-issue-${{ needs.route.outputs.issue_number || github.run_id }}'",
     );


### PR DESCRIPTION
## What this PR does

In the autofix route job's `issues` event handler, when the triggering label is not a recognized trigger label (`autofix/approved`, `status/ready-for-agent`, `type/bug`), the route now checks whether the issue **already carries** both `autofix/approved` and `status/ready-for-agent` in its label list before deciding to skip. If both are present and the issue is open, it proceeds with the issue phase instead of ignoring the event.

## Why it's needed

When triage adds multiple labels in sequence (e.g. `autofix/approved` → `status/ready-for-agent` → `scope/build-system`), each fires a separate `issues:labeled` event. The per-issue concurrency group (`cancel-in-progress`) cancels earlier runs. If the last label is not a trigger label, the surviving run logs `trigger_label=false` and skips — even though the issue is fully approved and ready. The trigger-label runs that would have processed it are already cancelled.

Observed in #7476: autofix never created a PR because `scope/build-system` was the last label event, and the cron fallback was blocked by the review-first scheduling policy.

## Reviewer Test Plan

### How to verify

1. Create a test issue and add `autofix/approved` + `status/ready-for-agent` labels
2. Immediately add a non-trigger label (e.g. `scope/build-system`)
3. Check the route job logs: should show `non-trigger label 'scope/build-system' but issue #N already approved+ready → issue phase` instead of `issue event ignored`
4. Verify `issue-autofix` job is no longer skipped

### Evidence (Before & After)

N/A — CI workflow change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A — GitHub Actions workflow change.

## Risk & Scope

- Main risk or tradeoff: a non-trigger label event on an already-approved issue now still requires the current sender to have write/maintain/admin permission before triggering the issue phase.
- Not validated / out of scope: the cron review-first scheduling starvation (issue 2 in #7480) is not addressed here.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #7480 (partial — addresses issue 1; issue 2 tracked separately)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 autofix route job 的 issues 事件处理中，当触发 label 不是已知的触发 label 时，新增回查逻辑：检查 issue 是否已经带有 `autofix/approved` 和 `status/ready-for-agent`。如果两者都有且 issue 是 open 状态，则继续走 issue phase，而不是直接跳过。

## 为什么需要

当 triage 连续添加多个 label 时，每个 label 触发一次 `issues:labeled` 事件。per-issue 并发组会取消先到的 run。如果最后一个 label 不是触发 label（如 `scope/build-system`），存活的 run 会判断 `trigger_label=false` 并跳过——即使 issue 已经被批准且就绪。

## 风险与范围

- 主要风险：非触发 label 事件在已批准的 issue 上触发 issue phase 前，仍要求当前事件的 sender 具备 write/maintain/admin 权限。
- 范围外：cron 的 review 优先调度导致 issue 饥饿的问题（#7480 的问题 2）不在本 PR 处理。

## 关联 Issue

Closes #7480（部分——解决问题 1；问题 2 另行跟踪）

</details>
