### PR TITLE
fix(core): convert subschemas of properties named after schema keywords

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -5871,6 +5871,35 @@ describe('OpenAIContentConverter', () => {
       });
     });
 
+    it('converts subschemas of properties named after schema keywords', () => {
+      // A tool can declare a parameter literally called `maximum` or
+      // `minItems`. Those are property NAMES, not constraints, so their
+      // subschemas must still be converted like any other property.
+      const params = {
+        type: 'OBJECT',
+        properties: {
+          maximum: {
+            type: 'INTEGER',
+            description: 'upper bound',
+            minimum: '5',
+          },
+          minItems: { type: 'STRING' },
+          normalProp: { type: 'STRING' },
+        },
+      };
+
+      const result = converter.convertGeminiToolParametersToOpenAI(params);
+      const properties = result?.['properties'] as Record<string, unknown>;
+
+      expect(properties?.['maximum']).toEqual({
+        type: 'integer',
+        description: 'upper bound',
+        minimum: 5,
+      });
+      expect(properties?.['minItems']).toEqual({ type: 'string' });
+      expect(properties?.['normalProp']).toEqual({ type: 'string' });
+    });
+
     it('should convert string numeric constraints to numbers', () => {
       const params = {
         type: 'object',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -270,7 +270,14 @@ export function convertGeminiToolParametersToOpenAI(
 
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      if (key === 'type' && typeof value === 'string') {
+      // A property can legitimately be NAMED after a JSON-Schema keyword —
+      // `{ properties: { maximum: { type: 'INTEGER' } } }` declares a tool
+      // parameter called "maximum". Recursing on any object value first keeps
+      // such subschemas converted; the keyword branches below then only ever
+      // see primitives, which is all they were meant to coerce.
+      if (typeof value === 'object' && value !== null) {
+        result[key] = convertTypes(value);
+      } else if (key === 'type' && typeof value === 'string') {
         // Convert Gemini types to OpenAI JSON Schema types
         const lowerValue = value.toLowerCase();
         if (lowerValue === 'integer') {
@@ -308,8 +315,6 @@ export function convertGeminiToolParametersToOpenAI(
         } else {
           result[key] = value;
         }
-      } else if (typeof value === 'object') {
-        result[key] = convertTypes(value);
       } else {
         result[key] = value;
       }


### PR DESCRIPTION
## What this PR does

`convertTypes` in `convertGeminiToolParametersToOpenAI` recursed into nested objects only *after* checking a list of JSON-Schema constraint keywords, and each of those branches copies non-string values verbatim. This moves the object recursion to the front of the chain so a property that happens to be *named* after a keyword still gets converted.

## Why it's needed

The keyword branches exist to coerce string constraints to numbers — `minimum: '5'` → `minimum: 5`. They match on the **key name**, but a key name in a `properties` map is a *parameter name*, not a constraint. A tool that declares a parameter called `maximum` (an entirely reasonable name for, say, a range query) hits the constraint branch, whose `else` does `result[key] = value` — copying the whole subschema through untouched.

Verified on `main`:

```ts
convertGeminiToolParametersToOpenAI({
  type: 'OBJECT',
  properties: {
    maximum:    { type: 'INTEGER', description: 'upper bound', minimum: '5' },
    minItems:   { type: 'STRING' },
    normalProp: { type: 'STRING' },
  },
});
```

| property | result on `main` | expected |
| --- | --- | --- |
| `maximum` | `{ type: 'INTEGER', …, minimum: '5' }` | `{ type: 'integer', …, minimum: 5 }` |
| `minItems` | `{ type: 'STRING' }` | `{ type: 'string' }` |
| `normalProp` | `{ type: 'string' }` | ✓ already correct |

So the subschema keeps Gemini's uppercase `INTEGER`/`STRING` — which is exactly what this function exists to normalize — and its own nested `minimum: '5'` stays a string. It affects all seven names the walker special-cases: `minimum`, `maximum`, `multipleOf`, `minLength`, `maxLength`, `minItems`, `maxItems`.

Recursing on any object value first fixes every one of them at once, and leaves the keyword branches seeing only primitives, which is all they were ever meant to coerce.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/core/openaiContentGenerator/converter.test.ts` → 211/211.
- The new test `converts subschemas of properties named after schema keywords` covers a property named `maximum` (with a nested string `minimum` to prove the inner coercion also runs), one named `minItems`, and a control property. Reverting only `converter.ts` fails it with `expected { type: 'INTEGER', …(2) } to deeply equal { type: 'integer', …(2) }`.
- The existing `should convert string numeric constraints to numbers` and `should convert string length constraints to integers` tests are untouched and still pass — they pin that real constraints still coerce.

### Evidence (Before & After)

- Before: `properties.maximum.type === 'INTEGER'` while `properties.normalProp.type === 'string'` — the same schema converted inconsistently depending on the property's name.
- After: both are `'integer'` / `'string'`, and `properties.maximum.minimum === 5` (number).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: the converter suite passes locally (211 tests) with proven fail-before/pass-after; typecheck and eslint clean. Pure object-tree transformation with no platform-dependent behavior, so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: the reordering changes which branch an object-valued key takes. Previously an object under a keyword name was copied verbatim; now it recurses. For every other key the behavior is identical, since a non-keyword object already fell through to the same `convertTypes(value)` call. Real constraints are unaffected because their values are primitives (`5`, `'5'`), which never enter the new branch.
- Not validated / out of scope: the now-dead `else if (typeof value === 'object')` branch is removed. After the hoist it was reachable only for `value === null` (`typeof null === 'object'`), and `convertTypes(null)` returns `null` — identical to the final `else`, so dropping it changes nothing.
- Breaking changes / migration notes: none. Schemas that were already converted correctly are byte-identical; only the previously-skipped subschemas change, and they change to the documented output.

## Linked Issues

None — found by reading the branch ordering in `convertTypes`.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`convertGeminiToolParametersToOpenAI` 中的 `convertTypes` 只有在检查完一串 JSON-Schema 约束关键字之后才会递归进嵌套对象，而这些分支对非字符串值一律原样拷贝。本 PR 把对象递归提到判断链最前面，使得「恰好以关键字命名」的属性也能被正常转换。

## 为什么需要

这些关键字分支的作用是把字符串形式的约束强制为数字——`minimum: '5'` → `minimum: 5`。它们依据**键名**匹配，但 `properties` 映射中的键名是*参数名*，并非约束。若某个工具声明了名为 `maximum` 的参数（对区间查询而言完全合理），就会落入约束分支，其 `else` 执行 `result[key] = value`，整个子 schema 被原封不动地拷贝出去。

在 `main` 上验证：

```ts
convertGeminiToolParametersToOpenAI({
  type: 'OBJECT',
  properties: {
    maximum:    { type: 'INTEGER', description: 'upper bound', minimum: '5' },
    minItems:   { type: 'STRING' },
    normalProp: { type: 'STRING' },
  },
});
```

| 属性 | `main` 上的结果 | 期望 |
| --- | --- | --- |
| `maximum` | `{ type: 'INTEGER', …, minimum: '5' }` | `{ type: 'integer', …, minimum: 5 }` |
| `minItems` | `{ type: 'STRING' }` | `{ type: 'string' }` |
| `normalProp` | `{ type: 'string' }` | ✓ 本就正确 |

于是该子 schema 保留了 Gemini 的大写 `INTEGER`/`STRING`——而这正是本函数存在的意义所在——其内部的 `minimum: '5'` 也仍是字符串。该问题影响这个遍历器特判的全部七个名字：`minimum`、`maximum`、`multipleOf`、`minLength`、`maxLength`、`minItems`、`maxItems`。

优先对任意对象值递归，可一次性修复全部七种情形，同时让关键字分支只会看到原始值——而这本就是它们唯一需要处理的。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/core/openaiContentGenerator/converter.test.ts` → 211/211 通过。
- 新增测试 `converts subschemas of properties named after schema keywords` 覆盖了名为 `maximum` 的属性（内含字符串 `minimum`，以证明内层强制转换同样生效）、名为 `minItems` 的属性，以及一个对照属性。仅还原 `converter.ts` 时该测试失败：`expected { type: 'INTEGER', …(2) } to deeply equal { type: 'integer', …(2) }`。
- 既有的 `should convert string numeric constraints to numbers` 与 `should convert string length constraints to integers` 未作改动且仍然通过——它们固定了真正的约束依然会被强制转换。

### 证据（修复前后对比）

- 修复前：`properties.maximum.type === 'INTEGER'`，而 `properties.normalProp.type === 'string'`——同一份 schema 因属性名不同而被不一致地转换。
- 修复后：两者分别为 `'integer'` / `'string'`，且 `properties.maximum.minimum === 5`（数字）。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：converter 测试套件本地通过（211 个测试），并验证了 fail-before/pass-after；typecheck 与 eslint 干净。纯对象树变换，无平台相关行为，因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：调整顺序改变了「对象值的键」所走的分支。此前处于关键字名下的对象会被原样拷贝，现在会递归。对其他所有键行为完全一致，因为非关键字的对象原本就落到同一个 `convertTypes(value)` 调用。真正的约束不受影响，因为其值是原始值（`5`、`'5'`），永远不会进入新分支。
- 未验证 / 范围之外：现已失效的 `else if (typeof value === 'object')` 分支被移除。提升递归之后，它仅在 `value === null` 时可达（`typeof null === 'object'`），而 `convertTypes(null)` 返回 `null`——与最后的 `else` 完全相同，故删除它不改变任何行为。
- 破坏性变更 / 迁移说明：无。原本就转换正确的 schema 逐字节一致；仅此前被跳过的子 schema 发生变化，且是变为文档所述的正确输出。

## 关联 Issue

无——通过阅读 `convertTypes` 的分支顺序发现。

</details>
