### PR TITLE
fix(web-shell): prevent React measure detail OOM

### DIFF
--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+function installMeasureGuard(
+  measure: (...args: unknown[]) => unknown,
+): Performance {
+  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
+  const script = Array.from(
+    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
+  )
+    .map((match) => match[1] ?? '')
+    .find((source) => source.includes('performance.measure ='));
+
+  if (!script) throw new Error('Performance measure guard not found');
+
+  const performance = { measure };
+  Function('performance', 'DOMException', script)(performance, DOMException);
+  return performance as Performance;
+}
+
+describe('React performance measure guard', () => {
+  it('removes React component detail before calling the native measure', () => {
+    const measure = vi.fn(() => 'measure');
+    const performance = installMeasureGuard(measure);
+    const options = {
+      start: 1,
+      end: 2,
+      detail: {
+        devtools: {
+          track: 'Components ⚛',
+          properties: [['transcript', new Array(50_000).fill('block')]],
+        },
+      },
+    };
+
+    const result = performance.measure('WebShell', options);
+    const forwardedOptions = measure.mock.calls[0]?.[1] as
+      | PerformanceMeasureOptions
+      | undefined;
+
+    expect(result).toBe('measure');
+    expect(forwardedOptions?.start).toBe(1);
+    expect(forwardedOptions?.end).toBe(2);
+    expect(forwardedOptions?.detail === null).toBe(true);
+    expect(options.detail.devtools.properties).toHaveLength(1);
+  });
+
+  it('preserves non-React performance measure detail', () => {
+    const measure = vi.fn(() => 'measure');
+    const performance = installMeasureGuard(measure);
+    const options = {
+      start: 1,
+      end: 2,
+      detail: { source: 'web-shell' },
+    };
+
+    performance.measure('custom-measure', options);
+
+    expect(measure).toHaveBeenCalledWith('custom-measure', options);
+  });
+});

--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -48,24 +48,28 @@
   </head>
   <body>
     <!--
-      Prevent React 19 dev-mode OOM crash: logComponentRender() calls
-      performance.measure() with component props as structured-clone detail.
-      Large transcript data exceeds the clone memory limit. This patch
-      silently drops the failing measure call; production builds are unaffected
-      because logComponentRender only exists in react-dom development bundles.
+      Prevent React 19 dev-mode OOM crashes. React records component prop
+      details through performance.measure(), which structured-clones and retains
+      those details. Strip the detail before large transcripts reach the native
+      call while preserving the component timing and non-React measures.
     -->
     <script>
       !(function () {
         if (typeof performance === 'undefined' || !performance.measure) return;
         var m = performance.measure.bind(performance);
         performance.measure = function () {
-          try {
-            return m.apply(this, arguments);
-          } catch (e) {
-            if (e instanceof DOMException && e.name === 'DataCloneError')
-              return;
-            throw e;
+          var options = arguments[1];
+          var devtools =
+            options &&
+            typeof options === 'object' &&
+            options.detail &&
+            options.detail.devtools;
+          if (devtools && devtools.track === 'Components ⚛') {
+            var args = Array.prototype.slice.call(arguments);
+            args[1] = Object.assign({}, options, { detail: null });
+            return m.apply(this, args);
           }
+          return m.apply(this, arguments);
         };
       })();
     </script>


### PR DESCRIPTION
## What this PR does

This change prevents React development instrumentation from structured-cloning and retaining Web Shell component property details while preserving component timing measurements. Non-React performance measurements and their details continue to pass through unchanged. Regression coverage verifies both behaviors.

## Why it's needed

In local daemon development, React records component render metadata through the browser Performance API. Large transcript properties can be cloned and retained for hundreds of component measures, causing renderer heap growth and intermittent Chrome `Aw, Snap!` crashes with error code 5. Catching only clone exceptions does not address successful clones or allocation failures.

## Reviewer Test Plan

### How to verify

Start Web Shell with `npm run dev:daemon`, open a transcript, and confirm the page remains responsive while React component performance entries contain `null` detail. Create a custom non-React performance measure and confirm its detail remains intact. The focused regression tests should confirm both forwarding behaviors.

### Evidence (Before & After)

Before: React component measures retained structured-cloned transcript property details, and local Chrome renderer crash dumps showed the Web Shell development origin during intermittent crashes.

After: In an isolated daemon development run, the Web Shell root rendered successfully and remained stable for 20 seconds with no page crash, console error, page error, or failed request. All 803 observed React component measures had `null` detail, while a custom measure preserved its detail.

### Tested on

| OS | Status |
| :--------: | :----: |
| 🍏 macOS | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

### Environment (optional)

Local `npm run dev:daemon` with an isolated Chrome profile, plus focused unit tests, full build, typecheck, and Web Shell lint.

## Risk & Scope

- Main risk or tradeoff: React component performance entries retain timing but no longer expose development-only component property details.
- Not validated / out of scope: Windows and Linux browser behavior; unrelated renderer memory consumers.
- Breaking changes / migration notes: None.

## Linked Issues

No linked issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

此变更阻止 React 开发模式的性能检测逻辑对 Web Shell 组件属性详情执行结构化克隆并长期保留，同时保留组件计时数据。非 React 的性能测量及其详情仍按原样传递。回归测试覆盖了这两种行为。

## 为什么需要此变更

在本地 daemon 开发模式中，React 会通过浏览器 Performance API 记录组件渲染元数据。大型会话记录属性可能被数百个组件测量条目反复克隆并保留，导致渲染进程堆内存持续增长，并偶发出现 Chrome `Aw, Snap!`、错误码 5 的页面崩溃。仅捕获克隆异常无法处理成功完成的克隆或内存分配失败。

## Reviewer Test Plan

### 如何验证

通过 `npm run dev:daemon` 启动 Web Shell，打开一个会话记录，确认页面保持响应，并且 React 组件性能条目的 `detail` 为 `null`。创建一个自定义的非 React 性能测量，确认其详情仍被保留。专项回归测试应同时验证这两种转发行为。

### 证据（修改前与修改后）

修改前：React 组件测量会保留经过结构化克隆的会话属性详情，本地 Chrome 渲染进程崩溃转储显示偶发崩溃时加载了 Web Shell 开发地址。

修改后：在隔离的 daemon 开发运行中，Web Shell 根节点成功渲染并稳定运行 20 秒，没有页面崩溃、控制台错误、页面错误或请求失败。观察到的 803 个 React 组件测量条目的详情全部为 `null`，同时自定义测量仍保留其详情。

### 测试平台

| 操作系统 | 状态 |
| :--------: | :----: |
| 🍏 macOS | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境（可选）

本地 `npm run dev:daemon`、隔离的 Chrome 配置，以及专项单元测试、完整构建、类型检查和 Web Shell lint。

## 风险与范围

- 主要风险或权衡：React 组件性能条目仍保留计时数据，但不再公开仅供开发使用的组件属性详情。
- 未验证或不在范围内：Windows 和 Linux 浏览器行为；其他无关的渲染进程内存消耗因素。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无关联 Issue。

</details>