### PR TITLE
fix(sdk-java): let a terminal continuation start the next prompt

### DIFF
--- a/docs/design/java-daemon-sdk-alpha.md
+++ b/docs/design/java-daemon-sdk-alpha.md
@@ -27,9 +27,13 @@ The shared timer only dispatches watchdog actions. Potentially blocking SSE
 stream closure runs on a separate bounded pool sized to the prompt concurrency
 limit, so one stalled close cannot delay another session's deadline or idle
 watchdog. Each admitted prompt reserves bounded stream-cleanup capacity until
-its final close task finishes. A stalled close can therefore cause a later
-`startPrompt` call to fail with `DaemonClientCapacityException`, but it cannot
-silently discard a deadline-triggered close or grow cleanup work without bound.
+its final close task finishes. A prompt publishes its terminal once its prompt
+slot is released, while its own stream is still closing, so that capacity
+allows one draining cleanup per prompt slot; a terminal continuation can start
+the next prompt even at the concurrency limit. Closes that stay stalled beyond
+that headroom can still cause a later `startPrompt` call to fail with
+`DaemonClientCapacityException`, but they cannot silently discard a
+deadline-triggered close or grow cleanup work without bound.
 
 `DaemonSessionClient` owns one daemon session and admits at most one local
 prompt at a time. `startPrompt` returns a `PromptCall` immediately. Its

--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/daemon/DaemonClient.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/daemon/DaemonClient.java
@@ -76,7 +76,11 @@ public final class DaemonClient implements AutoCloseable {
         this.heartbeatInterval = builder.heartbeatInterval;
         long clientNumber = CLIENT_SEQUENCE.incrementAndGet();
         this.promptSlots = new Semaphore(builder.maximumConcurrentPrompts);
-        int streamLifecycleCapacity = builder.maximumConcurrentPrompts;
+        // A prompt publishes its terminal once the prompt slot is released, while
+        // its stream keeps closing asynchronously, so admission must tolerate one
+        // draining cleanup per prompt slot.
+        int streamLifecycleCapacity = (int) Math.min(Integer.MAX_VALUE,
+                builder.maximumConcurrentPrompts * 2L);
         this.streamLifecycleSlots = new Semaphore(streamLifecycleCapacity);
         this.executor = new ThreadPoolExecutor(builder.maximumConcurrentPrompts,
                 builder.maximumConcurrentPrompts, 0L, TimeUnit.MILLISECONDS,

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
@@ -2412,10 +2412,34 @@ class DaemonSessionClientTest {
     }
 
     @Test
+    void pendingStreamCleanupDoesNotBlockNextPromptAdmission()
+            throws Exception {
+        CompletableFuture<Void> pendingCleanup = new CompletableFuture<>();
+        CountDownLatch released = new CountDownLatch(1);
+        CountDownLatch nextStarted = new CountDownLatch(1);
+
+        try (DaemonClient daemon = clientBuilder()
+                .maximumConcurrentPrompts(1)
+                .build()) {
+            daemon.submit(() -> { }, () -> { }, released::countDown,
+                    () -> pendingCleanup);
+            assertTrue(released.await(1, TimeUnit.SECONDS));
+
+            daemon.submit(nextStarted::countDown, () -> { }, () -> { },
+                    () -> CompletableFuture.completedFuture(null));
+            assertTrue(nextStarted.await(1, TimeUnit.SECONDS));
+        } finally {
+            pendingCleanup.complete(null);
+        }
+    }
+
+    @Test
     void stalledStreamCleanupAppliesBackpressureBeforePromptExecution()
             throws Exception {
         CompletableFuture<Void> firstCleanup = new CompletableFuture<>();
+        CompletableFuture<Void> secondCleanup = new CompletableFuture<>();
         CountDownLatch firstReleased = new CountDownLatch(1);
+        CountDownLatch secondReleased = new CountDownLatch(1);
         AtomicInteger rejectedTaskRuns = new AtomicInteger();
 
         try (DaemonClient daemon = clientBuilder()
@@ -2424,6 +2448,9 @@ class DaemonSessionClientTest {
             daemon.submit(() -> { }, () -> { }, firstReleased::countDown,
                     () -> firstCleanup);
             assertTrue(firstReleased.await(1, TimeUnit.SECONDS));
+            daemon.submit(() -> { }, () -> { }, secondReleased::countDown,
+                    () -> secondCleanup);
+            assertTrue(secondReleased.await(1, TimeUnit.SECONDS));
 
             assertThrows(DaemonClientCapacityException.class,
                     () -> daemon.submit(rejectedTaskRuns::incrementAndGet,
@@ -2438,6 +2465,7 @@ class DaemonSessionClientTest {
             assertTrue(recovered.await(1, TimeUnit.SECONDS));
         } finally {
             firstCleanup.complete(null);
+            secondCleanup.complete(null);
         }
     }
 


### PR DESCRIPTION
### Problem

`DaemonSessionClientTest.terminalContinuationCanStartNextPromptAtClientCapacity` fails intermittently on CI ([example](https://github.com/QwenLM/qwen-code/actions/runs/30019272445/job/89247408734)):

```
java.util.concurrent.ExecutionException: DaemonClientCapacityException: DaemonClient capacity is exhausted
Caused by: java.util.concurrent.RejectedExecutionException: Stream cleanup capacity is exhausted
    at DaemonClient.submit(DaemonClient.java:335)
    at DaemonSessionClient.startPrompt(DaemonSessionClient.java:93)
```

The flake exposes a real API defect rather than a bad assertion: chaining prompts off `completionFuture()` while the client is at its prompt-concurrency limit can randomly fail.

### Root cause

`DaemonClient.submit` reserves two semaphores per prompt, but they are released at different times:

- `promptSlots` is released synchronously in `FutureTask.done()`, right before `afterCapacityRelease` opens the terminal publication gate.
- `streamLifecycleSlots` is only released once the SSE stream has finished closing, because `registerStreamCleanup` attaches a `whenComplete` callback to the cleanup future, and the terminal path in `observe()` closes the stream through `closeStreamAsync` without waiting for it.

So a prompt's stream-cleanup reservation outlives its prompt slot by one generation. Both semaphores were sized to `maximumConcurrentPrompts`, which leaves no room for that overlap: when the previous prompt's close has not finished by the time its terminal is published, the continuation's `startPrompt` finds a free prompt slot but no free cleanup slot and throws. Normally the close wins the race; on a loaded runner it does not.

### Fix

Size the stream-cleanup semaphore to allow one draining cleanup per prompt slot — exactly the overlap the release ordering can produce. The stream-close executor queue is derived from the same capacity, so it still absorbs every reservation without rejecting work.

Admission backpressure is unchanged in kind: cleanups that stay stalled beyond that headroom still fail fast, now after two generations instead of one. `stalledStreamCleanupAppliesBackpressureBeforePromptExecution` is updated to stall two cleanups before asserting rejection, and `pendingStreamCleanupDoesNotBlockNextPromptAdmission` is added to pin the other half of the contract: one pending cleanup must not block the next admission.

With the fix, `terminalContinuationCanStartNextPromptAtClientCapacity` no longer depends on timing at all — at `maximumConcurrentPrompts(1)` the second prompt always finds the spare slot.

### Verification

- `mvn clean test` — 108 tests, green, repeated 3×.
- `mvn checkstyle:check` — 0 violations. `mvn -DskipTests package` — green.
- Causal check: injecting a 50 ms delay into the `closeStreamAsync` close task reproduces the exact CI failure on `main` (same exception chain, same line), and all three tests still pass with that delay once this fix is applied. Reverting only the capacity change with the delay still injected fails all three, so the new tests are not vacuous.

<details>
<summary>中文说明</summary>

### 问题

`DaemonSessionClientTest.terminalContinuationCanStartNextPromptAtClientCapacity` 在 CI 上间歇性失败（[示例](https://github.com/QwenLM/qwen-code/actions/runs/30019272445/job/89247408734)）：

```
java.util.concurrent.ExecutionException: DaemonClientCapacityException: DaemonClient capacity is exhausted
Caused by: java.util.concurrent.RejectedExecutionException: Stream cleanup capacity is exhausted
    at DaemonClient.submit(DaemonClient.java:335)
    at DaemonSessionClient.startPrompt(DaemonSessionClient.java:93)
```

这个 flake 暴露的是一个真实的 API 缺陷，而不是断言写得太严：客户端跑满 prompt 并发上限时，用 `completionFuture()` 串接下一个 prompt 会随机失败。

### 根因

`DaemonClient.submit` 为每个 prompt 预留两个信号量，但两者释放时机不同：

- `promptSlots` 在 `FutureTask.done()` 中同步释放，紧接着 `afterCapacityRelease` 就打开 terminal 发布 gate。
- `streamLifecycleSlots` 要等 SSE 流真正关完才释放：`registerStreamCleanup` 只是在 cleanup future 上挂了一个 `whenComplete` 回调，而 `observe()` 的 terminal 路径通过 `closeStreamAsync` 异步关流，并不等待。

也就是说，一个 prompt 的 stream cleanup 预留会比它的 prompt 槽位多活一代。而两个信号量的容量都按 `maximumConcurrentPrompts` 配置，没有给这次重叠留出空间：当上一个 prompt 的关流在其 terminal 发布时还没结束，续接里的 `startPrompt` 能拿到空闲的 prompt 槽位，却拿不到 cleanup 槽位，于是抛异常。平时关流总能赢下这场赛跑，机器负载高时就未必。

### 修复

把 stream cleanup 信号量的容量放宽为每个 prompt 槽位允许一个正在排水的 cleanup —— 这正是释放顺序会产生的重叠量。stream-close 执行器的队列由同一个容量推导，因此仍能容纳所有预留而不会拒绝任务。

准入背压的性质没有变：滞留超出这个余量的 cleanup 依然快速失败，只是从滞留一代变成滞留两代。`stalledStreamCleanupAppliesBackpressureBeforePromptExecution` 相应改为挂住两个 cleanup 再断言拒绝；新增 `pendingStreamCleanupDoesNotBlockNextPromptAdmission` 钉住契约的另一半：单个未完成的 cleanup 不得阻塞下一次准入。

修复后 `terminalContinuationCanStartNextPromptAtClientCapacity` 完全不再依赖时序 —— 在 `maximumConcurrentPrompts(1)` 下，第二个 prompt 必然能拿到那个备用槽位。

### 验证

- `mvn clean test` —— 108 个测试全绿，重复跑 3 次。
- `mvn checkstyle:check` —— 0 violations；`mvn -DskipTests package` —— 通过。
- 因果验证：在 `closeStreamAsync` 的关流任务中注入 50 ms 延迟，可在 `main` 上稳定复现 CI 的失败（异常链和行号完全一致）；打上本修复后，带着这个延迟三个测试依然全过。若只回退容量改动、保留注入延迟，三个测试全挂，说明新增测试不是空断言。

</details>
