### PR TITLE
fix(web-shell): open singleton subagent details

### DIFF
--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -558,6 +558,38 @@ describe('tool row rendering', () => {
     expect(container.querySelector('[class*="expandedCardHeader"]')).toBeNull();
   });
 
+  it('opens a single foreground agent from the tool summary', () => {
+    const onOpen = vi.fn();
+    const tool = makeTool({
+      toolName: 'agent',
+      status: 'completed',
+      args: {
+        subagent_type: 'Explore',
+        run_in_background: false,
+      },
+      subContent: 'investigation complete',
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <SubagentDetailsProvider onOpen={onOpen}>
+            <ToolGroup tools={[tool]} />
+          </SubagentDetailsProvider>
+        </I18nProvider>,
+      );
+    });
+    mounted.push({ root, container });
+
+    const summary = container.querySelector('button') as HTMLButtonElement;
+    expect(summary.hasAttribute('aria-expanded')).toBe(false);
+    act(() => summary.click());
+
+    expect(onOpen).toHaveBeenCalledWith(tool);
+  });
+
   it('opens on-demand agent details without mounting inline content', () => {
     const onOpen = vi.fn();
     const tool = makeTool({

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1434,11 +1434,15 @@ export const ToolGroup = memo(function ToolGroup({
 }: ToolGroupProps) {
   const { t } = useI18n();
   const compactMode = useContext(CompactModeContext);
+  const subagentDetails = useSubagentDetails();
   const [chatExpanded, setChatExpanded] = useState(false);
   const hasRunningTool = hasActiveTool(tools);
   const hasFailedTool = tools.some((tool) => tool.status === 'failed');
   const activeTool = tools.length > 0 ? getActiveTool(tools) : undefined;
   const singleTool = tools.length === 1 ? tools[0] : undefined;
+  const singleSubagent =
+    singleTool && isSubAgentToolCall(singleTool) ? singleTool : undefined;
+  const opensSubagentDetails = Boolean(singleSubagent && subagentDetails);
   const summaryIconTool = tools[0] ?? activeTool;
   const liveStartedAtRef = useRef(Date.now());
   const summaryNow = useSharedNow(hasRunningTool);
@@ -1471,9 +1475,21 @@ export const ToolGroup = memo(function ToolGroup({
         <button
           type="button"
           className={styles.chatSummary}
-          onClick={() => setChatExpanded((value) => !value)}
-          aria-expanded={chatExpanded}
-          title={chatExpanded ? t('tool.collapseHint') : t('tool.expand')}
+          onClick={() => {
+            if (singleSubagent && subagentDetails) {
+              subagentDetails.onOpen(singleSubagent);
+              return;
+            }
+            setChatExpanded((value) => !value);
+          }}
+          aria-expanded={opensSubagentDetails ? undefined : chatExpanded}
+          title={
+            opensSubagentDetails
+              ? undefined
+              : chatExpanded
+                ? t('tool.collapseHint')
+                : t('tool.expand')
+          }
         >
           <span className={styles.chatSummaryIcon} aria-hidden="true">
             {summaryIconTool ? (


### PR DESCRIPTION
## What this PR does

When a tool summary contains a single subagent, clicking its only visible summary now opens the subagent detail panel on the right. Ordinary single-tool summaries still expand and collapse inline, and subagent rendering without a detail provider keeps the existing inline behavior.

## Why it's needed

Single subagents were rendered with their inner header hidden to avoid duplicate chrome, but the right-panel action was attached only to that hidden header. The remaining visible summary button only toggled the inline container, so users could not open the subagent transcript in the right panel even though the daemon could resolve and load it successfully.

## Reviewer Test Plan

### How to verify

Load or create a session containing a single foreground subagent call, then click the visible agent summary. Confirm that the right-side subagent detail panel opens and displays its transcript. Also click a normal single-tool summary and confirm it still expands and collapses inline.

### Evidence (Before & After)

Before: clicking a singleton subagent summary only toggled the inline tool container; no right-side panel appeared. After: the same click opens the right-side subagent detail panel. The affected resolve and virtual-session load endpoints were separately verified to return 200 for the reproduced session.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Verified with the local Web Shell and daemon. The focused ToolGroup test file passes with 34 tests, and the Web Shell TypeScript typecheck passes.

## Risk & Scope

- Main risk or tradeoff: In a Web Shell surface that provides right-side subagent details, a singleton subagent summary now opens that panel instead of expanding inline.
- Not validated / out of scope: Windows and Linux browser behavior; changes to subagent persistence, task-to-tool-call matching, or daemon APIs.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当工具摘要中只有一个 subagent 时，点击唯一可见的摘要会打开右侧的 subagent 详情面板。普通的单工具摘要仍然保持原有的内联展开与收起行为；在没有提供详情面板能力的渲染场景中，subagent 也继续使用原有的内联展示。

## 为什么需要此改动

为了避免重复的界面头部，单个 subagent 渲染时会隐藏内部标题，但右侧面板的打开操作只绑定在这个被隐藏的标题上。剩余可见的摘要按钮只会切换内联容器，因此即使 daemon 能正常解析并加载 subagent 会话，用户也无法在右侧面板打开其详情。

## Reviewer 测试计划

### 如何验证

加载或创建一个包含单个前台 subagent 调用的会话，然后点击可见的 agent 摘要。确认右侧 subagent 详情面板打开并展示其会话内容。再点击一个普通的单工具摘要，确认它仍然在当前位置展开和收起。

### 修改前后证据

修改前：点击单个 subagent 摘要只会切换内联工具容器，右侧面板不会出现。修改后：相同的点击会打开右侧 subagent 详情面板。针对复现会话，也单独验证了相关解析接口和虚拟会话 load 接口均返回 200。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

使用本地 Web Shell 和 daemon 完成验证。ToolGroup 定向测试文件共 34 个测试全部通过，Web Shell TypeScript typecheck 通过。

## 风险与范围

- 主要风险或取舍：在提供右侧 subagent 详情能力的 Web Shell 场景中，单个 subagent 摘要现在会打开右侧面板，而不是内联展开。
- 未验证或范围外：Windows 和 Linux 浏览器行为；subagent 持久化、任务与 tool call 的匹配逻辑以及 daemon API 的改动。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
