### PR TITLE
fix(cli): prevent monitor notifications after task_stop

### DIFF
--- a/docs/design/monitor-cancel-notification.md
+++ b/docs/design/monitor-cancel-notification.md
@@ -1,0 +1,39 @@
+# Explicit Monitor Cancellation Notifications
+
+## Problem
+
+`task_stop` already returns a synchronous tool result confirming that a monitor
+was cancelled. The monitor registry also emits a terminal `cancelled`
+notification, which clients record as a notification user message and submit as
+a new model turn. A `running` event queued just before cancellation can cause the
+same extra turn even if the terminal notification is suppressed.
+
+## Design
+
+- Cancel monitors silently when cancellation comes from `task_stop`; the tool
+  result remains the user- and model-visible confirmation.
+- Keep the registry's default cancellation behavior unchanged for other callers.
+- At drain time, discard queued `running` monitor notifications whose registry
+  entry is now explicitly `cancelled`. This check applies to the interactive
+  queue, the persistent stream-json queue, and the one-shot headless queue.
+- Continue delivering natural `completed` and `failed` notifications, along with
+  terminal notifications emitted by non-`task_stop` cancellation paths.
+
+ACP already rejects `running` monitor notifications, so silent explicit
+cancellation is sufficient for that client.
+
+Owner-routed monitor notifications stay inside an agent's input queue rather
+than the user's conversation. They are outside this session-notification fix;
+in the common tool-call path, any queued event is delivered alongside the
+already-required `task_stop` tool result instead of creating a session turn.
+
+## Verification
+
+- `task_stop` cancels and aborts a monitor without invoking its notification
+  callback.
+- Each client drops a queued `running` event after the monitor is explicitly
+  cancelled.
+- Existing terminal-notification tests continue to demonstrate that natural
+  completion and failure are delivered.
+- A real model-driven `monitor` then `task_stop` run produces no follow-up
+  notification turn.

--- a/packages/cli/src/nonInteractive/session.test.ts
+++ b/packages/cli/src/nonInteractive/session.test.ts
@@ -60,6 +60,7 @@ interface ConfigOverrides {
 let mockMonitorRegistry: {
   setNotificationCallback: ReturnType<typeof vi.fn>;
   setRegisterCallback: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
   abortAll: ReturnType<typeof vi.fn>;
 };
 let mockBackgroundShellRegistry: {
@@ -190,6 +191,7 @@ describe('runNonInteractiveStreamJson', () => {
     mockMonitorRegistry = {
       setNotificationCallback: vi.fn(),
       setRegisterCallback: vi.fn(),
+      get: vi.fn().mockReturnValue({ status: 'running' }),
       abortAll: vi.fn(),
     };
     mockBackgroundShellRegistry = {
@@ -835,6 +837,65 @@ describe('runNonInteractiveStreamJson', () => {
         captureMonitorNotifications: false,
         captureMonitorRegistrations: false,
       }),
+    );
+  });
+
+  it('drops a queued running monitor event after cancellation', async () => {
+    const initRequest = createControlRequest('initialize');
+    const userMessage = createUserMessage('Start then stop a monitor');
+    let closeInput: (() => void) | undefined;
+    let monitorCallback:
+      | ((
+          displayText: string,
+          modelText: string,
+          meta: {
+            monitorId: string;
+            toolUseId?: string;
+            status: string;
+          },
+        ) => void)
+      | undefined;
+    let monitorStatus = 'running';
+
+    mockMonitorRegistry.get.mockImplementation(() => ({
+      status: monitorStatus,
+    }));
+    mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+      monitorCallback = cb;
+    });
+    runNonInteractiveMock.mockImplementationOnce(async () => {
+      monitorCallback?.(
+        'Monitor "logs" event #1: ready',
+        '<task-notification>running</task-notification>',
+        {
+          monitorId: 'mon_1',
+          toolUseId: 'tool_mon_1',
+          status: 'running',
+        },
+      );
+      monitorStatus = 'cancelled';
+    });
+
+    mockInputReader.read = async function* () {
+      yield initRequest;
+      yield userMessage;
+      await new Promise<void>((resolve) => {
+        closeInput = resolve;
+      });
+    };
+
+    const sessionPromise = runNonInteractiveStreamJson(config, '');
+    await vi.waitFor(() => {
+      expect(runNonInteractiveMock).toHaveBeenCalledTimes(1);
+    });
+    closeInput?.();
+    await sessionPromise;
+
+    expect(runNonInteractiveMock).toHaveBeenCalledTimes(1);
+    expect(mockOutputAdapter.emitUserMessage).not.toHaveBeenCalled();
+    expect(mockOutputAdapter.emitSystemMessage).not.toHaveBeenCalledWith(
+      'task_notification',
+      expect.anything(),
     );
   });
 

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -598,6 +598,19 @@ class Session {
   ): Promise<void> {
     await this.waitForInitialization();
 
+    batch = batch.filter((item) => {
+      if (item.sdkNotification.status !== 'running') {
+        return true;
+      }
+      return (
+        this.config.getMonitorRegistry().get(item.sdkNotification.task_id)
+          ?.status !== 'cancelled'
+      );
+    });
+    if (batch.length === 0) {
+      return;
+    }
+
     for (const item of batch) {
       this.outputAdapter.emitUserMessage([{ text: item.displayText }]);
       this.outputAdapter.emitSystemMessage(

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -3283,6 +3283,95 @@ describe('runNonInteractive', () => {
     expect(userEnvelopes).toHaveLength(0);
   });
 
+  it('drops a queued running monitor event after cancellation', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue(
+      OutputFormat.STREAM_JSON,
+    );
+    (mockConfig.getIncludePartialMessages as Mock).mockReturnValue(false);
+    setupMetricsMock();
+
+    const writes: string[] = [];
+    processStdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+      if (typeof chunk === 'string') {
+        writes.push(chunk);
+      } else {
+        writes.push(Buffer.from(chunk).toString('utf8'));
+      }
+      return true;
+    });
+
+    const notificationXml =
+      '<task-notification>\n' +
+      '<task-id>mon_1</task-id>\n' +
+      '<kind>monitor</kind>\n' +
+      '<status>running</status>\n' +
+      '<summary>Monitor emitted event #1.</summary>\n' +
+      '<result>ready</result>\n' +
+      '</task-notification>';
+    let monitorStatus = 'running';
+    mockMonitorRegistry.get.mockImplementation(() => ({
+      status: monitorStatus,
+    }));
+    mockMonitorRegistry.setNotificationCallback.mockImplementation((cb) => {
+      if (!cb) return;
+      cb('Monitor "logs" event #1: ready', notificationXml, {
+        monitorId: 'mon_1',
+        toolUseId: 'tool_mon_1',
+        status: 'running',
+        eventCount: 1,
+      });
+      monitorStatus = 'cancelled';
+    });
+    mockGeminiClient.sendMessageStream.mockReturnValueOnce(
+      createStreamFromEvents([
+        { type: GeminiEventType.Content, value: 'Monitor stopped.' },
+        {
+          type: GeminiEventType.Finished,
+          value: {
+            reason: undefined,
+            usageMetadata: { totalTokenCount: 2 },
+          },
+        },
+      ]),
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Start then stop a monitor',
+      'prompt-monitor-cancel',
+    );
+
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(1);
+    const envelopes = writes
+      .join('')
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+    expect(
+      envelopes.some(
+        (env) =>
+          env.type === 'user' &&
+          Array.isArray(env.message?.content) &&
+          env.message.content.some(
+            (block: unknown) =>
+              typeof block === 'object' &&
+              block !== null &&
+              'text' in block &&
+              block.text === 'Monitor "logs" event #1: ready',
+          ),
+      ),
+    ).toBe(false);
+    expect(
+      envelopes.some(
+        (env) =>
+          env.type === 'system' &&
+          env.subtype === 'task_notification' &&
+          env.data?.task_id === 'mon_1',
+      ),
+    ).toBe(false);
+  });
+
   it('does not let late monitor output keep one-shot runs alive', async () => {
     (mockConfig.getOutputFormat as Mock).mockReturnValue(
       OutputFormat.STREAM_JSON,

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -456,6 +456,7 @@ export async function runNonInteractive(
       displayText: string;
       modelText: string;
       sendMessageType: SendMessageType;
+      monitorId?: string;
       sdkNotification?: {
         task_id: string;
         tool_use_id?: string;
@@ -469,6 +470,13 @@ export async function runNonInteractive(
     }
     const localQueue: LocalQueueItem[] = [];
     const sdkOnlyMonitorQueue: LocalQueueItem[] = [];
+    const isCancelledMonitorEvent = (item: LocalQueueItem) =>
+      Boolean(
+        item.monitorId &&
+          item.sdkNotification?.status === 'running' &&
+          config.getMonitorRegistry().get(item.monitorId)?.status ===
+            'cancelled',
+      );
     const emitNotificationToSdk = (item: LocalQueueItem) => {
       if (item.sendMessageType !== SendMessageType.Notification) return;
       adapter.emitUserMessage([{ text: item.displayText }]);
@@ -478,7 +486,10 @@ export async function runNonInteractive(
     };
     const flushQueuedNotificationsToSdk = (queue: LocalQueueItem[]) => {
       while (queue.length > 0) {
-        emitNotificationToSdk(queue.shift()!);
+        const item = queue.shift()!;
+        if (!isCancelledMonitorEvent(item)) {
+          emitNotificationToSdk(item);
+        }
       }
     };
     let captureMonitorTurnsInLocalQueue = true;
@@ -935,6 +946,7 @@ export async function runNonInteractive(
               displayText,
               modelText,
               sendMessageType: SendMessageType.Notification,
+              monitorId: meta.monitorId,
               sdkNotification: {
                 task_id: meta.monitorId,
                 tool_use_id: meta.toolUseId,
@@ -1884,7 +1896,9 @@ export async function runNonInteractive(
                 splitIdx++;
               }
             }
-            const batch = localQueue.splice(0, splitIdx);
+            const batch = localQueue
+              .splice(0, splitIdx)
+              .filter((item) => !isCancelledMonitorEvent(item));
 
             if (batch.length === 0) return;
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -203,6 +203,10 @@ describe('useGeminiStream', () => {
   let mockCancelAllToolCalls: Mock;
   let mockMarkToolsAsSubmitted: Mock;
   let mockBackgroundShellRegistry: { setNotificationCallback: Mock };
+  let mockMonitorRegistry: {
+    setNotificationCallback: Mock;
+    get: Mock;
+  };
   let handleAtCommandSpy: MockInstance;
 
   beforeEach(() => {
@@ -234,6 +238,10 @@ describe('useGeminiStream', () => {
     };
     mockBackgroundShellRegistry = {
       setNotificationCallback: vi.fn(),
+    };
+    mockMonitorRegistry = {
+      setNotificationCallback: vi.fn(),
+      get: vi.fn().mockReturnValue({ status: 'running' }),
     };
 
     mockConfig = {
@@ -288,9 +296,7 @@ describe('useGeminiStream', () => {
         setNotificationCallback: vi.fn(),
       })),
       getBackgroundShellRegistry: vi.fn(() => mockBackgroundShellRegistry),
-      getMonitorRegistry: vi.fn(() => ({
-        setNotificationCallback: vi.fn(),
-      })),
+      getMonitorRegistry: vi.fn(() => mockMonitorRegistry),
     } as unknown as Config;
     mockOnDebugMessage = vi.fn();
     mockHandleSlashCommand = vi.fn().mockResolvedValue(false);
@@ -6970,6 +6976,41 @@ describe('useGeminiStream', () => {
         expect(
           mockSendMessageStream.mock.calls[0][3].modelOverride,
         ).toBeUndefined();
+      });
+
+      it('drops a queued running monitor event after cancellation', async () => {
+        let monitorStatus = 'running';
+        mockMonitorRegistry.get.mockImplementation(() => ({
+          status: monitorStatus,
+        }));
+        renderTestHook();
+
+        const callback = mockMonitorRegistry.setNotificationCallback.mock
+          .calls[0][0] as (
+          displayText: string,
+          modelText: string,
+          meta: {
+            monitorId: string;
+            status: string;
+          },
+        ) => void;
+        mockSendMessageStream.mockClear();
+        mockAddItem.mockClear();
+
+        await act(async () => {
+          callback(
+            'Monitor "logs" event #1: ready',
+            '<task-notification>running</task-notification>',
+            { monitorId: 'mon_1', status: 'running' },
+          );
+          monitorStatus = 'cancelled';
+        });
+
+        expect(mockSendMessageStream).not.toHaveBeenCalled();
+        expect(mockAddItem).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'notification' }),
+          expect.any(Number),
+        );
       });
 
       // Regression for #7156: progress setState calls issued from inside a

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3763,6 +3763,7 @@ export const useGeminiStream = (
       displayText: string;
       modelText: string;
       sendMessageType: SendMessageType;
+      monitor?: { id: string; status: string };
       onDelivered?: () => void;
       onDeliveryFailed?: () => void;
     }>
@@ -3922,6 +3923,7 @@ export const useGeminiStream = (
         displayText,
         modelText,
         sendMessageType: SendMessageType.Notification,
+        monitor: { id: meta.monitorId, status: meta.status },
       });
       setNotificationTrigger((n) => n + 1);
     });
@@ -3953,6 +3955,19 @@ export const useGeminiStream = (
       // triggered the commit.
       runOutsideAgentContext(() => {
         const queue = notificationQueueRef.current;
+        const monitorRegistry = config.getMonitorRegistry();
+        for (let i = queue.length - 1; i >= 0; i--) {
+          const monitor = queue[i]!.monitor;
+          if (
+            monitor?.status === 'running' &&
+            monitorRegistry.get(monitor.id)?.status === 'cancelled'
+          ) {
+            queue.splice(i, 1);
+          }
+        }
+        if (queue.length === 0) {
+          return;
+        }
         const targetType = queue[0]!.sendMessageType;
 
         // Cron prompts must run as individual turns — each needs its own
@@ -3997,7 +4012,7 @@ export const useGeminiStream = (
         });
       });
     }
-  }, [streamingState, submitQuery, notificationTrigger, addItem]);
+  }, [streamingState, submitQuery, notificationTrigger, addItem, config]);
 
   // ─── Teammate message integration ─────────────────────────
   // Each entry carries the full nonce-tagged envelope (`modelText`,

--- a/packages/core/src/tools/task-stop.test.ts
+++ b/packages/core/src/tools/task-stop.test.ts
@@ -233,6 +233,8 @@ describe('TaskStopTool', () => {
   describe('monitor support', () => {
     it('cancels a running monitor', async () => {
       const ac = new AbortController();
+      const notificationCallback = vi.fn();
+      monitorRegistry.setNotificationCallback(notificationCallback);
       monitorRegistry.register({
         monitorId: 'mon_123',
         command: 'tail -f app.log',
@@ -259,6 +261,7 @@ describe('TaskStopTool', () => {
       expect(result.returnDisplay).toContain('watch app log');
       expect(monitorRegistry.get('mon_123')!.status).toBe('cancelled');
       expect(ac.signal.aborted).toBe(true);
+      expect(notificationCallback).not.toHaveBeenCalled();
     });
 
     it('returns NOT_RUNNING when the monitor already completed', async () => {

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -122,7 +122,7 @@ class TaskStopInvocation extends BaseToolInvocation<
       if (monitorEntry.status !== 'running') {
         return notRunningError('monitor', taskId, monitorEntry.status);
       }
-      monitorRegistry.cancel(taskId);
+      monitorRegistry.cancel(taskId, { notify: false });
       return {
         llmContent:
           // Unlike background shells (which settle asynchronously when the


### PR DESCRIPTION
## What this PR does

Explicit monitor cancellation now uses the existing silent cancellation path because the synchronous tool result already confirms the action. Session notification queues also retain monitor identity long enough to discard a queued running event when that monitor has since been explicitly cancelled. Natural completion and failure notifications remain unchanged.

## Why it's needed

Stopping a monitor could emit a cancelled notification and drain an already queued running event after the original tool turn. Both were recorded as notification user messages and could wake the model again, polluting the conversation and consuming another full-history request.

## Reviewer Test Plan

### How to verify

1. In one-shot stream-json mode, ask the model to start a monitor that repeatedly prints a line, immediately stop the returned monitor task, return `STOPPED`, and return `NOTIFICATION_ACK` only if a later task notification arrives.
2. Confirm the model calls both monitor and task stop, returns `STOPPED`, emits no notification user envelope or monitor task-notification after cancellation, and never returns `NOTIFICATION_ACK`.
3. Confirm a naturally completed or failed monitor still reaches the existing notification path.

### Evidence (Before & After)

Before: the real reproduction recorded a notification user message after cancellation and made an extra model request with 17,395 input tokens, followed by `NOTIFICATION_ACK`.

After: a real `qwen3.6-max-preview` run called monitor once and task stop once, then returned only `STOPPED`. Its 16-line JSONL contained zero notification user records and zero `NOTIFICATION_ACK` responses, and the monitored process was absent after exit. Final verification session: `41558468-2323-4df8-a3a9-f98dba1b1279`.

Automated verification: full lint and typecheck passed; 299 targeted tests passed with one pre-existing skip; the full repository build passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local development entrypoint in one-shot stream-json mode, safe mode enabled, approval mode `yolo`, no sandbox, real `qwen3.6-max-preview` model through an OpenAI-compatible endpoint.

## Risk & Scope

- Main risk or tradeoff: queued running events are discarded only when the current registry state is explicitly cancelled, so events that race with natural completion or failure remain deliverable.
- Not validated / out of scope: real interactive TUI behavior and Windows/Linux runtime behavior; those paths are covered by focused unit tests or CI.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #7566

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

显式取消 monitor 时改用已有的静默取消路径，因为同步工具结果已经确认了取消动作。会话通知队列也会保留 monitor 标识，以便在消费前发现该 monitor 已被显式取消时，丢弃此前排队的 running 事件。自然完成和失败通知保持不变。

## 为什么需要

停止 monitor 后，系统可能同时发送 cancelled 通知，并在原始工具回合结束后继续消费一个已经排队的 running 事件。两者都会被记录为 notification 用户消息并再次唤醒模型，污染对话记录并额外消耗一次完整历史请求。

## Reviewer Test Plan

### 如何验证

1. 在 one-shot stream-json 模式下，让模型启动一个持续输出文本行的 monitor，立即停止返回的 monitor 任务，然后返回 `STOPPED`；仅当稍后收到任务通知时才返回 `NOTIFICATION_ACK`。
2. 确认模型实际调用 monitor 和 task stop，返回 `STOPPED`，取消后不输出 notification 用户 envelope 或 monitor task-notification，也不返回 `NOTIFICATION_ACK`。
3. 确认自然完成或失败的 monitor 仍会进入现有通知路径。

### Before & After 证据

修复前：真实复现会在取消后记录一条 notification 用户消息，并额外发起一次包含 17,395 个输入 token 的模型请求，随后返回 `NOTIFICATION_ACK`。

修复后：真实 `qwen3.6-max-preview` 调用分别执行了一次 monitor 和 task stop，最终只返回 `STOPPED`。对应 16 行 JSONL 中 notification 用户记录为 0，`NOTIFICATION_ACK` 为 0，退出后没有残留的 monitor 进程。最终验证会话：`41558468-2323-4df8-a3a9-f98dba1b1279`。

自动化验证：全仓 lint 和 typecheck 通过；299 个定向测试通过，另有 1 个既有 skip；全仓 build 通过。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地开发入口，one-shot stream-json 模式，启用 safe mode，approval mode 为 `yolo`，未启用 sandbox，通过 OpenAI-compatible endpoint 真实调用 `qwen3.6-max-preview`。

## 风险与范围

- 主要风险或取舍：仅当 registry 当前状态明确为 cancelled 时才丢弃已排队的 running 事件，因此与自然完成或失败竞态的事件仍可正常投递。
- 未验证 / 范围外：真实交互式 TUI 行为以及 Windows/Linux 运行时行为；相关路径由定向单测或 CI 覆盖。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Resolves #7566

</details>
