### PR TITLE
fix(cli): resolve npm wrappers to npm-cli.js

### DIFF
--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -7,6 +7,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   formatUpdateInstructions,
+  getNpmCliPath,
   getInstallationInfo,
   PackageManager,
   resolveUpdateCommand,
@@ -51,6 +52,16 @@ const mockedExistsSync = vi.mocked(fs.existsSync);
 const mockedLstatSync = vi.mocked(fs.lstatSync);
 const mockedReadFileSync = vi.mocked(fs.readFileSync);
 const mockedExecSync = vi.mocked(childProcess.execSync);
+
+describe('getNpmCliPath', () => {
+  it('falls back to npm-cli.js when adjacent npm is a wrapper', () => {
+    mockedRealPathSync.mockReturnValue('/prefix/bin/npm');
+
+    expect(getNpmCliPath('/prefix/bin/node', 'linux')).toBe(
+      '/prefix/lib/node_modules/npm/bin/npm-cli.js',
+    );
+  });
+});
 
 describe('getInstallationInfo', () => {
   const projectRoot = '/path/to/project';

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -35,6 +35,15 @@ export function getNpmCliPath(
       'npm-cli.js',
     );
   }
+  const npmCliPath = path.join(
+    path.dirname(nodePath),
+    '..',
+    'lib',
+    'node_modules',
+    'npm',
+    'bin',
+    'npm-cli.js',
+  );
   // Prefer the npm symlink that sits next to the node binary and resolve it to
   // the real npm-cli.js. On split layouts where npm is not adjacent to node,
   // fall back to the conventional `<prefix>/lib/node_modules/npm` location
@@ -43,17 +52,10 @@ export function getNpmCliPath(
   // downstream spawn surface any failure through its 'error' handler.
   const adjacentNpm = path.join(path.dirname(nodePath), 'npm');
   try {
-    return fs.realpathSync(adjacentNpm);
+    const resolvedNpm = fs.realpathSync(adjacentNpm);
+    return resolvedNpm.endsWith('.js') ? resolvedNpm : npmCliPath;
   } catch {
-    return path.join(
-      path.dirname(nodePath),
-      '..',
-      'lib',
-      'node_modules',
-      'npm',
-      'bin',
-      'npm-cli.js',
-    );
+    return npmCliPath;
   }
 }
 


### PR DESCRIPTION
## What this PR does

The update checker now ignores a non-JavaScript `npm` wrapper next to the Node executable and uses the conventional `npm-cli.js` path instead. Normal Node installations whose adjacent `npm` symlink resolves to JavaScript keep the existing behavior.

## Why it's needed

Version managers such as mise can place a shell wrapper at `bin/npm`. Passing that wrapper to Node produces a syntax error, so startup checks and `/update` incorrectly report a registry failure even when npm is reachable.

## Reviewer Test Plan

### How to verify

Resolve the npm CLI path with a Node executable whose adjacent `npm` entry resolves to a shell wrapper. It should return the conventional `lib/node_modules/npm/bin/npm-cli.js` path. An adjacent entry that resolves to `npm-cli.js` should still be preferred.

### Evidence (Before & After)

Before: the reproduced mise-style layout selected `/usr/bin/bash` as the npm CLI. After: the focused regression and all 33 installation-info tests pass, and the resolver selects `npm-cli.js`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js 22.22.1 with the repository lockfile dependencies.

## Risk & Scope

- Main risk or tradeoff: custom npm entry points without a `.js` suffix now use the standard fallback path.
- Not validated / out of scope: an end-to-end mise installation on macOS.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7543

<details>
<summary>中文说明</summary>

## 本 PR 的修改

更新检查器现在会忽略 Node 可执行文件旁边的非 JavaScript `npm` 包装脚本，改用常规的 `npm-cli.js` 路径。对于相邻 `npm` 符号链接解析到 JavaScript 文件的普通 Node 安装，现有行为保持不变。

## 修改原因

mise 等版本管理器可能会在 `bin/npm` 放置 shell 包装脚本。将该脚本传给 Node 会触发语法错误，因此即使 npm 仓库可访问，启动检查和 `/update` 也会错误地报告仓库故障。

## 审阅者测试计划

### 验证方法

使用一个相邻 `npm` 条目解析到 shell 包装脚本的 Node 可执行文件来解析 npm CLI 路径。结果应为常规的 `lib/node_modules/npm/bin/npm-cli.js` 路径。解析到 `npm-cli.js` 的相邻条目仍应优先使用。

### 修改前后证据

修改前：复现的 mise 风格布局错误地选择 `/usr/bin/bash` 作为 npm CLI。修改后：针对性回归测试和全部 33 个安装信息测试通过，解析器选择 `npm-cli.js`。

### 测试环境

| 操作系统 | 状态 |
| :------: | :--: |
| macOS | ⚠️ 未测试 |
| Windows | N/A |
| Linux | ✅ 已测试 |

Node.js 22.22.1，使用仓库锁文件依赖。

## 风险与范围

- 主要风险或权衡：没有 `.js` 后缀的自定义 npm 入口现在会使用标准回退路径。
- 未验证 / 范围外：macOS 上完整的 mise 端到端安装。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7543

</details>
