### PR TITLE
fix(core): preserve disabled reasoning effort

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -867,6 +867,41 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.reasoning).toBeUndefined();
     });
 
+    it('should preserve reasoning_effort none when thinking is disabled', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        samplingParams: { reasoning_effort: 'none' },
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'gpt-5',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'response-id',
+        choices: [{ message: { content: 'safe' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'side-query:permission-classifier');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning_effort).toBe('none');
+    });
+
     it('should preserve enable_thinking when thinking is not explicitly disabled', async () => {
       // Arrange — normal request (not forked query), enable_thinking should be preserved
       (mockProvider.buildRequest as Mock).mockImplementation((req) => ({

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -897,7 +897,7 @@ export class ContentGenerationPipeline {
       if ('reasoning' in typed) {
         delete typed['reasoning'];
       }
-      if ('reasoning_effort' in typed) {
+      if ('reasoning_effort' in typed && typed['reasoning_effort'] !== 'none') {
         delete typed['reasoning_effort'];
       }
       // DeepSeek V4+ defaults `thinking.type` to `'enabled'`, so removing


### PR DESCRIPTION
## What this PR does

Preserves an explicitly configured `reasoning_effort: "none"` when a side query disables thinking. Other reasoning effort values and nested reasoning configuration continue to be removed as before.

## Why it's needed

Structured side queries use a forced function call to produce schema-constrained output. Some OpenAI-compatible gateways reject function tools for GPT-5 models unless reasoning is explicitly disabled with `reasoning_effort: "none"`. The current pipeline removes that explicit opt-out, causing Auto Mode classification and other structured side queries to fail with a 400 response.

## Reviewer Test Plan

### How to verify

Configure an OpenAI-compatible GPT-5 model with `samplingParams.reasoning_effort` set to `none`, then trigger a structured side query with thinking disabled. Confirm the outbound request retains `reasoning_effort: "none"`. Also confirm non-disabled reasoning effort values are still removed when thinking is disabled.

### Evidence (Before & After)

Before: the gateway rejected structured side queries because the explicit `none` value was removed before the request was sent.

After: the same Auto Mode classifier request succeeds, and the focused pipeline suite passes all 112 tests including the new regression case.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 26.5.0; focused core unit tests, formatting, lint, and core typecheck.

## Risk & Scope

- Main risk or tradeoff: providers that interpret the literal `none` value differently will now receive the user-configured value instead of having it removed, matching the explicit configuration.
- Not validated / out of scope: Windows and Linux runtime validation; migration to the OpenAI Responses API.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 的作用

当侧查询禁用思考时，保留显式配置的 `reasoning_effort: "none"`。其他推理强度值和嵌套推理配置仍会像以前一样被移除。

## 为什么需要它

结构化侧查询使用强制函数调用来生成符合 schema 的输出。某些 OpenAI 兼容网关会拒绝 GPT-5 模型的函数工具调用，除非通过 `reasoning_effort: "none"` 显式禁用推理。当前管道会删除这个显式关闭值，导致 Auto Mode 分类和其他结构化侧查询返回 400 错误。

## Reviewer Test Plan

### 如何验证

配置一个 OpenAI 兼容的 GPT-5 模型，将 `samplingParams.reasoning_effort` 设置为 `none`，然后触发一个禁用思考的结构化侧查询。确认发出的请求仍包含 `reasoning_effort: "none"`。同时确认在禁用思考时，其他非禁用的推理强度值仍会被移除。

### 证据（修改前后）

修改前：由于显式的 `none` 值在发送请求前被删除，网关拒绝结构化侧查询。

修改后：同一个 Auto Mode 分类器请求成功，聚焦的管道测试套件全部 112 个测试通过，包括新的回归测试。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS     |  ✅  |
|     🪟 Windows   |  ⚠️  |
|      🐧 Linux    |  ⚠️  |

### 环境（可选）

Node.js 26.5.0；已运行聚焦的 core 单元测试、格式检查、lint 和 core 类型检查。

## 风险与范围

- 主要风险或权衡：如果某个提供商对字面量 `none` 有不同解释，它现在会收到用户显式配置的值，而不是删除该值；这与用户配置一致。
- 未验证或超出范围：Windows 和 Linux 运行时验证；迁移到 OpenAI Responses API。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
