### PR TITLE
docs(autofix): apply Simplicity First when addressing review feedback

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -184,6 +184,15 @@ Read `git diff origin/<base>...HEAD` first, then `<workdir>/feedback.md`.
 
 Classify every feedback point:
 
+Address each the way AGENTS.md's Simplicity First and Comments rules demand:
+the smallest change that resolves the point, no error handling for a condition
+that cannot occur, no comment that restates the code. Review rounds ratchet
+code UP — every round tends to add — so on each one also ask what the change
+lets you REMOVE or shrink, not only what to add. A suggestion whose only effect
+is more defense, configurability, or narration a senior engineer would call
+overcomplicated is a Decline (not worth the diff growth), not an automatic
+implement — satisfying a nit is never a reason to bloat the code.
+
 - Required: correctness bug, broken build/test, security issue, or a
   `CHANGES_REQUESTED` item naming a real defect. Verify it, then fix minimally.
 - Optional: suggestion, nit, or hardening — including `**[Suggestion]**`
@@ -201,8 +210,11 @@ unnecessarily.
 Finish with exactly one outcome:
 
 - Made a change: re-read the full diff as a skeptical reviewer — confirm each
-  feedback point is actually addressed AND that the change introduces no new
-  defect. Then ACTUALLY RUN `npm run build`, `npm run typecheck`,
+  feedback point is actually addressed, that the change introduces no new
+  defect, AND that it added no bloat: no defense for an impossible case, no
+  comment that is not a non-obvious "why", nothing a senior engineer would call
+  overcomplicated (AGENTS.md Simplicity First). Cut it before you commit. Then
+  ACTUALLY RUN `npm run build`, `npm run typecheck`,
   `npm run lint`, focused Vitest tests for the package(s) you touched, and
   integration tests after `npm run bundle` when the touched behavior is only
   exercised through the bundled CLI or integration harness (plus

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3398,6 +3398,12 @@ describe('qwen-autofix workflow', () => {
     expect(flat).toContain('## Verification');
     expect(flat).toContain('command you ran and its result');
     expect(flat).toContain('a bare "verified" is not acceptable');
+    // Simplicity First governs HOW findings are addressed against the additive
+    // ratchet of review rounds: the pre-commit self-audit rejects bloat, and a
+    // nit that would bloat the code is a decline, not an auto-implement.
+    expect(flat).toContain('Simplicity First');
+    expect(flat).toContain('added no bloat');
+    expect(flat).toContain('never a reason to bloat the code');
     // The rationale is structural, not etiquette: the gate re-runs the same
     // commands, so skipping them only moves the rejection later. Pin that
     // framing so the requirement is not softened back into "please verify".


### PR DESCRIPTION
## What this PR does

Wires **AGENTS.md's Simplicity First** and **Comments** rules into the autofix `address-review` flow, so the bot stops accreting over-defensive, over-commented bloat as it addresses review feedback round after round.

## Why

Review rounds **ratchet code upward**: every round tends to *add* — a guard, a comment, a test — to satisfy a finding, with no counter-pressure to simplify. Over many rounds a PR grows over-defensive and over-commented (e.g. #7471 went 1972 → 2690 lines). The verification gate rewards "builds/tests/lints pass" — an over-defended, over-commented version passes just as well — so the only place simplicity pressure can come from is the agent's own instructions.

AGENTS.md **already** states the principle, and strongly ("the principle we care about most"): *"Minimum code that solves the problem … No error handling for impossible scenarios … If you write 200 lines and it could be 50, rewrite it"* and *"Comments: Default to none. Add only when why is non-obvious."* The gap is that the address-review flow's *"implement each valuable finding, decline only with reason"* never invokes it — so the additive bias runs unchecked.

## How

Two small prose edits to `Mode: address-review` — pointers to the existing AGENTS.md rules, not a re-statement of them:

1. **Framing before the classification list**: address each finding the way Simplicity First and Comments demand (smallest change, no impossible-case guards, no restate-the-code comments); since rounds only add, each round also asks what the change lets you **remove**; and a suggestion whose only effect is more defense/config/narration is a **Decline** (not worth the diff growth), not an auto-implement — satisfying a nit is never a reason to bloat the code.
2. **Pre-commit self-audit** now also rejects **bloat**, not just defects: the skeptical re-read confirms no defense for an impossible case, no non-"why" comment, nothing a senior engineer would call overcomplicated — cut it before committing.

Deliberately minimal: it **points at** AGENTS.md rather than duplicating it, and adds no gate or metric (a diff-size cap or "complexity linter" would be blunt and unreliable — human/AI review stays the backstop; this just applies the principle at the source).

## Reviewer Test Plan

- `npx vitest run scripts/tests/qwen-autofix-workflow.test.js -t "requires the address path"` — the address-path SKILL test now also pins the simplicity wording (`Simplicity First`, `added no bloat`, `never a reason to bloat the code`). Passes.
- Mutation-verified: removing `added no bloat` from the SKILL turns that test red.
- prettier clean. Prose/markdown + three test assertions only — no workflow logic.

## Risk & Scope

- Agent-facing policy only; changes how the agent treats bloat-inducing findings, no workflow code path. Strictly safer than today's unchecked additive bias.
- Independent of #7636 (escalate) — both touch `address-review` but in different lines; the assertions here live in the `requires the address path` test, not the policy test #7636 edits.
- Breaking changes / migration notes: none.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 **AGENTS.md 的 Simplicity First 与 Comments 纪律** 接进 autofix 的 `address-review` 流,让 bot 在一轮轮处理评审反馈时,不再堆积过度防御、过度注释的膨胀。

## 为什么

评审轮次是**只增不减的棘轮**:每轮为满足一条 finding 而*加*东西(guard、注释、测试),却没有简化的反压力。多轮下来 PR 越来越过度防御、过度注释(如 #7471 从 1972→2690 行)。验证 gate 只奖励"build/test/lint 过"——过度防御、过度注释的版本照样过——所以简化压力只能来自 agent 自己的指令。

AGENTS.md **本就**写了这原则,且很强("我们最在意的原则"):*"解决问题的最少代码……不为不可能的情况做错误处理……200 行能写成 50 行就重写"*、*"注释:默认没有,只在 why 不显然时加"*。缺口在于 address-review 的 *"实现每条有价值的 finding、只能带理由 decline"* 从没调用它 —— 加法偏置无人约束。

## 怎么做

对 `Mode: address-review` 两处小 prose 改动 —— 指向现有 AGENTS.md 规则,不重述:

1. **分类列表前加框架**:按 Simplicity First 与 Comments 处理每条 finding(最小改动、不为不可能情况加防御、不加重述代码的注释);既然轮次只加,每轮也问这改动能**删掉**什么;仅带来更多防御/配置/叙述的建议是 **Decline**(理由:膨胀),不是自动实现 —— 满足一条 nit 绝不是膨胀代码的理由。
2. **提交前自审**现在也拒绝**膨胀**,不只是缺陷:挑剔重读确认无不可能情况的防御、无非-why 注释、无资深工程师会嫌 overcomplicated 之处 —— 提交前删掉。

刻意最小:**指向** AGENTS.md 而非复制;不加任何 gate/度量(diff 行数上限或"复杂度 linter"太钝、不可靠 —— 人工/AI 评审仍是兜底,本 PR 只是在源头应用原则)。

## 评审验证

- `-t "requires the address path"` —— address-path SKILL 测试现在也 pin 了 simplicity 措辞(`Simplicity First`、`added no bloat`、`never a reason to bloat the code`)。通过。
- 变异验证:从 SKILL 删 `added no bloat` → 该测试红。
- prettier clean。仅 prose/markdown + 三条断言,不改 workflow 逻辑。

## 风险与范围

- 仅 agent 面向策略;改的是 agent 对"膨胀型 finding"的处理,不触及 workflow 代码路径。严格优于今天无约束的加法偏置。
- 与 #7636(escalate)独立 —— 都动 `address-review` 但不同行;本 PR 断言放在 `requires the address path` 测试,而非 #7636 改的 policy 测试。
- 破坏性变更:无。

</details>
