### PR TITLE
fix(core): jsonl write([]) should leave an empty file, not a stray newline

### DIFF
--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -20,6 +20,7 @@ import {
   _recoverObjectsFromLine,
   _resetEnsuredDirsCacheForTest,
   countLines,
+  exists,
   parseLineTolerant,
   read,
   readLines,
@@ -354,6 +355,24 @@ describe('writeLine / writeLineSync / write', () => {
   // branch is never exercised. A regression that dropped that branch would
   // make write() fail with ENOENT only when callers target a brand-new
   // subdirectory.
+  it('write() with an empty array leaves a genuinely empty file', async () => {
+    const file = path.join(
+      tmpRoot,
+      `we-${Math.random().toString(36).slice(2)}.jsonl`,
+    );
+    await writeLine(file, { v: 1 });
+    expect(exists(file)).toBe(true);
+
+    // Clearing the file must not leave a stray newline behind: a 1-byte file
+    // makes exists() (size > 0) disagree with read() (no records).
+    write(file, []);
+
+    expect(fs.readFileSync(file, 'utf8')).toBe('');
+    expect(fs.statSync(file).size).toBe(0);
+    expect(await read(file)).toEqual([]);
+    expect(exists(file)).toBe(false);
+  });
+
   it('write() creates parent dirs when missing', () => {
     const nested = path.join(tmpRoot, 'a', 'b', 'c', 'file.jsonl');
     write(nested, [{ x: 1 }]);

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -323,13 +323,16 @@ export function writeLineSync(filePath: string, data: unknown): void {
  * Each object will be written as a separate line.
  */
 export function write(filePath: string, data: unknown[]): void {
-  const lines = data.map((item) => JSON.stringify(item)).join('\n');
+  // Terminate each record rather than joining with separators: joining an
+  // empty array yields '' and the trailing newline then writes a 1-byte file
+  // that read() reports as empty but exists() reports as non-empty.
+  const lines = data.map((item) => `${JSON.stringify(item)}\n`).join('');
   // Ensure directory exists before writing
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  atomicWriteFileSync(filePath, `${lines}\n`, { encoding: 'utf8' });
+  atomicWriteFileSync(filePath, lines, { encoding: 'utf8' });
 }
 
 /**


### PR DESCRIPTION
## What this PR does

`jsonl.write(path, [])` left a one-byte file containing a single `\n`. This terminates each record instead of joining with separators, so an empty array writes nothing. Output for a non-empty array is byte-identical.

## Why it's needed

```ts
const lines = data.map((item) => JSON.stringify(item)).join('\n');
atomicWriteFileSync(filePath, `${lines}\n`, { encoding: 'utf8' });
```

For `data = []` the join yields `''`, and the template literal then writes `'\n'`.

That makes the module's own accessors contradict each other:

| after `write(file, [])` | result |
| --- | --- |
| `fs.statSync(file).size` | `1` |
| `exists(file)` — documented as "exists and is not empty", tests `size > 0` | `true` |
| `read(file)` — skips blank lines | `[]` |
| `countLines(file)` — counts non-empty lines | `0` |

So clearing a JSONL file leaves something that reports as non-empty while containing no records, and any caller that branches on `exists()` before reading takes the wrong path.

`write` is part of the public core API (`export * from './utils/jsonl-utils.js'` in `packages/core/src/index.ts`), so this is reachable by SDK and extension consumers even though no in-repo caller passes an empty array today. Fixing it now keeps a future `write(file, [])` from quietly hitting this.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/utils/jsonl-utils.test.ts` → 29/29.
- The new test `write() with an empty array leaves a genuinely empty file` writes a record, clears the file with `write(file, [])`, then asserts all four accessors agree: content `''`, `size === 0`, `read() === []`, `exists() === false`. Reverting only `jsonl-utils.ts` fails it with `expected '\n' to be ''`.
- The existing `write() full-file replaces existing content via atomic write` and `write() creates parent dirs when missing` tests are untouched and still pass — they pin the non-empty output (`'{"x":1}\n'`) that must not change.

### Evidence (Before & After)

- Before: `write(f, [])` → file is `"\n"`, `statSync().size === 1`, `exists(f) === true`, `read(f) === []`.
- After: `write(f, [])` → file is `""`, `size === 0`, `exists(f) === false`, `read(f) === []`.
- Unchanged: `write(f, [{v:10},{v:20}])` → `'{"v":10}\n{"v":20}\n'` in both cases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: the `jsonl-utils` suite passes locally (29 tests) with proven fail-before/pass-after; eslint clean. String construction with no platform-dependent behavior — the test asserts on `\n` explicitly rather than on line endings the OS might vary — so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none identified. The two forms produce identical bytes for every non-empty input (`join('\n') + '\n'` and per-item `+ '\n'` differ only when the array is empty), which the untouched existing tests pin.
- Not validated / out of scope: `writeLine` / `writeLineSync` are append helpers with no empty-input case and are unchanged.
- Breaking changes / migration notes: none, unless something depended on a cleared JSONL file still reporting `exists() === true` — which is the bug being fixed.

## Linked Issues

None — found by reading `write` against `exists` and `read` in the same module.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`jsonl.write(path, [])` 会留下一个仅含单个 `\n` 的 1 字节文件。本 PR 改为逐条记录追加终止符，而非用分隔符 join，使空数组写出空内容。非空数组的输出逐字节完全一致。

## 为什么需要

```ts
const lines = data.map((item) => JSON.stringify(item)).join('\n');
atomicWriteFileSync(filePath, `${lines}\n`, { encoding: 'utf8' });
```

当 `data = []` 时 join 得到 `''`，模板字符串随即写入 `'\n'`。

这导致该模块自身的各个访问函数互相矛盾：

| 执行 `write(file, [])` 后 | 结果 |
| --- | --- |
| `fs.statSync(file).size` | `1` |
| `exists(file)`——文档写明「存在且非空」，判断 `size > 0` | `true` |
| `read(file)`——跳过空行 | `[]` |
| `countLines(file)`——统计非空行 | `0` |

于是清空一个 JSONL 文件后，会留下一个「报告为非空、却不含任何记录」的东西；任何在读取前依据 `exists()` 分支的调用方都会走错路径。

`write` 属于 core 的公开 API（`packages/core/src/index.ts` 中的 `export * from './utils/jsonl-utils.js'`），因此 SDK 与扩展使用方都可触达它——尽管当前仓库内尚无调用方传入空数组。现在修好，可避免将来某处 `write(file, [])` 悄悄踩中。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/utils/jsonl-utils.test.ts` → 29/29 通过。
- 新增测试 `write() with an empty array leaves a genuinely empty file` 先写入一条记录，再用 `write(file, [])` 清空，然后断言四个访问函数彼此一致：内容为 `''`、`size === 0`、`read() === []`、`exists() === false`。仅还原 `jsonl-utils.ts` 时该测试失败：`expected '\n' to be ''`。
- 既有的 `write() full-file replaces existing content via atomic write` 与 `write() creates parent dirs when missing` 未作改动且仍然通过——它们固定了不得改变的非空输出（`'{"x":1}\n'`）。

### 证据（修复前后对比）

- 修复前：`write(f, [])` → 文件为 `"\n"`，`statSync().size === 1`，`exists(f) === true`，`read(f) === []`。
- 修复后：`write(f, [])` → 文件为 `""`，`size === 0`，`exists(f) === false`，`read(f) === []`。
- 不变：`write(f, [{v:10},{v:20}])` → 两种实现均为 `'{"v":10}\n{"v":20}\n'`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`jsonl-utils` 套件本地通过（29 个测试），并验证了 fail-before/pass-after；eslint 干净。纯字符串构造，无平台相关行为——测试显式断言 `\n` 而非依赖系统可能不同的行尾——因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：未发现。对任何非空输入，两种写法产生的字节完全相同（`join('\n') + '\n'` 与逐条 `+ '\n'` 只在数组为空时才有差异），这一点由未改动的既有测试固定。
- 未验证 / 范围之外：`writeLine` / `writeLineSync` 是追加型辅助函数，不存在空输入场景，未作改动。
- 破坏性变更 / 迁移说明：无——除非有代码依赖「清空后的 JSONL 文件仍报告 `exists() === true`」，而那正是本次修复的 bug。

## 关联 Issue

无——通过在同一模块内对照阅读 `write`、`exists` 与 `read` 发现。

</details>
