### PR TITLE
docs(core): align JSDoc @param names with actual function signatures

### DIFF
--- a/packages/core/src/utils/editHelper.ts
+++ b/packages/core/src/utils/editHelper.ts
@@ -404,7 +404,6 @@ const SNIPPET_MAX_LINES = 1000;
  *
  * @param oldContent The original file content before the edit (null for new files)
  * @param newContent The new file content after the edit
- * @param contextLines Number of context lines to show before and after the change
  * @returns Snippet information, or null if no meaningful snippet can be extracted
  */
 export function extractEditSnippet(

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -218,10 +218,11 @@ async function readFullStructure(
 }
 
 /**
- * Reads the directory structure using BFS, respecting maxItems.
+ * Formats a folder structure tree node into indented text lines.
  * @param node The current node in the reduced structure.
- * @param indent The current indentation string.
- * @param isLast Sibling indicator.
+ * @param currentIndent The current indentation string.
+ * @param isLastChildOfParent Sibling indicator.
+ * @param isProcessingRootNode Whether this is the root node of the structure.
  * @param builder Array to build the string lines.
  */
 function formatStructure(

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -80,7 +80,7 @@ function validateUrl(
  * and resolves successfully to prevent application crashes.
  *
  * @param url - The URL to open.
- * @param options.allowFile - Allow file:// URLs for locally generated reports.
+ * @param browserOptions.allowFile - Allow file:// URLs for locally generated reports.
  * @returns A promise that resolves when the attempt is made (whether successful or logged).
  */
 export async function openBrowserSecurely(

--- a/packages/core/src/utils/subagentGenerator.ts
+++ b/packages/core/src/utils/subagentGenerator.ts
@@ -109,7 +109,7 @@ export interface SubagentGeneratedContent {
  * Generates subagent configuration content using LLM.
  *
  * @param userDescription - The user's description of what the subagent should do
- * @param geminiClient - Initialized GeminiClient instance
+ * @param config - Initialized Config instance
  * @param abortSignal - AbortSignal for cancelling the request
  * @returns Promise resolving to generated subagent content
  */

--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -47,7 +47,8 @@ export class QwenConnectionHandler {
    *
    * @param connection - ACP connection instance
    * @param workingDir - Working directory
-   * @param cliPath - CLI path (optional, if provided will override the path in configuration)
+   * @param cliEntryPath - CLI entry path (if provided will override the path in configuration)
+   * @param options - Optional connection settings
    */
   async connect(
     connection: AcpConnection,

--- a/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionManager.ts
@@ -44,9 +44,9 @@ export class QwenSessionManager {
   }
 
   /**
-   * Load a saved session by name
+   * Load a saved session by ID
    *
-   * @param sessionName - Name/tag of the session to load
+   * @param sessionId - ID of the session to load
    * @param workingDir - Current working directory
    * @returns Loaded session or null if not found
    */


### PR DESCRIPTION
## Summary

Fix 6 instances where JSDoc `@param` tags had drifted from their corresponding function signatures — parameters were renamed, removed, or undocumented over time but the doc blocks were not updated.

## Changes

| File | Function | Fix |
|------|----------|-----|
| `editHelper.ts` | `extractEditSnippet()` | Remove `@param contextLines` (parameter no longer in signature) |
| `getFolderStructure.ts` | `formatStructure()` | Correct summary line; `indent` → `currentIndent`, `isLast` → `isLastChildOfParent`; add missing `@param isProcessingRootNode` |
| `secure-browser-launcher.ts` | `openBrowserSecurely()` | `options.allowFile` → `browserOptions.allowFile` |
| `subagentGenerator.ts` | `subagentGenerator()` | `geminiClient` → `config` |
| `qwenConnectionHandler.ts` | `connect()` | `cliPath` → `cliEntryPath`; add missing `@param options` |
| `qwenSessionManager.ts` | `loadSession()` | Summary "by name" → "by ID"; `sessionName` → `sessionId` |

## Verification

- `npm run lint` ✅
- `npx tsc --noEmit` (core + vscode-ide-companion) ✅
- Grep scan confirmed no other `@param` drift in the two target directories

Closes #7446