### PR TITLE
fix(autofix): retry an agent timeout instead of advancing past its feedback

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2962,7 +2962,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md agent-api-error agent-api-error-kind resolved-comments.txt pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               cat "${WORKDIR}/${f}"
@@ -3264,6 +3264,16 @@ jobs:
             if [[ -s "${WORKDIR}/agent-api-error-kind" ]]; then
               API_ERROR_KIND="$(head -n 1 "${WORKDIR}/agent-api-error-kind" | tr -cd 'a-z')"
             fi
+            # A timeout means the agent evaluated NOTHING before its budget ran
+            # out (run-agent.mjs writes this signal). Routed to retry, not an
+            # evaluated advance — same as a pre-verdict crash. Bounded by the
+            # round cap and the consecutive-failure cap, so a PR that keeps
+            # timing out still stops; a one-off (usually followed by a good
+            # round) recovers on the next scan instead of stranding its feedback.
+            AGENT_TIMEOUT=''
+            if [[ -s "${WORKDIR}/agent-timeout" ]]; then
+              AGENT_TIMEOUT="$(head -n 1 "${WORKDIR}/agent-timeout" | cut -c1-120 | iconv -f utf-8 -t utf-8 -c || true)"
+            fi
             # If feedback was actually read (prepare ran), stamp its newest ts so
             # the watermark advances and the same feedback is not re-selected next
             # scan. If the crash happened before prepare, NEWEST is empty and the
@@ -3291,13 +3301,14 @@ jobs:
             MARK_TS="${NEWEST:-${WATERMARK:-9999-12-31T23:59:59Z}}"
             if [[ -n "${NEWEST:-}" ]]; then
               MARK_ROUND="$(( ROUND + 1 ))"
-              if [[ -z "${DETAIL_FILE}" || -n "${API_ERROR_DETAIL}" || "${GATE_CRASHED}" == 'true' ]]; then
-                # Prepare ran (NEWEST is set) but no verdict was reached. Three
-                # ways that happens, and in ALL of them the agent evaluated
-                # NOTHING: it produced no output at all (crashed before any
-                # verdict — a staged runner that fails to boot), it died on a
-                # model [API Error] (access/quota/5xx/transport), or the gate
-                # crashed after the agent wrote its summary. So the watermark
+              if [[ -z "${DETAIL_FILE}" || -n "${API_ERROR_DETAIL}" || -n "${AGENT_TIMEOUT}" || "${GATE_CRASHED}" == 'true' ]]; then
+                # Prepare ran (NEWEST is set) but no verdict was reached. Ways
+                # that happens, and in ALL of them the agent evaluated NOTHING:
+                # it produced no output at all (crashed before any verdict — a
+                # staged runner that fails to boot), it died on a model
+                # [API Error] (access/quota/5xx/transport), it TIMED OUT before
+                # finishing, or the gate crashed after the agent wrote its
+                # summary. So the watermark
                 # must NOT advance past this feedback: an advance makes the next
                 # scan see "nothing new" and never retry, stranding the PR on a
                 # transient failure (an infra blip, a quota reset minutes away, a
@@ -3319,6 +3330,13 @@ jobs:
                 if [[ -n "${API_ERROR_DETAIL}" ]]; then
                   CAUSE="could not reach the model — ${API_ERROR_DETAIL}"
                   LAST_FIX="a maintainer should check the autofix model key/access, then re-arm"
+                elif [[ -n "${AGENT_TIMEOUT}" ]]; then
+                  # A timeout evaluated nothing, so the feedback is unaddressed
+                  # and stays live for the retry. On a big / heavily-reviewed PR
+                  # this is usually a one-off; the last automatic attempt names
+                  # the real fix (split the PR or raise the budget).
+                  CAUSE="ran out of time before finishing (${AGENT_TIMEOUT})"
+                  LAST_FIX="a human should split the PR or raise the agent time budget, then re-arm"
                 elif [[ -z "${DETAIL_FILE}" ]]; then
                   CAUSE="crashed before it could evaluate the feedback"
                   LAST_FIX="a human should take over this PR"

--- a/.qwen/skills/autofix/scripts/run-agent.mjs
+++ b/.qwen/skills/autofix/scripts/run-agent.mjs
@@ -315,11 +315,24 @@ if (result.error || result.signal || result.status !== 0) {
           result.apiError ? ` ${result.apiError}` : ''
         }`,
       );
-      // Only a BARE, un-evaluated API failure is retryable. A loop guard, a
-      // timeout, or an agent-written failure.md is a real verdict — leave
-      // those terminal even if an API-error string appears in the output tail.
-      // Signals the workflow to retry (sentinel ts) instead of advancing the
-      // watermark and stranding the PR.
+      // A TIMEOUT evaluated NOTHING — the agent ran out of budget before
+      // finishing, so nothing was committed and the feedback is UNaddressed.
+      // Treat it like any other pre-verdict failure and RETRY (the workflow
+      // stamps a sentinel ts) rather than advancing the watermark and
+      // stranding the feedback the loop never actually handled. This is
+      // transient far more often than not — on a heavily-reviewed PR a
+      // timed-out round is usually followed by a successful one (#7471:
+      // rounds 11/13 timed out, 12 pushed) — and a PR that PERSISTENTLY times
+      // out is bounded by the consecutive-failure cap, not by one-shot
+      // terminal. A loop guard stays terminal (a tool-call loop is a real
+      // defect, not a budget blip), handled by the loopDetected branch above.
+      if (result.timedOut) {
+        writeFileSync(file(options.workdir, 'agent-timeout'), `${detail}\n`);
+      }
+      // Only a BARE, un-evaluated API failure is retryable. An agent-written
+      // failure.md is a real verdict — left terminal even if an API-error
+      // string appears in the output tail. Signals the workflow to retry
+      // (sentinel ts) instead of advancing the watermark and stranding the PR.
       if (result.apiError && !result.timedOut) {
         writeFileSync(
           file(options.workdir, 'agent-api-error'),

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4006,6 +4006,27 @@ describe('qwen-autofix workflow', () => {
     expect(noOutput.split('|')[0]).toBe(SENTINEL);
     expect(noOutput).toContain('crashed before it could evaluate the feedback');
 
+    // A TIMEOUT evaluated nothing → retry (sentinel), not an evaluated advance
+    // that would strand the unaddressed feedback. Even with OUTCOME=failed set
+    // by the gate (so GATE_CRASHED is false), the agent-timeout signal wins.
+    const timedOut = run({
+      OUTCOME: 'failed',
+      AGENT_TIMEOUT: 'timeout (3000000ms)',
+    });
+    expect(timedOut.split('|')[0]).toBe(SENTINEL);
+    expect(timedOut).toContain('ran out of time before finishing');
+    expect(timedOut).toContain('it will retry on the next scan');
+    // At the cap it names the real fix instead of promising a refused retry.
+    const timedOutCapped = run({
+      OUTCOME: 'failed',
+      AGENT_TIMEOUT: 'timeout (3000000ms)',
+      ROUND: '4',
+    });
+    expect(timedOutCapped).toContain('this was the last automatic attempt');
+    expect(timedOutCapped).toContain(
+      'split the PR or raise the agent time budget',
+    );
+
     // At the cap the gate crash names the operator fix rather than promising a
     // retry the scan's round gate would refuse.
     const capped = run({ OUTCOME: '', ROUND: '4' });
@@ -5687,6 +5708,16 @@ describe('qwen-autofix workflow', () => {
       expect(readFileSync(join(dir, 'failure.md'), 'utf8')).toContain(
         'timeout (100ms)',
       );
+      // A timeout drops the agent-timeout signal so the handoff routes it to a
+      // RETRY (sentinel ts), not an evaluated advance that strands the feedback
+      // the agent never finished addressing.
+      expect(existsSync(join(dir, 'agent-timeout'))).toBe(true);
+      expect(readFileSync(join(dir, 'agent-timeout'), 'utf8')).toContain(
+        'timeout (100ms)',
+      );
+      // It is NOT an API error — the api-error signal must stay absent so the
+      // model-key handoff is not shown for a budget timeout.
+      expect(existsSync(join(dir, 'agent-api-error'))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What this PR does

Makes an agent **timeout** during address-review retry the feedback instead of advancing the watermark past it — so a round that finished nothing does not strand the feedback it never addressed.

## Why it's needed

A timeout means the agent ran out of its 50-minute budget **before finishing**: nothing was committed, and the feedback is unaddressed. But the handoff treated it as an evaluated verdict — real timestamp, watermark advances — so the next scan sees "nothing new" and never retries. The batch the agent was mid-way through addressing is silently marked handled.

Observed on **#7471** (round 13/100), a heavily-reviewed 1871-line, 31-file PR:

```
round 11  TIMEOUT
round 12  push      ← the very next round succeeded
round 13  TIMEOUT   ← watermark advanced; no newer feedback → stranded
```

10 of 13 rounds pushed successfully — this is a healthy, active PR, not a stuck one. A timeout on it is transient far more often than not (round 11 timed out, round 12 pushed). Advancing past round 13's timeout left that feedback unhandled with nothing to re-trigger it.

This is the same principle as the crashes already handled — **if the agent evaluated nothing, the watermark must not advance** — applied to the one pre-verdict failure still treated as a verdict.

## How

- `run-agent.mjs` drops an `agent-timeout` signal file on `result.timedOut` (it already knew it timed out; it just did not surface it, by an explicit "timeout is a real verdict" choice this PR reverses).
- The handoff reads that signal and routes a timeout like a pre-verdict crash: **sentinel ts** (the feedback stays live) and a retry, with a cause line that at the round cap names the real fix — *split the PR or raise the agent time budget* — rather than promising a retry the round gate would refuse.

**Bounded, so it cannot loop.** The round counter still increments, and the consecutive-failure cap (#7482) stops a PR that keeps timing out. So a *persistent* timeout (a PR genuinely too big for the budget) still terminates for a human; only a *one-off* recovers on the next scan.

The loop guard stays terminal (a tool-call loop is a real defect, not a budget blip). An API error still routes to its own model-key handoff — the timeout signal is written only when it is **not** an API error.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` — 94/94, three runs (one hits the pre-existing load flakes). Two paths are covered end to end:
   - **run-agent side**: the existing real-timeout test (`QWEN_TIMEOUT_MS=100`, a hanging stub) now also asserts `agent-timeout` is written with the timeout detail, and `agent-api-error` is **not** (a budget timeout must not show the model-key handoff).
   - **handoff side**: the decision-block replay now drives a timeout with `OUTCOME=failed` (gate set it, so `GATE_CRASHED` is false) + `AGENT_TIMEOUT` set → sentinel ts, "ran out of time", "retry on the next scan"; and at the cap → "last automatic attempt", "split the PR or raise the agent time budget".

2. Mutation-verified: removing the `agent-timeout` write in run-agent turns the run-agent test red; removing `AGENT_TIMEOUT` from the handoff's retry condition turns the decision test red (it would advance and strand).

3. Static, run locally with the exact CI toolchain: `run-agent.mjs` passes `node --check`; `js-yaml` parses the workflow; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.

4. Post-merge smoke: a timed-out round should post `AutoFix ran out of time before finishing … it will retry on the next scan` and the next scan should re-select the PR, instead of a terminal "Could not address" that advances the watermark.

### Evidence (Before & After)

```
BEFORE  round times out -> "Could not address" (real ts) -> watermark advances
        -> next scan: nothing new -> feedback stranded, unaddressed

AFTER   round times out -> agent-timeout signal -> sentinel ts, "ran out of
        time … will retry" -> next scan re-selects and re-attempts
        (persistent timeout still bounded by the round + consecutive-failure caps)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- Main tradeoff: a timeout now costs another agent round (up to the cap) instead of stopping after one. On a genuinely-too-big PR that is more wasted runtime — but the consecutive-failure cap bounds it, and the far more common case (a one-off on a healthy PR) is exactly where the old behaviour was wrong.
- The change reverses a deliberate "timeout is terminal" choice in run-agent; that rationale (a timeout may recur) is now handled by the caps rather than by one-shot terminal. The comment is updated to say so.
- Not in scope: it does not change the timeout budget itself, and it does not affect the loop-guard or API-error paths (both keep their existing routing).
- Breaking changes / migration notes: none.

## Linked Issues

Found from #7471's round-13 timeout stranding a healthy, heavily-reviewed PR. Completes the "agent evaluated nothing → do not advance" line: #7490 (skipped Prepare), #7482 (consecutive-failure cap), and this (timeout).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 address-review 阶段的 agent **超时**去重试反馈,而不是把水位线推进过去 —— 这样一个什么都没做完的轮次,就不会把它没处理的反馈搁置掉。

## 为什么需要

超时意味着 agent 在 50 分钟预算内**没跑完**:什么都没提交,反馈没被处理。但交接却把它当成"已评估的判决"—— 真实时间戳、水位线推进 —— 于是下次扫描看到"无新反馈"、永不重试。agent 处理到一半的那批反馈被悄悄标记为已处理。

在 **#7471**(round 13/100)上实测,一个评审密集的 1871 行、31 文件大 PR:round 11 超时、**round 12 立刻推送成功**、round 13 又超时 → 水位线推进、无更新反馈 → 搁置。13 轮里 10 轮成功推送 —— 这是健康活跃的 PR,不是卡住。它上面的超时绝大多数是瞬时的。

这和已处理的各类崩溃是**同一原则** —— **agent 什么都没评估到,水位线就不该推进** —— 只是应用到最后一个仍被当作判决的读前失败上。

## 怎么做

- `run-agent.mjs` 在 `result.timedOut` 时落一个 `agent-timeout` 信号文件(它本就知道超时,只是刻意没暴露 —— 本 PR 反转了那个"超时是真实判决"的选择)。
- 交接读到该信号,把超时按读前崩溃处理:**sentinel ts**(反馈保持存活)+ 重试;在轮次上限处的成因文案点名真正的修复 —— *拆分 PR 或提高 agent 时间预算* —— 而非承诺一个轮次门会拒绝的重试。

**有界,不会循环**:轮次计数仍递增,#7482 的连续失败上限会停掉持续超时的 PR。所以*持续*超时(PR 确实太大)仍会终态交人;只有*偶发*超时才在下次扫描恢复。

loop guard 保持终态(工具调用死循环是真缺陷,非预算抖动)。API 错误仍走它自己的 model-key 交接 —— 超时信号只在**非** API 错误时写。

## 评审验证

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js` —— 94/94,连跑三次。两条路径端到端覆盖:run-agent 侧(既有真实超时测试新增断言 `agent-timeout` 被写、`agent-api-error` 不被写);交接侧(决策块回放:`OUTCOME=failed` + `AGENT_TIMEOUT` → sentinel、"ran out of time"、"retry";到上限 → "last automatic attempt"、"split the PR or raise the agent time budget")。
2. 变异验证:去掉 run-agent 的 `agent-timeout` 写入 → run-agent 测试红;去掉交接重试条件里的 `AGENT_TIMEOUT` → 决策测试红(会推进并搁置)。
3. 静态(均用 CI 一致工具):`run-agent.mjs` 过 `node --check`;YAML 可解析;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:超时轮次应发 `AutoFix ran out of time before finishing … it will retry on the next scan`,下次扫描重新选中,而非推进水位线的终态 "Could not address"。

## 风险与范围

- 主要权衡:超时现在会多花一个 agent 轮次(至上限)而非一次即停。在确实过大的 PR 上是更多浪费运行时 —— 但连续失败上限兜住它,而远更常见的情形(健康 PR 上的偶发超时)正是旧行为出错之处。
- 本改动反转了 run-agent 里刻意的"超时即终态"选择;其理由(超时可能复发)现由上限承担,而非一次性终态。注释已更新说明。
- 不在范围内:不改超时预算本身,也不影响 loop-guard 与 API-error 路径。
- 破坏性变更:无。

## 关联 Issue

由 #7471 的 round-13 超时搁置一个健康、评审密集的 PR 发现。补全"agent 什么都没评估到 → 不推进"主线:#7490(skipped Prepare)、#7482(连续失败上限)、以及本 PR(超时)。

</details>
