### PR TITLE
docs(autofix): require evidenced pre-commit verification, not a bare "verified"

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -23,12 +23,18 @@ owns the model-driven decisions, code changes, and pre-commit verification.
   verification expects the branch to be usable from this checkout.
 - Use additive commits only; do not amend, rebase, reset, or rewrite history.
 - Keep changes minimal and scoped. No drive-by refactors.
-- Run required verification commands before committing. Use only these project
-  commands: `npm run build`, `npm run typecheck`, `npm run lint`, focused
-  Vitest runs for touched packages, and `npm run generate:settings-schema` when
-  a settings source changed (see the generated-artifact rule below). If any
-  command fails, fix the cause and rerun it; if you cannot make the checks pass
-  confidently, write `<workdir>/failure.md` and do not commit.
+- Run required verification commands before committing — actually run them, do
+  not assert them from reading the diff. Use only these project commands:
+  `npm run build`, `npm run typecheck`, `npm run lint`, focused Vitest runs for
+  touched packages, and `npm run generate:settings-schema` when a settings
+  source changed (see the generated-artifact rule below). If any command fails,
+  fix the cause and rerun it; if you cannot make the checks pass confidently,
+  write `<workdir>/failure.md` and do not commit. The deterministic gate re-runs
+  these same commands after you push and discards the round on any failure, so a
+  commit that skips them is not faster — it just moves the rejection later and
+  wastes the round. Record the exact commands you ran and their results in your
+  summary (see the per-mode outcomes); a bare "verified" without them is not
+  acceptable.
 - Regenerate committed generated artifacts when you change their source. If you
   edit `packages/cli/src/config/settingsSchema.ts` (or `settings.ts`), run
   `npm run generate:settings-schema` and commit the regenerated
@@ -161,13 +167,24 @@ unnecessarily.
 
 Finish with exactly one outcome:
 
-- Made a change: re-read the full diff as a skeptical reviewer, run
-  `npm run build`, `npm run typecheck`, `npm run lint`, and focused Vitest
-  tests for touched packages (plus `npm run generate:settings-schema`, staging
-  the regenerated schema, if a settings source changed), commit once only after
-  they pass, then write `<workdir>/address-summary.md` with each feedback point,
-  decision, changes, conflict notes, and verification results (bilingual per
-  Shared Rules). Also write `<workdir>/resolved-comments.txt`: one inline
+- Made a change: re-read the full diff as a skeptical reviewer — confirm each
+  feedback point is actually addressed AND that the change introduces no new
+  defect. Then ACTUALLY RUN `npm run build`, `npm run typecheck`,
+  `npm run lint`, and focused Vitest tests for the package(s) you touched (plus
+  `npm run generate:settings-schema`, staging the regenerated schema, if a
+  settings source changed). The verification gate re-runs these exact commands
+  and rejects the commit if any fails, discarding the whole round — so running
+  them yourself first is how you avoid wasting a round on a defect you could
+  have caught. If typecheck or a touched-package test fails, DO NOT commit:
+  treat the feedback as unresolved and write `<workdir>/failure.md`. Only after
+  they pass, commit once, then write `<workdir>/address-summary.md` with each
+  feedback point, decision, changes, and conflict notes, ending with a
+  `## Verification` section (bilingual per Shared Rules) that lists **each
+  command you ran and its result** — e.g. `- npm run typecheck — passed`,
+  `- vitest packages/cli (touched) — 42 passed`. Record the commands you truly
+  ran; a bare "verified" is not acceptable, because a claim the gate then
+  contradicts wastes a round and misleads the reviewer. Also write
+  `<workdir>/resolved-comments.txt`: one inline
   comment id per line — the `rc:<id>` handle shown in `feedback.md` — for each
   finding you IMPLEMENTED. The workflow resolves exactly those review threads
   after the push, so a human re-reviewing sees only what is still open. List an

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -161,7 +161,8 @@ Implement the selected issue in the checked-out repository:
 9. Write all required outputs:
    - `<workdir>/e2e-report.md` (bilingual per Shared Rules — it is posted
      verbatim as a PR comment), ending with a `## Verification` section that
-     lists each command you ran and its result (see Shared Rules)
+     lists each command you ran and its result (see Shared Rules), before the
+     collapsed Chinese translation
    - `<workdir>/pr-title.txt`
    - `<workdir>/pr-body.md` using `.qwen/skills/prepare-pr/SKILL.md`
 
@@ -214,7 +215,8 @@ Finish with exactly one outcome:
   pass, commit once, then write `<workdir>/address-summary.md` with each
   feedback point, decision, changes, and conflict notes, ending with a
   `## Verification` section (bilingual per Shared Rules) that lists **each
-  command you ran and its result** — e.g. `- npm run typecheck — passed`,
+  command you ran and its result**, before the collapsed Chinese translation
+  — e.g. `- npm run typecheck — passed`,
   `- vitest packages/cli (touched) — 42 passed`. Record the commands you truly
   ran; a bare "verified" is not acceptable, because a claim the gate then
   contradicts wastes a round and misleads the reviewer. Also write

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2571,6 +2571,9 @@ describe('qwen-autofix workflow', () => {
     expect(flat).toContain(
       'section that lists each command you ran and its result (see Shared Rules)',
     );
+    // The Verification section ends the English body, before the collapsed
+    // Chinese translation — not after it.
+    expect(flat).toContain('before the collapsed Chinese translation');
   });
 
   it('requires bilingual bodies for files posted verbatim as PR comments', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2546,6 +2546,28 @@ describe('qwen-autofix workflow', () => {
     expect(skill).toContain('drop one silently');
   });
 
+  it('requires the address path to run verification and record it as evidence', () => {
+    // Observed: #7408 committed a fix with a TS error the gate then rejected,
+    // while its summary claimed "verified all 3 commits". A soft "run the
+    // checks" instruction let a bare assertion stand in for actually running
+    // them. The contract now demands the real commands AND their results in a
+    // Verification section, so a claim the gate contradicts is visible.
+    // Prose wraps at ~78 cols, so match across the wrap with \s+.
+    const flat = readAutofixSkill().replace(/\s+/g, ' ');
+    // Actually run — not assert from the diff — the deterministic checks.
+    expect(flat).toContain('actually run them, do not assert them');
+    expect(flat).toContain('touched-package test fails, DO NOT commit');
+    // The summary must carry a Verification section listing commands + results,
+    // and a bare "verified" is explicitly rejected.
+    expect(flat).toContain('## Verification');
+    expect(flat).toContain('command you ran and its result');
+    expect(flat).toContain('a bare "verified" is not acceptable');
+    // The rationale is structural, not etiquette: the gate re-runs the same
+    // commands, so skipping them only moves the rejection later. Pin that
+    // framing so the requirement is not softened back into "please verify".
+    expect(flat).toMatch(/gate re-runs these (?:same|exact) commands/);
+  });
+
   it('requires bilingual bodies for files posted verbatim as PR comments', () => {
     const skill = readAutofixSkill();
     // Comment bodies mirror the repository's PR-body convention: English


### PR DESCRIPTION
## What this PR does

Turns the autofix agent's pre-commit verification from a soft "run the checks" into an evidenced, hard requirement: actually run them, don't commit if they fail, and record each command and its result.

## Why it's needed

The skill already told the agent to run `build`/`typecheck`/`lint`/focused Vitest before committing. But it was soft, and a self-assessment is not a fact.

**#7408** committed a fix with a real TypeScript error:

```
src/daemon/session/DaemonSessionProvider.test.tsx(6410,44):
  error TS2554: Expected 1 argument
```

The verification gate caught it and rejected the round — but the agent's own summary for that round claimed *"verified all 3 commits at HEAD `a52458a8`"*. A bare "verified" stood in for actually running `typecheck`, and the gate rejection discarded the whole round (~a full agent run). Most `tests failed` gate rejections across the fleet share this shape: the commit could have been held back by the agent running the same command the gate was about to.

This is the **checkable** half of "audit before committing." The undirected / reverse-audit-until-clean practice does not transfer to an unsupervised agent — it has no verifiable stopping condition, the self-audit is unreviewed, and more self-checking worsens the timeouts already seen on large PRs (#6723). "Run the gate's own checks first and show the evidence" does transfer, because the gate is the objective signal and the evidence is auditable.

## How

The `address-review` outcome and the shared rule now require:

- **Actually run** `build`/`typecheck`/`lint`/touched-package Vitest — "do not assert them from reading the diff."
- If `typecheck` or a touched-package test **fails, do NOT commit** — treat the feedback as unresolved and write `failure.md`.
- End `address-summary.md` with a **`## Verification`** section listing **each command run and its result** (e.g. `- npm run typecheck — passed`). A bare "verified" is explicitly not acceptable.

The framing is deliberately structural, not etiquette: the deterministic gate re-runs these exact commands and discards the round on any failure, so skipping them does not save time — it moves the rejection later and wastes the round. That rationale is in the prose so the requirement reads as "why," not "please."

No new work is added — those commands were already required; the change is that they must be run and evidenced, not claimed.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 92/92 (a run in three hits the pre-existing `takeover-command toggle` load flake; see Risk). The new test pins the contract: run-don't-assert, no-commit-on-failure, the `## Verification` section, "each command … and its result," the explicit rejection of a bare "verified," and the gate-re-runs framing.
2. Mutation-verified: softening the summary requirement back to a bare "verified" turns the test red.
3. Static: prettier clean on the skill and the test (the skill passes `prettier --check` on `main` too, so nothing environmental).

### Evidence (Before & After)

```
BEFORE  skill: "run build/typecheck/lint/Vitest ... commit after they pass"
        #7408: committed a TS error, summary said "verified all 3 commits",
        gate rejected → round wasted

AFTER   "actually run them; if typecheck/tests fail, DO NOT commit;
         end the summary with ## Verification listing each command + result;
         a bare 'verified' is not acceptable"
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- This is a prompt change, not a gate — it cannot *force* the agent to run the commands. Its value is (a) making a false "verified" visible against the gate, and (b) nudging the agent to catch defects before the commit rather than after. The gate remains the actual enforcement; #7368 (merged) already feeds a gate rejection back so the next round fixes it.
- Deliberately NOT added: "multiple undirected / reverse audit rounds until no problems." That practice depends on human oversight and mutation-checking to know when to stop; an unsupervised agent given it either declares "no problems" prematurely (which is exactly #7408) or churns, and the extra rounds worsen large-PR timeouts. The checkable subset — re-read the diff adversarially, then run the gate's own checks and show the results — is what this PR adds.
- Pre-existing and unrelated: `takeover-command toggle` fails under full-suite subprocess load; unmodified `main` fails it at a comparable rate here and it passes in isolation.
- Breaking changes / migration notes: none.

## Linked Issues

Prompted by a maintainer asking whether the bot could be required to audit before committing. Part of the autofix-reliability line: #7368, #7438, #7482.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 autofix agent 的"提交前验证"从软要求("跑一下检查")变成**带证据的硬要求**:必须真的运行、失败则不提交、并逐条记录命令与结果。

## 为什么需要

skill 早就要求提交前跑 `build`/`typecheck`/`lint`/focused Vitest,但太软 —— 而**自评不是事实**。

**#7408** 提交了一个带真实 TS 错误的修复(`DaemonSessionProvider.test.tsx(6410,44): error TS2554`),门检查抓到并拒绝了整轮 —— 而 agent 那一轮的自述却写着*"verified all 3 commits"*。一句空洞的"verified"替代了真正运行 `typecheck`,门拒绝把整轮(约一次完整 agent 运行)作废。机群里大量 `tests failed` 的门拒绝都是同一形态:只要 agent 先跑一遍门即将跑的同一命令,这个提交本可以被拦下。

这是"提交前审计"里**可检查**的那一半。无方向/反向审计到没问题的做法**无法**搬到无监督 agent 上——它没有可验证的停止条件、自审无人复核,而且更多自审会加重大 PR 上已经出现的超时(#6723)。"先跑门自己的检查、并出示证据"是可以搬的,因为门是客观信号、证据可审计。

## 怎么做

`address-review` 的 outcome 与共享规则现在要求:

- **真的运行** `build`/`typecheck`/`lint`/改动包的 Vitest —— "不要靠读 diff 断言"。
- 若 `typecheck` 或改动包测试**失败,则不提交** —— 当作本轮未解决,写 `failure.md`。
- `address-summary.md` 以 **`## Verification`** 段收尾,逐条列出**跑了哪些命令、结果如何**(如 `- npm run typecheck — passed`)。空洞的"verified"明确不接受。

措辞刻意是结构性的而非礼节性的:确定性门会重跑这些完全相同的命令、任一失败即作废整轮,所以跳过它们并不省时间——只是把拒绝推迟、白费一轮。这个理由写在正文里,让要求读起来是"为什么",而不是"请"。

没有新增工作量——这些命令本就被要求;改变的是必须**运行并出示证据**,而非口头声称。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 92/92。新测试钉住契约:运行而非断言、失败不提交、`## Verification` 段、"逐条命令与结果"、明确拒绝空洞"verified"、以及"门会重跑同一命令"的措辞。
2. 变异验证:把 summary 要求软化回空洞"verified"即变红。
3. 静态:skill 与测试均过 prettier(skill 在 `main` 上本就过 `prettier --check`,无环境问题)。

## 风险与范围

- 这是 prompt 改动而非门——无法**强制** agent 真的运行。它的价值在于:(a) 让虚假的"verified"在门面前暴露;(b) 促使 agent 在提交前而非提交后拦住缺陷。真正的强制仍是门;#7368(已合)已让门拒绝喂回下一轮去修。
- 刻意**不加**:"多轮无方向/反向审计直到没问题"。该做法依赖人监督与变异检验才知道何时停;无监督 agent 拿到它,要么过早宣布"没问题"(#7408 正是如此),要么空转,且额外轮次会加重大 PR 超时。可检查的子集——以评审者视角重读 diff、再跑门自己的检查并出示结果——才是本 PR 所加。
- 既有且无关:`takeover-command toggle` 在全量子进程负载下失败;本机未修改的 `main` 以相当频率红它,单独跑通过。
- 破坏性变更:无。

## 关联 Issue

由维护者提问"能否要求 bot 提交前审计"促成。属 autofix 可靠性主线:#7368、#7438、#7482。

</details>
