### PR TITLE
fix(cli): say review coverage gaps in the author's units, not chunk ids

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -19,6 +19,7 @@ import { promptRecordDir, briefPath } from './lib/prompt-record.js';
 import {
   composeReview,
   composeReviewCommand,
+  describeChunkGap,
   verdictLine,
   type ComposeReviewInput,
   type ComposeReviewResult,
@@ -67,9 +68,23 @@ function plan(opts: { step45?: boolean } = {}): string {
       srcDiffLines: 5000,
       diffLines: 5000,
       files: [{ path: 'a.ts', kind: 'source', removedLines: 0, heavy: false }],
+      // Real plans carry each chunk's files (`DiffChunk.files`) — the body
+      // renderer names THEM, never the chunk id, so the fixture carries them
+      // too. The 3A fixture below stays file-less on purpose: it is the
+      // pre-files plan shape, and the renderer must fall back to counting.
       chunks: [
-        { id: 1, startLine: 1, endLine: 100 },
-        { id: 2, startLine: 101, endLine: 200 },
+        {
+          id: 1,
+          startLine: 1,
+          endLine: 100,
+          files: [{ path: 'src/a.ts', newStart: 1, newEnd: 80 }],
+        },
+        {
+          id: 2,
+          startLine: 101,
+          endLine: 200,
+          files: [{ path: 'src/b.ts', newStart: 1, newEnd: 90 }],
+        },
       ],
     }),
   );
@@ -1146,10 +1161,13 @@ describe('coverage is recomputed, never accepted', () => {
     const reason = 'launched with a prompt that is not the one the CLI built';
     // One clause for the shared cause — not one per chunk…
     expect(r.body.split(reason)).toHaveLength(2);
-    // …and both subjects ride it.
+    // …and the subjects ride it in the author's units: both chunks is the
+    // whole plan, and a chunk id is bookkeeping nothing on the PR page maps
+    // to code (#7268's body enumerated all 49 of a run's ids, unsorted).
     expect(r.body).toMatch(
-      new RegExp(`Not reviewed: [^.]*chunk 1[^.]*chunk 2[^.]*— ${reason}\\.`),
+      new RegExp(`Not reviewed: the entire diff — ${reason}\\.`),
     );
+    expect(r.body).not.toMatch(/chunk \d/);
   });
 
   it('an all-rewritten roster never claims nothing launched — precise cause, no contradicting aggregate', () => {
@@ -1174,7 +1192,7 @@ describe('coverage is recomputed, never accepted', () => {
     );
     const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
     expect(r.body).toMatch(
-      /Not reviewed: [^.]*chunk 1[^.]*chunk 2[^.]*— launched with a prompt that is not the one the CLI built\./,
+      /Not reviewed: the entire diff — launched with a prompt that is not the one the CLI built\./,
     );
     expect(r.body).not.toContain('every dimension');
     expect(r.body).not.toContain('stopped at the prompt builder');
@@ -1252,9 +1270,11 @@ describe('coverage is recomputed, never accepted', () => {
     const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
     expect(r.cappedBy).toContain('chunk-nobody-read'); // the cap keeps the fact
     expect(r.remediation.join(' ')).toContain('chunks nobody read');
-    expect(r.body).toContain('chunk 1');
+    // The gap, named by the files it covers — the id stays on stderr.
+    expect(r.body).toContain('the diff section covering src/a.ts');
+    expect(r.body).not.toMatch(/chunk \d/);
     // …but only under its cause: no second sentence restating the consequence.
-    expect(r.body).not.toContain('nobody read them');
+    expect(r.body).not.toContain('no agent reported covering');
   });
 
   it('keeps the nobody-read sentence for a chunk with no disclosed cause', () => {
@@ -1280,8 +1300,57 @@ describe('coverage is recomputed, never accepted', () => {
     const old = new Date(2020, 0, 1);
     utimesSync(p, old, old);
     const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
-    expect(r.body).toContain('nobody read them');
-    expect(r.body).toMatch(/chunk 1, chunk 2 — no agent reported covering/);
+    // Both chunks unread is the whole plan — said as the diff, not as ids.
+    expect(r.body).toMatch(/the entire diff — no agent reported covering it/);
+    expect(r.body).toContain('nobody read it');
+    expect(r.body).not.toMatch(/chunk \d/);
+  });
+
+  it('opens with the zero-certified warning when every chunk is disclosed — never "Reviewed." above a body that denies it', () => {
+    // #7268: the posted body opened "Reviewed. Suggestions are inline." and
+    // then disclosed all 49 chunks across two Not-reviewed sentences — the
+    // first sentence certified the exact thing every following one took back.
+    // Both rewritten agents here demonstrably READ their chunks, so coverage
+    // alone is not the test: certified is covered with no disclosure against
+    // it.
+    const p = plan();
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    transcript(
+      'a1',
+      `You are reviewing chunk 1 of 2.\nread_file(file_path="${DIFF}", offset=0, limit=100)`,
+      { toolCalls: 2 },
+    );
+    transcript(
+      'a2',
+      `You are reviewing chunk 2 of 2.\nread_file(file_path="${DIFF}", offset=100, limit=100)`,
+      { toolCalls: 2 },
+    );
+    const r = composeReview({
+      planPath: p,
+      env: ENV,
+      modelId: MODEL,
+      suggestionsInline: 1,
+    });
+    expect(r.event).toBe('COMMENT');
+    expect(r.body).toMatch(
+      /^⚠️ This run could not certify that any of this diff was reviewed\./,
+    );
+    expect(r.body).toContain('Suggestions are inline.');
+    expect(r.body).not.toContain('Reviewed.');
+  });
+
+  it('keeps the "Reviewed." opener while any chunk is certified', () => {
+    // chunk 1 built and never launched; chunk 2 reviewed properly. A partial
+    // gap is a disclosure, not a zero-certification.
+    const p = plan();
+    recordBuilt(p, 1);
+    recordBuilt(p, 2);
+    recordMatrix(p);
+    transcript('a2', goodPrompt(2), { toolCalls: 2 });
+    const r = composeReview({ planPath: p, env: ENV, modelId: MODEL });
+    expect(r.body).toContain('Reviewed.');
+    expect(r.body).not.toContain('could not certify');
   });
 
   it('does not merge two invariant files under one label — the em-dash is part of the subject', () => {
@@ -1314,6 +1383,9 @@ describe('coverage is recomputed, never accepted', () => {
     });
     expect(r.event).not.toBe('APPROVE');
     expect(r.body).toContain('no plan was given');
+    // No chunk universe to count means nothing countable was certified — the
+    // opener says so instead of "Reviewed."
+    expect(r.body).toMatch(/could not certify that any of this diff/);
   });
 
   it('caps when the agents made no tool call — whatever their prose said', () => {
@@ -1866,5 +1938,68 @@ describe('verdictLine — the terminal verdict, and its dangling colon', () => {
     expect(line({ event: 'APPROVE', baseEvent: 'APPROVE' })).toBe(
       'Verdict: Approve',
     );
+  });
+});
+
+describe('describeChunkGap — chunk ids leave in the author units', () => {
+  const planned = [
+    { id: 1, files: ['src/a.ts'] },
+    { id: 2, files: ['src/b.ts', 'src/c.ts'] },
+    { id: 3, files: ['src/d.ts'] },
+  ];
+
+  it('every planned chunk collapses to the diff itself', () => {
+    expect(describeChunkGap([2, 1, 3], planned)).toEqual({
+      phrase: 'the entire diff',
+      plural: false,
+    });
+  });
+
+  it('names the files of a narrow gap — sorted by id, deduped', () => {
+    expect(describeChunkGap([2], planned)).toEqual({
+      phrase: 'the diff section covering src/b.ts, src/c.ts',
+      plural: false,
+    });
+    expect(describeChunkGap([3, 1], planned)).toEqual({
+      phrase: 'the diff sections covering src/a.ts, src/d.ts',
+      plural: true,
+    });
+    // A subject disclosed twice is one gap.
+    expect(describeChunkGap([2, 2], planned).plural).toBe(false);
+  });
+
+  it('counts against the plan when the file list would sprawl', () => {
+    const wide = [
+      { id: 1, files: ['a.ts', 'b.ts', 'c.ts'] },
+      { id: 2, files: ['d.ts', 'e.ts'] },
+      { id: 3, files: ['f.ts'] },
+    ];
+    expect(describeChunkGap([1, 2], wide)).toEqual({
+      phrase: "2 of the diff's 3 sections",
+      plural: true,
+    });
+  });
+
+  it('one unknown chunk poisons the file list — naming the known files would overclaim the rest', () => {
+    const partial = [
+      { id: 1, files: ['src/a.ts'] },
+      { id: 2, files: [] },
+      { id: 3, files: ['src/d.ts'] },
+    ];
+    expect(describeChunkGap([1, 2], partial)).toEqual({
+      phrase: "2 of the diff's 3 sections",
+      plural: true,
+    });
+  });
+
+  it('still says something with no plan to count against', () => {
+    expect(describeChunkGap([7], [])).toEqual({
+      phrase: '1 section of the diff',
+      plural: false,
+    });
+    expect(describeChunkGap([9, 7], [])).toEqual({
+      phrase: '2 sections of the diff',
+      plural: true,
+    });
   });
 });

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -232,6 +232,13 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // the author a false cause.
   const missingReceipts: number[] = [];
 
+  // The plan's chunk→files table and the chunks somebody demonstrably read,
+  // for the body renderer and the opener. Empty when no plan could be used —
+  // `describeChunkGap` then counts against nothing, and the opener's
+  // zero-certified test falls to the `coverage` disclosure instead.
+  let plannedChunks: Array<{ id: number; files: string[] }> = [];
+  let coveredChunks: number[] = [];
+
   // The Criticals a verifier must have ruled on before this review may post
   // them as blockers. Deterministic `[build]`/`[test]` body findings are
   // pre-confirmed and skip verification by design; every other Critical —
@@ -272,6 +279,8 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   } else {
     try {
       const cov = coverageFromTranscripts(input.planPath, input.env);
+      plannedChunks = cov.plannedChunks;
+      coveredChunks = cov.coveredChunks;
       for (const id of cov.missingChunks) missingReceipts.push(id);
       for (const id of cov.uncoverableChunks) {
         // The caller may already have named this chunk, but in a richer form:
@@ -590,16 +599,34 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       (id) => !disclosedSubjects.has(`chunk ${id}`),
     );
     if (unexplainedReceipts.length > 0) {
+      const gap = describeChunkGap(unexplainedReceipts, plannedChunks);
+      const pron = gap.plural ? 'them' : 'it';
       notReviewedParts.push(
-        `Not reviewed: ${unexplainedReceipts
-          .map((id) => `chunk ${id}`)
-          .join(', ')} — no agent reported covering these; nobody read them.`,
+        `Not reviewed: ${gap.phrase} — no agent reported covering ${pron}; nobody read ${pron}.`,
       );
     }
   }
   if (uncoverable.length > 0) {
+    // The CLI's own entries are bare `chunk <id>` (pushed above, from the
+    // report) and render through the same translation as every other chunk
+    // gap; a caller's entry may already carry the file (`chunk 5
+    // (src/big.min.js)`) and renders verbatim — its structure is not ours to
+    // reparse.
+    const bareIds: number[] = [];
+    const callerNamed: string[] = [];
+    for (const e of uncoverable) {
+      const m = /^chunk (\d+)$/.exec(e);
+      if (m) bareIds.push(Number(m[1]));
+      else callerNamed.push(e);
+    }
+    const shown = [
+      ...(bareIds.length > 0
+        ? [describeChunkGap(bareIds, plannedChunks).phrase]
+        : []),
+      ...callerNamed,
+    ];
     notReviewedParts.push(
-      `Not reviewed: ${uncoverable.join(', ')} — a line there exceeds the read limit.`,
+      `Not reviewed: ${shown.join(', ')} — a line there exceeds the read limit.`,
     );
   }
   // One disclosure per subject, one sentence per cause — structurally, not by
@@ -660,10 +687,31 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     byReason.set(reason, subjects);
   }
   for (const [reason, subjects] of byReason) {
+    // Chunk subjects leave in the author's units, not the run's. `chunk 28`
+    // is bookkeeping — the id selects a rebuild command on stderr, and
+    // nothing on the PR page maps it to code. #7268's posted body enumerated
+    // all 49 of them, unsorted, across two of these sentences; the author's
+    // units are their files and, at the limit, the diff itself, which is what
+    // `describeChunkGap` renders. Role labels stay verbatim: they were
+    // written to be read (`roleLabel`), and reworking them here would fork
+    // the register the stderr twin shares.
+    const chunkIds: number[] = [];
+    const named: string[] = [];
+    for (const s of subjects) {
+      const m = /^chunk (\d+)$/.exec(s);
+      if (m) chunkIds.push(Number(m[1]));
+      else named.push(s);
+    }
+    const shown = [
+      ...(chunkIds.length > 0
+        ? [describeChunkGap(chunkIds, plannedChunks).phrase]
+        : []),
+      ...named,
+    ];
     notReviewedParts.push(
       reason
-        ? `Not reviewed: ${subjects.join(', ')} — ${reason}.`
-        : `Not reviewed: ${subjects.join(', ')}.`,
+        ? `Not reviewed: ${shown.join(', ')} — ${reason}.`
+        : `Not reviewed: ${shown.join(', ')}.`,
     );
   }
 
@@ -753,7 +801,32 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
       // body could open "Reviewed — no blockers." two lines above "nobody read
       // them." Nothing nobody read can be certified blocker-free.
       missingReceipts.length === 0;
-    clauses.push(canCertify ? 'Reviewed — no blockers.' : 'Reviewed.');
+    // The opener may not say "Reviewed." over a disclosure set that denies it.
+    // #7268's posted body opened exactly that way — "Reviewed. Suggestions are
+    // inline." above two sentences disclosing all 49 chunks — and the author's
+    // first sentence certified the thing every following one took back. A
+    // chunk counts as certified only when an agent read it AND no disclosure
+    // names it: the rewritten launches on that run had demonstrably read their
+    // chunks, which is why `coveredChunks` alone is not the test. The
+    // `coverage` subject is the no-plan/unreadable-transcripts family — there
+    // is no chunk universe to count, and what cannot be counted cannot be
+    // certified.
+    const disclosedChunkIds = new Set<number>();
+    for (const e of coverageEntries) {
+      const m = /^chunk (\d+)$/.exec(e.subject);
+      if (m) disclosedChunkIds.add(Number(m[1]));
+    }
+    const nothingCertified =
+      coverageEntries.some((e) => e.subject === 'coverage') ||
+      (plannedChunks.length > 0 &&
+        coveredChunks.every((id) => disclosedChunkIds.has(id)));
+    clauses.push(
+      nothingCertified
+        ? '⚠️ This run could not certify that any of this diff was reviewed.'
+        : canCertify
+          ? 'Reviewed — no blockers.'
+          : 'Reviewed.',
+    );
   }
 
   // 4. Suggestions clause — keyed off the POSTED count, not `s`: an
@@ -796,6 +869,65 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
     downgraded,
     downgradedFrom,
     remediation,
+  };
+}
+
+/**
+ * A set of unreviewed chunk ids, said in the PR author's units.
+ *
+ * `chunk 28` is the run's own bookkeeping: the id selects a rebuild command
+ * on stderr, and nothing on the PR page maps it to code. #7268's posted body
+ * was two sentences enumerating all 49 of them — unsorted, because the first
+ * group rode transcript order — and the one fact they carried (nothing was
+ * certified) is the opener's job, not an enumeration's. The author's units
+ * are their files and, at the limit, the diff itself, so the ids collapse to
+ * whichever of those fits:
+ *
+ * - every planned chunk → `the entire diff`;
+ * - a gap whose files are known and few → the files, named;
+ * - anything wider (or a plan whose chunks carry no files) → a count against
+ *   the plan's total.
+ *
+ * The ids never render. They stay in the structural entries — the caps, the
+ * caller-echo dedup and the certification test all key on `chunk <id>` — and
+ * in the stderr remediation, where the id is the selector a reader can act
+ * on. `plural` is the phrase's grammatical number, for the one caller whose
+ * sentence carries a pronoun.
+ */
+export function describeChunkGap(
+  ids: readonly number[],
+  planned: ReadonlyArray<{ id: number; files: string[] }>,
+): { phrase: string; plural: boolean } {
+  const uniq = [...new Set(ids)].sort((a, b) => a - b);
+  const inGap = new Set(uniq);
+  if (planned.length > 0 && planned.every((p) => inGap.has(p.id))) {
+    return { phrase: 'the entire diff', plural: false };
+  }
+  // The union of the gap's files, in plan order. One unknown chunk poisons
+  // the list: naming three files over a gap that also covers a fourth,
+  // unnameable one would tell the author the rest of their diff was read.
+  const byId = new Map(planned.map((p) => [p.id, p.files]));
+  const files: string[] = [];
+  let allKnown = planned.length > 0;
+  for (const id of uniq) {
+    const f = byId.get(id) ?? [];
+    if (f.length === 0) allKnown = false;
+    for (const p of f) {
+      if (!files.includes(p)) files.push(p);
+    }
+  }
+  if (allKnown && files.length <= 4) {
+    return {
+      phrase: `the diff ${uniq.length === 1 ? 'section' : 'sections'} covering ${files.join(', ')}`,
+      plural: uniq.length > 1,
+    };
+  }
+  return {
+    phrase:
+      planned.length > 0
+        ? `${uniq.length} of the diff's ${planned.length} sections`
+        : `${uniq.length} ${uniq.length === 1 ? 'section' : 'sections'} of the diff`,
+    plural: uniq.length > 1,
   };
 }
 

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -151,12 +151,28 @@ export interface CoverageFromTranscripts {
    * prose garbles exactly the entries it matters for.
    */
   disclosures: Array<{ subject: string; reason: string }>;
+  /**
+   * Every planned chunk with the source files it covers, in plan order — the
+   * body renderer's translation table. A chunk id is the run's own
+   * bookkeeping: it selects a rebuild command on stderr, and nothing on the PR
+   * page maps it to code, so the POSTED body names files (the author's units)
+   * or counts against this list's length instead. The ids themselves stay in
+   * the structural entries — the caps, the dedup and the remediation
+   * selectors all still key on them. `files` is empty for a plan written
+   * before chunks carried them.
+   */
+  plannedChunks: Array<{ id: number; files: string[] }>;
 }
 
 /** The plan, as far as coverage needs it. The roster reads more of it — see RosterPlan. */
 interface Plan {
   diffPathAbsolute: string;
-  chunks: Array<{ id: number; startLine: number; endLine: number }>;
+  chunks: Array<{
+    id: number;
+    startLine: number;
+    endLine: number;
+    files?: Array<{ path: string }>;
+  }>;
 }
 
 function readPlan(path: string): { plan: Plan; mtimeMs: number } {
@@ -670,6 +686,12 @@ export function coverageFromTranscripts(
     missingChunks,
     uncoverableChunks: [...uncoverable].sort((a, b) => a - b),
     coveredChunks: [...covered].sort((a, b) => a - b),
+    plannedChunks: plan.chunks.map((c) => ({
+      id: c.id,
+      files: (c.files ?? [])
+        .map((f) => f?.path)
+        .filter((p): p is string => typeof p === 'string' && p !== ''),
+    })),
   };
 }
 


### PR DESCRIPTION
## What this PR does

`/review`'s posted body rendered coverage disclosures with the run's own bookkeeping as subjects: bare chunk ids, unsorted, one subject per chunk. This PR makes the posted body say chunk-level gaps in the PR author's units instead, and stops the opener from certifying over a body that denies it.

Three changes, all at render time — the structural entries, the event caps, the caller-echo dedup and the stderr remediation still key on chunk ids, which is where the id is the selector a reader can act on:

- Coverage now returns the plan's chunk→files table. `DiffChunk.files` was already written into the plan JSON; the coverage type slice dropped it.
- `compose-review` renders chunk gaps through a new `describeChunkGap`: every planned chunk collapses to "the entire diff", a narrow gap with known files names the files, and anything wider is counted against the plan's total ("38 of the diff's 49 sections"). Applied to the receipt sentence, the uncoverable sentence (bare CLI entries only — caller-authored entries like `chunk 5 (src/big.min.js)` still render verbatim) and the grouped per-cause sentences.
- The COMMENT opener may no longer say "Reviewed." above a disclosure set that denies it: when no chunk is both covered and undisclosed — or no chunk universe could be read at all — it opens with "⚠️ This run could not certify that any of this diff was reviewed." A rewritten launch demonstrably read its chunk, so coverage alone is not the test; certified means covered with no disclosure against it.

## Why it's needed

The review posted on PR #7268 ([this comment](https://github.com/QwenLM/qwen-code/pull/7268#pullrequestreview-4757341042)) is the motivating incident. The run certified nothing — 11 chunks ran on rewritten prompts, the other 38 plus two roles were never launched with their built prompts — and the posted body enumerated all 49 chunk ids across two sentences, the first group in transcript order (`chunk 28, chunk 49, chunk 6, …`), while opening with "Reviewed. Suggestions are inline."

Two defects in one body: the opener certified the exact thing every following sentence took back, and the disclosure vocabulary was the operator's, not the author's — nothing on the PR page maps `chunk 28` to code, and the register comments in `coverage.ts` already require the posted gap text to be author-facing. The commands were scrubbed from that register; the nouns were not.

## Reviewer Test Plan

### How to verify

1. Re-run the #7268 shape (49 chunks, 11 rewritten, 38 unlaunched, Step 4/5 not launched verbatim) through `composeReview`. The body is now:

   > ⚠️ This run could not certify that any of this diff was reviewed. Suggestions are inline. Not reviewed: 11 of the diff's 49 sections — launched with a prompt that is not the one the CLI built. Not reviewed: 38 of the diff's 49 sections — its prompt was built, but no agent on record was launched with it. Not reviewed: Test coverage matrix (whole-diff) — … Not reviewed: reverse audit — … Not reviewed: verification — …

   against the previous ~250-word body that enumerated every id and opened "Reviewed."
2. Confirm a partial gap still names what the author owns: one unlaunched chunk over `src/a.ts` renders "the diff section covering src/a.ts", and the opener stays "Reviewed." while any chunk is certified.
3. Confirm the operator's channel is untouched: `remediation` still carries the exact `--chunk <id>` rebuild selectors, and `check-coverage`'s stderr output is unchanged.
4. `npx vitest run src/commands/review/` from `packages/cli` — 784 tests pass. `eslint --max-warnings 0` on the three changed files passes; `tsc -p packages/cli` reports no errors in `commands/review` (the pre-existing `acp-integration` errors are stale-dist noise, present on `main`).

### Evidence (Before & After)

Before (posted on #7268): "Reviewed. Suggestions are inline. Not reviewed: chunk 28, chunk 49, chunk 6, chunk 46, chunk 39, chunk 4, chunk 26, chunk 27, chunk 7, chunk 38, chunk 48 — launched with a prompt that is not the one the CLI built. Not reviewed: chunk 1, chunk 2, chunk 3, chunk 5, chunk 8, … chunk 47, Test coverage matrix (whole-diff), Agent 1c: Cross-file tracer — its prompt was built, but no agent on record was launched with it. …"

After: the body quoted in step 1 above — no chunk ids anywhere in the posted body, one phrase per cause, and an opener that matches the disclosures. No UI change, so screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

## Risk & Scope

- Main risk or tradeoff: an operator who reads only the posted PR body loses the chunk-id detail there; it remains on stderr (remediation and `check-coverage`), which is the channel the register comments assign it to. A plan written before chunks carried `files` falls back to counts — the field is optional in the coverage reader.
- Not validated / out of scope: the roster role labels (`Agent 1c: Cross-file tracer`) still render verbatim in the body — reworking those labels forks the register shared with stderr and is left for a follow-up, as is collapsing the near-duplicate reverse-audit/verification `rewritten` sentences.
- Breaking changes / migration notes: none. `CoverageFromTranscripts` gains an additive `plannedChunks` field; all body changes are phrasing.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`/review` 发布到 PR 上的 review body 此前用运行时的内部记账作为披露主语：裸的 chunk 编号、乱序、每个 chunk 一个主语。本 PR 让公开 body 以 PR 作者的单位来陈述 chunk 级缺口，并禁止开场白与后文的披露自相矛盾。

三处改动都在渲染层——结构化条目、verdict 上限、caller 回显去重和 stderr 修复命令仍以 chunk id 为键，那里 id 才是读者可以执行的选择器：

- coverage 现在返回 plan 的 chunk→files 映射表。`DiffChunk.files` 本来就写进了 plan JSON；只是 coverage 的类型切片把它丢掉了。
- `compose-review` 通过新的 `describeChunkGap` 渲染 chunk 缺口：覆盖全部 planned chunk 时收敛为 "the entire diff"；文件已知且数量少的窄缺口直接点名文件；更宽的缺口按 plan 总数计数（"38 of the diff's 49 sections"）。应用于 receipt 句、uncoverable 句（仅 CLI 自己加入的裸条目——caller 提供的 `chunk 5 (src/big.min.js)` 这类条目仍原样渲染）以及按 cause 分组的句子。
- COMMENT 开场白不得再在否定它的披露之上写 "Reviewed."：当没有任何 chunk 同时满足"被读过且无披露指向它"——或根本读不到 chunk 全集时——开场改为 "⚠️ This run could not certify that any of this diff was reviewed."。rewritten launch 的 agent 确实读了它的 chunk，所以仅凭 coverage 不够；"认证"意味着已覆盖且无披露与之相悖。

## 为什么需要它

动机事件是发布在 PR #7268 上的[这条 review](https://github.com/QwenLM/qwen-code/pull/7268#pullrequestreview-4757341042)。那次运行什么都没认证——11 个 chunk 跑在改写过的 prompt 上，其余 38 个加两个 role 从未按构建的 prompt 启动——而发布的 body 用两句话枚举了全部 49 个 chunk 编号（第一组还是 transcript 顺序：`chunk 28, chunk 49, chunk 6, …`），开头却写着 "Reviewed. Suggestions are inline."。

一个 body 两个缺陷：开场白认证了后面每句话都在收回的东西；披露词汇是 operator 的而非作者的——PR 页面上没有任何东西能把 `chunk 28` 映射到代码，而 `coverage.ts` 的语域注释本来就要求公开 gap 文案面向作者。命令被挡住了，名词没有。

## Reviewer 测试计划

### 如何验证

1. 用 #7268 的形态（49 chunk、11 rewritten、38 未启动、Step 4/5 未按原样启动）重跑 `composeReview`，body 现在是上文英文部分第 1 步引用的样子——对比之前约 250 词、逐个枚举编号、以 "Reviewed." 开头的 body。
2. 确认部分缺口仍点名作者拥有的东西：一个未启动、覆盖 `src/a.ts` 的 chunk 渲染为 "the diff section covering src/a.ts"；只要还有 chunk 被认证，开场白保持 "Reviewed."。
3. 确认 operator 通道不受影响：`remediation` 仍携带精确的 `--chunk <id>` 重建选择器，`check-coverage` 的 stderr 输出不变。
4. 在 `packages/cli` 下 `npx vitest run src/commands/review/`——784 个测试全部通过；三个改动文件通过 `eslint --max-warnings 0`；`tsc -p packages/cli` 在 `commands/review` 下无错误（`acp-integration` 的既有报错是 stale-dist 噪音，`main` 上同样存在）。

### 证据（Before & After）

Before（发布在 #7268 上）：逐个枚举 49 个 chunk 编号的两句话，开头 "Reviewed. Suggestions are inline."。

After：英文部分第 1 步引用的 body——公开 body 中不再出现任何 chunk 编号，每个 cause 一个短语，开场白与披露一致。无 UI 变更，截图 N/A。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ 未测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ✅ 已测试   |

## 风险与范围

- 主要风险或权衡：只看 PR body 的 operator 会失去那里的 chunk-id 细节；细节保留在 stderr（remediation 与 `check-coverage`），这正是语域注释为它指定的通道。chunk 不携带 `files` 的旧 plan 回退到计数——coverage 读取端该字段是可选的。
- 未验证或范围外：roster 的 role label（`Agent 1c: Cross-file tracer`）仍原样渲染进 body——改写这些 label 会分叉与 stderr 共享的语域，留作后续；reverse-audit 与 verification 的 `rewritten` 近重复句子的合并同样留作后续。
- Breaking changes / migration notes：无。`CoverageFromTranscripts` 新增 `plannedChunks` 字段（增量式）；body 改动均为措辞层。

</details>
