### PR TITLE
fix(acp-bridge): resource hardening for the session event pipeline (DAEMON-009/010/011)

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3575,7 +3575,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         if (published === undefined) {
           failureCount += 1;
           teeServeDebugLine(
-            `broadcastWorkspaceEvent: publish on session ${entry.sessionId} no-op (bus closed)`,
+            `broadcastWorkspaceEvent: publish on session ${entry.sessionId} no-op (bus closed or unserializable)`,
           );
         } else {
           successCount += 1;
@@ -6451,7 +6451,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           if (published === undefined) {
             failureCount += 1;
             teeServeDebugLine(
-              `publishWorkspaceEvent: publish on session ${entry.sessionId} no-op (bus closed)`,
+              `publishWorkspaceEvent: publish on session ${entry.sessionId} no-op (bus closed or unserializable)`,
             );
           } else {
             successCount += 1;

--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -614,6 +614,82 @@ describe('TurnBoundaryCompactionEngine', () => {
     });
   });
 
+  describe('liveJournal caps (DAEMON-009)', () => {
+    const markerOf = (snap: { liveJournal: BridgeEvent[] }) =>
+      snap.liveJournal.find((e) => e.type === 'history_truncated');
+
+    it('drops the oldest journal entries past maxJournalEvents and prepends a marker', () => {
+      const engine = new TurnBoundaryCompactionEngine({
+        maxJournalEvents: 3,
+      });
+      for (let i = 1; i <= 5; i++) {
+        engine.ingest(makeTextChunk(i, `chunk-${i}`));
+      }
+
+      const snap = engine.snapshot();
+      // marker + the 3 newest raw events; the 2 oldest were dropped.
+      expect(snap.liveJournal).toHaveLength(4);
+      const marker = markerOf(snap);
+      expect(marker?.data).toEqual({
+        reason: 'replay_window_exceeded',
+        scope: 'live_journal',
+        truncatedEvents: 2,
+        retainedEvents: 3,
+        maxBytes: 2 * 1024 * 1024,
+        fullTranscriptAvailable: true,
+      });
+      expect(snap.liveJournal[0]).toBe(marker);
+      expect(snap.liveJournal.slice(1).map((e) => e.id)).toEqual([3, 4, 5]);
+    });
+
+    it('drops the oldest journal entries past maxJournalBytes but keeps at least one', () => {
+      const engine = new TurnBoundaryCompactionEngine({
+        maxJournalBytes: 300,
+      });
+      engine.ingest(makeTextChunk(1, 'x'.repeat(200)));
+      engine.ingest(makeTextChunk(2, 'y'.repeat(200)));
+
+      const snap = engine.snapshot();
+      const marker = markerOf(snap);
+      expect(marker).toBeDefined();
+      expect(
+        (marker?.data as { truncatedEvents: number }).truncatedEvents,
+      ).toBe(1);
+      // The newest (still oversized alone) entry survives — first-item rule.
+      expect(snap.liveJournal.filter((e) => e.id !== undefined)).toHaveLength(
+        1,
+      );
+      expect(snap.liveJournal.at(-1)?.id).toBe(2);
+    });
+
+    it('does not let journal truncation corrupt the compacted turn', () => {
+      const engine = new TurnBoundaryCompactionEngine({
+        maxJournalEvents: 1,
+      });
+      engine.ingest(makeTextChunk(1, 'Hello'));
+      engine.ingest(makeTextChunk(2, ' world'));
+      engine.ingest(makeTurnComplete(3));
+
+      const snap = engine.snapshot();
+      // Compaction folds from the slots working set, not the journal:
+      // the merged text is complete even though the journal was capped.
+      expect(extractTexts(snap.compactedTurns)).toContain('Hello world');
+      // Turn boundary reset the journal AND the truncation counter.
+      expect(snap.liveJournal).toHaveLength(0);
+      expect(markerOf(snap)).toBeUndefined();
+    });
+
+    it('emits no marker while the journal stays within its caps', () => {
+      const engine = new TurnBoundaryCompactionEngine();
+      engine.ingest(makeTextChunk(1, 'H'));
+      engine.ingest(makeTextChunk(2, 'i'));
+
+      const snap = engine.snapshot();
+      expect(markerOf(snap)).toBeUndefined();
+      expect(snap.liveJournal).toHaveLength(2);
+    });
+  });
+
   describe('multi-turn sessions', () => {
     it('compacts multiple turns independently', () => {
       const engine = new TurnBoundaryCompactionEngine();

--- a/packages/acp-bridge/src/compactionEngine.test.ts
+++ b/packages/acp-bridge/src/compactionEngine.test.ts
@@ -636,6 +636,7 @@ describe('TurnBoundaryCompactionEngine', () => {
         truncatedEvents: 2,
         retainedEvents: 3,
         maxBytes: 2 * 1024 * 1024,
+        maxEvents: 3,
         fullTranscriptAvailable: true,
       });
       expect(snap.liveJournal[0]).toBe(marker);

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -445,7 +445,10 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
   private addReplaySegment(events: BridgeEvent[], turnCount: number): void {
     if (events.length === 0) return;
     const bytes = events.reduce(
-      (sum, event) => sum + serializedBridgeEventByteLength(event),
+      // Compacted events are folded from events that already passed the
+      // publish-time serializability gate, so sizing here cannot fail in
+      // practice; `?? 0` keeps the sum total-ordered if it ever does.
+      (sum, event) => sum + (serializedBridgeEventByteLength(event) ?? 0),
       0,
     );
     this.replaySegments.push({ events: events.slice(), bytes, turnCount });

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -6,6 +6,7 @@
 
 import {
   EVENT_SCHEMA_VERSION,
+  logEventSizingFailed,
   serializedBridgeEventByteLength,
   type BridgeEvent,
   type CompactionEngine,
@@ -104,6 +105,33 @@ export interface ReplayWindowEviction {
 export interface TurnBoundaryCompactionEngineOptions {
   maxReplayBytes?: number;
   onReplayWindowEviction?: (eviction: ReplayWindowEviction) => void;
+  /**
+   * Caps on the in-flight live journal (DAEMON-009). The journal holds the
+   * RAW events of the current unfinished turn and is only reset at turn
+   * boundaries, so a single long-running streaming turn grew it — and the
+   * cost of every `snapshot()` — without bound. When either cap is hit the
+   * oldest journal entries are dropped and `snapshot()` prepends a
+   * `history_truncated` marker (`reason: 'live_journal_exceeded'`) to the
+   * live journal. Turn compaction is unaffected: it folds from the `slots`
+   * working set, not the journal.
+   */
+  maxJournalEvents?: number;
+  maxJournalBytes?: number;
+}
+
+export const DEFAULT_MAX_JOURNAL_EVENTS = 2000;
+export const DEFAULT_MAX_JOURNAL_BYTES = 2 * 1024 * 1024;
+
+function normalizeJournalCap(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+  return value;
 }
 
 /**
@@ -119,6 +147,8 @@ export interface TurnBoundaryCompactionEngineOptions {
  */
 export class TurnBoundaryCompactionEngine implements CompactionEngine {
   private readonly maxReplayBytes: number;
+  private readonly maxJournalEvents: number;
+  private readonly maxJournalBytes: number;
   private readonly onReplayWindowEviction:
     | ((eviction: ReplayWindowEviction) => void)
     | undefined;
@@ -126,6 +156,10 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
   private replaySegmentStart = 0;
   private replayBytes = 0;
   private liveJournal: BridgeEvent[] = [];
+  /** Serialized size of each `liveJournal` entry, index-parallel. */
+  private journalEntryBytes: number[] = [];
+  private journalTotalBytes = 0;
+  private journalTruncatedEvents = 0;
   private lastEventId = 0;
   private closed = false;
   private truncatedEvents = 0;
@@ -143,10 +177,20 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
 
   constructor(opts: TurnBoundaryCompactionEngineOptions = {}) {
     this.maxReplayBytes = normalizeCompactedReplayMaxBytes(opts.maxReplayBytes);
+    this.maxJournalEvents = normalizeJournalCap(
+      opts.maxJournalEvents,
+      DEFAULT_MAX_JOURNAL_EVENTS,
+      'maxJournalEvents',
+    );
+    this.maxJournalBytes = normalizeJournalCap(
+      opts.maxJournalBytes,
+      DEFAULT_MAX_JOURNAL_BYTES,
+      'maxJournalBytes',
+    );
     this.onReplayWindowEviction = opts.onReplayWindowEviction;
   }
 
-  ingest(event: BridgeEvent): void {
+  ingest(event: BridgeEvent, byteLength?: number): void {
     if (this.closed) return;
     if (event.id !== undefined) {
       this.lastEventId = event.id;
@@ -155,6 +199,26 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
     if (TRANSIENT_TYPES.has(event.type)) return;
 
     this.liveJournal.push(event);
+    // The bus passes the byte size it already computed at publish time;
+    // self-compute only for callers that don't (defensive — events in the
+    // journal passed the publish serializability gate, so `?? 0` is
+    // unreachable in practice).
+    const bytes = byteLength ?? serializedBridgeEventByteLength(event) ?? 0;
+    this.journalEntryBytes.push(bytes);
+    this.journalTotalBytes += bytes;
+    // Journal cap (DAEMON-009): drop the OLDEST entries once either limit
+    // is exceeded. The byte cap keeps at least one entry (first-item rule,
+    // matching the queue byte cap) so a single oversized event doesn't
+    // wedge the journal empty forever.
+    while (
+      this.liveJournal.length > this.maxJournalEvents ||
+      (this.journalTotalBytes > this.maxJournalBytes &&
+        this.liveJournal.length > 1)
+    ) {
+      this.liveJournal.shift();
+      this.journalTotalBytes -= this.journalEntryBytes.shift() ?? 0;
+      this.journalTruncatedEvents += 1;
+    }
 
     if (TURN_BOUNDARY_TYPES.has(event.type)) {
       this.compactCurrentTurn(event);
@@ -176,9 +240,30 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
         this.makeHistoryTruncatedEvent(compactedTurns.length),
       );
     }
+    const liveJournal = this.liveJournal.slice();
+    if (this.journalTruncatedEvents > 0) {
+      // Same wire shape as the compacted-window marker: the SDK's
+      // normalizer and type guard both REQUIRE
+      // `reason === 'replay_window_exceeded'` (anything else degrades the
+      // frame to an unknown/debug event), so the journal marker reuses it
+      // and carries `scope: 'live_journal'` as the discriminator — extra
+      // fields pass both validators untouched.
+      liveJournal.unshift({
+        v: EVENT_SCHEMA_VERSION,
+        type: 'history_truncated',
+        data: {
+          reason: 'replay_window_exceeded',
+          scope: 'live_journal',
+          truncatedEvents: this.journalTruncatedEvents,
+          retainedEvents: this.liveJournal.length,
+          maxBytes: this.maxJournalBytes,
+          fullTranscriptAvailable: true,
+        },
+      });
+    }
     return {
       compactedTurns,
-      liveJournal: this.liveJournal.slice(),
+      liveJournal,
       lastEventId: this.lastEventId,
     };
   }
@@ -191,7 +276,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
       if (TRANSIENT_TYPES.has(event.type)) continue;
       this.addReplaySegment([event], 0);
     }
-    this.liveJournal = [];
+    this.resetJournal();
     this.slots = [];
     this.toolSlotIndex.clear();
     this.clearTextSlotIndex();
@@ -223,7 +308,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
       recordEvents.push(event);
     }
     flushRecord();
-    this.liveJournal = [];
+    this.resetJournal();
     this.slots = [];
     this.toolSlotIndex.clear();
     this.clearTextSlotIndex();
@@ -233,7 +318,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
     if (this.closed) return;
     this.closed = true;
     this.resetReplayWindow();
-    this.liveJournal = [];
+    this.resetJournal();
     this.slots = [];
     this.toolSlotIndex.clear();
     this.clearTextSlotIndex();
@@ -430,7 +515,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
 
     compacted.push(boundaryEvent);
     this.addReplaySegment(compacted, 1);
-    this.liveJournal = [];
+    this.resetJournal();
     this.slots = [];
     this.toolSlotIndex.clear();
     this.clearTextSlotIndex();
@@ -442,13 +527,28 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
     }
   }
 
+  private resetJournal(): void {
+    this.liveJournal = [];
+    this.journalEntryBytes = [];
+    this.journalTotalBytes = 0;
+    this.journalTruncatedEvents = 0;
+  }
+
   private addReplaySegment(events: BridgeEvent[], turnCount: number): void {
     if (events.length === 0) return;
     const bytes = events.reduce(
-      // Compacted events are folded from events that already passed the
-      // publish-time serializability gate, so sizing here cannot fail in
-      // practice; `?? 0` keeps the sum total-ordered if it ever does.
-      (sum, event) => sum + (serializedBridgeEventByteLength(event) ?? 0),
+      // Live events passed the publish-time serializability gate, but the
+      // seed paths (persisted transcripts) bypass it — log a diagnostic
+      // and count 0 so a single unserializable record can't wedge the
+      // replay-window accounting.
+      (sum, event) => {
+        const size = serializedBridgeEventByteLength(event);
+        if (size === undefined) {
+          logEventSizingFailed(event.type);
+          return sum;
+        }
+        return sum + size;
+      },
       0,
     );
     this.replaySegments.push({ events: events.slice(), bytes, turnCount });

--- a/packages/acp-bridge/src/compactionEngine.ts
+++ b/packages/acp-bridge/src/compactionEngine.ts
@@ -111,9 +111,9 @@ export interface TurnBoundaryCompactionEngineOptions {
    * boundaries, so a single long-running streaming turn grew it — and the
    * cost of every `snapshot()` — without bound. When either cap is hit the
    * oldest journal entries are dropped and `snapshot()` prepends a
-   * `history_truncated` marker (`reason: 'live_journal_exceeded'`) to the
-   * live journal. Turn compaction is unaffected: it folds from the `slots`
-   * working set, not the journal.
+   * `history_truncated` marker (`reason: 'replay_window_exceeded'`,
+   * `scope: 'live_journal'`) to the live journal. Turn compaction is
+   * unaffected: it folds from the `slots` working set, not the journal.
    */
   maxJournalEvents?: number;
   maxJournalBytes?: number;
@@ -257,6 +257,7 @@ export class TurnBoundaryCompactionEngine implements CompactionEngine {
           truncatedEvents: this.journalTruncatedEvents,
           retainedEvents: this.liveJournal.length,
           maxBytes: this.maxJournalBytes,
+          maxEvents: this.maxJournalEvents,
           fullTranscriptAvailable: true,
         },
       });

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -550,7 +550,7 @@ describe('EventBus', () => {
     abort.abort();
   });
 
-  it('does not size events that are delivered directly to a waiting subscriber', async () => {
+  it('rejects an unserializable event without throwing, even with a waiting subscriber', async () => {
     const bus = new EventBus(100, undefined, undefined, {
       maxQueuedBytes: 1,
     });
@@ -561,16 +561,21 @@ describe('EventBus', () => {
     const circular: Record<string, unknown> = {};
     circular['self'] = circular;
 
+    // never-throws holds; the circular event is rejected at the
+    // serializability gate (DAEMON-011) instead of being delivered
+    // with a fake 0-byte weight.
     expect(() => bus.publish({ type: 'foo', data: circular })).not.toThrow();
+    expect(bus.publish({ type: 'foo', data: 'tail' })?.id).toBe(1);
 
     const delivered = await next;
     expect(delivered.done).toBe(false);
-    expect(delivered.value.type).toBe('foo');
+    expect(delivered.value.data).toBe('tail');
+    expect(bus.subscriberCount).toBe(1);
     await it.return?.();
     abort.abort();
   });
 
-  it('does not poison queued bytes when buffered event sizing fails', async () => {
+  it('rejects a buffered unserializable event and keeps the queue healthy', async () => {
     const bus = new EventBus(100, undefined, undefined, {
       maxQueuedBytes: 256,
     });
@@ -593,13 +598,12 @@ describe('EventBus', () => {
       });
     }).not.toThrow();
 
+    // The unserializable event is rejected at the gate (DAEMON-011);
+    // only the healthy tail event reaches the buffered queue.
     const first = await it.next();
-    const second = await it.next();
     expect(first.done).toBe(false);
-    expect(first.value.type).toBe('foo');
-    expect(second.done).toBe(false);
-    expect(second.value.type).toBe('foo');
-    expect(second.value.data).toBe('tail');
+    expect(first.value.data).toBe('tail');
+    expect(first.value.id).toBe(1);
     expect(process.stderr.write).toHaveBeenCalledWith(
       expect.stringContaining(
         'qwen serve: EventBus event sizing failed {"type":"foo"}',
@@ -1207,6 +1211,68 @@ describe('EventBus', () => {
       expect(out[0]?.type).toBe('foo');
       expect(out.some((e) => e.type === 'state_resync_required')).toBe(false);
       abort.abort();
+    });
+  });
+
+  describe('serializability gate (DAEMON-011)', () => {
+    it('rejects an unserializable event without burning an id', async () => {
+      const bus = new EventBus();
+      const abort = new AbortController();
+      const iter = bus.subscribe({ signal: abort.signal });
+
+      const ok1 = bus.publish({ type: 'foo', data: 1 });
+      const rejected = bus.publish({
+        type: 'bad',
+        data: { big: BigInt(1) },
+      });
+      const ok2 = bus.publish({ type: 'foo', data: 2 });
+
+      expect(ok1?.id).toBe(1);
+      expect(rejected).toBeUndefined();
+      // The rejected event must not burn an id — a gap would be misread
+      // as ring eviction by resume logic.
+      expect(ok2?.id).toBe(2);
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('EventBus event sizing failed'),
+      );
+
+      // Live fanout skips the rejected event entirely.
+      const collected = await collect(iter, 2);
+      expect(collected.map((e) => e.data)).toEqual([1, 2]);
+      abort.abort();
+
+      // Replay (ring) never saw it either.
+      const replayAbort = new AbortController();
+      const replayed = await collect(
+        bus.subscribe({ lastEventId: 0, signal: replayAbort.signal }),
+        3,
+      );
+      expect(replayed.map((e) => e.type)).toEqual([
+        'foo',
+        'foo',
+        'replay_complete',
+      ]);
+      replayAbort.abort();
+    });
+
+    it('does not ingest a rejected event into the compaction engine', () => {
+      const ingested: BridgeEvent[] = [];
+      const engine = {
+        ingest(event: BridgeEvent) {
+          ingested.push(event);
+        },
+        seedReplayEvents() {},
+        snapshot() {
+          return { compactedTurns: [], liveJournal: [], lastEventId: 0 };
+        },
+        close() {},
+      };
+      const bus = new EventBus(100, undefined, engine);
+
+      bus.publish({ type: 'ok', data: 1 });
+      bus.publish({ type: 'bad', data: { big: BigInt(1) } });
+
+      expect(ingested.map((e) => e.type)).toEqual(['ok']);
     });
   });
 

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -1276,6 +1276,84 @@ describe('EventBus', () => {
     });
   });
 
+  describe('replay budget (DAEMON-011)', () => {
+    const bigPayload = () => 'x'.repeat(100);
+
+    it('truncates an over-budget replay burst and demands a resync', async () => {
+      const bus = new EventBus(100, undefined, undefined, {
+        replayBudgetBytes: 400,
+      });
+      for (let i = 0; i < 5; i++) {
+        bus.publish({ type: 'payload', data: bigPayload() });
+      }
+
+      const abort = new AbortController();
+      const iter = bus.subscribe({ lastEventId: 0, signal: abort.signal });
+      const it = iter[Symbol.asyncIterator]();
+      const frames: BridgeEvent[] = [];
+      for (let i = 0; i < 4; i++) {
+        frames.push((await it.next()).value as BridgeEvent);
+      }
+
+      // Two ~190-byte frames fit the 400-byte budget; the third trips it.
+      expect(frames[0]?.id).toBe(1);
+      expect(frames[1]?.id).toBe(2);
+      expect(frames[2]?.type).toBe('state_resync_required');
+      expect(frames[2]?.data).toEqual({
+        reason: 'replay_budget_exceeded',
+        lastDeliveredId: 2,
+        earliestAvailableId: 3,
+      });
+      expect(frames[3]?.type).toBe('replay_complete');
+      expect((frames[3]?.data as { replayedCount: number }).replayedCount).toBe(
+        2,
+      );
+
+      // Truncation is NOT eviction: the subscription stays live.
+      const nextLive = it.next();
+      const live = bus.publish({ type: 'after', data: 1 });
+      expect(((await nextLive).value as BridgeEvent).id).toBe(live?.id);
+      abort.abort();
+    });
+
+    it('replays a single frame larger than the budget (first-item rule)', async () => {
+      const bus = new EventBus(100, undefined, undefined, {
+        replayBudgetBytes: 10,
+      });
+      bus.publish({ type: 'payload', data: bigPayload() });
+
+      const abort = new AbortController();
+      const frames = await collect(
+        bus.subscribe({ lastEventId: 0, signal: abort.signal }),
+        2,
+      );
+      expect(frames[0]?.id).toBe(1);
+      expect(frames[1]?.type).toBe('replay_complete');
+      abort.abort();
+    });
+
+    it('does not emit a resync frame when the replay fits the budget', async () => {
+      const bus = new EventBus();
+      for (let i = 0; i < 5; i++) {
+        bus.publish({ type: 'payload', data: bigPayload() });
+      }
+
+      const abort = new AbortController();
+      const frames = await collect(
+        bus.subscribe({ lastEventId: 0, signal: abort.signal }),
+        6,
+      );
+      expect(frames.some((e) => e.type === 'state_resync_required')).toBe(
+        false,
+      );
+      expect(frames[5]?.type).toBe('replay_complete');
+      expect((frames[5]?.data as { replayedCount: number }).replayedCount).toBe(
+        5,
+      );
+      abort.abort();
+    });
+  });
+
   describe('epoch token (DAEMON-001)', () => {
     it('exposes a stable per-instance epoch that differs across instances', () => {
       const a = new EventBus();

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getEventListeners } from 'node:events';
 import {
   DEFAULT_MAX_QUEUED_BYTES,
   EventBus,
@@ -861,6 +862,27 @@ describe('EventBus', () => {
     }
     expect(events).toEqual([]);
     expect(bus.subscriberCount).toBe(0);
+  });
+
+  it('disposes never-iterated subscribers on bus.close(), detaching their abort listeners (DAEMON-010)', async () => {
+    const bus = new EventBus();
+    const abort = new AbortController();
+    // Subscribe but never iterate — the subscriber's abort listener is
+    // the only external reference keeping its queue + closures alive.
+    const iter = bus.subscribe({ signal: abort.signal });
+    expect(getEventListeners(abort.signal, 'abort')).toHaveLength(1);
+
+    bus.close();
+
+    // close() must dispose (not just close the queue): the listener is
+    // gone even though the consumer never called next().
+    expect(getEventListeners(abort.signal, 'abort')).toHaveLength(0);
+    expect(bus.subscriberCount).toBe(0);
+
+    // Idempotent, and a late iteration attempt unwinds immediately.
+    bus.close();
+    const first = await iter[Symbol.asyncIterator]().next();
+    expect(first.done).toBe(true);
   });
 
   it('force-pushes replay events past maxQueued so Last-Event-ID is honored', async () => {

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -35,7 +35,13 @@ export interface SessionReplaySnapshot {
 }
 
 export interface CompactionEngine {
-  ingest(event: BridgeEvent): void;
+  /**
+   * `byteLength` is the serialized size the bus already computed for the
+   * event (publish's eager sizing gate) so implementations that track
+   * byte budgets don't have to re-stringify. Optional — seeding paths
+   * and older callers may omit it and implementations self-compute.
+   */
+  ingest(event: BridgeEvent, byteLength?: number): void;
   seedReplayEvents(events: BridgeEvent[]): void;
   snapshot(): SessionReplaySnapshot;
   close(): void;
@@ -161,14 +167,20 @@ function normalizeMaxQueuedBytes(value: number | undefined): number {
   return value;
 }
 
-export function serializedBridgeEventByteLength(event: BridgeEvent): number {
+export function serializedBridgeEventByteLength(
+  event: BridgeEvent,
+): number | undefined {
   try {
     const serialized = JSON.stringify(event);
-    if (serialized === undefined) return 0;
+    // `undefined` (a bare non-JSON value) and throws (BigInt, circular
+    // references) both mean the event cannot survive the SSE wire —
+    // report that to the caller instead of pretending it weighs 0 bytes
+    // (which let unserializable events bypass every byte cap and then
+    // fail at send time — DAEMON-011).
+    if (serialized === undefined) return undefined;
     return Buffer.byteLength(serialized, 'utf8');
   } catch {
-    logEventSizingFailed(event.type);
-    return 0;
+    return undefined;
   }
 }
 
@@ -391,7 +403,11 @@ export class EventBus {
     if (this.closed) return undefined;
     const existingMeta = input._meta;
     const event: BridgeEvent = {
-      id: this.nextId++,
+      // Read WITHOUT incrementing: a rejected event must not burn an id —
+      // other subscribers would see a sequence gap (3 → 5) that resume
+      // logic misreads as ring eviction. `nextId` advances only after the
+      // event has passed the serializability gate below.
+      id: this.nextId,
       v: EVENT_SCHEMA_VERSION,
       ...input,
       _meta: {
@@ -399,9 +415,23 @@ export class EventBus {
         serverTimestamp: getServerTimestamp(existingMeta),
       },
     };
+    // Eager sizing doubles as the serializability gate (DAEMON-011): an
+    // event JSON.stringify cannot represent would bypass every byte cap
+    // at weight 0 and then fail at SSE send time anyway. Reject it here —
+    // no ring entry, no compaction ingest, no fanout — so "in the ring"
+    // implies "serializable" for the replay and journal byte accounting.
+    // The SSE route stringifies every delivered frame regardless, so this
+    // only moves that cost earlier (once per publish, memoized for all
+    // subscribers).
+    const eventBytes = serializedBridgeEventByteLength(event);
+    if (eventBytes === undefined) {
+      logEventSizingFailed(event.type);
+      return undefined;
+    }
+    this.nextId += 1;
     this.ring.push(event);
     try {
-      this.compactionEngine?.ingest(event);
+      this.compactionEngine?.ingest(event, eventBytes);
     } catch (err) {
       // CompactionEngine is best-effort; a throw must not break the
       // publish() never-throws contract (never-throws). Mark the snapshot
@@ -416,11 +446,7 @@ export class EventBus {
     // profiling actually flags it, or the operator bumps
     // `--event-ring-size` to an order of magnitude larger.
     if (this.ring.length > this.ringSize) this.ring.shift();
-    let eventBytes: number | undefined;
-    const getEventBytes = () => {
-      eventBytes ??= serializedBridgeEventByteLength(event);
-      return eventBytes;
-    };
+    const getEventBytes = () => eventBytes;
     // Snapshot the subscribers so an in-loop `this.subs.delete(sub)`
     // (the new immediate-eviction cleanup below) doesn't mutate the
     // Set we're iterating.

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -892,7 +892,19 @@ export class EventBus {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    for (const sub of this.subs) sub.queue.close();
+    for (const sub of this.subs) {
+      sub.queue.close();
+      // Dispose, not just close: `dispose()` also detaches the
+      // AbortSignal listener that `subscribe()` registered. Without it a
+      // subscriber that never started iterating kept its abort listener
+      // (and the queue + sub closures it captures) alive for as long as
+      // the caller's signal, long after the bus was gone — the same
+      // retention bug the eviction path fixed (see publish()) showing up
+      // on the close() path (DAEMON-010). Dispose is idempotent, and
+      // mutating `this.subs` mid-iteration is safe for Sets when only
+      // deleting the current element.
+      sub.dispose();
+    }
     this.subs.clear();
     this.compactionEngine?.close();
   }

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -107,6 +107,20 @@ export interface SubscribeOptions {
 export interface EventBusOptions {
   maxQueuedBytes?: number;
   /**
+   * Total serialized-byte budget for the `Last-Event-ID` replay burst a
+   * single `subscribe()` may force-push (DAEMON-011). Replay frames bypass
+   * the per-subscriber live caps by design (dropping them would break the
+   * resume contract), so without this bound a reconnect against a large
+   * ring materializes the whole backlog into the queue at once — up to
+   * `maxSubscribers` times under concurrent reconnects. When the budget
+   * runs out mid-replay the remaining frames are dropped and the consumer
+   * gets a `state_resync_required` (`reason: 'replay_budget_exceeded'`)
+   * telling it to recover via `loadSession`. NOT named `maxReplayBytes`:
+   * that name is taken by the compaction engine's compacted-window budget
+   * and both appear in the same `createSessionEventBus` construction.
+   */
+  replayBudgetBytes?: number;
+  /**
    * Invoked once, on the FIRST compaction failure (`ingest` /
    * `seedReplayEvents` throw). The bus itself doesn't know its session,
    * so the creator injects context-aware diagnostics here. Subsequent
@@ -117,6 +131,7 @@ export interface EventBusOptions {
 
 const DEFAULT_MAX_QUEUED = 256;
 export const DEFAULT_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_REPLAY_BUDGET_BYTES = 4 * DEFAULT_MAX_QUEUED_BYTES;
 /**
  * Default replay-ring depth per session. Sized for a 5-second
  * reconnect window over a chatty turn — a single long-running prompt
@@ -163,6 +178,14 @@ function normalizeMaxQueuedBytes(value: number | undefined): number {
   if (value === undefined) return DEFAULT_MAX_QUEUED_BYTES;
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new TypeError('maxQueuedBytes must be a positive safe integer');
+  }
+  return value;
+}
+
+function normalizeReplayBudgetBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_REPLAY_BUDGET_BYTES;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError('replayBudgetBytes must be a positive safe integer');
   }
   return value;
 }
@@ -296,6 +319,7 @@ export class EventBus {
   private readonly ring: BridgeEvent[] = [];
   private readonly subs = new Set<InternalSub>();
   private readonly maxQueuedBytes: number;
+  private readonly replayBudgetBytes: number;
   private closed = false;
 
   constructor(
@@ -305,6 +329,7 @@ export class EventBus {
     opts: EventBusOptions = {},
   ) {
     this.maxQueuedBytes = normalizeMaxQueuedBytes(opts.maxQueuedBytes);
+    this.replayBudgetBytes = normalizeReplayBudgetBytes(opts.replayBudgetBytes);
     this.onCompactionError = opts.onCompactionError;
   }
 
@@ -724,10 +749,14 @@ export class EventBus {
       // cap. The cap protects against a slow live consumer; replay is
       // already historical and silently dropping it would undermine the
       // `Last-Event-ID` resume contract (the consumer would think they
-      // caught up). If the gap really is enormous, the queue will be
-      // primed with a long backlog the consumer drains at its own pace.
+      // caught up). The bypass is still bounded: `replayBudgetBytes` caps
+      // the total serialized bytes one replay burst may materialize
+      // (DAEMON-011) — past it the remaining frames are dropped and the
+      // consumer is told to recover via loadSession (resync frame below).
       let replayedCount = 0;
       let lastReplayedId: number | undefined;
+      let replayBytes = 0;
+      let budgetExceededAtId: number | undefined;
       for (const e of this.ring) {
         // The ring only ever contains live events (publish() always
         // assigns an id before pushing to ring), so `e.id` is never
@@ -735,10 +764,39 @@ export class EventBus {
         // BridgeEvent.id is optional for synthetic terminal frames.
         // Guard explicitly to keep narrow typing without runtime cost.
         if (e.id !== undefined && e.id > replayFrom) {
+          if (budgetExceededAtId !== undefined) continue;
+          // Ring events passed publish's serializability gate, so sizing
+          // cannot fail here; `?? 0` keeps the accounting total-ordered
+          // if it ever does. Sized lazily per frame — replay is a
+          // low-frequency path.
+          replayBytes += serializedBridgeEventByteLength(e) ?? 0;
+          if (replayBytes > this.replayBudgetBytes && replayedCount > 0) {
+            budgetExceededAtId = e.id;
+            continue;
+          }
           queue.forcePush(e);
           replayedCount += 1;
           lastReplayedId = e.id;
         }
+      }
+      // Budget exhausted mid-replay: the frames already pushed are the
+      // contiguous prefix from `replayFrom + 1`, so the consumer applied
+      // them safely — but everything past `budgetExceededAtId` was
+      // dropped. Tell the consumer its accumulated state is no longer
+      // trustworthy (recover via loadSession), exactly like the
+      // ring-eviction path. `replayedCount > 0` above guarantees at least
+      // one frame always fits so a single event larger than the budget
+      // still resumes (parity with the live byte cap's first-item rule).
+      if (budgetExceededAtId !== undefined) {
+        queue.forcePush({
+          v: EVENT_SCHEMA_VERSION,
+          type: 'state_resync_required',
+          data: {
+            reason: 'replay_budget_exceeded',
+            lastDeliveredId: lastReplayedId ?? opts.lastEventId,
+            earliestAvailableId: budgetExceededAtId,
+          },
+        });
       }
       // Emit a `replay_complete` sentinel so consumers can deterministically
       // drop catch-up indicators. Fires both when replay actually

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -207,7 +207,7 @@ export function serializedBridgeEventByteLength(
   }
 }
 
-function logEventSizingFailed(type: string): void {
+export function logEventSizingFailed(type: string): void {
   try {
     process.stderr.write(
       `qwen serve: EventBus event sizing failed ${JSON.stringify({ type })}\n`,


### PR DESCRIPTION
## What this PR does

Hardens three resource boundaries in the per-session daemon event pipeline, the third batch of the daemon reliability audit (DAEMON-009/010/011). Fixes #7621.

1. **Publish now rejects unserializable events (DAEMON-011).** Event sizing used to report 0 bytes when `JSON.stringify` failed, so an event carrying a BigInt or circular reference bypassed every byte cap, entered the ring, the subscriber queues, and the compaction journal — and then failed at SSE send time anyway. Sizing now runs eagerly at publish and doubles as a serializability gate: a rejected event burns no id (the sequence stays contiguous, so resume logic never mistakes the rejection for ring eviction), leaves no trace in the ring or compaction state, and produces a stderr diagnostic. The never-throws contract is preserved, and the memoized byte value now feeds both the subscriber queues and the compaction journal accounting so nothing is stringified twice.

2. **The reconnect replay burst is byte-bounded (DAEMON-011).** Replay frames bypass the per-subscriber live caps by design, so a reconnect against a large ring (default 8000 frames) materialized the entire backlog into the queue at once — amplified by up to 64 concurrent subscribers. A new `replayBudgetBytes` option (default 4x the live byte cap, 8MB) bounds the total serialized bytes one replay burst may force-push. Past the budget the remaining frames are dropped and the consumer receives `state_resync_required` with `reason: 'replay_budget_exceeded'`, mirroring the existing ring-eviction recovery semantics (recover via session load). At least one frame always fits, so a single oversized event still resumes, and truncation is not eviction — the subscription stays live.

3. **Closing the bus disposes every subscriber (DAEMON-010).** `close()` only closed each subscriber queue and cleared the set, leaving the AbortSignal listener registered at subscribe time attached. For a subscriber that never started iterating, that listener — and the queue and closures it captures — stayed alive for as long as the caller's signal. This was the same retention bug the eviction path had already fixed, surfacing on the close path; close now runs the unified dispose.

4. **The in-flight live journal is capped (DAEMON-009).** The compaction engine accumulated every raw event of the current turn and only reset at turn boundaries, so a single long streaming turn grew the journal — and the cost of every snapshot — without bound. New `maxJournalEvents` (2000) and `maxJournalBytes` (2MB) caps drop the oldest entries once exceeded (the byte cap keeps at least one entry, matching the queue's first-item rule), and the snapshot prepends a `history_truncated` marker to the live journal so consumers know the current-turn replay is incomplete. The marker reuses the `replay_window_exceeded` reason — the SDK's normalizer and type guard both hard-require that value — and carries `scope: 'live_journal'` as the discriminator, so existing SDKs render it unchanged. Turn compaction is unaffected: it folds from the merged working set, not the journal.

All defaults are construction-time options; no CLI flags added and no SDK changes required (wire compatibility of the new resync reason and the journal marker was verified against the SDK's validators).

## Why it's needed

These are the last three items of the daemon reliability audit (after #7386, #7400, #7458). Each is a resource boundary that degrades a long-lived daemon: an unbounded journal grows heap and snapshot cost on a single chatty turn, leaked abort listeners accumulate retained closures across session churn, and the two byte-budget bypasses let a hostile or buggy client (or one unserializable event) sidestep the memory protections the byte caps exist to provide.

## Reviewer Test Plan

### How to verify

- `cd packages/acp-bridge && npx vitest run` — 933 tests across 19 files, including the new suites: `serializability gate (DAEMON-011)`, `replay budget (DAEMON-011)`, the `bus.close()` dispose test (DAEMON-010), and `liveJournal caps (DAEMON-009)`.
- Each new test was mutation-checked: reverting the corresponding fix (restoring the origin/main version of the touched file) makes exactly the new tests fail — 3 for the eventBus DAEMON-011 pair, 1 for DAEMON-010, 2 for DAEMON-009.
- Key behaviors a reviewer can spot-check in the tests: a rejected event burns no id and later events stay contiguous; a truncated replay still delivers the resync frame before `replay_complete` and the subscription stays live afterwards; `getEventListeners(signal, 'abort')` drops to zero after `close()` even when the consumer never iterated; journal truncation never corrupts the compacted turn (compaction folds from the merged slots, not the journal).
- Downstream suites: `packages/cli` serve tests (`transport`, `sse-last-event-id`, `server`) all green; `npm run build` and `npm run typecheck` clean.

### Evidence (Before & After)

N/A (no user-visible/TUI change; behavior is locked by the unit suites above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |
