### PR TITLE
fix(mcp): harden OAuth callback handling

### DIFF
--- a/docs/developers/tools/mcp-server.md
+++ b/docs/developers/tools/mcp-server.md
@@ -161,13 +161,13 @@ When connecting to an OAuth-enabled server:
 **Important:** OAuth authentication requires that the redirect URI is accessible:
 
 - **Default behavior**: Redirects to `http://localhost:7777/oauth/callback` (works for local setups)
-- **Custom redirect URI**: Use `--oauth-redirect-uri` or configure `redirectUri` in settings.json to specify a different URL
+- **Custom redirect URI**: Use `--oauth-redirect-uri` or configure `redirectUri` in settings.json to specify a public URL ending in `/oauth/callback`. Reverse-proxy that path to `http://127.0.0.1:7777/oauth/callback` on the machine running Qwen Code.
 
 For **remote/cloud server deployments** (e.g., web terminals, SSH sessions, cloud IDEs):
 
 - The default `localhost` redirect will NOT work
-- You MUST configure a custom `redirectUri` pointing to a publicly accessible URL
-- The user's browser must be able to reach this URL and redirect back to the server
+- You MUST configure a custom `redirectUri` pointing to a publicly accessible URL ending in `/oauth/callback`
+- Terminate TLS at a reverse proxy and forward only that path to `http://127.0.0.1:7777/oauth/callback`
 
 Example for remote servers:
 
@@ -194,7 +194,7 @@ servers and manage OAuth authentication.
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
-- **`redirectUri`** (string): Custom redirect URI. **Critical for remote deployments**: Defaults to `http://localhost:7777/oauth/callback`. When running Qwen Code on remote/cloud servers, set this to a publicly accessible URL (e.g., `https://your-server.com/oauth/callback`). Can be configured via `qwen mcp add --oauth-redirect-uri` or directly in settings.json.
+- **`redirectUri`** (string): Custom redirect URI. **Critical for remote deployments**: Defaults to `http://localhost:7777/oauth/callback`. For remote use, set a public URL ending in `/oauth/callback` and reverse-proxy it to the local callback listener. Can be configured via `qwen mcp add --oauth-redirect-uri` or directly in settings.json.
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
 - **`audiences`** (string[]): Audiences the token is valid for
 
@@ -795,7 +795,7 @@ qwen mcp add [options] <name> <commandOrUrl> [args...]
 - `--exclude-tools`: A comma-separated list of tools to exclude.
 - `--oauth-client-id`: OAuth client ID for MCP server authentication.
 - `--oauth-client-secret`: OAuth client secret for MCP server authentication.
-- `--oauth-redirect-uri`: OAuth redirect URI (e.g., `https://your-server.com/oauth/callback`). Defaults to `http://localhost:7777/oauth/callback` for local setups. **Important for remote deployments**: When running Qwen Code on remote/cloud servers, set this to a publicly accessible URL.
+- `--oauth-redirect-uri`: OAuth redirect URI (e.g., `https://your-server.com/oauth/callback`). Defaults to `http://localhost:7777/oauth/callback` for local setups. **Important for remote deployments**: Use a public URL ending in `/oauth/callback` and reverse-proxy it to `http://127.0.0.1:7777/oauth/callback`.
 - `--oauth-authorization-url`: OAuth authorization URL.
 - `--oauth-token-url`: OAuth token URL.
 - `--oauth-scopes`: OAuth scopes (comma-separated).

--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -295,13 +295,21 @@ The OAuth flow requires a redirect URI where the authorization provider sends th
 
 - **Local development**: By default, Qwen Code uses `http://localhost:7777/oauth/callback`. This works when running Qwen Code on your local machine with a local browser.
 
-- **Remote/cloud deployments**: When running Qwen Code on remote servers, cloud IDEs, or web terminals, the default `localhost` redirect will NOT work. You MUST configure `--oauth-redirect-uri` to point to a publicly accessible URL that can receive the OAuth callback.
+- **Remote/cloud deployments**: When running Qwen Code on remote servers, cloud IDEs, or web terminals, the default `localhost` redirect will NOT work. Configure `--oauth-redirect-uri` with a public URL ending in `/oauth/callback`, then reverse-proxy that path to `http://127.0.0.1:7777/oauth/callback` on the machine running Qwen Code. Qwen Code does not terminate TLS; the proxy must do so.
 
 Example for remote servers:
 
 ```bash
 qwen mcp add --transport sse remote-server https://api.example.com/sse/ \
   --oauth-redirect-uri https://your-remote-server.example.com/oauth/callback
+```
+
+For example, a reverse proxy can forward only this callback path to the local listener:
+
+```nginx
+location = /oauth/callback {
+  proxy_pass http://127.0.0.1:7777;
+}
 ```
 
 #### Manual configuration via settings.json

--- a/packages/core/src/mcp/oauth-provider.test.ts
+++ b/packages/core/src/mcp/oauth-provider.test.ts
@@ -236,6 +236,10 @@ describe('MCPOAuthProvider', () => {
       expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(
         expect.stringContaining('authorize'),
       );
+      expect(mockHttpServer.listen).toHaveBeenCalledWith(
+        { port: 7777, host: '127.0.0.1' },
+        expect.any(Function),
+      );
       const tokenStorage = new MCPOAuthTokenStorage();
       expect(tokenStorage.saveToken).toHaveBeenCalledWith(
         'test-server',
@@ -677,7 +681,7 @@ describe('MCPOAuthProvider', () => {
         callback?.();
         setTimeout(() => {
           const mockReq = {
-            url: '/oauth/callback?error=access_denied&error_description=User%20denied%20access',
+            url: '/oauth/callback?error=access_denied&error_description=User%20denied%20access&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
           };
           const mockRes = {
             writeHead: vi.fn(),
@@ -696,7 +700,7 @@ describe('MCPOAuthProvider', () => {
       ).rejects.toThrow('OAuth error: access_denied');
     });
 
-    it('should handle state mismatch in callback', async () => {
+    it('should ignore a callback with an invalid state and accept the valid callback', async () => {
       let callbackHandler: unknown;
       vi.mocked(http.createServer).mockImplementation((handler) => {
         callbackHandler = handler;
@@ -706,24 +710,36 @@ describe('MCPOAuthProvider', () => {
       mockHttpServer.listen.mockImplementation((port, callback) => {
         callback?.();
         setTimeout(() => {
-          const mockReq = {
-            url: '/oauth/callback?code=auth_code_123&state=wrong_state',
-          };
-          const mockRes = {
-            writeHead: vi.fn(),
-            end: vi.fn(),
-          };
           (callbackHandler as (req: unknown, res: unknown) => void)(
-            mockReq,
-            mockRes,
+            { url: '/oauth/callback?code=auth_code_123&state=wrong_state' },
+            { writeHead: vi.fn(), end: vi.fn() },
+          );
+          (callbackHandler as (req: unknown, res: unknown) => void)(
+            {
+              url: '/oauth/callback?code=auth_code_123&state=bW9ja19zdGF0ZV8xNl9ieXRlcw',
+            },
+            { writeHead: vi.fn(), end: vi.fn() },
           );
         }, 10);
       });
 
       const authProvider = new MCPOAuthProvider();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          ok: true,
+          contentType: 'application/json',
+          text: JSON.stringify(mockTokenResponse),
+          json: mockTokenResponse,
+        }),
+      );
       await expect(
         authProvider.authenticate('test-server', mockConfig),
-      ).rejects.toThrow('State mismatch - possible CSRF attack');
+      ).resolves.toMatchObject({
+        accessToken: mockToken.accessToken,
+        refreshToken: mockToken.refreshToken,
+        tokenType: mockToken.tokenType,
+        scope: mockToken.scope,
+      });
     });
 
     it('should handle token exchange failure', async () => {

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -277,6 +277,12 @@ export class MCPOAuthProvider {
             const state = url.searchParams.get('state');
             const error = url.searchParams.get('error');
 
+            if (!state || state !== expectedState) {
+              res.writeHead(400);
+              res.end('Invalid state parameter');
+              return;
+            }
+
             if (error) {
               res.writeHead(HTTP_OK, { 'Content-Type': 'text/html' });
               res.end(`
@@ -299,22 +305,9 @@ export class MCPOAuthProvider {
               return;
             }
 
-            if (!code || !state) {
+            if (!code) {
               res.writeHead(400);
-              res.end('Missing code or state parameter');
-              return;
-            }
-
-            if (state !== expectedState) {
-              res.writeHead(400);
-              res.end('Invalid state parameter');
-              activeCallbackServer = null;
-              if (activeCallbackTimeout) {
-                clearTimeout(activeCallbackTimeout);
-                activeCallbackTimeout = null;
-              }
-              server.close();
-              reject(new Error('State mismatch - possible CSRF attack'));
+              res.end('Missing code parameter');
               return;
             }
 
@@ -350,7 +343,7 @@ export class MCPOAuthProvider {
       );
 
       server.on('error', reject);
-      server.listen(OAUTH_REDIRECT_PORT, () => {
+      server.listen({ port: OAUTH_REDIRECT_PORT, host: '127.0.0.1' }, () => {
         debugLogger.debug(
           `OAuth callback server listening on port ${OAUTH_REDIRECT_PORT}`,
         );


### PR DESCRIPTION
## What this PR does

It binds the local MCP OAuth callback listener to loopback, verifies state before accepting either successful or error callbacks, and keeps an invalid callback from cancelling a legitimate login. It also documents the reverse-proxy setup required when OAuth runs on a remote machine.

## Why it's needed

Remote OAuth setup requires a public callback URL, but the running process receives callbacks only on its local listener. The documentation now explains how to forward the public callback path safely. The state checks prevent unsolicited requests from ending an active OAuth flow.

## Reviewer Test Plan

### How to verify

Start a local MCP OAuth flow and confirm a valid callback completes authentication. Send an invalid-state callback first, then the valid callback, and confirm the valid flow still completes. For a remote deployment, configure a public `/oauth/callback` URL and reverse-proxy that path to `127.0.0.1:7777`; complete the provider login and confirm the callback reaches the CLI.

### Evidence (Before & After)

Before: an invalid-state or error callback could end the active OAuth flow, and remote callback forwarding was undocumented. After: invalid-state callbacks are rejected while the active flow remains available, and the documented proxy route forwards only the callback path to the loopback listener.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v25.9.0. Ran the focused OAuth unit suite, formatting, linting, build, and type checking.

## Risk & Scope

- Main risk or tradeoff: Remote installations must forward the public callback path to the loopback listener; this is now explicit in the documentation.
- Not validated / out of scope: A live third-party OAuth provider and a public reverse proxy were not available locally.
- Breaking changes / migration notes: Existing local callbacks continue to use port 7777. Public forwarding should target `127.0.0.1:7777` rather than an externally exposed listener.

## Linked Issues

Fixes #7503

<details>
<summary>中文说明</summary>

## 此 PR 的内容

它将本地 MCP OAuth 回调监听器绑定到 loopback，在接受成功或错误回调之前验证 state，并确保无效回调不会取消正常的登录流程。同时，它补充了 OAuth 在远程机器上运行时所需的反向代理配置说明。

## 为什么需要它

远程 OAuth 配置需要公网回调 URL，但运行中的进程只会在本地监听器上接收回调。现在的文档说明了如何安全地转发公网回调路径。state 校验可防止未经请求的回调结束正在进行的 OAuth 流程。

## 审阅者测试计划

### 如何验证

启动本地 MCP OAuth 流程，并确认有效回调可以完成认证。先发送一个 state 无效的回调，再发送有效回调，并确认有效流程仍然可以完成。对于远程部署，配置公网 `/oauth/callback` URL，并将该路径反向代理到 `127.0.0.1:7777`；完成提供方登录，并确认回调可以到达 CLI。

### 证据（前后对比）

修改前：state 无效或错误的回调可能结束正在进行的 OAuth 流程，且远程回调转发没有文档说明。修改后：state 无效的回调会被拒绝，正在进行的流程仍可继续；文档中的代理路由只将回调路径转发给 loopback 监听器。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境（可选）

Node.js v25.9.0。已运行聚焦的 OAuth 单元测试、格式检查、lint、构建和类型检查。

## 风险与范围

- 主要风险或取舍：远程安装必须将公网回调路径转发到 loopback 监听器；文档现已明确这一点。
- 未验证或超出范围：本地没有可用的真实第三方 OAuth 提供方和公网反向代理。
- 破坏性变更或迁移说明：现有本地回调仍使用端口 7777。公网转发应指向 `127.0.0.1:7777`，而不是对外暴露的监听器。

## 关联问题

Fixes #7503

</details>
