### PR TITLE
fix(sdk-python): validate max_tool_calls and max_subagent_depth as integers

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -135,9 +135,7 @@ def validate_query_options(options: QueryOptions) -> None:
         )
 
     if options.max_session_turns is not None and (
-        isinstance(options.max_session_turns, bool)
-        or not isinstance(options.max_session_turns, int)
-        or options.max_session_turns < -1
+        not _is_int(options.max_session_turns) or options.max_session_turns < -1
     ):
         raise ValidationError("max_session_turns must be -1 or a non-negative integer")
 
@@ -147,11 +145,14 @@ def validate_query_options(options: QueryOptions) -> None:
     ):
         raise ValidationError("path_to_qwen_executable cannot be empty")
 
-    if options.max_tool_calls is not None and options.max_tool_calls < -1:
+    if options.max_tool_calls is not None and (
+        not _is_int(options.max_tool_calls) or options.max_tool_calls < -1
+    ):
         raise ValidationError("max_tool_calls must be -1 or a non-negative integer")
 
-    if options.max_subagent_depth is not None and not (
-        1 <= options.max_subagent_depth <= 100
+    if options.max_subagent_depth is not None and (
+        not _is_int(options.max_subagent_depth)
+        or not (1 <= options.max_subagent_depth <= 100)
     ):
         raise ValidationError("max_subagent_depth must be between 1 and 100")
 
@@ -203,6 +204,15 @@ def validate_query_options(options: QueryOptions) -> None:
 
     if options.proxy is not None and not options.proxy.strip():
         raise ValidationError("proxy cannot be empty")
+
+
+def _is_int(value: object) -> bool:
+    """True for a real integer.
+
+    ``bool`` subclasses ``int``, so ``isinstance(True, int)`` is True and a
+    bare isinstance check would let ``max_tool_calls=True`` through as 1.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _validate_optional_callable(

--- a/packages/sdk-python/src/qwen_code_sdk/validation.py
+++ b/packages/sdk-python/src/qwen_code_sdk/validation.py
@@ -154,7 +154,7 @@ def validate_query_options(options: QueryOptions) -> None:
         not _is_int(options.max_subagent_depth)
         or not (1 <= options.max_subagent_depth <= 100)
     ):
-        raise ValidationError("max_subagent_depth must be between 1 and 100")
+        raise ValidationError("max_subagent_depth must be an integer between 1 and 100")
 
     if options.agents:
         for i, agent in enumerate(options.agents):

--- a/packages/sdk-python/tests/unit/test_validation.py
+++ b/packages/sdk-python/tests/unit/test_validation.py
@@ -188,6 +188,31 @@ def test_rejects_invalid_max_subagent_depth() -> None:
         validate_query_options(QueryOptions(max_subagent_depth=0))
 
 
+@pytest.mark.parametrize("value", [True, False, 0.5])
+def test_rejects_non_integer_max_tool_calls(value: object) -> None:
+    # The error message promises "-1 or a non-negative integer", and the value
+    # is stringified straight onto the CLI, so `True` would become
+    # `--max-tool-calls True`.
+    with pytest.raises(ValidationError, match="max_tool_calls"):
+        validate_query_options(QueryOptions(max_tool_calls=cast(Any, value)))
+
+
+@pytest.mark.parametrize("value", [True, False, 2.5])
+def test_rejects_non_integer_max_subagent_depth(value: object) -> None:
+    with pytest.raises(ValidationError, match="max_subagent_depth"):
+        validate_query_options(QueryOptions(max_subagent_depth=cast(Any, value)))
+
+
+def test_accepts_valid_integer_limits() -> None:
+    # The in-range integers these options are documented to take must survive.
+    validate_query_options(
+        QueryOptions(max_tool_calls=-1, max_session_turns=-1, max_subagent_depth=1)
+    )
+    validate_query_options(
+        QueryOptions(max_tool_calls=0, max_session_turns=0, max_subagent_depth=100)
+    )
+
+
 def test_rejects_agents_missing_required_fields() -> None:
     with pytest.raises(ValidationError, match="missing required field"):
         validate_query_options(QueryOptions(agents=[{"name": "test"}]))


### PR DESCRIPTION
## What this PR does

`max_tool_calls` and `max_subagent_depth` only range-checked their input, while the sibling `max_session_turns` also rejects bools and non-integers. This applies the same integer check to all three by extracting the one `max_session_turns` already performed.

## Why it's needed

Each of these options states its contract in its own error message — "must be -1 or a non-negative integer", "must be between 1 and 100" — but only `max_session_turns` enforced the integer part. The value is then stringified straight onto the CLI in `transport.py`, so an accepted non-integer becomes a malformed argument rather than a clear `ValidationError` at the SDK boundary.

Verified against `validate_query_options` on `main`:

| input | `main` | forwarded as |
| --- | --- | --- |
| `max_tool_calls=True` | **accepted** | `--max-tool-calls True` |
| `max_tool_calls=2.5` | **accepted** | `--max-tool-calls 2.5` |
| `max_subagent_depth=True` | **accepted** | `--max-subagent-depth True` |
| `max_subagent_depth=2.5` | **accepted** | `--max-subagent-depth 2.5` |
| `max_session_turns=True` | rejected | — |
| `max_session_turns=2.5` | rejected | — |

`bool` is the sharp edge: it subclasses `int`, so `True` satisfies `isinstance(x, int)` *and* passes every range comparison as `1`. `max_subagent_depth=True` therefore slips through `1 <= x <= 100` as a valid depth of 1. (`False` is caught there by accident, since `0` fails the lower bound — but only by accident.)

The bool-aware check already existed inline in the `max_session_turns` branch; this names it `_is_int` and reuses it. `max_session_turns` keeps its exact previous behavior — same expression, just extracted.

## Reviewer Test Plan

### How to verify

- From the repo root, exactly as CI runs it:
  - `python -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q` → 123 passed, 29 skipped.
  - `python -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src` → success, 9 source files.
  - `python -m ruff check` / `ruff format --check` → clean on both changed files.
- Reverting only `validation.py` fails 5 of the new cases: `max_tool_calls[True]`, `[False]`, `[0.5]` and `max_subagent_depth[True]`, `[2.5]`. `max_subagent_depth[False]` passes before and after, because `False == 0` already failed the range check — the parametrization is deliberately precise about which cases are actually new.
- `test_accepts_valid_integer_limits` pins the other direction: `-1`, `0`, `1` and `100` still validate across all three options, so this cannot become an over-strict regression.
- The existing `test_rejects_invalid_max_tool_calls` (`-2`), `test_rejects_invalid_max_subagent_depth` (`0`) and the three `max_session_turns` tests are untouched and still pass.

### Evidence (Before & After)

- Before: `QueryOptions(max_tool_calls=True)` validates, and the CLI is invoked with `--max-tool-calls True`.
- After: `ValidationError: max_tool_calls must be -1 or a non-negative integer` — the message the option already promised.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS, CPython 3.12/3.13: full `sdk-python` suite, mypy, ruff check and ruff format all pass locally, with proven fail-before/pass-after. Type checking with no platform-dependent behavior, so no manual QA is required; the `sdk-python` workflow covers the CI matrix.

### Environment (optional)

CPython 3.12.10 / 3.13.3; `packages/sdk-python`; pytest via the repo's own `pyproject.toml` config.

## Risk & Scope

- Main risk or tradeoff: a caller passing `True` or a float for these options now gets a `ValidationError` instead of a confusing downstream CLI failure. Callers passing integers — the documented type — are unaffected, which `test_accepts_valid_integer_limits` pins.
- Not validated / out of scope: this is scoped to the three integer limits in `validate_query_options` that share the same contract. It is one gap (integer options not validated as integers), not three separate ones, so they are fixed together rather than split across PRs. Other validators are untouched.
- Breaking changes / migration notes: none for integer inputs.

## Linked Issues

None — found by comparing `max_tool_calls` against the stricter `max_session_turns` check a few lines above it.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`max_tool_calls` 与 `max_subagent_depth` 只做了范围检查，而同类的 `max_session_turns` 还会拒绝布尔值与非整数。本 PR 把 `max_session_turns` 已有的那段整数判断提取出来，并应用于全部三者。

## 为什么需要

这些选项各自在错误信息中声明了自己的契约——「must be -1 or a non-negative integer」「must be between 1 and 100」——但只有 `max_session_turns` 真正执行了其中的整数部分。该值随后在 `transport.py` 中被直接字符串化拼到 CLI 上，于是被放行的非整数会变成一个畸形参数，而不是在 SDK 边界抛出清晰的 `ValidationError`。

在 `main` 上针对 `validate_query_options` 验证：

| 输入 | `main` | 转发为 |
| --- | --- | --- |
| `max_tool_calls=True` | **接受** | `--max-tool-calls True` |
| `max_tool_calls=2.5` | **接受** | `--max-tool-calls 2.5` |
| `max_subagent_depth=True` | **接受** | `--max-subagent-depth True` |
| `max_subagent_depth=2.5` | **接受** | `--max-subagent-depth 2.5` |
| `max_session_turns=True` | 拒绝 | — |
| `max_session_turns=2.5` | 拒绝 | — |

`bool` 是最尖锐的一处：它是 `int` 的子类，因此 `True` 既满足 `isinstance(x, int)`，又以 `1` 的身份通过所有范围比较。于是 `max_subagent_depth=True` 会作为「深度 1」溜过 `1 <= x <= 100`。（`False` 在那里被拦下纯属偶然——`0` 未过下界而已。）

这段能识别布尔的判断本就以内联形式存在于 `max_session_turns` 分支中；本 PR 将其命名为 `_is_int` 并复用。`max_session_turns` 的行为与此前完全一致——表达式相同，只是被提取出来。

## 复核测试计划

### 如何验证

- 在仓库根目录，与 CI 完全一致地运行：
  - `python -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q` → 123 passed、29 skipped。
  - `python -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src` → 成功，9 个源文件。
  - `python -m ruff check` / `ruff format --check` → 两个改动文件均干净。
- 仅还原 `validation.py`，新增用例中有 5 个失败：`max_tool_calls[True]`、`[False]`、`[0.5]` 以及 `max_subagent_depth[True]`、`[2.5]`。`max_subagent_depth[False]` 在修复前后均通过，因为 `False == 0` 本就未过范围检查——参数化刻意精确区分了哪些用例才是真正新增覆盖的。
- `test_accepts_valid_integer_limits` 固定了反方向：`-1`、`0`、`1`、`100` 在三个选项上仍然通过校验，因此本改动不会演变成过度严格的回归。
- 既有的 `test_rejects_invalid_max_tool_calls`（`-2`）、`test_rejects_invalid_max_subagent_depth`（`0`）以及三个 `max_session_turns` 测试未作改动且仍然通过。

### 证据（修复前后对比）

- 修复前：`QueryOptions(max_tool_calls=True)` 校验通过，CLI 被以 `--max-tool-calls True` 调用。
- 修复后：`ValidationError: max_tool_calls must be -1 or a non-negative integer`——正是该选项早已承诺的那句提示。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS，CPython 3.12/3.13：完整 `sdk-python` 套件、mypy、ruff check 与 ruff format 本地全部通过，并验证了 fail-before/pass-after。纯类型检查，无平台相关行为，因此无需人工 QA；`sdk-python` workflow 覆盖 CI 矩阵。

### 运行环境（可选）

CPython 3.12.10 / 3.13.3；`packages/sdk-python`；pytest 使用仓库自带的 `pyproject.toml` 配置。

## 风险与影响范围

- 主要风险或权衡：为这些选项传入 `True` 或浮点数的调用方，现在会收到 `ValidationError`，而不再是下游一个令人困惑的 CLI 失败。传入整数（即文档所载类型）的调用方不受影响，这一点由 `test_accepts_valid_integer_limits` 固定。
- 未验证 / 范围之外：本改动限定于 `validate_query_options` 中共享同一契约的三个整数上限。这是**一个**缺口（整数选项未按整数校验），而非三个彼此独立的缺口，因此一并修复而不拆成多个 PR。其他校验函数未作改动。
- 破坏性变更 / 迁移说明：对整数输入无影响。

## 关联 Issue

无——通过将 `max_tool_calls` 与其上方几行更严格的 `max_session_turns` 判断对照发现。

</details>
