### PR TITLE
feat(serve): support forced MCP reconnects

### DIFF
--- a/docs/design/2026-07-22-daemon-mcp-force-reconnect.md
+++ b/docs/design/2026-07-22-daemon-mcp-force-reconnect.md
@@ -14,8 +14,9 @@ workspace MCP reload routes and their SDK/ACP bridge methods.
 `forceReconnectAll` defaults to `false`; `forceReconnectWhich` selects named
 servers. The fields are mutually exclusive.
 
-When `true`, the daemon first performs the normal settings reconciliation.
-It then reconnects every configured MCP server across the workspace:
+When either reconnect option is supplied, the daemon first performs the normal
+settings reconciliation. It then reconnects every configured MCP server across
+the workspace, or only the names selected by `forceReconnectWhich`:
 
 - pooled servers restart through the workspace transport pool once per server
   name, then refresh the model tool snapshots for live configs;

--- a/docs/design/2026-07-22-daemon-mcp-force-reconnect.md
+++ b/docs/design/2026-07-22-daemon-mcp-force-reconnect.md
@@ -1,0 +1,45 @@
+# Daemon MCP force reconnect
+
+## Problem
+
+`POST /workspace/mcp/reload` reloads persisted settings but reconciles MCP
+connections incrementally. A server whose settings are unchanged retains its
+existing transport. OAuth credentials written by another Qwen Code process are
+therefore not read until that transport reconnects.
+
+## Design
+
+Add optional `forceReconnectAll` and `forceReconnectWhich` fields to both
+workspace MCP reload routes and their SDK/ACP bridge methods.
+`forceReconnectAll` defaults to `false`; `forceReconnectWhich` selects named
+servers. The fields are mutually exclusive.
+
+When `true`, the daemon first performs the normal settings reconciliation.
+It then reconnects every configured MCP server across the workspace:
+
+- pooled servers restart through the workspace transport pool once per server
+  name, then refresh the model tool snapshots for live configs;
+- servers without a pool entry use the existing per-config discovery path,
+  which disconnects and reconnects before rediscovery.
+
+This deliberately does not initiate OAuth. It only causes a new connection,
+which reads the credentials currently persisted by the daemon's token storage.
+
+## API
+
+`POST /workspace/mcp/reload` and
+`POST /workspaces/:workspace/mcp/reload` accept:
+
+```json
+{ "forceReconnectAll": true }
+```
+
+`forceReconnectWhich` accepts an array of non-empty server names. Invalid
+values return 400.
+The response remains `202 { "accepted": true }` because the work is queued.
+
+## Verification
+
+- Route tests cover default forwarding, `true` forwarding, and invalid input.
+- ACP tests cover propagation to each live config and force reconnect behavior.
+- E2E plan documents an OAuth-token-written-externally scenario.

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2474,6 +2474,29 @@ Errors:
 
 SSE event (workspace-scoped): `workspace_initialized` with `{path, action, originatorClientId?}`.
 
+#### `POST /workspace/mcp/reload`
+
+Reload persisted MCP settings into the workspace discovery config and every
+active session. The workspace-qualified form is
+`POST /workspaces/:workspace/mcp/reload`.
+
+Request body:
+
+```json
+{ "forceReconnectAll": true }
+```
+
+`forceReconnectAll` is optional and defaults to `false`, preserving
+incremental reconciliation. When true, the daemon reconnects every eligible
+configured MCP server after the settings reconciliation. Alternatively, pass
+`forceReconnectWhich: ["server-a", "server-b"]` to reconnect only named
+servers. The options are mutually exclusive. A forced reconnect causes each
+transport to read credentials that another local Qwen Code process may have
+written to token storage; it does not start an OAuth authorization flow.
+
+The route returns `202 { "accepted": true }`; poll `GET /workspace/mcp` for
+the final connection status. Invalid option values return 400.
+
 #### `POST /workspace/mcp/:server/restart`
 
 Capability tag: `workspace_mcp_restart`. Bridge → ACP extMethod `qwen/control/workspace/mcp/restart`.

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -7641,7 +7641,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       }
     },
 
-    async reloadWorkspaceMcp() {
+    async reloadWorkspaceMcp(options) {
       const info = await ensureChannel();
       info.workspaceMcpDiscoveryRequested = true;
       try {
@@ -7649,7 +7649,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           withTimeout(
             info.connection.extMethod(
               SERVE_CONTROL_EXT_METHODS.workspaceMcpReload,
-              { cwd: boundWorkspace },
+              { cwd: boundWorkspace, ...options },
             ),
             initTimeoutMs,
             SERVE_CONTROL_EXT_METHODS.workspaceMcpReload,

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -1009,7 +1009,10 @@ export interface AcpSessionBridge {
   initializeWorkspaceMcp(): Promise<{ accepted: boolean }>;
 
   /** Reload persisted MCP settings into workspace and active session configs. */
-  reloadWorkspaceMcp(): Promise<{ accepted: boolean }>;
+  reloadWorkspaceMcp(options?: {
+    forceReconnectAll?: boolean;
+    forceReconnectWhich?: string[];
+  }): Promise<{ accepted: boolean }>;
 
   /**
    * Read discovered MCP tools for one server from the live ACP registry.

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -13069,6 +13069,7 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
       filesystem: { command: 'node', args: ['server.js'] },
     };
     const runtimeServer = { command: 'runtime-server' };
+    const forceDiscover = vi.fn().mockResolvedValue(undefined);
     let finishDiscovery!: () => void;
     const discoveryPending = new Promise<void>((resolve) => {
       finishDiscovery = resolve;
@@ -13116,6 +13117,7 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
     mockConfig.getWorkingDir = vi.fn().mockReturnValue('/tmp');
     mockConfig.isMcpServerDisabled = vi.fn().mockReturnValue(false);
     mockConfig.getToolRegistry = vi.fn().mockReturnValue({
+      discoverToolsForServer: forceDiscover,
       getMcpClientManager: vi.fn().mockReturnValue({
         getDiscoveryState: vi.fn().mockReturnValue(MCPDiscoveryState.COMPLETED),
         getMcpClientAccounting: vi.fn().mockReturnValue({
@@ -13210,6 +13212,15 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
         ],
       });
     });
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpReload, {
+        forceReconnectWhich: ['runtime'],
+      }),
+    ).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() =>
+      expect(forceDiscover).toHaveBeenCalledWith('runtime'),
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -13222,6 +13222,20 @@ describe('QwenAgent extMethod runtime MCP add/remove (T2.8)', () => {
       expect(forceDiscover).toHaveBeenCalledWith('runtime'),
     );
 
+    const secondaryServer = { command: 'secondary-server' };
+    mockConfig.getMcpServers = vi.fn().mockReturnValue({
+      runtime: runtimeServer,
+      secondary: secondaryServer,
+    });
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.workspaceMcpReload, {
+        forceReconnectAll: true,
+      }),
+    ).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() =>
+      expect(forceDiscover).toHaveBeenCalledWith('secondary'),
+    );
+
     mockConnectionState.resolve();
     await agentPromise;
   });

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3205,7 +3205,14 @@ class QwenAgent implements Agent {
     });
   }
 
-  private reloadWorkspaceMcpDiscovery(): { accepted: boolean } {
+  private reloadWorkspaceMcpDiscovery(
+    options: {
+      forceReconnectAll?: boolean;
+      forceReconnectWhich?: string[];
+    } = {},
+  ): {
+    accepted: boolean;
+  } {
     return this.enqueueWorkspaceMcpDiscovery('reload', async () => {
       const settings = loadSettings(this.config.getTargetDir());
       const discoveryConfig = this.workspaceMcpDiscoveryConfig;
@@ -3251,7 +3258,71 @@ class QwenAgent implements Agent {
           'Failed to synchronize MCP settings with live sessions',
         );
       }
+      if (
+        options.forceReconnectAll === true ||
+        options.forceReconnectWhich !== undefined
+      ) {
+        await this.forceReconnectWorkspaceMcp(options.forceReconnectWhich);
+      }
     });
+  }
+
+  private async forceReconnectWorkspaceMcp(
+    requestedServerNames?: readonly string[],
+  ): Promise<void> {
+    const serverNames = new Set<string>();
+    for (const config of [
+      this.workspaceMcpDiscoveryConfig,
+      this.config,
+      ...this.getActiveSessions().map((session) => session.getConfig()),
+    ]) {
+      for (const name of Object.keys(config?.getMcpServers() ?? {})) {
+        serverNames.add(name);
+      }
+    }
+
+    const selectedServerNames = requestedServerNames
+      ? [...new Set(requestedServerNames)].filter((name) =>
+          serverNames.has(name),
+        )
+      : [...serverNames];
+    const errors: unknown[] = [];
+    for (const serverName of selectedServerNames) {
+      try {
+        const poolHasEntries =
+          (this.mcpPool?.getSnapshot().byName[serverName]?.entryCount ?? 0) > 0;
+        if (this.mcpPool && poolHasEntries) {
+          const results = await this.mcpPool.restartByName(serverName);
+          const failed = results.find((result) => !result.restarted);
+          if (failed) {
+            throw new Error(
+              `MCP server ${JSON.stringify(serverName)} failed to reconnect: ${failed.reason ?? 'unknown error'}`,
+            );
+          }
+          await Promise.all(
+            this.getLiveMcpConfigs(serverName).map(async (config) => {
+              const geminiClient = config.getGeminiClient?.();
+              if (geminiClient?.isInitialized?.()) {
+                await geminiClient.setTools?.();
+              }
+            }),
+          );
+        } else {
+          await this.reconcileMcpServerAcrossLiveConfigs(
+            serverName,
+            'discover',
+          );
+        }
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        'Failed to force reconnect one or more MCP servers',
+      );
+    }
   }
 
   /**
@@ -7488,8 +7559,42 @@ class QwenAgent implements Agent {
       }
       case SERVE_CONTROL_EXT_METHODS.workspaceMcpInitialize:
         return this.initializeWorkspaceMcpDiscovery();
-      case SERVE_CONTROL_EXT_METHODS.workspaceMcpReload:
-        return this.reloadWorkspaceMcpDiscovery();
+      case SERVE_CONTROL_EXT_METHODS.workspaceMcpReload: {
+        const forceReconnectAll = params['forceReconnectAll'];
+        const forceReconnectWhich = params['forceReconnectWhich'];
+        if (
+          forceReconnectAll !== undefined &&
+          typeof forceReconnectAll !== 'boolean'
+        ) {
+          throw RequestError.invalidParams(
+            undefined,
+            'forceReconnectAll must be a boolean',
+          );
+        }
+        if (
+          forceReconnectWhich !== undefined &&
+          (!Array.isArray(forceReconnectWhich) ||
+            forceReconnectWhich.some(
+              (serverName) =>
+                typeof serverName !== 'string' || serverName.length === 0,
+            ))
+        ) {
+          throw RequestError.invalidParams(
+            undefined,
+            'forceReconnectWhich must be an array of server names',
+          );
+        }
+        if (forceReconnectAll === true && forceReconnectWhich !== undefined) {
+          throw RequestError.invalidParams(
+            undefined,
+            'forceReconnectAll and forceReconnectWhich cannot be used together',
+          );
+        }
+        return this.reloadWorkspaceMcpDiscovery({
+          forceReconnectAll: forceReconnectAll === true,
+          forceReconnectWhich: forceReconnectWhich as string[] | undefined,
+        });
+      }
       case SERVE_CONTROL_EXT_METHODS.workspaceMcpManage: {
         const serverName = params['serverName'];
         const action = params['action'];

--- a/packages/cli/src/serve/routes/workspace-mcp-control.ts
+++ b/packages/cli/src/serve/routes/workspace-mcp-control.ts
@@ -36,6 +36,55 @@ interface RegisterWorkspaceMcpControlRoutesDeps {
   ) => string | undefined | null;
 }
 
+interface McpReloadOptions {
+  forceReconnectAll?: boolean;
+  forceReconnectWhich?: string[];
+}
+
+function parseMcpReloadOptions(
+  body: Record<string, unknown>,
+  res: Response,
+): McpReloadOptions | null {
+  const forceReconnectAll = body['forceReconnectAll'];
+  if (
+    forceReconnectAll !== undefined &&
+    typeof forceReconnectAll !== 'boolean'
+  ) {
+    res.status(400).json({
+      error: '`forceReconnectAll` must be a boolean',
+      code: 'invalid_force_reconnect_all_flag',
+    });
+    return null;
+  }
+  const forceReconnectWhich = body['forceReconnectWhich'];
+  if (
+    forceReconnectWhich !== undefined &&
+    (!Array.isArray(forceReconnectWhich) ||
+      forceReconnectWhich.some(
+        (serverName) =>
+          typeof serverName !== 'string' || serverName.length === 0,
+      ))
+  ) {
+    res.status(400).json({
+      error: '`forceReconnectWhich` must be an array of server names',
+      code: 'invalid_force_reconnect_which',
+    });
+    return null;
+  }
+  if (forceReconnectAll === true && forceReconnectWhich !== undefined) {
+    res.status(400).json({
+      error:
+        '`forceReconnectAll` and `forceReconnectWhich` cannot be used together',
+      code: 'conflicting_force_reconnect_options',
+    });
+    return null;
+  }
+  return {
+    forceReconnectAll,
+    forceReconnectWhich,
+  };
+}
+
 export function registerWorkspaceMcpControlRoutes(
   app: Application,
   deps: RegisterWorkspaceMcpControlRoutesDeps,
@@ -67,9 +116,11 @@ export function registerWorkspaceMcpControlRoutes(
   app.post(
     '/workspace/mcp/reload',
     mutate({ strict: true }),
-    async (_req, res) => {
+    async (req, res) => {
+      const options = parseMcpReloadOptions(safeBody(req), res);
+      if (!options) return;
       try {
-        const result = await bridge.reloadWorkspaceMcp();
+        const result = await bridge.reloadWorkspaceMcp(options);
         res.status(202).json(result);
       } catch (err) {
         sendBridgeError(res, err, { route: 'POST /workspace/mcp/reload' });
@@ -305,9 +356,11 @@ export function registerWorkspaceQualifiedMcpControlRoutes(
         res,
       );
       if (!runtime) return;
+      const options = parseMcpReloadOptions(deps.safeBody(req), res);
+      if (!options) return;
       const route = 'POST /workspaces/:workspace/mcp/reload';
       try {
-        const result = await runtime.bridge.reloadWorkspaceMcp();
+        const result = await runtime.bridge.reloadWorkspaceMcp(options);
         res.status(202).json(result);
       } catch (err) {
         deps.sendBridgeError(res, err, { route });

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -14064,6 +14064,20 @@ describe('createServeApp', () => {
         code: 'invalid_force_reconnect_which',
       });
       expect(bridge.workspaceMcpReloadCalls).toBe(2);
+
+      const conflicting = await request(app)
+        .post('/workspace/mcp/reload')
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret')
+        .send({
+          forceReconnectAll: true,
+          forceReconnectWhich: ['docs'],
+        });
+      expect(conflicting.status).toBe(400);
+      expect(conflicting.body).toMatchObject({
+        code: 'conflicting_force_reconnect_options',
+      });
+      expect(bridge.workspaceMcpReloadCalls).toBe(2);
     });
   });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -829,6 +829,13 @@ interface FakeBridge extends AcpSessionBridge {
   workspaceMcpResourcesCalls: string[];
   workspaceMcpInitializeCalls: number;
   workspaceMcpReloadCalls: number;
+  workspaceMcpReloadOptions: Array<
+    | {
+        forceReconnectAll?: boolean;
+        forceReconnectWhich?: string[];
+      }
+    | undefined
+  >;
   workspaceSkillsCalls: number;
   workspaceToolsCalls: number;
   workspaceProvidersCalls: number;
@@ -998,6 +1005,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
   const workspaceMcpResourcesCalls: string[] = [];
   let workspaceMcpInitializeCalls = 0;
   let workspaceMcpReloadCalls = 0;
+  const workspaceMcpReloadOptions: FakeBridge['workspaceMcpReloadOptions'] = [];
   let workspaceSkillsCalls = 0;
   let workspaceToolsCalls = 0;
   let workspaceProvidersCalls = 0;
@@ -1594,6 +1602,9 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     get workspaceMcpReloadCalls() {
       return workspaceMcpReloadCalls;
     },
+    get workspaceMcpReloadOptions() {
+      return workspaceMcpReloadOptions;
+    },
     get workspaceMemoryDreamCalls() {
       return workspaceMemoryDreamCalls;
     },
@@ -1749,8 +1760,9 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       workspaceMcpInitializeCalls += 1;
       return initializeWorkspaceMcpImpl();
     },
-    async reloadWorkspaceMcp() {
+    async reloadWorkspaceMcp(options) {
       workspaceMcpReloadCalls += 1;
+      workspaceMcpReloadOptions.push(options);
       return reloadWorkspaceMcpImpl();
     },
     async getWorkspaceSkillsStatus() {
@@ -14005,6 +14017,53 @@ describe('createServeApp', () => {
       expect(res.status).toBe(202);
       expect(res.body).toEqual({ accepted: true });
       expect(bridge.workspaceMcpReloadCalls).toBe(1);
+      expect(bridge.workspaceMcpReloadOptions).toEqual([
+        {
+          forceReconnectAll: undefined,
+          forceReconnectWhich: undefined,
+        },
+      ]);
+    });
+
+    it('forwards reconnect options and rejects invalid values', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+
+      const enabled = await request(app)
+        .post('/workspace/mcp/reload')
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret')
+        .send({ forceReconnectAll: true });
+      expect(enabled.status).toBe(202);
+      expect(bridge.workspaceMcpReloadOptions).toEqual([
+        {
+          forceReconnectAll: true,
+          forceReconnectWhich: undefined,
+        },
+      ]);
+
+      const selected = await request(app)
+        .post('/workspace/mcp/reload')
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret')
+        .send({ forceReconnectWhich: ['docs'] });
+      expect(selected.status).toBe(202);
+      expect(bridge.workspaceMcpReloadOptions).toHaveLength(2);
+      expect(bridge.workspaceMcpReloadOptions[1]).toEqual({
+        forceReconnectAll: undefined,
+        forceReconnectWhich: ['docs'],
+      });
+
+      const invalid = await request(app)
+        .post('/workspace/mcp/reload')
+        .set('Host', `127.0.0.1:${tokenOpts.port}`)
+        .set('Authorization', 'Bearer secret')
+        .send({ forceReconnectWhich: ['docs', 1] });
+      expect(invalid.status).toBe(400);
+      expect(invalid.body).toMatchObject({
+        code: 'invalid_force_reconnect_which',
+      });
+      expect(bridge.workspaceMcpReloadCalls).toBe(2);
     });
   });
 

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -76,6 +76,7 @@ import type {
   DaemonGitCommitDetail,
   DaemonWorkspaceMcpStatus,
   DaemonWorkspaceMcpInitializeResult,
+  DaemonWorkspaceMcpReloadOptions,
   DaemonWorkspaceMcpToolsStatus,
   DaemonWorkspaceMcpResourcesStatus,
   DaemonWorkspaceMemoryStatus,
@@ -1008,13 +1009,15 @@ export class DaemonClient {
     );
   }
 
-  async reloadWorkspaceMcp(): Promise<DaemonWorkspaceMcpInitializeResult> {
+  async reloadWorkspaceMcp(
+    options: DaemonWorkspaceMcpReloadOptions = {},
+  ): Promise<DaemonWorkspaceMcpInitializeResult> {
     return await this.fetchWithTimeout(
       `${this.baseUrl}/workspace/mcp/reload`,
       {
         method: 'POST',
         headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: '{}',
+        body: JSON.stringify(options),
       },
       async (res) => {
         if (!res.ok) {
@@ -4233,11 +4236,13 @@ export class WorkspaceDaemonClient {
     );
   }
 
-  reloadWorkspaceMcp(): Promise<DaemonWorkspaceMcpInitializeResult> {
+  reloadWorkspaceMcp(
+    options: DaemonWorkspaceMcpReloadOptions = {},
+  ): Promise<DaemonWorkspaceMcpInitializeResult> {
     return this.post(
       '/mcp/reload',
       'POST /workspaces/:workspace/mcp/reload',
-      {},
+      options,
     );
   }
 

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -524,6 +524,7 @@ export type {
   DaemonWorkspaceMcpServerStatus,
   DaemonWorkspaceMcpStatus,
   DaemonWorkspaceMcpInitializeResult,
+  DaemonWorkspaceMcpReloadOptions,
   DaemonWorkspaceMcpToolStatus,
   DaemonWorkspaceMcpToolsStatus,
   DaemonWorkspaceMcpResourceStatus,

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1272,6 +1272,11 @@ export interface DaemonWorkspaceMcpInitializeResult {
   accepted: boolean;
 }
 
+export interface DaemonWorkspaceMcpReloadOptions {
+  forceReconnectAll?: boolean;
+  forceReconnectWhich?: string[];
+}
+
 export interface DaemonWorkspaceMcpToolStatus {
   name: string;
   serverToolName?: string;

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -742,9 +742,18 @@ describe('DaemonClient', () => {
       await expect(
         client.workspaceById('workspace/id').reloadWorkspaceMcp(),
       ).resolves.toEqual(result);
+      await expect(
+        client.reloadWorkspaceMcp({ forceReconnectWhich: ['docs'] }),
+      ).resolves.toEqual(result);
       expect(calls.map((c) => [c.method, c.url])).toEqual([
         ['POST', 'http://daemon/workspace/mcp/reload'],
         ['POST', 'http://daemon/workspaces/workspace%2Fid/mcp/reload'],
+        ['POST', 'http://daemon/workspace/mcp/reload'],
+      ]);
+      expect(calls.map((call) => call.body)).toEqual([
+        '{}',
+        '{}',
+        '{"forceReconnectWhich":["docs"]}',
       ]);
     });
 


### PR DESCRIPTION
## What this PR does

Adds targeted and workspace-wide forced reconnect controls to daemon MCP settings reloads. Clients can reconnect every eligible MCP server or select named servers without changing their settings.

## Why it's needed

An OAuth token written by another Qwen Code process is not a settings change, so ordinary incremental reloads retain the existing MCP transport and do not read the new token. A forced reconnect makes the daemon establish a fresh transport and discover tools using persisted credentials.

## Reviewer Test Plan

### How to verify

Configure an OAuth-protected MCP server, authenticate with another Qwen Code process as the same OS user, then call `POST /workspace/mcp/reload` with `{ "forceReconnectWhich": ["server-name"] }`. Confirm the named server reconnects and becomes usable by an existing session. Call the same route with `{ "forceReconnectAll": true }` to refresh every eligible configured server. Confirm that the two options together, non-boolean `forceReconnectAll`, and non-string array values in `forceReconnectWhich` return 400.

### Evidence (Before & After)

Before: an unchanged MCP configuration retained its transport after an external OAuth token was written, leaving the daemon unable to use the new credential. After: a selected or workspace-wide forced reconnect establishes fresh transports and re-discovers tools from the persisted token state.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |    ✅   |
| 🪟 Windows |    ⚠️   |
|  🐧 Linux  |    ⚠️   |

### Environment (optional)

Local package builds, typechecks, ESLint, and focused Vitest suites.

## Risk & Scope

- Main risk or tradeoff: forced reconnects briefly interrupt MCP availability while each transport reconnects.
- Not validated / out of scope: a live external OAuth provider E2E run; the checked-in E2E plan covers that scenario.
- Breaking changes / migration notes: this feature branch replaces the unreleased `forceReconnect` field with `forceReconnectAll` and `forceReconnectWhich`.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的内容

为 daemon MCP 设置重载增加按范围和按名称的强制重连控制。客户端无需修改设置，即可重连所有符合条件的 MCP server 或指定名称的 server。

## 为什么需要它

另一个 Qwen Code 进程写入 OAuth token 不属于设置变更，因此普通增量重载会保留现有 MCP transport，无法读取新 token。强制重连会让 daemon 建立新的 transport，并使用已持久化的凭据重新发现工具。

## 审阅者测试计划

### 如何验证

配置一个受 OAuth 保护的 MCP server，以同一 OS 用户身份通过另一个 Qwen Code 进程完成认证，然后调用 `POST /workspace/mcp/reload` 并传入 `{ "forceReconnectWhich": ["server-name"] }`。确认指定 server 重新连接，并能在已有 session 中使用。使用 `{ "forceReconnectAll": true }` 调用同一路由，确认所有符合条件的已配置 server 均被刷新。确认同时传递两个选项、`forceReconnectAll` 传入非布尔值、或 `forceReconnectWhich` 数组包含非字符串时均返回 400。

### 证据（前后对比）

之前：外部 OAuth token 写入后，未变化的 MCP 配置在重载时仍保留 transport，daemon 无法使用新凭据。之后：按名称或全工作区的强制重连会建立新的 transport，并根据持久化 token 状态重新发现工具。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### 环境（可选）

本地 package 构建、typecheck、ESLint 和聚焦 Vitest 测试。

## 风险与范围

- 主要风险或取舍：强制重连期间，每个 MCP transport 会短暂不可用。
- 未验证 / 不在范围内：真实外部 OAuth provider 的 E2E 运行；已提交的 E2E 计划覆盖该场景。
- 破坏性变更 / 迁移说明：此功能分支将尚未发布的 `forceReconnect` 字段替换为 `forceReconnectAll` 和 `forceReconnectWhich`。

## 关联 Issue

不适用

</details>
