### PR TITLE
docs(autofix): let the agent escalate a maintainer's decision, not decide it

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -193,6 +193,19 @@ Classify every feedback point:
   reason per finding (out of scope, conflicts with the PR's direction, or not
   worth the diff growth) so the deferral is visible in the PR thread — never
   drop one silently.
+- Needs a maintainer's decision: a finding that turns on a judgment that is
+  NOT yours to make — a product or scope tradeoff (is this acceptable for v1?
+  should the PR be split?), two reviewers asking for opposite things, or whether
+  the reported problem is worth solving at all. Do not settle it yourself:
+  neither quietly implement one contested direction nor decline it as "out of
+  scope" (declining IS deciding). Name the decision, lay out the options and
+  your recommendation, and leave the thread UNRESOLVED so the maintainer reads
+  an explicit question, not a verdict you already reached. This is not a
+  failure and not a "could not address" — do everything else this round; the
+  open question simply rides along in the summary until a human answers it (the
+  answer arrives as ordinary new feedback the next round). Distinguish it from
+  Decline: you decline when the CHANGE is not worth doing; you escalate when the
+  CALL is not yours to make.
 
 If `--conflict true`, merge `origin/<base>` and resolve conflicts by
 understanding both sides, never blindly taking one side. If false, do not merge
@@ -224,8 +237,9 @@ Finish with exactly one outcome:
   comment id per line — the `rc:<id>` handle shown in `feedback.md` — for each
   finding you IMPLEMENTED. The workflow resolves exactly those review threads
   after the push, so a human re-reviewing sees only what is still open. List an
-  id ONLY when you actually made the change: a finding you declined or deferred
-  must stay unresolved so its recorded reason gets read. Omit the file (or
+  id ONLY when you actually made the change: a finding you declined, deferred,
+  or escalated for a maintainer's decision must stay unresolved so its recorded
+  reason or open question gets read. Omit the file (or
   leave it empty) when you implemented nothing that came from an inline
   comment.
 - No change: write `<workdir>/no-action.md` (bilingual per Shared Rules).

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3380,6 +3380,10 @@ describe('qwen-autofix workflow', () => {
     const skill = readAutofixSkill();
     expect(skill).toContain('never');
     expect(skill).toContain('drop one silently');
+    // A third disposition beyond fix/decline: escalate a judgment that is the
+    // maintainer's to make, instead of silently deciding it.
+    expect(skill).toContain("Needs a maintainer's decision");
+    expect(skill).toContain('escalate when the');
   });
 
   it('requires the address path to run verification and record it as evidence', () => {


### PR DESCRIPTION
## What this PR does

Gives the address-review agent a third way to handle a finding — **escalate a maintainer's decision** — instead of being forced to either implement it or decline it (both of which are the agent *deciding*).

## Why

The SKILL classified every feedback point as **fix** or **decline-with-reason**. So when a finding turned on a judgment that is genuinely the maintainer's to make — a v1/product tradeoff, two reviewers asking for opposite things, or whether the reported problem is worth solving at all — the agent had no honest option: it either quietly implemented one contested direction, or declined it as "out of scope". Declining *is* deciding. And when the agent couldn't, it fell into the vague "could not address … a human should take over", which says nothing about *what* decision is needed.

Observed live on #7471: the agent declined several review findings as "design decision / out of scope" (the shared-checkout concurrency tradeoff, branch-metadata persistence). Those were the maintainer's calls — @wenshao then re-litigated them by hand. A cleaner flow names the decision and asks.

## How

One prose change to `Mode: address-review` — the smallest lever, no new marker or state:

- A third disposition, **"Needs a maintainer's decision"**: the agent does *not* settle it (neither implement nor decline). It names the decision, lays out the options and its recommendation, and leaves the review thread **unresolved** so the maintainer reads a question, not a verdict.
- Explicitly *not* a failure and *not* "could not address" — everything else is addressed this round, and the open question just rides along in the summary until a human answers it (the answer arrives as ordinary new feedback the next round). It reuses the existing bilingual summary comment and the review-reply channel — nothing new is built.
- Draws the line: **decline** when the *change* is not worth doing; **escalate** when the *call* is not the agent's to make. An escalated finding stays unresolved alongside declined/deferred ones so its question gets read.

Deliberately the minimal version: the agent-behaviour change (this) is the high-value, low-cost piece. A distinct paused "waiting-on-human" state + label was considered and **left unbuilt** until it's shown the summary/reply channel is insufficient.

## Reviewer Test Plan

- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js -t "decision logic in the project autofix skill"` — the SKILL policy test now also pins the escalate disposition (`Needs a maintainer's decision`, `escalate when the`). Passes.
- Full suite green apart from the pre-existing load flakes (`eligibility recheck`, `permanent API failures terminal`, `admits managed fork PRs` — each passes in isolation and on `main`).
- prettier clean. Prose/markdown + one test assertion only — no workflow logic changes.

## Risk & Scope

- Agent-facing policy only; changes what the agent *does* with a judgment-call finding, no code path in the workflow. Worst case the agent over- or under-uses "escalate", caught by normal human review — strictly safer than today's silent decide-or-bury.
- Breaking changes / migration notes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 address-review agent 处理评审意见的**第三种方式 —— 升级由维护者决策**,而不是被迫二选一(实现它 / 拒绝它,而这两者都是 agent 在**替人做决定**)。

## 为什么

SKILL 把每条反馈只分成 **修** 或 **带理由拒绝**。于是当一条意见的关键是"该由维护者拍板的判断"时 —— v1/产品取舍、两个 reviewer 要求相反、这问题到底值不值得修 —— agent 没有诚实的选项:要么默默实现某个有争议的方向,要么以"out of scope"拒绝(拒绝即是决定);实在不行就落进含糊的"could not address, 交人",却没说清**到底要人决什么**。

#7471 上实测:agent 把几条评审意见以"design decision / out of scope"拒绝(共享 checkout 的并发取舍、分支元数据持久化)—— 那本是维护者的判断,@wenshao 只好手动重新论证。更干净的做法是**点名这个决策并发问**。

## 怎么做

对 `Mode: address-review` 一处 prose 改动 —— 最小杠杆,不新增 marker/状态:

- 第三种处置 **"Needs a maintainer's decision"**:agent **不**自己定(既不实现也不拒绝),而是点名决策、给出选项 + 自己的建议,并让评审线程**保持 unresolved**,让维护者读到的是问题而非已下的判决。
- 明确**不算失败、不算 "could not address"** —— 本轮处理其它一切,开放问题只是"搭车"留在 summary 里,直到人回答(回答作为下一轮的普通新反馈到来)。复用现有 bilingual summary 评论 + 评审回帖通道,**不新建任何机制**。
- 划清界线:**decline** 是"这改动不值得做";**escalate** 是"这不该我定"。升级的意见与 declined/deferred 一样保持 unresolved,使其问题被读到。

刻意做最小版:改 agent 行为(本 PR)是高价值低成本的一块;一个独立的"等人决策"暂停态 + 标签**有意不做**,等证明 summary/回帖通道不够用再说。

## 评审验证

- `-t "decision logic in the project autofix skill"` —— SKILL policy 测试现在也 pin 了 escalate 处置。通过。
- 全量除既有 load flake 外全绿(隔离与 main 上均过)。prettier clean。仅 prose/markdown + 一条测试断言,不改 workflow 逻辑。

## 风险与范围

- 仅 agent 面向的策略,改的是 agent 对"判断题"反馈的处置,不触及 workflow 代码路径。最坏是 agent 多用/少用 "escalate",由正常人工评审兜住 —— 严格优于今天"默默决定或埋掉"。
- 破坏性变更:无。

</details>
