### PR TITLE
fix(channels)       : route Telegram replies to the correct forum topic

### DIFF
--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -100,6 +100,7 @@ export class TelegramChannel extends ChannelBase {
 
       const envelope = this.buildEnvelope(msg, text, msg.entities);
 
+      if (envelope.threadId) this.chatThreadMap.set(envelope.chatId, envelope.threadId);
       // Don't await — long prompts would block the update loop
       this.handleInbound(envelope).catch((err) => {
         process.stderr.write(
@@ -138,6 +139,7 @@ export class TelegramChannel extends ChannelBase {
         );
       }
 
+      if (envelope.threadId) this.chatThreadMap.set(envelope.chatId, envelope.threadId);
       this.handleInbound(envelope).catch((err) => {
         process.stderr.write(
           `[Telegram:${this.name}] Error handling message: ${err}\n`,
@@ -191,6 +193,7 @@ export class TelegramChannel extends ChannelBase {
           `\n\n(User sent a file "${fileName}" but download failed)`;
       }
 
+      if (envelope.threadId) this.chatThreadMap.set(envelope.chatId, envelope.threadId);
       this.handleInbound(envelope).catch((err) => {
         process.stderr.write(
           `[Telegram:${this.name}] Error handling message: ${err}\n`,
@@ -244,6 +247,7 @@ export class TelegramChannel extends ChannelBase {
           `\n\n(User sent a voice message but download failed)`;
       }
 
+      if (envelope.threadId) this.chatThreadMap.set(envelope.chatId, envelope.threadId);
       this.handleInbound(envelope).catch((err) => {
         process.stderr.write(
           `[Telegram:${this.name}] Error handling message: ${err}\n`,
@@ -280,6 +284,14 @@ export class TelegramChannel extends ChannelBase {
   /** Per-chat typing interval — repeats every 4s since Telegram expires it after 5s. */
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private activeTypingSessions = new Map<string, Set<string>>();
+
+  /**
+   * Cache of the most recent threadId per chatId, populated from inbound
+   * envelopes.  Used by {@link sendMessage} to route replies back to the
+   * correct Telegram forum topic when {@link ChannelBase} does not supply
+   * a threadId.
+   */
+  private chatThreadMap = new Map<string, string>();
 
   private sendTyping(chatId: string): void {
     try {
@@ -342,7 +354,7 @@ export class TelegramChannel extends ChannelBase {
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
-    await this.sendTelegramMessage(chatId, text);
+    await this.sendTelegramMessage(chatId, text, this.chatThreadMap.get(chatId));
   }
 
   protected override async pushProactive(


### PR DESCRIPTION
## What this PR does

Routes Telegram bot replies back to the same forum topic the user messaged from, instead of always landing in #general. Does this by caching the `threadId` from inbound envelopes and passing it through `sendMessage` to `sendTelegramMessage`.

## Why it's needed

When a Qwen Code Telegram bot is used in a supergroup with Topics enabled, all bot replies appear in #general regardless of which topic the user messaged from. `sessionScope: "thread"` creates isolated sessions per topic, but outbound replies don't route back to the correct thread.

Closes #7609

## Reviewer Test Plan

1. Create a Telegram supergroup with Topics enabled
2. Add the bot to the group
3. Send a message in a specific topic (not #general)
4. **Before fix:** bot reply appears in #general
5. **After fix:** bot reply appears in the same topic the user messaged from

## Risk & Scope

- **Risk:** Low. The change is local to `TelegramChannel` — it adds a `chatId → threadId` cache populated from inbound message handlers. If `threadId` is not in the cache (e.g. DM, non-topic group, or first message), `sendTelegramMessage` receives `undefined` and behaves exactly as before.
- **Out of scope:** Typing indicators still go to #general (they don't go through `sendMessage`). This can be addressed separately if needed.

## Linked Issues

Closes #7609
