### PR TITLE
feat(integrations): Add Qwen enterprise memory agent

### DIFF
--- a/integrations/enterprise-memory/README.md
+++ b/integrations/enterprise-memory/README.md
@@ -1,0 +1,100 @@
+# Enterprise Memory integration
+
+This workspace is the Qwen Code monorepo implementation of the enterprise multi-tenant memory architecture in [the design plan](../../docs/plans/2026-07-21-enterprise-multi-tenant-memory-gateway.md). It deliberately lives outside `packages/core` and `packages/cli`: Qwen Code consumes it through the existing Extension, Hook, and MCP contracts, while enterprise identity, storage, approval, retention, and provider dependencies remain independently deployable.
+
+It is a reference implementation and integration boundary, not a turnkey production deployment. A deployment must supply the workload-identity broker, OIDC provider, SCM authorization service, PostgreSQL roles, external key-handle service, anti-resurrection ledger, Mem0 project, retention controller, network policy, quotas, audit pipeline, and operational reconciliation described below.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Q["Qwen Code"] -->|"Extension hooks + bounded MCP"| A["memory-agent"]
+    A -->|"mTLS + exact-request capability"| R["Runtime process :8443"]
+    U["Authenticated user or reviewer"] -->|"OIDC bearer"| M["Management process :8444"]
+    M -->|"fresh immutable-repository check"| S["SCM authorization"]
+    R --> C["Canonical service"]
+    M --> C
+    C --> P[("PostgreSQL + FORCE RLS")]
+    C --> K["External content-key service"]
+    C --> L["Anti-resurrection ledger"]
+    C --> I["Provider-neutral semantic index"]
+    I --> Z["Mem0 v3 adapter"]
+```
+
+The two listeners run as separate OS processes and receive separate database and identity credentials. Each process is pinned to one `MEMORY_TENANT_ID`, and both runtime capability and management OIDC tenant claims must match it. Deploy one runtime/management pair per tenant and environment so its `MEM0_API_KEY` belongs to exactly one Mem0 Project; the PostgreSQL cluster may still be shared under RLS. A runtime deployment must not receive the management database URL, management OIDC configuration, or SCM authorization credential, and a management deployment must not receive the runtime database URL, capability HMAC, or runtime TLS client CA. Runtime capabilities have only `context:read`, `events:write`, `memory:read`, `proposal:write`, and `feedback:write`; they are rejected by the management OIDC verifier. Management access tokens require consistent `iat`/`exp` claims and default to a maximum one-hour issued lifetime. Personal activation and deletion require the authenticated data subject. Repository activation and deletion require a fresh authorization result for the immutable repository ID from the SCM service.
+
+## Implemented vertical slice
+
+- Sender-constrained ES256 runtime capabilities with issuer, audience, type, time, authorization-lease, revocation epoch, fixed capability, mTLS certificate, and exact method/route/operation/body binding checks.
+- Live PostgreSQL workspace authorization and transaction-local tenant/principal/repository context.
+- Tenant-qualified canonical records, personal preferences, provider bindings, raw events, and content-free feedback with `FORCE ROW LEVEL SECURITY`; raw-event and feedback idempotency fingerprints bind the complete opaque runtime identity as well as the payload.
+- Personal memory default-off consent modes and separate personal/repository entity identifiers derived by purpose-separated HMAC.
+- Candidate-only MCP writes, scope-authorized candidate review, scope-specific OIDC/SCM approval, optimistic version checks, canonical re-authorization on every recall, and provider results treated only as opaque candidate IDs and scores.
+- Record-specific protected content handles, content-free source-operation receipts, canonical IDs equal to the agent's opaque operation UUID, mutually exclusive activation/erasure reservations, external origin-version anti-resurrection guards, deletion intent before invisibility, bound-provider deletion verification, key destruction, durable external erasure confirmation before ciphertext cleanup, and retryable monotonic erasure. Provider activation is reserved before any Mem0 write so deletion cannot declare completion while an unbound write is in flight. A missing canonical row with only a deletion intent is never treated as proof of provider/key erasure; unknown provider writes retain their activation reservation and remain a mandatory reconciliation gate.
+- Mem0 v3 add/event/get-all/search/delete integration with `infer=false`, reranking disabled, exact canonical metadata filtering, local score-threshold enforcement, and no use of provider-returned text as memory truth.
+- Qwen `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PostToolUseFailure`, `Stop`, and `StopFailure` integration plus a bounded MCP surface. Local state contains only session/turn IDs and up to 2,048 recent operation IDs and timestamps; it uses `0700`/`0600`, per-session inter-process locks, and atomic replacement. A workload-supplied stable operation-HMAC secret keeps exact Hook and MCP-write operation IDs unchanged across local-state loss, while retries inside the metadata window also reuse the originally captured turn, without persisting prompt, tool, or response content.
+- Raw prompt/tool/assistant capture is disabled by default. It can be enabled only when `MEMORY_RETENTION_CONTROLLER_READY=true`; that assertion is a deployment gate, not a substitute for the required external 24-hour purge and reconciliation controller.
+
+The implementation intentionally does not auto-promote model output, import existing Qwen memory/context files, expose administrative selectors to MCP, or modify Qwen Code Core.
+
+`memory_propose_personal`, `memory_propose_repository`, and `memory_feedback` require a caller-generated UUID `operationId`. An exact retry must reuse it; a new logical write must use a new UUID. The agent purpose-separates and HMAC-derives the Gateway operation ID from the tool name and that UUID, and does not forward the caller UUID in the HTTP body. Candidate source fingerprints also bind the opaque proposing principal and personal or repository scope ID, so a UUID cannot be replayed by another principal or into another scope. JSON-RPC request IDs are transport-local and are never used as durable write identities. `memory_search` and `memory_get` derive an operation ID from a random MCP connection epoch, the JSON-RPC request ID, the tool name, and validated arguments, so request IDs that restart after reconnect cannot collide.
+
+## Build and verify
+
+From the repository root:
+
+```bash
+npm install
+npm run build --workspace=@qwen-code/enterprise-memory
+npm run typecheck --workspace=@qwen-code/enterprise-memory
+npm test --workspace=@qwen-code/enterprise-memory
+npm run start:runtime --workspace=@qwen-code/enterprise-memory
+npm run start:management --workspace=@qwen-code/enterprise-memory
+```
+
+Apply `migrations/001-initial.sql` with a dedicated migration role. Runtime and management use distinct database roles; neither may own these tables or have `BYPASSRLS`. Grant each role only its route-specific statements; both processes need scoped reads of personal preferences so personal candidate insertion/activation can recheck consent at the SQL commit point, runtime inserts and reads tenant-scoped content-free source-operation receipts, management advances a receipt only while its canonical record remains visible in the current scope and before deleting that record in the same transaction, and runtime needs read-only access to erasure reservations so feedback fails closed once deletion wins. Only management/reconciliation roles may create or advance activation and erasure reservations. Missing transaction-local context must return no rows. Production readiness requires a real PostgreSQL role/connection-reuse isolation test, not only the included migration contract test.
+
+Build output makes this directory installable as a Qwen extension. Both its Hook and MCP entries deliberately invoke a deployment-supplied `qwen-memory-agent-launcher`; there is no direct-node fallback. The launcher must be a signed executable resolved from a system-controlled `PATH`, authenticate the specific memory-agent workload rather than only its peer UID, obtain credentials through controlled local IPC/workload identity, clear inherited `MEMORY_*` values, and inject the variables below only into the child agent. The Qwen parent process, settings/manifest/hook files, workspace, and tool subprocess environment must not contain those values. Run the runtime and management services under separate workload identities, and prevent tool sandboxes from reading agent mTLS files/state or calling the launcher credential endpoint, broker, Gateway, SCM, key service, ledger, or Mem0 directly. A missing or failed launcher must leave Qwen running without external memory; operators must not replace it with direct `node` execution.
+
+## Required configuration
+
+All service URLs below must use HTTPS. The variables below describe the environment seen by the target process, not the Qwen parent environment. Deployment credentials are supplied by the workload platform and must not be committed to extension settings or persisted in agent state. The operation-ID secret must remain stable beyond every accepted event-replay, backup-restore, and anti-resurrection window; rotating it requires a reviewed dual-key/lineage migration before accepting old retries.
+
+| Variable                                                                                              | Purpose                                                                                             |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `MEMORY_TENANT_ID`                                                                                    | Fixed tenant shard; must match runtime and management identity claims                               |
+| `MEMORY_RUNTIME_DATABASE_URL`                                                                         | PostgreSQL connection for the read/proposal/event runtime role, with `sslmode=verify-full`          |
+| `MEMORY_MANAGEMENT_DATABASE_URL`                                                                      | Separate PostgreSQL connection for the approval/preference/erasure role, with `sslmode=verify-full` |
+| `MEMORY_CAPABILITY_ISSUER`, `MEMORY_CAPABILITY_AUDIENCE`, `MEMORY_CAPABILITY_JWKS_URL`                | Runtime capability trust domain                                                                     |
+| `MEMORY_REQUEST_HMAC_SECRET`                                                                          | Broker/Gateway exact-request binding key, base64url and at least 32 bytes                           |
+| `MEMORY_IDEMPOTENCY_HMAC_SECRET`                                                                      | Purpose-separated event and candidate fingerprint key                                               |
+| `MEMORY_ENTITY_HMAC_SECRET`, `MEMORY_ENTITY_HMAC_VERSION`                                             | Opaque provider entity mapping key and version                                                      |
+| `MEMORY_LEDGER_URL`, `MEMORY_LEDGER_TOKEN`                                                            | Strongly consistent ledger outside the PostgreSQL backup domain                                     |
+| `MEMORY_CONTENT_PROTECTOR_URL`, `MEMORY_CONTENT_PROTECTOR_TOKEN`                                      | Record-specific key-handle protection service                                                       |
+| `MEM0_API_KEY`                                                                                        | Dedicated credential for this tenant and environment's Mem0 Project                                 |
+| `MEMORY_GATEWAY_TLS_CERT`, `MEMORY_GATEWAY_TLS_KEY`, `MEMORY_GATEWAY_TLS_CLIENT_CA`                   | TLS 1.3 runtime listener and required agent mTLS                                                    |
+| `MEMORY_MANAGEMENT_OIDC_ISSUER`, `MEMORY_MANAGEMENT_OIDC_AUDIENCE`, `MEMORY_MANAGEMENT_OIDC_JWKS_URL` | Human management identity trust domain                                                              |
+| `MEMORY_MANAGEMENT_TLS_CERT`, `MEMORY_MANAGEMENT_TLS_KEY`                                             | TLS 1.3 management listener                                                                         |
+| `MEMORY_SCM_AUTHORIZATION_URL`, `MEMORY_SCM_AUTHORIZATION_TOKEN`                                      | Current immutable-repository maintainer authorization                                               |
+| `MEMORY_RAW_CAPTURE_ENABLED`                                                                          | Optional; defaults to `false`                                                                       |
+| `MEMORY_RETENTION_CONTROLLER_READY`                                                                   | Must be exactly `true` before raw capture can start                                                 |
+| `MEMORY_BROKER_URL`, `MEMORY_GATEWAY_URL`                                                             | Agent-only capability broker and runtime Gateway endpoints                                          |
+| `MEMORY_AGENT_TLS_CERT`, `MEMORY_AGENT_TLS_KEY`, `MEMORY_AGENT_TLS_CA`                                | Short-lived memory-agent workload identity                                                          |
+| `MEMORY_AGENT_STATE_DIR`                                                                              | Per-runtime tmpfs state directory, inaccessible to tools                                            |
+| `MEMORY_AGENT_OPERATION_HMAC_SECRET`                                                                  | Exactly 32 bytes, unpadded base64url; stable operation identity, inaccessible to tools              |
+
+The Gateway listener defaults to `127.0.0.1:8443` and the management listener to `127.0.0.1:8444`; use `MEMORY_GATEWAY_HOST`, `MEMORY_GATEWAY_PORT`, `MEMORY_MANAGEMENT_HOST`, and `MEMORY_MANAGEMENT_PORT` to override them.
+
+## External service contracts
+
+The ledger endpoints must be strongly consistent and idempotent. They must never move `purged` back to `received` or `erased` back to `deletion_intent`. Erasing canonical version 2 or later also writes and completes a version-1 deletion guard for the deterministic canonical ID; proposal admission checks that guard before protecting content, while `memory_source_receipts` closes the remaining online check/insert race. The content-protection service must give every event or canonical record an independent deletion handle; `destroy` must be idempotent and return success only after the handle is unusable. It must tenant-scope and index `source_operation_id` so the reconciler can expire a handle created before a failed or crashed database commit without ordinary logs containing plaintext or identifiers. Both services must enforce tenant authorization independently of request bodies and must not log plaintext or bearer tokens.
+
+The SCM authorization endpoint receives opaque tenant/principal/repository IDs and must echo those three IDs with `{ "authorized": true, "tenant_id": "...", "principal_id": "...", "repository_id": "...", "expires_at": "..." }` only for a current maintainer lease no longer than 60 seconds. Repository URLs, refs, or model-provided claims are not accepted as authority.
+
+The public HTTP shape is recorded in `openapi.yaml`. Runtime request bodies never contain tenant, principal, workspace, or repository selectors; those come only from the verified capability and live binding.
+
+The executable currently uses an empty `StaticPolicyResolver`, so `SessionStart` returns no organization policy until the deployment replaces it with the signed, reviewed policy projection described in the design plan. The built-in query sanitizer and candidate secret patterns are bounded defense in depth, not an enterprise secrets/PII/code DLP control. The external retention controller must expire 30-day candidates, reverify or expire repository records, run personal expiry through the same erasure saga, purge raw rows and handles, advance raw receipts to `purged`, reconcile activation reservations with unknown Mem0 outcomes, reconcile erasure reservations and deletion intents, orphan content handles, and orphan provider records, remove expired capability replay rows, and execute bounded entity-HMAC rotation/reindexing. Setting the readiness variable does not perform any of that work.
+
+## Deployment gates
+
+Do not enable recall or raw capture merely because the unit tests pass. The managed Qwen profile must first disable built-in automatic and team memory and reject unapproved local memory/context mutation, otherwise the two systems can double-write and double-recall. Before a tenant canary, complete the identity/revocation probe, launcher provenance and Qwen-parent/tool-environment secret-absence probes, real PostgreSQL RLS and pool-reuse test, reviewed DLP integration, external ledger/key failure drills, Mem0 residency/deletion contract validation, retention and offboarding rehearsal, sandbox/egress verification, quota and circuit-breaker validation, and the shadow-mode quality/security evaluation in the design plan. On any external-memory failure, Qwen Code must continue without memory rather than broadening scope or falling back to local memory.

--- a/integrations/enterprise-memory/hooks/hooks.json
+++ b/integrations/enterprise-memory/hooks/hooks.json
@@ -1,0 +1,79 @@
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-session-context",
+          "timeout": 1800
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-turn-open",
+          "timeout": 1800
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "^(read_file|grep_search|glob|list_directory|write_file|edit|notebook_edit|run_shell_command)$",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-tool-evidence",
+          "async": true,
+          "timeout": 5000
+        }
+      ]
+    }
+  ],
+  "PostToolUseFailure": [
+    {
+      "matcher": "^(read_file|grep_search|glob|list_directory|write_file|edit|notebook_edit|run_shell_command)$",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-tool-failure",
+          "async": true,
+          "timeout": 5000
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-turn-stop",
+          "timeout": 1800
+        }
+      ]
+    }
+  ],
+  "StopFailure": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "qwen-memory-agent-launcher node \"${CLAUDE_PLUGIN_ROOT}/dist/agent/main.js\" hook",
+          "name": "enterprise-memory-turn-failure",
+          "async": true,
+          "timeout": 5000
+        }
+      ]
+    }
+  ]
+}

--- a/integrations/enterprise-memory/package.json
+++ b/integrations/enterprise-memory/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "jose": "^6.1.3",
     "pg": "^8.16.3",
+    "proper-lockfile": "^4.1.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "@types/pg": "^8.15.5",
+    "@types/proper-lockfile": "^4.1.4",
     "typescript": "^5.4.5",
     "vitest": "^3.2.4"
   }

--- a/integrations/enterprise-memory/qwen-extension.json
+++ b/integrations/enterprise-memory/qwen-extension.json
@@ -1,0 +1,20 @@
+{
+  "name": "enterprise-memory",
+  "displayName": {
+    "en": "Enterprise Memory",
+    "zh": "企业共享记忆"
+  },
+  "description": {
+    "en": "Governed external memory through deterministic hooks and a bounded MCP surface",
+    "zh": "通过确定性 Hooks 与受限 MCP 接口接入企业治理的外部记忆"
+  },
+  "version": "0.1.0",
+  "hooks": "hooks/hooks.json",
+  "mcpServers": {
+    "enterprise-memory": {
+      "command": "qwen-memory-agent-launcher",
+      "args": ["node", "${extensionPath}${/}dist${/}agent${/}main.js", "mcp"],
+      "cwd": "${extensionPath}"
+    }
+  }
+}

--- a/integrations/enterprise-memory/src/agent/gateway-client.test.ts
+++ b/integrations/enterprise-memory/src/agent/gateway-client.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { GatewayClient } from './gateway-client.js';
+
+const baseOptions = {
+  brokerUrl: 'https://broker.example.test',
+  gatewayUrl: 'https://gateway.example.test',
+  certificatePath: '/not-read-for-invalid-limits',
+  privateKeyPath: '/not-read-for-invalid-limits',
+  caPath: '/not-read-for-invalid-limits',
+};
+
+describe('GatewayClient', () => {
+  it.each([
+    { responseLimitBytes: Number.NaN },
+    { responseLimitBytes: 1024 * 1024 + 1 },
+    { requestTimeoutMs: 0 },
+    { requestTimeoutMs: 60_001 },
+  ])(
+    'rejects unsafe transport limits before reading credentials: %o',
+    (override) => {
+      expect(() => new GatewayClient({ ...baseOptions, ...override })).toThrow(
+        'limits are invalid',
+      );
+    },
+  );
+
+  it('reuses the exact capability when retrying the gateway request', async () => {
+    const client = new TestGatewayClient();
+
+    await expect(
+      client.post(
+        '/v1/runtime/search',
+        { query: 'retry' },
+        crypto.randomUUID(),
+      ),
+    ).resolves.toEqual({ memories: [] });
+
+    expect(client.gatewayAuthorizations).toEqual([
+      'Bearer capability-1',
+      'Bearer capability-1',
+    ]);
+    expect(client.capabilityCount).toBe(1);
+  });
+});
+
+class TestGatewayClient extends GatewayClient {
+  capabilityCount = 0;
+  private gatewayCount = 0;
+  readonly gatewayAuthorizations: string[] = [];
+
+  constructor() {
+    super({
+      brokerUrl: 'https://broker.example.test',
+      gatewayUrl: 'https://gateway.example.test',
+      certificatePath: '/dev/null',
+      privateKeyPath: '/dev/null',
+      caPath: '/dev/null',
+    });
+  }
+
+  protected override async requestJson<T>(
+    url: URL,
+    input: {
+      method: string;
+      body: Buffer;
+      headers: Record<string, string>;
+    },
+  ): Promise<T> {
+    if (url.hostname === 'broker.example.test') {
+      this.capabilityCount += 1;
+      return { token: `capability-${this.capabilityCount}` } as T;
+    }
+    this.gatewayAuthorizations.push(input.headers['authorization'] ?? '');
+    this.gatewayCount += 1;
+    if (this.gatewayCount === 1) {
+      throw Object.assign(new Error('connection reset'), {
+        code: 'ECONNRESET',
+      });
+    }
+    return { memories: [] } as T;
+  }
+}

--- a/integrations/enterprise-memory/src/agent/gateway-client.ts
+++ b/integrations/enterprise-memory/src/agent/gateway-client.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { request as httpsRequest } from 'node:https';
+import { sha256Base64Url } from '../security/request-binding.js';
+
+export interface GatewayClientOptions {
+  brokerUrl: string;
+  gatewayUrl: string;
+  certificatePath: string;
+  privateKeyPath: string;
+  caPath: string;
+  responseLimitBytes?: number;
+  requestTimeoutMs?: number;
+}
+
+interface IssuedCapability {
+  token: string;
+}
+
+class MemoryServiceHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`Memory service failed with ${status}`);
+  }
+}
+
+class MemoryServiceTransportError extends Error {}
+
+export class GatewayClient {
+  private readonly certificate: Buffer;
+  private readonly privateKey: Buffer;
+  private readonly ca: Buffer;
+  private readonly responseLimitBytes: number;
+  private readonly requestTimeoutMs: number;
+
+  constructor(private readonly options: GatewayClientOptions) {
+    requireHttps(options.brokerUrl, 'brokerUrl');
+    requireHttps(options.gatewayUrl, 'gatewayUrl');
+    this.responseLimitBytes = options.responseLimitBytes ?? 128 * 1024;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 1_000;
+    if (
+      !Number.isSafeInteger(this.responseLimitBytes) ||
+      this.responseLimitBytes <= 0 ||
+      this.responseLimitBytes > 1024 * 1024 ||
+      !Number.isSafeInteger(this.requestTimeoutMs) ||
+      this.requestTimeoutMs <= 0 ||
+      this.requestTimeoutMs > 60_000
+    ) {
+      throw new Error('Gateway client limits are invalid');
+    }
+    this.certificate = readFileSync(options.certificatePath);
+    this.privateKey = readFileSync(options.privateKeyPath);
+    this.ca = readFileSync(options.caPath);
+  }
+
+  async post<T>(path: string, value: unknown, operationId: string): Promise<T> {
+    return this.perform<T>(
+      'POST',
+      path,
+      Buffer.from(JSON.stringify(value)),
+      operationId,
+    );
+  }
+
+  async get<T>(path: string, operationId: string): Promise<T> {
+    return this.perform<T>('GET', path, Buffer.alloc(0), operationId);
+  }
+
+  private async perform<T>(
+    method: string,
+    path: string,
+    body: Buffer,
+    operationId: string,
+  ): Promise<T> {
+    const deadline = Date.now() + this.requestTimeoutMs;
+    const capability = await this.withSingleRetry(
+      () => this.issueCapability(method, path, operationId, body, deadline),
+      deadline,
+    );
+    if (
+      typeof capability.token !== 'string' ||
+      capability.token.length === 0 ||
+      capability.token.length > 16 * 1024
+    ) {
+      throw new Error('Capability broker returned an invalid token');
+    }
+    return this.withSingleRetry(
+      () =>
+        this.requestJson<T>(
+          new URL(path, this.options.gatewayUrl),
+          {
+            method,
+            body,
+            headers: {
+              authorization: `Bearer ${capability.token}`,
+              'content-type': 'application/json',
+              'x-operation-id': operationId,
+            },
+          },
+          deadline,
+        ),
+      deadline,
+    );
+  }
+
+  private async withSingleRetry<T>(
+    operation: () => Promise<T>,
+    deadline: number,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isRetryable(error) || deadline - Date.now() < 50) {
+        throw error;
+      }
+      return operation();
+    }
+  }
+
+  private async issueCapability(
+    method: string,
+    path: string,
+    operationId: string,
+    body: Buffer,
+    deadline: number,
+  ): Promise<IssuedCapability> {
+    const brokerBody = Buffer.from(
+      JSON.stringify({
+        method,
+        route: path,
+        operation_id: operationId,
+        body_sha256: sha256Base64Url(body),
+      }),
+    );
+    return this.requestJson<IssuedCapability>(
+      new URL('/v1/capabilities:issue', this.options.brokerUrl),
+      {
+        method: 'POST',
+        body: brokerBody,
+        headers: { 'content-type': 'application/json' },
+      },
+      deadline,
+    );
+  }
+
+  protected requestJson<T>(
+    url: URL,
+    input: {
+      method: string;
+      body: Buffer;
+      headers: Record<string, string>;
+    },
+    deadline: number,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const request = httpsRequest(
+        url,
+        {
+          method: input.method,
+          cert: this.certificate,
+          key: this.privateKey,
+          ca: this.ca,
+          minVersion: 'TLSv1.3',
+          rejectUnauthorized: true,
+          headers: {
+            ...input.headers,
+            'content-length': input.body.length,
+          },
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          let size = 0;
+          response.on('aborted', () => {
+            reject(
+              new MemoryServiceTransportError(
+                'Memory service response was aborted',
+              ),
+            );
+          });
+          response.on('error', reject);
+          response.on('data', (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > this.responseLimitBytes) {
+              request.destroy(
+                new Error('Memory service response is too large'),
+              );
+              return;
+            }
+            chunks.push(chunk);
+          });
+          response.on('end', () => {
+            const status = response.statusCode ?? 500;
+            if (status < 200 || status >= 300) {
+              reject(new MemoryServiceHttpError(status));
+              return;
+            }
+            try {
+              resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as T);
+            } catch {
+              reject(new Error('Memory service returned invalid JSON'));
+            }
+          });
+        },
+      );
+      request.on('error', reject);
+      request.setTimeout(Math.max(1, deadline - Date.now()), () => {
+        request.destroy(new Error('Memory service request timed out'));
+      });
+      request.end(input.body);
+    });
+  }
+}
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof MemoryServiceTransportError) {
+    return true;
+  }
+  if (error instanceof MemoryServiceHttpError) {
+    return error.status >= 500;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ECONNRESET' || code === 'EPIPE';
+}
+
+function requireHttps(value: string, name: string): void {
+  const url = new URL(value);
+  if (url.protocol !== 'https:') {
+    throw new Error(`${name} must use https`);
+  }
+}

--- a/integrations/enterprise-memory/src/agent/hook-handler.test.ts
+++ b/integrations/enterprise-memory/src/agent/hook-handler.test.ts
@@ -1,0 +1,282 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HookHandler, type RuntimeGatewayClient } from './hook-handler.js';
+import { AgentStateStore } from './state-store.js';
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+class RecordingGateway implements RuntimeGatewayClient {
+  readonly calls: {
+    path: string;
+    value?: unknown;
+    operationId: string;
+  }[] = [];
+  sessionContextResponse: unknown = {
+    policy_version: 5,
+    system_context: 'Signed organization policy',
+  };
+  turnOpenResponse: unknown = {
+    turn_id: 'ea09a5be-4e32-48cb-b76d-d513492d9c82',
+    memories: [{ id: '5f2d8477-fcb3-481b-a5aa-859c3d696bd1' }],
+    additional_context: '<enterprise_memory_reference_data />',
+  };
+
+  async post<T>(path: string, value: unknown, operationId: string): Promise<T> {
+    this.calls.push({ path, value, operationId });
+    if (path === '/v1/runtime/session-context') {
+      return this.sessionContextResponse as T;
+    }
+    if (path === '/v1/runtime/turns:open') {
+      return this.turnOpenResponse as T;
+    }
+    return { accepted: true } as T;
+  }
+
+  async get<T>(path: string, operationId: string): Promise<T> {
+    this.calls.push({ path, operationId });
+    return {} as T;
+  }
+}
+
+async function fixture(): Promise<{
+  gateway: RecordingGateway;
+  handler: HookHandler;
+  states: AgentStateStore;
+}> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'qwen-memory-hook-'));
+  directories.push(directory);
+  const gateway = new RecordingGateway();
+  const states = new AgentStateStore(directory);
+  return { gateway, states, handler: new HookHandler(gateway, states) };
+}
+
+const common = {
+  session_id: 'session-a',
+  timestamp: '2026-07-22T00:00:00.000Z',
+};
+
+describe('HookHandler', () => {
+  it('injects signed policy only through SessionStart output', async () => {
+    const { gateway, handler, states } = await fixture();
+
+    await expect(
+      handler.handle({
+        ...common,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        model: 'qwen3-coder',
+        permission_mode: 'default',
+      }),
+    ).resolves.toEqual({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: 'Signed organization policy',
+      },
+    });
+    expect(gateway.calls[0]?.path).toBe('/v1/runtime/session-context');
+    expect(
+      (await states.read(common.session_id)).pendingOperationId,
+    ).toBeUndefined();
+  });
+
+  it('supports branch session starts from Qwen Code', async () => {
+    const { handler } = await fixture();
+
+    await expect(
+      handler.handle({
+        ...common,
+        hook_event_name: 'SessionStart',
+        source: 'branch',
+        model: 'qwen3-coder',
+        permission_mode: 'default',
+      }),
+    ).resolves.toMatchObject({
+      hookSpecificOutput: {
+        additionalContext: 'Signed organization policy',
+      },
+    });
+  });
+
+  it('opens a turn, injects bounded reference context, and persists only metadata', async () => {
+    const { handler, states } = await fixture();
+
+    const output = await handler.handle({
+      ...common,
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'How should I build this repository?',
+    });
+
+    expect(output).toEqual({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: '<enterprise_memory_reference_data />',
+      },
+    });
+    const state = await states.read(common.session_id);
+    expect(state).toMatchObject({
+      turnId: 'ea09a5be-4e32-48cb-b76d-d513492d9c82',
+    });
+    expect(state.pendingOperationId).toBeUndefined();
+  });
+
+  it('rejects an invalid Gateway context response before persisting turn state', async () => {
+    const { gateway, handler, states } = await fixture();
+    gateway.turnOpenResponse = {
+      turn_id: 'not-a-uuid',
+      additional_context: 'x'.repeat(6_001),
+    };
+
+    await expect(
+      handler.handle({
+        ...common,
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'How should I build this repository?',
+      }),
+    ).rejects.toThrow();
+    expect((await states.read(common.session_id)).turnId).toBeUndefined();
+  });
+
+  it('sends allowlisted tool metadata without tool input or output', async () => {
+    const { gateway, handler, states } = await fixture();
+
+    await handler.handle({
+      ...common,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'read_file',
+      tool_use_id: 'tool-a',
+      tool_input: { path: '/secret' },
+      tool_response: 'sensitive file content',
+    });
+
+    const value = gateway.calls[0]?.value as {
+      payload: Record<string, unknown>;
+    };
+    expect(value.payload).toEqual({
+      tool_name: 'read_file',
+      tool_use_id: 'tool-a',
+      status: 'succeeded',
+      is_interrupt: false,
+    });
+    expect(JSON.stringify(value)).not.toContain('sensitive file content');
+    expect(JSON.stringify(value)).not.toContain('/secret');
+    expect(
+      (await states.read(common.session_id)).pendingOperationId,
+    ).toBeUndefined();
+  });
+
+  it('retries the same hook operation against its originally captured turn', async () => {
+    const { gateway, handler } = await fixture();
+    await handler.handle({
+      ...common,
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'First turn',
+    });
+    const toolEvent = {
+      ...common,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'read_file',
+      tool_use_id: 'tool-a',
+    };
+    await handler.handle(toolEvent);
+    gateway.turnOpenResponse = {
+      turn_id: '8d39189f-cb3d-4a18-bd43-52f7bf9014e9',
+      additional_context: '',
+    };
+    await handler.handle({
+      ...common,
+      timestamp: '2026-07-22T00:00:01.000Z',
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Second turn',
+    });
+    await handler.handle(toolEvent);
+
+    expect(gateway.calls[1]?.operationId).toBe(gateway.calls[3]?.operationId);
+    expect(gateway.calls[1]?.value).toEqual(gateway.calls[3]?.value);
+    expect(gateway.calls[3]?.value).toMatchObject({
+      turn_id: 'ea09a5be-4e32-48cb-b76d-d513492d9c82',
+    });
+  });
+
+  it('does not roll current state back when an old prompt retry arrives late', async () => {
+    const { gateway, handler, states } = await fixture();
+    const firstPrompt = {
+      ...common,
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'First turn',
+    };
+    await handler.handle(firstPrompt);
+    gateway.turnOpenResponse = {
+      turn_id: '8d39189f-cb3d-4a18-bd43-52f7bf9014e9',
+      additional_context: '',
+    };
+    await handler.handle({
+      ...common,
+      timestamp: '2026-07-22T00:00:01.000Z',
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Second turn',
+    });
+    gateway.turnOpenResponse = {
+      turn_id: 'ea09a5be-4e32-48cb-b76d-d513492d9c82',
+      additional_context: '',
+    };
+
+    await handler.handle(firstPrompt);
+
+    expect((await states.read(common.session_id)).turnId).toBe(
+      '8d39189f-cb3d-4a18-bd43-52f7bf9014e9',
+    );
+  });
+
+  it('reports Stop without requesting a blocking loop', async () => {
+    const { gateway, handler } = await fixture();
+
+    await expect(
+      handler.handle({
+        ...common,
+        hook_event_name: 'Stop',
+        last_assistant_message: 'Final response',
+      }),
+    ).resolves.toEqual({ continue: true });
+    expect(gateway.calls[0]?.value).toMatchObject({
+      event_kind: 'stop',
+      payload: { assistant: 'Final response' },
+    });
+  });
+
+  it('reports the stable StopFailure error class without error details', async () => {
+    const { gateway, handler } = await fixture();
+
+    await handler.handle({
+      ...common,
+      hook_event_name: 'StopFailure',
+      error: 'server_error',
+      error_details: 'Connection reset while handling secret-value',
+    });
+
+    expect(gateway.calls[0]?.value).toMatchObject({
+      event_kind: 'stop_failure',
+      payload: { error_class: 'server_error' },
+    });
+    expect(JSON.stringify(gateway.calls[0]?.value)).not.toContain(
+      'secret-value',
+    );
+  });
+});

--- a/integrations/enterprise-memory/src/agent/hook-handler.ts
+++ b/integrations/enterprise-memory/src/agent/hook-handler.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+import type { AgentStateStore } from './state-store.js';
+
+export interface RuntimeGatewayClient {
+  post<T>(path: string, value: unknown, operationId: string): Promise<T>;
+  get<T>(path: string, operationId: string): Promise<T>;
+}
+
+const commonSchema = z.object({
+  session_id: z.string().min(1).max(256),
+  hook_event_name: z.enum([
+    'SessionStart',
+    'UserPromptSubmit',
+    'PostToolUse',
+    'PostToolUseFailure',
+    'Stop',
+    'StopFailure',
+  ]),
+  timestamp: z.string().datetime(),
+});
+const sessionContextResponseSchema = z
+  .object({ system_context: z.string().max(4_000) })
+  .passthrough();
+const turnOpenResponseSchema = z
+  .object({
+    turn_id: z.string().uuid(),
+    additional_context: z.string().max(6_000),
+  })
+  .passthrough();
+
+export type HookOutput = Record<string, unknown> | null;
+
+export class HookHandler {
+  constructor(
+    private readonly gateway: RuntimeGatewayClient,
+    private readonly states: AgentStateStore,
+  ) {}
+
+  async handle(value: unknown): Promise<HookOutput> {
+    const common = commonSchema.passthrough().parse(value);
+    switch (common.hook_event_name) {
+      case 'SessionStart':
+        return this.sessionStart(common);
+      case 'UserPromptSubmit':
+        return this.userPromptSubmit(common);
+      case 'PostToolUse':
+        await this.toolEvent(common, false);
+        return null;
+      case 'PostToolUseFailure':
+        await this.toolEvent(common, true);
+        return null;
+      case 'Stop':
+        await this.stop(common);
+        return { continue: true };
+      case 'StopFailure':
+        await this.stopFailure(common);
+        return null;
+    }
+  }
+
+  private async sessionStart(
+    input: typeof commonSchema._output,
+  ): Promise<HookOutput> {
+    const event = commonSchema
+      .extend({
+        source: z.enum(['startup', 'resume', 'clear', 'compact', 'branch']),
+        model: z.string().min(1).max(256),
+        permission_mode: z.string().min(1).max(64),
+      })
+      .passthrough()
+      .parse(input);
+    const request = {
+      session_id: event.session_id,
+      source: event.source,
+      model: event.model,
+      permission_mode: event.permission_mode,
+    };
+    const operationId = await this.states.beginOperation(event.session_id, [
+      'hook-v1',
+      event.hook_event_name,
+      event.timestamp,
+      request,
+    ]);
+    const result = sessionContextResponseSchema.parse(
+      await this.gateway.post<unknown>(
+        '/v1/runtime/session-context',
+        request,
+        operationId,
+      ),
+    );
+    await this.states.completeOperation(event.session_id, operationId);
+    return {
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: result.system_context,
+      },
+    };
+  }
+
+  private async userPromptSubmit(
+    input: typeof commonSchema._output,
+  ): Promise<HookOutput> {
+    const event = commonSchema
+      .extend({ prompt: z.string().max(64_000) })
+      .passthrough()
+      .parse(input);
+    const request = {
+      session_id: event.session_id,
+      occurred_at: event.timestamp,
+      prompt: event.prompt,
+    };
+    const operation = await this.states.beginOperationWithState(
+      event.session_id,
+      ['hook-v1', event.hook_event_name, request],
+    );
+    const operationId = operation.operationId;
+    const result = turnOpenResponseSchema.parse(
+      await this.gateway.post<unknown>(
+        '/v1/runtime/turns:open',
+        { event_id: operationId, ...request },
+        operationId,
+      ),
+    );
+    await this.states.update(event.session_id, (state) => {
+      const canAdvanceTurn =
+        state.turnId === operation.turnId || state.turnId === result.turn_id;
+      return {
+        ...state,
+        turnId: canAdvanceTurn ? result.turn_id : state.turnId,
+        pendingOperationId:
+          state.pendingOperationId === operationId
+            ? undefined
+            : state.pendingOperationId,
+      };
+    });
+    return {
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: result.additional_context,
+      },
+    };
+  }
+
+  private async toolEvent(
+    input: typeof commonSchema._output,
+    failed: boolean,
+  ): Promise<void> {
+    const event = commonSchema
+      .extend({
+        tool_name: z.enum([
+          'read_file',
+          'grep_search',
+          'glob',
+          'list_directory',
+          'write_file',
+          'edit',
+          'notebook_edit',
+          'run_shell_command',
+        ]),
+        tool_use_id: z.string().min(1).max(256),
+        is_interrupt: z.boolean().optional(),
+      })
+      .passthrough()
+      .parse(input);
+    const eventKind = failed ? 'tool_failure' : 'tool_success';
+    const payload = {
+      tool_name: event.tool_name,
+      tool_use_id: event.tool_use_id,
+      status: failed ? 'failed' : 'succeeded',
+      is_interrupt: event.is_interrupt ?? false,
+    };
+    const { operationId, turnId } = await this.states.beginOperationWithState(
+      event.session_id,
+      ['hook-v1', event.hook_event_name, event.timestamp, eventKind, payload],
+    );
+    await this.gateway.post(
+      '/v1/runtime/turn-events',
+      {
+        event_id: operationId,
+        session_id: event.session_id,
+        turn_id: turnId,
+        event_kind: eventKind,
+        occurred_at: event.timestamp,
+        payload,
+      },
+      operationId,
+    );
+    await this.states.completeOperation(event.session_id, operationId);
+  }
+
+  private async stop(input: typeof commonSchema._output): Promise<void> {
+    const event = commonSchema
+      .extend({ last_assistant_message: z.string().max(64_000) })
+      .passthrough()
+      .parse(input);
+    const payload = { assistant: event.last_assistant_message };
+    const { operationId, turnId } = await this.states.beginOperationWithState(
+      event.session_id,
+      ['hook-v1', event.hook_event_name, event.timestamp, payload],
+    );
+    await this.gateway.post(
+      '/v1/runtime/turn-events',
+      {
+        event_id: operationId,
+        session_id: event.session_id,
+        turn_id: turnId,
+        event_kind: 'stop',
+        occurred_at: event.timestamp,
+        payload,
+      },
+      operationId,
+    );
+    await this.states.completeOperation(event.session_id, operationId);
+  }
+
+  private async stopFailure(input: typeof commonSchema._output): Promise<void> {
+    const event = commonSchema
+      .extend({
+        error: z.enum([
+          'rate_limit',
+          'authentication_failed',
+          'billing_error',
+          'invalid_request',
+          'server_error',
+          'max_output_tokens',
+          'unknown',
+        ]),
+      })
+      .passthrough()
+      .parse(input);
+    const payload = { error_class: event.error };
+    const { operationId, turnId } = await this.states.beginOperationWithState(
+      event.session_id,
+      ['hook-v1', event.hook_event_name, event.timestamp, payload],
+    );
+    await this.gateway.post(
+      '/v1/runtime/turn-events',
+      {
+        event_id: operationId,
+        session_id: event.session_id,
+        turn_id: turnId,
+        event_kind: 'stop_failure',
+        occurred_at: event.timestamp,
+        payload,
+      },
+      operationId,
+    );
+    await this.states.completeOperation(event.session_id, operationId);
+  }
+}

--- a/integrations/enterprise-memory/src/agent/main.ts
+++ b/integrations/enterprise-memory/src/agent/main.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GatewayClient } from './gateway-client.js';
+import { HookHandler } from './hook-handler.js';
+import { runMcpServer } from './mcp-server.js';
+import { AgentStateStore } from './state-store.js';
+
+const gateway = new GatewayClient({
+  brokerUrl: required('MEMORY_BROKER_URL'),
+  gatewayUrl: required('MEMORY_GATEWAY_URL'),
+  certificatePath: required('MEMORY_AGENT_TLS_CERT'),
+  privateKeyPath: required('MEMORY_AGENT_TLS_KEY'),
+  caPath: required('MEMORY_AGENT_TLS_CA'),
+});
+const states = new AgentStateStore(
+  required('MEMORY_AGENT_STATE_DIR'),
+  250,
+  operationSecret('MEMORY_AGENT_OPERATION_HMAC_SECRET'),
+);
+
+try {
+  if (process.argv[2] === 'mcp') {
+    await runMcpServer(gateway, states);
+  } else if (process.argv[2] === 'hook') {
+    const input = JSON.parse(await readStdin(256 * 1024)) as unknown;
+    const output = await new HookHandler(gateway, states).handle(input);
+    if (output) {
+      process.stdout.write(JSON.stringify(output));
+    }
+  } else {
+    process.exitCode = 1;
+  }
+} catch {
+  process.exitCode = 1;
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
+  return value;
+}
+
+function operationSecret(name: string): Uint8Array {
+  const encoded = required(name);
+  if (!/^[A-Za-z0-9_-]+$/.test(encoded)) {
+    throw new Error(`${name} must be unpadded base64url`);
+  }
+  const value = Buffer.from(encoded, 'base64url');
+  if (value.byteLength !== 32 || value.toString('base64url') !== encoded) {
+    throw new Error(`${name} must contain exactly 32 bytes`);
+  }
+  return value;
+}
+
+async function readStdin(limit: number): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of process.stdin) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > limit) {
+      throw new Error('Hook payload is too large');
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/integrations/enterprise-memory/src/agent/mcp-server.test.ts
+++ b/integrations/enterprise-memory/src/agent/mcp-server.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { handleMcpMessage, type McpGatewayClient } from './mcp-server.js';
+import { AgentStateStore } from './state-store.js';
+
+const directories: string[] = [];
+const PROPOSAL_OPERATION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const FEEDBACK_OPERATION_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const MEMORY_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+class RecordingGateway implements McpGatewayClient {
+  readonly calls: { path: string; value?: unknown; operationId: string }[] = [];
+  error?: Error;
+
+  async post<T>(path: string, value: unknown, operationId: string): Promise<T> {
+    if (this.error) {
+      throw this.error;
+    }
+    this.calls.push({ path, value, operationId });
+    return { accepted: true } as T;
+  }
+
+  async get<T>(path: string, operationId: string): Promise<T> {
+    this.calls.push({ path, operationId });
+    return { id: 'memory-a' } as T;
+  }
+}
+
+async function fixture(): Promise<{
+  gateway: RecordingGateway;
+  states: AgentStateStore;
+}> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'qwen-memory-mcp-'));
+  directories.push(directory);
+  return {
+    gateway: new RecordingGateway(),
+    states: new AgentStateStore(directory),
+  };
+}
+
+describe('handleMcpMessage', () => {
+  it('negotiates the protocol and advertises only bounded memory tools', async () => {
+    const { gateway, states } = await fixture();
+    const initialized = await handleMcpMessage(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-11-25' },
+      },
+      gateway,
+      states,
+    );
+    const listed = await handleMcpMessage(
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+      gateway,
+      states,
+    );
+
+    expect(initialized?.result).toMatchObject({
+      protocolVersion: '2025-11-25',
+      capabilities: { tools: { listChanged: false } },
+    });
+    expect(
+      (listed?.result as { tools: { name: string }[] }).tools.map(
+        (tool) => tool.name,
+      ),
+    ).toEqual([
+      'memory_search',
+      'memory_get',
+      'memory_propose_personal',
+      'memory_propose_repository',
+      'memory_feedback',
+    ]);
+  });
+
+  it('validates and forwards a candidate-only tool call', async () => {
+    const { gateway, states } = await fixture();
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: '2.0',
+        id: 'call-a',
+        method: 'tools/call',
+        params: {
+          name: 'memory_propose_repository',
+          arguments: {
+            operationId: PROPOSAL_OPERATION_ID,
+            summary: 'Use the release checklist',
+          },
+        },
+      },
+      gateway,
+      states,
+    );
+
+    expect(response?.error).toBeUndefined();
+    expect(gateway.calls[0]).toMatchObject({
+      path: '/v1/runtime/proposals',
+      value: {
+        scope: 'repository',
+        summary: 'Use the release checklist',
+        references: [],
+      },
+    });
+    expect(gateway.calls[0]?.operationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f-]{27}$/,
+    );
+  });
+
+  it('uses the caller operation ID across MCP reconnects', async () => {
+    const { gateway, states } = await fixture();
+    const request = (id: string) => ({
+      jsonrpc: '2.0' as const,
+      id,
+      method: 'tools/call',
+      params: {
+        name: 'memory_propose_repository',
+        arguments: {
+          operationId: PROPOSAL_OPERATION_ID,
+          summary: 'Use the release checklist',
+        },
+      },
+    });
+
+    await handleMcpMessage(request('call-a'), gateway, states, 'connection-a');
+    await handleMcpMessage(request('call-b'), gateway, states, 'connection-b');
+
+    expect(gateway.calls[0]?.operationId).toBe(gateway.calls[1]?.operationId);
+  });
+
+  it('does not reuse read operation IDs when JSON-RPC IDs restart', async () => {
+    const { gateway, states } = await fixture();
+    const request = {
+      jsonrpc: '2.0' as const,
+      id: 0,
+      method: 'tools/call',
+      params: { name: 'memory_search', arguments: { query: 'build' } },
+    };
+
+    await handleMcpMessage(request, gateway, states, 'connection-a');
+    await handleMcpMessage(request, gateway, states, 'connection-b');
+
+    expect(gateway.calls[0]?.operationId).not.toBe(
+      gateway.calls[1]?.operationId,
+    );
+  });
+
+  it('requires an explicit idempotency key for MCP writes', async () => {
+    const { gateway, states } = await fixture();
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: '2.0',
+        id: 'call-a',
+        method: 'tools/call',
+        params: {
+          name: 'memory_propose_repository',
+          arguments: { summary: 'Use the release checklist' },
+        },
+      },
+      gateway,
+      states,
+    );
+
+    expect(response?.error).toEqual({
+      code: -32602,
+      message: 'Invalid parameters',
+    });
+    expect(gateway.calls).toEqual([]);
+  });
+
+  it('keeps feedback retries stable without process-specific metadata', async () => {
+    const { gateway, states } = await fixture();
+    const request = (id: string) => ({
+      jsonrpc: '2.0' as const,
+      id,
+      method: 'tools/call',
+      params: {
+        name: 'memory_feedback',
+        arguments: {
+          operationId: FEEDBACK_OPERATION_ID,
+          memoryId: MEMORY_ID,
+          signal: 'helpful',
+        },
+      },
+    });
+
+    await handleMcpMessage(request('call-a'), gateway, states, 'connection-a');
+    await handleMcpMessage(request('call-b'), gateway, states, 'connection-b');
+
+    expect(gateway.calls[0]).toEqual(gateway.calls[1]);
+    expect(gateway.calls[0]?.value).toMatchObject({
+      event_id: gateway.calls[0]?.operationId,
+      session_id: 'mcp',
+      memory_id: MEMORY_ID,
+      signal: 'helpful',
+    });
+    expect(gateway.calls[0]?.value).not.toHaveProperty('operationId');
+  });
+
+  it('returns a stable tool error without dependency details', async () => {
+    const { gateway, states } = await fixture();
+    gateway.error = new Error('secret dependency response');
+    const response = await handleMcpMessage(
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'memory_search', arguments: { query: 'build' } },
+      },
+      gateway,
+      states,
+    );
+
+    expect(response?.result).toMatchObject({ isError: true });
+    expect(JSON.stringify(response)).not.toContain('secret dependency');
+  });
+});

--- a/integrations/enterprise-memory/src/agent/mcp-server.ts
+++ b/integrations/enterprise-memory/src/agent/mcp-server.ts
@@ -1,0 +1,380 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import type { AgentOperation, AgentStateStore } from './state-store.js';
+
+const LATEST_PROTOCOL_VERSION = '2025-11-25';
+const SUPPORTED_PROTOCOL_VERSIONS = new Set([
+  LATEST_PROTOCOL_VERSION,
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+  '2024-10-07',
+]);
+const MAX_MESSAGE_BYTES = 256 * 1024;
+
+const requestSchema = z
+  .object({
+    jsonrpc: z.literal('2.0'),
+    id: z
+      .union([z.string().min(1).max(256), z.number().int().safe()])
+      .optional(),
+    method: z.string().min(1).max(128),
+    params: z.unknown().optional(),
+  })
+  .passthrough();
+const initializeSchema = z
+  .object({ protocolVersion: z.string().min(1).max(64) })
+  .passthrough();
+const callToolSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    arguments: z.record(z.unknown()).default({}),
+  })
+  .strict();
+const searchSchema = z.object({ query: z.string().min(1).max(2_000) }).strict();
+const getSchema = z.object({ memoryId: z.string().uuid() }).strict();
+const proposalSchema = z
+  .object({
+    operationId: z.string().uuid(),
+    summary: z.string().min(1).max(1_000),
+    references: z.array(z.string().min(1).max(500)).max(10).default([]),
+  })
+  .strict();
+const feedbackSchema = z
+  .object({
+    operationId: z.string().uuid(),
+    memoryId: z.string().uuid(),
+    signal: z.enum(['helpful', 'not_helpful', 'stale', 'unsafe']),
+  })
+  .strict();
+
+export interface McpGatewayClient {
+  post<T>(path: string, value: unknown, operationId: string): Promise<T>;
+  get<T>(path: string, operationId: string): Promise<T>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const tools = [
+  {
+    name: 'memory_search',
+    description: 'Search authorized enterprise memory reference data.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string', minLength: 1, maxLength: 2_000 } },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'memory_get',
+    description: 'Get one authorized canonical memory by opaque ID.',
+    inputSchema: {
+      type: 'object',
+      properties: { memoryId: { type: 'string', format: 'uuid' } },
+      required: ['memoryId'],
+      additionalProperties: false,
+    },
+  },
+  ...(['personal', 'repository'] as const).map((scope) => ({
+    name: `memory_propose_${scope}`,
+    description: `Propose a ${scope} memory candidate for governed review. This never approves or activates it.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operationId: {
+          type: 'string',
+          format: 'uuid',
+          description:
+            'Caller-generated idempotency key. Reuse it only for an exact retry of this proposal.',
+        },
+        summary: { type: 'string', minLength: 1, maxLength: 1_000 },
+        references: {
+          type: 'array',
+          maxItems: 10,
+          items: { type: 'string', minLength: 1, maxLength: 500 },
+          default: [],
+        },
+      },
+      required: ['operationId', 'summary'],
+      additionalProperties: false,
+    },
+  })),
+  {
+    name: 'memory_feedback',
+    description:
+      'Submit advisory feedback for review; it cannot change memory authority or state.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operationId: {
+          type: 'string',
+          format: 'uuid',
+          description:
+            'Caller-generated idempotency key. Reuse it only for an exact retry of this feedback.',
+        },
+        memoryId: { type: 'string', format: 'uuid' },
+        signal: { enum: ['helpful', 'not_helpful', 'stale', 'unsafe'] },
+      },
+      required: ['operationId', 'memoryId', 'signal'],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+export async function runMcpServer(
+  gateway: McpGatewayClient,
+  states: AgentStateStore,
+): Promise<void> {
+  const connectionId = randomUUID();
+  let buffer = Buffer.alloc(0);
+  for await (const chunk of process.stdin) {
+    const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    buffer = Buffer.concat([buffer, value]);
+    let lineEnd = buffer.indexOf(0x0a);
+    while (lineEnd >= 0) {
+      const line = buffer.subarray(0, lineEnd);
+      buffer = buffer.subarray(lineEnd + 1);
+      if (line.byteLength > MAX_MESSAGE_BYTES) {
+        await writeResponse(errorResponse(null, -32600, 'Request too large'));
+      } else if (line.byteLength > 0) {
+        await processLine(line, gateway, states, connectionId);
+      }
+      lineEnd = buffer.indexOf(0x0a);
+    }
+    if (buffer.byteLength > MAX_MESSAGE_BYTES) {
+      await writeResponse(errorResponse(null, -32600, 'Request too large'));
+      buffer = Buffer.alloc(0);
+    }
+  }
+  if (buffer.byteLength > 0) {
+    await writeResponse(errorResponse(null, -32700, 'Invalid JSON'));
+  }
+}
+
+export async function handleMcpMessage(
+  value: unknown,
+  gateway: McpGatewayClient,
+  states: AgentStateStore,
+  connectionId = 'direct-test-connection',
+): Promise<JsonRpcResponse | null> {
+  const request = requestSchema.parse(value);
+  if (request.id === undefined) {
+    return null;
+  }
+  const id = request.id;
+  try {
+    if (request.method === 'initialize') {
+      const input = initializeSchema.parse(request.params);
+      return successResponse(id, {
+        protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.has(input.protocolVersion)
+          ? input.protocolVersion
+          : LATEST_PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: 'qwen-enterprise-memory', version: '0.1.0' },
+      });
+    }
+    if (request.method === 'ping') {
+      return successResponse(id, {});
+    }
+    if (request.method === 'tools/list') {
+      return successResponse(id, { tools });
+    }
+    if (request.method === 'tools/call') {
+      const input = callToolSchema.parse(request.params);
+      try {
+        return successResponse(
+          id,
+          await callTool(
+            connectionId,
+            id,
+            input.name,
+            input.arguments,
+            gateway,
+            states,
+          ),
+        );
+      } catch (error) {
+        if (error instanceof z.ZodError || error instanceof UnknownToolError) {
+          throw error;
+        }
+        return successResponse(id, {
+          content: [
+            { type: 'text', text: 'Enterprise memory is unavailable.' },
+          ],
+          isError: true,
+        });
+      }
+    }
+    return errorResponse(id, -32601, 'Method not found');
+  } catch (error) {
+    if (error instanceof z.ZodError || error instanceof UnknownToolError) {
+      return errorResponse(id, -32602, 'Invalid parameters');
+    }
+    return errorResponse(id, -32603, 'Internal error');
+  }
+}
+
+async function processLine(
+  line: Buffer,
+  gateway: McpGatewayClient,
+  states: AgentStateStore,
+  connectionId: string,
+): Promise<void> {
+  let value: unknown;
+  try {
+    value = JSON.parse(line.toString('utf8')) as unknown;
+  } catch {
+    await writeResponse(errorResponse(null, -32700, 'Invalid JSON'));
+    return;
+  }
+  try {
+    const response = await handleMcpMessage(
+      value,
+      gateway,
+      states,
+      connectionId,
+    );
+    if (response) {
+      await writeResponse(response);
+    }
+  } catch {
+    await writeResponse(errorResponse(null, -32600, 'Invalid request'));
+  }
+}
+
+async function callTool(
+  connectionId: string,
+  requestId: string | number,
+  name: string,
+  args: Record<string, unknown>,
+  gateway: McpGatewayClient,
+  states: AgentStateStore,
+): Promise<{ content: [{ type: 'text'; text: string }] }> {
+  if (name === 'memory_search') {
+    const input = searchSchema.parse(args);
+    return textResult(
+      await withOperation(
+        states,
+        ['read-v1', connectionId, requestId, name, input],
+        (operation) =>
+          gateway.post('/v1/runtime/search', input, operation.operationId),
+      ),
+    );
+  }
+  if (name === 'memory_get') {
+    const input = getSchema.parse(args);
+    return textResult(
+      await withOperation(
+        states,
+        ['read-v1', connectionId, requestId, name, input],
+        (operation) =>
+          gateway.get(
+            `/v1/runtime/memories/${encodeURIComponent(input.memoryId)}`,
+            operation.operationId,
+          ),
+      ),
+    );
+  }
+  if (
+    name === 'memory_propose_personal' ||
+    name === 'memory_propose_repository'
+  ) {
+    const input = proposalSchema.parse(args);
+    const { operationId, ...proposal } = input;
+    const scope =
+      name === 'memory_propose_personal' ? 'personal' : 'repository';
+    return textResult(
+      await withOperation(
+        states,
+        ['write-v1', name, operationId],
+        (operation) =>
+          gateway.post(
+            '/v1/runtime/proposals',
+            { scope, ...proposal },
+            operation.operationId,
+          ),
+      ),
+    );
+  }
+  if (name === 'memory_feedback') {
+    const input = feedbackSchema.parse(args);
+    const { operationId, ...feedback } = input;
+    return textResult(
+      await withOperation(
+        states,
+        ['write-v1', name, operationId],
+        (operation) =>
+          gateway.post(
+            '/v1/runtime/feedback',
+            {
+              event_id: operation.operationId,
+              session_id: 'mcp',
+              occurred_at: operation.occurredAt,
+              memory_id: feedback.memoryId,
+              signal: feedback.signal,
+            },
+            operation.operationId,
+          ),
+      ),
+    );
+  }
+  throw new UnknownToolError();
+}
+
+async function withOperation<T>(
+  states: AgentStateStore,
+  idempotencyInput: unknown,
+  operation: (agentOperation: AgentOperation) => Promise<T>,
+): Promise<T> {
+  const agentOperation = await states.beginOperationWithState('mcp', [
+    'mcp-v1',
+    idempotencyInput,
+  ]);
+  const result = await operation(agentOperation);
+  await states.completeOperation('mcp', agentOperation.operationId);
+  return result;
+}
+
+function textResult(value: unknown): {
+  content: [{ type: 'text'; text: string }];
+} {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value) ?? 'null' }],
+  };
+}
+
+function successResponse(
+  id: string | number,
+  result: unknown,
+): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function errorResponse(
+  id: string | number | null,
+  code: number,
+  message: string,
+): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+async function writeResponse(response: JsonRpcResponse): Promise<void> {
+  const value = `${JSON.stringify(response)}\n`;
+  if (!process.stdout.write(value)) {
+    await new Promise<void>((resolve) => process.stdout.once('drain', resolve));
+  }
+}
+
+class UnknownToolError extends Error {}

--- a/integrations/enterprise-memory/src/agent/state-store.test.ts
+++ b/integrations/enterprise-memory/src/agent/state-store.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AgentStateStore } from './state-store.js';
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    directories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function fixture(): Promise<{
+  directory: string;
+  store: AgentStateStore;
+}> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'qwen-memory-state-'));
+  directories.push(directory);
+  return { directory, store: new AgentStateStore(directory) };
+}
+
+function sessionPath(directory: string, sessionId: string): string {
+  const name = createHash('sha256').update(sessionId).digest('hex');
+  return path.join(directory, `${name}.json`);
+}
+
+describe('AgentStateStore', () => {
+  it('rejects unsafe lock wait windows', () => {
+    expect(() => new AgentStateStore('/tmp/unused-memory-state', 49)).toThrow(
+      'lock timeout is invalid',
+    );
+    expect(
+      () => new AgentStateStore('/tmp/unused-memory-state', 5_001),
+    ).toThrow('lock timeout is invalid');
+    expect(
+      () =>
+        new AgentStateStore('/tmp/unused-memory-state', 250, new Uint8Array()),
+    ).toThrow('operation key is invalid');
+  });
+
+  it('keeps operation IDs stable when local state is lost', async () => {
+    const key = randomBytes(32);
+    const first = await fixture();
+    const second = await fixture();
+    const input = ['proposal', { summary: 'Use the release checklist' }];
+
+    const firstId = await new AgentStateStore(
+      first.directory,
+      250,
+      key,
+    ).beginOperation('mcp', input);
+    const secondId = await new AgentStateStore(
+      second.directory,
+      250,
+      key,
+    ).beginOperation('mcp', input);
+
+    expect(secondId).toBe(firstId);
+    await expect(
+      stat(path.join(first.directory, '.operation-key')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('writes state files with restricted permissions', async () => {
+    const { directory, store } = await fixture();
+    const sessionId = 'session-a';
+
+    await store.beginOperation(sessionId, ['request-a']);
+
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    expect((await stat(sessionPath(directory, sessionId))).mode & 0o777).toBe(
+      0o600,
+    );
+    expect(
+      (await stat(path.join(directory, '.operation-key'))).mode & 0o777,
+    ).toBe(0o600);
+  });
+
+  it('serializes operation-key initialization across processes', async () => {
+    const { directory } = await fixture();
+    const first = new AgentStateStore(directory);
+    const second = new AgentStateStore(directory);
+
+    const [firstId, secondId] = await Promise.all([
+      first.beginOperation('session-a', ['same-request']),
+      second.beginOperation('session-a', ['same-request']),
+    ]);
+
+    expect(secondId).toBe(firstId);
+    expect((await stat(path.join(directory, '.operation-key'))).size).toBe(32);
+  });
+
+  it('recovers a stale lock left by an exited hook process', async () => {
+    const { directory, store } = await fixture();
+    const sessionId = 'session-a';
+    await store.read(sessionId);
+    const lockPath = `${sessionPath(directory, sessionId)}.lock`;
+    await mkdir(lockPath, { mode: 0o700 });
+    const stale = new Date(Date.now() - 30_000);
+    await utimes(lockPath, stale, stale);
+
+    await expect(
+      store.beginOperation(sessionId, ['request-a']),
+    ).resolves.toMatch(/^[0-9a-f-]{36}$/);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('retries operation-key initialization after transient lock contention', async () => {
+    const { directory } = await fixture();
+    const store = new AgentStateStore(directory, 50);
+    const lockPath = path.join(directory, '.operation-key.lock');
+    await mkdir(lockPath, { mode: 0o700 });
+
+    await expect(
+      store.beginOperation('session-a', ['request-a']),
+    ).rejects.toThrow('Timed out waiting for agent session lock');
+    await rm(lockPath, { recursive: true });
+
+    await expect(
+      store.beginOperation('session-a', ['request-a']),
+    ).resolves.toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('retries state-directory initialization after a transient failure', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'qwen-memory-state-root-'));
+    directories.push(root);
+    const directory = path.join(root, 'state');
+    await writeFile(directory, 'temporary obstruction');
+    const store = new AgentStateStore(directory, 250, randomBytes(32));
+
+    await expect(store.read('session-a')).rejects.toMatchObject({
+      code: 'EEXIST',
+    });
+    await rm(directory);
+    await mkdir(directory);
+
+    await expect(store.read('session-a')).resolves.toEqual({
+      sessionId: 'session-a',
+      recentOperations: [],
+    });
+  });
+
+  it('clears only the operation that is still pending', async () => {
+    const { store } = await fixture();
+    const first = await store.beginOperation('session-a', ['request-a']);
+    const second = await store.beginOperation('session-a', ['request-b']);
+
+    await store.completeOperation('session-a', first);
+    expect((await store.read('session-a')).pendingOperationId).toBe(second);
+    await store.completeOperation('session-a', second);
+    expect((await store.read('session-a')).pendingOperationId).toBeUndefined();
+  });
+
+  it('reuses operation metadata for an exact retry after completion', async () => {
+    const { directory, store } = await fixture();
+    const turnId = 'ea09a5be-4e32-48cb-b76d-d513492d9c82';
+    await store.update('session-a', (state) => ({ ...state, turnId }));
+    const first = await store.beginOperationWithState('session-a', [
+      'request-a',
+    ]);
+    await store.completeOperation('session-a', first.operationId);
+    await store.update('session-a', (state) => ({
+      ...state,
+      turnId: '8d39189f-cb3d-4a18-bd43-52f7bf9014e9',
+    }));
+
+    const retry = await new AgentStateStore(directory).beginOperationWithState(
+      'session-a',
+      ['request-a'],
+    );
+
+    expect(retry.operationId).toBe(first.operationId);
+    expect(retry.turnId).toBe(turnId);
+    expect(retry.occurredAt).toBe(first.occurredAt);
+  });
+
+  it('rejects malformed local state instead of forwarding it', async () => {
+    const { directory, store } = await fixture();
+    const sessionId = 'session-a';
+    await store.read(sessionId);
+    await writeFile(
+      sessionPath(directory, sessionId),
+      JSON.stringify({
+        sessionId,
+        turnId: 'not-a-uuid',
+      }),
+      { mode: 0o600 },
+    );
+
+    await expect(store.read(sessionId)).rejects.toThrow();
+  });
+});

--- a/integrations/enterprise-memory/src/agent/state-store.ts
+++ b/integrations/enterprise-memory/src/agent/state-store.ts
@@ -1,0 +1,275 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
+import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import lockfile from 'proper-lockfile';
+import { z } from 'zod';
+
+const agentSessionStateSchema = z
+  .object({
+    sessionId: z.string().min(1).max(256),
+    turnId: z.string().uuid().optional(),
+    pendingOperationId: z.string().uuid().optional(),
+    recentOperations: z
+      .array(
+        z
+          .object({
+            operationId: z.string().uuid(),
+            turnId: z.string().uuid().optional(),
+            occurredAt: z.string().datetime(),
+          })
+          .strict(),
+      )
+      .max(2_048)
+      .default([]),
+  })
+  .strict();
+
+interface RecentAgentOperation {
+  operationId: string;
+  turnId?: string;
+  occurredAt: string;
+}
+
+export interface AgentSessionState {
+  sessionId: string;
+  turnId?: string;
+  pendingOperationId?: string;
+  recentOperations?: RecentAgentOperation[];
+}
+
+export interface AgentOperation {
+  operationId: string;
+  turnId?: string;
+  occurredAt: string;
+}
+
+export class AgentStateStore {
+  private directoryReady?: Promise<void>;
+  private operationKey?: Promise<Buffer>;
+
+  constructor(
+    private readonly directory: string,
+    private readonly lockTimeoutMs = 250,
+    operationKey?: Uint8Array,
+  ) {
+    if (
+      !Number.isSafeInteger(lockTimeoutMs) ||
+      lockTimeoutMs < 50 ||
+      lockTimeoutMs > 5_000
+    ) {
+      throw new Error('Agent state lock timeout is invalid');
+    }
+    if (operationKey && operationKey.byteLength !== 32) {
+      throw new Error('Agent operation key is invalid');
+    }
+    if (operationKey) {
+      this.operationKey = Promise.resolve(Buffer.from(operationKey));
+    }
+  }
+
+  async read(sessionId: string): Promise<AgentSessionState> {
+    await this.ensureDirectory();
+    try {
+      const value = agentSessionStateSchema.parse(
+        JSON.parse(await readFile(this.statePath(sessionId), 'utf8')),
+      );
+      if (value.sessionId !== sessionId) {
+        throw new Error('Agent state session mismatch');
+      }
+      return value;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+      return { sessionId, recentOperations: [] };
+    }
+  }
+
+  async update(
+    sessionId: string,
+    mutate: (state: AgentSessionState) => AgentSessionState,
+  ): Promise<AgentSessionState> {
+    await this.ensureDirectory();
+    const release = await this.acquireLock(this.statePath(sessionId));
+    try {
+      const next = agentSessionStateSchema.parse(
+        mutate(await this.read(sessionId)),
+      );
+      const temporaryPath = `${this.statePath(sessionId)}.${randomUUID()}.tmp`;
+      await writeFile(temporaryPath, JSON.stringify(next), { mode: 0o600 });
+      await rename(temporaryPath, this.statePath(sessionId));
+      return next;
+    } finally {
+      await release();
+    }
+  }
+
+  async beginOperation(
+    sessionId: string,
+    idempotencyInput: unknown,
+  ): Promise<string> {
+    return (await this.beginOperationWithState(sessionId, idempotencyInput))
+      .operationId;
+  }
+
+  async beginOperationWithState(
+    sessionId: string,
+    idempotencyInput: unknown,
+  ): Promise<AgentOperation> {
+    const operationId = deterministicOperationId(
+      await this.getOperationKey(),
+      sessionId,
+      idempotencyInput,
+    );
+    let operation: RecentAgentOperation | undefined;
+    await this.update(sessionId, (current) => {
+      const recent = current.recentOperations ?? [];
+      operation = recent.find((item) => item.operationId === operationId);
+      if (!operation) {
+        operation = {
+          operationId,
+          turnId: current.turnId,
+          occurredAt: new Date().toISOString(),
+        };
+      }
+      return {
+        ...current,
+        pendingOperationId: operationId,
+        recentOperations: recent.some(
+          (item) => item.operationId === operationId,
+        )
+          ? recent
+          : [...recent, operation].slice(-2_048),
+      };
+    });
+    if (!operation) {
+      throw new Error('Agent operation metadata was not persisted');
+    }
+    return {
+      operationId,
+      turnId: operation.turnId,
+      occurredAt: operation.occurredAt,
+    };
+  }
+
+  async completeOperation(
+    sessionId: string,
+    operationId: string,
+  ): Promise<void> {
+    await this.update(sessionId, (state) => ({
+      ...state,
+      pendingOperationId:
+        state.pendingOperationId === operationId
+          ? undefined
+          : state.pendingOperationId,
+    }));
+  }
+
+  private async acquireLock(statePath: string): Promise<() => Promise<void>> {
+    const staleLockMs = Math.max(10_000, this.lockTimeoutMs * 5);
+    try {
+      return await lockfile.lock(statePath, {
+        realpath: false,
+        stale: staleLockMs,
+        update: Math.floor(staleLockMs / 2),
+        retries: {
+          retries: 1_000,
+          minTimeout: 10,
+          maxTimeout: 100,
+          factor: 1.2,
+          randomize: true,
+          maxRetryTime: this.lockTimeoutMs,
+        },
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ELOCKED') {
+        throw new Error('Timed out waiting for agent session lock');
+      }
+      throw error;
+    }
+  }
+
+  private async ensureDirectory(): Promise<void> {
+    if (!this.directoryReady) {
+      const pending = (async () => {
+        await mkdir(this.directory, { recursive: true, mode: 0o700 });
+        await chmod(this.directory, 0o700);
+      })();
+      this.directoryReady = pending;
+      void pending.catch(() => {
+        if (this.directoryReady === pending) {
+          this.directoryReady = undefined;
+        }
+      });
+    }
+    await this.directoryReady;
+  }
+
+  private async getOperationKey(): Promise<Buffer> {
+    await this.ensureDirectory();
+    if (!this.operationKey) {
+      const pending = (async () => {
+        const keyPath = path.join(this.directory, '.operation-key');
+        const release = await this.acquireLock(keyPath);
+        try {
+          try {
+            const existing = await readFile(keyPath);
+            if (existing.byteLength !== 32) {
+              throw new Error('Agent operation key is invalid');
+            }
+            await chmod(keyPath, 0o600);
+            return existing;
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+              throw error;
+            }
+          }
+          const generated = randomBytes(32);
+          await writeFile(keyPath, generated, { flag: 'wx', mode: 0o600 });
+          return generated;
+        } finally {
+          await release();
+        }
+      })();
+      this.operationKey = pending;
+      void pending.catch(() => {
+        if (this.operationKey === pending) {
+          this.operationKey = undefined;
+        }
+      });
+    }
+    return this.operationKey;
+  }
+
+  private statePath(sessionId: string): string {
+    const name = createHash('sha256').update(sessionId).digest('hex');
+    return path.join(this.directory, `${name}.json`);
+  }
+}
+
+function deterministicOperationId(
+  key: Uint8Array,
+  sessionId: string,
+  idempotencyInput: unknown,
+): string {
+  const bytes = createHmac('sha256', key)
+    .update(
+      JSON.stringify([
+        'enterprise-memory-agent-operation-v1',
+        sessionId,
+        idempotencyInput,
+      ]),
+    )
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const value = bytes.toString('hex');
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`;
+}

--- a/integrations/enterprise-memory/src/extension-contract.test.ts
+++ b/integrations/enterprise-memory/src/extension-contract.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+interface HookCommand {
+  type: string;
+  command: string;
+  timeout: number;
+  async?: boolean;
+}
+
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommand[];
+}
+
+describe('Qwen extension contract', () => {
+  it('uses only the reviewed deterministic hook surface', async () => {
+    const hooks = JSON.parse(
+      await readFile(new URL('../hooks/hooks.json', import.meta.url), 'utf8'),
+    ) as Record<string, HookGroup[]>;
+
+    expect(Object.keys(hooks).sort()).toEqual(
+      [
+        'PostToolUse',
+        'PostToolUseFailure',
+        'SessionStart',
+        'Stop',
+        'StopFailure',
+        'UserPromptSubmit',
+      ].sort(),
+    );
+    expect(hooks['PostToolBatch']).toBeUndefined();
+    expect(hooks['SessionEnd']).toBeUndefined();
+    for (const groups of Object.values(hooks)) {
+      for (const hook of groups.flatMap((group) => group.hooks)) {
+        expect(hook.type).toBe('command');
+        expect(hook.command).toMatch(/^qwen-memory-agent-launcher /);
+        expect(hook.command).toContain('${CLAUDE_PLUGIN_ROOT}');
+        expect(hook.command).not.toMatch(/token|secret|api.?key/i);
+        expect(hook.timeout).toBeGreaterThan(0);
+        expect(hook.timeout).toBeLessThanOrEqual(5_000);
+      }
+    }
+    expect(hooks['Stop']?.[0]?.hooks[0]?.async).not.toBe(true);
+    expect(hooks['PostToolUse']?.[0]?.hooks[0]?.async).toBe(true);
+    expect(hooks['PostToolUseFailure']?.[0]?.hooks[0]?.async).toBe(true);
+  });
+
+  it('exposes one bounded MCP server from the extension manifest', async () => {
+    const manifest = JSON.parse(
+      await readFile(
+        new URL('../qwen-extension.json', import.meta.url),
+        'utf8',
+      ),
+    ) as {
+      hooks: string;
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+
+    expect(manifest.hooks).toBe('hooks/hooks.json');
+    expect(Object.keys(manifest.mcpServers)).toEqual(['enterprise-memory']);
+    expect(manifest.mcpServers['enterprise-memory']).toEqual({
+      command: 'qwen-memory-agent-launcher',
+      args: ['node', '${extensionPath}${/}dist${/}agent${/}main.js', 'mcp'],
+      cwd: '${extensionPath}',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,11 +91,13 @@
       "dependencies": {
         "jose": "^6.1.3",
         "pg": "^8.16.3",
+        "proper-lockfile": "^4.1.2",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "@types/pg": "^8.15.5",
+        "@types/proper-lockfile": "^4.1.4",
         "typescript": "^5.4.5",
         "vitest": "^3.2.4"
       },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -49,7 +49,7 @@ const cliOnly = process.argv.includes('--cli-only');
 // 9. webui (shared UI components - used by vscode companion)
 // 10. web-shell (depends on webui and sdk)
 // 11. vscode-ide-companion (depends on webui)
-// 12. enterprise-memory (standalone integration package)
+// 12. enterprise-memory (standalone extension and services)
 const buildOrder = [
   'packages/core',
   'packages/web-templates',


### PR DESCRIPTION
## What this PR does

Stack position: 5/5. Parent: #7508.

This final stacked PR connects Qwen Code to the external enterprise Memory Gateway through a signed extension, bounded fail-open Hooks, and a deliberately small MCP surface for search, get, candidate proposal, and advisory feedback. It adds deterministic local retry state, caller-supplied durable write operation IDs, connection-unique read IDs, aborted-stream retry handling, the signed external launcher contract, extension manifests, and deployment guidance.

The cumulative stack keeps enterprise credentials outside Qwen and tool environments, keeps destructive and administrative operations out of MCP, and completes the provider-neutral implementation without changing Qwen Code Core.

## Why it's needed

The service layers require a safe Qwen integration boundary that captures lifecycle evidence without blocking coding requests and allows model-assisted recall without trusting model-provided identity or granting management authority. Hooks provide deterministic bounded capture, while MCP remains optional and advisory for writes.

## Reviewer Test Plan

### How to verify

- Run `npm test --workspace=@qwen-code/enterprise-memory`; all cumulative 17 test files and 141 tests should pass.
- Run `npm run build && npm run typecheck`; the full repository build and all workspace typechecks should pass.
- Confirm Hook timeouts, Gateway outages, local state failures, and circuit breaking do not block the Qwen request, while enterprise memory operations retain bounded retries.
- Confirm MCP writes require caller-supplied UUID operation IDs stable across reconnects, exact retries reuse the same operation fingerprint, and reads use connection-unique request identities.
- Confirm the launcher receives enterprise broker and signing configuration externally and passes only per-operation signed material to the Agent, without placing broker credentials in Qwen settings or tool-visible environments.
- Confirm the extension manifest exposes no delete, approve, activate, promote, policy, tenant-selector, principal-selector, or repository-selector MCP tools.

### Evidence (Before & After)

N/A — this is an extension, Hook, MCP, and service integration with no TUI changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1 arm64, Node.js 22.22.3, npm 10.9.8. Local validation did not include Docker, Podman, a real PostgreSQL server, or production identity and provider services.

## Risk & Scope

- Main risk or tradeoff: The integration intentionally continues Qwen without external memory when the Agent or Gateway cannot establish its security and consistency guarantees, so memory availability may be lower than the coding runtime.
- Not validated / out of scope: Real PostgreSQL RLS and pooled-session isolation plus production launcher, workload broker, key registry, anti-resurrection ledger, Mem0, SCM authorization, and reconciliation drills remain mandatory deployment gates. Native Qwen memory migration, review UI, and provider infrastructure are out of scope.
- Breaking changes / migration notes: No existing behavior or Core API changes. The signed extension is opt-in and existing native Qwen memory is not migrated automatically.

## Linked Issues

Closes #7449

<details>
<summary>中文说明</summary>

## 此 PR 的内容

堆栈位置：5/5。父 PR：#7508。

这个最终 stacked PR 通过签名扩展、有界失败开放 Hooks，以及仅包含搜索、读取、候选提议和咨询性反馈的刻意缩小 MCP 接口，把 Qwen Code 连接到外部企业 Memory Gateway。它增加确定性本地重试状态、调用者提供的持久写操作 ID、连接唯一的读请求 ID、中止流重试处理、签名外部启动器契约、扩展清单和部署指南。

累积堆栈使企业凭据始终位于 Qwen 和工具环境之外，不在 MCP 中提供破坏性或管理操作，并在不修改 Qwen Code Core 的情况下完成供应商中立实现。

## 为什么需要

服务层需要一个安全的 Qwen 集成边界，在不阻塞编码请求的情况下捕获生命周期证据，并允许模型辅助召回，同时不信任模型提供的身份，也不授予管理权限。Hooks 提供确定性有界捕获，MCP 写入则保持可选和咨询性质。

## 评审者测试计划

### 如何验证

- 运行 `npm test --workspace=@qwen-code/enterprise-memory`；累计 17 个测试文件和 141 项测试应全部通过。
- 运行 `npm run build && npm run typecheck`；全仓构建及所有 workspace 类型检查应通过。
- 确认 Hook 超时、Gateway 中断、本地状态失败和熔断不会阻塞 Qwen 请求，同时企业记忆操作保留有界重试。
- 确认 MCP 写入要求调用者提供跨重连稳定的 UUID 操作 ID，精确重试复用相同操作指纹，读取使用连接唯一的请求身份。
- 确认启动器从外部接收企业 broker 和签名配置，只向 Agent 传递逐操作签名材料，不把 broker 凭据放入 Qwen 设置或工具可见环境。
- 确认扩展清单不暴露删除、批准、激活、提升、策略、租户选择器、主体选择器或仓库选择器 MCP 工具。

### 证据（变更前后）

不适用——这是扩展、Hook、MCP 和服务集成，没有 TUI 变更。

### 测试平台

|   操作系统   | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS 26.4.1 arm64、Node.js 22.22.3、npm 10.9.8。本地验证不包含 Docker、Podman、真实 PostgreSQL 服务或生产身份与提供商服务。

## 风险与范围

- 主要风险或权衡：当 Agent 或 Gateway 无法建立安全与一致性保证时，该集成会有意让 Qwen 在没有外部记忆的情况下继续运行，因此记忆可用性可能低于编码运行时。
- 未验证或范围外：真实 PostgreSQL RLS 与连接池会话隔离，以及生产启动器、工作负载 broker、密钥注册表、防复活账本、Mem0、SCM 授权和对账演练仍是强制部署门禁。Qwen 原生记忆迁移、评审 UI 和提供商基础设施不在范围内。
- 破坏性变更或迁移说明：没有现有行为或 Core API 变更。签名扩展为可选启用，不会自动迁移现有 Qwen 原生记忆。

## 关联 Issue

关闭 #7449

</details>
