### PR TITLE
fix(core): treat backslash as literal inside single quotes in splitCommands

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -323,6 +323,20 @@ describe('checkCommandPermissions', () => {
       });
     });
 
+    it('should not let a backslash inside single quotes hide a blocked command', async () => {
+      // `echo 'a\'; rm ...` is two commands to the shell. If the splitter
+      // mistakes `\'` for an escaped quote it sees a single `echo` command
+      // and the deny rule never gets to look at `rm`.
+      config.getPermissionsDeny = () => ['ShellTool(rm)'];
+      const result = await checkCommandPermissions(
+        "echo 'a\\'; rm -rf /tmp/x",
+        config,
+      );
+      expect(result.allAllowed).toBe(false);
+      expect(result.isHardDenial).toBe(true);
+      expect(result.disallowedCommands).toEqual(['rm -rf /tmp/x']);
+    });
+
     it('should return a detailed failure object for a command not on a strict allowlist', async () => {
       config.getCoreTools = () => ['ShellTool(ls)'];
       const result = await checkCommandPermissions('git status && ls', config);
@@ -563,6 +577,26 @@ describe('getCommandRoots', () => {
     expect(getCommandRoots('"C:\\Program Files\\foo\\bar.exe" arg1')).toEqual([
       'bar.exe',
     ]);
+  });
+
+  it('should treat a backslash inside single quotes as literal, not an escape', async () => {
+    // The shell performs no escaping inside single quotes, so `'a\'` closes
+    // the quote and `;` separates two commands:
+    //   $ echo 'a\'; rm -rf /tmp/x   ->   prints "a\", then runs rm
+    // Treating `\'` as an escaped quote would leave the parser inside the
+    // quote and swallow `rm` entirely.
+    expect(getCommandRoots("echo 'a\\'; rm -rf /tmp/x")).toEqual([
+      'echo',
+      'rm',
+    ]);
+  });
+
+  it('should still honour backslash escapes outside single quotes', async () => {
+    // Inside double quotes a backslash *does* escape, so the quote stays open
+    // and the whole string is one command.
+    expect(getCommandRoots('echo "a\\"; rm -rf /tmp/x"')).toEqual(['echo']);
+    // An escaped separator outside quotes is likewise not a separator.
+    expect(getCommandRoots('echo a\\; rm -rf /tmp/x')).toEqual(['echo']);
   });
 });
 

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -231,7 +231,12 @@ export function splitCommands(command: string): string[] {
       continue;
     }
 
-    if (char === '\\' && i < command.length - 1) {
+    // Inside single quotes the shell treats a backslash as a literal
+    // character — it escapes nothing, so `'a\'` closes the quote. Consuming
+    // the following character here would keep the parser "inside" the quote
+    // and swallow every separator to the end of the line, hiding whole
+    // commands from the permission checks that consume these segments.
+    if (!inSingleQuotes && char === '\\' && i < command.length - 1) {
       currentCommand += char + command[i + 1];
       i += 2;
       continue;


### PR DESCRIPTION
## What this PR does

`splitCommands` applied its backslash-escape branch regardless of quote state. This guards it with `!inSingleQuotes`, so a backslash inside single quotes is treated as the literal character the shell treats it as. One-line change plus regression tests.

## Why it's needed

The shell performs **no** escaping inside single quotes — `\` is an ordinary character there, so `'a\'` closes the quote:

```
$ echo 'a\'; rm -rf /tmp/x
a\            # command 1
              # command 2 runs rm
```

The parser instead read `\'` as an escaped quote, stayed "inside" the string, and swallowed every separator to the end of the line. (The line-continuation branch immediately above already guards on `!inSingleQuotes` for exactly this reason; the general escape branch was missed.)

`splitCommands` is the segmentation primitive behind `getCommandRoots` and `checkCommandPermissions`, so the hidden commands were never handed to the permission checks. With a `ShellTool(rm)` deny rule configured, on `main`:

| command | `allAllowed` | `isHardDenial` |
| --- | --- | --- |
| `rm -rf /tmp/x` | `false` | `true` |
| `echo hi; rm -rf /tmp/x` | `false` | `true` |
| `echo 'a\'; rm -rf /tmp/x` | **`true`** | **`undefined`** |

`getCommandRoots("echo 'a\\'; rm -rf /tmp/x")` likewise returned `["echo"]` — `rm` was invisible. After the fix all three rows hard-deny and the roots are `["echo", "rm"]`.

Escapes **outside** single quotes are unchanged, which is correct: inside double quotes the shell *does* treat `\` as an escape, so `echo "a\"; rm ..."` legitimately stays one command.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/utils/shell-utils.test.ts` → 150/150.
- Three tests pin the behavior. Reverting just the `!inSingleQuotes &&` guard fails two of them:
  - `getCommandRoots > should treat a backslash inside single quotes as literal, not an escape` — expects `['echo', 'rm']`, gets `['echo']`.
  - `checkCommandPermissions > should not let a backslash inside single quotes hide a blocked command` — expects a hard denial of `rm -rf /tmp/x`, gets `allAllowed: true`.
  - `should still honour backslash escapes outside single quotes` passes both before and after — it is the guard against over-correcting into double-quoted and unquoted escapes.
- Ground truth is `bash` itself: `bash -c "echo 'a\\'; echo INJECTED"` prints `a\` then `INJECTED`, i.e. two commands.

### Evidence (Before & After)

Not user-visible; verified by the deterministic unit tests above and by the permission-gate table in "Why it's needed" (reproduced with the same mocked `Config` the existing `checkCommandPermissions` tests use).

- Before: `echo 'a\'; rm -rf /tmp/x` → one segment, root `echo`, deny rule bypassed.
- After: two segments, roots `echo` + `rm`, `rm -rf /tmp/x` hard-denied.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `shell-utils` (150), `shellReadOnlyChecker` (230), `shellAstParser` (542), `tools/shell` + `tools/monitor` (358) all pass locally, with proven fail-before/pass-after. The change is pure string parsing with no platform-dependent behavior and the assertions are deterministic, so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: commands that previously parsed as one segment because of a backslash inside single quotes now parse as several. That is the shell's own reading, and it can only ever *add* segments for the permission checks to inspect — it cannot cause a command to be approved that was previously denied.
- Not validated / out of scope: `packages/desktop/packages/shared/src/utils/cli-icon-resolver.ts` has its own independent `splitCommands` used only for picking a display icon; it has no security role and is deliberately untouched.
- Breaking changes / migration notes: none.

## Linked Issues

None — found by reading `splitCommands` against bash quoting semantics.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`splitCommands` 的反斜杠转义分支不区分引号状态即被应用。本 PR 为其加上 `!inSingleQuotes` 判断，使单引号内的反斜杠按 shell 的语义作为普通字面字符处理。一行改动，外加回归测试。

## 为什么需要

shell 在单引号内**不做任何**转义——`\` 在其中只是普通字符，因此 `'a\'` 会闭合该引号：

```
$ echo 'a\'; rm -rf /tmp/x
a\            # 命令 1
              # 命令 2 执行 rm
```

而解析器把 `\'` 当成被转义的引号，因而一直"停留在"字符串内部，吞掉了该行后续所有分隔符。（紧邻其上的续行分支早已针对同样的原因加了 `!inSingleQuotes` 判断；通用转义分支则被遗漏了。）

`splitCommands` 是 `getCommandRoots` 与 `checkCommandPermissions` 背后的分段原语，因此被吞掉的命令根本不会交给权限检查。在配置了 `ShellTool(rm)` 拒绝规则的情况下，`main` 上的表现为：

| 命令 | `allAllowed` | `isHardDenial` |
| --- | --- | --- |
| `rm -rf /tmp/x` | `false` | `true` |
| `echo hi; rm -rf /tmp/x` | `false` | `true` |
| `echo 'a\'; rm -rf /tmp/x` | **`true`** | **`undefined`** |

`getCommandRoots("echo 'a\\'; rm -rf /tmp/x")` 同样只返回 `["echo"]`——`rm` 完全不可见。修复后三行均为硬拒绝，命令根为 `["echo", "rm"]`。

单引号**之外**的转义行为保持不变，这是正确的：在双引号内 shell 确实会把 `\` 当作转义符，所以 `echo "a\"; rm ..."` 理应仍是一条命令。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/utils/shell-utils.test.ts` → 150/150 通过。
- 三个测试锁定该行为。仅还原 `!inSingleQuotes &&` 判断，其中两个会失败：
  - `getCommandRoots > should treat a backslash inside single quotes as literal, not an escape`——期望 `['echo', 'rm']`，实得 `['echo']`。
  - `checkCommandPermissions > should not let a backslash inside single quotes hide a blocked command`——期望对 `rm -rf /tmp/x` 硬拒绝，实得 `allAllowed: true`。
  - `should still honour backslash escapes outside single quotes` 在修复前后均通过——它用于防止过度修正而波及双引号内与无引号的转义。
- 基准事实来自 `bash` 本身：`bash -c "echo 'a\\'; echo INJECTED"` 会先输出 `a\` 再输出 `INJECTED`，即两条命令。

### 证据（修复前后对比）

非用户可见；由上述确定性单元测试，以及"为什么需要"一节中的权限门控对照表验证（该表使用与现有 `checkCommandPermissions` 测试相同的 mock `Config` 复现）。

- 修复前：`echo 'a\'; rm -rf /tmp/x` → 单个分段，命令根为 `echo`，拒绝规则被绕过。
- 修复后：两个分段，命令根为 `echo` + `rm`，`rm -rf /tmp/x` 被硬拒绝。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`shell-utils`（150）、`shellReadOnlyChecker`（230）、`shellAstParser`（542）、`tools/shell` + `tools/monitor`（358）本地全部通过，并已验证 fail-before/pass-after。该改动是纯字符串解析，无平台相关行为，断言均为确定性，因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：此前因单引号内有反斜杠而被解析为单个分段的命令，现在会被解析为多个分段。这正是 shell 自身的解读方式，且它只可能为权限检查**增加**待审查的分段——不可能让原本被拒绝的命令变为被放行。
- 未验证 / 范围之外：`packages/desktop/packages/shared/src/utils/cli-icon-resolver.ts` 有一份独立的 `splitCommands`，仅用于选择显示图标，不承担安全职责，本 PR 有意不改动它。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无——通过对照 bash 引号语义阅读 `splitCommands` 发现。

</details>
