### PR TITLE
feat(channels): run loops in daemon workers

### DIFF
--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -13,6 +13,10 @@ const mockUpdateChannelMemoryEntry = vi.hoisted(() => vi.fn());
 const mockRemoveChannelMemoryEntries = vi.hoisted(() => vi.fn());
 const mockClearChannelMemory = vi.hoisted(() => vi.fn());
 const mockRecordChannelMemoryRecallMetrics = vi.hoisted(() => vi.fn());
+const mockNextFireTime = vi.hoisted(() =>
+  vi.fn(() => new Date('2026-01-01T00:01:00.000Z')),
+);
+const mockParseCron = vi.hoisted(() => vi.fn());
 const mockRegisterToolCallDispatch = vi.hoisted(() => vi.fn());
 const mockRegisterBackgroundResponseRelay = vi.hoisted(() => vi.fn());
 const mockRegisterPermissionRelay = vi.hoisted(() => vi.fn());
@@ -20,6 +24,9 @@ const mockRegisterSessionCleanup = vi.hoisted(() => vi.fn());
 const mockSessionsPath = vi.hoisted(() => vi.fn(() => '/tmp/sessions.json'));
 const mockDaemonSessionRoutesPath = vi.hoisted(() =>
   vi.fn(() => '/tmp/qwen/channels/daemon/workspace-hash/routes.json'),
+);
+const mockDaemonChannelLoopPath = vi.hoisted(() =>
+  vi.fn(() => '/tmp/qwen/channels/daemon/workspace-hash/cron.json'),
 );
 const mockDaemonObservedContactsPath = vi.hoisted(() =>
   vi.fn(
@@ -33,9 +40,19 @@ const mockObservedContactStore = vi.hoisted(() =>
   })),
 );
 const mockLoadSettings = vi.hoisted(() =>
-  vi.fn((_cwd?: string, _opts?: unknown) => ({
-    merged: { proxy: 'http://settings-proxy:8080' as string | undefined },
-  })),
+  vi.fn(
+    (
+      _cwd?: string,
+      _opts?: unknown,
+    ): {
+      merged: {
+        proxy?: string;
+        experimental?: { cron?: boolean };
+      };
+    } => ({
+      merged: { proxy: 'http://settings-proxy:8080' },
+    }),
+  ),
 );
 const mockResolveProxyUrl = vi.hoisted(() =>
   vi.fn((_cliProxy?: string, settingsProxy?: string) => settingsProxy),
@@ -110,6 +127,26 @@ const mockBridgeDiscardSession = vi.hoisted(() => vi.fn());
 const mockBridgeRespondToPermission = vi.hoisted(() => vi.fn());
 const mockBridgeShellCommand = vi.hoisted(() => vi.fn());
 const mockBridgeGetAvailableCommands = vi.hoisted(() => vi.fn(() => []));
+const mockChannelLoopStoreCreate = vi.hoisted(() => vi.fn());
+const mockChannelLoopStoreCreateForTarget = vi.hoisted(() => vi.fn());
+const mockChannelLoopStoreListForTarget = vi.hoisted(() => vi.fn());
+const mockChannelLoopStoreDisable = vi.hoisted(() => vi.fn());
+const mockChannelLoopStore = vi.hoisted(() =>
+  vi.fn(() => ({
+    create: mockChannelLoopStoreCreate,
+    createForTarget: mockChannelLoopStoreCreateForTarget,
+    listForTarget: mockChannelLoopStoreListForTarget,
+    disable: mockChannelLoopStoreDisable,
+  })),
+);
+const mockChannelLoopSchedulerStart = vi.hoisted(() => vi.fn());
+const mockChannelLoopSchedulerStop = vi.hoisted(() => vi.fn());
+const mockChannelLoopScheduler = vi.hoisted(() =>
+  vi.fn((_options?: unknown) => ({
+    start: mockChannelLoopSchedulerStart,
+    stop: mockChannelLoopSchedulerStop,
+  })),
+);
 const mockDaemonChannelBridge = vi.hoisted(() =>
   vi.fn(() => ({
     get availableCommands() {
@@ -162,6 +199,8 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   clearChannelMemory: mockClearChannelMemory,
   getChannelMemoryRevision: mockGetChannelMemoryRevision,
   listChannelMemoryEntries: mockListChannelMemoryEntries,
+  nextFireTime: mockNextFireTime,
+  parseCron: mockParseCron,
   readChannelMemory: mockReadChannelMemory,
   recordChannelMemoryRecallMetrics: mockRecordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries: mockRemoveChannelMemoryEntries,
@@ -183,6 +222,7 @@ vi.mock('./proxy.js', () => ({
 
 vi.mock('./runtime.js', () => ({
   createChannel: mockCreateChannel,
+  daemonChannelLoopPath: mockDaemonChannelLoopPath,
   daemonObservedContactsPath: mockDaemonObservedContactsPath,
   daemonSessionRoutesPath: mockDaemonSessionRoutesPath,
   loadChannelsConfig: mockLoadChannelsConfig,
@@ -201,6 +241,8 @@ vi.mock('./observed-contact-store.js', () => ({
 }));
 
 vi.mock('@qwen-code/channel-base', () => ({
+  ChannelLoopScheduler: mockChannelLoopScheduler,
+  ChannelLoopStore: mockChannelLoopStore,
   DaemonChannelBridge: mockDaemonChannelBridge,
   isChannelProactiveDeliveryError: mockIsChannelProactiveDeliveryError,
   sanitizeLogText: mockSanitizeLogText,
@@ -302,6 +344,7 @@ beforeEach(() => {
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn(),
     name,
+    runLoopPrompt: vi.fn().mockResolvedValue('done'),
     validateWebhookTask: vi.fn(),
   }));
   mockLoadChannelsConfig.mockReturnValue({
@@ -310,6 +353,10 @@ beforeEach(() => {
   });
   mockLoadChannelsFromExtensions.mockResolvedValue(0);
   mockParseConfiguredChannels.mockResolvedValue([parsedTelegram]);
+  mockChannelLoopStoreCreate.mockResolvedValue({ id: 'job-1' });
+  mockChannelLoopStoreCreateForTarget.mockResolvedValue({ id: 'job-1' });
+  mockChannelLoopStoreListForTarget.mockResolvedValue([]);
+  mockChannelLoopStoreDisable.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -799,6 +846,202 @@ describe('runChannelDaemonWorker', () => {
       mockRouterDispose.mock.invocationCallOrder[0]!,
     );
     expect(mockRouterClearAll).not.toHaveBeenCalled();
+  });
+
+  it('starts a workspace-scoped loop runtime for connected channels', async () => {
+    const sdk = createSdk();
+    const ready = vi.fn();
+
+    const handle = await runChannelDaemonWorker({
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'names', names: ['telegram'] },
+      loadDaemonSdk: async () => sdk,
+      sendReady: ready,
+    });
+
+    expect(mockDaemonChannelLoopPath).toHaveBeenCalledWith('/workspace');
+    expect(mockChannelLoopStore).toHaveBeenCalledWith({
+      filePath: '/tmp/qwen/channels/daemon/workspace-hash/cron.json',
+    });
+    const channelOptions = mockCreateChannel.mock.calls[0]![3] as {
+      loopController?: {
+        create: unknown;
+        createForTarget: unknown;
+        listForTarget: unknown;
+        disable: unknown;
+        validateCron: unknown;
+        nextFireTime: unknown;
+      };
+    };
+    expect(channelOptions.loopController).toEqual({
+      create: expect.any(Function),
+      createForTarget: expect.any(Function),
+      listForTarget: expect.any(Function),
+      disable: expect.any(Function),
+      validateCron: expect.any(Function),
+      nextFireTime: expect.any(Function),
+    });
+    const schedulerOptions = mockChannelLoopScheduler.mock.calls[0]![0] as {
+      store: unknown;
+      channels: Map<string, unknown>;
+      nextFireTime: unknown;
+    };
+    expect(schedulerOptions.store).toBe(
+      mockChannelLoopStore.mock.results[0]!.value,
+    );
+    expect([...schedulerOptions.channels.keys()]).toEqual(['telegram']);
+    expect(schedulerOptions.nextFireTime).toBe(mockNextFireTime);
+    expect(mockChannelLoopSchedulerStart).toHaveBeenCalledOnce();
+    const channel = mockCreateChannel.mock.results[0]!.value as {
+      connect: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+    };
+    expect(channel.connect.mock.invocationCallOrder[0]).toBeLessThan(
+      mockChannelLoopSchedulerStart.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      mockChannelLoopSchedulerStart.mock.invocationCallOrder[0],
+    ).toBeLessThan(ready.mock.invocationCallOrder[0]!);
+
+    await handle.close();
+
+    expect(mockChannelLoopSchedulerStop).toHaveBeenCalledOnce();
+    expect(
+      mockChannelLoopSchedulerStop.mock.invocationCallOrder[0],
+    ).toBeLessThan(channel.disconnect.mock.invocationCallOrder[0]!);
+    expect(channel.disconnect.mock.invocationCallOrder[0]).toBeLessThan(
+      mockBridgeStop.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('keeps disconnected channels out of the loop scheduler', async () => {
+    const sdk = createSdk();
+    const firstChannel = {
+      connect: vi.fn().mockRejectedValue(new Error('first down')),
+      disconnect: vi.fn(),
+      name: 'first',
+      runLoopPrompt: vi.fn(),
+      validateWebhookTask: vi.fn(),
+    };
+    const secondChannel = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      name: 'second',
+      runLoopPrompt: vi.fn(),
+      validateWebhookTask: vi.fn(),
+    };
+    mockParseConfiguredChannels.mockResolvedValueOnce([
+      { ...parsedTelegram, name: 'first' },
+      { ...parsedTelegram, name: 'second' },
+    ]);
+    mockCreateChannel.mockImplementation((name: string) =>
+      name === 'first' ? firstChannel : secondChannel,
+    );
+
+    const handle = await runChannelDaemonWorker({
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'all' },
+      loadDaemonSdk: async () => sdk,
+    });
+
+    const schedulerOptions = mockChannelLoopScheduler.mock.calls[0]![0] as {
+      channels: Map<string, unknown>;
+    };
+    expect([...schedulerOptions.channels.keys()]).toEqual(['second']);
+
+    await handle.close();
+  });
+
+  it('disables daemon loop jobs owned by another workspace', async () => {
+    const sdk = createSdk();
+    const handle = await runChannelDaemonWorker({
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'names', names: ['telegram'] },
+      loadDaemonSdk: async () => sdk,
+    });
+    const schedulerOptions = mockChannelLoopScheduler.mock.calls[0]![0] as {
+      channels: Map<
+        string,
+        {
+          runLoopPrompt(job: unknown): Promise<string | undefined>;
+        }
+      >;
+    };
+    const runner = schedulerOptions.channels.get('telegram')!;
+    const channel = mockCreateChannel.mock.results[0]!.value as {
+      runLoopPrompt: ReturnType<typeof vi.fn>;
+    };
+
+    await expect(
+      runner.runLoopPrompt({ id: 'foreign-loop', cwd: '/other' }),
+    ).rejects.toThrow('outside daemon workspace');
+    expect(mockChannelLoopStoreDisable).toHaveBeenCalledWith('foreign-loop');
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      '[Channel] Disabled loop "foreign-loop": its workspace does not match this daemon worker.',
+    );
+    expect(channel.runLoopPrompt).not.toHaveBeenCalled();
+
+    await expect(
+      runner.runLoopPrompt({ id: 'local-loop', cwd: '/workspace' }),
+    ).resolves.toBe('done');
+    expect(channel.runLoopPrompt).toHaveBeenCalledWith(
+      { id: 'local-loop', cwd: '/workspace' },
+      undefined,
+    );
+
+    await handle.close();
+  });
+
+  it('does not create loop runtime when cron is disabled in settings', async () => {
+    const sdk = createSdk();
+    mockLoadSettings.mockReturnValueOnce({
+      merged: { experimental: { cron: false } },
+    });
+
+    const handle = await runChannelDaemonWorker({
+      daemonUrl: 'http://127.0.0.1:4170',
+      workspace: '/workspace',
+      selection: { mode: 'names', names: ['telegram'] },
+      loadDaemonSdk: async () => sdk,
+    });
+
+    expect(mockDaemonChannelLoopPath).not.toHaveBeenCalled();
+    expect(mockChannelLoopStore).not.toHaveBeenCalled();
+    expect(mockChannelLoopScheduler).not.toHaveBeenCalled();
+    expect(mockCreateChannel.mock.calls[0]![3]).not.toHaveProperty(
+      'loopController',
+    );
+
+    await handle.close();
+  });
+
+  it('stops the loop scheduler when startup rolls back after connection', async () => {
+    const sdk = createSdk();
+    const sendReady = vi.fn(() => {
+      throw new Error('ready failed');
+    });
+
+    await expect(
+      runChannelDaemonWorker({
+        daemonUrl: 'http://127.0.0.1:4170',
+        workspace: '/workspace',
+        selection: { mode: 'names', names: ['telegram'] },
+        loadDaemonSdk: async () => sdk,
+        sendReady,
+      }),
+    ).rejects.toThrow('ready failed');
+
+    expect(mockChannelLoopSchedulerStart).toHaveBeenCalledOnce();
+    expect(mockChannelLoopSchedulerStop).toHaveBeenCalledOnce();
+    const channel = mockCreateChannel.mock.results[0]!.value as {
+      disconnect: ReturnType<typeof vi.fn>;
+    };
+    expect(
+      mockChannelLoopSchedulerStop.mock.invocationCallOrder[0],
+    ).toBeLessThan(channel.disconnect.mock.invocationCallOrder[0]!);
   });
 
   it('selects all configured channels in one shared router', async () => {

--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -984,6 +984,15 @@ describe('runChannelDaemonWorker', () => {
     );
     expect(channel.runLoopPrompt).not.toHaveBeenCalled();
 
+    mockChannelLoopStoreDisable.mockRejectedValueOnce(new Error('disk full'));
+    await expect(
+      runner.runLoopPrompt({ id: 'unwritable-loop', cwd: '/other' }),
+    ).rejects.toThrow('outside daemon workspace');
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      '[Channel] Disabled loop "unwritable-loop": its workspace does not match this daemon worker.',
+    );
+    expect(channel.runLoopPrompt).not.toHaveBeenCalled();
+
     await expect(
       runner.runLoopPrompt({ id: 'local-loop', cwd: '/workspace' }),
     ).resolves.toBe('done');

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -5,6 +5,7 @@ import {
   clearChannelMemory,
   getChannelMemoryRevision,
   listChannelMemoryEntries,
+  nextFireTime,
   readChannelMemory,
   recordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries,
@@ -12,6 +13,8 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
 import {
+  ChannelLoopScheduler,
+  ChannelLoopStore,
   DaemonChannelBridge,
   isChannelProactiveDeliveryError,
   sanitizeLogText,
@@ -20,6 +23,7 @@ import {
 import type {
   ChannelAgentBridge,
   ChannelBase,
+  ChannelLoopRunner,
   ChannelWebhookRunOptions,
   ChannelWebhookTask,
   DaemonChannelSessionClient,
@@ -62,6 +66,7 @@ import { writeStderrLine, writeStdoutLine } from '../../utils/stdioHelpers.js';
 import { resolveProxyUrl } from './proxy.js';
 import {
   createChannel,
+  daemonChannelLoopPath,
   daemonObservedContactsPath,
   daemonSessionRoutesPath,
   loadChannelsConfig,
@@ -76,6 +81,10 @@ import {
 } from './runtime.js';
 import { BridgeChannelMemoryIntentClassifier } from './memory-intent-classifier.js';
 import { ObservedChannelContactStore } from './observed-contact-store.js';
+import {
+  createChannelLoopController,
+  isChannelCronEnabled,
+} from './loop-runtime.js';
 
 const SESSION_SHELL_COMMAND_FEATURE = 'session_shell_command';
 const MAX_ACTIVE_WEBHOOK_TASKS = 16;
@@ -438,6 +447,14 @@ export async function runChannelDaemonWorker(
   const observedContacts = new ObservedChannelContactStore(
     daemonObservedContactsPath(daemonWorkspace),
   );
+  const loopStore = isChannelCronEnabled(settings)
+    ? new ChannelLoopStore({
+        filePath: daemonChannelLoopPath(daemonWorkspace),
+      })
+    : undefined;
+  const loopController = loopStore
+    ? createChannelLoopController(loopStore)
+    : undefined;
 
   const bridge = new DaemonChannelBridge({
     cwd: daemonWorkspace,
@@ -451,6 +468,7 @@ export async function runChannelDaemonWorker(
 
   const channels = new Map<string, ChannelBase>();
   const connected: string[] = [];
+  let scheduler: ChannelLoopScheduler | undefined;
   let connectFailureCount = 0;
   const diagnosticRedaction = {
     ...(opts.daemonToken ? { daemonToken: opts.daemonToken } : {}),
@@ -523,6 +541,7 @@ export async function runChannelDaemonWorker(
                 observedContacts.observe(channelName, observation);
               },
             },
+            ...(loopController ? { loopController } : {}),
           }),
           startupSignal,
         ),
@@ -603,6 +622,39 @@ export async function runChannelDaemonWorker(
       throw new Error('No channels connected.');
     }
 
+    if (loopStore) {
+      const schedulerChannels = new Map<string, ChannelLoopRunner>();
+      for (const name of connected) {
+        const channel = channels.get(name)!;
+        schedulerChannels.set(name, {
+          runLoopPrompt: async (job, options) => {
+            let jobWorkspace: string | undefined;
+            try {
+              jobWorkspace = canonicalizeWorkspace(job.cwd);
+            } catch {
+              jobWorkspace = undefined;
+            }
+            if (jobWorkspace !== daemonWorkspace) {
+              await loopStore.disable(job.id);
+              writeStderrLine(
+                `[Channel] Disabled loop "${sanitizeLogText(job.id, 128)}": its workspace does not match this daemon worker.`,
+              );
+              throw new Error(
+                `Loop ${sanitizeLogText(job.id, 128)} is outside daemon workspace and was disabled.`,
+              );
+            }
+            return channel.runLoopPrompt(job, options);
+          },
+        });
+      }
+      scheduler = new ChannelLoopScheduler({
+        store: loopStore,
+        channels: schedulerChannels,
+        nextFireTime,
+      });
+      scheduler.start();
+    }
+
     opts.sendReady?.({
       channels: connected,
       requestedChannels: parsed.map((p) => p.name),
@@ -646,6 +698,7 @@ export async function runChannelDaemonWorker(
         }
       },
       async close() {
+        scheduler?.stop();
         disconnectAll();
         try {
           bridge.stop();
@@ -655,6 +708,7 @@ export async function runChannelDaemonWorker(
       },
     };
   } catch (err) {
+    scheduler?.stop();
     disconnectAll();
     try {
       bridge.stop();

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -635,7 +635,7 @@ export async function runChannelDaemonWorker(
               jobWorkspace = undefined;
             }
             if (jobWorkspace !== daemonWorkspace) {
-              await loopStore.disable(job.id);
+              await loopStore.disable(job.id).catch(() => false);
               writeStderrLine(
                 `[Channel] Disabled loop "${sanitizeLogText(job.id, 128)}": its workspace does not match this daemon worker.`,
               );

--- a/packages/cli/src/commands/channel/loop-runtime.ts
+++ b/packages/cli/src/commands/channel/loop-runtime.ts
@@ -1,0 +1,31 @@
+import { nextFireTime, parseCron } from '@qwen-code/qwen-code-core';
+import type {
+  ChannelLoopController,
+  ChannelLoopStore,
+} from '@qwen-code/channel-base';
+
+export function createChannelLoopController(
+  store: ChannelLoopStore,
+): ChannelLoopController {
+  return {
+    create: (input) => store.create(input),
+    createForTarget: (input, maxEnabledLoops) =>
+      store.createForTarget(input, maxEnabledLoops),
+    listForTarget: (channelName, target) =>
+      store.listForTarget(channelName, target),
+    disable: (id) => store.disable(id),
+    validateCron: (cron) => {
+      parseCron(cron);
+      nextFireTime(cron, new Date());
+    },
+    nextFireTime: (job) =>
+      nextFireTime(job.cron, new Date(job.lastFiredAt ?? job.createdAt)),
+  };
+}
+
+export function isChannelCronEnabled(settings: {
+  merged: { experimental?: { cron?: boolean } };
+}): boolean {
+  if (process.env['QWEN_CODE_DISABLE_CRON'] === '1') return false;
+  return settings.merged.experimental?.cron !== false;
+}

--- a/packages/cli/src/commands/channel/runtime.test.ts
+++ b/packages/cli/src/commands/channel/runtime.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  channelLoopPath,
+  daemonChannelLoopPath,
   daemonObservedContactsPath,
   daemonSessionRoutesPath,
   parseConfiguredChannels,
@@ -52,6 +54,17 @@ it('isolates observed contact stores beside daemon routes', () => {
     '/tmp/qwen/channels/daemon/other-hash/observed-contacts.json',
   );
   expect(daemonObservedContactsPath('/workspace')).not.toBe(sessionsPath());
+});
+
+it('isolates daemon loop stores by workspace hash', () => {
+  expect(daemonChannelLoopPath('/workspace')).toBe(
+    '/tmp/qwen/channels/daemon/workspace-hash/cron.json',
+  );
+  expect(daemonChannelLoopPath('/other')).toBe(
+    '/tmp/qwen/channels/daemon/other-hash/cron.json',
+  );
+  expect(daemonChannelLoopPath('/workspace')).not.toBe(channelLoopPath());
+  expect(daemonChannelLoopPath('/workspace')).not.toBe(sessionsPath());
 });
 
 describe('parseConfiguredChannels', () => {

--- a/packages/cli/src/commands/channel/runtime.ts
+++ b/packages/cli/src/commands/channel/runtime.ts
@@ -31,24 +31,29 @@ export function sessionsPath(): string {
   return path.join(Storage.getGlobalQwenDir(), 'channels', 'sessions.json');
 }
 
-export function daemonSessionRoutesPath(workspaceCwd: string): string {
+function daemonChannelStatePath(
+  workspaceCwd: string,
+  fileName: string,
+): string {
   return path.join(
     Storage.getGlobalQwenDir(),
     'channels',
     'daemon',
     hashDaemonWorkspace(workspaceCwd),
-    'routes.json',
+    fileName,
   );
 }
 
+export function daemonSessionRoutesPath(workspaceCwd: string): string {
+  return daemonChannelStatePath(workspaceCwd, 'routes.json');
+}
+
 export function daemonObservedContactsPath(workspaceCwd: string): string {
-  return path.join(
-    Storage.getGlobalQwenDir(),
-    'channels',
-    'daemon',
-    hashDaemonWorkspace(workspaceCwd),
-    'observed-contacts.json',
-  );
+  return daemonChannelStatePath(workspaceCwd, 'observed-contacts.json');
+}
+
+export function daemonChannelLoopPath(workspaceCwd: string): string {
+  return daemonChannelStatePath(workspaceCwd, 'cron.json');
 }
 
 export function channelLoopPath(): string {

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -5,7 +5,6 @@ import {
   getChannelMemoryRevision,
   listChannelMemoryEntries,
   nextFireTime,
-  parseCron,
   readChannelMemory,
   recordChannelMemoryRecallMetrics,
   removeChannelMemoryEntries,
@@ -19,11 +18,7 @@ import {
   ChannelLoopStore,
   SessionRouter,
 } from '@qwen-code/channel-base';
-import type {
-  ChannelBase,
-  ChannelBaseOptions,
-  ChannelLoopController,
-} from '@qwen-code/channel-base';
+import type { ChannelBase, ChannelBaseOptions } from '@qwen-code/channel-base';
 import { findCliEntryPath, parseChannelConfig } from './config-utils.js';
 import { resolveProxy } from './proxy.js';
 import {
@@ -45,6 +40,10 @@ import {
   sessionsPath,
 } from './runtime.js';
 import { BridgeChannelMemoryIntentClassifier } from './memory-intent-classifier.js';
+import {
+  createChannelLoopController,
+  isChannelCronEnabled,
+} from './loop-runtime.js';
 
 export { resolveExtensionChannelEntrySpecifier } from './runtime.js';
 export { resolveProxy } from './proxy.js';
@@ -84,30 +83,6 @@ function channelMemoryOptions(
     ),
     channelMemoryRecallObserver: recordChannelMemoryRecallMetrics,
   };
-}
-
-function createLoopController(store: ChannelLoopStore): ChannelLoopController {
-  return {
-    create: (input) => store.create(input),
-    createForTarget: (input, maxEnabledLoops) =>
-      store.createForTarget(input, maxEnabledLoops),
-    listForTarget: (channelName, target) =>
-      store.listForTarget(channelName, target),
-    disable: (id) => store.disable(id),
-    validateCron: (cron) => {
-      parseCron(cron);
-      nextFireTime(cron, new Date());
-    },
-    nextFireTime: (job) =>
-      nextFireTime(job.cron, new Date(job.lastFiredAt ?? job.createdAt)),
-  };
-}
-
-function isChannelCronEnabled(settings: {
-  merged: { experimental?: { cron?: boolean } };
-}): boolean {
-  if (process.env['QWEN_CODE_DISABLE_CRON'] === '1') return false;
-  return settings.merged.experimental?.cron !== false;
 }
 
 function writeServiceInfoOrExit(channels: string[], cleanup: () => void): void {
@@ -219,7 +194,7 @@ async function startSingle(
     ? new ChannelLoopStore({ filePath: channelLoopPath() })
     : undefined;
   const loopController = loopStore
-    ? createLoopController(loopStore)
+    ? createChannelLoopController(loopStore)
     : undefined;
   const channels: Map<string, ChannelBase> = new Map();
 
@@ -379,7 +354,7 @@ async function startAll(
     ? new ChannelLoopStore({ filePath: channelLoopPath() })
     : undefined;
   const loopController = loopStore
-    ? createLoopController(loopStore)
+    ? createChannelLoopController(loopStore)
     : undefined;
   // Register per-channel scope overrides so each channel uses its own sessionScope
   for (const { name, config } of parsed) {


### PR DESCRIPTION
## What this PR does

Daemon-managed channels now create a workspace-scoped loop store and scheduler, expose the existing `/loop` commands, and resume persisted schedules when their worker restarts. Only successfully connected channels are scheduled, and loop execution is rejected and disabled if the stored workspace no longer matches the worker that owns it.

Standalone channels keep their existing global loop store. Daemon workers instead persist loops beside their workspace-scoped routing state so multiple workspace workers never share or race on one file.

## Why it's needed

Daemon-managed channels currently construct channel adapters without a loop controller or scheduler, so `/loop` reports that loops are unavailable and persisted channel schedules cannot run. This is also required before the channel documentation can accurately describe daemon-managed loop support.

## Reviewer Test Plan

### How to verify

Start `qwen serve` with a configured channel, send `/loop add "*/5 * * * *" "ping"` in that channel, and confirm `/loop list` reports the job and the proactive prompt is delivered. Restart the daemon and confirm the same workspace still lists the job. Configure a second workspace and confirm its loops are stored and executed independently. Finally, set `experimental.cron` to `false` or `QWEN_CODE_DISABLE_CRON=1` and confirm `/loop` reports loops as unavailable.

Automated tests verify the workspace-specific persistence path, connected-channel-only scheduler membership, controller wiring, cross-workspace execution rejection, feature gating, startup ordering, shutdown ordering, and startup rollback.

### Evidence (Before & After)

Before: daemon-managed channel adapters receive no loop controller and no loop scheduler is started, so `/loop` cannot manage or execute schedules.

After: daemon-managed channel adapters share their worker's loop controller, the worker starts one scheduler after channel connection succeeds, and the scheduler stops before adapter and bridge teardown.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v25.9.0. Verified with 118 focused channel tests, full workspace typecheck, full build, full lint, and the repository pre-commit checks.

## Risk & Scope

- Main risk or tradeoff: daemon loops are intentionally scoped per workspace rather than sharing the standalone global store; this avoids cross-process file races and cross-workspace execution.
- Not validated / out of scope: natural-language `channel_loop_create/list/cancel` MCP calls remain unavailable in daemon sessions and will be added in a follow-up PR; live delivery was not exercised against personal channel credentials.
- Breaking changes / migration notes: no existing files are migrated. Standalone loops remain in the global channel loop file, while daemon-managed loops use a workspace-hashed daemon path.

## Linked Issues

Related documentation PR: #7628.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

daemon 托管的 channel 现在会创建 workspace 级隔离的 loop store 和 scheduler，启用现有 `/loop` 命令，并在 worker 重启后恢复持久化调度。只有连接成功的 channel 会进入 scheduler；如果已存 job 的 workspace 不再属于当前 worker，该 job 会被拒绝执行并禁用。

standalone channel 继续使用原有全局 loop store。daemon worker 则把 loop 与 workspace 级路由状态存放在一起，避免多个 workspace worker 共享同一文件并产生竞争。

## 为什么需要

当前 daemon 托管的 channel 创建 adapter 时没有 loop controller 或 scheduler，因此 `/loop` 会提示 loop 不可用，持久化的 channel 调度也无法执行。这也是 channel 文档能够准确声明 daemon-managed loop 支持的前置实现。

## Reviewer 测试计划

### 如何验证

使用已配置的 channel 启动 `qwen serve`，在 channel 中发送 `/loop add "*/5 * * * *" "ping"`，确认 `/loop list` 能看到 job 且主动 prompt 能正常送达。重启 daemon，确认同一 workspace 仍能看到该 job。再配置第二个 workspace，确认两个 workspace 的 loop 独立存储和执行。最后将 `experimental.cron` 设为 `false` 或设置 `QWEN_CODE_DISABLE_CRON=1`，确认 `/loop` 提示 loop 不可用。

自动化测试覆盖 workspace 独立持久化路径、仅连接成功的 channel 进入 scheduler、controller 注入、跨 workspace 执行拒绝、feature gate、启动顺序、关闭顺序和启动回滚。

### 前后证据

之前：daemon-managed channel adapter 没有 loop controller，也不会启动 loop scheduler，因此 `/loop` 无法管理或执行调度。

之后：daemon-managed channel adapter 共享所属 worker 的 loop controller，worker 在 channel 连接成功后启动唯一 scheduler，并在 adapter 和 bridge 关闭前停止 scheduler。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

Node.js v25.9.0。已通过 118 个定向 channel 测试、全 workspace typecheck、全量 build、全量 lint 和仓库 pre-commit 检查。

## 风险与范围

- 主要风险或取舍：daemon loop 按 workspace 隔离，而不是与 standalone 共用全局 store；这样可以避免跨进程文件竞争和跨 workspace 执行。
- 未验证或不在范围内：daemon session 的自然语言 `channel_loop_create/list/cancel` MCP 调用仍不可用，将由后续 PR 实现；没有使用个人 channel 凭证验证真实推送。
- 破坏性变更或迁移说明：不会迁移现有文件。standalone loop 保留在全局 channel loop 文件中，daemon-managed loop 使用 workspace hash 的 daemon 路径。

## 关联

相关文档 PR：#7628。

</details>
