### PR TITLE
feat(autofix): stop a PR that fails to push for N rounds in a row

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -161,6 +161,17 @@ env:
   # explicitly delegated work; removing the label restores the strict cap,
   # and re-engaging opens a fresh counting window (see REARM_KEY below).
   TAKEOVER_MAX_ROUNDS: '100'
+  # Consecutive-failure sub-cap, distinct from the total round cap above. The
+  # total cap bounds how many PRODUCTIVE rounds a PR may take; this bounds how
+  # many rounds may fail IN A ROW with nothing pushed. Under takeover a PR gets
+  # up to 100 rounds, but a PR that fails to push this many times running is not
+  # iterating, it is stuck — a too-large / fast-conflicting PR whose fix keeps
+  # timing out or failing the gate. Retrying at the same budget will not fix
+  # that; a human has to rebase or split it. Any pushed round OR a legitimate
+  # "no changes needed" no-op resets the streak, so this only ever fires on an
+  # unbroken run of failures. Observed on #6723: 7 straight failed rounds (3
+  # timeouts, 4 gate rejections) over 8 hours, heading for 100.
+  CONSECUTIVE_FAILURE_CAP: '5'
   # Do not claim more issues when too many existing autofix PRs are still open.
   MAX_OPEN_AUTOFIX_PRS: '5'
 
@@ -3343,6 +3354,41 @@ jobs:
               # than promise a re-trigger that the guard would ignore.
               MARK_ROUND="${MAX_ROUNDS}"
               HEADLINE="🤖 AutoFix could not start evaluation — it crashed or timed out before reading the feedback, so no fix was attempted. This PR is now marked terminal and future scans (including forced dispatch) will skip it. To recover: delete this bot's terminal \`autofix-eval\` marker comment, then re-trigger if the failure looked transient."
+            fi
+
+            # Consecutive-failure circuit breaker, distinct from the round cap.
+            # Reaching this step at all means this round did NOT push (the push
+            # and no-op paths report from "Push and report"), so this round is a
+            # failure. Count how many failures precede it WITHOUT a break: walk
+            # the bot's prior eval markers newest-first and stop at the first
+            # one that pushed ("Addressed the latest review feedback") or was a
+            # deliberate no-op ("no changes needed") — either proves the loop
+            # was making progress, so the streak resets there. If the unbroken
+            # streak (this round included) reaches the cap, stop retrying even
+            # under takeover: a PR that fails this many times running is stuck
+            # on something a re-run at the same budget will not fix (observed on
+            # #6723: 7 straight failures, 3 timeouts + 4 gate rejections). Only
+            # overrides a would-be RETRY — a round already terminal for another
+            # reason keeps its own headline.
+            if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]]; then
+              CONSEC_FAIL=1
+              PRIOR_HEADS="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null \
+                | jq -r --arg ab "${AUTOFIX_BOT}" '.[]
+                  | select((.user.login // "") == $ab)
+                  | select((.body // "") | contains("<!-- autofix-eval "))
+                  | (.body | gsub("\r"; "") | split("\n")[0])' 2> /dev/null || true)"
+              while IFS= read -r H; do
+                [[ -n "${H}" ]] || continue
+                if [[ "${H}" == *"Addressed the latest review feedback"* || "${H}" == *"no changes needed"* ]]; then
+                  CONSEC_FAIL=1
+                else
+                  CONSEC_FAIL=$(( CONSEC_FAIL + 1 ))
+                fi
+              done <<< "${PRIOR_HEADS}"
+              if [[ "${CONSEC_FAIL}" -ge "${CONSECUTIVE_FAILURE_CAP}" ]]; then
+                MARK_ROUND="${MAX_ROUNDS}"
+                HEADLINE="🤖 AutoFix stopped after ${CONSEC_FAIL} consecutive rounds that failed to push anything (timeouts and/or gate rejections). Retrying at the same per-round budget is not converging — this usually means the PR is too large or conflicts with a fast-moving \`main\`. A human should rebase, split, or reduce it, then comment \`${RETRY_COMMAND}\` to re-arm. Until then future scans will skip this PR."
+              fi
             fi
             {
               echo "${HEADLINE}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3360,7 +3360,8 @@ jobs:
             # Reaching this step at all means this round did NOT push (the push
             # and no-op paths report from "Push and report"), so this round is a
             # failure. Count how many failures precede it WITHOUT a break: walk
-            # the bot's prior eval markers in API order (oldest-first) and
+            # the bot's prior eval markers in API order (oldest-first, pinned
+            # by sort_by so a stray reorder cannot corrupt the streak) and
             # reset the streak at each push ("Addressed the latest review
             # feedback") or deliberate no-op ("no changes needed"). After the
             # full walk, CONSEC_FAIL holds failures since the last progress
@@ -3371,19 +3372,26 @@ jobs:
             # #6723: 7 straight failures, 3 timeouts + 4 gate rejections). Only
             # overrides a would-be RETRY — a round already terminal for another
             # reason keeps its own headline.
-            if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]]; then
+            # Transient model errors (429/5xx) are exempt: the CAUSE_MAX logic
+            # above deliberately gives them the full round budget because they
+            # self-heal once the provider recovers. Letting the breaker override
+            # that would mark every in-flight PR terminal at once during a
+            # provider outage — the failures are not the PR's fault and DO
+            # self-heal. Auth errors are NOT exempt (they never self-heal).
+            if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]] && { [[ -z "${API_ERROR_DETAIL}" ]] || [[ "${API_ERROR_KIND}" == 'auth' ]]; }; then
               CONSEC_FAIL=1
               if [[ -f "${WORKDIR}/ic.json" ]]; then
                 COMMENTS_JSON="$(cat "${WORKDIR}/ic.json")"
               else
                 COMMENTS_JSON="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null || true)"
               fi
-              PRIOR_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '.[]
-                | select((.user.login // "") == $ab)
-                | select((.body // "") | contains("<!-- autofix-eval "))
-                | select(
-                    ((.body // "") | contains("win=" + $win + " -->"))
-                    or ($win == "none" and (((.body // "") | contains("win=")) | not)))
+              PRIOR_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '
+                [.[] | select((.user.login // "") == $ab)
+                     | select((.body // "") | contains("<!-- autofix-eval "))
+                     | select(
+                         ((.body // "") | contains("win=" + $win + " -->"))
+                         or ($win == "none" and (((.body // "") | contains("win=")) | not)))]
+                | sort_by(.created_at) | .[]
                 | (.body | gsub("\r"; "") | split("\n")[0])' <<< "${COMMENTS_JSON}" 2> /dev/null || true)"
               while IFS= read -r H; do
                 [[ -n "${H}" ]] || continue

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3360,10 +3360,11 @@ jobs:
             # Reaching this step at all means this round did NOT push (the push
             # and no-op paths report from "Push and report"), so this round is a
             # failure. Count how many failures precede it WITHOUT a break: walk
-            # the bot's prior eval markers newest-first and stop at the first
-            # one that pushed ("Addressed the latest review feedback") or was a
-            # deliberate no-op ("no changes needed") — either proves the loop
-            # was making progress, so the streak resets there. If the unbroken
+            # the bot's prior eval markers in API order (oldest-first) and
+            # reset the streak at each push ("Addressed the latest review
+            # feedback") or deliberate no-op ("no changes needed"). After the
+            # full walk, CONSEC_FAIL holds failures since the last progress
+            # point plus one for this round. If the unbroken
             # streak (this round included) reaches the cap, stop retrying even
             # under takeover: a PR that fails this many times running is stuck
             # on something a re-run at the same budget will not fix (observed on
@@ -3372,11 +3373,18 @@ jobs:
             # reason keeps its own headline.
             if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]]; then
               CONSEC_FAIL=1
-              PRIOR_HEADS="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null \
-                | jq -r --arg ab "${AUTOFIX_BOT}" '.[]
-                  | select((.user.login // "") == $ab)
-                  | select((.body // "") | contains("<!-- autofix-eval "))
-                  | (.body | gsub("\r"; "") | split("\n")[0])' 2> /dev/null || true)"
+              if [[ -f "${WORKDIR}/ic.json" ]]; then
+                COMMENTS_JSON="$(cat "${WORKDIR}/ic.json")"
+              else
+                COMMENTS_JSON="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2> /dev/null || true)"
+              fi
+              PRIOR_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '.[]
+                | select((.user.login // "") == $ab)
+                | select((.body // "") | contains("<!-- autofix-eval "))
+                | select(
+                    ((.body // "") | contains("win=" + $win + " -->"))
+                    or ($win == "none" and (((.body // "") | contains("win=")) | not)))
+                | (.body | gsub("\r"; "") | split("\n")[0])' <<< "${COMMENTS_JSON}" 2> /dev/null || true)"
               while IFS= read -r H; do
                 [[ -n "${H}" ]] || continue
                 if [[ "${H}" == *"Addressed the latest review feedback"* || "${H}" == *"no changes needed"* ]]; then

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4045,7 +4045,7 @@ describe('qwen-autofix workflow', () => {
     expect(cap).toBeLessThan(takeoverCap);
 
     const block = reviewAddressReportStep.match(
-      /if \[\[ "\$\{MARK_ROUND\}" != "\$\{MAX_ROUNDS\}" \]\]; then\n {14}CONSEC_FAIL=1\n[\s\S]*?\n {14}fi\n {12}fi\n/,
+      /if \[\[ "\$\{MARK_ROUND\}" != "\$\{MAX_ROUNDS\}" \]\] && \{ \[\[ -z "\$\{API_ERROR_DETAIL\}" \]\] \|\| \[\[ "\$\{API_ERROR_KIND\}" == 'auth' \]\]; \}; then\n {14}CONSEC_FAIL=1\n[\s\S]*?\n {14}fi\n {12}fi\n/,
     )?.[0];
     expect(block).toBeTruthy();
     const script = block.replace(/^ {12}/gm, '');
@@ -4056,18 +4056,22 @@ describe('qwen-autofix workflow', () => {
     const PUSH = '🤖 Addressed the latest review feedback (round 2/100).';
     const NOOP = '🤖 Reviewed the latest feedback — no changes needed.';
 
-    const run = (priorHeadlines, { window, markRound = 7 } = {}) => {
+    const run = (
+      priorHeadlines,
+      { window, markRound = 7, apiErrorDetail = '', apiErrorKind = '' } = {},
+    ) => {
       const dir = mkdtempSync(join(tmpdir(), 'consec-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
       writeFileSync(
         join(dir, 'ic.json'),
         JSON.stringify(
-          priorHeadlines.map((h) => {
+          priorHeadlines.map((h, i) => {
             const headline = typeof h === 'string' ? h : h.headline;
             const win = typeof h === 'string' ? undefined : h.win;
             return {
               user: { login: 'qwen-code-dev-bot' },
+              created_at: `2026-01-01T00:${String(i).padStart(2, '0')}:00Z`,
               body: `${headline}\n<!-- autofix-eval ts=x acted=y round=z${win ? ` win=${win}` : ''} -->`,
             };
           }),
@@ -4082,7 +4086,7 @@ describe('qwen-autofix workflow', () => {
         'bash',
         [
           '-c',
-          `set -uo pipefail\nWORKDIR='${dir}'\nMARK_ROUND=${markRound}\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nCONSEC_FAIL=0\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\n${window !== undefined ? `WINDOW='${window}'\n` : ''}HEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
+          `set -uo pipefail\nWORKDIR='${dir}'\nMARK_ROUND=${markRound}\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nCONSEC_FAIL=0\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\nAPI_ERROR_DETAIL='${apiErrorDetail}'\nAPI_ERROR_KIND='${apiErrorKind}'\n${window !== undefined ? `WINDOW='${window}'\n` : ''}HEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
         ],
         {
           env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
@@ -4119,16 +4123,46 @@ describe('qwen-autofix workflow', () => {
       consec: 2,
       terminal: false,
     });
-    // Timeouts and gate rejections both count — the streak is cause-agnostic.
+    // Prior-round headlines are cause-agnostic: timeouts and gate rejections
+    // both count toward the streak.
     expect(run([FAIL, FAIL_TIMEOUT, FAIL, FAIL_TIMEOUT])).toMatchObject({
       consec: cap,
       terminal: true,
     });
+    // A transient (non-auth) model error on the CURRENT round skips the
+    // breaker entirely — the CAUSE_MAX logic above gives it the full budget
+    // because it self-heals, and the breaker must not override that.
+    expect(
+      run(Array(cap - 1).fill(FAIL), {
+        apiErrorDetail: 'terminated',
+        apiErrorKind: 'transient',
+      }),
+    ).toMatchObject({ terminal: false, headline: 'orig' });
+    // An auth error on the current round is NOT exempt — it never self-heals.
+    expect(
+      run(Array(cap - 1).fill(FAIL), {
+        apiErrorDetail: 'access denied',
+        apiErrorKind: 'auth',
+      }),
+    ).toMatchObject({ consec: cap, terminal: true });
     // Already-terminal rounds skip the circuit breaker entirely.
     expect(run(Array(cap).fill(FAIL), { markRound: 100 })).toMatchObject({
       terminal: true,
       headline: 'orig',
     });
+    // The reset detector keys on literal substrings; pin them to the actual
+    // "Push and report" emit lines so a reword breaks this test, not silently
+    // the streak reset in production.
+    const pushEmit = pushAndReportStep.match(
+      /echo "(🤖 Addressed the latest review feedback[^"]*)"/,
+    );
+    expect(pushEmit).toBeTruthy();
+    expect(pushEmit[1]).toContain('Addressed the latest review feedback');
+    const noopEmit = pushAndReportStep.match(
+      /echo "(🤖 Reviewed the latest feedback — no changes needed[^"]*)"/,
+    );
+    expect(noopEmit).toBeTruthy();
+    expect(noopEmit[1]).toContain('no changes needed');
     // Window filtering: pre-re-arm failures don't count after a re-arm.
     expect(
       run(

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4056,29 +4056,33 @@ describe('qwen-autofix workflow', () => {
     const PUSH = '🤖 Addressed the latest review feedback (round 2/100).';
     const NOOP = '🤖 Reviewed the latest feedback — no changes needed.';
 
-    const run = (priorHeadlines) => {
+    const run = (priorHeadlines, { window, markRound = 7 } = {}) => {
       const dir = mkdtempSync(join(tmpdir(), 'consec-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
       writeFileSync(
-        join(dir, 'comments.json'),
+        join(dir, 'ic.json'),
         JSON.stringify(
-          priorHeadlines.map((h) => ({
-            user: { login: 'qwen-code-dev-bot' },
-            body: `${h}\n<!-- autofix-eval ts=x acted=y round=z -->`,
-          })),
+          priorHeadlines.map((h) => {
+            const headline = typeof h === 'string' ? h : h.headline;
+            const win = typeof h === 'string' ? undefined : h.win;
+            return {
+              user: { login: 'qwen-code-dev-bot' },
+              body: `${headline}\n<!-- autofix-eval ts=x acted=y round=z${win ? ` win=${win}` : ''} -->`,
+            };
+          }),
         ),
       );
       writeFileSync(
         join(bin, 'gh'),
-        `#!/usr/bin/env bash\ncat ${JSON.stringify(join(dir, 'comments.json'))}\n`,
+        `#!/usr/bin/env bash\ncat ${JSON.stringify(join(dir, 'ic.json'))}\n`,
       );
       chmodSync(join(bin, 'gh'), 0o755);
       const out = execFileSync(
         'bash',
         [
           '-c',
-          `set -uo pipefail\nMARK_ROUND=7\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\nHEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
+          `set -uo pipefail\nWORKDIR='${dir}'\nMARK_ROUND=${markRound}\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nCONSEC_FAIL=0\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\n${window !== undefined ? `WINDOW='${window}'\n` : ''}HEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
         ],
         {
           env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
@@ -4120,6 +4124,21 @@ describe('qwen-autofix workflow', () => {
       consec: cap,
       terminal: true,
     });
+    // Already-terminal rounds skip the circuit breaker entirely.
+    expect(run(Array(cap).fill(FAIL), { markRound: 100 })).toMatchObject({
+      terminal: true,
+      headline: 'orig',
+    });
+    // Window filtering: pre-re-arm failures don't count after a re-arm.
+    expect(
+      run(
+        [
+          ...Array(cap - 1).fill({ headline: FAIL, win: 'old-window' }),
+          { headline: FAIL, win: 'current-window' },
+        ],
+        { window: 'current-window' },
+      ),
+    ).toMatchObject({ consec: 2, terminal: false });
   });
 
   it('makes every known gate rejection declare its verdict', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3915,8 +3915,11 @@ describe('qwen-autofix workflow', () => {
     // judged the work at all; advancing there strands a fix the agent had
     // already written, which is exactly how the nested-package ENOENT stranded
     // #7329/#7336 until a human deleted the marker.
+    // Ends at the crash decision's own closing `fi`; the consecutive-failure
+    // block that follows is a separate unit with its own test, so anchor on it
+    // rather than the report `{` (which it now sits before).
     const decision = reviewAddressReportStep.match(
-      /(GATE_CRASHED=false\n[\s\S]*?\n {12}fi)\n {12}\{/,
+      /(GATE_CRASHED=false\n[\s\S]*?\n {12}fi)\n\n {12}# Consecutive-failure/,
     )?.[1];
     expect(decision).toBeTruthy();
     const SENTINEL = '9999-12-31T23:59:59Z';
@@ -4025,6 +4028,98 @@ describe('qwen-autofix workflow', () => {
         ROUND: '2',
       }),
     ).toContain('attempt 3/5');
+  });
+
+  it('stops a PR that fails to push for CONSECUTIVE_FAILURE_CAP rounds in a row', () => {
+    // The total round cap bounds productive iteration; this bounds an UNBROKEN
+    // run of failures under takeover, where the strict cap does not apply.
+    // Observed on #6723: 7 straight failed rounds (3 timeouts, 4 gate
+    // rejections) heading for round 100, each ~50 min. Any push or legitimate
+    // no-op resets the streak; only consecutive failures count.
+    const cap = Number(workflow.match(/CONSECUTIVE_FAILURE_CAP: '(\d+)'/)?.[1]);
+    expect(cap).toBeGreaterThan(0);
+    // The sub-cap must be below the takeover cap or it never binds there.
+    const takeoverCap = Number(
+      workflow.match(/TAKEOVER_MAX_ROUNDS: '(\d+)'/)?.[1],
+    );
+    expect(cap).toBeLessThan(takeoverCap);
+
+    const block = reviewAddressReportStep.match(
+      /if \[\[ "\$\{MARK_ROUND\}" != "\$\{MAX_ROUNDS\}" \]\]; then\n {14}CONSEC_FAIL=1\n[\s\S]*?\n {14}fi\n {12}fi\n/,
+    )?.[0];
+    expect(block).toBeTruthy();
+    const script = block.replace(/^ {12}/gm, '');
+
+    const FAIL =
+      '🤖 Could not address the latest feedback automatically (round 3/100).';
+    const FAIL_TIMEOUT = '🤖 AutoFix could not reach the model (attempt 2/3)';
+    const PUSH = '🤖 Addressed the latest review feedback (round 2/100).';
+    const NOOP = '🤖 Reviewed the latest feedback — no changes needed.';
+
+    const run = (priorHeadlines) => {
+      const dir = mkdtempSync(join(tmpdir(), 'consec-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      writeFileSync(
+        join(dir, 'comments.json'),
+        JSON.stringify(
+          priorHeadlines.map((h) => ({
+            user: { login: 'qwen-code-dev-bot' },
+            body: `${h}\n<!-- autofix-eval ts=x acted=y round=z -->`,
+          })),
+        ),
+      );
+      writeFileSync(
+        join(bin, 'gh'),
+        `#!/usr/bin/env bash\ncat ${JSON.stringify(join(dir, 'comments.json'))}\n`,
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const out = execFileSync(
+        'bash',
+        [
+          '-c',
+          `set -uo pipefail\nMARK_ROUND=7\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\nHEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
+        ],
+        {
+          env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+          encoding: 'utf8',
+        },
+      );
+      rmSync(dir, { recursive: true, force: true });
+      const [mark, consec, headline] = out.split('|');
+      return {
+        mark,
+        consec: Number(consec),
+        terminal: mark === '100',
+        headline,
+      };
+    };
+
+    // This round alone (no prior failures) never terminates.
+    expect(run([])).toMatchObject({ consec: 1, terminal: false });
+    // cap-1 prior failures + this round = cap → terminal, with the structural
+    // handoff, not the ordinary "could not address".
+    const capped = run(Array(cap - 1).fill(FAIL));
+    expect(capped).toMatchObject({ consec: cap, terminal: true });
+    expect(capped.headline).toContain('consecutive');
+    expect(capped.headline).toContain('/retry');
+    // One short of the cap keeps retrying.
+    expect(run(Array(cap - 2).fill(FAIL))).toMatchObject({ terminal: false });
+    // A push resets the streak — failures before it do not count.
+    expect(run([FAIL, FAIL, PUSH, FAIL, FAIL])).toMatchObject({
+      consec: 3,
+      terminal: false,
+    });
+    // A legitimate no-op resets it too (the loop was caught up, not stuck).
+    expect(run([...Array(cap).fill(FAIL), NOOP, FAIL])).toMatchObject({
+      consec: 2,
+      terminal: false,
+    });
+    // Timeouts and gate rejections both count — the streak is cause-agnostic.
+    expect(run([FAIL, FAIL_TIMEOUT, FAIL, FAIL_TIMEOUT])).toMatchObject({
+      consec: cap,
+      terminal: true,
+    });
   });
 
   it('makes every known gate rejection declare its verdict', () => {


### PR DESCRIPTION
## What this PR does

Adds a **consecutive-failure** sub-cap, separate from the total round cap, so a PR that fails to push every round stops instead of retrying up to 100 times under takeover.

## Why it's needed

The round cap answers "how many **productive** rounds may a PR take?" — and takeover raises it to 100 deliberately, for PRs that need many rounds of address-feedback-then-push. It does not answer "how many rounds may fail **in a row**?"

Observed on **#6723** (a 5700-line, 47-file, 5-day-old PR that conflicts with a fast-moving `main`):

| round | outcome |
| --- | --- |
| 1 | gate rejection — `tests failed in packages/core` |
| 2 | agent **timeout (50 min)** |
| 3 | agent **timeout (50 min)** |
| 4 | gate rejection — `tests failed in packages/cli` |
| 5 | gate rejection — push rejected, tests failed |
| 6 | agent **timeout (50 min)** |
| 7 | gate rejection — `tests failed` |

Seven straight failures over eight hours, **nothing pushed**, heading for round 100 — each round a ~50-minute agent run or a full gate cycle. Every round re-resolves a conflict the agent cannot finish inside the budget, or produces a fix that breaks tests. Retrying at the same per-round budget does not converge; a human has to rebase or split the PR.

The two failure kinds are handled elsewhere individually (a timeout, a gate rejection), but nothing notices that they are happening **back to back with no progress**.

## How

`CONSECUTIVE_FAILURE_CAP: '5'`, distinct from `TAKEOVER_MAX_ROUNDS: '100'`.

Reaching the handoff step at all means this round did **not** push — the push and no-op paths report from a different step. So the step counts the unbroken run of prior failure markers by walking the bot's own eval-comment headlines newest-first and **stopping at the first that pushed** (`Addressed the latest review feedback`) **or was a deliberate no-op** (`no changes needed`) — either proves the loop was making progress, so the streak resets there. If the run (this round included) reaches the cap, it forces the terminal round **even under takeover**, with a handoff that names the actual fix: rebase / split / reduce the PR, then `@qwen-code /retry` to re-arm.

It is **cause-agnostic**: a timeout and a gate rejection both count, because both are "failed, nothing pushed." A single push or no-op anywhere in the run resets it, so this only ever fires on a genuinely stuck PR.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 92/92 (a run in three hits the pre-existing `takeover-command toggle` load flake; see Risk). The new test **replays the real extracted counter+override block** under bash, with a stubbed `gh` serving a synthetic comment history:

   | prior markers | streak (incl. this round) | terminal? |
   | --- | --- | --- |
   | *(none)* | 1 | no |
   | 4 × failure | 5 | **yes** — structural handoff, mentions `/retry` |
   | 3 × failure | 4 | no |
   | fail, fail, **push**, fail, fail | 3 | no (push reset it) |
   | 5 × fail, **no-op**, fail | 2 | no (no-op reset it) |
   | fail, **timeout**, fail, **timeout** | 5 | **yes** (cause-agnostic) |

2. Mutation-verified, four reverts each turning it red: neutering the override; making a no-op not reset; making a push not reset; setting the cap equal to the takeover cap (so it never binds).

3. One existing test needed its extraction anchor updated: `retries a verification-gate crash` grabbed the decision block by its trailing `fi` + report `{`, which this block now sits between. It now anchors on the new block's comment, so it drives only the crash decision — unchanged behaviour, no `gh` call.

4. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.

5. Post-merge smoke: #6723's next scan should post the structural handoff and go terminal instead of a 8th failed round.

### Evidence (Before & After)

```
BEFORE  #6723: 7 straight failures (timeouts + gate rejections), 8h,
        heading for round 100 — ~50 min of agent time each

AFTER   at 5 in a row: terminal handoff — "rebase, split, or reduce it,
        then comment @qwen-code /retry" — and future scans skip it
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main tradeoff: a PR that genuinely needs 6+ **failing** rounds to eventually succeed now stops at 5 and asks for a human. That is the intended tradeoff — 5 consecutive failures with nothing pushed is a strong signal the per-round budget is the wrong tool — and `/retry` re-arms it after the human intervenes, opening a fresh window.
- Only fires in the handoff step, which already runs only on a non-pushing round; a healthy iterating PR (push, or a legitimate no-op) never accumulates a streak.
- One extra `gh api …/comments` fetch per failing round. On the fetch failing, `PRIOR_HEADS` is empty and the streak is 1 — so an API blip cannot force a spurious terminal (fail-open).
- Pre-existing and unrelated: `takeover-command toggle` fails under full-suite subprocess load — A/B on this machine shows unmodified `main` failing the same test at a comparable rate, and it passes in isolation.
- Not in scope: the opposite asymmetry — a crash *before* reading feedback goes terminal after ONE round (observed on #7458), which may be too aggressive for a transient blip. That is a separate change; `/retry` recovers it today.
- Breaking changes / migration notes: none.

## Linked Issues

Found while analysing why #6723 had burned 7 agent rounds under takeover with nothing pushed. Part of the autofix-reliability line: #7330, #7351, #7368, #7412, #7416, #7438.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增一个**连续失败**子上限,独立于总轮次上限,让"每轮都推送失败"的 PR 停下来,而不是在 takeover 下一路重试到 100。

## 为什么需要

轮次上限回答的是"一个 PR 可以用多少**有产出**的轮次",takeover 特意把它提到 100,是给需要多轮"处理反馈→推送"的 PR。它没有回答"可以**连续**失败多少轮"。

在 **#6723**(5700 行、47 文件、跑了 5 天、与飞速前进的 `main` 冲突)上实测:7 轮全败(3 次 agent 超时 50 分钟、4 次门拒绝——修复过不了测试),历时 8 小时**零推送**,正冲着 round 100 去,每轮要么 50 分钟 agent 运行、要么一整轮门检查。每轮都在重解一个解不完/过不了测试的冲突。以相同的单轮预算重试不会收敛,只能靠人 rebase 或拆分。

两类失败(超时、门拒绝)各自都有处理,但**没有任何机制注意到它们正在背靠背、毫无进展地连续发生**。

## 怎么做

`CONSECUTIVE_FAILURE_CAP: '5'`,独立于 `TAKEOVER_MAX_ROUNDS: '100'`。

能走到交接步骤,本身就意味着这一轮**没有推送**(推送与 no-op 路径从另一个步骤汇报)。于是该步骤统计"未被打断的连续失败":倒序遍历 bot 自己的 eval 评论标题,遇到第一个**推送**(`Addressed the latest review feedback`)或**合法 no-op**(`no changes needed`)即停——两者都证明循环在推进,连续计数在此重置。若这条连续段(含本轮)达到上限,即使在 takeover 下也强制终态,并给出真正的修复指引:rebase/拆分/精简该 PR,再 `@qwen-code /retry` 重新武装。

它**不区分成因**:超时和门拒绝都算"失败且未推送"。连续段中任意一次推送或 no-op 都会重置它,因此只会在真正卡住的 PR 上触发。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 92/92。新测试在 bash 下**回放真实提取的计数+override 块**,用桩 `gh` 喂合成评论历史,覆盖 6 种组合(见上方英文表格:无历史=1 不终态;4 败+本轮=5 终态;3 败+本轮=4 不终态;推送重置;no-op 重置;超时与门拒混合仍达 5 终态)。
2. 变异验证,四处回退各自变红:令 override 空转;令 no-op 不重置;令推送不重置;把阈值设成 takeover 上限(使其永不生效)。
3. 一个既有测试需更新提取锚点:`retries a verification-gate crash` 原来靠"结尾 `fi` + 报告 `{`"抓取决策块,而本块正插在两者之间。现改为锚定本块的注释,只驱动 crash 决策——行为不变,不调用 `gh`。
4. 静态(均用 CI 一致工具):YAML 可解析;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
5. 合并后冒烟:#6723 下一次扫描应给出结构性交接并终态,而不是第 8 轮失败。

## 风险与范围

- 主要权衡:一个确实需要 6+ 轮**失败**才最终成功的 PR,现在会在第 5 轮停下并请人介入。这正是预期权衡——连续 5 轮零推送强烈说明单轮预算是错的工具——人介入后 `/retry` 会重新武装、开启新窗口。
- 只在交接步骤触发,而该步骤本就只在"未推送"的轮次运行;健康迭代的 PR(推送或合法 no-op)永远不会累积连续段。
- 每个失败轮多一次 `gh api …/comments`。拉取失败时 `PRIOR_HEADS` 为空、连续数为 1——因此一次 API 抖动不会误判终态(fail-open)。
- 既有且无关:`takeover-command toggle` 在全量子进程负载下失败——本机 A/B 显示未修改的 `main` 以相当频率红同一测试,单独跑通过。
- 不在范围内:反向的不对称——读反馈**之前**崩溃会在**一轮**后即终态(见 #7458),对瞬时抖动可能过于激进。那是另一个改动;目前靠 `/retry` 恢复。
- 破坏性变更:无。

## 关联 Issue

在分析 #6723 为何在 takeover 下烧掉 7 个 agent 轮次却零推送时发现。属 autofix 可靠性主线:#7330、#7351、#7368、#7412、#7416、#7438。

</details>
