### PR TITLE
fix(core): retry requests when providers require thinking

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -826,6 +826,118 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.tool_choice).toBe(testCase.expectedToolChoice);
     });
 
+    it('learns required thinking from a provider error and retries once', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl:
+          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.8-max-preview',
+        extra_body: { enable_thinking: true },
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        enable_thinking: true,
+      }));
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'What is 2+2?' },
+      ]);
+      (mockConverter.convertGeminiToolsToOpenAI as Mock).mockResolvedValue([
+        { type: 'function', function: { name: 'respond_in_schema' } },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+
+      const requiredThinkingError = Object.assign(
+        new Error(
+          'The value of the enable_thinking parameter is restricted to True.',
+        ),
+        { status: 400 },
+      );
+      (mockClient.chat.completions.create as Mock)
+        .mockRejectedValueOnce(requiredThinkingError)
+        .mockResolvedValue({
+          id: 'r',
+          choices: [{ message: { content: '4' }, finish_reason: 'stop' }],
+        } as OpenAI.Chat.ChatCompletion);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen3.8-max-preview',
+        contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
+        config: {
+          thinkingConfig: { includeThoughts: false },
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'respond_in_schema',
+                  parameters: { type: Type.OBJECT, properties: {} },
+                },
+              ],
+            },
+          ],
+          toolConfig: {
+            functionCallingConfig: { mode: FunctionCallingConfigMode.ANY },
+          },
+        },
+      };
+
+      await pipeline.execute(request, 'forked_query');
+      await pipeline.execute(request, 'forked_query');
+
+      const calls = (mockClient.chat.completions.create as Mock).mock.calls;
+      expect(calls).toHaveLength(3);
+      expect(calls[0][0]).toMatchObject({
+        enable_thinking: false,
+        tool_choice: 'required',
+      });
+      expect(calls[1][0].enable_thinking).toBe(true);
+      expect(calls[1][0].tool_choice).toBeUndefined();
+      expect(calls[2][0].enable_thinking).toBe(true);
+      expect(calls[2][0].tool_choice).toBeUndefined();
+      expect(mockErrorHandler.handle).not.toHaveBeenCalled();
+    });
+
+    it('does not retry an unrelated 400 error', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl:
+          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.8-max-preview',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hello' },
+      ]);
+      const error = Object.assign(new Error('Invalid request parameter.'), {
+        status: 400,
+      });
+      (mockClient.chat.completions.create as Mock).mockRejectedValue(error);
+
+      await expect(
+        pipeline.execute(
+          {
+            model: 'qwen3.8-max-preview',
+            contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+            config: { thinkingConfig: { includeThoughts: false } },
+          },
+          'forked_query',
+        ),
+      ).rejects.toBe(error);
+      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+    });
+
     it('should strip reasoning key from extra_body when thinking is disabled', async () => {
       // Arrange — provider injects reasoning via extra_body
       (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
@@ -1672,6 +1784,73 @@ describe('ContentGenerationPipeline', () => {
   });
 
   describe('executeStream', () => {
+    it('retries stream creation when the provider requires thinking', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl:
+          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.8-max-preview',
+        extra_body: { enable_thinking: true },
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        enable_thinking: true,
+      }));
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+
+      const requiredThinkingError = Object.assign(
+        new Error(
+          'The value of the enable_thinking parameter is restricted to True.',
+        ),
+        { status: 400 },
+      );
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          // Empty response is sufficient: this test covers stream creation.
+        },
+      };
+      const failedCreate = Object.assign(Promise.resolve(stream), {
+        withResponse: () => Promise.reject(requiredThinkingError),
+      });
+      const successfulCreate = Object.assign(Promise.resolve(stream), {
+        withResponse: () =>
+          Promise.resolve({
+            data: stream,
+            response: new Response(null, {
+              headers: { 'content-type': 'text/event-stream' },
+            }),
+            request_id: 'retry-success',
+          }),
+      });
+      (mockClient.chat.completions.create as Mock)
+        .mockReturnValueOnce(failedCreate)
+        .mockReturnValueOnce(successfulCreate);
+
+      const result = await pipeline.executeStream(
+        {
+          model: 'qwen3.8-max-preview',
+          contents: [{ parts: [{ text: 'Quick question' }], role: 'user' }],
+          config: { thinkingConfig: { includeThoughts: false } },
+        },
+        'forked_query',
+      );
+      for await (const _ of result) {
+        // Drain the retried stream.
+      }
+
+      const calls = (mockClient.chat.completions.create as Mock).mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[0][0].enable_thinking).toBe(false);
+      expect(calls[1][0].enable_thinking).toBe(true);
+      expect(mockErrorHandler.handle).not.toHaveBeenCalled();
+    });
+
     it('should successfully execute streaming request', async () => {
       // Arrange
       const request: GenerateContentParameters = {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -27,6 +27,7 @@ import { StreamingToolCallParser } from './streamingToolCallParser.js';
 import type { Config } from '../../config/config.js';
 import { AuthType, type ContentGeneratorConfig } from '../contentGenerator.js';
 import type { OpenAICompatibleProvider } from './provider/index.js';
+import { DefaultOpenAICompatibleProvider } from './provider/default.js';
 import {
   DEFAULT_STREAM_IDLE_TIMEOUT_MS,
   MAX_STREAM_IDLE_TIMEOUT_MS,
@@ -904,19 +905,30 @@ describe('ContentGenerationPipeline', () => {
       expect(mockErrorHandler.handle).not.toHaveBeenCalled();
     });
 
-    it('retries when non-DashScope chat_template_kwargs disables required thinking', async () => {
+    it('retries without provider-configured thinking opt-outs on non-DashScope endpoints', async () => {
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,
         baseUrl: 'https://llm.example.com/v1',
         model: 'Qwen3.6-27B',
+        extra_body: {
+          enable_thinking: false,
+          chat_template_kwargs: {
+            apply_chat_template: true,
+            enable_thinking: false,
+          },
+        },
       } as ContentGeneratorConfig;
-      mockConfig = {
+      const provider = new DefaultOpenAICompatibleProvider(
+        mockContentGeneratorConfig,
+        mockCliConfig,
+      );
+      vi.spyOn(provider, 'buildClient').mockReturnValue(mockClient);
+      pipeline = new ContentGenerationPipeline({
         ...mockConfig,
+        provider,
         contentGeneratorConfig: mockContentGeneratorConfig,
-      };
-      pipeline = new ContentGenerationPipeline(mockConfig);
+      });
 
-      (mockProvider.buildRequest as Mock).mockImplementation((req) => req);
       (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
         { role: 'user', content: 'What is 2+2?' },
       ]);
@@ -947,10 +959,13 @@ describe('ContentGenerationPipeline', () => {
       const calls = (mockClient.chat.completions.create as Mock).mock.calls;
       expect(calls).toHaveLength(2);
       expect(calls[0][0].chat_template_kwargs).toEqual({
+        apply_chat_template: true,
         enable_thinking: false,
       });
       expect(calls[0][0].enable_thinking).toBeUndefined();
-      expect(calls[1][0].chat_template_kwargs).toBeUndefined();
+      expect(calls[1][0].chat_template_kwargs).toEqual({
+        apply_chat_template: true,
+      });
       expect(calls[1][0].enable_thinking).toBeUndefined();
       expect(mockErrorHandler.handle).not.toHaveBeenCalled();
     });

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -905,70 +905,100 @@ describe('ContentGenerationPipeline', () => {
       expect(mockErrorHandler.handle).not.toHaveBeenCalled();
     });
 
-    it('retries without provider-configured thinking opt-outs on non-DashScope endpoints', async () => {
-      mockContentGeneratorConfig = {
-        ...mockContentGeneratorConfig,
-        baseUrl: 'https://llm.example.com/v1',
-        model: 'Qwen3.6-27B',
-        extra_body: {
+    it.each([
+      {
+        name: 'preserving unrelated chat_template_kwargs',
+        extraBody: {
           enable_thinking: false,
           chat_template_kwargs: {
             apply_chat_template: true,
             enable_thinking: false,
           },
         },
-      } as ContentGeneratorConfig;
-      const provider = new DefaultOpenAICompatibleProvider(
-        mockContentGeneratorConfig,
-        mockCliConfig,
-      );
-      vi.spyOn(provider, 'buildClient').mockReturnValue(mockClient);
-      pipeline = new ContentGenerationPipeline({
-        ...mockConfig,
-        provider,
-        contentGeneratorConfig: mockContentGeneratorConfig,
-      });
-
-      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
-        { role: 'user', content: 'What is 2+2?' },
-      ]);
-      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
-        new GenerateContentResponse(),
-      );
-
-      const requiredThinkingError = Object.assign(
-        new Error('enable_thinking must be true for this model'),
-        { status: 400 },
-      );
-      (mockClient.chat.completions.create as Mock)
-        .mockRejectedValueOnce(requiredThinkingError)
-        .mockResolvedValue({
-          id: 'r',
-          choices: [{ message: { content: '4' }, finish_reason: 'stop' }],
-        } as OpenAI.Chat.ChatCompletion);
-
-      await pipeline.execute(
-        {
-          model: 'Qwen3.6-27B',
-          contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
-          config: { thinkingConfig: { includeThoughts: false } },
+        initialChatTemplateKwargs: {
+          apply_chat_template: true,
+          enable_thinking: false,
         },
-        'forked_query',
-      );
+        retryChatTemplateKwargs: { apply_chat_template: true },
+      },
+      {
+        name: 'removing empty chat_template_kwargs',
+        extraBody: {
+          chat_template_kwargs: {
+            enable_thinking: false,
+          },
+        },
+        initialChatTemplateKwargs: { enable_thinking: false },
+        retryChatTemplateKwargs: undefined,
+      },
+    ])(
+      'retries without provider-configured thinking opt-outs on non-DashScope endpoints: $name',
+      async ({
+        extraBody,
+        initialChatTemplateKwargs,
+        retryChatTemplateKwargs,
+      }) => {
+        mockContentGeneratorConfig = {
+          ...mockContentGeneratorConfig,
+          baseUrl: 'https://llm.example.com/v1',
+          model: 'Qwen3.6-27B',
+          extra_body: extraBody,
+        } as ContentGeneratorConfig;
+        const provider = new DefaultOpenAICompatibleProvider(
+          mockContentGeneratorConfig,
+          mockCliConfig,
+        );
+        vi.spyOn(provider, 'buildClient').mockReturnValue(mockClient);
+        pipeline = new ContentGenerationPipeline({
+          ...mockConfig,
+          provider,
+          contentGeneratorConfig: mockContentGeneratorConfig,
+        });
 
-      const calls = (mockClient.chat.completions.create as Mock).mock.calls;
-      expect(calls).toHaveLength(2);
-      expect(calls[0][0].chat_template_kwargs).toEqual({
-        apply_chat_template: true,
-        enable_thinking: false,
-      });
-      expect(calls[0][0].enable_thinking).toBeUndefined();
-      expect(calls[1][0].chat_template_kwargs).toEqual({
-        apply_chat_template: true,
-      });
-      expect(calls[1][0].enable_thinking).toBeUndefined();
-      expect(mockErrorHandler.handle).not.toHaveBeenCalled();
-    });
+        (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+          { role: 'user', content: 'What is 2+2?' },
+        ]);
+        (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+          new GenerateContentResponse(),
+        );
+
+        const requiredThinkingError = Object.assign(
+          new Error('enable_thinking must be true for this model'),
+          { status: 400 },
+        );
+        (mockClient.chat.completions.create as Mock)
+          .mockRejectedValueOnce(requiredThinkingError)
+          .mockResolvedValue({
+            id: 'r',
+            choices: [{ message: { content: '4' }, finish_reason: 'stop' }],
+          } as OpenAI.Chat.ChatCompletion);
+
+        await pipeline.execute(
+          {
+            model: 'Qwen3.6-27B',
+            contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
+            config: { thinkingConfig: { includeThoughts: false } },
+          },
+          'forked_query',
+        );
+
+        const calls = (mockClient.chat.completions.create as Mock).mock.calls;
+        expect(calls).toHaveLength(2);
+        expect(calls[0][0].chat_template_kwargs).toEqual(
+          initialChatTemplateKwargs,
+        );
+        expect(calls[0][0].enable_thinking).toBeUndefined();
+        if (retryChatTemplateKwargs === undefined) {
+          expect(calls[1][0].chat_template_kwargs).toBeUndefined();
+        } else {
+          expect(calls[1][0].chat_template_kwargs).toEqual(
+            retryChatTemplateKwargs,
+          );
+        }
+        expect(calls[1][0].enable_thinking).toBeUndefined();
+        expect(mockErrorHandler.handle).not.toHaveBeenCalled();
+      },
+    );
 
     it('handles the retry error when required-thinking retry fails', async () => {
       mockContentGeneratorConfig = {
@@ -1059,39 +1089,45 @@ describe('ContentGenerationPipeline', () => {
       );
     });
 
-    it('does not retry an unrelated 400 error', async () => {
-      mockContentGeneratorConfig = {
-        ...mockContentGeneratorConfig,
-        baseUrl:
-          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
-        model: 'qwen3.8-max-preview',
-      } as ContentGeneratorConfig;
-      mockConfig = {
-        ...mockConfig,
-        contentGeneratorConfig: mockContentGeneratorConfig,
-      };
-      pipeline = new ContentGenerationPipeline(mockConfig);
+    it.each([
+      'Invalid request parameter.',
+      'enable_thinking is not supported for this model',
+    ])(
+      'does not retry a non-required-thinking 400 error: %s',
+      async (message) => {
+        mockContentGeneratorConfig = {
+          ...mockContentGeneratorConfig,
+          baseUrl:
+            'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+          model: 'qwen3.8-max-preview',
+        } as ContentGeneratorConfig;
+        mockConfig = {
+          ...mockConfig,
+          contentGeneratorConfig: mockContentGeneratorConfig,
+        };
+        pipeline = new ContentGenerationPipeline(mockConfig);
 
-      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
-        { role: 'user', content: 'Hello' },
-      ]);
-      const error = Object.assign(new Error('Invalid request parameter.'), {
-        status: 400,
-      });
-      (mockClient.chat.completions.create as Mock).mockRejectedValue(error);
+        (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+          { role: 'user', content: 'Hello' },
+        ]);
+        const error = Object.assign(new Error(message), {
+          status: 400,
+        });
+        (mockClient.chat.completions.create as Mock).mockRejectedValue(error);
 
-      await expect(
-        pipeline.execute(
-          {
-            model: 'qwen3.8-max-preview',
-            contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
-            config: { thinkingConfig: { includeThoughts: false } },
-          },
-          'forked_query',
-        ),
-      ).rejects.toBe(error);
-      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
-    });
+        await expect(
+          pipeline.execute(
+            {
+              model: 'qwen3.8-max-preview',
+              contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+              config: { thinkingConfig: { includeThoughts: false } },
+            },
+            'forked_query',
+          ),
+        ).rejects.toBe(error);
+        expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+      },
+    );
 
     it('should strip reasoning key from extra_body when thinking is disabled', async () => {
       // Arrange — provider injects reasoning via extra_body

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -904,6 +904,56 @@ describe('ContentGenerationPipeline', () => {
       expect(mockErrorHandler.handle).not.toHaveBeenCalled();
     });
 
+    it('handles the retry error when required-thinking retry fails', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl:
+          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.8-max-preview',
+        extra_body: { enable_thinking: true },
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        enable_thinking: true,
+      }));
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'What is 2+2?' },
+      ]);
+
+      const requiredThinkingError = Object.assign(
+        new Error(
+          'The value of the enable_thinking parameter is restricted to True.',
+        ),
+        { status: 400 },
+      );
+      const retryError = new Error('retry failed');
+      (mockClient.chat.completions.create as Mock)
+        .mockRejectedValueOnce(requiredThinkingError)
+        .mockRejectedValueOnce(retryError);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen3.8-max-preview',
+        contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      await expect(pipeline.execute(request, 'forked_query')).rejects.toBe(
+        retryError,
+      );
+      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(2);
+      expect(mockErrorHandler.handle).toHaveBeenCalledWith(
+        retryError,
+        expect.any(Object),
+        request,
+      );
+    });
+
     it('does not retry an unrelated 400 error', async () => {
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -904,6 +904,57 @@ describe('ContentGenerationPipeline', () => {
       expect(mockErrorHandler.handle).not.toHaveBeenCalled();
     });
 
+    it('retries when non-DashScope chat_template_kwargs disables required thinking', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://llm.example.com/v1',
+        model: 'Qwen3.6-27B',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => req);
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'What is 2+2?' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+
+      const requiredThinkingError = Object.assign(
+        new Error('enable_thinking must be true for this model'),
+        { status: 400 },
+      );
+      (mockClient.chat.completions.create as Mock)
+        .mockRejectedValueOnce(requiredThinkingError)
+        .mockResolvedValue({
+          id: 'r',
+          choices: [{ message: { content: '4' }, finish_reason: 'stop' }],
+        } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(
+        {
+          model: 'Qwen3.6-27B',
+          contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
+          config: { thinkingConfig: { includeThoughts: false } },
+        },
+        'forked_query',
+      );
+
+      const calls = (mockClient.chat.completions.create as Mock).mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[0][0].chat_template_kwargs).toEqual({
+        enable_thinking: false,
+      });
+      expect(calls[0][0].enable_thinking).toBeUndefined();
+      expect(calls[1][0].chat_template_kwargs).toBeUndefined();
+      expect(calls[1][0].enable_thinking).toBeUndefined();
+      expect(mockErrorHandler.handle).not.toHaveBeenCalled();
+    });
+
     it('handles the retry error when required-thinking retry fails', async () => {
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1020,6 +1020,45 @@ describe('ContentGenerationPipeline', () => {
       );
     });
 
+    it('does not retry required-thinking errors after abort', async () => {
+      (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
+        ...req,
+        enable_thinking: true,
+      }));
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'What is 2+2?' },
+      ]);
+
+      const requiredThinkingError = Object.assign(
+        new Error(
+          'The value of the enable_thinking parameter is restricted to True.',
+        ),
+        { status: 400 },
+      );
+      (mockClient.chat.completions.create as Mock).mockRejectedValueOnce(
+        requiredThinkingError,
+      );
+
+      const request: GenerateContentParameters = {
+        model: 'qwen3.8-max-preview',
+        contents: [{ parts: [{ text: 'What is 2+2?' }], role: 'user' }],
+        config: {
+          abortSignal: AbortSignal.abort(),
+          thinkingConfig: { includeThoughts: false },
+        },
+      };
+
+      await expect(pipeline.execute(request, 'forked_query')).rejects.toBe(
+        requiredThinkingError,
+      );
+      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+      expect(mockErrorHandler.handle).toHaveBeenCalledWith(
+        requiredThinkingError,
+        expect.any(Object),
+        request,
+      );
+    });
+
     it('does not retry an unrelated 400 error', async () => {
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -1131,7 +1131,10 @@ export class ContentGenerationPipeline {
         isRequiredThinkingError(error)
       ) {
         this.requiredThinkingModels.add(model);
-        debugLogger.warn('Retrying with required thinking enabled', { model });
+        debugLogger.warn('Retrying with required thinking enabled', {
+          model,
+          originalError: getErrorMessage(error),
+        });
         try {
           return await executeAttempt();
         } catch (retryError) {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -31,8 +31,20 @@ import { getToolCallPreparations } from '../tool-call-preparation.js';
 import { InvalidStreamError } from '../invalid-stream-error.js';
 import { logProtocolTagSanitized } from '../../telemetry/loggers.js';
 import { ProtocolTagSanitizedEvent } from '../../telemetry/types.js';
+import { getErrorMessage, getErrorStatus } from '../../utils/errors.js';
+import { getRateLimitErrorDetails } from '../../utils/rateLimit.js';
 
 const debugLogger = createDebugLogger('OPENAI_PIPELINE');
+
+function isRequiredThinkingError(error: unknown): boolean {
+  if (getErrorStatus(error) !== 400) return false;
+  const providerMessage = getRateLimitErrorDetails(error).providerMessage;
+  const message = `${getErrorMessage(error)} ${providerMessage ?? ''}`;
+  return (
+    message.includes('enable_thinking') &&
+    /(?:restricted to|must be) true/i.test(message)
+  );
+}
 
 /**
  * Error thrown when the API returns an error embedded as stream content
@@ -281,6 +293,7 @@ export type { PipelineConfig } from './types.js';
 export class ContentGenerationPipeline {
   client: OpenAI;
   private contentGeneratorConfig: ContentGeneratorConfig;
+  private readonly requiredThinkingModels = new Set<string>();
   // Resolved once (config field > env > default) so the env read + any
   // invalid-value warning happen per pipeline, not per streaming request.
   private readonly streamIdleTimeoutMs: number;
@@ -826,10 +839,7 @@ export class ContentGenerationPipeline {
     const isDashScope = DashScopeOpenAICompatibleProvider.isDashScopeProvider(
       this.contentGeneratorConfig,
     );
-    const configModel = (this.contentGeneratorConfig.model ?? '').toLowerCase();
-    const thinkingMandatory =
-      this.contentGeneratorConfig.thinkingMandatory === true &&
-      model === configModel;
+    const thinkingMandatory = this.requiresThinking(model);
     const reasoningDisabled =
       request.config?.thinkingConfig?.includeThoughts === false ||
       this.contentGeneratorConfig.reasoning === false;
@@ -923,6 +933,16 @@ export class ContentGenerationPipeline {
     }
 
     return providerRequest;
+  }
+
+  private requiresThinking(model: string): boolean {
+    const normalizedModel = model.toLowerCase();
+    return (
+      this.requiredThinkingModels.has(normalizedModel) ||
+      (this.contentGeneratorConfig.thinkingMandatory === true &&
+        normalizedModel ===
+          (this.contentGeneratorConfig.model ?? '').toLowerCase())
+    );
   }
 
   private buildGenerateContentConfig(
@@ -1066,9 +1086,9 @@ export class ContentGenerationPipeline {
     ) => Promise<T>,
   ): Promise<T> {
     const context = this.createRequestContext(request, isStreaming);
-
-    try {
-      const openaiRequest = await this.buildRequest(
+    let openaiRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined;
+    const executeAttempt = async () => {
+      openaiRequest = await this.buildRequest(
         request,
         userPromptId,
         context,
@@ -1081,9 +1101,28 @@ export class ContentGenerationPipeline {
       openaiRequestCaptureContext.getStore()?.(openaiRequest);
       runtimeDiagnostics.recordOpenAIWireRequest(openaiRequest);
 
-      const result = await executor(openaiRequest, context);
-      return result;
+      return executor(openaiRequest, context);
+    };
+
+    try {
+      return await executeAttempt();
     } catch (error) {
+      const model = context.model.toLowerCase();
+      if (
+        (openaiRequest as Record<string, unknown> | undefined)?.[
+          'enable_thinking'
+        ] === false &&
+        request.config?.abortSignal?.aborted !== true &&
+        isRequiredThinkingError(error)
+      ) {
+        this.requiredThinkingModels.add(model);
+        debugLogger.warn('Retrying with required thinking enabled', { model });
+        try {
+          return await executeAttempt();
+        } catch (retryError) {
+          return await this.handleError(retryError, context, request);
+        }
+      }
       // Use shared error handling logic
       return await this.handleError(error, context, request);
     }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -921,13 +921,25 @@ export class ContentGenerationPipeline {
       }
     }
 
-    if (thinkingMandatory && isDashScope) {
+    if (thinkingMandatory) {
       const typed = providerRequest as unknown as Record<string, unknown>;
-      // DashScope rejects forced tool selection while thinking is enabled.
       if (typed['enable_thinking'] === false) {
         delete typed['enable_thinking'];
       }
-      if (typed['tool_choice'] === 'required') {
+      const chatTemplateKwargs = typed['chat_template_kwargs'] as
+        | Record<string, unknown>
+        | undefined;
+      if (chatTemplateKwargs?.['enable_thinking'] === false) {
+        const remaining = { ...chatTemplateKwargs };
+        delete remaining['enable_thinking'];
+        if (Object.keys(remaining).length > 0) {
+          typed['chat_template_kwargs'] = remaining;
+        } else {
+          delete typed['chat_template_kwargs'];
+        }
+      }
+      // DashScope rejects forced tool selection while thinking is enabled.
+      if (isDashScope && typed['tool_choice'] === 'required') {
         delete typed['tool_choice'];
       }
     }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -42,7 +42,7 @@ function isRequiredThinkingError(error: unknown): boolean {
   const message = `${getErrorMessage(error)} ${providerMessage ?? ''}`;
   return (
     message.includes('enable_thinking') &&
-    /(?:restricted to|must be) true/i.test(message)
+    /(?:restricted to|must be) true\b/i.test(message)
   );
 }
 
@@ -1108,10 +1108,13 @@ export class ContentGenerationPipeline {
       return await executeAttempt();
     } catch (error) {
       const model = context.model.toLowerCase();
+      const wireRequest = openaiRequest as Record<string, unknown> | undefined;
+      const chatTemplateKwargs = wireRequest?.['chat_template_kwargs'] as
+        | Record<string, unknown>
+        | undefined;
       if (
-        (openaiRequest as Record<string, unknown> | undefined)?.[
-          'enable_thinking'
-        ] === false &&
+        (wireRequest?.['enable_thinking'] === false ||
+          chatTemplateKwargs?.['enable_thinking'] === false) &&
         request.config?.abortSignal?.aborted !== true &&
         isRequiredThinkingError(error)
       ) {


### PR DESCRIPTION
## What this PR does

This change retries an OpenAI-compatible request once when the actual wire request sent `enable_thinking: false` and the provider returns HTTP 400 explicitly requiring it to be `true`. The retry rebuilds the request through the existing pipeline and remembers the model capability for the lifetime of that provider pipeline. Streaming and non-streaming requests share the same behavior; unrelated 400 responses and cancelled requests are unchanged.

## Why it's needed

#7303 added a config-driven `thinkingMandatory` capability for the current qwen3.8 Token Plan preset. Existing and custom provider configurations may still contain `extra_body.enable_thinking: true` without that capability field, so `/btw` can override it with `false` and reproduce the original 400 on 0.20.1.

Learning from the provider's explicit capability response closes that gap without adding another Token Plan or model-name special case.

## Reviewer Test Plan

### How to verify

Use an existing or custom Token Plan model configuration that enables thinking but does not include `thinkingMandatory`. The first `/btw` request should recover from the required-thinking 400 and complete; the next `/btw` request for the same model should send thinking enabled immediately. Confirm that an unrelated 400 is not retried and cancelling before the provider response does not start a retry.

### Evidence (Before & After)

Before, a real Token Plan request on 0.20.1 failed with:

`400 The value of the enable_thinking parameter is restricted to True.`

After, a real interactive TUI and OpenAI SDK protocol-boundary test produced:

- First `/btw`: `false → required-thinking 400 → true → BTW_RETRY_OK`
- Next `/btw`: `true → BTW_CACHE_OK`
- Unrelated 400: one `false` request, no retry
- Escape cancellation: one `false` request, no retry

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local TypeScript workspace using the real interactive TUI, OpenAI SDK, and a local HTTP/SSE protocol-boundary provider.

## Risk & Scope

- Main risk or tradeoff: One additional request is made only after the provider rejects the original request during parameter validation. The learned capability is process-local.
- Not validated / out of scope: A post-fix live Token Plan request could not be completed because the current credentials return 401; the original live failure and the full post-fix protocol boundary were both verified.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #7284

Related to #7440 and #7303

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当实际发送的 OpenAI 兼容请求包含 `enable_thinking: false`，且 provider 返回 HTTP 400 并明确要求该参数必须为 `true` 时，本改动会重试一次。重试会通过现有 pipeline 重新构造请求，并在当前 provider pipeline 的生命周期内记住该模型能力。流式和非流式请求共用相同行为；无关的 400 响应和已取消请求保持不变。

## 为什么需要

#7303 为当前 qwen3.8 Token Plan preset 增加了配置驱动的 `thinkingMandatory` 能力。已有或自定义 provider 配置可能仍然只有 `extra_body.enable_thinking: true`，而没有这个能力字段，因此 `/btw` 仍会把它覆盖为 `false`，并在 0.20.1 上复现原始 400。

根据 provider 明确返回的能力约束进行学习，可以覆盖这个缺口，同时不需要继续增加 Token Plan 或模型名称特判。

## Reviewer Test Plan

### 如何验证

使用一个开启 thinking、但没有 `thinkingMandatory` 的已有或自定义 Token Plan 模型配置。第一次 `/btw` 请求应从 required-thinking 400 中恢复并完成；同一模型的下一次 `/btw` 应直接开启 thinking。同时确认无关 400 不会触发重试，并且在 provider 响应前取消请求不会启动重试。

### 证据（修改前后）

修改前，0.20.1 上的真实 Token Plan 请求失败：

`400 The value of the enable_thinking parameter is restricted to True.`

修改后，真实交互式 TUI 与 OpenAI SDK 协议边界测试结果：

- 第一次 `/btw`：`false → required-thinking 400 → true → BTW_RETRY_OK`
- 下一次 `/btw`：`true → BTW_CACHE_OK`
- 无关 400：仅一个 `false` 请求，不重试
- Escape 取消：仅一个 `false` 请求，不重试

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

本地 TypeScript 工作区，使用真实交互式 TUI、OpenAI SDK 和本地 HTTP/SSE 协议边界 provider。

## 风险与范围

- 主要风险或权衡：只有 provider 在参数校验阶段拒绝原请求后，才会额外发送一次请求。学习到的能力仅在当前进程内有效。
- 未验证或超出范围：由于当前凭据返回 401，无法完成修复后的真实 Token Plan 请求；原始线上失败和修复后的完整协议边界均已验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Follow-up to #7284

Related to #7440 and #7303

</details>
