### PR TITLE
fix(ci): don't let one failing scenario sink the whole visual preview

### DIFF
--- a/.github/scripts/web-shell-visuals-publish.mjs
+++ b/.github/scripts/web-shell-visuals-publish.mjs
@@ -17,7 +17,7 @@
  * `buildComment`) are exported and tested. The file also runs as a CLI for the
  * workflow:
  *   node web-shell-visuals-publish.mjs stage   <screenshotsDir> <gifsDir> <stageDir>
- *   node web-shell-visuals-publish.mjs comment <stageDir> <rawBase> <shortSha> <runUrl> <bodyFile> [changedPathsFile]
+ *   node web-shell-visuals-publish.mjs comment <stageDir> <rawBase> <shortSha> <runUrl> <bodyFile> [changedPathsFile] [renderStatusFile]
  */
 
 import {
@@ -190,15 +190,21 @@ const codePath = (p) => `\`${esc(String(p).replace(/[`\r\n]/g, ''))}\``;
 
 /**
  * Pure comment builder. `files` is the list of staged filenames (png + gif).
- * `ctx` is `{ rawBase, shortSha, runUrl, changedPaths }`, where `changedPaths`
- * is the PR's full changed-file list (used only to triage an empty preview).
- * Returns the markdown body.
+ * `ctx` is `{ rawBase, shortSha, runUrl, changedPaths, renderIncomplete }`:
+ * `changedPaths` is the PR's full changed-file list (used only to triage an
+ * empty preview), and `renderIncomplete` is true when >=1 scenario failed to
+ * render on the PR head — in which case a missing view may be a render failure,
+ * not "no change", and the comment must say so instead of a clean bill of
+ * health. Returns the markdown body.
  */
 export function buildComment(files, ctx = {}) {
   const rawBase = ctx.rawBase ?? '';
   const shortSha = ctx.shortSha ?? '';
   const runUrl = ctx.runUrl ?? '';
+  const renderIncomplete = ctx.renderIncomplete === true;
   const url = (name) => `${rawBase}/${encodeURIComponent(name)}`;
+  // A "see the run" pointer for the render-failure notes (omitted if unknown).
+  const runLink = runUrl ? ` — see the [workflow run](${esc(runUrl)})` : '';
 
   // Screenshots are before/after COMPOSITES (`<view>-<theme>.png`), one per
   // changed view+theme. The compositor already dropped unchanged views, so an
@@ -218,12 +224,30 @@ export function buildComment(files, ctx = {}) {
   out.push('#### Screenshots · before / after');
   out.push('');
   if (shots.length > 0) {
+    // Some views rendered. If others FAILED, say so first: the set below is
+    // partial, and a view a reviewer expects but doesn't see may have crashed
+    // rather than stayed unchanged.
+    if (renderIncomplete) {
+      out.push(
+        `⚠️ _One or more scenarios failed to render_ on this head, so this preview may be missing views${runLink}. The composites below are the scenarios that did render.`,
+      );
+      out.push('');
+    }
     for (const f of shots) {
       out.push(
         `<img src="${url(f)}" width="900" alt="${esc(f.replace(/\.png$/i, ''))} before/after">`,
       );
       out.push('');
     }
+  } else if (renderIncomplete) {
+    // No composites AND the render failed: this is NOT "no visual change". A
+    // scenario that times out or throws produces no image, so treat the empty
+    // set as a render failure — never the reassuring green check or the
+    // coverage-gap prompt, both of which would imply the render actually ran.
+    out.push(
+      `⚠️ _No preview: one or more scenarios failed to render_ on this head${runLink}. This is not "no visual change" — a scenario that times out or throws produces no image. Fix the failing scenario (or a genuine regression it caught) and the preview returns on the next push.`,
+    );
+    out.push('');
   } else {
     // An empty preview is ambiguous, so say WHICH of the two things it means.
     // "No view changed" is only a clean bill of health if nothing that shapes a
@@ -333,7 +357,15 @@ function stageCli(screenshotsDir, gifsDir, stageDir) {
   process.stdout.write(`${accepted.length}\n`);
 }
 
-function commentCli(stageDir, rawBase, shortSha, runUrl, bodyFile, pathsFile) {
+function commentCli(
+  stageDir,
+  rawBase,
+  shortSha,
+  runUrl,
+  bodyFile,
+  pathsFile,
+  renderStatusFile,
+) {
   let files = [];
   try {
     files = readdirSync(stageDir);
@@ -352,7 +384,26 @@ function commentCli(stageDir, rawBase, shortSha, runUrl, bodyFile, pathsFile) {
       // Unreadable → treat as "unknown", not as "nothing changed".
     }
   }
-  const body = buildComment(files, { rawBase, shortSha, runUrl, changedPaths });
+  // Render status written by the capture job. Anything other than the literal
+  // 'success' is treated as incomplete; a MISSING/empty file (older run, no arg)
+  // means "unknown" and defaults to complete so this never fabricates a failure
+  // warning on a preview that actually rendered fine.
+  let renderIncomplete = false;
+  if (renderStatusFile) {
+    try {
+      renderIncomplete =
+        readFileSync(renderStatusFile, 'utf8').trim() !== 'success';
+    } catch {
+      // Unreadable → leave complete (fail open toward the normal preview).
+    }
+  }
+  const body = buildComment(files, {
+    rawBase,
+    shortSha,
+    runUrl,
+    changedPaths,
+    renderIncomplete,
+  });
   writeFileSync(bodyFile, body);
   process.stderr.write(`Comment body: ${body.split('\n').length} lines.\n`);
 }
@@ -362,7 +413,7 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   if (cmd === 'stage') {
     stageCli(rest[0], rest[1], rest[2]);
   } else if (cmd === 'comment') {
-    commentCli(rest[0], rest[1], rest[2], rest[3], rest[4], rest[5]);
+    commentCli(rest[0], rest[1], rest[2], rest[3], rest[4], rest[5], rest[6]);
   } else {
     process.stderr.write(`unknown command: ${cmd ?? '(none)'}\n`);
     process.exit(2);

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -283,3 +283,59 @@ test('buildComment neutralises a path that tries to break out of its code span',
   assert.equal(bullets.length, 1);
   assert.equal((bullets[0].match(/`/g) ?? []).length, 2);
 });
+
+// --- Render-incomplete honesty (a failed scenario must not read as "no change") ---
+
+test('buildComment: empty preview + renderIncomplete says RENDER FAILED, not no-change or coverage-gap', () => {
+  const body = buildComment([], {
+    shortSha: 'abc1234',
+    runUrl: 'https://run.example/9',
+    renderIncomplete: true,
+    // Even with render-shaping files changed, a failed render must NOT show the
+    // coverage-gap prompt — that would imply the render actually ran.
+    changedPaths: ['packages/web-shell/client/components/WelcomeScreen.tsx'],
+  });
+  assert.match(body, /failed to render/i);
+  assert.doesNotMatch(body, /✅/); // never the clean check
+  assert.doesNotMatch(body, /No screenshot changes against the PR base/);
+  assert.doesNotMatch(body, /coverage gap/); // coverage-gap prompt suppressed
+  assert.doesNotMatch(body, /render-shaping/);
+  assert.match(body, /https:\/\/run\.example\/9/); // links the run
+});
+
+test('buildComment: composites present + renderIncomplete warns the preview is PARTIAL', () => {
+  const body = buildComment(['home-dark.png'], {
+    rawBase: 'r',
+    runUrl: 'https://run.example/9',
+    renderIncomplete: true,
+  });
+  assert.match(body, /<img src="r\/home-dark\.png"/); // the shots that rendered still show
+  assert.match(body, /failed to render/i); // ...prefixed by the partial-preview warning
+  assert.match(body, /may be missing views/i);
+});
+
+test('buildComment: renderIncomplete false keeps the existing no-change / coverage-gap behavior', () => {
+  // Complete render, no shots, no render-shaping files → the plain green check.
+  const clean = buildComment([], {
+    shortSha: 'abc1234',
+    renderIncomplete: false,
+    changedPaths: ['packages/core/src/index.ts'],
+  });
+  assert.match(clean, /✅ _No screenshot changes against the PR base\._/);
+  assert.doesNotMatch(clean, /failed to render/i);
+
+  // Complete render, no shots, render-shaping files → the coverage-gap prompt.
+  const gap = buildComment([], {
+    shortSha: 'abc1234',
+    renderIncomplete: false,
+    changedPaths: ['packages/web-shell/client/components/WelcomeScreen.tsx'],
+  });
+  assert.match(gap, /no scenario renders this UI/);
+  assert.doesNotMatch(gap, /failed to render/i);
+});
+
+test('buildComment: render-failure note omits the run link when runUrl is absent', () => {
+  const body = buildComment([], { renderIncomplete: true });
+  assert.match(body, /failed to render/i);
+  assert.doesNotMatch(body, /\[workflow run\]/); // no dangling empty link
+});

--- a/.github/workflows/web-shell-visuals-publish.yml
+++ b/.github/workflows/web-shell-visuals-publish.yml
@@ -241,6 +241,15 @@ jobs:
             --paginate --jq '.[].filename' > "${CHANGED_PATHS_FILE}" 2>/dev/null \
             || echo "::warning::Could not list changed files for PR #${PR}; the preview will not flag coverage gaps."
 
+          # --- Render status, to keep an empty/partial preview honest --------
+          # 'failure' when >=1 scenario failed to render on the PR head (the
+          # render job's continue-on-error keeps the passing shots but the whole
+          # preview would otherwise read as a clean "no changes"). Absent/empty ⇒
+          # treat as complete (older runs, or the file was pruned), so this only
+          # ever ADDS a warning, never suppresses an existing preview.
+          RENDER_STATUS_FILE="${ART}/render-status.txt"
+          [ -f "${RENDER_STATUS_FILE}" ] || RENDER_STATUS_FILE=''
+
           # --- Build the comment body ---------------------------------------
           # Delegated to the same unit-tested script (light/dark pairing, flow
           # labels, and HTML escaping live in web-shell-visuals-publish.mjs).
@@ -249,7 +258,8 @@ jobs:
             "${STAGE}" \
             "${RAW_BASE}" \
             "${SHORT_SHA}" "${RUN_URL}" "${BODY_FILE}" \
-            "${CHANGED_PATHS_FILE}"
+            "${CHANGED_PATHS_FILE}" \
+            "${RENDER_STATUS_FILE}"
 
           # --- Post or update the PR comment --------------------------------
           # Dedup only against OUR OWN prior comment (bot author + marker), and

--- a/.github/workflows/web-shell-visuals.yml
+++ b/.github/workflows/web-shell-visuals.yml
@@ -98,7 +98,20 @@ jobs:
           echo "PLAYWRIGHT_PORT=${port}" >> "${GITHUB_ENV}"
           echo "Using web-shell Playwright port ${port}"
 
+      # continue-on-error: a single failing/timing-out scenario must NOT discard
+      # the whole preview. Playwright writes each PNG/webm as its test passes, so
+      # the captures from the scenarios that DID pass are already on disk; the
+      # steps below (compose/upload) then publish those instead of the job dying
+      # here and the passing shots never being uploaded. The real result is read
+      # from `steps.after_capture.outcome` (which continue-on-error does NOT mask,
+      # unlike `.conclusion`) and shipped to the publisher as render-status.txt,
+      # so the comment says "render incomplete" rather than a misleading
+      # "no changes" when a scenario broke. The job stays green because the
+      # publish workflow only runs on a `success` conclusion; the broken scenario
+      # is surfaced in the comment, not by sinking every other PR author's preview.
       - name: 'Capture screenshots and flow recordings (after / PR head)'
+        id: 'after_capture'
+        continue-on-error: true
         env:
           WEB_SHELL_VISUALS_OUTPUT_DIR: '${{ runner.temp }}/web-shell-visuals'
         run: 'npm run test:e2e:visuals --workspace=packages/web-shell'
@@ -227,6 +240,12 @@ jobs:
         env:
           OUT_DIR: '${{ runner.temp }}/web-shell-visuals'
           PR_NUMBER: '${{ github.event.pull_request.number }}'
+          # The TRUE after-render result. `.outcome` is the pre-continue-on-error
+          # value ('failure' when >=1 scenario failed), unlike `.conclusion` which
+          # the continue-on-error masks to 'success'. The publisher reads this to
+          # decide whether an empty/partial preview means "no visual change" or
+          # "a scenario failed to render" — the two must not look alike.
+          AFTER_OUTCOME: '${{ steps.after_capture.outcome }}'
         run: |-
           set -euo pipefail
           # Ensure both dirs exist so the counts below are robust even when an
@@ -257,8 +276,15 @@ jobs:
           # publish job binds to the authenticated github.event.workflow_run
           # .head_sha, and an artifact-sourced SHA would be untrusted.
           printf '%s\n' "${PR_NUMBER}" > "${OUT_DIR}/pr.txt"
+          # Render status for the publisher: 'failure' when >=1 scenario failed
+          # (default to 'failure' if the step somehow reported nothing, so an
+          # unknown state fails safe toward "incomplete" rather than a false
+          # all-clear). Anything other than the literal 'success' is treated as
+          # incomplete on the publish side.
+          printf '%s\n' "${AFTER_OUTCOME:-failure}" > "${OUT_DIR}/render-status.txt"
           echo "Screenshots: $(find "${OUT_DIR}/screenshots" -name '*.png' | wc -l | tr -d ' ')"
           echo "GIFs: $(find "${OUT_DIR}/gifs" -name '*.gif' | wc -l | tr -d ' ')"
+          echo "After-render outcome: ${AFTER_OUTCOME:-unknown}"
 
       # The privileged publish workflow downloads THIS artifact, so keep the raw
       # videos out of it: an untrusted PR could drop a multi-GB file under
@@ -272,6 +298,7 @@ jobs:
             ${{ runner.temp }}/web-shell-visuals/screenshots
             ${{ runner.temp }}/web-shell-visuals/gifs
             ${{ runner.temp }}/web-shell-visuals/pr.txt
+            ${{ runner.temp }}/web-shell-visuals/render-status.txt
           if-no-files-found: 'warn'
           retention-days: 7
 


### PR DESCRIPTION
## What this PR does

Makes the web-shell visual preview resilient to a single failing scenario. Today one broken or timing-out scenario fails the whole render job, so nothing is uploaded and no preview is posted — even for the scenarios that passed. This lets the passing captures through, and keeps the comment honest about the ones that didn't.

## Why it's needed

The render runs every screenshot **and** every flow in one `npm run test:e2e:visuals` step. That step has no `continue-on-error`, and the later compose/upload steps have no `if: always()`. So the moment any scenario fails, the job dies at that step, the artifact is never uploaded, and the `workflow_run` publisher has nothing to comment — the entire preview disappears.

A flow (a long multi-click drive: open settings → nav → dialog → sub-dialog) is by far the most fragile scenario kind, so the fragile one silently takes down the deterministic screenshots that were already captured to disk.

This is not hypothetical — #7498 hit it exactly:

```
1 failed
29 passed (3.5m)
```

29 scenarios passed (including the PR's new `channels manager` screenshots), one new channel-management **flow** timed out at 60s, and the PR got **no preview and no comment at all**. From the author's side it looks identical to "the bot didn't run".

## How it's fixed

- The after-capture step becomes `continue-on-error: true` with an `id`. Playwright writes each PNG/webm as its test passes, so the passing captures are already on disk; the compose and upload steps now run and publish them instead of the job dying first.
- The publish job only runs on a `success` conclusion, so the job must stay green. But a masked failure must not read as a clean preview. The step's real `.outcome` (which `continue-on-error` does **not** mask, unlike `.conclusion`) is written to `render-status.txt` in the artifact.
- `buildComment` reads it and stops conflating "render failed" with "no visual change":

| Situation | Before | After |
| --- | --- | --- |
| render OK, no changed views | ✅ no changes / coverage-gap prompt | *unchanged* |
| render OK, some changed views | before/after composites | *unchanged* |
| **render failed, some views rendered** | *(no comment at all)* | ⚠️ partial-preview warning **+** the shots that did render |
| **render failed, nothing rendered** | *(no comment at all)* | ⚠️ "one or more scenarios failed to render" — explicitly *not* the green check or coverage-gap prompt |

A missing `render-status.txt` (an older/in-flight run) defaults to complete, so this only ever **adds** a warning and never suppresses a preview that actually rendered.

The failing scenario still needs fixing — but it's now surfaced in the comment instead of by silently deleting every other PR's preview.

## Reviewer Test Plan

### How to verify

Unit tests cover the comment builder across the render-status cases:

```
node --test .github/scripts/web-shell-visuals-publish.test.mjs
# tests 23 / pass 23 / fail 0
```

The full CI helper set still passes (`92/92`), and `actionlint` is clean on both workflows (the one remaining `SC2034` on `web-shell-visuals.yml` is pre-existing on `main` — `for attempt in`, unrelated to this change).

Drive the real CLI the way the publish workflow does, with a `render-status.txt`:

```bash
mkdir -p /tmp/stage-empty
printf 'failure\n' > /tmp/rs-fail.txt
printf 'packages/web-shell/client/components/WelcomeScreen.tsx\n' > /tmp/paths.txt
node .github/scripts/web-shell-visuals-publish.mjs comment \
  /tmp/stage-empty '' abc1234 https://run.example/9 /tmp/body.md /tmp/paths.txt /tmp/rs-fail.txt
cat /tmp/body.md
```

Confirm it shows the render-failure notice and **not** the coverage-gap prompt. Swap `rs-fail.txt` to `success` and confirm the coverage-gap prompt returns; drop the arg entirely and confirm today's behavior is byte-identical.

### Evidence (Before & After)

**Render failed, nothing rendered (the #7498 case) — After:**

```
#### Screenshots · before / after

⚠️ _No preview: one or more scenarios failed to render_ on this head — see the [workflow run](…). This is not "no visual change" — a scenario that times out or throws produces no image. Fix the failing scenario (or a genuine regression it caught) and the preview returns on the next push.
```

Before: no comment at all.

**Render failed, some views rendered — After:**

```
#### Screenshots · before / after

⚠️ _One or more scenarios failed to render_ on this head, so this preview may be missing views — see the [workflow run](…). The composites below are the scenarios that did render.

<img src="…/home-dark.png" width="900" …>
```

Before: no comment at all.

**Render OK (control) — unchanged:** the green check, the coverage-gap prompt, and the normal before/after composites are all byte-identical to today (covered by the existing + new unit tests).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`node --test` for the helper tests, `actionlint` + `bash -n` (via js-yaml step extraction) for both workflows, and the CLI invocation above. No daemon or browser needed — the changed code is a pure comment builder plus workflow wiring.

## Risk & Scope

- **Main risk or tradeoff:** the "Capture web-shell visuals" check now shows **green** even when a scenario fails (it must, or the `success`-gated publish job wouldn't post the preview). The failing scenario is surfaced in the preview comment instead of by a red check. If a red signal on a broken scenario is wanted, that's a follow-up (e.g. a separate non-blocking status), but it can't share this job without also blocking the publish.
- **Not validated / out of scope:** does not fix #7498's flow itself — that's the author's to fix; this just stops it from erasing the preview. Screenshots and flows still run in one step, so a flow failure still marks the whole render "incomplete" even though the screenshots are fine; splitting them into separate `continue-on-error` steps (so a flow failure never even warns on the screenshot preview) is a reasonable follow-up.
- **Breaking changes / migration notes:** none. One new artifact file (`render-status.txt`), backward-compatible when absent.

## Linked Issues

Follow-up to #6880 / #6963 / #7375 (the preview + its comment builder). Motivated by the empty result on #7498.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell 视觉预览对**单个场景失败**有韧性。现在只要有一个场景失败或超时,整个渲染 job 就失败,产物不上传、预览不发——连那些通过了的场景也一起没了。这个改动让通过的截图照常发布,并让评论对失败的部分**说实话**。

## 为什么需要

渲染在同一个 `test:e2e:visuals` 步骤里跑**所有**截图**和** flow。这个步骤没有 `continue-on-error`,后面的 compose/upload 也没有 `if: always()`。所以任何一个场景一失败,job 就死在那一步,产物永不上传,`workflow_run` 的 publish 就没东西可评——整个预览消失。

flow(开设置 → 导航 → 对话框 → 子对话框 的长链多次点击)是最脆弱的场景类型,于是这个脆弱的家伙悄悄干掉了那些**已经**截好、躺在磁盘上的确定性截图。

这不是假设——#7498 正是如此:**1 failed / 29 passed**。29 个场景通过(包括这个 PR 新加的 `channels manager` 截图),一个新的 channel-management **flow** 60s 超时,于是这个 PR **一条评论、一张图都没有**。从作者角度看,和"bot 没跑"一模一样。

## 怎么修的

- after-capture 步骤改成 `continue-on-error: true` 并加 `id`。Playwright 是逐个测试写 PNG/webm 的,通过的截图已在磁盘上;compose/upload 现在会照常运行并发布它们,而不是 job 先死。
- publish job 只在 `success` conclusion 才跑,所以 job 必须保持绿。但被掩盖的失败**不能**被读成干净的预览。步骤真实的 `.outcome`(`continue-on-error` **不会**掩盖它,不同于 `.conclusion`)被写进产物的 `render-status.txt`。
- `buildComment` 读取它,不再把"渲染失败"和"无视觉变化"混为一谈(见上文英文表格):渲染失败+无图 → "一个或多个场景渲染失败",明确**不是**绿勾也不是 coverage-gap 提示;渲染失败+部分图 → 在已渲染的图上方标注"部分预览"。缺失 `render-status.txt`(旧的运行)默认视为完整,所以这只会**新增**警告,绝不压制真实预览。

失败的场景仍需修复——但现在它体现在评论里,而不是靠悄悄删掉所有其他 PR 的预览。

## 风险与范围

- **主要取舍:** "Capture web-shell visuals" 这个 check 现在即使有场景失败也显示**绿**(必须如此,否则 `success`-gated 的 publish 就不会发预览)。失败的场景通过预览评论体现,而非红 check。如果确实想要"场景坏了就红"的信号,那是后续(比如单独一个不阻塞的 status),但它没法和这个 job 共用而不同时阻塞 publish。
- **不在范围内:** 不修 #7498 那个 flow 本身——那是作者的事;这只是阻止它抹掉预览。截图和 flow 仍在同一步骤,所以 flow 失败仍会把整个渲染标为"不完整"(尽管截图没问题);把它们拆成各自 `continue-on-error` 的步骤(这样 flow 失败连截图预览的警告都不触发)是合理的后续。
- **破坏性改动:** 无。新增一个产物文件(`render-status.txt`),缺失时向后兼容。

</details>
