### PR TITLE
fix(web-shell): expose managedId in artifact open requests

### DIFF
--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -66,6 +66,7 @@ export type TurnOutputOpenRequest =
       title: string;
       turnId: string;
       artifactId: string;
+      managedId?: string;
       artifact: DaemonSessionArtifact;
       workspaceActions?: DaemonWorkspaceActions;
       previewContent?: string;
@@ -154,6 +155,7 @@ function TurnOutputsComponent({
         title: artifact.title ?? 'Artifact',
         turnId,
         artifactId: artifact.id,
+        ...(artifact.managedId ? { managedId: artifact.managedId } : {}),
         artifact,
         ...(previewContent !== undefined ? { previewContent } : {}),
       });


### PR DESCRIPTION
## What this PR does

This exposes an artifact's optional `managedId` at the top level of the public right-panel open request. The complete artifact object remains available, so existing consumers are unchanged while external open handlers can directly distinguish the session artifact id from the managed resource locator.

## Why it's needed

Consumers can replace Web Shell's built-in artifact opening behavior with `onRightPanelOpen`. The callback currently exposes `artifactId`, which identifies the session artifact record, but does not directly expose the `managedId` needed to open content owned by an extension or another managed resource provider.

## Reviewer Test Plan

### How to verify

1. Register or supply an artifact with a `managedId`, then render Web Shell with an `onRightPanelOpen` handler.
2. Click the artifact's Open action and confirm the artifact request contains both the session `artifactId` and the managed resource `managedId`.
3. Confirm the complete artifact remains available on `request.artifact`, including `kind`, `metadata`, and its locator fields.
4. Confirm artifacts without a managed id and Web Shell's built-in artifact panel continue to behave as before in both the main chat and split panes.

Local verification completed with the Web Shell production build, typecheck, lint, changed-file formatting check, and 315 existing related tests. No test file is added by this PR.

### Evidence (Before & After)

Before: external artifact open handlers must inspect the nested artifact object to discover a managed resource locator, while the top-level request only exposes the session artifact id.

After: managed artifact requests expose `managedId` directly and retain the complete nested artifact object.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Web Shell package build and focused test suite on macOS.

## Risk & Scope

- Main risk or tradeoff: None beyond adding an optional field to an existing callback payload.
- Not validated / out of scope: Adding new artifact kinds or specialized renderers; manual browser testing on Windows and Linux.
- Breaking changes / migration notes: None. Existing handlers and built-in artifact behavior remain compatible.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 将 artifact 可选的 `managedId` 暴露到公共右侧面板打开请求的顶层。完整的 artifact 对象仍然保留，因此现有消费者不受影响，外部打开处理器可以直接区分 session artifact id 和托管资源 locator。

## 为什么需要

接入方可以通过 `onRightPanelOpen` 替换 Web Shell 内置的 artifact 打开行为。当前回调提供的 `artifactId` 用于标识 session 中的 artifact 记录，但没有直接提供打开扩展或其他托管资源提供方内容时所需的 `managedId`。

## Reviewer 测试计划

### 如何验证

1. 登记或提供一个包含 `managedId` 的 artifact，然后使用 `onRightPanelOpen` handler 渲染 Web Shell。
2. 点击 artifact 的“打开”操作，确认 artifact 请求同时包含 session `artifactId` 和托管资源 `managedId`。
3. 确认完整 artifact 仍位于 `request.artifact`，其中包括 `kind`、`metadata` 和 locator 字段。
4. 确认不包含 managed id 的 artifact 以及 Web Shell 内置 artifact 面板在主聊天和 split pane 中都保持原有行为。

本地已完成 Web Shell 生产构建、类型检查、lint、变更文件格式检查，以及 315 项现有相关测试。本 PR 不新增测试文件。

### 证据（修改前与修改后）

修改前：外部 artifact 打开处理器必须检查嵌套的 artifact 对象才能找到托管资源 locator，而顶层请求只提供 session artifact id。

修改后：托管 artifact 请求直接暴露 `managedId`，同时保留完整的嵌套 artifact 对象。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 上的本地 Web Shell 包构建和聚焦测试套件。

## 风险与范围

- 主要风险或权衡：除在现有回调 payload 中新增一个可选字段外，没有其他风险。
- 未验证 / 超出范围：新增 artifact kind 或专用 renderer；Windows 和 Linux 上的手动浏览器测试。
- 破坏性变更 / 迁移说明：无。现有 handler 和内置 artifact 行为保持兼容。

## 关联 Issue

无。

</details>
