### PR TITLE
fix(cli): align all TUI icon columns to a uniform 2-col width

### DIFF
--- a/packages/cli/src/ui/FeedbackDialog.tsx
+++ b/packages/cli/src/ui/FeedbackDialog.tsx
@@ -4,6 +4,7 @@ import { t } from '../i18n/index.js';
 import { useUIActions } from './contexts/UIActionsContext.js';
 import { useUIState } from './contexts/UIStateContext.js';
 import { useKeypress } from './hooks/useKeypress.js';
+import { ICON } from './constants.js';
 
 export const FEEDBACK_OPTIONS = {
   GOOD: 1,
@@ -47,7 +48,7 @@ export const FeedbackDialog: React.FC = () => {
   return (
     <Box flexDirection="column" marginY={1}>
       <Box>
-        <Text color="cyan">● </Text>
+        <Text color="cyan">{ICON.CIRCLE_FILLED + ' '}</Text>
         <Text bold>{t('How is Qwen doing this session? (optional)')}</Text>
       </Box>
       <Box marginTop={1}>

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
@@ -345,8 +345,8 @@ describe('ProviderSetupSteps', () => {
     expect(inputLine).toContain('custom-model');
     expect(inputLine).not.toContain('MiniMax-M3');
     expect(inputLine).not.toContain('MiniMax-M2.7');
-    expect(frame).toMatch(/◉\s+MiniMax-M3/);
-    expect(frame).toMatch(/◉\s+MiniMax-M2\.7/);
+    expect(frame).toMatch(/◉\uFE0E\s+MiniMax-M3/);
+    expect(frame).toMatch(/◉\uFE0E\s+MiniMax-M2\.7/);
     unmount();
   });
 

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
@@ -11,6 +11,7 @@ import Link from 'ink-link';
 import { DescriptiveRadioButtonSelect } from '../components/shared/DescriptiveRadioButtonSelect.js';
 import { TextInput } from '../components/shared/TextInput.js';
 import { theme } from '../semantic-colors.js';
+import { ICON } from '../constants.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { t } from '../../i18n/index.js';
 import { AuthType } from '@qwen-code/qwen-code-core';
@@ -477,7 +478,9 @@ function ModelIdsStep({
               return (
                 <Box key={item.key} alignItems="flex-start">
                   <Box minWidth={4} flexShrink={0}>
-                    <Text color={textColor}>{isSelected ? '◉' : '○'}</Text>
+                    <Text color={textColor}>
+                      {isSelected ? ICON.RADIO_FILLED : ICON.CIRCLE_EMPTY}
+                    </Text>
                   </Box>
                   <Box flexGrow={1}>
                     <Text color={textColor}>{item.label}</Text>
@@ -556,7 +559,7 @@ function AdvancedConfigStep({
     modalityPdf,
     contextWindowSize,
   } = flow.state;
-  const checkmark = (v: boolean) => (v ? '◉' : '○');
+  const checkmark = (v: boolean) => (v ? ICON.RADIO_FILLED : ICON.CIRCLE_EMPTY);
   const cursor = (index: number) => (focusedConfigIndex === index ? '›' : ' ');
 
   const ctxIdx = modalityEnabled ? 6 : 2;

--- a/packages/cli/src/ui/components/CronPill.test.tsx
+++ b/packages/cli/src/ui/components/CronPill.test.tsx
@@ -17,7 +17,7 @@ describe('CronPill', () => {
 
   it('renders the active scheduled task count', () => {
     const { lastFrame, unmount } = renderWithProviders(<CronPill count={2} />);
-    expect(lastFrame()).toContain('◎ 2 scheduled tasks');
+    expect(lastFrame()).toContain('◎\uFE0E 2 scheduled tasks');
     unmount();
   });
 });

--- a/packages/cli/src/ui/components/CronPill.tsx
+++ b/packages/cli/src/ui/components/CronPill.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { Text } from 'ink';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { useConfig } from '../contexts/ConfigContext.js';
+import { ICON } from '../constants.js';
 import { theme } from '../semantic-colors.js';
 
 const POLL_INTERVAL_MS = 1000;
@@ -45,7 +46,7 @@ export const CronPill: React.FC<CronPillProps> = ({ count }) => {
   const noun = count === 1 ? 'scheduled task' : 'scheduled tasks';
   return (
     <Text color={theme.text.accent}>
-      ◎ {count} {noun}
+      {ICON.BULLSEYE} {count} {noun}
     </Text>
   );
 };

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -223,7 +223,7 @@ describe('<Footer />', () => {
       isCronEnabled: vi.fn(() => true),
       getCronScheduler: vi.fn(() => ({ size: 2 })),
     });
-    expect(lastFrame()).toContain('◎ 2 scheduled tasks');
+    expect(lastFrame()).toContain('◎\uFE0E 2 scheduled tasks');
   });
 
   it('refreshes the scheduled task count after mount', async () => {
@@ -248,7 +248,7 @@ describe('<Footer />', () => {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1000);
       });
-      expect(lastFrame()).toContain('◎ 1 scheduled task');
+      expect(lastFrame()).toContain('◎\uFE0E 1 scheduled task');
 
       schedulerSize = 0;
       await act(async () => {

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -18,7 +18,7 @@ import {
 import { theme } from '../semantic-colors.js';
 
 const TMUX_SPINNER_INTERVAL_MS = 750;
-const TMUX_SPINNER_FRAMES = ['.  ', '.. ', '...'];
+const TMUX_SPINNER_FRAMES = ['. ', '..'];
 
 interface GeminiRespondingSpinnerProps {
   /**

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -83,7 +83,7 @@ export const GeminiSpinner: React.FC<GeminiSpinnerProps> = ({
   if (isTmux) {
     // Note: must NOT wrap in <Box> here — GeminiSpinner is rendered inside a
     // <Text> in Footer.tsx (`<Text>...<GeminiSpinner /> {msg}</Text>`), and
-    // Ink forbids <Box> nested inside <Text>. The 3-char fixed-width frames
+    // Ink forbids <Box> nested inside <Text>. The 2-char fixed-width frames
     // already give us stable layout without an explicit width container.
     return (
       <Text color={theme.text.primary}>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -90,7 +90,8 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output.startsWith('\n')).toBe(true);
-    expect(output).toContain('◆ Hello');
+    expect(output).toContain('◆');
+    expect(output).toContain('Hello');
   });
 
   it('renders tool summaries without a leading spacer row', () => {

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -90,8 +90,7 @@ describe('<HistoryItemDisplay />', () => {
 
     const output = lastFrame() ?? '';
     expect(output.startsWith('\n')).toBe(true);
-    expect(output).toContain('◆');
-    expect(output).toContain('Hello');
+    expect(output).toContain('◆\uFE0E Hello');
   });
 
   it('renders tool summaries without a leading spacer row', () => {

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -68,6 +68,7 @@ import {
   layoutRowForEvent,
 } from '../utils/measure-element-position.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { ICON } from '../constants.js';
 
 interface HistoryItemDisplayProps {
   item: HistoryItem;
@@ -405,7 +406,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
       {itemForDisplay.type === 'tool_use_summary' && (
         <Box flexDirection="row">
           <Box width={2} flexShrink={0}>
-            <Text dimColor>●</Text>
+            <Text dimColor>{ICON.CIRCLE_FILLED}</Text>
           </Box>
           <Text dimColor>{itemForDisplay.summary}</Text>
         </Box>

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -403,8 +403,11 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
         />
       )}
       {itemForDisplay.type === 'tool_use_summary' && (
-        <Box paddingLeft={1}>
-          <Text dimColor>● {itemForDisplay.summary}</Text>
+        <Box flexDirection="row">
+          <Box width={2} flexShrink={0}>
+            <Text dimColor>●</Text>
+          </Box>
+          <Text dimColor>{itemForDisplay.summary}</Text>
         </Box>
       )}
       {itemForDisplay.type === 'compression' && (

--- a/packages/cli/src/ui/components/SettingsDialog.test.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.test.tsx
@@ -307,7 +307,7 @@ describe('SettingsDialog', () => {
       const secondLabel = secondKey
         ? (getSettingDefinition(secondKey)?.label ?? secondKey)
         : '';
-      expect(lastFrame()).toContain(`● ${secondLabel}`);
+      expect(lastFrame()).toContain(`●\uFE0E ${secondLabel}`);
 
       // The active index should have changed (tested indirectly through behavior)
       unmount();
@@ -367,7 +367,7 @@ describe('SettingsDialog', () => {
         : '';
 
       // The first item is highlighted while the list is focused.
-      expect(lastFrame()).toContain(`● ${firstLabel}`);
+      expect(lastFrame()).toContain(`●\uFE0E ${firstLabel}`);
 
       // ↑ from the first item moves focus to the search box: the list highlight
       // disappears and the tab bar is not yet focused.
@@ -375,7 +375,7 @@ describe('SettingsDialog', () => {
         stdin.write(TerminalKeys.UP_ARROW);
       });
       await wait();
-      expect(lastFrame()).not.toContain(`● ${firstLabel}`);
+      expect(lastFrame()).not.toContain(`●\uFE0E ${firstLabel}`);
       expect(lastFrame()).not.toContain('↓ to return');
 
       // ↑ again moves up to the tab bar (which shows its focused hint).
@@ -405,7 +405,7 @@ describe('SettingsDialog', () => {
 
       // Wait for initial render and verify we're on Tool Approval Mode (first setting)
       await waitFor(() => {
-        expect(lastFrame()).toContain('● Tool Approval Mode');
+        expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode');
       });
 
       const dialogKeys = getDialogSettingKeys();
@@ -420,7 +420,7 @@ describe('SettingsDialog', () => {
         await wait();
       }
       await waitFor(() => {
-        expect(lastFrame()).toContain('● Vim Mode');
+        expect(lastFrame()).toContain('●\uFE0E Vim Mode');
       });
 
       // Toggle the setting
@@ -520,7 +520,7 @@ describe('SettingsDialog', () => {
 
         // Verify we're on Tool Approval Mode (first setting, an enum)
         await waitFor(() => {
-          expect(lastFrame()).toContain('● Tool Approval Mode');
+          expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode');
         });
 
         // Press Enter to cycle the enum value
@@ -566,7 +566,7 @@ describe('SettingsDialog', () => {
 
         // Verify we're on Tool Approval Mode (first setting)
         await waitFor(() => {
-          expect(lastFrame()).toContain('● Tool Approval Mode');
+          expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode');
         });
 
         // Press Enter to cycle - should loop back to first value (Plan)
@@ -669,7 +669,7 @@ describe('SettingsDialog', () => {
       });
 
       // The UI should show settings mode is active (scope is in separate view)
-      expect(lastFrame()).toContain('● Tool Approval Mode'); // Settings section active
+      expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode'); // Settings section active
       expect(lastFrame()).not.toContain('Apply To'); // Scope is in a separate view
 
       // This test validates the initial state - scope selection is now
@@ -1137,7 +1137,7 @@ describe('SettingsDialog', () => {
       });
 
       // Verify initial state: settings mode active (scope is in separate view)
-      expect(lastFrame()).toContain('● Tool Approval Mode'); // Settings mode active
+      expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode'); // Settings mode active
       expect(lastFrame()).not.toContain('Apply To'); // Scope is in a separate view
 
       // This test validates the rendered UI structure for tab navigation
@@ -1200,7 +1200,7 @@ describe('SettingsDialog', () => {
 
       // Verify the complete UI is rendered (scope is in separate view)
       expect(lastFrame()).toContain('Settings'); // Title
-      expect(lastFrame()).toContain('● Tool Approval Mode'); // Active setting
+      expect(lastFrame()).toContain('●\uFE0E Tool Approval Mode'); // Active setting
       expect(lastFrame()).not.toContain('Apply To'); // Scope is in a separate view (Tab to access)
       expect(lastFrame()).toContain(
         '(Use Enter to select, Tab to configure scope)',

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -13,6 +13,7 @@ import { SettingScope } from '../../config/settings.js';
 import { getScopeMessageForSetting } from '../../utils/dialogScopeUtils.js';
 import { ScopeSelector } from './shared/ScopeSelector.js';
 import { t } from '../../i18n/index.js';
+import { ICON } from '../constants.js';
 import {
   getDialogSettingKeys,
   setPendingSettingValue,
@@ -1323,7 +1324,7 @@ export function SettingsDialog({
                       isActive ? theme.status.success : theme.text.secondary
                     }
                   >
-                    {isActive ? '●' : ''}
+                    {isActive ? ICON.CIRCLE_FILLED : ''}
                   </Text>
                 </Box>
                 <Box flexGrow={1} flexShrink={1}>

--- a/packages/cli/src/ui/components/StatsSessionTab.tsx
+++ b/packages/cli/src/ui/components/StatsSessionTab.tsx
@@ -7,6 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
+import { ICON } from '../constants.js';
 import { fmtTokens, getSeriesColors } from './stats-helpers.js';
 import { useSessionStats } from '../contexts/SessionContext.js';
 import { computeSessionStats } from '../utils/computeStats.js';
@@ -199,7 +200,9 @@ export const SessionTab: React.FC = () => {
           </Text>
           {Object.entries(metrics.models).map(([name, m], i) => (
             <Box key={name}>
-              <Text color={SERIES_COLORS[i % SERIES_COLORS.length]}>● </Text>
+              <Text color={SERIES_COLORS[i % SERIES_COLORS.length]}>
+                {ICON.CIRCLE_FILLED + ' '}
+              </Text>
               <Text color={theme.text.primary}>{name} </Text>
               <Text color={theme.text.secondary}>
                 {m.api.totalRequests} {t('reqs')} · {t('in')}=

--- a/packages/cli/src/ui/components/StickyTodoList.test.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.test.tsx
@@ -114,7 +114,7 @@ describe('StickyTodoList', () => {
     );
     const output = lastFrame() ?? '';
 
-    expect(output).toContain('10. ◐ Task 10');
+    expect(output).toContain('10. ◐\uFE0E Task 10');
     expect(output).not.toContain('... and 9 more');
   });
 

--- a/packages/cli/src/ui/components/StickyTodoList.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.tsx
@@ -9,6 +9,7 @@ import { memo, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { t } from '../../i18n/index.js';
 import { Colors } from '../colors.js';
+import { ICON } from '../constants.js';
 import { theme } from '../semantic-colors.js';
 import {
   getOrderedStickyTodos,
@@ -24,9 +25,9 @@ interface StickyTodoListProps {
 }
 
 const STATUS_ICONS = {
-  pending: '○',
+  pending: ICON.CIRCLE_EMPTY,
   in_progress: '◐',
-  completed: '●',
+  completed: ICON.CIRCLE_FILLED,
 } as const;
 
 function clampVisibleTodoCount(value: number): number {

--- a/packages/cli/src/ui/components/StickyTodoList.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.tsx
@@ -26,7 +26,7 @@ interface StickyTodoListProps {
 
 const STATUS_ICONS = {
   pending: ICON.CIRCLE_EMPTY,
-  in_progress: '◐',
+  in_progress: ICON.CIRCLE_LEFT_HALF,
   completed: ICON.CIRCLE_FILLED,
 } as const;
 

--- a/packages/cli/src/ui/components/TodoDisplay.tsx
+++ b/packages/cli/src/ui/components/TodoDisplay.tsx
@@ -7,6 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import { Colors } from '../colors.js';
+import { ICON } from '../constants.js';
 
 export interface TodoItem {
   id: string;
@@ -19,9 +20,9 @@ interface TodoDisplayProps {
 }
 
 const STATUS_ICONS = {
-  pending: '○',
+  pending: ICON.CIRCLE_EMPTY,
   in_progress: '◐',
-  completed: '●',
+  completed: ICON.CIRCLE_FILLED,
 } as const;
 
 export const TodoDisplay: React.FC<TodoDisplayProps> = ({ todos }) => {

--- a/packages/cli/src/ui/components/TodoDisplay.tsx
+++ b/packages/cli/src/ui/components/TodoDisplay.tsx
@@ -21,7 +21,7 @@ interface TodoDisplayProps {
 
 const STATUS_ICONS = {
   pending: ICON.CIRCLE_EMPTY,
-  in_progress: '◐',
+  in_progress: ICON.CIRCLE_LEFT_HALF,
   completed: ICON.CIRCLE_FILLED,
 } as const;
 

--- a/packages/cli/src/ui/components/__snapshots__/HistoryItemDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/HistoryItemDisplay.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<HistoryItemDisplay /> > should render a full gemini item when using availableTerminalHeightGemini 1`] = `
 "
-  ◆ Example code block:
+  ◆︎ Example code block:
       1 Line 1
       2 Line 2
       3 Line 3
@@ -111,7 +111,7 @@ exports[`<HistoryItemDisplay /> > should render a full gemini_content item when 
 
 exports[`<HistoryItemDisplay /> > should render a truncated gemini item 1`] = `
 "
-  ◆ Example code block:
+  ◆︎ Example code block:
      ... first 41 lines hidden ...
      42 Line 42
      43 Line 43

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SettingsDialog > Snapshot Tests > should render default state correctly
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -34,7 +34,7 @@ exports[`SettingsDialog > Snapshot Tests > should render focused on scope select
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -59,7 +59,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with accessibility sett
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -84,7 +84,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with all boolean settin
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -109,7 +109,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -134,7 +134,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -159,7 +159,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with file filtering set
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -184,7 +184,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with mixed boolean and 
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -209,7 +209,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with tools and security
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -234,7 +234,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with various boolean se
 │ │ ⌕ Search settings…                                                                           │ │
 │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
 │                                                                                                  │
-│ ● Tool Approval Mode                                                                        Auto │
+│ ●︎ Tool Approval Mode                                                                        Auto │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                       Auto (follow user input) │
 │   Theme                                                                              Qwen Dark ▸ │

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -1048,7 +1048,7 @@ describe('BackgroundTasksDialog', () => {
       h.call(() => h.probe.current!.actions.enterDetail());
       const frame = h.lastFrame() ?? '';
       expect(frame).toContain('Sub-agents');
-      expect(frame).toContain('○ explore — child work');
+      expect(frame).toContain('○\uFE0E explore — child work');
       // The parent itself is top-level: no Parent section, no badge.
       expect(frame).not.toContain('level 1 of');
     });

--- a/packages/cli/src/ui/components/background-view/LiveAgentPanel.test.tsx
+++ b/packages/cli/src/ui/components/background-view/LiveAgentPanel.test.tsx
@@ -719,7 +719,7 @@ describe('<LiveAgentPanel />', () => {
       });
       const { lastFrame } = renderPanel({ entries: [child, parent] });
       const frame = lastFrame() ?? '';
-      expect(frame).toContain('↳ ○ child work');
+      expect(frame).toContain('↳ ○\uFE0E child work');
       expect(frame.indexOf('parent work')).toBeLessThan(
         frame.indexOf('child work'),
       );
@@ -755,7 +755,7 @@ describe('<LiveAgentPanel />', () => {
       });
       const { lastFrame } = renderPanel({ entries: [orphan] });
       const frame = lastFrame() ?? '';
-      expect(frame).toContain('↳ ○ orphan work');
+      expect(frame).toContain('↳ ○\uFE0E orphan work');
       expect(frame).toContain('· from researcher');
       // Root gutter only (paddingX 2 + prefix 2 = 4 cols) — no tree indent
       // despite the launch depth of 2, which would add 4+ more columns.

--- a/packages/cli/src/ui/components/background-view/agent-forest.ts
+++ b/packages/cli/src/ui/components/background-view/agent-forest.ts
@@ -23,6 +23,8 @@
  * sort semantics for roots while keeping trees contiguous.
  */
 
+import { ICON } from '../../constants.js';
+
 /**
  * Minimal structural view of a task entry — satisfied by both `AgentTask`
  * (registry entries) and the CLI's `DialogEntry` union, so the helpers can
@@ -244,7 +246,7 @@ export function treeRowPrefix(
 export function statusGlyph(status: string): string {
   switch (status) {
     case 'running':
-      return '○';
+      return ICON.CIRCLE_EMPTY;
     case 'paused':
       return '⏸';
     case 'completed':
@@ -253,6 +255,6 @@ export function statusGlyph(status: string): string {
     case 'cancelled':
       return '✖';
     default:
-      return '○';
+      return ICON.CIRCLE_EMPTY;
   }
 }

--- a/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.test.tsx
+++ b/packages/cli/src/ui/components/extensions/ExtensionsManagerDialog.test.tsx
@@ -452,7 +452,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     // Enter on the nested row opens the MCP detail view with Extension source.
     stdin.write('\x1B[B'); // down: alpha -> alpha-mcp
     await waitFor(() => {
-      expect(lastFrame()).toMatch(/●\s+└ alpha-mcp/);
+      expect(lastFrame()).toMatch(/●\uFE0E\s+└ alpha-mcp/);
     });
     stdin.write('\r');
     await waitFor(() => {
@@ -499,7 +499,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     });
     stdin.write('\x1B[B'); // down: alpha -> alpha-mcp
     await waitFor(() => {
-      expect(lastFrame()).toMatch(/●\s+└ alpha-mcp/);
+      expect(lastFrame()).toMatch(/●\uFE0E\s+└ alpha-mcp/);
     });
     stdin.write(' '); // Space -> disable just this server
     await waitFor(() => {
@@ -611,7 +611,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     stdin.write('\x1B[B');
     stdin.write('\x1B[B');
     await waitFor(() => {
-      expect(lastFrame()).toContain('● Skills');
+      expect(lastFrame()).toContain('●\uFE0E Skills');
     });
     stdin.write('\r'); // Enter -> open detail
     await waitFor(() => {
@@ -660,7 +660,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     stdin.write('\x1B[B');
     stdin.write('\x1B[B');
     await waitFor(() => {
-      expect(lastFrame()).toContain('● Skills');
+      expect(lastFrame()).toContain('●\uFE0E Skills');
     });
     stdin.write('\r'); // open detail
     await waitFor(() => {
@@ -698,7 +698,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     stdin.write('\x1B[B');
     stdin.write('\x1B[B');
     await waitFor(() => {
-      expect(lastFrame()).toContain('● Skills');
+      expect(lastFrame()).toContain('●\uFE0E Skills');
     });
     stdin.write('\r'); // open detail -> first load fails
     await waitFor(() => {
@@ -759,7 +759,7 @@ describe('ExtensionsManagerDialog (tabbed)', () => {
     stdin.write('\x1B[B');
     stdin.write('\x1B[B');
     await waitFor(() => {
-      expect(lastFrame()).toContain('● Skills');
+      expect(lastFrame()).toContain('●\uFE0E Skills');
     });
     stdin.write('\r'); // Enter -> detail
     await waitFor(() => {

--- a/packages/cli/src/ui/components/extensions/tabs/InstalledTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/InstalledTab.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
+import { ICON } from '../../../constants.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
 import { useTerminalSize } from '../../../hooks/useTerminalSize.js';
 import { keyMatchers, Command } from '../../../keyMatchers.js';
@@ -750,7 +751,7 @@ export const InstalledTab = ({
         const item = row.item;
         const globalIndex = indexByKey.get(item.key) ?? -1;
         const isSelected = globalIndex === selectedIndex;
-        const marker = isSelected ? '●' : ' ';
+        const marker = isSelected ? ICON.CIRCLE_FILLED : ' ';
         const isChild = item.kind === 'mcp' && !!item.parentExtension;
         const kindBadge =
           item.kind === 'mcp'
@@ -803,7 +804,7 @@ export const InstalledTab = ({
                 {item.name}
               </Text>
               {item.isFavorite ? (
-                <Text color={theme.status.warning}> ★</Text>
+                <Text color={theme.status.warning}> {ICON.STAR}</Text>
               ) : null}
             </Box>
             <Text color={isSelected ? theme.text.accent : theme.text.secondary}>

--- a/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
+++ b/packages/cli/src/ui/components/extensions/tabs/SourcesTab.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
+import { ICON } from '../../../constants.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { TextInput } from '../../shared/TextInput.js';
@@ -562,7 +563,9 @@ export const SourcesTab = ({
                 {installedHere.slice(0, INSTALLED_PREVIEW_LIMIT).map((p) => (
                   <Box key={p.name}>
                     <Box minWidth={2} flexShrink={0}>
-                      <Text color={theme.status.success}>{'●'}</Text>
+                      <Text color={theme.status.success}>
+                        {ICON.CIRCLE_FILLED}
+                      </Text>
                     </Box>
                     <Text color={theme.text.primary}>
                       {stripUnsafeCharacters(p.name)}
@@ -646,7 +649,7 @@ export const SourcesTab = ({
       <Box key={`row-${index}`}>
         <Box minWidth={2} flexShrink={0}>
           <Text color={isSelected ? theme.text.accent : theme.text.primary}>
-            {isSelected ? '●' : ' '}
+            {isSelected ? ICON.CIRCLE_FILLED : ' '}
           </Text>
         </Box>
         <Box flexGrow={1}>

--- a/packages/cli/src/ui/components/mcp/steps/ServerListStep.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/ServerListStep.tsx
@@ -7,6 +7,7 @@
 import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
+import { ICON } from '../../../constants.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { t } from '../../../../i18n/index.js';
@@ -192,7 +193,7 @@ export const ServerListStep: React.FC<ServerListStepProps> = ({
       ) && (
         <Box marginTop={1}>
           <Text color={theme.status.warning}>
-            ※ {t('Run qwen --debug to see error logs')}
+            {ICON.REFERENCE} {t('Run qwen --debug to see error logs')}
           </Text>
         </Box>
       )}

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.test.tsx
@@ -555,7 +555,7 @@ describe('estimateCompactToolGroupHeight', () => {
       description: '中文中文中文中文',
     });
 
-    expect(estimateCompactToolGroupHeight([tool], 12)).toBe(4);
+    expect(estimateCompactToolGroupHeight([tool], 12)).toBe(3);
   });
 });
 

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -26,7 +26,7 @@ interface CompactToolGroupDisplayProps {
   contentWidth: number;
 }
 
-const COMPACT_GROUP_HORIZONTAL_PADDING = 2;
+const COMPACT_GROUP_HORIZONTAL_PADDING = 0;
 const ELAPSED_TIME_MARGIN_LEFT = 1;
 const EXECUTING_ELAPSED_TIME_RESERVED_LABEL = '99h 59m 59s';
 
@@ -421,7 +421,7 @@ export const CompactToolGroupDisplay: React.FC<
   const hint = getActiveToolHint(toolCalls);
 
   return (
-    <Box flexDirection="column" width={contentWidth} paddingX={1} gap={0}>
+    <Box flexDirection="column" width={contentWidth} gap={0}>
       <Box flexDirection="row">
         <ToolStatusIndicator status={overallStatus} name={activeTool.name} />
         <Box flexGrow={1}>

--- a/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/CompactToolGroupDisplay.tsx
@@ -26,7 +26,6 @@ interface CompactToolGroupDisplayProps {
   contentWidth: number;
 }
 
-const COMPACT_GROUP_HORIZONTAL_PADDING = 0;
 const ELAPSED_TIME_MARGIN_LEFT = 1;
 const EXECUTING_ELAPSED_TIME_RESERVED_LABEL = '99h 59m 59s';
 
@@ -398,7 +397,6 @@ export function estimateCompactToolGroupHeight(
   const summaryWidth = Math.max(
     1,
     contentWidth -
-      COMPACT_GROUP_HORIZONTAL_PADDING -
       STATUS_INDICATOR_WIDTH -
       getElapsedTimeReservedWidth(activeTool, overallStatus),
   );

--- a/packages/cli/src/ui/components/messages/CompressionMessage.tsx
+++ b/packages/cli/src/ui/components/messages/CompressionMessage.tsx
@@ -68,14 +68,14 @@ export function CompressionMessage({
 
   return (
     <Box flexDirection="row">
-      <Box marginRight={1}>
+      <Box width={2} flexShrink={0}>
         {isPending ? (
           <Spinner type="dots" />
         ) : (
           <Text color={theme.text.accent}>◆</Text>
         )}
       </Box>
-      <Box>
+      <Box flexGrow={1}>
         <Text
           color={
             compression.isPending ? theme.text.accent : theme.status.success

--- a/packages/cli/src/ui/components/messages/CompressionMessage.tsx
+++ b/packages/cli/src/ui/components/messages/CompressionMessage.tsx
@@ -11,6 +11,7 @@ import { theme } from '../../semantic-colors.js';
 import { SCREEN_READER_MODEL_PREFIX } from '../../textConstants.js';
 import { CompressionStatus } from '@qwen-code/qwen-code-core';
 import { t } from '../../../i18n/index.js';
+import { ICON } from '../../constants.js';
 
 export interface CompressionDisplayProps {
   compression: CompressionProps;
@@ -72,7 +73,7 @@ export function CompressionMessage({
         {isPending ? (
           <Spinner type="dots" />
         ) : (
-          <Text color={theme.text.accent}>◆</Text>
+          <Text color={theme.text.accent}>{ICON.DIAMOND}</Text>
         )}
       </Box>
       <Box flexGrow={1}>

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -129,7 +129,7 @@ const PrefixedTextMessage: React.FC<PrefixedTextMessageProps> = ({
       marginTop={marginTop}
       alignSelf={alignSelf}
     >
-      <Box width={prefixWidth}>
+      <Box width={prefixWidth} flexShrink={0}>
         <Text color={prefixColor} aria-label={ariaLabel}>
           {prefix}
         </Text>
@@ -158,7 +158,7 @@ const PrefixedMarkdownMessage: React.FC<PrefixedMarkdownMessageProps> = ({
 
   return (
     <Box flexDirection="row">
-      <Box width={prefixWidth}>
+      <Box width={prefixWidth} flexShrink={0}>
         <Text color={prefixColor} aria-label={ariaLabel}>
           {prefix}
         </Text>

--- a/packages/cli/src/ui/components/messages/ConversationMessages.tsx
+++ b/packages/cli/src/ui/components/messages/ConversationMessages.tsx
@@ -18,11 +18,12 @@ import {
   SCREEN_READER_USER_PREFIX,
 } from '../../textConstants.js';
 import { t } from '../../../i18n/index.js';
+import { ICON } from '../../constants.js';
 import { wrapToVisualLines } from '../../utils/textUtils.js';
 import { formatDuration } from '../../utils/displayUtils.js';
 
-export const THINKING_ICON = '∴ ';
-export const THINKING_ICON_PENDING = '∵ ';
+export const THINKING_ICON = `${ICON.THEREFORE} `;
+export const THINKING_ICON_PENDING = `${ICON.BECAUSE} `;
 
 export const toggleKeyHint =
   process.platform === 'darwin' ? 'option+t' : 'alt+t';
@@ -240,7 +241,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({
 }) => (
   <PrefixedMarkdownMessage
     text={text}
-    prefix="◆"
+    prefix={ICON.DIAMOND}
     prefixColor={theme.text.accent}
     ariaLabel={SCREEN_READER_MODEL_PREFIX}
     isPending={isPending}
@@ -264,7 +265,7 @@ export const AssistantMessageContent: React.FC<
     isPending={isPending}
     availableTerminalHeight={availableTerminalHeight}
     contentWidth={contentWidth}
-    basePrefix="◆"
+    basePrefix={ICON.DIAMOND}
     sourceCopyIndexOffsets={sourceCopyIndexOffsets}
   />
 );

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../semantic-colors.js';
+import { ICON } from '../../constants.js';
 import { formatDuration } from '../../utils/formatters.js';
 import { isTerminalGoalStatusKind, type GoalStatusKind } from '../../types.js';
 
@@ -40,7 +41,7 @@ const GoalStatusMessageInternal: React.FC<GoalStatusMessageProps> = ({
     return (
       <Box flexDirection="row">
         <Box width={2} flexShrink={0}>
-          <Text color={theme.text.secondary}>○</Text>
+          <Text color={theme.text.secondary}>{ICON.CIRCLE_EMPTY}</Text>
         </Box>
         <Box flexGrow={1} flexDirection="column">
           <Text color={theme.text.secondary}>
@@ -69,7 +70,7 @@ const GoalStatusMessageInternal: React.FC<GoalStatusMessageProps> = ({
         // ◎ matches the footer GoalPill's icon — same visual identity for
         // "goal is on / armed" between the history card and the live pill.
         return {
-          prefix: '◎',
+          prefix: ICON.BULLSEYE,
           prefixColor: theme.text.accent,
           title: 'Goal set',
         };
@@ -81,7 +82,7 @@ const GoalStatusMessageInternal: React.FC<GoalStatusMessageProps> = ({
         };
       case 'cleared':
         return {
-          prefix: '○',
+          prefix: ICON.CIRCLE_EMPTY,
           prefixColor: theme.text.secondary,
           title: 'Goal cleared',
         };

--- a/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/InlineParallelAgentsDisplay.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../utils/textUtils.js';
 import { TOOL_DISPLAY_BY_NAME } from '../../utils/tool-display-map.js';
 import { localizeToolDisplayName } from '../../../i18n/index.js';
+import { ICON } from '../../constants.js';
 
 interface InlineParallelAgentsDisplayProps {
   toolCalls: readonly IndividualToolCallDisplay[];
@@ -130,7 +131,7 @@ function statusGlyph(status: AgentResultDisplay['status']): {
   switch (status) {
     case 'running':
     case 'background':
-      return { glyph: '○', color: theme.status.warning };
+      return { glyph: ICON.CIRCLE_EMPTY, color: theme.status.warning };
     case 'completed':
       return { glyph: '✔', color: theme.status.success };
     case 'failed':

--- a/packages/cli/src/ui/components/messages/MemorySavedMessage.tsx
+++ b/packages/cli/src/ui/components/messages/MemorySavedMessage.tsx
@@ -27,7 +27,7 @@ export const MemorySavedMessage: React.FC<MemorySavedMessageProps> = ({
 
   return (
     <Box flexDirection="row">
-      <Box minWidth={2}>
+      <Box width={2} flexShrink={0}>
         <Text dimColor>●</Text>
       </Box>
       <Text dimColor>

--- a/packages/cli/src/ui/components/messages/MemorySavedMessage.tsx
+++ b/packages/cli/src/ui/components/messages/MemorySavedMessage.tsx
@@ -7,6 +7,7 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import type { HistoryItemMemorySaved } from '../../types.js';
+import { ICON } from '../../constants.js';
 
 interface MemorySavedMessageProps {
   item: HistoryItemMemorySaved;
@@ -28,7 +29,7 @@ export const MemorySavedMessage: React.FC<MemorySavedMessageProps> = ({
   return (
     <Box flexDirection="row">
       <Box width={2} flexShrink={0}>
-        <Text dimColor>●</Text>
+        <Text dimColor>{ICON.CIRCLE_FILLED}</Text>
       </Box>
       <Text dimColor>
         {verb} {n} {label}

--- a/packages/cli/src/ui/components/messages/StatusMessages.tsx
+++ b/packages/cli/src/ui/components/messages/StatusMessages.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import Link from 'ink-link';
 import stringWidth from 'string-width';
 import { theme } from '../../semantic-colors.js';
+import { ICON } from '../../constants.js';
 import { RenderInline } from '../../utils/InlineMarkdownRenderer.js';
 
 interface StatusMessageProps {
@@ -69,7 +70,7 @@ export const InfoMessage: React.FC<StatusTextProps> = ({
 }) => (
   <StatusMessage
     text={text}
-    prefix="●"
+    prefix={ICON.CIRCLE_FILLED}
     prefixColor={theme.text.primary}
     textColor={theme.text.primary}
     footer={
@@ -96,7 +97,7 @@ export const SuccessMessage: React.FC<StatusTextProps> = ({ text }) => (
 export const WarningMessage: React.FC<StatusTextProps> = ({ text }) => (
   <StatusMessage
     text={text}
-    prefix="△"
+    prefix={ICON.TRIANGLE}
     prefixColor={theme.status.warning}
     textColor={theme.status.warning}
   />
@@ -132,7 +133,7 @@ export const RetryCountdownMessage: React.FC<StatusTextProps> = ({ text }) => (
 export const VisionNoticeMessage: React.FC<StatusTextProps> = ({ text }) => (
   <StatusMessage
     text={text}
-    prefix="◎"
+    prefix={ICON.BULLSEYE}
     prefixColor={theme.text.secondary}
     textColor={theme.text.secondary}
   />
@@ -145,7 +146,7 @@ export const VisionNoticeMessage: React.FC<StatusTextProps> = ({ text }) => (
 export const AwayRecapMessage: React.FC<StatusTextProps> = ({ text }) => (
   <Box flexDirection="row">
     <Box width={2} flexShrink={0}>
-      <Text color={theme.text.secondary}>※</Text>
+      <Text color={theme.text.secondary}>{ICON.REFERENCE}</Text>
     </Box>
     <Text wrap="wrap">
       <Text color={theme.text.secondary} bold>

--- a/packages/cli/src/ui/components/messages/SummaryMessage.tsx
+++ b/packages/cli/src/ui/components/messages/SummaryMessage.tsx
@@ -49,8 +49,10 @@ export const SummaryMessage: React.FC<SummaryDisplayProps> = ({ summary }) => {
 
   return (
     <Box flexDirection="row">
-      <Box marginRight={1}>{getIcon()}</Box>
-      <Box>
+      <Box width={2} flexShrink={0}>
+        {getIcon()}
+      </Box>
+      <Box flexGrow={1}>
         <Text
           color={summary.isPending ? Colors.AccentPurple : Colors.AccentGreen}
         >

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -441,7 +441,10 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const memoryBadgeHeight = hasMemoryBadge ? 1 : 0;
   const staticHeight =
     /* marginBottom */ 1 + collapsibleSummaryHeight + memoryBadgeHeight;
-  const innerWidth = contentWidth - 2;
+  // ToolConfirmationMessage still has its own padding={1}, so it needs
+  // the -2 reservation. ToolMessage no longer pads itself (paddingX was
+  // removed in the icon-alignment PR), so it gets the full contentWidth.
+  const confirmationInnerWidth = contentWidth - 2;
 
   let countToolCallsWithResults = 0;
   for (const tool of nonCollapsibleTools) {
@@ -487,7 +490,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
               <ToolMessage
                 {...tool}
                 availableTerminalHeight={availableTerminalHeightPerToolMessage}
-                contentWidth={innerWidth}
+                contentWidth={contentWidth}
                 emphasis={
                   isConfirming
                     ? 'high'
@@ -521,7 +524,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   availableTerminalHeight={
                     availableTerminalHeightPerToolMessage
                   }
-                  contentWidth={innerWidth}
+                  contentWidth={confirmationInnerWidth}
                 />
               )}
           </Box>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -18,6 +18,7 @@ import {
 } from './CompactToolGroupDisplay.js';
 import { InlineParallelAgentsDisplay } from './InlineParallelAgentsDisplay.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
+import { ICON } from '../../constants.js';
 import type { AgentResultDisplay } from '@qwen-code/qwen-code-core';
 
 function isAgentWithPendingConfirmation(
@@ -347,7 +348,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         {readCount > 0 && (
           <Box paddingLeft={1}>
             <Text dimColor>
-              {'● '}
+              {ICON.CIRCLE_FILLED + ' '}
               Recalled {readCount} {readCount === 1 ? 'memory' : 'memories'}
             </Text>
           </Box>
@@ -355,7 +356,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         {writeCount > 0 && (
           <Box paddingLeft={1}>
             <Text dimColor>
-              {'● '}
+              {ICON.CIRCLE_FILLED + ' '}
               Wrote {writeCount} {writeCount === 1 ? 'memory' : 'memories'}
             </Text>
           </Box>
@@ -405,7 +406,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const memoryBadge = hasMemoryBadge ? (
     <Box paddingLeft={1}>
       <Text dimColor>
-        {'● '}
+        {ICON.CIRCLE_FILLED + ' '}
         {[
           (memoryReadCount ?? 0) > 0 &&
             `Recalled ${memoryReadCount} ${memoryReadCount === 1 ? 'memory' : 'memories'}`,

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -33,7 +33,7 @@ import {
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
 import { PlanSummaryDisplay } from '../PlanSummaryDisplay.js';
 import { ShellInputPrompt } from '../ShellInputPrompt.js';
-import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
+import { SHELL_COMMAND_NAME, SHELL_NAME, ICON } from '../../constants.js';
 import { isCollapsibleTool } from './CompactToolGroupDisplay.js';
 import { localizeToolDisplayName } from '../../../i18n/index.js';
 import { formatDuration, formatTokenCount } from '../../utils/formatters.js';
@@ -343,7 +343,7 @@ const SubagentApprovalContext: React.FC<{
             ? '✖'
             : call.status === 'success'
               ? '✔'
-              : '○';
+              : ICON.CIRCLE_EMPTY;
         const displayName = localizeToolDisplayName(
           TOOL_DISPLAY_BY_NAME[call.name] ?? call.name,
         );

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -863,7 +863,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
       effectiveDisplayRenderer.type === 'ansi');
 
   return (
-    <Box paddingX={1} paddingY={0} flexDirection="column">
+    <Box paddingY={0} flexDirection="column">
       <Box minHeight={1}>
         <ToolStatusIndicator status={status} name={name} />
         <ToolInfo

--- a/packages/cli/src/ui/components/shared/ToolStatusIndicator.tsx
+++ b/packages/cli/src/ui/components/shared/ToolStatusIndicator.tsx
@@ -15,10 +15,12 @@ import {
 } from '../../constants.js';
 import { theme } from '../../semantic-colors.js';
 
-// One column for the status glyph plus two trailing columns so the tool
+// One column for the status glyph plus one trailing column so the tool
 // name never sits flush against the indicator. Paired with flexShrink={0}
 // on the indicator Box so the reservation survives a tight header row.
-export const STATUS_INDICATOR_WIDTH = 3;
+// The fixed 2-col width ensures both 1-col and 2-col glyphs push text
+// to the same start position.
+export const STATUS_INDICATOR_WIDTH = 2;
 
 type ToolStatusIndicatorProps = {
   status: ToolCallStatus;

--- a/packages/cli/src/ui/components/shared/ToolStatusIndicator.tsx
+++ b/packages/cli/src/ui/components/shared/ToolStatusIndicator.tsx
@@ -35,6 +35,8 @@ export const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
   const statusColor = isShell ? theme.ui.symbol : theme.status.warning;
 
   return (
+    // minWidth (not width) so the box can grow for wider content like the
+    // tmux spinner frames or test mocks; all production glyphs are ≤2 cols.
     <Box minWidth={STATUS_INDICATOR_WIDTH} flexShrink={0}>
       {status === ToolCallStatus.Pending && (
         <Text color={theme.status.success}>{TOOL_STATUS.PENDING}</Text>

--- a/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.test.tsx
+++ b/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.test.tsx
@@ -68,12 +68,12 @@ describe('AgentSelectionStep', () => {
       />,
     );
 
-    expect(lastFrame()).toContain('● first');
+    expect(lastFrame()).toContain('●\uFE0E first');
 
     pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
-    expect(lastFrame()).toContain('● second');
+    expect(lastFrame()).toContain('●\uFE0E second');
 
     pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
-    expect(lastFrame()).toContain('● first');
+    expect(lastFrame()).toContain('●\uFE0E first');
   });
 });

--- a/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.tsx
+++ b/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
+import { ICON } from '../../../constants.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { type SubagentConfig } from '@qwen-code/qwen-code-core';
@@ -321,7 +322,7 @@ export const AgentSelectionStep = ({
       <Box key={`${agent.name}-${agent.level}`} alignItems="center">
         <Box minWidth={2} flexShrink={0}>
           <Text color={isSelected ? theme.text.accent : theme.text.primary}>
-            {isSelected ? '●' : ' '}
+            {isSelected ? ICON.CIRCLE_FILLED : ' '}
           </Text>
         </Box>
         <Text color={textColor} wrap="truncate">

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -27,3 +27,22 @@ export const TOOL_STATUS = {
   CANCELED: '-',
   ERROR: 'x',
 } as const;
+
+// Variation Selector 15 forces narrow (text) presentation for
+// East-Asian-Width "Ambiguous" glyphs so the terminal cursor advance
+// matches string-width's default (ambiguousIsNarrow: true).
+// Without this, CJK terminals render these glyphs as 2 columns while
+// Ink's layout engine allocates 1, causing a 1-column visual drift.
+const _VS15 = '\uFE0E';
+export const ICON = {
+  DIAMOND: `◆${_VS15}`,
+  CIRCLE_FILLED: `●${_VS15}`,
+  TRIANGLE: `△${_VS15}`,
+  CIRCLE_EMPTY: `○${_VS15}`,
+  BULLSEYE: `◎${_VS15}`,
+  REFERENCE: `※${_VS15}`,
+  THEREFORE: `∴${_VS15}`,
+  BECAUSE: `∵${_VS15}`,
+  STAR: `★${_VS15}`,
+  RADIO_FILLED: `◉${_VS15}`,
+} as const;

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -28,11 +28,11 @@ export const TOOL_STATUS = {
   ERROR: 'x',
 } as const;
 
-// Variation Selector 15 forces narrow (text) presentation for
-// East-Asian-Width "Ambiguous" glyphs so the terminal cursor advance
-// matches string-width's default (ambiguousIsNarrow: true).
-// Without this, CJK terminals render these glyphs as 2 columns while
-// Ink's layout engine allocates 1, causing a 1-column visual drift.
+// Variation Selector 15 (U+FE0E) is zero-width in string-width but forces
+// the terminal to render the preceding glyph in narrow (1-column) text
+// presentation. This ensures CJK terminals (which would otherwise render
+// East-Asian-Width "Ambiguous" glyphs as 2 columns) agree with Ink's
+// layout engine (which always measures them as 1 column).
 const _VS15 = '\uFE0E';
 export const ICON = {
   DIAMOND: `◆${_VS15}`,

--- a/packages/cli/src/ui/constants.ts
+++ b/packages/cli/src/ui/constants.ts
@@ -45,4 +45,5 @@ export const ICON = {
   BECAUSE: `∵${_VS15}`,
   STAR: `★${_VS15}`,
   RADIO_FILLED: `◉${_VS15}`,
+  CIRCLE_LEFT_HALF: `◐${_VS15}`,
 } as const;

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -1097,7 +1097,7 @@ Another paragraph.
       );
       const output = lastFrame();
       expect(output).toContain('✓ Done');
-      expect(output).toContain('○ Todo');
+      expect(output).toContain('○\uFE0E Todo');
     });
 
     it('keeps pipes inside markdown table code spans in the same cell', () => {

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Text, Box } from 'ink';
 import { theme } from '../semantic-colors.js';
+import { ICON } from '../constants.js';
 import { colorizeCode } from './CodeColorizer.js';
 import { TableRenderer, type ColumnAlign } from './TableRenderer.js';
 import { RenderInline } from './InlineMarkdownRenderer.js';
@@ -1087,7 +1088,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
   const isTaskChecked = taskMatch?.[1]?.toLowerCase() === 'x';
   const effectiveItemText = isTaskItem ? taskMatch[2] : itemText;
   const prefix = isTaskItem
-    ? `${isTaskChecked ? '✓' : '○'} `
+    ? `${isTaskChecked ? '✓' : ICON.CIRCLE_EMPTY} `
     : type === 'ol'
       ? `${marker}. `
       : `${marker} `;

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { Text, Box } from 'ink';
+import stringWidth from 'string-width';
 import { theme } from '../semantic-colors.js';
 import { ICON } from '../constants.js';
 import { colorizeCode } from './CodeColorizer.js';
@@ -1092,7 +1093,7 @@ const RenderListItemInternal: React.FC<RenderListItemProps> = ({
     : type === 'ol'
       ? `${marker}. `
       : `${marker} `;
-  const prefixWidth = prefix.length;
+  const prefixWidth = stringWidth(prefix);
   const indentation = leadingWhitespace.length;
 
   return (

--- a/packages/cli/src/ui/utils/displayUtils.ts
+++ b/packages/cli/src/ui/utils/displayUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import { theme } from '../semantic-colors.js';
+import { ICON } from '../constants.js';
 import { AgentStatus } from '@qwen-code/qwen-code-core';
 
 // --- Status Labels ---
@@ -26,11 +27,23 @@ export function getArenaStatusLabel(status: AgentStatus): StatusLabel {
     case AgentStatus.FAILED:
       return { icon: '✗', text: 'Failed', color: theme.status.error };
     case AgentStatus.RUNNING:
-      return { icon: '○', text: 'Running', color: theme.text.secondary };
+      return {
+        icon: ICON.CIRCLE_EMPTY,
+        text: 'Running',
+        color: theme.text.secondary,
+      };
     case AgentStatus.INITIALIZING:
-      return { icon: '○', text: 'Initializing', color: theme.text.secondary };
+      return {
+        icon: ICON.CIRCLE_EMPTY,
+        text: 'Initializing',
+        color: theme.text.secondary,
+      };
     default:
-      return { icon: '○', text: status, color: theme.text.secondary };
+      return {
+        icon: ICON.CIRCLE_EMPTY,
+        text: status,
+        color: theme.text.secondary,
+      };
   }
 }
 


### PR DESCRIPTION
## Motivation

In the TUI conversation view, tool status icons were visually indented relative to the assistant message prefix. This happened because ToolMessage wrapped its content in paddingX={1} (adding 1 column of left padding) and used STATUS_INDICATOR_WIDTH = 3 (1 glyph + 2 trailing spaces), while conversation message prefixes used a 2-column gutter (1 glyph + 1 trailing space). The result was a 2-column misalignment between the icon columns of different message types.

Additionally, several message components used inconsistent width strategies for their icon gutters: marginRight={1} (CompressionMessage, SummaryMessage), minWidth={2} (MemorySavedMessage), paddingLeft={1} inline (tool_use_summary), and hardcoded width={2} (GoalStatusMessage, AwayRecapMessage). This made the icon column width unpredictable across message types.

Some icons in the codebase are 2 terminal columns wide (e.g. U+2716, U+2714), which can overflow a gutter sized for 1-column glyphs. A uniform fixed-width gutter handles both 1-col and 2-col glyphs correctly: 1-col glyphs get 1 trailing space, 2-col glyphs fill the gutter exactly, and text always starts at the same column.

A separate but related issue: 8 icon glyphs used in the TUI have East-Asian-Width "Ambiguous" — they render as 1 column in narrow terminals but 2 columns in CJK terminals. Ink's layout engine uses string-width with ambiguousIsNarrow=true (always 1 column), causing a 1-column visual drift in CJK terminals. This is fixed by appending VS15 (U+FE0E, Variation Selector 15) to force narrow presentation in all terminals.

## Changes

- **ToolStatusIndicator**: reduce STATUS_INDICATOR_WIDTH from 3 to 2 so the tool status gutter matches the 2-column prefix width used everywhere else. Uses minWidth (not width) to allow growth for tmux spinner frames and test mocks.
- **ToolMessage**: remove paddingX={1} from the outer wrapper, eliminating the 1-column left indent that pushed tool icons rightward.
- **ToolGroupMessage**: split innerWidth so ToolMessage gets full contentWidth (no longer needs the -2 compensation) while ToolConfirmationMessage keeps contentWidth - 2 (it still has its own padding={1}).
- **CompactToolGroupDisplay**: remove paddingX={1} and remove the now-dead COMPACT_GROUP_HORIZONTAL_PADDING constant from the height estimation formula.
- **ConversationMessages**: add flexShrink={0} to the prefix Box in PrefixedTextMessage and PrefixedMarkdownMessage so the gutter never collapses under tight layouts.
- **CompressionMessage / SummaryMessage**: replace marginRight={1} with the standard width={2} flexShrink={0} prefix box pattern.
- **MemorySavedMessage**: replace minWidth={2} with width={2} flexShrink={0}.
- **HistoryItemDisplay**: restructure tool_use_summary from inline paddingLeft={1} to the standard prefix box pattern.
- **GeminiRespondingSpinner**: reduce TMUX_SPINNER_FRAMES from 3-char to 2-char equivalents so they fit the narrowed 2-col indicator box. This affects all tmux users including the Footer spinner.
- **VS15 narrow presentation**: append U+FE0E to all 8 ambiguous-width icon glyphs via a central ICON constant map in constants.ts. 25+ source files updated to use ICON.XXX instead of raw string literals. Also fixed MarkdownDisplay.tsx to use stringWidth(prefix) instead of prefix.length (which incorrectly counts VS15 as an extra code unit).

## How to verify

1. Start a conversation that triggers tool calls (e.g. ask the model to fetch a URL or read a file).
2. Observe that the assistant prefix, tool status icons, and status message icons all start at the same left column.
3. Observe that the text content after each icon starts at a uniform offset (2 columns from the icon column start).
4. Run /compress and /chat summary to verify CompressionMessage and SummaryMessage icons align with the rest.
5. In a CJK terminal (e.g. LANG=zh_CN.UTF-8), verify that ambiguous icons do not cause a 1-column visual drift.

## Verification (Ink test renderer, 120-col terminal)

Rendered output from an Ink test harness that mirrors the exact component layout (marginLeft=2, prefix/status boxes, paddingLeft=2 continuations):

```
  ◆ 直接抓取遇到了问题，让我用工具试试
  ✓ WebFetch Fetching https://example.com
    processing with proxy...
  x WebFetch {"url":"https://example.com"
    Error during fetch: status code 403
  ✓ Operation completed
  ● Info: something happened
  ✖ Goal failed (2-col icon test)
  △ Warning message
```

Column analysis (stripped of ANSI color codes):

| Line type | Icon | Icon col | Text col |
|-----------|------|----------|----------|
| Assistant message | ◆ (1-col) | 2 | 4 |
| Tool success | ✓ (1-col) | 2 | 4 |
| Tool continuation | — | — | 4 |
| Tool error | x (1-col) | 2 | 4 |
| Tool error continuation | — | — | 4 |
| Status success | ✓ (1-col) | 2 | 4 |
| Info message | ● (1-col) | 2 | 4 |
| **2-col icon** | ✖ U+2716 (2-col) | 2 | 4 |
| Warning | △ (1-col) | 2 | 4 |

All icons start at column 2 (after the outer marginLeft=2), all text starts at column 4. The 2-column-wide ✖ glyph fills the 2-col gutter exactly and text still starts at column 4 — no overflow, no misalignment.
