### PR TITLE
fix(core): strip daemon secrets from hook and tool-discovery child env

### DIFF
--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -123,6 +123,49 @@ describe('HookRunner', () => {
       expect(mockSpawn).toHaveBeenCalled();
     });
 
+    it('strips Qwen-internal daemon secrets from the hook child env (#6601)', async () => {
+      const originalServerToken = process.env['QWEN_SERVER_TOKEN'];
+      const originalDaemonToken = process.env['QWEN_DAEMON_TOKEN'];
+      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
+      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
+      try {
+        const mockProcess = createMockProcess(0, 'hello');
+        mockSpawn.mockImplementation(() => mockProcess);
+
+        const hookConfig: HookConfig = {
+          type: HookType.Command,
+          command: 'echo hello',
+          source: HooksConfigSource.Project,
+        };
+
+        await hookRunner.executeHook(
+          hookConfig,
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        const spawnOptions = mockSpawn.mock.calls[0][2];
+        // A user-authored hook command is a child process launched on the
+        // agent's behalf; internal daemon secrets must not leak into it.
+        expect(spawnOptions.env['QWEN_SERVER_TOKEN']).toBeUndefined();
+        expect(spawnOptions.env['QWEN_DAEMON_TOKEN']).toBeUndefined();
+        // Benign inherited env and the hook's own vars are still present.
+        expect(spawnOptions.env['PATH']).toBeDefined();
+        expect(spawnOptions.env['QWEN_PROJECT_DIR']).toBe('/test');
+      } finally {
+        if (originalServerToken === undefined) {
+          delete process.env['QWEN_SERVER_TOKEN'];
+        } else {
+          process.env['QWEN_SERVER_TOKEN'] = originalServerToken;
+        }
+        if (originalDaemonToken === undefined) {
+          delete process.env['QWEN_DAEMON_TOKEN'];
+        } else {
+          process.env['QWEN_DAEMON_TOKEN'] = originalDaemonToken;
+        }
+      }
+    });
+
     it('should return failure for non-zero exit code', async () => {
       const mockProcess = createMockProcess(1, '', 'error');
       mockSpawn.mockImplementation(() => mockProcess);

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -31,6 +31,7 @@ import { PromptHookRunner } from './promptHookRunner.js';
 import { AsyncHookRegistry, generateHookId } from './asyncHookRegistry.js';
 import type { Config } from '../config/config.js';
 import { getShellContextEnvVars } from '../utils/shellContextEnv.js';
+import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
@@ -584,7 +585,9 @@ export class HookRunner {
       );
 
       const env = {
-        ...process.env,
+        // Hook commands are child processes launched on the agent's behalf,
+        // so they must not inherit Qwen-internal daemon secrets.
+        ...sanitizeChildEnv(process.env),
         GEMINI_PROJECT_DIR: input.cwd,
         CLAUDE_PROJECT_DIR: input.cwd, // For compatibility
         QWEN_PROJECT_DIR: input.cwd, // For Qwen Code compatibility

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -842,6 +842,96 @@ describe('ToolRegistry', () => {
       });
     });
 
+    it('strips Qwen-internal daemon secrets from the discovery and tool-call child env (#6601)', async () => {
+      const originalServerToken = process.env['QWEN_SERVER_TOKEN'];
+      const originalDaemonToken = process.env['QWEN_DAEMON_TOKEN'];
+      process.env['QWEN_SERVER_TOKEN'] = 'serve-secret';
+      process.env['QWEN_DAEMON_TOKEN'] = 'daemon-secret';
+      try {
+        mockConfigGetToolDiscoveryCommand.mockReturnValue(
+          'my-discovery-command',
+        );
+        vi.spyOn(config, 'getToolCallCommand').mockReturnValue(
+          'my-call-command',
+        );
+
+        const toolDeclaration: FunctionDeclaration = {
+          name: 'secret-probe',
+          description: 'A tool',
+          parametersJsonSchema: { type: 'object', properties: {} },
+        };
+
+        const mockSpawn = vi.mocked(spawn);
+        const discoveryProcess = {
+          stdout: { on: vi.fn(), removeListener: vi.fn() },
+          stderr: { on: vi.fn(), removeListener: vi.fn() },
+          on: vi.fn(),
+        };
+        mockSpawn.mockReturnValueOnce(discoveryProcess as any);
+        discoveryProcess.stdout.on.mockImplementation((event, callback) => {
+          if (event === 'data') {
+            callback(
+              Buffer.from(
+                JSON.stringify([{ functionDeclarations: [toolDeclaration] }]),
+              ),
+            );
+          }
+        });
+        discoveryProcess.on.mockImplementation((event, callback) => {
+          if (event === 'close') {
+            callback(0);
+          }
+        });
+
+        await toolRegistry.discoverAllTools();
+        const discoveredTool = toolRegistry.getTool('secret-probe');
+        expect(discoveredTool).toBeDefined();
+
+        const executionProcess = {
+          stdout: { on: vi.fn(), removeListener: vi.fn() },
+          stderr: { on: vi.fn(), removeListener: vi.fn() },
+          stdin: { write: vi.fn(), end: vi.fn() },
+          on: vi.fn(),
+          connected: true,
+          disconnect: vi.fn(),
+          removeListener: vi.fn(),
+        };
+        mockSpawn.mockReturnValueOnce(executionProcess as any);
+        executionProcess.on.mockImplementation((event, callback) => {
+          if (event === 'close') {
+            callback(0);
+          }
+        });
+
+        await (discoveredTool as DiscoveredTool)
+          .build({})
+          .execute(new AbortController().signal);
+
+        // Both the discovery command and the tool-call command are child
+        // processes launched on the agent's behalf, so neither may inherit
+        // the internal daemon secrets.
+        for (const call of mockSpawn.mock.calls) {
+          const env = (call[2] as { env: NodeJS.ProcessEnv }).env;
+          expect(env['QWEN_SERVER_TOKEN']).toBeUndefined();
+          expect(env['QWEN_DAEMON_TOKEN']).toBeUndefined();
+          // Benign inherited env is preserved.
+          expect(env['PATH']).toBeDefined();
+        }
+        expect(mockSpawn.mock.calls).toHaveLength(2);
+      } finally {
+        if (originalServerToken === undefined) {
+          delete process.env['QWEN_SERVER_TOKEN'];
+        } else {
+          process.env['QWEN_SERVER_TOKEN'] = originalServerToken;
+        }
+        if (originalDaemonToken === undefined) {
+          delete process.env['QWEN_DAEMON_TOKEN'];
+        } else {
+          process.env['QWEN_DAEMON_TOKEN'] = originalDaemonToken;
+        }
+      }
+    });
+
     it('should return a DISCOVERED_TOOL_EXECUTION_ERROR on tool failure', async () => {
       const discoveryCommand = 'my-discovery-command';
       mockConfigGetToolDiscoveryCommand.mockReturnValue(discoveryCommand);

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -25,6 +25,7 @@ import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import type { EventEmitter } from 'node:events';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
+import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { normalizeMcpToolName } from '../utils/tool-name-utils.js';
 
@@ -64,8 +65,11 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     const callCommand = this.config.getToolCallCommand()!;
     // The user-configured tool-call command is a child process launched on the
     // agent's behalf, so it must not inherit Qwen-internal daemon secrets.
+    // Passing `env` explicitly loses the native inheritance that resolved
+    // Windows' case-insensitive PATH keys, so normalize as the shell and MCP
+    // spawn sites do (a no-op off win32).
     const child = spawn(callCommand, [this.toolName], {
-      env: sanitizeChildEnv(process.env),
+      env: normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
     });
     child.stdin.write(JSON.stringify(this.params));
     child.stdin.end();
@@ -598,9 +602,10 @@ export class ToolRegistry {
         );
       }
       // Same as the tool-call command above: the discovery command is
-      // agent-launched and must not inherit Qwen-internal daemon secrets.
+      // agent-launched, must not inherit Qwen-internal daemon secrets, and
+      // needs the Windows PATH normalization that comes with an explicit env.
       const proc = spawn(cmdParts[0] as string, cmdParts.slice(1) as string[], {
-        env: sanitizeChildEnv(process.env),
+        env: normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
       });
       let stdout = '';
       const stdoutDecoder = new StringDecoder('utf8');

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -24,6 +24,7 @@ import { ToolErrorType } from './tool-error.js';
 import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 import type { EventEmitter } from 'node:events';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { normalizeMcpToolName } from '../utils/tool-name-utils.js';
 
@@ -61,7 +62,11 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     _updateOutput?: (output: ToolResultDisplay) => void,
   ): Promise<ToolResult> {
     const callCommand = this.config.getToolCallCommand()!;
-    const child = spawn(callCommand, [this.toolName]);
+    // The user-configured tool-call command is a child process launched on the
+    // agent's behalf, so it must not inherit Qwen-internal daemon secrets.
+    const child = spawn(callCommand, [this.toolName], {
+      env: sanitizeChildEnv(process.env),
+    });
     child.stdin.write(JSON.stringify(this.params));
     child.stdin.end();
 
@@ -592,7 +597,11 @@ export class ToolRegistry {
           'Tool discovery command is empty or contains only whitespace.',
         );
       }
-      const proc = spawn(cmdParts[0] as string, cmdParts.slice(1) as string[]);
+      // Same as the tool-call command above: the discovery command is
+      // agent-launched and must not inherit Qwen-internal daemon secrets.
+      const proc = spawn(cmdParts[0] as string, cmdParts.slice(1) as string[], {
+        env: sanitizeChildEnv(process.env),
+      });
       let stdout = '';
       const stdoutDecoder = new StringDecoder('utf8');
       let stderr = '';


### PR DESCRIPTION
## What this PR does

Follow-up to the just-merged #7256. That PR added `sanitizeChildEnv()` and applied it to the shell, monitor, and MCP stdio spawn paths. This routes the three remaining agent-launched child processes through it as well:

| site | before |
| --- | --- |
| `hooks/hookRunner.ts` | spreads `...process.env` into the hook command's env |
| `tools/tool-registry.ts` (tool-call command) | `spawn(callCommand, …)` with no `env` option → implicit full inheritance |
| `tools/tool-registry.ts` (discovery command) | same |

## Why it's needed

All three run a user- or config-supplied command **on the agent's behalf**, which is exactly the category `sanitizeChildEnv` was written for — its doc comment names "shell commands, the monitor tool, or a stdio MCP server", and hooks and the tool-discovery/tool-call commands are the same shape of thing. None of them has any need for `QWEN_SERVER_TOKEN` or `QWEN_DAEMON_TOKEN`, so leaving them inherited is the same credential-exposure gap #6601 describes: a hook or discovery script that runs `printenv` sees the daemon bearer tokens.

The two `tool-registry.ts` sites are easy to miss because they pass no `env` option at all — the inheritance is implicit rather than a visible `...process.env`.

This is deliberately narrow and mirrors #7256 exactly: `sanitizeChildEnv` strips only the two Qwen-internal vars and leaves third-party credentials (`GH_TOKEN`, `AWS_*`, …) alone, so hooks and discovery scripts that legitimately depend on them keep working.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/hooks/hookRunner.test.ts src/tools/tool-registry.test.ts` → 82/82.
- Two new tests, both with proven fail-before/pass-after (revert only the two source files and re-run):
  - `HookRunner > executeHook > strips Qwen-internal daemon secrets from the hook child env (#6601)` — fails on `main` with `expected 'serve-secret' to be undefined`.
  - `ToolRegistry > discoverTools > strips Qwen-internal daemon secrets from the discovery and tool-call child env (#6601)` — asserts over **both** spawn calls; fails on `main` with `Cannot read properties of undefined (reading 'env')`, i.e. no `env` option was passed at all.
- Both tests also assert the benign env survives (`PATH` still defined, `QWEN_PROJECT_DIR` still `/test`), so this cannot silently blank a child's environment.

### Evidence (Before & After)

Not user-visible; verified by the deterministic unit tests above.

- Before: a hook command or tool-discovery script launched by the agent inherits `QWEN_SERVER_TOKEN` / `QWEN_DAEMON_TOKEN`.
- After: both are absent from all three child environments; everything else is unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `hookRunner` + `tool-registry` (82) pass locally with proven fail-before/pass-after; typecheck and eslint clean on all four touched files. The change is an env-object transformation with no platform-dependent behavior and the assertions are deterministic, so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: the two `tool-registry.ts` spawns now pass an explicit `env` where they previously passed none. `sanitizeChildEnv(process.env)` is a full shallow copy minus the two internal vars, so the child sees the same environment it did before apart from those — verified by the `PATH` assertion in the new test.
- Not validated / out of scope: no new call sites are introduced and the denylist itself is unchanged from #7256.
- Breaking changes / migration notes: a hook or discovery script that was (accidentally) relying on `QWEN_SERVER_TOKEN` being present will no longer see it. That is the intended fix.

## Linked Issues

Follow-up to #7256; same root cause as #6601.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

这是刚刚合并的 #7256 的后续。那个 PR 引入了 `sanitizeChildEnv()` 并将其应用于 shell、monitor 和 MCP stdio 的 spawn 路径。本 PR 将其余三处由 agent 启动的子进程也接入该函数：

| 位置 | 修复前 |
| --- | --- |
| `hooks/hookRunner.ts` | 将 `...process.env` 展开进 hook 命令的 env |
| `tools/tool-registry.ts`（工具调用命令） | `spawn(callCommand, …)` 未传 `env` 选项 → 隐式完整继承 |
| `tools/tool-registry.ts`（工具发现命令） | 同上 |

## 为什么需要

这三处都是**代表 agent**执行用户或配置提供的命令，正是 `sanitizeChildEnv` 所针对的场景——其文档注释点名了「shell 命令、monitor 工具、stdio MCP server」，而 hook 与工具发现/调用命令属于同一类。它们都不需要 `QWEN_SERVER_TOKEN` 或 `QWEN_DAEMON_TOKEN`，因此继续继承就是 #6601 所描述的同一个凭据泄露缺口：一个执行 `printenv` 的 hook 或发现脚本即可看到守护进程的 bearer token。

`tool-registry.ts` 的两处很容易被漏掉，因为它们**完全没有**传 `env` 选项——继承是隐式的，而非可见的 `...process.env`。

本改动刻意保持窄范围，与 #7256 完全一致：`sanitizeChildEnv` 只剥离两个 Qwen 内部变量，不动第三方凭据（`GH_TOKEN`、`AWS_*` 等），因此合理依赖这些变量的 hook 与发现脚本仍可正常工作。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/hooks/hookRunner.test.ts src/tools/tool-registry.test.ts` → 82/82 通过。
- 两个新增测试均已验证 fail-before/pass-after（仅还原两个源文件后重跑）：
  - `HookRunner > executeHook > strips Qwen-internal daemon secrets from the hook child env (#6601)`——在 `main` 上失败：`expected 'serve-secret' to be undefined`。
  - `ToolRegistry > discoverTools > strips Qwen-internal daemon secrets from the discovery and tool-call child env (#6601)`——对**两次** spawn 调用同时断言；在 `main` 上失败：`Cannot read properties of undefined (reading 'env')`，即根本没有传入 `env` 选项。
- 两个测试还断言无害的 env 得以保留（`PATH` 仍存在、`QWEN_PROJECT_DIR` 仍为 `/test`），因此不会悄悄清空子进程环境。

### 证据（修复前后对比）

非用户可见；由上述确定性单元测试验证。

- 修复前：由 agent 启动的 hook 命令或工具发现脚本会继承 `QWEN_SERVER_TOKEN` / `QWEN_DAEMON_TOKEN`。
- 修复后：这两个变量在全部三处子进程环境中均不存在；其余保持不变。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`hookRunner` + `tool-registry`（82）本地通过，并验证了 fail-before/pass-after；四个改动文件的 typecheck 与 eslint 均干净。该改动是对 env 对象的变换，无平台相关行为，断言均为确定性，因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：`tool-registry.ts` 的两处 spawn 现在显式传入 `env`，而此前完全不传。`sanitizeChildEnv(process.env)` 是去掉两个内部变量后的完整浅拷贝，因此除这两者外子进程看到的环境与之前相同——新增测试中的 `PATH` 断言已验证这一点。
- 未验证 / 范围之外：未引入新的调用点，denylist 本身相对 #7256 未作改动。
- 破坏性变更 / 迁移说明：若某个 hook 或发现脚本（意外地）依赖 `QWEN_SERVER_TOKEN` 存在，它将不再能看到该变量。这正是本次修复的预期效果。

## 关联 Issue

#7256 的后续；与 #6601 同源。

</details>
