### PR TITLE
fix(web-shell): avoid redundant Git status requests

### DIFF
--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -226,6 +226,23 @@ describe('WorkspaceSection git chip', () => {
     expect(workspaceGit).toHaveBeenCalledTimes(2);
   });
 
+  it('does not re-fetch git status when only the diff handler changes', async () => {
+    workspaceGit.mockResolvedValue({
+      v: 2,
+      workspaceCwd: '/tmp/project',
+      branch: 'main',
+    });
+    const client = makeClient();
+
+    renderSection({ client, onOpenGitDiff: vi.fn() });
+    await flush();
+    expect(workspaceGit).toHaveBeenCalledTimes(1);
+
+    renderSection({ client, onOpenGitDiff: vi.fn() });
+    await flush();
+    expect(workspaceGit).toHaveBeenCalledTimes(1);
+  });
+
   it('hides the chip when the workspace is not a git repo (null branch)', async () => {
     workspaceGit.mockResolvedValue({
       v: 2,

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -223,12 +223,13 @@ export function WorkspaceSection({
   // Undefined when `cwd` is not a real path (synthetic fallback workspace), so
   // the poll — which qualifies the route with the cwd — is skipped entirely.
   const gitPollCwd = isAbsolutePath(workspace.cwd) ? workspace.cwd : undefined;
+  const gitStatusEnabled = Boolean(onOpenGitDiff);
 
   // Log a poll failure only on the success→failure transition, not on every
   // 60s/focus tick, so an unreachable workspace doesn't spam a long-lived tab.
   const gitPollFailed = useRef(false);
   const loadGitStatus = useCallback(async () => {
-    if (!onOpenGitDiff || !workspace.trusted || !gitPollCwd) return;
+    if (!gitStatusEnabled || !workspace.trusted || !gitPollCwd) return;
     try {
       const status = await client.workspaceByCwd(gitPollCwd).workspaceGit();
       gitPollFailed.current = false;
@@ -242,7 +243,7 @@ export function WorkspaceSection({
         gitPollFailed.current = true;
       }
     }
-  }, [client, gitPollCwd, onOpenGitDiff, workspace.trusted]);
+  }, [client, gitPollCwd, gitStatusEnabled, workspace.trusted]);
 
   // The git chip lives in the always-visible folder header, so it polls
   // independently of session expansion: on mount/trust, on window focus, and on
@@ -250,7 +251,7 @@ export function WorkspaceSection({
   // per call, so the cadence stays gentle). Skipped entirely when no diff
   // handler is wired, since the chip — its only consumer — would not render.
   useEffect(() => {
-    if (!onOpenGitDiff || !workspace.trusted || !gitPollCwd) {
+    if (!gitStatusEnabled || !workspace.trusted || !gitPollCwd) {
       setGitStatus(undefined);
       return;
     }
@@ -266,8 +267,8 @@ export function WorkspaceSection({
     };
   }, [
     gitPollCwd,
+    gitStatusEnabled,
     loadGitStatus,
-    onOpenGitDiff,
     reloadToken,
     workspace.trusted,
   ]);


### PR DESCRIPTION
## What this PR does

Prevents the Web Shell sidebar from refreshing Git status when a render only changes the identity of the callback used to open the changes dialog. Git status polling now reacts to whether the feature is enabled, while preserving refreshes on mount, focus, the periodic timer, and workspace reloads. A regression test covers callback-only rerenders.

## Why it's needed

The callback passed from the app is recreated during normal renders. Input interactions and streaming response updates therefore restarted the Git status effect for every trusted workspace, producing repeated API requests and Git subprocesses unrelated to repository changes.

## Reviewer Test Plan

### How to verify

Open Web Shell with a trusted Git workspace and observe Git status requests. Focus or type in the composer and stream a response; these renders should not produce additional sidebar Git status requests. Refocusing the browser, waiting for the polling interval, or triggering a workspace-session reload should still refresh Git status. The Git branch chip should continue to open the changes dialog.

### Evidence (Before & After)

The regression test rerenders the workspace section with identical workspace state and a newly created changes-dialog callback. Before the fix, the Git status mock is called twice; after the fix, it remains at one call.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 22 workspace; verified with the focused unit test, Web Shell typecheck, build, and lint.

## Risk & Scope

- Main risk or tradeoff: A callback change no longer refreshes Git status unless it changes whether the Git UI is enabled; the latest callback is still used when the chip is clicked.
- Not validated / out of scope: Browser-level network capture on Windows and Linux. Existing repository-wide CLI type errors and an unrelated formatting issue in the Web Shell HTML entry are outside this change.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

避免 Web Shell 侧边栏在仅用于打开变更对话框的回调函数引用发生变化时刷新 Git 状态。Git 状态轮询现在只响应功能是否启用，同时保留组件挂载、窗口聚焦、定时轮询以及工作区刷新时的正常请求。新增回归测试覆盖仅回调变化的重新渲染。

## 为什么需要此改动

应用传入的回调会在普通渲染期间重新创建。因此，输入框交互和流式响应更新会让每个可信工作区的 Git 状态 effect 重新启动，产生与仓库变化无关的重复 API 请求和 Git 子进程。

## Reviewer Test Plan

### 验证方式

使用可信 Git 工作区打开 Web Shell 并观察 Git 状态请求。聚焦输入框、输入内容并启动流式响应，这些渲染不应产生额外的侧边栏 Git 状态请求。重新聚焦浏览器、等待轮询周期或触发工作区会话刷新时，Git 状态仍应正常刷新。点击 Git 分支标签仍应打开变更对话框。

### 修复前后证据

回归测试使用相同工作区状态和新创建的变更对话框回调重新渲染工作区区域。修复前 Git 状态 mock 被调用两次；修复后保持为一次。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Node.js 22 工作区；已通过定向单元测试、Web Shell 类型检查、构建和 lint 验证。

## 风险与范围

- 主要风险或权衡：回调变化不再刷新 Git 状态，除非它改变了 Git UI 是否启用；点击分支标签时仍会使用最新回调。
- 未验证或不在范围内：未在 Windows 和 Linux 上进行浏览器级网络抓包。仓库现有的 CLI 全局类型错误以及 Web Shell HTML 入口中无关的格式问题不属于本次改动。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
