### PR TITLE
fix(desktop): scale formatBytes past GB so terabyte sizes don't render as "undefined"

### DIFF
--- a/packages/desktop/packages/shared/src/utils/__tests__/binary-detection.test.ts
+++ b/packages/desktop/packages/shared/src/utils/__tests__/binary-detection.test.ts
@@ -16,6 +16,8 @@ import {
   extractBase64Binary,
   detectExtensionFromMagic,
   getMimeExtension,
+  formatBytes,
+  MAX_DOWNLOAD_SIZE,
 } from '../binary-detection.ts';
 import { guardLargeResult } from '../large-response.ts';
 
@@ -423,5 +425,47 @@ describe('getMimeExtension', () => {
 
   test('returns empty for unknown MIME and no buffer', () => {
     expect(getMimeExtension('application/x-something')).toBe('');
+  });
+});
+
+// ============================================================
+// formatBytes
+// ============================================================
+
+describe('formatBytes', () => {
+  test('formats within the byte/KB/MB/GB range', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(5 * 1024)).toBe('5.0 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2.0 GB');
+  });
+
+  test('reports the 500MB download limit unchanged', () => {
+    expect(formatBytes(MAX_DOWNLOAD_SIZE)).toBe('500.0 MB');
+  });
+
+  test('scales past GB instead of overflowing to "undefined"', () => {
+    // A remote Content-Length in the terabytes reaches formatBytes via the
+    // "Response too large" guard in api-tools; it must not read as "undefined".
+    const tb = 1024 ** 4;
+    expect(formatBytes(2 * tb)).toBe('2.0 TB');
+    expect(formatBytes(3 * 1024 ** 5)).toBe('3.0 PB');
+    expect(formatBytes(4 * 1024 ** 6)).toBe('4.0 EB');
+    expect(formatBytes(tb)).not.toContain('undefined');
+  });
+
+  test('clamps absurdly large inputs to the last unit', () => {
+    const result = formatBytes(1024 ** 8);
+    expect(result).toContain('EB');
+    expect(result).not.toContain('undefined');
+  });
+
+  test('renders non-positive and non-finite inputs as "0 B"', () => {
+    expect(formatBytes(-1)).toBe('0 B');
+    expect(formatBytes(0.5)).toBe('0 B');
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
   });
 });

--- a/packages/desktop/packages/shared/src/utils/binary-detection.ts
+++ b/packages/desktop/packages/shared/src/utils/binary-detection.ts
@@ -287,10 +287,17 @@ export function extractBase64Binary(text: string): Base64ExtractionResult | null
 
 /** Format bytes to human-readable string. */
 export function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
+  // Byte counts below 1 (0, sub-byte fractions, and — defensively — negatives
+  // or NaN) have no meaningful unit; render them as "0 B" rather than "undefined".
+  if (!Number.isFinite(bytes) || bytes < 1) return '0 B';
   const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+  // Clamp the exponent to the last unit so a very large input (e.g. a remote
+  // Content-Length reporting terabytes) never indexes past the array.
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(k)),
+    sizes.length - 1,
+  );
   const size = bytes / Math.pow(k, i);
   return `${size.toFixed(i > 0 ? 1 : 0)} ${sizes[i]}`;
 }


### PR DESCRIPTION
## What this PR does

`formatBytes` in the desktop `shared` package turns a byte count into a human-readable string. It only knew the units `B`, `KB`, `MB`, `GB` and indexed that array with an unclamped, log-derived exponent. Any value of 1 TB or more pushed the index past the end of the array, so the size rendered as `"1.0 undefined"`. This PR extends the unit table through `EB`, clamps the exponent to the last known unit, and guards non-finite and below-one inputs so the function is total.

## Why it's needed

The overflow is reachable with attacker-influenced input. In `sources/api-tools.ts`, the "Response too large" guard reads a remote server's `Content-Length` header and formats it: `` `Response too large: ${formatBytes(size)} exceeds ${formatBytes(MAX_DOWNLOAD_SIZE)} limit.` ``. A server can report a `Content-Length` in the terabytes, so the very message meant to explain the rejection would read `Response too large: 1.0 undefined exceeds 500.0 MB limit` — confusing, and it leaks a formatting bug into agent-visible output. The same helper also formats saved-file and large-response sizes, so any future caller handed a terabyte-scale value hits the same corruption.

Secondarily, the old function returned `"NaN undefined"` for negative or `NaN` input and `"… undefined"` for sub-byte fractions. Those aren't reachable through today's integer callers, but a size formatter should never emit `undefined`/`NaN`, so this hardens the function rather than leaving a sharp edge.

## The fix

- Add `TB`, `PB`, `EB` to the unit table.
- Clamp the exponent with `Math.min(…, sizes.length - 1)` so an out-of-range magnitude renders in the largest unit (e.g. `1024.0 EB`) instead of indexing past the array.
- Return `"0 B"` for any input that is not finite or is below `1` (covers `0` unchanged, plus — defensively — negatives, `NaN`, `Infinity`, and sub-byte fractions).

The in-range behavior (`0` → `0 B`, `500 MB` limit → `500.0 MB`, etc.) is unchanged; the only observable difference is that previously-corrupt output now renders correctly.

## Reviewer Test Plan

### How to verify

- From `packages/desktop/packages/shared`: `bun test src/utils/__tests__/binary-detection.test.ts` → **42/42** (was 37; +5 new `formatBytes` cases).
- Reverting only `binary-detection.ts` fails exactly the three new-behavior cases and keeps the two range/limit guards green:
  - `scales past GB instead of overflowing to "undefined"` → old output `"2.0 undefined"`
  - `clamps absurdly large inputs to the last unit` → old output `"1.0 undefined"`
  - `renders non-positive and non-finite inputs as "0 B"` → old output `"NaN undefined"`
- Hand-checkable: `formatBytes(2 * 1024**4) → "2.0 TB"`, `formatBytes(MAX_DOWNLOAD_SIZE) → "500.0 MB"`, `formatBytes(1024**8) → "1024.0 EB"` (clamped, no `undefined`).

### Evidence (Before & After)

Non-UI (pure string helper). Before: a remote `Content-Length` of 2 TB yields `Response too large: 1.0 undefined exceeds 500.0 MB limit`. After: `Response too large: 2.0 TB exceeds 500.0 MB limit`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS: `binary-detection.test.ts` 42/42; the full `@craft-agent/shared` `bun test` run shows the same pre-existing pass/fail counts as a clean checkout except for the +5 new passing tests (the unrelated failures are missing-dependency/environment issues present before this change). Prettier and eslint clean via the repo pre-commit hook. Pure arithmetic/string logic with no platform-dependent behavior.

### Environment (optional)

bun 1.3.14; `@craft-agent/shared` workspace.

## Risk & Scope

- Main risk or tradeoff: `bytes === 0` became `bytes < 1`, so inputs in `[0, 1)` now render `"0 B"` instead of the previous corrupt string. Every current caller passes integer byte counts, so `0` is the only value in that range they reach and its output is unchanged.
- Not validated / out of scope: the other independent `formatBytes` copies elsewhere in the tree (CLI memory diagnostics, browser tool runtime, daemon status dialog) are untouched — this PR fixes only the desktop `shared` helper with the reachable `Content-Length` path.
- Breaking changes / migration notes: none.

## Linked Issues

None — found while reading `formatBytes` against its untrusted `Content-Length` caller in `api-tools.ts`.

<details>
<summary>中文说明</summary>

## 本 PR 的作用

desktop `shared` 包中的 `formatBytes` 将字节数转换为便于阅读的字符串。它只认识 `B`、`KB`、`MB`、`GB` 这几个单位，并用一个未做上限约束、由对数推导出的指数去索引该数组。任何 1 TB 及以上的值都会让索引越过数组末尾，于是大小被渲染成 `"1.0 undefined"`。本 PR 将单位表扩展到 `EB`，把指数钳制到已知的最后一个单位，并对非有限值和小于 1 的输入加以防护，使该函数成为全函数。

## 为什么需要

这个溢出可通过受攻击者影响的输入触达。在 `sources/api-tools.ts` 中，「Response too large」防护会读取远端服务器的 `Content-Length` 头并进行格式化：`` `Response too large: ${formatBytes(size)} exceeds ${formatBytes(MAX_DOWNLOAD_SIZE)} limit.` ``。服务器可以报告一个以 TB 计的 `Content-Length`，于是本应解释拒绝原因的这条消息会显示为 `Response too large: 1.0 undefined exceeds 500.0 MB limit`——既令人困惑，又把一个格式化 bug 泄漏进了 agent 可见的输出。该辅助函数同样用于格式化已保存文件和大响应的大小，因此未来任何拿到 TB 级数值的调用方都会遇到同样的破坏。

其次，旧函数对负数或 `NaN` 输入返回 `"NaN undefined"`，对不足一字节的小数返回 `"… undefined"`。这些在当前的整数调用方下不可达，但一个大小格式化函数绝不应输出 `undefined`/`NaN`，因此本改动是加固该函数，而不是留一个尖锐边角。

## 修复方式

- 在单位表中加入 `TB`、`PB`、`EB`。
- 用 `Math.min(…, sizes.length - 1)` 钳制指数，使越界的量级以最大单位渲染（例如 `1024.0 EB`），而不是索引越过数组。
- 对任何非有限或小于 `1` 的输入返回 `"0 B"`（`0` 保持不变，另外——出于防御——涵盖负数、`NaN`、`Infinity` 和不足一字节的小数）。

范围内的行为（`0` → `0 B`，`500 MB` 上限 → `500.0 MB` 等）保持不变；唯一可观察到的差别是先前被破坏的输出现在能正确渲染。

## 复核测试计划

### 如何验证

- 在 `packages/desktop/packages/shared` 下：`bun test src/utils/__tests__/binary-detection.test.ts` → **42/42**（原为 37；新增 5 个 `formatBytes` 用例）。
- 仅还原 `binary-detection.ts` 时，恰好这三个新行为用例失败，而两个范围/上限守护用例仍为绿：
  - `scales past GB instead of overflowing to "undefined"` → 旧输出 `"2.0 undefined"`
  - `clamps absurdly large inputs to the last unit` → 旧输出 `"1.0 undefined"`
  - `renders non-positive and non-finite inputs as "0 B"` → 旧输出 `"NaN undefined"`
- 可手工核对：`formatBytes(2 * 1024**4) → "2.0 TB"`，`formatBytes(MAX_DOWNLOAD_SIZE) → "500.0 MB"`，`formatBytes(1024**8) → "1024.0 EB"`（已钳制，无 `undefined`）。

### 证据（修复前后对比）

非 UI（纯字符串辅助函数）。修复前：远端 `Content-Length` 为 2 TB 时得到 `Response too large: 1.0 undefined exceeds 500.0 MB limit`。修复后：`Response too large: 2.0 TB exceeds 500.0 MB limit`。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

macOS：`binary-detection.test.ts` 42/42；完整的 `@craft-agent/shared` `bun test` 运行显示与干净检出相同的既有通过/失败计数，仅多出这 5 个新通过的测试（无关的失败是本改动之前就存在的缺少依赖/环境问题）。经仓库 pre-commit 钩子，prettier 与 eslint 均干净。纯算术/字符串逻辑，无平台相关行为。

### 运行环境（可选）

bun 1.3.14；`@craft-agent/shared` 工作区。

## 风险与影响范围

- 主要风险或权衡：`bytes === 0` 改为 `bytes < 1`，因此 `[0, 1)` 区间的输入现在渲染为 `"0 B"`，而非此前被破坏的字符串。当前所有调用方都传入整数字节数，故它们在该区间内唯一可达的值是 `0`，其输出保持不变。
- 未验证 / 范围之外：仓库中其他独立的 `formatBytes` 副本（CLI 内存诊断、浏览器工具运行时、daemon 状态对话框）未触及——本 PR 只修复带有可达 `Content-Length` 路径的 desktop `shared` 辅助函数。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无——在对照其不受信任的 `Content-Length` 调用方（`api-tools.ts`）阅读 `formatBytes` 时发现。

</details>
