### PR TITLE
fix(web-shell): honor locked workspace session actions

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -557,6 +557,10 @@ export function WebShellSidebar({
     () => providedWorkspaces ?? workspace.capabilities?.workspaces ?? [],
     [providedWorkspaces, workspace.capabilities?.workspaces],
   );
+  const workspaceCatalogAdvertised =
+    workspaces.length > 0 ||
+    workspace.capabilities?.workspaces !== undefined ||
+    connection.capabilities?.workspaces !== undefined;
   const primaryWorkspaceCwd =
     workspaces.find((entry) => entry.primary)?.cwd ??
     workspace.capabilities?.workspaceCwd ??
@@ -809,6 +813,9 @@ export function WebShellSidebar({
       const workspaceEntry = workspaces.find((entry) => entry.cwd === cwd);
 
       if (explicitCwd && !workspaceEntry) {
+        if (!workspaceCatalogAdvertised && cwd === primaryWorkspaceCwd) {
+          return { kind: 'primary', cwd };
+        }
         return { kind: 'unknown', cwd };
       }
       if (workspaceEntry && !workspaceEntry.trusted) {
@@ -826,7 +833,12 @@ export function WebShellSidebar({
       }
       return { kind: 'restricted', cwd, workspace: workspaceEntry };
     },
-    [lockedWorkspaceCwd, primaryWorkspaceCwd, workspaces],
+    [
+      lockedWorkspaceCwd,
+      primaryWorkspaceCwd,
+      workspaceCatalogAdvertised,
+      workspaces,
+    ],
   );
   const getSessionWorkspaceCwd = useCallback(
     (session: DaemonSessionSummary) =>
@@ -1984,6 +1996,16 @@ export function WebShellSidebar({
     if (!name || !color) return;
     void (async () => {
       setGroupBusy(true);
+      const reportCreatedGroupAssignmentFailure = (error: unknown) => {
+        setGroupEditor(null);
+        setGroupName('');
+        if (groupEditor.workspaceCwd) {
+          bumpWorkspaceReload();
+        } else {
+          void reloadGroups().catch(() => undefined);
+        }
+        onError(error, t('sidebar.groupAssignFailedAfterCreate'));
+      };
       try {
         const scope = resolveWorkspaceScope(groupEditor.workspaceCwd);
         const groupActions =
@@ -2020,12 +2042,20 @@ export function WebShellSidebar({
                 targetScope.kind !== scope.kind ||
                 targetScope.cwd !== scope.cwd
               ) {
+                reportCreatedGroupAssignmentFailure(
+                  new Error(t('sidebar.groupAssignFailedAfterCreate')),
+                );
                 return;
               }
               const targetActions = livePolicy.getSessionWorkspaceActions(
                 groupEditor.targetSession,
               );
-              if (!targetActions) return;
+              if (!targetActions) {
+                reportCreatedGroupAssignmentFailure(
+                  new Error(t('sidebar.groupAssignFailedAfterCreate')),
+                );
+                return;
+              }
               await targetActions.updateSessionOrganization(
                 groupEditor.targetSession.sessionId,
                 // Assigning a named group clears any color tag (single choice
@@ -2037,12 +2067,7 @@ export function WebShellSidebar({
               }
               bumpWorkspaceReload();
             } catch (err) {
-              setGroupEditor(null);
-              setGroupName('');
-              if (!groupEditor.workspaceCwd) {
-                void reloadGroups().catch(() => undefined);
-              }
-              onError(err, t('sidebar.groupAssignFailedAfterCreate'));
+              reportCreatedGroupAssignmentFailure(err);
               return;
             }
           }
@@ -2986,20 +3011,63 @@ export function WebShellSidebar({
                         onClick={(event) => event.stopPropagation()}
                         onKeyDown={(event) => event.stopPropagation()}
                       >
-                        <button
-                          className={styles.sessionActionButton}
-                          type="button"
-                          disabled={busy || isCurrent}
-                          aria-label={t('sidebar.archive')}
-                          title={
-                            isCurrent
-                              ? t('sidebar.archiveCurrentDisabled')
-                              : t('sidebar.archive')
-                          }
-                          onClick={() => handleArchive(session)}
-                        >
-                          <ArchiveIcon />
-                        </button>
+                        {inlineActionItems.has('archive') ? (
+                          <button
+                            className={styles.sessionActionButton}
+                            type="button"
+                            disabled={busy || isCurrent}
+                            aria-label={t('sidebar.archive')}
+                            title={
+                              isCurrent
+                                ? t('sidebar.archiveCurrentDisabled')
+                                : t('sidebar.archive')
+                            }
+                            onClick={() => handleArchive(session)}
+                          >
+                            <ArchiveIcon />
+                          </button>
+                        ) : (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className={styles.sessionActionButton}
+                                type="button"
+                                aria-label={t('sidebar.moreActions')}
+                                title={t('sidebar.moreActions')}
+                              >
+                                <EllipsisVerticalIcon />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              align="end"
+                              className="w-auto min-w-40"
+                              onPointerDownOutside={() => {
+                                sessionMenuPointerDismissRef.current = true;
+                              }}
+                              onCloseAutoFocus={(event) => {
+                                if (!sessionMenuPointerDismissRef.current)
+                                  return;
+                                sessionMenuPointerDismissRef.current = false;
+                                event.preventDefault();
+                              }}
+                            >
+                              <DropdownMenuGroup>
+                                <DropdownMenuItem
+                                  disabled={busy || isCurrent}
+                                  title={
+                                    isCurrent
+                                      ? t('sidebar.archiveCurrentDisabled')
+                                      : undefined
+                                  }
+                                  onSelect={() => handleArchive(session)}
+                                >
+                                  <ArchiveIcon />
+                                  {t('sidebar.archive')}
+                                </DropdownMenuItem>
+                              </DropdownMenuGroup>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
                       </div>
                     )}
                     {!readOnly && (
@@ -3331,12 +3399,12 @@ export function WebShellSidebar({
           expanded={expanded}
           onToggle={() => toggleSessionSection(section.id)}
           onRename={
-            section.kind === 'group' && group
+            section.kind === 'group' && group && canOrganizeWorkspace()
               ? () => handleRenameGroup(group)
               : undefined
           }
           onDelete={
-            section.kind === 'group' && group
+            section.kind === 'group' && group && canOrganizeWorkspace()
               ? () => handleDeleteGroup(group)
               : undefined
           }
@@ -3350,6 +3418,7 @@ export function WebShellSidebar({
     });
   }, [
     collapsedSessionSectionIds,
+    canOrganizeWorkspace,
     error,
     filteredSessions,
     groupBusy,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -257,6 +257,13 @@ interface GroupMenuState {
   left: number;
 }
 
+type SessionWorkspaceScope =
+  | { kind: 'primary'; cwd: string }
+  | { kind: 'locked'; cwd: string; workspace: DaemonWorkspaceCapability }
+  | { kind: 'restricted'; cwd: string; workspace: DaemonWorkspaceCapability }
+  | { kind: 'untrusted'; cwd: string; workspace: DaemonWorkspaceCapability }
+  | { kind: 'unknown'; cwd: string };
+
 interface WebShellSidebarProps {
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -634,7 +641,9 @@ export function WebShellSidebar({
     DaemonSessionGroupPresetColor[]
   >([]);
   const [groupBusy, setGroupBusy] = useState(false);
-  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [editingSessionIdentity, setEditingSessionIdentity] = useState<
+    string | null
+  >(null);
   const [editingName, setEditingName] = useState('');
   const [busySessionIds, setBusySessionIds] = useState<Set<string>>(
     () => new Set(),
@@ -741,12 +750,18 @@ export function WebShellSidebar({
   );
   const canExportSessions =
     connection.capabilities?.features?.includes('session_export') ?? false;
+  const canExportWorkspaceSessions =
+    connection.capabilities?.features?.includes('workspace_session_export') ??
+    false;
   const canExportArchivedSessions =
     connection.capabilities?.features?.includes(
       'workspace_archived_session_export',
     ) ?? false;
   const currentSessionIdentity = currentSessionId
-    ? getSessionIdentity(currentSessionId, connection.workspaceCwd)
+    ? getSessionIdentity(
+        currentSessionId,
+        connection.workspaceCwd || primaryWorkspaceCwd,
+      )
     : null;
   const projectName =
     getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
@@ -787,66 +802,197 @@ export function WebShellSidebar({
     primaryPinnedSessions,
     secondaryPinnedSessions,
   ]);
+  const resolveSessionWorkspaceScope = useCallback(
+    (session: DaemonSessionSummary): SessionWorkspaceScope => {
+      const explicitCwd = session.workspaceCwd;
+      const cwd = explicitCwd || primaryWorkspaceCwd || '';
+      const workspaceEntry = workspaces.find((entry) => entry.cwd === cwd);
+
+      if (explicitCwd && !workspaceEntry) {
+        return { kind: 'unknown', cwd };
+      }
+      if (workspaceEntry && !workspaceEntry.trusted) {
+        return { kind: 'untrusted', cwd, workspace: workspaceEntry };
+      }
+      if (
+        workspaceEntry?.primary ||
+        (!explicitCwd && cwd === primaryWorkspaceCwd)
+      ) {
+        return { kind: 'primary', cwd };
+      }
+      if (!workspaceEntry) return { kind: 'unknown', cwd };
+      if (lockedWorkspaceCwd === cwd) {
+        return { kind: 'locked', cwd, workspace: workspaceEntry };
+      }
+      return { kind: 'restricted', cwd, workspace: workspaceEntry };
+    },
+    [lockedWorkspaceCwd, primaryWorkspaceCwd, workspaces],
+  );
+  const getSessionWorkspaceCwd = useCallback(
+    (session: DaemonSessionSummary) =>
+      resolveSessionWorkspaceScope(session).cwd,
+    [resolveSessionWorkspaceScope],
+  );
+  const isMutableSessionScope = useCallback(
+    (scope: SessionWorkspaceScope) =>
+      scope.kind === 'primary' || scope.kind === 'locked',
+    [],
+  );
+  const canUseWorkspaceQualifiedActions = useCallback(
+    (scope: SessionWorkspaceScope) =>
+      scope.kind === 'primary' ||
+      (scope.kind === 'locked' && workspaceQualifiedRestCoreEnabled),
+    [workspaceQualifiedRestCoreEnabled],
+  );
+  const isActiveSessionReadOnly = useCallback(
+    (session: DaemonSessionSummary) =>
+      !isMutableSessionScope(resolveSessionWorkspaceScope(session)),
+    [isMutableSessionScope, resolveSessionWorkspaceScope],
+  );
   const getSessionWorkspaceActions = useCallback(
     (session: DaemonSessionSummary) => {
-      const sessionWorkspace = displayedWorkspaces.find(
-        (entry) => entry.cwd === session.workspaceCwd,
-      );
-      return !sessionWorkspace || sessionWorkspace.primary
-        ? workspaceActions
-        : workspace.client.workspaceByCwd(sessionWorkspace.cwd);
+      const scope = resolveSessionWorkspaceScope(session);
+      if (scope.kind === 'primary') return workspaceActions;
+      if (scope.kind === 'locked') {
+        return workspace.client.workspaceByCwd(scope.cwd);
+      }
+      return undefined;
     },
-    [displayedWorkspaces, workspace.client, workspaceActions],
-  );
-  const isPrimaryWorkspaceCwd = useCallback(
-    (workspaceCwd: string | undefined) =>
-      !workspaceCwd ||
-      displayedWorkspaces.find((entry) => entry.cwd === workspaceCwd)
-        ?.primary !== false,
-    [displayedWorkspaces],
+    [resolveSessionWorkspaceScope, workspace.client, workspaceActions],
   );
   const getIdentityForSession = useCallback(
     (session: DaemonSessionSummary) =>
-      getSessionIdentity(
-        session.sessionId,
-        session.workspaceCwd || primaryWorkspaceCwd,
-      ),
-    [primaryWorkspaceCwd],
+      getSessionIdentity(session.sessionId, getSessionWorkspaceCwd(session)),
+    [getSessionWorkspaceCwd],
   );
   const isCurrentSession = useCallback(
     (session: DaemonSessionSummary) =>
       currentSessionIdentity === getIdentityForSession(session),
     [currentSessionIdentity, getIdentityForSession],
   );
+  const canRenameSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      sessionActionItems.has('rename') &&
+      isCurrentSession(session) &&
+      isMutableSessionScope(resolveSessionWorkspaceScope(session)),
+    [
+      isCurrentSession,
+      isMutableSessionScope,
+      resolveSessionWorkspaceScope,
+      sessionActionItems,
+    ],
+  );
+  const canShowDeleteSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      sessionActionItems.has('delete') &&
+      canUseWorkspaceQualifiedActions(resolveSessionWorkspaceScope(session)),
+    [
+      canUseWorkspaceQualifiedActions,
+      resolveSessionWorkspaceScope,
+      sessionActionItems,
+    ],
+  );
+  const canDeleteSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      !isCurrentSession(session) && canShowDeleteSession(session),
+    [canShowDeleteSession, isCurrentSession],
+  );
+  const canOrganizeSession = useCallback(
+    (session: DaemonSessionSummary, item: 'pin' | 'group') =>
+      organizationEnabled &&
+      sessionActionItems.has(item) &&
+      canUseWorkspaceQualifiedActions(resolveSessionWorkspaceScope(session)),
+    [
+      canUseWorkspaceQualifiedActions,
+      organizationEnabled,
+      resolveSessionWorkspaceScope,
+      sessionActionItems,
+    ],
+  );
+  const resolveWorkspaceScope = useCallback(
+    (workspaceCwd?: string) =>
+      resolveSessionWorkspaceScope({
+        sessionId: '',
+        workspaceCwd,
+      } as DaemonSessionSummary),
+    [resolveSessionWorkspaceScope],
+  );
+  const canOrganizeWorkspace = useCallback(
+    (workspaceCwd?: string) =>
+      organizationEnabled &&
+      sessionActionItems.has('group') &&
+      canUseWorkspaceQualifiedActions(resolveWorkspaceScope(workspaceCwd)),
+    [
+      canUseWorkspaceQualifiedActions,
+      organizationEnabled,
+      resolveWorkspaceScope,
+      sessionActionItems,
+    ],
+  );
+  const groupAssignmentPolicyRef = useRef<{
+    canOrganizeSession: typeof canOrganizeSession;
+    getSessionWorkspaceActions: typeof getSessionWorkspaceActions;
+    resolveWorkspaceScope: typeof resolveWorkspaceScope;
+  } | null>(null);
+  groupAssignmentPolicyRef.current = {
+    canOrganizeSession,
+    getSessionWorkspaceActions,
+    resolveWorkspaceScope,
+  };
   const canMutateSessionArchive = useCallback(
     (session: DaemonSessionSummary) => {
-      const sessionWorkspace = displayedWorkspaces.find(
-        (entry) => entry.cwd === session.workspaceCwd,
-      );
-      if (sessionWorkspace?.trusted === false) return false;
+      const scope = resolveSessionWorkspaceScope(session);
+      if (scope.kind === 'unknown' || scope.kind === 'untrusted') return false;
       return (
         sessionArchiveEnabled &&
-        (sessionWorkspace?.primary !== false ||
-          workspaceQualifiedRestCoreEnabled)
+        (scope.kind === 'primary' || workspaceQualifiedRestCoreEnabled)
       );
     },
     [
-      displayedWorkspaces,
+      resolveSessionWorkspaceScope,
       sessionArchiveEnabled,
       workspaceQualifiedRestCoreEnabled,
     ],
   );
+  const getActiveExportScope = useCallback(
+    (session: DaemonSessionSummary) => {
+      const scope = resolveSessionWorkspaceScope(session);
+      if (scope.kind === 'primary' && canExportSessions) {
+        return scope;
+      }
+      if (scope.kind === 'locked' && canExportWorkspaceSessions) {
+        return scope;
+      }
+      return undefined;
+    },
+    [
+      canExportSessions,
+      canExportWorkspaceSessions,
+      resolveSessionWorkspaceScope,
+    ],
+  );
   const getArchivedExportWorkspaceCwd = useCallback(
     (session: DaemonSessionSummary) => {
-      const workspaceCwd = session.workspaceCwd || primaryWorkspaceCwd;
-      const sessionWorkspace = displayedWorkspaces.find(
-        (entry) => entry.cwd === workspaceCwd,
-      );
-      return canExportArchivedSessions && sessionWorkspace?.trusted === true
-        ? sessionWorkspace.cwd
+      const scope = resolveSessionWorkspaceScope(session);
+      return canExportArchivedSessions &&
+        scope.kind !== 'unknown' &&
+        scope.kind !== 'untrusted'
+        ? scope.cwd
         : undefined;
     },
-    [canExportArchivedSessions, displayedWorkspaces, primaryWorkspaceCwd],
+    [canExportArchivedSessions, resolveSessionWorkspaceScope],
+  );
+  const canArchiveSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      sessionActionItems.has('archive') &&
+      !isCurrentSession(session) &&
+      canMutateSessionArchive(session),
+    [canMutateSessionArchive, isCurrentSession, sessionActionItems],
+  );
+  const canUnarchiveSession = useCallback(
+    (session: DaemonSessionSummary) =>
+      sessionActionItems.has('archive') && canMutateSessionArchive(session),
+    [canMutateSessionArchive, sessionActionItems],
   );
 
   useEffect(() => {
@@ -1505,28 +1651,61 @@ export function WebShellSidebar({
     ],
   );
 
-  const startRename = useCallback((session: DaemonSessionSummary) => {
-    setEditingSessionId(session.sessionId);
-    setEditingName(getSessionLabel(session));
-  }, []);
+  const startRename = useCallback(
+    (session: DaemonSessionSummary) => {
+      if (!canRenameSession(session)) return;
+      setEditingSessionIdentity(getIdentityForSession(session));
+      setEditingName(getSessionLabel(session));
+    },
+    [canRenameSession, getIdentityForSession],
+  );
 
   const cancelRename = useCallback(() => {
-    setEditingSessionId(null);
+    setEditingSessionIdentity(null);
     setEditingName('');
   }, []);
 
+  useEffect(() => {
+    const currentSession = currentSessionId
+      ? ({
+          sessionId: currentSessionId,
+          workspaceCwd: connection.workspaceCwd,
+        } as DaemonSessionSummary)
+      : undefined;
+    if (
+      editingSessionIdentity !== null &&
+      (!currentSession ||
+        editingSessionIdentity !== currentSessionIdentity ||
+        !canRenameSession(currentSession))
+    ) {
+      cancelRename();
+    }
+  }, [
+    canRenameSession,
+    cancelRename,
+    connection.workspaceCwd,
+    currentSessionId,
+    currentSessionIdentity,
+    editingSessionIdentity,
+  ]);
+
   const saveRename = useCallback(() => {
     const nextName = editingName.trim();
-    if (!nextName || editingSessionId !== currentSessionId) {
+    if (
+      !nextName ||
+      !currentSessionId ||
+      editingSessionIdentity !== currentSessionIdentity ||
+      !canRenameSession({
+        sessionId: currentSessionId,
+        workspaceCwd: connection.workspaceCwd,
+      } as DaemonSessionSummary)
+    ) {
       cancelRename();
       return;
     }
-    const sessionId = editingSessionId;
-    if (
-      busySessionIdsRef.current.has(
-        getSessionIdentity(sessionId, connection.workspaceCwd),
-      )
-    ) {
+    const sessionId = currentSessionId;
+    const sessionIdentity = currentSessionIdentity;
+    if (!sessionIdentity || busySessionIdsRef.current.has(sessionIdentity)) {
       return;
     }
     setSessionBusy(sessionId, true, connection.workspaceCwd);
@@ -1547,11 +1726,13 @@ export function WebShellSidebar({
   }, [
     actions,
     bumpWorkspaceReload,
+    canRenameSession,
     cancelRename,
     connection.workspaceCwd,
+    currentSessionIdentity,
     currentSessionId,
     editingName,
-    editingSessionId,
+    editingSessionIdentity,
     onError,
     reload,
     setSessionBusy,
@@ -1560,10 +1741,10 @@ export function WebShellSidebar({
 
   const handleDeleteSession = useCallback(
     (session: DaemonSessionSummary) => {
-      if (isCurrentSession(session)) return;
+      if (!canDeleteSession(session)) return;
       setDeleteCandidate(session);
     },
-    [isCurrentSession],
+    [canDeleteSession],
   );
 
   const setSessionExporting = useCallback(
@@ -1589,10 +1770,12 @@ export function WebShellSidebar({
       const sessionId = session.sessionId;
       const sessionIdentity = getIdentityForSession(session);
       const archived = session.isArchived === true;
+      const activeExportScope = getActiveExportScope(session);
       if (
+        !sessionActionItems.has('export') ||
         (archived
           ? !getArchivedExportWorkspaceCwd(session)
-          : !canExportSessions) ||
+          : !activeExportScope) ||
         exportingSessionIdsRef.current.has(sessionIdentity)
       ) {
         return;
@@ -1607,8 +1790,14 @@ export function WebShellSidebar({
             result = await workspace.client
               .workspaceByCwd(workspaceCwd)
               .exportArchivedSession(sessionId, { format: 'html' });
-          } else {
+          } else if (activeExportScope?.kind === 'primary') {
             result = await exportSession(sessionId, 'html');
+          } else if (activeExportScope?.kind === 'locked') {
+            result = await workspace.client
+              .workspaceByCwd(activeExportScope.cwd)
+              .exportSession(sessionId, { format: 'html' });
+          } else {
+            return;
           }
           const blob = new Blob([result.content], {
             type: result.mimeType || 'text/html',
@@ -1632,12 +1821,13 @@ export function WebShellSidebar({
       })();
     },
     [
-      canExportSessions,
       exportSession,
+      getActiveExportScope,
       getArchivedExportWorkspaceCwd,
       getIdentityForSession,
       onError,
       setSessionExporting,
+      sessionActionItems,
       t,
       workspace.client,
     ],
@@ -1647,22 +1837,32 @@ export function WebShellSidebar({
     if (!deleteCandidate) return;
     const sessionId = deleteCandidate.sessionId;
     const sessionIdentity = getIdentityForSession(deleteCandidate);
-    if (isCurrentSession(deleteCandidate)) {
+    if (!canDeleteSession(deleteCandidate)) {
       setDeleteCandidate(null);
       return;
     }
+    const scope = resolveSessionWorkspaceScope(deleteCandidate);
     const isArchived = Boolean(deleteCandidate.isArchived);
+    const removeSession =
+      scope.kind === 'locked'
+        ? async (id: string) => {
+            const result = await workspace.client
+              .workspaceByCwd(scope.cwd)
+              .deleteSessionsData([id]);
+            const itemError = result.errors.find(
+              (entry) => entry.sessionId === id,
+            );
+            if (itemError) throw new Error(itemError.error);
+          }
+        : scope.kind === 'primary'
+          ? isArchived
+            ? deleteArchivedSession
+            : deleteSession
+          : undefined;
     setDeleteCandidate(null);
+    if (!removeSession) return;
     if (busySessionIdsRef.current.has(sessionIdentity)) return;
     setSessionBusy(sessionId, true, deleteCandidate.workspaceCwd);
-    const removeSession = !isPrimaryWorkspaceCwd(deleteCandidate.workspaceCwd)
-      ? (id: string) =>
-          workspace.client
-            .workspaceByCwd(deleteCandidate.workspaceCwd!)
-            .deleteSessionsData([id])
-      : isArchived
-        ? deleteArchivedSession
-        : deleteSession;
     removeSession(sessionId)
       .then(() => {
         // A hard delete unlinks the transcript from BOTH the active and
@@ -1677,15 +1877,15 @@ export function WebShellSidebar({
       });
   }, [
     bumpWorkspaceReload,
+    canDeleteSession,
     deleteArchivedSession,
     deleteCandidate,
     deleteSession,
     getIdentityForSession,
-    isCurrentSession,
-    isPrimaryWorkspaceCwd,
     onError,
     reload,
     reloadArchived,
+    resolveSessionWorkspaceScope,
     setSessionBusy,
     t,
     workspace.client,
@@ -1700,15 +1900,17 @@ export function WebShellSidebar({
   );
 
   const handleCreateGroup = useCallback(() => {
+    if (!canOrganizeWorkspace()) return;
     setGroupMenu(null);
     setGroupName('');
     setGroupColor(getDefaultGroupColor(colorOptions));
     setLastValidCustomGroupColor(DEFAULT_CUSTOM_GROUP_COLOR);
     setGroupEditor({ mode: 'create' });
-  }, [colorOptions]);
+  }, [canOrganizeWorkspace, colorOptions]);
 
   const handleCreateWorkspaceGroup = useCallback(
     (workspaceCwd: string) => {
+      if (!canOrganizeWorkspace(workspaceCwd)) return;
       void (async () => {
         try {
           const catalog = await workspace.client
@@ -1724,11 +1926,12 @@ export function WebShellSidebar({
         }
       })();
     },
-    [onError, t, workspace.client],
+    [canOrganizeWorkspace, onError, t, workspace.client],
   );
 
   const handleCreateGroupForSession = useCallback(
     (session: DaemonSessionSummary) => {
+      if (!canOrganizeSession(session, 'group')) return;
       setGroupMenu(null);
       setGroupName('');
       setGroupColor(getDefaultGroupColor(colorOptions));
@@ -1739,11 +1942,12 @@ export function WebShellSidebar({
         workspaceCwd: session.workspaceCwd,
       });
     },
-    [colorOptions],
+    [canOrganizeSession, colorOptions],
   );
 
   const handleRenameGroup = useCallback(
     (group: DaemonSessionGroup, workspaceCwd?: string) => {
+      if (!canOrganizeWorkspace(workspaceCwd)) return;
       setGroupName(group.name);
       setGroupColor(group.color);
       setLastValidCustomGroupColor(
@@ -1751,7 +1955,7 @@ export function WebShellSidebar({
       );
       setGroupEditor({ mode: 'edit', group, workspaceCwd });
     },
-    [],
+    [canOrganizeWorkspace],
   );
 
   const closeGroupEditor = useCallback(() => {
@@ -1764,6 +1968,14 @@ export function WebShellSidebar({
 
   const saveGroupEditor = useCallback(() => {
     if (!groupEditor) return;
+    if (
+      !canOrganizeWorkspace(groupEditor.workspaceCwd) ||
+      (groupEditor.targetSession &&
+        !canOrganizeSession(groupEditor.targetSession, 'group'))
+    ) {
+      closeGroupEditor();
+      return;
+    }
     const name = groupName.trim();
     const color = normalizeGroupColorInput(
       groupColor,
@@ -1773,9 +1985,14 @@ export function WebShellSidebar({
     void (async () => {
       setGroupBusy(true);
       try {
-        const groupActions = !isPrimaryWorkspaceCwd(groupEditor.workspaceCwd)
-          ? workspace.client.workspaceByCwd(groupEditor.workspaceCwd!)
-          : workspaceActions;
+        const scope = resolveWorkspaceScope(groupEditor.workspaceCwd);
+        const groupActions =
+          scope.kind === 'primary'
+            ? workspaceActions
+            : scope.kind === 'locked'
+              ? workspace.client.workspaceByCwd(scope.cwd)
+              : undefined;
+        if (!groupActions) return;
         const group =
           groupEditor.mode === 'create'
             ? await groupActions.createSessionGroup({
@@ -1789,7 +2006,27 @@ export function WebShellSidebar({
         if (groupEditor.mode === 'create') {
           if (groupEditor.targetSession) {
             try {
-              await groupActions.updateSessionOrganization(
+              const livePolicy = groupAssignmentPolicyRef.current;
+              const targetScope = livePolicy?.resolveWorkspaceScope(
+                groupEditor.targetSession.workspaceCwd,
+              );
+              if (
+                !livePolicy ||
+                !targetScope ||
+                !livePolicy.canOrganizeSession(
+                  groupEditor.targetSession,
+                  'group',
+                ) ||
+                targetScope.kind !== scope.kind ||
+                targetScope.cwd !== scope.cwd
+              ) {
+                return;
+              }
+              const targetActions = livePolicy.getSessionWorkspaceActions(
+                groupEditor.targetSession,
+              );
+              if (!targetActions) return;
+              await targetActions.updateSessionOrganization(
                 groupEditor.targetSession.sessionId,
                 // Assigning a named group clears any color tag (single choice
                 // in the UI), matching assignSessionGroup.
@@ -1834,10 +2071,13 @@ export function WebShellSidebar({
     groupColor,
     groupEditor,
     groupName,
-    isPrimaryWorkspaceCwd,
+    canOrganizeSession,
+    canOrganizeWorkspace,
+    closeGroupEditor,
     onError,
     reload,
     reloadGroups,
+    resolveWorkspaceScope,
     t,
     workspaceActions,
     workspace.client,
@@ -1845,19 +2085,30 @@ export function WebShellSidebar({
 
   const handleDeleteGroup = useCallback(
     (group: DaemonSessionGroup, workspaceCwd?: string) => {
+      if (!canOrganizeWorkspace(workspaceCwd)) return;
       setDeleteGroupCandidate({ group, workspaceCwd });
     },
-    [],
+    [canOrganizeWorkspace],
   );
 
   const confirmDeleteGroup = useCallback(() => {
     if (!deleteGroupCandidate) return;
+    if (!canOrganizeWorkspace(deleteGroupCandidate.workspaceCwd)) {
+      setDeleteGroupCandidate(null);
+      return;
+    }
     setGroupBusy(true);
-    const groupActions = !isPrimaryWorkspaceCwd(
-      deleteGroupCandidate.workspaceCwd,
-    )
-      ? workspace.client.workspaceByCwd(deleteGroupCandidate.workspaceCwd!)
-      : workspaceActions;
+    const scope = resolveWorkspaceScope(deleteGroupCandidate.workspaceCwd);
+    const groupActions =
+      scope.kind === 'primary'
+        ? workspaceActions
+        : scope.kind === 'locked'
+          ? workspace.client.workspaceByCwd(scope.cwd)
+          : undefined;
+    if (!groupActions) {
+      setGroupBusy(false);
+      return;
+    }
     groupActions
       .deleteSessionGroup(deleteGroupCandidate.group.id)
       .then(() => {
@@ -1874,28 +2125,66 @@ export function WebShellSidebar({
       .finally(() => setGroupBusy(false));
   }, [
     deleteGroupCandidate,
-    isPrimaryWorkspaceCwd,
+    canOrganizeWorkspace,
     onError,
     reload,
     reloadGroups,
     t,
     bumpWorkspaceReload,
+    resolveWorkspaceScope,
     workspace.client,
     workspaceActions,
   ]);
+
+  useEffect(() => {
+    if (deleteCandidate && !canDeleteSession(deleteCandidate)) {
+      setDeleteCandidate(null);
+    }
+  }, [canDeleteSession, deleteCandidate]);
+
+  useEffect(() => {
+    if (groupMenu && !canOrganizeSession(groupMenu.session, 'group')) {
+      setGroupMenu(null);
+    }
+  }, [canOrganizeSession, groupMenu]);
+
+  useEffect(() => {
+    if (
+      groupEditor &&
+      (!canOrganizeWorkspace(groupEditor.workspaceCwd) ||
+        (groupEditor.targetSession &&
+          !canOrganizeSession(groupEditor.targetSession, 'group')))
+    ) {
+      setGroupEditor(null);
+      setGroupName('');
+    }
+  }, [canOrganizeSession, canOrganizeWorkspace, groupEditor]);
+
+  useEffect(() => {
+    if (
+      deleteGroupCandidate &&
+      !canOrganizeWorkspace(deleteGroupCandidate.workspaceCwd)
+    ) {
+      setDeleteGroupCandidate(null);
+    }
+  }, [canOrganizeWorkspace, deleteGroupCandidate]);
 
   const handleTogglePin = useCallback(
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
       const sessionIdentity = getIdentityForSession(session);
       if (
-        !organizationEnabled ||
+        !canOrganizeSession(session, 'pin') ||
         busySessionIdsRef.current.has(sessionIdentity)
       ) {
         return;
       }
       setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
+      if (!sessionActions) {
+        setSessionBusy(sessionId, false, session.workspaceCwd);
+        return;
+      }
       sessionActions
         .updateSessionOrganization(sessionId, {
           isPinned: !session.isPinned,
@@ -1915,7 +2204,7 @@ export function WebShellSidebar({
       getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
-      organizationEnabled,
+      canOrganizeSession,
       reload,
       reloadPinnedSessions,
       setSessionBusy,
@@ -1929,15 +2218,15 @@ export function WebShellSidebar({
       const sessionIdentity = getIdentityForSession(session);
       // The daemon force-ends a live turn on archive; keep the current
       // session off-limits, mirroring the delete guard.
-      if (!canMutateSessionArchive(session) || isCurrentSession(session))
-        return;
+      if (!canArchiveSession(session)) return;
       if (busySessionIdsRef.current.has(sessionIdentity)) return;
       setSessionBusy(sessionId, true, session.workspaceCwd);
       void (async () => {
         try {
-          if (!isPrimaryWorkspaceCwd(session.workspaceCwd)) {
+          const scope = resolveSessionWorkspaceScope(session);
+          if (scope.kind === 'locked' || scope.kind === 'restricted') {
             const result = await workspace.client
-              .workspaceByCwd(session.workspaceCwd)
+              .workspaceByCwd(scope.cwd)
               .archiveSessionsData([sessionId]);
             const itemError = result.errors.find(
               (entry) => entry.sessionId === sessionId,
@@ -1945,8 +2234,10 @@ export function WebShellSidebar({
             if (itemError) {
               onError(new Error(itemError.error), t('sidebar.archiveFailed'));
             }
-          } else {
+          } else if (scope.kind === 'primary') {
             await archiveSession(sessionId);
+          } else {
+            return;
           }
         } catch (err) {
           onError(err, t('sidebar.archiveFailed'));
@@ -1961,15 +2252,14 @@ export function WebShellSidebar({
     [
       archiveSession,
       bumpWorkspaceReload,
-      canMutateSessionArchive,
+      canArchiveSession,
       getIdentityForSession,
-      isPrimaryWorkspaceCwd,
-      isCurrentSession,
       onError,
       reload,
       reloadArchived,
       setSessionBusy,
       t,
+      resolveSessionWorkspaceScope,
       workspace.client,
     ],
   );
@@ -1978,14 +2268,15 @@ export function WebShellSidebar({
     (session: DaemonSessionSummary) => {
       const sessionId = session.sessionId;
       const sessionIdentity = getIdentityForSession(session);
-      if (!canMutateSessionArchive(session)) return;
+      if (!canUnarchiveSession(session)) return;
       if (busySessionIdsRef.current.has(sessionIdentity)) return;
       setSessionBusy(sessionId, true, session.workspaceCwd);
       void (async () => {
         try {
-          if (!isPrimaryWorkspaceCwd(session.workspaceCwd)) {
+          const scope = resolveSessionWorkspaceScope(session);
+          if (scope.kind === 'locked' || scope.kind === 'restricted') {
             const result = await workspace.client
-              .workspaceByCwd(session.workspaceCwd)
+              .workspaceByCwd(scope.cwd)
               .unarchiveSessionsData([sessionId]);
             const itemError = result.errors.find(
               (entry) => entry.sessionId === sessionId,
@@ -1993,8 +2284,10 @@ export function WebShellSidebar({
             if (itemError) {
               onError(new Error(itemError.error), t('sidebar.unarchiveFailed'));
             }
-          } else {
+          } else if (scope.kind === 'primary') {
             await unarchiveSession(sessionId);
+          } else {
+            return;
           }
         } catch (err) {
           onError(err, t('sidebar.unarchiveFailed'));
@@ -2008,25 +2301,28 @@ export function WebShellSidebar({
     },
     [
       bumpWorkspaceReload,
-      canMutateSessionArchive,
+      canUnarchiveSession,
       getIdentityForSession,
-      isPrimaryWorkspaceCwd,
       onError,
       reload,
       reloadArchived,
       setSessionBusy,
       t,
       unarchiveSession,
+      resolveSessionWorkspaceScope,
       workspace.client,
     ],
   );
 
   const openGroupMenuFromAnchor = useCallback(
     async (anchorEl: HTMLElement, session: DaemonSessionSummary) => {
+      if (!canOrganizeSession(session, 'group')) return;
       let groupCount = 0;
       try {
-        const catalog =
-          await getSessionWorkspaceActions(session).listSessionGroups();
+        const sessionActions = getSessionWorkspaceActions(session);
+        if (!sessionActions) return;
+        const catalog = await sessionActions.listSessionGroups();
+        if (!canOrganizeSession(session, 'group')) return;
         setMenuGroups(catalog.groups);
         setColorOptions(catalog.colorOptions);
         groupCount = catalog.groups.length;
@@ -2066,7 +2362,7 @@ export function WebShellSidebar({
         left,
       });
     },
-    [getSessionWorkspaceActions, onError, t],
+    [canOrganizeSession, getSessionWorkspaceActions, onError, t],
   );
 
   const assignSessionGroup = useCallback(
@@ -2074,7 +2370,7 @@ export function WebShellSidebar({
       const sessionId = session.sessionId;
       const sessionIdentity = getIdentityForSession(session);
       if (
-        !organizationEnabled ||
+        !canOrganizeSession(session, 'group') ||
         busySessionIdsRef.current.has(sessionIdentity)
       ) {
         return;
@@ -2082,6 +2378,10 @@ export function WebShellSidebar({
       setGroupMenu(null);
       setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
+      if (!sessionActions) {
+        setSessionBusy(sessionId, false, session.workspaceCwd);
+        return;
+      }
       sessionActions
         // Group and color are a single choice in the UI: assigning a named
         // group (or "Ungrouped", groupId=null) clears any color tag.
@@ -2100,7 +2400,7 @@ export function WebShellSidebar({
       getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
-      organizationEnabled,
+      canOrganizeSession,
       reload,
       setSessionBusy,
       t,
@@ -2115,7 +2415,7 @@ export function WebShellSidebar({
       const sessionId = session.sessionId;
       const sessionIdentity = getIdentityForSession(session);
       if (
-        !organizationEnabled ||
+        !canOrganizeSession(session, 'group') ||
         busySessionIdsRef.current.has(sessionIdentity)
       ) {
         return;
@@ -2123,6 +2423,10 @@ export function WebShellSidebar({
       setGroupMenu(null);
       setSessionBusy(sessionId, true, session.workspaceCwd);
       const sessionActions = getSessionWorkspaceActions(session);
+      if (!sessionActions) {
+        setSessionBusy(sessionId, false, session.workspaceCwd);
+        return;
+      }
       sessionActions
         // Picking a color clears any named-group assignment (single choice).
         .updateSessionOrganization(sessionId, { color, groupId: null })
@@ -2140,7 +2444,7 @@ export function WebShellSidebar({
       getIdentityForSession,
       getSessionWorkspaceActions,
       onError,
-      organizationEnabled,
+      canOrganizeSession,
       reload,
       setSessionBusy,
       t,
@@ -2420,12 +2724,13 @@ export function WebShellSidebar({
       session: DaemonSessionSummary,
       options: {
         isArchived?: boolean;
-        // Suppress per-session mutations other than an explicitly supported
-        // archive action. Secondary workspace rows remain otherwise load-only.
+        // Keep unlocked secondary rows conservative while allowing a trusted
+        // locked workspace to use normal session controls.
         readOnly?: boolean;
       } = {},
     ) => {
-      const { isArchived = false, readOnly = false } = options;
+      const { isArchived = false } = options;
+      const readOnly = options.readOnly ?? isActiveSessionReadOnly(session);
       const sessionIdentity = getIdentityForSession(session);
       const label = getSessionLabel(session);
       const stamp = session.updatedAt || session.createdAt;
@@ -2456,6 +2761,19 @@ export function WebShellSidebar({
         </div>
       );
       if (isArchived) {
+        const archivedExportWorkspaceCwd =
+          getArchivedExportWorkspaceCwd(session);
+        const showArchivedDetails = sessionActionItems.has('details');
+        const showArchivedExport =
+          sessionActionItems.has('export') &&
+          Boolean(archivedExportWorkspaceCwd);
+        const showArchivedUnarchive = canUnarchiveSession(session);
+        const showArchivedDelete = canDeleteSession(session);
+        const hasArchivedActions =
+          showArchivedDetails ||
+          showArchivedExport ||
+          showArchivedUnarchive ||
+          showArchivedDelete;
         return (
           <div
             key={sessionIdentity}
@@ -2468,79 +2786,85 @@ export function WebShellSidebar({
             <span className={styles.sessionText}>{label}</span>
             <div className={styles.sessionMetaSlot}>
               <span className={styles.sessionTime}>{time}</span>
-              <div
-                className={styles.sessionActions}
-                onClick={(event) => event.stopPropagation()}
-                onKeyDown={(event) => event.stopPropagation()}
-              >
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className={styles.sessionActionButton}
-                      type="button"
-                      aria-label={t('sidebar.moreActions')}
-                      title={t('sidebar.moreActions')}
-                    >
-                      <EllipsisVerticalIcon />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="end"
-                    className="w-auto min-w-40"
-                    onPointerDownOutside={() => {
-                      sessionMenuPointerDismissRef.current = true;
-                    }}
-                    onCloseAutoFocus={(event) => {
-                      if (!sessionMenuPointerDismissRef.current) return;
-                      sessionMenuPointerDismissRef.current = false;
-                      event.preventDefault();
-                    }}
-                  >
-                    <DropdownMenuGroup>
-                      <DropdownMenuSub>
-                        <DropdownMenuSubTrigger>
-                          <InfoIcon />
-                          {t('sidebar.details')}
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="min-w-64 p-3">
-                          {details}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
-                      {getArchivedExportWorkspaceCwd(session) && (
-                        <DropdownMenuItem
-                          disabled={exporting}
-                          onSelect={() => handleExportSession(session)}
-                        >
-                          <DownloadIcon />
-                          {t('sidebar.export')}
-                        </DropdownMenuItem>
-                      )}
-                      {canMutateSessionArchive(session) && (
-                        <DropdownMenuItem
-                          onSelect={() => handleUnarchive(session)}
-                        >
-                          <ArchiveRestoreIcon />
-                          {t('sidebar.unarchive')}
-                        </DropdownMenuItem>
-                      )}
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onSelect={() => handleDeleteSession(session)}
+              {hasArchivedActions && (
+                <div
+                  className={styles.sessionActions}
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
+                >
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className={styles.sessionActionButton}
+                        type="button"
+                        aria-label={t('sidebar.moreActions')}
+                        title={t('sidebar.moreActions')}
                       >
-                        <Trash2Icon />
-                        {t('sidebar.delete')}
-                      </DropdownMenuItem>
-                    </DropdownMenuGroup>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+                        <EllipsisVerticalIcon />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      className="w-auto min-w-40"
+                      onPointerDownOutside={() => {
+                        sessionMenuPointerDismissRef.current = true;
+                      }}
+                      onCloseAutoFocus={(event) => {
+                        if (!sessionMenuPointerDismissRef.current) return;
+                        sessionMenuPointerDismissRef.current = false;
+                        event.preventDefault();
+                      }}
+                    >
+                      <DropdownMenuGroup>
+                        {showArchivedDetails && (
+                          <DropdownMenuSub>
+                            <DropdownMenuSubTrigger>
+                              <InfoIcon />
+                              {t('sidebar.details')}
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent className="min-w-64 p-3">
+                              {details}
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
+                        )}
+                        {showArchivedExport && (
+                          <DropdownMenuItem
+                            disabled={exporting}
+                            onSelect={() => handleExportSession(session)}
+                          >
+                            <DownloadIcon />
+                            {t('sidebar.export')}
+                          </DropdownMenuItem>
+                        )}
+                        {showArchivedUnarchive && (
+                          <DropdownMenuItem
+                            onSelect={() => handleUnarchive(session)}
+                          >
+                            <ArchiveRestoreIcon />
+                            {t('sidebar.unarchive')}
+                          </DropdownMenuItem>
+                        )}
+                        {showArchivedDelete && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={() => handleDeleteSession(session)}
+                          >
+                            <Trash2Icon />
+                            {t('sidebar.delete')}
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              )}
             </div>
           </div>
         );
       }
 
       const isCurrent = isCurrentSession(session);
-      const isEditing = isCurrent && editingSessionId === session.sessionId;
+      const isEditing = isCurrent && editingSessionIdentity === sessionIdentity;
       const needsUserInput =
         !session.isWaitingForPermission && session.isWaitingForUserQuestion;
       const attentionLabel = session.isWaitingForPermission
@@ -2548,6 +2872,15 @@ export function WebShellSidebar({
         : needsUserInput
           ? t('sidebar.userInputNeeded')
           : null;
+      const mutableScope = !isActiveSessionReadOnly(session);
+      const showPin = canOrganizeSession(session, 'pin');
+      const showArchive =
+        sessionActionItems.has('archive') && canMutateSessionArchive(session);
+      const showRename = sessionActionItems.has('rename') && mutableScope;
+      const activeExportScope = getActiveExportScope(session);
+      const showExport =
+        sessionActionItems.has('export') && Boolean(activeExportScope);
+      const showDelete = canShowDeleteSession(session);
       return (
         <div
           key={sessionIdentity}
@@ -2565,7 +2898,7 @@ export function WebShellSidebar({
             handleLoadSession(session.sessionId, session.workspaceCwd)
           }
           onDoubleClick={() => {
-            if (!readOnly && isCurrent && !collapsed) startRename(session);
+            if (!collapsed && canRenameSession(session)) startRename(session);
           }}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
@@ -2583,7 +2916,7 @@ export function WebShellSidebar({
                   />
                 ) : null}
               </span>
-              {isEditing && !readOnly ? (
+              {isEditing && canRenameSession(session) ? (
                 <form
                   className={styles.renameForm}
                   onClick={(event) => event.stopPropagation()}
@@ -2647,30 +2980,28 @@ export function WebShellSidebar({
                     ) : !attentionLabel ? (
                       <span className={styles.sessionTime}>{time}</span>
                     ) : null}
-                    {readOnly &&
-                      canMutateSessionArchive(session) &&
-                      sessionActionItems.has('archive') && (
-                        <div
-                          className={styles.sessionActions}
-                          onClick={(event) => event.stopPropagation()}
-                          onKeyDown={(event) => event.stopPropagation()}
+                    {readOnly && showArchive && (
+                      <div
+                        className={styles.sessionActions}
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => event.stopPropagation()}
+                      >
+                        <button
+                          className={styles.sessionActionButton}
+                          type="button"
+                          disabled={busy || isCurrent}
+                          aria-label={t('sidebar.archive')}
+                          title={
+                            isCurrent
+                              ? t('sidebar.archiveCurrentDisabled')
+                              : t('sidebar.archive')
+                          }
+                          onClick={() => handleArchive(session)}
                         >
-                          <button
-                            className={styles.sessionActionButton}
-                            type="button"
-                            disabled={busy || isCurrent}
-                            aria-label={t('sidebar.archive')}
-                            title={
-                              isCurrent
-                                ? t('sidebar.archiveCurrentDisabled')
-                                : t('sidebar.archive')
-                            }
-                            onClick={() => handleArchive(session)}
-                          >
-                            <ArchiveIcon />
-                          </button>
-                        </div>
-                      )}
+                          <ArchiveIcon />
+                        </button>
+                      </div>
+                    )}
                     {!readOnly && (
                       <div
                         className={styles.sessionActions}
@@ -2697,10 +3028,7 @@ export function WebShellSidebar({
                                 : t('sidebar.pin'),
                               disabled: busy,
                               active: session.isPinned,
-                              visible:
-                                organizationEnabled &&
-                                sessionActionItems.has('pin') &&
-                                inlineActionItems.has('pin'),
+                              visible: showPin && inlineActionItems.has('pin'),
                               onClick: () => handleTogglePin(session),
                             },
                             {
@@ -2712,9 +3040,7 @@ export function WebShellSidebar({
                                 ? t('sidebar.archiveCurrentDisabled')
                                 : t('sidebar.archive'),
                               visible:
-                                canMutateSessionArchive(session) &&
-                                sessionActionItems.has('archive') &&
-                                inlineActionItems.has('archive'),
+                                showArchive && inlineActionItems.has('archive'),
                               onClick: () => handleArchive(session),
                             },
                             {
@@ -2726,8 +3052,7 @@ export function WebShellSidebar({
                                 ? t('sidebar.renameCurrentOnly')
                                 : undefined,
                               visible:
-                                sessionActionItems.has('rename') &&
-                                inlineActionItems.has('rename'),
+                                showRename && inlineActionItems.has('rename'),
                               onClick: () => handleRenameFromMenu(session),
                             },
                             {
@@ -2738,9 +3063,7 @@ export function WebShellSidebar({
                               label: t('sidebar.export'),
                               disabled: exporting,
                               visible:
-                                canExportSessions &&
-                                sessionActionItems.has('export') &&
-                                inlineActionItems.has('export'),
+                                showExport && inlineActionItems.has('export'),
                               onClick: () => handleExportSession(session),
                             },
                             {
@@ -2753,8 +3076,7 @@ export function WebShellSidebar({
                                 ? t('sidebar.currentDeleteDisabled')
                                 : undefined,
                               visible:
-                                sessionActionItems.has('delete') &&
-                                inlineActionItems.has('delete'),
+                                showDelete && inlineActionItems.has('delete'),
                               onClick: () => handleDeleteSession(session),
                             },
                           ];
@@ -2789,22 +3111,13 @@ export function WebShellSidebar({
                               </button>
                             ));
                         })()}
-                        {(organizationEnabled &&
-                          sessionActionItems.has('pin') &&
-                          !inlineActionItems.has('pin')) ||
-                        (canMutateSessionArchive(session) &&
-                          sessionActionItems.has('archive') &&
-                          !inlineActionItems.has('archive')) ||
+                        {(showPin && !inlineActionItems.has('pin')) ||
+                        (showArchive && !inlineActionItems.has('archive')) ||
                         sessionActionItems.has('details') ||
-                        (sessionActionItems.has('rename') &&
-                          !inlineActionItems.has('rename')) ||
-                        (organizationEnabled &&
-                          sessionActionItems.has('group')) ||
-                        (canExportSessions &&
-                          sessionActionItems.has('export') &&
-                          !inlineActionItems.has('export')) ||
-                        (sessionActionItems.has('delete') &&
-                          !inlineActionItems.has('delete')) ? (
+                        (showRename && !inlineActionItems.has('rename')) ||
+                        canOrganizeSession(session, 'group') ||
+                        (showExport && !inlineActionItems.has('export')) ||
+                        (showDelete && !inlineActionItems.has('delete')) ? (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
@@ -2830,21 +3143,18 @@ export function WebShellSidebar({
                               }}
                             >
                               <DropdownMenuGroup>
-                                {organizationEnabled &&
-                                  sessionActionItems.has('pin') &&
-                                  !inlineActionItems.has('pin') && (
-                                    <DropdownMenuItem
-                                      disabled={busy}
-                                      onSelect={() => handleTogglePin(session)}
-                                    >
-                                      <PinIcon />
-                                      {session.isPinned
-                                        ? t('sidebar.unpin')
-                                        : t('sidebar.pin')}
-                                    </DropdownMenuItem>
-                                  )}
-                                {canMutateSessionArchive(session) &&
-                                  sessionActionItems.has('archive') &&
+                                {showPin && !inlineActionItems.has('pin') && (
+                                  <DropdownMenuItem
+                                    disabled={busy}
+                                    onSelect={() => handleTogglePin(session)}
+                                  >
+                                    <PinIcon />
+                                    {session.isPinned
+                                      ? t('sidebar.unpin')
+                                      : t('sidebar.pin')}
+                                  </DropdownMenuItem>
+                                )}
+                                {showArchive &&
                                   !inlineActionItems.has('archive') && (
                                     <DropdownMenuItem
                                       disabled={busy || isCurrent}
@@ -2870,7 +3180,7 @@ export function WebShellSidebar({
                                     </DropdownMenuSubContent>
                                   </DropdownMenuSub>
                                 )}
-                                {sessionActionItems.has('rename') &&
+                                {showRename &&
                                   !inlineActionItems.has('rename') && (
                                     <DropdownMenuItem
                                       disabled={!isCurrent}
@@ -2887,23 +3197,21 @@ export function WebShellSidebar({
                                       {t('sidebar.rename')}
                                     </DropdownMenuItem>
                                   )}
-                                {organizationEnabled &&
-                                  sessionActionItems.has('group') && (
-                                    <DropdownMenuItem
-                                      disabled={busy}
-                                      onSelect={(event) =>
-                                        openGroupMenuFromAnchor(
-                                          event.currentTarget as HTMLElement,
-                                          session,
-                                        )
-                                      }
-                                    >
-                                      <FolderInputIcon />
-                                      {t('sidebar.sessionGroup')}
-                                    </DropdownMenuItem>
-                                  )}
-                                {canExportSessions &&
-                                  sessionActionItems.has('export') &&
+                                {canOrganizeSession(session, 'group') && (
+                                  <DropdownMenuItem
+                                    disabled={busy}
+                                    onSelect={(event) =>
+                                      openGroupMenuFromAnchor(
+                                        event.currentTarget as HTMLElement,
+                                        session,
+                                      )
+                                    }
+                                  >
+                                    <FolderInputIcon />
+                                    {t('sidebar.sessionGroup')}
+                                  </DropdownMenuItem>
+                                )}
+                                {showExport &&
                                   !inlineActionItems.has('export') && (
                                     <DropdownMenuItem
                                       disabled={exporting}
@@ -2915,7 +3223,7 @@ export function WebShellSidebar({
                                       {t('sidebar.export')}
                                     </DropdownMenuItem>
                                   )}
-                                {sessionActionItems.has('delete') &&
+                                {showDelete &&
                                   !inlineActionItems.has('delete') && (
                                     <DropdownMenuItem
                                       variant="destructive"
@@ -2949,15 +3257,20 @@ export function WebShellSidebar({
     },
     [
       busySessionIds,
+      canDeleteSession,
+      canShowDeleteSession,
+      canOrganizeSession,
+      canRenameSession,
+      canUnarchiveSession,
       canMutateSessionArchive,
-      canExportSessions,
       cancelRename,
       collapsed,
       completedUnreadIds,
       editingName,
-      editingSessionId,
+      editingSessionIdentity,
       exportingSessionIds,
       getArchivedExportWorkspaceCwd,
+      getActiveExportScope,
       getIdentityForSession,
       handleArchive,
       handleDeleteSession,
@@ -2968,10 +3281,10 @@ export function WebShellSidebar({
       handleUnarchive,
       isCurrentSession,
       openGroupMenuFromAnchor,
-      organizationEnabled,
       saveRename,
       sessionActionItems,
       inlineActionItems,
+      isActiveSessionReadOnly,
       startRename,
       t,
     ],
@@ -3643,7 +3956,11 @@ export function WebShellSidebar({
                 </div>
                 {pinnedExpanded && (
                   <div className={styles.pinnedSessionList}>
-                    {pinnedSessions.map((session) => renderSessionRow(session))}
+                    {pinnedSessions.map((session) =>
+                      renderSessionRow(session, {
+                        readOnly: isActiveSessionReadOnly(session),
+                      }),
+                    )}
                   </div>
                 )}
               </>
@@ -3734,8 +4051,16 @@ export function WebShellSidebar({
                             loadErrorLabel={t('sidebar.loadFailed')}
                             organizationEnabled={organizationEnabled}
                             ungroupedLabel={t('sidebar.groupUngrouped')}
-                            onRenameGroup={handleRenameGroup}
-                            onDeleteGroup={handleDeleteGroup}
+                            onRenameGroup={
+                              canOrganizeWorkspace(ws.cwd)
+                                ? handleRenameGroup
+                                : undefined
+                            }
+                            onDeleteGroup={
+                              canOrganizeWorkspace(ws.cwd)
+                                ? handleDeleteGroup
+                                : undefined
+                            }
                             renameGroupLabel={t('sidebar.groupRename')}
                             deleteGroupLabel={t('sidebar.groupDelete')}
                             groupActionsDisabled={groupBusy}
@@ -3759,7 +4084,12 @@ export function WebShellSidebar({
                                   ...session,
                                   workspaceCwd: ws.cwd,
                                 },
-                                { readOnly: !ws.primary },
+                                {
+                                  readOnly: isActiveSessionReadOnly({
+                                    ...session,
+                                    workspaceCwd: ws.cwd,
+                                  }),
+                                },
                               )
                             }
                             headerActions={(visible) => {
@@ -3785,22 +4115,31 @@ export function WebShellSidebar({
                                 >
                                   {ws.trusted && (
                                     <>
-                                      <button
-                                        className={styles.workspaceHeaderAction}
-                                        type="button"
-                                        aria-label={t('sidebar.groupCreate')}
-                                        onClick={(event) => {
-                                          event.preventDefault();
-                                          event.stopPropagation();
-                                          if (ws.primary) {
-                                            handleCreateGroup();
-                                          } else {
-                                            handleCreateWorkspaceGroup(ws.cwd);
+                                      {canOrganizeWorkspace(ws.cwd) && (
+                                        <button
+                                          className={
+                                            styles.workspaceHeaderAction
                                           }
-                                        }}
-                                      >
-                                        <PlusIcon size={16} strokeWidth={1.2} />
-                                      </button>
+                                          type="button"
+                                          aria-label={t('sidebar.groupCreate')}
+                                          onClick={(event) => {
+                                            event.preventDefault();
+                                            event.stopPropagation();
+                                            if (ws.primary) {
+                                              handleCreateGroup();
+                                            } else {
+                                              handleCreateWorkspaceGroup(
+                                                ws.cwd,
+                                              );
+                                            }
+                                          }}
+                                        >
+                                          <PlusIcon
+                                            size={16}
+                                            strokeWidth={1.2}
+                                          />
+                                        </button>
+                                      )}
                                       <button
                                         className={styles.workspaceHeaderAction}
                                         type="button"

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -2679,6 +2679,18 @@ describe('WebShellSidebar non-primary archive', () => {
     expect(
       inlineSessionAction('Untrusted primary active', 'Pin'),
     ).toBeUndefined();
+    expect(
+      inlineSessionAction('Untrusted primary active', 'Delete'),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction(
+        'Untrusted primary active',
+        'Export conversation record',
+      ),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction('Untrusted primary active', 'Rename'),
+    ).toBeUndefined();
     expect(archiveButtonFor('Untrusted primary active')).toBeUndefined();
     expect(sessionActions.renameSession).not.toHaveBeenCalled();
     expect(active.archiveSession).not.toHaveBeenCalled();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -19,7 +19,11 @@ const {
   listWorkspaceSessions,
   archiveSessionsData,
   unarchiveSessionsData,
+  deleteSessionsData,
+  updateSessionOrganization,
+  exportSession,
   exportArchivedSession,
+  sessionActions,
 } = vi.hoisted(() => {
   const makeSessions = () => ({
     sessions: [] as DaemonSessionSummary[],
@@ -44,12 +48,20 @@ const {
     notFound: [],
     errors: [],
   });
+  const deleteSessionsData = vi.fn().mockResolvedValue({
+    removed: [],
+    notFound: [],
+    errors: [],
+  });
+  const updateSessionOrganization = vi.fn().mockResolvedValue({});
+  const exportSession = vi.fn();
   const active = makeSessions();
   const archived = makeSessions();
   const useSessions = vi.fn((options?: { archiveState?: string }) =>
     options?.archiveState === 'archived' ? archived : active,
   );
   const exportArchivedSession = vi.fn();
+  const sessionActions = { renameSession: vi.fn() };
   return {
     connection: {
       status: 'connected',
@@ -93,13 +105,17 @@ const {
     listWorkspaceSessions,
     archiveSessionsData,
     unarchiveSessionsData,
+    deleteSessionsData,
+    updateSessionOrganization,
+    exportSession,
     exportArchivedSession,
+    sessionActions,
   };
 });
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useConnection: () => connection,
-  useActions: () => ({ renameSession: vi.fn() }),
+  useActions: () => sessionActions,
   useWorkspace: () => workspace,
   useWorkspaceActions: () => workspaceActions,
   useSessions,
@@ -168,9 +184,28 @@ function renderSidebar(
     onError?: (error: unknown, message: string) => void;
     onOpenGoals?: () => void;
     onOpenAddWorkspace?: () => void;
+    onNewSession?: (workspaceCwd?: string) => boolean;
     lockedWorkspaceCwd?: string;
     lockedWorkspace?: {
       render?: (workspace: DaemonWorkspaceCapability) => ReactNode;
+    };
+    sessionActions?: {
+      items?: readonly (
+        | 'pin'
+        | 'archive'
+        | 'details'
+        | 'rename'
+        | 'group'
+        | 'export'
+        | 'delete'
+      )[];
+      inlineItems?: readonly (
+        | 'pin'
+        | 'archive'
+        | 'rename'
+        | 'export'
+        | 'delete'
+      )[];
     };
   } = {},
 ) {
@@ -186,7 +221,7 @@ function renderSidebar(
           onOpenGoals={overrides.onOpenGoals ?? (() => {})}
           onOpenSessions={() => {}}
           onOpenSplitView={() => {}}
-          onNewSession={() => false}
+          onNewSession={overrides.onNewSession ?? (() => false)}
           onLoadSession={() => {}}
           onError={overrides.onError ?? (() => {})}
           selectedWorkspaceCwd={overrides.selectedWorkspaceCwd}
@@ -194,6 +229,7 @@ function renderSidebar(
           onOpenAddWorkspace={overrides.onOpenAddWorkspace}
           lockedWorkspaceCwd={overrides.lockedWorkspaceCwd}
           lockedWorkspace={overrides.lockedWorkspace}
+          sessionActions={overrides.sessionActions}
         />
       </I18nProvider>,
     );
@@ -220,6 +256,14 @@ function click(element: HTMLElement): void {
   element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 }
 
+function setInputValue(input: HTMLInputElement, value: string): void {
+  Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  )?.set?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 async function expandWorkspace(name: string): Promise<void> {
   const button = Array.from(
     container.querySelectorAll<HTMLButtonElement>('button'),
@@ -230,6 +274,20 @@ async function expandWorkspace(name: string): Promise<void> {
     await Promise.resolve();
     await Promise.resolve();
   });
+}
+
+async function ensureWorkspaceExpanded(name: string): Promise<void> {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('button'),
+  ).find((candidate) => candidate.textContent?.includes(name));
+  expect(button).toBeDefined();
+  if (button?.getAttribute('aria-expanded') !== 'true') {
+    await act(async () => {
+      click(button);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
 }
 
 function archiveButtonFor(label: string): HTMLButtonElement | undefined {
@@ -266,6 +324,21 @@ function sessionAction(label: string): HTMLButtonElement | undefined {
   );
 }
 
+function inlineSessionAction(
+  label: string,
+  action: string,
+): HTMLButtonElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      `button[aria-label="${action}"]`,
+    ),
+  ).find((button) =>
+    button
+      .closest<HTMLElement>('[class*="sessionRow"]')
+      ?.textContent?.includes(label),
+  );
+}
+
 async function selectSessionMenuItem(
   label: string,
   itemLabel: string,
@@ -286,6 +359,18 @@ async function selectSessionMenuItem(
   });
 }
 
+async function openSessionMenuItems(label: string): Promise<string[]> {
+  const trigger = sessionAction(label);
+  expect(trigger).toBeDefined();
+  await act(async () => {
+    click(trigger!);
+    await Promise.resolve();
+  });
+  return Array.from(
+    document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+  ).map((item) => item.textContent ?? '');
+}
+
 function useWorkspaceSessionCatalog(
   resolve: (
     cwd: string,
@@ -303,6 +388,9 @@ function useWorkspaceSessionCatalog(
     listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
     archiveSessionsData,
     unarchiveSessionsData,
+    deleteSessionsData,
+    updateSessionOrganization,
+    exportSession,
     exportArchivedSession,
   }));
 }
@@ -353,12 +441,26 @@ beforeEach(() => {
     notFound: [],
     errors: [],
   });
+  deleteSessionsData.mockReset();
+  deleteSessionsData.mockResolvedValue({
+    removed: [],
+    notFound: [],
+    errors: [],
+  });
+  updateSessionOrganization.mockReset();
+  updateSessionOrganization.mockResolvedValue({});
+  exportSession.mockReset();
+  sessionActions.renameSession.mockReset();
+  sessionActions.renameSession.mockResolvedValue(undefined);
   exportArchivedSession.mockReset();
   workspace.client.workspaceByCwd.mockImplementation(() => ({
     listWorkspaceSessions,
     listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
     archiveSessionsData,
     unarchiveSessionsData,
+    deleteSessionsData,
+    updateSessionOrganization,
+    exportSession,
     exportArchivedSession,
   }));
   workspaceActions.removeWorkspace.mockReset();
@@ -367,6 +469,13 @@ beforeEach(() => {
   workspaceActions.addWorkspace.mockResolvedValue({ persisted: true });
   active.reload.mockReset();
   active.reload.mockResolvedValue(undefined);
+  active.deleteSession.mockReset();
+  active.deleteSession.mockResolvedValue(true);
+  active.archiveSession.mockReset();
+  active.archiveSession.mockResolvedValue(true);
+  active.unarchiveSession.mockReset();
+  active.unarchiveSession.mockResolvedValue(true);
+  active.exportSession.mockReset();
   archived.reload.mockReset();
   archived.reload.mockResolvedValue(undefined);
   useSessions.mockClear();
@@ -480,6 +589,1390 @@ describe('WebShellSidebar workspace removal', () => {
         ([options]) => !Object.hasOwn(options ?? {}, 'sourceType'),
       ),
     ).toBe(true);
+  });
+
+  it('gives a locked trusted secondary active row normal actions through its workspace', async () => {
+    const exportResult = {
+      content: '<p>secondary export</p>',
+      filename: 'secondary.html',
+      mimeType: 'text/html',
+      format: 'html' as const,
+    };
+    connection.sessionId = 'current-secondary';
+    connection.workspaceCwd = '/tmp/other';
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_session_export',
+      ],
+    };
+    const primaryOrganization = vi.fn().mockResolvedValue({});
+    const primaryArchive = vi.fn().mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [],
+    });
+    const primaryExport = vi.fn().mockResolvedValue(exportResult);
+    const secondaryOrganization = vi.fn().mockResolvedValue({});
+    const secondaryArchive = vi.fn().mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [],
+    });
+    const secondaryExport = vi.fn().mockResolvedValue(exportResult);
+    const makeClient = (
+      cwd: string,
+      actions: {
+        organization: ReturnType<typeof vi.fn>;
+        archive: ReturnType<typeof vi.fn>;
+        export: ReturnType<typeof vi.fn>;
+      },
+    ) => ({
+      listWorkspaceSessions: async (options?: { archiveState?: string }) =>
+        cwd === '/tmp/other' && options?.archiveState === 'active'
+          ? [
+              {
+                sessionId: 'current-secondary',
+                workspaceCwd: cwd,
+                displayName: 'Current secondary',
+              },
+              {
+                sessionId: 'other-secondary',
+                workspaceCwd: cwd,
+                displayName: 'Other secondary',
+              },
+            ]
+          : [],
+      listSessionGroups: vi.fn().mockResolvedValue({
+        groups: [
+          {
+            id: 'secondary-group',
+            name: 'Secondary group',
+            color: 'blue',
+          },
+        ],
+        colorOptions: ['blue'],
+      }),
+      archiveSessionsData: actions.archive,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization: actions.organization,
+      exportSession: actions.export,
+      exportArchivedSession,
+    });
+    const primaryClient = makeClient('/tmp/project', {
+      organization: primaryOrganization,
+      archive: primaryArchive,
+      export: primaryExport,
+    });
+    const secondaryClient = makeClient('/tmp/other', {
+      organization: secondaryOrganization,
+      archive: secondaryArchive,
+      export: secondaryExport,
+    });
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) =>
+      cwd === '/tmp/other' ? secondaryClient : primaryClient,
+    );
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:secondary-export'),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await ensureWorkspaceExpanded('other');
+
+    expect(inlineSessionAction('Current secondary', 'Pin')).toBeDefined();
+    expect(archiveButtonFor('Other secondary')).toBeDefined();
+    expect(sessionAction('Current secondary')).toBeDefined();
+    expect(sessionAction('Other secondary')).toBeDefined();
+
+    await act(async () => {
+      click(inlineSessionAction('Current secondary', 'Pin')!);
+      await secondaryOrganization.mock.results.at(-1)?.value;
+    });
+    expect(secondaryOrganization).toHaveBeenCalledWith('current-secondary', {
+      isPinned: true,
+    });
+    expect(primaryOrganization).not.toHaveBeenCalled();
+
+    await selectSessionMenuItem('Current secondary', 'Export');
+    await act(async () => {
+      await secondaryExport.mock.results.at(-1)?.value;
+    });
+    expect(secondaryExport).toHaveBeenCalledWith('current-secondary', {
+      format: 'html',
+    });
+    expect(primaryExport).not.toHaveBeenCalled();
+
+    await act(async () => {
+      click(archiveButtonFor('Other secondary')!);
+      await secondaryArchive.mock.results.at(-1)?.value;
+    });
+    expect(secondaryArchive).toHaveBeenCalledWith(['other-secondary']);
+    expect(primaryArchive).not.toHaveBeenCalled();
+  });
+
+  it('allows only the current locked-secondary session to rename', async () => {
+    connection.sessionId = 'locked-current';
+    connection.workspaceCwd = '/tmp/other';
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue(
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'locked-current',
+                workspaceCwd: cwd,
+                displayName: 'Locked current',
+              },
+              {
+                sessionId: 'locked-other',
+                workspaceCwd: cwd,
+                displayName: 'Locked other',
+              },
+            ]
+          : [],
+      ),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: {
+        items: ['rename', 'delete', 'archive'],
+        inlineItems: ['rename', 'delete', 'archive'],
+      },
+    });
+    await expandWorkspace('other');
+
+    expect(inlineSessionAction('Locked current', 'Delete')?.disabled).toBe(
+      true,
+    );
+    expect(inlineSessionAction('Locked current', 'Archive')?.disabled).toBe(
+      true,
+    );
+    expect(inlineSessionAction('Locked other', 'Rename')?.disabled).toBe(true);
+
+    const currentRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((row) => row.textContent?.includes('Locked current'));
+    await act(async () => {
+      currentRow?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+      await Promise.resolve();
+    });
+    const input = container.querySelector<HTMLInputElement>('input');
+    expect(input).not.toBeNull();
+    await act(async () => {
+      setInputValue(input!, 'Renamed locked current');
+      input!
+        .closest('form')
+        ?.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true }),
+        );
+      await sessionActions.renameSession.mock.results.at(-1)?.value;
+    });
+    expect(sessionActions.renameSession).toHaveBeenCalledWith(
+      'Renamed locked current',
+    );
+  });
+
+  it('does not assign a created group after its locked workspace unlocks', async () => {
+    let resolveCreate!: (group: {
+      id: string;
+      name: string;
+      color: 'blue';
+    }) => void;
+    const createSessionGroup = vi.fn(
+      () =>
+        new Promise<{ id: string; name: string; color: 'blue' }>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    const secondaryOrganization = vi.fn().mockResolvedValue({});
+    const primaryOrganization = vi.fn().mockResolvedValue({});
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [],
+      colorOptions: ['blue'],
+    });
+    Object.assign(workspaceActions, {
+      updateSessionOrganization: primaryOrganization,
+    });
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue(
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'group-target',
+                workspaceCwd: cwd,
+                displayName: 'Locked group target',
+              },
+            ]
+          : [],
+      ),
+      listSessionGroups: vi.fn().mockResolvedValue({
+        groups: [],
+        colorOptions: ['blue'],
+      }),
+      createSessionGroup,
+      updateSessionGroup: vi.fn(),
+      deleteSessionGroup: vi.fn(),
+      updateSessionOrganization: secondaryOrganization,
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      exportSession,
+      exportArchivedSession,
+    }));
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_qualified_rest_core',
+      ],
+    };
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: { items: ['group'] },
+    });
+    await ensureWorkspaceExpanded('other');
+    const groupTrigger = sessionAction('Locked group target');
+    expect(groupTrigger).toBeDefined();
+    await act(async () => {
+      click(groupTrigger!);
+      await Promise.resolve();
+    });
+    const groupItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes('Group'));
+    expect(groupItem).toBeDefined();
+    await act(async () => {
+      click(groupItem!);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const createGroup = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>(
+        'button[role="menuitem"]',
+      ),
+    ).find((button) => button.textContent?.includes('Create group'));
+    expect(createGroup).toBeDefined();
+    await act(async () => {
+      click(createGroup!);
+      await Promise.resolve();
+    });
+
+    const groupName = document.body.querySelector<HTMLInputElement>(
+      '#session-group-name',
+    );
+    expect(groupName).not.toBeNull();
+    await act(async () => {
+      setInputValue(groupName!, 'Created during unlock');
+      groupName!
+        .closest('form')
+        ?.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true }),
+        );
+      await Promise.resolve();
+    });
+    expect(createSessionGroup).toHaveBeenCalledWith({
+      name: 'Created during unlock',
+      color: 'blue',
+    });
+
+    renderSidebar({ sessionActions: { items: ['group'] } });
+    await act(async () => {
+      await Promise.resolve();
+      resolveCreate({
+        id: 'created-during-unlock',
+        name: 'Created during unlock',
+        color: 'blue',
+      });
+      await createSessionGroup.mock.results[0]?.value;
+      await Promise.resolve();
+    });
+
+    expect(secondaryOrganization).not.toHaveBeenCalled();
+    expect(primaryOrganization).not.toHaveBeenCalled();
+  });
+
+  it('routes locked secondary delete, archive, color, and pinned mutations only to its client', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_session_export',
+      ],
+    };
+    const primaryDelete = vi.fn().mockResolvedValue({
+      removed: [],
+      notFound: [],
+      errors: [],
+    });
+    const primaryArchive = vi.fn().mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [],
+    });
+    const primaryOrganization = vi.fn().mockResolvedValue({});
+    const secondaryDelete = vi.fn().mockResolvedValue({
+      removed: ['locked-delete'],
+      notFound: [],
+      errors: [],
+    });
+    const secondaryArchive = vi.fn().mockResolvedValue({
+      archived: ['locked-archive'],
+      alreadyArchived: [],
+      notFound: [],
+      errors: [],
+    });
+    const secondaryOrganization = vi.fn().mockResolvedValue({});
+    const makeClient = (
+      cwd: string,
+      actions: {
+        delete: ReturnType<typeof vi.fn>;
+        archive: ReturnType<typeof vi.fn>;
+        organization: ReturnType<typeof vi.fn>;
+      },
+    ) => ({
+      listWorkspaceSessions: vi
+        .fn()
+        .mockImplementation((options?: { group?: string }) =>
+          cwd !== '/tmp/other'
+            ? []
+            : options?.group === 'pinned'
+              ? [
+                  {
+                    sessionId: 'locked-pinned',
+                    workspaceCwd: cwd,
+                    displayName: 'Locked pinned',
+                    isPinned: true,
+                  },
+                ]
+              : [
+                  {
+                    sessionId: 'locked-delete',
+                    workspaceCwd: cwd,
+                    displayName: 'Locked delete',
+                  },
+                  {
+                    sessionId: 'locked-archive',
+                    workspaceCwd: cwd,
+                    displayName: 'Locked archive',
+                  },
+                  {
+                    sessionId: 'locked-color',
+                    workspaceCwd: cwd,
+                    displayName: 'Locked color',
+                  },
+                ],
+        ),
+      listSessionGroups: vi.fn().mockResolvedValue({
+        groups:
+          cwd === '/tmp/other'
+            ? [
+                {
+                  id: 'secondary-group',
+                  name: 'Secondary group',
+                  color: 'blue',
+                },
+              ]
+            : [],
+        colorOptions: ['blue'],
+      }),
+      archiveSessionsData: actions.archive,
+      unarchiveSessionsData,
+      deleteSessionsData: actions.delete,
+      updateSessionOrganization: actions.organization,
+      exportSession,
+      exportArchivedSession,
+    });
+    const primaryClient = makeClient('/tmp/project', {
+      delete: primaryDelete,
+      archive: primaryArchive,
+      organization: primaryOrganization,
+    });
+    const secondaryClient = makeClient('/tmp/other', {
+      delete: secondaryDelete,
+      archive: secondaryArchive,
+      organization: secondaryOrganization,
+    });
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) =>
+      cwd === '/tmp/other' ? secondaryClient : primaryClient,
+    );
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: {
+        items: ['pin', 'group', 'archive', 'delete'],
+        inlineItems: ['pin'],
+      },
+    });
+    await expandWorkspace('other');
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await selectSessionMenuItem('Locked delete', 'Delete');
+    await act(async () => {
+      click(dialogButton('Delete'));
+      await secondaryDelete.mock.results.at(-1)?.value;
+    });
+    expect(secondaryDelete).toHaveBeenCalledWith(['locked-delete']);
+
+    await selectSessionMenuItem('Locked archive', 'Archive');
+    await act(async () => {
+      await secondaryArchive.mock.results.at(-1)?.value;
+    });
+    expect(secondaryArchive).toHaveBeenCalledWith(['locked-archive']);
+
+    await selectSessionMenuItem('Locked color', 'Group');
+    const blue = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+    ).find((button) => button.textContent?.includes('Blue'));
+    expect(blue).toBeDefined();
+    await act(async () => {
+      click(blue!);
+      await secondaryOrganization.mock.results.at(-1)?.value;
+    });
+    expect(secondaryOrganization).toHaveBeenCalledWith('locked-color', {
+      color: 'blue',
+      groupId: null,
+    });
+
+    await selectSessionMenuItem('Locked color', 'Group');
+    const namedGroup = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+    ).find((button) => button.textContent?.includes('Secondary group'));
+    expect(namedGroup).toBeDefined();
+    await act(async () => {
+      click(namedGroup!);
+      await secondaryOrganization.mock.results.at(-1)?.value;
+    });
+    expect(secondaryOrganization).toHaveBeenCalledWith('locked-color', {
+      groupId: 'secondary-group',
+      color: null,
+    });
+
+    await act(async () => {
+      click(inlineSessionAction('Locked pinned', 'Unpin')!);
+      await secondaryOrganization.mock.results.at(-1)?.value;
+    });
+    expect(secondaryOrganization).toHaveBeenCalledWith('locked-pinned', {
+      isPinned: false,
+    });
+    expect(primaryDelete).not.toHaveBeenCalled();
+    expect(primaryArchive).not.toHaveBeenCalled();
+    expect(primaryOrganization).not.toHaveBeenCalled();
+  });
+
+  it('requires workspace_qualified_rest_core for locked secondary destructive and organization controls', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        'multi_workspace_sessions',
+        'session_archive',
+        'session_organization',
+        'workspace_session_export',
+      ],
+    };
+    const secondaryDelete = vi.fn();
+    const secondaryOrganization = vi.fn();
+    const secondaryArchive = vi.fn();
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue(
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'without-rest',
+                workspaceCwd: cwd,
+                displayName: 'Without rest capability',
+              },
+            ]
+          : [],
+      ),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData: secondaryArchive,
+      unarchiveSessionsData,
+      deleteSessionsData: secondaryDelete,
+      updateSessionOrganization: secondaryOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: {
+        items: ['pin', 'group', 'archive', 'delete', 'export', 'details'],
+        inlineItems: ['pin', 'archive', 'delete'],
+      },
+    });
+    await expandWorkspace('other');
+
+    expect(
+      inlineSessionAction('Without rest capability', 'Pin'),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction('Without rest capability', 'Archive'),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction('Without rest capability', 'Delete'),
+    ).toBeUndefined();
+    const trigger = sessionAction('Without rest capability');
+    expect(trigger).toBeDefined();
+    await act(async () => {
+      click(trigger!);
+      await Promise.resolve();
+    });
+    const items = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).map((item) => item.textContent);
+    expect(items).not.toContain('Pin');
+    expect(items).not.toContain('Archive');
+    expect(items).not.toContain('Session group');
+    expect(items).not.toContain('Delete');
+    expect(secondaryDelete).not.toHaveBeenCalled();
+    expect(secondaryOrganization).not.toHaveBeenCalled();
+    expect(secondaryArchive).not.toHaveBeenCalled();
+  });
+
+  it('keeps a trusted locked workspace New Task available without session organization', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: capabilities.features.filter(
+        (feature) => feature !== 'session_organization',
+      ),
+    };
+    const onNewSession = vi.fn(() => true);
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other', onNewSession });
+    await expandWorkspace('other');
+
+    expect(
+      container.querySelector('button[aria-label="Create session group"]'),
+    ).toBeNull();
+    const newTaskButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="New task"]',
+      ),
+    );
+    expect(newTaskButtons.length).toBeGreaterThanOrEqual(2);
+    await act(async () => {
+      click(newTaskButtons.at(-1)!);
+      await Promise.resolve();
+    });
+    expect(onNewSession).toHaveBeenCalledWith('/tmp/other');
+  });
+
+  it('applies items and inlineItems consistently to locked normal, pinned, and archived rows', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_session_export',
+        'workspace_archived_session_export',
+      ],
+    };
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi
+        .fn()
+        .mockImplementation(
+          (options?: { group?: string; archiveState?: string }) => {
+            if (cwd !== '/tmp/other') return [];
+            if (options?.group === 'pinned') {
+              return [
+                {
+                  sessionId: 'configured-pinned',
+                  workspaceCwd: cwd,
+                  displayName: 'Configured pinned',
+                  isPinned: true,
+                },
+              ];
+            }
+            if (options?.archiveState === 'archived') {
+              return [
+                {
+                  sessionId: 'configured-archived',
+                  workspaceCwd: cwd,
+                  displayName: 'Configured archived',
+                  isArchived: true,
+                },
+              ];
+            }
+            return [
+              {
+                sessionId: 'configured-normal',
+                workspaceCwd: cwd,
+                displayName: 'Configured normal',
+              },
+            ];
+          },
+        ),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: {
+        items: ['details', 'pin', 'group', 'archive', 'export', 'delete'],
+        inlineItems: ['pin'],
+      },
+    });
+    await expandWorkspace('other');
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('button[aria-label="Create group"]'),
+    ).not.toBeNull();
+    expect(inlineSessionAction('Configured normal', 'Pin')).toBeDefined();
+    expect(inlineSessionAction('Configured normal', 'Archive')).toBeUndefined();
+    const normalItems = await openSessionMenuItems('Configured normal');
+    expect(normalItems).toEqual(
+      expect.arrayContaining([
+        'Archive',
+        'Details',
+        'Group',
+        'Export conversation record',
+        'Delete',
+      ]),
+    );
+
+    expect(inlineSessionAction('Configured pinned', 'Unpin')).toBeDefined();
+    expect(inlineSessionAction('Configured pinned', 'Archive')).toBeUndefined();
+
+    await expandArchived();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const archivedItems = await openSessionMenuItems('Configured archived');
+    expect(archivedItems).toEqual(
+      expect.arrayContaining([
+        'Details',
+        'Export conversation record',
+        'Restore',
+        'Delete',
+      ]),
+    );
+    expect(archivedItems).not.toContain('Pin');
+    expect(archivedItems).not.toContain('Group');
+  });
+
+  it('renders locked normal, pinned, and archived rows action-free when no items are configured', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_session_export',
+        'workspace_archived_session_export',
+      ],
+    };
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi
+        .fn()
+        .mockImplementation(
+          (options?: { group?: string; archiveState?: string }) => {
+            if (cwd !== '/tmp/other') return [];
+            if (options?.group === 'pinned') {
+              return [
+                {
+                  sessionId: 'empty-actions-pinned',
+                  workspaceCwd: cwd,
+                  displayName: 'Empty actions pinned',
+                  isPinned: true,
+                },
+              ];
+            }
+            if (options?.archiveState === 'archived') {
+              return [
+                {
+                  sessionId: 'empty-actions-archived',
+                  workspaceCwd: cwd,
+                  displayName: 'Empty actions archived',
+                  isArchived: true,
+                },
+              ];
+            }
+            return [
+              {
+                sessionId: 'empty-actions-normal',
+                workspaceCwd: cwd,
+                displayName: 'Empty actions normal',
+                groupId: 'empty-actions-group',
+              },
+            ];
+          },
+        ),
+      listSessionGroups: vi.fn().mockResolvedValue({
+        groups: [
+          {
+            id: 'empty-actions-group',
+            name: 'Empty actions group',
+            color: 'blue',
+          },
+        ],
+      }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      sessionActions: { items: [] },
+    });
+    await expandWorkspace('other');
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    for (const label of ['Empty actions normal', 'Empty actions pinned']) {
+      expect(sessionAction(label)).toBeUndefined();
+      expect(inlineSessionAction(label, 'Pin')).toBeUndefined();
+      expect(archiveButtonFor(label)).toBeUndefined();
+    }
+    expect(container.textContent).toContain('Empty actions group');
+    expect(
+      container.querySelector('button[aria-label="Create group"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Rename group"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Delete group"]'),
+    ).toBeNull();
+
+    await expandArchived();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(sessionAction('Empty actions archived')).toBeUndefined();
+    expect(archiveSessionsData).not.toHaveBeenCalled();
+    expect(unarchiveSessionsData).not.toHaveBeenCalled();
+    expect(deleteSessionsData).not.toHaveBeenCalled();
+    expect(updateSessionOrganization).not.toHaveBeenCalled();
+    expect(exportSession).not.toHaveBeenCalled();
+    expect(exportArchivedSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps equal-id active export and current state isolated by workspace cwd', async () => {
+    const exportResult = {
+      content: '<p>export</p>',
+      filename: 'shared.html',
+      mimeType: 'text/html',
+      format: 'html' as const,
+    };
+    let resolveSecondaryExport:
+      | ((value: typeof exportResult) => void)
+      | undefined;
+    const secondaryExport = vi.fn(
+      () =>
+        new Promise<typeof exportResult>((resolve) => {
+          resolveSecondaryExport = resolve;
+        }),
+    );
+    connection.sessionId = 'shared-active';
+    connection.workspaceCwd = '/tmp/other';
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_export',
+        'workspace_session_export',
+      ],
+    };
+    active.sessions.push({
+      sessionId: 'shared-active',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Primary shared active',
+    });
+    active.exportSession.mockResolvedValue(exportResult);
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: async () =>
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'shared-active',
+                workspaceCwd: cwd,
+                displayName: 'Secondary shared active',
+              },
+            ]
+          : [],
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession: secondaryExport,
+      exportArchivedSession,
+    }));
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:shared'),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await ensureWorkspaceExpanded('other');
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(container.textContent).toContain('Secondary shared active');
+    await selectSessionMenuItem(
+      'Secondary shared active',
+      'Export conversation record',
+    );
+    expect(secondaryExport).toHaveBeenCalledOnce();
+
+    connection.workspaceCwd = '/tmp/project';
+    renderSidebar();
+    const primaryRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((row) => row.textContent?.includes('Primary shared active'));
+    expect(primaryRow?.getAttribute('aria-current')).toBe('page');
+    await selectSessionMenuItem(
+      'Primary shared active',
+      'Export conversation record',
+    );
+    await act(async () => {
+      await active.exportSession.mock.results.at(-1)?.value;
+      resolveSecondaryExport?.(exportResult);
+      await Promise.resolve();
+    });
+    expect(active.exportSession).toHaveBeenCalledWith('shared-active', 'html');
+  });
+
+  it('keeps primary active export on the primary action under session_export only', async () => {
+    const exportResult = {
+      content: '<p>primary export</p>',
+      filename: 'primary.html',
+      mimeType: 'text/html',
+      format: 'html' as const,
+    };
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_export'],
+    };
+    active.sessions.push({
+      sessionId: 'primary-export',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Primary export',
+    });
+    active.exportSession.mockResolvedValue(exportResult);
+    const secondaryExport = vi.fn().mockResolvedValue(exportResult);
+    workspace.client.workspaceByCwd.mockImplementation((_cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession: secondaryExport,
+      exportArchivedSession,
+    }));
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:primary-export'),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    renderSidebar();
+    await selectSessionMenuItem('Primary export', 'Export');
+    await act(async () => {
+      await active.exportSession.mock.results.at(-1)?.value;
+    });
+
+    expect(active.exportSession).toHaveBeenCalledWith('primary-export', 'html');
+    expect(secondaryExport).not.toHaveBeenCalled();
+  });
+
+  it('does not infer secondary active export from session_export', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_export'],
+    };
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue(
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'secondary-legacy-export',
+                workspaceCwd: cwd,
+                displayName: 'Secondary legacy export',
+              },
+            ]
+          : [],
+      ),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await expandWorkspace('other');
+
+    expect(
+      inlineSessionAction('Secondary legacy export', 'Export'),
+    ).toBeUndefined();
+    const trigger = sessionAction('Secondary legacy export');
+    expect(trigger).toBeDefined();
+    await act(async () => {
+      click(trigger!);
+      await Promise.resolve();
+    });
+    expect(
+      Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).some((item) => item.textContent?.includes('Export')),
+    ).toBe(false);
+  });
+
+  it('applies configured, trusted archived actions without a stale-cwd fallback', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'workspace_archived_session_export'],
+    };
+    archived.sessions.push(
+      {
+        sessionId: 'primary-archived-controlled',
+        workspaceCwd: '/tmp/project',
+        displayName: 'Primary archived controlled',
+        isArchived: true,
+      },
+      {
+        sessionId: 'stale-archived-controlled',
+        workspaceCwd: '/tmp/stale',
+        displayName: 'Stale archived controlled',
+        isArchived: true,
+      },
+    );
+
+    renderSidebar({
+      sessionActions: {
+        items: ['details', 'archive', 'delete', 'export'],
+      },
+    });
+    await expandArchived();
+
+    await selectSessionMenuItem('Primary archived controlled', 'Restore');
+    await act(async () => {
+      await archived.unarchiveSession.mock.results.at(-1)?.value;
+    });
+    expect(archived.unarchiveSession).toHaveBeenCalledWith(
+      'primary-archived-controlled',
+    );
+
+    const staleTrigger = sessionAction('Stale archived controlled');
+    expect(staleTrigger).toBeDefined();
+    await act(async () => {
+      click(staleTrigger!);
+      await Promise.resolve();
+    });
+    const staleMenuItems = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).map((item) => item.textContent);
+    expect(staleMenuItems).toContain('Details');
+    expect(staleMenuItems).not.toContain('Export');
+    expect(staleMenuItems).not.toContain('Restore');
+    expect(staleMenuItems).not.toContain('Delete');
+    expect(deleteSessionsData).not.toHaveBeenCalled();
+    expect(exportArchivedSession).not.toHaveBeenCalled();
+  });
+
+  it('clears a secondary delete candidate after its workspace disappears', async () => {
+    const primaryDelete = active.deleteSession;
+    const secondaryDelete = vi.fn().mockResolvedValue({
+      removed: ['secondary-delete'],
+      notFound: [],
+      errors: [],
+    });
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi.fn().mockResolvedValue(
+        cwd === '/tmp/other'
+          ? [
+              {
+                sessionId: 'secondary-delete',
+                workspaceCwd: cwd,
+                displayName: 'Secondary delete',
+              },
+            ]
+          : [],
+      ),
+      listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData:
+        cwd === '/tmp/other' ? secondaryDelete : deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await expandWorkspace('other');
+    await selectSessionMenuItem('Secondary delete', 'Delete');
+    expect(document.body.textContent).toContain('Delete Session');
+
+    const catalogWithoutSecondary = {
+      ...capabilities,
+      workspaces: capabilities.workspaces.filter(
+        (entry) => entry.cwd !== '/tmp/other',
+      ),
+    };
+    connection.capabilities = catalogWithoutSecondary;
+    workspace.capabilities = catalogWithoutSecondary;
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).not.toContain('Delete Session');
+    expect(secondaryDelete).not.toHaveBeenCalled();
+    expect(primaryDelete).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for an explicit primary cwd that disappears from the catalog', async () => {
+    const primaryOnlyCatalog = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'session_export',
+      ],
+      workspaces: capabilities.workspaces.filter((entry) => entry.primary),
+    };
+    connection.capabilities = primaryOnlyCatalog;
+    workspace.capabilities = primaryOnlyCatalog;
+    active.sessions.push(
+      {
+        sessionId: 'explicit-primary-stale',
+        workspaceCwd: '/tmp/project',
+        displayName: 'Explicit primary stale',
+      },
+      {
+        sessionId: 'implicit-primary-fallback',
+        displayName: 'Implicit primary fallback',
+      },
+    );
+
+    const mutationActions = {
+      items: ['rename', 'pin', 'group', 'archive', 'export', 'delete'] as const,
+      inlineItems: ['rename', 'pin', 'archive', 'export', 'delete'] as const,
+    };
+    renderSidebar({ sessionActions: mutationActions });
+    await expandWorkspace('project');
+    await act(async () => {
+      click(inlineSessionAction('Explicit primary stale', 'Delete')!);
+      await Promise.resolve();
+    });
+    expect(document.body.textContent).toContain('Delete Session');
+
+    const catalogWithoutPrimary = {
+      ...primaryOnlyCatalog,
+      workspaces: [],
+    };
+    connection.capabilities = catalogWithoutPrimary;
+    workspace.capabilities = catalogWithoutPrimary;
+    renderSidebar({ sessionActions: mutationActions });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).not.toContain('Delete Session');
+    expect(sessionAction('Explicit primary stale')).toBeUndefined();
+    expect(
+      inlineSessionAction('Explicit primary stale', 'Pin'),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction('Explicit primary stale', 'Delete'),
+    ).toBeUndefined();
+    expect(archiveButtonFor('Explicit primary stale')).toBeUndefined();
+    expect(
+      inlineSessionAction('Explicit primary stale', 'Export'),
+    ).toBeUndefined();
+    expect(
+      inlineSessionAction('Implicit primary fallback', 'Delete'),
+    ).toBeDefined();
+    expect(active.deleteSession).not.toHaveBeenCalled();
+    expect(active.archiveSession).not.toHaveBeenCalled();
+    expect(active.exportSession).not.toHaveBeenCalled();
+  });
+
+  it('treats a no-cwd primary row as current when the connection cwd is omitted', async () => {
+    connection.sessionId = 'current-no-cwd';
+    connection.workspaceCwd = '';
+    active.sessions.push({
+      sessionId: 'current-no-cwd',
+      displayName: 'Current no-cwd primary',
+    });
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'current-no-cwd',
+              workspaceCwd: cwd,
+              displayName: 'Equal-id secondary',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar({
+      sessionActions: {
+        items: ['rename', 'archive', 'delete'],
+        inlineItems: ['rename', 'archive', 'delete'],
+      },
+    });
+    await expandWorkspace('project');
+    await expandWorkspace('other');
+
+    const rename = inlineSessionAction('Current no-cwd primary', 'Rename');
+    const archive = archiveButtonFor('Current no-cwd primary');
+    const remove = inlineSessionAction('Current no-cwd primary', 'Delete');
+    expect(rename?.disabled).toBe(false);
+    expect(archive?.disabled).toBe(true);
+    expect(remove?.disabled).toBe(true);
+    expect(archiveButtonFor('Equal-id secondary')?.disabled).toBe(false);
+
+    await act(async () => {
+      click(archive!);
+      click(remove!);
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).not.toContain('Delete Session');
+    expect(active.archiveSession).not.toHaveBeenCalled();
+    expect(active.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates pending no-cwd primary renames and clears the busy identity afterward', async () => {
+    let resolveFirstRename!: () => void;
+    connection.sessionId = 'rename-no-cwd';
+    connection.workspaceCwd = '';
+    active.sessions.push({
+      sessionId: 'rename-no-cwd',
+      displayName: 'Rename no-cwd primary',
+    });
+    sessionActions.renameSession
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstRename = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    vi.spyOn(HTMLInputElement.prototype, 'focus').mockImplementation(() => {});
+
+    renderSidebar({
+      sessionActions: { items: ['rename'], inlineItems: ['rename'] },
+    });
+    await expandWorkspace('project');
+
+    expect(
+      inlineSessionAction('Rename no-cwd primary', 'Rename')?.disabled,
+    ).toBe(false);
+    await act(async () => {
+      click(inlineSessionAction('Rename no-cwd primary', 'Rename')!);
+      await Promise.resolve();
+    });
+    const input = container.querySelector<HTMLInputElement>('input');
+    expect(input).not.toBeNull();
+    const form = input!.closest('form')!;
+    await act(async () => {
+      setInputValue(input!, 'First rename');
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      );
+      await Promise.resolve();
+    });
+    expect(sessionActions.renameSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      );
+      await Promise.resolve();
+    });
+    expect(sessionActions.renameSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstRename();
+      await sessionActions.renameSession.mock.results[0]?.value;
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      click(inlineSessionAction('Rename no-cwd primary', 'Rename')!);
+      await Promise.resolve();
+    });
+    const secondInput = container.querySelector<HTMLInputElement>('input');
+    expect(secondInput).not.toBeNull();
+    await act(async () => {
+      setInputValue(secondInput!, 'Second rename');
+      secondInput!
+        .closest('form')
+        ?.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true }),
+        );
+      await sessionActions.renameSession.mock.results[1]?.value;
+    });
+    expect(sessionActions.renameSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors a missing rename item for double-click editing', async () => {
+    connection.sessionId = 'current-primary';
+    active.sessions.push({
+      sessionId: 'current-primary',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Current primary',
+    });
+    renderSidebar({ sessionActions: { items: ['details'] } });
+
+    const row = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((candidate) => candidate.textContent?.includes('Current primary'));
+    expect(row).toBeDefined();
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('input')).toBeNull();
+    expect(sessionActions.renameSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps a pinned secondary row restricted until that workspace is locked', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.group === 'pinned'
+        ? [
+            {
+              sessionId: 'pinned-secondary',
+              workspaceCwd: cwd,
+              displayName: 'Pinned secondary',
+              isPinned: true,
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeUndefined();
+    expect(sessionAction('Pinned secondary')).toBeUndefined();
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(inlineSessionAction('Pinned secondary', 'Unpin')).toBeDefined();
+    expect(sessionAction('Pinned secondary')).toBeDefined();
+  });
+
+  it('does not carry an active rename edit across equal session ids in another workspace', async () => {
+    connection.sessionId = 'shared-session';
+    connection.workspaceCwd = '/tmp/other';
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    active.sessions.push({
+      sessionId: 'shared-session',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Primary shared',
+      isPinned: true,
+    });
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.group === 'pinned'
+        ? [
+            {
+              sessionId: 'shared-session',
+              workspaceCwd: cwd,
+              displayName: 'Secondary shared',
+              isPinned: true,
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    const secondaryRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((row) => row.textContent?.includes('Secondary shared'));
+    expect(secondaryRow).toBeDefined();
+    await act(async () => {
+      secondaryRow?.dispatchEvent(
+        new MouseEvent('dblclick', { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+    expect(container.querySelector('input')).not.toBeNull();
+
+    connection.workspaceCwd = '/tmp/project';
+    await act(async () => {
+      renderSidebar({ lockedWorkspaceCwd: '/tmp/project' });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(container.textContent).toContain('Primary shared');
+    expect(container.querySelector('input')).toBeNull();
+    expect(sessionActions.renameSession).not.toHaveBeenCalled();
   });
 
   it('shows only the locked workspace without registration controls', () => {
@@ -873,7 +2366,11 @@ describe('WebShellSidebar non-primary archive', () => {
     expect(container.textContent).not.toContain('Archived');
   });
 
-  it('keeps untrusted secondary sessions read-only', async () => {
+  it('keeps a locked untrusted secondary active row read-only', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
     useWorkspaceSessionCatalog(async (cwd, options) =>
       cwd === '/tmp/danger' && options?.archiveState === 'active'
         ? [
@@ -886,11 +2383,125 @@ describe('WebShellSidebar non-primary archive', () => {
         : [],
     );
 
-    renderSidebar();
-    await expandWorkspace('danger');
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/danger' });
+    await ensureWorkspaceExpanded('danger');
     expect(container.textContent).toContain('Untrusted active');
+    expect(sessionAction('Untrusted active')).toBeUndefined();
+    expect(inlineSessionAction('Untrusted active', 'Pin')).toBeUndefined();
+    expect(inlineSessionAction('Untrusted active', 'Delete')).toBeUndefined();
     expect(archiveButtonFor('Untrusted active')).toBeUndefined();
     expect(archiveSessionsData).not.toHaveBeenCalled();
+    expect(deleteSessionsData).not.toHaveBeenCalled();
+    expect(updateSessionOrganization).not.toHaveBeenCalled();
+  });
+
+  it('keeps an untrusted primary active row read-only and action-free', async () => {
+    connection.sessionId = 'untrusted-primary-active';
+    connection.workspaceCwd = '/tmp/project';
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'session_export',
+      ],
+      workspaces: capabilities.workspaces.map((entry) =>
+        entry.primary ? { ...entry, trusted: false } : entry,
+      ),
+    };
+    workspace.capabilities = connection.capabilities;
+    active.sessions.push({
+      sessionId: 'untrusted-primary-active',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Untrusted primary active',
+    });
+
+    renderSidebar({
+      sessionActions: {
+        items: [
+          'details',
+          'rename',
+          'pin',
+          'group',
+          'archive',
+          'export',
+          'delete',
+        ],
+        inlineItems: ['rename', 'pin', 'archive', 'export', 'delete'],
+      },
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(container.textContent).toContain('Untrusted primary active');
+    // Active read-only rows have no action menu; archived rows retain the
+    // separately configured Details-only menu below.
+    expect(sessionAction('Untrusted primary active')).toBeUndefined();
+    expect(
+      inlineSessionAction('Untrusted primary active', 'Pin'),
+    ).toBeUndefined();
+    expect(archiveButtonFor('Untrusted primary active')).toBeUndefined();
+    expect(sessionActions.renameSession).not.toHaveBeenCalled();
+    expect(active.archiveSession).not.toHaveBeenCalled();
+    expect(active.deleteSession).not.toHaveBeenCalled();
+    expect(active.exportSession).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a locked-secondary delete item error without falling back to primary', async () => {
+    const onError = vi.fn();
+    deleteSessionsData.mockResolvedValue({
+      removed: [],
+      notFound: [],
+      errors: [
+        {
+          sessionId: 'locked-delete-error',
+          error: 'daemon denied delete',
+        },
+      ],
+    });
+    useWorkspaceSessionCatalog(async (cwd, options) =>
+      cwd === '/tmp/other' && options?.archiveState === 'active'
+        ? [
+            {
+              sessionId: 'locked-delete-error',
+              workspaceCwd: cwd,
+              displayName: 'Locked delete error',
+            },
+          ]
+        : [],
+    );
+
+    renderSidebar({
+      lockedWorkspaceCwd: '/tmp/other',
+      onError,
+      sessionActions: { items: ['delete'], inlineItems: ['delete'] },
+    });
+    await ensureWorkspaceExpanded('other');
+    const deleteButton = inlineSessionAction('Locked delete error', 'Delete');
+    expect(deleteButton).toBeDefined();
+
+    await act(async () => {
+      click(deleteButton!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      click(dialogButton('Delete'));
+      await deleteSessionsData.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(deleteSessionsData).toHaveBeenCalledWith(['locked-delete-error']);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'daemon denied delete' }),
+      'Failed to delete session',
+    );
+    expect(active.deleteSession).not.toHaveBeenCalled();
+    expect(active.reload).not.toHaveBeenCalled();
+    expect(archived.reload).not.toHaveBeenCalled();
+    expect(inlineSessionAction('Locked delete error', 'Delete')?.disabled).toBe(
+      false,
+    );
   });
 
   it('treats an idempotent secondary archive as success despite a matching current id', async () => {
@@ -1087,11 +2698,57 @@ describe('WebShellSidebar archived session export', () => {
       await Promise.resolve();
     });
 
-    expect(
-      Array.from(
-        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
-      ).some((item) => item.textContent?.includes('Export')),
-    ).toBe(false);
+    const archivedItems = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).map((item) => item.textContent);
+    expect(archivedItems).toEqual(['Details']);
+    expect(deleteSessionsData).not.toHaveBeenCalled();
+    expect(unarchiveSessionsData).not.toHaveBeenCalled();
+  });
+
+  it('keeps an untrusted primary archived row action-free except configured Details', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'session_export',
+        'workspace_archived_session_export',
+      ],
+      workspaces: capabilities.workspaces.map((entry) =>
+        entry.primary ? { ...entry, trusted: false } : entry,
+      ),
+    };
+    workspace.capabilities = connection.capabilities;
+    archived.sessions.push({
+      sessionId: 'untrusted-primary-archived',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Untrusted primary archived',
+      isArchived: true,
+    });
+    archived.deleteSession.mockClear();
+    archived.unarchiveSession.mockClear();
+
+    renderSidebar({
+      sessionActions: {
+        items: [
+          'details',
+          'rename',
+          'pin',
+          'group',
+          'archive',
+          'export',
+          'delete',
+        ],
+      },
+    });
+    await expandArchived();
+
+    const items = await openSessionMenuItems('Untrusted primary archived');
+    expect(items).toEqual(['Details']);
+    expect(archived.unarchiveSession).not.toHaveBeenCalled();
+    expect(archived.deleteSession).not.toHaveBeenCalled();
+    expect(exportArchivedSession).not.toHaveBeenCalled();
   });
 
   it('exports equal-id archived rows through their owning workspaces', async () => {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -71,7 +71,8 @@ const {
         | {
             qwenCodeVersion: string;
             features: string[];
-            workspaces: DaemonWorkspaceCapability[];
+            workspaceCwd?: string;
+            workspaces?: DaemonWorkspaceCapability[];
           }
         | undefined,
     },
@@ -80,7 +81,8 @@ const {
         | {
             qwenCodeVersion: string;
             features: string[];
-            workspaces: DaemonWorkspaceCapability[];
+            workspaceCwd?: string;
+            workspaces?: DaemonWorkspaceCapability[];
           }
         | undefined,
       client: {
@@ -185,6 +187,7 @@ function renderSidebar(
     onOpenGoals?: () => void;
     onOpenAddWorkspace?: () => void;
     onNewSession?: (workspaceCwd?: string) => boolean;
+    workspaces?: DaemonWorkspaceCapability[];
     lockedWorkspaceCwd?: string;
     lockedWorkspace?: {
       render?: (workspace: DaemonWorkspaceCapability) => ReactNode;
@@ -227,6 +230,7 @@ function renderSidebar(
           selectedWorkspaceCwd={overrides.selectedWorkspaceCwd}
           onSelectWorkspace={overrides.onSelectWorkspace}
           onOpenAddWorkspace={overrides.onOpenAddWorkspace}
+          workspaces={overrides.workspaces}
           lockedWorkspaceCwd={overrides.lockedWorkspaceCwd}
           lockedWorkspace={overrides.lockedWorkspace}
           sessionActions={overrides.sessionActions}
@@ -808,6 +812,7 @@ describe('WebShellSidebar workspace removal', () => {
     );
     const secondaryOrganization = vi.fn().mockResolvedValue({});
     const primaryOrganization = vi.fn().mockResolvedValue({});
+    const onError = vi.fn();
     workspaceActions.listSessionGroups.mockResolvedValue({
       groups: [],
       colorOptions: ['blue'],
@@ -852,6 +857,7 @@ describe('WebShellSidebar workspace removal', () => {
 
     renderSidebar({
       lockedWorkspaceCwd: '/tmp/other',
+      onError,
       sessionActions: { items: ['group'] },
     });
     await ensureWorkspaceExpanded('other');
@@ -886,13 +892,12 @@ describe('WebShellSidebar workspace removal', () => {
       '#session-group-name',
     );
     expect(groupName).not.toBeNull();
+    const groupForm = groupName!.closest('form')!;
     await act(async () => {
       setInputValue(groupName!, 'Created during unlock');
-      groupName!
-        .closest('form')
-        ?.dispatchEvent(
-          new Event('submit', { bubbles: true, cancelable: true }),
-        );
+      groupForm.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      );
       await Promise.resolve();
     });
     expect(createSessionGroup).toHaveBeenCalledWith({
@@ -914,6 +919,20 @@ describe('WebShellSidebar workspace removal', () => {
 
     expect(secondaryOrganization).not.toHaveBeenCalled();
     expect(primaryOrganization).not.toHaveBeenCalled();
+    expect(
+      document.body.querySelector<HTMLInputElement>('#session-group-name'),
+    ).toBeNull();
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Group created, but failed to move session into it',
+    );
+    await act(async () => {
+      groupForm.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true }),
+      );
+      await Promise.resolve();
+    });
+    expect(createSessionGroup).toHaveBeenCalledTimes(1);
   });
 
   it('routes locked secondary delete, archive, color, and pinned mutations only to its client', async () => {
@@ -1391,6 +1410,66 @@ describe('WebShellSidebar workspace removal', () => {
     expect(exportArchivedSession).not.toHaveBeenCalled();
   });
 
+  it('gates primary group header controls on the live organization policy', async () => {
+    const organizedCapabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    connection.capabilities = organizedCapabilities;
+    workspace.capabilities = organizedCapabilities;
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [
+        {
+          id: 'primary-policy-group',
+          name: 'Primary policy group',
+          color: 'blue',
+        },
+      ],
+      colorOptions: ['blue'],
+    });
+
+    renderSidebar({ sessionActions: { items: ['group'] } });
+    await act(async () => {
+      await workspaceActions.listSessionGroups.mock.results.at(-1)?.value;
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Primary policy group');
+    expect(
+      container.querySelector('button[aria-label="Rename group"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Delete group"]'),
+    ).not.toBeNull();
+
+    renderSidebar({ sessionActions: { items: [] } });
+    expect(container.textContent).toContain('Primary policy group');
+    expect(
+      container.querySelector('button[aria-label="Rename group"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Delete group"]'),
+    ).toBeNull();
+
+    connection.capabilities = {
+      ...organizedCapabilities,
+      features: organizedCapabilities.features.filter(
+        (feature) => feature !== 'session_organization',
+      ),
+    };
+    workspace.capabilities = connection.capabilities;
+    renderSidebar({ sessionActions: { items: ['group'] } });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('button[aria-label="Rename group"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Delete group"]'),
+    ).toBeNull();
+  });
+
   it('keeps equal-id active export and current state isolated by workspace cwd', async () => {
     const exportResult = {
       content: '<p>export</p>',
@@ -1676,6 +1755,50 @@ describe('WebShellSidebar workspace removal', () => {
     expect(primaryDelete).not.toHaveBeenCalled();
   });
 
+  it('keeps legacy primary actions when capabilities omit the workspace catalog', async () => {
+    const legacyCapabilities = {
+      qwenCodeVersion: '1.2.3',
+      workspaceCwd: '/tmp/project',
+      features: ['session_archive', 'session_export', 'session_organization'],
+    };
+    connection.capabilities = legacyCapabilities;
+    workspace.capabilities = legacyCapabilities;
+    active.sessions.push({
+      sessionId: 'legacy-primary',
+      workspaceCwd: '/tmp/project',
+      displayName: 'Legacy primary',
+    });
+
+    renderSidebar({
+      // App normalizes an omitted capabilities.workspaces field to [].
+      workspaces: [],
+      sessionActions: {
+        items: [
+          'rename',
+          'details',
+          'pin',
+          'group',
+          'archive',
+          'export',
+          'delete',
+        ],
+        inlineItems: ['rename', 'pin', 'archive', 'export', 'delete'],
+      },
+    });
+    await expandWorkspace('project');
+
+    expect(inlineSessionAction('Legacy primary', 'Rename')).toBeDefined();
+    expect(inlineSessionAction('Legacy primary', 'Pin')).toBeDefined();
+    expect(archiveButtonFor('Legacy primary')?.disabled).toBe(false);
+    expect(
+      inlineSessionAction('Legacy primary', 'Export conversation record'),
+    ).toBeDefined();
+    expect(inlineSessionAction('Legacy primary', 'Delete')?.disabled).toBe(
+      false,
+    );
+    expect(sessionAction('Legacy primary')).toBeDefined();
+  });
+
   it('fails closed for an explicit primary cwd that disappears from the catalog', async () => {
     const primaryOnlyCatalog = {
       ...capabilities,
@@ -1922,6 +2045,119 @@ describe('WebShellSidebar workspace removal', () => {
     expect(sessionAction('Pinned secondary')).toBeDefined();
   });
 
+  it('keeps unlocked secondary actions conservative across every sidebar surface', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [
+        ...capabilities.features,
+        'session_organization',
+        'workspace_archived_session_export',
+      ],
+    };
+    workspace.capabilities = connection.capabilities;
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [],
+      colorOptions: ['blue'],
+    });
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      listWorkspaceSessions: vi
+        .fn()
+        .mockImplementation(
+          (options?: { archiveState?: string; group?: string }) => {
+            if (cwd !== '/tmp/other') return [];
+            if (options?.archiveState === 'archived') {
+              return [
+                {
+                  sessionId: 'unlocked-archived',
+                  workspaceCwd: cwd,
+                  displayName: 'Unlocked archived',
+                  isArchived: true,
+                },
+              ];
+            }
+            if (options?.group === 'pinned') {
+              return [
+                {
+                  sessionId: 'unlocked-pinned',
+                  workspaceCwd: cwd,
+                  displayName: 'Unlocked pinned',
+                  isPinned: true,
+                },
+              ];
+            }
+            return [
+              {
+                sessionId: 'unlocked-normal',
+                workspaceCwd: cwd,
+                displayName: 'Unlocked normal',
+                groupId: 'restricted-group',
+              },
+            ];
+          },
+        ),
+      listSessionGroups: vi.fn().mockResolvedValue({
+        groups: [
+          {
+            id: 'restricted-group',
+            name: 'Restricted group',
+            color: 'blue',
+          },
+        ],
+        colorOptions: ['blue'],
+      }),
+      archiveSessionsData,
+      unarchiveSessionsData,
+      deleteSessionsData,
+      updateSessionOrganization,
+      exportSession,
+      exportArchivedSession,
+    }));
+
+    renderSidebar();
+    await expandWorkspace('other');
+    await expandArchived();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(archiveButtonFor('Unlocked normal')?.disabled).toBe(false);
+    expect(sessionAction('Unlocked normal')).toBeUndefined();
+    expect(inlineSessionAction('Unlocked normal', 'Pin')).toBeUndefined();
+    expect(inlineSessionAction('Unlocked normal', 'Delete')).toBeUndefined();
+
+    expect(archiveButtonFor('Unlocked pinned')?.disabled).toBe(false);
+    expect(sessionAction('Unlocked pinned')).toBeUndefined();
+    expect(inlineSessionAction('Unlocked pinned', 'Unpin')).toBeUndefined();
+
+    const archivedItems = await openSessionMenuItems('Unlocked archived');
+    expect(archivedItems).toEqual([
+      'Details',
+      'Export conversation record',
+      'Restore',
+    ]);
+    expect(deleteSessionsData).not.toHaveBeenCalled();
+    expect(updateSessionOrganization).not.toHaveBeenCalled();
+
+    expect(container.textContent).toContain('Restricted group');
+    const secondaryCreateGroup = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        'button[aria-label="Create group"]',
+      ),
+    ).find((button) =>
+      button
+        .closest<HTMLElement>('[class*="headerRow"]')
+        ?.textContent?.includes('other'),
+    );
+    expect(secondaryCreateGroup).toBeUndefined();
+    expect(
+      container.querySelector('button[aria-label="Rename group"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('button[aria-label="Delete group"]'),
+    ).toBeNull();
+  });
+
   it('does not carry an active rename edit across equal session ids in another workspace', async () => {
     connection.sessionId = 'shared-session';
     connection.workspaceCwd = '/tmp/other';
@@ -2156,20 +2392,22 @@ describe('WebShellSidebar non-primary archive', () => {
       errors: [],
     });
 
-    renderSidebar();
+    renderSidebar({
+      sessionActions: { items: ['archive'], inlineItems: [] },
+    });
     await expandWorkspace('other');
     await expandArchived();
     const archiveButton = archiveButtonFor('Secondary active');
-    expect(archiveButton).toBeDefined();
-    const secondaryRow = Array.from(
-      container.querySelectorAll<HTMLElement>('[role="button"]'),
-    ).find((row) => row.textContent?.includes('Secondary active'));
-    expect(
-      secondaryRow?.querySelector('button[aria-label="More actions"]'),
-    ).toBeNull();
+    expect(archiveButton).toBeUndefined();
+    const menuItems = await openSessionMenuItems('Secondary active');
+    expect(menuItems).toEqual(['Archive']);
+    const archiveItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent === 'Archive');
+    expect(archiveItem).toBeDefined();
 
     await act(async () => {
-      click(archiveButton!);
+      click(archiveItem!);
       await archiveSessionsData.mock.results.at(-1)?.value;
       await Promise.resolve();
     });


### PR DESCRIPTION
## What this PR does

This change treats a trusted workspace whose cwd matches `lockWorkspaceCwd` as the host's current actionable workspace even when the daemon reports `primary: false`. It preserves the conservative behavior for ordinary unlocked secondary workspaces, keeps untrusted workspaces read-only, and does not rewrite daemon workspace metadata.

Session details, rename, delete, pin, group, archive, and export controls now share the same workspace-scoped policy across normal, pinned, and archived sections. Every action remains gated by the daemon capability and `sessionActions` configuration, destructive current-session restrictions remain intact, and export is enabled only when the workspace-scoped export capability is explicitly available. Session state is keyed by both cwd and session ID so identical IDs in different workspaces cannot interfere.

The compatibility path also distinguishes a legacy daemon that omits the workspace catalog from a daemon that explicitly publishes a stale or empty catalog: the former may use the trusted locked target, while the latter fails closed. Group creation and group-header actions revalidate the live workspace scope; if the scope disappears after an async create, the editor is closed, the correct catalog is reloaded, and no duplicate group is created. Restricted secondary rows continue to honor `sessionActions.inlineItems` while retaining the existing conservative archive/restore lifecycle.

The change is intentionally delivered with its regression matrix in one PR. Most of the diff is test coverage for the same sidebar policy across trust, lock state, capabilities, configuration, row sections, current-session restrictions, and duplicate session IDs; splitting the component change from those tests would make neither part independently reviewable.

## Why it's needed

A host can explicitly lock WebShell to a dynamically selected workspace and bind the session provider to that workspace. Such a workspace may be trusted and current for the host while still being non-primary in the daemon catalog. The sidebar previously reduced workspace operability to `!workspace.primary`, so these sessions exposed only the conservative archive/load behavior and hid otherwise supported actions.

`primary` describes the daemon's workspace catalog role; it should not override an explicit trusted host lock. The repaired policy recognizes that narrow case without expanding permissions for other secondary workspaces.

## Reviewer Test Plan

### How to verify

1. Configure WebShell with `lockWorkspaceCwd` pointing to a trusted workspace whose daemon entry has `primary: false`, and expose the relevant workspace session capabilities.
2. Confirm a current session can be renamed but cannot be deleted or archived.
3. Confirm a non-current session can expose details, delete, pin, group, archive, and workspace-scoped export only when each corresponding capability and `sessionActions` entry permits it.
4. Repeat with normal, pinned, and archived rows and confirm the policy is consistent.
5. Remove the lock and confirm an ordinary secondary workspace keeps the existing conservative archive/load-only behavior.
6. Mark the workspace untrusted and confirm mutation controls are hidden.
7. Use the same session ID in two workspace cwds and confirm pending/current/action state remains isolated.
8. Remove or replace the locked workspace while a group-create request is in flight and confirm the stale editor closes without creating a duplicate group.

Local verification:

- `npm run test --workspace @qwen-code/web-shell -- components/sidebar/WebShellSidebar.workspace-removal.test.tsx` — 47/47 passed.
- `npm run build --workspace @qwen-code/web-shell` — passed.
- `npm run typecheck --workspace @qwen-code/web-shell` — passed.
- WebShell's full test suite within `npm run preflight` — 131 test files / 2,131 tests passed.
- `npm run pre-commit` — passed twice with the staged patch unchanged.
- `npm run preflight` completed clean install, formatting, lint, build, typecheck, Core, WebShell, and the remaining non-CLI workspace suites, but the overall command exited 1 in four unrelated CLI tests on this current-main-based checkout: extensions-list locale expectation, workspace-permissions 400/401 expectation, workspace-settings socket hang-up, and AuthDialog keyboard selection.
- Independent review on the final upstream base found no P0/P1/P2 issue.

### Evidence (Before & After)

Before: a trusted, explicitly locked secondary workspace was classified read-only solely because `primary` was false, leaving only the conservative archive/load behavior visible.

After: that locked workspace exposes only the actions allowed by its live capabilities and `sessionActions`; current-session, untrusted-workspace, unlocked-secondary, and workspace-scoped export restrictions continue to apply. The behavior was also manually verified in a host integration's pre-release environment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js 22.17.1, npm 10.9.2, browser-hosted WebShell integration.

## Risk & Scope

- Main risk or tradeoff: trusted locked secondary workspaces expose more controls than ordinary secondary workspaces; the scope is deliberately narrow and every mutation revalidates the live workspace policy before dispatch.
- Not validated / out of scope: unlocked secondary workspace policy is unchanged; untrusted workspaces remain read-only; daemon `primary` values are untouched; export remains closed unless the workspace-scoped capability is confirmed.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此修改将 cwd 与 `lockWorkspaceCwd` 匹配的可信 workspace 视为宿主当前可操作的 workspace，即使 daemon 返回 `primary: false`。普通未锁定 secondary workspace 仍保持保守策略，untrusted workspace 继续只读，也不会改写 daemon 返回的 workspace 元数据。

普通、置顶和已归档区域中的会话详情、重命名、删除、置顶、分组、归档和导出现在统一使用 workspace-scoped 权限策略。每项操作仍受 daemon capability 与 `sessionActions` 配置控制，当前会话的破坏性操作限制保持不变；只有明确具备 workspace-scoped 导出 capability 时才开放导出。会话状态同时以 cwd 和 session ID 为键，避免不同 workspace 中相同 ID 的会话互相干扰。

兼容路径还会区分“旧 daemon 未返回 workspace catalog”和“daemon 明确返回了过期或空 catalog”：前者可以使用可信的锁定目标，后者保持 fail-closed。分组创建和分组头操作会重新校验实时 workspace scope；如果异步创建完成后 scope 已失效，会关闭编辑器、重载正确 catalog 并避免重复创建分组。受限 secondary 会话行继续遵循 `sessionActions.inlineItems`，同时保留现有保守的归档/恢复生命周期。

此修改与回归测试矩阵需要在同一个 PR 中交付。diff 的大部分内容是围绕同一 Sidebar 权限策略补充的测试，覆盖信任状态、锁定状态、capability、配置、展示区域、当前会话限制和重复 session ID；如果将组件修改与这些测试拆开，两部分都无法独立完成有效评审。

## 为什么需要

宿主可以明确将 WebShell 锁定到动态选择的 workspace，并把 session provider 绑定到该 workspace。这个 workspace 对宿主来说可能是可信且当前的，但在 daemon 目录中仍然是 non-primary。Sidebar 之前直接使用 `!workspace.primary` 判断整体可操作性，因此这些会话只暴露保守的归档/加载行为，其他本应支持的操作全部被隐藏。

`primary` 描述的是 daemon workspace 目录中的角色，不应覆盖宿主明确指定的可信锁定目标。修复只识别这一窄场景，不会扩大其他 secondary workspace 的权限。

## 评审测试计划

### 如何验证

1. 使用 `lockWorkspaceCwd` 将 WebShell 指向一个 daemon 条目中 `primary: false` 的可信 workspace，并开放相关 workspace session capabilities。
2. 确认当前会话可以重命名，但不能删除或归档。
3. 确认非当前会话仅在相应 capability 与 `sessionActions` 允许时展示详情、删除、置顶、分组、归档和 workspace-scoped 导出。
4. 在普通、置顶和已归档会话区域重复验证，确认策略一致。
5. 移除锁定，确认普通 secondary workspace 保持现有保守的 archive/load-only 行为。
6. 将 workspace 标记为 untrusted，确认变更类操作被隐藏。
7. 在两个 workspace cwd 中使用相同 session ID，确认 pending、current 与 action 状态互不干扰。
8. 在分组创建请求进行中移除或替换锁定 workspace，确认过期编辑器会关闭且不会重复创建分组。

本地验证：

- `npm run test --workspace @qwen-code/web-shell -- components/sidebar/WebShellSidebar.workspace-removal.test.tsx` — 47/47 通过。
- `npm run build --workspace @qwen-code/web-shell` — 通过。
- `npm run typecheck --workspace @qwen-code/web-shell` — 通过。
- `npm run preflight` 中的 WebShell 全量测试 — 131 个测试文件、2,131 个测试通过。
- `npm run pre-commit` — 执行两次均通过，暂存 patch 未变化。
- `npm run preflight` 已完成干净安装、格式化、lint、构建、类型检查、Core、WebShell 和其他非 CLI workspace 测试，但在基于当前 main 的 checkout 中因四个无关 CLI 测试而整体以 1 退出：扩展列表 locale 期望、workspace-permissions 的 400/401 期望、workspace-settings 的 socket hang-up，以及 AuthDialog 键盘选择。
- 最终上游基线上的独立评审未发现 P0/P1/P2 问题。

### 证据（修改前后）

修改前：可信且被宿主明确锁定的 secondary workspace 仅因 `primary` 为 false 就被整体判为只读，只显示保守的归档/加载行为。

修改后：该锁定 workspace 只展示其实时 capability 与 `sessionActions` 允许的操作；当前会话、untrusted workspace、未锁定 secondary workspace 和 workspace-scoped 导出限制继续生效。该行为也已在宿主集成的预发环境中人工验证。

### 测试系统

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js 22.17.1、npm 10.9.2、浏览器宿主中的 WebShell 集成。

## 风险与范围

- 主要风险或权衡：可信的 locked secondary workspace 会比普通 secondary workspace 暴露更多操作；范围被严格限定，每次 mutation 分发前都会重新校验实时 workspace 策略。
- 未验证或范围外：未锁定 secondary workspace 策略不变；untrusted workspace 继续只读；不修改 daemon 的 `primary` 值；未确认 workspace-scoped capability 时导出继续关闭。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
