### PR TITLE
fix(shell): expose background task liveness

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -185,6 +185,8 @@ describe('ShellTool', () => {
       end: vi.fn(),
       on: vi.fn(),
     } as unknown as fs.WriteStream);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
 
     vi.mocked(os.platform).mockReturnValue('linux');
     vi.mocked(os.tmpdir).mockReturnValue('/tmp');
@@ -1162,6 +1164,48 @@ describe('ShellTool', () => {
       // Returns immediately with id + output path; agent's turn isn't blocked.
       expect(result.llmContent).toContain(entry.shellId);
       expect(result.llmContent).toContain(entry.outputPath);
+      expect(result.llmContent).toContain('Status: running');
+      expect(result.llmContent).toContain('status file:');
+      expect(result.llmContent).toContain(
+        'A quiet or empty output file does not mean the process exited',
+      );
+      expect(result.llmContent).toContain(
+        'Do not relaunch solely because captured output is empty',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining(`shell-${entry.shellId}.status`),
+        expect.stringContaining('status: RUNNING'),
+        'utf8',
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('pid: 12345'),
+        'utf8',
+      );
+    });
+
+    it('refreshes the running status while a quiet background command is alive', async () => {
+      vi.useFakeTimers();
+      try {
+        const invocation = shellTool.build({
+          command: 'quiet-server',
+          is_background: true,
+        });
+
+        await invocation.execute(mockAbortSignal);
+        expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+        expect(fs.writeFileSync).toHaveBeenLastCalledWith(
+          expect.stringContaining('.status'),
+          expect.stringContaining('status: RUNNING'),
+          'utf8',
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('settles a background entry as completed when the process exits cleanly', async () => {
@@ -1193,6 +1237,9 @@ describe('ShellTool', () => {
       );
       expect(registry.fail).not.toHaveBeenCalled();
       expect(registry.cancel).not.toHaveBeenCalled();
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
+        expect.stringContaining(`shell-${entry.shellId}.status`),
+      );
     });
 
     it('settles a background entry as failed when ShellExecutionService reports error', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -980,6 +980,7 @@ export function parseNumstat(numstatOutput: string): Map<string, number> {
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 export const DEFAULT_SHELL_HEARTBEAT_INTERVAL_MS = 10_000;
+const BACKGROUND_SHELL_STATUS_INTERVAL_MS = 5_000;
 const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
 
 /**
@@ -3558,6 +3559,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
     const shellId = `bg_${crypto.randomBytes(4).toString('hex')}`;
     const outputPath = path.join(outputDir, `shell-${shellId}.output`);
+    const statusPath = path.join(outputDir, `shell-${shellId}.status`);
 
     // Background shells are explicitly independent of the current turn:
     // the user pressing Ctrl+C on a turn (which aborts `signal`) should
@@ -3647,10 +3649,50 @@ export class ShellToolInvocation extends BaseToolInvocation<
       throw e;
     }
 
+    const writeRunningStatus = () => {
+      try {
+        fs.writeFileSync(
+          statusPath,
+          [
+            `id: ${shellId}`,
+            'status: RUNNING',
+            `pid: ${pid ?? 'unknown'}`,
+            `alive as of: ${new Date().toISOString()}`,
+            'An empty output file does not mean this process exited; programs may buffer output.',
+          ].join('\n') + '\n',
+          'utf8',
+        );
+      } catch (e) {
+        debugLogger.warn(
+          `background shell ${shellId} status write error: ${getErrorMessage(e)}`,
+        );
+      }
+    };
+    writeRunningStatus();
+    const statusTimer = setInterval(
+      writeRunningStatus,
+      BACKGROUND_SHELL_STATUS_INTERVAL_MS,
+    );
+    statusTimer.unref();
+
+    const removeRunningStatus = () => {
+      clearInterval(statusTimer);
+      try {
+        fs.unlinkSync(statusPath);
+      } catch (e) {
+        if (!(isNodeError(e) && e.code === 'ENOENT')) {
+          debugLogger.warn(
+            `background shell ${shellId} status cleanup error: ${getErrorMessage(e)}`,
+          );
+        }
+      }
+    };
+
     // Settle in the background — do NOT await here, the agent should be
     // unblocked immediately.
     void resultPromise.then(
       (result) => {
+        removeRunningStatus();
         outputStream.end();
         const endTime = Date.now();
         if (entryAc.signal.aborted) {
@@ -3677,6 +3719,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         }
       },
       (err) => {
+        removeRunningStatus();
         outputStream.end();
         registry.fail(shellId, getErrorMessage(err), Date.now());
       },
@@ -3689,6 +3732,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `id: ${shellId}\n` +
         pidLine +
         `output file: ${outputPath}\n` +
+        `status file: ${statusPath}\n` +
+        `Status: running. Use the status file for liveness. A quiet or empty output file does not mean the process exited; programs may buffer output. Do not relaunch solely because captured output is empty.\n` +
         `To inspect: /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter — detail view + live updates). Read the output file directly to view the captured output.`,
       returnDisplay: `Background shell ${shellId} started${pid !== undefined ? ` (pid ${pid})` : ''}.`,
     };


### PR DESCRIPTION
## What this PR does

Adds a lightweight liveness sidecar for managed background shell commands. The sidecar records the shell ID, PID, `RUNNING` state, and a timestamp refreshed every five seconds. It is removed when the process settles.

The launch response now points the model to that status file and makes clear that an empty output file may mean the child is buffering output, not that it exited.

## Why it's needed

Some programs buffer stdout when they are not attached to a terminal. Their captured output can therefore remain empty for seconds even though the process is healthy. Without an authoritative liveness signal, the model can mistake that silence for a dead process and launch duplicates.

## Reviewer Test Plan

### How to verify

1. Start a managed background command that remains quiet or buffers its output.
2. Confirm the launch result includes a `.status` path and reports `Status: running`.
3. Read the status file twice at least five seconds apart and confirm its `alive as of` timestamp advances while the process remains active.
4. Let the process exit and confirm the status file is removed and the background registry records the terminal state.
5. Run `npm test -- --run src/tools/shell.test.ts` from `packages/core`.

The regression tests cover the initial status, PID, model guidance, heartbeat refresh, and cleanup after successful completion.

### Evidence (Before & After)

Before: a buffered Python child remained alive with `exitCode: null` while its captured output file stayed at 0 bytes after both 500 ms and 2 seconds. The output appeared only after exit.

After: a quiet background process gets an immediately readable `RUNNING` status file whose timestamp refreshes independently of stdout.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js unit tests and a real Python child-process buffering reproduction on Linux.

## Risk & Scope

- Main risk or tradeoff: one small unreferenced timer and status-file write every five seconds per active managed background shell.
- Not validated / out of scope: foreground-to-background promotion, which already exposes registry status through its existing lifecycle and messaging.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7626

<details>
<summary>中文说明</summary>

## 本 PR 的作用

为受管理的后台 shell 命令增加一个轻量级的存活状态文件。该文件记录 shell ID、PID、`RUNNING` 状态，以及每五秒刷新的时间戳；进程结束后会删除该文件。

启动结果现在会向模型提供该状态文件的路径，并明确说明输出文件为空可能只是子进程正在缓冲输出，并不代表进程已经退出。

## 为什么需要它

某些程序在未连接终端时会缓冲标准输出。因此，即使进程运行正常，捕获的输出也可能在数秒内保持为空。缺少可靠的存活信号时，模型可能把这种安静状态误判为进程已终止，并重复启动命令。

## 审阅者测试计划

### 验证方法

1. 启动一个保持安静或缓冲输出的受管理后台命令。
2. 确认启动结果包含 `.status` 路径并显示 `Status: running`。
3. 间隔至少五秒读取两次状态文件，确认进程运行时 `alive as of` 时间戳会更新。
4. 等待进程退出，确认状态文件被删除，并且后台任务注册表记录了最终状态。
5. 在 `packages/core` 目录运行 `npm test -- --run src/tools/shell.test.ts`。

回归测试覆盖初始状态、PID、模型提示、心跳刷新，以及成功结束后的清理。

### 前后对比证据

修复前：一个使用缓冲输出的 Python 子进程仍然存活且 `exitCode: null`，但在 500 毫秒和 2 秒后捕获的输出文件仍为 0 字节；只有进程退出后才出现输出。

修复后：安静的后台进程会立即获得可读取的 `RUNNING` 状态文件，其时间戳独立于标准输出持续刷新。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

Linux 上的 Node.js 单元测试和真实 Python 子进程缓冲复现。

## 风险与范围

- 主要风险或权衡：每个活动的受管理后台 shell 会增加一个不阻止进程退出的小型定时器，并每五秒写入一次状态文件。
- 未验证或范围之外：前台转后台流程；该流程已通过现有生命周期和提示公开注册表状态。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #7626

</details>
