### PR TITLE
ci(autofix): add cross-package contract verification

### DIFF
--- a/.github/scripts/check-autofix-contracts.sh
+++ b/.github/scripts/check-autofix-contracts.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+fail() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "outcome=failed" >> "${GITHUB_OUTPUT}"
+  fi
+  exit 1
+}
+
+changed_files="$(cat)"
+
+if ! npm run check-i18n; then
+  echo '❌ i18n verification failed.'
+  fail
+fi
+
+if grep -Fxq 'packages/core/src/tools/tool-names.ts' <<< "${changed_files}"; then
+  if ! npm run test --workspace packages/web-shell -- \
+    client/components/messages/toolFormatting.drift.test.ts; then
+    echo '❌ Web Shell tool-display contract verification failed.'
+    fail
+  fi
+fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -644,6 +644,7 @@ jobs:
       - name: 'Stage trusted schema gate'
         run: |-
           cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
+          cp .github/scripts/check-autofix-contracts.sh "${RUNNER_TEMP}/check-autofix-contracts.sh"
           cp .github/scripts/resolve-owning-packages.sh "${RUNNER_TEMP}/resolve-owning-packages.sh"
 
       - name: 'Check bot credentials'
@@ -1151,6 +1152,8 @@ jobs:
           # and kill the gate with no outcome), and the gate logic must come
           # from the trusted base, not the branch under verification.
           bash "${RUNNER_TEMP}/check-settings-schema.sh"
+          git diff --name-only "origin/main...${BRANCH}" \
+            | bash "${RUNNER_TEMP}/check-autofix-contracts.sh"
 
           # Run changed/related tests for the packages this fix touches.
           # --changed follows the import graph so transitive breakage is caught.
@@ -2480,6 +2483,7 @@ jobs:
       - name: 'Stage trusted schema gate and agent runner'
         run: |-
           cp .github/scripts/check-settings-schema.sh "${RUNNER_TEMP}/check-settings-schema.sh"
+          cp .github/scripts/check-autofix-contracts.sh "${RUNNER_TEMP}/check-autofix-contracts.sh"
           cp .github/scripts/resolve-owning-packages.sh "${RUNNER_TEMP}/resolve-owning-packages.sh"
           # The agent step runs AFTER prepare checks out the PR branch, so
           # invoking the runner from the working tree would execute
@@ -3075,6 +3079,8 @@ jobs:
           # and kill the gate with no outcome), and the gate logic must come
           # from the trusted base, not the branch under verification.
           bash "${RUNNER_TEMP}/check-settings-schema.sh"
+          git diff --name-only "origin/main...${BRANCH}" \
+            | bash "${RUNNER_TEMP}/check-autofix-contracts.sh"
 
           if git diff --quiet "origin/${BRANCH}...${BRANCH}"; then
             # No new commit. That is only legitimate as a deliberate no-action.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -25,6 +25,8 @@ const sandboxImageResolverScript = readFileSync(
   '.github/scripts/resolve-sandbox-image.mjs',
   'utf8',
 );
+const autofixContractsScriptPath = '.github/scripts/check-autofix-contracts.sh';
+const autofixContractsScript = readFileSync(autofixContractsScriptPath, 'utf8');
 const autofixRunnerScriptPath = '.qwen/skills/autofix/scripts/run-agent.mjs';
 const checkBotCredentialsStep =
   workflow.match(
@@ -4103,6 +4105,12 @@ describe('qwen-autofix workflow', () => {
       expect(step).not.toContain(
         'bash .github/scripts/check-settings-schema.sh',
       );
+      expect(step).toContain(
+        'bash "${RUNNER_TEMP}/check-autofix-contracts.sh"',
+      );
+      expect(step).not.toContain(
+        'bash .github/scripts/check-autofix-contracts.sh',
+      );
       // The owning-package resolver is likewise a shared script staged from the
       // trusted base, invoked (not inlined) so the two gates cannot drift into
       // resolving packages differently. The old inline detection must be gone.
@@ -4123,6 +4131,11 @@ describe('qwen-autofix workflow', () => {
     expect(
       workflow.match(
         /cp \.github\/scripts\/check-settings-schema\.sh "\$\{RUNNER_TEMP\}\/check-settings-schema\.sh"/g,
+      ) ?? [],
+    ).toHaveLength(2);
+    expect(
+      workflow.match(
+        /cp \.github\/scripts\/check-autofix-contracts\.sh "\$\{RUNNER_TEMP\}\/check-autofix-contracts\.sh"/g,
       ) ?? [],
     ).toHaveLength(2);
     // The owning-package resolver is staged the same way, in the same steps.
@@ -4201,6 +4214,88 @@ describe('qwen-autofix workflow', () => {
         'bash "${RUNNER_TEMP}/check-settings-schema.sh"',
       ),
     ).toBeLessThan(reviewVerifyGate.indexOf('outcome=noop'));
+    expect(
+      reviewVerifyGate.indexOf(
+        'bash "${RUNNER_TEMP}/check-autofix-contracts.sh"',
+      ),
+    ).toBeLessThan(reviewVerifyGate.indexOf('outcome=noop'));
+    expect(autofixContractsScript).toContain('npm run check-i18n');
+    expect(autofixContractsScript).toContain(
+      'packages/core/src/tools/tool-names.ts',
+    );
+    expect(autofixContractsScript).toContain(
+      'client/components/messages/toolFormatting.drift.test.ts',
+    );
+    expect(autofixContractsScript).toContain('outcome=failed');
+    expect(ciWorkflow).toContain("run: 'npm run check-i18n'");
+    expect(ciWorkflow).toContain('npm run test:ci');
+  });
+
+  it('runs cross-package autofix contracts only when their source changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'autofix-contracts-'));
+    const npmLog = join(dir, 'npm.log');
+    try {
+      writeFileSync(
+        join(dir, 'npm'),
+        [
+          '#!/usr/bin/env bash',
+          'printf \'%s\\n\' "$*" >> "${NPM_LOG}"',
+          'if [[ "$*" == "run check-i18n" ]]; then',
+          '  exit "${I18N_EXIT:-0}"',
+          'fi',
+          'exit "${DRIFT_EXIT:-0}"',
+          '',
+        ].join('\n'),
+      );
+      chmodSync(join(dir, 'npm'), 0o755);
+
+      const run = (changedFiles, extraEnv = {}) =>
+        spawnSync('bash', [resolve(autofixContractsScriptPath)], {
+          input: changedFiles,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${dir}:${process.env.PATH}`,
+            NPM_LOG: npmLog,
+            ...extraEnv,
+          },
+        });
+
+      expect(run('packages/core/src/config/config.ts\n').status).toBe(0);
+      expect(readFileSync(npmLog, 'utf8').trim().split('\n')).toEqual([
+        'run check-i18n',
+      ]);
+
+      writeFileSync(npmLog, '');
+      expect(run('packages/core/src/tools/tool-names.ts\n').status).toBe(0);
+      expect(readFileSync(npmLog, 'utf8').trim().split('\n')).toEqual([
+        'run check-i18n',
+        'run test --workspace packages/web-shell -- client/components/messages/toolFormatting.drift.test.ts',
+      ]);
+
+      writeFileSync(npmLog, '');
+      const output = join(dir, 'output');
+      expect(
+        run('packages/core/src/tools/tool-names.ts\n', {
+          GITHUB_OUTPUT: output,
+          I18N_EXIT: '1',
+        }).status,
+      ).toBe(1);
+      expect(readFileSync(npmLog, 'utf8').trim()).toBe('run check-i18n');
+      expect(readFileSync(output, 'utf8')).toContain('outcome=failed');
+
+      writeFileSync(npmLog, '');
+      writeFileSync(output, '');
+      expect(
+        run('packages/core/src/tools/tool-names.ts\n', {
+          GITHUB_OUTPUT: output,
+          DRIFT_EXIT: '1',
+        }).status,
+      ).toBe(1);
+      expect(readFileSync(output, 'utf8')).toContain('outcome=failed');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('passes model credentials directly to qwen subprocesses', () => {


### PR DESCRIPTION
## What this PR does

Adds a trusted cross-package contract gate to both autofix verification paths. Every candidate now runs the repository i18n check before it can be published, and candidates that change the canonical tool-name contract also run the Web Shell tool-display drift test.

The verifier is staged from the trusted base checkout before the candidate branch is selected, matching the existing security boundary for verification helpers. Failures produce an explicit failed outcome, including on the review no-op path.

## Why it's needed

The existing affected-workspace tests only exercise the workspace that owns a changed file. A core tool-name change therefore does not select the independent Web Shell workspace, so a stale display-name mapping can pass takeover verification and fail later in full CI. The autofix gate also omitted the i18n check that full CI already treats as required.

## Reviewer Test Plan

### How to verify

1. Run the workflow regression test and confirm all 102 tests pass.
2. Feed a non-contract path to the helper and confirm it runs only the i18n check.
3. Feed the canonical tool-name path to the helper and confirm it additionally runs the Web Shell drift test.
4. Force either command to fail and confirm the helper exits non-zero and emits `outcome=failed`.
5. Confirm both autofix verification paths invoke only the helper copy staged from the trusted base, and that review verification runs it before accepting a no-op.

### Evidence (Before & After)

N/A — workflow-only change with behavioral regression coverage.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  |  ✅ tested    |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node.js 22 workspace. Verified with the focused workflow suite (102/102), the real i18n command, the targeted Web Shell drift test (2/2), full build, typecheck, ESLint, and targeted Prettier check.

## Risk & Scope

- Main risk or tradeoff: Every autofix candidate now pays the cost of the i18n check; the Web Shell test remains conditional on the canonical tool-name contract changing.
- Not validated / out of scope: Hosted-runner end-to-end execution and unrelated cross-package contracts; GitHub CI covers the hosted workflow environment.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #7638

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为两条 autofix 验证路径增加 trusted cross-package contract gate。现在每个候选修改在发布前都会执行仓库 i18n 检查；当候选修改 canonical tool-name contract 时，还会执行 Web Shell 的 tool-display drift 测试。

验证脚本会在切换到候选分支前从 trusted base checkout 暂存，与现有验证 helper 的安全边界一致。失败会产生明确的 failed outcome，包括 review no-op 路径。

## 为什么需要

现有 affected-workspace 测试只会执行 changed file 所属 workspace 的测试。因此 core tool-name 变化不会选中独立的 Web Shell workspace，过期的 display-name mapping 可能通过 takeover 验证，之后才在完整 CI 失败。autofix gate 也遗漏了完整 CI 已要求的 i18n 检查。

## Reviewer Test Plan

### 如何验证

1. 运行 workflow 回归测试，确认 102 个测试全部通过。
2. 向 helper 输入非 contract 路径，确认仅执行 i18n 检查。
3. 向 helper 输入 canonical tool-name 路径，确认额外执行 Web Shell drift 测试。
4. 强制任一命令失败，确认 helper 非零退出并输出 `outcome=failed`。
5. 确认两条 autofix 验证路径都只调用从 trusted base 暂存的 helper 副本，并且 review verification 会在接受 no-op 之前执行它。

### 证据（Before & After）

不适用——这是仅修改 workflow 的变更，并有行为回归测试覆盖。

### 测试平台

|     OS     |    状态     |
| :--------: | :---------: |
|  🍏 macOS  |  ✅ 已测试  |
| 🪟 Windows | ⚠️ 未测试   |
|  🐧 Linux  | ⚠️ 未测试   |

### 环境（可选）

本地 Node.js 22 workspace。已验证 focused workflow suite（102/102）、真实 i18n 命令、定向 Web Shell drift 测试（2/2）、完整 build、typecheck、ESLint 和定向 Prettier 检查。

## 风险与范围

- 主要风险或取舍：每个 autofix 候选现在都会承担 i18n 检查开销；Web Shell 测试仍只在 canonical tool-name contract 变化时执行。
- 未验证 / 不在范围内：hosted-runner 端到端执行和其他 cross-package contract；GitHub CI 会覆盖 hosted workflow 环境。
- Breaking changes / 迁移说明：无。

## 关联 Issue

Refs #7638

</details>
