### PR TITLE
fix(cli): keep role codenames and brief paths out of the posted review body

### DIFF
--- a/packages/cli/src/commands/review/check-coverage.test.ts
+++ b/packages/cli/src/commands/review/check-coverage.test.ts
@@ -1607,4 +1607,53 @@ describe('verificationGaps — Step 4 and Step 5 ran, and read their briefs', ()
       /verification — its prompt was built, but no agent was launched with it/,
     );
   });
+
+  it('merges both steps into one gap when they failed the same way', () => {
+    // #7268: the posted body carried the verify and reverse-audit `rewritten`
+    // sentences back to back, near-identical but for the tail. One shape, one
+    // sentence, two subjects — and still both consequences and both honesty
+    // limits (each demonstrably RAN and opened its brief).
+    const p = plan();
+    step45(p, 'reverse-audit', { rewritten: true });
+    step45(p, 'verify', { rewritten: true });
+    const r = verificationGaps(p, { postsFindings: true }, ENV);
+    expect(r.ok).toBe(false);
+    expect(r.gaps).toHaveLength(1);
+    const gap = r.gaps[0];
+    expect(gap).toMatch(/^verification and reverse audit — /);
+    expect(gap).toMatch(/each ran and opened its brief/);
+    expect(gap).toMatch(/written by hand/);
+    expect(gap).toMatch(/cannot be counted as verified/);
+    // The remediation stays per-role: the two rebuild commands differ.
+    const fix = r.remediation.join(' ');
+    expect(fix).toContain('--role reverse-audit');
+    expect(fix).toContain('--role verify');
+    expect(r.unverifiedFindings).toBe(true);
+  });
+
+  it('keeps two precise gaps when the steps failed differently', () => {
+    // Mixed shapes have different mechanisms and different fixes; a sentence
+    // vague enough to cover both would misname one of them.
+    const p = plan();
+    step45(p, 'reverse-audit', { rewritten: true });
+    step45(p, 'verify', { launch: false });
+    const r = verificationGaps(p, { postsFindings: true }, ENV);
+    expect(r.gaps).toHaveLength(2);
+    expect(r.gaps.join(' ')).toMatch(
+      /reverse audit — an auditor ran and opened its brief/,
+    );
+    expect(r.gaps.join(' ')).toMatch(
+      /verification — its prompt was built, but no agent was launched with it/,
+    );
+    expect(r.gaps.join(' ')).not.toMatch(/verification and reverse audit/);
+  });
+
+  it('does not merge when the review posts no findings — verify was never owed', () => {
+    // A zero-finding review with the reverse audit skipped keeps the solo
+    // reverse-audit text: there is no verify failure to share a sentence with.
+    const p = plan(); // neither step on record
+    const r = verificationGaps(p, { postsFindings: false }, ENV);
+    expect(r.gaps).toHaveLength(1);
+    expect(r.gaps[0]).toMatch(/^reverse audit — /);
+  });
 });

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1126,9 +1126,11 @@ describe('coverage is recomputed, never accepted', () => {
         'a subject only the caller noticed — the auditor returned nothing twice',
       ],
     });
-    // One clause for the shared subject — and it is the machine's sentence,
-    // not the caller's paraphrase.
-    expect(r.body.split(label)).toHaveLength(2);
+    // One clause for the shared subject — the machine's sentence, not the
+    // caller's paraphrase, and in the author's register: the internal
+    // codename stays off the posted body (it is the stderr selector).
+    expect(r.body.split('the whole-diff test-coverage check')).toHaveLength(2);
+    expect(r.body).not.toContain(label);
     expect(r.body).toContain('no record shows its brief reaching an agent');
     expect(r.body).not.toContain('described this gap in its own words');
     // A subject the coverage recomputation cannot see survives untouched.
@@ -1250,7 +1252,10 @@ describe('coverage is recomputed, never accepted', () => {
       ],
       modelId: MODEL,
     });
-    expect(r.body.split(label)).toHaveLength(2);
+    // The caller's echo (internal label) dedupes against the internal
+    // subject; the one surviving sentence prints the author's phrase.
+    expect(r.body).not.toContain(label);
+    expect(r.body.split('the whole-diff test-coverage check')).toHaveLength(2);
     expect(
       r.body.match(/no record shows its brief reaching an agent/g) ?? [],
     ).toHaveLength(1);
@@ -1510,8 +1515,12 @@ describe('coverage is recomputed, never accepted', () => {
     expect(fixes).toMatch(/rewritten launches: re-run/);
     expect(fixes).toMatch(/unread briefs: relaunch/);
     expect(fixes).toMatch(/agents that never opened the diff: relaunch/);
-    // And none of the three disclosures drags a command into the body.
+    // And none of the three disclosures drags a command into the body —
+    // nor the unread brief's filesystem path: the path names the file an
+    // OPERATOR makes the agent open, and it stays on stderr with the fix.
     expect(r.body).not.toMatch(/agent-prompt|--roster|--chunk/);
+    expect(r.body).not.toContain('.brief.md');
+    expect(r.body).toContain('never opened its brief, so it reviewed without');
   });
 
   it('the handler prints every FIX to stderr, before the verdict, never to stdout', () => {
@@ -1628,6 +1637,29 @@ describe('the Step 4/5 gate — verify and reverse audit must have run (high eff
     expect(r.body).toMatch(
       /reverse audit — no auditor was launched with a prompt this skill builds/,
     );
+  });
+
+  it('says one sentence when verify and the reverse audit failed the same way', () => {
+    // #7268's posted body carried the two `rewritten` sentences back to back,
+    // near-identical but for the tail. Both steps down the same way is one
+    // failure with two subjects — while the stderr remediation keeps BOTH
+    // rebuild commands, which differ.
+    const r = composeReview({
+      criticalsInline: 0,
+      suggestionsInline: 1,
+      planPath: coveredPlan([]), // neither verify nor reverse audit on record
+      env: ENV,
+      modelId: MODEL,
+    });
+    expect(r.event).toBe('COMMENT');
+    expect(r.body).toMatch(
+      /Not reviewed: verification and reverse audit — neither the verifier nor the reverse auditor was launched with a prompt this skill builds/,
+    );
+    expect(r.body).not.toMatch(/reverse audit — no auditor/);
+    expect(r.body).not.toMatch(/verification — the review posts findings/);
+    const fixes = r.remediation.join(' ');
+    expect(fixes).toContain('--role reverse-audit');
+    expect(fixes).toContain('--role verify');
   });
 
   it('softens an unverified Request changes to Comment — no verifier, no blocker', () => {

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -207,7 +207,15 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // The coverage-derived disclosures, kept STRUCTURAL ({subject, reason})
   // from the site that knows the boundary — reparsing the rendered prose for
   // it was the bug. `unreviewed` above stays what the caller wrote, verbatim.
-  const coverageEntries: Array<{ subject: string; reason: string }> = [];
+  // The `public*` fields are the body's register (`Brief.publicLabel`, a
+  // path-free reason); `subject`/`reason` stay the internal keys every dedup
+  // and certification check below matches on.
+  const coverageEntries: Array<{
+    subject: string;
+    reason: string;
+    publicSubject?: string;
+    publicReason?: string;
+  }> = [];
   // The fixes for the gaps above, for stderr — never for the body. The gap says
   // what the review cannot certify, to the PR author; the remediation names the
   // command that repairs it, to the orchestrator. #7012's public body was fourteen
@@ -678,29 +686,38 @@ export function composeReview(input: ComposeReviewInput): ComposeReviewResult {
   // cause would tell the author "no agent was launched" about an agent that
   // demonstrably ran.
   const seenSubjects = new Set<string>();
-  const byReason = new Map<string, string[]>();
-  for (const { subject, reason } of covEntries) {
-    if (seenSubjects.has(subject)) continue;
-    seenSubjects.add(subject);
-    const subjects = byReason.get(reason) ?? [];
-    subjects.push(subject);
-    byReason.set(reason, subjects);
+  const byReason = new Map<
+    string,
+    Array<{ subject: string; publicSubject?: string }>
+  >();
+  for (const e of covEntries) {
+    if (seenSubjects.has(e.subject)) continue;
+    seenSubjects.add(e.subject);
+    // Keyed on the reason the body will PRINT — public over internal. Two
+    // unread briefs differ internally only by their brief paths; grouped on
+    // those, the path-free public sentence would render once per role, which
+    // is the per-subject repetition this map exists to kill.
+    const key = e.publicReason ?? e.reason;
+    const group = byReason.get(key) ?? [];
+    group.push({ subject: e.subject, publicSubject: e.publicSubject });
+    byReason.set(key, group);
   }
-  for (const [reason, subjects] of byReason) {
+  for (const [reason, entries] of byReason) {
     // Chunk subjects leave in the author's units, not the run's. `chunk 28`
     // is bookkeeping — the id selects a rebuild command on stderr, and
     // nothing on the PR page maps it to code. #7268's posted body enumerated
     // all 49 of them, unsorted, across two of these sentences; the author's
     // units are their files and, at the limit, the diff itself, which is what
-    // `describeChunkGap` renders. Role labels stay verbatim: they were
-    // written to be read (`roleLabel`), and reworking them here would fork
-    // the register the stderr twin shares.
+    // `describeChunkGap` renders. Role subjects ride their `publicSubject`
+    // (`Brief.publicLabel`) — the codename stays on stderr, where it is the
+    // selector — and the partition below keys on the INTERNAL subject, so a
+    // public phrase can never shadow a chunk id out of the chunk collapse.
     const chunkIds: number[] = [];
     const named: string[] = [];
-    for (const s of subjects) {
-      const m = /^chunk (\d+)$/.exec(s);
+    for (const e of entries) {
+      const m = /^chunk (\d+)$/.exec(e.subject);
       if (m) chunkIds.push(Number(m[1]));
-      else named.push(s);
+      else named.push(e.publicSubject ?? e.subject);
     }
     const shown = [
       ...(chunkIds.length > 0

--- a/packages/cli/src/commands/review/lib/agent-briefs.ts
+++ b/packages/cli/src/commands/review/lib/agent-briefs.ts
@@ -57,6 +57,17 @@ export interface Brief {
   /** How the role is named to a human reading a coverage failure. */
   label: string;
   /**
+   * How the role is named in the POSTED review body — the author's register.
+   *
+   * `label` above carries the run's own codename (`Agent 1c: …`), which is the
+   * selector an operator acts on and means nothing on a PR page; #7550 moved
+   * chunk ids out of the posted body for exactly that reason, and this field
+   * does the same for role names: the dimension, said as what it checks.
+   * Distinct per role — two roles sharing a phrase would merge under one
+   * subject in a grouped disclosure.
+   */
+  publicLabel: string;
+  /**
    * Does a path rule belong in this agent's brief?
    *
    * The path-scoped checklists (see `path-rules.ts`) name defects in the *code*.
@@ -118,6 +129,7 @@ export interface Brief {
 export const BRIEFS: Record<RoleId, Brief> = {
   '0': {
     label: 'Agent 0: Issue fidelity & root-cause ownership',
+    publicLabel: 'the linked-issue fidelity pass',
     readsDiff: true,
     brief: `You are **Agent 0: Issue Fidelity & Root-Cause Ownership**. Your scope is issue fidelity, not general code review — do not report ordinary code defects; other agents own those.
 
@@ -140,6 +152,7 @@ If \`gh\` fails (auth, rate limit, network), **retry that fetch once**. If it fa
   '1a': {
     reviewsCode: true,
     label: 'Agent 1a: Line-by-line correctness',
+    publicLabel: 'the line-by-line correctness pass',
     readsDiff: true,
     brief: `You are **Agent 1a: the line-by-line scan**. Your dimension is defined by *how you walk*, not by a topic — a topical "find correctness bugs" brief makes every agent converge on the same visibly-suspicious hunks, which is redundancy, not coverage.
 
@@ -157,6 +170,7 @@ Scope guard: reading the enclosing function is for **context**. A defect entirel
   '1b': {
     reviewsCode: true,
     label: 'Agent 1b: Removed-behavior audit',
+    publicLabel: 'the removed-behavior audit',
     readsDiff: true,
     brief: `You are **Agent 1b: the removed-behavior audit**. You own the diff's **deleted side**, and you are the only agent who can see it: the \`-\` lines exist *only* in the diff. The post-change tree carries no trace of what was removed — the line is simply not there, and nothing marks where it was — so no agent reading the new code alone can find this class of defect.
 
@@ -174,6 +188,7 @@ Each failure scenario must name what input or state now slips past the removed b
   '1c': {
     reviewsCode: true,
     label: 'Agent 1c: Cross-file tracer',
+    publicLabel: 'the cross-file consistency pass',
     readsDiff: true,
     brief: `You are **Agent 1c: the cross-file tracer**. You own the *whole* cross-file walk, end to end. It used to be a duty shared by six agents, and a duty shared by six agents is a duty nobody finishes while the same symbols get grepped six times.
 
@@ -200,6 +215,7 @@ Expect the three ends to be far apart. The declaration, the pass-through, and th
   '2': {
     reviewsCode: true,
     label: 'Agent 2: Security',
+    publicLabel: 'the security pass',
     readsDiff: true,
     brief: `You are **Agent 2: Security**. Review the diff for:
 
@@ -216,6 +232,7 @@ Expect the three ends to be far apart. The declaration, the pass-through, and th
   '3': {
     reviewsCode: true,
     label: 'Agent 3: Code quality',
+    publicLabel: 'the code-quality pass',
     readsDiff: true,
     brief: `You are **Agent 3: Code Quality**. Review the diff for:
 
@@ -229,6 +246,7 @@ Expect the three ends to be far apart. The declaration, the pass-through, and th
   '4': {
     reviewsCode: true,
     label: 'Agent 4: Performance & efficiency',
+    publicLabel: 'the performance pass',
     readsDiff: true,
     brief: `You are **Agent 4: Performance & Efficiency**. Review the diff for:
 
@@ -243,6 +261,7 @@ Expect the three ends to be far apart. The declaration, the pass-through, and th
   '5': {
     reviewsCode: true,
     label: 'Agent 5: Test coverage',
+    publicLabel: 'the test-coverage pass',
     readsDiff: true,
     brief: `You are **Agent 5: Test Coverage**. Review the diff for:
 
@@ -259,6 +278,7 @@ Expect the three ends to be far apart. The declaration, the pass-through, and th
   '6a': {
     reviewsCode: true,
     label: 'Agent 6a: Undirected audit — attacker mindset',
+    publicLabel: 'the open-ended audit (attacker mindset)',
     readsDiff: true,
     brief: `You are **Agent 6a: the undirected audit, attacker mindset.**
 
@@ -278,6 +298,7 @@ You are undirected on purpose. Do not restrict yourself to the list.`,
   '6b': {
     reviewsCode: true,
     label: 'Agent 6b: Undirected audit — 3 AM oncall mindset',
+    publicLabel: 'the open-ended audit (oncall mindset)',
     readsDiff: true,
     brief: `You are **Agent 6b: the undirected audit, 3 AM oncall mindset.**
 
@@ -297,6 +318,7 @@ You are undirected on purpose. Do not restrict yourself to the list.`,
   '6c': {
     reviewsCode: true,
     label: 'Agent 6c: Undirected audit — six-months-later maintainer',
+    publicLabel: 'the open-ended audit (maintainer mindset)',
     readsDiff: true,
     brief: `You are **Agent 6c: the undirected audit, six-months-later maintainer mindset.**
 
@@ -315,6 +337,7 @@ You are undirected on purpose. Do not restrict yourself to the list.`,
 
   '7': {
     label: 'Agent 7: Build & test verification',
+    publicLabel: 'the build-and-test check',
     readsDiff: false,
     brief: `You are **Agent 7: Build & Test Verification**. You do not review the diff — you run the project's own deterministic checks and report what they say. Your evidence is **the commands you ran and their output**; a return that names no command has not done this job.
 
@@ -330,6 +353,7 @@ Use \`Source: [build]\` or \`Source: [test]\`, never \`[review]\`.`,
 
   'test-matrix': {
     label: 'Test coverage matrix (whole-diff)',
+    publicLabel: 'the whole-diff test-coverage check',
     readsDiff: true,
     brief: `You are the **test-coverage matrix** agent — Agent 5's cross-chunk counterpart. The territory agents each see either an implementation or a test, rarely both. You see the whole diff, so you own the pairing.
 
@@ -341,6 +365,7 @@ Use \`Source: [build]\` or \`Source: [test]\`, never \`[review]\`.`,
   'invariant-a': {
     reviewsCode: true,
     label: 'Invariant agent A: state, timers, collections',
+    publicLabel: 'the invariant check (state, timers, collections)',
     readsDiff: true,
     brief: `You are **invariant agent A: state, timers, and collections.**
 
@@ -358,6 +383,8 @@ Report a **Critical** for each violation, and give **both** locations that toget
   'invariant-b': {
     reviewsCode: true,
     label: 'Invariant agent B: counters, return values, error taxonomies',
+    publicLabel:
+      'the invariant check (counters, return values, error taxonomies)',
     readsDiff: true,
     brief: `You are **invariant agent B: counters, return values, and error taxonomies.**
 
@@ -375,6 +402,7 @@ Report a **Critical** for each violation, and give **both** locations that toget
   'invariant-c': {
     reviewsCode: true,
     label: 'Invariant agent C: config fields, early returns',
+    publicLabel: 'the invariant check (config fields, early returns)',
     readsDiff: true,
     brief: `You are **invariant agent C: config fields and early returns.**
 
@@ -393,6 +421,7 @@ Report a **Critical** for each violation, and give **both** locations that toget
     output: 'verdicts',
     acceptsFindings: true,
     label: 'Verification agent',
+    publicLabel: 'verification',
     readsDiff: true,
     brief: `You are a **verification agent**. You do not look for new problems — you rule on the findings you were handed, listed in the message that launched you, each with a file, a line, an issue, and a **failure scenario**. The failure scenario is the finding's testable claim, and your verdict is the **result of tracing it through the real code**, not a plausibility vote on how the finding reads.
 
@@ -422,6 +451,7 @@ Return, for each finding, one verdict:
     acceptsChunk: true,
     acceptsFindings: true,
     label: 'Reverse audit agent',
+    publicLabel: 'reverse audit',
     readsDiff: true,
     brief: `You are a **reverse audit agent**. Prior agents have already reviewed this diff and their confirmed findings are listed in the message that launched you. Your job is not to re-report them — it is to find the **gaps**: the important issues no prior agent or round caught.
 

--- a/packages/cli/src/commands/review/lib/coverage.ts
+++ b/packages/cli/src/commands/review/lib/coverage.ts
@@ -150,7 +150,24 @@ export interface CoverageFromTranscripts {
    * can carry anything), so a subject/reason boundary recovered from rendered
    * prose garbles exactly the entries it matters for.
    */
-  disclosures: Array<{ subject: string; reason: string }>;
+  disclosures: Array<{
+    subject: string;
+    reason: string;
+    /**
+     * The subject, said in the POSTED body's register (`Brief.publicLabel`) —
+     * absent when the internal subject already is that register (`chunk N`
+     * is translated downstream by `describeChunkGap`; `every dimension`,
+     * `coverage` and the Step 4/5 subjects are plain English). The internal
+     * `subject` stays the dedup and certification key, and the stderr twin
+     * keeps it: the codename is the selector an operator acts on.
+     */
+    publicSubject?: string;
+    /**
+     * The reason for the POSTED body, when the internal one carries something
+     * only an operator can use — today, the unread brief's filesystem path.
+     */
+    publicReason?: string;
+  }>;
   /**
    * Every planned chunk with the source files it covers, in plan order — the
    * body renderer's translation table. A chunk id is the run's own
@@ -280,6 +297,20 @@ function roleLabel(req: RequiredAgent): string {
   return req.file ? `${base} — ${req.file}` : base;
 }
 
+/**
+ * The same requirement, named for the PR author — or undefined when the
+ * internal label already is that register. A chunk requirement stays `chunk N`
+ * here on purpose: the body renderer translates chunk ids collectively
+ * (`describeChunkGap`), and a public subject would hide the id from that
+ * partition. The invariant agents' file rides `on`, not ` — `: in the posted
+ * sentence an em-dash reads as the subject/reason boundary.
+ */
+function publicRoleLabel(req: RequiredAgent): string | undefined {
+  if (req.role === 'chunk') return undefined;
+  const base = BRIEFS[req.role].publicLabel;
+  return req.file ? `${base} on ${req.file}` : base;
+}
+
 /** Something a reader can act on. `agentName` is `general-purpose` for all of them. */
 function label(rec: AgentRecord, chunk: number | null): string {
   if (chunk !== null) return `chunk ${chunk}`;
@@ -312,13 +343,25 @@ export function coverageFromTranscripts(
   const idleAgents: string[] = [];
   const unopenedAgents: string[] = [];
   const rewrittenPrompts: string[] = [];
-  const disclosures: Array<{ subject: string; reason: string }> = [];
+  const disclosures: CoverageFromTranscripts['disclosures'] = [];
   // The one source for both registers: the structural entry feeds the posted
   // body (compose-review), and the returned prose feeds the stderr arrays —
   // maintained as a pair, an edit to one and not the other would silently
-  // diverge what the operator reads from what the author was told.
-  const disclose = (subject: string, reason: string): string => {
-    disclosures.push({ subject, reason });
+  // diverge what the operator reads from what the author was told. `pub`
+  // carries the body-register variants; the returned prose always keeps the
+  // internal subject and reason, because stderr is where the codename and the
+  // path are the things a reader acts on.
+  const disclose = (
+    subject: string,
+    reason: string,
+    pub?: { subject?: string; reason?: string },
+  ): string => {
+    disclosures.push({
+      subject,
+      reason,
+      publicSubject: pub?.subject,
+      publicReason: pub?.reason,
+    });
     return `${subject} — ${reason}`;
   };
   const covered = new Set<number>();
@@ -596,6 +639,7 @@ export function coverageFromTranscripts(
             roleLabel(req),
             'no record shows its brief reaching an agent, so this dimension ' +
               'was reviewed, if at all, from a prompt the run wrote for itself',
+            { subject: publicRoleLabel(req) },
           ),
         );
       }
@@ -617,6 +661,7 @@ export function coverageFromTranscripts(
                 'transcript cannot certify two dimensions'
             : 'its prompt was built, but no agent on record was launched ' +
                 'with it',
+          { subject: publicRoleLabel(req) },
         ),
       );
       missingRoleSelectors.push(selectorOf(req));
@@ -646,11 +691,20 @@ export function coverageFromTranscripts(
       a.includes(JSON.stringify(brief)),
     );
     if (!opened) {
+      // The brief PATH is the operator's — it names the file to make the agent
+      // open. The author's copy drops it: a filesystem path in a posted PR
+      // body is the same register leak as a chunk id.
       unreadBriefs.push(
         disclose(
           roleLabel(req),
           `never opened its brief (${brief}), so it reviewed without the ` +
             'instructions it was launched to follow',
+          {
+            subject: publicRoleLabel(req),
+            reason:
+              'never opened its brief, so it reviewed without the ' +
+              'instructions it was launched to follow',
+          },
         ),
       );
     }
@@ -839,6 +893,39 @@ const VERIFY_GAP: GapText = {
   },
 };
 
+/**
+ * Both steps down the same way is ONE failure with two subjects, not two
+ * paragraphs. #7268's posted body carried the verify and reverse-audit
+ * `rewritten` sentences back to back, near-identical but for the tail — the
+ * same repetition the chunk grouping exists to kill, one layer up. Merged only
+ * on an EXACT shape match: mixed shapes have different mechanisms and
+ * different fixes, and a sentence vague enough to cover both would misname
+ * one of them. Each text keeps both steps' consequences and both honesty
+ * limits of its per-role twins: `not-built`/`not-launched` may not claim
+ * nobody ran, `rewritten` may not claim the brief never arrived. The
+ * remediation stays per-role — the two rebuild commands differ.
+ */
+const COMBINED_STEP45_GAP: Record<Exclude<Delivery, 'ok'>, string> = {
+  'not-built':
+    'neither the verifier nor the reverse auditor was launched with a prompt ' +
+    'this skill builds — the posted findings were ruled on, and the misses ' +
+    'the rest of the review left were hunted, if at all, without the briefs ' +
+    'this skill certifies against',
+  'not-launched':
+    'both prompts were built, but no agent was launched with either — the ' +
+    'posted findings cannot be counted as verified, and the pass that hunts ' +
+    'what the rest of the review missed cannot be certified',
+  rewritten:
+    'each ran and opened its brief, but neither was launched with the prompt ' +
+    'the CLI built — the launches were written by hand, so the posted ' +
+    'findings cannot be counted as verified, and what the agents were ' +
+    'actually asked is not what this skill certifies',
+  'brief-unread':
+    'each was launched with its built prompt and never opened its brief, so ' +
+    'the findings were ruled on without the verdict bar, and the audit ran ' +
+    'without the gaps-only method it was launched to follow',
+};
+
 export interface VerificationReport {
   /** True when every required Step 4/5 agent ran and read its brief. */
   ok: boolean;
@@ -962,7 +1049,6 @@ export function verificationGaps(
   );
   const reverse = bestDelivery(reverseKeys);
   if (reverse !== 'ok') {
-    gaps.push(`reverse audit — ${REVERSE_AUDIT_GAP[reverse].gap}`);
     // The fix template carries `--plan <plan>`; a literal `<plan>` pasted into a
     // POSIX shell parses as input redirection, so the one repair round Step 6
     // prescribes could never run. This function is handed the real path.
@@ -982,6 +1068,7 @@ export function verificationGaps(
   // findings, which are pre-confirmed and skip verification by design. A review that
   // confirmed nothing has nothing to verify.
   let unverifiedFindings = false;
+  let verify: Delivery | null = null;
   if (opts.postsFindings) {
     // The whole key family: `verify--<digest>` per shard (the record now folds
     // the findings in, so a launch that dropped them matches nothing), plus the
@@ -989,10 +1076,9 @@ export function verificationGaps(
     const verifyKeys = [...built.keys()].filter(
       (k) => k === 'verify' || k.startsWith('verify--'),
     );
-    const verify = bestDelivery(verifyKeys);
+    verify = bestDelivery(verifyKeys);
     if (verify !== 'ok') {
       unverifiedFindings = true;
-      gaps.push(`verification — ${VERIFY_GAP[verify].gap}`);
       remediation.push(
         `verification: ${VERIFY_GAP[verify].fix.replace(
           '--plan <plan>',
@@ -1001,6 +1087,24 @@ export function verificationGaps(
           () => `--plan ${shellQuotePath(planPath)}`,
         )}`,
       );
+    }
+  }
+
+  // The gaps, after both shapes are known: both steps failing the SAME way is
+  // one sentence with two subjects (see COMBINED_STEP45_GAP); anything else
+  // keeps its own precise text. The remediation above stays per-role either
+  // way — the two rebuild commands differ, and the combined sentence lands in
+  // the posted body while the fixes land on stderr.
+  if (reverse !== 'ok' && verify !== null && verify === reverse) {
+    gaps.push(
+      `verification and reverse audit — ${COMBINED_STEP45_GAP[reverse]}`,
+    );
+  } else {
+    if (reverse !== 'ok') {
+      gaps.push(`reverse audit — ${REVERSE_AUDIT_GAP[reverse].gap}`);
+    }
+    if (verify !== null && verify !== 'ok') {
+      gaps.push(`verification — ${VERIFY_GAP[verify].gap}`);
     }
   }
 


### PR DESCRIPTION
## What this PR does

Follow-up of #7550, which moved chunk ids out of `/review`'s posted body. Two operator registers were left in place, and this PR removes them — plus one repetition #7550 documented as a known follow-up:

- **Role codenames.** Roster role subjects rendered their internal labels — `Agent 1c: Cross-file tracer`, `Test coverage matrix (whole-diff)` — in the posted body. Every `Brief` now carries a `publicLabel` (the dimension said as what it checks: "the cross-file consistency pass", "the whole-diff test-coverage check"), and coverage's structural disclosures carry it as `publicSubject` beside the internal subject. The codename stays on stderr, where it is the selector an operator acts on; every dedup and certification check still keys on the internal subject, so a public phrase can never shadow a chunk id out of the chunk collapse.
- **Brief filesystem paths.** An unread brief's disclosure interpolated its path (`never opened its brief (/…/plan.briefs/….brief.md)`) into the posted body. The disclosure now carries a path-free `publicReason`; the path stays in the stderr twin. `compose-review` groups by the reason the body *prints*, so two unread briefs share one path-free sentence instead of repeating it per role.
- **Near-duplicate Step 4/5 sentences.** When verify and the reverse audit failed the same way, the body said it twice in two near-identical sentences. `verificationGaps` now merges same-shape failures into one sentence with both subjects and both consequences ("verification and reverse audit — each ran and opened its brief, but neither was launched with the prompt the CLI built…"). Mixed shapes keep their precise per-role texts — different mechanisms, different fixes — and the per-role rebuild commands stay on stderr either way.

## Why it's needed

Same principle as #7550: the posted body's reader is the PR author, and nothing on a PR page maps `Agent 1c` or a brief path to anything they can act on. The register comments in `coverage.ts` already require author-facing gap text; the commands were scrubbed, then the chunk ids, and this completes the nouns. The #7268 body that motivated #7550 carried all three leaks: two role codenames and back-to-back `rewritten` sentences for verify and the reverse audit.

The #7268 shape now renders as:

> ⚠️ This run could not certify that any of this diff was reviewed. Suggestions are inline. Not reviewed: 11 of the diff's 49 sections — launched with a prompt that is not the one the CLI built. Not reviewed: 38 of the diff's 49 sections — its prompt was built, but no agent on record was launched with it. Not reviewed: the whole-diff test-coverage check — no record shows its brief reaching an agent, so this dimension was reviewed, if at all, from a prompt the run wrote for itself. Not reviewed: verification and reverse audit — neither the verifier nor the reverse auditor was launched with a prompt this skill builds — the posted findings were ruled on, and the misses the rest of the review left were hunted, if at all, without the briefs this skill certifies against.

## Reviewer Test Plan

### How to verify

1. Simulate a run with a briefless `test-matrix` role: the posted body says "the whole-diff test-coverage check", never `Test coverage matrix (whole-diff)`; the stderr remediation still names `--role test-matrix`.
2. Simulate an agent that got its built prompt and never opened its brief: the body carries the path-free sentence, `grep '.brief.md'` on the body finds nothing, and the stderr twin still names the exact brief file.
3. Fail verify and the reverse audit the same way (e.g. both launches rewritten): one `verification and reverse audit — …` sentence, `remediation` still carries both `--role verify` and `--role reverse-audit` rebuild commands. Fail them differently: two precise per-role sentences, no merged aggregate.
4. `npx vitest run src/commands/review/` from `packages/cli` — 788 tests pass (4 new). `eslint --max-warnings 0` on the changed files passes; `tsc -p packages/cli` reports no errors under `commands/review`.

### Evidence (Before & After)

Before (#7268's posted body, abridged): "… Not reviewed: …, Test coverage matrix (whole-diff), Agent 1c: Cross-file tracer — its prompt was built, but no agent on record was launched with it. Not reviewed: reverse audit — an auditor ran and opened its brief, but no agent was launched with the prompt the CLI built — the launch was written by hand, and what the agent was actually asked is not what this skill certifies. Not reviewed: verification — a verifier ran and opened its brief, but no agent was launched with the prompt the CLI built — the launch was written by hand, and the posted findings cannot be counted as verified against it."

After: the body quoted above — role dimensions in the author's words, one sentence for the shared Step 4/5 failure, no codenames, no paths. No UI change, so screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

## Risk & Scope

- Main risk or tradeoff: the merged Step 4/5 sentence fires only on an exact delivery-shape match; mixed shapes intentionally stay two sentences, so some bodies remain longer than the minimum. The public labels must stay distinct per role — two roles sharing a phrase would merge under one subject in a grouped disclosure; the `Brief.publicLabel` doc comment states this invariant.
- Not validated / out of scope: the transcript-derived labels for idle/blind non-chunk agents (a launch prompt's first line) still render as-is in the rare case such an agent is not a chunk agent; posting behavior for zero-certified runs (post vs. suppress) is a separate design question.
- Breaking changes / migration notes: none. `disclosures` gains optional `publicSubject`/`publicReason` fields; `Brief` gains a required `publicLabel` (all 18 roles populated); stderr output is unchanged.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

#7550（把 chunk 编号移出 `/review` 公开 body）的后续。还有两处 operator 语域残留，本 PR 一并移除，外加一处 #7550 已注明的重复文案：

- **role 代号**：roster role 主语此前在公开 body 里渲染内部 label——`Agent 1c: Cross-file tracer`、`Test coverage matrix (whole-diff)`。现在每个 `Brief` 携带 `publicLabel`（用"它检查什么"来称呼这个维度："the cross-file consistency pass"、"the whole-diff test-coverage check"），coverage 的结构化披露在内部 subject 旁携带 `publicSubject`。代号保留在 stderr——那是 operator 执行修复命令的选择器；所有去重和认证检查仍以内部 subject 为键，公开短语永远不会把 chunk id 从收敛逻辑中遮蔽。
- **brief 文件路径**：unread brief 的披露此前把文件系统路径（`never opened its brief (/…/plan.briefs/….brief.md)`）插进公开 body。现在披露携带去掉路径的 `publicReason`，路径只留在 stderr 孪生文案里。`compose-review` 按 body **实际打印**的 reason 分组，两个 unread brief 共享一句话而不是每个 role 重复一遍。
- **Step 4/5 近重复句子**：verify 和 reverse audit 以同一形态失败时，body 此前用两句几乎相同的话说同一件事。`verificationGaps` 现在把同形态失败合并成一句、两个主语、两个后果；形态不同时保留各自精确文案——机制不同、修复不同——stderr 上的 per-role 重建命令两种情况下都完整保留。

## 为什么需要它

与 #7550 同一原则：公开 body 的读者是 PR 作者，PR 页面上没有任何东西能把 `Agent 1c` 或一条 brief 路径映射为作者可操作的信息。`coverage.ts` 的语域注释本来就要求 gap 文案面向作者；命令挡住了，chunk 编号挡住了，本 PR 补齐名词。触发 #7550 的 #7268 body 同时携带这三种泄漏：两个 role 代号、以及 verify 与 reverse audit 背靠背的 `rewritten` 句子。

#7268 形态现在渲染为英文部分引用的样子。

## Reviewer 测试计划

### 如何验证

1. 模拟 `test-matrix` role 未构建 brief 的 run：body 显示 "the whole-diff test-coverage check"，绝不出现 `Test coverage matrix (whole-diff)`；stderr 修复命令仍指名 `--role test-matrix`。
2. 模拟 agent 拿到构建的 prompt 但从未打开 brief：body 是去路径的句子（body 里 grep `.brief.md` 无结果），stderr 孪生文案仍指名确切的 brief 文件。
3. 让 verify 和 reverse audit 以同一形态失败（如都被改写 launch）：一句 `verification and reverse audit — …`，`remediation` 仍同时携带 `--role verify` 和 `--role reverse-audit`；以不同形态失败：两句各自精确的文案，无合并聚合。
4. 在 `packages/cli` 下 `npx vitest run src/commands/review/`——788 个测试通过（新增 4 个）；改动文件通过 `eslint --max-warnings 0`；`tsc -p packages/cli` 在 `commands/review` 下无错误。

### 证据（Before & After）

Before（#7268 的公开 body，节选）：role 代号直出 + verify / reverse audit 两句近重复文案。

After：英文部分引用的 body——维度用作者的语言、共享失败一句话、无代号、无路径。无 UI 变更，截图 N/A。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ 未测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ✅ 已测试   |

## 风险与范围

- 主要风险或权衡：Step 4/5 合并句只在 delivery 形态**完全一致**时触发；混合形态有意保留两句，因此部分 body 不是最短形式。publicLabel 必须每个 role 唯一——两个 role 共用短语会在分组披露中合并成一个主语；`Brief.publicLabel` 的文档注释写明了该不变量。
- 未验证或范围外：idle/blind 的非 chunk agent 从 transcript 推导的 label（launch prompt 首行）在罕见场景仍原样渲染；零认证 run 是否干脆不发评论是另一个独立的设计问题。
- Breaking changes / migration notes：无。`disclosures` 新增可选 `publicSubject`/`publicReason` 字段；`Brief` 新增必填 `publicLabel`（18 个 role 全部填充）；stderr 输出不变。

</details>
