### PR TITLE
fix(core): persist usage for tool-only subagent rounds

### DIFF
--- a/packages/core/src/agents/agent-transcript.test.ts
+++ b/packages/core/src/agents/agent-transcript.test.ts
@@ -445,6 +445,22 @@ describe('agent-transcript', () => {
       });
     });
 
+    it('drops ROUND_TEXT with no text, thought, or usage', () => {
+      const jsonlPath = path.join(tempDir, 's', 'agent-x.jsonl');
+      const { emitter, cleanup } = makeWriter(jsonlPath);
+
+      emitter.emit(AgentEventType.ROUND_TEXT, {
+        subagentId: 'agent-x',
+        round: 1,
+        text: '',
+        thoughtText: '',
+        timestamp: Date.now(),
+      });
+      cleanup();
+
+      expect(fs.existsSync(jsonlPath)).toBe(false);
+    });
+
     it('writes TOOL_CALL events as assistant records with functionCall parts', () => {
       const jsonlPath = path.join(tempDir, 's', 'agent-x.jsonl');
       const { emitter, cleanup } = makeWriter(jsonlPath);

--- a/packages/core/src/agents/agent-transcript.test.ts
+++ b/packages/core/src/agents/agent-transcript.test.ts
@@ -409,21 +409,40 @@ describe('agent-transcript', () => {
       cleanup();
     });
 
-    it('drops usage-only ROUND_TEXT to keep the canonical view valid', () => {
+    it('writes usage-only ROUND_TEXT with a model message for exporters', () => {
       const jsonlPath = path.join(tempDir, 's', 'agent-x.jsonl');
       const { emitter, cleanup } = makeWriter(jsonlPath);
 
       emitter.emit(AgentEventType.ROUND_TEXT, {
         subagentId: 'agent-x',
+        runId: 'run-1',
         round: 1,
         text: '',
         thoughtText: '',
-        usageMetadata: { totalTokenCount: 42 },
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 20,
+          cachedContentTokenCount: 40,
+          totalTokenCount: 120,
+        },
         timestamp: Date.now(),
       });
       cleanup();
 
-      expect(fs.existsSync(jsonlPath)).toBe(false);
+      const records = readJsonl(jsonlPath);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        type: 'assistant',
+        message: { role: 'model', parts: [] },
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 20,
+          cachedContentTokenCount: 40,
+          totalTokenCount: 120,
+        },
+        agentRunId: 'run-1',
+        agentRound: 1,
+      });
     });
 
     it('writes TOOL_CALL events as assistant records with functionCall parts', () => {

--- a/packages/core/src/agents/agent-transcript.ts
+++ b/packages/core/src/agents/agent-transcript.ts
@@ -458,18 +458,16 @@ export function attachJsonlTranscriptWriter(
   };
 
   const onRoundText = (event: AgentRoundTextEvent) => {
-    if (!event.text && !event.thoughtText) return;
+    const parts = [
+      ...(event.thoughtText
+        ? [{ text: event.thoughtText, thought: true }]
+        : []),
+      ...(event.text ? [{ text: event.text }] : []),
+    ];
+    if (parts.length === 0 && !event.usageMetadata) return;
     append({
       ...baseFields('assistant'),
-      message: {
-        role: 'model',
-        parts: [
-          ...(event.thoughtText
-            ? [{ text: event.thoughtText, thought: true }]
-            : []),
-          ...(event.text ? [{ text: event.text }] : []),
-        ],
-      },
+      message: { role: 'model', parts },
       usageMetadata: event.usageMetadata,
       agentRunId: event.runId ?? streamRunId,
       agentRound: event.round,

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1002,7 +1002,7 @@ export class AgentCore {
           break;
         }
 
-        if (roundText || roundThoughtText) {
+        if (roundText || roundThoughtText || lastUsage) {
           this.eventEmitter?.emit(AgentEventType.ROUND_TEXT, {
             subagentId: this.subagentId,
             runId,

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -43,6 +43,7 @@ import {
 import {
   AgentEventEmitter,
   AgentEventType,
+  type AgentRoundTextEvent,
   type AgentStreamTextEvent,
   type AgentToolCallEvent,
   type AgentToolResultEvent,
@@ -2088,6 +2089,59 @@ describe('subagent.ts', () => {
         expect(events[0]!.thought).toBe(true);
         expect(events[1]!.text).toBe('Here is the answer.');
         expect(events[1]!.thought).toBe(false);
+      });
+
+      it('should emit usage for a tool-call-only model round', async () => {
+        const { config } = await createMockConfig();
+        const usageMetadata = {
+          promptTokenCount: 100,
+          candidatesTokenCount: 10,
+          cachedContentTokenCount: 5,
+          totalTokenCount: 110,
+        };
+        mockSendMessageStream.mockImplementation(async () =>
+          (async function* () {
+            yield {
+              type: 'chunk',
+              value: {
+                functionCalls: [
+                  {
+                    id: 'call-1',
+                    name: 'missing_tool',
+                    args: {},
+                  },
+                ],
+                usageMetadata,
+              },
+            };
+          })(),
+        );
+
+        const eventEmitter = new AgentEventEmitter();
+        const events: AgentRoundTextEvent[] = [];
+        eventEmitter.on(AgentEventType.ROUND_TEXT, (event) => {
+          events.push(event);
+        });
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          { ...defaultRunConfig, max_turns: 1 },
+          undefined,
+          eventEmitter,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(events).toEqual([
+          expect.objectContaining({
+            round: 1,
+            text: '',
+            thoughtText: '',
+            usageMetadata,
+          }),
+        ]);
       });
 
       it('should exclude thought text from finalText', async () => {


### PR DESCRIPTION
## What this PR does

This change persists provider usage metadata for every sub-agent model round, including responses that contain only tool calls and no text or reasoning. Usage-only rounds are written as assistant records with an empty model message so trajectory exporters can consume their token fields, while existing text and reasoning records keep their current shape.

## Why it's needed

Sub-agents already emit per-round usage at runtime, but the sidechain transcript was only materialized when a response contained text or reasoning. Tool-heavy agents therefore lost prompt, completion, and cached-token usage for tool-call-only rounds. Harbor can recursively aggregate sub-agent trajectories, but incomplete Qwen Code sidechains still caused root `final_metrics` and cache-hit statistics to be under-counted.

## Reviewer Test Plan

### How to verify

Run a foreground or background sub-agent that must inspect a file before answering. In the generated per-agent JSONL, confirm that both the tool-call-only model round and the final text round contain exactly one `usageMetadata` object. The tool-call-only usage record should have `message: {"role":"model","parts":[]}`. Resume a persisted background sub-agent and confirm the usage-only record is not added to model history. The focused transcript and headless-agent tests cover these behaviors.

### Evidence (Before & After)

N/A — this changes persisted transcript metadata and has no TUI presentation change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22; local package build, TypeScript typecheck, focused ESLint/Prettier checks, and core unit tests.

## Risk & Scope

- Main risk or tradeoff: Sidechain JSONL gains one metadata-bearing assistant record for model rounds that previously produced no canonical text record.
- Not validated / out of scope: Historical transcripts are not backfilled; runs created before this change still require proxy-log recovery or reruns.
- Breaking changes / migration notes: None. Usage-only records use the existing `ChatRecord` shape and are already filtered from resumed model history.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个改动会为每一个 sub-agent 模型回合持久化 provider usage metadata，包括只有工具调用、没有文本或思考内容的响应。仅包含 usage 的回合会写成带空 model message 的 assistant 记录，以便 trajectory exporter 消费其中的 token 字段；已有文本和思考记录的格式保持不变。

## 为什么需要

Sub-agent 运行时已经会产生逐回合 usage，但之前只有响应包含文本或思考内容时才会生成 sidechain transcript 记录。因此，工具调用密集型 agent 会丢失纯工具调用回合的 prompt、completion 和 cached-token usage。Harbor 可以递归聚合 sub-agent trajectory，但 Qwen Code sidechain 本身不完整时，根 `final_metrics` 和缓存命中统计仍会被低估。

## Reviewer 测试计划

### 如何验证

运行一个必须先读取文件再回答的前台或后台 sub-agent。检查生成的 per-agent JSONL，确认纯工具调用模型回合和最终文本回合都各自只包含一个 `usageMetadata`。纯工具调用的 usage 记录应包含 `message: {"role":"model","parts":[]}`。恢复一个已持久化的后台 sub-agent，并确认 usage-only 记录不会加入模型历史。定向 transcript 和 headless-agent 测试已覆盖这些行为。

### 证据（修改前后）

N/A——该改动只影响持久化 transcript metadata，不改变 TUI 展示。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22；已执行本地 package build、TypeScript typecheck、定向 ESLint/Prettier 检查和 core 单元测试。

## 风险与范围

- 主要风险或取舍：对于以前没有 canonical 文本记录的模型回合，sidechain JSONL 会新增一条携带 metadata 的 assistant 记录。
- 未验证或范围外：不会回填历史 transcript；本次改动之前生成的运行仍需通过代理日志恢复或重新运行。
- 破坏性变更或迁移说明：无。Usage-only 记录使用已有的 `ChatRecord` 格式，并且在恢复模型历史时已经会被过滤。

## 关联 Issue

N/A

</details>
