### PR TITLE
fix(web-shell): isolate slash command plugin pages

### DIFF
--- a/docs/design/web-shell-plugin-shadow-surfaces.md
+++ b/docs/design/web-shell-plugin-shadow-surfaces.md
@@ -1,0 +1,30 @@
+# Web Shell Plugin Shadow Surfaces
+
+## Goal
+
+Make `shadowDom={{ plugins: true }}` isolate every plugin-management page,
+regardless of whether it was opened from the unified Plugins navigation or a
+slash-command compatibility route.
+
+## Surfaces
+
+The plugin Shadow DOM boundary applies to these inline panel IDs:
+
+- `plugins`
+- `extensions`
+- `mcp`
+- `skills`
+- `agents`
+
+`agents` is included for compatibility with the `AgentsManagerPage` and
+`AgentCreatePage` introduced by PR #7572. The create page is rendered inside
+the agents manager, so both pages share the same boundary.
+
+Settings, daemon status, and session overview remain in the Light DOM.
+Portal-based UI remains controlled independently by `shadowDom.portals`.
+
+## Implementation
+
+Use one boundary around the inline panel body and enable it only for the
+plugin-management panel IDs. This preserves a single rendering path and keeps
+the legacy slash routes consistent with the unified Plugins page.

--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -68,7 +68,8 @@ import customShadowStyles from './web-shell-shadow.css?inline';
 />;
 ```
 
-- `plugins` 只隔离插件管理页面主体。
+- `plugins` 隔离所有插件管理页面主体，包括统一的 Plugins 页面，以及
+  `/extensions`、`/mcp`、`/skills` 等兼容入口打开的页面。
 - `portals` 统一隔离 Web Shell 的所有弹窗层，包括 Dialog、Drawer、Popover、
   DropdownMenu、Select 和 Tooltip；插件页面发起的弹窗也由这个开关管理。
 - `styles` 会追加到每个启用的 ShadowRoot，供 render props 等业务自定义内容继续

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -3512,7 +3512,7 @@ describe('App session callbacks', () => {
     ).toBe('true');
   });
 
-  it('shadow-isolates only the plugin manager body when plugins is enabled', async () => {
+  it('shadow-isolates the unified plugin manager body when plugins is enabled', async () => {
     const { container } = renderApp({
       shadowDom: {
         plugins: true,
@@ -3545,6 +3545,45 @@ describe('App session callbacks', () => {
       document.querySelector('[data-web-shell-portal-root]'),
     ).not.toBeNull();
   });
+
+  it.each([
+    ['/extensions manage', 'Manage Extensions'],
+    ['/mcp', 'MCP Servers'],
+    ['/skills details', 'Skills'],
+  ])(
+    'shadow-isolates the %s compatibility page when plugins is enabled',
+    async (command, panelLabel) => {
+      mockWorkspaceActions.loadMcpStatus.mockResolvedValue({
+        initialized: true,
+        discoveryState: 'completed',
+        servers: [],
+      });
+      const { container } = renderApp({
+        shadowDom: {
+          plugins: true,
+          portals: false,
+        },
+      });
+      await flush();
+
+      testState.prompt = command;
+      await clickSubmit(container);
+      await flush();
+
+      const panel = container.querySelector('[data-testid="inline-panel"]');
+      const host = panel?.querySelector<HTMLElement>(
+        '[data-web-shell-shadow-host="plugins"]',
+      );
+      expect(panel?.getAttribute('aria-label')).toBe(panelLabel);
+      expect(host?.shadowRoot).not.toBeNull();
+      expect(
+        host?.shadowRoot?.querySelector(
+          '[data-web-shell-shadow-root="plugins"]',
+        ),
+      ).not.toBeNull();
+      expect(panel?.querySelector('button')).toBeNull();
+    },
+  );
 
   it('uses one shadow root for all portals without moving plugin content', async () => {
     const { container } = renderApp({

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -134,6 +134,7 @@ import { RewindDialog } from './components/dialogs/RewindDialog';
 import { AddWorkspaceDialog } from './components/dialogs/AddWorkspaceDialog';
 import { Button } from './components/ui/button';
 import {
+  isPluginShadowPanel,
   installWebShellShadowStyles,
   resolveWebShellShadowDom,
   type WebShellShadowDom,
@@ -7189,7 +7190,32 @@ export function App({
                     </div>
                   )}
                   <div className={styles.panelBody} key={activePanel}>
-                    {activePanel === 'settings' ? (
+                    <ShadowDomBoundary
+                      enabled={
+                        shadowDomOptions.plugins &&
+                        isPluginShadowPanel(activePanel)
+                      }
+                      language={selectedLanguage}
+                      themeClassName={[
+                        selectedTheme === WebShellThemeId.Light
+                          ? styles.themeLight
+                          : styles.themeDark,
+                        selectedTheme === WebShellThemeId.Dark
+                          ? 'dark'
+                          : undefined,
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                      styles={shadowDomOptions.styles}
+                      initialFocusRef={
+                        activePanel === 'plugins'
+                          ? pluginTabRef
+                          : activePanel === 'extensions'
+                            ? panelHeadingRef
+                            : undefined
+                      }
+                    >
+                      {activePanel === 'settings' ? (
                       <SettingsMessage
                         settingsState={workspaceSettingsState}
                         embedded
@@ -7277,37 +7303,20 @@ export function App({
                         onUseSkill={handleUseSkill}
                       />
                     ) : activePanel === 'plugins' ? (
-                      <ShadowDomBoundary
-                        enabled={shadowDomOptions.plugins}
-                        language={selectedLanguage}
-                        themeClassName={[
-                          selectedTheme === WebShellThemeId.Light
-                            ? styles.themeLight
-                            : styles.themeDark,
-                          selectedTheme === WebShellThemeId.Dark
-                            ? 'dark'
-                            : undefined,
-                        ]
-                          .filter(Boolean)
-                          .join(' ')}
-                        styles={shadowDomOptions.styles}
+                      <PluginManagerPage
+                        mcpMessage={mcpDialogMessage}
+                        loadMcpMessage={async () => {
+                          try {
+                            await loadMcpManagerMessage();
+                          } catch (error) {
+                            reportError(error, 'Failed to load MCP status');
+                            throw error;
+                          }
+                        }}
+                        onClose={closePanel}
+                        onUseSkill={handleUseSkill}
                         initialFocusRef={pluginTabRef}
-                      >
-                        <PluginManagerPage
-                          mcpMessage={mcpDialogMessage}
-                          loadMcpMessage={async () => {
-                            try {
-                              await loadMcpManagerMessage();
-                            } catch (error) {
-                              reportError(error, 'Failed to load MCP status');
-                              throw error;
-                            }
-                          }}
-                          onClose={closePanel}
-                          onUseSkill={handleUseSkill}
-                          initialFocusRef={pluginTabRef}
-                        />
-                      </ShadowDomBoundary>
+                      />
                     ) : (
                       <SessionOverviewPanel
                         onOpenSession={handleOpenSessionFromOverview}
@@ -7316,6 +7325,7 @@ export function App({
                         workspaceCwd={lockedWorkspaceCwd}
                       />
                     )}
+                    </ShadowDomBoundary>
                   </div>
                 </section>
               )}

--- a/packages/web-shell/client/shadowDom.test.ts
+++ b/packages/web-shell/client/shadowDom.test.ts
@@ -1,9 +1,26 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
+  isPluginShadowPanel,
   installWebShellShadowStyles,
   resolveWebShellShadowDom,
 } from './shadowDom';
+
+describe('isPluginShadowPanel', () => {
+  it.each(['plugins', 'extensions', 'mcp', 'skills', 'agents'])(
+    'includes the %s management surface',
+    (panel) => {
+      expect(isPluginShadowPanel(panel)).toBe(true);
+    },
+  );
+
+  it.each([null, 'settings', 'status', 'sessions'])(
+    'excludes the %s non-plugin surface',
+    (panel) => {
+      expect(isPluginShadowPanel(panel)).toBe(false);
+    },
+  );
+});
 
 describe('resolveWebShellShadowDom', () => {
   it('keeps Shadow DOM disabled by default', () => {

--- a/packages/web-shell/client/shadowDom.ts
+++ b/packages/web-shell/client/shadowDom.ts
@@ -15,6 +15,18 @@ export interface ResolvedWebShellShadowDomOptions {
   styles?: string;
 }
 
+const PLUGIN_SHADOW_PANELS = new Set([
+  'plugins',
+  'extensions',
+  'mcp',
+  'skills',
+  'agents',
+]);
+
+export function isPluginShadowPanel(panel: string | null): boolean {
+  return panel !== null && PLUGIN_SHADOW_PANELS.has(panel);
+}
+
 export function resolveWebShellShadowDom(
   value: WebShellShadowDom | undefined,
 ): ResolvedWebShellShadowDomOptions {


### PR DESCRIPTION
## What this PR does

Extends the existing `shadowDom.plugins` option to isolate every plugin-management surface, including the unified Plugins page and the compatibility pages opened by `/extensions`, `/mcp`, and `/skills`. It also recognizes the `agents` panel introduced by #7572 so the agents manager and its nested create/edit page use the same boundary once that change is present.

## Why it's needed

Consumers can opt into Shadow DOM isolation for the unified Plugins page, but opening the equivalent managers through slash commands currently renders them in the host page's Light DOM. That creates inconsistent style isolation depending on how the same management UI was opened.

## Reviewer Test Plan

### How to verify

Embed Web Shell with `shadowDom={{ plugins: true, portals: false }}`. Open the unified Plugins page, then run `/extensions manage`, `/mcp`, and `/skills details`; each manager body should render under the plugins ShadowRoot. Open Settings, Daemon Status, and Session Overview and confirm they remain in the Light DOM. Enabling `shadowDom.portals` should remain the only way to move dialogs, dropdowns, and other portal content into a ShadowRoot.

With #7572 present, open `/agents` and its create/edit flow; both the manager and nested form should remain in the same plugins ShadowRoot.

### Evidence (Before & After)

Before: only the unified Plugins page body was isolated; compatibility pages opened by slash commands rendered in the Light DOM.

After: the unified page and all plugin-management compatibility pages share the same opt-in Shadow DOM behavior, while unrelated panels and portals retain their existing behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local standalone Web Shell via `npm run dev:daemon`; 183 targeted Vitest tests, Web Shell typecheck, build, lint, and formatting checks passed.

## Risk & Scope

- Main risk or tradeoff: #7572 changes the same panel-rendering area and may require a manual merge conflict resolution; its agents branch must remain inside the shared boundary.
- Not validated / out of scope: Windows and Linux manual browser verification; portal isolation behavior is intentionally unchanged.
- Breaking changes / migration notes: None. Shadow DOM remains opt-in.

## Linked Issues

Related to #7572.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

扩展现有的 `shadowDom.plugins` 选项，使它隔离所有插件管理界面，包括统一 Plugins 页面以及通过 `/extensions`、`/mcp`、`/skills` 打开的兼容页面。同时预先识别 #7572 引入的 `agents` 面板，使该改动合入后 Agents 管理页及其内部的创建/编辑页面使用同一个 Shadow DOM 边界。

## 为什么需要

使用方可以为统一 Plugins 页面启用 Shadow DOM 隔离，但通过斜杠命令打开相同管理功能时，页面目前仍渲染在宿主页的 Light DOM 中。这会导致同一管理界面因打开方式不同而具有不一致的样式隔离行为。

## Reviewer 测试计划

### 验证方式

使用 `shadowDom={{ plugins: true, portals: false }}` 嵌入 Web Shell。打开统一 Plugins 页面，然后分别执行 `/extensions manage`、`/mcp` 和 `/skills details`；每个管理页面主体都应渲染在 plugins ShadowRoot 中。打开 Settings、Daemon Status 和 Session Overview，确认它们仍在 Light DOM 中。只有启用 `shadowDom.portals` 时，弹窗、下拉菜单等 portal 内容才应进入 ShadowRoot。

在包含 #7572 的代码上打开 `/agents` 及其创建/编辑流程；管理页和内部表单应始终位于同一个 plugins ShadowRoot 中。

### 前后对比证据

修改前：只有统一 Plugins 页面主体被隔离，通过斜杠命令打开的兼容页面渲染在 Light DOM 中。

修改后：统一页面和所有插件管理兼容页面共享相同的可选 Shadow DOM 行为，无关面板和 portal 保持原有行为。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

通过 `npm run dev:daemon` 启动本地 standalone Web Shell；183 个定向 Vitest 测试、Web Shell 类型检查、构建、lint 和格式检查均通过。

## 风险与范围

- 主要风险或取舍：#7572 修改了相同的面板渲染区域，合并时可能需要手工解决冲突；其 agents 分支必须保留在共享边界内。
- 未验证或不在范围内：未在 Windows 和 Linux 浏览器中手工验证；portal 隔离行为有意保持不变。
- 破坏性变更或迁移说明：无，Shadow DOM 仍为可选功能。

## 关联 Issue

关联 #7572。

</details>
