### PR TITLE
ci: label a PR that closes an issue its own author opened

### DIFF
--- a/.github/workflows/pr-self-report-label.yml
+++ b/.github/workflows/pr-self-report-label.yml
@@ -9,7 +9,7 @@ name: 'PR self-report label'
 
 on:
   pull_request_target:
-    types: ['opened', 'edited', 'reopened']
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 permissions:
   contents: 'read'
@@ -39,9 +39,12 @@ jobs:
         run: |
           set -euo pipefail
           # Issues this PR closes — "Fixes/Closes #N" keywords AND Development
-          # sidebar links — and the login that OPENED each. Fail-open to empty
-          # (an API blip must never strip a correct label).
-          ISSUE_AUTHORS="$(gh api graphql \
+          # sidebar links — and the login that OPENED each. Track whether the
+          # query succeeded: an API blip must never strip a correct label, so a
+          # failed query sets API_OK=false and blocks removal (fail-open) rather
+          # than masquerading as "no linked issues".
+          API_OK='false'
+          if ISSUE_AUTHORS="$(gh api graphql \
             -f owner="${REPO%/*}" -f name="${REPO#*/}" -F pr="${PR}" -f query='
             query($owner: String!, $name: String!, $pr: Int!) {
               repository(owner: $owner, name: $name) {
@@ -50,7 +53,9 @@ jobs:
                 }
               }
             }' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]
-                     | .author.login // empty' 2> /dev/null || true)"
+                     | .author.login // empty' 2> /dev/null)"; then
+            API_OK='true'
+          fi
 
           # Self-reported iff SOME closed issue was opened by the PR author.
           SELF='false'
@@ -71,11 +76,12 @@ jobs:
               2> /dev/null || true
             gh pr edit "${PR}" --repo "${REPO}" --add-label "${LABEL}"
             echo "🏷️ #${PR}: added ${LABEL} — a closed issue was opened by ${PR_AUTHOR}"
-          elif [[ "${SELF}" != 'true' && "${HAS_LABEL}" == 'true' ]]; then
+          elif [[ "${SELF}" != 'true' && "${HAS_LABEL}" == 'true' && "${API_OK}" == 'true' ]]; then
             # The link was removed or re-pointed to someone else's issue — clear
-            # the now-stale label so it never lies.
+            # the now-stale label so it never lies. Only when the query itself
+            # succeeded: an API failure must not look like "no self-reported link".
             gh pr edit "${PR}" --repo "${REPO}" --remove-label "${LABEL}"
             echo "🏷️ #${PR}: removed ${LABEL} — no self-reported linked issue"
           else
-            echo "#${PR}: no change (self=${SELF}, labeled=${HAS_LABEL})"
+            echo "#${PR}: no change (self=${SELF}, labeled=${HAS_LABEL}, api=${API_OK})"
           fi

--- a/.github/workflows/pr-self-report-label.yml
+++ b/.github/workflows/pr-self-report-label.yml
@@ -25,6 +25,7 @@ jobs:
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code' }}
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
     steps:
       - name: 'Label a self-reported PR'
         # PR-controlled values reach the script ONLY through env, never

--- a/.github/workflows/pr-self-report-label.yml
+++ b/.github/workflows/pr-self-report-label.yml
@@ -1,0 +1,80 @@
+name: PR self-report label
+
+# When a PR closes an issue that its OWN author opened (self-reported and
+# self-fixed), apply a label so a reviewer can see at a glance that the problem
+# itself was not independently reported — worth a look that the issue is real,
+# not only that the fix is correct. Metadata only: it reads the PR's linked
+# issues and applies a label, and NEVER checks out the PR's code, so running
+# under pull_request_target (needed for write access on fork PRs) is safe.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-self-report-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    if: ${{ github.repository == 'QwenLM/qwen-code' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Label a self-reported PR'
+        # PR-controlled values reach the script ONLY through env, never
+        # interpolated into the run body — the injection-safe pattern for
+        # pull_request_target.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          LABEL: review/self-reported
+        run: |
+          set -euo pipefail
+          # Issues this PR closes — "Fixes/Closes #N" keywords AND Development
+          # sidebar links — and the login that OPENED each. Fail-open to empty
+          # (an API blip must never strip a correct label).
+          ISSUE_AUTHORS="$(gh api graphql \
+            -f owner="${REPO%/*}" -f name="${REPO#*/}" -F pr="${PR}" -f query='
+            query($owner: String!, $name: String!, $pr: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 50) { nodes { author { login } } }
+                }
+              }
+            }' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[]
+                     | .author.login // empty' 2> /dev/null || true)"
+
+          # Self-reported iff SOME closed issue was opened by the PR author.
+          SELF='false'
+          while IFS= read -r a; do
+            if [[ -n "${a}" && "${a}" == "${PR_AUTHOR}" ]]; then
+              SELF='true'
+              break
+            fi
+          done <<< "${ISSUE_AUTHORS}"
+
+          HAS_LABEL="$(gh pr view "${PR}" --repo "${REPO}" --json labels \
+            --jq "[.labels[].name] | index(\"${LABEL}\") != null" 2> /dev/null || echo 'false')"
+
+          if [[ "${SELF}" == 'true' && "${HAS_LABEL}" != 'true' ]]; then
+            # Create the label on first use (idempotent), then apply it.
+            gh label create "${LABEL}" --repo "${REPO}" --color 'BFD4F2' \
+              --description 'The linked issue was opened by the PR author (self-reported)' \
+              2> /dev/null || true
+            gh pr edit "${PR}" --repo "${REPO}" --add-label "${LABEL}"
+            echo "🏷️ #${PR}: added ${LABEL} — a closed issue was opened by ${PR_AUTHOR}"
+          elif [[ "${SELF}" != 'true' && "${HAS_LABEL}" == 'true' ]]; then
+            # The link was removed or re-pointed to someone else's issue — clear
+            # the now-stale label so it never lies.
+            gh pr edit "${PR}" --repo "${REPO}" --remove-label "${LABEL}"
+            echo "🏷️ #${PR}: removed ${LABEL} — no self-reported linked issue"
+          else
+            echo "#${PR}: no change (self=${SELF}, labeled=${HAS_LABEL})"
+          fi

--- a/.github/workflows/pr-self-report-label.yml
+++ b/.github/workflows/pr-self-report-label.yml
@@ -1,4 +1,4 @@
-name: PR self-report label
+name: 'PR self-report label'
 
 # When a PR closes an issue that its OWN author opened (self-reported and
 # self-fixed), apply a label so a reviewer can see at a glance that the problem
@@ -9,32 +9,33 @@ name: PR self-report label
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: ['opened', 'edited', 'reopened']
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: 'read'
+  issues: 'write'
+  pull-requests: 'write'
 
 concurrency:
-  group: pr-self-report-${{ github.event.pull_request.number }}
+  group: 'pr-self-report-${{ github.event.pull_request.number }}'
   cancel-in-progress: true
 
 jobs:
   label:
-    if: ${{ github.repository == 'QwenLM/qwen-code' }}
-    runs-on: ubuntu-latest
+    if: |-
+      ${{ github.repository == 'QwenLM/qwen-code' }}
+    runs-on: 'ubuntu-latest'
     steps:
       - name: 'Label a self-reported PR'
         # PR-controlled values reach the script ONLY through env, never
         # interpolated into the run body — the injection-safe pattern for
         # pull_request_target.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          LABEL: review/self-reported
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          REPO: '${{ github.repository }}'
+          PR: '${{ github.event.pull_request.number }}'
+          PR_AUTHOR: '${{ github.event.pull_request.user.login }}'
+          LABEL: 'review/self-reported'
         run: |
           set -euo pipefail
           # Issues this PR closes — "Fixes/Closes #N" keywords AND Development

--- a/scripts/tests/pr-self-report-label.test.js
+++ b/scripts/tests/pr-self-report-label.test.js
@@ -71,6 +71,7 @@ describe('pr-self-report-label', () => {
     return {
       added: /add-label/.test(calls),
       removed: /remove-label/.test(calls),
+      labelCreated: /label create/.test(calls),
       out: out.trim(),
     };
   };
@@ -79,6 +80,7 @@ describe('pr-self-report-label', () => {
     expect(run({ prAuthor: 'alice', issueAuthors: 'alice' })).toMatchObject({
       added: true,
       removed: false,
+      labelCreated: true,
     });
     // One self-reported issue among several linked is enough.
     expect(

--- a/scripts/tests/pr-self-report-label.test.js
+++ b/scripts/tests/pr-self-report-label.test.js
@@ -17,9 +17,9 @@ import {
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
-import yaml from 'js-yaml';
+import { parse } from 'yaml';
 
-const workflow = yaml.load(
+const workflow = parse(
   readFileSync('.github/workflows/pr-self-report-label.yml', 'utf8'),
 );
 const runBlock = workflow.jobs.label.steps[0].run;
@@ -31,7 +31,7 @@ const GH_STUB = [
   '#!/usr/bin/env bash',
   'echo "gh $*" >> "${CALLS_LOG}"',
   'case "$*" in',
-  "  *'api graphql'*) printf '%s\\n' ${GH_ISSUE_AUTHORS:-} ;;",
+  "  *'api graphql'*) [ \"${GH_API_FAILS:-false}\" = true ] && exit 1; printf '%s\\n' ${GH_ISSUE_AUTHORS:-} ;;",
   "  *'pr view'*labels*) { [ \"${GH_HAS_LABEL:-false}\" = true ] && printf 'true' || printf 'false'; } ;;",
   '  *) : ;;',
   'esac',
@@ -39,7 +39,12 @@ const GH_STUB = [
 ].join('\n');
 
 describe('pr-self-report-label', () => {
-  const run = ({ prAuthor = 'alice', issueAuthors = '', hasLabel = false }) => {
+  const run = ({
+    prAuthor = 'alice',
+    issueAuthors = '',
+    hasLabel = false,
+    apiFails = false,
+  }) => {
     const dir = mkdtempSync(join(tmpdir(), 'lbl-'));
     const bin = join(dir, 'bin');
     mkdirSync(bin);
@@ -57,6 +62,7 @@ describe('pr-self-report-label', () => {
         LABEL: 'review/self-reported',
         GH_ISSUE_AUTHORS: issueAuthors,
         GH_HAS_LABEL: String(hasLabel),
+        GH_API_FAILS: String(apiFails),
       },
       encoding: 'utf8',
     });
@@ -101,6 +107,18 @@ describe('pr-self-report-label', () => {
     // A PR that closes no issue is never labelled.
     expect(
       run({ prAuthor: 'alice', issueAuthors: '', hasLabel: false }),
+    ).toMatchObject({ added: false, removed: false });
+  });
+
+  it('fails open: a GraphQL failure never adds or removes the label', () => {
+    // gh api graphql 5xx → API_OK=false. The label state is unknown, so the
+    // step must leave it untouched rather than read empty results as
+    // "no self-reported link" and strip a correct label.
+    expect(
+      run({ prAuthor: 'alice', hasLabel: true, apiFails: true }),
+    ).toMatchObject({ added: false, removed: false });
+    expect(
+      run({ prAuthor: 'alice', hasLabel: false, apiFails: true }),
     ).toMatchObject({ added: false, removed: false });
   });
 

--- a/scripts/tests/pr-self-report-label.test.js
+++ b/scripts/tests/pr-self-report-label.test.js
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import yaml from 'js-yaml';
+
+const workflow = yaml.load(
+  readFileSync('.github/workflows/pr-self-report-label.yml', 'utf8'),
+);
+const runBlock = workflow.jobs.label.steps[0].run;
+
+// The step decides label state from two inputs: the logins that opened the PR's
+// closed issues (gh api graphql) and whether the label is already present (gh pr
+// view). Stub both and record which mutation, if any, it makes.
+const GH_STUB = [
+  '#!/usr/bin/env bash',
+  'echo "gh $*" >> "${CALLS_LOG}"',
+  'case "$*" in',
+  "  *'api graphql'*) printf '%s\\n' ${GH_ISSUE_AUTHORS:-} ;;",
+  "  *'pr view'*labels*) { [ \"${GH_HAS_LABEL:-false}\" = true ] && printf 'true' || printf 'false'; } ;;",
+  '  *) : ;;',
+  'esac',
+  'exit 0',
+].join('\n');
+
+describe('pr-self-report-label', () => {
+  const run = ({ prAuthor = 'alice', issueAuthors = '', hasLabel = false }) => {
+    const dir = mkdtempSync(join(tmpdir(), 'lbl-'));
+    const bin = join(dir, 'bin');
+    mkdirSync(bin);
+    const callsLog = join(dir, 'calls.log');
+    writeFileSync(join(bin, 'gh'), GH_STUB);
+    chmodSync(join(bin, 'gh'), 0o755);
+    const out = execFileSync('bash', ['-c', runBlock], {
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        CALLS_LOG: callsLog,
+        REPO: 'o/r',
+        PR: '1',
+        PR_AUTHOR: prAuthor,
+        LABEL: 'review/self-reported',
+        GH_ISSUE_AUTHORS: issueAuthors,
+        GH_HAS_LABEL: String(hasLabel),
+      },
+      encoding: 'utf8',
+    });
+    const calls = existsSync(callsLog) ? readFileSync(callsLog, 'utf8') : '';
+    rmSync(dir, { recursive: true, force: true });
+    return {
+      added: /add-label/.test(calls),
+      removed: /remove-label/.test(calls),
+      out: out.trim(),
+    };
+  };
+
+  it('labels a PR that closes an issue its own author opened', () => {
+    expect(run({ prAuthor: 'alice', issueAuthors: 'alice' })).toMatchObject({
+      added: true,
+      removed: false,
+    });
+    // One self-reported issue among several linked is enough.
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: 'bob\nalice\ncarol' }).added,
+    ).toBe(true);
+  });
+
+  it('removes the label once no closed issue is self-reported', () => {
+    // The link was re-pointed to someone else's issue…
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: 'bob', hasLabel: true }),
+    ).toMatchObject({ added: false, removed: true });
+    // …or removed entirely.
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: '', hasLabel: true }).removed,
+    ).toBe(true);
+  });
+
+  it('makes no change when the label already matches the state', () => {
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: 'alice', hasLabel: true }),
+    ).toMatchObject({ added: false, removed: false });
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: 'bob', hasLabel: false }),
+    ).toMatchObject({ added: false, removed: false });
+    // A PR that closes no issue is never labelled.
+    expect(
+      run({ prAuthor: 'alice', issueAuthors: '', hasLabel: false }),
+    ).toMatchObject({ added: false, removed: false });
+  });
+
+  it('never interpolates PR-controlled data into the run body (env only)', () => {
+    // pull_request_target hardening: the author/number/label reach the script
+    // only through env, so a crafted title or body cannot inject shell.
+    expect(runBlock).not.toMatch(/\$\{\{/);
+  });
+});


### PR DESCRIPTION
## What this PR does

Applies a **`review/self-reported`** label to any PR that closes an issue **its own author opened** — self-reported *and* self-fixed — so a reviewer sees it at a glance and can filter for it.

## Why

Most fixes close an issue someone *else* reported, so the problem was independently validated before the fix. When the reporter and the PR author are the same person, that validation is missing: the review should confirm the issue is real and worth fixing, not only that the diff is correct. Today that requires opening the linked issue and checking who filed it; the label surfaces it in the PR list.

## How

A small `pull_request_target` workflow (`opened` / `edited` / `reopened`). It is **metadata only — it never checks out the PR's code**, which is what makes `pull_request_target` safe here:

1. Reads the PR's `closingIssuesReferences` via GraphQL — this covers both `Fixes/Closes #N` keywords **and** issues linked through the Development sidebar — and the login that opened each.
2. If any of those issues was opened by the PR author → adds `review/self-reported` (creating the label on first use). If a later edit re-points or drops the link so none is self-reported → removes it, so the label never lies.

**Hardening (`pull_request_target`):** PR-controlled values (number, author, repo) reach the script only through `env:`, never interpolated into the `run:` body; permissions are the minimum (`issues: write` to manage the label, `pull-requests: write` to apply it); it is gated to `QwenLM/qwen-code`. Any API failure is fail-open — it never strips a correct label on a blip.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/pr-self-report-label.test.js` — extracts the real `run:` block and replays it under bash with a stubbed `gh`, over: self-reported issue → **add**; one match among several linked → add; link re-pointed to another author (or dropped) → **remove**; state already correct → **no change**; PR closing no issue → no label. Plus a guard that the block contains no `${{ }}` interpolation (the injection-safe pattern).
2. Mutation-verified: flipping the author-equality check (`==` → `!=`) turns the three behavioural tests red.
3. Static, exact CI toolchain: `js-yaml` parses; the `run:` block passes `bash -n`; actionlint 1.7.12 clean; prettier clean.
4. Post-merge smoke: open a PR with `Fixes #<an-issue-you-filed>` → it gets `review/self-reported`; edit the body to drop the reference → the label clears.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ CI |

## Risk & Scope

- The label name `review/self-reported` is a single `env:` constant — trivial to rename if you prefer another (e.g. `status/self-reported`).
- Coverage: `Fixes/Closes #N` keywords fire on `edited`; a purely sidebar-linked issue added later (no PR event) is picked up on the next `edited`/`reopened`, not instantly. Good enough for the common case; a scheduled sweep could close that gap later if it matters.
- No behaviour change to any existing workflow; this is an additive, metadata-only labeler.
- Breaking changes / migration notes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给任何"关闭了**由其作者本人提出的** issue"的 PR(自己报、自己修)打上 **`review/self-reported`** 标签,让评审者一眼看到、并能筛选。

## 为什么

大多数修复关闭的是**别人**报的 issue,问题在修复前已被独立验证。当报告者与 PR 作者是同一人时,这层验证缺失:评审应确认这个问题是真的、值得修,而不仅是 diff 对不对。现在这需要点开关联 issue 看是谁提的;标签把它直接暴露在 PR 列表里。

## 怎么做

一个小的 `pull_request_target` workflow(`opened`/`edited`/`reopened`),**纯 metadata —— 从不 checkout PR 代码**,这正是 `pull_request_target` 在此安全的原因:

1. 用 GraphQL 读 PR 的 `closingIssuesReferences`(既含 `Fixes/Closes #N` 关键字,也含 Development 侧栏链接的 issue)及各自的开启者 login。
2. 若其中任一 issue 由 PR 作者开启 → 打 `review/self-reported`(首次使用时创建该标签)。若之后编辑把链接改指他人/移除、致无自报 issue → 摘除,标签绝不说谎。

**加固(`pull_request_target`):** PR 可控值(编号、作者、仓库)只经 `env:` 进入脚本,绝不插入 `run:` 正文;权限最小化;仅限 `QwenLM/qwen-code`。任一 API 失败均 fail-open,绝不因抖动误摘正确标签。

## 评审验证

1. `npx vitest run scripts/tests/pr-self-report-label.test.js` —— 抽出真实 `run:` 块、桩 `gh` 回放(自报→add;多个关联其一匹配→add;改指他人/移除→remove;状态已对→no change;不关闭任何 issue→不打标),外加"块内无 `${{ }}` 插值"的守卫。
2. 变异验证:把作者相等判断(`==`→`!=`)翻转,三个行为测试转红。
3. 静态(CI 一致工具):js-yaml 可解析;`run:` 块过 `bash -n`;actionlint 1.7.12 clean;prettier clean。
4. 合并后冒烟:开一个带 `Fixes #<你提的issue>` 的 PR → 得到 `review/self-reported`;编辑移除该引用 → 标签清除。

## 风险与范围

- 标签名 `review/self-reported` 是单个 `env:` 常量,想改名(如 `status/self-reported`)很容易。
- 覆盖范围:`Fixes/Closes #N` 关键字在 `edited` 时触发;纯侧栏后加的链接(无 PR 事件)会在下次 `edited`/`reopened` 时被捕获,而非即时。常见情形足够;若需要可后续加定时补扫。
- 不改任何现有 workflow 的行为,纯增量、纯 metadata 的打标器。
- 破坏性变更:无。

</details>
