### PR TITLE
fix(channels): stop dropping multi-task messages when a channel memory is saved

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2128,10 +2128,88 @@ describe('ChannelBase', () => {
         ['回复前必须说 1122'],
         'alice',
       );
+      expect(ch.sent).toEqual([{ chatId: 'chat1', text: 'agent response' }]);
+      expect(bridge.prompt).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('你记一下以后回复前要说 1122'),
+        expect.anything(),
+      );
+    });
+
+    it('classifier remember in a multi-task message saves memory and still runs the other tasks', async () => {
+      const channelMemory = createChannelMemory();
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'remember',
+          memory: 'Code reviews should use inline comments',
+          confidence: 0.93,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+      const text =
+        'Review PR #123. Remember that code reviews should use inline ' +
+        'comments. Also check PR #456.';
+
+      await ch.handleInbound(envelope({ text, senderId: 'alice' }));
+
+      expect(channelMemory.addChannelMemoryEntries).toHaveBeenCalledWith(
+        {
+          channelName: 'test-chan',
+          chatId: 'chat1',
+          threadId: undefined,
+        },
+        ['Code reviews should use inline comments'],
+        'alice',
+      );
+      // The full message reaches the agent so the non-memory tasks run, and
+      // no bot-injected confirmation precedes the agent's reply.
+      expect(bridge.prompt).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('Review PR #123'),
+        expect.anything(),
+      );
+      expect(ch.sent).toEqual([{ chatId: 'chat1', text: 'agent response' }]);
+    });
+
+    it('classifier remember save failures report the error and still forward the message', async () => {
+      const channelMemory = createChannelMemory();
+      channelMemory.addChannelMemoryEntries.mockRejectedValue(
+        new Error('disk full'),
+      );
+      const memoryIntentClassifier = {
+        classifyChannelMemoryIntent: vi.fn().mockResolvedValue({
+          intent: 'remember',
+          memory: 'Use staging.',
+          confidence: 0.91,
+        }),
+      };
+      const ch = createChannel(
+        { allowedUsers: ['alice'] },
+        { channelMemory, memoryIntentClassifier },
+      );
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+
+      await ch.handleInbound(
+        envelope({
+          text: 'Deploy the fix and remember to use staging',
+          senderId: 'alice',
+        }),
+      );
+
       expect(ch.sent).toEqual([
-        { chatId: 'chat1', text: 'Channel memory m-000000000001 saved.' },
+        {
+          chatId: 'chat1',
+          text: 'Failed to save channel memory: An error occurred while accessing channel memory.',
+        },
+        { chatId: 'chat1', text: 'agent response' },
       ]);
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
+      stderrSpy.mockRestore();
     });
 
     it('dispatches all validated classifier facts in one memory write', async () => {
@@ -2166,7 +2244,7 @@ describe('ChannelBase', () => {
         ['Use staging.', 'Run tests first.', 'Deploy after approval.'],
         'alice',
       );
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches the validated snapshot when classifier memories getter mutates', async () => {
@@ -2204,7 +2282,7 @@ describe('ChannelBase', () => {
         'alice',
       );
       expect(memoriesReads).toBe(1);
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches the first indexed value when a classifier memory changes on a second read', async () => {
@@ -2245,7 +2323,7 @@ describe('ChannelBase', () => {
         'alice',
       );
       expect(secondFactReads).toBe(1);
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches the first indexed value when a classifier memory becomes non-string on a second read', async () => {
@@ -2286,7 +2364,7 @@ describe('ChannelBase', () => {
         'alice',
       );
       expect(secondFactReads).toBe(1);
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
     it.each(['confidence', 'intent'] as const)(
@@ -2478,10 +2556,10 @@ describe('ChannelBase', () => {
         ['Use staging.'],
         'alice',
       );
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
-    it('reports saved and skipped IDs once for mixed batch results', async () => {
+    it('suppresses save confirmations for mixed batch results and forwards the message', async () => {
       const channelMemory = createChannelMemory();
       channelMemory.addChannelMemoryEntries.mockResolvedValue({
         changed: true,
@@ -2518,13 +2596,8 @@ describe('ChannelBase', () => {
       );
 
       expect(invalidateUnattendedMemory).toHaveBeenCalledTimes(1);
-      expect(ch.sent).toEqual([
-        {
-          chatId: 'chat1',
-          text: 'Channel memory saved: m-a31f0d82c7e4, m-b82c4e190a6f. Skipped duplicates: m-c93d5f20b7a8.',
-        },
-      ]);
-      expect(bridge.prompt).not.toHaveBeenCalled();
+      expect(ch.sent).toEqual([{ chatId: 'chat1', text: 'agent response' }]);
+      expect(bridge.prompt).toHaveBeenCalledTimes(1);
     });
 
     it('regex memory intent skips the llm classifier', async () => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -3131,6 +3131,7 @@ export abstract class ChannelBase {
   private async handleChannelMemoryIntent(
     envelope: Envelope,
     intent: ResolvedChannelMemoryIntent,
+    options: { suppressSaveConfirmation?: boolean } = {},
   ): Promise<void> {
     if (intent.kind === 'no_match') {
       await this.sendMessage(
@@ -3343,6 +3344,13 @@ export abstract class ChannelBase {
       }
       if (result.changed) {
         this.invalidateUnattendedMemory(envelope);
+      }
+      // When the save is a side-effect of a message that continues to the
+      // agent, skip the confirmation: the agent's reply is the single
+      // response, and a bot-injected "memory saved" message would read as a
+      // separate turn. Failures above still surface unconditionally.
+      if (options.suppressSaveConfirmation) {
+        return;
       }
       if (result.added.length > 0) {
         const ids = result.added.map((entry) => entry.id);
@@ -4256,6 +4264,7 @@ export abstract class ChannelBase {
 
     let memoryIntent: ResolvedChannelMemoryIntent | null =
       parseChannelMemoryIntent(envelope.text);
+    let memoryIntentFromClassifier = false;
     if (memoryIntent?.kind === 'update' || memoryIntent?.kind === 'remove') {
       this.deletePendingChannelMemoryMutation(envelope);
     }
@@ -4264,10 +4273,24 @@ export abstract class ChannelBase {
       this.shouldClassifyChannelMemoryIntent(envelope.text)
     ) {
       memoryIntent = await this.classifyChannelMemoryIntent(envelope);
+      memoryIntentFromClassifier = memoryIntent !== null;
     }
     if (memoryIntent) {
-      await this.handleChannelMemoryIntent(envelope, memoryIntent);
-      return;
+      // A classifier-detected `remember` rides inside a free-form message
+      // that may carry other tasks; the save is a side-effect, so the rest
+      // of the message must still reach the agent (with the confirmation
+      // suppressed — the agent's reply is the single response). Explicit
+      // memory phrases and every management intent (list/inspect/update/
+      // remove/clear and their confirmations) consume the whole message by
+      // design and keep the early return.
+      const memorySaveIsSideEffect =
+        memoryIntentFromClassifier && memoryIntent.kind === 'remember';
+      await this.handleChannelMemoryIntent(envelope, memoryIntent, {
+        suppressSaveConfirmation: memorySaveIsSideEffect,
+      });
+      if (!memorySaveIsSideEffect) {
+        return;
+      }
     }
 
     // 3. Slash command handling — before session/agent routing


### PR DESCRIPTION
## What this PR does

Makes a classifier-detected `remember` intent a side-effect instead of a message-consuming command: `ChannelBase.processInbound()` still saves the memory, but now suppresses the bot's "Channel memory … saved." confirmation and lets the full message continue through normal routing to the agent, so the other tasks in the message actually run. The agent's reply becomes the single response, and because the save invalidates unattended memory before the prompt is built, the just-saved entry reaches that same prompt via channel-memory recall — the model knows the save happened without any injected turn. Save failures still surface unconditionally. Everything else keeps its early return by design: explicit remember phrases matched by `parseChannelMemoryIntent` (there the whole message *is* the command) and every management intent — list/inspect/update/remove/clear and their confirmation flows.

## Why it's needed

#7601: a multi-task message like "Review PR #123. Remember that code reviews should use inline comments. Also check PR #456" saved the memory, replied with a save confirmation, and silently dropped tasks 1 and 3 — the early `return` after `handleChannelMemoryIntent()` never routed the message to the agent. The triage confirmed this root cause in `processInbound()` and endorsed exactly this fix direction (option 2: make the save silent and continue with the full message), scoped to `processInbound()` and `handleChannelMemoryIntent()`.

## Reviewer Test Plan

### How to verify

1. In a channel session (e.g. `qwen serve --channel dingtalk-qa`), send one message that combines a real task with a natural-language remember, e.g. "Review PR #123. Remember that code reviews should use inline comments. Also check PR #456." Before this PR: the bot only replies "Channel memory … saved." and the PR-review tasks never run. After: the memory is saved, no bot confirmation is injected, and the agent handles the whole message (its prompt even contains the just-saved entry via recall).
2. Explicit commands are unchanged: "帮我记一下，发布前跑 npm run build" still gets the immediate confirmation without waking the agent, and list/inspect/update/remove/clear flows behave as before.
3. `npx vitest run src/ChannelBase.test.ts` in `packages/channels/base` (502/502; whole package 890/890).

### Evidence (Before & After)

E2E against the compiled `ChannelBase` (real Map-backed memory store, bridge records exactly what reaches the agent, deterministic stand-in for the LLM classifier), before/after via `git stash` + rebuild:

![before/after E2E + tests](https://raw.githubusercontent.com/zjunothing/qwen-code/pr-assets-7601/verify-7601.png)

| check | unpatched (origin/main) | patched |
| --- | --- | --- |
| memory saved from the multi-task message | ✅ | ✅ |
| "Review PR #123" / "check PR #456" reach the agent | ❌ (nothing reaches the agent) | ✅ (full message + recalled memory) |
| chat reply | "Channel memory m-…1 saved." only | agent's single reply |
| new test: multi-task remember saves and still runs the other tasks | ❌ | ✅ |
| new test: save failure reports the error and still forwards the message | ❌ | ✅ |
| explicit remember / management intents keep early return | ✅ | ✅ (unchanged) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (Darwin 24.6), Node v22; vitest. `npm run typecheck`, `eslint --max-warnings 0`, `prettier --check` all clean.

## Risk & Scope

- Main risk or tradeoff: for a message that is *purely* a natural remember (no other tasks), the confirmation with the memory id is replaced by the agent's natural acknowledgement — the classifier has no way to tell "pure remember" from "remember + tasks", and a silent-save-plus-continue gives a single coherent reply in both cases (the id remains discoverable via the list/inspect commands). Existing classifier-remember tests were updated accordingly.
- Not validated / out of scope: the multi-id confirmation strings in `handleChannelMemoryIntent` are now only reachable from the explicit single-text parse path; left in place to keep the diff minimal. No classifier/prompt changes.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7601

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把分类器识别出的 `remember` 意图从「吞掉整条消息的命令」改为「副作用」：`ChannelBase.processInbound()` 仍然保存记忆，但抑制机器人的 "Channel memory … saved." 确认消息，并让完整消息继续走常规路由交给 agent，消息里的其它任务得以真正执行。agent 的回复成为唯一响应；且由于保存后会失效未读记忆缓存，刚保存的条目会经 channel-memory recall 注入同一条 prompt——模型无需任何注入回合就知道保存已发生。保存失败仍然无条件提示。其余路径按设计保持早退：`parseChannelMemoryIntent` 命中的显式记忆短语（整条消息就是命令本身），以及全部管理类意图——list/inspect/update/remove/clear 及其确认流程。

## 为什么需要

#7601：多任务消息如 "Review PR #123. Remember that code reviews should use inline comments. Also check PR #456" 会保存记忆、回复保存确认，然后静默丢弃任务 1 和 3——`handleChannelMemoryIntent()` 之后的早退 `return` 使消息永远到不了 agent。triage 已确认 `processInbound()` 中的这一根因，并背书了正是本 PR 的修复方向（方案 2：静默保存并继续处理完整消息），范围限定在 `processInbound()` 与 `handleChannelMemoryIntent()`。

## 审阅测试计划

### 如何验证

1. 在 channel 会话（如 `qwen serve --channel dingtalk-qa`）发送一条「真实任务 + 自然语言记忆」组合消息：本 PR 之前机器人只回 "Channel memory … saved." 且任务不执行；之后记忆保存、无确认注入、agent 处理整条消息（其 prompt 中还能通过 recall 看到刚保存的条目）。
2. 显式命令不变："帮我记一下，发布前跑 npm run build" 仍立即确认且不唤醒 agent；list/inspect/update/remove/clear 流程行为如旧。
3. `packages/channels/base` 下 `npx vitest run src/ChannelBase.test.ts`（502/502；整包 890/890）。

### 证据（Before & After）

对编译产物 `ChannelBase` 的 E2E（真实 Map 存储、bridge 记录到达 agent 的内容、确定性分类器替身），`git stash` + 重建做前后对照：未修复时 agent 收不到任何内容、只回保存确认；修复后完整消息 + recall 记忆到达 agent、单一回复。两条新测试在未修复源码上失败；显式/管理类路径行为不变。

### 测试平台

macOS 已本地验证（✅）；Windows / Linux 依赖 CI（⚠️）。

### 环境

macOS（Darwin 24.6）、Node v22；vitest；typecheck / eslint / prettier 全绿。

## 风险与范围

- 主要风险/权衡：纯自然语言记忆消息（无其它任务）的带 id 确认被 agent 的自然确认取代——分类器无法区分「纯记忆」与「记忆+任务」，静默保存并继续在两种情况下都给出单一连贯回复（id 仍可通过 list/inspect 查询）。相应更新了既有分类器 remember 测试。
- 未验证/超出范围：`handleChannelMemoryIntent` 中的多 id 确认文案现仅显式单条解析路径可达，为保持最小 diff 原样保留；未改动分类器/提示词。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #7601

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
