### PR TITLE
feat(serve): scope channel lifecycle to workspace runtimes

### DIFF
--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -162,7 +162,7 @@ describe('createChannelManagementService', () => {
       lastError: 'invalid token token=<redacted>',
     });
     expect(manager.reload).not.toHaveBeenCalled();
-    expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE);
+    expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE, 'bot');
   });
 
   it('does not delete config when worker stop is unconfirmed', async () => {

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -69,7 +69,9 @@ function setup(options: {
     }),
   };
   let names = options.committedNames ?? [];
-  const manager: ChannelManagementWorkerManager = {
+  const manager: ChannelManagementWorkerManager & {
+    reloadWorkspace: ReturnType<typeof vi.fn>;
+  } = {
     committedChannelNames: vi.fn(() => [...names]),
     state: vi.fn(() => ({
       enabled: names.length > 0,
@@ -106,6 +108,11 @@ function setup(options: {
       state: 'running' as const,
       channels: [...names],
     })),
+    reloadWorkspace: vi.fn(async () => ({
+      enabled: true,
+      state: 'running' as const,
+      channels: [...names],
+    })),
   };
   const service = createChannelManagementService({
     workspaceCwd: WORKSPACE,
@@ -134,7 +141,7 @@ describe('createChannelManagementService', () => {
     const { service, store, manager, persisted } = setup({
       committedNames: ['other', 'bot'],
     });
-    vi.mocked(manager.reload).mockRejectedValueOnce(
+    manager.reloadWorkspace.mockRejectedValueOnce(
       new Error('invalid token token=start-secret'),
     );
 
@@ -144,7 +151,7 @@ describe('createChannelManagementService', () => {
       secrets: { token: { operation: 'clear' } },
     });
 
-    expect(store.upsert).toHaveBeenCalledBefore(vi.mocked(manager.reload));
+    expect(store.upsert).toHaveBeenCalledBefore(manager.reloadWorkspace);
     expect(persisted().channels['bot']).not.toHaveProperty('token');
     expect(manager.setSelection).toHaveBeenCalledWith({
       mode: 'names',
@@ -154,6 +161,8 @@ describe('createChannelManagementService', () => {
       state: 'error',
       lastError: 'invalid token token=<redacted>',
     });
+    expect(manager.reload).not.toHaveBeenCalled();
+    expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE);
   });
 
   it('does not delete config when worker stop is unconfirmed', async () => {
@@ -187,10 +196,14 @@ describe('createChannelManagementService', () => {
     });
 
     await service.start('bot');
-    expect(manager.setSelection).toHaveBeenNthCalledWith(1, {
-      mode: 'names',
-      names: ['first', 'second', 'bot'],
-    });
+    expect(manager.setSelection).toHaveBeenNthCalledWith(
+      1,
+      {
+        mode: 'names',
+        names: ['first', 'second', 'bot'],
+      },
+      { name: 'bot', workspaceCwd: WORKSPACE },
+    );
 
     await service.stop('second');
     expect(manager.setSelection).toHaveBeenNthCalledWith(2, {
@@ -211,5 +224,25 @@ describe('createChannelManagementService', () => {
       code: 'channel_runtime_owner_mismatch',
     });
     expect(manager.reload).not.toHaveBeenCalled();
+  });
+
+  it('rejects an inactive cross-workspace start before lifecycle mutation', async () => {
+    const { service, manager } = setup({ committedNames: [] });
+    vi.mocked(manager.setSelection).mockRejectedValueOnce(
+      Object.assign(new Error('owner mismatch'), {
+        code: 'channel_runtime_owner_mismatch',
+      }),
+    );
+
+    await expect(service.start('bot')).rejects.toMatchObject({
+      code: 'channel_runtime_owner_mismatch',
+    });
+
+    expect(manager.setSelection).toHaveBeenCalledWith(
+      { mode: 'names', names: ['bot'] },
+      { name: 'bot', workspaceCwd: WORKSPACE },
+    );
+    expect(manager.reload).not.toHaveBeenCalled();
+    expect(manager.reloadWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -79,7 +79,9 @@ function setup(options: {
   };
   let names = options.committedNames ?? [];
   const manager: ChannelManagementWorkerManager & {
+    reload: ReturnType<typeof vi.fn>;
     reloadWorkspace: ReturnType<typeof vi.fn>;
+    setChannelEnabled: ReturnType<typeof vi.fn>;
   } = {
     committedChannelNames: vi.fn(() => [...names]),
     state: vi.fn(() => ({
@@ -106,11 +108,12 @@ function setup(options: {
             ]
           : [],
     })),
-    setSelection: vi.fn(async (selection) => {
-      names = [...selection.names];
-    }),
-    stopSelection: vi.fn(async () => {
-      names = [];
+    setChannelEnabled: vi.fn(async ({ name }, enabled) => {
+      names = enabled
+        ? names.includes(name)
+          ? names
+          : [...names, name]
+        : names.filter((item) => item !== name);
     }),
     reload: vi.fn(async () => ({
       enabled: true,
@@ -231,10 +234,10 @@ describe('createChannelManagementService', () => {
 
     expect(store.upsert).toHaveBeenCalledBefore(manager.reloadWorkspace);
     expect(persisted().channels['bot']).not.toHaveProperty('clientSecret');
-    expect(manager.setSelection).toHaveBeenCalledWith({
-      mode: 'names',
-      names: ['other'],
-    });
+    expect(manager.setChannelEnabled).toHaveBeenCalledWith(
+      { name: 'bot', workspaceCwd: WORKSPACE },
+      false,
+    );
     expect(result.instance.runtime).toEqual({
       state: 'error',
       lastError: 'invalid token clientSecret=<redacted>',
@@ -247,7 +250,7 @@ describe('createChannelManagementService', () => {
     const { service, store, manager, persisted } = setup({
       committedNames: ['bot'],
     });
-    vi.mocked(manager.stopSelection).mockRejectedValueOnce(
+    vi.mocked(manager.setChannelEnabled).mockRejectedValueOnce(
       Object.assign(new Error('stop unconfirmed'), {
         code: 'channel_worker_stop_failed',
       }),
@@ -269,11 +272,10 @@ describe('createChannelManagementService', () => {
     ).rejects.toMatchObject({ code: 'channel_settings_conflict' });
 
     expect(store.remove).not.toHaveBeenCalled();
-    expect(manager.stopSelection).not.toHaveBeenCalled();
-    expect(manager.setSelection).not.toHaveBeenCalled();
+    expect(manager.setChannelEnabled).not.toHaveBeenCalled();
   });
 
-  it('starts and stops from the manager committed order without persisting startup names', async () => {
+  it('delegates starts and stops to the manager atomic mutation lane', async () => {
     const { service, store, manager } = setup({
       committedNames: ['first', 'second'],
       snapshot: settingsSnapshot({
@@ -286,20 +288,18 @@ describe('createChannelManagementService', () => {
     });
 
     await service.start('bot');
-    expect(manager.setSelection).toHaveBeenNthCalledWith(
+    expect(manager.setChannelEnabled).toHaveBeenNthCalledWith(
       1,
-      {
-        mode: 'names',
-        names: ['first', 'second', 'bot'],
-      },
       { name: 'bot', workspaceCwd: WORKSPACE },
+      true,
     );
 
     await service.stop('second');
-    expect(manager.setSelection).toHaveBeenNthCalledWith(2, {
-      mode: 'names',
-      names: ['first', 'bot'],
-    });
+    expect(manager.setChannelEnabled).toHaveBeenNthCalledWith(
+      2,
+      { name: 'second', workspaceCwd: WORKSPACE },
+      false,
+    );
     expect(store.upsert).not.toHaveBeenCalled();
     expect(store.remove).not.toHaveBeenCalled();
   });
@@ -317,7 +317,7 @@ describe('createChannelManagementService', () => {
     });
     expect(result.instance.startsWithServe).toBe(true);
     expect(result.instance.runtime.state).toBe('connected');
-    expect(manager.setSelection).not.toHaveBeenCalled();
+    expect(manager.setChannelEnabled).not.toHaveBeenCalled();
     expect(manager.reloadWorkspace).not.toHaveBeenCalled();
   });
 
@@ -363,7 +363,7 @@ describe('createChannelManagementService', () => {
 
       expect(store.setStartupNames).not.toHaveBeenCalled();
       expect(manager.committedChannelNames).not.toHaveBeenCalled();
-      expect(manager.setSelection).not.toHaveBeenCalled();
+      expect(manager.setChannelEnabled).not.toHaveBeenCalled();
     },
   );
 
@@ -380,8 +380,7 @@ describe('createChannelManagementService', () => {
       });
 
       expect(manager.committedChannelNames).not.toHaveBeenCalled();
-      expect(manager.setSelection).not.toHaveBeenCalled();
-      expect(manager.stopSelection).not.toHaveBeenCalled();
+      expect(manager.setChannelEnabled).not.toHaveBeenCalled();
     },
   );
 
@@ -399,7 +398,7 @@ describe('createChannelManagementService', () => {
 
   it('rejects an inactive cross-workspace start before lifecycle mutation', async () => {
     const { service, manager } = setup({ committedNames: [] });
-    vi.mocked(manager.setSelection).mockRejectedValueOnce(
+    vi.mocked(manager.setChannelEnabled).mockRejectedValueOnce(
       Object.assign(new Error('owner mismatch'), {
         code: 'channel_runtime_owner_mismatch',
       }),
@@ -409,9 +408,9 @@ describe('createChannelManagementService', () => {
       code: 'channel_runtime_owner_mismatch',
     });
 
-    expect(manager.setSelection).toHaveBeenCalledWith(
-      { mode: 'names', names: ['bot'] },
+    expect(manager.setChannelEnabled).toHaveBeenCalledWith(
       { name: 'bot', workspaceCwd: WORKSPACE },
+      true,
     );
     expect(manager.reload).not.toHaveBeenCalled();
     expect(manager.reloadWorkspace).not.toHaveBeenCalled();
@@ -438,10 +437,13 @@ describe('createChannelManagementService', () => {
     });
     const stopping = service.stop('bot');
 
-    expect(manager.stopSelection).not.toHaveBeenCalled();
+    expect(manager.setChannelEnabled).not.toHaveBeenCalled();
     finishReload();
     await restarting;
     await stopping;
-    expect(manager.stopSelection).toHaveBeenCalledOnce();
+    expect(manager.setChannelEnabled).toHaveBeenCalledWith(
+      { name: 'bot', workspaceCwd: WORKSPACE },
+      false,
+    );
   });
 });

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -246,6 +246,28 @@ describe('createChannelManagementService', () => {
     expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE, 'bot');
   });
 
+  it('clears a stale runtime diagnostic after a successful replacement', async () => {
+    const { service, manager } = setup({ committedNames: ['bot'] });
+    manager.reloadWorkspace.mockRejectedValueOnce(new Error('stale failure'));
+
+    await expect(service.restart('bot')).rejects.toThrow('stale failure');
+    expect((await service.list()).instances['bot']?.runtime).toEqual({
+      state: 'error',
+      lastError: 'stale failure',
+    });
+
+    const result = await service.upsert('bot', {
+      expectedRevision: 'rev-1',
+      config: {
+        type: 'dingtalk',
+        clientId: 'client-id',
+        senderPolicy: 'pairing',
+      },
+    });
+
+    expect(result.instance.runtime).toEqual({ state: 'connected' });
+  });
+
   it('does not delete config when worker stop is unconfirmed', async () => {
     const { service, store, manager, persisted } = setup({
       committedNames: ['bot'],

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -351,6 +351,11 @@ describe('createChannelManagementService', () => {
     async (name) => {
       const { service, store, manager } = setup({ committedNames: [] });
 
+      await expect(
+        service.remove(name, { expectedRevision: 'rev-1' }),
+      ).rejects.toMatchObject({
+        code: 'invalid_channel_instance_name',
+      });
       await expect(service.start(name)).rejects.toMatchObject({
         code: 'invalid_channel_instance_name',
       });
@@ -361,6 +366,7 @@ describe('createChannelManagementService', () => {
         }),
       ).rejects.toMatchObject({ code: 'invalid_channel_instance_name' });
 
+      expect(store.remove).not.toHaveBeenCalled();
       expect(store.setStartupNames).not.toHaveBeenCalled();
       expect(manager.committedChannelNames).not.toHaveBeenCalled();
       expect(manager.setChannelEnabled).not.toHaveBeenCalled();

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -246,6 +246,34 @@ describe('createChannelManagementService', () => {
     expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE, 'bot');
   });
 
+  it('retains the reload diagnostic when stopping the failed replacement also fails', async () => {
+    const { service, manager } = setup({ committedNames: ['bot'] });
+    manager.reloadWorkspace.mockRejectedValueOnce(
+      new Error('invalid token clientSecret=start-secret'),
+    );
+    manager.setChannelEnabled.mockRejectedValueOnce(
+      new Error('stop failed clientSecret=stop-secret'),
+    );
+
+    const result = await service.upsert('bot', {
+      expectedRevision: 'rev-1',
+      config: {
+        type: 'dingtalk',
+        clientId: 'client-id',
+        senderPolicy: 'pairing',
+      },
+    });
+
+    expect(result.instance.runtime).toEqual({
+      state: 'error',
+      lastError: 'invalid token clientSecret=<redacted>',
+    });
+    expect(manager.setChannelEnabled).toHaveBeenCalledWith(
+      { name: 'bot', workspaceCwd: WORKSPACE },
+      false,
+    );
+  });
+
   it('clears a stale runtime diagnostic after a successful replacement', async () => {
     const { service, manager } = setup({ committedNames: ['bot'] });
     manager.reloadWorkspace.mockRejectedValueOnce(new Error('stale failure'));

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelSettingsSnapshot } from './channel-settings-store.js';
+import {
+  createChannelManagementService,
+  type ChannelManagementWorkerManager,
+} from './channel-management-service.js';
+
+const WORKSPACE = '/ws/primary';
+
+function settingsSnapshot(
+  overrides: Partial<ChannelSettingsSnapshot> = {},
+): ChannelSettingsSnapshot {
+  return {
+    revision: 'rev-1',
+    channels: {
+      bot: {
+        type: 'telegram',
+        token: '$BOT_TOKEN',
+        senderPolicy: 'open',
+      },
+    },
+    startupNames: [],
+    ...overrides,
+  };
+}
+
+function setup(options: {
+  snapshot?: ChannelSettingsSnapshot;
+  committedNames?: string[];
+  workspaceCwd?: string;
+}) {
+  let persisted = options.snapshot ?? settingsSnapshot();
+  const store = {
+    snapshot: vi.fn(() => persisted),
+    upsert: vi.fn(async (name, request) => {
+      const previous = persisted.channels[name] ?? {};
+      const token =
+        request.secrets?.token?.operation === 'clear'
+          ? undefined
+          : previous['token'];
+      persisted = settingsSnapshot({
+        revision: 'rev-2',
+        channels: {
+          ...persisted.channels,
+          [name]: {
+            ...request.config,
+            ...(token === undefined ? {} : { token }),
+          },
+        },
+        startupNames: persisted.startupNames,
+      });
+      return persisted;
+    }),
+    remove: vi.fn(async (name) => {
+      const channels = { ...persisted.channels };
+      delete channels[name];
+      persisted = settingsSnapshot({
+        revision: 'rev-2',
+        channels,
+        startupNames: persisted.startupNames.filter((item) => item !== name),
+      });
+      return persisted;
+    }),
+  };
+  let names = options.committedNames ?? [];
+  const manager: ChannelManagementWorkerManager = {
+    committedChannelNames: vi.fn(() => [...names]),
+    state: vi.fn(() => ({
+      enabled: names.length > 0,
+      selection:
+        names.length > 0 ? { mode: 'names' as const, names: [...names] } : null,
+      transition: 'idle' as const,
+      workers:
+        names.length > 0
+          ? [
+              {
+                enabled: true,
+                state: 'running' as const,
+                channels: [...names],
+                requestedChannels: [...names],
+                adapters: names.map((name) => ({
+                  name,
+                  state: 'connected' as const,
+                })),
+                workspaceId: 'primary',
+                workspaceCwd: options.workspaceCwd ?? WORKSPACE,
+                primary: true,
+              },
+            ]
+          : [],
+    })),
+    setSelection: vi.fn(async (selection) => {
+      names = [...selection.names];
+    }),
+    stopSelection: vi.fn(async () => {
+      names = [];
+    }),
+    reload: vi.fn(async () => ({
+      enabled: true,
+      state: 'running' as const,
+      channels: [...names],
+    })),
+  };
+  const service = createChannelManagementService({
+    workspaceCwd: WORKSPACE,
+    store,
+    manager,
+  });
+  return { service, store, manager, persisted: () => persisted };
+}
+
+describe('createChannelManagementService', () => {
+  it('lists sanitized config, secret presence, startup selection, and runtime', async () => {
+    const { service } = setup({ committedNames: ['bot'] });
+
+    const result = await service.list();
+
+    expect(result.instances['bot']).toEqual({
+      name: 'bot',
+      config: { type: 'telegram', senderPolicy: 'open' },
+      secrets: { token: { present: true, source: 'environment' } },
+      startsWithServe: false,
+      runtime: { state: 'connected' },
+    });
+  });
+
+  it('keeps a failed replacement config and reports the instance as error', async () => {
+    const { service, store, manager, persisted } = setup({
+      committedNames: ['other', 'bot'],
+    });
+    vi.mocked(manager.reload).mockRejectedValueOnce(
+      new Error('invalid token token=start-secret'),
+    );
+
+    const result = await service.upsert('bot', {
+      expectedRevision: 'rev-1',
+      config: { type: 'telegram', senderPolicy: 'pairing' },
+      secrets: { token: { operation: 'clear' } },
+    });
+
+    expect(store.upsert).toHaveBeenCalledBefore(vi.mocked(manager.reload));
+    expect(persisted().channels['bot']).not.toHaveProperty('token');
+    expect(manager.setSelection).toHaveBeenCalledWith({
+      mode: 'names',
+      names: ['other'],
+    });
+    expect(result.instance.runtime).toEqual({
+      state: 'error',
+      lastError: 'invalid token token=<redacted>',
+    });
+  });
+
+  it('does not delete config when worker stop is unconfirmed', async () => {
+    const { service, store, manager, persisted } = setup({
+      committedNames: ['bot'],
+    });
+    vi.mocked(manager.stopSelection).mockRejectedValueOnce(
+      Object.assign(new Error('stop unconfirmed'), {
+        code: 'channel_worker_stop_failed',
+      }),
+    );
+
+    await expect(
+      service.remove('bot', { expectedRevision: 'rev-1' }),
+    ).rejects.toMatchObject({ code: 'channel_worker_stop_failed' });
+
+    expect(store.remove).not.toHaveBeenCalled();
+    expect(persisted().channels['bot']).toBeDefined();
+  });
+
+  it('starts and stops from the manager committed order without persisting startup names', async () => {
+    const { service, store, manager } = setup({
+      committedNames: ['first', 'second'],
+      snapshot: settingsSnapshot({
+        channels: {
+          first: { type: 'telegram' },
+          second: { type: 'telegram' },
+          bot: { type: 'telegram' },
+        },
+      }),
+    });
+
+    await service.start('bot');
+    expect(manager.setSelection).toHaveBeenNthCalledWith(1, {
+      mode: 'names',
+      names: ['first', 'second', 'bot'],
+    });
+
+    await service.stop('second');
+    expect(manager.setSelection).toHaveBeenNthCalledWith(2, {
+      mode: 'names',
+      names: ['first', 'bot'],
+    });
+    expect(store.upsert).not.toHaveBeenCalled();
+    expect(store.remove).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an active instance belongs to another workspace', async () => {
+    const { service, manager } = setup({
+      committedNames: ['bot'],
+      workspaceCwd: '/ws/secondary',
+    });
+
+    await expect(service.restart('bot')).rejects.toMatchObject({
+      code: 'channel_runtime_owner_mismatch',
+    });
+    expect(manager.reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -68,6 +68,14 @@ function setup(options: {
       });
       return persisted;
     }),
+    setStartupNames: vi.fn(async (startupNames) => {
+      persisted = settingsSnapshot({
+        revision: 'rev-2',
+        channels: persisted.channels,
+        startupNames: [...startupNames],
+      });
+      return persisted;
+    }),
   };
   let names = options.committedNames ?? [];
   const manager: ChannelManagementWorkerManager & {
@@ -144,6 +152,65 @@ describe('createChannelManagementService', () => {
     });
   });
 
+  it('projects the all startup sentinel onto configured instances', async () => {
+    const { service } = setup({
+      snapshot: settingsSnapshot({ startupNames: [' all '] }),
+    });
+
+    const result = await service.list();
+
+    expect(result.instances['bot']?.startsWithServe).toBe(true);
+  });
+
+  it('does not expose config fields from an unmanaged channel type', async () => {
+    const { service } = setup({
+      snapshot: settingsSnapshot({
+        channels: {
+          legacy: {
+            type: 'telegram',
+            token: '$LEGACY_TOKEN',
+            senderPolicy: 'open',
+          },
+        },
+      }),
+    });
+
+    const result = await service.list();
+
+    expect(result.instances['legacy']).toMatchObject({
+      config: { type: 'telegram' },
+      secrets: {},
+    });
+    expect(JSON.stringify(result.instances['legacy'])).not.toContain(
+      'LEGACY_TOKEN',
+    );
+  });
+
+  it('redacts credentials from adapter runtime errors', async () => {
+    const { service, manager } = setup({ committedNames: ['bot'] });
+    const state = manager.state();
+    vi.mocked(manager.state).mockReturnValue({
+      ...state,
+      workers: state.workers.map((worker) => ({
+        ...worker,
+        adapters: [
+          {
+            name: 'bot',
+            state: 'error' as const,
+            error: 'connect failed clientSecret=top-secret',
+          },
+        ],
+      })),
+    });
+
+    const result = await service.list();
+
+    expect(result.instances['bot']?.runtime).toEqual({
+      state: 'error',
+      lastError: 'connect failed clientSecret=<redacted>',
+    });
+  });
+
   it('keeps a failed replacement config and reports the instance as error', async () => {
     const { service, store, manager, persisted } = setup({
       committedNames: ['other', 'bot'],
@@ -194,6 +261,18 @@ describe('createChannelManagementService', () => {
     expect(persisted().channels['bot']).toBeDefined();
   });
 
+  it('rejects stale removal before changing runtime state', async () => {
+    const { service, store, manager } = setup({ committedNames: ['bot'] });
+
+    await expect(
+      service.remove('bot', { expectedRevision: 'stale' }),
+    ).rejects.toMatchObject({ code: 'channel_settings_conflict' });
+
+    expect(store.remove).not.toHaveBeenCalled();
+    expect(manager.stopSelection).not.toHaveBeenCalled();
+    expect(manager.setSelection).not.toHaveBeenCalled();
+  });
+
   it('starts and stops from the manager committed order without persisting startup names', async () => {
     const { service, store, manager } = setup({
       committedNames: ['first', 'second'],
@@ -225,6 +304,87 @@ describe('createChannelManagementService', () => {
     expect(store.remove).not.toHaveBeenCalled();
   });
 
+  it('updates persisted startup selection without mutating runtime state', async () => {
+    const { service, store, manager } = setup({ committedNames: ['bot'] });
+
+    const result = await service.setStartup('bot', {
+      expectedRevision: 'rev-1',
+      enabled: true,
+    });
+
+    expect(store.setStartupNames).toHaveBeenCalledWith(['bot'], {
+      expectedRevision: 'rev-1',
+    });
+    expect(result.instance.startsWithServe).toBe(true);
+    expect(result.instance.runtime.state).toBe('connected');
+    expect(manager.setSelection).not.toHaveBeenCalled();
+    expect(manager.reloadWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('expands all to the other instances when disabling one startup', async () => {
+    const { service, store } = setup({
+      snapshot: settingsSnapshot({
+        channels: {
+          first: { type: 'dingtalk' },
+          bot: { type: 'dingtalk' },
+          last: { type: 'dingtalk' },
+        },
+        startupNames: [' all '],
+      }),
+    });
+
+    const result = await service.setStartup('bot', {
+      expectedRevision: 'rev-1',
+      enabled: false,
+    });
+
+    expect(store.setStartupNames).toHaveBeenCalledWith(['first', 'last'], {
+      expectedRevision: 'rev-1',
+    });
+    expect(result.instance.startsWithServe).toBe(false);
+    expect(result.snapshot.instances['first']?.startsWithServe).toBe(true);
+    expect(result.snapshot.instances['last']?.startsWithServe).toBe(true);
+  });
+
+  it.each(['all', ' all ', '\tall\n'])(
+    'rejects reserved channel name %j before lifecycle mutation',
+    async (name) => {
+      const { service, store, manager } = setup({ committedNames: [] });
+
+      await expect(service.start(name)).rejects.toMatchObject({
+        code: 'invalid_channel_instance_name',
+      });
+      await expect(
+        service.setStartup(name, {
+          expectedRevision: 'rev-1',
+          enabled: true,
+        }),
+      ).rejects.toMatchObject({ code: 'invalid_channel_instance_name' });
+
+      expect(store.setStartupNames).not.toHaveBeenCalled();
+      expect(manager.committedChannelNames).not.toHaveBeenCalled();
+      expect(manager.setSelection).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['constructor', 'toString', '__proto__'])(
+    'rejects inherited instance name %s before start or stop reaches the manager',
+    async (name) => {
+      const { service, manager } = setup({ committedNames: [] });
+
+      await expect(service.start(name)).rejects.toMatchObject({
+        code: 'channel_instance_not_found',
+      });
+      await expect(service.stop(name)).rejects.toMatchObject({
+        code: 'channel_instance_not_found',
+      });
+
+      expect(manager.committedChannelNames).not.toHaveBeenCalled();
+      expect(manager.setSelection).not.toHaveBeenCalled();
+      expect(manager.stopSelection).not.toHaveBeenCalled();
+    },
+  );
+
   it('fails closed when an active instance belongs to another workspace', async () => {
     const { service, manager } = setup({
       committedNames: ['bot'],
@@ -255,5 +415,33 @@ describe('createChannelManagementService', () => {
     );
     expect(manager.reload).not.toHaveBeenCalled();
     expect(manager.reloadWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('serializes lifecycle mutations for one workspace service', async () => {
+    const { service, manager } = setup({ committedNames: ['bot'] });
+    let finishReload!: () => void;
+    manager.reloadWorkspace.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishReload = () =>
+            resolve({
+              enabled: true,
+              state: 'running' as const,
+              channels: ['bot'],
+            });
+        }),
+    );
+
+    const restarting = service.restart('bot');
+    await vi.waitFor(() => {
+      expect(manager.reloadWorkspace).toHaveBeenCalledOnce();
+    });
+    const stopping = service.stop('bot');
+
+    expect(manager.stopSelection).not.toHaveBeenCalled();
+    finishReload();
+    await restarting;
+    await stopping;
+    expect(manager.stopSelection).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -20,8 +20,9 @@ function settingsSnapshot(
     revision: 'rev-1',
     channels: {
       bot: {
-        type: 'telegram',
-        token: '$BOT_TOKEN',
+        type: 'dingtalk',
+        clientId: 'client-id',
+        clientSecret: '$BOT_SECRET',
         senderPolicy: 'open',
       },
     },
@@ -40,17 +41,17 @@ function setup(options: {
     snapshot: vi.fn(() => persisted),
     upsert: vi.fn(async (name, request) => {
       const previous = persisted.channels[name] ?? {};
-      const token =
-        request.secrets?.token?.operation === 'clear'
+      const clientSecret =
+        request.secrets?.clientSecret?.operation === 'clear'
           ? undefined
-          : previous['token'];
+          : previous['clientSecret'];
       persisted = settingsSnapshot({
         revision: 'rev-2',
         channels: {
           ...persisted.channels,
           [name]: {
             ...request.config,
-            ...(token === undefined ? {} : { token }),
+            ...(clientSecret === undefined ? {} : { clientSecret }),
           },
         },
         startupNames: persisted.startupNames,
@@ -130,8 +131,14 @@ describe('createChannelManagementService', () => {
 
     expect(result.instances['bot']).toEqual({
       name: 'bot',
-      config: { type: 'telegram', senderPolicy: 'open' },
-      secrets: { token: { present: true, source: 'environment' } },
+      config: {
+        type: 'dingtalk',
+        clientId: 'client-id',
+        senderPolicy: 'open',
+      },
+      secrets: {
+        clientSecret: { present: true, source: 'environment' },
+      },
       startsWithServe: false,
       runtime: { state: 'connected' },
     });
@@ -142,24 +149,28 @@ describe('createChannelManagementService', () => {
       committedNames: ['other', 'bot'],
     });
     manager.reloadWorkspace.mockRejectedValueOnce(
-      new Error('invalid token token=start-secret'),
+      new Error('invalid token clientSecret=start-secret'),
     );
 
     const result = await service.upsert('bot', {
       expectedRevision: 'rev-1',
-      config: { type: 'telegram', senderPolicy: 'pairing' },
-      secrets: { token: { operation: 'clear' } },
+      config: {
+        type: 'dingtalk',
+        clientId: 'client-id',
+        senderPolicy: 'pairing',
+      },
+      secrets: { clientSecret: { operation: 'clear' } },
     });
 
     expect(store.upsert).toHaveBeenCalledBefore(manager.reloadWorkspace);
-    expect(persisted().channels['bot']).not.toHaveProperty('token');
+    expect(persisted().channels['bot']).not.toHaveProperty('clientSecret');
     expect(manager.setSelection).toHaveBeenCalledWith({
       mode: 'names',
       names: ['other'],
     });
     expect(result.instance.runtime).toEqual({
       state: 'error',
-      lastError: 'invalid token token=<redacted>',
+      lastError: 'invalid token clientSecret=<redacted>',
     });
     expect(manager.reload).not.toHaveBeenCalled();
     expect(manager.reloadWorkspace).toHaveBeenCalledWith(WORKSPACE, 'bot');
@@ -188,9 +199,9 @@ describe('createChannelManagementService', () => {
       committedNames: ['first', 'second'],
       snapshot: settingsSnapshot({
         channels: {
-          first: { type: 'telegram' },
-          second: { type: 'telegram' },
-          bot: { type: 'telegram' },
+          first: { type: 'dingtalk' },
+          second: { type: 'dingtalk' },
+          bot: { type: 'dingtalk' },
         },
       }),
     });

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -95,7 +95,10 @@ export interface ChannelManagementWorkerManager {
   ): Promise<unknown>;
   stopSelection(): Promise<unknown>;
   reload(): Promise<ChannelWorkerSnapshot>;
-  reloadWorkspace(workspaceCwd: string): Promise<ChannelWorkerSnapshot>;
+  reloadWorkspace(
+    workspaceCwd: string,
+    name: string,
+  ): Promise<ChannelWorkerSnapshot>;
 }
 
 export interface CreateChannelManagementServiceOptions {
@@ -296,7 +299,7 @@ export function createChannelManagementService(
       diagnostics.delete(name);
       if (active) {
         try {
-          await opts.manager.reloadWorkspace(opts.workspaceCwd);
+          await opts.manager.reloadWorkspace(opts.workspaceCwd, name);
         } catch (error) {
           await stopFromNames(name, committedNames);
           diagnostics.set(name, diagnostic(error));
@@ -355,7 +358,7 @@ export function createChannelManagementService(
       }
       assertOwnedRuntime(name);
       try {
-        await opts.manager.reloadWorkspace(opts.workspaceCwd);
+        await opts.manager.reloadWorkspace(opts.workspaceCwd, name);
         diagnostics.delete(name);
       } catch (error) {
         diagnostics.set(name, diagnostic(error));

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -347,8 +347,12 @@ export function createChannelManagementService(
         try {
           await opts.manager.reloadWorkspace(opts.workspaceCwd, name);
         } catch (error) {
-          await stopChannel(name);
           diagnostics.set(name, diagnostic(error));
+          try {
+            await stopChannel(name);
+          } catch {
+            // Keep the reload diagnostic when best-effort cleanup also fails.
+          }
         }
       }
       return resultFor(name, persisted);

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -354,6 +354,7 @@ export function createChannelManagementService(
       return resultFor(name, persisted);
     },
     async remove(name, request) {
+      assertManageableInstanceName(name);
       const current = opts.store.snapshot();
       assertExpectedRevision(current, request.expectedRevision);
       if (!isAllChannelSelectionName(name)) {

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -1,0 +1,360 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { redactLogCredentials } from '@qwen-code/acp-bridge/logRedaction';
+import { sanitizeLogText } from '@qwen-code/channel-base';
+import { getPlugin } from '../commands/channel/channel-registry.js';
+import type {
+  ChannelSecretUpdate,
+  ChannelSettingsMutationOptions,
+  ChannelSettingsSnapshot,
+  ChannelSettingsUpsertOptions,
+  WorkspaceChannelSettingsStore,
+} from './channel-settings-store.js';
+import { normalizeWorkerDiagnostic } from './channel-worker-diagnostics.js';
+import type {
+  ChannelWorkerControlState,
+  ChannelWorkerManager,
+} from './channel-worker-manager.js';
+import type { ChannelWorkerSnapshot } from './channel-worker-supervisor.js';
+import type { ServeChannelSelection } from './types.js';
+
+export interface ChannelRuntimeState {
+  state: 'stopped' | 'starting' | 'connected' | 'partial' | 'error';
+  lastError?: string;
+}
+
+export interface ChannelSecretState {
+  present: boolean;
+  source?: 'literal' | 'environment';
+}
+
+export interface ChannelInstanceSnapshot {
+  name: string;
+  config: Record<string, unknown>;
+  secrets: Record<string, ChannelSecretState>;
+  startsWithServe: boolean;
+  runtime: ChannelRuntimeState;
+}
+
+export interface DaemonChannelsSnapshot {
+  revision: string;
+  instances: Record<string, ChannelInstanceSnapshot>;
+}
+
+export interface ChannelUpsertRequest {
+  expectedRevision: string;
+  config: Record<string, unknown> & { type: string };
+  secrets?: Record<string, ChannelSecretUpdate>;
+}
+
+export type RevisionRequest = ChannelSettingsMutationOptions;
+
+export interface ChannelMutationResult {
+  snapshot: DaemonChannelsSnapshot;
+  instance: ChannelInstanceSnapshot;
+}
+
+export interface ChannelManagementService {
+  list(): Promise<DaemonChannelsSnapshot>;
+  upsert(
+    name: string,
+    request: ChannelUpsertRequest,
+  ): Promise<ChannelMutationResult>;
+  remove(
+    name: string,
+    request: RevisionRequest,
+  ): Promise<ChannelMutationResult>;
+  start(name: string): Promise<ChannelMutationResult>;
+  stop(name: string): Promise<ChannelMutationResult>;
+  restart(name: string): Promise<ChannelMutationResult>;
+}
+
+interface ChannelManagementSettingsStore {
+  snapshot(): ChannelSettingsSnapshot;
+  upsert(
+    name: string,
+    options: ChannelSettingsUpsertOptions,
+  ): Promise<ChannelSettingsSnapshot>;
+  remove(
+    name: string,
+    options: ChannelSettingsMutationOptions,
+  ): Promise<ChannelSettingsSnapshot>;
+}
+
+export interface ChannelManagementWorkerManager {
+  committedChannelNames(): string[];
+  state(): ChannelWorkerControlState;
+  setSelection(selection: ServeChannelSelection): Promise<unknown>;
+  stopSelection(): Promise<unknown>;
+  reload(): Promise<ChannelWorkerSnapshot>;
+}
+
+export interface CreateChannelManagementServiceOptions {
+  workspaceCwd: string;
+  store: ChannelManagementSettingsStore | WorkspaceChannelSettingsStore;
+  manager: ChannelManagementWorkerManager | ChannelWorkerManager;
+}
+
+export class ChannelManagementError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ChannelManagementError';
+  }
+}
+
+function diagnostic(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return sanitizeLogText(
+    redactLogCredentials(normalizeWorkerDiagnostic(message)),
+    512,
+  );
+}
+
+function usesEnvironment(value: unknown): boolean {
+  return (
+    typeof value === 'string' && /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(value)
+  );
+}
+
+export function createChannelManagementService(
+  opts: CreateChannelManagementServiceOptions,
+): ChannelManagementService {
+  const diagnostics = new Map<string, string>();
+
+  const workerFor = (name: string) => {
+    const matches = opts.manager
+      .state()
+      .workers.filter(
+        (worker) =>
+          worker.adapters?.some((adapter) => adapter.name === name) ||
+          worker.requestedChannels?.includes(name) ||
+          worker.channels.includes(name),
+      );
+    return matches;
+  };
+
+  const assertOwnedRuntime = (name: string): void => {
+    if (!opts.manager.committedChannelNames().includes(name)) return;
+    const workers = workerFor(name);
+    if (
+      workers.length !== 1 ||
+      workers[0]!.workspaceCwd !== opts.workspaceCwd
+    ) {
+      throw new ChannelManagementError(
+        'channel_runtime_owner_mismatch',
+        `Channel "${name}" does not have one confirmed runtime owner in this workspace.`,
+      );
+    }
+  };
+
+  const runtimeFor = (name: string): ChannelRuntimeState => {
+    const retainedError = diagnostics.get(name);
+    if (retainedError) return { state: 'error', lastError: retainedError };
+    const committed = opts.manager.committedChannelNames();
+    if (!committed.includes(name)) return { state: 'stopped' };
+    const state = opts.manager.state();
+    const workers = workerFor(name);
+    if (
+      workers.length !== 1 ||
+      workers[0]!.workspaceCwd !== opts.workspaceCwd
+    ) {
+      return {
+        state: 'error',
+        lastError: 'Channel runtime owner is unknown or ambiguous.',
+      };
+    }
+    const worker = workers[0]!;
+    const adapter = worker.adapters?.find((item) => item.name === name);
+    if (adapter?.state === 'connected') return { state: 'connected' };
+    if (adapter?.state === 'error') {
+      return {
+        state: 'error',
+        ...(adapter.error ? { lastError: adapter.error } : {}),
+      };
+    }
+    if (
+      adapter?.state === 'starting' ||
+      state.transition === 'starting' ||
+      state.transition === 'reconciling'
+    ) {
+      return { state: 'starting' };
+    }
+    if (worker.state === 'running') return { state: 'partial' };
+    return {
+      state: 'error',
+      ...(worker.error ? { lastError: worker.error } : {}),
+    };
+  };
+
+  const instanceFrom = async (
+    name: string,
+    rawConfig: Record<string, unknown>,
+    startupNames: readonly string[],
+  ): Promise<ChannelInstanceSnapshot> => {
+    const type = typeof rawConfig['type'] === 'string' ? rawConfig['type'] : '';
+    const plugin = type ? await getPlugin(type) : undefined;
+    const secretKeys = new Set(
+      plugin?.management?.fields
+        .filter((field) => field.kind === 'secret')
+        .map((field) => field.key) ?? [],
+    );
+    const config: Record<string, unknown> = {};
+    const secrets: Record<string, ChannelSecretState> = {};
+    for (const [key, value] of Object.entries(rawConfig)) {
+      if (!secretKeys.has(key)) {
+        config[key] = value;
+        continue;
+      }
+      secrets[key] = {
+        present: value !== undefined,
+        ...(value !== undefined
+          ? { source: usesEnvironment(value) ? 'environment' : 'literal' }
+          : {}),
+      };
+    }
+    for (const key of secretKeys) {
+      secrets[key] ??= { present: false };
+    }
+    return {
+      name,
+      config,
+      secrets,
+      startsWithServe: startupNames.includes(name),
+      runtime: runtimeFor(name),
+    };
+  };
+
+  const listFrom = async (
+    persisted: ChannelSettingsSnapshot,
+  ): Promise<DaemonChannelsSnapshot> => {
+    const entries = await Promise.all(
+      Object.entries(persisted.channels).map(
+        async ([name, config]) =>
+          [
+            name,
+            await instanceFrom(name, config, persisted.startupNames),
+          ] as const,
+      ),
+    );
+    return {
+      revision: persisted.revision,
+      instances: Object.fromEntries(entries),
+    };
+  };
+
+  const resultFor = async (
+    name: string,
+    persisted = opts.store.snapshot(),
+  ): Promise<ChannelMutationResult> => {
+    const snapshot = await listFrom(persisted);
+    const instance =
+      snapshot.instances[name] ??
+      ({
+        name,
+        config: {},
+        secrets: {},
+        startsWithServe: false,
+        runtime: runtimeFor(name),
+      } satisfies ChannelInstanceSnapshot);
+    return { snapshot, instance };
+  };
+
+  const stopFromNames = async (
+    name: string,
+    committedNames: readonly string[],
+  ): Promise<void> => {
+    const next = committedNames.filter((item) => item !== name);
+    if (next.length === committedNames.length) return;
+    if (next.length === 0) {
+      await opts.manager.stopSelection();
+    } else {
+      await opts.manager.setSelection({ mode: 'names', names: next });
+    }
+  };
+
+  const service: ChannelManagementService = {
+    async list() {
+      return listFrom(opts.store.snapshot());
+    },
+    async upsert(name, request) {
+      const committedNames = opts.manager.committedChannelNames();
+      const active = committedNames.includes(name);
+      if (active) assertOwnedRuntime(name);
+      const persisted = await opts.store.upsert(name, request);
+      diagnostics.delete(name);
+      if (active) {
+        try {
+          await opts.manager.reload();
+        } catch (error) {
+          await stopFromNames(name, committedNames);
+          diagnostics.set(name, diagnostic(error));
+        }
+      }
+      return resultFor(name, persisted);
+    },
+    async remove(name, request) {
+      const committedNames = opts.manager.committedChannelNames();
+      if (committedNames.includes(name)) {
+        assertOwnedRuntime(name);
+        await stopFromNames(name, committedNames);
+      }
+      const persisted = await opts.store.remove(name, request);
+      diagnostics.delete(name);
+      return resultFor(name, persisted);
+    },
+    async start(name) {
+      const persisted = opts.store.snapshot();
+      if (!persisted.channels[name]) {
+        throw new ChannelManagementError(
+          'channel_instance_not_found',
+          `Channel "${name}" is not configured in this workspace.`,
+        );
+      }
+      const committedNames = opts.manager.committedChannelNames();
+      if (!committedNames.includes(name)) {
+        await opts.manager.setSelection({
+          mode: 'names',
+          names: [...committedNames, name],
+        });
+      } else {
+        assertOwnedRuntime(name);
+      }
+      diagnostics.delete(name);
+      return resultFor(name, persisted);
+    },
+    async stop(name) {
+      const persisted = opts.store.snapshot();
+      const committedNames = opts.manager.committedChannelNames();
+      if (committedNames.includes(name)) assertOwnedRuntime(name);
+      await stopFromNames(name, committedNames);
+      diagnostics.delete(name);
+      return resultFor(name, persisted);
+    },
+    async restart(name) {
+      const persisted = opts.store.snapshot();
+      if (!opts.manager.committedChannelNames().includes(name)) {
+        throw new ChannelManagementError(
+          'channel_worker_not_enabled',
+          `Channel "${name}" is not running.`,
+        );
+      }
+      assertOwnedRuntime(name);
+      try {
+        await opts.manager.reload();
+        diagnostics.delete(name);
+      } catch (error) {
+        diagnostics.set(name, diagnostic(error));
+        throw error;
+      }
+      return resultFor(name, persisted);
+    },
+  };
+  return service;
+}

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -22,7 +22,6 @@ import type {
   ChannelWorkerRequiredOwner,
 } from './channel-worker-manager.js';
 import type { ChannelWorkerSnapshot } from './channel-worker-supervisor.js';
-import type { ServeChannelSelection } from './types.js';
 
 export interface ChannelRuntimeState {
   state: 'stopped' | 'starting' | 'connected' | 'partial' | 'error';
@@ -102,12 +101,10 @@ interface ChannelManagementSettingsStore {
 export interface ChannelManagementWorkerManager {
   committedChannelNames(): string[];
   state(): ChannelWorkerControlState;
-  setSelection(
-    selection: ServeChannelSelection,
-    requiredOwner?: ChannelWorkerRequiredOwner,
+  setChannelEnabled(
+    owner: ChannelWorkerRequiredOwner,
+    enabled: boolean,
   ): Promise<unknown>;
-  stopSelection(): Promise<unknown>;
-  reload(): Promise<ChannelWorkerSnapshot>;
   reloadWorkspace(
     workspaceCwd: string,
     name: string,
@@ -320,18 +317,11 @@ export function createChannelManagementService(
     return { snapshot, instance };
   };
 
-  const stopFromNames = async (
-    name: string,
-    committedNames: readonly string[],
-  ): Promise<void> => {
-    const next = committedNames.filter((item) => item !== name);
-    if (next.length === committedNames.length) return;
-    if (next.length === 0) {
-      await opts.manager.stopSelection();
-    } else {
-      await opts.manager.setSelection({ mode: 'names', names: next });
-    }
-  };
+  const stopChannel = (name: string): Promise<unknown> =>
+    opts.manager.setChannelEnabled(
+      { name, workspaceCwd: opts.workspaceCwd },
+      false,
+    );
 
   const assertManageableInstanceName = (name: string): void => {
     if (isAllChannelSelectionName(name)) {
@@ -357,7 +347,7 @@ export function createChannelManagementService(
         try {
           await opts.manager.reloadWorkspace(opts.workspaceCwd, name);
         } catch (error) {
-          await stopFromNames(name, committedNames);
+          await stopChannel(name);
           diagnostics.set(name, diagnostic(error));
         }
       }
@@ -370,7 +360,7 @@ export function createChannelManagementService(
         const committedNames = opts.manager.committedChannelNames();
         if (committedNames.includes(name)) {
           assertOwnedRuntime(name);
-          await stopFromNames(name, committedNames);
+          await stopChannel(name);
         }
       }
       const persisted = await opts.store.remove(name, request);
@@ -414,18 +404,10 @@ export function createChannelManagementService(
           `Channel "${name}" is not configured in this workspace.`,
         );
       }
-      const committedNames = opts.manager.committedChannelNames();
-      if (!committedNames.includes(name)) {
-        await opts.manager.setSelection(
-          {
-            mode: 'names',
-            names: [...committedNames, name],
-          },
-          { name, workspaceCwd: opts.workspaceCwd },
-        );
-      } else {
-        assertOwnedRuntime(name);
-      }
+      await opts.manager.setChannelEnabled(
+        { name, workspaceCwd: opts.workspaceCwd },
+        true,
+      );
       diagnostics.delete(name);
       return resultFor(name, persisted);
     },
@@ -438,9 +420,10 @@ export function createChannelManagementService(
           `Channel "${name}" is not configured in this workspace.`,
         );
       }
-      const committedNames = opts.manager.committedChannelNames();
-      if (committedNames.includes(name)) assertOwnedRuntime(name);
-      await stopFromNames(name, committedNames);
+      await opts.manager.setChannelEnabled(
+        { name, workspaceCwd: opts.workspaceCwd },
+        false,
+      );
       diagnostics.delete(name);
       return resultFor(name, persisted);
     },

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -14,6 +14,7 @@ import type {
   ChannelSettingsUpsertOptions,
   WorkspaceChannelSettingsStore,
 } from './channel-settings-store.js';
+import { isAllChannelSelectionName } from './channel-selection.js';
 import { normalizeWorkerDiagnostic } from './channel-worker-diagnostics.js';
 import type {
   ChannelWorkerControlState,
@@ -54,6 +55,10 @@ export interface ChannelUpsertRequest {
 
 export type RevisionRequest = ChannelSettingsMutationOptions;
 
+export interface ChannelStartupRequest extends RevisionRequest {
+  enabled: boolean;
+}
+
 export interface ChannelMutationResult {
   snapshot: DaemonChannelsSnapshot;
   instance: ChannelInstanceSnapshot;
@@ -69,6 +74,10 @@ export interface ChannelManagementService {
     name: string,
     request: RevisionRequest,
   ): Promise<ChannelMutationResult>;
+  setStartup(
+    name: string,
+    request: ChannelStartupRequest,
+  ): Promise<ChannelMutationResult>;
   start(name: string): Promise<ChannelMutationResult>;
   stop(name: string): Promise<ChannelMutationResult>;
   restart(name: string): Promise<ChannelMutationResult>;
@@ -82,6 +91,10 @@ interface ChannelManagementSettingsStore {
   ): Promise<ChannelSettingsSnapshot>;
   remove(
     name: string,
+    options: ChannelSettingsMutationOptions,
+  ): Promise<ChannelSettingsSnapshot>;
+  setStartupNames(
+    names: readonly string[],
     options: ChannelSettingsMutationOptions,
   ): Promise<ChannelSettingsSnapshot>;
 }
@@ -126,15 +139,35 @@ function diagnostic(error: unknown): string {
 }
 
 function usesEnvironment(value: unknown): boolean {
-  return (
-    typeof value === 'string' && /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(value)
-  );
+  return typeof value === 'string' && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 export function createChannelManagementService(
   opts: CreateChannelManagementServiceOptions,
 ): ChannelManagementService {
   const diagnostics = new Map<string, string>();
+  let mutationTail = Promise.resolve();
+
+  const inMutationLane = <T>(mutation: () => Promise<T>): Promise<T> => {
+    const result = mutationTail.then(mutation, mutation);
+    mutationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const assertExpectedRevision = (
+    snapshot: ChannelSettingsSnapshot,
+    expectedRevision: string,
+  ): void => {
+    if (snapshot.revision !== expectedRevision) {
+      throw new ChannelManagementError(
+        'channel_settings_conflict',
+        'Channel settings changed; reload before trying again.',
+      );
+    }
+  };
 
   const workerFor = (name: string) => {
     const matches = opts.manager
@@ -184,7 +217,7 @@ export function createChannelManagementService(
     if (adapter?.state === 'error') {
       return {
         state: 'error',
-        ...(adapter.error ? { lastError: adapter.error } : {}),
+        ...(adapter.error ? { lastError: diagnostic(adapter.error) } : {}),
       };
     }
     if (
@@ -197,7 +230,7 @@ export function createChannelManagementService(
     if (worker.state === 'running') return { state: 'partial' };
     return {
       state: 'error',
-      ...(worker.error ? { lastError: worker.error } : {}),
+      ...(worker.error ? { lastError: diagnostic(worker.error) } : {}),
     };
   };
 
@@ -208,10 +241,21 @@ export function createChannelManagementService(
   ): Promise<ChannelInstanceSnapshot> => {
     const type = typeof rawConfig['type'] === 'string' ? rawConfig['type'] : '';
     const plugin = type ? await getPlugin(type) : undefined;
+    if (!plugin?.management) {
+      return {
+        name,
+        config: type ? { type } : {},
+        secrets: {},
+        startsWithServe:
+          startupNames.some(isAllChannelSelectionName) ||
+          startupNames.includes(name),
+        runtime: runtimeFor(name),
+      };
+    }
     const secretKeys = new Set(
-      plugin?.management?.fields
+      plugin.management.fields
         .filter((field) => field.kind === 'secret')
-        .map((field) => field.key) ?? [],
+        .map((field) => field.key),
     );
     const config: Record<string, unknown> = {};
     const secrets: Record<string, ChannelSecretState> = {};
@@ -234,7 +278,9 @@ export function createChannelManagementService(
       name,
       config,
       secrets,
-      startsWithServe: startupNames.includes(name),
+      startsWithServe:
+        startupNames.some(isAllChannelSelectionName) ||
+        startupNames.includes(name),
       runtime: runtimeFor(name),
     };
   };
@@ -262,15 +308,15 @@ export function createChannelManagementService(
     persisted = opts.store.snapshot(),
   ): Promise<ChannelMutationResult> => {
     const snapshot = await listFrom(persisted);
-    const instance =
-      snapshot.instances[name] ??
-      ({
-        name,
-        config: {},
-        secrets: {},
-        startsWithServe: false,
-        runtime: runtimeFor(name),
-      } satisfies ChannelInstanceSnapshot);
+    const instance = Object.hasOwn(snapshot.instances, name)
+      ? snapshot.instances[name]!
+      : ({
+          name,
+          config: {},
+          secrets: {},
+          startsWithServe: false,
+          runtime: runtimeFor(name),
+        } satisfies ChannelInstanceSnapshot);
     return { snapshot, instance };
   };
 
@@ -287,11 +333,21 @@ export function createChannelManagementService(
     }
   };
 
+  const assertManageableInstanceName = (name: string): void => {
+    if (isAllChannelSelectionName(name)) {
+      throw new ChannelManagementError(
+        'invalid_channel_instance_name',
+        'Channel instance name "all" is reserved for startup selection.',
+      );
+    }
+  };
+
   const service: ChannelManagementService = {
     async list() {
       return listFrom(opts.store.snapshot());
     },
     async upsert(name, request) {
+      assertManageableInstanceName(name);
       const committedNames = opts.manager.committedChannelNames();
       const active = committedNames.includes(name);
       if (active) assertOwnedRuntime(name);
@@ -308,18 +364,51 @@ export function createChannelManagementService(
       return resultFor(name, persisted);
     },
     async remove(name, request) {
-      const committedNames = opts.manager.committedChannelNames();
-      if (committedNames.includes(name)) {
-        assertOwnedRuntime(name);
-        await stopFromNames(name, committedNames);
+      const current = opts.store.snapshot();
+      assertExpectedRevision(current, request.expectedRevision);
+      if (!isAllChannelSelectionName(name)) {
+        const committedNames = opts.manager.committedChannelNames();
+        if (committedNames.includes(name)) {
+          assertOwnedRuntime(name);
+          await stopFromNames(name, committedNames);
+        }
       }
       const persisted = await opts.store.remove(name, request);
       diagnostics.delete(name);
       return resultFor(name, persisted);
     },
+    async setStartup(name, request) {
+      assertManageableInstanceName(name);
+      const current = opts.store.snapshot();
+      if (!Object.hasOwn(current.channels, name)) {
+        throw new ChannelManagementError(
+          'channel_instance_not_found',
+          `Channel "${name}" is not configured in this workspace.`,
+        );
+      }
+      const startsAll = current.startupNames.some(isAllChannelSelectionName);
+      if (startsAll && request.enabled) {
+        assertExpectedRevision(current, request.expectedRevision);
+        return resultFor(name, current);
+      }
+      const startupNames = startsAll
+        ? Object.keys(current.channels).filter(
+            (item) => !isAllChannelSelectionName(item) && item !== name,
+          )
+        : request.enabled
+          ? current.startupNames.includes(name)
+            ? current.startupNames
+            : [...current.startupNames, name]
+          : current.startupNames.filter((item) => item !== name);
+      const persisted = await opts.store.setStartupNames(startupNames, {
+        expectedRevision: request.expectedRevision,
+      });
+      return resultFor(name, persisted);
+    },
     async start(name) {
+      assertManageableInstanceName(name);
       const persisted = opts.store.snapshot();
-      if (!persisted.channels[name]) {
+      if (!Object.hasOwn(persisted.channels, name)) {
         throw new ChannelManagementError(
           'channel_instance_not_found',
           `Channel "${name}" is not configured in this workspace.`,
@@ -341,7 +430,14 @@ export function createChannelManagementService(
       return resultFor(name, persisted);
     },
     async stop(name) {
+      assertManageableInstanceName(name);
       const persisted = opts.store.snapshot();
+      if (!Object.hasOwn(persisted.channels, name)) {
+        throw new ChannelManagementError(
+          'channel_instance_not_found',
+          `Channel "${name}" is not configured in this workspace.`,
+        );
+      }
       const committedNames = opts.manager.committedChannelNames();
       if (committedNames.includes(name)) assertOwnedRuntime(name);
       await stopFromNames(name, committedNames);
@@ -349,6 +445,7 @@ export function createChannelManagementService(
       return resultFor(name, persisted);
     },
     async restart(name) {
+      assertManageableInstanceName(name);
       const persisted = opts.store.snapshot();
       if (!opts.manager.committedChannelNames().includes(name)) {
         throw new ChannelManagementError(
@@ -367,5 +464,16 @@ export function createChannelManagementService(
       return resultFor(name, persisted);
     },
   };
-  return service;
+  return {
+    list: () => service.list(),
+    upsert: (name, request) =>
+      inMutationLane(() => service.upsert(name, request)),
+    remove: (name, request) =>
+      inMutationLane(() => service.remove(name, request)),
+    setStartup: (name, request) =>
+      inMutationLane(() => service.setStartup(name, request)),
+    start: (name) => inMutationLane(() => service.start(name)),
+    stop: (name) => inMutationLane(() => service.stop(name)),
+    restart: (name) => inMutationLane(() => service.restart(name)),
+  };
 }

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -18,6 +18,7 @@ import { normalizeWorkerDiagnostic } from './channel-worker-diagnostics.js';
 import type {
   ChannelWorkerControlState,
   ChannelWorkerManager,
+  ChannelWorkerRequiredOwner,
 } from './channel-worker-manager.js';
 import type { ChannelWorkerSnapshot } from './channel-worker-supervisor.js';
 import type { ServeChannelSelection } from './types.js';
@@ -88,9 +89,13 @@ interface ChannelManagementSettingsStore {
 export interface ChannelManagementWorkerManager {
   committedChannelNames(): string[];
   state(): ChannelWorkerControlState;
-  setSelection(selection: ServeChannelSelection): Promise<unknown>;
+  setSelection(
+    selection: ServeChannelSelection,
+    requiredOwner?: ChannelWorkerRequiredOwner,
+  ): Promise<unknown>;
   stopSelection(): Promise<unknown>;
   reload(): Promise<ChannelWorkerSnapshot>;
+  reloadWorkspace(workspaceCwd: string): Promise<ChannelWorkerSnapshot>;
 }
 
 export interface CreateChannelManagementServiceOptions {
@@ -291,7 +296,7 @@ export function createChannelManagementService(
       diagnostics.delete(name);
       if (active) {
         try {
-          await opts.manager.reload();
+          await opts.manager.reloadWorkspace(opts.workspaceCwd);
         } catch (error) {
           await stopFromNames(name, committedNames);
           diagnostics.set(name, diagnostic(error));
@@ -319,10 +324,13 @@ export function createChannelManagementService(
       }
       const committedNames = opts.manager.committedChannelNames();
       if (!committedNames.includes(name)) {
-        await opts.manager.setSelection({
-          mode: 'names',
-          names: [...committedNames, name],
-        });
+        await opts.manager.setSelection(
+          {
+            mode: 'names',
+            names: [...committedNames, name],
+          },
+          { name, workspaceCwd: opts.workspaceCwd },
+        );
       } else {
         assertOwnedRuntime(name);
       }
@@ -347,7 +355,7 @@ export function createChannelManagementService(
       }
       assertOwnedRuntime(name);
       try {
-        await opts.manager.reload();
+        await opts.manager.reloadWorkspace(opts.workspaceCwd);
         diagnostics.delete(name);
       } catch (error) {
         diagnostics.set(name, diagnostic(error));

--- a/packages/cli/src/serve/channel-selection.test.ts
+++ b/packages/cli/src/serve/channel-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   channelSelectionNames,
+  isAllChannelSelectionName,
   normalizeServeChannelSelection,
 } from './channel-selection.js';
 
@@ -33,6 +34,13 @@ describe('normalizeServeChannelSelection', () => {
     expect(() => normalizeServeChannelSelection(['all', 'telegram'])).toThrow(
       '--channel all cannot be combined with channel names.',
     );
+  });
+});
+
+describe('isAllChannelSelectionName', () => {
+  it('recognizes the trimmed all sentinel only', () => {
+    expect(isAllChannelSelectionName(' all ')).toBe(true);
+    expect(isAllChannelSelectionName('allx')).toBe(false);
   });
 });
 

--- a/packages/cli/src/serve/channel-selection.test.ts
+++ b/packages/cli/src/serve/channel-selection.test.ts
@@ -19,8 +19,8 @@ describe('normalizeServeChannelSelection', () => {
     });
   });
 
-  it('parses all as a dedicated selection mode', () => {
-    expect(normalizeServeChannelSelection(['all'])).toEqual({ mode: 'all' });
+  it('parses trimmed all as a dedicated selection mode', () => {
+    expect(normalizeServeChannelSelection([' all '])).toEqual({ mode: 'all' });
   });
 
   it('rejects empty channel values', () => {

--- a/packages/cli/src/serve/channel-selection.ts
+++ b/packages/cli/src/serve/channel-selection.ts
@@ -1,5 +1,9 @@
 import type { ServeChannelSelection } from './types.js';
 
+export function isAllChannelSelectionName(name: string): boolean {
+  return name.trim() === 'all';
+}
+
 export function normalizeServeChannelSelection(
   rawChannels: string[] | undefined,
 ): ServeChannelSelection | undefined {
@@ -19,7 +23,7 @@ export function normalizeServeChannelSelection(
     names.push(name);
   }
 
-  if (seen.has('all')) {
+  if (names.some(isAllChannelSelectionName)) {
     if (names.length > 1) {
       throw new Error('--channel all cannot be combined with channel names.');
     }

--- a/packages/cli/src/serve/channel-worker-group.test.ts
+++ b/packages/cli/src/serve/channel-worker-group.test.ts
@@ -930,6 +930,44 @@ describe('createChannelWorkerGroup', () => {
     expect(recorded[1]!.supervisor.start).toHaveBeenCalledTimes(1);
   });
 
+  it('force-reconciles only the targeted workspace', async () => {
+    const registry = fakeRegistry([
+      fakeRuntime(PRIMARY, true),
+      fakeRuntime(SECONDARY, false),
+    ]);
+    const { createSupervisor, recorded } = makeCreateSupervisor(() =>
+      snapshot({}),
+    );
+    const groups: ChannelWorkspaceGroup[] = [
+      { workspaceCwd: PRIMARY, selection: { mode: 'names', names: ['a'] } },
+      { workspaceCwd: SECONDARY, selection: { mode: 'names', names: ['b'] } },
+    ];
+    const group = createChannelWorkerGroup({
+      groups,
+      registry,
+      createSupervisor,
+      shared,
+    });
+    await group.start();
+
+    await group.reconcile(
+      [
+        groups[0]!,
+        {
+          workspaceCwd: SECONDARY,
+          selection: { mode: 'names', names: ['changed-elsewhere'] },
+        },
+      ],
+      { forceWorkspaceCwd: PRIMARY },
+    );
+
+    expect(recorded).toHaveLength(3);
+    expect(recorded[0]!.supervisor.stop).toHaveBeenCalledOnce();
+    expect(recorded[1]!.supervisor.stop).not.toHaveBeenCalled();
+    expect(recorded[2]!.opts.workspace).toBe(PRIMARY);
+    expect(recorded[2]!.supervisor.start).toHaveBeenCalledOnce();
+  });
+
   it('coalesces concurrent reconciles onto the in-flight operation', async () => {
     const registry = fakeRegistry([fakeRuntime(PRIMARY, true)]);
     let releaseReplacement!: () => void;

--- a/packages/cli/src/serve/channel-worker-group.test.ts
+++ b/packages/cli/src/serve/channel-worker-group.test.ts
@@ -931,9 +931,11 @@ describe('createChannelWorkerGroup', () => {
   });
 
   it('force-reconciles only the targeted workspace', async () => {
+    const third = '/ws/third';
     const registry = fakeRegistry([
       fakeRuntime(PRIMARY, true),
       fakeRuntime(SECONDARY, false),
+      fakeRuntime(third, false),
     ]);
     const { createSupervisor, recorded } = makeCreateSupervisor(() =>
       snapshot({}),
@@ -957,6 +959,10 @@ describe('createChannelWorkerGroup', () => {
           workspaceCwd: SECONDARY,
           selection: { mode: 'names', names: ['changed-elsewhere'] },
         },
+        {
+          workspaceCwd: third,
+          selection: { mode: 'names', names: ['new-elsewhere'] },
+        },
       ],
       { forceWorkspaceCwd: PRIMARY },
     );
@@ -966,6 +972,10 @@ describe('createChannelWorkerGroup', () => {
     expect(recorded[1]!.supervisor.stop).not.toHaveBeenCalled();
     expect(recorded[2]!.opts.workspace).toBe(PRIMARY);
     expect(recorded[2]!.supervisor.start).toHaveBeenCalledOnce();
+
+    await group.restoreWorkspace(third);
+    expect(recorded).toHaveLength(3);
+    expect(group.snapshots()).toHaveLength(2);
   });
 
   it('coalesces concurrent reconciles onto the in-flight operation', async () => {

--- a/packages/cli/src/serve/channel-worker-group.ts
+++ b/packages/cli/src/serve/channel-worker-group.ts
@@ -67,7 +67,11 @@ export interface ChannelWorkerGroup {
   stop(): Promise<void>;
   reconcile(
     groups: readonly ChannelWorkspaceGroup[],
-    options?: { force?: boolean; onRollingBack?: () => void },
+    options?: {
+      force?: boolean;
+      forceWorkspaceCwd?: string;
+      onRollingBack?: () => void;
+    },
   ): Promise<ChannelWorkerGroupReconcileResult>;
   isHealthy(): boolean;
   killAllSync(): void;
@@ -467,9 +471,20 @@ export function createChannelWorkerGroup(
         for (const [workspaceCwd, entry] of entries) {
           const target = targets.get(workspaceCwd);
           const healthy = entry.supervisor.snapshot().state === 'running';
+          const forceWorkspace =
+            reconcileOptions?.forceWorkspaceCwd === workspaceCwd;
+          const preserveOtherWorkspace =
+            reconcileOptions?.forceWorkspaceCwd !== undefined &&
+            !forceWorkspace;
+          if (preserveOtherWorkspace) {
+            unchanged.set(workspaceCwd, entry);
+            targets.delete(workspaceCwd);
+            continue;
+          }
           if (
             target &&
             !reconcileOptions?.force &&
+            !forceWorkspace &&
             healthy &&
             selectionsEqual(entry.selection, target.selection)
           ) {
@@ -563,16 +578,17 @@ export function createChannelWorkerGroup(
           committed.set(entry.workspaceCwd, entry);
         }
         entries = committed;
-        const targetWorkspaceCwds = new Set(
-          targetGroups.map((target) => target.workspaceCwd),
-        );
+        const targetWorkspaceCwds = new Set(committed.keys());
         for (const workspaceCwd of groupsByWorkspace.keys()) {
           if (!targetWorkspaceCwds.has(workspaceCwd)) {
             groupsByWorkspace.delete(workspaceCwd);
           }
         }
-        for (const target of targetGroups) {
-          groupsByWorkspace.set(target.workspaceCwd, target);
+        for (const entry of committed.values()) {
+          groupsByWorkspace.set(entry.workspaceCwd, {
+            workspaceCwd: entry.workspaceCwd,
+            selection: entry.selection,
+          });
         }
         return { changed: true, workers: entrySnapshots() };
       })().finally(() => {

--- a/packages/cli/src/serve/channel-worker-group.ts
+++ b/packages/cli/src/serve/channel-worker-group.ts
@@ -464,6 +464,13 @@ export function createChannelWorkerGroup(
         const targets = new Map(
           targetGroups.map((target) => [target.workspaceCwd, target]),
         );
+        if (reconcileOptions?.forceWorkspaceCwd) {
+          for (const workspaceCwd of targets.keys()) {
+            if (workspaceCwd !== reconcileOptions.forceWorkspaceCwd) {
+              targets.delete(workspaceCwd);
+            }
+          }
+        }
         const unchanged = new Map<string, ChannelWorkerGroupEntry>();
         const oldAffected: ChannelWorkerGroupEntry[] = [];
         const newEntries: ChannelWorkerGroupEntry[] = [];

--- a/packages/cli/src/serve/channel-worker-manager.test.ts
+++ b/packages/cli/src/serve/channel-worker-manager.test.ts
@@ -451,9 +451,9 @@ describe('createChannelWorkerManager', () => {
       names: ['telegram', 'feishu'],
     });
 
-    await expect(test.manager.reloadWorkspace(PRIMARY)).resolves.toEqual(
-      primary,
-    );
+    await expect(
+      test.manager.reloadWorkspace(PRIMARY, 'telegram'),
+    ).resolves.toEqual(primary);
 
     expect(group.reconcile).toHaveBeenLastCalledWith(targetGroups, {
       forceWorkspaceCwd: PRIMARY,
@@ -464,6 +464,68 @@ describe('createChannelWorkerManager', () => {
       initialGroups,
     );
   });
+
+  it.each([
+    {
+      label: 'moves to another workspace',
+      targetGroups: [
+        {
+          workspaceCwd: PRIMARY,
+          selection: { mode: 'names' as const, names: ['other'] },
+        },
+        {
+          workspaceCwd: '/ws/secondary',
+          selection: { mode: 'names' as const, names: ['feishu', 'bot'] },
+        },
+      ],
+    },
+    {
+      label: 'becomes ownerless',
+      targetGroups: [
+        {
+          workspaceCwd: PRIMARY,
+          selection: { mode: 'names' as const, names: ['other'] },
+        },
+        {
+          workspaceCwd: '/ws/secondary',
+          selection: { mode: 'names' as const, names: ['feishu'] },
+        },
+      ],
+    },
+  ])(
+    'rejects targeted reload when the edited channel $label',
+    async ({ targetGroups }) => {
+      const initialGroups: ChannelWorkspaceGroup[] = [
+        {
+          workspaceCwd: PRIMARY,
+          selection: { mode: 'names', names: ['bot', 'other'] },
+        },
+        {
+          workspaceCwd: '/ws/secondary',
+          selection: { mode: 'names', names: ['feishu'] },
+        },
+      ];
+      const test = setup();
+      test.resolveGroups
+        .mockResolvedValueOnce(initialGroups)
+        .mockResolvedValueOnce(targetGroups);
+      await test.manager.setSelection({
+        mode: 'names',
+        names: ['bot', 'other', 'feishu'],
+      });
+      vi.mocked(test.group.reconcile).mockClear();
+
+      await expect(
+        test.manager.reloadWorkspace(PRIMARY, 'bot'),
+      ).rejects.toMatchObject({ code: 'channel_runtime_owner_mismatch' });
+
+      expect(test.group.reconcile).not.toHaveBeenCalled();
+      expect(test.onCommittedSelection).toHaveBeenLastCalledWith(
+        { mode: 'names', names: ['bot', 'other', 'feishu'] },
+        initialGroups,
+      );
+    },
+  );
 
   it('rejects a required owner mismatch before reconciling selection', async () => {
     const test = setup();

--- a/packages/cli/src/serve/channel-worker-manager.test.ts
+++ b/packages/cli/src/serve/channel-worker-manager.test.ts
@@ -19,11 +19,47 @@ import type { ChannelWorkspaceGroup } from './channel-workspace-grouping.js';
 import type { ServeChannelSelection } from './types.js';
 
 const PRIMARY = '/ws/primary';
+const SECONDARY = '/ws/secondary';
 
 function workspaceGroups(
   selection: ServeChannelSelection,
 ): ChannelWorkspaceGroup[] {
   return [{ workspaceCwd: PRIMARY, selection }];
+}
+
+function splitWorkspaceGroups(
+  selection: ServeChannelSelection,
+): ChannelWorkspaceGroup[] {
+  if (selection.mode === 'all') {
+    return [
+      { workspaceCwd: PRIMARY, selection },
+      { workspaceCwd: SECONDARY, selection },
+    ];
+  }
+  const primary = selection.names.filter(
+    (name) => !name.startsWith('secondary-'),
+  );
+  const secondary = selection.names.filter((name) =>
+    name.startsWith('secondary-'),
+  );
+  return [
+    ...(primary.length > 0
+      ? [
+          {
+            workspaceCwd: PRIMARY,
+            selection: { mode: 'names' as const, names: primary },
+          },
+        ]
+      : []),
+    ...(secondary.length > 0
+      ? [
+          {
+            workspaceCwd: SECONDARY,
+            selection: { mode: 'names' as const, names: secondary },
+          },
+        ]
+      : []),
+  ];
 }
 
 function workerSnapshot(
@@ -112,6 +148,54 @@ describe('createChannelWorkerManager', () => {
       'telegram',
       'feishu',
     ]);
+  });
+
+  it('serializes concurrent owner-scoped channel starts', async () => {
+    const test = setup();
+    const manager = test.manager;
+    test.resolveGroups.mockImplementation(async (selection) =>
+      splitWorkspaceGroups(selection),
+    );
+    await manager.setSelection({ mode: 'names', names: ['telegram'] });
+
+    await Promise.all([
+      manager.setChannelEnabled(
+        { name: 'primary-bot', workspaceCwd: PRIMARY },
+        true,
+      ),
+      manager.setChannelEnabled(
+        { name: 'secondary-bot', workspaceCwd: SECONDARY },
+        true,
+      ),
+    ]);
+
+    expect(manager.committedChannelNames()).toEqual([
+      'telegram',
+      'primary-bot',
+      'secondary-bot',
+    ]);
+  });
+
+  it('serializes an owner-scoped start with a concurrent stop', async () => {
+    const test = setup();
+    const manager = test.manager;
+    test.resolveGroups.mockImplementation(async (selection) =>
+      splitWorkspaceGroups(selection),
+    );
+    await manager.setSelection({ mode: 'names', names: ['telegram'] });
+
+    await Promise.all([
+      manager.setChannelEnabled(
+        { name: 'secondary-bot', workspaceCwd: SECONDARY },
+        true,
+      ),
+      manager.setChannelEnabled(
+        { name: 'telegram', workspaceCwd: PRIMARY },
+        false,
+      ),
+    ]);
+
+    expect(manager.committedChannelNames()).toEqual(['secondary-bot']);
   });
 
   it('enables a disabled manager and makes an equal healthy PUT idempotent', async () => {

--- a/packages/cli/src/serve/channel-worker-manager.test.ts
+++ b/packages/cli/src/serve/channel-worker-manager.test.ts
@@ -417,6 +417,76 @@ describe('createChannelWorkerManager', () => {
     );
   });
 
+  it('reloads only the requested workspace worker', async () => {
+    const primary = workerSnapshot();
+    const secondary = workerSnapshot({
+      workspaceId: 'secondary',
+      workspaceCwd: '/ws/secondary',
+      primary: false,
+    });
+    const initialGroups: ChannelWorkspaceGroup[] = [
+      {
+        workspaceCwd: PRIMARY,
+        selection: { mode: 'names', names: ['telegram'] },
+      },
+      {
+        workspaceCwd: '/ws/secondary',
+        selection: { mode: 'names', names: ['feishu'] },
+      },
+    ];
+    const targetGroups: ChannelWorkspaceGroup[] = [
+      initialGroups[0]!,
+      {
+        workspaceCwd: '/ws/secondary',
+        selection: { mode: 'names', names: ['changed-elsewhere'] },
+      },
+    ];
+    const group = fakeGroup({ snapshots: vi.fn(() => [primary, secondary]) });
+    const test = setup(group);
+    test.resolveGroups
+      .mockResolvedValueOnce(initialGroups)
+      .mockResolvedValueOnce(targetGroups);
+    await test.manager.setSelection({
+      mode: 'names',
+      names: ['telegram', 'feishu'],
+    });
+
+    await expect(test.manager.reloadWorkspace(PRIMARY)).resolves.toEqual(
+      primary,
+    );
+
+    expect(group.reconcile).toHaveBeenLastCalledWith(targetGroups, {
+      forceWorkspaceCwd: PRIMARY,
+      onRollingBack: expect.any(Function),
+    });
+    expect(test.onCommittedSelection).toHaveBeenLastCalledWith(
+      { mode: 'names', names: ['telegram', 'feishu'] },
+      initialGroups,
+    );
+  });
+
+  it('rejects a required owner mismatch before reconciling selection', async () => {
+    const test = setup();
+    test.resolveGroups.mockResolvedValueOnce([
+      {
+        workspaceCwd: '/ws/secondary',
+        selection: { mode: 'names', names: ['bot'] },
+      },
+    ]);
+
+    await expect(
+      test.manager.setSelection(
+        { mode: 'names', names: ['bot'] },
+        { name: 'bot', workspaceCwd: PRIMARY },
+      ),
+    ).rejects.toMatchObject({ code: 'channel_runtime_owner_mismatch' });
+
+    expect(test.createGroup).not.toHaveBeenCalled();
+    expect(test.group.reconcile).not.toHaveBeenCalled();
+    expect(test.reserveLease).not.toHaveBeenCalled();
+    expect(test.onStateChange).not.toHaveBeenCalled();
+  });
+
   it('preserves workspace-attributed startup failures from reload', async () => {
     const test = setup();
     const selection: ServeChannelSelection = {

--- a/packages/cli/src/serve/channel-worker-manager.test.ts
+++ b/packages/cli/src/serve/channel-worker-manager.test.ts
@@ -95,6 +95,25 @@ function setup(group = fakeGroup()) {
 }
 
 describe('createChannelWorkerManager', () => {
+  it('exposes committed channel names in selection order', async () => {
+    const test = setup();
+    const selection: ServeChannelSelection = {
+      mode: 'names',
+      names: ['telegram', 'feishu'],
+    };
+
+    expect(test.manager.committedChannelNames()).toEqual([]);
+    await test.manager.setSelection(selection);
+
+    const names = test.manager.committedChannelNames();
+    expect(names).toEqual(['telegram', 'feishu']);
+    names.reverse();
+    expect(test.manager.committedChannelNames()).toEqual([
+      'telegram',
+      'feishu',
+    ]);
+  });
+
   it('enables a disabled manager and makes an equal healthy PUT idempotent', async () => {
     const test = setup();
     const selection: ServeChannelSelection = {

--- a/packages/cli/src/serve/channel-worker-manager.ts
+++ b/packages/cli/src/serve/channel-worker-manager.ts
@@ -56,6 +56,7 @@ export class ChannelWorkerControlError extends Error {
     | 'channel_worker_start_failed'
     | 'channel_worker_stop_failed'
     | 'channel_worker_not_enabled'
+    | 'channel_runtime_owner_mismatch'
     | 'daemon_draining';
   readonly rolledBack?: boolean;
   readonly rollbackError?: string;
@@ -104,9 +105,11 @@ export interface ChannelWorkerManager {
   startInitial(selection: ServeChannelSelection): Promise<void>;
   setSelection(
     selection: ServeChannelSelection,
+    requiredOwner?: ChannelWorkerRequiredOwner,
   ): Promise<ChannelWorkerSetResult>;
   stopSelection(): Promise<ChannelWorkerStopResult>;
   reload(): Promise<ChannelWorkerSnapshot>;
+  reloadWorkspace(workspaceCwd: string): Promise<ChannelWorkerSnapshot>;
   state(): ChannelWorkerControlState;
   primarySnapshot(): ChannelWorkerSnapshot;
   snapshots(): ChannelWorkerGroupSnapshot[];
@@ -125,6 +128,11 @@ export interface ChannelWorkerManager {
   killAllSync(): void;
 }
 
+export interface ChannelWorkerRequiredOwner {
+  name: string;
+  workspaceCwd: string;
+}
+
 const DISABLED_SNAPSHOT: ChannelWorkerSnapshot = {
   enabled: false,
   state: 'disabled',
@@ -137,6 +145,15 @@ function cloneSelection(
   return selection.mode === 'all'
     ? { mode: 'all' }
     : { mode: 'names', names: [...selection.names] };
+}
+
+function cloneGroups(
+  groups: readonly ChannelWorkspaceGroup[],
+): ChannelWorkspaceGroup[] {
+  return groups.map((group) => ({
+    workspaceCwd: group.workspaceCwd,
+    selection: cloneSelection(group.selection),
+  }));
 }
 
 function selectionsEqual(
@@ -157,6 +174,31 @@ function isPartial(workers: readonly ChannelWorkerGroupSnapshot[]): boolean {
     const connected = new Set(worker.channels);
     return worker.requestedChannels.some((name) => !connected.has(name));
   });
+}
+
+function groupIncludesName(
+  group: ChannelWorkspaceGroup,
+  name: string,
+): boolean {
+  return group.selection.mode === 'all' || group.selection.names.includes(name);
+}
+
+function assertRequiredOwner(
+  targetGroups: readonly ChannelWorkspaceGroup[],
+  requiredOwner: ChannelWorkerRequiredOwner,
+): void {
+  const owners = targetGroups.filter((target) =>
+    groupIncludesName(target, requiredOwner.name),
+  );
+  if (
+    owners.length !== 1 ||
+    owners[0]!.workspaceCwd !== requiredOwner.workspaceCwd
+  ) {
+    throw new ChannelWorkerControlError(
+      'channel_runtime_owner_mismatch',
+      `Channel "${requiredOwner.name}" does not resolve to workspace "${requiredOwner.workspaceCwd}".`,
+    );
+  }
 }
 
 function errorMessage(error: unknown): string {
@@ -188,6 +230,7 @@ export function createChannelWorkerManager(
   opts: CreateChannelWorkerManagerOptions,
 ): ChannelWorkerManager {
   let committedSelection: ServeChannelSelection | undefined;
+  let committedGroups: ChannelWorkspaceGroup[] = [];
   let pendingSelection: ServeChannelSelection | undefined;
   let transition: ChannelWorkerControlTransition = 'idle';
   let group: ChannelWorkerGroup | undefined;
@@ -253,6 +296,7 @@ export function createChannelWorkerManager(
     groups: readonly ChannelWorkspaceGroup[],
   ) => {
     committedSelection = selection ? cloneSelection(selection) : undefined;
+    committedGroups = cloneGroups(groups);
     transition = 'idle';
     pendingSelection = undefined;
     opts.onCommittedSelection?.(committedSelection, groups);
@@ -288,6 +332,7 @@ export function createChannelWorkerManager(
   const applySelection = async (
     selection: ServeChannelSelection,
     initial: boolean,
+    resolvedGroups?: readonly ChannelWorkspaceGroup[],
   ): Promise<ChannelWorkerSetResult> => {
     if (hardKilled) throw drainingError();
     const enabling = !snapshot().enabled;
@@ -306,10 +351,9 @@ export function createChannelWorkerManager(
     setTransition(replacing ? 'reconciling' : 'starting', selection);
     let targetGroups: readonly ChannelWorkspaceGroup[];
     try {
-      targetGroups = await opts.resolveGroups(
-        selection,
-        initial ? 'initial' : 'set',
-      );
+      targetGroups =
+        resolvedGroups ??
+        (await opts.resolveGroups(selection, initial ? 'initial' : 'set'));
       if (hardKilled) throw drainingError();
       reserve(selection);
     } catch (error) {
@@ -412,11 +456,17 @@ export function createChannelWorkerManager(
         await applySelection(selection, true);
       });
     },
-    setSelection(selection) {
+    setSelection(selection, requiredOwner) {
       if (draining) {
         return Promise.reject(drainingError());
       }
-      return enqueue(() => applySelection(selection, false));
+      return enqueue(async () => {
+        if (!requiredOwner) return applySelection(selection, false);
+        const targetGroups = await opts.resolveGroups(selection, 'set');
+        assertRequiredOwner(targetGroups, requiredOwner);
+        if (hardKilled) throw drainingError();
+        return applySelection(selection, false, targetGroups);
+      });
     },
     stopSelection() {
       if (draining) {
@@ -478,6 +528,70 @@ export function createChannelWorkerManager(
           snapshots.find((worker) => worker.primary) ??
           snapshots[0] ?? { ...DISABLED_SNAPSHOT }
         );
+      });
+    },
+    reloadWorkspace(workspaceCwd) {
+      if (draining) {
+        return Promise.reject(drainingError());
+      }
+      return enqueue(async () => {
+        if (!group || !committedSelection) {
+          throw new ChannelWorkerControlError(
+            'channel_worker_not_enabled',
+            'This daemon has no channel worker to reload.',
+          );
+        }
+        setTransition('reconciling', committedSelection);
+        let targetGroups: readonly ChannelWorkspaceGroup[];
+        try {
+          targetGroups = await opts.resolveGroups(committedSelection, 'reload');
+          if (
+            targetGroups.filter(
+              (target) => target.workspaceCwd === workspaceCwd,
+            ).length !== 1 ||
+            committedGroups.filter(
+              (target) => target.workspaceCwd === workspaceCwd,
+            ).length !== 1
+          ) {
+            throw new ChannelWorkerControlError(
+              'channel_runtime_owner_mismatch',
+              `Workspace "${workspaceCwd}" does not own a committed channel worker.`,
+            );
+          }
+        } catch (error) {
+          setTransition('idle');
+          throw error;
+        }
+        if (hardKilled) throw drainingError();
+        try {
+          await group.reconcile(targetGroups, {
+            forceWorkspaceCwd: workspaceCwd,
+            onRollingBack: () =>
+              setTransition('rolling_back', committedSelection),
+          });
+        } catch (error) {
+          setTransition('idle');
+          throw classifyFailure(error, 'channel_worker_start_failed');
+        }
+        const targetGroup = targetGroups.find(
+          (target) => target.workspaceCwd === workspaceCwd,
+        )!;
+        const nextCommittedGroups = committedGroups.map((committedGroup) =>
+          committedGroup.workspaceCwd === workspaceCwd
+            ? targetGroup
+            : committedGroup,
+        );
+        commit(committedSelection, nextCommittedGroups);
+        const worker = group
+          .snapshots()
+          .find((snapshot) => snapshot.workspaceCwd === workspaceCwd);
+        if (!worker) {
+          throw new ChannelWorkerControlError(
+            'channel_runtime_owner_mismatch',
+            `Workspace "${workspaceCwd}" has no channel worker after reload.`,
+          );
+        }
+        return worker;
       });
     },
     state: snapshot,

--- a/packages/cli/src/serve/channel-worker-manager.ts
+++ b/packages/cli/src/serve/channel-worker-manager.ts
@@ -107,6 +107,10 @@ export interface ChannelWorkerManager {
     selection: ServeChannelSelection,
     requiredOwner?: ChannelWorkerRequiredOwner,
   ): Promise<ChannelWorkerSetResult>;
+  setChannelEnabled(
+    owner: ChannelWorkerRequiredOwner,
+    enabled: boolean,
+  ): Promise<ChannelWorkerSetResult | ChannelWorkerStopResult>;
   stopSelection(): Promise<ChannelWorkerStopResult>;
   reload(): Promise<ChannelWorkerSnapshot>;
   reloadWorkspace(
@@ -452,6 +456,62 @@ export function createChannelWorkerManager(
     }
   };
 
+  const committedChannelNames = (): string[] => {
+    if (!committedSelection) return [];
+    if (committedSelection.mode === 'names') {
+      return [...committedSelection.names];
+    }
+    const names = new Set<string>();
+    for (const worker of group?.snapshots() ?? []) {
+      for (const name of worker.requestedChannels ?? worker.channels) {
+        names.add(name);
+      }
+    }
+    return [...names];
+  };
+
+  const assertCommittedOwner = (
+    requiredOwner: ChannelWorkerRequiredOwner,
+  ): void => {
+    const owners = (group?.snapshots() ?? []).filter(
+      (worker) =>
+        worker.adapters?.some(
+          (adapter) => adapter.name === requiredOwner.name,
+        ) ||
+        worker.requestedChannels?.includes(requiredOwner.name) ||
+        worker.channels.includes(requiredOwner.name),
+    );
+    if (
+      owners.length !== 1 ||
+      owners[0]!.workspaceCwd !== requiredOwner.workspaceCwd
+    ) {
+      throw new ChannelWorkerControlError(
+        'channel_runtime_owner_mismatch',
+        `Channel "${requiredOwner.name}" does not have one confirmed runtime owner in workspace "${requiredOwner.workspaceCwd}".`,
+      );
+    }
+  };
+
+  const stopSelectionNow = async (): Promise<ChannelWorkerStopResult> => {
+    const hadState = group !== undefined || leaseReserved;
+    if (!hadState) {
+      return { changed: false, state: snapshot() };
+    }
+    setTransition('stopping');
+    try {
+      if (group) {
+        await group.stop();
+        group = undefined;
+      }
+      release();
+    } catch (error) {
+      setTransition('idle');
+      throw classifyFailure(error, 'channel_worker_stop_failed');
+    }
+    commit(undefined, []);
+    return { changed: hadState, state: snapshot() };
+  };
+
   const manager: ChannelWorkerManager = {
     async startInitial(selection) {
       if (draining) throw drainingError();
@@ -471,29 +531,47 @@ export function createChannelWorkerManager(
         return applySelection(selection, false, targetGroups);
       });
     },
-    stopSelection() {
+    setChannelEnabled(owner, enabled) {
       if (draining) {
         return Promise.reject(drainingError());
       }
       return enqueue(async () => {
-        const hadState = group !== undefined || leaseReserved;
-        if (!hadState) {
+        const committedNames = committedChannelNames();
+        const currentlyEnabled = committedNames.includes(owner.name);
+        if (currentlyEnabled) assertCommittedOwner(owner);
+        if (enabled) {
+          if (currentlyEnabled) {
+            return {
+              changed: false,
+              replaced: false,
+              partial: isPartial(group?.snapshots() ?? []),
+              state: snapshot(),
+              created: false,
+            };
+          }
+          const selection: ServeChannelSelection = {
+            mode: 'names',
+            names: [...committedNames, owner.name],
+          };
+          const targetGroups = await opts.resolveGroups(selection, 'set');
+          assertRequiredOwner(targetGroups, owner);
+          if (hardKilled) throw drainingError();
+          return applySelection(selection, false, targetGroups);
+        }
+        if (!currentlyEnabled) {
           return { changed: false, state: snapshot() };
         }
-        setTransition('stopping');
-        try {
-          if (group) {
-            await group.stop();
-            group = undefined;
-          }
-          release();
-        } catch (error) {
-          setTransition('idle');
-          throw classifyFailure(error, 'channel_worker_stop_failed');
-        }
-        commit(undefined, []);
-        return { changed: hadState, state: snapshot() };
+        const names = committedNames.filter((name) => name !== owner.name);
+        return names.length === 0
+          ? stopSelectionNow()
+          : applySelection({ mode: 'names', names }, false);
       });
+    },
+    stopSelection() {
+      if (draining) {
+        return Promise.reject(drainingError());
+      }
+      return enqueue(stopSelectionNow);
     },
     reload() {
       if (draining) {
@@ -601,19 +679,7 @@ export function createChannelWorkerManager(
     state: snapshot,
     primarySnapshot: () => group?.primarySnapshot() ?? { ...DISABLED_SNAPSHOT },
     snapshots: () => group?.snapshots() ?? [],
-    committedChannelNames() {
-      if (!committedSelection) return [];
-      if (committedSelection.mode === 'names') {
-        return [...committedSelection.names];
-      }
-      const names = new Set<string>();
-      for (const worker of group?.snapshots() ?? []) {
-        for (const name of worker.requestedChannels ?? worker.channels) {
-          names.add(name);
-        }
-      }
-      return [...names];
-    },
+    committedChannelNames,
     enqueueWebhookTask(task) {
       if (!group || draining) {
         return Promise.reject(

--- a/packages/cli/src/serve/channel-worker-manager.ts
+++ b/packages/cli/src/serve/channel-worker-manager.ts
@@ -110,6 +110,7 @@ export interface ChannelWorkerManager {
   state(): ChannelWorkerControlState;
   primarySnapshot(): ChannelWorkerSnapshot;
   snapshots(): ChannelWorkerGroupSnapshot[];
+  committedChannelNames(): string[];
   enqueueWebhookTask(
     task: ChannelWebhookTask,
   ): ReturnType<ChannelWorkerGroup['enqueueWebhookTask']>;
@@ -482,6 +483,19 @@ export function createChannelWorkerManager(
     state: snapshot,
     primarySnapshot: () => group?.primarySnapshot() ?? { ...DISABLED_SNAPSHOT },
     snapshots: () => group?.snapshots() ?? [],
+    committedChannelNames() {
+      if (!committedSelection) return [];
+      if (committedSelection.mode === 'names') {
+        return [...committedSelection.names];
+      }
+      const names = new Set<string>();
+      for (const worker of group?.snapshots() ?? []) {
+        for (const name of worker.requestedChannels ?? worker.channels) {
+          names.add(name);
+        }
+      }
+      return [...names];
+    },
     enqueueWebhookTask(task) {
       if (!group || draining) {
         return Promise.reject(

--- a/packages/cli/src/serve/channel-worker-manager.ts
+++ b/packages/cli/src/serve/channel-worker-manager.ts
@@ -109,7 +109,10 @@ export interface ChannelWorkerManager {
   ): Promise<ChannelWorkerSetResult>;
   stopSelection(): Promise<ChannelWorkerStopResult>;
   reload(): Promise<ChannelWorkerSnapshot>;
-  reloadWorkspace(workspaceCwd: string): Promise<ChannelWorkerSnapshot>;
+  reloadWorkspace(
+    workspaceCwd: string,
+    name: string,
+  ): Promise<ChannelWorkerSnapshot>;
   state(): ChannelWorkerControlState;
   primarySnapshot(): ChannelWorkerSnapshot;
   snapshots(): ChannelWorkerGroupSnapshot[];
@@ -530,7 +533,7 @@ export function createChannelWorkerManager(
         );
       });
     },
-    reloadWorkspace(workspaceCwd) {
+    reloadWorkspace(workspaceCwd, name) {
       if (draining) {
         return Promise.reject(drainingError());
       }
@@ -545,6 +548,7 @@ export function createChannelWorkerManager(
         let targetGroups: readonly ChannelWorkspaceGroup[];
         try {
           targetGroups = await opts.resolveGroups(committedSelection, 'reload');
+          assertRequiredOwner(targetGroups, { name, workspaceCwd });
           if (
             targetGroups.filter(
               (target) => target.workspaceCwd === workspaceCwd,

--- a/packages/cli/src/serve/channel-worker-startup-ipc.ts
+++ b/packages/cli/src/serve/channel-worker-startup-ipc.ts
@@ -16,6 +16,12 @@ export interface ChannelStartupFailure {
   message: string;
 }
 
+export interface ChannelAdapterSnapshot {
+  name: string;
+  state: 'starting' | 'connected' | 'error';
+  error?: string;
+}
+
 export interface ChannelStartupFailureMessage {
   type: 'channel_startup_failure';
   failure: ChannelStartupFailure;

--- a/packages/cli/src/serve/channel-worker-supervisor.test.ts
+++ b/packages/cli/src/serve/channel-worker-supervisor.test.ts
@@ -183,6 +183,14 @@ describe('createChannelWorkerSupervisor', () => {
     await started;
 
     const first = supervisor.snapshot();
+    expect(first.adapters).toEqual([
+      {
+        name: 'telegram',
+        state: 'error',
+        error: 'connection refused',
+      },
+      { name: 'feishu', state: 'connected' },
+    ]);
     expect(first.startupFailures).toEqual([
       {
         channel: 'telegram',

--- a/packages/cli/src/serve/channel-worker-supervisor.ts
+++ b/packages/cli/src/serve/channel-worker-supervisor.ts
@@ -40,6 +40,7 @@ import {
   MAX_CHANNEL_STARTUP_FAILURE_CHANNEL_LENGTH,
   MAX_CHANNEL_STARTUP_FAILURE_CODE_LENGTH,
   MAX_CHANNEL_STARTUP_FAILURE_MESSAGE_LENGTH,
+  type ChannelAdapterSnapshot,
   type ChannelStartupFailure,
 } from './channel-worker-startup-ipc.js';
 
@@ -119,6 +120,7 @@ export interface ChannelWorkerSnapshot {
   staleHeartbeatAt?: string;
   startupFailures?: ChannelStartupFailure[];
   startupFailuresTruncated?: boolean;
+  adapters?: ChannelAdapterSnapshot[];
 }
 
 export interface ChannelWorkerSupervisor {
@@ -487,6 +489,9 @@ export function createChannelWorkerSupervisor(
           })),
         }
       : {}),
+    ...(snapshot.adapters
+      ? { adapters: snapshot.adapters.map((adapter) => ({ ...adapter })) }
+      : {}),
   });
 
   const clearRestartTimer = () => {
@@ -673,6 +678,14 @@ export function createChannelWorkerSupervisor(
       state: 'starting',
       channels: channelSelectionNames(opts.selection),
       ...(requestedChannels ? { requestedChannels } : {}),
+      ...(requestedChannels
+        ? {
+            adapters: requestedChannels.map((name) => ({
+              name,
+              state: 'starting' as const,
+            })),
+          }
+        : {}),
       startedAt,
       restartCount: snapshot.restartCount ?? 0,
       ...(snapshot.lastExitAt ? { lastExitAt: snapshot.lastExitAt } : {}),
@@ -881,6 +894,15 @@ export function createChannelWorkerSupervisor(
         snapshot = {
           ...snapshot,
           startupFailures: [...(snapshot.startupFailures ?? []), failure],
+          adapters: snapshot.adapters?.map((adapter) =>
+            adapter.name === failure.channel
+              ? {
+                  name: adapter.name,
+                  state: 'error' as const,
+                  error: failure.message,
+                }
+              : adapter,
+          ),
         };
         acknowledgeStartupReport();
       };
@@ -909,6 +931,24 @@ export function createChannelWorkerSupervisor(
         if (message.requestedChannels?.length) {
           next.requestedChannels = [...message.requestedChannels];
         }
+        const adapterNames = message.requestedChannels?.length
+          ? message.requestedChannels
+          : (next.requestedChannels ?? next.channels);
+        const connected = new Set(next.channels);
+        const failures = new Map(
+          next.startupFailures?.map((failure) => [failure.channel, failure]),
+        );
+        next.adapters = adapterNames.map((name) => {
+          if (connected.has(name)) {
+            return { name, state: 'connected' as const };
+          }
+          const failure = failures.get(name);
+          return {
+            name,
+            state: 'error' as const,
+            ...(failure ? { error: failure.message } : {}),
+          };
+        });
         snapshot = next;
         armStaleHeartbeatTimer(startedChild);
         notifyReady(opts.onReady, snapshotCopy());


### PR DESCRIPTION
## What this PR does

This is the second part of #7209, following the merged persistence foundation in #7514. It adds a workspace-scoped channel management service and extends the existing channel worker manager so a single configured channel can be started, stopped, restarted, or reloaded only inside its resolved workspace runtime.

Targeted reloads preserve workers owned by other workspaces, validate the required owner before changing runtime state, and retain the previously committed topology after rollback. Per-adapter runtime states are exposed for management consumers, while unmanaged channel configuration and credentials in runtime errors remain redacted.

Persisted startup selection is independent from immediate runtime start/stop. The reserved `all` selection is projected across configured instances and safely expanded when one instance is disabled.

## Why it's needed

Channel configuration is workspace-owned, but the daemon worker manager coordinates all active workspace workers. The management layer therefore needs an explicit ownership check and a targeted reconciliation path; a process-global reload could restart or replace unrelated workspace channels.

Keeping this lifecycle layer separate from HTTP routes, SDK types, and WebShell UI makes the multi-workspace failure and rollback semantics independently reviewable.

## Reviewer Test Plan

### How to verify

Confirm that starting a channel requires it to resolve to the requested workspace, targeted reload replaces only that workspace worker, changes discovered in other workspaces are not committed by the targeted operation, and ownerless or cross-workspace resolutions fail before reconciliation.

Confirm that stale removal requests do not stop a running worker, lifecycle mutations are serialized, unmanaged channel fields are not returned, secrets are represented only by presence/source metadata, and runtime errors redact credential values.

Local verification: 170 focused tests passed across the management service, selection normalization, worker manager, worker group, and worker supervisor. Full repository build, repository typecheck, focused ESLint, Prettier, and diff checks also passed.

### Evidence (Before & After)

N/A — this PR adds the runtime lifecycle layer and does not expose a user-visible route or UI yet.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 on macOS.

## Risk & Scope

- Main risk or tradeoff: Channel lifecycle mutations now depend on a uniquely resolved workspace owner and fail closed when ownership is missing or ambiguous.
- Not validated / out of scope: HTTP routes, bearer-token enforcement, SDK/WebUI clients, WebShell UI, pairing approval, QR authentication, and channel types beyond the three made manageable by #7514.
- Breaking changes / migration notes: None. Existing process-level channel control remains available; the new targeted methods are not externally exposed until the route PR.

## Linked Issues

Part of #7209.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是 #7209 的第二部分，承接已经合入的持久化基础 PR #7514。它新增工作区级频道管理服务，并扩展现有频道 worker manager，使单个已配置频道只能在解析出的所属工作区运行时中启动、停止、重启或重载。

定向重载会保留其他工作区拥有的 worker，在改变运行态之前校验指定 owner，并在回滚后保留此前已提交的拓扑。管理消费者可以读取每个 adapter 的运行状态；不可管理频道的配置不会被暴露，运行错误中的凭据也会被脱敏。

持久化的随服务启动选择与即时启停相互独立。保留的 `all` 选择会投影到所有已配置实例；关闭其中一个实例时，会安全地展开为明确实例列表。

## 为什么需要

频道配置归工作区所有，但 daemon worker manager 同时协调所有活跃工作区的 worker。因此管理层需要显式 owner 校验和定向 reconcile 路径；进程级全量 reload 可能重启或替换无关工作区的频道。

把生命周期层与 HTTP 路由、SDK 类型和 WebShell UI 分开，可以独立评审多工作区失败与回滚语义。

## Reviewer 测试计划

### 如何验证

确认启动频道时必须解析到请求的工作区，定向重载只替换该工作区的 worker，定向操作不会提交其他工作区中发现的变化，并且无 owner 或跨工作区解析会在 reconcile 之前失败。

确认过期删除请求不会停止正在运行的 worker，生命周期变更按顺序执行，不可管理频道字段不会返回，密钥仅以是否存在及来源元数据表示，运行错误中的凭据值会被脱敏。

本地验证：管理服务、选择规范化、worker manager、worker group 和 worker supervisor 共 170 个聚焦测试通过。全仓构建、全仓类型检查、聚焦 ESLint、Prettier 和 diff 检查均通过。

### 证据（Before & After）

不适用——本 PR 增加运行时生命周期层，尚未暴露用户可见路由或 UI。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 上的 Node.js 22。

## 风险与范围

- 主要风险或取舍：频道生命周期变更现在依赖唯一解析出的工作区 owner；owner 缺失或存在歧义时会 fail closed。
- 未验证或范围外：HTTP 路由、Bearer Token 强制校验、SDK/WebUI 客户端、WebShell UI、配对审批、扫码认证，以及 #7514 开放的三个频道之外的频道类型。
- 破坏性变更或迁移说明：无。已有进程级频道控制仍可用；新增定向方法会在后续路由 PR 中才对外暴露。

## 关联 Issue

#7209 的一部分。

</details>
