### PR TITLE
fix(core): avoid empty transcript history pages

### DIFF
--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -329,6 +329,32 @@ describe('SessionTranscriptReader', () => {
     });
   });
 
+  it('includes leading session metadata with the first backward page', async () => {
+    const sessionSource = {
+      ...record('source', null, 'session source'),
+      type: 'system' as const,
+      subtype: 'session_source' as const,
+    };
+    await writeRecords([
+      sessionSource,
+      record('u1', 'source', 'first prompt'),
+      record('a1', 'u1', 'first answer'),
+    ]);
+
+    const page = await new SessionTranscriptReader(workspaceDir).readPage(
+      sessionId,
+      { direction: 'backward', limit: 100 },
+    );
+
+    expect(page.records.map((item) => item.uuid)).toEqual([
+      'source',
+      'u1',
+      'a1',
+    ]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursorState).toBeUndefined();
+  });
+
   it('keeps backward pages within a normal user turn boundary', async () => {
     const toolCall = record('a-tool', 'u1', 'call tool');
     const toolResult = {

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -517,24 +517,38 @@ function selectBackwardPageUuids(
       break;
     }
   }
-  if (!alignedToReplayBoundary) {
+  let expandedSelection = false;
+  if (alignedToReplayBoundary && selectedStart > 0) {
+    let previousTurnStart = selectedStart - 1;
+    while (
+      previousTurnStart >= 0 &&
+      !isReplayTurnStart(index, index.activeUuids[previousTurnStart]!)
+    ) {
+      previousTurnStart--;
+    }
+    if (previousTurnStart < 0) {
+      selectedStart = 0;
+      expandedSelection = true;
+    }
+  } else if (!alignedToReplayBoundary) {
     while (
       selectedStart > 0 &&
       !isReplayTurnStart(index, index.activeUuids[selectedStart]!)
     ) {
       selectedStart--;
     }
-    if (maxBytes !== undefined) {
-      const alignedBytes = index.activeUuids
-        .slice(selectedStart, position)
-        .reduce((total, uuid) => total + recordSegmentBytes(index, uuid), 0);
-      if (alignedBytes > maxBytes) {
-        throw new SessionTranscriptPageTooLargeError(
-          sessionId,
-          alignedBytes,
-          maxBytes,
-        );
-      }
+    expandedSelection = true;
+  }
+  if (expandedSelection && maxBytes !== undefined) {
+    const alignedBytes = index.activeUuids
+      .slice(selectedStart, position)
+      .reduce((total, uuid) => total + recordSegmentBytes(index, uuid), 0);
+    if (alignedBytes > maxBytes) {
+      throw new SessionTranscriptPageTooLargeError(
+        sessionId,
+        alignedBytes,
+        maxBytes,
+      );
     }
   }
 


### PR DESCRIPTION
## What this PR does

Backward transcript pagination now includes leading session metadata with the first conversation page when no earlier user turn exists. This prevents an otherwise empty metadata-only continuation page from being advertised as additional history.

## Why it's needed

A persisted session can begin with an internal session-source record before its first user turn. Turn-aligned backward pagination previously left that record behind and reported more history, even though replaying the follow-up page produced no visible events. Clients consequently issued a redundant transcript request and observed `historyHasMore: true` followed by `events: []`.

## Reviewer Test Plan

### How to verify

Create a transcript whose active chain is `session_source -> user -> assistant`, then request a backward page with a limit larger than the transcript. Confirm the initial page includes the complete chain, reports `hasMore: false`, and has no continuation cursor. Also confirm ordinary multi-turn backward pages remain aligned to user turns.

### Evidence (Before & After)

Before: the initial page omitted the leading session-source record and reported `hasMore: true`; the continuation page returned `events: []` and `hasMore: false`.

After: the initial page consumes all 21 records in the reproduced session, reports `hasMore: false`, and returns no continuation cursor.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Node.js 22; targeted unit tests plus repository lint, build, and typecheck.

## Risk & Scope

- Main risk or tradeoff: Leading metadata may make the first backward page exceed its nominal record limit, matching the existing behavior for complete user turns; the byte budget is still enforced after expansion.
- Not validated / out of scope: Archived transcripts and non-filesystem transcript implementations were not exercised end to end.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当第一个用户轮次之前不存在更早的用户轮次时，向后加载 transcript 会把会话前置元数据并入第一个对话页。这样不会再把一个只能产生空结果的纯元数据续页标记为“还有历史”。

## 为什么需要

持久化会话可能在第一个用户轮次之前包含内部的 session-source 记录。此前按轮次对齐的向后分页会把该记录单独留在前一页，并报告还有历史，但续页 replay 后没有任何可展示事件。客户端因此会发出一次多余的 transcript 请求，并观察到 `historyHasMore: true` 后紧接着 `events: []`。

## Reviewer 测试计划

### 如何验证

创建 active chain 为 `session_source -> user -> assistant` 的 transcript，并使用大于 transcript 长度的 limit 请求向后分页。确认第一页包含完整链、返回 `hasMore: false` 且没有 continuation cursor；同时确认普通多轮会话的向后分页仍按用户轮次对齐。

### 修复前后证据

修复前：第一页遗漏前置 session-source 记录并返回 `hasMore: true`；续页返回 `events: []` 和 `hasMore: false`。

修复后：复现会话的第一页一次消费全部 21 条记录，返回 `hasMore: false`，且没有 continuation cursor。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境

Node.js 22；运行了定点单元测试以及仓库 lint、build 和 typecheck。

## 风险与范围

- 主要风险或取舍：前置元数据可能使第一个向后分页超过名义 record limit，这与完整用户轮次已有行为一致；扩展后仍会执行字节预算检查。
- 未验证或范围外：未对归档 transcript 和非文件系统 transcript 实现执行端到端验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
