### PR TITLE
fix(sdk-python): require canonical form in validate_session_id

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -226,3 +226,14 @@ def validate_session_id(value: str, param_name: str) -> None:
         raise ValidationError(
             f"Invalid {param_name}: {value!r}. UUID variant must be RFC 4122."
         )
+
+    # UUID() also accepts braced, urn:uuid: and dash-less spellings, but the
+    # value is forwarded to the CLI verbatim as --session-id/--resume, so
+    # anything but the canonical 8-4-4-4-12 form produces a malformed id
+    # downstream. Case is not part of canonical form: UUID() lowercases, and
+    # an all-uppercase spelling is still valid input.
+    if str(parsed) != value.lower():
+        raise ValidationError(
+            f"Invalid {param_name}: {value!r}. Must be a UUID in canonical "
+            f"8-4-4-4-12 form (got the equivalent of {str(parsed)!r})."
+        )

--- a/packages/sdk-python/tests/unit/test_validation.py
+++ b/packages/sdk-python/tests/unit/test_validation.py
@@ -40,6 +40,40 @@ def test_rejects_invalid_resume() -> None:
         validate_query_options(QueryOptions(resume="not-a-uuid"))
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "{12345678-1234-4234-8234-123456781234}",
+        "urn:uuid:12345678-1234-4234-8234-123456781234",
+        "12345678123442348234123456781234",
+    ],
+)
+def test_rejects_non_canonical_session_id(value: str) -> None:
+    # uuid.UUID() accepts these spellings, but the value is passed to the CLI
+    # verbatim as --session-id, so only the canonical 8-4-4-4-12 form works.
+    with pytest.raises(ValidationError, match="canonical"):
+        validate_query_options(QueryOptions(session_id=value))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "{12345678-1234-4234-8234-123456781234}",
+        "urn:uuid:12345678-1234-4234-8234-123456781234",
+        "12345678123442348234123456781234",
+    ],
+)
+def test_rejects_non_canonical_resume(value: str) -> None:
+    with pytest.raises(ValidationError, match="canonical"):
+        validate_query_options(QueryOptions(resume=value))
+
+
+def test_accepts_canonical_session_id_in_either_case() -> None:
+    # Case is not part of canonical form; an uppercase UUID is valid input.
+    validate_query_options(QueryOptions(session_id=VALID_UUID))
+    validate_query_options(QueryOptions(session_id=VALID_UUID.upper()))
+
+
 def test_rejects_invalid_permission_mode() -> None:
     with pytest.raises(ValidationError, match="Invalid permission_mode"):
         validate_query_options(


### PR DESCRIPTION
## What this PR does

`validate_session_id` accepted any spelling `uuid.UUID()` accepts. This adds a canonical-form check so only the `8-4-4-4-12` spelling passes, matching what the CLI actually needs.

## Why it's needed

`uuid.UUID()` is lenient by design — it strips braces, a `urn:uuid:` prefix, and dashes before parsing. All of these currently pass validation:

| input | `UUID()` result | validated today |
| --- | --- | --- |
| `12345678-1234-4234-8234-123456781234` | canonical | ✅ correct |
| `{12345678-1234-4234-8234-123456781234}` | same UUID | ✅ **wrong** |
| `urn:uuid:12345678-1234-4234-8234-123456781234` | same UUID | ✅ **wrong** |
| `12345678123442348234123456781234` | same UUID | ✅ **wrong** |

The existing `parsed.variant != RFC_4122` check does not catch these, because the parsed value is a perfectly good RFC 4122 UUID — it is only the *spelling* that is off. And the spelling is what matters here: `validate_session_id` never returns the parsed object, so `transport.py` forwards the **original string** verbatim (`args.extend(["--session-id", options.session_id])`, and the same for `--resume`). The CLI receives `{12345678-…}` including the braces.

The result is a malformed session id surfacing somewhere downstream instead of a clear `ValidationError` at the SDK boundary, which is the entire point of this function.

Case is deliberately **not** part of the check: `UUID()` renders lowercase, and an all-uppercase canonical UUID is valid input, so the comparison is against `value.lower()`.

## Reviewer Test Plan

### How to verify

- From the repo root, exactly as CI runs it:
  - `python -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q` → 123 passed, 29 skipped.
  - `python -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src` → success, 9 source files.
  - `python -m ruff check` / `ruff format --check` → clean on both changed files.
- Six new parametrized cases (three spellings × `session_id` and `resume`) fail without the fix:
  `test_rejects_non_canonical_session_id[{12345678-…}]` and the `urn:uuid:` and dash-less variants, same again for `resume` — `6 failed, 100 passed` when only `validation.py` is reverted.
- `test_accepts_canonical_session_id_in_either_case` pins the other direction: both `123e4567-e89b-12d3-a456-426614174000` and its uppercase spelling still validate, so this cannot become an over-strict regression.
- The existing `test_rejects_invalid_session_id` / `test_rejects_invalid_resume` (`"not-a-uuid"`) are untouched and still pass.

### Evidence (Before & After)

- Before: `QueryOptions(session_id="{12345678-1234-4234-8234-123456781234}")` validates, and the CLI is invoked as `--session-id {12345678-1234-4234-8234-123456781234}` — braces included.
- After: it raises `ValidationError: Invalid session_id: '{12345678-…}'. Must be a UUID in canonical 8-4-4-4-12 form (got the equivalent of '12345678-1234-4234-8234-123456781234')`. The message includes the canonical equivalent so the fix is obvious to the caller.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS, CPython 3.12/3.13: the full `sdk-python` test suite, mypy, ruff check and ruff format all pass locally, with proven fail-before/pass-after. String comparison with no platform-dependent behavior, so no manual QA is required; the `sdk-python` workflow covers the CI matrix.

### Environment (optional)

CPython 3.12.10 / 3.13.3; `packages/sdk-python`; pytest via the repo's own `pyproject.toml` config.

## Risk & Scope

- Main risk or tradeoff: a caller currently passing a braced/urn/dash-less session id gets a `ValidationError` where it previously got a confusing downstream failure. That is the intended change, and the error message names the canonical form to use.
- Not validated / out of scope: no other validator is touched, and `transport.py` is unchanged — normalizing instead of rejecting would mean `validate_session_id` returning a value, which changes its contract; a validator that rejects seemed the smaller and more predictable change. Happy to switch to normalization if maintainers prefer it.
- Breaking changes / migration notes: none for canonical UUIDs, which is what `uuid.uuid4()` and the CLI both produce.

## Linked Issues

None — found by reading `validate_session_id` against how `transport.py` consumes the value.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`validate_session_id` 接受 `uuid.UUID()` 所能接受的任意写法。本 PR 增加规范形式（canonical form）校验，使其只放行 `8-4-4-4-12` 写法——即 CLI 实际需要的形式。

## 为什么需要

`uuid.UUID()` 在设计上就很宽松——它会先去掉花括号、`urn:uuid:` 前缀与连字符再解析。以下写法目前全部能通过校验：

| 输入 | `UUID()` 解析结果 | 当前是否通过 |
| --- | --- | --- |
| `12345678-1234-4234-8234-123456781234` | 规范形式 | ✅ 正确 |
| `{12345678-1234-4234-8234-123456781234}` | 同一 UUID | ✅ **错误** |
| `urn:uuid:12345678-1234-4234-8234-123456781234` | 同一 UUID | ✅ **错误** |
| `12345678123442348234123456781234` | 同一 UUID | ✅ **错误** |

既有的 `parsed.variant != RFC_4122` 判断无法拦住它们，因为解析后的值本身就是完全合法的 RFC 4122 UUID——出问题的只是*写法*。而写法在这里恰恰是关键：`validate_session_id` 从不返回解析后的对象，因此 `transport.py` 会把**原始字符串**原样转发（`args.extend(["--session-id", options.session_id])`，`--resume` 同理）。CLI 收到的是连花括号一起的 `{12345678-…}`。

结果是下游某处冒出一个畸形的 session id，而不是在 SDK 边界抛出清晰的 `ValidationError`——而后者正是这个函数存在的意义。

大小写**有意**不纳入判断：`UUID()` 输出为小写，而全大写的规范 UUID 也是合法输入，因此比较对象是 `value.lower()`。

## 复核测试计划

### 如何验证

- 在仓库根目录，与 CI 完全一致地运行：
  - `python -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q` → 123 passed、29 skipped。
  - `python -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src` → 成功，9 个源文件。
  - `python -m ruff check` / `ruff format --check` → 两个改动文件均干净。
- 六个新增参数化用例（三种写法 × `session_id` 与 `resume`）在未修复时失败：
  `test_rejects_non_canonical_session_id[{12345678-…}]` 及 `urn:uuid:`、无连字符两种变体，`resume` 同理——仅还原 `validation.py` 时为 `6 failed, 100 passed`。
- `test_accepts_canonical_session_id_in_either_case` 固定了反方向：`123e4567-e89b-12d3-a456-426614174000` 及其大写写法仍然通过校验，因此本改动不会演变成过度严格的回归。
- 既有的 `test_rejects_invalid_session_id` / `test_rejects_invalid_resume`（`"not-a-uuid"`）未作改动且仍然通过。

### 证据（修复前后对比）

- 修复前：`QueryOptions(session_id="{12345678-1234-4234-8234-123456781234}")` 校验通过，CLI 被以 `--session-id {12345678-1234-4234-8234-123456781234}` 调用——花括号一并带上。
- 修复后：抛出 `ValidationError: Invalid session_id: '{12345678-…}'. Must be a UUID in canonical 8-4-4-4-12 form (got the equivalent of '12345678-1234-4234-8234-123456781234')`。错误信息包含其规范等价形式，调用方一眼即可看出如何修正。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS，CPython 3.12/3.13：完整的 `sdk-python` 测试套件、mypy、ruff check 与 ruff format 本地全部通过，并验证了 fail-before/pass-after。纯字符串比较，无平台相关行为，因此无需人工 QA；`sdk-python` workflow 覆盖 CI 矩阵。

### 运行环境（可选）

CPython 3.12.10 / 3.13.3；`packages/sdk-python`；pytest 使用仓库自带的 `pyproject.toml` 配置。

## 风险与影响范围

- 主要风险或权衡：当前传入花括号 / urn / 无连字符写法的调用方，会收到 `ValidationError`，而不再是下游一个令人困惑的失败。这正是本次改动的目的，且错误信息已给出应使用的规范形式。
- 未验证 / 范围之外：未触及其他校验函数，`transport.py` 也未改动——若选择「归一化」而非「拒绝」，就意味着 `validate_session_id` 需要有返回值，从而改变其契约；一个只做拒绝的校验函数是更小、更可预期的改动。若维护者更倾向归一化，我很乐意改。
- 破坏性变更 / 迁移说明：对规范 UUID 无影响，而 `uuid.uuid4()` 与 CLI 产出的都是规范形式。

## 关联 Issue

无——通过对照 `transport.py` 如何消费该值来阅读 `validate_session_id` 时发现。

</details>
