### PR TITLE
test(sdk-java): widen the SSE idle-watchdog margins in the slow-line test

### DIFF
--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
@@ -1061,8 +1061,8 @@ class DaemonSessionClientTest {
             exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
             exchange.sendResponseHeaders(200, 0);
             byte[] bytes = terminalEvent(1).getBytes(StandardCharsets.UTF_8);
-            for (int offset = 0; offset < bytes.length; offset += 20) {
-                int count = Math.min(20, bytes.length - offset);
+            for (int offset = 0; offset < bytes.length; offset += 8) {
+                int count = Math.min(8, bytes.length - offset);
                 exchange.getResponseBody().write(bytes, offset, count);
                 exchange.getResponseBody().flush();
                 sleep(50);
@@ -1071,8 +1071,11 @@ class DaemonSessionClientTest {
         });
         server.createContext("/session/session-1/detach", noContent());
 
+        // The event needs about a second of 50ms steps to arrive, so a watchdog
+        // that only saw whole frames would still expire well inside the run.
         try (DaemonClient daemon = clientBuilder()
-                .sseIdleTimeout(Duration.ofMillis(150)).build();
+                .promptObservationTimeout(Duration.ofSeconds(15))
+                .sseIdleTimeout(Duration.ofMillis(500)).build();
                 DaemonSessionClient session = daemon.createSession()) {
             assertEquals(PromptTerminal.Kind.COMPLETE,
                     session.promptText("go").getTerminal().getKind());


### PR DESCRIPTION
### Problem

`DaemonSessionClientTest.slowSseLineBytesKeepIdleWatchdogAlive` fails intermittently, most recently on `main` ([job](https://github.com/QwenLM/qwen-code/actions/runs/30025946135/job/89270312326)):

```
DaemonSessionClientTest.slowSseLineBytesKeepIdleWatchdogAlive:1078
  PromptOutcomeIndeterminateException: SSE reconnect attempts exhausted
Caused by: java.io.IOException: SSE idle timeout
```

It has failed the same way on `macos-latest / Java 21` in several earlier runs (30012191939, 30011211178, 29980041650). This one is test-side timing tolerance, not a product defect.

### Root cause

The test writes the 173-byte terminal event in 20-byte steps 50ms apart, against `sseIdleTimeout(150ms)`. The margin between one step and the watchdog is 3×, so any step the client observes more than 150ms apart — server thread scheduling, a flush, a GC pause on a loaded runner — trips the idle watchdog.

That alone would be survivable, except an idle close restarts the whole event: the handler replays it from byte 0, so every attempt costs another full delivery. With `maximumReconnectAttempts(2)` and the 3s observation budget from `clientBuilder()`, only about three attempts fit, and a handful of slow steps exhausts them.

Locally the current test starts failing once the steps reach 260ms, and 200ms steps already take 2.4s of the 3s budget.

### Fix

Send the event in 8-byte steps and raise the idle timeout to 500ms. The property under test is preserved, because it depends on the ratio rather than the absolute numbers: a step must stay under the idle timeout while the whole event must take longer than it. The event now needs ~1.1s of 50ms steps to arrive, so a watchdog fed only by whole frames still expires well inside the run — and a slow runner only stretches the delivery, which strengthens that direction.

Also raise the observation timeout for this test so one slow step is absorbed by a reconnect instead of ending the prompt.

### Verification

- `mvn clean test` — 108 tests, green; `mvn checkstyle:check` — 0 violations.
- Tolerance: with the fix the test survives 400ms steps (8× the nominal 50ms), where the current version fails at 260ms.
- Not vacuous: neutering `SseReader` so activity is reported per frame instead of per byte makes the new test fail with the exact CI error, so it still catches the regression it exists for.

### Not covered here

Two other tests in this class have failed once each in CI — `rejectsClientWidePromptCapacityBeforeMutation` (detach timeout, ubuntu/11) and `acceptanceContinuationDoesNotHoldSessionLifecycleLock` (windows/21). Neither reproduces locally and neither shares this root cause, so they are left alone rather than patched on a guess.

<details>
<summary>中文说明</summary>

### 问题

`DaemonSessionClientTest.slowSseLineBytesKeepIdleWatchdogAlive` 间歇性失败，最近一次直接挂在 `main` 上（[job](https://github.com/QwenLM/qwen-code/actions/runs/30025946135/job/89270312326)）：

```
DaemonSessionClientTest.slowSseLineBytesKeepIdleWatchdogAlive:1078
  PromptOutcomeIndeterminateException: SSE reconnect attempts exhausted
Caused by: java.io.IOException: SSE idle timeout
```

此前在 `macos-latest / Java 21` 上已经以同样方式失败过多次（30012191939、30011211178、29980041650）。这一个属于测试自身的时间容忍度问题，不是产品缺陷。

### 根因

测试把 173 字节的 terminal 事件按 20 字节一步、每步间隔 50ms 写出，而客户端 `sseIdleTimeout(150ms)`。一步与看门狗之间只有 3 倍余量，因此只要客户端观测到的某一步间隔超过 150ms —— 服务端线程调度、一次 flush、负载高时的一次 GC 停顿 —— 就会触发 idle 看门狗。

单次触发本来还能扛过去，问题在于 idle 关流会让整个事件重来：handler 从第 0 字节重新发一遍，于是每次重试都要付出一次完整的传输时间。而 `clientBuilder()` 给的是 `maximumReconnectAttempts(2)` 加 3 秒观测预算，总共只够约三次尝试，几步慢一点就把重试次数耗光。

本地实测：当前这个测试在步长间隔达到 260ms 时开始失败；间隔 200ms 时已经吃掉 3 秒预算里的 2.4 秒。

### 修复

改成 8 字节一步，并把 idle 超时提到 500ms。被测性质得以保留，因为它依赖的是比例而非绝对数值：单步必须小于 idle 超时，而整个事件必须长于 idle 超时。现在整个事件需要约 1.1 秒的 50ms 步进才能送完，因此一个只按整帧喂食的看门狗仍然会在测试跑完之前超时 —— 而机器越慢，传输只会越长，这个方向反而更稳。

同时为这个测试放宽观测超时，让偶发的一步慢可以由一次重连吸收，而不是直接结束 prompt。

### 验证

- `mvn clean test` —— 108 个测试全绿；`mvn checkstyle:check` —— 0 violations。
- 容忍度：修复后步长间隔 400ms（标称 50ms 的 8 倍）仍然通过，而当前版本在 260ms 就挂。
- 不是空断言：把 `SseReader` 改成按帧而非按字节上报活跃度后，新版测试会以和 CI 完全一致的错误失败，说明它仍然守得住它该守的回归。

### 本 PR 未覆盖的部分

这个测试类里另有两个测试各在 CI 上失败过一次 —— `rejectsClientWidePromptCapacityBeforeMutation`（detach 超时，ubuntu/11）和 `acceptanceContinuationDoesNotHoldSessionLifecycleLock`（windows/21）。两者本地都无法复现，也都不是本次这个根因，因此不做猜测性修改，留待单独排查。

</details>
