### PR TITLE
perf(cli): Defer ACP telemetry initialization

### DIFF
--- a/docs/design/2026-07-23-defer-acp-telemetry-initialization.md
+++ b/docs/design/2026-07-23-defer-acp-telemetry-initialization.md
@@ -1,0 +1,83 @@
+# Defer ACP telemetry initialization until after protocol initialization
+
+- **Issue**: #7264 candidate 2
+- **Scope**: telemetry-enabled ACP child startup
+- **Status**: implemented and validated
+
+## Problem
+
+An ACP child currently starts telemetry from the `Config` constructor. The call is fire-and-forget, but loading and evaluating the telemetry implementation and configured exporter chain still competes for the same event loop and CPU as CLI bootstrap, ACP module loading, bootstrap config initialization, and the protocol `initialize` handler. On a constrained host, candidate 1's measurements showed that this contention adds work back to the user-visible initialization window.
+
+Telemetry events already use an initialized gate: events emitted before the SDK finishes starting are dropped. Deferring the start therefore extends an existing loss window rather than introducing a new buffering or ordering model.
+
+## Design
+
+ACP configuration sets the existing `deferTelemetryInitialization` option. This suppresses the constructor's fire-and-forget start without changing the default, headless, stream-JSON, interactive TUI, or daemon runtime paths.
+
+`runAcpAgent` uses the existing message-observation hook on its NDJSON transport to remember the JSON-RPC ID of an incoming `initialize` request. The hook runs after the parsed request is enqueued but before its pending read continuation can handle it. For outgoing messages, the same hook runs only after the encoded response has been successfully written to the underlying stdout stream. When a successful response with the remembered ID is observed, the child starts telemetry through the existing single-flight facade and clears the remembered ID.
+
+This creates a transport-defined boundary: telemetry loading cannot begin before the initialization response write resolves. It does not depend on event-loop scheduling assumptions.
+
+## Ownership and downstream consumers
+
+The ACP child has one process-global telemetry SDK and one bootstrap `Config`. The deferred option is config-scoped, while the eventual initializer is process-global and single-flight. Per-session configs continue sharing that process-global SDK and do not own independent telemetry runtimes.
+
+The affected consumers are:
+
+- **ACP bootstrap child**: changes from constructor-started telemetry to response-write-started telemetry.
+- **ACP session creation and prompts**: retain the existing initialized gates; very early events may now be dropped for longer while SDK loading finishes.
+- **Ordinary interactive TUI**: retains post-first-render startup through `startPostRenderPrefetches`.
+- **Headless and stream-JSON CLI**: retain constructor startup.
+- **`qwen serve` parent/daemon runtime**: retains its explicit deferred core-runtime initialization and shutdown.
+- **Process exit cleanup**: retains `Config.shutdown()`. A child that disconnects before a successful protocol initialization never starts telemetry. If disconnect races a just-started import, the initializer's internal catch prevents an unhandled rejection and the ACP outer path still exits the process; current config cleanup does not promise to flush an SDK that has not finished initializing.
+
+## Failure and compatibility behavior
+
+- Telemetry disabled remains a facade no-op after the response and loads no heavy telemetry modules.
+- A malformed or rejected `initialize` request does not start telemetry. A later valid initialize request can still start it.
+- A stdout write failure does not run the sent-message hook, so telemetry is not started for a response the client did not receive.
+- Repeated or unrelated JSON-RPC responses cannot start telemetry because the request ID and successful-response shape must both match; the remembered ID is consumed once.
+- SDK loading remains fire-and-forget and best-effort. Its existing implementation catches import, assembly, and startup failures.
+- No protocol shape, capability, authentication timing, provider selection, MCP behavior, or telemetry configuration surface changes.
+
+## Alternatives rejected
+
+- **Start inside `QwenAgent.initialize()`**: this is before the handler returns and therefore before the SDK can serialize or write the response.
+- **Use `queueMicrotask`, `setImmediate`, or a timer after the handler returns**: none proves that the SDK's private write queue has completed, and a timer adds an arbitrary latency policy.
+- **Wrap or fork `AgentSideConnection`**: unnecessary because the package-local NDJSON stream already exposes post-write message observations.
+- **Wait until the first session response**: could remove more contention but widens the dropped-event window beyond candidate 2 and never initializes telemetry for an idle initialized channel.
+- **Buffer early telemetry**: materially changes telemetry semantics and memory ownership; candidate 2 explicitly accepts dropped early events.
+
+## Verification
+
+Unit tests cover ACP config deferral and the exact transport ordering: no start on receipt, unrelated response, error response, or failed write; one start after the matching successful response has been written. Existing transport tests prove sent hooks run after the underlying write and are skipped on write rejection.
+
+The release bundle is exercised through the real ACP parent/child path with telemetry enabled and disabled. Compatibility checks cover cold and preheated channels, concurrent first sessions, legacy single-session mode, early disconnect, cleanup, and outfile record production.
+
+The change lands only if it passes #7264's 2C4G gate: 30 alternating paired serial cold starts reporting `channel.initialize`, child process to initialize response, cold session request, process to first session, peak RSS, preheated behavior, and telemetry on/off compatibility. Because work moves later rather than disappearing, the gate must report both initialization and first-session timing; a gain that is merely repaid before the first session is not treated as a successful optimization.
+
+## Results
+
+The control was `origin/main` at `14f1f2bb365280a6e1d4a45b452f7992f1928187`; the candidate was the same commit plus this exact working-tree change. Both release bundles were built from the same lockfile and tested on the supplied Linux host with 2 vCPUs, approximately 3.5 GiB RAM, no swap, and bundled Node.js 22.23.1.
+
+With outfile telemetry enabled, 30 alternating paired cold starts produced:
+
+| Metric                               | Control P50 / P95  | Candidate P50 / P95 | P50 delta    |
+| ------------------------------------ | ------------------ | ------------------- | ------------ |
+| `channel.initialize`                 | 968.0 / 1029.2 ms  | 923.8 / 958.9 ms    | **-44.2 ms** |
+| Child process to initialize response | 973.8 / 1034.9 ms  | 928.9 / 964.2 ms    | **-44.9 ms** |
+| Cold `POST /session`                 | 1284.9 / 1348.2 ms | 1285.7 / 1330.0 ms  | +0.7 ms      |
+| Process to first session             | 1908.0 / 1986.9 ms | 1907.0 / 1978.0 ms  | -1.0 ms      |
+| Peak RSS                             | 414.1 / 446.4 MiB  | 410.6 / 438.6 MiB   | -3.6 MiB     |
+
+The paired distribution showed `channel.initialize` faster in 28 of 30 pairs with a -53.0 ms paired-median delta. Cold session request and process-to-first-session remained neutral: their paired-median deltas were -13.2 ms and +0.4 ms respectively, with wins split 17/30 and 15/30. The change therefore improves the direct ACP initialization boundary without imposing an end-to-end regression when a session is requested immediately; it does not claim a cold process-to-session improvement.
+
+The formal 30-pair preheated run had two isolated candidate session outliers, so the preheated phase was repeated for another 30 pairs. In the replication, `channel.initialize` improved from 963.2 / 1018.0 ms to 906.9 / 940.8 ms P50/P95. The already-preheated session request changed from 81.7 / 86.0 ms to 83.4 / 90.4 ms, while process-to-session remained neutral at 3694.1 / 3721.9 ms versus 3694.3 / 3719.0 ms. The first run's outliers did not recur; the replication's paired session median was +1.8 ms and process-to-session median was -0.6 ms. RSS moved in opposite directions across the two preheated runs, so no preheated memory change is claimed.
+
+Candidate functional runs passed concurrent first sessions, telemetry disabled with zero records, and legacy single-session mode. Every telemetry-enabled run reported a valid startup profile, and every run exited without a residual process. Two telemetry-enabled live-prompt smokes against the available OpenAI-compatible endpoint both completed and produced non-empty telemetry outfiles. Direct bundled-ACP smoke tests also passed both early-disconnect boundaries: EOF before initialize exited cleanly without starting telemetry, while EOF immediately after a successful initialize response exited cleanly after creating the outfile, with no stderr output in either case.
+
+Raw host artifacts are under:
+
+- `/root/qwen-7264-c2-20260723/results/formal/2026-07-23T03-03-41.303Z`
+- `/root/qwen-7264-c2-20260723/results/preheated-replication/2026-07-23T03-12-45.750Z`
+- `/root/qwen-7264-c2-20260723/results/prompt-smoke/2026-07-23T03-23-26.883Z`

--- a/docs/design/2026-07-23-defer-acp-telemetry-initialization.md
+++ b/docs/design/2026-07-23-defer-acp-telemetry-initialization.md
@@ -14,7 +14,7 @@ Telemetry events already use an initialized gate: events emitted before the SDK 
 
 ACP configuration sets the existing `deferTelemetryInitialization` option. This suppresses the constructor's fire-and-forget start without changing the default, headless, stream-JSON, interactive TUI, or daemon runtime paths.
 
-`runAcpAgent` uses the existing message-observation hook on its NDJSON transport to remember the JSON-RPC ID of an incoming `initialize` request. The hook runs after the parsed request is enqueued but before its pending read continuation can handle it. For outgoing messages, the same hook runs only after the encoded response has been successfully written to the underlying stdout stream. When a successful response with the remembered ID is observed, the child starts telemetry through the existing single-flight facade and clears the remembered ID.
+`runAcpAgent` uses the existing message-observation hook on its NDJSON transport to remember the JSON-RPC ID of an incoming `initialize` request. The hook runs after the parsed request is enqueued but before its pending read continuation can handle it. For outgoing messages, the same hook runs only after the encoded response has been successfully written to the underlying stdout stream. When a successful response with the remembered ID is observed, the child starts telemetry through the existing single-flight facade, registers its event-loop gauge only after that initialization settles, and clears the remembered ID. This ordering is required because the metrics API caches a no-op meter if a gauge is registered before the SDK installs the global meter provider.
 
 This creates a transport-defined boundary: telemetry loading cannot begin before the initialization response write resolves. It does not depend on event-loop scheduling assumptions.
 
@@ -24,16 +24,17 @@ The ACP child has one process-global telemetry SDK and one bootstrap `Config`. T
 
 The affected consumers are:
 
-- **ACP bootstrap child**: changes from constructor-started telemetry to response-write-started telemetry.
+- **ACP bootstrap child**: changes from constructor-started telemetry to response-write-started telemetry. Its event-loop gauge registration moves behind SDK initialization so early registration cannot permanently disable all metrics.
 - **ACP session creation and prompts**: retain the existing initialized gates; very early events may now be dropped for longer while SDK loading finishes.
 - **Ordinary interactive TUI**: retains post-first-render startup through `startPostRenderPrefetches`.
 - **Headless and stream-JSON CLI**: retain constructor startup.
 - **`qwen serve` parent/daemon runtime**: retains its explicit deferred core-runtime initialization and shutdown.
-- **Process exit cleanup**: retains `Config.shutdown()`. A child that disconnects before a successful protocol initialization never starts telemetry. If disconnect races a just-started import, the initializer's internal catch prevents an unhandled rejection and the ACP outer path still exits the process; current config cleanup does not promise to flush an SDK that has not finished initializing.
+- **Process exit cleanup**: retains `Config.shutdown()`. A child that disconnects before a successful protocol initialization never starts telemetry. If disconnect races a just-started import, the initializer's internal catch prevents an unhandled rejection and the ACP outer path still exits the process. Although `shutdownTelemetry()` can await an in-flight initializer, `Config.shutdown()` calls it only after the SDK reports initialized, so current config cleanup can skip an initialization that is still in flight.
 
 ## Failure and compatibility behavior
 
 - Telemetry disabled remains a facade no-op after the response and loads no heavy telemetry modules.
+- One-shot bootstrap events emitted before the response, including the initial `qwen-code.auth` event and one early `qwen-code.config` event, are permanently absent from ACP telemetry rather than merely delayed. This is the accepted cost of moving SDK initialization behind the response; the change does not synthesize or buffer replacement events.
 - A malformed or rejected `initialize` request does not start telemetry. A later valid initialize request can still start it.
 - A stdout write failure does not run the sent-message hook, so telemetry is not started for a response the client did not receive.
 - Repeated or unrelated JSON-RPC responses cannot start telemetry because the request ID and successful-response shape must both match; the remembered ID is consumed once.
@@ -64,20 +65,19 @@ With outfile telemetry enabled, 30 alternating paired cold starts produced:
 
 | Metric                               | Control P50 / P95  | Candidate P50 / P95 | P50 delta    |
 | ------------------------------------ | ------------------ | ------------------- | ------------ |
-| `channel.initialize`                 | 968.0 / 1029.2 ms  | 923.8 / 958.9 ms    | **-44.2 ms** |
-| Child process to initialize response | 973.8 / 1034.9 ms  | 928.9 / 964.2 ms    | **-44.9 ms** |
-| Cold `POST /session`                 | 1284.9 / 1348.2 ms | 1285.7 / 1330.0 ms  | +0.7 ms      |
-| Process to first session             | 1908.0 / 1986.9 ms | 1907.0 / 1978.0 ms  | -1.0 ms      |
-| Peak RSS                             | 414.1 / 446.4 MiB  | 410.6 / 438.6 MiB   | -3.6 MiB     |
+| `channel.initialize`                 | 942.1 / 1245.0 ms  | 898.3 / 1002.4 ms   | **-43.8 ms** |
+| Child process to initialize response | 947.0 / 1249.8 ms  | 903.0 / 998.4 ms    | **-43.9 ms** |
+| Cold `POST /session`                 | 1235.5 / 1591.7 ms | 1245.1 / 1462.0 ms  | +9.6 ms      |
+| Process to first session             | 1833.1 / 2190.6 ms | 1845.5 / 2417.0 ms  | +12.4 ms     |
+| Peak RSS                             | 418.7 / 443.6 MiB  | 406.7 / 438.4 MiB   | -11.9 MiB    |
 
-The paired distribution showed `channel.initialize` faster in 28 of 30 pairs with a -53.0 ms paired-median delta. Cold session request and process-to-first-session remained neutral: their paired-median deltas were -13.2 ms and +0.4 ms respectively, with wins split 17/30 and 15/30. The change therefore improves the direct ACP initialization boundary without imposing an end-to-end regression when a session is requested immediately; it does not claim a cold process-to-session improvement.
+The paired distribution showed `channel.initialize` faster in 26 of 30 pairs with a -44.2 ms paired-median delta. Cold session request and process-to-first-session had paired-median deltas of +15.0 ms and +13.8 ms respectively, with candidate wins in 13/30 and 11/30 pairs. The process-to-first-session paired-median bootstrap 95% interval was -2.8 to +27.5 ms, so this run did not establish either an end-to-end regression or an improvement. The change therefore claims only the direct ACP initialization-boundary gain.
 
-The formal 30-pair preheated run had two isolated candidate session outliers, so the preheated phase was repeated for another 30 pairs. In the replication, `channel.initialize` improved from 963.2 / 1018.0 ms to 906.9 / 940.8 ms P50/P95. The already-preheated session request changed from 81.7 / 86.0 ms to 83.4 / 90.4 ms, while process-to-session remained neutral at 3694.1 / 3721.9 ms versus 3694.3 / 3719.0 ms. The first run's outliers did not recur; the replication's paired session median was +1.8 ms and process-to-session median was -0.6 ms. RSS moved in opposite directions across the two preheated runs, so no preheated memory change is claimed.
+In the same run's 30-pair preheated phase, `channel.initialize` improved from 950.5 / 1323.7 ms to 908.4 / 964.4 ms P50/P95. The already-preheated session request changed from 82.1 / 94.8 ms to 83.7 / 131.6 ms, while process-to-session changed from 3683.5 / 4105.0 ms to 3686.1 / 3749.2 ms. The paired session and process-to-session medians were +1.4 ms and +1.0 ms respectively. Two isolated candidate session outliers and several control initialization outliers widened the unpaired P95 values; the paired medians remained neutral. No preheated memory change is claimed.
 
-Candidate functional runs passed concurrent first sessions, telemetry disabled with zero records, and legacy single-session mode. Every telemetry-enabled run reported a valid startup profile, and every run exited without a residual process. Two telemetry-enabled live-prompt smokes against the available OpenAI-compatible endpoint both completed and produced non-empty telemetry outfiles. Direct bundled-ACP smoke tests also passed both early-disconnect boundaries: EOF before initialize exited cleanly without starting telemetry, while EOF immediately after a successful initialize response exited cleanly after creating the outfile, with no stderr output in either case.
+Candidate functional runs passed concurrent first sessions, telemetry disabled with zero records, and legacy single-session mode. All 120 telemetry-enabled benchmark runs reported a valid startup profile and non-empty outfile, and every run exited without a residual process. A release-bundle smoke through the official ACP client additionally waited past the metric export interval and confirmed both `qwen-code.session.count` and `qwen-code.acp.event_loop.lag`, guarding against registration on a cached no-op meter. Two telemetry-enabled live-prompt smokes against the available OpenAI-compatible endpoint both completed and produced non-empty telemetry outfiles. Direct bundled-ACP smoke tests also passed both early-disconnect boundaries: EOF before initialize exited cleanly without starting telemetry, while EOF immediately after a successful initialize response exited cleanly after creating the outfile, with no stderr output in either case.
 
 Raw host artifacts are under:
 
-- `/root/qwen-7264-c2-20260723/results/formal/2026-07-23T03-03-41.303Z`
-- `/root/qwen-7264-c2-20260723/results/preheated-replication/2026-07-23T03-12-45.750Z`
+- `/root/qwen-7264-c2-20260723/results/fixed-formal-rerun/2026-07-23T05-14-14.236Z`
 - `/root/qwen-7264-c2-20260723/results/prompt-smoke/2026-07-23T03-23-26.883Z`

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -180,6 +180,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
       ? payload
       : undefined,
   ),
+  initializeTelemetry: vi.fn().mockResolvedValue(undefined),
   createDebugLogger: () => mockDebugLogger,
   extractDaemonTraceContext: mockExtractDaemonTraceContext,
   withDaemonSpan: mockWithDaemonSpan,
@@ -784,6 +785,7 @@ import {
   MCPServerStatus,
   getMCPDiscoveryState,
   getMCPServerStatus,
+  initializeTelemetry,
   tokenLimit,
   McpBudgetWouldExceedError,
   buildInstallPlan,
@@ -804,6 +806,7 @@ import {
   mcpServerRequiresOAuth,
   APPROVAL_MODES,
 } from '@qwen-code/qwen-code-core';
+import { ndJsonStream } from '@qwen-code/acp-bridge/ndJsonStream';
 import type {
   LoadSessionResponse,
   McpServer,
@@ -923,6 +926,70 @@ describe('runAcpAgent shutdown cleanup', () => {
   afterAll(() => {
     processOnSpy.mockRestore();
     processOffSpy.mockRestore();
+  });
+
+  it('starts telemetry only after a matching successful initialize response is sent', async () => {
+    const agentPromise = runAcpAgent(mockConfig, mockSettings, mockArgv);
+    await vi.waitFor(() => expect(ndJsonStream).toHaveBeenCalledOnce());
+
+    const hooks = vi.mocked(ndJsonStream).mock.calls[0]?.[2];
+    expect(hooks?.onMessageObserved).toEqual(expect.any(Function));
+    expect(initializeTelemetry).not.toHaveBeenCalled();
+
+    hooks?.onMessageObserved?.({
+      direction: 'received',
+      bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'initialize',
+        params: {},
+      },
+    });
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
+      message: { jsonrpc: '2.0', id: 8, result: {} },
+    });
+    expect(initializeTelemetry).not.toHaveBeenCalled();
+
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id: 7,
+        error: { code: -32602, message: 'invalid params' },
+      },
+    });
+    expect(initializeTelemetry).not.toHaveBeenCalled();
+
+    hooks?.onMessageObserved?.({
+      direction: 'received',
+      bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id: null,
+        method: 'initialize',
+        params: {},
+      },
+    });
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
+      message: { jsonrpc: '2.0', id: null, result: {} },
+    });
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
+      message: { jsonrpc: '2.0', id: null, result: {} },
+    });
+
+    expect(initializeTelemetry).toHaveBeenCalledOnce();
+    expect(initializeTelemetry).toHaveBeenCalledWith(mockConfig);
+
+    mockConnectionState.resolve();
+    await agentPromise;
   });
 
   it('calls runExitCleanup and process.exit on SIGTERM', async () => {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -949,6 +949,18 @@ describe('runAcpAgent shutdown cleanup', () => {
     hooks?.onMessageObserved?.({
       direction: 'sent',
       bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id: 7,
+        method: 'session/request_permission',
+        params: {},
+      },
+    });
+    expect(initializeTelemetry).not.toHaveBeenCalled();
+
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
       message: { jsonrpc: '2.0', id: 8, result: {} },
     });
     expect(initializeTelemetry).not.toHaveBeenCalled();
@@ -1093,14 +1105,42 @@ describe('runAcpAgent shutdown cleanup', () => {
       snapshot,
       dispose,
     });
+    let resolveTelemetryInitialization: () => void = () => {};
+    vi.mocked(initializeTelemetry).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTelemetryInitialization = resolve;
+        }),
+    );
 
     const agentPromise = runAcpAgent(mockConfig, mockSettings, mockArgv);
+    await vi.waitFor(() => expect(ndJsonStream).toHaveBeenCalledOnce());
+    const hooks = vi.mocked(ndJsonStream).mock.calls[0]?.[2];
 
-    await vi.waitFor(() => {
+    expect(registerAcpEventLoopLagGauge).not.toHaveBeenCalled();
+    hooks?.onMessageObserved?.({
+      direction: 'received',
+      bytes: 1,
+      message: {
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'initialize',
+        params: {},
+      },
+    });
+    hooks?.onMessageObserved?.({
+      direction: 'sent',
+      bytes: 1,
+      message: { jsonrpc: '2.0', id: 0, result: {} },
+    });
+    expect(registerAcpEventLoopLagGauge).not.toHaveBeenCalled();
+
+    resolveTelemetryInitialization();
+    await vi.waitFor(() =>
       expect(registerAcpEventLoopLagGauge).toHaveBeenCalledWith(
         expect.any(Function),
-      );
-    });
+      ),
+    );
     const readGauge = vi.mocked(registerAcpEventLoopLagGauge).mock.calls[0]![0];
     expect(readGauge()).toEqual({
       meanMs: 0,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2721,7 +2721,9 @@ export async function runAcpAgent(
         }
         initializeRequestId = undefined;
         if ('result' in message) {
-          void initializeTelemetry(config);
+          void initializeTelemetry(config).then(() => {
+            registerAcpEventLoopLagGauge(() => eventLoopMonitor.snapshot());
+          });
         }
       },
     });
@@ -2735,7 +2737,6 @@ export async function runAcpAgent(
     eventLoopMonitor.dispose();
     throw err;
   }
-  registerAcpEventLoopLagGauge(() => eventLoopMonitor.snapshot());
 
   // Both the SIGTERM handler and the IDE-initiated close path need
   // to drain the MCP pool before runExitCleanup. Single helper

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -38,6 +38,7 @@ import {
   tokenLimit,
   getMCPDiscoveryState,
   getMCPServerStatus,
+  initializeTelemetry,
   MCPDiscoveryState,
   MCPServerStatus,
   McpTransportPool,
@@ -2697,7 +2698,33 @@ export async function runAcpAgent(
     console.info = console.error;
     console.debug = console.error;
 
-    const stream = ndJsonStream(stdout, stdin);
+    let initializeRequestId: string | number | null | undefined;
+    const stream = ndJsonStream(stdout, stdin, {
+      onMessageObserved: ({ direction, message }) => {
+        if (
+          direction === 'received' &&
+          'id' in message &&
+          'method' in message &&
+          message.method === 'initialize'
+        ) {
+          initializeRequestId = message.id;
+          return;
+        }
+        if (
+          direction !== 'sent' ||
+          initializeRequestId === undefined ||
+          !('id' in message) ||
+          'method' in message ||
+          message.id !== initializeRequestId
+        ) {
+          return;
+        }
+        initializeRequestId = undefined;
+        if ('result' in message) {
+          void initializeTelemetry(config);
+        }
+      },
+    });
     connection = new AgentSideConnection((conn) => {
       acpConnection = conn;
       agentInstance = new QwenAgent(config, settings, argv, conn);

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1871,6 +1871,19 @@ describe('loadCliConfig telemetry', () => {
     );
   });
 
+  it('should defer telemetry for ACP startup', async () => {
+    process.argv = ['node', 'script.js', '--acp', '--telemetry'];
+    const argv = await parseArguments();
+
+    await loadCliConfig({}, argv);
+
+    expect(mockConfigConstructorParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deferTelemetryInitialization: true,
+      }),
+    );
+  });
+
   it('should set telemetry to false when --no-telemetry flag is present', async () => {
     process.argv = ['node', 'script.js', '--no-telemetry'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2126,12 +2126,11 @@ export async function loadCliConfig(
     showResponseTokensPerSecond:
       settings.ui?.showResponseTokensPerSecond === true,
     telemetry: telemetrySettings,
-    // Ordinary interactive TUI defers telemetry until after first paint. Auth
-    // events emitted before the deferred init are an accepted startup-latency
-    // tradeoff. This intentionally differs from IDE deferral: `qwen -i
-    // "prompt"` must await IDE context before auto-submit, but telemetry can
-    // still initialize after render unless an initial prompt is present.
-    deferTelemetryInitialization: interactive && !isAcpMode && !question,
+    // Ordinary interactive TUI defers telemetry until after first paint; ACP
+    // defers it until after the initialize response is written. Events emitted
+    // before deferred init are an accepted startup-latency tradeoff. `qwen -i
+    // "prompt"` still initializes eagerly because it auto-submits after render.
+    deferTelemetryInitialization: isAcpMode || (interactive && !question),
     outboundCorrelation: settings.outboundCorrelation,
     usageStatisticsEnabled: settings.privacy?.usageStatisticsEnabled ?? true,
     clearContextOnIdle: settings.context?.clearContextOnIdle,


### PR DESCRIPTION
## What this PR does

This PR defers telemetry SDK initialization in ACP children until the successful protocol `initialize` response has been written to stdout. The existing NDJSON transport observation boundary records the incoming initialize request ID and starts the existing single-flight telemetry facade only after the matching result is sent.

Other startup modes retain their current behavior: ordinary interactive TUI startup still defers telemetry until after first paint, prompt-interactive and headless modes initialize eagerly, and the daemon parent keeps its existing deferred runtime initialization.

## Why it's needed

ACP previously started telemetry from the bootstrap `Config` constructor. Although initialization is fire-and-forget, loading and evaluating the telemetry implementation and exporter chain competes with ACP bootstrap work on the same event loop and CPU. On the constrained 2-vCPU validation host, moving that work behind the protocol boundary reduced `channel.initialize` P50 by 43.8 ms and its paired median by 44.2 ms across 30 alternating cold pairs. Cold process-to-first-session time did not show a statistically demonstrated change, so this PR claims a direct ACP initialization improvement rather than a broader end-to-end startup reduction.

## Reviewer Test Plan

### How to verify

Run the focused CLI configuration and ACP agent tests and confirm telemetry is deferred for ACP, does not start on receipt, unrelated responses, agent-to-client requests with a colliding ID, or rejected initialization, and starts exactly once after a matching successful response. Confirm the ACP event-loop gauge is not registered until telemetry initialization settles. Run the ACP NDJSON transport tests and confirm sent observations occur only after the underlying write succeeds and do not run when it rejects. Build and type-check the workspace, then start a bundled ACP child with outfile telemetry enabled: a successful initialize response should be emitted before telemetry starts, while EOF before initialize should exit cleanly without creating telemetry output. After creating a session and waiting for one metric export interval, both the session counter and ACP event-loop lag gauge should appear in the outfile.

Observed validation: 593 focused CLI tests passed, 11 ACP transport tests passed, focused ESLint and Prettier checks passed, and the full workspace build and typecheck passed. A release-bundle smoke using the official ACP client waited past the metric export interval and confirmed both `qwen-code.session.count` and `qwen-code.acp.event_loop.lag` are exported after deferred initialization. On Linux, 30 alternating cold pairs improved `channel.initialize` from 942.1 / 1245.0 ms to 898.3 / 1002.4 ms P50/P95; cold process-to-first-session changed from 1833.1 / 2190.6 ms to 1845.5 / 2417.0 ms, with a +13.8 ms paired median whose bootstrap 95% interval (-2.8 to +27.5 ms) crossed zero. The same run's 30-pair preheated phase improved initialization P50 by 42.1 ms while its process-to-session paired median was +1.0 ms. All 120 telemetry-enabled benchmark runs produced valid profiles and non-empty outfiles. Concurrency, telemetry-disabled, legacy single-session, early-disconnect, cleanup, and two live-prompt smoke checks passed without residual processes.

### Evidence (Before & After)

N/A — no TUI or other user-visible rendering changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS local workspace with Node.js 22 for unit tests, lint, formatting, build, typecheck, and bundled ACP smoke tests. Linux 6.6 x64 host with 2 vCPUs, approximately 3.5 GiB RAM, no swap, and bundled Node.js 22.23.1 for the 2C4G benchmark, functional matrix, and live-prompt smoke tests.

## Risk & Scope

- Main risk or tradeoff: Telemetry events emitted before initialization completes are dropped for a longer window, consistent with the existing initialized-gate behavior; the change deliberately adds no buffer. One-shot bootstrap events emitted before the response, including the initial `qwen-code.auth` event and one early `qwen-code.config` event, are therefore permanently absent from ACP telemetry rather than delayed. If the ACP child exits immediately after the response while initialization is still in flight, `Config.shutdown()` can skip that in-flight SDK even though the lower-level telemetry shutdown can await it.
- Not validated / out of scope: Windows runtime behavior and live prompts against every supported provider were not exercised. The benchmark measures ACP protocol initialization and immediate session creation; it does not claim a cold process-to-session improvement or a stable preheated RSS change.
- Breaking changes / migration notes: None. ACP protocol messages, capabilities, configuration, authentication timing, provider selection, MCP behavior, and non-ACP startup paths are unchanged.

## Linked Issues

Implements candidate 2 from #7264 and contributes to #4748 without closing either tracking issue.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将 ACP 子进程中的 telemetry SDK 初始化推迟到协议 `initialize` 成功响应已经写入 stdout 之后。实现复用现有 NDJSON 传输层的消息观察边界，记录收到的 initialize 请求 ID，并且只在匹配的 result 发送完成后启动现有的单飞 telemetry 门面。

其他启动模式保持现有行为：普通交互式 TUI 仍在首屏渲染后推迟启动 telemetry，带初始 prompt 的交互模式和 headless 模式仍会提前初始化，daemon 父进程也继续使用现有的延迟运行时初始化。

## 为什么需要

ACP 之前会从启动 `Config` 构造函数中开始 telemetry。虽然初始化是 fire-and-forget，但加载和执行 telemetry 实现及 exporter 链仍会在同一个事件循环和 CPU 上与 ACP 启动工作竞争。在受限的 2 vCPU 验证机器上，将这部分工作移到协议边界之后，使 30 组交替冷启动中的 `channel.initialize` P50 降低 43.8 ms、配对中位数降低 44.2 ms。冷启动进程到首个 session 的耗时没有显示出统计上已证实的变化，因此本 PR 只声明直接改善 ACP 初始化，不扩大为整体端到端启动收益。

## Reviewer 测试计划

### 如何验证

运行聚焦的 CLI 配置和 ACP agent 测试，确认 ACP 会推迟 telemetry，在收到请求、无关响应、ID 碰撞的 agent 到 client 请求或初始化被拒绝时不会启动，并且仅在匹配的成功响应之后启动一次。确认 ACP event-loop gauge 在 telemetry 初始化完成前不会注册。运行 ACP NDJSON 传输测试，确认 sent 观察只在底层写入成功后发生，写入失败时不会触发。构建整个工作区并执行类型检查，然后在开启 outfile telemetry 的情况下启动打包后的 ACP 子进程：成功的 initialize 响应应先于 telemetry 启动发出，而 initialize 前收到 EOF 时应干净退出且不创建 telemetry 输出。创建 session 并等待一个指标导出周期后，session counter 和 ACP event-loop lag gauge 都应出现在 outfile 中。

实际验证结果：593 个聚焦 CLI 测试通过，11 个 ACP 传输测试通过，聚焦 ESLint 和 Prettier 检查通过，完整工作区 build 和 typecheck 通过。使用官方 ACP client 的 release bundle 冒烟测试等待超过 metric 导出间隔后，确认延迟初始化后 `qwen-code.session.count` 和 `qwen-code.acp.event_loop.lag` 均能导出。在 Linux 上，30 组交替冷启动使 `channel.initialize` P50/P95 从 942.1 / 1245.0 ms 降至 898.3 / 1002.4 ms；冷启动进程到首个 session 从 1833.1 / 2190.6 ms 变为 1845.5 / 2417.0 ms，其配对中位数为 +13.8 ms，但 bootstrap 95% 区间（-2.8 到 +27.5 ms）跨过 0。同一次测试的 30 组预热阶段使初始化 P50 降低 42.1 ms，而进程到 session 的配对中位数为 +1.0 ms。120 次开启 telemetry 的基准运行均生成有效 profile 和非空 outfile。并发、关闭 telemetry、旧版单 session、提前断开、清理以及两次真实 prompt 冒烟检查均通过，且没有残留进程。

### 证据（改动前后）

N/A——没有 TUI 或其他用户可见的渲染变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

macOS 本地工作区使用 Node.js 22 完成单元测试、lint、格式检查、build、typecheck 和打包 ACP 冒烟测试。Linux 6.6 x64 主机使用 2 vCPU、约 3.5 GiB 内存、无 swap 和打包 Node.js 22.23.1，完成 2C4G 基准、功能矩阵和真实 prompt 冒烟测试。

## 风险与范围

- 主要风险或取舍：初始化完成前产生的 telemetry 事件会在更长的窗口内被丢弃，这与现有 initialized gate 行为一致；本改动刻意不增加缓冲。响应前只产生一次的启动事件，包括初始 `qwen-code.auth` 事件和一条较早的 `qwen-code.config` 事件，会永久缺失于 ACP telemetry，而不只是延迟。如果 ACP 子进程在响应后、初始化仍进行时立即退出，即使底层 telemetry shutdown 能等待初始化，`Config.shutdown()` 仍可能跳过这个进行中的 SDK。
- 未验证 / 范围外：未验证 Windows 运行时行为，也没有针对所有受支持 provider 运行真实 prompt。基准测量 ACP 协议初始化和紧接着的 session 创建；不声明冷启动进程到 session 的改善，也不声明稳定的预热 RSS 变化。
- 破坏性变更 / 迁移说明：无。ACP 协议消息、能力、配置、认证时序、provider 选择、MCP 行为和非 ACP 启动路径均未改变。

## 关联 Issue

实现 #7264 的 candidate 2，并推进 #4748，但不关闭这两个跟踪 issue。

</details>
