### PR TITLE
fix(core,cli): isolate teammate leader turns from agent context

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -1128,6 +1128,42 @@ describe('useGeminiStream', () => {
     expect(addedTexts.some((t) => t.includes('teammate_message'))).toBe(false);
   });
 
+  it('drains teammate reports outside the teammate runtime context', async () => {
+    const mockManager = { setLeaderMessageCallback: vi.fn() };
+    (mockConfig.getTeamManager as unknown as Mock).mockReturnValue(mockManager);
+    renderTestHook();
+
+    await waitFor(() => {
+      expect(mockManager.setLeaderMessageCallback).toHaveBeenCalledWith(
+        expect.any(Function),
+      );
+    });
+
+    let capturedRuntimeView: unknown = 'unset';
+    mockSendMessageStream.mockImplementationOnce(() => {
+      capturedRuntimeView = getRuntimeContentGenerator();
+      return (async function* () {})();
+    });
+
+    const callback = (mockManager.setLeaderMessageCallback as Mock).mock
+      .calls[0][0] as (modelText: string, display: string) => void;
+    const teammateView = {
+      contentGenerator: {},
+      contentGeneratorConfig: { model: 'teammate-model' },
+    } as never;
+    await runWithRuntimeContentGenerator(teammateView, async () => {
+      await act(async () => {
+        callback('<teammate_message>report</teammate_message>', 'reported');
+      });
+    });
+
+    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+    expect(mockSendMessageStream.mock.calls[0][3]).toMatchObject({
+      type: SendMessageType.Teammate,
+    });
+    expect(capturedRuntimeView).toBeUndefined();
+  });
+
   it('should not submit tool responses if not all tool calls are completed', () => {
     const toolCalls: TrackedToolCall[] = [
       {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -4071,20 +4071,23 @@ export const useGeminiStream = (
       !isSubmittingQueryRef.current &&
       teammateQueueRef.current.length > 0
     ) {
-      const batch = teammateQueueRef.current.splice(0);
-      // Render one compact `● …` line per teammate report; the full
-      // envelope goes only to the model (the USER bubble is suppressed
-      // for SendMessageType.Teammate in prepareQueryForGemini).
-      for (const entry of batch) {
-        addItem(
-          { type: 'notification' as const, text: entry.display },
-          Date.now(),
-        );
-      }
-      const modelText = batch.map((e) => e.modelText).join('\n\n');
-      const display = batch.map((e) => e.display).join('; ');
-      submitQuery(modelText, SendMessageType.Teammate, undefined, {
-        notificationDisplayText: display,
+      // React can flush this effect after restoring the teammate frame.
+      runOutsideAgentContext(() => {
+        const batch = teammateQueueRef.current.splice(0);
+        // Render one compact `● …` line per teammate report; the full
+        // envelope goes only to the model (the USER bubble is suppressed
+        // for SendMessageType.Teammate in prepareQueryForGemini).
+        for (const entry of batch) {
+          addItem(
+            { type: 'notification' as const, text: entry.display },
+            Date.now(),
+          );
+        }
+        const modelText = batch.map((e) => e.modelText).join('\n\n');
+        const display = batch.map((e) => e.display).join('; ');
+        submitQuery(modelText, SendMessageType.Teammate, undefined, {
+          notificationDisplayText: display,
+        });
       });
     }
   }, [streamingState, submitQuery, teammateTrigger, addItem]);

--- a/packages/core/src/agents/team/TeamManager.plan-approval.test.ts
+++ b/packages/core/src/agents/team/TeamManager.plan-approval.test.ts
@@ -11,6 +11,12 @@ import { Storage } from '../../config/storage.js';
 import { AgentStatus } from '../runtime/agent-types.js';
 import { ApprovalMode } from '../../config/config.js';
 import { PermissionMode } from '../../hooks/types.js';
+import {
+  getCurrentAgentId,
+  getRuntimeContentGenerator,
+  runWithAgentContext,
+  runWithRuntimeContentGenerator,
+} from '../runtime/agent-context.js';
 
 vi.mock('../../config/storage.js', async (importOriginal) => {
   const original =
@@ -131,6 +137,53 @@ describe('TeamManager plan approval requests', () => {
       targetMode: ApprovalMode.DEFAULT,
       message: 'Proceed.',
     });
+  });
+
+  it('delivers plan approval requests outside the teammate agent context', async () => {
+    const h = await createHarness();
+    await h.teamManager.spawnTeammate({
+      name: 'planner',
+      cwd: h.tmpDir,
+      planModeRequired: true,
+    });
+
+    let callbackAgentId: string | null = 'unset';
+    let callbackRuntimeView: unknown = 'unset';
+    let approvalMessage = '';
+    h.teamManager.setLeaderMessageCallback((message) => {
+      approvalMessage = message;
+      callbackAgentId = getCurrentAgentId();
+      callbackRuntimeView = getRuntimeContentGenerator();
+    });
+
+    let pending:
+      | ReturnType<typeof h.teamManager.requestPlanApproval>
+      | undefined;
+    const teammateView = {
+      contentGenerator: {},
+      contentGeneratorConfig: { model: 'teammate-model' },
+    } as never;
+    await runWithAgentContext('planner-agent', () =>
+      runWithRuntimeContentGenerator(teammateView, async () => {
+        pending = h.teamManager.requestPlanApproval({
+          teammateName: 'planner',
+          plan: 'Inspect and patch',
+        });
+      }),
+    );
+
+    const requestId = approvalMessage.match(/request_id="([^"]+)"/)?.[1];
+    expect(requestId).toBeDefined();
+    h.teamManager.resolvePlanApprovalRequest(requestId!, {
+      action: 'reject',
+      message: 'Done testing.',
+    });
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      message: 'Done testing.',
+    });
+    expect(callbackAgentId).toBeNull();
+    expect(callbackRuntimeView).toBeUndefined();
   });
 
   it('frames teammate-authored plan payload as untrusted data', async () => {

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -74,6 +74,7 @@ import { buildTeammatePromptAddendum } from './promptAddendum.js';
 import { runWithTeammateIdentity } from './identity.js';
 import type { SubagentManager } from '../../subagents/subagent-manager.js';
 import type { ToolConfig } from '../runtime/agent-types.js';
+import { runOutsideAgentContext } from '../runtime/agent-context.js';
 
 const debug = createDebugLogger('AGENTS_TEAM_MANAGER');
 
@@ -763,7 +764,9 @@ export class TeamManager {
   setLeaderMessageCallback(
     cb: ((message: string, display: string) => void) | null,
   ): void {
-    this.leaderMessageCallback = cb;
+    this.leaderMessageCallback = cb
+      ? (message, display) => runOutsideAgentContext(() => cb(message, display))
+      : null;
   }
 
   requestPlanApproval(


### PR DESCRIPTION
## What this PR does

This change ensures that teammate-to-leader messages cross a clean async-local boundary before entering the leader conversation. It also isolates the React consumer that submits queued teammate messages, because React can restore an outer teammate frame after the producer callback returns. Focused regressions cover both boundaries independently.

## Why it's needed

A plan-required teammate can request approval while running inside its own agent and model context. The leader callback and the later React drain could inherit that context, causing the approval turn to use the teammate model and appear to be a nested rather than top-level session.

## Reviewer Test Plan

### How to verify

Run the focused plan-approval tests and confirm that a request emitted from a teammate frame reaches the leader callback with no agent ID or teammate runtime. Run the CLI stream-hook tests and confirm that a React flush triggered inside a teammate runtime submits the resulting leader turn without that runtime.

### Evidence (Before & After)

Before: the deterministic reproduction observed `agentId='planner-agent'`, the teammate runtime/model, and `isTopLevelSession=false` in the leader drain. After: the producer callback observes no agent frame, and the consumer submission observes no teammate runtime. This is a non-visual runtime fix, so screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.0. Verified with 11 focused core tests, 160 CLI stream-hook tests, the repository lint, full build, and full typecheck.

## Risk & Scope

- Main risk or tradeoff: registered leader-message callbacks now intentionally execute outside every teammate agent frame; the consumer repeats this boundary because producer-only isolation is insufficient across React batching.
- Not validated / out of scope: no live dual-model interactive TUI run; the real manager and React hook boundaries are covered deterministically without model calls. The separately tracked nested `run_in_background` fallback behavior is not changed.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7574

Related to #7156 and #7194.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本改动确保 teammate 发往 leader 的消息在进入 leader 对话前跨过一个干净的异步本地上下文边界。同时也隔离了提交 teammate 队列消息的 React 消费端，因为 producer 回调返回后，React 仍可能恢复外层 teammate frame。两条聚焦回归测试分别独立覆盖这两个边界。

## 为什么需要

要求审批计划的 teammate 会在自己的 agent 和模型上下文中发起审批请求。leader 回调以及后续 React drain 可能继承该上下文，导致审批轮次使用 teammate 模型，并被误判为嵌套会话而不是顶层会话。

## Reviewer Test Plan

### 如何验证

运行聚焦的计划审批测试，确认从 teammate frame 发出的请求到达 leader 回调时既没有 agent ID，也没有 teammate runtime。运行 CLI stream hook 测试，确认在 teammate runtime 内触发的 React flush 所提交的 leader 轮次不再携带该 runtime。

### 证据（修复前后）

修复前：确定性复现中，leader drain 观察到 `agentId='planner-agent'`、teammate runtime/model，以及 `isTopLevelSession=false`。修复后：producer 回调观察不到 agent frame，consumer 提交也观察不到 teammate runtime。该修复不涉及视觉变化，因此截图不适用。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22.22.0。已通过 11 个聚焦 Core 测试、160 个 CLI stream hook 测试、仓库 lint、完整 build 和完整 typecheck。

## 风险与范围

- 主要风险或取舍：注册的 leader message 回调现在会有意在所有 teammate agent frame 之外执行；由于仅隔离 producer 无法跨 React batching 保证安全，consumer 会再次建立该边界。
- 未验证 / 范围外：未运行真实双模型交互式 TUI；真实 manager 与 React hook 边界已在无模型调用的情况下得到确定性覆盖。另行跟踪的嵌套 `run_in_background` fallback 行为不在本次修改范围内。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7574

关联 #7156 和 #7194。

</details>
