### PR TITLE
fix(web-shell): parse 256-color and truecolor SGR sequences in parseAnsi

### DIFF
--- a/packages/web-shell/client/utils/ansi.test.ts
+++ b/packages/web-shell/client/utils/ansi.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { hasAnsi, parseAnsi } from './ansi';
+
+const ESC = '\x1b[';
+
+describe('parseAnsi', () => {
+  it('applies basic and bright colors, bold and dim', () => {
+    expect(parseAnsi(`${ESC}32mok`)).toEqual([
+      { text: 'ok', color: '#48bb78', bold: false, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}1;91mhot`)).toEqual([
+      { text: 'hot', color: '#feb2b2', bold: true, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}2mfaint`)).toEqual([
+      { text: 'faint', color: undefined, bold: false, dim: true },
+    ]);
+  });
+
+  it('resets state on 0, 22 and 39', () => {
+    expect(parseAnsi(`${ESC}1;31ma${ESC}0mb`)).toEqual([
+      { text: 'a', color: '#fc8181', bold: true, dim: false },
+      { text: 'b', color: undefined, bold: false, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}1;2;31ma${ESC}22mb`)).toEqual([
+      { text: 'a', color: '#fc8181', bold: true, dim: true },
+      { text: 'b', color: '#fc8181', bold: false, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}31ma${ESC}39mb`)[1]!.color).toBeUndefined();
+  });
+
+  // The arguments of 38/48/58 are not SGR codes. Reading them as codes is what
+  // made `38;5;2` set dim (from the color index) instead of a color.
+  it('does not read 256-color arguments as SGR codes', () => {
+    expect(parseAnsi(`${ESC}38;5;2mgreen`)).toEqual([
+      { text: 'green', color: '#48bb78', bold: false, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}38;5;1mred`)[0]!.color).toBe('#fc8181');
+    // Bright half of the standard range maps onto the 90-97 palette.
+    expect(parseAnsi(`${ESC}38;5;9mbright`)[0]!.color).toBe('#feb2b2');
+    // 6x6x6 cube: 208 -> (5, 2, 0) -> #ff8700.
+    expect(parseAnsi(`${ESC}38;5;208morange`)[0]!.color).toBe('#ff8700');
+    // Cube corners.
+    expect(parseAnsi(`${ESC}38;5;16ma`)[0]!.color).toBe('#000000');
+    expect(parseAnsi(`${ESC}38;5;231ma`)[0]!.color).toBe('#ffffff');
+    // Grayscale ramp: 232 -> 8, 255 -> 238.
+    expect(parseAnsi(`${ESC}38;5;232ma`)[0]!.color).toBe('#080808');
+    expect(parseAnsi(`${ESC}38;5;255ma`)[0]!.color).toBe('#eeeeee');
+  });
+
+  it('does not let truecolor channels reset the style', () => {
+    expect(parseAnsi(`${ESC}38;2;255;0;0mred`)).toEqual([
+      { text: 'red', color: '#ff0000', bold: false, dim: false },
+    ]);
+    // A zero channel used to hit the `code === 0` reset, clearing the bold
+    // that was already set; two more channels are 128 and 255, neither of
+    // which is an SGR code at all.
+    expect(parseAnsi(`${ESC}1m${ESC}38;2;0;128;255mblue`)).toEqual([
+      { text: 'blue', color: '#0080ff', bold: true, dim: false },
+    ]);
+  });
+
+  it('keeps background and underline color out of the code stream', () => {
+    // 48;5;22 used to feed `22` to the reset-intensity branch, so setting a
+    // background silently un-bolded the text.
+    expect(parseAnsi(`${ESC}1m${ESC}48;5;22mtext`)).toEqual([
+      { text: 'text', color: undefined, bold: true, dim: false },
+    ]);
+    // Foreground survives a background change on the same sequence, and the
+    // trailing 1 is still read as bold once the 48 arguments are consumed.
+    expect(parseAnsi(`${ESC}31;48;2;0;0;0;1mtext`)).toEqual([
+      { text: 'text', color: '#fc8181', bold: true, dim: false },
+    ]);
+    expect(parseAnsi(`${ESC}1m${ESC}58;5;2mtext`)[0]!.bold).toBe(true);
+  });
+
+  it('drops malformed extended-color sequences without corrupting state', () => {
+    // Out-of-range index and truncated argument lists yield no color rather
+    // than a bogus one, and never fall through to the plain-code branches.
+    for (const seq of ['38;5;300', '38;5', '38;2;1;2', '38;7;1', '38']) {
+      expect(parseAnsi(`${ESC}1m${ESC}${seq}mtext`)).toEqual([
+        { text: 'text', color: undefined, bold: true, dim: false },
+      ]);
+    }
+  });
+
+  it('splits text around sequences and keeps the trailing run', () => {
+    expect(parseAnsi(`plain${ESC}1mbold${ESC}0mtail`)).toEqual([
+      { text: 'plain', color: undefined, bold: false, dim: false },
+      { text: 'bold', color: undefined, bold: true, dim: false },
+      { text: 'tail', color: undefined, bold: false, dim: false },
+    ]);
+    expect(parseAnsi('no escapes')).toEqual([
+      { text: 'no escapes', color: undefined, bold: false, dim: false },
+    ]);
+    // `ESC[m` is shorthand for `ESC[0m`.
+    expect(parseAnsi(`${ESC}1ma${ESC}mb`)[1]!.bold).toBe(false);
+  });
+});
+
+describe('hasAnsi', () => {
+  it('detects a CSI introducer', () => {
+    expect(hasAnsi(`${ESC}0mx`)).toBe(true);
+    expect(hasAnsi('plain text')).toBe(false);
+  });
+});

--- a/packages/web-shell/client/utils/ansi.test.ts
+++ b/packages/web-shell/client/utils/ansi.test.ts
@@ -83,6 +83,18 @@ describe('parseAnsi', () => {
     }
   });
 
+  it('leaves an already-set color alone when the sequence is malformed', () => {
+    // An unreadable sequence is ignored, not treated as a reset: the red from
+    // code 31 has to survive it.
+    for (const seq of ['38;5;300', '38;5', '38;2;1;2', '38;7;1', '38']) {
+      expect(parseAnsi(`${ESC}31m${ESC}${seq}mtext`)).toEqual([
+        { text: 'text', color: '#fc8181', bold: false, dim: false },
+      ]);
+    }
+    // A well-formed sequence still replaces it.
+    expect(parseAnsi(`${ESC}31m${ESC}38;5;21mtext`)[0]!.color).toBe('#0000ff');
+  });
+
   it('splits text around sequences and keeps the trailing run', () => {
     expect(parseAnsi(`plain${ESC}1mbold${ESC}0mtail`)).toEqual([
       { text: 'plain', color: undefined, bold: false, dim: false },

--- a/packages/web-shell/client/utils/ansi.test.ts
+++ b/packages/web-shell/client/utils/ansi.test.ts
@@ -70,13 +70,26 @@ describe('parseAnsi', () => {
     expect(parseAnsi(`${ESC}31;48;2;0;0;0;1mtext`)).toEqual([
       { text: 'text', color: '#fc8181', bold: true, dim: false },
     ]);
-    expect(parseAnsi(`${ESC}1m${ESC}58;5;2mtext`)[0]!.bold).toBe(true);
+    // Asserting the whole segment, not just `bold`: dropping 58 from the trio
+    // leaks its `2` argument into the dim branch, which a bold-only assertion
+    // cannot see.
+    expect(parseAnsi(`${ESC}1m${ESC}58;5;2mtext`)).toEqual([
+      { text: 'text', color: undefined, bold: true, dim: false },
+    ]);
   });
 
   it('drops malformed extended-color sequences without corrupting state', () => {
     // Out-of-range index and truncated argument lists yield no color rather
     // than a bogus one, and never fall through to the plain-code branches.
-    for (const seq of ['38;5;300', '38;5', '38;2;1;2', '38;7;1', '38']) {
+    // `38;2;999;0;0` is the truecolor equivalent: a channel outside 0–255.
+    for (const seq of [
+      '38;5;300',
+      '38;5',
+      '38;2;1;2',
+      '38;7;1',
+      '38',
+      '38;2;999;0;0',
+    ]) {
       expect(parseAnsi(`${ESC}1m${ESC}${seq}mtext`)).toEqual([
         { text: 'text', color: undefined, bold: true, dim: false },
       ]);
@@ -86,7 +99,14 @@ describe('parseAnsi', () => {
   it('leaves an already-set color alone when the sequence is malformed', () => {
     // An unreadable sequence is ignored, not treated as a reset: the red from
     // code 31 has to survive it.
-    for (const seq of ['38;5;300', '38;5', '38;2;1;2', '38;7;1', '38']) {
+    for (const seq of [
+      '38;5;300',
+      '38;5',
+      '38;2;1;2',
+      '38;7;1',
+      '38',
+      '38;2;999;0;0',
+    ]) {
       expect(parseAnsi(`${ESC}31m${ESC}${seq}mtext`)).toEqual([
         { text: 'text', color: '#fc8181', bold: false, dim: false },
       ]);

--- a/packages/web-shell/client/utils/ansi.ts
+++ b/packages/web-shell/client/utils/ansi.ts
@@ -17,11 +17,40 @@ const ANSI_COLORS: Record<number, string> = {
   97: '#ffffff',
 };
 
+/** The six channel levels of the xterm 6x6x6 color cube (indices 16-231). */
+const CUBE_LEVELS = [0, 95, 135, 175, 215, 255];
+
 interface Segment {
   text: string;
   color?: string;
   bold?: boolean;
   dim?: boolean;
+}
+
+function toHex(r: number, g: number, b: number): string | undefined {
+  if (![r, g, b].every((v) => Number.isInteger(v) && v >= 0 && v <= 255)) {
+    return undefined;
+  }
+  return `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/** Resolve an xterm 256-color index to a hex string. */
+function xterm256(index: number): string | undefined {
+  if (!Number.isInteger(index) || index < 0 || index > 255) return undefined;
+  // 0-15 stay on the palette above, so a tool emitting `38;5;2` and one
+  // emitting `32` render as the same green.
+  if (index < 8) return ANSI_COLORS[30 + index];
+  if (index < 16) return ANSI_COLORS[90 + (index - 8)];
+  if (index < 232) {
+    const v = index - 16;
+    return toHex(
+      CUBE_LEVELS[Math.floor(v / 36)]!,
+      CUBE_LEVELS[Math.floor(v / 6) % 6]!,
+      CUBE_LEVELS[v % 6]!,
+    );
+  }
+  const level = 8 + (index - 232) * 10;
+  return toHex(level, level, level);
 }
 
 export function parseAnsi(input: string): Segment[] {
@@ -41,8 +70,33 @@ export function parseAnsi(input: string): Segment[] {
     pos = match.index + match[0].length;
 
     const codes = match[1].split(';').map(Number);
-    for (const code of codes) {
-      if (code === 0) {
+    for (let i = 0; i < codes.length; i++) {
+      const code = codes[i];
+      // 38/48/58 (foreground/background/underline color) never stand alone:
+      // each is followed by `5;<index>` or `2;<r>;<g>;<b>`. Those arguments
+      // have to be consumed here, or the loop reads them as codes in their own
+      // right — `38;5;2` would take the color index for "dim", and a truecolor
+      // value with a zero channel would hit the reset below and drop the
+      // color, bold and dim state that was already correct.
+      if (code === 38 || code === 48 || code === 58) {
+        const mode = codes[i + 1];
+        let value: string | undefined;
+        if (mode === 5) {
+          value = xterm256(codes[i + 2]!);
+          i += 2;
+        } else if (mode === 2) {
+          value = toHex(codes[i + 2]!, codes[i + 3]!, codes[i + 4]!);
+          i += 4;
+        } else {
+          // An unrecognized form has an unknown argument count, so there is no
+          // safe place to resume; drop the rest of this sequence rather than
+          // guess where the color ends.
+          break;
+        }
+        // Only the foreground maps onto a Segment. Background and underline
+        // color are still parsed so their arguments cannot leak into the loop.
+        if (code === 38) color = value;
+      } else if (code === 0) {
         color = undefined;
         bold = false;
         dim = false;

--- a/packages/web-shell/client/utils/ansi.ts
+++ b/packages/web-shell/client/utils/ansi.ts
@@ -27,16 +27,28 @@ interface Segment {
   dim?: boolean;
 }
 
-function toHex(r: number, g: number, b: number): string | undefined {
-  if (![r, g, b].every((v) => Number.isInteger(v) && v >= 0 && v <= 255)) {
-    return undefined;
+// The channel and index parameters are read straight out of the escape
+// sequence, so a truncated one yields `undefined` — the types say so rather
+// than asserting the value away, and the guards below are what reject it.
+function toHex(
+  r: number | undefined,
+  g: number | undefined,
+  b: number | undefined,
+): string | undefined {
+  let hex = '#';
+  for (const v of [r, g, b]) {
+    if (v === undefined || !Number.isInteger(v) || v < 0 || v > 255) {
+      return undefined;
+    }
+    hex += v.toString(16).padStart(2, '0');
   }
-  return `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+  return hex;
 }
 
 /** Resolve an xterm 256-color index to a hex string. */
-function xterm256(index: number): string | undefined {
-  if (!Number.isInteger(index) || index < 0 || index > 255) return undefined;
+function xterm256(index: number | undefined): string | undefined {
+  if (index === undefined || !Number.isInteger(index)) return undefined;
+  if (index < 0 || index > 255) return undefined;
   // 0-15 stay on the palette above, so a tool emitting `38;5;2` and one
   // emitting `32` render as the same green.
   if (index < 8) return ANSI_COLORS[30 + index];
@@ -44,9 +56,9 @@ function xterm256(index: number): string | undefined {
   if (index < 232) {
     const v = index - 16;
     return toHex(
-      CUBE_LEVELS[Math.floor(v / 36)]!,
-      CUBE_LEVELS[Math.floor(v / 6) % 6]!,
-      CUBE_LEVELS[v % 6]!,
+      CUBE_LEVELS[Math.floor(v / 36)],
+      CUBE_LEVELS[Math.floor(v / 6) % 6],
+      CUBE_LEVELS[v % 6],
     );
   }
   const level = 8 + (index - 232) * 10;
@@ -82,10 +94,10 @@ export function parseAnsi(input: string): Segment[] {
         const mode = codes[i + 1];
         let value: string | undefined;
         if (mode === 5) {
-          value = xterm256(codes[i + 2]!);
+          value = xterm256(codes[i + 2]);
           i += 2;
         } else if (mode === 2) {
-          value = toHex(codes[i + 2]!, codes[i + 3]!, codes[i + 4]!);
+          value = toHex(codes[i + 2], codes[i + 3], codes[i + 4]);
           i += 4;
         } else {
           // An unrecognized form has an unknown argument count, so there is no
@@ -95,7 +107,9 @@ export function parseAnsi(input: string): Segment[] {
         }
         // Only the foreground maps onto a Segment. Background and underline
         // color are still parsed so their arguments cannot leak into the loop.
-        if (code === 38) color = value;
+        // A malformed value leaves the current color alone: an unreadable
+        // sequence is ignored, not treated as a reset.
+        if (code === 38 && value !== undefined) color = value;
       } else if (code === 0) {
         color = undefined;
         bold = false;


### PR DESCRIPTION
## What this PR does

`parseAnsi` renders shell tool output in the web shell. It split each SGR escape on `;` and treated every parameter as a standalone code — but the arguments of `38`/`48`/`58` (extended foreground/background/underline color) are **not** codes. This PR consumes those arguments instead of re-reading them, and resolves the foreground to a hex color.

## Why it's needed

Feeding the color arguments back into the code loop corrupts the output — and not only for the color itself, but for styling that was already correct:

| sequence | before | after |
| --- | --- | --- |
| `\e[38;5;2m` (256-color green) | `dim: true`, no color | `#48bb78` |
| `\e[1m\e[38;2;0;128;255m` (bold + truecolor) | **`bold: false`**, no color | `bold: true`, `#0080ff` |
| `\e[1m\e[48;5;22m` (bold + 256-color bg) | **`bold: false`** | `bold: true` |

Three distinct failures, all from the same root cause:

- `38;5;2` → the index `2` is read as SGR `2`, setting **dim** and producing no color.
- Truecolor almost always contains a zero channel (any component at 0). That `0` hits the `code === 0` branch and **resets color, bold and dim** mid-line.
- A **background** like `48;5;22` feeds `22` to the reset-intensity branch, so setting a background **silently un-bolds** the text.

`parseAnsi` feeds `ToolGroup.tsx`, which renders the output of shell tools, so this affects any 256-color CLI — which is most of them.

## The fix

When a parameter is `38`, `48` or `58`, read its argument form (`5;<index>` or `2;<r>;<g>;<b>`) and advance past it. The foreground (`38`) resolves to hex:

- **0–15** map onto the existing themed `ANSI_COLORS` palette, so `38;5;2` and `32` render as the same green.
- **16–231** map onto the xterm 6×6×6 cube (levels `0, 95, 135, 175, 215, 255`).
- **232–255** map onto the 24-step grayscale ramp.

Background (`48`) and underline (`58`) color are parsed but not rendered — `Segment` has no field for them — so their arguments still cannot leak into the code stream. Malformed sequences (out-of-range index, truncated argument list, unknown form) yield no color rather than a bogus one and never fall through to the plain-code branches.

## Reviewer Test Plan

### How to verify

- `cd packages/web-shell && npx vitest run --config vitest.config.ts utils/ansi.test.ts` → 9/9.
- `ansi.test.ts` is new — there was no test for this module. Five cases assert the fixed behavior and pass only with this change; four more pin the pre-existing basic-color / bold / dim / reset behavior so the change can't regress it.
- Reverting only `ansi.ts` fails exactly the five new cases:
  - `does not read 256-color arguments as SGR codes`
  - `does not let truecolor channels reset the style`
  - `keeps background and underline color out of the code stream`
  - `drops malformed extended-color sequences without corrupting state`
  - `leaves an already-set color alone when the sequence is malformed`
- The palette-mapping assertions are checkable by hand: cube index `208 → (5,2,0) → #ff8700`, corners `16 → #000000` and `231 → #ffffff`, grayscale `232 → #080808` and `255 → #eeeeee`.

### Evidence (Before & After)

- Before: a tool that prints a 256-color prompt (e.g. `\e[38;5;208m➜\e[0m`) renders the glyph uncolored and, if it was inside a bold run, un-bolded.
- After: it renders orange (`#ff8700`) with bold preserved.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `ansi.test.ts` 9/9. In the full `packages/web-shell` run (1160 tests) this branch is 1151 passed / 9 failed — byte-identical failures to a clean checkout of the same tree, which is 1150 passed / 9 failed; the only delta is the one test this change adds. Those 9 pre-existing failures are all `build artifact — package boundary` cases that need a built dist, and the 47 test files that fail to load do so on unresolved workspace modules (`@qwen-code/sdk/daemon`, `@qwen-code/webui/daemon-react-sdk`) — neither is touched here. `tsc --noEmit` reports zero errors in `ansi.ts` / `ansi.test.ts`; eslint and prettier clean. Pure string parsing with no platform-dependent behavior, so no manual QA is required; CI covers Windows/Linux.

### Environment (optional)

Node v24; `@qwen-code/web-shell` workspace; vitest 3.2.

## Risk & Scope

- Main risk or tradeoff: 256/truecolor foreground now renders as a computed hex rather than falling through to the (wrong) old behavior. The mapping is the standard xterm one; the 0–15 range deliberately reuses the existing palette so basic colors are unchanged whether written as `32` or `38;5;2`.
- Not validated / out of scope: background and underline color are still not rendered — `Segment` has no field for them. This PR only stops their arguments from corrupting the code stream; surfacing them is a separate feature. Cursor-movement and other non-SGR escapes are likewise untouched.
- Breaking changes / migration notes: none — the only behavior change is that previously-corrupted output now renders correctly.

## Linked Issues

None — found while reading `parseAnsi` against the SGR extended-color grammar.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

`parseAnsi` 负责在 web shell 中渲染 shell 工具输出。它按 `;` 拆分每个 SGR 转义序列并把每个参数都当作独立的 code——但 `38`/`48`/`58`（扩展前景/背景/下划线颜色）后面的参数**并不是** code。本 PR 改为消费这些参数，并将前景色解析为 hex。

## 为什么需要

把颜色参数重新塞回 code 循环会破坏输出——而且不仅是颜色本身，连原本正确的样式也会被破坏：

| 序列 | 修复前 | 修复后 |
| --- | --- | --- |
| `\e[38;5;2m`（256 色绿） | `dim: true`，无颜色 | `#48bb78` |
| `\e[1m\e[38;2;0;128;255m`（粗体 + 真彩） | **`bold: false`**，无颜色 | `bold: true`，`#0080ff` |
| `\e[1m\e[48;5;22m`（粗体 + 256 色背景） | **`bold: false`** | `bold: true` |

三种不同的失效，根因相同：

- `38;5;2` → 索引 `2` 被当作 SGR `2`，从而设置 **dim** 且无颜色。
- 真彩几乎总含有为 0 的通道（某个分量为 0）。该 `0` 命中 `code === 0` 分支，在行中途**重置颜色、bold 与 dim**。
- 像 `48;5;22` 这样的**背景**会把 `22` 送入「重置粗细」分支，于是设置背景会**悄悄取消粗体**。

`parseAnsi` 供给 `ToolGroup.tsx`，后者渲染 shell 工具的输出，因此凡是 256 色 CLI（也就是绝大多数）都会受影响。

## 修复方式

当参数为 `38`、`48` 或 `58` 时，读取其参数形式（`5;<索引>` 或 `2;<r>;<g>;<b>`）并跳过。前景（`38`）解析为 hex：

- **0–15** 映射到既有的主题化 `ANSI_COLORS` 调色板，因此 `38;5;2` 与 `32` 渲染为同一种绿。
- **16–231** 映射到 xterm 6×6×6 色立方（各档为 `0, 95, 135, 175, 215, 255`）。
- **232–255** 映射到 24 级灰阶。

背景（`48`）与下划线（`58`）颜色被解析但不渲染——`Segment` 没有相应字段——因此它们的参数仍不会泄漏进 code 流。畸形序列（越界索引、参数截断、未知形式）返回无颜色而非错误颜色，且绝不会落到普通 code 分支。

## 复核测试计划

### 如何验证

- `cd packages/web-shell && npx vitest run --config vitest.config.ts utils/ansi.test.ts` → 9/9 通过。
- `ansi.test.ts` 为新增——此前该模块没有测试。五个用例断言修复后的行为，仅在本改动下通过；另有四个固定既有的基础色 / bold / dim / reset 行为，防止回归。
- 仅还原 `ansi.ts` 时，恰好这五个新用例失败：
  - `does not read 256-color arguments as SGR codes`
  - `does not let truecolor channels reset the style`
  - `keeps background and underline color out of the code stream`
  - `drops malformed extended-color sequences without corrupting state`
  - `leaves an already-set color alone when the sequence is malformed`
- 调色板映射可手工核对：色立方 `208 → (5,2,0) → #ff8700`，角点 `16 → #000000`、`231 → #ffffff`，灰阶 `232 → #080808`、`255 → #eeeeee`。

### 证据（修复前后对比）

- 修复前：打印 256 色提示符（如 `\e[38;5;208m➜\e[0m`）的工具，其字形无颜色，且若处于粗体段内还会被取消粗体。
- 修复后：渲染为橙色（`#ff8700`）并保留粗体。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`ansi.test.ts` 9/9。在 `packages/web-shell` 完整运行（1160 个测试）中，本分支为 1151 通过 / 9 失败——与同一棵树的干净检出（1150 通过 / 9 失败）失败项完全一致，唯一差异是本改动新增的那个测试。这 9 个既有失败全部是需要已构建产物的 `build artifact — package boundary` 用例；另有 47 个测试文件因无法解析工作区模块（`@qwen-code/sdk/daemon`、`@qwen-code/webui/daemon-react-sdk`）而加载失败——两者本 PR 均未触及。`tsc --noEmit` 对 `ansi.ts` / `ansi.test.ts` 零报错；eslint 与 prettier 干净。纯字符串解析、无平台相关行为，故无需人工 QA；Windows/Linux 由 CI 覆盖。

### 运行环境（可选）

Node v24；`@qwen-code/web-shell` 工作区；vitest 3.2。

## 风险与影响范围

- 主要风险或权衡：256/真彩前景现在渲染为计算得到的 hex，而不再落回（错误的）旧行为。所用映射是标准 xterm 映射；0–15 区间刻意复用既有调色板，因此基础色无论写作 `32` 还是 `38;5;2` 都保持不变。
- 未验证 / 范围之外：背景与下划线颜色仍未渲染——`Segment` 没有相应字段。本 PR 只是阻止其参数破坏 code 流；将其呈现出来是另一项功能。光标移动等非 SGR 转义同样未触及。
- 破坏性变更 / 迁移说明：无——唯一的行为变化是此前被破坏的输出现在能正确渲染。

## 关联 Issue

无——在对照 SGR 扩展色文法阅读 `parseAnsi` 时发现。

</details>


