### PR TITLE
test(core): stub the registry methods agent.ts actually calls

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -132,6 +132,13 @@ describe('AgentTool', () => {
     // paths, which now register/unregister in the BackgroundTaskRegistry
     // to surface the run in the pill+dialog. A no-op stub registry is
     // enough for these tests — they don't assert on registry behavior.
+    //
+    // It must still stub every registry method `agent.ts` reaches, though.
+    // The background body wraps its work in a try/catch that routes any
+    // throw to `registry.fail()`, so a method missing here does not surface
+    // as "not a function" — it silently turns a successful run into a
+    // failed one. Keep this list in sync with the `registry.*` calls in
+    // agent.ts.
     const stubRegistry = {
       assertCanStartBackgroundAgent: vi.fn(),
       canStartBackgroundAgent: vi.fn().mockReturnValue(true),
@@ -142,8 +149,15 @@ describe('AgentTool', () => {
         .fn()
         .mockResolvedValue({ id: Symbol('background-slot') }),
       releaseBackgroundSlot: vi.fn(),
+      getQueuedCount: vi.fn().mockReturnValue(0),
       register: vi.fn(),
       unregisterForeground: vi.fn(),
+      registerResidentAgent: vi.fn(),
+      // Returns boolean on the real registry; the GOAL completion path calls
+      // this immediately before registry.complete().
+      unregisterResidentAgent: vi.fn().mockReturnValue(true),
+      // AgentTask | undefined — undefined means "nothing to restart".
+      restartCompletedAgent: vi.fn(),
       complete: vi.fn(),
       fail: vi.fn(),
       finalizeCancelled: vi.fn(),
@@ -152,11 +166,15 @@ describe('AgentTool', () => {
       get: vi.fn(),
       getAll: vi.fn().mockReturnValue([]),
       drainMessages: vi.fn().mockReturnValue([]),
+      waitForMessages: vi.fn().mockResolvedValue([]),
       beginFinishing: vi.fn().mockReturnValue(true),
       queueMessage: vi.fn(),
       queueExternalInput: vi.fn(),
       wakeExternalInputWaiters: vi.fn(),
       appendActivity: vi.fn(),
+      // Real signature returns the unsubscribe callback, which agent.ts
+      // stores and later invokes — a bare vi.fn() would throw on cleanup.
+      bridgeApprovalEvents: vi.fn().mockReturnValue(vi.fn()),
     };
     const stubMonitorRegistry = {
       setAgentNotificationCallback: vi.fn(),
@@ -3116,6 +3134,7 @@ describe('AgentTool', () => {
           getBackgroundTaskRegistry: () => {
             register: ReturnType<typeof vi.fn>;
             complete: ReturnType<typeof vi.fn>;
+            fail: ReturnType<typeof vi.fn>;
           };
         }
       ).getBackgroundTaskRegistry();
@@ -3154,6 +3173,11 @@ describe('AgentTool', () => {
       );
 
       await vi.runAllTimersAsync();
+      // Checked before the completion assertion on purpose: the background
+      // body funnels any throw into registry.fail(), so an incomplete stub
+      // shows up here as the actual error message rather than as an
+      // inscrutable "complete: 0 calls" further down.
+      expect(stubRegistry.fail).not.toHaveBeenCalled();
       expect(stubRegistry.complete).toHaveBeenCalledWith(
         expect.any(String),
         'headless fork result',


### PR DESCRIPTION
Fixes #7537 — `packages/core`'s `test:ci` is red on `main`, so every open PR's `Test (ubuntu-latest, Node 22.x)` job fails regardless of its own diff.

## What this PR does

Adds the six `BackgroundTaskRegistry` methods that `agent.ts` calls but the shared `stubRegistry` in `agent.test.ts` never stubbed, and asserts `registry.fail` was not called before asserting completion. Test-only change; no production code touched.

## Why it's needed

`agent.test.ts`'s outer `beforeEach` hand-rolls a stub registry. Diffing the `registry.*` calls in `agent.ts` against that stub's keys:

| missing from stub | real signature |
| --- | --- |
| `unregisterResidentAgent` | `(agentId, resident?) => boolean` |
| `registerResidentAgent` | `(agentId, resident) => void` |
| `restartCompletedAgent` | `(agentId, abortController) => AgentTask \| undefined` |
| `bridgeApprovalEvents` | `(agentId, emitter) => () => void` |
| `waitForMessages` | `(agentId, signal) => Promise<AgentExternalInput[]>` |
| `getQueuedCount` | `() => number` |

This is not a benign omission. The background body wraps its work in a `try/catch` that routes any throw into `registry.fail()`, so a missing method never surfaces as `"not a function"` — it silently turns a successful run into a failed one.

On the GOAL completion path, `unregisterResidentAgent` is called immediately before `complete()` (`agent.ts:3370` and `:3378`), so the `TypeError` replaced the completion outright. Confirmed by instrumenting `registry.fail` in the failing test:

```
FAIL CALLS: [["fork-06a26e81",
              "registry2.unregisterResidentAgent is not a function",
              "[object Object]"]]
```

That is exactly why `runs a non-interactive fork through the background registry` fails with `complete → Number of calls: 0` while every earlier assertion in the same test passes.

**Why this only appeared now:** #7460 *added* the `registry.complete` assertion. Before it, nothing checked whether the background body finished successfully, so the `TypeError` was swallowed by the `.catch` handler and the incomplete stub went unnoticed. The stub has been out of date since the resident-agent lifecycle landed; #7460 is what made it visible.

`bridgeApprovalEvents` is stubbed to return a callback rather than `undefined` because `agent.ts` stores the result and later invokes it as the unsubscribe — a bare `vi.fn()` would throw the same class of error on cleanup.

## Reviewer Test Plan

### How to verify

- On `main`: `npx vitest run --root packages/core src/tools/agent/agent.test.ts` → `1 failed | 196 passed (197)`.
- On this branch: same command → **197 passed (197)**.
- Broader: `npx vitest run --root packages/core src/tools/agent/ src/agents/` → 1386 passed, 6 skipped (40 files).
- Typecheck and eslint clean. Note `tsc` initially flagged the new `fail` assertion, because the test's local cast of `getBackgroundTaskRegistry()` declared only `register` and `complete`; the cast now includes `fail`.

### Evidence (Before & After)

```
# main (d064bd7dc)
 FAIL  src/tools/agent/agent.test.ts > AgentTool > Fork dispatch (subagent_type: "fork")
       > runs a non-interactive fork through the background registry
 AssertionError: expected "spy" to be called with arguments: [ Any<String>, …(2) ]
 Number of calls: 0
      Tests  1 failed | 196 passed (197)

# this branch
      Tests  197 passed (197)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `agent.test.ts` 197/197 and the wider agent suites 1386/1392 pass locally; typecheck and eslint clean. Test-only change to mock objects with no platform-dependent behavior, so no manual QA is required; CI covers Windows/Linux — and this PR's own green `Test (ubuntu)` job is the direct confirmation.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: none to production — only mock objects in a test file change. The added methods are no-ops returning the shapes the real registry returns, so no existing assertion changes meaning; all 197 tests in the file pass, including the 196 that already did.
- Not validated / out of scope: **the swallowing behavior itself.** That the background body converts a `TypeError` into `registry.fail(...)` means a genuine production bug on this path would be reported as a failed agent with a cryptic message rather than surfacing as a crash. That seemed worth flagging but not worth changing error handling in the agent background path in a PR whose job is to get CI green. The new `expect(stubRegistry.fail).not.toHaveBeenCalled()` at least makes it visible in this test.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7537.

<details>
<summary>中文说明</summary>

修复 #7537 —— `packages/core` 的 `test:ci` 在 `main` 上是红的，导致每个已开启 PR 的 `Test (ubuntu-latest, Node 22.x)` 任务都会失败，与其自身改动无关。

## 本 PR 的作用

补齐 `agent.ts` 会调用、但 `agent.test.ts` 中共享的 `stubRegistry` 从未 stub 的六个 `BackgroundTaskRegistry` 方法，并在断言完成之前先断言 `registry.fail` 未被调用。纯测试改动，不涉及任何生产代码。

## 为什么需要

`agent.test.ts` 的外层 `beforeEach` 手写了一个 stub registry。将 `agent.ts` 中的 `registry.*` 调用与该 stub 的键做差集：

| stub 中缺失 | 真实签名 |
| --- | --- |
| `unregisterResidentAgent` | `(agentId, resident?) => boolean` |
| `registerResidentAgent` | `(agentId, resident) => void` |
| `restartCompletedAgent` | `(agentId, abortController) => AgentTask \| undefined` |
| `bridgeApprovalEvents` | `(agentId, emitter) => () => void` |
| `waitForMessages` | `(agentId, signal) => Promise<AgentExternalInput[]>` |
| `getQueuedCount` | `() => number` |

这并非无害的遗漏。后台执行体将其工作包在 `try/catch` 中，任何抛出都会被导流至 `registry.fail()`，因此缺失的方法根本不会以 `"not a function"` 的形式浮现——它会悄无声息地把一次成功的运行变成失败。

在 GOAL 完成路径上，`unregisterResidentAgent` 恰好在 `complete()` 之前被调用（`agent.ts:3370` 与 `:3378`），于是 `TypeError` 直接取代了完成流程。通过在失败测试中给 `registry.fail` 加探针得到确认：

```
FAIL CALLS: [["fork-06a26e81",
              "registry2.unregisterResidentAgent is not a function",
              "[object Object]"]]
```

这正是 `runs a non-interactive fork through the background registry` 以 `complete → Number of calls: 0` 失败、而同一测试中此前所有断言却都通过的原因。

**为何现在才暴露：** #7460 *新增*了 `registry.complete` 断言。在此之前，没有任何测试检查后台执行体是否成功完成，`TypeError` 被 `.catch` 处理器吞掉，这个不完整的 stub 便一直无人察觉。自 resident-agent 生命周期引入以来该 stub 就已过时，#7460 只是让它显形。

`bridgeApprovalEvents` 被 stub 为返回一个回调而非 `undefined`，因为 `agent.ts` 会保存该返回值并在稍后作为取消订阅函数调用——若用裸的 `vi.fn()`，清理时会抛出同一类错误。

## 复核测试计划

### 如何验证

- 在 `main` 上：`npx vitest run --root packages/core src/tools/agent/agent.test.ts` → `1 failed | 196 passed (197)`。
- 在本分支上：同一命令 → **197 passed (197)**。
- 更大范围：`npx vitest run --root packages/core src/tools/agent/ src/agents/` → 1386 passed、6 skipped（40 个文件）。
- typecheck 与 eslint 均干净。注意 `tsc` 最初对新增的 `fail` 断言报错，因为该测试中对 `getBackgroundTaskRegistry()` 的局部类型断言只声明了 `register` 与 `complete`；现已补入 `fail`。

### 证据（修复前后对比）

```
# main (d064bd7dc)
 FAIL  src/tools/agent/agent.test.ts > AgentTool > Fork dispatch (subagent_type: "fork")
       > runs a non-interactive fork through the background registry
 AssertionError: expected "spy" to be called with arguments: [ Any<String>, …(2) ]
 Number of calls: 0
      Tests  1 failed | 196 passed (197)

# 本分支
      Tests  197 passed (197)
```

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`agent.test.ts` 197/197、更大范围的 agent 套件 1386/1392 本地通过；typecheck 与 eslint 干净。纯测试文件中 mock 对象的改动，无平台相关行为，因此无需人工 QA；Windows/Linux 由 CI 覆盖——本 PR 自身变绿的 `Test (ubuntu)` 任务就是最直接的确认。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：对生产代码无风险——仅改动测试文件中的 mock 对象。新增方法均为返回真实 registry 对应形状的空实现，因此不改变任何既有断言的含义；该文件全部 197 个测试通过，其中包括原本已通过的 196 个。
- 未验证 / 范围之外：**吞异常这一行为本身。** 后台执行体把 `TypeError` 转成 `registry.fail(...)`，意味着该路径上真正的生产 bug 会表现为「一个带着晦涩信息的失败 agent」，而非直接暴露为崩溃。这一点值得指出，但在一个以「让 CI 变绿」为目标的 PR 里改动 agent 后台路径的错误处理并不合适。新增的 `expect(stubRegistry.fail).not.toHaveBeenCalled()` 至少让它在本测试中可见。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7537。

</details>
