### PR TITLE
fix(daemon): address epoch cursor review follow-ups

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3631,7 +3631,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         // session, so the sessionId context is injected here.
         onCompactionError: (err) => {
           writeStderrLine(
-            `qwen serve: compaction degraded for session=${sessionId}; replay snapshot may lag behind live events: ${
+            `qwen serve: compaction degraded for session=${JSON.stringify(sessionId)}; replay snapshot may lag behind live events: ${
               err instanceof Error ? err.message : String(err)
             }`,
           );

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -8745,7 +8745,7 @@ describe('createServeApp', () => {
       ]);
     });
 
-    it('surfaces partial response-mode replay details from load', async () => {
+    it('surfaces response-mode replay details from load', async () => {
       const bridge = fakeBridge({
         loadImpl: async (req) => ({
           sessionId: req.sessionId,
@@ -8755,6 +8755,8 @@ describe('createServeApp', () => {
           state: {},
           partial: true,
           replayError: 'replay boom',
+          eventEpoch: 'epoch-load',
+          replayDegraded: true,
         }),
       });
       const app = createServeApp(baseOpts, undefined, { bridge });
@@ -8764,8 +8766,12 @@ describe('createServeApp', () => {
         .send({});
 
       expect(res.status).toBe(200);
-      expect(res.body.partial).toBe(true);
-      expect(res.body.replayError).toBe('replay boom');
+      expect(res.body).toMatchObject({
+        partial: true,
+        replayError: 'replay boom',
+        eventEpoch: 'epoch-load',
+        replayDegraded: true,
+      });
       expect(bridge.loadCalls).toEqual([
         {
           sessionId: 'persisted-partial',

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -400,10 +400,10 @@ export interface DaemonStateResyncRequiredData {
    */
   reason: string;
   /**
-   * Optional trigger discriminator carried via the index signature on
-   * the wire. `'epoch_mismatch'` marks an `'epoch_reset'` produced by
-   * the epoch token comparison rather than the numeric heuristic.
-   * Operational/wire-level field — UI consumers key on `reason` alone.
+   * Optional trigger discriminator on the wire. `'epoch_mismatch'` marks an
+   * `'epoch_reset'` produced by the epoch token comparison rather than the
+   * numeric heuristic. Operational/wire-level field — UI consumers key on
+   * `reason` alone.
    */
   detail?: string;
   /** Consumer's `Last-Event-ID` at reconnect time. */


### PR DESCRIPTION
## What this PR does

This PR adds an HTTP-route regression assertion that the session load response preserves the event-bus epoch token and replay-degradation flag returned by the bridge. It also JSON-escapes the session identifier in compaction-degradation breadcrumbs and corrects a misleading SDK comment about the explicit resync detail field.

The browser-bundle ledger correction originally included in this follow-up is no longer part of the diff because current `main` now contains equivalent, newer budget history through 170KB.

## Why it's needed

The epoch cursor and degradation fields were previously covered only at the bridge layer, so a future route DTO or response whitelist could silently remove them while all existing tests remained green. The compaction breadcrumb interpolated the session identifier directly instead of following the surrounding JSON-stringification convention. The SDK comment also referred to an index signature even though the field is declared explicitly.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/serve/server.test.ts -t 'surfaces response-mode replay details from load'` and confirm the real HTTP response includes both `eventEpoch` and `replayDegraded`.

Run `cd packages/acp-bridge && npx vitest run src/bridge.test.ts -t 'surfaces replayDegraded on loadSession when compaction fails'` and confirm the degraded breadcrumb prints the session identifier as a quoted JSON string.

Run `cd packages/sdk-typescript && npm run typecheck` and confirm the SDK declarations typecheck.

### Evidence (Before & After)

N/A — this is a non-UI test, log-safety, and documentation correction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS with Node.js v22.22.3 and npm 10.9.8.

## Risk & Scope

- Main risk or tradeoff: The only production behavior change is that compaction-degradation logs now quote and escape the session identifier; consumers that parse the previous unquoted breadcrumb format may need to accept the quoted value.
- Not validated / out of scope: Windows and Linux were not tested locally. Full-repository build and typecheck remain blocked locally by pre-existing Ink selection typing errors and missing generated Web Shell SDK artifacts; the affected ACP bridge and TypeScript SDK workspaces pass their targeted checks.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up to #7458.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 增加了一条 HTTP 路由回归断言，确保 session load 响应会保留 bridge 返回的 event-bus epoch token 和 replay degradation 标记。同时对 compaction degradation 面包屑日志中的 session 标识符进行 JSON 转义，并修正一处关于显式 resync detail 字段的误导性 SDK 注释。

本后续修正最初包含的浏览器 bundle 预算 ledger 更正已不再出现在 diff 中，因为当前 `main` 已包含等价且更新到 170KB 的预算历史。

## 为什么需要

此前 epoch cursor 和 degradation 字段只在 bridge 层有覆盖，因此未来若路由引入 DTO 或响应白名单并静默丢弃这些字段，现有测试仍可能全部通过。compaction 面包屑日志直接插值 session 标识符，没有遵循周边 JSON stringify 的一致写法。SDK 注释还在字段已经显式声明的情况下声称它来自 index signature。

## Reviewer 测试计划

### 如何验证

运行 `cd packages/cli && npx vitest run src/serve/server.test.ts -t 'surfaces response-mode replay details from load'`，确认真实 HTTP 响应同时包含 `eventEpoch` 和 `replayDegraded`。

运行 `cd packages/acp-bridge && npx vitest run src/bridge.test.ts -t 'surfaces replayDegraded on loadSession when compaction fails'`，确认 degraded 面包屑日志将 session 标识符输出为带引号的 JSON 字符串。

运行 `cd packages/sdk-typescript && npm run typecheck`，确认 SDK 声明通过类型检查。

### 证据（修改前后）

N/A——这是非 UI 的测试、日志安全性和文档修正。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS，Node.js v22.22.3，npm 10.9.8。

## 风险与范围

- 主要风险或权衡：唯一的生产行为变化是 compaction degradation 日志现在会为 session 标识符加引号并进行转义；解析旧版无引号面包屑格式的消费者可能需要兼容带引号的值。
- 未验证或范围外：未在本地测试 Windows 和 Linux。全仓库 build 和 typecheck 在本地仍被既有的 Ink selection 类型错误和缺失的 Web Shell SDK 生成产物阻断；受影响的 ACP bridge 和 TypeScript SDK 工作区已通过各自的定向检查。
- 破坏性变更或迁移说明：无。

## 关联事项

#7458 的后续修正。

</details>
