### PR TITLE
feat(autofix): auto-rerun a check that died on infrastructure, once

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -131,13 +131,16 @@ env:
   NON_BLOCKING_CHECKS: '["review-pr"]'
   # Failed-check annotation patterns that mean the INFRASTRUCTURE died, not the
   # code — a self-hosted runner losing the server, the disk filling, a runner
-  # shutdown. Such a check is red for a reason unrelated to the PR and clears on
-  # a re-run (observed: #7490's E2E "runner lost communication" → green on the
-  # rerun). The scan auto-reruns those failed jobs ONCE, guarded by run_attempt
-  # so a persistent infra problem cannot loop. Deliberately conservative — only
-  # unambiguous machine failures, never a test-level timeout, which could be a
-  # real regression. Case-insensitive, matched against the check's annotations.
-  INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)'
+  # shutdown, or a git fetch/clone dying mid-transfer. Such a check is red for a
+  # reason unrelated to the PR and clears on a re-run (observed: #7490's E2E
+  # "runner lost communication"; #6506's checkout "RPC failed; curl 92" /
+  # "fetch-pack: invalid index-pack output" — both green on the rerun). The scan
+  # auto-reruns those failed jobs ONCE, guarded by run_attempt so a persistent
+  # infra problem cannot loop. Deliberately conservative — only unambiguous
+  # machine/transport failures, never a bare test-level timeout, which could be
+  # a real regression (a co-present timeout does not block a match — one
+  # matching line classifies the run). Case-insensitive, vs the annotations.
+  INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)|invalid index-pack output|RPC failed'
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1840,16 +1840,23 @@ jobs:
               FAILED_CRS="$(gh api --paginate "repos/${REPO}/commits/${PR_HEAD_OID}/check-runs" \
                 --jq '.check_runs[] | select(.conclusion == "failure")
                   | select(((.output.annotations_count // 0) > 0))
-                  | [(.id | tostring), (.details_url // "")] | @tsv' 2> /dev/null | sort -u || true)"
-              while IFS=$'\t' read -r CR_ID DETAILS_URL; do
+                  | [(.id | tostring), (.details_url // ""), (.name // "")] | @tsv' 2> /dev/null | sort -u || true)"
+              while IFS=$'\t' read -r CR_ID DETAILS_URL CR_NAME; do
                 [[ -n "${CR_ID}" && "${DETAILS_URL}" == *"/actions/runs/"* ]] || continue
                 RUN_ID="${DETAILS_URL#*/actions/runs/}"
                 RUN_ID="${RUN_ID%%/*}"
                 [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || continue
-                ANNS="$(gh api "repos/${REPO}/check-runs/${CR_ID}/annotations" \
+                ANNS="$(gh api --paginate "repos/${REPO}/check-runs/${CR_ID}/annotations" \
                   --jq '[.[].message] | join("\n")' 2> /dev/null || true)"
                 grep -qiE "${INFRA_FAILURE_SIGNATURES}" <<< "${ANNS}" || continue
-                ATTEMPT="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.run_attempt // 0' 2> /dev/null || echo 0)"
+                RUN_META="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '[(.run_attempt // 0), (.name // "")] | @tsv' 2> /dev/null || printf '0\t')"
+                ATTEMPT="${RUN_META%%$'\t'*}"
+                WF_NAME="${RUN_META#*$'\t'}"
+                # Mirror the gate's self-trigger guard: skip Qwen Autofix runs
+                # unless the check is a review-address job.
+                if [[ "${WF_NAME}" == "Qwen Autofix" && "${CR_NAME}" != review-address* ]]; then
+                  continue
+                fi
                 if [[ "${ATTEMPT}" == '1' ]]; then
                   if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs" > /dev/null 2>&1; then
                     echo "♻️ #${PR}: a check died on infrastructure (run ${RUN_ID}, attempt 1) — reran its failed jobs; not the PR's code"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -137,7 +137,7 @@ env:
   # so a persistent infra problem cannot loop. Deliberately conservative — only
   # unambiguous machine failures, never a test-level timeout, which could be a
   # real regression. Case-insensitive, matched against the check's annotations.
-  INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (?:was|has been) (?:lost|terminated)'
+  INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)'
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -129,6 +129,15 @@ env:
   # invisible to the scan even when it already had unaddressed feedback.
   # Names must match job ids in qwen-code-pr-review.yml; a test pins that.
   NON_BLOCKING_CHECKS: '["review-pr"]'
+  # Failed-check annotation patterns that mean the INFRASTRUCTURE died, not the
+  # code — a self-hosted runner losing the server, the disk filling, a runner
+  # shutdown. Such a check is red for a reason unrelated to the PR and clears on
+  # a re-run (observed: #7490's E2E "runner lost communication" → green on the
+  # rerun). The scan auto-reruns those failed jobs ONCE, guarded by run_attempt
+  # so a persistent infra problem cannot loop. Deliberately conservative — only
+  # unambiguous machine failures, never a test-level timeout, which could be a
+  # real regression. Case-insensitive, matched against the check's annotations.
+  INFRA_FAILURE_SIGNATURES: 'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (?:was|has been) (?:lost|terminated)'
   # Upper bound on review targets emitted per scan (fan-out defense-in-depth;
   # excess is logged and deferred to the next scan).
   MAX_TARGETS_PER_SCAN: '10'
@@ -1809,6 +1818,49 @@ jobs:
               ISSUE="${PR}"
             fi
             CHECKS_JSON="$(jq -c '.statusCheckRollup // []' <<< "${PR_META}")"
+
+            # Auto-rerun a check that died on INFRASTRUCTURE, not the code (see
+            # INFRA_FAILURE_SIGNATURES). Only reached when the PR has a FAILED
+            # check; then, for each, we read its annotations and — if they carry
+            # a machine-death signature — rerun that run's failed jobs ONCE. The
+            # once is enforced by run_attempt: a run already retried to attempt 2
+            # and still infra-failing is persistent, so we stop and leave it. No
+            # marker needed; the attempt counter is the guard, and after a rerun
+            # the attempt increments so the next scan skips it. Any API failure
+            # here is fail-safe: it just means no rerun.
+            PR_HEAD_OID="$(jq -r '.headRefOid // ""' <<< "${PR_META}")"
+            if [[ -n "${PR_HEAD_OID}" ]] && jq -e 'any(.[]; ((.conclusion // .state // "") | IN("FAILURE","FAILED","ERROR","TIMED_OUT","ACTION_REQUIRED")) and (((.workflowName // "") != "Qwen Autofix") or ((.name // "") | startswith("review-address"))))' <<< "${CHECKS_JSON}" > /dev/null 2>&1; then
+              RERAN_INFRA=false
+              # Failed check-runs on this head, with their run id and annotation
+              # count — fetched once. External statuses (no check-run) are absent
+              # here, which is fine: only Actions runs can be reran.
+              FAILED_CRS="$(gh api --paginate "repos/${REPO}/commits/${PR_HEAD_OID}/check-runs" \
+                --jq '.check_runs[] | select(.conclusion == "failure")
+                  | select(((.output.annotations_count // 0) > 0))
+                  | [(.id | tostring), (.details_url // "")] | @tsv' 2> /dev/null | sort -u || true)"
+              while IFS=$'\t' read -r CR_ID DETAILS_URL; do
+                [[ -n "${CR_ID}" && "${DETAILS_URL}" == *"/actions/runs/"* ]] || continue
+                RUN_ID="${DETAILS_URL#*/actions/runs/}"
+                RUN_ID="${RUN_ID%%/*}"
+                [[ "${RUN_ID}" =~ ^[0-9]+$ ]] || continue
+                ANNS="$(gh api "repos/${REPO}/check-runs/${CR_ID}/annotations" \
+                  --jq '[.[].message] | join("\n")' 2> /dev/null || true)"
+                grep -qiE "${INFRA_FAILURE_SIGNATURES}" <<< "${ANNS}" || continue
+                ATTEMPT="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.run_attempt // 0' 2> /dev/null || echo 0)"
+                if [[ "${ATTEMPT}" == '1' ]]; then
+                  if gh api -X POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs" > /dev/null 2>&1; then
+                    echo "♻️ #${PR}: a check died on infrastructure (run ${RUN_ID}, attempt 1) — reran its failed jobs; not the PR's code"
+                    fleet_row "${PR}" 'infra-reran' "infra failure (run ${RUN_ID}) reran once"
+                    RERAN_INFRA=true
+                    break
+                  fi
+                else
+                  echo "⚠️ #${PR}: infra failure persisted after a rerun (run ${RUN_ID}, attempt ${ATTEMPT}) — leaving for a human"
+                fi
+              done <<< "${FAILED_CRS}"
+              [[ "${RERAN_INFRA}" == 'true' ]] && continue
+            fi
+
             # startedAt is the only staleness clock: a check blocks only if it
             # started within the bound; one with no startedAt (queued, not yet
             # running) is not blocking (the next scan re-checks once it starts).

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -401,6 +401,124 @@ describe('qwen-autofix workflow', () => {
     expect(run([{ ...llm, name: 'resolve-pr' }])).toBe('true');
   });
 
+  it('auto-reruns a check that died on infrastructure, once, guarded by run_attempt', () => {
+    // A self-hosted runner losing the server (or the disk filling) reds a check
+    // for a reason unrelated to the PR; it clears on a rerun (#7490's E2E:
+    // "runner lost communication" → green on the rerun). The scan reruns such a
+    // failed job ONCE, and run_attempt is the guard: a run already at attempt 2
+    // and still infra-failing is persistent and left alone — no infinite loop.
+    const block = reviewScanJob.match(
+      /( {12}PR_HEAD_OID="\$\(jq -r '\.headRefOid[\s\S]*?\n {12}fi\n)\n {12}# startedAt is the only staleness/,
+    )?.[1];
+    expect(block).toBeTruthy();
+    const script = block.replace(/^ {12}/gm, '');
+
+    const run = ({ checks, annotations, attempt = 1, rerunOk = true }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'infra-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      // Stubbed gh: check-runs → one failed run-1 check-run with annotations;
+      // annotations → the given message; runs/{id} → run_attempt; POST
+      // rerun-failed-jobs → success/fail. Records the rerun POST.
+      // The workflow calls check-runs with a --jq filter that yields, per
+      // failed check-run WITH annotations, a `<id>\t<details_url>` line; the
+      // stub emits what that filter would produce (a single line when there is
+      // an annotation, nothing otherwise) rather than raw JSON the stub can't
+      // filter.
+      const crTsv = annotations
+        ? '42\thttps://github.com/o/r/actions/runs/9001/job/5\n'
+        : '';
+      writeFileSync(
+        join(bin, 'gh'),
+        [
+          '#!/usr/bin/env bash',
+          `echo "$*" >> ${JSON.stringify(join(dir, 'calls.log'))}`,
+          'args="$*"',
+          `case "$args" in`,
+          // %b so the \t/\n in the stubbed tsv become a real tab/newline (the
+          // filter's @tsv output), which `IFS=$'\\t' read` then splits.
+          `  *"/commits/"*"/check-runs"*) printf '%b' ${JSON.stringify(crTsv)}; exit 0;;`,
+          `  *"/check-runs/42/annotations"*) printf '%s' ${JSON.stringify(annotations || '')}; exit 0;;`,
+          `  *"/actions/runs/9001"*"rerun-failed-jobs"*) exit ${rerunOk ? 0 : 1};;`,
+          `  *"/actions/runs/9001"*) printf '${attempt}'; exit 0;;`,
+          'esac',
+          'exit 0',
+        ].join('\n'),
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const out = execFileSync(
+        'bash',
+        [
+          '-c',
+          `set -uo pipefail\nfleet_row(){ :; }\nfor _ in x; do\n${script}\nprintf 'FELL_THROUGH'\ndone`,
+        ],
+        {
+          env: {
+            ...process.env,
+            REPO: 'o/r',
+            PR: '1',
+            PR_META: JSON.stringify({ headRefOid: 'headSHA' }),
+            CHECKS_JSON: JSON.stringify(checks),
+            INFRA_FAILURE_SIGNATURES:
+              'lost communication with the server|No space left on device',
+            PATH: `${bin}:${process.env.PATH}`,
+          },
+          encoding: 'utf8',
+        },
+      );
+      const calls = existsSync(join(dir, 'calls.log'))
+        ? readFileSync(join(dir, 'calls.log'), 'utf8')
+        : '';
+      rmSync(dir, { recursive: true, force: true });
+      return {
+        reran: /rerun-failed-jobs/.test(calls),
+        continued: !out.includes('FELL_THROUGH'),
+      };
+    };
+    const FAIL = { name: 'E2E', conclusion: 'FAILURE' };
+    const OK = { name: 'E2E', conclusion: 'SUCCESS' };
+
+    // Infra death (runner lost the server) on attempt 1 → rerun & skip.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations:
+          'The self-hosted runner lost communication with the server',
+      }),
+    ).toEqual({ reran: true, continued: true });
+    // A REAL failure (no infra signature in the annotation) → never rerun; the
+    // agent/human handles it. This is the gate that stops masking real bugs.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'Expected 1 argument but got 2 — src/foo.ts:10',
+      }),
+    ).toEqual({ reran: false, continued: false });
+    // Already reran once (attempt 2) and still infra-failing → persistent, do
+    // not loop.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'No space left on device',
+        attempt: 2,
+      }),
+    ).toEqual({ reran: false, continued: false });
+    // No failed check at all → the block is skipped entirely.
+    expect(run({ checks: [OK], annotations: '' })).toEqual({
+      reran: false,
+      continued: false,
+    });
+    // Infra signature but the rerun POST fails (e.g. PAT lacks actions:write) →
+    // no crash, falls through to normal processing.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'No space left on device',
+        rerunOk: false,
+      }),
+    ).toEqual({ reran: true, continued: false });
+  });
+
   it('keeps a still-red check visible, but only once per head', () => {
     // A red check is a STATE, not the instant it turned red. Counting only
     // "failed since the watermark" made a still-failing PR invisible the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -460,7 +460,7 @@ describe('qwen-autofix workflow', () => {
             PR_META: JSON.stringify({ headRefOid: 'headSHA' }),
             CHECKS_JSON: JSON.stringify(checks),
             INFRA_FAILURE_SIGNATURES:
-              'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)',
+              'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)|invalid index-pack output|RPC failed',
             PATH: `${bin}:${process.env.PATH}`,
           },
           encoding: 'utf8',
@@ -527,12 +527,36 @@ describe('qwen-autofix workflow', () => {
       'The runner was terminated',
       'The runner has been lost',
       'The runner has been terminated',
+      'fatal: fetch-pack: invalid index-pack output',
+      'error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)',
     ]) {
       expect(run({ checks: [FAIL], annotations: msg })).toEqual({
         reran: true,
         continued: true,
       });
     }
+    // #6506: a git fetch died mid-checkout, then hung the job into the 20m
+    // limit. The bare timeout line is deliberately NOT a signature (it can be a
+    // real regression), but the transport death IS — and one matching line
+    // classifies the whole run, so the co-present timeout does not block it.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: [
+          'The job has exceeded the maximum execution time of 20m0s',
+          'fatal: fetch-pack: invalid index-pack output',
+          'error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)',
+        ].join('\n'),
+      }),
+    ).toEqual({ reran: true, continued: true });
+    // A BARE job timeout with no transport/infra signature is NOT rerun — it
+    // can be a real regression (a test hanging on the PR's own code).
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'The job has exceeded the maximum execution time of 20m0s',
+      }),
+    ).toEqual({ reran: false, continued: false });
     // Self-trigger guard: a "Qwen Autofix" workflow's own failed check must NOT
     // be rerun (prevents the autofix from re-triggering itself), UNLESS the
     // check is a review-address job (the exception carved out in the jq filter).
@@ -556,7 +580,9 @@ describe('qwen-autofix workflow', () => {
         annotations: 'No space left on device',
       }),
     ).toEqual({ reran: true, continued: true });
-  });
+    // Spawn-heavy: each run() forks bash + a stubbed gh. The default 5s per-test
+    // budget is tight for this many cases, so give it a comfortable margin.
+  }, 20000);
 
   it('keeps a still-red check visible, but only once per head', () => {
     // A red check is a STATE, not the instant it turned red. Counting only

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -413,7 +413,14 @@ describe('qwen-autofix workflow', () => {
     expect(block).toBeTruthy();
     const script = block.replace(/^ {12}/gm, '');
 
-    const run = ({ checks, annotations, attempt = 1, rerunOk = true }) => {
+    const run = ({
+      checks,
+      annotations,
+      attempt = 1,
+      rerunOk = true,
+      crName = 'E2E',
+      wfName = 'CI',
+    }) => {
       const dir = mkdtempSync(join(tmpdir(), 'infra-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
@@ -421,12 +428,12 @@ describe('qwen-autofix workflow', () => {
       // annotations → the given message; runs/{id} → run_attempt; POST
       // rerun-failed-jobs → success/fail. Records the rerun POST.
       // The workflow calls check-runs with a --jq filter that yields, per
-      // failed check-run WITH annotations, a `<id>\t<details_url>` line; the
-      // stub emits what that filter would produce (a single line when there is
-      // an annotation, nothing otherwise) rather than raw JSON the stub can't
-      // filter.
+      // failed check-run WITH annotations, a `<id>\t<details_url>\t<name>`
+      // line; the stub emits what that filter would produce (a single line
+      // when there is an annotation, nothing otherwise) rather than raw JSON
+      // the stub can't filter.
       const crTsv = annotations
-        ? '42\thttps://github.com/o/r/actions/runs/9001/job/5\n'
+        ? `42\thttps://github.com/o/r/actions/runs/9001/job/5\t${crName}\n`
         : '';
       writeFileSync(
         join(bin, 'gh'),
@@ -440,7 +447,7 @@ describe('qwen-autofix workflow', () => {
           `  *"/commits/"*"/check-runs"*) printf '%b' ${JSON.stringify(crTsv)}; exit 0;;`,
           `  *"/check-runs/42/annotations"*) printf '%s' ${JSON.stringify(annotations || '')}; exit 0;;`,
           `  *"/actions/runs/9001"*"rerun-failed-jobs"*) exit ${rerunOk ? 0 : 1};;`,
-          `  *"/actions/runs/9001"*) printf '${attempt}'; exit 0;;`,
+          `  *"/actions/runs/9001"*) printf '${attempt}\\t${wfName}'; exit 0;;`,
           'esac',
           'exit 0',
         ].join('\n'),
@@ -578,6 +585,28 @@ describe('qwen-autofix workflow', () => {
           },
         ],
         annotations: 'No space left on device',
+      }),
+    ).toEqual({ reran: true, continued: true });
+    // In-loop self-trigger guard: the gate above blocks a PR whose ONLY
+    // failed check is Qwen Autofix, but when a non-Autofix check ALSO failed
+    // the gate passes and FAILED_CRS returns ALL failed check-runs — the
+    // in-loop filter must skip the Autofix run so it cannot consume the
+    // single rerun slot.
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'No space left on device',
+        wfName: 'Qwen Autofix',
+      }),
+    ).toEqual({ reran: false, continued: false });
+    // …but a review-address job from the Autofix workflow IS rerun (the
+    // exception carved out in both the gate and the in-loop filter).
+    expect(
+      run({
+        checks: [FAIL],
+        annotations: 'No space left on device',
+        crName: 'review-address issue-123',
+        wfName: 'Qwen Autofix',
       }),
     ).toEqual({ reran: true, continued: true });
     // Spawn-heavy: each run() forks bash + a stubbed gh. The default 5s per-test

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -460,7 +460,7 @@ describe('qwen-autofix workflow', () => {
             PR_META: JSON.stringify({ headRefOid: 'headSHA' }),
             CHECKS_JSON: JSON.stringify(checks),
             INFRA_FAILURE_SIGNATURES:
-              'lost communication with the server|No space left on device',
+              'lost communication with the server|No space left on device|ENOSPC|received a shutdown signal|The runner has received|Failed to initialize container|runner (was|has been) (lost|terminated)',
             PATH: `${bin}:${process.env.PATH}`,
           },
           encoding: 'utf8',
@@ -517,6 +517,45 @@ describe('qwen-autofix workflow', () => {
         rerunOk: false,
       }),
     ).toEqual({ reran: true, continued: false });
+    // Each remaining production signature also triggers a rerun.
+    for (const msg of [
+      'ENOSPC',
+      'The runner has received a shutdown signal',
+      'The runner has received an unexpected signal',
+      'Failed to initialize container for job',
+      'The runner was lost',
+      'The runner was terminated',
+      'The runner has been lost',
+      'The runner has been terminated',
+    ]) {
+      expect(run({ checks: [FAIL], annotations: msg })).toEqual({
+        reran: true,
+        continued: true,
+      });
+    }
+    // Self-trigger guard: a "Qwen Autofix" workflow's own failed check must NOT
+    // be rerun (prevents the autofix from re-triggering itself), UNLESS the
+    // check is a review-address job (the exception carved out in the jq filter).
+    const AUTOFIX_CHECK = {
+      name: 'E2E',
+      conclusion: 'FAILURE',
+      workflowName: 'Qwen Autofix',
+    };
+    expect(
+      run({ checks: [AUTOFIX_CHECK], annotations: 'No space left on device' }),
+    ).toEqual({ reran: false, continued: false });
+    expect(
+      run({
+        checks: [
+          {
+            name: 'review-address issue-123',
+            conclusion: 'FAILURE',
+            workflowName: 'Qwen Autofix',
+          },
+        ],
+        annotations: 'No space left on device',
+      }),
+    ).toEqual({ reran: true, continued: true });
   });
 
   it('keeps a still-red check visible, but only once per head', () => {


### PR DESCRIPTION
## What this PR does

Teaches the autofix scan to automatically re-run a check that went red because the **infrastructure died** — a self-hosted runner losing the server, the disk filling — not because of the PR's code. Exactly once, guarded so it can never loop.

> **Update (follow-up commit `also treat a git fetch/clone transport death as infra`):** the whitelist now also covers a **git fetch/clone dying mid-transfer** — the motivating case being **#6506**, whose checkout failed with `fetch-pack: invalid index-pack output` and `RPC failed; curl 92 … CANCEL`, then hung into the 20m limit. Signatures `invalid index-pack output` and `RPC failed` were added. A co-present bare timeout line does **not** block the match (one matching line classifies the run); a **bare** timeout with no transport signature is still left alone (it can be a real regression). Both new signatures are pinned in the per-signature test loop, plus a case on #6506's real composite annotation and a bare-timeout-is-not-rerun guard.

## Why it's needed

`#7490`'s `web-shell E2E Smoke` failed with the annotation:

> **The self-hosted runner lost communication with the server.**

That is a machine death, unrelated to the PR (`#7490` only touches a workflow file). Re-running it made it **green** — the failure was transient. Today that took a human noticing and clicking "Re-run". This automates the recovery for that specific, recognisable class.

It is the transient-infra sibling of #7554: that PR merges current `main` when a check is red from a **stale base**; this one re-runs when a check died on the **runner**. Neither ever touches a check that is a genuine failure.

## How

Only when a PR actually has a failed check, for each such check the scan reads its **annotations** and, if they match `INFRA_FAILURE_SIGNATURES`, re-runs that run's failed jobs. Two design choices carry the safety:

1. **Conservative signature whitelist** — only unambiguous machine failures (`lost communication with the server`, `No space left on device`, `ENOSPC`, runner shutdown/init failures). **Never a test-level timeout**, which could be a real regression. A failure without an infra annotation is left for the agent/human.

2. **`run_attempt` is the one-shot guard, not a marker** — it re-runs only a run at `attempt == 1`. A run already retried to attempt 2 and still infra-failing is persistent, so it is left for a human. After a re-run the attempt increments, so the next scan will not re-run it. Self-limiting, no state to store.

Everything is fail-safe: any API call failing just means no re-run. The gate carries the same `review-address` carve-out as the other check selectors, so the loop never re-runs its own runs.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 94/94, three runs (one hits the pre-existing load flakes). The new test **replays the real extracted block** under bash with a stubbed `gh` (check-runs → annotations → run_attempt → POST rerun), over five cases:

   | failed check | annotation | attempt | → |
   | --- | --- | --- | --- |
   | E2E FAIL | "runner lost communication with the server" | 1 | **rerun + skip** |
   | E2E FAIL | "Expected 1 argument … src/foo.ts:10" (a real bug) | 1 | **no rerun** |
   | E2E FAIL | "No space left on device" | **2** | no rerun (already retried) |
   | E2E OK | — | — | block skipped (no failed check) |
   | E2E FAIL | "No space left on device", rerun POST **fails** | 1 | attempted, no crash, falls through |

2. Mutation-verified: removing the infra-signature gate (would re-run any red, masking real bugs) turns it red; removing the `attempt == 1` guard (would re-run forever) turns it red.

3. Static, run locally with the exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.

4. Post-merge smoke: when a self-hosted runner dies on a managed PR's check, the next scan should log `♻️ #N: a check died on infrastructure … reran its failed jobs` and the PR should recover, instead of a human clicking "Re-run".

### Evidence (Before & After)

```
BEFORE  runner dies mid-check -> red "runner lost communication"
        -> a human notices and clicks Re-run

AFTER   scan reads the annotation, sees the infra signature, run at attempt 1
        -> POST rerun-failed-jobs -> recovers; attempt 2, so no re-loop
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- **Dependency: the PAT must hold `actions: write`** to call `rerun-failed-jobs`. If it does not, the POST returns 403, is swallowed, and the PR simply isn't re-run (fail-safe, no crash) — but the feature is inert until the scope is granted. Flagging so a maintainer can confirm/grant it.
- Main tradeoff: a mis-classified real failure whose annotation happens to contain an infra phrase would be re-run once. The whitelist is deliberately narrow (machine-death phrases only), and the `attempt` guard bounds it to one wasted re-run even then.
- API cost: only for PRs with a failed check — one `check-runs` fetch plus one `annotations` + one `run` fetch per failed check with annotations. Red PRs are few.
- Not in scope: it does not re-run a check that failed on the CODE (no infra annotation) — that is the agent's/human's job; and it does not fix the infra itself. It also does not cover a check with no GitHub-Actions run (an external status), which cannot be re-run through this API.
- Breaking changes / migration notes: none.

## Linked Issues

Motivated by #7490's E2E dying on a runner-communication loss. Part of the autofix-reliability line: #7438, #7482, #7490, #7554.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

> **更新(跟进 commit `also treat a git fetch/clone transport death as infra`):** 白名单现在也覆盖 **git fetch/clone 传输中途死亡** —— 起因是 **#6506**:其 checkout 以 `fetch-pack: invalid index-pack output` 与 `RPC failed; curl 92 … CANCEL` 失败,随后拖到 20 分钟上限。新增签名 `invalid index-pack output` 与 `RPC failed`。同一 run 中共存的**裸超时行不会阻断匹配**(任一命中行即分类该 run);而**无任何传输签名的裸超时仍不重跑**(可能是真回归)。两个新签名在逐签名测试循环中锁定,另加一个 #6506 真实复合 annotation 用例与"裸超时不重跑"守卫。

让 autofix 扫描自动重跑一个**因基础设施死亡**而变红的检查 —— 自建 runner 掉线、磁盘满 —— 而非 PR 代码的问题。恰好一次,且由构造保证不会循环。

## 为什么需要

`#7490` 的 `web-shell E2E Smoke` 失败,annotation 是:**"The self-hosted runner lost communication with the server."** 这是机器死亡,与 PR 无关(#7490 只改了一个 workflow 文件)。重跑后变**绿** —— 是瞬时故障。今天这要靠人注意到并点 "Re-run"。本 PR 把这一可识别类别的恢复自动化。

它是 #7554(旧 base)的瞬时-infra 姊妹:那个在检查因**旧 base** 变红时合入当前 main;这个在检查因 **runner** 死亡变红时重跑。两者都绝不碰真正失败的检查。

## 怎么做

仅当 PR 确有失败检查时,对每个这样的检查读其 **annotations**,若匹配 `INFRA_FAILURE_SIGNATURES` 则重跑该 run 的失败作业。两个设计承载安全:

1. **保守的签名白名单** —— 只含无歧义的机器故障(`lost communication with the server`、`No space left on device`、`ENOSPC`、runner shutdown/init 失败)。**绝不含测试级超时**(那可能是真回归)。没有 infra annotation 的失败留给 agent/人。
2. **`run_attempt` 作为一次性守卫,而非 marker** —— 只重跑 `attempt == 1` 的 run。已重试到 attempt 2 仍 infra 失败的是持续故障,留给人;重跑后 attempt 递增,下次扫描不再重跑。自限,无需存状态。

一切失败安全:任一 API 调用失败即不重跑。该门带与其它检查选择器相同的 `review-address` carve-out,循环绝不重跑自己的运行。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 94/94,连跑三次。新测试用桩 `gh`(check-runs → annotations → run_attempt → POST rerun)在 bash 下**回放真实提取的块**,覆盖五种情形(见上方英文表格)。
2. 变异验证:去掉 infra 签名门(会重跑任何红、掩盖真 bug)变红;去掉 `attempt == 1` 守卫(会无限重跑)变红。
3. 静态(均用 CI 一致工具):YAML 可解析;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:当自建 runner 在某托管 PR 的检查上死亡,下一次扫描应打印 `♻️ #N: a check died on infrastructure … reran its failed jobs`,PR 自行恢复,而非靠人点 Re-run。

## 风险与范围

- **依赖:PAT 需持有 `actions: write`** 才能调 `rerun-failed-jobs`。若无,POST 返回 403、被吞掉、PR 不被重跑(失败安全、不崩),但在授予该 scope 前功能处于惰性。特此标注供维护者确认/授予。
- 主要权衡:一个被误分类的真实失败,若其 annotation 恰含 infra 短语,会被重跑一次。白名单刻意狭窄(仅机器死亡短语),且 `attempt` 守卫即便如此也只浪费一次重跑。
- API 成本:仅对有失败检查的 PR —— 一次 `check-runs` + 每个带 annotation 的失败检查一次 `annotations` + 一次 `run`。红 PR 很少。
- 不在范围内:不重跑因**代码**失败(无 infra annotation)的检查 —— 那是 agent/人的活;也不修 infra 本身;也不覆盖无 GitHub Actions run 的检查(外部状态),那无法经此 API 重跑。
- 破坏性变更:无。

## 关联 Issue

由 #7490 的 E2E 死于 runner 通信丢失促成。属 autofix 可靠性主线:#7438、#7482、#7490、#7554。

</details>

