### PR TITLE
fix(core): stringify const-derived enums in toOpenAPI30

### DIFF
--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -71,6 +71,21 @@ describe('convertSchema', () => {
       expect(convertSchema(input, 'openapi_30')).toEqual(expected);
     });
 
+    it('should stringify a non-string const like any other enum', () => {
+      // `enum: [1, 2]` becomes `['1', '2']` because Gemini requires string
+      // enums; a const-derived enum is the same kind of value and must obey
+      // the same rule.
+      expect(convertSchema({ const: 5 }, 'openapi_30')).toEqual({
+        enum: ['5'],
+      });
+      expect(convertSchema({ const: true }, 'openapi_30')).toEqual({
+        enum: ['true'],
+      });
+      expect(
+        convertSchema({ type: 'integer', const: 0 }, 'openapi_30'),
+      ).toEqual({ type: 'integer', enum: ['0'] });
+    });
+
     it('should convert exclusiveMinimum number to boolean', () => {
       const input = { type: 'number', exclusiveMinimum: 10 };
       const expected = {

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -65,8 +65,12 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
     }
 
     // 2. Const Handling (Draft 6+) -> Enum (OpenAPI 3.0)
+    // Stringified for the same reason step 5 stringifies `enum`: this
+    // produces an enum, and Gemini requires those to be strings. Step 5
+    // cannot cover it, since it keys off `source['enum']`, which a
+    // const-only schema never sets.
     if (source['const'] !== undefined) {
-      target['enum'] = [source['const']];
+      target['enum'] = [String(source['const'])];
       delete target['const'];
     }
 


### PR DESCRIPTION
## What this PR does

`toOpenAPI30` builds its `const`-derived enum with `String()`, so it obeys the same string-enum rule the converter already enforces for `enum`. One-line change plus tests.

## Why it's needed

The converter does two related things in separate steps:

```ts
// 2. Const Handling (Draft 6+) -> Enum (OpenAPI 3.0)
if (source['const'] !== undefined) {
  target['enum'] = [source['const']];
  delete target['const'];
}

// 5. Enum Stringification
// Gemini strictly requires enums to be strings
if (Array.isArray(source['enum'])) {
  target['enum'] = source['enum'].map(String);
}
```

Step 5 keys off `source['enum']` — the **source** schema — which a const-only schema never sets. So the enum step 2 just created is never stringified, and the converter violates its own documented invariant. Verified via `convertSchema(schema, 'openapi_30')` on `main`:

| input | output on `main` | |
| --- | --- | --- |
| `{ const: 5 }` | `{ enum: [5] }` | number — breaks the rule |
| `{ const: true }` | `{ enum: [true] }` | boolean — likewise |
| `{ const: 'x' }` | `{ enum: ['x'] }` | fine, but only because it was already a string |
| `{ enum: [1, 2] }` | `{ enum: ['1', '2'] }` | the intended behavior |

So two schemas that mean the same thing — `{ const: 5 }` and `{ enum: [5] }` — convert to different value types, and the one that goes through `const` is the one the comment says Gemini will reject.

## Reviewer Test Plan

### How to verify

- From the repo root: `npx vitest run --root packages/core src/utils/schemaConverter.test.ts` → 23/23.
- The new test `should stringify a non-string const like any other enum` covers `{ const: 5 }`, `{ const: true }`, and `{ type: 'integer', const: 0 }` (the last one also pins that `type` is left alone). Reverting only `schemaConverter.ts` fails it with `expected { enum: [ 5 ] } to deeply equal { enum: [ '5' ] }`.
- The existing `should convert const to enum` (`{ const: 'foo' }` → `{ enum: ['foo'] }`) and `should stringify enums` tests are untouched and still pass.
- The only consumer, `anthropicContentGenerator/converter.ts`, is unaffected: `schemaConverter` + `anthropic converter` suites are 90/90 together.

### Evidence (Before & After)

- Before: `convertSchema({ const: 5 }, 'openapi_30')` → `{ enum: [5] }`.
- After: `{ enum: ['5'] }`, matching `convertSchema({ enum: [5] }, 'openapi_30')` → `{ enum: ['5'] }`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `schemaConverter` (23) and the `anthropicContentGenerator` converter suite pass locally with proven fail-before/pass-after; typecheck and eslint clean. Pure value transformation with no platform-dependent behavior, so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/qwen-code-core` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: a numeric or boolean `const` now reaches the model as a string. That is the point — the module states Gemini requires string enums and already does exactly this to every `enum` array, so this makes the two paths agree rather than introducing a new policy.
- Not validated / out of scope: `type` is deliberately left untouched, so `{ type: 'integer', const: 0 }` becomes `{ type: 'integer', enum: ['0'] }`. That mirrors what the existing `enum` stringification already produces for `{ type: 'integer', enum: [0] }` — whether the converter should also coerce `type` to `'string'` alongside a stringified enum is a pre-existing question that applies equally to both paths, so it did not belong in this change.
- Breaking changes / migration notes: none for string consts, which are unchanged.

## Linked Issues

None — found by reading step 2 against step 5 in `toOpenAPI30`.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`toOpenAPI30` 在构造由 `const` 派生的 enum 时改用 `String()`，使其遵守该转换器已对 `enum` 强制执行的同一条「字符串 enum」规则。一行改动，外加测试。

## 为什么需要

转换器在两个独立步骤中做了两件相关的事：

```ts
// 2. Const Handling (Draft 6+) -> Enum (OpenAPI 3.0)
if (source['const'] !== undefined) {
  target['enum'] = [source['const']];
  delete target['const'];
}

// 5. Enum Stringification
// Gemini strictly requires enums to be strings
if (Array.isArray(source['enum'])) {
  target['enum'] = source['enum'].map(String);
}
```

第 5 步依据的是 `source['enum']`——**源** schema——而只含 `const` 的 schema 从不设置它。于是第 2 步刚刚创建的 enum 永远不会被字符串化，转换器违反了自己文档化的不变式。在 `main` 上通过 `convertSchema(schema, 'openapi_30')` 验证：

| 输入 | `main` 上的输出 | |
| --- | --- | --- |
| `{ const: 5 }` | `{ enum: [5] }` | 数字——违反规则 |
| `{ const: true }` | `{ enum: [true] }` | 布尔——同样违反 |
| `{ const: 'x' }` | `{ enum: ['x'] }` | 正常，但只是因为它本就是字符串 |
| `{ enum: [1, 2] }` | `{ enum: ['1', '2'] }` | 预期行为 |

于是语义相同的两个 schema——`{ const: 5 }` 与 `{ enum: [5] }`——会转换成不同的值类型，而走 `const` 的那条恰恰是注释所说 Gemini 会拒绝的形式。

## 复核测试计划

### 如何验证

- 在仓库根目录：`npx vitest run --root packages/core src/utils/schemaConverter.test.ts` → 23/23 通过。
- 新增测试 `should stringify a non-string const like any other enum` 覆盖 `{ const: 5 }`、`{ const: true }` 与 `{ type: 'integer', const: 0 }`（最后一项同时固定了 `type` 不被改动）。仅还原 `schemaConverter.ts` 时该测试失败：`expected { enum: [ 5 ] } to deeply equal { enum: [ '5' ] }`。
- 既有的 `should convert const to enum`（`{ const: 'foo' }` → `{ enum: ['foo'] }`）与 `should stringify enums` 未作改动且仍然通过。
- 唯一的消费方 `anthropicContentGenerator/converter.ts` 不受影响：`schemaConverter` 与 anthropic converter 两个套件合计 90/90 通过。

### 证据（修复前后对比）

- 修复前：`convertSchema({ const: 5 }, 'openapi_30')` → `{ enum: [5] }`。
- 修复后：`{ enum: ['5'] }`，与 `convertSchema({ enum: [5] }, 'openapi_30')` → `{ enum: ['5'] }` 一致。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`schemaConverter`（23）与 `anthropicContentGenerator` converter 套件本地通过，并验证了 fail-before/pass-after；typecheck 与 eslint 干净。纯值变换，无平台相关行为，因此无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/qwen-code-core` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：数字或布尔型 `const` 现在会以字符串形式送达模型。这正是本意——该模块明确声明 Gemini 要求字符串 enum，并且已对每个 `enum` 数组做了完全相同的处理；本改动只是让两条路径保持一致，而非引入新策略。
- 未验证 / 范围之外：有意不改动 `type`，因此 `{ type: 'integer', const: 0 }` 变为 `{ type: 'integer', enum: ['0'] }`。这与既有的 enum 字符串化对 `{ type: 'integer', enum: [0] }` 的产出完全一致——转换器是否应在字符串化 enum 的同时把 `type` 也改为 `'string'`，是一个对两条路径同样适用的既有问题，不属于本次改动。
- 破坏性变更 / 迁移说明：对字符串型 const 无影响，其行为不变。

## 关联 Issue

无——通过将 `toOpenAPI30` 的第 2 步与第 5 步对照阅读发现。

</details>
