### PR TITLE
perf(cli): Propagate compile cache to ACP children

### DIFF
--- a/docs/design/acp-compile-cache-propagation.md
+++ b/docs/design/acp-compile-cache-propagation.md
@@ -1,0 +1,96 @@
+# ACP compile-cache propagation
+
+## Context
+
+The production `cli-entry.js` wrapper already enables Node's module compile cache for the in-process `serve` fast path. The daemon later spawns an ACP child through `createSpawnChannelFactory()`, but `module.enableCompileCache()` affects only the current process and does not populate `NODE_COMPILE_CACHE`. The ACP child therefore starts without the cache unless the operator set that environment variable before launching Qwen Code.
+
+This is the orthogonal compile-cache candidate recorded on #7264. It does not shrink the eager module graph; it reuses V8 code cache for the graph that remains after the lazy-loading work.
+
+## Goals
+
+- Let production ACP descendants reuse the compile-cache directory already enabled by the daemon entry wrapper.
+- Preserve an operator-provided `NODE_COMPILE_CACHE`.
+- Preserve `NODE_DISABLE_COMPILE_CACHE=1`.
+- Keep cache failures a quiet optimization failure rather than an application failure.
+- Avoid changing the ACP bridge, configuration, or session lifecycle.
+
+## Non-goals
+
+- Do not introduce a Qwen-specific cache location, eviction policy, or cleanup command.
+- Do not force compile-cache support on Node versions where the JavaScript API is unavailable.
+- Do not flush the cache from the daemon or ACP lifecycle.
+- Do not change test or coverage environments globally.
+
+## Startup topology
+
+The production daemon path is:
+
+1. `cli-entry.js serve`
+2. `module.enableCompileCache()` in the daemon process
+3. in-process import of the bundled CLI
+4. `createSpawnChannelFactory()` copies `process.env`
+5. a new Node process reads `NODE_COMPILE_CACHE` during startup
+6. the child runs the selected CLI entry with `--acp` (`cli.js` by default, or `QWEN_CLI_ENTRY` when explicitly configured)
+
+Today step 2 benefits only the daemon. The environment copied at step 4 has no compile-cache directory, so the child at steps 5 and 6 does not opt in.
+
+## Proposed change
+
+Capture the result of the existing `module.enableCompileCache()` call. When it reports a newly enabled cache, exposes a directory, and the operator did not provide `NODE_COMPILE_CACHE`, publish that directory in `process.env`. Existing child-process construction already copies the environment, so no ACP-layer change is necessary.
+
+Do not overwrite an existing environment value. When Node enabled the cache from a pre-existing environment variable it reports an already-enabled state and the original base directory must remain intact. Replacing it with `getCompileCacheDir()` or the already-enabled result can create a nested version directory in descendants.
+
+Do not synthesize a directory when enabling fails, is disabled, or the API is unavailable. These cases retain the current behavior.
+
+## Alternatives considered
+
+### Set the environment variable in `spawnChannel`
+
+Rejected. Compile-cache ownership is process-global entry behavior, while `spawnChannel` is shared ACP infrastructure used by embedded hosts. Moving policy there broadens the architectural surface and duplicates Node bootstrap behavior.
+
+### Set a Qwen-versioned cache under `QWEN_HOME`
+
+Rejected. Node already separates incompatible Node versions and keys entries by module content. Node recommends its temporary-directory default to avoid accumulating stale cache. A persistent Qwen-specific cache would require new cleanup, permissions, and lifecycle policy without evidence that it improves the measured path.
+
+### Export `getCompileCacheDir()` unconditionally
+
+Rejected. When the cache was enabled from an existing environment variable, the reported directory is already Node-version-specific. Reusing it as the next process's base creates another nested version directory and prevents the intended sharing.
+
+## Failure and compatibility behavior
+
+- Node without `enableCompileCache()`: no environment mutation and no behavior change.
+- `NODE_DISABLE_COMPILE_CACHE=1`: Node reports disabled; no directory is propagated.
+- Operator-provided `NODE_COMPILE_CACHE`: preserved verbatim and inherited normally.
+- Unwritable or otherwise invalid cache directory: Node reports failure without throwing; Qwen Code continues without a cache.
+- Node or Qwen upgrade: Node isolates incompatible runtime versions and source-content changes produce different cache entries.
+- Coverage: the production fast path is the only mutation point. Unit-test runners are not globally opted into compile caching.
+- Shutdown: Node writes accumulated code cache during normal process exit. Forced termination can lose newly generated entries but cannot affect correctness.
+
+## Verification
+
+Feasibility is gated before implementation using one identical release bundle for both variants. Both daemon variants receive the same warm parent-process cache. The control removes the cache environment before importing the bundle, so ACP descendants remain uncached; the candidate publishes the same base directory before import, so ACP descendants inherit it.
+
+The 2-vCPU reference-host gate covers:
+
+- 30 alternating paired cold daemon starts
+- 30 alternating paired preheated starts
+- `channel.initialize`, process-to-first-session, listener readiness, and peak RSS
+- a warm second session
+- concurrent first sessions
+- telemetry enabled and disabled
+- legacy single-session behavior
+- empty-cache first use, warm-cache reuse, cache footprint, and residual processes
+
+Implementation proceeds only if the child-specific warm-cache comparison shows a repeatable initialization or process-to-session benefit without a functional regression.
+
+## Validation results
+
+The gate ran on a 2-vCPU, 4-GB Linux x64 host with Node.js 22.23.1. The control and candidate used the same bundle from `77af061e` and differed only in whether the ACP child inherited the parent compile-cache directory.
+
+Across 30 warm-cache paired runs, the candidate won every `channel.initialize` comparison. Its paired median improvement was 176.6 ms, with a bootstrap 95% confidence interval of 167.7–186.2 ms. The paired median process-to-first-session improvement was 199.0 ms, with a 95% confidence interval of 177.6–226.5 ms. The candidate's median peak process-tree RSS was 8.6 MB higher.
+
+An additional 10-pair confirmation used the unmodified production entry from `origin/main` as the control and the patched production entry as the candidate. It reproduced a 181.6 ms median `channel.initialize` improvement and a 189.4 ms median process-to-first-session improvement.
+
+Across 20 independent empty-cache pairs, the first process-to-session run was 117.2 ms slower at the median, with a 95% confidence interval of 69.3–130.9 ms. The second ACP startup therefore recovers the one-time generation cost under the measured workload. The stable cache contained 362 files and used 9.4 MB.
+
+All measured runs completed successfully without residual processes. The candidate also passed concurrent first-session creation, telemetry-disabled startup, and legacy single-session behavior.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -21,6 +21,7 @@ import {
 } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import nodeModule from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { FatalError } from '@qwen-code/qwen-code-core';
@@ -401,6 +402,68 @@ describe('bootstrap import boundaries', () => {
     expect(source).toContain("hasFlag('--help', '-h')");
     expect(source).toContain("hasFlag('--version', '-v')");
     expect(source).toContain('UPDATE_COMPLETE_EXIT_CODE = 44');
+  });
+
+  it('publishes the daemon compile cache without overriding user policy', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'qwen-compile-cache-'));
+    const entryPath = path.join(tempDir, 'cli-entry.mjs');
+    const unsupportedEntryPath = path.join(
+      tempDir,
+      'unsupported-cli-entry.mjs',
+    );
+    try {
+      copyFileSync('../../scripts/cli-entry.js', entryPath);
+      writeFileSync(
+        unsupportedEntryPath,
+        readFileSync('../../scripts/cli-entry.js', 'utf8').replace(
+          "const { default: module } = await import('node:module');",
+          'const module = {};',
+        ),
+      );
+      writeFileSync(
+        path.join(tempDir, 'cli.js'),
+        'process.stdout.write(JSON.stringify({ cacheDir: process.env.NODE_COMPILE_CACHE }));\n',
+      );
+      const baseEnv = { ...process.env };
+      delete baseEnv['NODE_COMPILE_CACHE'];
+      delete baseEnv['NODE_DISABLE_COMPILE_CACHE'];
+      const runEntry = (
+        env: NodeJS.ProcessEnv,
+        args: string[] = ['serve'],
+        selectedEntryPath = entryPath,
+      ) =>
+        JSON.parse(
+          execFileSync(process.execPath, [selectedEntryPath, ...args], {
+            encoding: 'utf8',
+            env,
+          }),
+        );
+
+      if (typeof Reflect.get(nodeModule, 'enableCompileCache') === 'function') {
+        expect(runEntry(baseEnv).cacheDir).toBeTruthy();
+      } else {
+        expect(runEntry(baseEnv)).toEqual({});
+      }
+      expect(runEntry(baseEnv, ['serve'], unsupportedEntryPath)).toEqual({});
+      expect(runEntry(baseEnv, ['mcp', 'list'])).toEqual({});
+
+      const configuredCacheDir = path.join(tempDir, 'configured-cache');
+      expect(
+        runEntry({
+          ...baseEnv,
+          NODE_COMPILE_CACHE: configuredCacheDir,
+        }).cacheDir,
+      ).toBe(configuredCacheDir);
+
+      expect(
+        runEntry({
+          ...baseEnv,
+          NODE_DISABLE_COMPILE_CACHE: '1',
+        }),
+      ).toEqual({});
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('reloads the CLI through a stable shim after an update', () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -21,7 +21,6 @@ import {
 } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import nodeModule from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { FatalError } from '@qwen-code/qwen-code-core';
@@ -411,6 +410,7 @@ describe('bootstrap import boundaries', () => {
       tempDir,
       'unsupported-cli-entry.mjs',
     );
+    const probeEntryPath = path.join(tempDir, 'compile-cache-probe.mjs');
     try {
       copyFileSync('../../scripts/cli-entry.js', entryPath);
       writeFileSync(
@@ -419,6 +419,17 @@ describe('bootstrap import boundaries', () => {
           "const { default: module } = await import('node:module');",
           'const module = {};',
         ),
+      );
+      writeFileSync(
+        probeEntryPath,
+        [
+          "import module from 'node:module';",
+          'const result = module.enableCompileCache?.();',
+          'process.stdout.write(JSON.stringify(Boolean(',
+          '  result?.status === module.constants?.compileCacheStatus?.ENABLED &&',
+          '    result?.directory,',
+          ')));',
+        ].join('\n'),
       );
       writeFileSync(
         path.join(tempDir, 'cli.js'),
@@ -439,7 +450,13 @@ describe('bootstrap import boundaries', () => {
           }),
         );
 
-      if (typeof Reflect.get(nodeModule, 'enableCompileCache') === 'function') {
+      const canEnableCompileCache = JSON.parse(
+        execFileSync(process.execPath, [probeEntryPath], {
+          encoding: 'utf8',
+          env: baseEnv,
+        }),
+      );
+      if (canEnableCompileCache) {
         expect(runEntry(baseEnv).cacheDir).toBeTruthy();
       } else {
         expect(runEntry(baseEnv)).toEqual({});

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -433,7 +433,12 @@ describe('bootstrap import boundaries', () => {
       );
       writeFileSync(
         path.join(tempDir, 'cli.js'),
-        'process.stdout.write(JSON.stringify({ cacheDir: process.env.NODE_COMPILE_CACHE }));\n',
+        [
+          'process.stdout.write(JSON.stringify({',
+          '  cacheDir: process.env.NODE_COMPILE_CACHE,',
+          '  pendingCacheDir: process.env.QWEN_CODE_PENDING_COMPILE_CACHE,',
+          '}));',
+        ].join('\n'),
       );
       const baseEnv = { ...process.env };
       delete baseEnv['NODE_COMPILE_CACHE'];
@@ -457,7 +462,9 @@ describe('bootstrap import boundaries', () => {
         }),
       );
       if (canEnableCompileCache) {
-        expect(runEntry(baseEnv).cacheDir).toBeTruthy();
+        expect(runEntry(baseEnv)).toEqual({
+          pendingCacheDir: expect.any(String),
+        });
       } else {
         expect(runEntry(baseEnv)).toEqual({});
       }
@@ -469,8 +476,8 @@ describe('bootstrap import boundaries', () => {
         runEntry({
           ...baseEnv,
           NODE_COMPILE_CACHE: configuredCacheDir,
-        }).cacheDir,
-      ).toBe(configuredCacheDir);
+        }),
+      ).toEqual({ cacheDir: configuredCacheDir });
 
       expect(
         runEntry({

--- a/packages/cli/src/config/compile-cache.ts
+++ b/packages/cli/src/config/compile-cache.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const PENDING_COMPILE_CACHE_ENV = 'QWEN_CODE_PENDING_COMPILE_CACHE';
+
+export function publishPendingCompileCache(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const pendingDirectory = env[PENDING_COMPILE_CACHE_ENV];
+  delete env[PENDING_COMPILE_CACHE_ENV];
+  if (
+    pendingDirectory &&
+    !env['NODE_COMPILE_CACHE'] &&
+    env['NODE_DISABLE_COMPILE_CACHE'] !== '1'
+  ) {
+    env['NODE_COMPILE_CACHE'] = pendingDirectory;
+  }
+}

--- a/packages/cli/src/config/environment.test.ts
+++ b/packages/cli/src/config/environment.test.ts
@@ -22,7 +22,10 @@ const TRACKED_ENV = [
   'RUNTIME_SETTINGS_ONLY',
   'BASH_ENV',
   'NODE_OPTIONS',
+  'NODE_COMPILE_CACHE',
+  'NODE_DISABLE_COMPILE_CACHE',
   'QWEN_HOME',
+  'QWEN_CODE_PENDING_COMPILE_CACHE',
   'QWEN_RUNTIME_DIR',
   'QWEN_SERVER_TOKEN',
 ] as const;
@@ -169,6 +172,50 @@ describe('buildRuntimeEnvironment', () => {
 });
 
 describe('loadEnvironment', () => {
+  it('preserves settings.env compile cache over the pending default', () => {
+    const workspace = makeWorkspace();
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] = '/tmp/generated-cache';
+
+    loadEnvironment(
+      testSettings({
+        env: {
+          NODE_COMPILE_CACHE: '/tmp/operator-cache',
+        },
+      }),
+      workspace,
+    );
+
+    expect(process.env['NODE_COMPILE_CACHE']).toBe('/tmp/operator-cache');
+    expect(process.env['QWEN_CODE_PENDING_COMPILE_CACHE']).toBeUndefined();
+  });
+
+  it('publishes the pending compile cache after environment loading', () => {
+    const workspace = makeWorkspace();
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] = '/tmp/generated-cache';
+
+    loadEnvironment(testSettings({}), workspace);
+
+    expect(process.env['NODE_COMPILE_CACHE']).toBe('/tmp/generated-cache');
+    expect(process.env['QWEN_CODE_PENDING_COMPILE_CACHE']).toBeUndefined();
+  });
+
+  it('does not publish the pending compile cache when disabled by settings.env', () => {
+    const workspace = makeWorkspace();
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] = '/tmp/generated-cache';
+
+    loadEnvironment(
+      testSettings({
+        env: {
+          NODE_DISABLE_COMPILE_CACHE: '1',
+        },
+      }),
+      workspace,
+    );
+
+    expect(process.env['NODE_COMPILE_CACHE']).toBeUndefined();
+    expect(process.env['QWEN_CODE_PENDING_COMPILE_CACHE']).toBeUndefined();
+  });
+
   it('filters reload-excluded keys from settings.env on initial load', () => {
     const workspace = makeWorkspace();
 

--- a/packages/cli/src/config/environment.ts
+++ b/packages/cli/src/config/environment.ts
@@ -15,6 +15,7 @@ import {
   HOME_ENV_BOOTSTRAP_KEYS,
   PROJECT_ENV_HARDCODED_EXCLUSIONS,
 } from './shared-env-keys.js';
+import { publishPendingCompileCache } from './compile-cache.js';
 export {
   DEFAULT_EXCLUDED_ENV_VARS,
   ENV_CORRUPTED_PATH,
@@ -541,6 +542,7 @@ export function loadEnvironment(
     }
   }
   lastReloadSnapshotSeeded = true;
+  publishPendingCompileCache();
 }
 
 export interface EnvReloadResult {

--- a/packages/cli/src/serve/fast-path-settings.ts
+++ b/packages/cli/src/serve/fast-path-settings.ts
@@ -25,6 +25,7 @@ import {
   getPathComparisonVariants,
   isWithinRoot,
 } from '../config/path-comparison.js';
+import { publishPendingCompileCache } from '../config/compile-cache.js';
 import type { Settings } from '../config/settingsSchema.js';
 import { resolveEnvVarsInObject } from '../utils/envVarResolver.js';
 
@@ -290,6 +291,7 @@ export function loadServeFastPathEnvironment(
       }
     }
   }
+  publishPendingCompileCache();
 }
 
 function readTrustedFolderRulesFastPath(): readonly CachedTrustRule[] {

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -69,6 +69,11 @@ const originalRateLimit = process.env['QWEN_SERVE_RATE_LIMIT'];
 const originalRateLimitPrompt = process.env['QWEN_SERVE_RATE_LIMIT_PROMPT'];
 const originalCloudShell = process.env['CLOUD_SHELL'];
 const originalGoogleCloudProject = process.env['GOOGLE_CLOUD_PROJECT'];
+const originalNodeCompileCache = process.env['NODE_COMPILE_CACHE'];
+const originalNodeDisableCompileCache =
+  process.env['NODE_DISABLE_COMPILE_CACHE'];
+const originalPendingCompileCache =
+  process.env['QWEN_CODE_PENDING_COMPILE_CACHE'];
 const originalCwd = process.cwd();
 const cliPackageRoot = process.cwd();
 
@@ -333,6 +338,22 @@ afterEach(() => {
     delete process.env['GOOGLE_CLOUD_PROJECT'];
   } else {
     process.env['GOOGLE_CLOUD_PROJECT'] = originalGoogleCloudProject;
+  }
+  if (originalNodeCompileCache === undefined) {
+    delete process.env['NODE_COMPILE_CACHE'];
+  } else {
+    process.env['NODE_COMPILE_CACHE'] = originalNodeCompileCache;
+  }
+  if (originalNodeDisableCompileCache === undefined) {
+    delete process.env['NODE_DISABLE_COMPILE_CACHE'];
+  } else {
+    process.env['NODE_DISABLE_COMPILE_CACHE'] = originalNodeDisableCompileCache;
+  }
+  if (originalPendingCompileCache === undefined) {
+    delete process.env['QWEN_CODE_PENDING_COMPILE_CACHE'];
+  } else {
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] =
+      originalPendingCompileCache;
   }
   if (originalQwenRuntimeDir === undefined) {
     delete process.env['QWEN_RUNTIME_DIR'];
@@ -1131,6 +1152,26 @@ describe('serve fast path environment bootstrap', () => {
     await bootstrapServeFastPathEnvironment(tempWorkspace);
 
     expect(process.env['QWEN_SERVER_TOKEN']).toBe('from-workspace-env');
+  });
+
+  it('preserves workspace .env compile cache over the pending default', async () => {
+    delete process.env['NODE_COMPILE_CACHE'];
+    delete process.env['NODE_DISABLE_COMPILE_CACHE'];
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] = '/tmp/generated-cache';
+    useTempQwenHome();
+    tempWorkspace = realpathSync(
+      mkdtempSync(join(os.tmpdir(), 'qws-fast-path-compile-cache-')),
+    );
+    mkdirSync(join(tempWorkspace, '.qwen'));
+    writeFileSync(
+      join(tempWorkspace, '.qwen', '.env'),
+      'NODE_COMPILE_CACHE=/tmp/operator-cache\n',
+    );
+
+    await bootstrapServeFastPathEnvironment(tempWorkspace);
+
+    expect(process.env['NODE_COMPILE_CACHE']).toBe('/tmp/operator-cache');
+    expect(process.env['QWEN_CODE_PENDING_COMPILE_CACHE']).toBeUndefined();
   });
 
   it('loads .env from --workspace even when launched from another directory', async () => {

--- a/scripts/cli-entry.js
+++ b/scripts/cli-entry.js
@@ -27,6 +27,7 @@ try {
   // Ignore stale or user-provided junk; normal argv is still usable.
 }
 delete process.env['QWEN_CODE_RELAUNCH_ARGS'];
+delete process.env['QWEN_CODE_PENDING_COMPILE_CACHE'];
 
 function hasFlag(flag, alias) {
   for (const arg of cliArgs) {
@@ -289,7 +290,7 @@ if (isInProcessFastPath()) {
     compileCache?.status === module.constants?.compileCacheStatus?.ENABLED &&
     compileCache?.directory
   ) {
-    process.env['NODE_COMPILE_CACHE'] = compileCache.directory;
+    process.env['QWEN_CODE_PENDING_COMPILE_CACHE'] = compileCache.directory;
   }
   process.argv[1] = cliPath;
   await import(pathToFileURL(cliPath).href);

--- a/scripts/cli-entry.js
+++ b/scripts/cli-entry.js
@@ -282,7 +282,15 @@ if (isTopLevelVersion) {
 
 if (isInProcessFastPath()) {
   const { default: module } = await import('node:module');
-  module.enableCompileCache?.();
+  const compileCache = module.enableCompileCache?.();
+  if (
+    cliArgs[0] === 'serve' &&
+    !process.env['NODE_COMPILE_CACHE'] &&
+    compileCache?.status === module.constants?.compileCacheStatus?.ENABLED &&
+    compileCache?.directory
+  ) {
+    process.env['NODE_COMPILE_CACHE'] = compileCache.directory;
+  }
   process.argv[1] = cliPath;
   await import(pathToFileURL(cliPath).href);
 } else {


### PR DESCRIPTION
## What this PR does

This PR publishes the compile-cache directory already enabled by the production `serve` entry to its environment, allowing subsequently spawned ACP children to reuse Node's module compile cache. It only publishes a directory when Node reports that this process newly enabled the cache, and it leaves user-provided, disabled, failed, and unsupported configurations unchanged.

It also documents the startup topology, compatibility boundaries, alternatives considered, and the paired benchmark results used to gate the implementation.

## Why it's needed

The daemon entry already enables Node's compile cache for its own in-process module loading, but programmatic enablement affects only that process. Because no `NODE_COMPILE_CACHE` value was exported, ACP children repeatedly compiled the same eager module graph on every session startup.

On a 2-vCPU, 4-GB Linux host, 30 warm-cache paired runs showed a 176.6 ms median improvement in ACP `channel.initialize` and a 199.0 ms median improvement from daemon process start to the first completed session. A separate 10-pair test using the actual production entries reproduced the result. The one-time empty-cache cost was 117.2 ms at the median, so the measured workload recovers that cost on the second ACP startup.

## Reviewer Test Plan

### How to verify

- Run the focused CLI entry test and confirm all cases pass, including default propagation, preserving a custom cache path, honoring `NODE_DISABLE_COMPILE_CACHE=1`, limiting publication to `serve`, and behaving safely when the compile-cache API is unavailable.
- Start the daemon without `NODE_COMPILE_CACHE`, create an ACP-backed session, and confirm the child starts successfully and inherits the directory published by the daemon entry.
- Start the daemon with a custom `NODE_COMPILE_CACHE` and confirm that exact value remains unchanged; repeat with `NODE_DISABLE_COMPILE_CACHE=1` and confirm no cache directory is published.
- Run the build and workspace typecheck and confirm both complete without errors.

### Evidence (Before & After)

N/A for UI. On the 2-vCPU Linux reference host, the warm-cache median ACP initialization changed from 880.2 ms to 704.0 ms across 30 paired runs. The median process-to-first-session time changed from 1,662.2 ms to 1,472.8 ms. All runs and the concurrent, telemetry-disabled, and legacy-session checks completed without residual processes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS arm64 with Node.js 22.22.3 for unit tests, lint, build, and workspace typecheck. Linux x64 with 2 vCPUs, 4 GB RAM, and Node.js 22.23.1 for paired performance and functional validation.

## Risk & Scope

- Main risk or tradeoff: The first empty-cache startup was 117.2 ms slower at the median, and the warm-cache candidate used 8.6 MB more median peak process-tree RSS. The stable cache used 9.4 MB; subsequent ACP startups recovered the first-run cost.
- Not validated / out of scope: Windows performance was not benchmarked. This PR does not change the eager module graph, introduce cache cleanup or eviction, or force support on Node versions without the API.
- Breaking changes / migration notes: None. Existing `NODE_COMPILE_CACHE` and `NODE_DISABLE_COMPILE_CACHE` policy is preserved.

## Linked Issues

#7264

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

本 PR 将生产环境 `serve` 入口已经启用的编译缓存目录发布到进程环境中，使后续创建的 ACP 子进程能够复用 Node 模块编译缓存。只有当 Node 报告当前进程刚刚成功启用缓存时才会发布目录；用户预设、显式禁用、启用失败以及运行时不支持等情况均保持原样。

同时补充了启动拓扑、兼容性边界、备选方案以及用于决定是否实施的配对基准测试结果。

## 为什么需要

守护进程入口已经为自身的进程内模块加载启用 Node 编译缓存，但通过 API 启用只影响当前进程。由于此前没有导出 `NODE_COMPILE_CACHE`，ACP 子进程会在每次会话启动时重复编译相同的急切加载模块图。

在 2 vCPU、4 GB 的 Linux 主机上，30 组热缓存配对运行显示 ACP `channel.initialize` 中位数改善 176.6 ms，从守护进程启动到首个会话完成的中位数改善 199.0 ms。另有 10 组直接使用真实生产入口的配对测试复现了该结果。首次空缓存的中位数成本为 117.2 ms，因此在实测负载下第二次 ACP 启动即可收回这部分成本。

## Reviewer 测试计划

### 如何验证

- 运行聚焦的 CLI 入口测试，确认所有场景通过，包括默认传播、保留自定义缓存路径、遵守 `NODE_DISABLE_COMPILE_CACHE=1`、仅在 `serve` 发布，以及编译缓存 API 不可用时安全运行。
- 在未设置 `NODE_COMPILE_CACHE` 的情况下启动守护进程并创建 ACP 会话，确认子进程成功启动并继承守护进程入口发布的目录。
- 使用自定义 `NODE_COMPILE_CACHE` 启动守护进程，确认该值原样保留；再设置 `NODE_DISABLE_COMPILE_CACHE=1`，确认不发布缓存目录。
- 运行构建和全 workspace 类型检查，确认均无错误完成。

### 证据（Before & After）

UI 不适用。在 2 vCPU Linux 参考主机上，30 组配对运行的热缓存 ACP 初始化中位数从 880.2 ms 降至 704.0 ms；从进程启动到首个会话完成的中位数从 1,662.2 ms 降至 1,472.8 ms。所有运行以及并发、关闭遥测和 legacy 会话检查均成功完成，且没有残留进程。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

macOS arm64、Node.js 22.22.3，用于单元测试、lint、构建和全 workspace 类型检查。Linux x64、2 vCPU、4 GB RAM、Node.js 22.23.1，用于配对性能与功能验证。

## 风险与范围

- 主要风险或权衡：首次空缓存启动的中位数慢 117.2 ms，热缓存候选的进程树峰值 RSS 中位数增加 8.6 MB。稳定缓存占用 9.4 MB；后续 ACP 启动可以收回首次运行成本。
- 未验证 / 范围外：未对 Windows 性能进行基准测试。本 PR 不改变急切加载模块图，不引入缓存清理或淘汰机制，也不会在缺少该 API 的 Node 版本上强制启用。
- 破坏性变更 / 迁移说明：无。现有 `NODE_COMPILE_CACHE` 与 `NODE_DISABLE_COMPILE_CACHE` 策略保持不变。

## 关联 Issue

#7264

</details>
