### PR TITLE
fix(channels): route Telegram replies to forum topics

### DIFF
--- a/packages/channels/telegram/src/TelegramAdapter.test.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.test.ts
@@ -55,6 +55,29 @@ class TestTelegramChannel extends TelegramChannel {
       text,
     );
   }
+
+  sendTestResponse(chatId: string, text: string, sessionId: string) {
+    return this.sendResponseMessage(chatId, text, sessionId);
+  }
+
+  sendTestResponseFromThread(
+    threadId: string | undefined,
+    chatId: string,
+    text: string,
+    sessionId: string,
+  ) {
+    const inboundRoute = (
+      this as unknown as {
+        inboundRoute: {
+          run<T>(store: { threadId?: string }, callback: () => T): T;
+        };
+      }
+    ).inboundRoute;
+    const route = threadId === undefined ? {} : { threadId };
+    return inboundRoute.run(route, () =>
+      this.sendResponseMessage(chatId, text, sessionId),
+    );
+  }
 }
 
 const config: ChannelConfig = {
@@ -333,6 +356,89 @@ describe('TelegramChannel', () => {
     expect(bot.api.sendMessage).toHaveBeenCalledWith(
       'chat-1',
       expect.stringContaining('Qwen Code Telegram bot'),
+      { parse_mode: 'HTML' },
+    );
+  });
+
+  it('sends command replies back to the Telegram forum topic', async () => {
+    const channel = createChannel({
+      groupPolicy: 'open',
+      groups: { '*': { requireMention: false } },
+    });
+    const bot = installFakeBot(channel);
+
+    await channel.handleInbound(
+      envelope({
+        chatId: '2',
+        threadId: '42',
+        text: '/start',
+        isGroup: true,
+      }),
+    );
+
+    expect(bot.api.sendMessage).toHaveBeenCalledWith(
+      '2',
+      expect.stringContaining('Qwen Code Telegram bot'),
+      { parse_mode: 'HTML', message_thread_id: 42 },
+    );
+  });
+
+  it('sends agent responses back to their routed Telegram forum topic', async () => {
+    const router = {
+      getTarget: vi.fn().mockReturnValue({
+        channelName: 'telegram',
+        senderId: 'user-1',
+        chatId: '2',
+        threadId: '42',
+      }),
+    };
+    const channel = createChannel({}, router);
+    const bot = installFakeBot(channel);
+
+    await channel.sendTestResponse('2', 'topic response', 'session-1');
+
+    expect(router.getTarget).toHaveBeenCalledWith('session-1');
+    expect(bot.api.sendMessage).toHaveBeenCalledWith('2', expect.any(String), {
+      parse_mode: 'HTML',
+      message_thread_id: 42,
+    });
+  });
+
+  it('prefers the current inbound topic over a stale session route', async () => {
+    const router = {
+      getTarget: vi.fn().mockReturnValue({
+        channelName: 'telegram',
+        senderId: 'user-1',
+        chatId: '2',
+        threadId: '42',
+      }),
+    };
+    const channel = createChannel({}, router);
+    const bot = installFakeBot(channel);
+
+    await channel.sendTestResponseFromThread(
+      '43',
+      '2',
+      'new topic response',
+      'session-1',
+    );
+    await channel.sendTestResponseFromThread(
+      undefined,
+      '2',
+      'general response',
+      'session-1',
+    );
+
+    expect(bot.api.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      '2',
+      expect.any(String),
+      { parse_mode: 'HTML', message_thread_id: 43 },
+    );
+    expect(bot.api.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      '2',
+      expect.any(String),
       { parse_mode: 'HTML' },
     );
   });

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Bot } from 'grammy';
@@ -44,6 +45,9 @@ export class TelegramChannel extends ChannelBase {
   private botUsername: string = '';
   private hasConnectedOnce = false;
   private signalHandlersRegistered = false;
+  private readonly inboundRoute = new AsyncLocalStorage<{
+    threadId?: string;
+  }>();
 
   constructor(
     name: string,
@@ -341,8 +345,34 @@ export class TelegramChannel extends ChannelBase {
     super.onSessionDied(sessionId);
   }
 
+  override async handleInbound(envelope: Envelope): Promise<void> {
+    const route =
+      envelope.threadId === undefined ? {} : { threadId: envelope.threadId };
+    await this.inboundRoute.run(route, () => super.handleInbound(envelope));
+  }
+
   async sendMessage(chatId: string, text: string): Promise<void> {
-    await this.sendTelegramMessage(chatId, text);
+    await this.sendTelegramMessage(
+      chatId,
+      text,
+      this.inboundRoute.getStore()?.threadId,
+    );
+  }
+
+  protected override async sendResponseMessage(
+    chatId: string,
+    text: string,
+    sessionId: string,
+  ): Promise<void> {
+    const inboundRoute = this.inboundRoute.getStore();
+    const target = this.router.getTarget(sessionId);
+    const threadId =
+      inboundRoute !== undefined
+        ? inboundRoute.threadId
+        : target?.channelName === this.name && target.chatId === chatId
+          ? target.threadId
+          : undefined;
+    await this.sendTelegramMessage(chatId, text, threadId);
   }
 
   protected override async pushProactive(


### PR DESCRIPTION
## What this PR does

Telegram replies now return to the forum topic that initiated the request. This covers immediate command replies and regular agent output while keeping concurrent topics isolated from each other.

## Why it's needed

In Telegram supergroups with Topics enabled, inbound messages already carry their topic ID, but regular outbound replies dropped that context and appeared in #general. Keeping the route scoped to the active inbound request also avoids one topic overwriting another while multiple requests run in the same chat.

## Reviewer Test Plan

### How to verify

Configure a Telegram supergroup with Topics enabled and send `/start` or a normal prompt from a non-general topic. The response should appear in the same topic. Requests started in different topics should keep their own routes, and a message from #general should not inherit a previous topic.

### Evidence (Before & After)

Before: the focused reproduction extracted topic `42` from the inbound message, but the outbound Telegram API call contained only `parse_mode` and omitted `message_thread_id`.

After: all 17 Telegram adapter tests pass. The regression coverage verifies command replies in topic `42`, agent replies using the stored session target, a newer inbound topic taking precedence over a stale session route, and #general remaining unthreaded.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js 22.22.1 with the repository lockfile dependencies. Verified with the Telegram adapter unit suite, package ESLint and TypeScript build, plus the repository build and typecheck.

## Risk & Scope

- Main risk or tradeoff: topic routing relies on Node's async context for immediate inbound replies and falls back to the validated session target for delivery outside that context.
- Not validated / out of scope: end-to-end delivery through a live Telegram bot.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7609

<details>
<summary>中文说明</summary>

## 本 PR 的修改

Telegram 回复现在会返回到发起请求的论坛话题中。该修复覆盖即时命令回复和常规代理输出，同时确保并发话题之间的路由相互隔离。

## 修改原因

在启用 Topics 的 Telegram 超级群组中，入站消息已经包含话题 ID，但常规出站回复会丢失该上下文并出现在 #general 中。将路由限制在当前入站请求的异步上下文中，也可以避免同一聊天内多个请求并发运行时，一个话题覆盖另一个话题。

## 审阅者测试计划

### 验证方法

配置一个启用 Topics 的 Telegram 超级群组，并在非 general 话题中发送 `/start` 或普通提示。回复应出现在同一话题中。从不同话题启动的请求应各自保留路由，而来自 #general 的消息不应继承之前的话题。

### 修改前后证据

修改前：针对性复现从入站消息中提取了话题 `42`，但出站 Telegram API 调用只包含 `parse_mode`，缺少 `message_thread_id`。

修改后：全部 17 个 Telegram 适配器测试通过。回归测试覆盖话题 `42` 中的命令回复、使用已存储会话目标的代理回复、较新的入站话题优先于过期的会话路由，以及 #general 保持非话题路由。

### 测试环境

| 操作系统 | 状态 |
| :------: | :--: |
| macOS | ⚠️ 未测试 |
| Windows | ⚠️ 未测试 |
| Linux | ✅ 已测试 |

Node.js 22.22.1，使用仓库锁文件依赖。已通过 Telegram 适配器单元测试、包级 ESLint 和 TypeScript 构建，以及仓库构建和类型检查进行验证。

## 风险与范围

- 主要风险或权衡：即时入站回复的话题路由依赖 Node 异步上下文；在该上下文之外发送时，会回退到经过验证的会话目标。
- 未验证 / 范围外：通过真实 Telegram 机器人的端到端消息传递。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #7609

</details>
