### PR TITLE
fix(autofix): make the review-address report comment fully bilingual

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3088,7 +3088,7 @@ jobs:
               echo "🧵 resolved ${RESOLVED_N} review thread(s) the agent implemented"
             fi
             {
-              echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on:"
+              echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
               echo
               # Neutralize the comment-opening token itself: model output
               # posted verbatim under the bot identity could smuggle a forged
@@ -3099,9 +3099,9 @@ jobs:
               # render away in markdown, so the visible text is unchanged.
               sed 's/<!--/<!\\-\\-/g' "${WORKDIR}/address-summary.md"
               echo
-              echo "Base-conflict check: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicted with main — resolved in this push.' || echo 'no conflict with main.')"
+              echo "Base-conflict check · 基分支冲突检查: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicted with main — resolved in this push. · 与 main 有冲突——已在本次推送中解决。' || echo 'no conflict with main. · 与 main 无冲突。')"
               echo
-              echo "Re-review when you have a moment. After round ${MAX_ROUNDS} this bot stops and leaves the PR for a human."
+              echo "Re-review when you have a moment. After round ${MAX_ROUNDS} this bot stops and leaves the PR for a human. · 有空请复审；第 ${MAX_ROUNDS} 轮后本 bot 停止并将 PR 交给人工。"
               echo
               echo "---"
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"
@@ -3114,11 +3114,11 @@ jobs:
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
             {
-              echo "🤖 Reviewed the latest feedback — no changes needed. Why, point by point:"
+              echo "🤖 Reviewed the latest feedback — no changes needed. Why, point by point: · 已审阅最新反馈——无需改动。逐点说明原因如下："
               echo
               sed 's/<!--/<!\\-\\-/g' "${WORKDIR}/no-action.md"
               echo
-              echo "Base-conflict check: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicts with main (no review fix needed, but a rebase/merge is required before merge).' || echo 'no conflict with main.')"
+              echo "Base-conflict check · 基分支冲突检查: $([[ "${CONFLICT}" == "true" ]] && echo 'conflicts with main (no review fix needed, but a rebase/merge is required before merge). · 与 main 有冲突（无需评审修复，但合并前需 rebase/merge）。' || echo 'no conflict with main. · 与 main 无冲突。')"
               echo
               echo "---"
               echo "🧠 Handled by **Qwen Code** · model/模型 \`${MODEL_DISPLAY}\`"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4365,6 +4365,33 @@ describe('qwen-autofix workflow', () => {
     ).toMatchObject({ consec: 2, terminal: false });
   });
 
+  it('posts the review-address report wrapper lines bilingually', () => {
+    // The agent's own address-summary.md / no-action.md ends with a collapsed
+    // Chinese block, but these workflow-appended wrapper lines sit OUTSIDE it —
+    // so each must carry its own inline translation (the `model/模型` footer in
+    // this same step is the idiom) or the posted comment is only half in
+    // Chinese. Pin the English↔Chinese pairs so a reword that drops the Chinese
+    // fails here. The English halves are load-bearing elsewhere too: the streak
+    // reset detector globs `*"Addressed the latest review feedback"*` and
+    // `*"no changes needed"*`, so they must stay verbatim.
+    for (const [en, zh] of [
+      ['Addressed the latest review feedback', '已处理最新评审反馈'],
+      ['Re-review when you have a moment', '有空请复审'],
+      ['Reviewed the latest feedback — no changes needed', '无需改动'],
+      ['conflicted with main — resolved in this push', '已在本次推送中解决'],
+      ['conflicts with main (no review fix needed', '合并前需 rebase/merge'],
+      ['no conflict with main', '与 main 无冲突'],
+    ]) {
+      expect(pushAndReportStep, `English anchor missing: ${en}`).toContain(en);
+      expect(pushAndReportStep, `Chinese missing for: ${en}`).toContain(zh);
+    }
+    // Every posted line in the step is either bilingual, the agent's own
+    // (already-bilingual) markdown, a structural token (---), or the footer
+    // (model/模型). Guard specifically that no Base-conflict label is emitted
+    // English-only.
+    expect(pushAndReportStep).not.toMatch(/echo "Base-conflict check:/);
+  });
+
   it('makes every known gate rejection declare its verdict', () => {
     // The retry/advance split above is only sound while each real rejection
     // writes outcome=failed; an unwired check would read as a gate crash and be


### PR DESCRIPTION
## What this PR does

Makes the **review-address report comment fully bilingual**. The agent's own markdown already ends with a collapsed Chinese translation, but the wrapper lines the *workflow* appends around it were English-only — so the posted comment was only half translated.

## Why it's needed

A review-address comment is assembled as: a `🤖 …` lead-in, then the agent's `address-summary.md` / `no-action.md` (which ends with a collapsed `中文说明` block), then a `Base-conflict check:` line, a `Re-review when you have a moment…` footer, and the `🧠 Handled by … model/模型` sign-off.

Three of those workflow-appended lines were **English-only and sat outside** the agent's Chinese block:

```
🤖 Reviewed the latest feedback — no changes needed. Why, point by point:   ← EN only
   …agent body + <details>中文说明</details>…                                ← bilingual
Base-conflict check: no conflict with main.                                  ← EN only
Re-review when you have a moment. After round N this bot stops…              ← EN only
🧠 Handled by Qwen Code · model/模型 `…`                                      ← already bilingual
```

Every other workflow-generated comment is already bilingual — the takeover-ack / re-arm / paused comments carry a full collapsed `中文说明` block, and the `model/模型` sign-off in this very report is inline-bilingual. These three lines just never followed suit.

## How

Each wrapper line gets an inline Chinese translation, using the `·` separator already established by the `model/模型` sign-off (inline is the right form here — the body already contains a `<details>` block, so a second one would be awkward). The **English halves are preserved verbatim**, because they are load-bearing:

- the streak-reset detector globs `*"Addressed the latest review feedback"*` and `*"no changes needed"*` on prior comment bodies;
- a test extracts these exact `echo` lines.

So behaviour is unchanged — only the Chinese is added, and old English-only comments already posted still match the detector. A new test (`posts the review-address report wrapper lines bilingually`) pins each English↔Chinese pair, so a future reword that drops the Chinese fails loudly.

**Out of scope (deliberate):** the terminal *handoff/failure* comment (`AutoFix could not start…`, `What I found before stopping`) is left English-only for now — SKILL.md keeps `handoff.md`/`failure.md` English-only by design, and several of those headlines are keyed by the reset detector and pinned by separate tests. Making the failure path bilingual is a larger, separate change.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js -t bilingually` — the new test passes; it asserts each wrapper line carries both its English anchor and its Chinese.
2. Mutation-verified: deleting any one Chinese phrase from the workflow turns the new test red with a `Chinese missing for: …` message. The existing streak-reset and emit-extraction tests still pass (the English substrings are untouched).
3. Full suite: 95/95 across three runs (one hits the pre-existing load flakes `eligibility recheck` / `permanent API failures terminal`, green on re-run).
4. Static, exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n` (the `Base-conflict check` lines keep their `$(…)` conditional intact); actionlint 1.7.12 clean; prettier clean.

### Evidence (Before & After)

```
BEFORE  Base-conflict check: no conflict with main.
        Re-review when you have a moment. After round 100 this bot stops…

AFTER   Base-conflict check · 基分支冲突检查: no conflict with main. · 与 main 无冲突。
        Re-review when you have a moment. After round 100 this bot stops… · 有空请复审；第 100 轮后本 bot 停止并将 PR 交给人工。
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- User-facing text only; no control-flow change. The English substrings the reset detector and extraction tests depend on are preserved verbatim.
- The `Base-conflict check` lines embed the Chinese inside the existing `$(… && echo '…' || echo '…')`; `bash -n` confirms the conditional still parses, and the phrases contain no single quote that would break the single-quoted echoes.
- Not in scope: the terminal handoff/failure comment (see above).
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up on the observation that a review-address comment (e.g. on #6433) rendered its wrapper lines in English only while the body was bilingual.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 **review-address 报告评论完全双语**。agent 自己的 markdown 已以折叠中文翻译结尾,但*工作流*在其外围追加的包裹行是纯英文 —— 于是发出的评论只翻译了一半。

## 为什么需要

一条 review-address 评论的组装是:`🤖 …` 开头 → agent 的 `address-summary.md` / `no-action.md`(以折叠 `中文说明` 块结尾)→ `Base-conflict check:` 行 → `Re-review when you have a moment…` 尾行 → `🧠 Handled by … model/模型` 落款。

其中三条工作流追加的行**纯英文、且落在** agent 中文块**之外**:开头 lead-in、`Base-conflict check`、`Re-review`。而其它工作流生成的评论早已双语 —— takeover-ack / re-arm / paused 都带完整折叠 `中文说明`,本报告里的 `model/模型` 落款也是内联双语。这三行只是没跟上。

## 怎么做

每条包裹行加内联中文,用 `model/模型` 落款已确立的 `·` 分隔(此处内联是对的 —— 正文已含 `<details>` 块,再套一个会别扭)。**英文半边逐字保留**,因为它们是承重的:

- 连续失败的重置检测器对历史评论体做 `*"Addressed the latest review feedback"*`、`*"no changes needed"*` 的 glob;
- 有测试提取这些确切的 `echo` 行。

所以行为不变 —— 只加中文,且已发出的旧纯英文评论仍能被检测器匹配。新测试(`posts the review-address report wrapper lines bilingually`)锁定每对英↔中,未来 reword 若丢掉中文会响亮报红。

**刻意不在范围内:** 终态 *handoff/failure* 评论(`AutoFix could not start…` 等)暂保持纯英文 —— SKILL.md 有意让 `handoff.md`/`failure.md` 纯英文,且其中若干 headline 被重置检测器 key 住并有独立测试锁定。把失败路径双语化是更大的独立改动。

## 评审验证

1. `npx vitest run ... -t bilingually` —— 新测试通过;断言每条包裹行同时带英文锚点与中文。
2. 变异验证:从工作流删掉任一中文短语 → 新测试以 `Chinese missing for: …` 报红。既有重置与 emit 提取测试仍通过(英文子串未动)。
3. 全量:95/95,连跑三次(一次命中既有 load flake,重跑即绿)。
4. 静态(CI 一致工具):YAML 可解析;37 个 `run:` 块过 `bash -n`(`Base-conflict check` 行保留 `$(…)` 条件);actionlint 1.7.12 clean;prettier clean。

## 风险与范围

- 仅用户可见文案,无控制流改动。重置检测器与提取测试依赖的英文子串逐字保留。
- `Base-conflict check` 行把中文嵌入既有 `$(… && echo '…' || echo '…')`;`bash -n` 确认条件仍可解析,短语内无会破坏单引号 echo 的单引号。
- 不在范围内:终态 handoff/failure 评论(见上)。
- 破坏性变更:无。

## 关联 Issue

源于观察到一条 review-address 评论(如 #6433)正文双语、但包裹行只有英文。

</details>
