### PR TITLE
fix(core): validate run_in_background parameter type

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -394,6 +394,9 @@ describe('AgentTool', () => {
       expect(tool.description).toContain(
         'foreground regular agent returns its result inline',
       );
+      expect(tool.description).toContain(
+        'explicitly setting `run_in_background: true` from a nested agent is rejected',
+      );
     });
 
     it('explains how to continue reusable background agents', async () => {
@@ -478,6 +481,9 @@ describe('AgentTool', () => {
       );
       expect(properties.properties.run_in_background.description).toContain(
         'interactive fork',
+      );
+      expect(properties.properties.run_in_background.description).toContain(
+        'explicit true is rejected',
       );
     });
 
@@ -893,6 +899,16 @@ describe('AgentTool', () => {
           working_dir: '.qwen/tmp/review-pr-1',
         }),
       ).toMatch(/fork/i);
+    });
+
+    it('rejects a non-boolean run_in_background value', () => {
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          // @ts-expect-error: raw model parameters are untrusted
+          run_in_background: 'true',
+        }),
+      ).toMatch(/run_in_background.*boolean/i);
     });
 
     it('rejects working_dir combined with run_in_background', () => {
@@ -5058,12 +5074,7 @@ describe('AgentTool', () => {
       );
     });
 
-    it('downgrades a background request from a nested sub-agent to an awaited foreground run', async () => {
-      // Background delegation is top-level-only in v1: a nested launcher
-      // cannot honor the background completion contract (send_message /
-      // task_stop are excluded from its toolset, and completion
-      // notifications go to the top-level session). The run must complete
-      // inline instead of orphaning the child's results.
+    it('rejects an explicit background request from a nested sub-agent', async () => {
       vi.mocked(config.getMaxSubagentDepth).mockReturnValue(5);
       const params: AgentParams = {
         description: 'Start monitor from a nested sub-agent',
@@ -5080,11 +5091,15 @@ describe('AgentTool', () => {
       );
 
       const llmText = partToString(result.llmContent);
-      expect(llmText).not.toContain('Background agent launched');
-      expect(llmText).toContain('Monitor done');
-      expect(mockRegistry.register).toHaveBeenCalledWith(
-        expect.objectContaining({ isBackgrounded: false }),
-      );
+      expect(llmText).toMatch(/run_in_background.*nested sub-agent/i);
+      expect(result.error?.message).toBe(llmText);
+      expect(result.returnDisplay).toMatchObject({
+        type: 'task_execution',
+        status: 'failed',
+        terminateReason: 'Nested background agents are not supported',
+      });
+      expect(mockSubagentManager.createAgentHeadless).not.toHaveBeenCalled();
+      expect(mockRegistry.register).not.toHaveBeenCalled();
     });
 
     it('keeps an omitted background flag in the foreground for nested sub-agents', async () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -791,7 +791,7 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
           type: 'boolean',
           default: true,
           description:
-            'Defaults to true for top-level regular subagents. Set to false to run a regular agent in the foreground and return its result inline. Set to true for an interactive fork to receive its completion notification; headless forks always run in the background. Nested agents run in the foreground. Caller-owned working_dir launches default to foreground and cannot run in the background.',
+            'Defaults to true for top-level regular subagents. Set to false to run a regular agent in the foreground and return its result inline. Set to true for an interactive fork to receive its completion notification; headless forks always run in the background. Nested agents run in the foreground; an explicit true is rejected. Caller-owned working_dir launches default to foreground and cannot run in the background.',
         },
         ...(config.isAgentTeamEnabled()
           ? {
@@ -911,7 +911,7 @@ Usage notes:
 - Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent
 - If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
 - If the user asks for agents "in parallel", group independent launches in a single message with multiple Agent tool use content blocks. Do not parallelize overlapping code changes.
-- Top-level regular subagents run in the background by default. Set \`run_in_background: false\` when the current turn must wait for the result before continuing. Nested agent launches run in the foreground and return to their direct parent, so the main agent cannot independently address them as background tasks. Caller-owned \`working_dir\` launches default to foreground and cannot run in the background.
+- Top-level regular subagents run in the background by default. Set \`run_in_background: false\` when the current turn must wait for the result before continuing. Nested agent launches run in the foreground and return to their direct parent; explicitly setting \`run_in_background: true\` from a nested agent is rejected. Caller-owned \`working_dir\` launches default to foreground and cannot run in the background.
 - You can optionally set \`isolation: "worktree"\` to run the agent in a temporary git worktree, giving it an isolated copy of the repository. The worktree is automatically cleaned up if the agent makes no changes; if changes are made, the worktree path and branch are returned in the result so you can review or merge them.
 ## When to fork
 
@@ -1005,6 +1005,13 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       params.prompt.trim() === ''
     ) {
       return 'Parameter "prompt" must be a non-empty string.';
+    }
+
+    if (
+      params.run_in_background !== undefined &&
+      typeof params.run_in_background !== 'boolean'
+    ) {
+      return 'Parameter "run_in_background" must be a boolean when set.';
     }
 
     if (params.subagent_type !== undefined) {
@@ -2363,6 +2370,12 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           'Nested forks are not supported',
         );
       }
+      if (this.params.run_in_background === true && !isTopLevelSession()) {
+        return this.buildSpawnBlockedResult(
+          'Error: run_in_background: true is not supported from within a nested sub-agent. Set run_in_background: false, or omit it, to run the child inline.',
+          'Nested background agents are not supported',
+        );
+      }
       const isFork = isForkRequested;
       if (isFork) {
         debugLogger.debug(
@@ -2447,8 +2460,8 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
       // BackgroundTaskRegistry's single session-level notification callback
       // would inject the child's completion into the top-level conversation
       // while the launcher (typically finished by then) never hears back.
-      // Downgrade to an awaited foreground run instead of orphaning the
-      // child's results.
+      // Explicit background requests are rejected above. Implicit defaults
+      // downgrade to an awaited foreground run instead of orphaning results.
       const backgroundRequested =
         isFork && !this.config.isInteractive()
           ? true


### PR DESCRIPTION
## What this PR does

Rejects non-boolean `run_in_background` values at the Agent tool's raw parameter boundary, before an invocation is created.

## Why it's needed

The Agent tool uses custom parameter validation and does not invoke the base JSON Schema validator. OpenAI-compatible tool arguments are parsed from model-provided JSON and reach this validator without property-level type enforcement. A value such as `"true"` therefore bypasses the strict boolean guard added by #7593 and then participates in background routing through JavaScript truthiness: a top-level call runs in the background, while a nested call silently falls back to the foreground.

Rejecting malformed values keeps the execution contract consistent and prevents non-boolean inputs from bypassing the nested-background fix.

## Reviewer Test Plan

### How to verify

1. Supply `run_in_background: "true"` as a raw Agent tool parameter and confirm validation returns a boolean-type error before invocation construction.
2. Confirm valid `true`, `false`, and omitted values retain their existing behavior.
3. Confirm nested explicit boolean `true` remains handled by the guard merged in #7593.

### Evidence (Before & After)

Before: latest `main` accepts a raw string value and routes it according to JavaScript truthiness.

After: the malformed value is rejected during parameter validation. The complete core Agent test file passes 198/198 tests; build, typecheck, and ESLint also pass. Screenshots are N/A because this is a non-UI parameter-validation change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js 22 development environment.

## Risk & Scope

- Main risk or tradeoff: malformed non-boolean values that were previously interpreted through JavaScript truthiness now fail validation.
- Not validated / out of scope: restoring base schema validation for all Agent parameters; that would also affect existing normalization and compatibility behavior.
- Breaking changes / migration notes: none for schema-compliant callers.

## Linked Issues

Follow-up to #7593

Related: #7571

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在创建 invocation 之前，于 Agent 工具的原始参数边界拒绝非 boolean 类型的 `run_in_background` 值。

## 为什么需要

Agent 工具使用自定义参数校验，并不会调用基础 JSON Schema 校验器。OpenAI 兼容的工具参数从模型提供的 JSON 中解析后，在没有属性级类型约束的情况下到达该校验逻辑。因此，`"true"` 这样的值会绕过 #7593 添加的严格 boolean 保护，并通过 JavaScript truthiness 参与后台路由：顶层调用会在后台执行，嵌套调用则会静默回退到前台。

拒绝异常类型的值可以保持执行契约一致，并防止非 boolean 输入绕过嵌套后台修复。

## Reviewer 测试计划

### 如何验证

1. 将 `run_in_background: "true"` 作为 Agent 工具原始参数传入，确认校验会在构造 invocation 之前返回 boolean 类型错误。
2. 确认合法的 `true`、`false` 以及省略该参数时，原有行为保持不变。
3. 确认嵌套场景中显式传入 boolean `true` 时，仍由 #7593 合入的保护逻辑处理。

### 前后证据

修复前：最新 `main` 会接受原始字符串值，并根据 JavaScript truthiness 对其进行路由。

修复后：异常类型的值会在参数校验阶段被拒绝。完整 core Agent 测试文件 198/198 通过，build、typecheck 和 ESLint 也均通过。该变更属于非 UI 参数校验，因此截图不适用。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

本地 Node.js 22 开发环境。

## 风险与范围

- 主要风险或取舍：此前会通过 JavaScript truthiness 解释的异常非 boolean 值，现在会校验失败。
- 未验证或不在范围内：恢复所有 Agent 参数的基础 schema 校验；这样做还会影响现有的参数归一化与兼容行为。
- 破坏性变更或迁移说明：对于符合 schema 的调用方没有影响。

## 关联 Issue

#7593 的后续补强

相关：#7571

</details>
