### PR TITLE
test(core): pin the archived-copy usage salvage in the conflict deletion test

### DIFF
--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -1606,6 +1606,15 @@ describe('SessionService', () => {
       expect(unlinkSyncSpy).toHaveBeenCalledWith(
         expect.stringContaining(`/chats/archive/${sessionIdA}.jsonl`),
       );
+      // #7425 review follow-up: the archived copy's usage must be salvaged
+      // before deletion too — with a telemetry-less fresh active copy it is
+      // the only holder of the session's history. Pin the call so removing
+      // the "redundant-looking" archived salvage fails this test.
+      expect(
+        vi.mocked(persistUsageBeforeTranscriptDeletion),
+      ).toHaveBeenCalledWith(
+        expect.stringContaining(`/chats/archive/${sessionIdA}.jsonl`),
+      );
     });
   });
 


### PR DESCRIPTION
## What this PR does

Adds one assertion to the existing `should remove both JSONL files when active and archived copies conflict` test: `persistUsageBeforeTranscriptDeletion` must be called with the archived transcript path before deletion.

## Why it's needed

Post-merge review on #7425 flagged that the conflict test only asserted the `unlinkSync` calls — a future refactor removing the archived-path salvage (easy to misread as redundant with the active-path salvage above it) would pass every existing test while silently re-opening the interrupted-archive usage-loss edge that #7425 fixed. The dedup guard makes the archived call a no-op when the active copy already wrote, so the call itself is always expected.

## Reviewer Test Plan

### How to verify

`npx vitest run src/services/sessionService.test.ts` (packages/core): 121/121; deleting the `salvageUsageBestEffort(archivedPath)` line in the conflict branch now fails this test.

### Evidence (Before & After)

Test-only change; the pinned behavior itself shipped and was verified in #7425.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Test-only; no production code changes.

## Linked Issues

Follow-up to #7425 (issue #7384).

<details>
<summary>中文说明</summary>

#7425 合并后 review 指出：双副本冲突测试只断言了 unlink 调用——未来若有人把 archived 路径的 salvage 当作冗余删掉，所有既有测试仍会通过，而 #7425 修复的中断归档丢数据边缘会静默复活。本 PR 在该测试补一条断言：删除前必须以 archived 路径调用过 salvage（查重门保证 active 已写时该调用为 no-op，因此调用本身恒为预期）。纯测试改动，121/121。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)