### PR TITLE
fix(vscode): use file picker image paths for vision input

### DIFF
--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -264,12 +264,21 @@ describe('SessionMessageHandler', () => {
             value: '/workspace/screen shot.png',
             isImage: true,
           },
+          {
+            type: 'file',
+            name: 'notes.md',
+            value: '/workspace/notes.md',
+            isImage: false,
+          },
         ],
       },
     });
 
     expect(agentManager.sendMessage).toHaveBeenCalledWith([
-      { type: 'text', text: '/workspace/screen shot.png\n\ndescribe it' },
+      {
+        type: 'text',
+        text: '/workspace/screen shot.png\n/workspace/notes.md\n\ndescribe it',
+      },
       {
         type: 'resource_link',
         name: 'screen shot.png',

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -224,6 +224,61 @@ describe('SessionMessageHandler', () => {
     ]);
   });
 
+  it('sends image file context as prompt image blocks', async () => {
+    mockProcessImageAttachments.mockImplementation(
+      async (promptText: string) => ({
+        formattedText: promptText,
+        displayText: promptText,
+        savedImageCount: 0,
+        promptImages: [],
+      }),
+    );
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const conversationStore = {
+      createConversation: vi.fn().mockResolvedValue({ id: 'conversation-1' }),
+      getConversation: vi.fn().mockResolvedValue(null),
+      addMessage: vi.fn(),
+      renameConversationId: vi.fn().mockResolvedValue(true),
+    };
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conversation-1',
+      vi.fn(),
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: 'describe it',
+        context: [
+          {
+            type: 'file',
+            name: 'screen shot.png',
+            value: '/workspace/screen shot.png',
+            isImage: true,
+          },
+        ],
+      },
+    });
+
+    expect(agentManager.sendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '/workspace/screen shot.png\n\ndescribe it' },
+      {
+        type: 'resource_link',
+        name: 'screen shot.png',
+        mimeType: 'image/png',
+        uri: 'file:///workspace/screen shot.png',
+      },
+    ]);
+  });
+
   it('keeps the conversation store aligned with the ACP session id before editing', async () => {
     mockProcessImageAttachments.mockImplementation(
       async (promptText: string) => ({

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -274,7 +274,7 @@ describe('SessionMessageHandler', () => {
         type: 'resource_link',
         name: 'screen shot.png',
         mimeType: 'image/png',
-        uri: 'file:///workspace/screen shot.png',
+        uri: 'file:///workspace/screen%20shot.png',
       },
     ]);
   });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -9,7 +9,10 @@ import * as vscode from 'vscode';
 import { BaseMessageHandler } from './BaseMessageHandler.js';
 import type { ChatMessage } from '../../services/qwenAgentManager.js';
 import type { Conversation } from '../../services/conversationStore.js';
-import type { ImageAttachment } from '../../utils/imageSupport.js';
+import {
+  getDisplayableImageMimeType,
+  type ImageAttachment,
+} from '../../utils/imageSupport.js';
 import type { ApprovalModeValue } from '../../types/approvalModeValueTypes.js';
 import {
   processImageAttachments,
@@ -484,6 +487,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
       value: string;
       startLine?: number;
       endLine?: number;
+      isImage?: boolean;
     }>,
     fileContext?: {
       fileName: string;
@@ -544,6 +548,18 @@ export class SessionMessageHandler extends BaseMessageHandler {
       savedImageCount,
       promptImages,
     } = await processImageAttachments(promptText, attachments);
+    for (const ctx of context ?? []) {
+      const mimeType = ctx.isImage
+        ? getDisplayableImageMimeType(ctx.value)
+        : undefined;
+      if (mimeType) {
+        promptImages.push({
+          path: ctx.value,
+          name: ctx.name,
+          mimeType,
+        });
+      }
+    }
     promptText = formattedText;
     displayText = updatedDisplayText;
 

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -89,6 +89,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
                 value: string;
                 startLine?: number;
                 endLine?: number;
+                isImage?: boolean;
               }>
             | undefined,
           data?.fileContext as
@@ -113,6 +114,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
                 value: string;
                 startLine?: number;
                 endLine?: number;
+                isImage?: boolean;
               }>
             | undefined,
           data?.fileContext as

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
@@ -310,6 +310,53 @@ describe('useMessageSubmit', () => {
     });
   });
 
+  it('resolves multiple file references in one message', () => {
+    const imagePath = '/workspace/screen shot.png';
+    const notePath = '/workspace/notes.md';
+    const props = createDefaultProps({
+      inputText: `compare @${imagePath} with @${notePath}`,
+    });
+    props.fileContext.getFileReference = vi.fn((name: string) => {
+      if (name === imagePath) {
+        return imagePath;
+      }
+      if (name === notePath) {
+        return notePath;
+      }
+      return undefined;
+    });
+    const rendered = renderHookHarness(props);
+    root = rendered.root;
+    container = rendered.container;
+
+    act(() => {
+      rendered.api.handleSubmit(createSubmitEvent());
+    });
+
+    expect(props.vscode.postMessage).toHaveBeenCalledWith({
+      type: 'sendMessage',
+      data: {
+        text: `compare @${imagePath} with @${notePath}`,
+        context: [
+          {
+            type: 'file',
+            name: imagePath,
+            value: imagePath,
+            isImage: true,
+          },
+          {
+            type: 'file',
+            name: notePath,
+            value: notePath,
+            isImage: false,
+          },
+        ],
+        fileContext: undefined,
+        attachments: undefined,
+      },
+    });
+  });
+
   it('does not resolve file references from strict token prefixes', () => {
     const props = createDefaultProps({
       inputText: 'open @data.csv.bak',

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
@@ -301,8 +301,35 @@ describe('useMessageSubmit', () => {
             type: 'file',
             name: imagePath,
             value: imagePath,
+            isImage: true,
           },
         ],
+        fileContext: undefined,
+        attachments: undefined,
+      },
+    });
+  });
+
+  it('does not resolve file references from strict token prefixes', () => {
+    const props = createDefaultProps({
+      inputText: 'open @data.csv.bak',
+    });
+    props.fileContext.getFileReference = vi.fn((name: string) =>
+      name === 'data.csv' ? '/workspace/data.csv' : undefined,
+    );
+    const rendered = renderHookHarness(props);
+    root = rendered.root;
+    container = rendered.container;
+
+    act(() => {
+      rendered.api.handleSubmit(createSubmitEvent());
+    });
+
+    expect(props.vscode.postMessage).toHaveBeenCalledWith({
+      type: 'sendMessage',
+      data: {
+        text: 'open @data.csv.bak',
+        context: undefined,
         fileContext: undefined,
         attachments: undefined,
       },

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
@@ -275,4 +275,37 @@ describe('useMessageSubmit', () => {
       },
     });
   });
+
+  it('resolves raw image picker paths with spaces on submit', () => {
+    const imagePath = 'C:\\Users\\Me\\Pictures\\screen shot.png';
+    const props = createDefaultProps({
+      inputText: `describe @${imagePath} please`,
+    });
+    props.fileContext.getFileReference = vi.fn((name: string) =>
+      name === imagePath ? imagePath : undefined,
+    );
+    const rendered = renderHookHarness(props);
+    root = rendered.root;
+    container = rendered.container;
+
+    act(() => {
+      rendered.api.handleSubmit(createSubmitEvent());
+    });
+
+    expect(props.vscode.postMessage).toHaveBeenCalledWith({
+      type: 'sendMessage',
+      data: {
+        text: `describe @${imagePath} please`,
+        context: [
+          {
+            type: 'file',
+            name: imagePath,
+            value: imagePath,
+          },
+        ],
+        fileContext: undefined,
+        attachments: undefined,
+      },
+    });
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
@@ -57,6 +57,40 @@ export const shouldSendMessage = ({
   return hasText || hasAttachments;
 };
 
+function findFileReferences(
+  text: string,
+  getFileReference: (fileName: string) => string | undefined,
+): Array<{ name: string; value: string }> {
+  const references: Array<{ name: string; value: string }> = [];
+  let currentIndex = 0;
+
+  while (currentIndex < text.length) {
+    const atIndex = text.indexOf('@', currentIndex);
+    if (atIndex === -1) {
+      break;
+    }
+
+    let matched = false;
+    // ponytail: O(n²) against short composer text; replace with map-key scan if composer parsing gets hot.
+    for (let end = text.length; end > atIndex + 1; end -= 1) {
+      const name = text.slice(atIndex + 1, end).trimEnd();
+      const value = getFileReference(name);
+      if (value) {
+        references.push({ name, value });
+        currentIndex = end;
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      currentIndex = atIndex + 1;
+    }
+  }
+
+  return references;
+}
+
 /**
  * Message submit Hook
  * Handles message submission logic and context parsing
@@ -137,20 +171,15 @@ export const useMessageSubmit = ({
         startLine?: number;
         endLine?: number;
       }> = [];
-      const fileRefPattern = /@([^\s]+)/g;
-      let match;
-
-      while ((match = fileRefPattern.exec(textToSend)) !== null) {
-        const fileName = match[1];
-        const filePath = fileContext.getFileReference(fileName);
-
-        if (filePath) {
-          context.push({
-            type: 'file',
-            name: fileName,
-            value: filePath,
-          });
-        }
+      for (const reference of findFileReferences(
+        textToSend,
+        fileContext.getFileReference,
+      )) {
+        context.push({
+          type: 'file',
+          name: reference.name,
+          value: reference.value,
+        });
       }
 
       // Add active file selection context if present and not skipped

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
@@ -9,6 +9,7 @@ import type { VSCodeAPI } from './useVSCode.js';
 import { getRandomLoadingMessage } from '../../constants/loadingMessages.js';
 import type { ImageAttachment } from './useImage.js';
 import { ZERO_WIDTH_SPACE, stripZeroWidthSpaces } from '@qwen-code/webui';
+import { isDisplayableImagePath } from '../../utils/imageSupport.js';
 
 interface UseMessageSubmitProps {
   vscode: VSCodeAPI;
@@ -76,6 +77,10 @@ function findFileReferences(
       const name = text.slice(atIndex + 1, end).trimEnd();
       const value = getFileReference(name);
       if (value) {
+        const nextChar = end < text.length ? text[end] : '';
+        if (nextChar !== '' && nextChar !== '@' && !/\s/.test(nextChar)) {
+          continue;
+        }
         references.push({ name, value });
         currentIndex = end;
         matched = true;
@@ -170,6 +175,7 @@ export const useMessageSubmit = ({
         value: string;
         startLine?: number;
         endLine?: number;
+        isImage?: boolean;
       }> = [];
       for (const reference of findFileReferences(
         textToSend,
@@ -179,6 +185,7 @@ export const useMessageSubmit = ({
           type: 'file',
           name: reference.name,
           value: reference.value,
+          isImage: isDisplayableImagePath(reference.value),
         });
       }
 

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
@@ -594,4 +594,72 @@ describe('useWebViewMessages', () => {
       '/tmp/insight-report.html',
     );
   });
+
+  it('inserts resolved image attachments as escaped absolute references', () => {
+    const rendered = renderHookHarness();
+    root = rendered.root;
+    container = rendered.container;
+
+    const input = document.createElement('div');
+    (
+      rendered.handlers.inputFieldRef as { current: HTMLDivElement | null }
+    ).current = input;
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'fileAttached',
+            data: {
+              id: 'file-1',
+              type: 'file',
+              name: 'screen shot.png',
+              value: 'C:\\Users\\Me\\Pictures\\screen shot.png',
+            },
+          },
+        }),
+      );
+    });
+
+    expect(rendered.handlers.fileContext.addFileReference).toHaveBeenCalledWith(
+      'screen shot.png',
+      'C:\\Users\\Me\\Pictures\\screen shot.png',
+    );
+    expect(input.textContent).toBe(
+      '@C:\\Users\\Me\\Pictures\\screen\\ shot.png ',
+    );
+    expect(rendered.handlers.setInputText).toHaveBeenCalledWith(
+      '@C:\\Users\\Me\\Pictures\\screen\\ shot.png ',
+    );
+  });
+
+  it('keeps non-image attachments as file-name references', () => {
+    const rendered = renderHookHarness();
+    root = rendered.root;
+    container = rendered.container;
+
+    const input = document.createElement('div');
+    (
+      rendered.handlers.inputFieldRef as { current: HTMLDivElement | null }
+    ).current = input;
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'fileAttached',
+            data: {
+              id: 'file-1',
+              type: 'file',
+              name: 'notes.txt',
+              value: 'C:\\Users\\Me\\Documents\\notes.txt',
+            },
+          },
+        }),
+      );
+    });
+
+    expect(input.textContent).toBe('@notes.txt ');
+    expect(rendered.handlers.setInputText).toHaveBeenCalledWith('@notes.txt ');
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
@@ -595,7 +595,7 @@ describe('useWebViewMessages', () => {
     );
   });
 
-  it('inserts resolved image attachments as escaped absolute references', () => {
+  it('inserts resolved image attachments as raw absolute references', () => {
     const rendered = renderHookHarness();
     root = rendered.root;
     container = rendered.container;
@@ -626,10 +626,10 @@ describe('useWebViewMessages', () => {
       'C:\\Users\\Me\\Pictures\\screen shot.png',
     );
     expect(input.textContent).toBe(
-      '@C:\\Users\\Me\\Pictures\\screen\\ shot.png ',
+      '@C:\\Users\\Me\\Pictures\\screen shot.png ',
     );
     expect(rendered.handlers.setInputText).toHaveBeenCalledWith(
-      '@C:\\Users\\Me\\Pictures\\screen\\ shot.png ',
+      '@C:\\Users\\Me\\Pictures\\screen shot.png ',
     );
   });
 

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
@@ -625,6 +625,10 @@ describe('useWebViewMessages', () => {
       'screen shot.png',
       'C:\\Users\\Me\\Pictures\\screen shot.png',
     );
+    expect(rendered.handlers.fileContext.addFileReference).toHaveBeenCalledWith(
+      'C:\\Users\\Me\\Pictures\\screen shot.png',
+      'C:\\Users\\Me\\Pictures\\screen shot.png',
+    );
     expect(input.textContent).toBe(
       '@C:\\Users\\Me\\Pictures\\screen shot.png ',
     );

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -1300,6 +1300,12 @@ export const useWebViewMessages = ({
             const referenceText = isDisplayableImagePath(attachment.value)
               ? attachment.value
               : attachment.name;
+            if (referenceText !== attachment.name) {
+              handlers.fileContext.addFileReference(
+                referenceText,
+                attachment.value,
+              );
+            }
             const newText = currentText
               ? `${currentText} @${referenceText} `
               : `@${referenceText} `;

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -21,10 +21,7 @@ import {
   type WebViewMessage,
   type WebViewMessageBase,
 } from './useImage.js';
-import {
-  escapePath,
-  isDisplayableImagePath,
-} from '../../utils/imageSupport.js';
+import { isDisplayableImagePath } from '../../utils/imageSupport.js';
 
 const FORCE_CLEAR_STREAM_END_REASONS = new Set([
   'user_cancelled',
@@ -1301,7 +1298,7 @@ export const useWebViewMessages = ({
           if (inputFieldRef.current) {
             const currentText = inputFieldRef.current.textContent || '';
             const referenceText = isDisplayableImagePath(attachment.value)
-              ? escapePath(attachment.value)
+              ? attachment.value
               : attachment.name;
             const newText = currentText
               ? `${currentText} @${referenceText} `

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -21,6 +21,10 @@ import {
   type WebViewMessage,
   type WebViewMessageBase,
 } from './useImage.js';
+import {
+  escapePath,
+  isDisplayableImagePath,
+} from '../../utils/imageSupport.js';
 
 const FORCE_CLEAR_STREAM_END_REASONS = new Set([
   'user_cancelled',
@@ -1296,9 +1300,12 @@ export const useWebViewMessages = ({
 
           if (inputFieldRef.current) {
             const currentText = inputFieldRef.current.textContent || '';
+            const referenceText = isDisplayableImagePath(attachment.value)
+              ? escapePath(attachment.value)
+              : attachment.name;
             const newText = currentText
-              ? `${currentText} @${attachment.name} `
-              : `@${attachment.name} `;
+              ? `${currentText} @${referenceText} `
+              : `@${referenceText} `;
             inputFieldRef.current.textContent = newText;
             setInputText(newText);
 

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.test.ts
@@ -155,7 +155,26 @@ describe('buildPromptBlocks', () => {
         type: 'resource_link',
         name: 'pasted image.png',
         mimeType: 'image/png',
-        uri: 'file:///tmp/My Images/pasted image.png',
+        uri: 'file:///tmp/My%20Images/pasted%20image.png',
+      },
+    ]);
+  });
+
+  it('builds valid file URIs from Windows image paths', () => {
+    expect(
+      buildPromptBlocks('', [
+        {
+          path: 'C:\\Users\\Me\\Pictures\\screen shot.png',
+          name: 'screen shot.png',
+          mimeType: 'image/png',
+        },
+      ]),
+    ).toEqual([
+      {
+        type: 'resource_link',
+        name: 'screen shot.png',
+        mimeType: 'image/png',
+        uri: 'file:///C:/Users/Me/Pictures/screen%20shot.png',
       },
     ]);
   });

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
@@ -194,7 +194,7 @@ export function buildPromptBlocks(
 }
 
 function toFileUrlPath(imagePath: string): string {
-  if (/^[a-zA-Z]:[\\/]/.test(imagePath)) {
+  if (process.platform !== 'win32' && /^[a-zA-Z]:[\\/]/.test(imagePath)) {
     return `/${imagePath.replace(/\\/g, '/')}`;
   }
   return imagePath;

--- a/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/imageHandler.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
 import type { ContentBlock } from '@agentclientprotocol/sdk';
 import { Storage } from '@qwen-code/qwen-code-core';
 import type {
@@ -185,11 +186,18 @@ export function buildPromptBlocks(
       type: 'resource_link',
       name: image.name,
       mimeType: image.mimeType,
-      uri: `file://${image.path}`,
+      uri: pathToFileURL(toFileUrlPath(image.path)).href,
     });
   }
 
   return blocks;
+}
+
+function toFileUrlPath(imagePath: string): string {
+  if (/^[a-zA-Z]:[\\/]/.test(imagePath)) {
+    return `/${imagePath.replace(/\\/g, '/')}`;
+  }
+  return imagePath;
 }
 
 // ---------- Image path resolution ----------


### PR DESCRIPTION
## What this PR does

When the VS Code Companion file picker attaches an image, the chat input now receives an escaped absolute image reference instead of only the display filename. Non-image file attachments keep the existing filename reference behavior.

## Why it's needed

The image-sending path already understands explicit `@/absolute/path/to/image.png` references, and users could work around the bug by typing the full path manually. The file picker, however, inserted only `@image.png`, so the selected image was treated like plain text and never reached the model as vision input.

## Reviewer Test Plan

### How to verify

Use the VS Code Companion file picker to attach an image whose name contains a space, send a prompt asking the model to describe it, and confirm the model can analyze the image content. Also attach a non-image file and confirm it still appears as a filename reference.

Run the focused webview tests and the extension checks:

```bash
cd packages/vscode-ide-companion
npx vitest run src/webview/hooks/useWebViewMessages.test.tsx src/webview/hooks/useImage.test.ts
npm run check-types
npm run lint -- src/webview/hooks/useWebViewMessages.ts src/webview/hooks/useWebViewMessages.test.tsx
```

Package-level verification used for manual testing:

```bash
npm run build
npm run bundle
npm run package --workspace=qwen-code-vscode-ide-companion -- --out /tmp/qwen-7489-artifacts/qwen-code-vscode-ide-companion-0.20.1-image-picker-fix.vsix
```

### Evidence (Before & After)

Before: the regression test fails with the input field containing only `@screen shot.png` instead of the selected absolute path.

After: the same flow inserts the escaped absolute image path, and the model receives the image content. Manual verification screenshot:

![](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/codex-clipboard-0eec2f1a-1203-46d0-8cec-60567a4e4ba5.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

macOS with Node.js 22.22.0. Verified with focused webview tests, VS Code Companion typecheck and lint, full repository build, root bundle, and a locally packaged VSIX.

## Risk & Scope

- Main risk or tradeoff: the visible text for image picker attachments now shows the full escaped path, which is necessary for the existing image-reference pipeline to send the image.
- Not validated / out of scope: Windows VS Code manual testing; the original report was Windows, but the fixed path construction is platform-independent and covered with a Windows-style path regression test.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #7489

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 VS Code Companion 的文件选择器附加图片时，聊天输入框现在会插入转义后的绝对图片路径引用，而不再只插入展示用文件名。非图片文件附件仍保持原来的文件名引用行为。

## 为什么需要

现有图片发送链路已经能识别显式的 `@/absolute/path/to/image.png` 引用，用户也可以通过手动输入完整路径绕过这个问题。但文件选择器只插入 `@image.png`，导致所选图片被当成普通文本，模型没有收到 vision 输入。

## Reviewer Test Plan

### 如何验证

使用 VS Code Companion 的文件选择器附加一个文件名包含空格的图片，发送让模型描述图片的 prompt，确认模型能分析图片内容。再附加一个非图片文件，确认它仍以文件名引用形式出现。

运行聚焦 webview 测试和扩展检查：

```bash
cd packages/vscode-ide-companion
npx vitest run src/webview/hooks/useWebViewMessages.test.tsx src/webview/hooks/useImage.test.ts
npm run check-types
npm run lint -- src/webview/hooks/useWebViewMessages.ts src/webview/hooks/useWebViewMessages.test.tsx
```

用于手动测试的打包验证：

```bash
npm run build
npm run bundle
npm run package --workspace=qwen-code-vscode-ide-companion -- --out /tmp/qwen-7489-artifacts/qwen-code-vscode-ide-companion-0.20.1-image-picker-fix.vsix
```

### 证据（Before & After）

修复前：回归测试失败，输入框里只有 `@screen shot.png`，而不是所选文件的绝对路径。

修复后：同一流程插入转义后的绝对图片路径，模型可以收到图片内容。手动验证截图见上方。

### 已测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 本地未测试 |
|  🐧 Linux  | ⚠️ 本地未测试 |

### 环境（可选）

macOS，Node.js 22.22.0。已通过聚焦 webview 测试、VS Code Companion typecheck 和 lint、全仓 build、root bundle，以及本地 VSIX 打包。

## 风险与范围

- 主要风险或权衡：图片选择器附件在输入框中现在会显示完整转义路径，这是复用现有图片引用链路发送图片所必需的。
- 未验证 / 不在范围内：Windows VS Code 手动测试；原始报告来自 Windows，但修复的路径构造是平台无关的，并由 Windows 风格路径回归测试覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Resolves #7489

</details>
