### PR TITLE
test(core): stub resident-agent methods in the agent test registry

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -157,6 +157,8 @@ describe('AgentTool', () => {
       queueExternalInput: vi.fn(),
       wakeExternalInputWaiters: vi.fn(),
       appendActivity: vi.fn(),
+      registerResidentAgent: vi.fn(),
+      unregisterResidentAgent: vi.fn(),
     };
     const stubMonitorRegistry = {
       setAgentNotificationCallback: vi.fn(),


### PR DESCRIPTION
## What this PR does

Un-reds main's ubuntu CI: `agent.test.ts > runs a non-interactive fork through the background registry` fails on every current main run.

## Why it's needed

#7460 added an assertion that the fork completes through `registry.complete`, but the shared stub registry in `beforeEach` lacks `registerResidentAgent` / `unregisterResidentAgent`. The background turn hits the missing method, the turn promise rejects into `reportUnexpectedBackgroundError`, and `complete` never runs. I reproduced it locally: `execute()` is called once, then the turn dies at the resident-agent line. Two stub methods fix it. The production path is fine; forks are supposed to stay resident.

## Reviewer Test Plan

### How to verify

On current main the focused test fails 1/197. With this change `npx vitest run packages/core/src/tools/agent/agent.test.ts` is 197/197.

### Evidence (Before & After)

N/A (test-only change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->
