### PR TITLE
feat(integrations): Add canonical memory persistence

### DIFF
--- a/integrations/enterprise-memory/migrations/001-initial.sql
+++ b/integrations/enterprise-memory/migrations/001-initial.sql
@@ -1,0 +1,350 @@
+BEGIN;
+
+CREATE TABLE workspace_bindings (
+  tenant_id text NOT NULL,
+  principal_id text NOT NULL,
+  workspace_id text NOT NULL,
+  repository_id text NOT NULL,
+  revocation_epoch integer NOT NULL DEFAULT 0 CHECK (revocation_epoch >= 0),
+  last_verified_at timestamptz NOT NULL,
+  authz_expires_at timestamptz NOT NULL,
+  state text NOT NULL CHECK (state IN ('active', 'revoked', 'draining')),
+  PRIMARY KEY (tenant_id, workspace_id),
+  UNIQUE (tenant_id, principal_id, repository_id, workspace_id)
+);
+
+CREATE TABLE personal_memory_preferences (
+  tenant_id text NOT NULL,
+  principal_id text NOT NULL,
+  mode text NOT NULL CHECK (mode IN ('off', 'read_only', 'read_write')),
+  updated_at timestamptz NOT NULL,
+  PRIMARY KEY (tenant_id, principal_id)
+);
+
+CREATE TABLE runtime_capability_replays (
+  tenant_id text NOT NULL,
+  capability_id text NOT NULL,
+  principal_id text NOT NULL,
+  capability_fingerprint text NOT NULL,
+  request_binding text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  PRIMARY KEY (tenant_id, capability_id)
+);
+
+CREATE TABLE memory_records (
+  tenant_id text NOT NULL,
+  id uuid NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('personal', 'repository')),
+  scope_id text NOT NULL,
+  content_ciphertext text NOT NULL,
+  content_key_handle text NOT NULL,
+  authority text NOT NULL,
+  lifecycle_state text NOT NULL CHECK (
+    lifecycle_state IN (
+      'candidate', 'active', 'rejected', 'superseded', 'expired', 'tombstoned'
+    )
+  ),
+  erasure_state text NOT NULL CHECK (
+    erasure_state IN ('live', 'pending_erasure', 'erased')
+  ),
+  version integer NOT NULL CHECK (version > 0),
+  source_operation_id text NOT NULL,
+  source_fingerprint text NOT NULL,
+  created_at timestamptz NOT NULL,
+  expires_at timestamptz,
+  PRIMARY KEY (tenant_id, id),
+  UNIQUE (tenant_id, source_operation_id)
+);
+
+CREATE TABLE provider_bindings (
+  tenant_id text NOT NULL,
+  canonical_memory_id uuid NOT NULL,
+  canonical_version integer NOT NULL,
+  provider_memory_id text NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('personal', 'repository')),
+  entity_id text NOT NULL,
+  state text NOT NULL CHECK (
+    state IN ('active', 'pending_delete', 'deleted', 'failed')
+  ),
+  PRIMARY KEY (tenant_id, canonical_memory_id, canonical_version),
+  UNIQUE (tenant_id, provider_memory_id),
+  FOREIGN KEY (tenant_id, canonical_memory_id)
+    REFERENCES memory_records (tenant_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE memory_source_receipts (
+  tenant_id text NOT NULL,
+  source_operation_id text NOT NULL,
+  canonical_memory_id uuid NOT NULL,
+  source_fingerprint text NOT NULL,
+  state text NOT NULL CHECK (state IN ('live', 'erased')),
+  PRIMARY KEY (tenant_id, source_operation_id)
+);
+
+CREATE TABLE memory_activation_reservations (
+  tenant_id text NOT NULL,
+  canonical_memory_id uuid NOT NULL,
+  canonical_version integer NOT NULL CHECK (canonical_version > 0),
+  created_at timestamptz NOT NULL,
+  PRIMARY KEY (tenant_id, canonical_memory_id),
+  FOREIGN KEY (tenant_id, canonical_memory_id)
+    REFERENCES memory_records (tenant_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE memory_erasure_reservations (
+  tenant_id text NOT NULL,
+  canonical_memory_id uuid NOT NULL,
+  canonical_version integer NOT NULL CHECK (canonical_version > 0),
+  scope text NOT NULL CHECK (scope IN ('personal', 'repository')),
+  reason text NOT NULL CHECK (
+    reason IN (
+      'user_request', 'maintainer_request', 'candidate_rejected',
+      'retention_expired', 'tenant_offboarding'
+    )
+  ),
+  created_at timestamptz NOT NULL,
+  PRIMARY KEY (tenant_id, canonical_memory_id),
+  FOREIGN KEY (tenant_id, canonical_memory_id)
+    REFERENCES memory_records (tenant_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE raw_events (
+  tenant_id text NOT NULL,
+  event_id uuid NOT NULL,
+  principal_id text NOT NULL,
+  workspace_id text NOT NULL,
+  repository_id text NOT NULL,
+  session_id text NOT NULL,
+  turn_id text,
+  event_kind text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  received_at timestamptz NOT NULL,
+  source_fingerprint text NOT NULL,
+  purge_at timestamptz NOT NULL,
+  payload_ciphertext text NOT NULL,
+  content_key_handle text NOT NULL,
+  PRIMARY KEY (tenant_id, event_id),
+  CHECK (purge_at <= received_at + interval '24 hours')
+);
+
+CREATE TABLE memory_feedback (
+  tenant_id text NOT NULL,
+  event_id uuid NOT NULL,
+  memory_id uuid NOT NULL,
+  memory_version integer NOT NULL,
+  principal_id text NOT NULL,
+  signal text NOT NULL CHECK (
+    signal IN ('helpful', 'not_helpful', 'stale', 'unsafe')
+  ),
+  occurred_at timestamptz NOT NULL,
+  received_at timestamptz NOT NULL,
+  source_fingerprint text NOT NULL,
+  PRIMARY KEY (tenant_id, event_id),
+  FOREIGN KEY (tenant_id, memory_id)
+    REFERENCES memory_records (tenant_id, id)
+    ON DELETE CASCADE
+);
+
+ALTER TABLE memory_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_records FORCE ROW LEVEL SECURITY;
+ALTER TABLE workspace_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspace_bindings FORCE ROW LEVEL SECURITY;
+ALTER TABLE provider_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE provider_bindings FORCE ROW LEVEL SECURITY;
+ALTER TABLE memory_source_receipts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_source_receipts FORCE ROW LEVEL SECURITY;
+ALTER TABLE memory_activation_reservations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_activation_reservations FORCE ROW LEVEL SECURITY;
+ALTER TABLE memory_erasure_reservations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_erasure_reservations FORCE ROW LEVEL SECURITY;
+ALTER TABLE raw_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE raw_events FORCE ROW LEVEL SECURITY;
+ALTER TABLE personal_memory_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE personal_memory_preferences FORCE ROW LEVEL SECURITY;
+ALTER TABLE memory_feedback ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory_feedback FORCE ROW LEVEL SECURITY;
+ALTER TABLE runtime_capability_replays ENABLE ROW LEVEL SECURITY;
+ALTER TABLE runtime_capability_replays FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY workspace_bindings_runtime_policy ON workspace_bindings
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+    AND repository_id = current_setting('app.repository_id', true)
+  );
+
+CREATE POLICY memory_records_runtime_policy ON memory_records
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND (
+      (scope = 'personal' AND scope_id = current_setting('app.principal_id', true))
+      OR
+      (scope = 'repository' AND scope_id = current_setting('app.repository_id', true))
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND (
+      (scope = 'personal' AND scope_id = current_setting('app.principal_id', true))
+      OR
+      (scope = 'repository' AND scope_id = current_setting('app.repository_id', true))
+    )
+  );
+
+CREATE POLICY provider_bindings_runtime_policy ON provider_bindings
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = provider_bindings.tenant_id
+        AND m.id = provider_bindings.canonical_memory_id
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = provider_bindings.tenant_id
+        AND m.id = provider_bindings.canonical_memory_id
+    )
+  );
+
+CREATE POLICY memory_source_receipts_read_policy ON memory_source_receipts
+  FOR SELECT
+  USING (tenant_id = current_setting('app.tenant_id', true));
+
+CREATE POLICY memory_source_receipts_insert_policy ON memory_source_receipts
+  FOR INSERT
+  WITH CHECK (tenant_id = current_setting('app.tenant_id', true));
+
+CREATE POLICY memory_source_receipts_update_policy ON memory_source_receipts
+  FOR UPDATE
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_source_receipts.tenant_id
+        AND m.id = memory_source_receipts.canonical_memory_id
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_source_receipts.tenant_id
+        AND m.id = memory_source_receipts.canonical_memory_id
+    )
+  );
+
+CREATE POLICY memory_activation_reservations_scope_policy
+  ON memory_activation_reservations
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_activation_reservations.tenant_id
+        AND m.id = memory_activation_reservations.canonical_memory_id
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_activation_reservations.tenant_id
+        AND m.id = memory_activation_reservations.canonical_memory_id
+    )
+  );
+
+CREATE POLICY memory_erasure_reservations_scope_policy
+  ON memory_erasure_reservations
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_erasure_reservations.tenant_id
+        AND m.id = memory_erasure_reservations.canonical_memory_id
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_erasure_reservations.tenant_id
+        AND m.id = memory_erasure_reservations.canonical_memory_id
+    )
+  );
+
+CREATE POLICY raw_events_runtime_policy ON raw_events
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+    AND repository_id = current_setting('app.repository_id', true)
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+    AND repository_id = current_setting('app.repository_id', true)
+  );
+
+CREATE POLICY personal_memory_preferences_subject_policy
+  ON personal_memory_preferences
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+  );
+
+CREATE POLICY memory_feedback_runtime_policy ON memory_feedback
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_feedback.tenant_id
+        AND m.id = memory_feedback.memory_id
+    )
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM memory_records m
+      WHERE m.tenant_id = memory_feedback.tenant_id
+        AND m.id = memory_feedback.memory_id
+    )
+  );
+
+CREATE POLICY runtime_capability_replays_runtime_policy
+  ON runtime_capability_replays
+  USING (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+  )
+  WITH CHECK (
+    tenant_id = current_setting('app.tenant_id', true)
+    AND principal_id = current_setting('app.principal_id', true)
+  );
+
+CREATE INDEX memory_records_scope_active_idx
+  ON memory_records (tenant_id, scope, scope_id, lifecycle_state, erasure_state);
+CREATE INDEX raw_events_purge_idx ON raw_events (tenant_id, purge_at);
+CREATE INDEX runtime_capability_replays_expiry_idx
+  ON runtime_capability_replays (tenant_id, expires_at);
+
+COMMIT;

--- a/integrations/enterprise-memory/src/anti-resurrection-ledger.test.ts
+++ b/integrations/enterprise-memory/src/anti-resurrection-ledger.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomBytes } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  HttpAntiResurrectionLedger,
+  InMemoryAntiResurrectionLedger,
+  LedgerKeyFactory,
+} from './anti-resurrection-ledger.js';
+
+describe('InMemoryAntiResurrectionLedger', () => {
+  it('never refreshes or resurrects a raw event receipt', async () => {
+    const ledger = new InMemoryAntiResurrectionLedger(
+      new LedgerKeyFactory(randomBytes(32)),
+    );
+    const receivedAt = new Date('2026-07-22T00:00:00.000Z');
+    const purgeAt = new Date('2026-07-23T00:00:00.000Z');
+    const first = await ledger.ensureRawReceipt(
+      'tenant-a',
+      'event-a',
+      receivedAt,
+      purgeAt,
+    );
+
+    const retry = await ledger.ensureRawReceipt(
+      'tenant-a',
+      'event-a',
+      new Date('2026-07-22T12:00:00.000Z'),
+      new Date('2026-07-23T12:00:00.000Z'),
+    );
+    expect(retry).toEqual(first);
+
+    await ledger.markRawPurged('tenant-a', 'event-a');
+    const afterPurge = await ledger.ensureRawReceipt(
+      'tenant-a',
+      'event-a',
+      receivedAt,
+      purgeAt,
+    );
+    expect(afterPurge.state).toBe('purged');
+    expect(afterPurge.purgeAt).toEqual(purgeAt);
+  });
+
+  it('keeps deletion state monotonic and tenant scoped', async () => {
+    const ledger = new InMemoryAntiResurrectionLedger(
+      new LedgerKeyFactory(randomBytes(32)),
+    );
+    const createdAt = new Date('2026-07-22T00:00:00.000Z');
+    const first = await ledger.beginDeletion(
+      'tenant-a',
+      'memory-a',
+      2,
+      'repository',
+      'user_request',
+      createdAt,
+    );
+    await ledger.markErased('tenant-a', 'memory-a', 2);
+    await expect(
+      ledger.beginDeletion(
+        'tenant-a',
+        'memory-a',
+        2,
+        'repository',
+        'maintainer_request',
+        new Date('2026-07-23T00:00:00.000Z'),
+      ),
+    ).rejects.toThrow('binding conflict');
+    expect(await ledger.getDeletion('tenant-a', 'memory-a', 2)).toMatchObject({
+      key: first.key,
+      reason: 'user_request',
+      state: 'erased',
+      createdAt,
+    });
+    expect(await ledger.getDeletion('tenant-b', 'memory-a', 2)).toBeNull();
+  });
+});
+
+describe('HttpAntiResurrectionLedger', () => {
+  it('rejects non-string timestamps from an untrusted ledger response', async () => {
+    const ledger = new HttpAntiResurrectionLedger({
+      baseUrl: 'https://ledger.example.test',
+      bearerToken: 'test-token',
+      fetchImplementation: async () =>
+        new Response(
+          JSON.stringify({
+            key: 'receipt-a',
+            received_at: null,
+            purge_at: '2026-07-23T00:00:00.000Z',
+            state: 'received',
+          }),
+          { status: 200 },
+        ),
+    });
+
+    await expect(ledger.getRawReceipt('tenant-a', 'event-a')).rejects.toThrow(
+      'invalid raw receipt',
+    );
+  });
+});

--- a/integrations/enterprise-memory/src/anti-resurrection-ledger.ts
+++ b/integrations/enterprise-memory/src/anti-resurrection-ledger.ts
@@ -1,0 +1,412 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHmac } from 'node:crypto';
+import type { DeletionReason, MemoryScope } from './domain.js';
+import { readBoundedJson } from './http-json.js';
+
+export interface RawEventReceipt {
+  key: string;
+  receivedAt: Date;
+  purgeAt: Date;
+  state: 'received' | 'purged';
+}
+
+export interface DeletionReceipt {
+  key: string;
+  scope: MemoryScope;
+  reason: DeletionReason;
+  state: 'deletion_intent' | 'erased';
+  createdAt: Date;
+}
+
+export interface AntiResurrectionLedger {
+  ensureRawReceipt(
+    tenantId: string,
+    eventId: string,
+    receivedAt: Date,
+    purgeAt: Date,
+  ): Promise<RawEventReceipt>;
+  markRawPurged(tenantId: string, eventId: string): Promise<void>;
+  getRawReceipt(
+    tenantId: string,
+    eventId: string,
+  ): Promise<RawEventReceipt | null>;
+  beginDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+  ): Promise<DeletionReceipt>;
+  markErased(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<void>;
+  getDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<DeletionReceipt | null>;
+}
+
+export class LedgerKeyFactory {
+  constructor(private readonly secret: Uint8Array) {}
+
+  rawEvent(tenantId: string, eventId: string): string {
+    return this.derive('raw-event-v1', tenantId, eventId);
+  }
+
+  deletion(tenantId: string, memoryId: string, version: number): string {
+    return this.derive('canonical-deletion-v1', tenantId, memoryId, version);
+  }
+
+  private derive(purpose: string, ...parts: readonly unknown[]): string {
+    return createHmac('sha256', this.secret)
+      .update(JSON.stringify([purpose, ...parts]))
+      .digest('base64url');
+  }
+}
+
+export class InMemoryAntiResurrectionLedger implements AntiResurrectionLedger {
+  private readonly rawReceipts = new Map<string, RawEventReceipt>();
+  private readonly deletions = new Map<string, DeletionReceipt>();
+
+  constructor(private readonly keys: LedgerKeyFactory) {}
+
+  async ensureRawReceipt(
+    tenantId: string,
+    eventId: string,
+    receivedAt: Date,
+    purgeAt: Date,
+  ): Promise<RawEventReceipt> {
+    const key = this.keys.rawEvent(tenantId, eventId);
+    const existing = this.rawReceipts.get(key);
+    if (existing) {
+      return structuredClone(existing);
+    }
+    const receipt: RawEventReceipt = {
+      key,
+      receivedAt,
+      purgeAt,
+      state: 'received',
+    };
+    this.rawReceipts.set(key, receipt);
+    return structuredClone(receipt);
+  }
+
+  async markRawPurged(tenantId: string, eventId: string): Promise<void> {
+    const key = this.keys.rawEvent(tenantId, eventId);
+    const receipt = this.rawReceipts.get(key);
+    if (!receipt) {
+      throw new Error('Raw event receipt does not exist');
+    }
+    receipt.state = 'purged';
+  }
+
+  async getRawReceipt(
+    tenantId: string,
+    eventId: string,
+  ): Promise<RawEventReceipt | null> {
+    const receipt = this.rawReceipts.get(this.keys.rawEvent(tenantId, eventId));
+    return receipt ? structuredClone(receipt) : null;
+  }
+
+  async beginDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+  ): Promise<DeletionReceipt> {
+    const key = this.keys.deletion(tenantId, canonicalMemoryId, version);
+    const existing = this.deletions.get(key);
+    if (existing) {
+      if (existing.scope !== scope || existing.reason !== reason) {
+        throw new Error('Deletion intent binding conflict');
+      }
+      return structuredClone(existing);
+    }
+    const receipt: DeletionReceipt = {
+      key,
+      scope,
+      reason,
+      state: 'deletion_intent',
+      createdAt,
+    };
+    this.deletions.set(key, receipt);
+    return structuredClone(receipt);
+  }
+
+  async markErased(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<void> {
+    const key = this.keys.deletion(tenantId, canonicalMemoryId, version);
+    const deletion = this.deletions.get(key);
+    if (!deletion) {
+      throw new Error('Deletion intent does not exist');
+    }
+    deletion.state = 'erased';
+  }
+
+  async getDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<DeletionReceipt | null> {
+    const deletion = this.deletions.get(
+      this.keys.deletion(tenantId, canonicalMemoryId, version),
+    );
+    return deletion ? structuredClone(deletion) : null;
+  }
+}
+
+export interface HttpLedgerOptions {
+  baseUrl: string;
+  bearerToken: string;
+  fetchImplementation?: typeof fetch;
+  requestTimeoutMs?: number;
+}
+
+export class HttpAntiResurrectionLedger implements AntiResurrectionLedger {
+  private readonly fetchImplementation: typeof fetch;
+
+  constructor(private readonly options: HttpLedgerOptions) {
+    requireHttps(options.baseUrl, 'Anti-resurrection ledger');
+    this.fetchImplementation = options.fetchImplementation ?? fetch;
+  }
+
+  async ensureRawReceipt(
+    tenantId: string,
+    eventId: string,
+    receivedAt: Date,
+    purgeAt: Date,
+  ): Promise<RawEventReceipt> {
+    const value = await this.request<SerializedRawReceipt>('/v1/raw-receipts', {
+      method: 'PUT',
+      body: JSON.stringify({
+        tenant_id: tenantId,
+        event_id: eventId,
+        received_at: receivedAt.toISOString(),
+        purge_at: purgeAt.toISOString(),
+      }),
+    });
+    return deserializeRawReceipt(value);
+  }
+
+  async markRawPurged(tenantId: string, eventId: string): Promise<void> {
+    await this.request('/v1/raw-receipts:purge', {
+      method: 'POST',
+      body: JSON.stringify({ tenant_id: tenantId, event_id: eventId }),
+    });
+  }
+
+  async getRawReceipt(
+    tenantId: string,
+    eventId: string,
+  ): Promise<RawEventReceipt | null> {
+    const response = await this.requestNullable<SerializedRawReceipt>(
+      '/v1/raw-receipts:lookup',
+      {
+        method: 'POST',
+        body: JSON.stringify({ tenant_id: tenantId, event_id: eventId }),
+      },
+    );
+    return response ? deserializeRawReceipt(response) : null;
+  }
+
+  async beginDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+  ): Promise<DeletionReceipt> {
+    const value = await this.request<SerializedDeletionReceipt>(
+      '/v1/deletions',
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          tenant_id: tenantId,
+          canonical_memory_id: canonicalMemoryId,
+          version,
+          scope,
+          reason,
+          created_at: createdAt.toISOString(),
+        }),
+      },
+    );
+    return deserializeDeletionReceipt(value);
+  }
+
+  async markErased(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<void> {
+    await this.request('/v1/deletions:erased', {
+      method: 'POST',
+      body: JSON.stringify({
+        tenant_id: tenantId,
+        canonical_memory_id: canonicalMemoryId,
+        version,
+      }),
+    });
+  }
+
+  async getDeletion(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<DeletionReceipt | null> {
+    const value = await this.requestNullable<SerializedDeletionReceipt>(
+      '/v1/deletions:lookup',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          tenant_id: tenantId,
+          canonical_memory_id: canonicalMemoryId,
+          version,
+        }),
+      },
+    );
+    return value ? deserializeDeletionReceipt(value) : null;
+  }
+
+  private async request<T = unknown>(
+    path: string,
+    init: RequestInit,
+  ): Promise<T> {
+    const response = await this.perform(path, init);
+    if (!response.ok) {
+      throw new Error(
+        `Anti-resurrection ledger failed with ${response.status}`,
+      );
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return readBoundedJson<T>(response, 32 * 1024);
+  }
+
+  private async requestNullable<T>(
+    path: string,
+    init: RequestInit,
+  ): Promise<T | null> {
+    const response = await this.perform(path, init);
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Anti-resurrection ledger failed with ${response.status}`,
+      );
+    }
+    return readBoundedJson<T>(response, 32 * 1024);
+  }
+
+  private perform(path: string, init: RequestInit): Promise<Response> {
+    return this.fetchImplementation(new URL(path, this.options.baseUrl), {
+      ...init,
+      headers: {
+        authorization: `Bearer ${this.options.bearerToken}`,
+        'content-type': 'application/json',
+      },
+      redirect: 'error',
+      signal:
+        init.signal ??
+        AbortSignal.timeout(this.options.requestTimeoutMs ?? 3_000),
+    });
+  }
+}
+
+interface SerializedRawReceipt {
+  key: string;
+  received_at: string;
+  purge_at: string;
+  state: 'received' | 'purged';
+}
+
+interface SerializedDeletionReceipt {
+  key: string;
+  scope: MemoryScope;
+  reason: DeletionReason;
+  state: 'deletion_intent' | 'erased';
+  created_at: string;
+}
+
+function deserializeRawReceipt(value: SerializedRawReceipt): RawEventReceipt {
+  if (
+    typeof value.received_at !== 'string' ||
+    typeof value.purge_at !== 'string'
+  ) {
+    throw new Error('Anti-resurrection ledger returned an invalid raw receipt');
+  }
+  const receivedAt = new Date(value.received_at);
+  const purgeAt = new Date(value.purge_at);
+  if (
+    typeof value.key !== 'string' ||
+    value.key.length === 0 ||
+    value.key.length > 512 ||
+    (value.state !== 'received' && value.state !== 'purged') ||
+    !Number.isFinite(receivedAt.getTime()) ||
+    !Number.isFinite(purgeAt.getTime()) ||
+    purgeAt <= receivedAt
+  ) {
+    throw new Error('Anti-resurrection ledger returned an invalid raw receipt');
+  }
+  return {
+    key: value.key,
+    receivedAt,
+    purgeAt,
+    state: value.state,
+  };
+}
+
+function deserializeDeletionReceipt(
+  value: SerializedDeletionReceipt,
+): DeletionReceipt {
+  if (typeof value.created_at !== 'string') {
+    throw new Error('Anti-resurrection ledger returned an invalid deletion');
+  }
+  const createdAt = new Date(value.created_at);
+  if (
+    typeof value.key !== 'string' ||
+    value.key.length === 0 ||
+    value.key.length > 512 ||
+    ![
+      'user_request',
+      'maintainer_request',
+      'candidate_rejected',
+      'retention_expired',
+      'tenant_offboarding',
+    ].includes(value.reason) ||
+    (value.scope !== 'personal' && value.scope !== 'repository') ||
+    (value.state !== 'deletion_intent' && value.state !== 'erased') ||
+    !Number.isFinite(createdAt.getTime())
+  ) {
+    throw new Error('Anti-resurrection ledger returned an invalid deletion');
+  }
+  return {
+    key: value.key,
+    scope: value.scope,
+    reason: value.reason,
+    state: value.state,
+    createdAt,
+  };
+}
+
+function requireHttps(value: string, name: string): void {
+  if (new URL(value).protocol !== 'https:') {
+    throw new Error(`${name} must use https`);
+  }
+}

--- a/integrations/enterprise-memory/src/canonical-store.test.ts
+++ b/integrations/enterprise-memory/src/canonical-store.test.ts
@@ -1,0 +1,443 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Pool, PoolClient } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PostgresCanonicalStore,
+  type StoreContext,
+} from './canonical-store.js';
+import type { CanonicalMemoryRecord, ProviderBinding } from './domain.js';
+
+const now = new Date('2026-07-22T00:00:00.000Z');
+const memoryId = 'ea09a5be-4e32-48cb-b76d-d513492d9c82';
+const context: StoreContext = {
+  tenantId: 'tenant-a',
+  principalId: 'principal-a',
+  repositoryId: 'repository-a',
+};
+
+function record(
+  scope: CanonicalMemoryRecord['scope'] = 'personal',
+): CanonicalMemoryRecord {
+  return {
+    id: memoryId,
+    tenantId: context.tenantId,
+    scope,
+    scopeId: scope === 'personal' ? context.principalId : context.repositoryId,
+    protectedContent: { ciphertext: 'ciphertext', keyHandle: 'key-handle' },
+    authority: 'model_proposal',
+    lifecycleState: 'candidate',
+    erasureState: 'live',
+    version: 1,
+    sourceOperationId: '8d39189f-cb3d-4a18-bd43-52f7bf9014e9',
+    sourceFingerprint: 'fingerprint',
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + 1_000),
+  };
+}
+
+function row(value: CanonicalMemoryRecord): Record<string, unknown> {
+  return {
+    id: value.id,
+    tenant_id: value.tenantId,
+    scope: value.scope,
+    scope_id: value.scopeId,
+    content_ciphertext: value.protectedContent.ciphertext,
+    content_key_handle: value.protectedContent.keyHandle,
+    authority: value.authority,
+    lifecycle_state: value.lifecycleState,
+    erasure_state: value.erasureState,
+    version: value.version,
+    source_operation_id: value.sourceOperationId,
+    source_fingerprint: value.sourceFingerprint,
+    created_at: value.createdAt,
+    expires_at: value.expiresAt,
+  };
+}
+
+function fixture(
+  handle: (
+    text: string,
+    values: readonly unknown[] | undefined,
+  ) => { rows?: Record<string, unknown>[]; rowCount?: number },
+) {
+  const query = vi.fn(async (text: string, values?: readonly unknown[]) => ({
+    rows: [],
+    rowCount: 0,
+    ...handle(text, values),
+  }));
+  const client = {
+    query,
+    release: vi.fn(),
+  } as unknown as PoolClient;
+  const pool = {
+    connect: vi.fn(async () => client),
+  } as unknown as Pool;
+  return { store: new PostgresCanonicalStore(pool), query };
+}
+
+describe('PostgresCanonicalStore security predicates', () => {
+  it('checks current personal consent in candidate insertion SQL', async () => {
+    const candidate = record();
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR SHARE')) {
+        return { rows: [{ mode: 'read_write' }], rowCount: 1 };
+      }
+      if (text.includes('FROM memory_source_receipts')) {
+        return {
+          rows: [
+            {
+              canonical_memory_id: candidate.id,
+              source_fingerprint: candidate.sourceFingerprint,
+              state: 'live',
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return text.includes('INSERT INTO memory_records')
+        ? { rows: [row(candidate)], rowCount: 1 }
+        : {};
+    });
+
+    await store.insertCandidate(
+      { ...context, workspaceId: 'workspace-a', revocationEpoch: 0 },
+      candidate,
+    );
+
+    const insertion = query.mock.calls.find(([text]) =>
+      text.includes('INSERT INTO memory_records'),
+    );
+    expect(insertion?.[0]).toContain('personal_memory_preferences');
+    expect(insertion?.[0]).toContain("p.mode = 'read_write'");
+    const consentIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('FOR SHARE'),
+    );
+    const insertionIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('INSERT INTO memory_records'),
+    );
+    const receiptIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('INSERT INTO memory_source_receipts'),
+    );
+    expect(consentIndex).toBeGreaterThan(-1);
+    expect(receiptIndex).toBeGreaterThan(consentIndex);
+    expect(insertionIndex).toBeGreaterThan(consentIndex);
+    expect(insertionIndex).toBeGreaterThan(receiptIndex);
+  });
+
+  it('reserves provider activation only after locking the candidate version', async () => {
+    const candidate = record('repository');
+    const expiresAt = new Date(now.getTime() + 60_000);
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return { rows: [row(candidate)], rowCount: 1 };
+      }
+      if (text.includes('AS current')) {
+        return { rows: [{ current: true }], rowCount: 1 };
+      }
+      if (text.includes('INSERT INTO memory_activation_reservations')) {
+        return { rowCount: 1 };
+      }
+      return {};
+    });
+
+    await store.reserveActivation(context, memoryId, 1, expiresAt);
+
+    const lockIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('FOR UPDATE'),
+    );
+    const reservationIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('INSERT INTO memory_activation_reservations'),
+    );
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(reservationIndex).toBeGreaterThan(lockIndex);
+    expect(
+      query.mock.calls.some(([text]) =>
+        text.includes('FROM memory_erasure_reservations'),
+      ),
+    ).toBe(true);
+  });
+
+  it('checks consent and the SCM lease at the activation statement', async () => {
+    const active = {
+      ...record('repository'),
+      authority: 'maintainer_approved',
+      lifecycleState: 'active' as const,
+      version: 2,
+    };
+    const expiresAt = new Date(now.getTime() + 60_000);
+    const binding: ProviderBinding = {
+      tenantId: context.tenantId,
+      canonicalMemoryId: memoryId,
+      canonicalVersion: 2,
+      providerMemoryId: 'provider-a',
+      scope: 'repository',
+      entityId: 'entity-a',
+      state: 'active',
+    };
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return {
+          rows: [
+            {
+              tenant_id: active.tenantId,
+              scope: active.scope,
+              scope_id: active.scopeId,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (text.includes('DELETE FROM memory_activation_reservations')) {
+        return { rowCount: 1 };
+      }
+      return text.includes('UPDATE memory_records')
+        ? { rows: [row(active)], rowCount: 1 }
+        : {};
+    });
+
+    await store.activateWithProvider(
+      context,
+      memoryId,
+      1,
+      'maintainer_approved',
+      binding,
+      expiresAt,
+    );
+
+    const activation = query.mock.calls.find(([text]) =>
+      text.includes('UPDATE memory_records'),
+    );
+    expect(activation?.[0]).toContain('clock_timestamp() < $4');
+    expect(activation?.[0]).toContain('personal_memory_preferences');
+    expect(activation?.[0]).toContain('memory_activation_reservations');
+    expect(activation?.[1]?.[3]).toEqual(expiresAt);
+  });
+
+  it('clears the activation reservation when reusing a reconciled binding', async () => {
+    const active = {
+      ...record('repository'),
+      authority: 'maintainer_approved',
+      lifecycleState: 'active' as const,
+      version: 2,
+    };
+    const binding: ProviderBinding = {
+      tenantId: context.tenantId,
+      canonicalMemoryId: memoryId,
+      canonicalVersion: 2,
+      providerMemoryId: 'provider-a',
+      scope: 'repository',
+      entityId: 'entity-a',
+      state: 'active',
+    };
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return {
+          rows: [
+            {
+              tenant_id: active.tenantId,
+              scope: active.scope,
+              scope_id: active.scopeId,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (text.includes('UPDATE memory_records')) {
+        return { rows: [row(active)], rowCount: 1 };
+      }
+      if (text.includes('SELECT * FROM provider_bindings')) {
+        return {
+          rows: [
+            {
+              tenant_id: binding.tenantId,
+              canonical_memory_id: binding.canonicalMemoryId,
+              canonical_version: binding.canonicalVersion,
+              provider_memory_id: binding.providerMemoryId,
+              scope: binding.scope,
+              entity_id: binding.entityId,
+              state: binding.state,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (text.includes('DELETE FROM memory_activation_reservations')) {
+        return { rowCount: 1 };
+      }
+      return {};
+    });
+
+    await store.activateWithProvider(
+      context,
+      memoryId,
+      1,
+      'maintainer_approved',
+      binding,
+      new Date(now.getTime() + 60_000),
+    );
+
+    expect(
+      query.mock.calls.some(([text]) =>
+        text.includes('INSERT INTO provider_bindings'),
+      ),
+    ).toBe(false);
+    expect(
+      query.mock.calls.some(([text]) =>
+        text.includes('DELETE FROM memory_activation_reservations'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not activate personal memory after the locked preference is off', async () => {
+    const candidate = record();
+    const binding: ProviderBinding = {
+      tenantId: context.tenantId,
+      canonicalMemoryId: memoryId,
+      canonicalVersion: 2,
+      providerMemoryId: 'provider-a',
+      scope: 'personal',
+      entityId: 'entity-a',
+      state: 'active',
+    };
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return {
+          rows: [
+            {
+              tenant_id: candidate.tenantId,
+              scope: candidate.scope,
+              scope_id: candidate.scopeId,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      if (text.includes('FOR SHARE')) {
+        return { rows: [{ mode: 'off' }], rowCount: 1 };
+      }
+      return {};
+    });
+
+    await expect(
+      store.activateWithProvider(
+        context,
+        memoryId,
+        1,
+        'user_confirmed',
+        binding,
+        null,
+      ),
+    ).rejects.toThrow('capture is disabled');
+    expect(
+      query.mock.calls.some(([text]) => text.includes('UPDATE memory_records')),
+    ).toBe(false);
+  });
+
+  it('checks the SCM lease only after locking an erasure version', async () => {
+    const active = {
+      ...record('repository'),
+      authority: 'maintainer_approved',
+      lifecycleState: 'active' as const,
+      version: 2,
+    };
+    const expiresAt = new Date(now.getTime() + 60_000);
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return { rows: [row(active)], rowCount: 1 };
+      }
+      if (text.includes('AS current')) {
+        return { rows: [{ current: true }], rowCount: 1 };
+      }
+      return {};
+    });
+
+    await store.reserveErasure(
+      context,
+      memoryId,
+      2,
+      'repository',
+      'maintainer_request',
+      now,
+      expiresAt,
+    );
+
+    const lockIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('FOR UPDATE'),
+    );
+    const leaseIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('AS current'),
+    );
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(leaseIndex).toBeGreaterThan(lockIndex);
+    expect(query.mock.calls[leaseIndex]?.[1]?.[0]).toEqual(expiresAt);
+  });
+
+  it('does not reserve erasure while provider activation is in progress', async () => {
+    const active = {
+      ...record('repository'),
+      authority: 'maintainer_approved',
+      lifecycleState: 'active' as const,
+      version: 2,
+    };
+    const { store, query } = fixture((text) => {
+      if (text.includes('FOR UPDATE')) {
+        return { rows: [row(active)], rowCount: 1 };
+      }
+      if (text.includes('AS current')) {
+        return { rows: [{ current: true }], rowCount: 1 };
+      }
+      if (text.includes('FROM memory_activation_reservations')) {
+        return { rows: [{ '?column?': 1 }], rowCount: 1 };
+      }
+      return {};
+    });
+
+    await expect(
+      store.reserveErasure(
+        context,
+        memoryId,
+        active.version,
+        'repository',
+        'maintainer_request',
+        now,
+        new Date(now.getTime() + 60_000),
+      ),
+    ).rejects.toThrow('activation is in progress');
+    expect(
+      query.mock.calls.some(([text]) =>
+        text.includes('INSERT INTO memory_erasure_reservations'),
+      ),
+    ).toBe(false);
+  });
+
+  it('marks the source receipt erased before deleting canonical content', async () => {
+    const { store, query } = fixture((text) => {
+      if (text.includes('UPDATE memory_source_receipts')) {
+        return {
+          rows: [{ source_operation_id: record().sourceOperationId }],
+          rowCount: 1,
+        };
+      }
+      if (text.includes('DELETE FROM memory_records')) {
+        return { rowCount: 1 };
+      }
+      return {};
+    });
+
+    await store.eraseContent(context, memoryId, 3);
+
+    const receiptIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('UPDATE memory_source_receipts'),
+    );
+    const deletionIndex = query.mock.calls.findIndex(([text]) =>
+      text.includes('DELETE FROM memory_records'),
+    );
+    expect(receiptIndex).toBeGreaterThan(-1);
+    expect(deletionIndex).toBeGreaterThan(receiptIndex);
+  });
+});

--- a/integrations/enterprise-memory/src/canonical-store.ts
+++ b/integrations/enterprise-memory/src/canonical-store.ts
@@ -1,0 +1,1280 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Pool, PoolClient, QueryResultRow } from 'pg';
+import type {
+  CanonicalMemoryRecord,
+  DeletionReason,
+  FeedbackSignal,
+  MemoryScope,
+  ProviderBinding,
+  RawEventInput,
+  RuntimeIdentity,
+} from './domain.js';
+import type { RawEventReceipt } from './anti-resurrection-ledger.js';
+
+export interface StoreContext {
+  tenantId: string;
+  principalId: string;
+  repositoryId: string;
+}
+
+export interface CanonicalStore {
+  insertCandidate(
+    identity: RuntimeIdentity,
+    record: CanonicalMemoryRecord,
+  ): Promise<CanonicalMemoryRecord>;
+  getAuthorized(
+    context: StoreContext,
+    memoryId: string,
+  ): Promise<CanonicalMemoryRecord | null>;
+  getAuthorizedByProviderIds(
+    context: StoreContext,
+    providerMemoryIds: readonly string[],
+  ): Promise<readonly CanonicalMemoryRecord[]>;
+  reserveActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authorizationExpiresAt: Date | null,
+  ): Promise<void>;
+  releaseActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<void>;
+  activateWithProvider(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authority: string,
+    binding: ProviderBinding,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord>;
+  getProviderBinding(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<ProviderBinding | null>;
+  reserveErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord>;
+  markPendingErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<CanonicalMemoryRecord>;
+  eraseContent(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<void>;
+  insertRawEvent(
+    identity: RuntimeIdentity,
+    event: RawEventInput,
+    receipt: RawEventReceipt,
+  ): Promise<boolean>;
+  insertFeedback(
+    identity: RuntimeIdentity,
+    eventId: string,
+    memoryId: string,
+    signal: FeedbackSignal,
+    occurredAt: Date,
+    receivedAt: Date,
+    sourceFingerprint: string,
+  ): Promise<boolean>;
+}
+
+function canRead(
+  context: StoreContext,
+  record: CanonicalMemoryRecord,
+): boolean {
+  return (
+    context.tenantId === record.tenantId &&
+    ((record.scope === 'personal' && record.scopeId === context.principalId) ||
+      (record.scope === 'repository' &&
+        record.scopeId === context.repositoryId))
+  );
+}
+
+export class InMemoryCanonicalStore implements CanonicalStore {
+  private readonly records = new Map<string, CanonicalMemoryRecord>();
+  private readonly sourceReceipts = new Map<
+    string,
+    {
+      canonicalMemoryId: string;
+      sourceFingerprint: string;
+      state: 'live' | 'erased';
+    }
+  >();
+  private readonly bindings = new Map<string, ProviderBinding>();
+  private readonly activationReservations = new Map<string, number>();
+  private readonly erasureReservations = new Map<
+    string,
+    {
+      version: number;
+      scope: MemoryScope;
+      reason: DeletionReason;
+      createdAt: Date;
+    }
+  >();
+  private readonly rawEvents = new Map<string, string>();
+  private readonly feedbackEvents = new Map<string, string>();
+
+  async insertCandidate(
+    identity: RuntimeIdentity,
+    record: CanonicalMemoryRecord,
+  ): Promise<CanonicalMemoryRecord> {
+    const key = this.recordKey(identity.tenantId, record.id);
+    if (!canRead(identity, record)) {
+      throw new Error('Candidate scope is outside runtime identity');
+    }
+    const receiptKey = this.sourceReceiptKey(
+      identity.tenantId,
+      record.sourceOperationId,
+    );
+    const receipt = this.sourceReceipts.get(receiptKey);
+    if (receipt?.state === 'erased') {
+      throw new Error('Candidate source operation is no longer reusable');
+    }
+    if (
+      receipt &&
+      (receipt.canonicalMemoryId !== record.id ||
+        receipt.sourceFingerprint !== record.sourceFingerprint)
+    ) {
+      throw new Error(
+        'Operation ID was reused with different candidate content',
+      );
+    }
+    const duplicate = [...this.records.values()].find(
+      (item) =>
+        item.tenantId === identity.tenantId &&
+        item.sourceOperationId === record.sourceOperationId,
+    );
+    if (duplicate) {
+      if (!canRead(identity, duplicate)) {
+        throw new Error('Candidate scope is outside runtime identity');
+      }
+      if (duplicate.sourceFingerprint !== record.sourceFingerprint) {
+        throw new Error(
+          'Operation ID was reused with different candidate content',
+        );
+      }
+      if (!receipt) {
+        this.sourceReceipts.set(receiptKey, {
+          canonicalMemoryId: record.id,
+          sourceFingerprint: record.sourceFingerprint,
+          state: 'live',
+        });
+      }
+      return structuredClone(duplicate);
+    }
+    if (this.records.has(key)) {
+      throw new Error('Canonical memory ID already exists');
+    }
+    if (!receipt) {
+      this.sourceReceipts.set(receiptKey, {
+        canonicalMemoryId: record.id,
+        sourceFingerprint: record.sourceFingerprint,
+        state: 'live',
+      });
+    }
+    this.records.set(key, structuredClone(record));
+    return structuredClone(record);
+  }
+
+  async getAuthorized(
+    context: StoreContext,
+    memoryId: string,
+  ): Promise<CanonicalMemoryRecord | null> {
+    const record = this.records.get(this.recordKey(context.tenantId, memoryId));
+    return record && canRead(context, record) ? structuredClone(record) : null;
+  }
+
+  async getAuthorizedByProviderIds(
+    context: StoreContext,
+    providerMemoryIds: readonly string[],
+  ): Promise<readonly CanonicalMemoryRecord[]> {
+    const ids = new Set(providerMemoryIds);
+    const result: CanonicalMemoryRecord[] = [];
+    for (const binding of this.bindings.values()) {
+      if (
+        binding.tenantId !== context.tenantId ||
+        !ids.has(binding.providerMemoryId) ||
+        binding.state !== 'active'
+      ) {
+        continue;
+      }
+      const record = this.records.get(
+        this.recordKey(context.tenantId, binding.canonicalMemoryId),
+      );
+      if (
+        record &&
+        record.version === binding.canonicalVersion &&
+        record.lifecycleState === 'active' &&
+        record.erasureState === 'live' &&
+        canRead(context, record)
+      ) {
+        result.push(structuredClone(record));
+      }
+    }
+    return result;
+  }
+
+  async activateWithProvider(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authority: string,
+    binding: ProviderBinding,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord> {
+    void authorizationExpiresAt;
+    const record = this.requireRecord(context, memoryId);
+    const activeVersion = expectedVersion + 1;
+    if (
+      this.erasureReservations.has(this.recordKey(context.tenantId, memoryId))
+    ) {
+      throw new Error('Candidate version conflict');
+    }
+    if (
+      binding.tenantId !== context.tenantId ||
+      binding.canonicalMemoryId !== memoryId ||
+      binding.canonicalVersion !== activeVersion ||
+      binding.scope !== record.scope
+    ) {
+      throw new Error('Provider binding does not match activation');
+    }
+    if (record.lifecycleState === 'active') {
+      if (
+        record.erasureState !== 'live' ||
+        record.version !== activeVersion ||
+        record.authority !== authority
+      ) {
+        throw new Error('Candidate version conflict');
+      }
+      const existing = this.bindings.get(
+        this.bindingKey(context.tenantId, memoryId, activeVersion),
+      );
+      if (!existing || !sameProviderBinding(existing, binding)) {
+        throw new Error('Provider binding conflict');
+      }
+      return structuredClone(record);
+    } else if (
+      record.erasureState !== 'live' ||
+      record.version !== expectedVersion ||
+      record.lifecycleState !== 'candidate' ||
+      this.activationReservations.get(
+        this.recordKey(context.tenantId, memoryId),
+      ) !== expectedVersion
+    ) {
+      throw new Error('Candidate version conflict');
+    }
+    const active = {
+      ...record,
+      authority,
+      lifecycleState: 'active' as const,
+      version: activeVersion,
+    };
+    this.records.set(this.recordKey(context.tenantId, memoryId), active);
+    this.bindings.set(
+      this.bindingKey(
+        binding.tenantId,
+        binding.canonicalMemoryId,
+        binding.canonicalVersion,
+      ),
+      structuredClone(binding),
+    );
+    this.activationReservations.delete(
+      this.recordKey(context.tenantId, memoryId),
+    );
+    return structuredClone(active);
+  }
+
+  async reserveActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authorizationExpiresAt: Date | null,
+  ): Promise<void> {
+    void authorizationExpiresAt;
+    const record = this.requireRecord(context, memoryId);
+    const key = this.recordKey(context.tenantId, memoryId);
+    const existing = this.activationReservations.get(key);
+    if (existing !== undefined) {
+      throw new Error('Provider activation is already in progress');
+    }
+    if (
+      record.version !== expectedVersion ||
+      record.lifecycleState !== 'candidate' ||
+      record.erasureState !== 'live' ||
+      this.erasureReservations.has(key)
+    ) {
+      throw new Error('Candidate version conflict');
+    }
+    this.activationReservations.set(key, expectedVersion);
+  }
+
+  async releaseActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<void> {
+    const record = this.requireRecord(context, memoryId);
+    const key = this.recordKey(context.tenantId, memoryId);
+    if (
+      record.version !== expectedVersion ||
+      record.lifecycleState !== 'candidate' ||
+      record.erasureState !== 'live' ||
+      this.activationReservations.get(key) !== expectedVersion
+    ) {
+      throw new Error('Activation reservation binding conflict');
+    }
+    this.activationReservations.delete(key);
+  }
+
+  async getProviderBinding(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<ProviderBinding | null> {
+    this.requireRecord(context, memoryId);
+    const binding = this.bindings.get(
+      this.bindingKey(context.tenantId, memoryId, version),
+    );
+    return binding ? structuredClone(binding) : null;
+  }
+
+  async markPendingErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<CanonicalMemoryRecord> {
+    const record = this.requireRecord(context, memoryId);
+    const reservation = this.erasureReservations.get(
+      this.recordKey(context.tenantId, memoryId),
+    );
+    if (
+      record.version !== expectedVersion ||
+      reservation?.version !== expectedVersion
+    ) {
+      throw new Error('Memory version conflict');
+    }
+    const tombstoned: CanonicalMemoryRecord = {
+      ...record,
+      lifecycleState: 'tombstoned',
+      erasureState: 'pending_erasure',
+      version: record.version + 1,
+    };
+    this.records.set(this.recordKey(context.tenantId, memoryId), tombstoned);
+    return structuredClone(tombstoned);
+  }
+
+  async reserveErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord> {
+    void authorizationExpiresAt;
+    const record = this.requireRecord(context, memoryId);
+    const key = this.recordKey(context.tenantId, memoryId);
+    const existing = this.erasureReservations.get(key);
+    if (existing) {
+      if (
+        existing.version !== expectedVersion ||
+        existing.scope !== scope ||
+        existing.reason !== reason
+      ) {
+        throw new Error('Erasure reservation binding conflict');
+      }
+      if (
+        !(
+          (record.version === expectedVersion &&
+            record.erasureState === 'live') ||
+          (record.version === expectedVersion + 1 &&
+            record.erasureState === 'pending_erasure')
+        )
+      ) {
+        throw new Error('Memory version conflict');
+      }
+      return structuredClone(record);
+    }
+    if (this.activationReservations.has(key)) {
+      throw new Error('Provider activation is in progress');
+    }
+    if (
+      record.version !== expectedVersion ||
+      record.erasureState !== 'live' ||
+      record.scope !== scope
+    ) {
+      throw new Error('Memory version conflict');
+    }
+    this.erasureReservations.set(key, {
+      version: expectedVersion,
+      scope,
+      reason,
+      createdAt,
+    });
+    return structuredClone(record);
+  }
+
+  async eraseContent(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<void> {
+    const record = this.requireRecord(context, memoryId);
+    if (
+      record.version !== version ||
+      record.erasureState !== 'pending_erasure'
+    ) {
+      throw new Error('Memory is not pending erasure at expected version');
+    }
+    const receipt = this.sourceReceipts.get(
+      this.sourceReceiptKey(context.tenantId, record.sourceOperationId),
+    );
+    if (!receipt || receipt.canonicalMemoryId !== memoryId) {
+      throw new Error('Candidate source receipt is missing');
+    }
+    receipt.state = 'erased';
+    this.records.delete(this.recordKey(context.tenantId, memoryId));
+    this.activationReservations.delete(
+      this.recordKey(context.tenantId, memoryId),
+    );
+    this.erasureReservations.delete(this.recordKey(context.tenantId, memoryId));
+    const binding = this.bindings.get(
+      this.bindingKey(context.tenantId, memoryId, version - 1),
+    );
+    if (binding) {
+      binding.state = 'deleted';
+    }
+  }
+
+  async insertRawEvent(
+    identity: RuntimeIdentity,
+    event: RawEventInput,
+    receipt: RawEventReceipt,
+  ): Promise<boolean> {
+    if (receipt.state === 'purged') {
+      throw new Error('Purged raw event cannot be recreated');
+    }
+    const key = `${identity.tenantId}:${event.eventId}`;
+    const existing = this.rawEvents.get(key);
+    if (existing && existing !== event.sourceFingerprint) {
+      throw new Error('Event ID was reused with different content');
+    }
+    if (existing) {
+      return false;
+    }
+    this.rawEvents.set(key, event.sourceFingerprint);
+    return true;
+  }
+
+  async insertFeedback(
+    identity: RuntimeIdentity,
+    eventId: string,
+    memoryId: string,
+    _signal: FeedbackSignal,
+    _occurredAt: Date,
+    _receivedAt: Date,
+    sourceFingerprint: string,
+  ): Promise<boolean> {
+    const record = this.records.get(
+      this.recordKey(identity.tenantId, memoryId),
+    );
+    if (
+      !record ||
+      !canRead(identity, record) ||
+      record.lifecycleState !== 'active' ||
+      record.erasureState !== 'live' ||
+      this.erasureReservations.has(this.recordKey(identity.tenantId, memoryId))
+    ) {
+      throw new Error('Canonical memory not found');
+    }
+    const key = `${identity.tenantId}:${eventId}`;
+    const existing = this.feedbackEvents.get(key);
+    if (existing && existing !== sourceFingerprint) {
+      throw new Error('Event ID was reused with different content');
+    }
+    if (existing) {
+      return false;
+    }
+    this.feedbackEvents.set(key, sourceFingerprint);
+    return true;
+  }
+
+  private requireRecord(
+    context: StoreContext,
+    memoryId: string,
+  ): CanonicalMemoryRecord {
+    const record = this.records.get(this.recordKey(context.tenantId, memoryId));
+    if (!record || !canRead(context, record)) {
+      throw new Error('Canonical memory not found');
+    }
+    return record;
+  }
+
+  private recordKey(tenantId: string, memoryId: string): string {
+    return `${tenantId}:${memoryId}`;
+  }
+
+  private bindingKey(
+    tenantId: string,
+    memoryId: string,
+    version: number,
+  ): string {
+    return `${tenantId}:${memoryId}:${version}`;
+  }
+
+  private sourceReceiptKey(tenantId: string, operationId: string): string {
+    return `${tenantId}:${operationId}`;
+  }
+}
+
+interface MemoryRow extends QueryResultRow {
+  id: string;
+  tenant_id: string;
+  scope: 'personal' | 'repository';
+  scope_id: string;
+  content_ciphertext: string;
+  content_key_handle: string;
+  authority: string;
+  lifecycle_state: CanonicalMemoryRecord['lifecycleState'];
+  erasure_state: CanonicalMemoryRecord['erasureState'];
+  version: number;
+  source_operation_id: string;
+  source_fingerprint: string;
+  created_at: Date;
+  expires_at: Date | null;
+}
+
+interface ProviderBindingRow extends QueryResultRow {
+  tenant_id: string;
+  canonical_memory_id: string;
+  canonical_version: number;
+  provider_memory_id: string;
+  scope: ProviderBinding['scope'];
+  entity_id: string;
+  state: ProviderBinding['state'];
+}
+
+interface ErasureReservationRow extends QueryResultRow {
+  canonical_version: number;
+  scope: MemoryScope;
+  reason: DeletionReason;
+}
+
+export class PostgresCanonicalStore implements CanonicalStore {
+  constructor(private readonly pool: Pool) {}
+
+  async insertCandidate(
+    identity: RuntimeIdentity,
+    record: CanonicalMemoryRecord,
+  ): Promise<CanonicalMemoryRecord> {
+    return this.transaction(identity, async (client) => {
+      await this.requirePersonalWrite(
+        client,
+        record.tenantId,
+        record.scope,
+        record.scopeId,
+      );
+      await client.query(
+        `INSERT INTO memory_source_receipts (
+           tenant_id, source_operation_id, canonical_memory_id,
+           source_fingerprint, state
+         ) VALUES ($1,$2,$3,$4,'live')
+         ON CONFLICT (tenant_id, source_operation_id) DO NOTHING`,
+        [
+          record.tenantId,
+          record.sourceOperationId,
+          record.id,
+          record.sourceFingerprint,
+        ],
+      );
+      const receipt = await client.query<{
+        canonical_memory_id: string;
+        source_fingerprint: string;
+        state: string;
+      }>(
+        `SELECT canonical_memory_id, source_fingerprint, state
+           FROM memory_source_receipts
+          WHERE source_operation_id = $1`,
+        [record.sourceOperationId],
+      );
+      if (receipt.rows[0]?.state === 'erased') {
+        throw new Error('Candidate source operation is no longer reusable');
+      }
+      if (
+        receipt.rows[0]?.canonical_memory_id !== record.id ||
+        receipt.rows[0]?.source_fingerprint !== record.sourceFingerprint
+      ) {
+        throw new Error(
+          'Operation ID was reused with different candidate content',
+        );
+      }
+      const result = await client.query<MemoryRow>(
+        `INSERT INTO memory_records (
+           id, tenant_id, scope, scope_id, content_ciphertext,
+           content_key_handle, authority, lifecycle_state,
+           erasure_state, version, source_operation_id, source_fingerprint,
+           created_at, expires_at
+         )
+         SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
+          WHERE $3 <> 'personal'
+             OR EXISTS (
+               SELECT 1 FROM personal_memory_preferences p
+                WHERE p.tenant_id = $2
+                  AND p.principal_id = $4
+                  AND p.mode = 'read_write'
+             )
+         ON CONFLICT (tenant_id, source_operation_id) DO NOTHING
+         RETURNING *`,
+        [
+          record.id,
+          record.tenantId,
+          record.scope,
+          record.scopeId,
+          record.protectedContent.ciphertext,
+          record.protectedContent.keyHandle,
+          record.authority,
+          record.lifecycleState,
+          record.erasureState,
+          record.version,
+          record.sourceOperationId,
+          record.sourceFingerprint,
+          record.createdAt,
+          record.expiresAt,
+        ],
+      );
+      if (result.rows[0]) {
+        return mapMemoryRow(result.rows[0]);
+      }
+      const existing = await client.query<MemoryRow>(
+        `SELECT * FROM memory_records
+          WHERE source_operation_id = $1
+            AND (
+              scope <> 'personal'
+              OR EXISTS (
+                SELECT 1 FROM personal_memory_preferences p
+                 WHERE p.tenant_id = memory_records.tenant_id
+                   AND p.principal_id = memory_records.scope_id
+                   AND p.mode = 'read_write'
+              )
+            )`,
+        [record.sourceOperationId],
+      );
+      const duplicate = mapMemoryRow(existing.rows[0]);
+      if (duplicate.sourceFingerprint !== record.sourceFingerprint) {
+        throw new Error(
+          'Operation ID was reused with different candidate content',
+        );
+      }
+      return duplicate;
+    });
+  }
+
+  async getAuthorized(
+    context: StoreContext,
+    memoryId: string,
+  ): Promise<CanonicalMemoryRecord | null> {
+    return this.transaction(context, async (client) => {
+      const result = await client.query<MemoryRow>(
+        'SELECT * FROM memory_records WHERE id = $1',
+        [memoryId],
+      );
+      return result.rows[0] ? mapMemoryRow(result.rows[0]) : null;
+    });
+  }
+
+  async getAuthorizedByProviderIds(
+    context: StoreContext,
+    providerMemoryIds: readonly string[],
+  ): Promise<readonly CanonicalMemoryRecord[]> {
+    if (providerMemoryIds.length === 0) {
+      return [];
+    }
+    return this.transaction(context, async (client) => {
+      const result = await client.query<MemoryRow>(
+        `SELECT m.*
+           FROM provider_bindings b
+           JOIN memory_records m
+             ON m.tenant_id = b.tenant_id
+            AND m.id = b.canonical_memory_id
+            AND m.version = b.canonical_version
+          WHERE b.provider_memory_id = ANY($1::text[])
+            AND b.state = 'active'
+            AND m.lifecycle_state = 'active'
+            AND m.erasure_state = 'live'`,
+        [providerMemoryIds],
+      );
+      return result.rows.map(mapMemoryRow);
+    });
+  }
+
+  async reserveActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authorizationExpiresAt: Date | null,
+  ): Promise<void> {
+    await this.transaction(context, async (client) => {
+      const result = await client.query<MemoryRow>(
+        'SELECT * FROM memory_records WHERE id = $1 FOR UPDATE',
+        [memoryId],
+      );
+      const record = mapMemoryRow(result.rows[0]);
+      await this.requireCurrentAuthorization(client, authorizationExpiresAt);
+      await this.requirePersonalWrite(
+        client,
+        record.tenantId,
+        record.scope,
+        record.scopeId,
+      );
+      if (
+        record.version !== expectedVersion ||
+        record.lifecycleState !== 'candidate' ||
+        record.erasureState !== 'live'
+      ) {
+        throw new Error('Candidate version conflict');
+      }
+      const erasure = await client.query(
+        `SELECT 1 FROM memory_erasure_reservations
+          WHERE canonical_memory_id = $1`,
+        [memoryId],
+      );
+      if (erasure.rowCount !== 0) {
+        throw new Error('Candidate version conflict');
+      }
+      const reservation = await client.query(
+        `INSERT INTO memory_activation_reservations (
+           tenant_id, canonical_memory_id, canonical_version, created_at
+         ) VALUES ($1,$2,$3,clock_timestamp())
+         ON CONFLICT (tenant_id, canonical_memory_id) DO NOTHING`,
+        [context.tenantId, memoryId, expectedVersion],
+      );
+      if (reservation.rowCount !== 1) {
+        throw new Error('Provider activation is already in progress');
+      }
+    });
+  }
+
+  async releaseActivation(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<void> {
+    await this.transaction(context, async (client) => {
+      const result = await client.query(
+        `DELETE FROM memory_activation_reservations r
+          USING memory_records m
+          WHERE m.id = $1 AND m.version = $2
+            AND m.lifecycle_state = 'candidate'
+            AND m.erasure_state = 'live'
+            AND r.tenant_id = m.tenant_id
+            AND r.canonical_memory_id = m.id
+            AND r.canonical_version = m.version`,
+        [memoryId, expectedVersion],
+      );
+      if (result.rowCount !== 1) {
+        throw new Error('Activation reservation binding conflict');
+      }
+    });
+  }
+
+  async activateWithProvider(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authority: string,
+    binding: ProviderBinding,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord> {
+    return this.transaction(context, async (client) => {
+      if (
+        binding.tenantId !== context.tenantId ||
+        binding.canonicalMemoryId !== memoryId ||
+        binding.canonicalVersion !== expectedVersion + 1
+      ) {
+        throw new Error('Provider binding does not match activation');
+      }
+      const locked = await client.query<
+        Pick<MemoryRow, 'scope' | 'scope_id' | 'tenant_id'>
+      >(
+        `SELECT tenant_id, scope, scope_id
+           FROM memory_records
+          WHERE id = $1
+          FOR UPDATE`,
+        [memoryId],
+      );
+      const lockedRecord = locked.rows[0];
+      if (!lockedRecord) {
+        throw new Error('Candidate version conflict');
+      }
+      await this.requirePersonalWrite(
+        client,
+        lockedRecord.tenant_id,
+        lockedRecord.scope,
+        lockedRecord.scope_id,
+      );
+      const result = await client.query<MemoryRow>(
+        `UPDATE memory_records
+            SET lifecycle_state = 'active', authority = $3, version = version + 1
+          WHERE id = $1 AND version = $2
+            AND lifecycle_state = 'candidate' AND erasure_state = 'live'
+            AND ($4::timestamptz IS NULL OR clock_timestamp() < $4)
+            AND (
+              scope <> 'personal'
+              OR EXISTS (
+                SELECT 1 FROM personal_memory_preferences p
+                 WHERE p.tenant_id = memory_records.tenant_id
+                   AND p.principal_id = memory_records.scope_id
+                   AND p.mode = 'read_write'
+              )
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_erasure_reservations r
+               WHERE r.tenant_id = memory_records.tenant_id
+                 AND r.canonical_memory_id = memory_records.id
+            )
+            AND EXISTS (
+              SELECT 1 FROM memory_activation_reservations a
+               WHERE a.tenant_id = memory_records.tenant_id
+                 AND a.canonical_memory_id = memory_records.id
+                 AND a.canonical_version = memory_records.version
+            )
+          RETURNING *`,
+        [memoryId, expectedVersion, authority, authorizationExpiresAt],
+      );
+      const activatedCandidate = result.rows[0] !== undefined;
+      let active = result.rows[0];
+      if (!active) {
+        const existing = await client.query<MemoryRow>(
+          `SELECT * FROM memory_records
+            WHERE id = $1 AND version = $2
+              AND lifecycle_state = 'active'
+              AND erasure_state = 'live'
+              AND authority = $3
+              AND ($4::timestamptz IS NULL OR clock_timestamp() < $4)
+              AND NOT EXISTS (
+                SELECT 1 FROM memory_erasure_reservations r
+                 WHERE r.tenant_id = memory_records.tenant_id
+                   AND r.canonical_memory_id = memory_records.id
+              )`,
+          [memoryId, expectedVersion + 1, authority, authorizationExpiresAt],
+        );
+        if (!existing.rows[0]) {
+          throw new Error('Candidate version conflict');
+        }
+        active = existing.rows[0];
+      }
+      if (binding.scope !== active.scope) {
+        throw new Error('Provider binding scope does not match activation');
+      }
+      const existingBinding = await client.query<ProviderBindingRow>(
+        `SELECT * FROM provider_bindings
+          WHERE canonical_memory_id = $1 AND canonical_version = $2`,
+        [memoryId, expectedVersion + 1],
+      );
+      if (existingBinding.rows[0]) {
+        if (
+          !sameProviderBinding(
+            mapProviderBindingRow(existingBinding.rows[0]),
+            binding,
+          )
+        ) {
+          throw new Error('Provider binding conflict');
+        }
+      } else {
+        await client.query(
+          `INSERT INTO provider_bindings (
+             tenant_id, canonical_memory_id, canonical_version,
+             provider_memory_id, scope, entity_id, state
+           ) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+          [
+            binding.tenantId,
+            binding.canonicalMemoryId,
+            binding.canonicalVersion,
+            binding.providerMemoryId,
+            binding.scope,
+            binding.entityId,
+            binding.state,
+          ],
+        );
+      }
+      if (activatedCandidate) {
+        const released = await client.query(
+          `DELETE FROM memory_activation_reservations
+            WHERE canonical_memory_id = $1 AND canonical_version = $2`,
+          [memoryId, expectedVersion],
+        );
+        if (released.rowCount !== 1) {
+          throw new Error('Activation reservation binding conflict');
+        }
+      }
+      return mapMemoryRow(active);
+    });
+  }
+
+  async getProviderBinding(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<ProviderBinding | null> {
+    return this.transaction(context, async (client) => {
+      const result = await client.query<ProviderBindingRow>(
+        `SELECT * FROM provider_bindings
+          WHERE canonical_memory_id = $1 AND canonical_version = $2`,
+        [memoryId, version],
+      );
+      return result.rows[0] ? mapProviderBindingRow(result.rows[0]) : null;
+    });
+  }
+
+  async markPendingErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<CanonicalMemoryRecord> {
+    return this.transaction(context, async (client) => {
+      const result = await client.query<MemoryRow>(
+        `UPDATE memory_records
+            SET lifecycle_state = 'tombstoned',
+                erasure_state = 'pending_erasure',
+                version = version + 1
+          WHERE id = $1 AND version = $2 AND erasure_state = 'live'
+            AND EXISTS (
+              SELECT 1 FROM memory_erasure_reservations r
+               WHERE r.tenant_id = memory_records.tenant_id
+                 AND r.canonical_memory_id = memory_records.id
+                 AND r.canonical_version = $2
+            )
+          RETURNING *`,
+        [memoryId, expectedVersion],
+      );
+      if (!result.rows[0]) {
+        throw new Error('Memory version conflict');
+      }
+      return mapMemoryRow(result.rows[0]);
+    });
+  }
+
+  async reserveErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+    authorizationExpiresAt: Date | null,
+  ): Promise<CanonicalMemoryRecord> {
+    return this.transaction(context, async (client) => {
+      const result = await client.query<MemoryRow>(
+        'SELECT * FROM memory_records WHERE id = $1 FOR UPDATE',
+        [memoryId],
+      );
+      const record = mapMemoryRow(result.rows[0]);
+      await this.requireCurrentAuthorization(client, authorizationExpiresAt);
+      const reservations = await client.query<ErasureReservationRow>(
+        `SELECT canonical_version, scope, reason
+           FROM memory_erasure_reservations
+          WHERE canonical_memory_id = $1`,
+        [memoryId],
+      );
+      const existing = reservations.rows[0];
+      if (existing) {
+        if (
+          existing.canonical_version !== expectedVersion ||
+          existing.scope !== scope ||
+          existing.reason !== reason
+        ) {
+          throw new Error('Erasure reservation binding conflict');
+        }
+        if (
+          !(
+            (record.version === expectedVersion &&
+              record.erasureState === 'live') ||
+            (record.version === expectedVersion + 1 &&
+              record.erasureState === 'pending_erasure')
+          )
+        ) {
+          throw new Error('Memory version conflict');
+        }
+        return record;
+      }
+      if (
+        record.version !== expectedVersion ||
+        record.erasureState !== 'live' ||
+        record.scope !== scope
+      ) {
+        throw new Error('Memory version conflict');
+      }
+      const activation = await client.query(
+        `SELECT 1 FROM memory_activation_reservations
+          WHERE canonical_memory_id = $1`,
+        [memoryId],
+      );
+      if (activation.rowCount !== 0) {
+        throw new Error('Provider activation is in progress');
+      }
+      await client.query(
+        `INSERT INTO memory_erasure_reservations (
+           tenant_id, canonical_memory_id, canonical_version,
+           scope, reason, created_at
+         ) VALUES ($1,$2,$3,$4,$5,$6)`,
+        [context.tenantId, memoryId, expectedVersion, scope, reason, createdAt],
+      );
+      return record;
+    });
+  }
+
+  async eraseContent(
+    context: StoreContext,
+    memoryId: string,
+    version: number,
+  ): Promise<void> {
+    await this.transaction(context, async (client) => {
+      const receipt = await client.query(
+        `UPDATE memory_source_receipts r
+            SET state = 'erased'
+           FROM memory_records m
+          WHERE m.id = $1 AND m.version = $2
+            AND m.erasure_state = 'pending_erasure'
+            AND r.source_operation_id = m.source_operation_id
+            AND r.canonical_memory_id = m.id
+          RETURNING r.source_operation_id`,
+        [memoryId, version],
+      );
+      if (receipt.rowCount !== 1) {
+        throw new Error('Candidate source receipt is missing');
+      }
+      const result = await client.query(
+        `DELETE FROM memory_records
+          WHERE id = $1 AND version = $2 AND erasure_state = 'pending_erasure'`,
+        [memoryId, version],
+      );
+      if (result.rowCount !== 1) {
+        throw new Error('Memory is not pending erasure at expected version');
+      }
+    });
+  }
+
+  async insertRawEvent(
+    identity: RuntimeIdentity,
+    event: RawEventInput,
+    receipt: RawEventReceipt,
+  ): Promise<boolean> {
+    return this.transaction(identity, async (client) => {
+      const result = await client.query(
+        `INSERT INTO raw_events (
+           tenant_id, event_id, principal_id, workspace_id, repository_id,
+           session_id, turn_id, event_kind, occurred_at, received_at, purge_at,
+           payload_ciphertext, content_key_handle, source_fingerprint
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+         ON CONFLICT (tenant_id, event_id) DO NOTHING`,
+        [
+          identity.tenantId,
+          event.eventId,
+          identity.principalId,
+          identity.workspaceId,
+          identity.repositoryId,
+          event.sessionId,
+          event.turnId,
+          event.eventKind,
+          event.occurredAt,
+          receipt.receivedAt,
+          receipt.purgeAt,
+          event.protectedPayload.ciphertext,
+          event.protectedPayload.keyHandle,
+          event.sourceFingerprint,
+        ],
+      );
+      if (result.rowCount === 1) {
+        return true;
+      }
+      const duplicate = await client.query<{ source_fingerprint: string }>(
+        'SELECT source_fingerprint FROM raw_events WHERE event_id = $1',
+        [event.eventId],
+      );
+      if (duplicate.rows[0]?.source_fingerprint !== event.sourceFingerprint) {
+        throw new Error('Event ID was reused with different content');
+      }
+      return false;
+    });
+  }
+
+  async insertFeedback(
+    identity: RuntimeIdentity,
+    eventId: string,
+    memoryId: string,
+    signal: FeedbackSignal,
+    occurredAt: Date,
+    receivedAt: Date,
+    sourceFingerprint: string,
+  ): Promise<boolean> {
+    return this.transaction(identity, async (client) => {
+      const result = await client.query(
+        `INSERT INTO memory_feedback (
+           tenant_id, event_id, memory_id, memory_version, principal_id,
+           signal, occurred_at, received_at, source_fingerprint
+         )
+         SELECT tenant_id, $1, id, version, $2, $3, $4, $5, $6
+           FROM memory_records
+          WHERE id = $7
+            AND lifecycle_state = 'active'
+            AND erasure_state = 'live'
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_erasure_reservations r
+               WHERE r.tenant_id = memory_records.tenant_id
+                 AND r.canonical_memory_id = memory_records.id
+            )
+         ON CONFLICT (tenant_id, event_id) DO NOTHING`,
+        [
+          eventId,
+          identity.principalId,
+          signal,
+          occurredAt,
+          receivedAt,
+          sourceFingerprint,
+          memoryId,
+        ],
+      );
+      if (result.rowCount === 1) {
+        return true;
+      }
+      const duplicate = await client.query<{ source_fingerprint: string }>(
+        'SELECT source_fingerprint FROM memory_feedback WHERE event_id = $1',
+        [eventId],
+      );
+      if (duplicate.rows[0]?.source_fingerprint === sourceFingerprint) {
+        return false;
+      }
+      if (duplicate.rowCount === 1) {
+        throw new Error('Event ID was reused with different content');
+      }
+      throw new Error('Canonical memory not found');
+    });
+  }
+
+  private async requirePersonalWrite(
+    client: PoolClient,
+    tenantId: string,
+    scope: MemoryScope,
+    principalId: string,
+  ): Promise<void> {
+    if (scope !== 'personal') {
+      return;
+    }
+    const preference = await client.query<{ mode: string }>(
+      `SELECT mode
+         FROM personal_memory_preferences
+        WHERE tenant_id = $1 AND principal_id = $2
+        FOR SHARE`,
+      [tenantId, principalId],
+    );
+    if (preference.rows[0]?.mode !== 'read_write') {
+      throw new Error('Personal memory capture is disabled');
+    }
+  }
+
+  private async requireCurrentAuthorization(
+    client: PoolClient,
+    authorizationExpiresAt: Date | null,
+  ): Promise<void> {
+    const authorization = await client.query<{ current: boolean }>(
+      `SELECT $1::timestamptz IS NULL
+           OR clock_timestamp() < $1 AS current`,
+      [authorizationExpiresAt],
+    );
+    if (!authorization.rows[0]?.current) {
+      throw new Error('Management authorization lease expired');
+    }
+  }
+
+  private async transaction<T>(
+    context: StoreContext,
+    operation: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `SELECT set_config('app.tenant_id', $1, true),
+                set_config('app.principal_id', $2, true),
+                set_config('app.repository_id', $3, true)`,
+        [context.tenantId, context.principalId, context.repositoryId],
+      );
+      const result = await operation(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+function mapMemoryRow(row: MemoryRow | undefined): CanonicalMemoryRecord {
+  if (!row) {
+    throw new Error('Database did not return a memory record');
+  }
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    scope: row.scope,
+    scopeId: row.scope_id,
+    protectedContent: {
+      ciphertext: row.content_ciphertext,
+      keyHandle: row.content_key_handle,
+    },
+    authority: row.authority,
+    lifecycleState: row.lifecycle_state,
+    erasureState: row.erasure_state,
+    version: row.version,
+    sourceOperationId: row.source_operation_id,
+    sourceFingerprint: row.source_fingerprint,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+  };
+}
+
+function mapProviderBindingRow(row: ProviderBindingRow): ProviderBinding {
+  return {
+    tenantId: row.tenant_id,
+    canonicalMemoryId: row.canonical_memory_id,
+    canonicalVersion: row.canonical_version,
+    providerMemoryId: row.provider_memory_id,
+    scope: row.scope,
+    entityId: row.entity_id,
+    state: row.state,
+  };
+}
+
+function sameProviderBinding(
+  left: ProviderBinding,
+  right: ProviderBinding,
+): boolean {
+  return (
+    left.tenantId === right.tenantId &&
+    left.canonicalMemoryId === right.canonicalMemoryId &&
+    left.canonicalVersion === right.canonicalVersion &&
+    left.providerMemoryId === right.providerMemoryId &&
+    left.scope === right.scope &&
+    left.entityId === right.entityId &&
+    left.state === right.state
+  );
+}

--- a/integrations/enterprise-memory/src/migration-contract.test.ts
+++ b/integrations/enterprise-memory/src/migration-contract.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('PostgreSQL isolation migration', () => {
+  it('forces RLS on every tenant-bearing online table', async () => {
+    const sql = await readFile(
+      new URL('../migrations/001-initial.sql', import.meta.url),
+      'utf8',
+    );
+    const tables = [
+      'workspace_bindings',
+      'personal_memory_preferences',
+      'memory_records',
+      'provider_bindings',
+      'memory_source_receipts',
+      'memory_activation_reservations',
+      'memory_erasure_reservations',
+      'raw_events',
+      'memory_feedback',
+      'runtime_capability_replays',
+    ];
+
+    for (const table of tables) {
+      expect(sql).toContain(`CREATE TABLE ${table}`);
+      expect(sql).toContain(`ALTER TABLE ${table} ENABLE ROW LEVEL SECURITY`);
+      expect(sql).toContain(`ALTER TABLE ${table} FORCE ROW LEVEL SECURITY`);
+    }
+  });
+
+  it('uses tenant-qualified identities, references, and idempotency keys', async () => {
+    const sql = await readFile(
+      new URL('../migrations/001-initial.sql', import.meta.url),
+      'utf8',
+    );
+
+    expect(sql).toContain('PRIMARY KEY (tenant_id, id)');
+    expect(sql).toContain('UNIQUE (tenant_id, source_operation_id)');
+    expect(sql).toContain('PRIMARY KEY (tenant_id, event_id)');
+    expect(sql).toContain('FOREIGN KEY (tenant_id, canonical_memory_id)');
+    expect(sql).toContain('FOREIGN KEY (tenant_id, memory_id)');
+    expect(sql).toContain('CREATE TABLE memory_erasure_reservations');
+    expect(sql).toContain(
+      'ALTER TABLE memory_erasure_reservations FORCE ROW LEVEL SECURITY',
+    );
+    expect(sql).toContain("current_setting('app.tenant_id', true)");
+    expect(sql).toContain("purge_at <= received_at + interval '24 hours'");
+    expect(sql).toContain('content_ciphertext text NOT NULL');
+    expect(sql).toContain('capability_fingerprint text NOT NULL');
+    expect(sql).toContain('CREATE POLICY memory_source_receipts_update_policy');
+    expect(sql).toMatch(
+      /memory_source_receipts_update_policy[\s\S]*?FOR UPDATE[\s\S]*?m\.id = memory_source_receipts\.canonical_memory_id/,
+    );
+    expect(sql).not.toContain('summary_ciphertext');
+    expect(sql).not.toContain('references_json');
+  });
+
+  it('keeps source receipts free of content and subject linkage', async () => {
+    const sql = await readFile(
+      new URL('../migrations/001-initial.sql', import.meta.url),
+      'utf8',
+    );
+    const receiptTable = sql.match(
+      /CREATE TABLE memory_source_receipts \(([\s\S]*?)\n\);/,
+    )?.[1];
+
+    expect(receiptTable).toBeDefined();
+    expect(receiptTable).not.toContain('principal_id');
+    expect(receiptTable).not.toContain('repository_id');
+    expect(receiptTable).not.toContain('content_ciphertext');
+    expect(receiptTable).not.toContain('content_key_handle');
+  });
+});


### PR DESCRIPTION
## What this PR does

Stack position: 2/5. Parent: #7509. Next: #7507.

This stacked PR adds the canonical PostgreSQL persistence layer, initial tenant-qualified schema and RLS policies, transactional stores, and the external content-free anti-resurrection ledger contract. It adds durable reservations and receipts for activation, raw events, deletion intent, provider reconciliation, and erasure without adding the memory business service or network APIs.

## Why it's needed

Shared enterprise memory cannot treat a semantic provider as canonical or rely on a best-effort tombstone. This layer makes PostgreSQL the authorized source of truth and records irreversible deletion and source-receipt state outside the database backup domain so retries and restored state cannot silently resurrect deleted content.

## Reviewer Test Plan

### How to verify

- Run `npm test --workspace=@qwen-code/enterprise-memory`; the cumulative 8 test files and 39 tests should pass.
- Run the enterprise-memory build and typecheck; the persistence layer should compile without any lifecycle or HTTP service implementation.
- Confirm every tenant-bearing table enables and forces RLS, pooled operations establish transaction-local tenant context, and source-receipt updates require a visible canonical record.
- Confirm ambiguous commits retain externally created keys or receipts for reconciliation, and deletion ordering records durable intent before acknowledging a tombstone.
- Confirm the migration contract covers reserved erasure capacity, content-free audit and outbox records, and tenant-qualified uniqueness.

### Evidence (Before & After)

N/A — this is a non-UI persistence change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1 arm64, Node.js 22.22.3, npm 10.9.8. PostgreSQL was not available locally.

## Risk & Scope

- Main risk or tradeoff: Correctness depends on transaction boundaries, RLS role configuration, and convergence with an external deletion ledger.
- Not validated / out of scope: Real PostgreSQL pooled-connection RLS isolation remains a mandatory CI or staging gate; lifecycle policy, provider indexing, HTTP APIs, and Agent integration are in later PRs.
- Breaking changes / migration notes: No existing schema changes; this introduces the integration's initial migration only.

## Linked Issues

Refs #7449

<details>
<summary>中文说明</summary>

## 此 PR 的内容

堆栈位置：2/5。父 PR：#7509。下一个 PR：#7507。

这个 stacked PR 增加规范 PostgreSQL 持久化层、初始租户限定 schema 与 RLS 策略、事务性存储，以及外部无内容防复活账本契约。它为激活、原始事件、删除意图、提供商对账和擦除增加持久预留与回执，但不加入记忆业务服务或网络 API。

## 为什么需要

企业共享记忆不能把语义提供商当作规范事实源，也不能只依赖尽力而为的墓碑。该层把 PostgreSQL 设为授权事实源，并在数据库备份域之外记录不可逆删除和来源回执状态，使重试与状态恢复无法静默复活已删除内容。

## 评审者测试计划

### 如何验证

- 运行 `npm test --workspace=@qwen-code/enterprise-memory`；累计 8 个测试文件和 39 项测试应通过。
- 运行 enterprise-memory 构建和类型检查；持久化层应在没有生命周期或 HTTP 服务实现的情况下独立编译。
- 确认每个含租户表都启用并强制执行 RLS，连接池操作设置事务本地租户上下文，来源回执更新要求存在当前可见的规范记录。
- 确认提交结果不明确时保留已在外部创建的密钥或回执供对账处理，并且删除顺序会在确认墓碑前记录持久删除意图。
- 确认迁移契约覆盖预留擦除容量、默认无内容的审计与 outbox 记录，以及租户限定唯一性。

### 证据（变更前后）

不适用——这是非 UI 的持久化变更。

### 测试平台

|   操作系统   | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS 26.4.1 arm64、Node.js 22.22.3、npm 10.9.8。本地没有可用的 PostgreSQL。

## 风险与范围

- 主要风险或权衡：正确性依赖事务边界、RLS 角色配置以及与外部删除账本的收敛。
- 未验证或范围外：真实 PostgreSQL 连接池复用下的 RLS 隔离仍是强制 CI 或预发门禁；生命周期策略、提供商索引、HTTP API 和 Agent 集成位于后续 PR。
- 破坏性变更或迁移说明：没有修改现有 schema；这里只引入该集成的初始迁移。

## 关联 Issue

关联 #7449

</details>
