### PR TITLE
feat(web-shell): add renderChatHeader slot for custom session header

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -908,6 +908,10 @@
   margin-bottom: 8px;
 }
 
+.chatHeader {
+  flex-shrink: 0;
+}
+
 .customFooter {
   flex-shrink: 0;
 }

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -253,6 +253,7 @@ import {
   type ComposerToolbarEndRenderer,
   type ComposerToolbarRightRenderer,
   type ComposerHeaderRenderer,
+  type ChatHeaderRenderer,
   type FooterRenderer,
   type LoadingPhrasesResolver,
   type MarkdownTableMode,
@@ -600,6 +601,11 @@ export interface WebShellProps {
   renderComposerToolbarRight?: ComposerToolbarRightRenderer;
   /** Custom renderer shown directly above the chat composer input. */
   renderComposerHeader?: ComposerHeaderRenderer;
+  /**
+   * Custom renderer shown at the top of the chat view, above the message list.
+   * Only rendered when a session is active (not in the welcome/empty state).
+   */
+  renderChatHeader?: ChatHeaderRenderer;
   /** Custom component for the footer area below the Editor. Replaces the built-in StatusBar. */
   renderFooter?: FooterRenderer;
   /** Extra status items shown in the floating bottom panel beside the TODO summary. */
@@ -1073,6 +1079,7 @@ export function App({
   renderComposerToolbarEnd,
   renderComposerToolbarRight,
   renderComposerHeader,
+  renderChatHeader,
   renderFooter,
   bottomStatusItems,
   chatMaxWidth,
@@ -7662,14 +7669,27 @@ export function App({
                                 </div>
                               );
                             }
+                            const chatHeader =
+                              !isChatEmptyState && renderChatHeader ? (
+                                <div className={styles.chatHeader}>
+                                  {renderChatHeader({
+                                    sessionId: connection.sessionId,
+                                    sessionName: sessionDisplayName,
+                                    workspaceCwd: connection.workspaceCwd,
+                                  })}
+                                </div>
+                              ) : null;
                             return (
-                              <div
-                                style={contentStyle}
-                                className={contentClassName}
-                              >
-                                {messageList}
-                                {btwPanel}
-                              </div>
+                              <>
+                                {chatHeader}
+                                <div
+                                  style={contentStyle}
+                                  className={contentClassName}
+                                >
+                                  {messageList}
+                                  {btwPanel}
+                                </div>
+                              </>
                             );
                           })()}
                         </InteractionBlockContext.Provider>

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -91,6 +91,22 @@ export type ToolHeaderExtraRenderer = (
 export type WelcomeHeaderRenderer = (props: WelcomeHeaderProps) => ReactNode;
 export type WelcomeFooterRenderer = (props: WelcomeHeaderProps) => ReactNode;
 
+/** Context passed to the chat header renderer. */
+export interface ChatHeaderRenderInfo {
+  /** Current session id, if connected. */
+  sessionId?: string;
+  /** Display name for the current session. */
+  sessionName?: string;
+  /** Workspace cwd for the current session. */
+  workspaceCwd?: string;
+}
+
+/**
+ * Custom renderer shown at the top of the chat view, above the message list.
+ * Only rendered when a session is active (not in the welcome/empty state).
+ */
+export type ChatHeaderRenderer = (info: ChatHeaderRenderInfo) => ReactNode;
+
 export interface UserMessageContentRenderInfo {
   content: string;
   images?: readonly { data: string; mimeType: string }[];

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -191,6 +191,8 @@ export type {
   WebShellComposerTextOptions,
   WelcomeFooterRenderer,
   WelcomeHeaderRenderer,
+  ChatHeaderRenderer,
+  ChatHeaderRenderInfo,
   WebShellFooterRenderInfo,
   FooterRenderer,
   LoadingPhrasesResolver,


### PR DESCRIPTION
## What this PR does

Adds a new `renderChatHeader` prop to WebShell that lets consumers inject custom content at the top of the chat view, above the message list. The header only renders when a session is active — it does not appear in the welcome/empty state.

The slot receives session context (`sessionId`, `sessionName`, `workspaceCwd`) so consumers can build context-aware headers (e.g. session info bars, custom action buttons, breadcrumbs).

## Why it's needed

WebShell consumers (embedded integrations) need a way to display session-specific metadata or actions above the transcript — things like workspace indicators, export/share buttons, or custom breadcrumbs. Today there is no extension point in this position; the closest is `renderComposerHeader` which sits above the composer input, far below the message list.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev` in `packages/web-shell`
2. Open the web shell in a browser
3. **Welcome state (no session):** confirm no header area appears above the chat area
4. **Active session:** pass a `renderChatHeader` callback that returns custom JSX (e.g. a bar with session name + action buttons) — confirm it renders above the message list
5. **Switch sessions:** confirm the header updates with the new session context
6. **Remove `renderChatHeader`:** confirm the chat area renders identically to before (no empty container, no layout shift)

### Evidence (Before & After)
<img width="3824" height="1894" alt="image" src="https://github.com/user-attachments/assets/b3540b45-71b7-49f5-9566-5f51d2970a8f" />

<img width="1200" height="608" alt="image" src="https://github.com/user-attachments/assets/06dd4d7f-e913-4107-9941-77cc263eb872" />

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` in `packages/web-shell`, macOS 14.6.1, Chrome.

## Risk & Scope

- Main risk or tradeoff: None — pure addition, `renderChatHeader` is optional and defaults to `undefined` (no header rendered). The return type change from single `<div>` to `<>` Fragment is transparent to consumers.
- Not validated / out of scope: Split view panes do not render the chat header (they have their own per-pane headers via `ChatPane`). Mobile welcome-middle layout path is unaffected.
- Breaking changes / migration notes: None. The new prop is optional; omitting it produces identical behavior to the previous version.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本次 PR 做了什么

为 WebShell 新增 `renderChatHeader` 属性，允许消费者在聊天视图顶部（消息列表上方）注入自定义内容。该头部仅在有活跃会话时渲染，welcome/空白状态下不显示。

插槽接收会话上下文（`sessionId`、`sessionName`、`workspaceCwd`），消费者可以构建上下文感知的头部（如会话信息栏、自定义操作按钮、面包屑导航）。

## 为什么需要

WebShell 消费者（嵌入式集成）需要在 transcript 上方展示会话特定的元数据或操作——如工作区指示器、导出/分享按钮或自定义面包屑。目前该位置没有扩展点；最近的 `renderComposerHeader` 位于 composer 输入框上方，距消息列表很远。

## Reviewer 测试计划

### 如何验证

1. 在 `packages/web-shell` 中运行 `npm run dev`
2. 在浏览器中打开 web shell
3. **Welcome 状态（无会话）：** 确认聊天区域上方没有出现头部区域
4. **有活跃会话：** 传入 `renderChatHeader` 回调返回自定义 JSX（如包含会话名 + 操作按钮的栏）—— 确认它渲染在消息列表上方
5. **切换会话：** 确认头部随新会话上下文更新
6. **移除 `renderChatHeader`：** 确认聊天区域渲染与改动前完全一致（无空容器、无布局偏移）

### 证据（前后对比）

<!-- 🔖 请在此处粘贴截图或录屏 -->

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

`npm run dev` in `packages/web-shell`，macOS 14.6.1，Chrome。

## 风险与范围

- 主要风险或权衡：无 —— 纯加法，`renderChatHeader` 可选且默认为 `undefined`（不渲染头部）。从单个 `<div>` 到 `<>` Fragment 的返回类型变更对消费者透明。
- 未验证/不在范围内：Split view 面板不渲染 chat header（它们有自己的 `ChatPane` 头部）。移动端 welcome-middle 布局路径不受影响。
- 破坏性变更/迁移说明：无。新属性可选，省略时行为与之前版本完全一致。

</details>