### PR TITLE
fix(acp): hide discontinued OAuth model for other auth types

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -412,7 +412,26 @@ function setupAcpTest(
 
   it('returns internal error details when model auth is required', async () => {
     const rig = new TestRig();
-    rig.setup('acp auth methods in error data');
+    rig.setup('acp auth methods in error data', {
+      settings: {
+        modelProviders: {
+          openai: [
+            {
+              id: 'e2e-authenticated-model',
+              name: 'E2E Authenticated Model',
+              baseUrl: 'http://127.0.0.1:9/v1',
+              envKey: 'E2E_OPENAI_API_KEY',
+            },
+          ],
+        },
+        env: { E2E_OPENAI_API_KEY: 'test-key' },
+        security: { auth: { selectedType: 'openai' } },
+        model: {
+          name: 'e2e-authenticated-model',
+          baseUrl: 'http://127.0.0.1:9/v1',
+        },
+      },
+    });
 
     const { sendRequest, cleanup, stderr } = setupAcpTest(rig);
 
@@ -430,21 +449,15 @@ function setupAcpTest(
         mcpServers: [],
       })) as {
         sessionId: string;
-        models: {
-          availableModels: Array<{ modelId: string }>;
-        };
       };
 
-      // Choose a qwen-oauth model to trigger auth-required path deterministically.
-      const qwenOauthModel = newSession.models.availableModels.find((model) =>
-        model.modelId.includes('qwen-oauth'),
-      );
-      expect(qwenOauthModel).toBeDefined();
+      // Request the discontinued route directly: non-OAuth sessions no longer
+      // advertise it, but the auth error path must still stay structured.
       await expect(
         sendRequest('session/set_config_option', {
           sessionId: newSession.sessionId,
           configId: 'model',
-          value: qwenOauthModel!.modelId,
+          value: 'coder-model(qwen-oauth)',
         }),
       ).rejects.toMatchObject({
         response: {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4098,6 +4098,100 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it.each([
+    {
+      description: 'hide discontinued qwen-oauth for other auth types',
+      authType: 'openai',
+      model: 'qwen3.6-27b',
+      expectedCurrent: 'qwen3.6-27b(openai)',
+      expectedModels: ['qwen3.6-27b(openai)'],
+    },
+    {
+      description: 'keep qwen-oauth for existing qwen-oauth sessions',
+      authType: 'qwen-oauth',
+      model: 'coder-model',
+      expectedCurrent: 'coder-model(qwen-oauth)',
+      expectedModels: ['coder-model(qwen-oauth)', 'qwen3.6-27b(openai)'],
+    },
+  ])(
+    'session model selectors $description',
+    async ({ authType, model, expectedCurrent, expectedModels }) => {
+      const sessionId = '11111111-1111-1111-1111-111111111111';
+      const innerConfig = await setupSessionMocks(sessionId);
+      Object.assign(innerConfig, {
+        getModel: vi.fn().mockReturnValue(model),
+        getAuthType: vi.fn().mockReturnValue(authType),
+        getAllConfiguredModels: vi.fn().mockReturnValue([
+          {
+            id: 'coder-model',
+            label: 'coder-model',
+            authType: 'qwen-oauth',
+          },
+          {
+            id: 'qwen3.6-27b',
+            label: 'Qwen3.6-27B Local',
+            authType: 'openai',
+          },
+        ]),
+      });
+
+      const agentPromise = runAcpAgent(
+        mockConfig,
+        makeSessionSettings(),
+        mockArgv,
+      );
+      await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+
+      const agent = capturedAgentFactory!({
+        get closed() {
+          return mockConnectionState.promise;
+        },
+      }) as AgentLike;
+
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as {
+        models: {
+          currentModelId: string;
+          availableModels: Array<{ modelId: string }>;
+        };
+        configOptions: Array<{
+          id: string;
+          currentValue: string;
+          options: Array<{ value: string }>;
+        }>;
+      };
+      const context = (await agent.extMethod(
+        SERVE_STATUS_EXT_METHODS.sessionContext,
+        { sessionId },
+      )) as {
+        state: {
+          models: {
+            currentModelId: string;
+            availableModels: Array<{ modelId: string }>;
+          };
+        };
+      };
+      const modelOption = session.configOptions.find(
+        (option) => option.id === 'model',
+      );
+
+      expect(session.models.currentModelId).toBe(expectedCurrent);
+      expect(
+        session.models.availableModels.map((option) => option.modelId),
+      ).toEqual(expectedModels);
+      expect(modelOption?.currentValue).toBe(expectedCurrent);
+      expect(modelOption?.options.map((option) => option.value)).toEqual(
+        expectedModels,
+      );
+      expect(context.state.models).toMatchObject(session.models);
+
+      mockConnectionState.resolve();
+      await agentPromise;
+    },
+  );
+
   it('session model selectors distinguish the same model id on different endpoints', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
     const innerConfig = await setupSessionMocks(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -10401,7 +10401,7 @@ class QwenAgent implements Agent {
       ''
     ).trim();
     const currentAuthType = config.getAuthType();
-    const modelOptions = buildAcpModelOptions(config.getAllConfiguredModels());
+    const modelOptions = this.buildSelectableModelOptions(config);
 
     const activeRuntimeSnapshot = config.getActiveRuntimeModelSnapshot?.();
     const currentModelId = getCurrentAcpModelId(
@@ -10445,7 +10445,7 @@ class QwenAgent implements Agent {
 
   private buildConfigOptions(config: Config): SessionConfigOption[] {
     const currentApprovalMode = config.getApprovalMode();
-    const modelOptions = buildAcpModelOptions(config.getAllConfiguredModels());
+    const modelOptions = this.buildSelectableModelOptions(config);
     const rawCurrentModelId = (config.getModel() || '').trim();
     const currentAuthType = config.getAuthType?.();
 
@@ -10492,6 +10492,19 @@ class QwenAgent implements Agent {
     };
 
     return [modeConfigOption, modelConfigOption];
+  }
+
+  private buildSelectableModelOptions(config: Config) {
+    const currentAuthType = config.getAuthType();
+    return buildAcpModelOptions(
+      config
+        .getAllConfiguredModels()
+        .filter(
+          (model) =>
+            model.authType !== AuthType.QWEN_OAUTH ||
+            currentAuthType === AuthType.QWEN_OAUTH,
+        ),
+    );
   }
 }
 


### PR DESCRIPTION
## What this PR does

ACP sessions now omit the discontinued built-in Qwen OAuth model from model selectors when another authentication type is active. Existing Qwen OAuth sessions keep their current model and selector entry. Session creation, model configuration, and daemon session context use the same filtered options.

## Why it's needed

The global model registry includes a built-in OAuth model even for users who configured only a local or custom OpenAI-compatible provider. Raw ACP responses consequently advertised that unrelated model first, allowing clients to present it as the preferred choice. The interactive model picker already filters the same discontinued entry; this brings the ACP surface in line with that behavior.

## Reviewer Test Plan

### How to verify

Create an ACP session with an authenticated OpenAI-compatible provider and a non-OAuth model selected. Confirm that the current model is unchanged, the discontinued OAuth model is absent from both model selectors, and the daemon session context matches. Then create a Qwen OAuth session and confirm its active model remains available. The regression tests exercise both cases and preserve the structured authentication error for a direct request to the hidden route.

### Evidence (Before & After)

Before, the reproduced raw ACP response for an OpenAI-compatible session reported `qwen3.6-27b(openai)` as current but placed `coder-model(qwen-oauth)` first in both available model lists. After, the same built CLI reports only the configured OpenAI-compatible models; the current model remains `qwen3.6-27b(openai)`. The separate incorrect-current-model label reported by an external SDK was not reproduced on current main.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Built CLI with a local deterministic OpenAI-compatible test configuration; no external model request was required.

## Risk & Scope

- Main risk or tradeoff: A user on another authentication type can no longer select the discontinued OAuth route from the advertised ACP list; direct requests still return the existing structured authentication error.
- Not validated / out of scope: The external SDK's incorrect current-model label was not reproducible on current main. Interactive model selection and registry contents are unchanged.
- Breaking changes / migration notes: None. Active Qwen OAuth sessions retain the built-in model.

## Linked Issues

Addresses the reproducible ACP model-list portion of #7433.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当会话当前使用其他认证类型时，ACP 模型选择器不再展示已停用的内置 Qwen OAuth 模型。已有的 Qwen OAuth 会话仍保留当前模型及其选择项。会话创建、模型配置和守护进程会话上下文现在使用同一组过滤后的选项。

## 为什么需要此改动

即使用户只配置了本地或自定义的 OpenAI 兼容提供商，全局模型注册表仍会包含一个内置 OAuth 模型。因此，原始 ACP 响应会把这个无关模型放在第一位，客户端可能将其显示为首选项。交互式模型选择器已经过滤了同一个已停用条目；本改动让 ACP 接口与该行为保持一致。

## 审阅者测试计划

### 验证方法

使用已认证的 OpenAI 兼容提供商并选择非 OAuth 模型来创建 ACP 会话。确认当前模型不变、两个模型选择器都不包含已停用的 OAuth 模型，并且守护进程会话上下文与其一致。然后创建 Qwen OAuth 会话，确认其当前模型仍可选择。回归测试覆盖这两种情况，同时保留直接请求隐藏路由时的结构化认证错误。

### 证据（修改前后）

修改前，在 OpenAI 兼容会话中复现的原始 ACP 响应将 `qwen3.6-27b(openai)` 正确报告为当前模型，但在两个可用模型列表中都把 `coder-model(qwen-oauth)` 放在第一位。修改后，同一个构建后的 CLI 只报告已配置的 OpenAI 兼容模型，当前模型仍为 `qwen3.6-27b(openai)`。外部 SDK 报告的另一项“当前模型标签错误”在当前 main 分支上未能复现。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|    macOS     |  ⚠️  |
|   Windows    |  ⚠️  |
|    Linux     |  ✅  |

### 环境（可选）

使用本地确定性的 OpenAI 兼容测试配置运行构建后的 CLI；无需向外部模型发起请求。

## 风险与范围

- 主要风险或取舍：使用其他认证类型的用户无法再从 ACP 公布的列表中选择已停用的 OAuth 路由；直接请求仍会返回原有的结构化认证错误。
- 未验证或超出范围：外部 SDK 的“当前模型标签错误”在当前 main 分支上无法复现。交互式模型选择和模型注册表内容均未更改。
- 破坏性变更或迁移说明：无。已有的 Qwen OAuth 会话仍保留内置模型。

## 关联 Issue

本 PR 处理 #7433 中可复现的 ACP 模型列表问题。

</details>
