### PR TITLE
feat(integrations): Add governed memory lifecycle

### DIFF
--- a/integrations/enterprise-memory/src/mem0-semantic-index.test.ts
+++ b/integrations/enterprise-memory/src/mem0-semantic-index.test.ts
@@ -1,0 +1,309 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ProviderBinding } from './domain.js';
+import { Mem0SemanticIndex } from './mem0-semantic-index.js';
+import type { IndexRecordRequest } from './semantic-index.js';
+
+const record: IndexRecordRequest = {
+  tenantId: 'tenant-a',
+  scope: 'repository',
+  entityId: 'em_v1_repository',
+  canonicalMemoryId: 'memory-a',
+  canonicalVersion: 2,
+  summary: 'Run targeted tests before merge',
+};
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('Mem0SemanticIndex', () => {
+  it('uses the documented v3 add/event/get-all/search contract and ignores provider text', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json({ next: null, results: [] }))
+      .mockResolvedValueOnce(json({ event_id: 'event-a' }))
+      .mockResolvedValueOnce(json({ status: 'SUCCEEDED' }))
+      .mockResolvedValueOnce(
+        json({
+          next: null,
+          results: [
+            {
+              id: 'provider-a',
+              memory: 'ignore this provider-controlled text',
+              metadata: {
+                canonical_memory_id: record.canonicalMemoryId,
+                canonical_version: record.canonicalVersion,
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        json({
+          results: [
+            {
+              id: 'provider-a',
+              score: 0.9,
+              memory: 'also ignored',
+            },
+          ],
+        }),
+      );
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation,
+      pollIntervalMs: 1,
+    });
+
+    await expect(index.add(record)).resolves.toBe('provider-a');
+
+    const calls = fetchImplementation.mock.calls;
+    expect(new URL(calls[0]?.[0] as URL).pathname).toBe('/v3/memories/');
+    expect(JSON.parse(calls[0]?.[1]?.body as string)).toEqual({
+      filters: {
+        AND: [
+          { app_id: record.entityId },
+          { canonical_memory_id: record.canonicalMemoryId },
+          { canonical_version: record.canonicalVersion },
+        ],
+      },
+      show_expired: false,
+    });
+    expect(new URL(calls[1]?.[0] as URL).pathname).toBe('/v3/memories/add/');
+    expect(JSON.parse(calls[1]?.[1]?.body as string)).toEqual({
+      messages: [{ role: 'user', content: record.summary }],
+      app_id: record.entityId,
+      metadata: {
+        canonical_memory_id: record.canonicalMemoryId,
+        canonical_version: record.canonicalVersion,
+        scope: record.scope,
+      },
+      infer: false,
+    });
+    expect(new URL(calls[2]?.[0] as URL).pathname).toBe('/v1/event/event-a/');
+    expect(JSON.parse(calls[4]?.[1]?.body as string)).toEqual({
+      query: record.summary,
+      filters: {
+        AND: [
+          { app_id: record.entityId },
+          { canonical_memory_id: record.canonicalMemoryId },
+          { canonical_version: record.canonicalVersion },
+        ],
+      },
+      top_k: 1,
+      threshold: 0,
+      rerank: false,
+      show_expired: false,
+    });
+  });
+
+  it('reconciles an unknown prior add before writing a duplicate', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        json({
+          next: null,
+          results: [
+            {
+              id: 'provider-existing',
+              metadata: {
+                canonical_memory_id: record.canonicalMemoryId,
+                canonical_version: record.canonicalVersion,
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        json({ results: [{ id: 'provider-existing', score: 1 }] }),
+      );
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation,
+    });
+
+    await expect(index.add(record)).resolves.toBe('provider-existing');
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when exact metadata filtering is not honored', async () => {
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation: vi.fn<typeof fetch>().mockResolvedValue(
+        json({
+          next: null,
+          results: [{ id: 'unrelated', metadata: {} }],
+        }),
+      ),
+    });
+
+    await expect(index.add(record)).rejects.toThrow('was not unique');
+  });
+
+  it('fails closed when exact metadata filtering returns duplicates', async () => {
+    const duplicate = {
+      metadata: {
+        canonical_memory_id: record.canonicalMemoryId,
+        canonical_version: record.canonicalVersion,
+      },
+    };
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation: vi.fn<typeof fetch>().mockResolvedValue(
+        json({
+          next: '/v3/memories/?page=2',
+          results: [
+            { id: 'provider-a', ...duplicate },
+            { id: 'provider-b', ...duplicate },
+          ],
+        }),
+      ),
+    });
+
+    await expect(index.add(record)).rejects.toThrow('was not unique');
+  });
+
+  it('fails closed when exact lookup omits its pagination marker', async () => {
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(json({ results: [] })),
+    });
+
+    await expect(index.add(record)).rejects.toThrow('was not unique');
+  });
+
+  it('rejects provider results above the requested bound', async () => {
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation: vi.fn<typeof fetch>().mockResolvedValue(
+        json({
+          results: [
+            { id: 'provider-a', score: 1 },
+            { id: 'provider-b', score: 0.9 },
+          ],
+        }),
+      ),
+    });
+
+    await expect(
+      index.search({
+        tenantId: record.tenantId,
+        scope: record.scope,
+        entityId: record.entityId,
+        query: record.summary,
+        limit: 1,
+        threshold: 0,
+      }),
+    ).rejects.toThrow('result limit');
+  });
+
+  it.each([-0.1, 1.1, Number.NaN])(
+    'rejects an out-of-contract provider score: %s',
+    async (score) => {
+      const index = new Mem0SemanticIndex({
+        apiKey: 'test-key',
+        fetchImplementation: vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(json({ results: [{ id: 'provider-a', score }] })),
+      });
+
+      await expect(
+        index.search({
+          tenantId: record.tenantId,
+          scope: record.scope,
+          entityId: record.entityId,
+          query: record.summary,
+          limit: 1,
+          threshold: 0,
+        }),
+      ).rejects.toThrow('invalid score');
+    },
+  );
+
+  it('enforces the configured score threshold locally', async () => {
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation: vi.fn<typeof fetch>().mockResolvedValue(
+        json({
+          results: [
+            { id: 'below-threshold', score: 0.4 },
+            { id: 'at-threshold', score: 0.5 },
+          ],
+        }),
+      ),
+    });
+
+    await expect(
+      index.search({
+        tenantId: record.tenantId,
+        scope: record.scope,
+        entityId: record.entityId,
+        query: record.summary,
+        limit: 2,
+        threshold: 0.5,
+      }),
+    ).resolves.toEqual([{ providerMemoryId: 'at-threshold', score: 0.5 }]);
+  });
+
+  it('deletes by opaque provider ID and verifies exact absence', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(json({ next: null, results: [] }));
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation,
+    });
+    const binding: ProviderBinding = {
+      tenantId: record.tenantId,
+      canonicalMemoryId: record.canonicalMemoryId,
+      canonicalVersion: record.canonicalVersion,
+      providerMemoryId: 'provider-a',
+      scope: record.scope,
+      entityId: record.entityId,
+      state: 'pending_delete',
+    };
+
+    await index.delete(binding);
+
+    const first = fetchImplementation.mock.calls[0];
+    expect(new URL(first?.[0] as URL).pathname).toBe(
+      '/v1/memories/provider-a/',
+    );
+    expect(first?.[1]?.method).toBe('DELETE');
+  });
+
+  it('treats an already absent provider record as a successful retry', async () => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(json({ next: null, results: [] }));
+    const index = new Mem0SemanticIndex({
+      apiKey: 'test-key',
+      fetchImplementation,
+    });
+
+    await expect(
+      index.delete({
+        tenantId: record.tenantId,
+        canonicalMemoryId: record.canonicalMemoryId,
+        canonicalVersion: record.canonicalVersion,
+        providerMemoryId: 'provider-absent',
+        scope: record.scope,
+        entityId: record.entityId,
+        state: 'pending_delete',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/integrations/enterprise-memory/src/mem0-semantic-index.ts
+++ b/integrations/enterprise-memory/src/mem0-semantic-index.ts
@@ -1,0 +1,317 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProviderBinding, ProviderSearchResult } from './domain.js';
+import type {
+  IndexRecordRequest,
+  SearchIndexRequest,
+  SemanticIndex,
+} from './semantic-index.js';
+import { readBoundedJson } from './http-json.js';
+
+interface Mem0Memory {
+  id: string;
+  metadata?: Record<string, unknown>;
+  score?: number;
+}
+
+interface Mem0Page {
+  next: string | null;
+  results: Mem0Memory[];
+}
+
+export interface Mem0SemanticIndexOptions {
+  apiKey: string;
+  baseUrl?: string;
+  pollIntervalMs?: number;
+  operationTimeoutMs?: number;
+  fetchImplementation?: typeof fetch;
+}
+
+export class Mem0SemanticIndex implements SemanticIndex {
+  private readonly baseUrl: string;
+  private readonly pollIntervalMs: number;
+  private readonly operationTimeoutMs: number;
+  private readonly fetchImplementation: typeof fetch;
+
+  constructor(private readonly options: Mem0SemanticIndexOptions) {
+    this.baseUrl = options.baseUrl ?? 'https://api.mem0.ai';
+    if (new URL(this.baseUrl).protocol !== 'https:') {
+      throw new Error('Mem0 base URL must use https');
+    }
+    this.pollIntervalMs = options.pollIntervalMs ?? 250;
+    this.operationTimeoutMs = options.operationTimeoutMs ?? 30_000;
+    if (
+      options.apiKey.length === 0 ||
+      !Number.isSafeInteger(this.pollIntervalMs) ||
+      this.pollIntervalMs <= 0 ||
+      !Number.isSafeInteger(this.operationTimeoutMs) ||
+      this.operationTimeoutMs <= 0
+    ) {
+      throw new Error('Mem0 adapter configuration is invalid');
+    }
+    this.fetchImplementation = options.fetchImplementation ?? fetch;
+  }
+
+  async add(request: IndexRecordRequest): Promise<string> {
+    const existing = await this.findExact(request);
+    if (existing) {
+      await this.ensureDiscoverable(request, existing.id);
+      return existing.id;
+    }
+    const response = await this.request<{ event_id: string }>(
+      '/v3/memories/add/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          messages: [{ role: 'user', content: request.summary }],
+          ...entityField(request.scope, request.entityId),
+          metadata: {
+            canonical_memory_id: request.canonicalMemoryId,
+            canonical_version: request.canonicalVersion,
+            scope: request.scope,
+          },
+          infer: false,
+        }),
+      },
+    );
+    if (
+      typeof response.event_id !== 'string' ||
+      response.event_id.length === 0 ||
+      response.event_id.length > 512
+    ) {
+      throw new Error('Mem0 add response has no event ID');
+    }
+    await this.waitForEvent(response.event_id);
+    const indexed = await this.findExact(request);
+    if (!indexed) {
+      throw new Error('Mem0 add succeeded without exact indexed record');
+    }
+    await this.ensureDiscoverable(request, indexed.id);
+    return indexed.id;
+  }
+
+  private async ensureDiscoverable(
+    request: IndexRecordRequest,
+    providerMemoryId: string,
+  ): Promise<void> {
+    const response = await this.request<{ results: Mem0Memory[] }>(
+      '/v3/memories/search/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          query: request.summary,
+          filters: exactFilter(request),
+          top_k: 1,
+          threshold: 0,
+          rerank: false,
+          show_expired: false,
+        }),
+      },
+    );
+    if (
+      !Array.isArray(response.results) ||
+      response.results.length > 1 ||
+      response.results[0]?.id !== providerMemoryId ||
+      typeof response.results[0].score !== 'number' ||
+      !Number.isFinite(response.results[0].score) ||
+      response.results[0].score < 0 ||
+      response.results[0].score > 1
+    ) {
+      throw new Error('Mem0 record is not discoverable after successful add');
+    }
+  }
+
+  async search(
+    request: SearchIndexRequest,
+  ): Promise<readonly ProviderSearchResult[]> {
+    const response = await this.request<{ results: Mem0Memory[] }>(
+      '/v3/memories/search/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          query: request.query,
+          filters: entityFilter(request.scope, request.entityId),
+          top_k: request.limit,
+          threshold: request.threshold,
+          rerank: false,
+          show_expired: false,
+        }),
+      },
+    );
+    if (!Array.isArray(response.results)) {
+      throw new Error('Mem0 search response has no results');
+    }
+    if (response.results.length > request.limit) {
+      throw new Error('Mem0 search exceeded the requested result limit');
+    }
+    return response.results
+      .map((item) => {
+        if (
+          typeof item.id !== 'string' ||
+          item.id.length === 0 ||
+          item.id.length > 512
+        ) {
+          throw new Error('Mem0 search returned an invalid memory ID');
+        }
+        if (
+          typeof item.score !== 'number' ||
+          !Number.isFinite(item.score) ||
+          item.score < 0 ||
+          item.score > 1
+        ) {
+          throw new Error('Mem0 search returned an invalid score');
+        }
+        return { providerMemoryId: item.id, score: item.score };
+      })
+      .filter((item) => item.score >= request.threshold);
+  }
+
+  async delete(binding: ProviderBinding): Promise<void> {
+    await this.request(
+      `/v1/memories/${encodeURIComponent(binding.providerMemoryId)}/`,
+      { method: 'DELETE' },
+      [404],
+    );
+    const exact = await this.findExact({
+      tenantId: binding.tenantId,
+      scope: binding.scope,
+      entityId: binding.entityId,
+      canonicalMemoryId: binding.canonicalMemoryId,
+      canonicalVersion: binding.canonicalVersion,
+      summary: '',
+    });
+    if (exact) {
+      throw new Error('Mem0 deletion did not remove exact provider binding');
+    }
+  }
+
+  private async waitForEvent(eventId: string): Promise<void> {
+    const deadline = Date.now() + this.operationTimeoutMs;
+    while (Date.now() < deadline) {
+      const event = await this.request<Record<string, unknown>>(
+        `/v1/event/${encodeURIComponent(eventId)}/`,
+        { method: 'GET' },
+      );
+      const status = readEventStatus(event);
+      if (status === 'SUCCEEDED') {
+        return;
+      }
+      if (status === 'FAILED') {
+        throw new Error('Mem0 asynchronous add failed');
+      }
+      await new Promise((resolve) => setTimeout(resolve, this.pollIntervalMs));
+    }
+    throw new Error('Mem0 asynchronous add timed out');
+  }
+
+  private async findExact(
+    request: IndexRecordRequest,
+  ): Promise<Mem0Memory | null> {
+    const response = await this.request<Mem0Page>(
+      '/v3/memories/?page=1&page_size=200',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          filters: exactFilter(request),
+          show_expired: false,
+        }),
+      },
+    );
+    if (!Array.isArray(response.results)) {
+      throw new Error('Mem0 exact lookup has no results');
+    }
+    const matches = response.results.filter(
+      (item) =>
+        typeof item.id === 'string' &&
+        item.id.length > 0 &&
+        item.id.length <= 512 &&
+        item.metadata?.['canonical_memory_id'] === request.canonicalMemoryId &&
+        item.metadata?.['canonical_version'] === request.canonicalVersion,
+    );
+    if (
+      matches.length !== response.results.length ||
+      matches.length > 1 ||
+      response.next !== null
+    ) {
+      throw new Error('Mem0 exact lookup was not unique');
+    }
+    return matches[0] ?? null;
+  }
+
+  private async request<T = unknown>(
+    path: string,
+    init: RequestInit,
+    acceptedStatuses: readonly number[] = [],
+  ): Promise<T> {
+    const response = await this.fetchImplementation(
+      new URL(path, this.baseUrl),
+      {
+        ...init,
+        headers: {
+          accept: 'application/json',
+          authorization: `Token ${this.options.apiKey}`,
+          ...(init.body ? { 'content-type': 'application/json' } : {}),
+        },
+        redirect: 'error',
+        signal: init.signal ?? AbortSignal.timeout(this.operationTimeoutMs),
+      },
+    );
+    if (!response.ok && !acceptedStatuses.includes(response.status)) {
+      throw new Error(`Mem0 request failed with ${response.status}`);
+    }
+    if (response.status === 204 || acceptedStatuses.includes(response.status)) {
+      return undefined as T;
+    }
+    return readBoundedJson<T>(response, 2 * 1024 * 1024);
+  }
+}
+
+function entityField(
+  scope: IndexRecordRequest['scope'],
+  entityId: string,
+): { user_id: string } | { app_id: string } {
+  return scope === 'personal' ? { user_id: entityId } : { app_id: entityId };
+}
+
+function entityFilter(
+  scope: IndexRecordRequest['scope'],
+  entityId: string,
+): { user_id: string } | { app_id: string } {
+  return entityField(scope, entityId);
+}
+
+function exactFilter(request: IndexRecordRequest): {
+  AND: readonly Record<string, string | number>[];
+} {
+  return {
+    AND: [
+      entityFilter(request.scope, request.entityId),
+      { canonical_memory_id: request.canonicalMemoryId },
+      { canonical_version: request.canonicalVersion },
+    ],
+  };
+}
+
+function readEventStatus(
+  event: Record<string, unknown>,
+): 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' {
+  const metadata =
+    typeof event['metadata'] === 'object' && event['metadata'] !== null
+      ? (event['metadata'] as Record<string, unknown>)
+      : undefined;
+  const value =
+    event['status'] ?? event['event_status'] ?? metadata?.['status'];
+  if (
+    value === 'PENDING' ||
+    value === 'RUNNING' ||
+    value === 'SUCCEEDED' ||
+    value === 'FAILED'
+  ) {
+    return value;
+  }
+  throw new Error('Mem0 event response has no recognized status');
+}

--- a/integrations/enterprise-memory/src/memory-service.test.ts
+++ b/integrations/enterprise-memory/src/memory-service.test.ts
@@ -1,0 +1,1470 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomBytes, randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryAntiResurrectionLedger,
+  LedgerKeyFactory,
+  type RawEventReceipt,
+} from './anti-resurrection-ledger.js';
+import {
+  InMemoryCanonicalStore,
+  type StoreContext,
+} from './canonical-store.js';
+import { InMemoryContentProtector } from './content-protector.js';
+import type {
+  CanonicalMemoryRecord,
+  DeletionReason,
+  MemoryScope,
+  ProviderBinding,
+  ProviderSearchResult,
+  RawEventInput,
+  RuntimeIdentity,
+} from './domain.js';
+import {
+  MemoryService,
+  type ManagementIdentity,
+  StaticPolicyResolver,
+  StaticPrivacyModeResolver,
+} from './memory-service.js';
+import {
+  EntityIdMapper,
+  FakeSemanticIndex,
+  type SemanticIndex,
+} from './semantic-index.js';
+
+const now = new Date('2026-07-22T00:00:00.000Z');
+
+function identity(
+  tenantId = 'tenant-a',
+  principalId = 'principal-a',
+  repositoryId = 'repository-a',
+): RuntimeIdentity {
+  return {
+    tenantId,
+    principalId,
+    workspaceId: `workspace-${tenantId}-${principalId}-${repositoryId}`,
+    repositoryId,
+    revocationEpoch: 0,
+  };
+}
+
+function manager(
+  runtime: RuntimeIdentity,
+  authority: ManagementIdentity['authority'],
+): ManagementIdentity {
+  const context = {
+    tenantId: runtime.tenantId,
+    principalId: runtime.principalId,
+    repositoryId: runtime.repositoryId,
+  };
+  return authority === 'repository_maintainer'
+    ? {
+        ...context,
+        authority,
+        authorizationExpiresAt: new Date(now.getTime() + 60_000),
+      }
+    : { ...context, authority };
+}
+
+function fixture(
+  store = new InMemoryCanonicalStore(),
+  index: SemanticIndex = new FakeSemanticIndex(),
+  ledger = new InMemoryAntiResurrectionLedger(
+    new LedgerKeyFactory(randomBytes(32)),
+  ),
+  rawCaptureEnabled = false,
+) {
+  const privacy = new StaticPrivacyModeResolver();
+  const protector = new InMemoryContentProtector();
+  const service = new MemoryService(
+    store,
+    ledger,
+    protector,
+    index,
+    new EntityIdMapper(randomBytes(32), 'v1'),
+    privacy,
+    new StaticPolicyResolver(),
+    {
+      idempotencySecret: randomBytes(32),
+      now: () => now,
+      searchThreshold: 0,
+      rawCaptureEnabled,
+    },
+  );
+  return { service, store, index, privacy, ledger, protector };
+}
+
+describe('MemoryService', () => {
+  it.each([
+    { idempotencySecret: new Uint8Array() },
+    { rawRetentionMs: Number.NaN },
+    { personalRetentionMs: Number.POSITIVE_INFINITY },
+    { personalRetentionMs: 365 * 24 * 60 * 60 * 1000 + 1 },
+    { searchLimit: 7 },
+    { searchThreshold: -0.1 },
+    { maxEventClockSkewMs: 0.5 },
+    { maxEventClockSkewMs: 5 * 60 * 1000 + 1 },
+  ])('rejects unsafe service configuration: %o', (override) => {
+    expect(
+      () =>
+        new MemoryService(
+          new InMemoryCanonicalStore(),
+          new InMemoryAntiResurrectionLedger(
+            new LedgerKeyFactory(randomBytes(32)),
+          ),
+          new InMemoryContentProtector(),
+          new FakeSemanticIndex(),
+          new EntityIdMapper(randomBytes(32), 'v1'),
+          new StaticPrivacyModeResolver(),
+          new StaticPolicyResolver(),
+          { idempotencySecret: randomBytes(32), ...override },
+        ),
+    ).toThrow('configuration is invalid');
+  });
+
+  it('rejects organization policy context above the injection budget', async () => {
+    const runtime = identity();
+    const service = new MemoryService(
+      new InMemoryCanonicalStore(),
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      new InMemoryContentProtector(),
+      new FakeSemanticIndex(),
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      new StaticPrivacyModeResolver(),
+      new StaticPolicyResolver({
+        version: 1,
+        expiresAt: new Date(now.getTime() + 60_000),
+        systemContext: 'x'.repeat(4_001),
+      }),
+      { idempotencySecret: randomBytes(32), now: () => now },
+    );
+
+    await expect(service.getSessionContext(runtime)).rejects.toThrow(
+      'Policy snapshot is invalid',
+    );
+  });
+
+  it('defaults personal memory to off and requires explicit read-write consent to capture', async () => {
+    const runtime = identity();
+    const { service, privacy } = fixture();
+
+    await expect(
+      service.propose(
+        runtime,
+        { scope: 'personal', summary: 'Use pnpm', references: [] },
+        randomUUID(),
+      ),
+    ).rejects.toThrow('disabled');
+
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Use pnpm', references: [] },
+      randomUUID(),
+    );
+    expect(candidate.lifecycleState).toBe('candidate');
+  });
+
+  it('keeps a candidate key when the database commit result is uncertain', async () => {
+    const runtime = identity();
+    const store = new AmbiguousCandidateCommitStore();
+    const { service, protector } = fixture(store);
+
+    await expect(
+      service.propose(
+        runtime,
+        {
+          scope: 'repository',
+          summary: 'Preserve ambiguous data',
+          references: [],
+        },
+        randomUUID(),
+      ),
+    ).rejects.toThrow('ambiguous commit');
+
+    await expect(
+      protector.reveal(runtime.tenantId, store.committed.protectedContent),
+    ).resolves.toContain('Preserve ambiguous data');
+  });
+
+  it('applies current personal consent to approval, search, and exact reads', async () => {
+    const runtime = identity();
+    const { service, privacy } = fixture();
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Prefer concise output', references: [] },
+      randomUUID(),
+    );
+    const subject = manager(runtime, 'data_subject');
+    privacy.set(runtime.tenantId, runtime.principalId, 'off');
+    await expect(
+      service.approveCandidate(subject, candidate.id, candidate.version),
+    ).rejects.toThrow('disabled');
+
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const active = await service.approveCandidate(
+      subject,
+      candidate.id,
+      candidate.version,
+    );
+    await expect(service.get(runtime, active.id)).resolves.toMatchObject({
+      id: active.id,
+    });
+
+    privacy.set(runtime.tenantId, runtime.principalId, 'off');
+    await expect(service.get(runtime, active.id)).resolves.toBeNull();
+    expect((await service.search(runtime, 'concise output')).memories).toEqual(
+      [],
+    );
+  });
+
+  it('does not activate personal memory when consent changes during indexing', async () => {
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const privacy = new StaticPrivacyModeResolver();
+    const index = new DelayedAddIndex(() => {
+      privacy.set(runtime.tenantId, runtime.principalId, 'off');
+    });
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      new InMemoryContentProtector(),
+      index,
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      privacy,
+      new StaticPolicyResolver(),
+      { idempotencySecret: randomBytes(32), now: () => now },
+    );
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Prefer concise output', references: [] },
+      randomUUID(),
+    );
+
+    await expect(
+      service.approveCandidate(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('disabled');
+    await expect(service.get(runtime, candidate.id)).resolves.toBeNull();
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+        'personal',
+        'user_request',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not activate an expired personal candidate', async () => {
+    let current = now;
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const privacy = new StaticPrivacyModeResolver();
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      new InMemoryContentProtector(),
+      new FakeSemanticIndex(),
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      privacy,
+      new StaticPolicyResolver(),
+      {
+        idempotencySecret: randomBytes(32),
+        personalRetentionMs: 1,
+        now: () => current,
+      },
+    );
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Use concise output', references: [] },
+      randomUUID(),
+    );
+    current = new Date(now.getTime() + 2);
+
+    await expect(
+      service.approveCandidate(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('version conflict');
+  });
+
+  it('does not activate a candidate that expires during indexing', async () => {
+    let current = now;
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const privacy = new StaticPrivacyModeResolver();
+    const index = new DelayedAddIndex(() => {
+      current = new Date(now.getTime() + 2);
+    });
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      new InMemoryContentProtector(),
+      index,
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      privacy,
+      new StaticPolicyResolver(),
+      {
+        idempotencySecret: randomBytes(32),
+        personalRetentionMs: 1,
+        now: () => current,
+      },
+    );
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Prefer concise output', references: [] },
+      randomUUID(),
+    );
+
+    await expect(
+      service.approveCandidate(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('version conflict');
+    await expect(service.get(runtime, candidate.id)).resolves.toBeNull();
+  });
+
+  it('does not activate a repository candidate after the SCM lease expires', async () => {
+    let current = now;
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const index = new DelayedAddIndex(() => {
+      current = new Date(now.getTime() + 61_000);
+    });
+    const privacy = new StaticPrivacyModeResolver();
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      new InMemoryContentProtector(),
+      index,
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      privacy,
+      new StaticPolicyResolver(),
+      { idempotencySecret: randomBytes(32), now: () => current },
+    );
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Run governed checks', references: [] },
+      randomUUID(),
+    );
+
+    await expect(
+      service.approveCandidate(
+        {
+          tenantId: runtime.tenantId,
+          principalId: runtime.principalId,
+          repositoryId: runtime.repositoryId,
+          authority: 'repository_maintainer',
+          authorizationExpiresAt: new Date(now.getTime() + 60_000),
+        },
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('authority');
+    await expect(service.get(runtime, candidate.id)).resolves.toBeNull();
+  });
+
+  it('does not review or approve a version with a durable deletion intent', async () => {
+    const runtime = identity();
+    const { service, ledger } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Use the governed release process',
+        references: [],
+      },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    await ledger.beginDeletion(
+      runtime.tenantId,
+      candidate.id,
+      candidate.version,
+      'repository',
+      'candidate_rejected',
+      now,
+    );
+
+    await expect(
+      service.getCandidateForReview(maintainer, candidate.id),
+    ).resolves.toBeNull();
+    await expect(
+      service.approveCandidate(maintainer, candidate.id, candidate.version),
+    ).rejects.toThrow('deletion is in progress');
+  });
+
+  it('does not report an active approval retry after deletion starts', async () => {
+    const runtime = identity();
+    const { service, ledger } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Run governed checks', references: [] },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    const active = await service.approveCandidate(
+      maintainer,
+      candidate.id,
+      candidate.version,
+    );
+    await ledger.beginDeletion(
+      runtime.tenantId,
+      active.id,
+      active.version,
+      'repository',
+      'maintainer_request',
+      now,
+    );
+
+    await expect(
+      service.approveCandidate(maintainer, candidate.id, candidate.version),
+    ).rejects.toThrow('deletion is in progress');
+  });
+
+  it('does not return candidate content after concurrent activation', async () => {
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const protector = new BlockingRevealProtector();
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      protector,
+      new FakeSemanticIndex(),
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      new StaticPrivacyModeResolver(),
+      new StaticPolicyResolver(),
+      { idempotencySecret: randomBytes(32), now: () => now },
+    );
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Run governed checks', references: [] },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    const blocked = protector.blockNextReveal();
+    const review = service.getCandidateForReview(maintainer, candidate.id);
+    await blocked.entered;
+
+    await service.approveCandidate(maintainer, candidate.id, candidate.version);
+    blocked.release();
+
+    await expect(review).resolves.toBeNull();
+  });
+
+  it('keeps candidate creation idempotent and rejects operation ID content changes', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+    const operationId = randomUUID();
+    const input = {
+      scope: 'repository' as const,
+      summary: 'Run npm test before merge',
+      references: ['docs/testing.md'],
+    };
+
+    const first = await service.propose(runtime, input, operationId);
+    const retry = await service.propose(runtime, input, operationId);
+    expect(retry.id).toBe(first.id);
+
+    await expect(
+      service.propose(
+        runtime,
+        { ...input, summary: 'Skip all tests' },
+        operationId,
+      ),
+    ).rejects.toThrow('different candidate content');
+  });
+
+  it('binds candidate idempotency to the opaque principal or repository scope', async () => {
+    const firstRuntime = identity();
+    const secondRuntime = identity('tenant-a', 'principal-a', 'repository-b');
+    const { service } = fixture();
+    const operationId = randomUUID();
+    const input = {
+      scope: 'repository' as const,
+      summary: 'Run npm test before merge',
+      references: [] as string[],
+    };
+
+    await service.propose(firstRuntime, input, operationId);
+
+    await expect(
+      service.propose(secondRuntime, input, operationId),
+    ).rejects.toThrow('different candidate content');
+    await expect(
+      service.propose(
+        identity('tenant-a', 'principal-b', 'repository-a'),
+        input,
+        operationId,
+      ),
+    ).rejects.toThrow('different candidate content');
+  });
+
+  it('rejects credentials embedded in candidate references', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+
+    await expect(
+      service.propose(
+        runtime,
+        {
+          scope: 'repository',
+          summary: 'Use the release checklist',
+          references: ['ghp_abcdefghijklmnopqrstuvwxyz123456'],
+        },
+        randomUUID(),
+      ),
+    ).rejects.toThrow('reference is invalid');
+  });
+
+  it('rejects candidate summaries above the stored-content limit', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+
+    await expect(
+      service.propose(
+        runtime,
+        {
+          scope: 'repository',
+          summary: `x${' '.repeat(1_000)}`,
+          references: [],
+        },
+        randomUUID(),
+      ),
+    ).rejects.toThrow('1-1000 characters');
+  });
+
+  it('activates only through matching scope authority and never recalls across tenants', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Run targeted vitest before merge',
+        references: ['docs/testing.md'],
+      },
+      randomUUID(),
+    );
+
+    await expect(
+      service.approveCandidate(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('authority');
+
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    expect((await service.search(runtime, 'targeted vitest')).memories).toEqual(
+      [expect.objectContaining({ id: active.id, scope: 'repository' })],
+    );
+    expect(
+      (await service.search(identity('tenant-b'), 'targeted vitest')).memories,
+    ).toEqual([]);
+  });
+
+  it('keeps an ambiguous provider activation reserved until reconciliation', async () => {
+    const store = new FailFirstBindingStore();
+    const index = new FakeSemanticIndex();
+    const runtime = identity();
+    const { service } = fixture(store, index);
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Build with npm run build',
+        references: [],
+      },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+
+    await expect(
+      service.approveCandidate(maintainer, candidate.id, candidate.version),
+    ).rejects.toThrow('simulated binding failure');
+    await expect(service.get(runtime, candidate.id)).resolves.toBeNull();
+    await expect(
+      service.approveCandidate(maintainer, candidate.id, candidate.version),
+    ).rejects.toThrow('already in progress');
+
+    await store.releaseActivation(maintainer, candidate.id, candidate.version);
+    const active = await service.approveCandidate(
+      maintainer,
+      candidate.id,
+      candidate.version,
+    );
+
+    expect(active.version).toBe(candidate.version + 1);
+    expect(
+      (await service.search(runtime, 'npm run build')).memories,
+    ).toHaveLength(1);
+  });
+
+  it('stops recall at deletion intent and converges repeated erasure', async () => {
+    const runtime = identity();
+    const { service, ledger, protector } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Use the release checklist',
+        references: ['docs/release.md'],
+      },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    const protectedContent = active.protectedContent;
+
+    await service.eraseMemory(
+      manager(runtime, 'repository_maintainer'),
+      active.id,
+      active.version,
+      'repository',
+      'maintainer_request',
+    );
+
+    expect(await service.get(runtime, active.id)).toBeNull();
+    expect(
+      (await service.search(runtime, 'release checklist')).memories,
+    ).toEqual([]);
+    expect(
+      await ledger.getDeletion(runtime.tenantId, active.id, active.version),
+    ).toMatchObject({ state: 'erased' });
+    expect(
+      await ledger.getDeletion(runtime.tenantId, active.id, 1),
+    ).toMatchObject({ state: 'erased' });
+    await expect(
+      protector.reveal(runtime.tenantId, protectedContent),
+    ).rejects.toThrow('unavailable');
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'repository_maintainer'),
+        active.id,
+        active.version,
+        'repository',
+        'maintainer_request',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not resurrect an erased memory when its proposal is replayed', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+    const operationId = randomUUID();
+    const input = {
+      scope: 'repository' as const,
+      summary: 'Keep the governed release process',
+      references: [] as const,
+    };
+    const candidate = await service.propose(runtime, input, operationId);
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    await service.eraseMemory(
+      manager(runtime, 'repository_maintainer'),
+      active.id,
+      active.version,
+      'repository',
+      'maintainer_request',
+    );
+
+    await expect(service.propose(runtime, input, operationId)).rejects.toThrow(
+      'already erased',
+    );
+  });
+
+  it('rejects deletion reasons outside the caller authority and scope', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'repository_maintainer'),
+        randomUUID(),
+        1,
+        'repository',
+        'user_request',
+      ),
+    ).rejects.toThrow('reason does not match');
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'data_subject'),
+        randomUUID(),
+        1,
+        'personal',
+        'tenant_offboarding',
+      ),
+    ).rejects.toThrow('reason does not match');
+  });
+
+  it('does not label deletion of an active memory as candidate rejection', async () => {
+    const runtime = identity();
+    const { service, ledger } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Use governed checks', references: [] },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'repository_maintainer'),
+        active.id,
+        active.version,
+        'repository',
+        'candidate_rejected',
+      ),
+    ).rejects.toThrow('requires a candidate');
+    await expect(
+      ledger.getDeletion(runtime.tenantId, active.id, active.version),
+    ).resolves.toBeNull();
+  });
+
+  it('rechecks deletion intent after content reveal before returning memory', async () => {
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const ledger = new InMemoryAntiResurrectionLedger(
+      new LedgerKeyFactory(randomBytes(32)),
+    );
+    const protector = new BlockingRevealProtector();
+    const service = new MemoryService(
+      store,
+      ledger,
+      protector,
+      new FakeSemanticIndex(),
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      new StaticPrivacyModeResolver(),
+      new StaticPolicyResolver(),
+      { idempotencySecret: randomBytes(32), now: () => now },
+    );
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Use governed checks', references: [] },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    const blocked = protector.blockNextReveal();
+
+    const recall = service.get(runtime, active.id);
+    await blocked.entered;
+    await ledger.beginDeletion(
+      runtime.tenantId,
+      active.id,
+      active.version,
+      'repository',
+      'maintainer_request',
+      now,
+    );
+    blocked.release();
+
+    await expect(recall).resolves.toBeNull();
+  });
+
+  it('rechecks personal expiry after content reveal before returning memory', async () => {
+    let current = now;
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const privacy = new StaticPrivacyModeResolver();
+    const protector = new BlockingRevealProtector();
+    const service = new MemoryService(
+      store,
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      protector,
+      new FakeSemanticIndex(),
+      new EntityIdMapper(randomBytes(32), 'v1'),
+      privacy,
+      new StaticPolicyResolver(),
+      {
+        idempotencySecret: randomBytes(32),
+        personalRetentionMs: 1,
+        now: () => current,
+      },
+    );
+    privacy.set(runtime.tenantId, runtime.principalId, 'read_write');
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'personal', summary: 'Prefer governed output', references: [] },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'data_subject'),
+      candidate.id,
+      candidate.version,
+    );
+    const blocked = protector.blockNextReveal();
+
+    const recall = service.get(runtime, active.id);
+    await blocked.entered;
+    current = new Date(now.getTime() + 2);
+    blocked.release();
+
+    await expect(recall).resolves.toBeNull();
+    await expect(
+      service.approveCandidate(
+        manager(runtime, 'data_subject'),
+        candidate.id,
+        candidate.version,
+      ),
+    ).rejects.toThrow('version conflict');
+  });
+
+  it('retains ciphertext until external erasure is durably confirmed', async () => {
+    const runtime = identity();
+    const ledger = new FailFirstMarkErasedLedger(
+      new LedgerKeyFactory(randomBytes(32)),
+    );
+    const { service, store } = fixture(
+      new InMemoryCanonicalStore(),
+      new FakeSemanticIndex(),
+      ledger,
+    );
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Use the checked release process',
+        references: [],
+      },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+
+    await expect(
+      service.eraseMemory(
+        maintainer,
+        active.id,
+        active.version,
+        'repository',
+        'maintainer_request',
+      ),
+    ).rejects.toThrow('simulated ledger outage');
+    await expect(
+      store.getAuthorized(maintainer, active.id),
+    ).resolves.toMatchObject({ erasureState: 'pending_erasure' });
+    await expect(
+      service.eraseMemory(
+        maintainer,
+        active.id,
+        active.version,
+        'repository',
+        'maintainer_request',
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      store.getAuthorized(maintainer, active.id),
+    ).resolves.toBeNull();
+    expect(
+      await ledger.getDeletion(runtime.tenantId, active.id, active.version),
+    ).toMatchObject({ state: 'erased' });
+  });
+
+  it('does not infer external erasure from a missing canonical row', async () => {
+    const runtime = identity();
+    const { service, ledger } = fixture();
+    const memoryId = randomUUID();
+    await ledger.beginDeletion(
+      runtime.tenantId,
+      memoryId,
+      1,
+      'repository',
+      'maintainer_request',
+      now,
+    );
+
+    await expect(
+      service.eraseMemory(
+        manager(runtime, 'repository_maintainer'),
+        memoryId,
+        1,
+        'repository',
+        'maintainer_request',
+      ),
+    ).rejects.toThrow('orphan reconciliation');
+    await expect(
+      ledger.getDeletion(runtime.tenantId, memoryId, 1),
+    ).resolves.toMatchObject({ state: 'deletion_intent' });
+  });
+
+  it('retries the database tombstone after ledger intent succeeds first', async () => {
+    const runtime = identity();
+    const store = new FailFirstTombstoneStore();
+    const { service, ledger } = fixture(store);
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Use the governed deploy workflow',
+        references: [],
+      },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    const active = await service.approveCandidate(
+      maintainer,
+      candidate.id,
+      candidate.version,
+    );
+
+    await expect(
+      service.eraseMemory(
+        maintainer,
+        active.id,
+        active.version,
+        'repository',
+        'maintainer_request',
+      ),
+    ).rejects.toThrow('simulated tombstone failure');
+    expect(
+      await ledger.getDeletion(runtime.tenantId, active.id, active.version),
+    ).toMatchObject({ state: 'deletion_intent' });
+    await expect(
+      service.eraseMemory(
+        maintainer,
+        active.id,
+        active.version,
+        'repository',
+        'maintainer_request',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not create a deletion intent when the version CAS loses to approval', async () => {
+    const runtime = identity();
+    const store = new BlockingReservationStore();
+    const { service, ledger } = fixture(store);
+    const candidate = await service.propose(
+      runtime,
+      {
+        scope: 'repository',
+        summary: 'Use the governed release process',
+        references: [],
+      },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    const erasure = service.eraseMemory(
+      maintainer,
+      candidate.id,
+      candidate.version,
+      'repository',
+      'candidate_rejected',
+    );
+    await store.reservationEntered;
+
+    await service.approveCandidate(maintainer, candidate.id, candidate.version);
+    store.continueReservation();
+
+    await expect(erasure).rejects.toThrow('version conflict');
+    await expect(
+      ledger.getDeletion(runtime.tenantId, candidate.id, candidate.version),
+    ).resolves.toBeNull();
+  });
+
+  it('does not accept erasure while an unbound provider write is in flight', async () => {
+    const runtime = identity();
+    const store = new InMemoryCanonicalStore();
+    const index = new BlockingAddIndex();
+    const { service, ledger } = fixture(store, index);
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Use governed checks', references: [] },
+      randomUUID(),
+    );
+    const maintainer = manager(runtime, 'repository_maintainer');
+    const approval = service.approveCandidate(
+      maintainer,
+      candidate.id,
+      candidate.version,
+    );
+    await index.entered;
+
+    await expect(
+      service.eraseMemory(
+        maintainer,
+        candidate.id,
+        candidate.version,
+        'repository',
+        'candidate_rejected',
+      ),
+    ).rejects.toThrow('activation is in progress');
+    await expect(
+      ledger.getDeletion(runtime.tenantId, candidate.id, candidate.version),
+    ).resolves.toBeNull();
+
+    index.continue();
+    await expect(approval).resolves.toMatchObject({
+      lifecycleState: 'active',
+      version: candidate.version + 1,
+    });
+  });
+
+  it('discards provider IDs that are not authorized by the canonical store', async () => {
+    const runtime = identity();
+    const index = new ForeignResultIndex();
+    const { service } = fixture(new InMemoryCanonicalStore(), index);
+
+    expect((await service.search(runtime, 'anything')).memories).toEqual([]);
+  });
+
+  it('uses canonical IDs as a deterministic score tie-breaker', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+    const activeIds: string[] = [];
+    for (const summary of ['shared build alpha', 'shared build beta']) {
+      const candidate = await service.propose(
+        runtime,
+        { scope: 'repository', summary, references: [] },
+        randomUUID(),
+      );
+      const active = await service.approveCandidate(
+        manager(runtime, 'repository_maintainer'),
+        candidate.id,
+        candidate.version,
+      );
+      activeIds.push(active.id);
+    }
+
+    const result = await service.search(runtime, 'shared build');
+
+    expect(result.memories.map((memory) => memory.id)).toEqual(
+      activeIds.sort(),
+    );
+  });
+
+  it('keeps raw turn IDs deterministic and rejects event ID content changes', async () => {
+    const runtime = identity();
+    const { service } = fixture(
+      new InMemoryCanonicalStore(),
+      new FakeSemanticIndex(),
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      true,
+    );
+    const request = {
+      eventId: randomUUID(),
+      sessionId: 'session-a',
+      occurredAt: now,
+      prompt: 'How do I build this repository?',
+    };
+
+    const first = await service.openTurn(runtime, request);
+    const retry = await service.openTurn(runtime, request);
+    expect(retry.turnId).toBe(first.turnId);
+    await expect(
+      service.openTurn(identity('tenant-a', 'principal-b'), request),
+    ).rejects.toThrow('different content');
+    await expect(
+      service.openTurn(runtime, { ...request, prompt: 'Different prompt' }),
+    ).rejects.toThrow('different content');
+    await expect(
+      service.openTurn(runtime, {
+        ...request,
+        eventId: randomUUID(),
+        occurredAt: new Date(now.getTime() + 10 * 60 * 1000),
+      }),
+    ).rejects.toThrow('clock skew');
+  });
+
+  it('keeps a raw-event key when the database commit result is uncertain', async () => {
+    const runtime = identity();
+    const store = new AmbiguousRawCommitStore();
+    const { service, protector } = fixture(
+      store,
+      new FakeSemanticIndex(),
+      new InMemoryAntiResurrectionLedger(new LedgerKeyFactory(randomBytes(32))),
+      true,
+    );
+
+    await expect(
+      service.openTurn(runtime, {
+        eventId: randomUUID(),
+        sessionId: 'session-a',
+        occurredAt: now,
+        prompt: 'Preserve an ambiguous raw event',
+      }),
+    ).rejects.toThrow('ambiguous commit');
+
+    await expect(
+      protector.reveal(runtime.tenantId, store.committed.protectedPayload),
+    ).resolves.toContain('Preserve an ambiguous raw event');
+  });
+
+  it('rejects a ledger receipt that extends the configured raw retention', async () => {
+    const runtime = identity();
+    const { service } = fixture(
+      new InMemoryCanonicalStore(),
+      new FakeSemanticIndex(),
+      new OversizedRetentionLedger(new LedgerKeyFactory(randomBytes(32))),
+      true,
+    );
+
+    await expect(
+      service.openTurn(runtime, {
+        eventId: randomUUID(),
+        sessionId: 'session-a',
+        occurredAt: now,
+        prompt: 'How do I test this?',
+      }),
+    ).rejects.toThrow('retention already expired');
+  });
+
+  it('stores idempotent content-free feedback for an authorized active memory', async () => {
+    const runtime = identity();
+    const { service } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Use npm run test', references: [] },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    const eventId = randomUUID();
+
+    await expect(
+      service.recordFeedback(
+        runtime,
+        eventId,
+        'session-a',
+        active.id,
+        'helpful',
+        now,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      service.recordFeedback(
+        identity('tenant-a', 'principal-b'),
+        eventId,
+        'session-a',
+        active.id,
+        'helpful',
+        now,
+      ),
+    ).rejects.toThrow('different content');
+    await expect(
+      service.recordFeedback(
+        runtime,
+        eventId,
+        'session-a',
+        active.id,
+        'helpful',
+        now,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      service.recordFeedback(
+        runtime,
+        eventId,
+        'session-a',
+        active.id,
+        'unsafe',
+        now,
+      ),
+    ).rejects.toThrow('different content');
+    await expect(
+      service.recordFeedback(
+        runtime,
+        eventId,
+        'session-b',
+        active.id,
+        'helpful',
+        now,
+      ),
+    ).rejects.toThrow('different content');
+  });
+
+  it('rejects new feedback after erasure reserves the canonical version', async () => {
+    const runtime = identity();
+    const { service, store } = fixture();
+    const candidate = await service.propose(
+      runtime,
+      { scope: 'repository', summary: 'Use npm run test', references: [] },
+      randomUUID(),
+    );
+    const active = await service.approveCandidate(
+      manager(runtime, 'repository_maintainer'),
+      candidate.id,
+      candidate.version,
+    );
+    await store.reserveErasure(
+      runtime,
+      active.id,
+      active.version,
+      'repository',
+      'maintainer_request',
+      now,
+      null,
+    );
+
+    await expect(
+      service.recordFeedback(
+        runtime,
+        randomUUID(),
+        'session-a',
+        active.id,
+        'helpful',
+        now,
+      ),
+    ).rejects.toThrow('Canonical memory not found');
+  });
+});
+
+class FailFirstBindingStore extends InMemoryCanonicalStore {
+  private failed = false;
+
+  override async activateWithProvider(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    authority: string,
+    binding: ProviderBinding,
+    authorizationExpiresAt: Date | null,
+  ) {
+    if (!this.failed) {
+      this.failed = true;
+      throw new Error('simulated binding failure');
+    }
+    return super.activateWithProvider(
+      context,
+      memoryId,
+      expectedVersion,
+      authority,
+      binding,
+      authorizationExpiresAt,
+    );
+  }
+}
+
+class ForeignResultIndex implements SemanticIndex {
+  async add(): Promise<string> {
+    return 'foreign-provider-id';
+  }
+
+  async search(): Promise<readonly ProviderSearchResult[]> {
+    return [{ providerMemoryId: 'foreign-provider-id', score: 1 }];
+  }
+
+  async delete(): Promise<void> {}
+}
+
+class DelayedAddIndex extends FakeSemanticIndex {
+  constructor(private readonly afterAdd: () => void) {
+    super();
+  }
+
+  override async add(request: Parameters<FakeSemanticIndex['add']>[0]) {
+    const result = await super.add(request);
+    this.afterAdd();
+    return result;
+  }
+}
+
+class BlockingAddIndex extends FakeSemanticIndex {
+  private release!: () => void;
+  private readonly released = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+  private notifyEntered!: () => void;
+  readonly entered = new Promise<void>((resolve) => {
+    this.notifyEntered = resolve;
+  });
+
+  continue(): void {
+    this.release();
+  }
+
+  override async add(request: Parameters<FakeSemanticIndex['add']>[0]) {
+    this.notifyEntered();
+    await this.released;
+    return super.add(request);
+  }
+}
+
+class BlockingRevealProtector extends InMemoryContentProtector {
+  private nextBlock:
+    | {
+        entered: () => void;
+        wait: Promise<void>;
+      }
+    | undefined;
+
+  blockNextReveal(): { entered: Promise<void>; release: () => void } {
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      markEntered = resolve;
+    });
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.nextBlock = { entered: markEntered, wait };
+    return { entered, release };
+  }
+
+  override async reveal(
+    tenantId: string,
+    content: Parameters<InMemoryContentProtector['reveal']>[1],
+  ): Promise<string> {
+    const block = this.nextBlock;
+    this.nextBlock = undefined;
+    if (block) {
+      block.entered();
+      await block.wait;
+    }
+    return super.reveal(tenantId, content);
+  }
+}
+
+class FailFirstMarkErasedLedger extends InMemoryAntiResurrectionLedger {
+  private failed = false;
+
+  override async markErased(
+    tenantId: string,
+    canonicalMemoryId: string,
+    version: number,
+  ): Promise<void> {
+    if (!this.failed) {
+      this.failed = true;
+      throw new Error('simulated ledger outage');
+    }
+    await super.markErased(tenantId, canonicalMemoryId, version);
+  }
+}
+
+class AmbiguousCandidateCommitStore extends InMemoryCanonicalStore {
+  committed!: CanonicalMemoryRecord;
+
+  override async insertCandidate(
+    identity: RuntimeIdentity,
+    record: CanonicalMemoryRecord,
+  ): Promise<CanonicalMemoryRecord> {
+    this.committed = await super.insertCandidate(identity, record);
+    throw new Error('ambiguous commit');
+  }
+}
+
+class AmbiguousRawCommitStore extends InMemoryCanonicalStore {
+  committed!: RawEventInput;
+
+  override async insertRawEvent(
+    identity: RuntimeIdentity,
+    event: RawEventInput,
+    receipt: RawEventReceipt,
+  ): Promise<boolean> {
+    await super.insertRawEvent(identity, event, receipt);
+    this.committed = event;
+    throw new Error('ambiguous commit');
+  }
+}
+
+class FailFirstTombstoneStore extends InMemoryCanonicalStore {
+  private failed = false;
+
+  override async markPendingErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+  ) {
+    if (!this.failed) {
+      this.failed = true;
+      throw new Error('simulated tombstone failure');
+    }
+    return super.markPendingErasure(context, memoryId, expectedVersion);
+  }
+}
+
+class BlockingReservationStore extends InMemoryCanonicalStore {
+  private releaseReservation!: () => void;
+  private readonly reservationRelease = new Promise<void>((resolve) => {
+    this.releaseReservation = resolve;
+  });
+  private reservationStarted!: () => void;
+  readonly reservationEntered = new Promise<void>((resolve) => {
+    this.reservationStarted = resolve;
+  });
+
+  continueReservation(): void {
+    this.releaseReservation();
+  }
+
+  override async reserveErasure(
+    context: StoreContext,
+    memoryId: string,
+    expectedVersion: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+    createdAt: Date,
+    authorizationExpiresAt: Date | null,
+  ) {
+    this.reservationStarted();
+    await this.reservationRelease;
+    return super.reserveErasure(
+      context,
+      memoryId,
+      expectedVersion,
+      scope,
+      reason,
+      createdAt,
+      authorizationExpiresAt,
+    );
+  }
+}
+
+class OversizedRetentionLedger extends InMemoryAntiResurrectionLedger {
+  override async ensureRawReceipt(
+    tenantId: string,
+    eventId: string,
+    receivedAt: Date,
+  ) {
+    return {
+      key: new LedgerKeyFactory(randomBytes(32)).rawEvent(tenantId, eventId),
+      receivedAt,
+      purgeAt: new Date(receivedAt.getTime() + 25 * 60 * 60 * 1000),
+      state: 'received' as const,
+    };
+  }
+}

--- a/integrations/enterprise-memory/src/memory-service.ts
+++ b/integrations/enterprise-memory/src/memory-service.ts
@@ -1,0 +1,1008 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHmac } from 'node:crypto';
+import type { AntiResurrectionLedger } from './anti-resurrection-ledger.js';
+import type { CanonicalStore, StoreContext } from './canonical-store.js';
+import type { ContentProtector } from './content-protector.js';
+import type {
+  CandidateInput,
+  CanonicalMemoryRecord,
+  DeletionReason,
+  FeedbackSignal,
+  MemoryScope,
+  PolicySnapshot,
+  RawEventInput,
+  RecalledMemory,
+  RuntimeIdentity,
+} from './domain.js';
+import {
+  type EntityIdMapper,
+  sanitizeRetrievalQuery,
+  type SemanticIndex,
+} from './semantic-index.js';
+
+export type PersonalMemoryMode = 'off' | 'read_only' | 'read_write';
+
+export interface PrivacyIdentity {
+  tenantId: string;
+  principalId: string;
+}
+
+export interface PrivacyModeResolver {
+  getPersonalMode(identity: PrivacyIdentity): Promise<PersonalMemoryMode>;
+}
+
+export interface PolicyResolver {
+  getPolicy(identity: RuntimeIdentity): Promise<PolicySnapshot | null>;
+}
+
+export type ManagementIdentity = StoreContext &
+  (
+    | { authority: 'data_subject' }
+    | {
+        authority: 'repository_maintainer';
+        authorizationExpiresAt: Date;
+      }
+  );
+
+export interface MemoryServiceOptions {
+  idempotencySecret: Uint8Array;
+  rawRetentionMs?: number;
+  personalRetentionMs?: number;
+  searchLimit?: number;
+  searchThreshold?: number;
+  now?: () => Date;
+  rawCaptureEnabled?: boolean;
+  maxEventClockSkewMs?: number;
+}
+
+export interface SearchResponse {
+  memories: readonly RecalledMemory[];
+}
+
+export interface TurnOpenRequest {
+  eventId: string;
+  sessionId: string;
+  occurredAt: Date;
+  prompt: string;
+}
+
+export interface TurnOpenResponse extends SearchResponse {
+  turnId: string;
+}
+
+export interface CandidateReview {
+  id: string;
+  scope: MemoryScope;
+  summary: string;
+  references: readonly string[];
+  version: number;
+  state: 'candidate';
+}
+
+export interface TurnEventRequest {
+  eventId: string;
+  sessionId: string;
+  turnId?: string;
+  eventKind: string;
+  occurredAt: Date;
+  payload: unknown;
+}
+
+export class StaticPrivacyModeResolver implements PrivacyModeResolver {
+  private readonly modes = new Map<string, PersonalMemoryMode>();
+
+  set(tenantId: string, principalId: string, mode: PersonalMemoryMode): void {
+    this.modes.set(JSON.stringify([tenantId, principalId]), mode);
+  }
+
+  async getPersonalMode(
+    identity: PrivacyIdentity,
+  ): Promise<PersonalMemoryMode> {
+    return (
+      this.modes.get(
+        JSON.stringify([identity.tenantId, identity.principalId]),
+      ) ?? 'off'
+    );
+  }
+}
+
+export class StaticPolicyResolver implements PolicyResolver {
+  constructor(private readonly snapshot: PolicySnapshot | null = null) {}
+
+  async getPolicy(): Promise<PolicySnapshot | null> {
+    return this.snapshot ? structuredClone(this.snapshot) : null;
+  }
+}
+
+export class MemoryService {
+  private readonly rawRetentionMs: number;
+  private readonly personalRetentionMs: number;
+  private readonly searchLimit: number;
+  private readonly searchThreshold: number;
+  private readonly idempotencySecret: Uint8Array;
+  private readonly now: () => Date;
+  private readonly rawCaptureEnabled: boolean;
+  private readonly maxEventClockSkewMs: number;
+
+  constructor(
+    private readonly store: CanonicalStore,
+    private readonly ledger: AntiResurrectionLedger,
+    private readonly contentProtector: ContentProtector,
+    private readonly semanticIndex: SemanticIndex,
+    private readonly entityIds: EntityIdMapper,
+    private readonly privacyModes: PrivacyModeResolver,
+    private readonly policies: PolicyResolver,
+    options: MemoryServiceOptions,
+  ) {
+    this.rawRetentionMs = options.rawRetentionMs ?? 24 * 60 * 60 * 1000;
+    this.personalRetentionMs =
+      options.personalRetentionMs ?? 365 * 24 * 60 * 60 * 1000;
+    this.searchLimit = options.searchLimit ?? 6;
+    this.searchThreshold = options.searchThreshold ?? 0.1;
+    this.idempotencySecret = options.idempotencySecret;
+    this.now = options.now ?? (() => new Date());
+    this.rawCaptureEnabled = options.rawCaptureEnabled ?? false;
+    this.maxEventClockSkewMs = options.maxEventClockSkewMs ?? 5 * 60 * 1000;
+    if (
+      options.idempotencySecret.byteLength < 32 ||
+      !Number.isSafeInteger(this.rawRetentionMs) ||
+      this.rawRetentionMs <= 0 ||
+      this.rawRetentionMs > 24 * 60 * 60 * 1000 ||
+      !Number.isSafeInteger(this.personalRetentionMs) ||
+      this.personalRetentionMs <= 0 ||
+      this.personalRetentionMs > 365 * 24 * 60 * 60 * 1000 ||
+      !Number.isSafeInteger(this.searchLimit) ||
+      this.searchLimit <= 0 ||
+      this.searchLimit > 6 ||
+      !Number.isFinite(this.searchThreshold) ||
+      this.searchThreshold < 0 ||
+      this.searchThreshold > 1 ||
+      !Number.isSafeInteger(this.maxEventClockSkewMs) ||
+      this.maxEventClockSkewMs < 0 ||
+      this.maxEventClockSkewMs > 5 * 60 * 1000
+    ) {
+      throw new Error(
+        'Memory service retention or limit configuration is invalid',
+      );
+    }
+  }
+
+  async getSessionContext(
+    identity: RuntimeIdentity,
+  ): Promise<PolicySnapshot | null> {
+    const snapshot = await this.policies.getPolicy(identity);
+    if (!snapshot || snapshot.expiresAt <= this.now()) {
+      return null;
+    }
+    if (
+      !Number.isSafeInteger(snapshot.version) ||
+      snapshot.version < 0 ||
+      !Number.isFinite(snapshot.expiresAt.getTime()) ||
+      snapshot.systemContext.length > 4_000
+    ) {
+      throw new Error('Policy snapshot is invalid');
+    }
+    return snapshot;
+  }
+
+  async openTurn(
+    identity: RuntimeIdentity,
+    request: TurnOpenRequest,
+  ): Promise<TurnOpenResponse> {
+    const turnId = deterministicUuid(
+      createHmac('sha256', this.idempotencySecret)
+        .update(
+          JSON.stringify(['turn-id-v1', identity.tenantId, request.eventId]),
+        )
+        .digest(),
+    );
+    if (this.rawCaptureEnabled) {
+      await this.recordRawEvent(identity, {
+        eventId: request.eventId,
+        sessionId: request.sessionId,
+        turnId,
+        eventKind: 'prompt',
+        occurredAt: request.occurredAt,
+        payload: { prompt: request.prompt },
+      });
+    }
+    const recall = await this.search(identity, request.prompt);
+    return { turnId, ...recall };
+  }
+
+  async recordTurnEvent(
+    identity: RuntimeIdentity,
+    request: TurnEventRequest,
+  ): Promise<void> {
+    if (this.rawCaptureEnabled) {
+      await this.recordRawEvent(identity, request);
+    }
+  }
+
+  async recordFeedback(
+    identity: RuntimeIdentity,
+    eventId: string,
+    sessionId: string,
+    memoryId: string,
+    signal: FeedbackSignal,
+    occurredAt: Date,
+  ): Promise<void> {
+    this.assertEventTime(occurredAt);
+    await this.store.insertFeedback(
+      identity,
+      eventId,
+      memoryId,
+      signal,
+      occurredAt,
+      this.now(),
+      this.fingerprint('feedback-idempotency-v1', [
+        identity.tenantId,
+        identity.principalId,
+        identity.workspaceId,
+        identity.repositoryId,
+        eventId,
+        sessionId,
+        memoryId,
+        signal,
+        occurredAt.toISOString(),
+      ]),
+    );
+  }
+
+  async propose(
+    identity: RuntimeIdentity,
+    input: CandidateInput,
+    operationId: string,
+  ): Promise<CanonicalMemoryRecord> {
+    validateCandidate(input);
+    if (
+      input.scope === 'personal' &&
+      (await this.privacyModes.getPersonalMode(identity)) !== 'read_write'
+    ) {
+      throw new Error('Personal memory capture is disabled');
+    }
+    const now = this.now();
+    const scopeId =
+      input.scope === 'personal' ? identity.principalId : identity.repositoryId;
+    const canonicalId = operationId;
+    if (await this.ledger.getDeletion(identity.tenantId, canonicalId, 1)) {
+      throw new Error('Candidate operation was already erased');
+    }
+    const protectedContent = await this.contentProtector.protect({
+      tenantId: identity.tenantId,
+      principalId:
+        input.scope === 'personal' ? identity.principalId : undefined,
+      sourceOperationId: operationId,
+      plaintext: JSON.stringify({
+        summary: input.summary,
+        references: input.references,
+      }),
+      expiresAt:
+        input.scope === 'personal'
+          ? new Date(now.getTime() + this.personalRetentionMs)
+          : null,
+    });
+    const record: CanonicalMemoryRecord = {
+      id: canonicalId,
+      tenantId: identity.tenantId,
+      scope: input.scope,
+      scopeId,
+      protectedContent,
+      authority: 'model_proposal',
+      lifecycleState: 'candidate',
+      erasureState: 'live',
+      version: 1,
+      sourceOperationId: operationId,
+      sourceFingerprint: createHmac('sha256', this.idempotencySecret)
+        .update(
+          JSON.stringify([
+            'candidate-idempotency-v1',
+            identity.tenantId,
+            identity.principalId,
+            operationId,
+            input.scope,
+            scopeId,
+            input.summary,
+            input.references,
+          ]),
+        )
+        .digest('base64url'),
+      createdAt: now,
+      expiresAt:
+        input.scope === 'personal'
+          ? new Date(now.getTime() + this.personalRetentionMs)
+          : null,
+    };
+    if (
+      input.scope === 'personal' &&
+      (await this.privacyModes.getPersonalMode(identity)) !== 'read_write'
+    ) {
+      await this.contentProtector.destroy(
+        identity.tenantId,
+        protectedContent.keyHandle,
+      );
+      throw new Error('Personal memory capture is disabled');
+    }
+    const stored = await this.store.insertCandidate(identity, record);
+    if (stored.protectedContent.keyHandle !== protectedContent.keyHandle) {
+      await this.contentProtector.destroy(
+        identity.tenantId,
+        protectedContent.keyHandle,
+      );
+    }
+    return stored;
+  }
+
+  async approveCandidate(
+    manager: ManagementIdentity,
+    memoryId: string,
+    expectedVersion: number,
+  ): Promise<CanonicalMemoryRecord> {
+    const candidate = await this.store.getAuthorized(manager, memoryId);
+    if (!candidate) {
+      throw new Error('Candidate not found');
+    }
+    assertManagementAuthority(manager, candidate.scope, this.now());
+    if (
+      await this.ledger.getDeletion(
+        candidate.tenantId,
+        candidate.id,
+        candidate.version,
+      )
+    ) {
+      throw new Error('Candidate deletion is in progress');
+    }
+    if (
+      candidate.scope === 'personal' &&
+      (await this.privacyModes.getPersonalMode(manager)) !== 'read_write'
+    ) {
+      throw new Error('Personal memory capture is disabled');
+    }
+    const authority =
+      candidate.scope === 'personal' ? 'user_confirmed' : 'maintainer_approved';
+    if (candidate.lifecycleState === 'active') {
+      if (
+        candidate.erasureState === 'live' &&
+        candidate.version === expectedVersion + 1 &&
+        candidate.authority === authority &&
+        (candidate.expiresAt === null || candidate.expiresAt > this.now())
+      ) {
+        assertManagementAuthority(manager, candidate.scope, this.now());
+        return candidate;
+      }
+      throw new Error('Candidate version conflict');
+    }
+    if (
+      candidate.lifecycleState !== 'candidate' ||
+      candidate.erasureState !== 'live' ||
+      candidate.version !== expectedVersion ||
+      (candidate.expiresAt !== null && candidate.expiresAt <= this.now())
+    ) {
+      throw new Error('Candidate version conflict');
+    }
+    const content = await this.revealCanonicalContent(
+      candidate.tenantId,
+      candidate.protectedContent,
+    );
+    const canonicalVersion = expectedVersion + 1;
+    const entityId = this.entityId(candidate, manager);
+    await this.store.reserveActivation(
+      manager,
+      memoryId,
+      expectedVersion,
+      managementAuthorizationExpiry(manager),
+    );
+    const providerMemoryId = await this.semanticIndex.add({
+      tenantId: candidate.tenantId,
+      scope: candidate.scope,
+      entityId,
+      canonicalMemoryId: candidate.id,
+      canonicalVersion,
+      summary: content.summary,
+    });
+    const binding = {
+      tenantId: candidate.tenantId,
+      canonicalMemoryId: candidate.id,
+      canonicalVersion,
+      providerMemoryId,
+      scope: candidate.scope,
+      entityId,
+      state: 'active' as const,
+    };
+    try {
+      if (
+        candidate.scope === 'personal' &&
+        (await this.privacyModes.getPersonalMode(manager)) !== 'read_write'
+      ) {
+        throw new Error('Personal memory capture is disabled');
+      }
+      if (candidate.expiresAt !== null && candidate.expiresAt <= this.now()) {
+        throw new Error('Candidate version conflict');
+      }
+      assertManagementAuthority(manager, candidate.scope, this.now());
+      if (
+        await this.ledger.getDeletion(
+          candidate.tenantId,
+          candidate.id,
+          candidate.version,
+        )
+      ) {
+        throw new Error('Candidate deletion is in progress');
+      }
+    } catch (error) {
+      try {
+        await this.semanticIndex.delete(binding);
+        await this.store.releaseActivation(manager, memoryId, expectedVersion);
+      } catch {
+        throw new Error('Provider activation requires reconciliation', {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    return this.store.activateWithProvider(
+      manager,
+      memoryId,
+      expectedVersion,
+      authority,
+      binding,
+      managementAuthorizationExpiry(manager),
+    );
+  }
+
+  async getCandidateForReview(
+    manager: ManagementIdentity,
+    memoryId: string,
+  ): Promise<CandidateReview | null> {
+    const candidate = await this.store.getAuthorized(manager, memoryId);
+    if (
+      !candidate ||
+      candidate.lifecycleState !== 'candidate' ||
+      candidate.erasureState !== 'live' ||
+      (candidate.expiresAt !== null && candidate.expiresAt <= this.now())
+    ) {
+      return null;
+    }
+    assertManagementAuthority(manager, candidate.scope, this.now());
+    if (
+      await this.ledger.getDeletion(
+        candidate.tenantId,
+        candidate.id,
+        candidate.version,
+      )
+    ) {
+      return null;
+    }
+    const content = await this.revealCanonicalContent(
+      candidate.tenantId,
+      candidate.protectedContent,
+    );
+    const current = await this.store.getAuthorized(manager, candidate.id);
+    if (
+      !current ||
+      current.version !== candidate.version ||
+      current.lifecycleState !== 'candidate' ||
+      current.erasureState !== 'live' ||
+      (current.expiresAt !== null && current.expiresAt <= this.now())
+    ) {
+      return null;
+    }
+    assertManagementAuthority(manager, current.scope, this.now());
+    if (
+      await this.ledger.getDeletion(
+        current.tenantId,
+        current.id,
+        current.version,
+      )
+    ) {
+      return null;
+    }
+    assertManagementAuthority(manager, current.scope, this.now());
+    return {
+      id: candidate.id,
+      scope: candidate.scope,
+      summary: content.summary,
+      references: content.references,
+      version: candidate.version,
+      state: 'candidate',
+    };
+  }
+
+  async search(
+    identity: RuntimeIdentity,
+    prompt: string,
+  ): Promise<SearchResponse> {
+    const query = sanitizeRetrievalQuery(prompt);
+    if (!query) {
+      return { memories: [] };
+    }
+    const searches: Promise<
+      readonly { providerMemoryId: string; score: number }[]
+    >[] = [];
+    const personalMode = await this.privacyModes.getPersonalMode(identity);
+    if (personalMode !== 'off') {
+      searches.push(
+        this.semanticIndex.search({
+          tenantId: identity.tenantId,
+          scope: 'personal',
+          entityId: this.entityIds.personal(
+            identity.tenantId,
+            identity.principalId,
+          ),
+          query,
+          limit: this.searchLimit,
+          threshold: this.searchThreshold,
+        }),
+      );
+    }
+    searches.push(
+      this.semanticIndex.search({
+        tenantId: identity.tenantId,
+        scope: 'repository',
+        entityId: this.entityIds.repository(
+          identity.tenantId,
+          identity.repositoryId,
+        ),
+        query,
+        limit: this.searchLimit,
+        threshold: this.searchThreshold,
+      }),
+    );
+    const providerResults = (await Promise.all(searches)).flat();
+    const currentPersonalMode =
+      personalMode === 'off'
+        ? 'off'
+        : await this.privacyModes.getPersonalMode(identity);
+    const scoreByProviderId = new Map(
+      providerResults.map((result) => [result.providerMemoryId, result.score]),
+    );
+    const records = await this.store.getAuthorizedByProviderIds(identity, [
+      ...scoreByProviderId.keys(),
+    ]);
+    const recalled = (
+      await Promise.all(
+        records.map((record) =>
+          this.recallSearchRecord(
+            identity,
+            record,
+            scoreByProviderId,
+            currentPersonalMode,
+          ),
+        ),
+      )
+    ).filter((memory): memory is RecalledMemory => memory !== null);
+    recalled.sort(
+      (left, right) =>
+        right.score - left.score ||
+        (left.id < right.id ? -1 : left.id > right.id ? 1 : 0),
+    );
+    return { memories: recalled.slice(0, this.searchLimit) };
+  }
+
+  async get(
+    identity: RuntimeIdentity,
+    memoryId: string,
+  ): Promise<RecalledMemory | null> {
+    const record = await this.store.getAuthorized(identity, memoryId);
+    if (
+      !record ||
+      record.lifecycleState !== 'active' ||
+      record.erasureState !== 'live' ||
+      (record.expiresAt !== null && record.expiresAt <= this.now()) ||
+      (record.scope === 'personal' &&
+        (await this.privacyModes.getPersonalMode(identity)) === 'off') ||
+      (await this.ledger.getDeletion(
+        record.tenantId,
+        record.id,
+        record.version,
+      ))
+    ) {
+      return null;
+    }
+    const content = await this.revealCanonicalContent(
+      record.tenantId,
+      record.protectedContent,
+    );
+    const current = await this.store.getAuthorized(identity, record.id);
+    if (
+      !current ||
+      current.version !== record.version ||
+      current.lifecycleState !== 'active' ||
+      current.erasureState !== 'live' ||
+      (current.expiresAt !== null && current.expiresAt <= this.now()) ||
+      (record.scope === 'personal' &&
+        (await this.privacyModes.getPersonalMode(identity)) === 'off') ||
+      (await this.ledger.getDeletion(
+        record.tenantId,
+        record.id,
+        record.version,
+      ))
+    ) {
+      return null;
+    }
+    return {
+      id: record.id,
+      scope: record.scope,
+      authority: record.authority,
+      summary: content.summary,
+      references: content.references,
+      score: 1,
+    };
+  }
+
+  async eraseMemory(
+    manager: ManagementIdentity,
+    memoryId: string,
+    expectedVersion: number,
+    scope: MemoryScope,
+    reason: DeletionReason,
+  ): Promise<void> {
+    if (
+      (scope === 'personal' &&
+        reason !== 'user_request' &&
+        reason !== 'candidate_rejected') ||
+      (scope === 'repository' &&
+        reason !== 'maintainer_request' &&
+        reason !== 'candidate_rejected')
+    ) {
+      throw new Error('Deletion reason does not match memory scope');
+    }
+    assertManagementAuthority(manager, scope, this.now());
+    const existingDeletion = await this.ledger.getDeletion(
+      manager.tenantId,
+      memoryId,
+      expectedVersion,
+    );
+    const existingOriginGuard =
+      expectedVersion === 1
+        ? existingDeletion
+        : await this.ledger.getDeletion(manager.tenantId, memoryId, 1);
+    assertManagementAuthority(manager, scope, this.now());
+    assertDeletionBinding(existingDeletion, scope, reason);
+    assertDeletionBinding(existingOriginGuard, scope, reason);
+    let pending = await this.store.getAuthorized(manager, memoryId);
+    if (!pending) {
+      if (
+        existingDeletion?.state === 'erased' &&
+        (expectedVersion === 1 || existingOriginGuard?.state === 'erased')
+      ) {
+        return;
+      }
+      if (existingDeletion || existingOriginGuard) {
+        throw new Error('Missing memory requires orphan reconciliation');
+      }
+      throw new Error('Memory not found');
+    }
+    if (pending.scope !== scope) {
+      throw new Error('Memory scope mismatch');
+    }
+    if (
+      !existingDeletion &&
+      reason === 'candidate_rejected' &&
+      pending.lifecycleState !== 'candidate'
+    ) {
+      throw new Error('Candidate rejection requires a candidate memory');
+    }
+    assertManagementAuthority(manager, scope, this.now());
+    pending = await this.store.reserveErasure(
+      manager,
+      memoryId,
+      expectedVersion,
+      scope,
+      reason,
+      this.now(),
+      managementAuthorizationExpiry(manager),
+    );
+    if (expectedVersion !== 1 && !existingOriginGuard) {
+      const guard = await this.ledger.beginDeletion(
+        manager.tenantId,
+        memoryId,
+        1,
+        scope,
+        reason,
+        this.now(),
+      );
+      assertDeletionBinding(guard, scope, reason);
+    }
+    if (!existingDeletion) {
+      const deletion = await this.ledger.beginDeletion(
+        manager.tenantId,
+        memoryId,
+        expectedVersion,
+        scope,
+        reason,
+        this.now(),
+      );
+      assertDeletionBinding(deletion, scope, reason);
+    }
+    if (
+      pending.version === expectedVersion &&
+      pending.erasureState === 'live'
+    ) {
+      pending = await this.store.markPendingErasure(
+        manager,
+        memoryId,
+        expectedVersion,
+      );
+    } else if (
+      pending.version !== expectedVersion + 1 ||
+      pending.erasureState !== 'pending_erasure'
+    ) {
+      throw new Error('Deletion state conflict');
+    }
+
+    const binding = await this.store.getProviderBinding(
+      manager,
+      memoryId,
+      expectedVersion,
+    );
+    if (binding && binding.state !== 'deleted') {
+      await this.semanticIndex.delete(binding);
+    }
+    await this.contentProtector.destroy(
+      pending.tenantId,
+      pending.protectedContent.keyHandle,
+    );
+    await this.ledger.markErased(manager.tenantId, memoryId, expectedVersion);
+    if (expectedVersion !== 1) {
+      await this.ledger.markErased(manager.tenantId, memoryId, 1);
+    }
+    await this.store.eraseContent(manager, memoryId, pending.version);
+  }
+
+  private async recordRawEvent(
+    identity: RuntimeIdentity,
+    request: TurnEventRequest & { payload: unknown },
+  ): Promise<void> {
+    const receivedAt = this.now();
+    this.assertEventTime(request.occurredAt, receivedAt);
+    const purgeAt = new Date(receivedAt.getTime() + this.rawRetentionMs);
+    const receipt = await this.ledger.ensureRawReceipt(
+      identity.tenantId,
+      request.eventId,
+      receivedAt,
+      purgeAt,
+    );
+    if (
+      receipt.state === 'purged' ||
+      receipt.receivedAt > receivedAt ||
+      receipt.purgeAt <= receipt.receivedAt ||
+      receipt.purgeAt.getTime() - receipt.receivedAt.getTime() >
+        this.rawRetentionMs ||
+      receipt.purgeAt <= receivedAt
+    ) {
+      throw new Error('Raw event retention already expired');
+    }
+    const protectedPayload = await this.contentProtector.protect({
+      tenantId: identity.tenantId,
+      principalId: identity.principalId,
+      sourceOperationId: request.eventId,
+      plaintext: JSON.stringify(request.payload),
+      expiresAt: receipt.purgeAt,
+    });
+    const event: RawEventInput = {
+      eventId: request.eventId,
+      sessionId: request.sessionId,
+      turnId: request.turnId,
+      eventKind: request.eventKind,
+      occurredAt: request.occurredAt,
+      protectedPayload,
+      sourceFingerprint: this.fingerprint('raw-event-idempotency-v1', [
+        identity.tenantId,
+        identity.principalId,
+        identity.workspaceId,
+        identity.repositoryId,
+        request.eventId,
+        request.sessionId,
+        request.turnId,
+        request.eventKind,
+        request.occurredAt.toISOString(),
+        request.payload,
+      ]),
+    };
+    const inserted = await this.store.insertRawEvent(identity, event, receipt);
+    if (!inserted) {
+      await this.contentProtector.destroy(
+        identity.tenantId,
+        protectedPayload.keyHandle,
+      );
+    }
+  }
+
+  private async recallSearchRecord(
+    identity: RuntimeIdentity,
+    record: CanonicalMemoryRecord,
+    scoreByProviderId: ReadonlyMap<string, number>,
+    personalMode: PersonalMemoryMode,
+  ): Promise<RecalledMemory | null> {
+    if (
+      (record.scope === 'personal' && personalMode === 'off') ||
+      (record.expiresAt !== null && record.expiresAt <= this.now()) ||
+      (await this.ledger.getDeletion(
+        record.tenantId,
+        record.id,
+        record.version,
+      ))
+    ) {
+      return null;
+    }
+    const binding = await this.store.getProviderBinding(
+      identity,
+      record.id,
+      record.version,
+    );
+    const score = binding
+      ? scoreByProviderId.get(binding.providerMemoryId)
+      : undefined;
+    if (score === undefined) {
+      return null;
+    }
+    const content = await this.revealCanonicalContent(
+      record.tenantId,
+      record.protectedContent,
+    );
+    const current = await this.store.getAuthorized(identity, record.id);
+    if (
+      !current ||
+      current.version !== record.version ||
+      current.lifecycleState !== 'active' ||
+      current.erasureState !== 'live' ||
+      (current.expiresAt !== null && current.expiresAt <= this.now()) ||
+      (record.scope === 'personal' &&
+        (await this.privacyModes.getPersonalMode(identity)) === 'off') ||
+      (await this.ledger.getDeletion(
+        record.tenantId,
+        record.id,
+        record.version,
+      ))
+    ) {
+      return null;
+    }
+    return {
+      id: current.id,
+      scope: current.scope,
+      authority: current.authority,
+      summary: content.summary,
+      references: content.references,
+      score,
+    };
+  }
+
+  private entityId(
+    record: CanonicalMemoryRecord,
+    context: StoreContext,
+  ): string {
+    return record.scope === 'personal'
+      ? this.entityIds.personal(record.tenantId, context.principalId)
+      : this.entityIds.repository(record.tenantId, context.repositoryId);
+  }
+
+  private fingerprint(purpose: string, parts: readonly unknown[]): string {
+    return createHmac('sha256', this.idempotencySecret)
+      .update(JSON.stringify([purpose, ...parts]))
+      .digest('base64url');
+  }
+
+  private async revealCanonicalContent(
+    tenantId: string,
+    content: CanonicalMemoryRecord['protectedContent'],
+  ): Promise<{ summary: string; references: readonly string[] }> {
+    const plaintext = await this.contentProtector.reveal(tenantId, content);
+    const value = JSON.parse(plaintext) as unknown;
+    if (typeof value !== 'object' || value === null) {
+      throw new Error('Canonical memory content is invalid');
+    }
+    const fields = value as Record<string, unknown>;
+    const summary = fields['summary'];
+    const references = fields['references'];
+    if (
+      typeof summary !== 'string' ||
+      summary.length === 0 ||
+      summary.length > 1_000 ||
+      !Array.isArray(references) ||
+      references.length > 10 ||
+      !references.every(
+        (reference) =>
+          typeof reference === 'string' &&
+          reference.length > 0 &&
+          reference.length <= 500,
+      )
+    ) {
+      throw new Error('Canonical memory content is invalid');
+    }
+    return {
+      summary,
+      references,
+    };
+  }
+
+  private assertEventTime(occurredAt: Date, now = this.now()): void {
+    if (
+      !Number.isFinite(occurredAt.getTime()) ||
+      Math.abs(occurredAt.getTime() - now.getTime()) > this.maxEventClockSkewMs
+    ) {
+      throw new Error('Event timestamp is outside the allowed clock skew');
+    }
+  }
+}
+
+function deterministicUuid(digest: Uint8Array): string {
+  const bytes = Buffer.from(digest.subarray(0, 16));
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const value = bytes.toString('hex');
+  return [
+    value.slice(0, 8),
+    value.slice(8, 12),
+    value.slice(12, 16),
+    value.slice(16, 20),
+    value.slice(20),
+  ].join('-');
+}
+
+function validateCandidate(input: CandidateInput): void {
+  const summary = input.summary.trim();
+  if (summary.length === 0 || input.summary.length > 1_000) {
+    throw new Error('Candidate summary must contain 1-1000 characters');
+  }
+  if (containsDisallowedCandidateContent(summary)) {
+    throw new Error('Candidate summary contains disallowed content');
+  }
+  if (input.references.length > 10) {
+    throw new Error('Candidate has too many references');
+  }
+  for (const reference of input.references) {
+    if (
+      reference.trim().length === 0 ||
+      reference.length > 500 ||
+      containsDisallowedCandidateContent(reference)
+    ) {
+      throw new Error('Candidate reference is invalid');
+    }
+  }
+}
+
+function containsDisallowedCandidateContent(value: string): boolean {
+  return /```|BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY|\b(?:sk|ghp|github_pat|AKIA)[-_A-Za-z0-9]{12,}\b|\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/i.test(
+    value,
+  );
+}
+
+function assertManagementAuthority(
+  manager: ManagementIdentity,
+  scope: MemoryScope,
+  now: Date,
+): void {
+  if (
+    (scope === 'personal' && manager.authority !== 'data_subject') ||
+    (scope === 'repository' &&
+      (manager.authority !== 'repository_maintainer' ||
+        !Number.isFinite(manager.authorizationExpiresAt.getTime()) ||
+        manager.authorizationExpiresAt <= now))
+  ) {
+    throw new Error('Management authority does not match memory scope');
+  }
+}
+
+function managementAuthorizationExpiry(
+  manager: ManagementIdentity,
+): Date | null {
+  return manager.authority === 'repository_maintainer'
+    ? manager.authorizationExpiresAt
+    : null;
+}
+
+function assertDeletionBinding(
+  deletion: Awaited<ReturnType<AntiResurrectionLedger['getDeletion']>>,
+  scope: MemoryScope,
+  reason: DeletionReason,
+): void {
+  if (deletion && (deletion.scope !== scope || deletion.reason !== reason)) {
+    throw new Error('Deletion intent binding conflict');
+  }
+}

--- a/integrations/enterprise-memory/src/privacy-mode-store.ts
+++ b/integrations/enterprise-memory/src/privacy-mode-store.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Pool, PoolClient } from 'pg';
+import type {
+  PersonalMemoryMode,
+  PrivacyIdentity,
+  PrivacyModeResolver,
+} from './memory-service.js';
+
+export interface PersonalPreferenceIdentity {
+  tenantId: string;
+  principalId: string;
+}
+
+export interface PersonalMemoryPreferenceStore extends PrivacyModeResolver {
+  setPersonalMode(
+    identity: PersonalPreferenceIdentity,
+    mode: PersonalMemoryMode,
+  ): Promise<void>;
+}
+
+export class PostgresPersonalMemoryPreferenceStore
+  implements PersonalMemoryPreferenceStore
+{
+  constructor(private readonly pool: Pool) {}
+
+  async getPersonalMode(
+    identity: PrivacyIdentity,
+  ): Promise<PersonalMemoryMode> {
+    return this.transaction(identity, async (client) => {
+      const result = await client.query<{ mode: PersonalMemoryMode }>(
+        `SELECT mode FROM personal_memory_preferences
+          WHERE tenant_id = $1 AND principal_id = $2`,
+        [identity.tenantId, identity.principalId],
+      );
+      return result.rows[0]?.mode ?? 'off';
+    });
+  }
+
+  async setPersonalMode(
+    identity: PersonalPreferenceIdentity,
+    mode: PersonalMemoryMode,
+  ): Promise<void> {
+    await this.transaction(identity, async (client) => {
+      await client.query(
+        `INSERT INTO personal_memory_preferences (
+           tenant_id, principal_id, mode, updated_at
+         ) VALUES ($1,$2,$3,clock_timestamp())
+         ON CONFLICT (tenant_id, principal_id)
+         DO UPDATE SET mode = EXCLUDED.mode, updated_at = EXCLUDED.updated_at`,
+        [identity.tenantId, identity.principalId, mode],
+      );
+    });
+  }
+
+  private async transaction<T>(
+    identity: PersonalPreferenceIdentity,
+    operation: (client: PoolClient) => Promise<T>,
+  ): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `SELECT set_config('app.tenant_id', $1, true),
+                set_config('app.principal_id', $2, true),
+                set_config('app.repository_id', '', true)`,
+        [identity.tenantId, identity.principalId],
+      );
+      const result = await operation(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}


### PR DESCRIPTION
## What this PR does

Stack position: 3/5. Parent: #7505. Next: #7508.

This stacked PR adds the governed memory lifecycle over the canonical store: capture, candidate proposal, consent and review, activation, authorized recall, tombstoning, erasure, provider outbox reconciliation, and privacy preferences. It also adds the provider-neutral semantic-index service contract implementation and a Mem0 adapter that is treated strictly as a replaceable index.

## Why it's needed

The persistence layer alone does not define who may share, review, recall, or delete memory, nor how asynchronous provider state converges. This layer centralizes those invariants and always reauthorizes provider results against active canonical records so provider output never becomes identity, authorization, or canonical truth.

## Reviewer Test Plan

### How to verify

- Run `npm test --workspace=@qwen-code/enterprise-memory`; the cumulative 10 test files and 94 tests should pass.
- Confirm personal, repository, and organization scopes enforce separate consent, review, promotion, and deletion authorities.
- Confirm candidate activation reserves the canonical operation before provider writes and requires exact provider discovery before becoming recallable.
- Confirm recall reapplies tenant, scope, ACL, tombstone, expiry, deletion-intent, and current authorization checks after semantic search.
- Confirm retries, concurrent consent changes, lease expiry, deletion races, malformed provider pagination, and orphan reconciliation preserve the documented fail-closed memory semantics.

### Evidence (Before & After)

N/A — this is a non-UI lifecycle and provider-adapter change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1 arm64, Node.js 22.22.3, npm 10.9.8. Provider behavior was verified with deterministic test doubles rather than a live Mem0 project.

## Risk & Scope

- Main risk or tradeoff: Recall availability is intentionally sacrificed when canonical authorization, deletion-ledger state, or exact provider reconciliation cannot be established.
- Not validated / out of scope: Live Mem0 residency, retention, deletion SLA, and subprocessor controls are deployment gates; HTTP exposure and Qwen Agent integration are in later PRs.
- Breaking changes / migration notes: No existing behavior changes; this consumes the initial schema from the parent persistence PR.

## Linked Issues

Refs #7449

<details>
<summary>中文说明</summary>

## 此 PR 的内容

堆栈位置：3/5。父 PR：#7505。下一个 PR：#7508。

这个 stacked PR 在规范存储之上增加受治理的记忆生命周期：捕获、候选提议、同意与评审、激活、授权召回、墓碑、擦除、提供商 outbox 对账和隐私偏好。它还增加供应商中立的语义索引服务契约实现，以及一个被严格视为可替换索引的 Mem0 适配器。

## 为什么需要

仅有持久化层无法定义谁可以共享、评审、召回或删除记忆，也无法定义异步提供商状态如何收敛。该层集中实现这些不变量，并始终根据活动规范记录重新授权提供商结果，因此提供商输出永远不会成为身份、授权依据或规范事实。

## 评审者测试计划

### 如何验证

- 运行 `npm test --workspace=@qwen-code/enterprise-memory`；累计 10 个测试文件和 94 项测试应通过。
- 确认个人、仓库和组织作用域分别执行独立的同意、评审、提升和删除权限。
- 确认候选激活在写入提供商前预留规范操作，并且只有精确发现提供商记录后才可被召回。
- 确认召回在语义搜索后重新执行租户、作用域、ACL、墓碑、过期、删除意图和当前授权检查。
- 确认重试、并发同意变化、租约过期、删除竞态、错误提供商分页和孤儿对账均保持文档定义的记忆失败关闭语义。

### 证据（变更前后）

不适用——这是非 UI 的生命周期和提供商适配器变更。

### 测试平台

|   操作系统   | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS 26.4.1 arm64、Node.js 22.22.3、npm 10.9.8。提供商行为使用确定性测试替身验证，而不是连接真实 Mem0 项目。

## 风险与范围

- 主要风险或权衡：当无法建立规范授权、删除账本状态或精确提供商对账时，会有意牺牲召回可用性。
- 未验证或范围外：真实 Mem0 的驻留、保留、删除 SLA 和分包商控制属于部署门禁；HTTP 暴露和 Qwen Agent 集成位于后续 PR。
- 破坏性变更或迁移说明：没有现有行为变更；此 PR 使用父级持久化 PR 引入的初始 schema。

## 关联 Issue

关联 #7449

</details>
