### PR TITLE
ci: matrix ECS runner update + sudo install + repository_dispatch trigger

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,7 @@
 self-hosted-runner:
   labels:
     - 'ecs-qwen'
+    - 'ecs-update-sg'
+    - 'ecs-update-64c'
 
 config-variables: null

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 'Resolve version'
         id: 'version'
         env:
-          INPUT_VERSION: '${{ inputs.version }}'
+          INPUT_VERSION: '${{ inputs.version || github.event.client_payload.version }}'
         run: |-
           set -euo pipefail
           specifier="@qwen-code/qwen-code@${INPUT_VERSION#v}"

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -8,19 +8,24 @@ on:
         required: false
         default: ''
         type: 'string'
+  repository_dispatch:
+    types: ['npm-published']
 
 permissions:
   contents: 'read'
 
-concurrency:
-  group: 'update-ecs-runner-qwen-sg'
-  cancel-in-progress: false
-
 jobs:
   update:
-    name: 'Update Qwen on Singapore ECS runner'
+    name: 'Update Qwen on ${{ matrix.runner }}'
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
-    runs-on: ['self-hosted', 'linux', 'x64', 'ecs-qwen']
+    strategy:
+      matrix:
+        runner: ['ecs-update-sg', 'ecs-update-64c']
+      fail-fast: false
+    runs-on: ['self-hosted', 'linux', 'x64', '${{ matrix.runner }}']
+    concurrency:
+      group: 'update-ecs-runner-qwen-${{ matrix.runner }}'
+      cancel-in-progress: false
     timeout-minutes: 10
     steps:
       - name: 'Resolve version'
@@ -46,16 +51,11 @@ jobs:
           VERSION: '${{ steps.version.outputs.version }}'
         run: |-
           set -euo pipefail
-          global_root="$(npm root -g)"
-          global_bin="$(npm prefix -g)/bin"
-          if [[ -w "${global_root}" && -w "${global_bin}" ]]; then
-            npm install -g "@qwen-code/qwen-code@${VERSION}"
-          elif command -v sudo >/dev/null 2>&1 && sudo -n true; then
-            sudo npm install -g "@qwen-code/qwen-code@${VERSION}"
-          else
-            echo "::error::Global npm install directories are not writable and passwordless sudo is unavailable."
-            exit 1
-          fi
+          # Always use sudo so the package lands in /usr/local (the system-wide
+          # global prefix that every user's PATH resolves first).  Without sudo
+          # the runner user (github-runner) installs into its own home directory
+          # which is shadowed by the older root-installed binary in /usr/local/bin.
+          sudo npm install -g "@qwen-code/qwen-code@${VERSION}"
 
       - name: 'Verify version'
         env:


### PR DESCRIPTION
## Summary

The existing `update-ecs-runner-qwen.yml` workflow has two issues that prevent it from reliably keeping ECS runners on the latest qwen-code version:

1. **Wrong install target.** The runner service runs as the `github-runner` user (`/home/github-runner/actions-runner-N/`). When the workflow executes `npm install -g`, npm resolves the global prefix to the runner user's home directory. However, `/usr/local/bin` (where root originally installed qwen 0.20.0) appears earlier in PATH, so `qwen --version` still returns the old version and the verify step fails. The `changed 7 packages` output from npm is real — it just lands in the wrong place.

2. **Single-runner scheduling.** The `runs-on` label `ecs-qwen` matches multiple runners, but each workflow_dispatch only schedules one job, leaving the other runner(s) unupdated.

### Changes

- **Matrix strategy** (`ecs-update-sg`, `ecs-update-64c`) with `fail-fast: false` so both runners are updated in parallel and independently.
- **`sudo npm install -g`** unconditionally, ensuring the package lands in `/usr/local` — the system-wide prefix that every user's PATH resolves first.
- **Job-level per-runner concurrency group** (`update-ecs-runner-qwen-${{ matrix.runner }}`) so updates on the same runner queue instead of overlapping, while the two matrix jobs don't block each other.
- **`repository_dispatch`** (`npm-published`) so `release.yml` can trigger runner updates automatically after a publish (follow-up PR to wire the dispatch call). The resolve step reads `client_payload.version` so a release-triggered dispatch pins the exact published version instead of racing the npm `latest` dist-tag propagation.
- **Register the new self-hosted labels** in `.github/actionlint.yaml` so actionlint keeps passing.

### Prerequisite

Each ECS runner needs a unique label added in **Settings → Actions → Runners**:

| Instance | New label |
|---|---|
| `i-t4neqpisqczs6hsm7xn2` (sg-1) | `ecs-update-sg` |
| `i-t4ne2fxw78cka1n2cbko` (64c) | `ecs-update-64c` |

The existing shared `ecs-qwen` label should be kept so other workflows (`qwen-code-pr-review.yml`, `qwen-triage.yml`) continue to work without changes.

## Test plan

- [ ] Add `ecs-update-sg` / `ecs-update-64c` labels to the two ECS runners in GitHub Settings.
- [ ] One-time cleanup on both instances: remove the stale copy previously installed into the runner user's npm prefix (`npm uninstall -g @qwen-code/qwen-code` as `github-runner`), then `sudo npm install -g @qwen-code/qwen-code@latest`.
- [ ] Trigger the workflow via `workflow_dispatch` and verify both matrix jobs succeed.
- [ ] Confirm `qwen --version` returns the latest version on both runners after the run.
