### PR TITLE
feat(autofix): update a stale base when the gate rejects a behind-main fix

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3438,7 +3438,39 @@ jobs:
                   MARK_ROUND="${MAX_ROUNDS}"
                 fi
               else
-                HEADLINE="🤖 Could not address the latest feedback automatically (round ${MARK_ROUND}/${MAX_ROUNDS}). A human should take over this PR."
+                # The gate ran and rejected the agent's fix (a build/test
+                # failure). Before handing to a human, check whether the PR is
+                # merely BEHIND main: a build that fails on something main
+                # already changed — e.g. #7471's update-notifier, removed by
+                # #7515, left its import unresolved on a stale branch — is a
+                # stale-base failure, NOT the fix. If behind, merge main in and
+                # retry: the next round builds against current main. After the
+                # update the PR is current, so a genuine fix-failure next round
+                # is no longer "behind" and falls through to the handoff below —
+                # which self-limits this to ONE base-update. update-branch is a
+                # CAS on the checked-out head; any API failure is fail-safe (fall
+                # through to the handoff). This is the agent-gate sibling of the
+                # scan's stale-base auto-update, which only sees PR status
+                # checks, never the gate's own build.
+                STALE_BASE_RETRY=false
+                MAIN_HEAD_R="$(gh api "repos/${REPO}/commits/${DEFAULT_BRANCH:-main}" --jq '.sha' 2> /dev/null || echo '')"
+                if [[ -n "${MAIN_HEAD_R}" && -n "${REPORT_HEAD}" ]]; then
+                  CMP_R="$(gh api "repos/${REPO}/compare/${MAIN_HEAD_R}...${REPORT_HEAD}" --jq '.status' 2> /dev/null || echo '')"
+                  if [[ "${CMP_R}" == 'behind' || "${CMP_R}" == 'diverged' ]] \
+                    && gh api -X PUT "repos/${REPO}/pulls/${PR}/update-branch" -f expected_head_sha="${REPORT_HEAD}" > /dev/null 2>&1; then
+                    STALE_BASE_RETRY=true
+                  fi
+                fi
+                if [[ "${STALE_BASE_RETRY}" == 'true' ]]; then
+                  # Feedback stays live (sentinel ts) so the retry re-reads it
+                  # against the freshly-merged base; the incremented round still
+                  # bounds it, and the consecutive-failure exemption below keeps
+                  # this not-the-PR's-fault round from counting toward the cap.
+                  MARK_TS='9999-12-31T23:59:59Z'
+                  HEADLINE="🤖 AutoFix updated a stale base — the fix did not pass verification, but this PR was behind \`${DEFAULT_BRANCH:-main}\`, so it merged current main in via update-branch and will retry on the next scan. A stale base (a dependency or symbol main already changed) can fail the build without being the fix's fault; if it still fails once current, it hands off to a human."
+                else
+                  HEADLINE="🤖 Could not address the latest feedback automatically (round ${MARK_ROUND}/${MAX_ROUNDS}). A human should take over this PR."
+                fi
               fi
             elif [[ "${PREPARE_OUTCOME}" != 'success' && "${PREPARE_OUTCOME}" != 'failure' ]]; then
               # NEWEST is empty because Prepare never RAN TO A VERDICT — an
@@ -3507,8 +3539,11 @@ jobs:
             # crash is not the PR's fault, self-heals, and hits the whole scan
             # batch at once — the exact scenario the retry path above exists to
             # prevent. The round cap + sentinel-ts /retry recovery already
-            # bounds a persistently broken base.
-            if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]] && [[ "${PREPARE_OUTCOME}" == 'success' || "${PREPARE_OUTCOME}" == 'failure' ]] && { [[ -z "${API_ERROR_DETAIL}" ]] || [[ "${API_ERROR_KIND}" == 'auth' ]]; }; then
+            # bounds a persistently broken base. A stale-base retry (the gate
+            # rejected the fix but the PR was behind main, so the base was just
+            # updated) is exempt for the same reason — it is not the PR's fault
+            # and self-limits to one round (after the update the PR is current).
+            if [[ "${MARK_ROUND}" != "${MAX_ROUNDS}" ]] && [[ "${PREPARE_OUTCOME}" == 'success' || "${PREPARE_OUTCOME}" == 'failure' ]] && [[ "${STALE_BASE_RETRY:-false}" != 'true' ]] && { [[ -z "${API_ERROR_DETAIL}" ]] || [[ "${API_ERROR_KIND}" == 'auth' ]]; }; then
               CONSEC_FAIL=1
               if [[ -f "${WORKDIR}/ic.json" ]]; then
                 COMMENTS_JSON="$(cat "${WORKDIR}/ic.json")"
@@ -3525,7 +3560,7 @@ jobs:
                 | (.body | gsub("\r"; "") | split("\n")[0])' <<< "${COMMENTS_JSON}" 2> /dev/null || true)"
               while IFS= read -r H; do
                 [[ -n "${H}" ]] || continue
-                if [[ "${H}" == *"Addressed the latest review feedback"* || "${H}" == *"no changes needed"* || "${H}" == *"AutoFix could not start —"* ]]; then
+                if [[ "${H}" == *"Addressed the latest review feedback"* || "${H}" == *"no changes needed"* || "${H}" == *"AutoFix could not start —"* || "${H}" == *"updated a stale base"* ]]; then
                   CONSEC_FAIL=1
                 else
                   CONSEC_FAIL=$(( CONSEC_FAIL + 1 ))

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4183,8 +4183,29 @@ describe('qwen-autofix workflow', () => {
     expect(decision).toBeTruthy();
     const SENTINEL = '9999-12-31T23:59:59Z';
     const NEWEST = '2026-07-20T10:00:00Z';
-    const run = (env) =>
-      execFileSync(
+    const run = (env) => {
+      // The gate-rejection branch (OUTCOME=failed, no crash/timeout) now probes
+      // whether the PR is behind main and, if so, updates the base — so stub gh:
+      // commits/<main> → a SHA, compare → CMP_STATUS_STUB (default 'ahead', i.e.
+      // NOT behind, so the existing rejection cases still hand off), and
+      // update-branch → UPDATE_OK_STUB (default success).
+      const dir = mkdtempSync(join(tmpdir(), 'decision-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      writeFileSync(
+        join(bin, 'gh'),
+        [
+          '#!/usr/bin/env bash',
+          'for a in "$@"; do case "$a" in',
+          "  */commits/main) printf 'mainsha123'; exit 0;;",
+          '  */compare/*) printf \'%s\' "${CMP_STATUS_STUB:-ahead}"; exit 0;;',
+          '  */update-branch) [ "${UPDATE_OK_STUB:-1}" = 1 ] && exit 0 || exit 1;;',
+          'esac; done',
+          'exit 0',
+        ].join('\n'),
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const out = execFileSync(
         'bash',
         [
           '-c',
@@ -4193,6 +4214,10 @@ describe('qwen-autofix workflow', () => {
         {
           env: {
             ...process.env,
+            PATH: `${bin}:${process.env.PATH}`,
+            REPO: 'o/r',
+            PR: '1',
+            REPORT_HEAD: 'prhead123',
             NEWEST,
             WATERMARK: '2026-07-20T09:00:00Z',
             ROUND: '1',
@@ -4206,11 +4231,40 @@ describe('qwen-autofix workflow', () => {
           encoding: 'utf8',
         },
       );
+      rmSync(dir, { recursive: true, force: true });
+      return out;
+    };
 
-    // Declared rejection: the agent was judged -> advance the watermark.
+    // Declared rejection, PR up to date ('ahead') -> a genuine fix failure ->
+    // advance the watermark and hand off to a human.
     const rejected = run({ OUTCOME: 'failed' });
     expect(rejected.split('|')[0]).toBe(NEWEST);
     expect(rejected).toContain('Could not address the latest feedback');
+
+    // #7471: the gate rejected the fix, but the PR was BEHIND main — the build
+    // failed on a stale base (a dependency main already removed), not the fix.
+    // Update the base and retry (sentinel keeps the feedback live) instead of
+    // advancing to a human handoff.
+    const staleBehind = run({ OUTCOME: 'failed', CMP_STATUS_STUB: 'behind' });
+    expect(staleBehind.split('|')[0]).toBe(SENTINEL);
+    expect(staleBehind).toContain('updated a stale base');
+    expect(staleBehind).toContain('will retry on the next scan');
+    // 'diverged' (ahead AND behind) also merges main in.
+    const staleDiverged = run({
+      OUTCOME: 'failed',
+      CMP_STATUS_STUB: 'diverged',
+    });
+    expect(staleDiverged.split('|')[0]).toBe(SENTINEL);
+    expect(staleDiverged).toContain('updated a stale base');
+    // Behind but update-branch FAILS (a merge conflict) -> no retry; fall
+    // through to the human handoff so the conflict is not silently swallowed.
+    const staleConflict = run({
+      OUTCOME: 'failed',
+      CMP_STATUS_STUB: 'behind',
+      UPDATE_OK_STUB: '0',
+    });
+    expect(staleConflict.split('|')[0]).toBe(NEWEST);
+    expect(staleConflict).toContain('Could not address the latest feedback');
 
     // Gate crash (no verdict): keep the feedback live and retry.
     const crashed = run({ OUTCOME: '' });
@@ -4412,7 +4466,7 @@ describe('qwen-autofix workflow', () => {
     expect(cap).toBeLessThan(takeoverCap);
 
     const block = reviewAddressReportStep.match(
-      /if \[\[ "\$\{MARK_ROUND\}" != "\$\{MAX_ROUNDS\}" \]\] && \[\[ "\$\{PREPARE_OUTCOME\}" == 'success' \|\| "\$\{PREPARE_OUTCOME\}" == 'failure' \]\] && \{ \[\[ -z "\$\{API_ERROR_DETAIL\}" \]\] \|\| \[\[ "\$\{API_ERROR_KIND\}" == 'auth' \]\]; \}; then\n {14}CONSEC_FAIL=1\n[\s\S]*?\n {14}fi\n {12}fi\n/,
+      /if \[\[ "\$\{MARK_ROUND\}" != "\$\{MAX_ROUNDS\}" \]\] && \[\[ "\$\{PREPARE_OUTCOME\}" == 'success' \|\| "\$\{PREPARE_OUTCOME\}" == 'failure' \]\] && \[\[ "\$\{STALE_BASE_RETRY:-false\}" != 'true' \]\] && \{ \[\[ -z "\$\{API_ERROR_DETAIL\}" \]\] \|\| \[\[ "\$\{API_ERROR_KIND\}" == 'auth' \]\]; \}; then\n {14}CONSEC_FAIL=1\n[\s\S]*?\n {14}fi\n {12}fi\n/,
     )?.[0];
     expect(block).toBeTruthy();
     const script = block.replace(/^ {12}/gm, '');
@@ -4428,6 +4482,8 @@ describe('qwen-autofix workflow', () => {
       '🤖 AutoFix could not start — reached the round cap (100) because a setup step (base install/build) kept failing.';
     const CRASH_TERMINAL =
       '🤖 AutoFix could not start evaluation — it crashed or timed out before reading the feedback.';
+    const STALE_BASE =
+      '🤖 AutoFix updated a stale base — the fix did not pass verification, but this PR was behind `main`, so it merged current main in via update-branch and will retry on the next scan.';
 
     const run = (
       priorHeadlines,
@@ -4437,6 +4493,7 @@ describe('qwen-autofix workflow', () => {
         apiErrorDetail = '',
         apiErrorKind = '',
         prepareOutcome = 'success',
+        staleBaseRetry = false,
       } = {},
     ) => {
       const dir = mkdtempSync(join(tmpdir(), 'consec-'));
@@ -4465,7 +4522,7 @@ describe('qwen-autofix workflow', () => {
         'bash',
         [
           '-c',
-          `set -uo pipefail\nWORKDIR='${dir}'\nMARK_ROUND=${markRound}\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nCONSEC_FAIL=0\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\nAPI_ERROR_DETAIL='${apiErrorDetail}'\nAPI_ERROR_KIND='${apiErrorKind}'\nPREPARE_OUTCOME='${prepareOutcome}'\n${window !== undefined ? `WINDOW='${window}'\n` : ''}HEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
+          `set -uo pipefail\nWORKDIR='${dir}'\nMARK_ROUND=${markRound}\nMAX_ROUNDS=100\nCONSECUTIVE_FAILURE_CAP=${cap}\nCONSEC_FAIL=0\nREPO=o/r\nPR=1\nAUTOFIX_BOT=qwen-code-dev-bot\nRETRY_COMMAND='@qwen-code /retry'\nAPI_ERROR_DETAIL='${apiErrorDetail}'\nAPI_ERROR_KIND='${apiErrorKind}'\nPREPARE_OUTCOME='${prepareOutcome}'\nSTALE_BASE_RETRY='${staleBaseRetry}'\n${window !== undefined ? `WINDOW='${window}'\n` : ''}HEADLINE=orig\n${script}\nprintf '%s|%s|%s' "$MARK_ROUND" "${'${CONSEC_FAIL}'}" "$HEADLINE"`,
         ],
         {
           env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
@@ -4557,6 +4614,19 @@ describe('qwen-autofix workflow', () => {
       consec: cap,
       terminal: true,
     });
+    // A prior stale-base retry is not the PR's fault either (the base was
+    // updated, not the fix rejected), so it resets the streak like the infra
+    // headlines above.
+    expect(run([FAIL, FAIL, STALE_BASE, FAIL, FAIL])).toMatchObject({
+      consec: 3,
+      terminal: false,
+    });
+    // The CURRENT round being a stale-base retry is exempt from the breaker
+    // entirely — the base was just updated and the next round builds fresh, so
+    // cap-1 prior failures must not trip it.
+    expect(
+      run(Array(cap - 1).fill(FAIL), { staleBaseRetry: true }),
+    ).toMatchObject({ terminal: false, headline: 'orig' });
     // Already-terminal rounds skip the circuit breaker entirely.
     expect(run(Array(cap).fill(FAIL), { markRound: 100 })).toMatchObject({
       terminal: true,


### PR DESCRIPTION
## What this PR does

When the agent's verification gate rejects a fix on a **build/test failure** but the PR is **behind main**, the scan now merges current main in (`update-branch`) and **retries** — instead of advancing the watermark and handing off to a human. It self-limits to one base-update, so a genuine fix failure still terminates.

## Why it's needed

A fix that fails to build isn't always the fix's fault. **#7471** was stuck for exactly this: the agent addressed a review, but the gate build failed with

```
packages/cli/src/ui/utils/updateCheck.ts: error TS2307:
  Cannot find module 'update-notifier'
```

That module was **removed from main by #7515** — #7471's branch was 32 commits behind and still imported it. The failure had nothing to do with the review or the feature (a web-shell git-mode selector); it was a **stale base**. The loop couldn't tell, so it posted *"Could not address … a human should take over"* and advanced past the feedback. A human (me) had to diagnose it, click Update-branch, and re-arm — three round-trips plus a scan wait each.

This is the **agent-gate sibling of the scan's stale-base auto-update (#7554)**, which only inspects PR *status checks* and never sees the gate's own build. This closes that gap so the loop self-heals the #7471 class with no human round-trip.

## How

In the gate-rejection branch of the handoff decision (the gate ran, `outcome=failed`, so it's not a crash/timeout/API path), before the human handoff:

1. Fetch main's head and `compare` it with the checked-out PR head.
2. If the PR is `behind` or `diverged`, call `update-branch` (a compare-and-swap on `REPORT_HEAD`, the exact head the agent built) to merge main in.
3. On success → **sentinel ts** (feedback stays live) + a retry headline naming the cause. The next scan re-runs the agent against the freshly-merged base.

**Self-limiting, no counter needed:** after the update the PR is current, so if the *next* round's gate also rejects, it is no longer "behind" and falls straight through to the human handoff. So a genuine fix failure costs at most one extra base-update; a stale-base failure recovers automatically.

**Not the PR's fault → exempt from the consecutive-failure breaker (#7482):** the current stale-base-retry round is excluded from the streak (like a skipped-Prepare), and a prior stale-base-retry headline resets it (like the infra headlines) — so a base that was merely stale never trips the cap.

Everything is fail-safe: any of the three API calls failing just means no update, and the branch falls through to the existing human handoff. The loop-guard, timeout, API-error and gate-crash paths are all untouched.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/qwen-autofix-workflow.test.js -t "retries a verification-gate crash"` — the decision-block replay now stubs `gh` (commits/main → sha, compare → status, update-branch → ok/fail) and drives three new cases:
   - rejected + `behind` → **sentinel**, "updated a stale base", "will retry";
   - rejected + `diverged` → sentinel (also merges);
   - rejected + `behind` but update-branch **fails** (a conflict) → advance + human handoff (conflict not swallowed);
   - rejected + up-to-date (`ahead`, the default stub) → advance + handoff (a genuine fix failure — unchanged).
2. `-t "CONSECUTIVE_FAILURE_CAP rounds in a row"` — a prior `updated a stale base` headline resets the streak; a current `STALE_BASE_RETRY=true` round is exempt from the breaker.
3. **Mutation-verified** (each intended test, not a neighbour): flipping the `STALE_BASE_RETRY=true` assignment turns the verification-gate-crash test red (`Expected sentinel, Received NEWEST`); dropping `updated a stale base` from the reset detector turns the consecutive-failure test red.
4. Full suite: 96/96 across three runs (one hits the pre-existing load flakes `eligibility recheck` / `permanent API failures terminal`). Static, exact CI toolchain: `js-yaml` parses; all 37 `run:` blocks pass `bash -n`; actionlint 1.7.12 clean; prettier clean.

### Evidence (Before & After)

```
BEFORE  gate build fails on a stale base (e.g. update-notifier removed by
        main) -> "Could not address … a human should take over" -> watermark
        advances -> a human diagnoses, updates the base, and re-arms

AFTER   gate build fails + PR behind main -> update-branch merges main in ->
        sentinel "updated a stale base … will retry" -> next scan re-runs the
        agent on the fresh base; if it STILL fails, no longer behind -> human
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- **Dependency: the PAT needs `contents: write` (or the update-branch scope)** to merge main in; without it the PUT 403s, is swallowed, and the PR falls through to the existing human handoff (fail-safe, no crash) — the feature is simply inert until granted.
- Main tradeoff: a genuine fix failure that happens while the PR is behind costs one extra base-update round before the handoff. The "behind" check bounds it to one, and that round is exempt from the consecutive-failure cap.
- API cost: only on a gate rejection (already a rare, expensive event) — one commits + one compare + at most one update-branch call.
- Not in scope: it does not proactively update PRs that are behind but green (that would churn every managed PR's CI); it only reacts to a build/test rejection. It also does not change merge-time branch-protection policy.
- Breaking changes / migration notes: none.

## Linked Issues

Motivated by #7471's takeover stalling on a stale-base gate build failure (`update-notifier`, removed by #7515). Completes the "not the PR's fault → self-recover" line: #7554 (stale base on a PR check), #7562 (infra rerun), #7563 (timeout), #7490 (skipped Prepare), and this (stale base on the gate build).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 agent 验证 gate 因**构建/测试失败**拒绝了修复,但该 PR **落后于 main** 时,扫描现在合入当前 main(`update-branch`)并**重试** —— 而非推进水位、交给人工。它天然自限为一次 base 更新,所以真正的修复失败仍会终态交人。

## 为什么需要

构建失败不总是修复之过。**#7471** 正卡在这:agent 处理了 review,但 gate 构建失败于 `packages/cli/.../updateCheck.ts: Cannot find module 'update-notifier'`。该依赖**已被 #7515 从 main 移除**,而 #7471 分支落后 32 个 commit、仍 import 它。失败与 review、与特性(web-shell git-mode 选择器)都无关 —— 是**陈旧 base**。loop 无法分辨,便发"could not address, 人工接管"并推进过反馈。只能靠人诊断、点 Update-branch、再 re-arm —— 三次往返,每次还要等扫描。

这是**扫描侧 stale-base 自动更新(#7554)的 agent-gate 姊妹** —— #7554 只看 PR 的**状态检查**,看不到 gate 自身的构建。本 PR 补上这个缺口,让 loop 无需人工往返即可自愈 #7471 这一类。

## 怎么做

在交接决策的 gate-rejection 分支(gate 跑了、`outcome=failed`,非崩溃/超时/API 路径),在交人之前:

1. 取 main head,与 checked-out 的 PR head 做 `compare`。
2. 若 `behind` 或 `diverged`,调 `update-branch`(以 `REPORT_HEAD` 做 compare-and-swap)合入 main。
3. 成功 → **sentinel ts**(反馈存活)+ 点名成因的重试文案。下次扫描在新合并的 base 上重跑 agent。

**自限、无需计数器:** 更新后 PR 已最新,若*下一*轮 gate 仍拒绝,便不再"落后"、直接落到人工交接。所以真正的修复失败至多多花一次 base 更新;陈旧 base 失败则自动恢复。

**非 PR 之过 → 豁免连续失败断路器(#7482):** 当前 stale-base-retry 轮不计入 streak(同 skipped-Prepare),过往 stale-base-retry headline 重置 streak(同 infra headlines)—— 仅仅陈旧的 base 绝不触发上限。

一切失败安全:三个 API 调用任一失败即不更新、落回既有人工交接。loop-guard、超时、API-error、gate-crash 路径均不动。

## 评审验证

1. `-t "retries a verification-gate crash"` —— 决策块回放现桩 `gh`,驱动三条新用例(behind→sentinel+"updated a stale base"+"will retry";diverged→sentinel;behind 但 update-branch 失败→推进+交人;up-to-date→推进+交人,不变)。
2. `-t "CONSECUTIVE_FAILURE_CAP rounds in a row"` —— 过往 `updated a stale base` headline 重置 streak;当前 `STALE_BASE_RETRY=true` 轮被豁免。
3. **变异验证**(针对正确的测试):翻转 `STALE_BASE_RETRY=true` → verification-gate-crash 测试红(Expected sentinel, Received NEWEST);从重置检测器删 `updated a stale base` → 连续失败测试红。
4. 全量:96/96 连跑三次(一次命中既有 load flake)。静态:YAML 可解析;37 个 `run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。

## 风险与范围

- **依赖:PAT 需 `contents: write`(或 update-branch scope)** 才能合入 main;若无,PUT 返回 403、被吞、落回既有人工交接(失败安全、不崩)—— 授予前功能惰性。
- 主要权衡:落后时发生的真实修复失败,在交人前多花一次 base 更新轮;"落后"检查将其限为一次,且该轮豁免连续失败上限。
- API 成本:仅在 gate rejection(本就稀少昂贵)时 —— 一次 commits + 一次 compare + 至多一次 update-branch。
- 不在范围内:不主动更新"落后但绿"的 PR(那会 churn 每个托管 PR 的 CI);只对构建/测试拒绝作反应。也不改合并门的分支保护策略。
- 破坏性变更:无。

## 关联 Issue

由 #7471 的托管卡在 stale-base gate 构建失败(`update-notifier`,#7515 移除)促成。补全"非 PR 之过 → 自恢复"主线:#7554、#7562、#7563、#7490,以及本 PR。

</details>
