### PR TITLE
fix(core): add image modality support for qwen3.8-max and kimi-k3 models

### DIFF
--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -216,6 +216,14 @@ describe('defaultModalities', () => {
   });
 
   describe('Kimi', () => {
+    it('returns image + video for kimi-k3', () => {
+      const m = defaultModalities('kimi-k3');
+      expect(m.image).toBe(true);
+      expect(m.video).toBe(true);
+      expect(m.pdf).toBeUndefined();
+      expect(m.audio).toBeUndefined();
+    });
+
     it('returns image + video for kimi-k2.5', () => {
       const m = defaultModalities('kimi-k2.5');
       expect(m.image).toBe(true);

--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -151,6 +151,17 @@ describe('defaultModalities', () => {
       expect(defaultModalities('qwen3.7-max')).toEqual({});
     });
 
+    it('returns image for qwen3.8-max', () => {
+      const m = defaultModalities('qwen3.8-max');
+      expect(m.image).toBe(true);
+      expect(m.video).toBeUndefined();
+    });
+
+    it('returns image for qwen3.8-max-preview (provider-prefixed)', () => {
+      const m = defaultModalities('bailian-token-plan/qwen3.8-max-preview');
+      expect(m.image).toBe(true);
+    });
+
     it('returns image + video for qwen3.6-35b variants', () => {
       const m = defaultModalities('qwen3.6-35b-a3b-nvfp4');
       expect(m.image).toBe(true);

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -79,6 +79,7 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   // -------------------
   // Moonshot / Kimi
   // -------------------
+  [/^kimi-k3/, { image: true, video: true }],
   [/^kimi-k2\./, { image: true, video: true }],
   [/^kimi-/, {}],
 

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -40,10 +40,12 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   // -------------------
   // Alibaba / Qwen
   // -------------------
-  // Qwen Plus models: image + video support (Max models are text-only)
+  // Qwen Plus models: image + video support
   [/^qwen3\.5-plus/, { image: true, video: true }],
   [/^qwen3\.6-plus/, { image: true, video: true }],
   [/^qwen3\.7-plus/, { image: true, video: true }],
+  // Qwen Max models (3.8+): image support
+  [/^qwen3\.8-max/, { image: true }],
   [/^coder-model$/, { image: true, video: true }],
 
   // Qwen VL (vision-language) models: image + video


### PR DESCRIPTION
## Motivation

`qwen3.8-max-preview` and `kimi-k3` both support image input, but the name-based modality heuristic in `modalityDefaults.ts` had no matching patterns for them. After normalization, they fell through to catch-all text-only rules, causing the vision bridge to unnecessarily transcribe images via a secondary model instead of sending them directly to the primary model.

For qwen3.8-max, this produced the error:

> Cannot read "clipboard-xxx.png" (this model does not support image input). Inform the user.

## Changes

- Added `[/^qwen3\.8-max/, { image: true }]` so `qwen3.8-max` (and provider-prefixed / `-preview` suffixed variants) are recognized as image-capable.
- Added `[/^kimi-k3/, { image: true, video: true }]` so `kimi-k3` is recognized as multimodal (officially supports image + video input per Moonshot docs).
- Updated comments to reflect that Max models are no longer universally text-only.
- Added unit tests for both models.

## How to verify

1. Set model to `qwen3.8-max-preview` or `kimi-k3`.
2. Paste or attach an image in the conversation.
3. The image should be sent directly to the model without triggering the vision bridge fallback or the "does not support image input" error.